### PR TITLE
feat(llm): register anthropic claude-opus-4.8

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -204,6 +204,77 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Opus 4.8 — Anthropic adaptive thinker. Live-certified 2026-05-29 via
+    # ``pytest tests/integration/llm/ -k claude-opus-4.8`` (OpenRouter route).
+    # This is NOT a copy of the 4.7 posture: per the runbook anti-pattern
+    # (docs/ADD_NEW_MODEL.md § "copying a sibling cert verbatim"), every 4.7
+    # ``known_unsupported`` entry was flipped to ``required`` and re-run live.
+    # The 4.8 results diverge from 4.7 in two ways:
+    #
+    #   * DICT_MAP_TOOL_CALL + DECIMAL_FIELD_TOOL_CALL now PASS under
+    #     Anthropic's PassthroughSchema — 4.6/4.7 declared them unsupported,
+    #     4.8 handles them natively. Promoted to ``required``.
+    #   * DISCRIMINATED_UNION_TOOL_CALL still FAILS the explicit_discriminator
+    #     variant. Stays ``known_unsupported`` (see per-entry note).
+    #
+    # IMPLICIT_PROMPT_CACHING and UNSIGNED_THINKING_REPLAY also pass the
+    # synthetic probe live, but are kept ``known_unsupported`` deliberately —
+    # the probes are satisfied by an artifact / wrong-shape, not by the
+    # contract they name. Each entry documents why (verified 2026-05-29).
+    MC(
+        model_id="openrouter__anthropic_claude-opus-4.8",
+        provider="openrouter",
+        name="anthropic/claude-opus-4.8",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+                # Promoted from 4.6/4.7's known_unsupported — 4.8 passes both
+                # live under Anthropic PassthroughSchema (verified 2026-05-29);
+                # the 4.7 "strict-trio only" rationale no longer holds for 4.8.
+                C.DICT_MAP_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # explicit_discriminator variant emits ``item`` as a
+                # JSON-encoded string instead of a nested dict (bare_union
+                # passes); no JsonCoerce recovery on the Anthropic passthrough
+                # route. Verified live 2026-05-29.
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                # Passes the synthetic probe live, kept unsupported on purpose:
+                # the probe only fires because our anthropic_ephemeral
+                # cache_policy injects explicit cache_control markers, so it is
+                # really measuring EXPLICIT caching (covered by PROMPT_CACHING,
+                # required above). The test's own docstring lists anthropic as
+                # known_unsupported — Anthropic has no implicit auto-cache
+                # surface. Pass-but-artifact, verified 2026-05-29.
+                C.IMPLICIT_PROMPT_CACHING,
+                # Passes the synthetic probe live, kept unsupported on purpose:
+                # test_unsigned_thinking_replay asserts the Gemini-lineage
+                # reasoning_details/reasoning.text replay shape. Anthropic's
+                # real replay contract is the SIGNED variant
+                # (THINKING_REPLAY_ROUNDTRIP, required above). Kept consistent
+                # with opus-4.6/4.7. Pass-but-wrong-shape, verified 2026-05-29.
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
     # -----------------------------------------------------------------
     # Qwen — preset routes it through the same strict trio as GPT-5.
     # Reasoning surface is OpenAI-style summary only, no signed blocks,

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -28,6 +28,25 @@ default:
     reasoning_via_extra_body: false
 
 presets:
+  # Claude 4.8 (Opus + Sonnet) — same adaptive-thinker contract as 4.7:
+  # ignores ``reasoning_effort``, requires the canonical litellm ``thinking=``
+  # kwarg + explicit ``budget_tokens``. Listed FIRST so first-match-wins
+  # routing picks the version-specific preset before the generic ``anthropic``.
+  anthropic_claude_4_8:
+    match:
+      - "anthropic/claude-opus-4.8*"
+      - "anthropic/claude-sonnet-4.8*"
+      - "*claude-opus-4.8*"
+      - "*claude-sonnet-4.8*"
+    content_policy: anthropic
+    reasoning_codec: anthropic
+    cache_policy: anthropic_ephemeral
+    params:
+      supports_seed: false
+      reasoning_via_thinking_kwarg: true
+      drop_sampling_when_thinking: true
+      reasoning_budget_default: 8000
+
   # Claude 4.7 (Opus + Sonnet) — Anthropic's adaptive thinker that ignores
   # ``reasoning_effort`` and requires the canonical litellm ``thinking=``
   # kwarg + explicit ``budget_tokens``. Listed BEFORE the generic

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -187,6 +187,12 @@
       "cache_read": 3.0,
       "cache_write": 37.5
     },
+    "anthropic/claude-opus-4.8": {
+      "input": 5.0,
+      "output": 25.0,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
     "anthropic/claude-sonnet-4": {
       "input": 3.0,
       "output": 15.0,


### PR DESCRIPTION
## What

Registers **Opus 4.8** (`anthropic/claude-opus-4.8`) in the shared model catalogs.

## Files

| File | Change |
|---|---|
| `tolokaforge/core/data/pricing.json` | `anthropic/claude-opus-4.8` @ 5 / 25 / 0.5 / 6.25 per 1M |
| `tolokaforge/core/data/model_presets.yaml` | `anthropic_claude_4_8` preset, before `_4_7` + generic `anthropic` (first-match-wins; adaptive-thinker contract) |
| `tests/integration/llm/registry.py` | `ModelCertificate` — live-certified & calibrated (see below) |

## Pre-flight (OpenRouter API, 2026-05-29)

Slug `anthropic/claude-opus-4.8` exists; pricing **5 / 25 / 0.5 / 6.25** — identical to opus-4.6/4.7; no promo, no `_pins`.

## Capability suite — live, 2026-05-29 ✅

```
scripts/with_env.sh uv run pytest tests/integration/llm/ -k claude-opus-4.8 -v
```

```
test_basic_completion            PASSED      test_progress_after_success     PASSED
test_cost_usd_populated          PASSED      test_prompt_caching             PASSED
test_decimal_field_tool_call     PASSED      test_re2_pattern_tolerance      PASSED
test_dict_map_tool_call          PASSED      test_required_fields_complete   PASSED
test_discriminated_union[bare]   SKIPPED     test_simple_tool_call           PASSED
test_discriminated_union[expl]   SKIPPED     test_thinking_emits_blocks      PASSED
test_enum_slash_tolerance        PASSED      test_thinking_replay_roundtrip  PASSED
test_implicit_prompt_caching     SKIPPED     test_tool_name_discipline       PASSED
test_lexical_tool_invention      PASSED      test_unsigned_thinking_replay   SKIPPED
test_multi_turn_error_recovery   PASSED      test_usage_metrics_populated    PASSED
test_multi_turn_tool_use         PASSED

================ 17 passed, 4 skipped ================
```

## Cert calibration — NOT a 4.7 copy

Per the runbook anti-pattern check (`docs/ADD_NEW_MODEL.md` § "copying a sibling cert verbatim"), every 4.7 `known_unsupported` entry was **flipped to `required` and re-run live**:

| Capability | 4.6/4.7 | 4.8 live | Decision |
|---|---|---|---|
| `DICT_MAP_TOOL_CALL` | known_unsupported | **PASS** | → **required** (4.8 handles it natively under passthrough) |
| `DECIMAL_FIELD_TOOL_CALL` | known_unsupported | **PASS** | → **required** |
| `DISCRIMINATED_UNION_TOOL_CALL` | known_unsupported | bare PASS / explicit **FAIL** | **kept known_unsupported** (`item` emitted as JSON string) |
| `IMPLICIT_PROMPT_CACHING` | known_unsupported | PASS* | **kept known_unsupported** — *probe satisfied by explicit-cache injection; real contract = `PROMPT_CACHING` (required). Test docstring lists anthropic as known_unsupported. |
| `UNSIGNED_THINKING_REPLAY` | known_unsupported | PASS* | **kept known_unsupported** — *Gemini-shaped probe; Anthropic's real contract = signed `THINKING_REPLAY_ROUNDTRIP` (required). |

**Net vs 4.7:** Opus 4.8 gains two schema capabilities (`DICT_MAP`, `DECIMAL`). The two "pass-but-artifact" capabilities are kept `known_unsupported` deliberately and documented inline in `registry.py` with reasoning + 2026-05-29 date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)