### PR TITLE
feat(devcontainer): Codespaces-ready dev container for the public engine

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "tolokaforge",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "remoteUser": "vscode",
+  "forwardPorts": [8000, 8080, 8001],
+  "portsAttributes": {
+    "8000": { "label": "json-db" },
+    "8080": { "label": "mock-web" },
+    "8001": { "label": "rag" }
+  },
+  "secrets": {
+    "OPENROUTER_API_KEY": {
+      "description": "OpenRouter API key used by the example evals. Set it as a Codespaces secret (or add it to .env after the container starts)."
+    },
+    "ANTHROPIC_API_KEY": {
+      "description": "Optional Anthropic API key (used when a model config sets provider=anthropic)."
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "eamodio.gitlens",
+        "github.vscode-github-actions",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": ".venv/bin/python"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Devcontainer post-create for the public tolokaforge engine.
+#
+# Sets up everything an OSS developer needs to run an evaluation:
+#   - uv (package manager)
+#   - the project venv via uv sync + Playwright (reuses scripts/setup/*)
+#   - Git LFS objects (test fixtures)
+#   - pre-commit hooks
+#   - a .env seeded from any provided API-key secret
+#
+# Docker-in-Docker is provided by the devcontainer feature, so `tolokaforge run`
+# can build and run the containerised runner. No internal/Azure auth is used.
+set -euo pipefail
+
+echo "[post-create] installing uv..."
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+# Make uv available to this script and to future interactive shells.
+export PATH="$HOME/.local/bin:$PATH"
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env" || true
+
+echo "[post-create] creating venv (uv sync + Playwright)..."
+scripts/setup/create_python_venv.sh
+
+echo "[post-create] initializing Git LFS (non-fatal)..."
+scripts/setup/init_git_lfs.sh || echo "[post-create] git-lfs step skipped/failed (non-fatal)"
+
+echo "[post-create] installing pre-commit hooks (non-fatal)..."
+uv run pre-commit install || echo "[post-create] pre-commit install skipped (non-fatal)"
+
+# Seed .env. We never bake secrets into the image; if a key is present in the
+# environment (e.g. a Codespaces secret), copy it into .env, otherwise leave the
+# documented template for the developer to fill in.
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "[post-create] created .env from .env.example"
+fi
+for var in OPENROUTER_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY; do
+  val="${!var:-}"
+  if [ -n "$val" ]; then
+    if grep -qE "^#?[[:space:]]*${var}=" .env; then
+      sed -i "s|^#\?[[:space:]]*${var}=.*|${var}=${val}|" .env
+    else
+      echo "${var}=${val}" >> .env
+    fi
+    echo "[post-create] wrote ${var} to .env from an environment secret"
+  fi
+done
+
+echo "[post-create] done."
+echo "[post-create] Run an example eval (needs an LLM key in .env):"
+echo "    scripts/with_env.sh uv run tolokaforge run --config examples/native/coding/run_config.yaml"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -29,24 +29,41 @@ scripts/setup/init_git_lfs.sh || echo "[post-create] git-lfs step skipped/failed
 echo "[post-create] installing pre-commit hooks (non-fatal)..."
 uv run pre-commit install || echo "[post-create] pre-commit install skipped (non-fatal)"
 
-# Seed .env. We never bake secrets into the image; if a key is present in the
-# environment (e.g. a Codespaces secret), copy it into .env, otherwise leave the
-# documented template for the developer to fill in.
+# Seed .env. We never bake secrets into the image.
+#
+# Important: scripts/with_env.sh loads .env with `set -o allexport`, so values in
+# .env OVERRIDE the process environment. .env.example ships an *active*
+# placeholder (OPENROUTER_API_KEY=your-openrouter-api-key-here); if left as-is it
+# would (a) masquerade as "set" and (b) clobber a real key provided via a
+# Codespaces secret / shell env — causing a 401. So we neutralize the placeholder
+# and only ever write *real* values.
 if [ ! -f .env ]; then
   cp .env.example .env
   echo "[post-create] created .env from .env.example"
 fi
+
+# Comment out the active placeholder so it can't shadow a real key.
+sed -i 's|^[[:space:]]*OPENROUTER_API_KEY=your-openrouter-api-key-here.*|# OPENROUTER_API_KEY=  # set a real key here, or provide one via a Codespaces secret / shell env|' .env
+
+# If a real key is present in the environment (e.g. a Codespaces secret with
+# repository access), write it into .env.
 for var in OPENROUTER_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY GEMINI_API_KEY; do
   val="${!var:-}"
-  if [ -n "$val" ]; then
-    if grep -qE "^#?[[:space:]]*${var}=" .env; then
-      sed -i "s|^#\?[[:space:]]*${var}=.*|${var}=${val}|" .env
-    else
-      echo "${var}=${val}" >> .env
-    fi
-    echo "[post-create] wrote ${var} to .env from an environment secret"
+  [ -n "$val" ] || continue
+  [ "$val" = "your-openrouter-api-key-here" ] && continue
+  if grep -qE "^#?[[:space:]]*${var}=" .env; then
+    sed -i "s|^#\?[[:space:]]*${var}=.*|${var}=${val}|" .env
+  else
+    echo "${var}=${val}" >> .env
   fi
+  echo "[post-create] wrote ${var} to .env from an environment secret"
 done
+
+if ! grep -qE '^OPENROUTER_API_KEY=.' .env; then
+  echo "[post-create] NOTE: no OpenRouter key configured yet. Set a Codespaces secret"
+  echo "[post-create]       named OPENROUTER_API_KEY (with access to this repo) and rebuild,"
+  echo "[post-create]       or add the key to .env, before running an eval."
+fi
 
 echo "[post-create] done."
 echo "[post-create] Run an example eval (needs an LLM key in .env):"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ uv pip list
 
 **Troubleshooting `uv` availability:** If you get `command not found: uv`, use `scripts/with_env.sh uv ...` — it loads the shell profile correctly in addition to `.env` variables.
 
-**Installing additional tools/packages:** Install them locally for immediate use, then also add the installation to `.devcontainer/Dockerfile` so the devcontainer stays reproducible.
+**Installing additional tools/packages:** Install them locally for immediate use. To keep the dev container reproducible, add OS-level tools via a [feature](https://containers.dev/features) in `.devcontainer/devcontainer.json` (or a step in `.devcontainer/post-create.sh`), and Python dependencies via `pyproject.toml` + `uv sync`.
 
 ### Linting and Formatting
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ uv sync
 
 See [Python Package Guide](docs/PYTHON_PACKAGE.md) for all extras and programmatic API usage.
 
+## Dev container / GitHub Codespaces
+
+The fastest way to run an evaluation with zero local setup. Open the repo in a
+[dev container](https://containers.dev) (VS Code: **Reopen in Container**) or in
+**GitHub Codespaces**. The container provisions Python 3.12 + `uv`, installs the
+project (`uv sync` + Playwright), and enables **Docker-in-Docker** so `tolokaforge run`
+can build and run the sandboxed runner.
+
+Add an LLM key — set a Codespaces secret named `OPENROUTER_API_KEY` (it is written
+into `.env` automatically on first start) or edit `.env` directly — then run an example:
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/coding/run_config.yaml
+```
+
+The first run builds the runner image inside the container (slower); later runs reuse it.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

A Codespaces- and local-ready dev container for the public engine, so OSS
contributors can open the repo and run an evaluation with no local setup.

## Why minimal (official image + features), not a port of the internal devcontainer

- The tools/tasks devcontainer **can't be reused as-is**: its lifecycle scripts bake in
  internal Azure DevOps PyPI auth (`setup_toloka_pypi.sh` / `AZURE_DEVOPS_TOKEN`) and an
  internal `codespaces.repositories` grant — none of which can ship in a public repo.
  "Reusing" it really means forking it, stripping the internal bits, and maintaining a
  third hand-rolled `ubuntu:jammy` image.
- This uses the official `mcr.microsoft.com/devcontainers/python:3.12` image + the
  `docker-in-docker` and `git-lfs` features, and reuses the engine's own (Azure-free)
  `scripts/setup/*`. **2 files, no internal coupling.** Official base images are built to
  behave identically in local VS Code and Codespaces, so it's the lower-risk answer to
  "works in both" — and the leaner build (no from-scratch apt/node layers).

## Contents

- `.devcontainer/devcontainer.json` — `python:3.12` + `docker-in-docker` (required:
  `tolokaforge run` builds/runs the containerized runner) + `git-lfs`; declares
  `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` as Codespaces secrets (never baked into the image).
- `.devcontainer/post-create.sh` — installs `uv`, runs `scripts/setup/create_python_venv.sh`
  (uv sync + Playwright) and `init_git_lfs.sh`, installs pre-commit, and safely seeds `.env`
  (comments the placeholder so it can't shadow a real key via `with_env.sh`'s `allexport`
  sourcing; writes a key from a Codespaces secret if present).
- README: "Dev container / GitHub Codespaces" section. AGENTS.md: dropped the stale
  `.devcontainer/Dockerfile` reference.

## Verification — proven end-to-end in BOTH environments

| Environment | Build + DinD | Example eval (`examples/native/coding`) |
|---|---|---|
| GitHub Codespaces | ✅ | ✅ scores 0.78 / 0.35 |
| Local VS Code dev container (Docker Desktop) | ✅ | ✅ scores 0.78 / 0.51 |

Both: `local-source` wheel built (no `NoWheelError`), services auto-started, results produced.
First build is a one-time cost (base pull + DinD + `uv sync` + runner image); reopen is fast.

## Notes

- Optional follow-ups (not required): Codespaces **prebuilds** for instant opens; trim
  `post-create.sh`; port the Docker `credsStore` fix from the internal devcontainer if anyone
  hits it (not observed in either validation run).
- Public engine only — tools/tasks have their own internal dev containers.

Closes #25