### PR TITLE
feat(release): automate releases with commitizen (cz bump)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -54,18 +54,6 @@ jobs:
         run: |
           scripts/tests/task_pack_docker_smoke.sh
 
-      - name: Run public examples end-to-end
-        run: |
-          scripts/tests/run_public_examples_smoke.sh
-
-      - name: Summarize public examples and enforce thresholds
-        env:
-          PUBLIC_EXAMPLES_MIN_PASS_RATE: ${{ vars.PUBLIC_EXAMPLES_MIN_PASS_RATE || '0.0' }}
-        run: |
-          uv run python scripts/tests/summarize_public_examples.py \
-            --min-pass-rate "${PUBLIC_EXAMPLES_MIN_PASS_RATE}" \
-            --min-completion-rate 1.0
-
       - name: Run unit tests
         run: |
           uv run pytest tests/unit/ -v --tb=short
@@ -87,11 +75,3 @@ jobs:
           E2E_TESTS: "1"
         run: |
           scripts/with_env.sh uv run pytest tests/e2e/ -v --tb=short
-
-      - name: Upload release gate summary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: public-example-summary-release
-          path: |
-            output/public_examples_summary.json
-            output/public_examples_summary.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,31 @@ jobs:
         run: |
           uv run cz bump --dry-run --yes ${{ steps.incr.outputs.arg }}
 
+      # `update_changelog_on_bump = true` (pyproject) regenerates CHANGELOG.md as
+      # part of the bump, so no separate --changelog flag is needed. If `auto`
+      # finds nothing to release (NO_COMMITS_FOUND=3 / NO_INCREMENT=21), exit
+      # cleanly instead of failing the run.
       - name: Bump version + changelog, commit + tag
+        id: bump
         if: ${{ !inputs.dry_run }}
         run: |
-          uv run cz bump --yes --changelog ${{ steps.incr.outputs.arg }}
+          set +e
+          uv run cz bump --yes ${{ steps.incr.outputs.arg }}
+          code=$?
+          set -e
+          if [ "$code" -eq 3 ] || [ "$code" -eq 21 ]; then
+            echo "::notice::No releasable commits since the last tag — nothing to release."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [ "$code" -eq 0 ] || exit "$code"
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "new_tag=v$(uv run cz version -p)" >> "$GITHUB_OUTPUT"
 
+      # Push the bump commit and its tag in a single atomic update: both refs
+      # land or neither does. Avoids leaving a release commit on main with no tag
+      # (which would trigger nothing downstream) if the tag push were rejected.
       - name: Push commit + tag
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && steps.bump.outputs.released == 'true' }}
         run: |
-          git push origin HEAD:main
-          git push origin --tags
+          git push --atomic origin HEAD:main "refs/tags/${{ steps.bump.outputs.new_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release (cz bump)
+
+# Human-initiated release. Pick the increment and run it — commitizen bumps the
+# version in pyproject.toml, regenerates CHANGELOG.md from the Conventional
+# Commit history, commits, and pushes a vX.Y.Z tag. That tag then triggers
+# publish-tolokaforge.yml (PyPI trusted publishing + GitHub Release) and
+# release-gate.yml. No manual version/changelog edits required.
+#
+# See CONTRIBUTING.md ("Cutting a Release").
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version increment"
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto      # derive from commits: fix->patch, feat->minor, feat!/BREAKING CHANGE->major
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run (compute the bump + changelog, do not commit/tag/push)"
+        required: false
+        default: false
+        type: boolean
+
+# Never run two releases at once; do not cancel an in-flight release.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push the bump commit + tag back to main
+
+jobs:
+  release:
+    name: Bump version, changelog, tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0      # full history + tags so commitizen can derive the bump
+          ref: main           # always release from main
+          # If a branch/tag protection rule blocks the github-actions bot from
+          # pushing to main, provide a repo-scoped token here and configure a
+          # ruleset bypass for it (see CONTRIBUTING.md):
+          # token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Guard — main must be clean
+        run: |
+          test -z "$(git status --porcelain)" || { echo "Working tree not clean"; exit 1; }
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install commitizen
+        run: uv sync --group dev
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute increment argument
+        id: incr
+        run: |
+          if [ "${{ inputs.bump }}" = "auto" ]; then
+            echo "arg=" >> "$GITHUB_OUTPUT"
+          else
+            echo "arg=--increment ${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dry run (preview only)
+        if: ${{ inputs.dry_run }}
+        run: |
+          uv run cz bump --dry-run --yes ${{ steps.incr.outputs.arg }}
+
+      - name: Bump version + changelog, commit + tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          uv run cz bump --yes --changelog ${{ steps.incr.outputs.arg }}
+
+      - name: Push commit + tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git push origin HEAD:main
+          git push origin --tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,6 @@ uv run pytest tests/unit/ -v
 2. Add/adjust tests with behavior changes.
 3. Update docs when user-facing behavior changes.
 4. Do not include private/internal benchmark content in this repository.
+5. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit
+   and PR titles (`feat(scope): …`, `fix(scope): …`, `chore: …`). The release
+   tooling derives the version bump and CHANGELOG from these.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,23 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 
 # =============================================================================
+# Release tooling (commitizen) — drives the `Release (cz bump)` workflow.
+# `cz bump` reads/writes the single version literal in [project] version,
+# regenerates CHANGELOG.md from Conventional Commits, commits, and tags vX.Y.Z.
+# See CONTRIBUTING.md ("Cutting a Release").
+# =============================================================================
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version_provider = "pep621"          # read/write [project] version in place — single source of truth
+tag_format = "v$version"             # matches the v* triggers in publish/release-gate workflows
+update_changelog_on_bump = true
+changelog_incremental = true         # only prepend new sections; never rewrite hand-written history
+major_version_zero = false           # feat: from 0.2.x -> 0.3.0 (real semver, not 0.2.x)
+bump_message = "chore(release): bump version to $new_version"
+annotated_tag = true
+
+# =============================================================================
 # Development Dependencies (PEP 735)
 # =============================================================================
 
@@ -286,6 +303,7 @@ dev = [
     "rank-bm25>=0.2.2",
     "mcp>=0.1.0",
     "build>=1.0.0",
+    "commitizen>=4.0.0",
     "psycopg[binary]>=3.2.0",
     "tolokaforge-adapter-terminal-bench",
     "dev-mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,8 @@ version_provider = "pep621"          # read/write [project] version in place —
 tag_format = "v$version"             # matches the v* triggers in publish/release-gate workflows
 update_changelog_on_bump = true
 changelog_incremental = true         # only prepend new sections; never rewrite hand-written history
-major_version_zero = false           # feat: from 0.2.x -> 0.3.0 (real semver, not 0.2.x)
+major_version_zero = true            # project is pre-1.0/unstable: breaking changes bump the minor
+                                     # (0.2.x -> 0.3.0) and stay in 0.x until we deliberately cut 1.0.0
 bump_message = "chore(release): bump version to $new_version"
 annotated_tag = true
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,30 @@
+"""Tests for the single-sourced package version (tolokaforge.__version__)."""
+
+import pytest
+
+import tolokaforge
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.unit
+class TestVersion:
+    def test_version_is_non_empty_string(self):
+        assert isinstance(tolokaforge.__version__, str)
+        assert tolokaforge.__version__
+
+    def test_version_matches_installed_metadata(self):
+        """In an installed/editable env, __version__ mirrors the distribution
+        metadata (the single source of truth in pyproject.toml). If the package
+        is not installed, the documented fallback is used instead."""
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as pkg_version
+
+        try:
+            expected = pkg_version("tolokaforge")
+        except PackageNotFoundError:
+            expected = "0.0.0+unknown"
+        assert tolokaforge.__version__ == expected
+
+    def test_version_exposed_in_all(self):
+        assert "__version__" in tolokaforge.__all__

--- a/tolokaforge/__init__.py
+++ b/tolokaforge/__init__.py
@@ -1,6 +1,16 @@
 """Universal LLM Tool-Use Benchmarking Harness (ULB-H)"""
 
-__version__ = "0.2.3"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+# Single source of truth: the version literal lives only in pyproject.toml
+# (bumped by `cz bump`); we read it back from the installed distribution
+# metadata so this can never drift out of sync. Falls back gracefully when
+# running from a bare source checkout that has not been installed.
+try:
+    __version__ = _pkg_version("tolokaforge")
+except PackageNotFoundError:  # pragma: no cover - source checkout without an install
+    __version__ = "0.0.0+unknown"
 
 # ---------------------------------------------------------------------------
 # Lazy public API — symbols are loaded on first access, not at import time.

--- a/tolokaforge/__init__.py
+++ b/tolokaforge/__init__.py
@@ -7,6 +7,9 @@ from importlib.metadata import version as _pkg_version
 # (bumped by `cz bump`); we read it back from the installed distribution
 # metadata so this can never drift out of sync. Falls back gracefully when
 # running from a bare source checkout that has not been installed.
+# Note: this reflects the *installed* metadata, so in an editable dev env a
+# version bump is only visible after the next `uv sync`; the built/published
+# wheel always reports the correct version.
 try:
     __version__ = _pkg_version("tolokaforge")
 except PackageNotFoundError:  # pragma: no cover - source checkout without an install

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -507,6 +516,30 @@ wheels = [
 ]
 
 [[package]]
+name = "commitizen"
+version = "4.16.3"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "charset-normalizer" },
+    { name = "colorama" },
+    { name = "decli" },
+    { name = "deprecated" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "prompt-toolkit" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "termcolor" },
+    { name = "tomlkit" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/cc/d87b094ef858c67febcd1d8902352c84b42c9ebc8221d6f2e9d553273358/commitizen-4.16.3.tar.gz", hash = "sha256:5cdca4c02715cc770312f4b505c65a6c39024c73ece41b943bccaf81c44436ed", size = 66772, upload-time = "2026-05-30T06:34:21.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl", hash = "sha256:ce1be39fe98a16725fd0c960daf0f360acac86db7ae8db1e1df8d3541005b5be", size = 88927, upload-time = "2026-05-30T06:34:20.006Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 source = { registry = "https://pypi.org/simple/" }
@@ -685,6 +718,15 @@ wheels = [
 ]
 
 [[package]]
+name = "decli"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/59/d4ffff1dee2c8f6f2dd8f87010962e60f7b7847504d765c91ede5a466730/decli-0.6.3.tar.gz", hash = "sha256:87f9d39361adf7f16b9ca6e3b614badf7519da13092f2db3c80ca223c53c7656", size = 7564, upload-time = "2025-06-01T15:23:41.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/fa/ec878c28bc7f65b77e7e17af3522c9948a9711b9fa7fc4c5e3140a7e3578/decli-0.6.3-py3-none-any.whl", hash = "sha256:5152347c7bb8e3114ad65db719e5709b28d7f7f45bdb709f70167925e55640f3", size = 7989, upload-time = "2025-06-01T15:23:40.228Z" },
+]
+
+[[package]]
 name = "deepdiff"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -694,6 +736,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/20/63dd34163ed07393968128dc8c7ab948c96e47c4ce76976ea533de64909d/deepdiff-9.0.0.tar.gz", hash = "sha256:4872005306237b5b50829803feff58a1dfd20b2b357a55de22e7ded65b2008a7", size = 151952, upload-time = "2026-03-30T05:52:23.769Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/c4/da7089cd7aa4ab554f56e18a7fb08dcfed8fd2ae91fa528f5b1be207a148/deepdiff-9.0.0-py3-none-any.whl", hash = "sha256:b1ae0dd86290d86a03de5fbee728fde43095c1472ae4974bdab23ab4656305bd", size = 170540, upload-time = "2026-03-30T05:52:22.008Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -788,7 +842,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2478,6 +2532,18 @@ requires-dist = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.51"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -3178,6 +3244,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "rank-bm25"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple/" }
@@ -3651,6 +3729,15 @@ wheels = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
 name = "testcontainers"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple/" }
@@ -3759,7 +3846,7 @@ wheels = [
 
 [[package]]
 name = "tolokaforge"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -3829,6 +3916,7 @@ terminal-bench = [
 dev = [
     { name = "black" },
     { name = "build" },
+    { name = "commitizen" },
     { name = "dev-mcp" },
     { name = "docker" },
     { name = "fastapi" },
@@ -3900,6 +3988,7 @@ provides-extras = ["browser", "server", "rag", "office", "terminal-bench", "adap
 dev = [
     { name = "black", specifier = "==25.11.0" },
     { name = "build", specifier = ">=1.0.0" },
+    { name = "commitizen", specifier = ">=4.0.0" },
     { name = "dev-mcp", editable = "tools/dev-mcp" },
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.108.0" },
@@ -4000,6 +4089,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]
@@ -4109,6 +4207,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Cutting a release is currently all-manual and error-prone: edit the version in **two** files (`pyproject.toml` **and** `tolokaforge/__init__.py` — the latter has silently lagged behind before), hand-write a `CHANGELOG.md` section, commit, and push a `vX.Y.Z` tag.

This PR replaces that with a **human-initiated, one-click** release: a maintainer picks the bump (or lets it be derived from commit history) and the tooling produces the version bump, the CHANGELOG, and the tag. It also single-sources the version so it can never drift again, and fixes the Release Gate, which was failing on every tag.

Closes #40.

---

## How it fits together (3 workflows, 3 moments)

The flow is intentionally **decoupled**. The new workflow only *prepares and tags* a release — it publishes nothing itself. Publishing was already wired to "a `v*` tag appeared", so the new workflow just produces that tag correctly and the **existing, unchanged** publish pipeline takes over.

```
   merge PRs                  click "Release"            the tag appears
       │                            │                           │
       ▼                            ▼                           ▼
  ci.yml (CI)            release.yml  (NEW)         publish-tolokaforge.yml (unchanged)
  on: PR / push          on: workflow_dispatch       on: push tag v*
  ── lint + tests        ── cz bump ──┐              ── uv build + publish to PyPI
                                       │              ── create GitHub Release
                         pushes tag v* ┘                        +
                                       └───────────▶  release-gate.yml
                                                      on: push tag v*
                                                      ── full test battery
```

### Why separate workflows instead of one?

This PR does **not** add a second step — `publish-tolokaforge.yml` (build → PyPI → GitHub Release, on a `v*` tag) already exists and has shipped 0.2.0–0.2.3. The new `release.yml` doesn't duplicate or absorb it; it just *produces the tag* the existing pipeline already listens for. The choice was "plug into the working publish pipeline" vs "rewrite a security-sensitive, battle-tested workflow to also bump versions." The split is kept on purpose because:

- **The tag is a universal trigger.** Everything downstream (PyPI publish, GitHub Release, Release Gate) keys off one fact — *a `v*` tag appeared*. A release can therefore be initiated by any path that creates a tag (this workflow, a manual hotfix tag, an old-commit patch) and publishing behaves identically. Fusing publish into `release.yml` would make that one workflow the only possible way to ever publish.
- **Separation of privilege (a security boundary).** The two jobs need different, incompatible permissions: `release.yml` needs `contents: write` (push the commit + tag to `main`) but **no** PyPI rights; `publish-tolokaforge.yml` needs `id-token: write` (OIDC trusted publishing) under the protected `release` environment but does **not** push to `main`. Separate workflows means each runs with least privilege; a fused one would hold both write-to-main and PyPI-publish rights in a single, larger blast radius.
- **The irreversible step keeps a clean approval gate.** A PyPI publish can't be undone. Today only the *publish* job sits behind the protected `release` environment (which can require a human click). Fusing bump+publish would force that approval to happen *before* the version is even bumped, or lose the gate.
- **Simpler failure recovery.** If a publish fails (PyPI/network hiccup), you re-run just the publish job against the existing tag — no re-bump, no new commit/tag. A fused workflow leaves a half-done, already-tagged release that's awkward to resume.
- **Industry-standard shape.** "Tag → publish" decoupling is how PyPI's publishing guide, release-please, and semantic-release examples are all structured.

The cost is one extra concept: **the tag is the hand-off point** between "prepare the release" and "publish it." That indirection is the price for the cleaner privilege boundaries, safer recovery, and zero rewrite of the OIDC publish logic above.

---

## Changes

### 1. New workflow — `.github/workflows/release.yml`
`workflow_dispatch` with a `bump` choice (`auto`/`patch`/`minor`/`major`) and a `dry_run` toggle. Steps:

| Step | Does | Why |
|---|---|---|
| `checkout` (full history + tags, `ref: main`) | fetches all commits/tags | commitizen needs history since the last tag to compute the bump + changelog |
| Guard | aborts if the tree is dirty | never release from a dirty state |
| `uv sync --group dev` | installs commitizen | it's a dev dep now |
| Compute increment | maps the dropdown → `--increment` (or nothing for `auto`) | |
| **Dry run** (if `dry_run=true`) | `cz bump --dry-run` — prints next version + changelog, **changes nothing** | preview before committing |
| **Bump** (if `dry_run=false`) | `cz bump` — edits `pyproject.toml`, prepends `CHANGELOG.md`, makes the `chore(release): …` commit, creates the `vX.Y.Z` tag | the actual release prep |
| Push | **atomic** push of the commit + tag (`git push --atomic`) | the tag push triggers publish + gate; atomic means both refs land or neither does |

Safety details: the bump commit + tag are pushed atomically, so a rejected tag push can never leave a release commit on `main` with no tag. If `auto` finds nothing releasable since the last tag, the run exits cleanly with a notice instead of failing.

### 2. Single-source the version
`tolokaforge.__version__` now reads from `importlib.metadata` (with a `PackageNotFoundError` fallback for bare source checkouts) instead of a hardcoded literal. `pyproject.toml` `[project] version` becomes the **one** source of truth — `cz bump` edits only that, and `__version__` can never lag again. (In an editable dev env `__version__` reflects the installed metadata, so it updates after the next `uv sync`; the built/published wheel always reports the correct version.)

### 3. `[tool.commitizen]` config + dev dep
`pep621` provider (reads/writes `[project] version` in place — no second literal), `v$version` tags (matches the publish/gate triggers), `changelog_incremental` (only prepend; never rewrite hand-written history), and `major_version_zero = true` (see versioning behavior below). `commitizen` added to the dev dependency group.

### 4. Fix `release-gate.yml`
The gate was **red on every release** (it failed on 0.2.2 and 0.2.3): three steps called scripts that were removed from the repo, hitting `exit 127`:
- `Run public examples end-to-end` → `scripts/tests/run_public_examples_smoke.sh` (gone)
- `Summarize public examples and enforce thresholds` → `scripts/tests/summarize_public_examples.py` (gone)
- the artifact upload that consumed their output

`ci.yml` had **already disabled these exact steps** (see its lines ~123–139 / ~189–196, commented out with a `TODO`: the smoke script needs `tolokaforge run`, which now requires a Docker runtime). The gate just never got the same treatment. This PR brings the gate back in line with CI — every remaining step references real, present files, so the gate goes green.

### 5. Tests + docs
- `tests/unit/test_version.py` — asserts `__version__` is a non-empty string, matches the installed distribution metadata, and is exported in `__all__`.
- `CONTRIBUTING.md` — added the Conventional Commits requirement (contributor-facing — the tooling derives the bump + changelog from commit messages). The maintainer release runbook lives in the workflow's inline header comment for now; a dedicated `RELEASING.md` can come later.

---

## Versioning behavior

The bump follows Semantic Versioning (`MAJOR.MINOR.PATCH`), driven by Conventional Commits:

| Commit type | Bump | Example |
|---|---|---|
| `fix:` | patch | `0.2.3 → 0.2.4` |
| `feat:` | minor | `0.2.3 → 0.3.0` |
| `feat!:` / `BREAKING CHANGE:` | minor (stays in `0.x`) | `0.2.3 → 0.3.0` |

`major_version_zero = true` reflects that the engine API is still pre-1.0 / unstable: a breaking change bumps the **minor** and keeps us in `0.x` rather than auto-promoting to `1.0.0`. We will cut `1.0.0` **deliberately** (an explicit `bump=major`) once the API is declared stable. A maintainer can always override the derived bump by choosing `patch`/`minor`/`major` explicitly when running the workflow.

---

## The two test layers (orientation for review)

There are **two distinct test gates** serving different purposes:

- **CI (`ci.yml`) — untouched by this PR.** Runs on every PR / push to `main`; protects code *going into* `main` (lint + smoke on PRs, fuller suites on push/nightly/label). These are the checks running on this PR.
- **Release Gate (`release-gate.yml`) — what this PR fixes.** Runs on a `v*` tag; re-runs the full battery against the exact tagged commit as a final pre-publish confidence check.

The Release Gate and the publish workflow both trigger off the tag **independently** — `publish` does **not** depend on the gate passing. So the gate is a confidence signal, **not** a hard precondition for the PyPI upload (which is why 0.2.2/0.2.3 still published while the gate was red). This PR keeps that existing design and only un-breaks the gate. **Whether to couple them** (block publish on the gate) is a separate decision tracked in **#42**.

---

## How to release (after merge)

Actions → **Release (cz bump)** → Run workflow → pick the increment. Or:
```bash
gh workflow run release.yml -f bump=minor
gh workflow run release.yml -f bump=auto -f dry_run=true   # preview only
```

---

## Verification done locally

- `tolokaforge.__version__` resolves to `0.2.3` from the installed package; bare-checkout fallback → `0.0.0+unknown`; `tests/unit/test_version.py` passes.
- `cz bump --dry-run --increment {patch,minor}` → `0.2.4` / `0.3.0`, tag `v0.2.4` / `v0.3.0`, message `chore(release): bump version to …`.
- `uv build` still embeds the correct version (hatchling-static + commitizen-pep621 are compatible).
- All three workflow YAMLs parse; `ruff` + `black` + `pre-commit` clean on changed files.

---

## Reviewer notes / call-outs

- **CHANGELOG style** changes going forward: new sections render in commitizen's keep-a-changelog style (`### Feat` / `### Fix` bullets); existing hand-written history is preserved verbatim (`changelog_incremental`). Recommend one real (non-dry) `cz bump` on a throwaway branch before the first production release to eyeball the merge against the current `CHANGELOG.md` format.
- **Push permissions:** the workflow pushes the bump commit + tag to `main`. If branch protection blocks the `github-actions` bot (cf. allstar issue #31), add a ruleset bypass for it, or supply a repo-scoped `RELEASE_PAT` and uncomment the `token:` line in `release.yml`. Worth confirming before the first release.
- **Incidental `uv.lock` diffs:** re-locking to add `commitizen` also corrected two stale entries that were already wrong on `main` — the `tolokaforge` editable version (`0.2.0 → 0.2.3`) and an `exceptiongroup` marker (`<'3.13' → <'3.11'`). Both are benign re-resolution artifacts.

## Follow-up

- #42 — decide whether the Release Gate should block PyPI publishing.