### PR TITLE
TECHDEL-237: Public repo cleanup — remove stale Docker paths, fix conftest, scrub telecom

### DIFF
--- a/docs/DB_SERVICE_API.md
+++ b/docs/DB_SERVICE_API.md
@@ -675,8 +675,8 @@ PATCH /trials/airline_task_001:0/state/reservations
 POST /trials/airline_task_001:1/init
 PATCH /trials/airline_task_001:1/state/reservations
 
-# Trial 3: telecom_task_002:0 (different task)
-POST /trials/telecom_task_002:0/init
+# Trial 3: retail_task_002:0 (different task)
+POST /trials/retail_task_002:0/init
 ```
 
 ### Cleanup

--- a/docs/GRADING_VERIFICATION.md
+++ b/docs/GRADING_VERIFICATION.md
@@ -132,7 +132,7 @@ state_diff: null
 
 **REWARD=0 (Fail):**
 ```yaml
-# output/sandbox_telecom_field_service_v1_docker_20260308_065713/trials/DC-F-001/0/grade.yaml
+# output/sandbox_example_docker_20260308_065713/trials/DC-F-001/0/grade.yaml
 binary_pass: false
 score: 0.0
 components:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -74,7 +74,7 @@ These numbers confirm the harness can sustain high throughput even when agent an
 
 ## Historical (Real LLM) Reference
 
-Previous Sonnet 4.5 runs with real API calls (4 workers × telecom slice) produced roughly:
+Previous Sonnet 4.5 runs with real API calls (4 workers on a realistic task slice) produced roughly:
 
 | Metric | Value |
 |--------|-------|

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -61,7 +61,7 @@ evaluation:
 ```yaml
 task_id: "unique_task_identifier"
 name: "Human-readable task name"
-category: "terminal"                # terminal, web, telecom, airline, etc.
+category: "terminal"                # e.g. terminal, web, airline, retail
 description: |
   Detailed task description.
 
@@ -275,7 +275,7 @@ from tolokaforge.core.grading.combine import GradingEngine
 engine = GradingEngine(
     grading_config: GradingConfig,
     judge_model: ModelConfig | None = None,
-    task_domain: str = "telecom",
+    task_domain: str = "general",
     task_dir: Path | None = None,
 )
 

--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -63,7 +63,7 @@ class ToolSource(BaseModel):
     implementation in the container. Tool code must be pre-installed
     or mounted in the container.
     """
-    toolset: str                                  # Package/directory: "zendesk", "airline", "telecom"
+    toolset: str                                  # Package/directory: e.g. "zendesk", "airline", "retail"
     module_path: str                              # Module within toolset: "tools.create_item"
     class_name: str                               # Class/function: "CreateItem", "BookReservation"
     invocation_style: InvocationStyle = InvocationStyle.TAU_SYNC
@@ -273,7 +273,7 @@ class TaskDescription(BaseModel):
     # --- Identity ---
     task_id: str
     name: str
-    category: str                                 # Domain: "airline", "telecom", "retail"
+    category: str                                 # Domain: e.g. "airline", "retail"
     description: str                              # Task description / user goal
     adapter_type: AdapterType
     schema_version: str = "1.0.0"
@@ -514,14 +514,14 @@ class TaskDescription(BaseModel):
 
 ```json
 {
-  "task_id": "telecom_task_002",
+  "task_id": "example_task_002",
   "name": "Mobile Data / Slow Internet Issues",
-  "category": "telecom",
+  "category": "general",
   "description": "User experiencing mobile data issues",
   "adapter_type": "native",
   "schema_version": "1.0.0",
 
-  "system_prompt": "# Telecom Support Manual\n\nYou are a customer service agent...",
+  "system_prompt": "# Support Manual\n\nYou are a customer service agent...",
 
   "agent_tools": [
     {
@@ -533,7 +533,7 @@ class TaskDescription(BaseModel):
         "required": ["phone_number"]
       },
       "source": {
-        "toolset": "telecom",
+        "toolset": "example_support",
         "module_path": "mcp_server",
         "class_name": "get_customer_by_phone",
         "invocation_style": "mcp_server",
@@ -548,7 +548,7 @@ class TaskDescription(BaseModel):
       "description": "Toggle airplane mode on/off",
       "parameters": {"type": "object", "properties": {}},
       "source": {
-        "toolset": "telecom_user",
+        "toolset": "example_user",
         "module_path": "user_device",
         "class_name": "toggle_airplane_mode",
         "invocation_style": "tau_sync"
@@ -601,8 +601,8 @@ class TaskDescription(BaseModel):
   },
 
   "source_files": {
-    "task": "tasks/telecom/task_002/task.yaml",
-    "grading": "tasks/telecom/task_002/grading.yaml"
+    "task": "tasks/example/task_002/task.yaml",
+    "grading": "tasks/example/task_002/grading.yaml"
   }
 }
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,27 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_marker)
 
 
-# Import shared fixtures so they're available to all tests
-from tests.utils.containers import (  # noqa: E402
-    json_db_container,
-    rag_service_container,
-    runner_container,
-)
+# ---------------------------------------------------------------------------
+# Shared fixture imports
+# ---------------------------------------------------------------------------
+#
+# Fixtures split into two groups:
+#
+#   1. Always available — generic Python/gRPC fixtures that only depend on
+#      tolokaforge core and the standard library.
+#   2. Docker-dependent — require the ``docker`` and ``testcontainers``
+#      packages, which ship with the ``[docker]`` extra.  When that extra
+#      is not installed (e.g. during unit-test-only CI runs or on a dev
+#      laptop without Docker), importing these modules raises
+#      ``ModuleNotFoundError`` at collection time, which blocks *every*
+#      test from running — including the pure unit tests that never touch
+#      Docker.
+#
+# We guard the docker-dependent imports so pytest can still collect and
+# run the generic suite without the extra.  Tests that actually need a
+# Docker fixture will fail with pytest's standard ``fixture 'X' not
+# found`` message, pointing the developer at the missing extra.
+
 from tests.utils.docker_helpers import (  # noqa: E402
     skip_if_no_docker_runner,
 )
@@ -36,11 +51,43 @@ from tests.utils.fixtures import (  # noqa: E402
     test_data_dir,
     test_task_path,
 )
-from tests.utils.networks import (  # noqa: E402
-    env_files_volume,
-    env_network,
-    rag_data_volume,
-)
+
+_DOCKER_EXTRA_FIXTURES: list[str] = []
+
+try:  # noqa: E402
+    from tests.utils.containers import (  # noqa: F401,E402
+        json_db_container,
+        rag_service_container,
+        runner_container,
+    )
+    from tests.utils.networks import (  # noqa: F401,E402
+        env_files_volume,
+        env_network,
+        rag_data_volume,
+    )
+
+    _DOCKER_EXTRA_FIXTURES = [
+        "env_network",
+        "env_files_volume",
+        "rag_data_volume",
+        "json_db_container",
+        "rag_service_container",
+        "runner_container",
+    ]
+except ModuleNotFoundError as exc:  # pragma: no cover - environment-dependent
+    # docker / testcontainers are shipped via the ``[docker]`` extra.  When
+    # missing, we keep the rest of the suite runnable; tests that need the
+    # docker fixtures will fail loudly at fixture-resolution time.
+    import warnings
+
+    warnings.warn(
+        (
+            "Docker test fixtures unavailable "
+            f"({exc.name!r} missing). "
+            "Install the '[docker]' extra to run Docker-dependent tests."
+        ),
+        stacklevel=1,
+    )
 
 __all__ = [
     # Utility fixtures
@@ -55,12 +102,6 @@ __all__ = [
     "runner_service",
     # Docker helper fixtures
     "skip_if_no_docker_runner",
-    # Network and volume fixtures
-    "env_network",
-    "env_files_volume",
-    "rag_data_volume",
-    # Container fixtures
-    "json_db_container",
-    "rag_service_container",
-    "runner_container",
+    # Docker-extra fixtures (only available when the ``[docker]`` extra is installed)
+    *_DOCKER_EXTRA_FIXTURES,
 ]

--- a/tolokaforge/core/env_state.py
+++ b/tolokaforge/core/env_state.py
@@ -84,7 +84,7 @@ class EnvironmentState:
         # Ensure db_state has consistent structure (device + surroundings mirrors user_db)
         self._normalize_db_state()
 
-        # Apply per-task device state overrides (for τ² telecom tasks)
+        # Apply per-task device state overrides (for τ² tasks with device state)
         if self.config.device_overrides and "device" in self.db_state:
             for key, value in self.config.device_overrides.items():
                 self.db_state["device"][key] = value

--- a/tolokaforge/core/evaluators/environment_evaluator.py
+++ b/tolokaforge/core/evaluators/environment_evaluator.py
@@ -56,13 +56,13 @@ class EnvironmentEvaluator:
     def __init__(self):
         self.assertion_modules = {}  # Cache loaded modules
 
-    def load_assertion_function(self, func_name: str, domain: str = "telecom") -> callable:
+    def load_assertion_function(self, func_name: str, domain: str = "general") -> callable:
         """
         Load an assertion function dynamically
 
         Args:
             func_name: Name of the assertion function
-            domain: Domain to load from (telecom, airline, etc.)
+            domain: Domain to load from (e.g. airline, retail)
 
         Returns:
             Callable assertion function
@@ -103,7 +103,7 @@ class EnvironmentEvaluator:
         assertion: EnvAssertion,
         agent_env_state: dict[str, Any],
         user_env_state: dict[str, Any],
-        domain: str = "telecom",
+        domain: str = "general",
     ) -> EnvAssertionResult:
         """
         Evaluate a single environment assertion
@@ -142,7 +142,7 @@ class EnvironmentEvaluator:
         final_state: dict[str, Any],
         state_checks_config: StateChecksConfig,
         expected_db_hash: str | None = None,
-        domain: str = "telecom",
+        domain: str = "general",
     ) -> StateCheckResult:
         """
         Evaluate all state checks including env assertions and DB hash

--- a/tolokaforge/core/grading/combine.py
+++ b/tolokaforge/core/grading/combine.py
@@ -45,7 +45,7 @@ class GradingEngine:
         self,
         grading_config: GradingConfig,
         judge_model: ModelConfig | None = None,
-        task_domain: str = "telecom",
+        task_domain: str = "general",
         task_dir: Path | None = None,
         task_initial_state: InitialStateConfig | None = None,
         task_mcp_server: str | None = None,

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -286,7 +286,7 @@ class StateChecker:
             task_dir: Task directory containing data files
             initial_state_path: Path to initial state JSON file (relative to task_dir)
             mcp_server_path: Path to MCP server module (relative to task_dir)
-            task_domain: Domain name (e.g., "airline", "telecom")
+            task_domain: Domain name (e.g., "airline", "retail")
 
         Returns:
             State after executing golden actions
@@ -372,7 +372,7 @@ class StateChecker:
             task_dir: Task directory containing data files
             initial_state_path: Path to initial state JSON file (relative to task_dir)
             mcp_server_path: Path to MCP server module (relative to task_dir)
-            task_domain: Domain name (e.g., "airline", "telecom")
+            task_domain: Domain name (e.g., "airline", "retail")
 
         Returns:
             Expected SHA256 hash of state after executing golden actions
@@ -426,7 +426,7 @@ class StateChecker:
 
         # Extract database state from final state structure
         # Final state has structure: {"agent": {...}, "user": {...}, "db": {...}, ...}
-        # For airline/telecom tasks, we want to hash the "db" key (legacy format) or "agent" key
+        # For airline/retail tasks, we want to hash the "db" key (legacy format) or "agent" key
         # The initial state JSON file contains the raw database state
         db_state = state.get("db", state.get("agent", state))
 

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -53,9 +53,6 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "pyproject.toml",
             "README.md",
             "tolokaforge/",
-            "contrib/tau-bench/",
-            "tasks/telecom/tau_tools/",
-            "tasks/telecom/data/",
         ],
     },
     "rag-service": {

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -54,7 +54,7 @@ class ToolSource(BaseModel):
     or mounted in the container.
     """
 
-    toolset: str  # Package/directory: "zendesk", "airline", "telecom"
+    toolset: str  # Package/directory: "zendesk", "airline", "retail"
     module_path: str  # Module within toolset: "tools.create_item"
     class_name: str  # Class/function: "CreateItem", "BookReservation"
     invocation_style: InvocationStyle = InvocationStyle.TAU_SYNC
@@ -324,7 +324,7 @@ class TaskDescription(BaseModel):
     # --- Identity ---
     task_id: str
     name: str
-    category: str  # Domain: "airline", "telecom", "retail"
+    category: str  # Domain: "airline", "retail"
     description: str  # Task description / user goal
     adapter_type: AdapterType
     schema_version: str = "1.0.0"

--- a/tolokaforge/tools/user_tools.py
+++ b/tolokaforge/tools/user_tools.py
@@ -14,7 +14,7 @@ from tolokaforge.tools.registry import Tool, ToolResult, sanitize_tool_schema
 class CheckDeviceLightsTool(Tool):
     """User tool to check status lights on a device
 
-    Example: In telecom scenarios, user can check if lights are blinking
+    Example: User can check if lights are blinking
     indicating network connectivity issues.
     """
 


### PR DESCRIPTION
## Summary

Three independent cleanup commits for the ongoing repo split (TLK-SPLIT-1):

### Commits

1. **`3cbf6e1` fix(docker/builder): remove stale context_files** — `IMAGE_DEFINITIONS["runner"]` listed paths (`contrib/tau-bench/`, `tasks/telecom/tau_tools/`, `tasks/telecom/data/`) that don't exist in the public tree. Align with the canonical definition in `stacks/core.py`.

2. **`3c11da8` test(conftest): allow collection without [docker] extra** — `tests/conftest.py` unconditionally imported docker/testcontainers at module load. Wrapped in try/except so `pytest --collect-only` works on a minimal install (no Docker SDK needed for unit tests).

3. **`0c2e49e` refactor: scrub internal telecom references** — Per team decision: keep airline/retail (standard tau-bench domains), scrub telecom (synthetic internal slice). Changes `task_domain`/`domain` defaults from `"telecom"` to `"general"`, updates docstrings and docs.

### Verified

- `ruff check` passes on all changed files.
- Only 2 remaining `telecom` references: `tests/BASELINE.md` historical changelog entries (factually accurate, kept).
- The full test suite cannot run in this CI environment due to missing core deps; that's a pre-existing gap being addressed separately (testing strategy decision pending).
