### PR TITLE
fix(presets): enable empty-assistant filler for OpenRouter Amazon Nova

### DIFF
--- a/tests/unit/llm/test_aws_nova_openrouter_preset.py
+++ b/tests/unit/llm/test_aws_nova_openrouter_preset.py
@@ -1,0 +1,106 @@
+"""Preset routing - ``aws_nova_openrouter``.
+
+Amazon Nova routed through OpenRouter arrives as model id ``amazon/nova-*``
+(e.g. ``amazon/nova-2-lite-v1``) with provider ``openrouter``. That org-prefixed
+id matches NEITHER ``aws_nova.match`` (``nova*`` name glob) NOR
+``match_provider: [nova]``, so pre-fix it fell through to the ``default`` preset
+(``content_policy: openai`` → ``inject_empty_assistant_filler`` OFF). Bedrock
+behind OpenRouter then rejects blank-content assistant tool turns with a 400
+("The text field in the ContentBlock ... is blank"), crashing the domain.
+
+The fix is a dedicated preset that turns the Nova filler ON
+(``content_policy: nova``) while KEEPING the default ``standard`` response
+policy - the OpenRouter route emits clean native-dict tool args that round-trip
+under ``standard``, and ``UnwrapInputResponse`` (used by the direct ``aws_nova``
+preset) is not a strict no-op on clean dicts. The preset is declared AFTER
+``aws_nova`` so the direct-Nova path keeps winning first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm import (
+    StandardResponse,
+    UnwrapInputResponse,
+    build_capabilities,
+)
+from tolokaforge.core.llm.presets import resolve_effective_preset, resolve_policy_names
+
+pytestmark = pytest.mark.unit
+
+
+# Both id forms the benchmark may present: org-prefixed name, and the full
+# ``openrouter/...`` form in case the provider prefix is not stripped.
+_OPENROUTER_NOVA_IDS = [
+    "amazon/nova-2-lite-v1",
+    "openrouter/amazon/nova-2-lite-v1",
+]
+
+
+@pytest.mark.parametrize("model", _OPENROUTER_NOVA_IDS)
+def test_openrouter_nova_resolves_to_dedicated_preset(model: str) -> None:
+    """OpenRouter Amazon Nova → ``aws_nova_openrouter`` (not ``default``)."""
+    assert resolve_effective_preset(model, "openrouter") == "aws_nova_openrouter"
+
+
+@pytest.mark.parametrize("model", _OPENROUTER_NOVA_IDS)
+def test_openrouter_nova_turns_filler_on(model: str) -> None:
+    """``content_policy: nova`` gates ``inject_empty_assistant_filler`` ON -
+    the whole point of the fix (Bedrock rejects blank tool turns otherwise)."""
+    caps = build_capabilities(model, "openrouter")
+    assert resolve_policy_names(caps)["content_policy"] == "nova"
+    assert caps.content_policy.inject_empty_assistant_filler is True
+
+
+@pytest.mark.parametrize("model", _OPENROUTER_NOVA_IDS)
+def test_openrouter_nova_keeps_standard_response_policy(model: str) -> None:
+    """Response/arg handling must stay ``standard`` (the policy the data shows
+    works on Nova's clean native-dict args) - NOT ``unwrap_input``."""
+    caps = build_capabilities(model, "openrouter")
+    assert isinstance(caps.response_policy, StandardResponse)
+    assert not isinstance(caps.response_policy, UnwrapInputResponse)
+    assert resolve_policy_names(caps)["response_policy"] == "standard"
+
+
+# --- Regression guards: the fix must change nothing else --------------------
+
+
+@pytest.mark.parametrize("model", ["nova-2-lite-v1", "nova-pro-v1"])
+def test_direct_nova_path_still_resolves_to_aws_nova(model: str) -> None:
+    """Direct Nova (provider ``nova``) keeps the original ``aws_nova`` preset
+    with ``unwrap_input`` - first-match-wins picks it before the new preset."""
+    assert resolve_effective_preset(model, "nova") == "aws_nova"
+    caps = build_capabilities(model, "nova")
+    assert isinstance(caps.response_policy, UnwrapInputResponse)
+    assert caps.content_policy.inject_empty_assistant_filler is True
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_preset"),
+    [
+        ("openai/gpt-5.5", "openai_gpt5"),
+        ("anthropic/claude-opus-4.7", "anthropic_claude_4_7"),
+        ("qwen/qwen3.7-max", "qwen"),
+        ("x-ai/grok-4", "xai_grok"),
+        ("google/gemini-3-pro", "gemini"),
+    ],
+)
+def test_unrelated_models_unchanged(model: str, expected_preset: str) -> None:
+    """A spread of unrelated routes must resolve exactly as before the fix."""
+    assert resolve_effective_preset(model, "openrouter") == expected_preset
+    # And none of them turn the Nova filler on.
+    caps = build_capabilities(model, "openrouter")
+    assert caps.content_policy.inject_empty_assistant_filler is False
+
+
+def test_new_glob_does_not_match_non_nova_models() -> None:
+    """``*amazon/nova*`` must only catch Amazon Nova ids - no false positives."""
+    for model in (
+        "openai/gpt-5.5",
+        "anthropic/claude-opus-4.7",
+        "x-ai/grok-4",
+        "google/gemini-3-pro",
+        "qwen/qwen3.7-max",
+    ):
+        assert resolve_effective_preset(model, "openrouter") != "aws_nova_openrouter"

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -146,6 +146,25 @@ presets:
     content_policy: nova
     response_policy: unwrap_input
 
+  # Amazon Nova via OpenRouter arrives org-prefixed as ``amazon/nova-*``
+  # (e.g. ``amazon/nova-2-lite-v1``) with provider ``openrouter``, which
+  # matches NEITHER ``aws_nova``'s ``nova*`` name glob NOR its
+  # ``match_provider: [nova]``, so it fell through to ``default``
+  # (``content_policy: openai`` -> ``inject_empty_assistant_filler`` OFF).
+  # Bedrock-behind-OpenRouter then 400s on blank-content assistant tool
+  # turns ("The text field in the ContentBlock ... is blank"), crashing
+  # multi-turn domains (ots_08_travel_internal scored 0%). Turn the filler
+  # ON via ``content_policy: nova`` while KEEPING ``response_policy:
+  # standard``: the OpenRouter route emits clean native-dict tool args that
+  # round-trip under ``standard``; ``unwrap_input`` (used by direct
+  # ``aws_nova``) is not a no-op on them. Declared AFTER ``aws_nova`` so the
+  # direct-Nova path keeps winning first-match.
+  aws_nova_openrouter:
+    match:
+      - "*amazon/nova*"
+    content_policy: nova
+    response_policy: standard
+
   # Google Gemini family (3.x preview + 3.x GA + 2.5 backstop).
   # ``GeminiReasoningCodec`` decodes Gemini's OpenRouter
   # ``provider_specific_fields.reasoning_details`` envelope: handles


### PR DESCRIPTION
## Problem

OpenRouter serves Amazon Nova as `amazon/nova-2-lite-v1` (provider `openrouter`). The preset matcher binds the Nova preset (`aws_nova`) only to `nova*` / `match_provider: [nova]`, which does not match `amazon/nova-*`. So OpenRouter Nova fell through to the `default` (passthrough) preset, where `inject_empty_assistant_filler` is OFF.

Amazon Bedrock (behind OpenRouter) rejects an assistant turn that has `tool_calls` and empty content with a 400: `"The text field in the ContentBlock ... is blank"`. That crashes multi-turn tasks.

Impact: `nova_2_lite` scored 0% on `ots_08_travel_internal` (0/615 trials), every trial carrying that Bedrock 400 immediately after an empty-content assistant tool turn.

## Fix

A dedicated `aws_nova_openrouter` preset matching `*amazon/nova*`:

- `content_policy: nova` turns the empty-assistant filler ON (the actual fix).
- `response_policy: standard`, NOT `unwrap_input`. The OpenRouter route emits clean native-dict tool args; `unwrap_input` (which direct Bedrock `aws_nova` needs for its `{input: {...}}` wrapper) is not a no-op on clean dicts and would corrupt a legitimate single-`input`-object arg.
- Declared after `aws_nova` so the direct-Nova path keeps first-match.

This is why it is a separate preset rather than broadening `aws_nova`'s globs: the two Nova entry points (direct Bedrock vs OpenRouter) need the same filler but different response handling.

## How it was tested

1. **Resolver (driven in code, not eyeballed):** pre-fix, `amazon/nova-2-lite-v1 @ openrouter` resolved to `default` (filler OFF); post-fix, to `aws_nova_openrouter` (filler ON). Direct `nova-* @ nova` still resolves to `aws_nova` (unchanged); Claude unaffected.
2. **Collected evidence:** all 615 `nova_2_lite` `ots_08_travel_internal` trials carry the verbatim Bedrock 400, each immediately preceded by a `role: assistant, content: '', tool_calls: [...]` turn (e.g. AE-UNI-010, AE-ADM-002, EL-XFR-003).
3. **Live A/B** (OpenRouter `amazon/nova-2-lite-v1`, n=12 each, minimal empty-assistant + tool_call reproduction):

   | variant | result |
   |---|---|
   | no filler (`content=""`) | 0/12, byte-identical Bedrock 400 |
   | filler (`content="I'll help you with that."`) | 12/12 clean replies |

4. **Unit tests:** the new `test_aws_nova_openrouter_preset.py` (14 tests) passes; the broader preset suite (80 tests) passes.

## Result

The fix eliminates the artificial crash (0/12 to 12/12). Note: `nova_2_lite` is a weak model regardless; the fix lifts `travel_internal` off the 0% floor to the model's intrinsic (low) capability, not to a high score.
