### PR TITLE
fix(adapters): drop stale FrozenMcpCoreAdapter export and docstring

### DIFF
--- a/tolokaforge/adapters/__init__.py
+++ b/tolokaforge/adapters/__init__.py
@@ -36,15 +36,12 @@ _FAILED_ADAPTERS: dict[str, Exception] = {}
 def _discover_adapters() -> dict[str, type]:
     """Discover adapter plugins via importlib.metadata entry-points.
 
-    Always includes NativeAdapter and FrozenMcpCoreAdapter (built-in).
-    External adapters are loaded from the ``tolokaforge.adapters``
-    entry-point group.
+    NativeAdapter is the only built-in adapter; all others are entry-point
+    plugins loaded from the ``tolokaforge.adapters`` group.
     """
     from tolokaforge.adapters.native import NativeAdapter
 
     adapters: dict[str, type] = {"native": NativeAdapter}
-
-    # Register built-in frozen adapter (does NOT import mcp_core at module level)
 
     for ep in importlib.metadata.entry_points(group="tolokaforge.adapters"):
         try:
@@ -127,7 +124,6 @@ __all__ = [
     "BaseAdapter",
     "AdapterEnvironment",
     "DockerStackRequirements",
-    "FrozenMcpCoreAdapter",
     "NativeAdapter",
     "NativeTaskBundle",
     "available_adapters",


### PR DESCRIPTION
## Summary

`FrozenMcpCoreAdapter` was removed from the engine during the OSS split but it was still listed
in `tolokaforge/adapters/__init__.py` `__all__`. That made a wildcard import of
the adapters package raise `AttributeError` because the name is no longer
imported in the module.

This PR:
- Removes `FrozenMcpCoreAdapter` from `__all__` (the actual bug).
- Fixes the `_discover_adapters` docstring to state that `NativeAdapter` is the
  only built-in adapter; all others are entry-point plugins.
- Drops the dangling "register built-in frozen adapter" comment.

Prose docstrings in `native.py` / `_task_loader.py` that mention
`FrozenMcpCoreAdapter` are left as-is — they accurately describe the data-format
contract the frozen adapter (in tolokaforge-tools) consumes.

## Test plan

- [x] Wildcard import of the adapters package succeeds; `available_adapters()` returns `['native', 'terminal_bench']`.
- [x] `ruff check` + `ruff format --check` clean on the changed file.
- [x] `pytest tests/unit -k adapter` — 44 passed.

Jira: TECHDEL-311


Closes #16
