### PR TITLE
ci(release): push the release commit + tag with a deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,12 @@ jobs:
         with:
           fetch-depth: 0      # full history + tags so commitizen can derive the bump
           ref: main           # always release from main
-          # If a branch/tag protection rule blocks the github-actions bot from
-          # pushing to main, provide a repo-scoped token here and configure a
-          # ruleset bypass for it (see CONTRIBUTING.md):
-          # token: ${{ secrets.RELEASE_PAT }}
+          # The `main` branch ruleset requires a PR + 1 approval for every push and
+          # only allows a *deploy key* to bypass it. `ssh-key` makes actions/checkout
+          # set `origin` to the SSH URL and authenticate as the deploy key, so the
+          # bump commit + tag can be pushed straight to main. See CONTRIBUTING.md and
+          # the PR that introduced this for the full rationale.
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Guard — main must be clean
         run: |


### PR DESCRIPTION
## What

Points the `Release (cz bump)` workflow's `actions/checkout` at a **deploy key** (`secrets.RELEASE_SSH_KEY`) so it can push the version-bump commit and the `vX.Y.Z` tag to `main`. Replaces the inaccurate `RELEASE_PAT` placeholder left in #41.

```yaml
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0
          ref: main
          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
```

## Why this is necessary (the core problem)

The release flow only works if the workflow can push the bump commit + tag **directly to `main`** — the version literal in `pyproject.toml` has to advance on `main`, and the tag is what triggers PyPI publishing. But `main` is governed by an **active ruleset** that blocks exactly that kind of push:

| Ruleset rule on `main` | Effect |
|---|---|
| `pull_request` (`required_approving_review_count: 1`) | **every** change to `main` must go through a PR with 1 approval — no direct pushes |
| `non_fast_forward`, `deletion` | no force-pushes, no branch deletion |
| `bypass_actors` | **only a Deploy Key** may bypass the above |

So a direct push from CI is rejected for every actor *except a deploy key*. Concretely:

- **Default `GITHUB_TOKEN` (github-actions bot)** — not in the bypass list → push rejected.
- **A user PAT** — authenticates as a user who also isn't a bypass actor → push rejected. (This is why the `RELEASE_PAT` note from #41 was wrong, and it's corrected here.)
- **A deploy key with write access** — *is* the configured bypass actor → push succeeds. ✅

## Decision: deploy key now, GitHub App later

This is **not** the most secure option in absolute terms — that would be a **GitHub App** minting short-lived (~1h) tokens per run. The security ordering is: GitHub App 🥇 > deploy key 🥈 > user PAT 🥉.

We deliberately chose the **deploy key** because:
- It's the **least-setup, least-privilege** path for a *single* repo — the ruleset *already* bypasses deploy keys, so no ruleset edit is needed, and the key is scoped to this one repo (narrower than a user PAT).
- A GitHub App is **overkill for one repo today**; it earns its keep when release automation expands to other public facing repos.

The accepted tradeoff is that a deploy key is a **long-lived secret**. The upgrade to a GitHub App — plus optional hardening (a commit-file allowlist guard; scoping the credential to a protected environment).

## How it works

`ssh-key:` makes `actions/checkout` install the private key on the runner and set the `origin` remote to the **SSH** URL (`git@github.com:…`). The workflow's existing `git push --atomic origin HEAD:main refs/tags/vX.Y.Z` then authenticates **as the deploy key**, which the ruleset lets through. No other workflow step changes.

## Can a stray file reach `main`?

No — by construction:
- `git push` only ever transmits **commits**, never uncommitted working-tree changes.
- `cz bump` commits **only** the files it edits (`pyproject.toml` via the pep621 provider + `CHANGELOG.md`) via a targeted `git add` — so even if an earlier step dirties e.g. `uv.lock`, that is never committed and never pushed.
- The ruleset's `non_fast_forward` rule means the push can only fast-forward `main` — history can't be rewritten.

An explicit allowlist guard that *fails the run* if the bump commit ever touches anything outside `{pyproject.toml, CHANGELOG.md}` is captured as optional hardening in #45.

## Required configuration (already done)

- A **deploy key** named `tolokaforge-release` added under repo **Settings → Deploy keys** with **Allow write access** enabled (the public half of an `ed25519` keypair).
- The private half stored as the repo Actions secret **`RELEASE_SSH_KEY`**.

## Verification plan

1. Actions → **Release (cz bump)** → Run workflow with `dry_run = true` → confirms checkout/auth and prints the next version without pushing.
2. Run again with `dry_run = false` → confirm the push to `main` succeeds, the `chore(release): …` commit + `vX.Y.Z` tag appear, and `publish-tolokaforge.yml` + `release-gate.yml` fire off the tag.

## Security notes

- The deploy key is **repo-scoped** and grants only git read/write to this one repository — narrower than a user PAT.
- It's a long-lived secret; rotate by generating a new keypair and replacing both the deploy key and the `RELEASE_SSH_KEY` secret. The private key never leaves GitHub's secret store.
