### PR TITLE
chore(release): cut v0.2.1 with reconciled CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased] — LLM Reasoning & Observability Overhaul
+## [0.2.1] - 2026-05-29 — LLM Reasoning & Observability Overhaul
 
 ### Breaking Changes
 
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 3. **`Metrics.tokens_input`** / **`Metrics.tokens_output`** removed — replaced by `Metrics.usage: Usage`. Aggregators expose `avg_<field>` / `total_<field>` per `Usage` field (e.g. `avg_reasoning_tokens`, `total_cache_read_input_tokens`).
 4. **`Message.reasoning: str`** migrated to `Message.reasoning: StructuredReasoning | None` — preserves provider signatures + block types for replay.
 5. **`tolokaforge.core.model_client`** / **`tolokaforge.core.model_policies`** modules deleted — every concept moved into `tolokaforge.core.llm.*`. Update imports accordingly.
+6. **`in-process` runtime mode removed.** Docker is now the only supported runtime (`runtime: "docker"`). All tool execution is routed through the containerised executor service. Existing configs that specify `runtime: "in-process"` must be updated to `runtime: "docker"`.
 
 ### Fixed
 
@@ -38,6 +39,7 @@ All notable changes to this project are documented in this file.
 2. `tolokaforge/core/output/artifacts.py` with `TrialArtifactWriter` Protocol + `FileArtifactWriter` + `model_id_slug`.
 3. [`docs/LLM_LAYER.md`](docs/LLM_LAYER.md) — single authoritative reference for the new package.
 4. [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md) — six-step contributor guide for adding a new model / provider.
+5. `anthropic/claude-opus-4.8` registered in pricing catalog, model presets (version-specific `anthropic_claude_4_8` preset ordered before generic `anthropic` for first-match-wins routing), and integration `ModelCertificate` (live-certified 2026-05-29; promotes `DICT_MAP_TOOL_CALL` + `DECIMAL_FIELD_TOOL_CALL` to `required` versus 4.6/4.7's `known_unsupported`).
 
 ### Changed
 
@@ -47,12 +49,6 @@ All notable changes to this project are documented in this file.
 ### Traceability
 
 Every P# in [`plans/llm_reasoning_and_observability_fix.md`](plans/llm_reasoning_and_observability_fix.md) maps to a closed fix. Integration evals (Stage 10) require live API keys and are run manually — see [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md) for the capability suite.
-
-## [0.3.0] - 2026-03-30
-
-### Breaking Changes
-
-1. Removed `in-process` runtime mode. Docker is now the only supported runtime (`runtime: "docker"`). All tool execution is routed through the containerised executor service. Existing configs that specify `runtime: "in-process"` must be updated to `runtime: "docker"`.
 
 ## [0.2.0] - 2026-02-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tolokaforge"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tolokaforge - LLM Tool-Use Benchmarking Harness"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tolokaforge/__init__.py
+++ b/tolokaforge/__init__.py
@@ -1,6 +1,6 @@
 """Universal LLM Tool-Use Benchmarking Harness (ULB-H)"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # ---------------------------------------------------------------------------
 # Lazy public API — symbols are loaded on first access, not at import time.


### PR DESCRIPTION
## Summary

Cuts **v0.2.1** to ship the accumulated unreleased work on `main` to PyPI:
- Bumps version `0.2.0 → 0.2.1` in `pyproject.toml` and `tolokaforge/__init__.py`
- Reconciles the CHANGELOG so it accurately describes what the next `v0.2.1` tag will publish

## Why a CHANGELOG reconciliation

The CHANGELOG was in an inconsistent state before this PR:

- `[Unreleased] — LLM Reasoning & Observability Overhaul` — 5 breaking changes + 10 fixes already on `main`, never tagged
- `[0.3.0] - 2026-03-30` — another breaking change (in-process runtime removed) drafted but never tagged
- `[0.2.0] - 2026-02-25` — the actual last PyPI release

Both `[Unreleased]` and the never-tagged `[0.3.0]` sections describe code that is already on `main` but has never been published. Whatever tag we push next ships all of it. This PR folds both into a single **`[0.2.1] - 2026-05-29`** section and adds the opus-4.8 entry from #10, so the CHANGELOG truthfully describes the next release.

## Supersedes #9

#9 also tried to consolidate the CHANGELOG, but it backdated `[Unreleased]` + `[0.3.0]` onto **`[0.2.0]`** itself. That doesn't match reality — `v0.2.0` was tagged and uploaded to PyPI on 2026-02-25 with only the originally-listed feature set; rewriting its release notes to include the LLM Reasoning Overhaul + Docker-only runtime would lie about what users actually got from `pip install tolokaforge==0.2.0`. The right home for accumulated post-0.2.0 work is the **next** tag, which is what this PR does.

Closes #9.

## Release flow after merge

```bash
git checkout main && git pull
git tag v0.2.1
git push origin v0.2.1
```

That fires `publish-tolokaforge.yml` (build → trusted-publish to PyPI → GitHub Release) and `release-gate.yml` (full test suite, parallel).

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, dry-run via `workflow_dispatch` → `testpypi` before pushing the `v0.2.1` tag
- [ ] Verify TestPyPI artifact installs cleanly and `tolokaforge.__version__ == "0.2.1"`
- [ ] Push `v0.2.1` tag; confirm PyPI receives the upload and GitHub Release is created