### PR TITLE
chore(release): cut v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.2.2] - 2026-06-03
+
+### Fixed
+
+1. **Wheel resolver — relocated uv cache.** The Docker runner is provisioned from a host-resolved `tolokaforge` wheel; for a git-source install the `pip-cache` provider recovers the wheel `uv` built during `uv sync`. `_walk_pip_wheel_caches()` hard-coded `~/.cache/uv`, so when the cache was relocated (e.g. `astral-sh/setup-uv` sets `UV_CACHE_DIR` in CI) the wheel was missed and `tolokaforge run` failed at service start-up with `NoWheelError`. Cache *location* is now discovered via `uv cache dir` / `UV_CACHE_DIR` / `PIP_CACHE_DIR` (with the `~/.cache` defaults preserved); the uv-internal layout scan is unchanged, and `NoWheelError` now reports the caches it searched. (#27, #28)
+2. **Adapters package export.** Removed the stale `FrozenMcpCoreAdapter` entry from `tolokaforge.adapters.__all__` (it is no longer importable from the engine), which had broken `from tolokaforge.adapters import *`. (#14)
+
 ## [0.2.1] - 2026-05-29 — LLM Reasoning & Observability Overhaul
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tolokaforge"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tolokaforge - LLM Tool-Use Benchmarking Harness"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release bundling the two bug fixes already merged to `main` since v0.2.1.

- Bumps `pyproject.toml` 0.2.1 → 0.2.2.
- Adds the `## [0.2.2]` CHANGELOG section.

### Included
- #28 — wheel resolver: resolve the engine wheel under a relocated uv cache (`UV_CACHE_DIR`); fixes #27.
- #14 — adapters: drop stale `FrozenMcpCoreAdapter` export that broke `from tolokaforge.adapters import *`.

### Release steps after merge
Tag `v0.2.2` on the merge commit → triggers `publish-tolokaforge.yml` (PyPI, trusted publishing, `release` environment) + `release-gate.yml` + GitHub Release.