### PR TITLE
docs: add architecture overview and ADR scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ examples/             # Reference task layouts with runnable run_config.yaml
 
 | Topic | Link |
 | --- | --- |
+| Architecture overview | [docs/architecture/README.md](docs/architecture/README.md) |
 | Getting started | [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) |
 | Task authoring | [docs/TASKS.md](docs/TASKS.md) |
 | Grading system | [docs/GRADING.md](docs/GRADING.md) |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -96,38 +96,27 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    subgraph Orchestrator["Orchestrator Process (single host)"]
-        CLI["CLI<br/>(run · prepare · worker · validate · status · analyze)"]
-        Core["Orchestrator + Core<br/>(orchestration · grading combine · metrics · search)"]
-        TR["TrialRunner<br/>(in-process agent–user loop)"]
-        Adapters["Adapter Layer<br/>(BaseAdapter · NativeAdapter · entry-point plugins)"]
-        LLMLayer["LLM Layer<br/>(LiteLLM client · presets · schema sanitizers · reasoning codecs · cache policy)"]
-        ToolsLocal["Tool Registry + Executor<br/>(built-ins + MCP, in-process)"]
-        Secrets["SecretManager"]
-        QueueLib["Run-queue client<br/>(SqliteRunQueue · PostgresRunQueue)"]
+    subgraph Process["Orchestrator process (always in-process)"]
+        Adapter["Adapter Layer"]
+        Loop["Orchestrator + TrialRunner<br/>(agent–user loop)"]
+        LLM["LLM Layer<br/>(LiteLLM + presets)"]
+        Local["Local Tool Executor"]
     end
 
-    subgraph DockerOpt["Docker stack (Docker mode only)"]
-        RunnerSvc["Runner Service<br/>(gRPC: RegisterTrial · ExecuteTool · GradeTrial · GetState · ResetTrial · CleanupTrial)"]
-        DBSvc["db-service<br/>(JSON state DB)"]
-        RAGSvc["rag-service<br/>(optional)"]
-        MockWeb["mock-web<br/>(optional)"]
+    subgraph DockerStack["Docker stack (Docker mode only)"]
+        Runner["Runner Service<br/>(gRPC)"]
+        Env["db-service<br/>+ rag-service · mock-web"]
     end
 
-    CLI --> Core
-    Core --> Adapters
-    Core --> TR
-    Core --> QueueLib
-    TR --> LLMLayer
-    TR -- "local mode" --> ToolsLocal
-    TR -- "Docker mode" --> RunnerSvc
-    LLMLayer --> Secrets
-    RunnerSvc <--> DBSvc
-    RunnerSvc <--> RAGSvc
-    ToolsLocal <--> DBSvc
-    ToolsLocal <--> RAGSvc
-    ToolsLocal <--> MockWeb
+    Adapter --> Loop
+    Loop --> LLM
+    Loop -- "local mode" --> Local
+    Loop -- "Docker mode" --> Runner
+    Local <--> Env
+    Runner <--> Env
 ```
+
+Component-level detail (CLI commands, the run-queue client, SecretManager, individual env services) is described in the table below rather than spelled out in the diagram, to keep the container view at C4 Level 2.
 
 ### Block responsibilities
 
@@ -183,73 +172,29 @@ These four contracts are the entire integration surface. Anything an external ta
 
 ## 6. Runtime View — One Trial
 
-### Local mode (default)
-
 ```mermaid
 sequenceDiagram
     autonumber
-    participant U as User
     participant CLI
-    participant O as Orchestrator
-    participant A as Adapter
-    participant Q as RunQueue (SQLite)
-    participant TR as TrialRunner (in-process)
+    participant Loop as Orchestrator + TrialRunner
     participant LLM as LiteLLM
-    participant TE as Tool Executor (in-process)
-    participant DB as db-service / rag-service (HTTP)
-    participant G as GradingEngine
+    participant Tools as Tool Executor or Runner gRPC
+    participant G as Grader
 
-    U->>CLI: tolokaforge run --config run.yaml
-    CLI->>O: load config + resolve task list
-    O->>A: get_task · create_environment · get_registry_tools
-    A-->>O: TaskConfig + tools + initial state
-    O->>Q: enqueue (task_id, trial_index)
-    Q-->>O: lease
-    O->>TR: run trial
-    loop until done, error, or max_turns
-        TR->>LLM: agent.completion(messages, tool_schemas)
-        LLM-->>TR: response (+ tool_calls)
-        TR->>TE: execute(tool_call)
-        TE<->>DB: state read/write
-        TE-->>TR: tool_result
-        TR->>LLM: user_simulator.reply(messages)
-        LLM-->>TR: user turn
+    CLI->>Loop: run config + tasks
+    loop agent–user loop
+        Loop->>LLM: agent completion
+        LLM-->>Loop: response + tool calls
+        Loop->>Tools: execute tool call
+        Tools-->>Loop: tool result
+        Loop->>LLM: user simulator reply
+        LLM-->>Loop: user turn
     end
-    TR-->>O: trajectory + final_state
-    O->>G: grade(trajectory, final_state, env)
-    G-->>O: verdict + metrics
-    O-->>CLI: write artifacts (trajectory.yaml, metrics.yaml, ...)
+    Loop->>G: grade trajectory
+    G-->>Loop: verdict + metrics
 ```
 
-### Docker mode
-
-The flow is identical except every interaction between TrialRunner and the tool/state/grading stack goes over gRPC to the Runner service:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant TR as TrialRunner (in orchestrator process)
-    participant LLM as LiteLLM
-    participant RC as RunnerClient (gRPC)
-    participant RS as Runner Service (gRPC, separate container)
-    participant DB as db-service (HTTP)
-
-    Note over TR,RS: Setup: orchestrator calls RegisterTrial(task_description)
-    loop until done, error, or max_turns
-        TR->>LLM: agent.completion(...)
-        LLM-->>TR: response (+ tool_calls)
-        TR->>RC: ExecuteTool(trial_id, tool_call)
-        RC->>RS: ExecuteTool RPC
-        RS<->>DB: state read/write
-        RS-->>RC: tool_result
-        RC-->>TR: tool_result
-    end
-    TR->>RC: GradeTrial(trial_id)
-    RC->>RS: GradeTrial RPC
-    RS-->>RC: verdict + metrics
-```
-
-The agent loop and the LLM calls always happen in the orchestrator process. Only tool execution, environment state, and grading move to the Runner service when Docker mode is active.
+The `Tools` lane is the in-process `ToolExecutor` in local mode and the Runner gRPC service (in a separate container) in Docker mode. The agent loop, the user-simulator loop, and the LLM calls always happen in the orchestrator process regardless of mode. Setup steps (loading config, resolving tasks via the adapter, enqueueing attempts, writing artifacts) bracket the loop but are omitted from the diagram for clarity.
 
 ---
 
@@ -257,42 +202,24 @@ The agent loop and the LLM calls always happen in the orchestrator process. Only
 
 ```mermaid
 flowchart TB
-    subgraph Local["Local single-host, in-process"]
-        L_CLI["tolokaforge CLI"]
-        L_Orch["Orchestrator process<br/>(TrialRunner + LLM client + in-process tools)"]
-        L_SQLite[("SQLite<br/>(attempt queue)")]
-        L_DB["docker-compose: db-service<br/>(+ rag-service, mock-web optional)"]
-        L_CLI --> L_Orch
-        L_Orch --> L_SQLite
-        L_Orch <--> L_DB
+    subgraph Local["Local mode"]
+        L_Orch["Orchestrator process"]
+        L_Q[("Attempt queue · SQLite")]
+        L_Env["docker-compose<br/>db-service + optional rag/mock-web"]
+        L_Orch --> L_Q
+        L_Orch <--> L_Env
     end
 
-    subgraph Docker["Single-host Docker mode"]
-        D_CLI["tolokaforge CLI"]
-        D_Orch["Orchestrator process<br/>(TrialRunner + LLM client)"]
-        D_Runner["runner container<br/>(Runner gRPC service)"]
-        D_DB["db-service container"]
-        D_Extras["optional:<br/>rag-service · mock-web · dind"]
-        D_SQLite[("SQLite<br/>(attempt queue)")]
-        D_CLI --> D_Orch
-        D_Orch --> D_SQLite
-        D_Orch <-->|gRPC| D_Runner
-        D_Runner <--> D_DB
-        D_Runner <--> D_Extras
-    end
-
-    subgraph Dist["Distributed (prepare + worker)"]
-        D2_Prep["tolokaforge prepare<br/>(host: any)"]
-        D2_PG[("Postgres<br/>(shared attempt queue)")]
-        D2_W1["tolokaforge worker<br/>(host A)<br/>orchestrator + optional local Runner"]
-        D2_W2["tolokaforge worker<br/>(host B)<br/>orchestrator + optional local Runner"]
-        D2_Prep --> D2_PG
-        D2_W1 <--> D2_PG
-        D2_W2 <--> D2_PG
+    subgraph DockerMode["Docker mode"]
+        D_Orch["Orchestrator process"]
+        D_Q[("Attempt queue · SQLite or Postgres")]
+        D_Stack["Docker stack<br/>runner + db-service<br/>+ optional rag/mock-web/dind"]
+        D_Orch --> D_Q
+        D_Orch <-->|gRPC + HTTP| D_Stack
     end
 ```
 
-The same orchestrator binary drives all three modes. Workers in distributed mode each contain a full orchestrator process and can independently run in local or Docker mode. Coordination happens entirely through the shared attempt queue — there is no central scheduler service. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
+**Distributed runs** share the queue across hosts: one host runs `tolokaforge prepare` to populate a Postgres attempt queue; one or more hosts run `tolokaforge worker`, each instantiating a full orchestrator process. Workers independently choose local or Docker mode. There is no central scheduler — coordination is entirely through the queue. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,13 +4,13 @@ This document is the entry point for the system-level architecture of Tolokaforg
 
 For deep dives into individual subsystems, follow the links to `docs/*.md` from each section. For decision history and rationale, see [`adr/`](adr/).
 
-> **How to evolve this doc:** keep the diagrams here at C4 Levels 1–2 (Context and Container). When a building block changes shape or a boundary moves, update the relevant section *and* add an ADR. When you want to propose a future state, add an ADR with status `Proposed`; once accepted, update the diagram in this file.
+> **How to evolve this doc:** keep the diagrams here at C4 Levels 1–2 (Context and Container) and treat them as a *reflection of what the code actually does today* — not what we plan to build. When a building block changes shape or a boundary moves, update the relevant section *and* add an ADR. When you want to propose a future state, add an ADR with status `Proposed`; once accepted, update the diagram in this file. Verify diagrams against the source (`tolokaforge/`) before merging changes here.
 
 ---
 
 ## 1. Introduction and Goals
 
-Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It runs multi-turn agent/user loops against sandboxed task environments and produces deterministic pass/fail verdicts plus rich telemetry.
+Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It runs multi-turn agent/user loops against task environments and produces deterministic pass/fail verdicts plus rich telemetry.
 
 ### Quality goals
 
@@ -18,7 +18,7 @@ Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It r
 |---|---|
 | **Determinism** | Same task + same model + same seed should yield the same verdict. State hashes, snapshot grading, transcript rules. |
 | **Provider-agnostic** | Any LLM reachable via LiteLLM is a first-class citizen. Provider-specific quirks are isolated in per-preset capability policies. |
-| **Isolation** | Tool calls execute against sandboxed services with no external network reach by default. |
+| **Isolation** | Tool calls can run in a separate process (and on a separate host) in Docker mode, with the agent loop never touching tool state directly. |
 | **Honesty over convenience** | Failures surface explicitly. No silent fallbacks; no defaults that hide configuration mistakes. |
 | **Extensibility** | New benchmark formats plug in as adapters without touching the core. |
 
@@ -35,11 +35,11 @@ Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It r
 ### Technical
 
 - **Language**: Python (managed via `uv`).
-- **Service decomposition**: gRPC services (`agent`, `executor`, `runner`) so trial execution can be remoted and isolated.
-- **LLM access**: routed through [LiteLLM](https://github.com/BerriAI/litellm) to keep provider-specific glue out of the core. Per-provider differences live in the LLM-layer preset registry.
-- **Tools**: built-in tool registry plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs.
-- **Environment services**: containerised JSON state DB, mock web, RAG indexer — orchestrated via Docker Compose.
-- **Persistence**: SQLite for local single-host runs, Postgres for multi-host distributed runs.
+- **LLM access**: routed through [LiteLLM](https://github.com/BerriAI/litellm) — provider-specific glue is kept out of the core. Per-provider differences live in the LLM-layer preset registry (`tolokaforge/core/llm/presets.py`).
+- **Tools**: in-process tool registry plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs.
+- **Environment services** (optional, started by `make docker-up`): JSON state DB, mock web, RAG indexer — each one a separate container.
+- **Trial-loop transport**: the agent–user loop runs **in-process** inside the orchestrator (`tolokaforge/core/runner.py:TrialRunner`). When the orchestrator runs in Docker mode, tool execution, environment state, and grading are delegated to a single **Runner gRPC service** (`tolokaforge/runner/service.py`).
+- **Durable attempt queue**: SQLite for single-host runs, optional Postgres for multi-host workers (`tolokaforge/core/run_queue.py`).
 
 ### Organisational
 
@@ -58,24 +58,24 @@ flowchart TB
     Forge["Tolokaforge<br/>(benchmarking harness)"]
     LiteLLM["LLM Providers via LiteLLM<br/>OpenAI · Anthropic · Google · Bedrock · OpenRouter · ..."]
     TaskPacks["Task Packs<br/>(external repos, glob-loaded)"]
-    Docker["Docker Engine<br/>(env services + sandboxes)"]
+    Docker["Docker Engine<br/>(optional: env services + Runner sandbox)"]
     Results["Result Artifacts<br/>(trajectories, metrics, schemas)"]
-    Store[("Run Store<br/>(SQLite local / Postgres distributed)")]
+    Queue[("Attempt Queue<br/>(SQLite local / Postgres distributed)")]
 
     Evaluator -->|runs benchmarks| Forge
     TaskAuthor -->|authors| TaskPacks
     Forge -->|loads via adapter| TaskPacks
-    Forge <-->|tool calls in sandbox| Docker
+    Forge <-->|tool execution, state, grading<br/>(Docker mode only)| Docker
     Forge <-->|completions, tool schemas| LiteLLM
     Forge -->|writes| Results
-    Forge <-->|queue, state, trajectories| Store
+    Forge <-->|durable attempts, leases| Queue
 ```
 
 ### Boundaries (what is *not* Tolokaforge)
 
 - **LLM providers** — out of scope; accessed via LiteLLM.
 - **Task content** — out of scope; lives in task pack repos. Tolokaforge defines the *contract* (task schema, tool interface, grading config), not the content.
-- **Result analysis UI** — out of scope; result artifacts are stable YAML/JSON, consumed by downstream tooling.
+- **Result analysis UI** — out of scope; result artifacts are stable YAML/JSON, consumed by downstream tooling (see [`tools/benchmark-analyzer`](../../tools/benchmark-analyzer/)).
 
 ---
 
@@ -83,11 +83,12 @@ flowchart TB
 
 | Decision | Rationale | Detail |
 |---|---|---|
-| **Adapter plugin architecture for benchmark formats** | Lets external task formats (tau-bench, terminal-bench, MCP-core, private formats) plug in without forking the core. | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
-| **gRPC service decomposition (`agent`, `executor`, `runner`)** | Each role has different isolation, scaling, and dependency profiles. gRPC makes the boundaries explicit and lets services live on different hosts in distributed runs. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **Adapter plugin architecture for benchmark formats** | Lets external task formats (`native` built-in, `terminal_bench` and other plugins) plug in without forking the core. | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **In-process agent–user loop, Docker-delegated tool execution** | Keeping the loop in-process keeps the trial control flow debuggable; Docker delegation via the Runner gRPC service gives sandbox isolation when needed without forcing a service-mesh on local users. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
 | **Provider-agnostic LLM layer with per-preset capability policies** | LiteLLM normalises envelopes, but providers diverge on schema dialects, reasoning encodings, caching, and tool naming. A preset registry keeps the quirks out of the orchestrator. | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
 | **Single secret abstraction** | One audited code path for every credential read; CI-enforced via static grep. | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
 | **Deterministic grading by default; LLM judges opt-in** | Deterministic verdicts are reproducible and cheap; judge calls are reserved for cases that genuinely need them. | [`docs/GRADING.md`](../GRADING.md) |
+| **Durable attempt queue (SQLite / Postgres) with worker leases** | Lets long runs survive crashes and lets `prepare` + `worker` commands split a run across hosts. | `tolokaforge/core/run_queue.py` |
 
 ---
 
@@ -95,51 +96,62 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    subgraph Forge["Tolokaforge"]
-        CLI["CLI<br/>(run · validate · status · analyze)"]
-        Core["Core<br/>(orchestrator · grading · metrics · queue · search)"]
+    subgraph Orchestrator["Orchestrator Process (single host)"]
+        CLI["CLI<br/>(run · prepare · worker · validate · status · analyze)"]
+        Core["Orchestrator + Core<br/>(orchestration · grading combine · metrics · search)"]
+        TR["TrialRunner<br/>(in-process agent–user loop)"]
         Adapters["Adapter Layer<br/>(BaseAdapter · NativeAdapter · entry-point plugins)"]
-        Runner["Runner<br/>(gRPC service)"]
-        Agent["Agent<br/>(gRPC service)"]
-        Executor["Executor<br/>(gRPC service)"]
-        LLMLayer["LLM Layer<br/>(presets · schema sanitizers · reasoning codecs · cache policy)"]
-        Tools["Tool Registry<br/>(built-ins + MCP)"]
+        LLMLayer["LLM Layer<br/>(LiteLLM client · presets · schema sanitizers · reasoning codecs · cache policy)"]
+        ToolsLocal["Tool Registry + Executor<br/>(built-ins + MCP, in-process)"]
         Secrets["SecretManager"]
-        EnvSvc["Env Services<br/>(JSON DB · mock-web · RAG)"]
+        QueueLib["Run-queue client<br/>(SqliteRunQueue · PostgresRunQueue)"]
+    end
+
+    subgraph DockerOpt["Docker stack (Docker mode only)"]
+        RunnerSvc["Runner Service<br/>(gRPC: RegisterTrial · ExecuteTool · GradeTrial · GetState · ResetTrial · CleanupTrial)"]
+        DBSvc["db-service<br/>(JSON state DB)"]
+        RAGSvc["rag-service<br/>(optional)"]
+        MockWeb["mock-web<br/>(optional)"]
     end
 
     CLI --> Core
     Core --> Adapters
-    Core --> Runner
-    Runner --> Agent
-    Runner --> Executor
-    Agent --> LLMLayer
-    Executor --> Tools
-    Adapters --> Tools
+    Core --> TR
+    Core --> QueueLib
+    TR --> LLMLayer
+    TR -- "local mode" --> ToolsLocal
+    TR -- "Docker mode" --> RunnerSvc
     LLMLayer --> Secrets
-    Tools --> EnvSvc
+    RunnerSvc <--> DBSvc
+    RunnerSvc <--> RAGSvc
+    ToolsLocal <--> DBSvc
+    ToolsLocal <--> RAGSvc
+    ToolsLocal <--> MockWeb
 ```
 
 ### Block responsibilities
 
 | Block | Responsibility | Source | Detail |
 |---|---|---|---|
-| **CLI** | User-facing commands; loads a run config and hands it to the orchestrator. | `tolokaforge/cli` | — |
-| **Core** | Orchestration loop, trial queue, grading pipeline, metrics aggregation, task search. | `tolokaforge/core` | [`docs/RUNNER.md`](../RUNNER.md) |
-| **Adapter Layer** | Resolves a benchmark format into `(TaskConfig, tools, grading, environment)`. Built-in `native` plus plugins discovered via `tolokaforge.adapters` entry points. | `tolokaforge/adapters` + `external_adapters/` | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
-| **Runner (gRPC)** | Owns trial lifecycle: starts agent/executor, mediates DB and RAG access, runs the grader. | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) |
-| **Agent (gRPC)** | Wraps a single agent turn: prompt assembly, model call, tool-call extraction. | `tolokaforge/agent` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
-| **Executor (gRPC)** | Executes tool calls in an isolated environment; never sees model credentials. | `tolokaforge/executor` | — |
-| **LLM Layer** | Provider-agnostic completion API. Per-provider presets carry capability policies for schema dialect, reasoning encoding, parameter handling, caching, tool-name discipline. | `tolokaforge/core/llm` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
-| **Tool Registry** | Registers built-in tools and loads MCP servers declared by tasks. | `tolokaforge/tools` | [`docs/TOOLS.md`](../TOOLS.md) |
+| **CLI** | User-facing commands. `run` executes locally end-to-end; `prepare` + `worker` split a run for distributed execution. | `tolokaforge/cli` | — |
+| **Orchestrator + Core** | Loads run config, instantiates the adapter, builds the task list, manages the attempt queue, runs trials, aggregates grades and metrics, writes artifacts. | `tolokaforge/core` (`orchestrator.py`, `grading/`, `metrics.py`, `search/`) | [`docs/RUNNER.md`](../RUNNER.md) |
+| **TrialRunner** | One instance per trial. Owns the agent–user message loop, calls the LLM for both agent and user simulator turns, dispatches tool calls. | `tolokaforge/core/runner.py` | — |
+| **Adapter Layer** | Resolves a benchmark format into `(TaskConfig, tools, grading, environment, docker_stack_requirements, task_description)`. Built-in `native` plus plugins discovered via the `tolokaforge.adapters` entry-point group. | `tolokaforge/adapters` + `external_adapters/` | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **LLM Layer** | Provider-agnostic completion API on top of LiteLLM. Per-provider presets carry capability policies for schema dialect, reasoning encoding, parameter handling, caching, tool-name discipline. Used by both agent and user-simulator turns. | `tolokaforge/core/llm` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Tool Registry + Executor (local)** | In-process tool registry and executor used in local (non-Docker) mode. Registers built-in tools and loads MCP servers declared by tasks. | `tolokaforge/tools` | [`docs/TOOLS.md`](../TOOLS.md) |
+| **Runner Service (gRPC)** | Docker-mode delegate: owns per-trial state, reconstructs tools from a `TaskDescription`, executes tool calls, runs grading. Single service — not split into "agent" and "executor" services. | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **db-service** | JSON state DB accessed over HTTP by tools (both local and Docker mode). Namespaced per `(task_id, trial_index)` for parallel isolation. | `tolokaforge/env/json_db_service` | — |
+| **rag-service / mock-web** | Optional support services for RAG tasks and browser-style tasks. | `tolokaforge/env/rag_service`, `tolokaforge/env/mock_web_service` | [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
 | **SecretManager** | Single read path for every credential (API keys, DB URLs, OAuth, signing keys). Subprocess export is the only sanctioned `os.environ` mutation, scoped narrowly. | `tolokaforge/secrets` | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
-| **Env Services** | Containerised support services tasks may need: JSON state DB, mock web, RAG index. | `tolokaforge/env` | [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
+| **Run-queue client** | Durable attempt queue. SQLite for single-host runs, Postgres for distributed worker pools. | `tolokaforge/core/run_queue.py` | — |
+
+> **Note on the `tolokaforge/agent/` and `tolokaforge/executor/` packages.** These contain protobuf definitions and `*ServiceServicer` implementations for a planned multi-service decomposition, but they are not currently invoked by the orchestrator (`grep -rn "AgentServiceStub\|ExecutorServiceStub" tolokaforge/` returns no callers). Today only the single **Runner Service** is part of the live architecture. The dormant scaffolding is preserved while a decision about service decomposition is open — when that decision lands, an ADR should record the direction.
 
 ### Adapter plugin shape (zoom on the Adapter Layer)
 
 ```mermaid
 flowchart TB
-    Config["Run Config<br/>harness_adapter.type = native | tau | terminal_bench | ..."]
+    Config["Run Config<br/>harness_adapter.type = native | terminal_bench | ..."]
     Disco["Entry-point discovery<br/>group: tolokaforge.adapters"]
     Base["BaseAdapter (abstract)"]
     Native["NativeAdapter<br/>(built-in · task.yaml)"]
@@ -152,11 +164,26 @@ flowchart TB
     Base --> Ext2
 ```
 
-Every adapter implements the same `BaseAdapter` contract (`get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, …). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
+Every adapter implements the same `BaseAdapter` contract — including `get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, `to_task_description` (for Docker Runner registration), and `docker_stack_requirements` (to declare bind-mounts, Docker socket access, or DinD needs). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
+
+### Extension points (where external repos plug in)
+
+Tolokaforge is the harness; the *content* (tasks, domain tools, grading data) lives in repositories outside this one. Four contracts let external repos extend the system without forking the core. Public adapter repos and internal/private task-and-tool repos use the same four contracts.
+
+| Surface | Contract | Lives where |
+|---|---|---|
+| **Task packs** | A directory tree of `task.yaml` files (for the `native` adapter) or whatever format the adapter expects. Resolved via `evaluation.tasks_glob` and `evaluation.task_packs` in the run config. | Any directory the operator points at, in any repo. |
+| **Domain tools (MCP servers)** | Each `task.yaml` may set `tools.agent.mcp_server: "mcp_server.py"` — a path *relative to the task directory* to a Python module that implements the task's tools (typically [FastMCP](https://github.com/modelcontextprotocol/python-sdk)). The harness imports it dynamically. Tools may also be declared as built-ins via `tools.agent.enabled`. | Alongside the task pack, or vendored from a separate tool library and referenced by import path. |
+| **Custom adapters** | A separate Python package that subclasses `BaseAdapter` and registers under `[project.entry-points."tolokaforge.adapters"]`. The harness discovers it on `pip install`. | Independent Python package. `external_adapters/` shows the public pattern. |
+| **Custom secret providers** | A subclass of `SecretProvider` registered with the `SecretManager` chain. Used to integrate Vault, AWS Secrets Manager, or other backends without changing call sites. | Anywhere in your Python environment; wired in at startup. |
+
+These four contracts are the entire integration surface. Anything an external task-and-tool repo wants to do — supply new benchmark content, ship custom tools, register a new task format, swap credential backends — should fit through one of them. If something doesn't, that's a signal the contract needs an ADR-recorded extension.
 
 ---
 
 ## 6. Runtime View — One Trial
+
+### Local mode (default)
 
 ```mermaid
 sequenceDiagram
@@ -165,32 +192,64 @@ sequenceDiagram
     participant CLI
     participant O as Orchestrator
     participant A as Adapter
-    participant R as Runner (gRPC)
-    participant Ag as Agent (gRPC)
-    participant E as Executor (gRPC)
-    participant L as LiteLLM
+    participant Q as RunQueue (SQLite)
+    participant TR as TrialRunner (in-process)
+    participant LLM as LiteLLM
+    participant TE as Tool Executor (in-process)
+    participant DB as db-service / rag-service (HTTP)
     participant G as GradingEngine
 
     U->>CLI: tolokaforge run --config run.yaml
     CLI->>O: load config + resolve task list
-    O->>A: get_task(task_id) · create_environment
+    O->>A: get_task · create_environment · get_registry_tools
     A-->>O: TaskConfig + tools + initial state
-    O->>R: enqueue trial
-    R->>Ag: start agent loop
+    O->>Q: enqueue (task_id, trial_index)
+    Q-->>O: lease
+    O->>TR: run trial
     loop until done, error, or max_turns
-        Ag->>L: completion(messages, tool_schemas)
-        L-->>Ag: response (+ tool_calls)
-        Ag->>E: execute(tool_call)
-        E-->>Ag: tool_result
+        TR->>LLM: agent.completion(messages, tool_schemas)
+        LLM-->>TR: response (+ tool_calls)
+        TR->>TE: execute(tool_call)
+        TE<->>DB: state read/write
+        TE-->>TR: tool_result
+        TR->>LLM: user_simulator.reply(messages)
+        LLM-->>TR: user turn
     end
-    Ag-->>R: trajectory
-    R->>G: grade(trajectory, final_state)
-    G-->>R: verdict + metrics
-    R-->>O: trial result
+    TR-->>O: trajectory + final_state
+    O->>G: grade(trajectory, final_state, env)
+    G-->>O: verdict + metrics
     O-->>CLI: write artifacts (trajectory.yaml, metrics.yaml, ...)
 ```
 
-The agent never touches the executor's environment directly, and the executor never sees model credentials. The runner is the only component that joins the two views together.
+### Docker mode
+
+The flow is identical except every interaction between TrialRunner and the tool/state/grading stack goes over gRPC to the Runner service:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TR as TrialRunner (in orchestrator process)
+    participant LLM as LiteLLM
+    participant RC as RunnerClient (gRPC)
+    participant RS as Runner Service (gRPC, separate container)
+    participant DB as db-service (HTTP)
+
+    Note over TR,RS: Setup: orchestrator calls RegisterTrial(task_description)
+    loop until done, error, or max_turns
+        TR->>LLM: agent.completion(...)
+        LLM-->>TR: response (+ tool_calls)
+        TR->>RC: ExecuteTool(trial_id, tool_call)
+        RC->>RS: ExecuteTool RPC
+        RS<->>DB: state read/write
+        RS-->>RC: tool_result
+        RC-->>TR: tool_result
+    end
+    TR->>RC: GradeTrial(trial_id)
+    RC->>RS: GradeTrial RPC
+    RS-->>RC: verdict + metrics
+```
+
+The agent loop and the LLM calls always happen in the orchestrator process. Only tool execution, environment state, and grading move to the Runner service when Docker mode is active.
 
 ---
 
@@ -198,30 +257,42 @@ The agent never touches the executor's environment directly, and the executor ne
 
 ```mermaid
 flowchart TB
-    subgraph Local["Local single-host run"]
+    subgraph Local["Local single-host, in-process"]
         L_CLI["tolokaforge CLI"]
-        L_Orch["Orchestrator (in-process)"]
-        L_SQLite[("SQLite")]
-        L_Compose["docker-compose<br/>(JSON DB · mock-web · RAG)"]
+        L_Orch["Orchestrator process<br/>(TrialRunner + LLM client + in-process tools)"]
+        L_SQLite[("SQLite<br/>(attempt queue)")]
+        L_DB["docker-compose: db-service<br/>(+ rag-service, mock-web optional)"]
         L_CLI --> L_Orch
         L_Orch --> L_SQLite
-        L_Orch <--> L_Compose
+        L_Orch <--> L_DB
     end
 
-    subgraph Dist["Distributed multi-host run"]
+    subgraph Docker["Single-host Docker mode"]
         D_CLI["tolokaforge CLI"]
-        D_Orch["Orchestrator"]
-        D_PG[("Postgres<br/>(shared queue + state)")]
-        D_R1["Runner host A<br/>(agent + executor + tools)"]
-        D_R2["Runner host B<br/>(agent + executor + tools)"]
+        D_Orch["Orchestrator process<br/>(TrialRunner + LLM client)"]
+        D_Runner["runner container<br/>(Runner gRPC service)"]
+        D_DB["db-service container"]
+        D_Extras["optional:<br/>rag-service · mock-web · dind"]
+        D_SQLite[("SQLite<br/>(attempt queue)")]
         D_CLI --> D_Orch
-        D_Orch --> D_PG
-        D_R1 <--> D_PG
-        D_R2 <--> D_PG
+        D_Orch --> D_SQLite
+        D_Orch <-->|gRPC| D_Runner
+        D_Runner <--> D_DB
+        D_Runner <--> D_Extras
+    end
+
+    subgraph Dist["Distributed (prepare + worker)"]
+        D2_Prep["tolokaforge prepare<br/>(host: any)"]
+        D2_PG[("Postgres<br/>(shared attempt queue)")]
+        D2_W1["tolokaforge worker<br/>(host A)<br/>orchestrator + optional local Runner"]
+        D2_W2["tolokaforge worker<br/>(host B)<br/>orchestrator + optional local Runner"]
+        D2_Prep --> D2_PG
+        D2_W1 <--> D2_PG
+        D2_W2 <--> D2_PG
     end
 ```
 
-The same code path drives both modes. The runner is the deployment unit that scales out; the orchestrator and storage scale up. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
+The same orchestrator binary drives all three modes. Workers in distributed mode each contain a full orchestrator process and can independently run in local or Docker mode. Coordination happens entirely through the shared attempt queue — there is no central scheduler service. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
 
 ---
 
@@ -253,7 +324,8 @@ See [`adr/README.md`](adr/README.md) for the process and [`adr/0000-template.md`
 |---|---|
 | **Provider drift** | Tool-schema dialects and reasoning encodings change without notice. Mitigated by capability tests per preset (see [`docs/LLM_LAYER.md`](../LLM_LAYER.md)) and explicit `ModelCertificate` declarations. |
 | **Multi-turn vs single-turn behaviour gap** | Some model failures only surface in long-context multi-turn runs and pass synthetic single-turn probes. Tracked in [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) #22. |
-| **Container resource accounting** | Sandboxed executors share the host; resource accounting is per-process, not cgroup-bounded. |
+| **Dormant gRPC scaffolding** | `tolokaforge/agent/` and `tolokaforge/executor/` packages contain gRPC service implementations that nothing currently calls. Whether to wire them up or remove them is an open decision; an ADR should land before the next significant change to the Runner boundary. See also [`docs/FUTURE_DEVELOPMENT.md`](../FUTURE_DEVELOPMENT.md). |
+| **Container resource accounting** | Sandboxed Runner shares the host; resource accounting is per-process, not cgroup-bounded. |
 
 ---
 
@@ -265,5 +337,8 @@ See [`adr/README.md`](adr/README.md) for the process and [`adr/0000-template.md`
 | **Task pack** | A directory tree of tasks resolved by an adapter (`task.yaml` for native; format varies per adapter). |
 | **Trial** | One attempt at one task with one model configuration. A run produces `N_tasks × repeats` trials. |
 | **Trajectory** | The full message + tool-call log for one trial, written as `trajectory.yaml`. |
+| **TrialRunner** | The in-process Python class (`tolokaforge/core/runner.py`) that owns one trial's agent–user loop. |
+| **Runner Service** | The gRPC service (`tolokaforge/runner/service.py`) that the orchestrator delegates to in Docker mode for tool execution, state, and grading. Distinct from `TrialRunner`. |
 | **Preset** | Per-provider capability bundle (schema sanitizer, reasoning codec, params policy, cache policy, tool-content policy). |
 | **Grading config** | Declarative spec of how a trajectory and final state are turned into a pass/fail verdict. |
+| **Attempt queue** | Durable record of pending and in-flight trial attempts (SQLite single-host or Postgres distributed); leased by workers. |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -65,7 +65,7 @@ flowchart TB
     Evaluator -->|runs benchmarks| Forge
     TaskAuthor -->|authors| TaskPacks
     Forge -->|loads via adapter| TaskPacks
-    Forge <-->|tool execution, state, grading<br/>(Docker mode only)| Docker
+    Forge <-->|"tool execution, state, grading<br/>(Docker mode only)"| Docker
     Forge <-->|completions, tool schemas| LiteLLM
     Forge -->|writes| Results
     Forge <-->|durable attempts, leases| Queue

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,7 +18,7 @@ Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It r
 |---|---|
 | **Determinism** | Same task + same model + same seed should yield the same verdict. State hashes, snapshot grading, transcript rules. |
 | **Provider-agnostic** | Any LLM reachable via LiteLLM is a first-class citizen. Provider-specific quirks are isolated in per-preset capability policies. |
-| **Isolation** | Tool calls can run in a separate process (and on a separate host) in Docker mode, with the agent loop never touching tool state directly. |
+| **Isolation** | Tool calls always execute in a separate process — a Docker-hosted Runner gRPC service — so the agent loop never touches tool state directly. |
 | **Honesty over convenience** | Failures surface explicitly. No silent fallbacks; no defaults that hide configuration mistakes. |
 | **Extensibility** | New benchmark formats plug in as adapters without touching the core. |
 
@@ -36,9 +36,9 @@ Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It r
 
 - **Language**: Python (managed via `uv`).
 - **LLM access**: routed through [LiteLLM](https://github.com/BerriAI/litellm) — provider-specific glue is kept out of the core. Per-provider differences live in the LLM-layer preset registry (`tolokaforge/core/llm/presets.py`).
-- **Tools**: in-process tool registry plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs.
-- **Environment services** (optional, started by `make docker-up`): JSON state DB, mock web, RAG indexer — each one a separate container.
-- **Trial-loop transport**: the agent–user loop runs **in-process** inside the orchestrator (`tolokaforge/core/runner.py:TrialRunner`). When the orchestrator runs in Docker mode, tool execution, environment state, and grading are delegated to a single **Runner gRPC service** (`tolokaforge/runner/service.py`).
+- **Tools**: built-in Python tools plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs. All tool code runs inside the Runner container; the orchestrator only sees the gRPC interface.
+- **Docker is required.** Tool execution, environment state, and grading always run inside a Docker stack containing a **Runner gRPC service** (`tolokaforge/runner/service.py`) and supporting environment services (JSON state DB, plus optional RAG indexer / mock web). The orchestrator auto-starts this stack on `tolokaforge run` (`auto_start_services: true` by default) — there is no in-process tool-execution path.
+- **In-process loop, remote tools.** The agent–user message loop itself (`tolokaforge/core/runner.py:TrialRunner`) and the LLM calls run inside the orchestrator process; every tool call from that loop is dispatched as a gRPC `ExecuteTool` RPC to the Runner service.
 - **Durable attempt queue**: SQLite for single-host runs, optional Postgres for multi-host workers (`tolokaforge/core/run_queue.py`).
 
 ### Organisational
@@ -58,14 +58,14 @@ flowchart TB
     Forge["Tolokaforge<br/>(benchmarking harness)"]
     LiteLLM["LLM Providers via LiteLLM<br/>OpenAI · Anthropic · Google · Bedrock · OpenRouter · ..."]
     TaskPacks["Task Packs<br/>(external repos, glob-loaded)"]
-    Docker["Docker Engine<br/>(optional: env services + Runner sandbox)"]
+    Docker["Docker Engine<br/>(Runner gRPC + env services)"]
     Results["Result Artifacts<br/>(trajectories, metrics, schemas)"]
-    Queue[("Attempt Queue<br/>(SQLite local / Postgres distributed)")]
+    Queue[("Attempt Queue<br/>SQLite or Postgres")]
 
     Evaluator -->|runs benchmarks| Forge
     TaskAuthor -->|authors| TaskPacks
     Forge -->|loads via adapter| TaskPacks
-    Forge <-->|"tool execution, state, grading<br/>(Docker mode only)"| Docker
+    Forge <-->|tool execution, state, grading| Docker
     Forge <-->|completions, tool schemas| LiteLLM
     Forge -->|writes| Results
     Forge <-->|durable attempts, leases| Queue
@@ -84,7 +84,7 @@ flowchart TB
 | Decision | Rationale | Detail |
 |---|---|---|
 | **Adapter plugin architecture for benchmark formats** | Lets external task formats (`native` built-in, `terminal_bench` and other plugins) plug in without forking the core. | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
-| **In-process agent–user loop, Docker-delegated tool execution** | Keeping the loop in-process keeps the trial control flow debuggable; Docker delegation via the Runner gRPC service gives sandbox isolation when needed without forcing a service-mesh on local users. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **In-process agent–user loop, Docker-delegated tools/state/grading** | The trial control flow (agent prompt assembly, LLM calls, user simulator, message accumulation) stays in the orchestrator process so it can be debugged and instrumented with normal Python tooling. Everything that touches task state — tool execution, env services, grading — runs inside a Docker stack reached over gRPC, giving sandbox isolation and the same code path on every host. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
 | **Provider-agnostic LLM layer with per-preset capability policies** | LiteLLM normalises envelopes, but providers diverge on schema dialects, reasoning encodings, caching, and tool naming. A preset registry keeps the quirks out of the orchestrator. | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
 | **Single secret abstraction** | One audited code path for every credential read; CI-enforced via static grep. | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
 | **Deterministic grading by default; LLM judges opt-in** | Deterministic verdicts are reproducible and cheap; judge calls are reserved for cases that genuinely need them. | [`docs/GRADING.md`](../GRADING.md) |
@@ -96,23 +96,20 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    subgraph Process["Orchestrator process (always in-process)"]
+    subgraph Process["Orchestrator process"]
         Adapter["Adapter Layer"]
         Loop["Orchestrator + TrialRunner<br/>(agent–user loop)"]
         LLM["LLM Layer<br/>(LiteLLM + presets)"]
-        Local["Local Tool Executor"]
     end
 
-    subgraph DockerStack["Docker stack (Docker mode only)"]
+    subgraph DockerStack["Docker stack (required)"]
         Runner["Runner Service<br/>(gRPC)"]
-        Env["db-service<br/>+ rag-service · mock-web"]
+        Env["db-service<br/>+ optional rag-service · mock-web"]
     end
 
     Adapter --> Loop
     Loop --> LLM
-    Loop -- "local mode" --> Local
-    Loop -- "Docker mode" --> Runner
-    Local <--> Env
+    Loop -->|gRPC| Runner
     Runner <--> Env
 ```
 
@@ -124,12 +121,11 @@ Component-level detail (CLI commands, the run-queue client, SecretManager, indiv
 |---|---|---|---|
 | **CLI** | User-facing commands. `run` executes locally end-to-end; `prepare` + `worker` split a run for distributed execution. | `tolokaforge/cli` | — |
 | **Orchestrator + Core** | Loads run config, instantiates the adapter, builds the task list, manages the attempt queue, runs trials, aggregates grades and metrics, writes artifacts. | `tolokaforge/core` (`orchestrator.py`, `grading/`, `metrics.py`, `search/`) | [`docs/RUNNER.md`](../RUNNER.md) |
-| **TrialRunner** | One instance per trial. Owns the agent–user message loop, calls the LLM for both agent and user simulator turns, dispatches tool calls. | `tolokaforge/core/runner.py` | — |
+| **TrialRunner** | One instance per trial. Owns the agent–user message loop, calls the LLM for both agent and user simulator turns, and dispatches every tool call as a gRPC `ExecuteTool` RPC to the Runner service. | `tolokaforge/core/runner.py` | — |
 | **Adapter Layer** | Resolves a benchmark format into `(TaskConfig, tools, grading, environment, docker_stack_requirements, task_description)`. Built-in `native` plus plugins discovered via the `tolokaforge.adapters` entry-point group. | `tolokaforge/adapters` + `external_adapters/` | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
 | **LLM Layer** | Provider-agnostic completion API on top of LiteLLM. Per-provider presets carry capability policies for schema dialect, reasoning encoding, parameter handling, caching, tool-name discipline. Used by both agent and user-simulator turns. | `tolokaforge/core/llm` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
-| **Tool Registry + Executor (local)** | In-process tool registry and executor used in local (non-Docker) mode. Registers built-in tools and loads MCP servers declared by tasks. | `tolokaforge/tools` | [`docs/TOOLS.md`](../TOOLS.md) |
-| **Runner Service (gRPC)** | Docker-mode delegate: owns per-trial state, reconstructs tools from a `TaskDescription`, executes tool calls, runs grading. Single service — not split into "agent" and "executor" services. | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
-| **db-service** | JSON state DB accessed over HTTP by tools (both local and Docker mode). Namespaced per `(task_id, trial_index)` for parallel isolation. | `tolokaforge/env/json_db_service` | — |
+| **Runner Service (gRPC)** | The sole tool-execution path. Owns per-trial state, reconstructs tools from a `TaskDescription`, executes tool calls, runs grading. A single service — not split into separate "agent" and "executor" services. Auto-started by the orchestrator (`auto_start_services: true`). | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **db-service** | JSON state DB accessed by the Runner over HTTP. Namespaced per `(task_id, trial_index)` for parallel isolation. | `tolokaforge/env/json_db_service` | — |
 | **rag-service / mock-web** | Optional support services for RAG tasks and browser-style tasks. | `tolokaforge/env/rag_service`, `tolokaforge/env/mock_web_service` | [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
 | **SecretManager** | Single read path for every credential (API keys, DB URLs, OAuth, signing keys). Subprocess export is the only sanctioned `os.environ` mutation, scoped narrowly. | `tolokaforge/secrets` | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
 | **Run-queue client** | Durable attempt queue. SQLite for single-host runs, Postgres for distributed worker pools. | `tolokaforge/core/run_queue.py` | — |
@@ -178,23 +174,23 @@ sequenceDiagram
     participant CLI
     participant Loop as Orchestrator + TrialRunner
     participant LLM as LiteLLM
-    participant Tools as Tool Executor or Runner gRPC
-    participant G as Grader
+    participant Runner as Runner Service (gRPC)
 
     CLI->>Loop: run config + tasks
+    Loop->>Runner: RegisterTrial(task_description)
     loop agent–user loop
         Loop->>LLM: agent completion
         LLM-->>Loop: response + tool calls
-        Loop->>Tools: execute tool call
-        Tools-->>Loop: tool result
+        Loop->>Runner: ExecuteTool
+        Runner-->>Loop: tool result
         Loop->>LLM: user simulator reply
         LLM-->>Loop: user turn
     end
-    Loop->>G: grade trajectory
-    G-->>Loop: verdict + metrics
+    Loop->>Runner: GradeTrial
+    Runner-->>Loop: verdict + metrics
 ```
 
-The `Tools` lane is the in-process `ToolExecutor` in local mode and the Runner gRPC service (in a separate container) in Docker mode. The agent loop, the user-simulator loop, and the LLM calls always happen in the orchestrator process regardless of mode. Setup steps (loading config, resolving tasks via the adapter, enqueueing attempts, writing artifacts) bracket the loop but are omitted from the diagram for clarity.
+The agent loop, the user-simulator loop, and the LLM calls all happen inside the orchestrator process; every tool call and the final grade go over gRPC to the Runner service. Setup steps (loading config, resolving tasks via the adapter, enqueueing attempts, writing artifacts) bracket the loop but are omitted from the diagram for clarity.
 
 ---
 
@@ -202,24 +198,15 @@ The `Tools` lane is the in-process `ToolExecutor` in local mode and the Runner g
 
 ```mermaid
 flowchart TB
-    subgraph Local["Local mode"]
-        L_Orch["Orchestrator process"]
-        L_Q[("Attempt queue · SQLite")]
-        L_Env["docker-compose<br/>db-service + optional rag/mock-web"]
-        L_Orch --> L_Q
-        L_Orch <--> L_Env
-    end
+    Orch["Orchestrator process<br/>(TrialRunner + LLM client)"]
+    Q[("Attempt queue · SQLite or Postgres")]
+    Stack["Docker stack on the same host<br/>runner + db-service<br/>+ optional rag-service · mock-web · dind"]
 
-    subgraph DockerMode["Docker mode"]
-        D_Orch["Orchestrator process"]
-        D_Q[("Attempt queue · SQLite or Postgres")]
-        D_Stack["Docker stack<br/>runner + db-service<br/>+ optional rag/mock-web/dind"]
-        D_Orch --> D_Q
-        D_Orch <-->|gRPC + HTTP| D_Stack
-    end
+    Orch --> Q
+    Orch <-->|gRPC + HTTP| Stack
 ```
 
-**Distributed runs** share the queue across hosts: one host runs `tolokaforge prepare` to populate a Postgres attempt queue; one or more hosts run `tolokaforge worker`, each instantiating a full orchestrator process. Workers independently choose local or Docker mode. There is no central scheduler — coordination is entirely through the queue. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
+The orchestrator process and the Docker stack live on the same host. There is no in-process tool path — Docker is always required. **Distributed runs** share the attempt queue across hosts: one host runs `tolokaforge prepare` to populate a Postgres queue; one or more hosts run `tolokaforge worker`, each instantiating a full orchestrator + Docker stack. There is no central scheduler — coordination is entirely through the queue. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
 
 ---
 
@@ -264,8 +251,8 @@ See [`adr/README.md`](adr/README.md) for the process and [`adr/0000-template.md`
 | **Task pack** | A directory tree of tasks resolved by an adapter (`task.yaml` for native; format varies per adapter). |
 | **Trial** | One attempt at one task with one model configuration. A run produces `N_tasks × repeats` trials. |
 | **Trajectory** | The full message + tool-call log for one trial, written as `trajectory.yaml`. |
-| **TrialRunner** | The in-process Python class (`tolokaforge/core/runner.py`) that owns one trial's agent–user loop. |
-| **Runner Service** | The gRPC service (`tolokaforge/runner/service.py`) that the orchestrator delegates to in Docker mode for tool execution, state, and grading. Distinct from `TrialRunner`. |
+| **TrialRunner** | The in-process Python class (`tolokaforge/core/runner.py`) that owns one trial's agent–user loop and dispatches every tool call to the Runner Service over gRPC. |
+| **Runner Service** | The gRPC service (`tolokaforge/runner/service.py`) that owns tool execution, environment state, and grading. Runs in a Docker container; always required. Distinct from `TrialRunner`. |
 | **Preset** | Per-provider capability bundle (schema sanitizer, reasoning codec, params policy, cache policy, tool-content policy). |
 | **Grading config** | Declarative spec of how a trajectory and final state are turned into a pass/fail verdict. |
 | **Attempt queue** | Durable record of pending and in-flight trial attempts (SQLite single-host or Postgres distributed); leased by workers. |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,269 @@
+# Tolokaforge Architecture
+
+This document is the entry point for the system-level architecture of Tolokaforge. It follows the [arc42](https://arc42.org/) section structure inlined as a single file, with [C4 model](https://c4model.com/) views drawn as Mermaid diagrams that render natively on GitHub.
+
+For deep dives into individual subsystems, follow the links to `docs/*.md` from each section. For decision history and rationale, see [`adr/`](adr/).
+
+> **How to evolve this doc:** keep the diagrams here at C4 Levels 1–2 (Context and Container). When a building block changes shape or a boundary moves, update the relevant section *and* add an ADR. When you want to propose a future state, add an ADR with status `Proposed`; once accepted, update the diagram in this file.
+
+---
+
+## 1. Introduction and Goals
+
+Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It runs multi-turn agent/user loops against sandboxed task environments and produces deterministic pass/fail verdicts plus rich telemetry.
+
+### Quality goals
+
+| Goal | What it means in practice |
+|---|---|
+| **Determinism** | Same task + same model + same seed should yield the same verdict. State hashes, snapshot grading, transcript rules. |
+| **Provider-agnostic** | Any LLM reachable via LiteLLM is a first-class citizen. Provider-specific quirks are isolated in per-preset capability policies. |
+| **Isolation** | Tool calls execute against sandboxed services with no external network reach by default. |
+| **Honesty over convenience** | Failures surface explicitly. No silent fallbacks; no defaults that hide configuration mistakes. |
+| **Extensibility** | New benchmark formats plug in as adapters without touching the core. |
+
+### Primary stakeholders
+
+- Model evaluators running benchmarks across providers.
+- Task authors writing new benchmark task packs.
+- Researchers analysing trajectories, failure modes, and cost/latency.
+
+---
+
+## 2. Constraints
+
+### Technical
+
+- **Language**: Python (managed via `uv`).
+- **Service decomposition**: gRPC services (`agent`, `executor`, `runner`) so trial execution can be remoted and isolated.
+- **LLM access**: routed through [LiteLLM](https://github.com/BerriAI/litellm) to keep provider-specific glue out of the core. Per-provider differences live in the LLM-layer preset registry.
+- **Tools**: built-in tool registry plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs.
+- **Environment services**: containerised JSON state DB, mock web, RAG indexer — orchestrated via Docker Compose.
+- **Persistence**: SQLite for local single-host runs, Postgres for multi-host distributed runs.
+
+### Organisational
+
+- **Open source**: this repository is Apache-2.0; nothing committed here may reference internal-only systems by name.
+- **Secrets**: only `SecretManager` reads credentials. Direct `os.environ` access for any secret is forbidden and CI-enforced. See [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction).
+- **Task packs are external**: benchmark task definitions live in separate repositories (public examples ship under `examples/`; production task packs are loaded via adapter glob from any directory the operator points at).
+
+---
+
+## 3. Context and Scope (C4 Level 1)
+
+```mermaid
+flowchart TB
+    Evaluator["Evaluator / Researcher"]
+    TaskAuthor["Task Author"]
+    Forge["Tolokaforge<br/>(benchmarking harness)"]
+    LiteLLM["LLM Providers via LiteLLM<br/>OpenAI · Anthropic · Google · Bedrock · OpenRouter · ..."]
+    TaskPacks["Task Packs<br/>(external repos, glob-loaded)"]
+    Docker["Docker Engine<br/>(env services + sandboxes)"]
+    Results["Result Artifacts<br/>(trajectories, metrics, schemas)"]
+    Store[("Run Store<br/>(SQLite local / Postgres distributed)")]
+
+    Evaluator -->|runs benchmarks| Forge
+    TaskAuthor -->|authors| TaskPacks
+    Forge -->|loads via adapter| TaskPacks
+    Forge <-->|tool calls in sandbox| Docker
+    Forge <-->|completions, tool schemas| LiteLLM
+    Forge -->|writes| Results
+    Forge <-->|queue, state, trajectories| Store
+```
+
+### Boundaries (what is *not* Tolokaforge)
+
+- **LLM providers** — out of scope; accessed via LiteLLM.
+- **Task content** — out of scope; lives in task pack repos. Tolokaforge defines the *contract* (task schema, tool interface, grading config), not the content.
+- **Result analysis UI** — out of scope; result artifacts are stable YAML/JSON, consumed by downstream tooling.
+
+---
+
+## 4. Solution Strategy
+
+| Decision | Rationale | Detail |
+|---|---|---|
+| **Adapter plugin architecture for benchmark formats** | Lets external task formats (tau-bench, terminal-bench, MCP-core, private formats) plug in without forking the core. | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **gRPC service decomposition (`agent`, `executor`, `runner`)** | Each role has different isolation, scaling, and dependency profiles. gRPC makes the boundaries explicit and lets services live on different hosts in distributed runs. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **Provider-agnostic LLM layer with per-preset capability policies** | LiteLLM normalises envelopes, but providers diverge on schema dialects, reasoning encodings, caching, and tool naming. A preset registry keeps the quirks out of the orchestrator. | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Single secret abstraction** | One audited code path for every credential read; CI-enforced via static grep. | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
+| **Deterministic grading by default; LLM judges opt-in** | Deterministic verdicts are reproducible and cheap; judge calls are reserved for cases that genuinely need them. | [`docs/GRADING.md`](../GRADING.md) |
+
+---
+
+## 5. Building Block View (C4 Level 2 — Container)
+
+```mermaid
+flowchart LR
+    subgraph Forge["Tolokaforge"]
+        CLI["CLI<br/>(run · validate · status · analyze)"]
+        Core["Core<br/>(orchestrator · grading · metrics · queue · search)"]
+        Adapters["Adapter Layer<br/>(BaseAdapter · NativeAdapter · entry-point plugins)"]
+        Runner["Runner<br/>(gRPC service)"]
+        Agent["Agent<br/>(gRPC service)"]
+        Executor["Executor<br/>(gRPC service)"]
+        LLMLayer["LLM Layer<br/>(presets · schema sanitizers · reasoning codecs · cache policy)"]
+        Tools["Tool Registry<br/>(built-ins + MCP)"]
+        Secrets["SecretManager"]
+        EnvSvc["Env Services<br/>(JSON DB · mock-web · RAG)"]
+    end
+
+    CLI --> Core
+    Core --> Adapters
+    Core --> Runner
+    Runner --> Agent
+    Runner --> Executor
+    Agent --> LLMLayer
+    Executor --> Tools
+    Adapters --> Tools
+    LLMLayer --> Secrets
+    Tools --> EnvSvc
+```
+
+### Block responsibilities
+
+| Block | Responsibility | Source | Detail |
+|---|---|---|---|
+| **CLI** | User-facing commands; loads a run config and hands it to the orchestrator. | `tolokaforge/cli` | — |
+| **Core** | Orchestration loop, trial queue, grading pipeline, metrics aggregation, task search. | `tolokaforge/core` | [`docs/RUNNER.md`](../RUNNER.md) |
+| **Adapter Layer** | Resolves a benchmark format into `(TaskConfig, tools, grading, environment)`. Built-in `native` plus plugins discovered via `tolokaforge.adapters` entry points. | `tolokaforge/adapters` + `external_adapters/` | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **Runner (gRPC)** | Owns trial lifecycle: starts agent/executor, mediates DB and RAG access, runs the grader. | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) |
+| **Agent (gRPC)** | Wraps a single agent turn: prompt assembly, model call, tool-call extraction. | `tolokaforge/agent` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Executor (gRPC)** | Executes tool calls in an isolated environment; never sees model credentials. | `tolokaforge/executor` | — |
+| **LLM Layer** | Provider-agnostic completion API. Per-provider presets carry capability policies for schema dialect, reasoning encoding, parameter handling, caching, tool-name discipline. | `tolokaforge/core/llm` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Tool Registry** | Registers built-in tools and loads MCP servers declared by tasks. | `tolokaforge/tools` | [`docs/TOOLS.md`](../TOOLS.md) |
+| **SecretManager** | Single read path for every credential (API keys, DB URLs, OAuth, signing keys). Subprocess export is the only sanctioned `os.environ` mutation, scoped narrowly. | `tolokaforge/secrets` | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
+| **Env Services** | Containerised support services tasks may need: JSON state DB, mock web, RAG index. | `tolokaforge/env` | [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
+
+### Adapter plugin shape (zoom on the Adapter Layer)
+
+```mermaid
+flowchart TB
+    Config["Run Config<br/>harness_adapter.type = native | tau | terminal_bench | ..."]
+    Disco["Entry-point discovery<br/>group: tolokaforge.adapters"]
+    Base["BaseAdapter (abstract)"]
+    Native["NativeAdapter<br/>(built-in · task.yaml)"]
+    Ext1["External adapter A<br/>(separate package)"]
+    Ext2["External adapter B<br/>(separate package)"]
+
+    Config --> Disco --> Base
+    Base --> Native
+    Base --> Ext1
+    Base --> Ext2
+```
+
+Every adapter implements the same `BaseAdapter` contract (`get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, …). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
+
+---
+
+## 6. Runtime View — One Trial
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant CLI
+    participant O as Orchestrator
+    participant A as Adapter
+    participant R as Runner (gRPC)
+    participant Ag as Agent (gRPC)
+    participant E as Executor (gRPC)
+    participant L as LiteLLM
+    participant G as GradingEngine
+
+    U->>CLI: tolokaforge run --config run.yaml
+    CLI->>O: load config + resolve task list
+    O->>A: get_task(task_id) · create_environment
+    A-->>O: TaskConfig + tools + initial state
+    O->>R: enqueue trial
+    R->>Ag: start agent loop
+    loop until done, error, or max_turns
+        Ag->>L: completion(messages, tool_schemas)
+        L-->>Ag: response (+ tool_calls)
+        Ag->>E: execute(tool_call)
+        E-->>Ag: tool_result
+    end
+    Ag-->>R: trajectory
+    R->>G: grade(trajectory, final_state)
+    G-->>R: verdict + metrics
+    R-->>O: trial result
+    O-->>CLI: write artifacts (trajectory.yaml, metrics.yaml, ...)
+```
+
+The agent never touches the executor's environment directly, and the executor never sees model credentials. The runner is the only component that joins the two views together.
+
+---
+
+## 7. Deployment View
+
+```mermaid
+flowchart TB
+    subgraph Local["Local single-host run"]
+        L_CLI["tolokaforge CLI"]
+        L_Orch["Orchestrator (in-process)"]
+        L_SQLite[("SQLite")]
+        L_Compose["docker-compose<br/>(JSON DB · mock-web · RAG)"]
+        L_CLI --> L_Orch
+        L_Orch --> L_SQLite
+        L_Orch <--> L_Compose
+    end
+
+    subgraph Dist["Distributed multi-host run"]
+        D_CLI["tolokaforge CLI"]
+        D_Orch["Orchestrator"]
+        D_PG[("Postgres<br/>(shared queue + state)")]
+        D_R1["Runner host A<br/>(agent + executor + tools)"]
+        D_R2["Runner host B<br/>(agent + executor + tools)"]
+        D_CLI --> D_Orch
+        D_Orch --> D_PG
+        D_R1 <--> D_PG
+        D_R2 <--> D_PG
+    end
+```
+
+The same code path drives both modes. The runner is the deployment unit that scales out; the orchestrator and storage scale up. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
+
+---
+
+## 8. Cross-cutting Concepts
+
+| Concern | Where to look |
+|---|---|
+| **Secrets handling** | [AGENTS.md § Secrets — single abstraction](../../AGENTS.md#secrets--single-abstraction) · `tolokaforge/secrets` |
+| **Determinism & state hashing** | [`docs/GRADING.md`](../GRADING.md) · [`docs/GOLDEN_TRIALS.md`](../GOLDEN_TRIALS.md) |
+| **Per-provider capability handling** | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) · [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) |
+| **Tool isolation & sandboxing** | [`docs/SECURITY.md`](../SECURITY.md) · [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
+| **Telemetry & metrics** | [`docs/LOGGING.md`](../LOGGING.md) · [`docs/ANALYTICS.md`](../ANALYTICS.md) |
+| **Result artifact layout** | [`docs/OUTPUT_FORMAT.md`](../OUTPUT_FORMAT.md) |
+| **Configuration reference** | [`docs/CONFIG.md`](../CONFIG.md) · [`docs/REFERENCE.md`](../REFERENCE.md) |
+
+---
+
+## 9. Architecture Decisions
+
+All architecturally significant decisions are recorded as ADRs in [`adr/`](adr/). The index is maintained by appending new ADRs in numerical order — never renumber, never delete. When an ADR is superseded, change its status and link forward to the superseding ADR.
+
+See [`adr/README.md`](adr/README.md) for the process and [`adr/0000-template.md`](adr/0000-template.md) for the template.
+
+---
+
+## 10. Risks and Known Limitations
+
+| Area | Note |
+|---|---|
+| **Provider drift** | Tool-schema dialects and reasoning encodings change without notice. Mitigated by capability tests per preset (see [`docs/LLM_LAYER.md`](../LLM_LAYER.md)) and explicit `ModelCertificate` declarations. |
+| **Multi-turn vs single-turn behaviour gap** | Some model failures only surface in long-context multi-turn runs and pass synthetic single-turn probes. Tracked in [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) #22. |
+| **Container resource accounting** | Sandboxed executors share the host; resource accounting is per-process, not cgroup-bounded. |
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Adapter** | Plugin that maps a benchmark format to the harness contract (`BaseAdapter`). |
+| **Task pack** | A directory tree of tasks resolved by an adapter (`task.yaml` for native; format varies per adapter). |
+| **Trial** | One attempt at one task with one model configuration. A run produces `N_tasks × repeats` trials. |
+| **Trajectory** | The full message + tool-call log for one trial, written as `trajectory.yaml`. |
+| **Preset** | Per-provider capability bundle (schema sanitizer, reasoning codec, params policy, cache policy, tool-content policy). |
+| **Grading config** | Declarative spec of how a trajectory and final state are turned into a pass/fail verdict. |

--- a/docs/architecture/adr/0000-template.md
+++ b/docs/architecture/adr/0000-template.md
@@ -1,0 +1,49 @@
+# NNNN. Short imperative title
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Deciders:** @handles
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+What problem is this ADR resolving? What forces — technical, organisational, regulatory — make a decision necessary now? Keep this focused on the forces, not the implementation.
+
+## Decision Drivers
+
+- Driver 1 (e.g. quality goal it supports)
+- Driver 2 (e.g. constraint it must respect)
+- Driver 3
+
+## Considered Options
+
+1. **Option A** — one-line summary.
+2. **Option B** — one-line summary.
+3. **Option C** — one-line summary.
+
+## Decision
+
+We will adopt **Option X** because …
+
+## Consequences
+
+### Positive
+
+- …
+
+### Negative / Trade-offs
+
+- …
+
+### Follow-ups
+
+- Code changes required: …
+- Documentation to update: …
+- Tests to add: …
+
+## Links
+
+- Related ADRs:
+- Related code:
+- External references:

--- a/docs/architecture/adr/0001-record-architecture-decisions.md
+++ b/docs/architecture/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,59 @@
+# 0001. Record architecture decisions in ADRs
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Deciders:** Tolokaforge maintainers
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Tolokaforge has accumulated a set of architecturally significant decisions — the adapter plugin model, the gRPC service split, the per-provider preset registry, the single-secret-abstraction rule — that today live implicitly across `AGENTS.md`, scattered `docs/*.md` files, and commit history. New contributors (human and agent) re-derive the rationale every time, and proposed changes can't be cleanly weighed against the original forces because those forces aren't written down.
+
+We need a low-friction, durable place to capture *why* an architectural choice was made, not just *what* it is.
+
+## Decision Drivers
+
+- Decisions must survive the people who made them.
+- Format must be agent-friendly: plain markdown, in-repo, no toolchain.
+- Each decision must be individually addressable (linkable, supersedable).
+- Cost of writing one must be low enough that we actually do it.
+
+## Considered Options
+
+1. **In-repo Markdown ADRs (MADR-style).** One file per decision under `docs/architecture/adr/`, numbered, kept forever.
+2. **Wiki / Notion / Confluence.** Centralised, searchable — but lives outside the repo, drifts from code, hostile to agents reading the codebase.
+3. **Long-form `ARCHITECTURE.md`.** Everything in one file. Simple, but conflates the *current* shape with the *history* of how we got there; status transitions are awkward.
+4. **No formal record.** Continue relying on `AGENTS.md` and commit messages.
+
+## Decision
+
+We will adopt **Option 1: in-repo MADR-style ADRs** under [`docs/architecture/adr/`](.), using the template in [`0000-template.md`](0000-template.md).
+
+Each ADR is a single Markdown file with a monotonically increasing four-digit prefix, never renumbered. Status moves through `Proposed → Accepted → (Deprecated | Superseded by ADR-NNNN)`. The current-state architecture continues to live in [`docs/architecture/README.md`](../README.md); ADRs capture the *transitions and rationale*.
+
+## Consequences
+
+### Positive
+
+- Decisions are version-controlled alongside the code they govern.
+- Agents reading the repo encounter rationale in the same place as architecture diagrams.
+- Superseding a decision is explicit (status flip + forward link) rather than silent drift.
+- No tooling investment required.
+
+### Negative / Trade-offs
+
+- Discipline cost: someone has to remember to write the ADR when a significant decision is made. Mitigated by listing the prompt in `docs/architecture/adr/README.md` and in PR review checklists.
+- ADRs can drift from reality if not maintained — but so can any documentation, and the in-repo location makes drift easier to catch in code review.
+
+### Follow-ups
+
+- Code changes required: none.
+- Documentation to update: link `docs/architecture/README.md` from the top-level `README.md` Documentation table.
+- Tests to add: none.
+- Backfill: significant existing decisions (adapter plugin model, gRPC decomposition, secret abstraction) should be written up as ADRs over time — but not in this PR, to keep this one reviewable.
+
+## Links
+
+- Format reference: [adr.github.io/madr](https://adr.github.io/madr/)
+- Architecture overview: [`docs/architecture/README.md`](../README.md)

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory records architecturally significant decisions about Tolokaforge. We follow the [Markdown ADR (MADR)](https://adr.github.io/madr/) format, lightly adapted.
+
+## When to write an ADR
+
+Write one when a decision:
+
+- changes a boundary in the [Building Block View](../README.md#5-building-block-view-c4-level-2--container),
+- introduces or removes a cross-cutting rule,
+- locks in a quality trade-off (e.g. determinism vs. flexibility, isolation vs. simplicity),
+- or replaces an earlier ADR.
+
+Day-to-day implementation choices that don't affect the system shape do *not* need an ADR — a clear PR description is enough.
+
+## How to write one
+
+1. Copy [`0000-template.md`](0000-template.md) to `NNNN-kebab-case-title.md`, where `NNNN` is the next free number. **Never renumber existing ADRs.**
+2. Fill in the sections. Keep "Context" focused on the forces that drove the decision, not the implementation.
+3. Open the PR with status `Proposed`. Flip to `Accepted` when merged.
+4. If a later decision overrides this one, set the old ADR's status to `Superseded by ADR-NNNN` and add the back-link in the new ADR's "Decision Drivers".
+
+## Statuses
+
+- `Proposed` — under discussion in a PR.
+- `Accepted` — merged and in effect.
+- `Deprecated` — no longer applies, but not replaced by anything specific.
+- `Superseded by ADR-NNNN` — replaced; keep the old file as historical record.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions in ADRs | Accepted |


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/README.md` as the system-level architecture entry point, structured as an inlined arc42 outline with C4 Levels 1 and 2 drawn as Mermaid diagrams (GitHub renders these natively).
- Adds `docs/architecture/adr/` with an MADR-style template (`0000-template.md`) and `0001-record-architecture-decisions.md` establishing the ADR process itself.
- Links the new architecture overview from the top-level `README.md` Documentation table.

## Rationale

Tolokaforge has accumulated significant architectural choices — the adapter plugin model, the gRPC service split, the per-provider preset registry, the single-secret-abstraction rule — that today live implicitly across `AGENTS.md`, scattered `docs/*.md` files, and commit history. New contributors (human and agent) re-derive the rationale every time, and proposed changes can't be cleanly weighed against the original forces because those forces aren't written down.

This PR lands the *scaffolding* (overview doc + ADR mechanics) without claiming to capture every decision. Backfill ADRs for the adapter plugin model, gRPC decomposition, and the secret abstraction will follow in separate PRs to keep this one reviewable. The pattern for proposing future architecture (current vs. target diagrams paired with `Proposed` ADRs) is described in the overview but intentionally not exercised yet.

## What this PR does *not* do

- Touch the existing `docs/ADAPTER_ARCHITECTURE.md`, `docs/RUNNER.md`, `docs/LLM_LAYER.md`, or other subsystem docs. They remain the deep-dive references; the new overview links to them.
- Mandate any tooling beyond Markdown + Mermaid. No renderer, no diagrams-as-code build step.

## Test plan

- [ ] `docs/architecture/README.md` renders on GitHub with all four Mermaid diagrams visible (Context, Container, Adapter zoom, Runtime sequence, Deployment).
- [ ] All cross-links from the overview resolve (`docs/ADAPTER_ARCHITECTURE.md`, `docs/LLM_LAYER.md`, `docs/RUNNER.md`, `docs/GRADING.md`, `AGENTS.md` § Secrets, etc.).
- [ ] `docs/architecture/adr/README.md` index entry for ADR-0001 resolves.
- [ ] Top-level `README.md` Documentation table shows the new "Architecture overview" row above "Getting started".