### PR TITLE
feat(llm): register 7 arena-lineup models with preset routing

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -803,6 +803,69 @@ _ALL: list[MC] = [
         ),
     ),
     # -----------------------------------------------------------------
+    # DeepSeek V4-Flash — lighter/cheaper sibling of deepseek-v4-pro on
+    # the OpenRouter route, shares the existing ``*deepseek-v4*`` preset
+    # (openrouter_dict_stringify_recovery). Live-certified 2026-06-05 via
+    # ``pytest tests/integration/llm/ -k deepseek-v4-flash`` (17 required
+    # passed, 3 known_unsupported). STRICTLY STRONGER than the v4-pro
+    # sibling: it additionally passes DECIMAL_FIELD_TOOL_CALL,
+    # THINKING_EMITS_BLOCKS and IMPLICIT_PROMPT_CACHING live, which v4-pro
+    # marks known_unsupported — re-tested per docs/ADD_NEW_MODEL.md (the
+    # caching ratchet forced the implicit-cache promotion), not copied.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__deepseek_deepseek-v4-flash",
+        provider="openrouter",
+        name="deepseek/deepseek-v4-flash",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                # Implicit auto-cache IS observable on this route: a warm
+                # 2-call ~8 k-token probe reported cache_read_input_tokens
+                # =8192 on call 2 (cold call 1 = 0). Promoted to required
+                # per test_implicit_prompt_caching_unsupported_ratchet;
+                # DeepSeek caches in aggregate (~80%) in production. Cold
+                # single-shot probes may read 0. Verified live 2026-06-05.
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Reasoning surfaces as an UNSIGNED summary on the
+                # OpenRouter route: signed-block replay has no source ("no
+                # signed blocks on turn 1") and the unsigned codec's
+                # ``encode_for_replay`` path is not wired for the v4 route
+                # (assistant dict carries no ``reasoning_details``). Same
+                # posture as the v4-pro sibling. Verified live 2026-06-05.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No Anthropic-style ephemeral cache: call 1 created 0
+                # cache_creation_input_tokens (the OpenRouter DeepSeek
+                # route exposes no explicit cache-control markers). This
+                # is distinct from IMPLICIT_PROMPT_CACHING (provider
+                # auto-cache), which IS observable and is declared
+                # ``required`` above. Verified live 2026-06-05.
+                C.PROMPT_CACHING,
+            }
+        ),
+    ),
+    # -----------------------------------------------------------------
     # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning line on
     # the OpenRouter route. Live-certified 2026-06-03 via
     # ``pytest tests/integration/llm/ -k deepseek-v3.2-exp`` (14 passed,
@@ -1002,6 +1065,308 @@ _ALL: list[MC] = [
                 # No implicit upstream cache surfaced on the OpenRouter
                 # google/gemini-* routes — same as Flash.
                 C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # =================================================================
+    # Arena lineup refresh (2026-06). Six models, live-certified
+    # 2026-06-05 via ``pytest tests/integration/llm/ -k <model>``.
+    # Per-model preset routing lives in model_presets.yaml; each entry
+    # documents which capabilities were demoted to ``known_unsupported``
+    # and why. The universal demotions across this cohort are PROMPT_
+    # CACHING (no Anthropic-style ephemeral cache on these OpenRouter
+    # routes) and the signed/unsigned thinking-replay pair (OpenAI-codec
+    # routes have a no-op replay path).
+    # =================================================================
+    # GLM-5.1 (Zhipu / Z.AI via OpenRouter). Routes through the shared
+    # ``openrouter_dict_stringify_recovery`` preset: it stringified the
+    # discriminated-union ``item`` on the default route, which json_coerce
+    # decodes, and the openai codec surfaces its reasoning summary so
+    # THINKING_EMITS_BLOCKS passes. Implicit auto-cache observed cold.
+    # 17 required / 3 known_unsupported. Live-certified 2026-06-05.
+    MC(
+        model_id="openrouter__z-ai_glm-5.1",
+        provider="openrouter",
+        name="z-ai/glm-5.1",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # No Anthropic-style ephemeral cache markers on this route.
+                C.PROMPT_CACHING,
+                # Reasoning surfaces only as an unsigned summary via the
+                # openai codec: no signed blocks to replay, and the codec's
+                # replay path is a no-op. Verified live 2026-06-05.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
+    # Mistral-Medium-3.5 (Mistral AI via OpenRouter). Clean tool-caller on
+    # the default route — dict-map, discriminated-union, decimal all
+    # round-trip natively, so no preset is needed. It is a NON-reasoning
+    # model (0 reasoning tokens live), so the thinking capabilities are
+    # genuinely out of scope. 15 required / 5 known_unsupported.
+    # Live-certified 2026-06-05.
+    MC(
+        model_id="openrouter__mistralai_mistral-medium-3-5",
+        provider="openrouter",
+        name="mistralai/mistral-medium-3-5",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Non-reasoning model: emits no structured reasoning at
+                # all (0 reasoning tokens live 2026-06-05), so neither the
+                # emit nor the replay capabilities apply.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No ephemeral cache markers and the 2-call ~8 k-token
+                # auto-cache probe read cached_tokens=0 on both calls.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # Gemma-4-31B-IT (Google open-weights via OpenRouter). Routes through
+    # the ``gemma`` preset (Gemini *schema* sanitizer, no gemini reasoning
+    # codec): the dict-map-to-array transform fixes DICT_MAP_TOOL_CALL,
+    # but the discriminated union still fails because the model substitutes
+    # ``title`` for the registered ``subject`` even on the flattened
+    # schema — a field-name-adherence gap, not a schema-construct one, so
+    # it stays known_unsupported. Non-reasoning model. 14 required /
+    # 6 known_unsupported. Live-certified 2026-06-05.
+    MC(
+        model_id="openrouter__google_gemma-4-31b-it",
+        provider="openrouter",
+        name="google/gemma-4-31b-it",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Emits ``title`` instead of the registered ``subject`` on
+                # the union branch even under the flattened Gemini schema —
+                # genuine field-name gap, not a construct the sanitizer can
+                # rewrite. Verified live 2026-06-05.
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                # Non-reasoning model (0 reasoning tokens live).
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No ephemeral cache markers; auto-cache probe read 0.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # Nemotron-3-Super-120B-A12B (NVIDIA via OpenRouter). Routes through
+    # the shared ``openrouter_dict_stringify_recovery`` preset: it emits
+    # the discriminated-union ``item`` as a native dict on some calls and a
+    # JSON-encoded string on others (live 2026-06-05), so it needs
+    # json_coerce to make DISCRIMINATED_UNION_TOOL_CALL reliable. It is an
+    # adaptive reasoner that intermittently returns no reasoning at all
+    # (``reasoning=None`` on a re-run), so THINKING_EMITS_BLOCKS is not
+    # reliable enough for ``required`` — the openai codec still surfaces
+    # the summary in logs when it does reason. 15 required /
+    # 5 known_unsupported. Live-certified 2026-06-05.
+    MC(
+        model_id="openrouter__nvidia_nemotron-3-super-120b-a12b",
+        provider="openrouter",
+        name="nvidia/nemotron-3-super-120b-a12b",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Adaptive reasoner: returns no structured reasoning on
+                # some calls (reasoning=None live 2026-06-05), so emit is
+                # not reliable. Replay is a no-op on the openai codec.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No ephemeral cache markers; auto-cache probe read 0.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # GPT-OSS-120B (OpenAI open-weights via OpenRouter). The ``gpt_oss``
+    # preset adds only the openai reasoning codec (THINKING_EMITS_BLOCKS
+    # passes). It substitutes synonyms for registered field names
+    # (``title`` for ``subject``, ``quantity`` for ``qty``) that persists
+    # even under the Gemini schema sanitizer's oneOf-flatten +
+    # dict-map-to-array, so both schema caps are genuine model gaps, not
+    # construct gaps — declared known_unsupported rather than papered over
+    # with a sanitizer that gives no lift. 14 required / 6 known_unsupported.
+    # Live-certified 2026-06-05.
+    MC(
+        model_id="openrouter__openai_gpt-oss-120b",
+        provider="openrouter",
+        name="openai/gpt-oss-120b",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Emits ``quantity`` for ``qty`` / ``title`` for
+                # ``subject`` — synonym substitution that survives the
+                # Gemini schema flatten. Genuine field-name gap. Verified
+                # live 2026-06-05.
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                # openai-codec reasoning is an unsigned summary, no-op
+                # replay.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                # No ephemeral cache markers; auto-cache probe read 0.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # HY3-Preview (Tencent Hunyuan 3 via OpenRouter). Routes through the
+    # shared ``openrouter_dict_stringify_recovery`` preset (json_coerce
+    # decodes its stringified tool args; the openai codec surfaces its
+    # reasoning summary so THINKING_EMITS_BLOCKS passes reliably). Two
+    # tool-call capabilities are intermittently unreliable across repeated
+    # live runs (2026-06-05), so they are known_unsupported rather than a
+    # flaky merge gate. 14 required / 6 known_unsupported.
+    MC(
+        model_id="openrouter__tencent_hy3-preview",
+        provider="openrouter",
+        name="tencent/hy3-preview",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Intermittently answers in prose instead of emitting the
+                # tool call ("no tool call returned" on ~2 of 5 live runs
+                # 2026-06-05) — same unreliable posture as the DeepSeek
+                # Decimal route. Not a reliable required gate.
+                C.DECIMAL_FIELD_TOOL_CALL,
+                # Mostly round-trips the union (json_coerce handles the
+                # stringified calls) but intermittently renames the branch
+                # field (``title`` for the registered ``subject``) the way
+                # gpt-oss / gemma do — a field-name gap json_coerce cannot
+                # fix, on ~1 of 5 live runs 2026-06-05. Not reliable.
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                # No ephemeral cache markers, and the 2-call ~8 k-token
+                # auto-cache probe read cached_tokens=0 cold. Paired with
+                # test_implicit_prompt_caching_unsupported_ratchet, which
+                # promotes IMPLICIT_PROMPT_CACHING the day a 2-call probe
+                # observes caching. Verified live 2026-06-05.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                # openai-codec reasoning is an unsigned summary, no-op
+                # replay.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
             }
         ),
     ),

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -806,12 +806,14 @@ _ALL: list[MC] = [
     # DeepSeek V4-Flash — lighter/cheaper sibling of deepseek-v4-pro on
     # the OpenRouter route, shares the existing ``*deepseek-v4*`` preset
     # (openrouter_dict_stringify_recovery). Live-certified 2026-06-05 via
-    # ``pytest tests/integration/llm/ -k deepseek-v4-flash`` (17 required
-    # passed, 3 known_unsupported). STRICTLY STRONGER than the v4-pro
-    # sibling: it additionally passes DECIMAL_FIELD_TOOL_CALL,
-    # THINKING_EMITS_BLOCKS and IMPLICIT_PROMPT_CACHING live, which v4-pro
-    # marks known_unsupported — re-tested per docs/ADD_NEW_MODEL.md (the
-    # caching ratchet forced the implicit-cache promotion), not copied.
+    # ``pytest tests/integration/llm/ -k deepseek-v4-flash`` (16 required,
+    # 4 known_unsupported). Stronger than the v4-pro sibling on
+    # DECIMAL_FIELD_TOOL_CALL and THINKING_EMITS_BLOCKS (both pass reliably
+    # here, both known_unsupported on v4-pro) — re-tested per
+    # docs/ADD_NEW_MODEL.md, not copied. Caching matches v4-pro (both ku):
+    # an initial warm probe promoted IMPLICIT_PROMPT_CACHING, but a clean
+    # cold 2-call probe reads 0, so it stays known_unsupported with the
+    # ratchet guarding it.
     # -----------------------------------------------------------------
     MC(
         model_id="openrouter__deepseek_deepseek-v4-flash",
@@ -830,13 +832,6 @@ _ALL: list[MC] = [
                 C.DISCRIMINATED_UNION_TOOL_CALL,
                 C.DECIMAL_FIELD_TOOL_CALL,
                 C.THINKING_EMITS_BLOCKS,
-                # Implicit auto-cache IS observable on this route: a warm
-                # 2-call ~8 k-token probe reported cache_read_input_tokens
-                # =8192 on call 2 (cold call 1 = 0). Promoted to required
-                # per test_implicit_prompt_caching_unsupported_ratchet;
-                # DeepSeek caches in aggregate (~80%) in production. Cold
-                # single-shot probes may read 0. Verified live 2026-06-05.
-                C.IMPLICIT_PROMPT_CACHING,
                 C.USAGE_METRICS_POPULATED,
                 C.COST_USD_POPULATED,
                 C.TOOL_NAME_DISCIPLINE,
@@ -857,11 +852,18 @@ _ALL: list[MC] = [
                 C.UNSIGNED_THINKING_REPLAY,
                 # No Anthropic-style ephemeral cache: call 1 created 0
                 # cache_creation_input_tokens (the OpenRouter DeepSeek
-                # route exposes no explicit cache-control markers). This
-                # is distinct from IMPLICIT_PROMPT_CACHING (provider
-                # auto-cache), which IS observable and is declared
-                # ``required`` above. Verified live 2026-06-05.
+                # route exposes no explicit cache-control markers).
                 C.PROMPT_CACHING,
+                # Implicit auto-cache is NOT reliably observable on a clean
+                # 2-call ~8 k-token probe: a cold run reads
+                # cache_read_input_tokens=0 (an earlier warm probe read
+                # 8192, but that was contaminated by back-to-back runs).
+                # DeepSeek caches in aggregate (~80%) in production. Same
+                # posture as the v4-pro sibling; paired with
+                # test_implicit_prompt_caching_unsupported_ratchet, which
+                # flips it back to required the day a clean 2-call probe
+                # observes caching. Verified live cold 2026-06-05.
+                C.IMPLICIT_PROMPT_CACHING,
             }
         ),
     ),

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -125,6 +125,15 @@ presets:
   # a bespoke codec for these routes; ``openai`` codec is the safe baseline
   # — it surfaces ``reasoning_content`` summaries via OpenAI-canonical fields
   # without making structural assumptions.
+  # z-ai/glm-5.1, tencent/hy3-preview and nvidia/nemotron-3-super join
+  # this preset (arena lineup refresh 2026-06): each emits the
+  # discriminated-union ``item`` as a JSON-encoded string that
+  # JsonCoerceResponse decodes — glm/hy3 every call, nemotron
+  # intermittently (native dict on some calls, stringified on others;
+  # without json_coerce the stringified calls fail, so it needs this
+  # preset to make the capability reliable). All three also surface a
+  # reasoning_content summary the ``openai`` codec lands in the logs.
+  # Live 2026-06-05.
   openrouter_dict_stringify_recovery:
     match:
       - "xiaomi/mimo*"
@@ -133,6 +142,12 @@ presets:
       - "*kimi-k2*"
       - "deepseek/deepseek-v4*"
       - "*deepseek-v4*"
+      - "z-ai/glm-5*"
+      - "*glm-5*"
+      - "tencent/hy3*"
+      - "*hy3-preview*"
+      - "nvidia/nemotron*"
+      - "*nemotron-*"
     schema_sanitizer: passthrough
     response_policy: json_coerce
     prompt_policy: dict_map_hints
@@ -206,6 +221,36 @@ presets:
     # gemini-3.1-pro-preview: registered field names round-trip
     # correctly under this routing. See gotcha #21 in AGENTS.md
     # for the failure surface the routing closes.
+    schema_sanitizer: gemini
+    response_policy: array_dict_map
+
+  # ---- Arena lineup refresh (2026-06) ----------------------------------
+  # GPT-OSS 120B (OpenAI open-weights via OpenRouter) — NOT the GPT-5 API
+  # line, so it does not match ``openai_gpt5``. Only non-default policy is
+  # the ``openai`` reasoning codec so its reasoning_content summary lands
+  # in the trajectory logs (observability only). It substitutes synonyms
+  # for registered field names (``title`` for ``subject``, ``quantity``
+  # for ``qty``) and this persists even under the Gemini schema
+  # sanitizer's oneOf-flatten + dict-map-to-array (verified live
+  # 2026-06-05), so that is a genuine model gap, NOT a schema-construct
+  # one: DICT_MAP_TOOL_CALL + DISCRIMINATED_UNION_TOOL_CALL are declared
+  # ``known_unsupported`` in registry.py rather than papered over with a
+  # sanitizer that gives no lift but risks regressing the calls that pass.
+  gpt_oss:
+    match:
+      - "openai/gpt-oss*"
+      - "*gpt-oss*"
+    reasoning_codec: openai
+
+  # Gemma 4 (Google open-weights via OpenRouter) — NOT the Gemini API line
+  # (no reasoning_details envelope), so it borrows the Gemini *schema*
+  # sanitizer (oneOf-flatten + $ref-inline + dict-map-to-array) WITHOUT the
+  # gemini reasoning codec. Gemma surfaces no structured reasoning, so no
+  # reasoning_codec is set. Live 2026-06-05.
+  gemma:
+    match:
+      - "google/gemma*"
+      - "*gemma-*"
     schema_sanitizer: gemini
     response_policy: array_dict_map
 

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1610,9 +1610,9 @@
       "output": 0.57
     },
     "tencent/hy3-preview": {
-      "input": 0.066,
-      "output": 0.26,
-      "cache_read": 0.029
+      "input": 0.063,
+      "output": 0.21,
+      "cache_read": 0.021
     },
     "thedrummer/cydonia-24b-v4.1": {
       "input": 0.3,


### PR DESCRIPTION
## Summary

Registers the **2026-06 arena lineup refresh** (7 new models) in the engine's integration registry, with per-model preset routing. Live-certified 2026-06-05 via `pytest tests/integration/llm/ -k <model>`. Files:

- `tests/integration/llm/registry.py` — 7 `ModelCertificate`s
- `tolokaforge/core/data/model_presets.yaml` — preset routing
- `tolokaforge/core/data/pricing.json` — one correction (`tencent/hy3-preview`; the other 6 slugs already matched OpenRouter)

Per [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md), no version bump / CHANGELOG here — those land at release time, mirroring the `deepseek-v3.2-exp` registration → release split (#36 → #39).

## Models

| Model | required / ku | Preset | Notes |
|---|---|---|---|
| `deepseek/deepseek-v4-flash` | 16 / 4 | `openrouter_dict_stringify_recovery` | stronger than v4-pro on decimal + emits; caching ku (cold 2-call probe = 0, matches v4-pro) |
| `z-ai/glm-5.1` | 17 / 3 | `openrouter_dict_stringify_recovery` | `json_coerce` fixes stringified union; openai codec → emits; implicit-cache observed cold |
| `mistralai/mistral-medium-3-5` | 15 / 5 | default | clean tool-caller; non-reasoning model |
| `nvidia/nemotron-3-super-120b-a12b` | 15 / 5 | `openrouter_dict_stringify_recovery` | intermittently stringifies union → `json_coerce`; adaptive reasoner → emits ku |
| `google/gemma-4-31b-it` | 14 / 6 | `gemma` (Gemini schema sanitizer) | dict-map fixed by schema; union field-rename → ku; non-reasoning |
| `openai/gpt-oss-120b` | 14 / 6 | `gpt_oss` (openai codec) | synonym field-rename on dict-map + union → ku |
| `tencent/hy3-preview` | 14 / 6 | `openrouter_dict_stringify_recovery` | union + decimal intermittently unreliable → ku |

Universal `known_unsupported` across the cohort: `PROMPT_CACHING` (no Anthropic-style ephemeral cache on these routes) and the signed/unsigned thinking-replay pair (OpenAI-codec routes have a no-op replay path).

## Preset changes

- **`openrouter_dict_stringify_recovery`** — added `z-ai/glm-5*`, `tencent/hy3*`, `nvidia/nemotron*`. Each emits the discriminated-union `item` as a JSON-encoded string (glm/hy3 consistently, nemotron intermittently) that `JsonCoerceResponse` decodes; the `openai` codec lands their reasoning summaries in the trajectory logs.
- **`gpt_oss`** (new) — `openai` reasoning codec only. The Gemini schema sanitizer gave no lift (gpt-oss substitutes `title`/`quantity` for `subject`/`qty` even on a flattened schema — a model gap, not a construct gap), so it is not imposed.
- **`gemma`** (new) — Gemini *schema* sanitizer (no gemini reasoning codec, gemma emits no structured reasoning). The dict-map-to-array transform fixes `DICT_MAP_TOOL_CALL`; the union field-rename is a model gap.

## Methodology / reliability

`known_unsupported` follows the live result, never a hunch (per `docs/ADD_NEW_MODEL.md`). Each model was run all-`required` first to discover failures, then the hard capabilities (`decimal_field`, `dict_map`, `discriminated_union`, `thinking_emits_blocks`) were re-run **3×** to separate genuine support from flakiness. A capability is `required` only if it passes reliably; intermittently-failing ones (hy3 union ~80% with field-rename, hy3 decimal ~60%, nemotron emits) are `known_unsupported`, consistent with the DeepSeek-Decimal precedent. Distinction applied: a **wrong-output** defect (field-rename) or a **high-rate** no-tool-call → ku; a capability that yields correct output with only a **sporadic** (~1/7) no-tool-call blip stays `required` (e.g. deepseek-v4-flash union, 7/8 live). Transient litellm provider errors (instant mass-fail) were excluded.

## Live certification evidence

`pytest tests/integration/llm/ -k <model>` — green, 0 genuine failures (skipped = the model's `known_unsupported` capabilities, which auto-skip):

```
deepseek/deepseek-v4-flash          18 passed, 4 skipped
z-ai/glm-5.1                        18 passed, 3 skipped
mistralai/mistral-medium-3-5        17 passed, 5 skipped
nvidia/nemotron-3-super-120b-a12b   17 passed, 5 skipped
google/gemma-4-31b-it               15 passed, 7 skipped
openai/gpt-oss-120b                 15 passed, 7 skipped
tencent/hy3-preview                 15 passed, 7 skipped
```

Plus `tests/canonical/test_capability_registry.py` (9 passed), preset routing unit/canonical tests green, `ruff` clean.

## Review refinements (post-initial-push)

Two corrections surfaced by re-verification and committed on top:

1. **`fix(pricing)`** — `tencent/hy3-preview` was overstated (output 0.26 vs OpenRouter 0.21, ~24% high); corrected input/output/cache_read to the live OpenRouter values. All 7 slugs now match exactly.
2. **`fix(llm)`** — `deepseek-v4-flash` `IMPLICIT_PROMPT_CACHING` demoted `required → known_unsupported`. A clean **cold** 2-call probe reads `cache_read_input_tokens=0` (matching v4-pro); the initial promotion was driven by a **warm** probe (8192) contaminated by back-to-back runs. Now ku + the unsupported-ratchet guard, exactly like v4-pro.

Note: deepseek-v4-flash exhibits a low-rate sporadic empty-response (a random tool-calling capability occasionally returns no tool call, ~1 per full run); the affected capabilities are genuinely supported and remain `required` — this is a model reliability characteristic, not a per-capability gap.

## Follow-ups (separate)

- Release: `__version__` / `pyproject.toml` bump + CHANGELOG entry.
- Eval branch (tasks repo): per-domain + sampled configs, launch-lineup, and the collector `frontend.yaml` entries for these 7 models. For `openai/gpt-oss-120b:nitro`, confirm the cost lookup resolves (pricing.json keys the base slug; the `*gpt-oss*` preset glob already matches the `:nitro` variant).
