### PR TITLE
feat(llm): register deepseek/deepseek-v3.2-exp

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -802,6 +802,80 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning line on
+    # the OpenRouter route. Live-certified 2026-06-03 via
+    # ``pytest tests/integration/llm/ -k deepseek-v3.2-exp`` (14 passed,
+    # 6 skipped). Routes through the dedicated ``deepseek_v32`` preset
+    # (OpenAI reasoning codec only): unlike the deepseek-v4-pro sibling it
+    # round-trips dict-map and discriminated-union calls on the *standard*
+    # response policy, so it needs neither json_coerce nor dict_map_hints,
+    # only the codec so its reasoning_content summary lands in the
+    # trajectory logs like every other reasoning route. Reasoning is
+    # requested as ``extra_body.reasoning.effort`` via the openrouter
+    # provider overlay (eval configs use reasoning: adaptive).
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__deepseek_deepseek-v3.2-exp",
+        provider="openrouter",
+        name="deepseek/deepseek-v3.2-exp",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Tool-call reliability on a registered Decimal field is
+                # flaky: 1 pass / 5 fails across 6 live calls on
+                # 2026-06-03, every failure being "no tool call returned"
+                # (the model answers in prose instead of invoking the
+                # tool). Same posture as the deepseek-v4-pro sibling; a
+                # ``required`` capability must pass reliably, so Decimal
+                # stays ``known_unsupported`` until the route stabilises.
+                C.DECIMAL_FIELD_TOOL_CALL,
+                # OpenRouter surfaces only a ``reasoning_content`` summary,
+                # which OpenAIReasoningCodec yields as a single
+                # ``summary_text`` block, never the structured signed
+                # thinking blocks this capability requires. Same posture as
+                # the deepseek-v4-pro sibling under the identical OpenAI
+                # codec and the GPT-5 family. Verified live 2026-06-03.
+                C.THINKING_EMITS_BLOCKS,
+                # OpenAI-route reasoning has no replay path:
+                # ``OpenAIReasoningCodec.encode_for_replay`` returns ``{}``
+                # and DeepSeek does not accept echoed reasoning on later
+                # turns, exactly like the deepseek-v4-pro sibling. Verified
+                # live 2026-06-03.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No Anthropic-style ephemeral cache: the first call created
+                # 0 cache_creation_input_tokens. Verified live 2026-06-03.
+                C.PROMPT_CACHING,
+                # OpenRouter auto-cache not reproducible in a clean 2-call
+                # 8 k-token probe (``cached_tokens=0`` on both calls),
+                # exactly like deepseek-v4-pro; production large-prompt runs
+                # may still cache in aggregate. Paired with the ratchet in
+                # ``test_implicit_prompt_caching_unsupported_ratchet`` (which
+                # passes), so the day a 2-call probe observes caching it
+                # flips back to ``required``. Verified live 2026-06-03.
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
     MC(
         model_id="openrouter__xiaomi_mimo-v2.5-pro",
         provider="openrouter",

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -138,6 +138,22 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
+  # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning route.
+  # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
+  # round-trips dict-map and discriminated-union tool calls cleanly on
+  # the standard response policy, so it needs neither json_coerce nor
+  # dict_map_hints. The one non-default policy it needs is the OpenAI
+  # reasoning codec, so its OpenRouter reasoning_content summary surfaces
+  # in the trajectory logs like every other reasoning route here. The
+  # codec's replay is a no-op on the OpenAI route, so this is
+  # observability only; it does not change tool-calling or the
+  # deterministic scoring. Live-certified 2026-06-03 (see registry.py).
+  deepseek_v32:
+    match:
+      - "deepseek/deepseek-v3.2-exp*"
+      - "*deepseek-v3.2-exp*"
+    reasoning_codec: openai
+
   aws_nova:
     match:
       - "nova*"


### PR DESCRIPTION
## Summary

Registers `deepseek/deepseek-v3.2-exp` on the arena-eval catalog ([TECHDEL-334](https://toloka.atlassian.net/browse/TECHDEL-334)).

Adds two things:
1. The `ModelCertificate` in `tests/integration/llm/registry.py`.
2. A dedicated `deepseek_v32` preset in `model_presets.yaml` that sets **only** `reasoning_codec: openai`.

Pricing for `deepseek/deepseek-v3.2-exp` is already present in `pricing.json` (input 0.27 / output 0.41 per 1M, matching the live OpenRouter API), so it is unchanged.

## Why a minimal preset (reasoning codec only)?

Unlike its `deepseek-v4-pro` sibling, which needs `openrouter_dict_stringify_recovery` (`json_coerce` + `dict_map_hints`) because it stringifies nested tool args, **V3.2-Exp round-trips dict-map and discriminated-union tool calls cleanly on the standard response policy** (both pass live). The one thing it shares with every other reasoning route in the registry is that it benefits from the OpenAI reasoning codec, so its `reasoning_content` summary is captured in the trajectory logs. Without a preset it would be the only registered model on `reasoning_codec: none`.

This is observability only: reasoning is requested either way (`extra_body.reasoning.effort` via the openrouter provider overlay), and `OpenAIReasoningCodec.encode_for_replay` is a no-op, so the codec changes neither tool-calling nor the deterministic scoring.

## Capability suite (live, 2026-06-03, under the `deepseek_v32` preset)

`scripts/with_env.sh uv run pytest tests/integration/llm/ -k deepseek-v3.2-exp -v`

```
test_basic_completion[...deepseek-v3.2-exp] PASSED
test_cost_usd_populated[...deepseek-v3.2-exp] PASSED
test_decimal_field_tool_call[...deepseek-v3.2-exp] SKIPPED
test_dict_map_tool_call[...deepseek-v3.2-exp] PASSED
test_discriminated_union_tool_call_two_turns[...deepseek-v3.2-exp-bare_union] PASSED
test_discriminated_union_tool_call_two_turns[...deepseek-v3.2-exp-explicit_discriminator] PASSED
test_enum_slash_tolerance[...deepseek-v3.2-exp] PASSED
test_implicit_prompt_caching[...deepseek-v3.2-exp] SKIPPED
test_known_unsupported_routes_do_not_auto_cache[...deepseek-v3.2-exp] PASSED
test_lexical_tool_invention[...deepseek-v3.2-exp] PASSED
test_multi_turn_error_recovery[...deepseek-v3.2-exp] PASSED
test_multi_turn_tool_use[...deepseek-v3.2-exp] PASSED
test_progress_after_success[...deepseek-v3.2-exp] PASSED
test_prompt_caching[...deepseek-v3.2-exp] SKIPPED
test_re2_pattern_tolerance[...deepseek-v3.2-exp] PASSED
test_required_fields_complete[...deepseek-v3.2-exp] PASSED
test_simple_tool_call[...deepseek-v3.2-exp] PASSED
test_thinking_emits_blocks[...deepseek-v3.2-exp] SKIPPED
test_thinking_replay_roundtrip[...deepseek-v3.2-exp] SKIPPED
test_tool_name_discipline[...deepseek-v3.2-exp] PASSED
test_unsigned_thinking_replay[...deepseek-v3.2-exp] SKIPPED
test_usage_metrics_populated[...deepseek-v3.2-exp] PASSED

========== 16 passed, 6 skipped, 348 deselected in 221.87s ==========
```

## `known_unsupported` justification

Per `ADD_NEW_MODEL.md` §3, the cert started from the v4-pro sibling with every `known_unsupported` flipped to `required`, then only the genuine live failures were moved back. All six match the `deepseek-v4-pro` sibling, which runs the identical OpenAI codec:

| Capability | Why `known_unsupported` |
|---|---|
| `thinking_emits_blocks` | OpenRouter surfaces only a `reasoning_content` summary; `OpenAIReasoningCodec` yields a single `summary_text` block, not structured signed blocks. |
| `thinking_replay_roundtrip` | `OpenAIReasoningCodec.encode_for_replay` returns `{}`; DeepSeek doesn't accept echoed reasoning on later turns. |
| `unsigned_thinking_replay` | Same — no replay path on the OpenAI route. |
| `prompt_caching` | No Anthropic-style ephemeral cache (first call produced 0 `cache_creation_input_tokens`). |
| `implicit_prompt_caching` | OpenRouter auto-cache not reproducible in a clean 2-call 8k-token probe (`cached_tokens=0`); paired ratchet test passes. |
| `decimal_field_tool_call` | Flaky: **1 pass / 5 fails** across 6 live calls, every failure "no tool call returned" (model answers in prose). Matches the v4-pro sibling. |

Everything else (14 caps incl. dict-map, discriminated-union, multi-turn error recovery, enum-slash, RE2, tool-name discipline, lexical-invention, progress-after-success) is `required` and passes live.

## Downstream / release note

The `deepseek_v32` preset ships **in the engine package**, but the benchmark run consumes a pinned engine tag (`tolokaforge-tasks` pins `v0.2.1`, which predates this preset). So to make eval runs actually use the OpenAI codec, an engine release (`v0.2.2`) + a `tolokaforge-tasks` repin are needed. Until then the model resolves to the `default` preset on `v0.2.1` (tool-calling and scoring identical; only the reasoning trace is not decoded). The `ModelCertificate` itself lives in the test suite and is consumed only by the capability suite, not the run.

Eval configs + benchmark-results-collector registration land separately in `tolokaforge-tasks` (not on engine `main`, per `ADD_NEW_MODEL.md`).


[TECHDEL-334]: https://toloka.atlassian.net/browse/TECHDEL-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ