### PR TITLE
chore(release): cut v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.2.3] - 2026-06-04
+
+### Added
+
+1. **`deepseek/deepseek-v3.2-exp` support.** New `ModelCertificate` (14 required / 6 known_unsupported, live-certified 2026-06-03) plus a dedicated `deepseek_v32` preset routing the experimental V3.2 line through the OpenAI reasoning codec. Unlike the V4 line it round-trips dict-map and discriminated-union tool calls on the standard response policy, so it needs neither `json_coerce` nor `dict_map_hints`; pricing was already present in `pricing.json`. (#36)
+
+### Fixed
+
+1. **`tolokaforge.__version__` reconciled** to match `pyproject.toml` (it had lagged at `0.2.1` through the 0.2.2 release).
+
 ## [0.2.2] - 2026-06-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tolokaforge"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tolokaforge - LLM Tool-Use Benchmarking Harness"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tolokaforge/__init__.py
+++ b/tolokaforge/__init__.py
@@ -1,6 +1,6 @@
 """Universal LLM Tool-Use Benchmarking Harness (ULB-H)"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"
 
 # ---------------------------------------------------------------------------
 # Lazy public API — symbols are loaded on first access, not at import time.


### PR DESCRIPTION
Cuts **v0.2.3**.

## Included

- **feat(llm): register `deepseek/deepseek-v3.2-exp`** (#36): `ModelCertificate` (14 required / 6 known_unsupported, live-certified 2026-06-03) + dedicated `deepseek_v32` preset (`reasoning_codec: openai`).

## Release mechanics

- Version bumped `0.2.2` -> `0.2.3` in `pyproject.toml` and `tolokaforge/__init__.py` (the latter had lagged at `0.2.1` since the 0.2.2 release; now reconciled).
- CHANGELOG `[0.2.3]` section added.

## Why now

`tolokaforge-tasks` pins the engine to a release tag and the benchmark run consumes that pinned engine. The `deepseek_v32` preset ships in the engine, so it must be in a tagged release for the TECHDEL-334 arena eval to run with the OpenAI reasoning codec. After this merges, pushing the `v0.2.3` tag triggers `publish-tolokaforge.yml`, then `tolokaforge-tasks` repins to `v0.2.3`.
