### PR TITLE
fix(adapters): restore bundle_writer so `adapter convert` works

### DIFF
--- a/docs/CONVERSION_LAYER.md
+++ b/docs/CONVERSION_LAYER.md
@@ -4,8 +4,9 @@
 
 ## Overview
 
-The conversion layer allows external adapter formats (Tau-bench, TLK MCP Core)
-to be converted into native TolokaForge format on disk.  This enables:
+The conversion layer allows an external task format — read by an installed
+conversion adapter — to be converted into native TolokaForge format on disk.
+This enables:
 
 1. **Debuggability** — inspect exactly what the orchestrator sees for any task.
 2. **Caching** — pre-generate converted tasks to avoid runtime adapter loading.
@@ -16,23 +17,18 @@ to be converted into native TolokaForge format on disk.  This enables:
 ## CLI Usage
 
 ```bash
-# Convert Tau-bench tasks to native format
+# Convert an external task set to native format using an installed
+# conversion adapter (registered via the tolokaforge.adapters entry-point group)
 tolokaforge adapter convert \
-    --name tau \
-    --tasks-glob "contrib/tau-bench/tau_bench/envs/retail" \
-    --output converted/retail/
-
-# Convert TLK MCP Core testcases to native format
-tolokaforge adapter convert \
-    --name tlk_mcp_core \
-    --tasks-glob "contrib/project-m-copilot-mock-tools/mcp_servers/.../testcases/*.json" \
-    --output converted/logistics/
+    --name <adapter-name> \
+    --tasks-glob "path/to/source/tasks/**" \
+    --output converted/example/
 
 # With validation (checks that converted task.yaml is parsable as TaskConfig)
 tolokaforge adapter convert \
-    --name tau \
-    --tasks-glob "contrib/tau-bench/tau_bench/envs/retail" \
-    --output converted/retail/ \
+    --name <adapter-name> \
+    --tasks-glob "path/to/source/tasks/**" \
+    --output converted/example/ \
     --validate
 ```
 
@@ -40,8 +36,8 @@ tolokaforge adapter convert \
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--name` | Yes | Adapter name: `tau`, `tlk_mcp_core` |
-| `--tasks-glob` | Yes | Glob pattern for source tasks (or env path for Tau) |
+| `--name` | Yes | Adapter name (`native`, `terminal_bench`, or an installed conversion adapter) |
+| `--tasks-glob` | Yes | Glob pattern for source tasks (interpretation is adapter-specific) |
 | `--output` | Yes | Output directory |
 | `--adapter-params` | No | JSON string of extra adapter params |
 | `--validate` | No | Run validation pass on converted output |
@@ -173,7 +169,7 @@ bundle = NativeTaskBundle(
 ### convert_to_native()
 
 ```python
-adapter = get_adapter("tau", {"env_path": "path/to/env"})
+adapter = get_adapter("<adapter-name>", {"tasks_glob": "path/to/source/**"})
 task_ids = adapter.get_task_ids()
 bundle = adapter.convert_to_native(task_ids[0])
 ```
@@ -191,7 +187,7 @@ task_dir = write_bundle(bundle, output_dir=Path("converted"), task_id="task-001"
 The conversion layer extracts **tool schemas only** — it does not produce
 runtime tool wrappers.  Converted `fixtures/tools.json` contains the
 name/description/parameters for each tool, but the actual tool implementation
-stays in the adapter backend (`contrib/tau-bench` or `mcp-tools-library`).
+stays in the adapter backend that owns the tool implementations.
 
 This means:
 
@@ -203,9 +199,12 @@ This means:
 
 | Adapter | Source Format | Notes |
 |---------|--------------|-------|
-| `tau` | Tau-bench Python env directory | Reads tasks_test.py, data/, tools/, wiki |
-| `tlk_mcp_core` | MCP Core JSON testcases | Reads testcase JSON, domain config, tools library |
 | `native` | Already native | `convert_to_native()` raises `NotImplementedError` |
+
+Conversion-capable adapters are distributed as separate installable plugins,
+registered via the `tolokaforge.adapters` entry-point group. Install one to
+convert its source format; an adapter that produces shared, cross-task resources
+emits them by overriding `BaseAdapter.write_shared_resources()`.
 
 ## See Also
 

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -868,7 +868,7 @@ _ALL: list[MC] = [
         ),
     ),
     # -----------------------------------------------------------------
-    # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning line on
+    # DeepSeek V3.2-Exp experimental V3.2 reasoning line on
     # the OpenRouter route. Live-certified 2026-06-03 via
     # ``pytest tests/integration/llm/ -k deepseek-v3.2-exp`` (14 passed,
     # 6 skipped). Routes through the dedicated ``deepseek_v32`` preset

--- a/tests/unit/test_adapter_convert_cli.py
+++ b/tests/unit/test_adapter_convert_cli.py
@@ -1,0 +1,106 @@
+"""End-to-end tests for the ``tolokaforge adapter convert`` command.
+
+Exercise the full command with a stub conversion adapter and assert it writes
+native task bundles and invokes the shared-resources hook. Also guards that the
+command's imports (notably ``tolokaforge.adapters.bundle_writer``) resolve, so a
+missing module surfaces as a test failure rather than a runtime crash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+import tolokaforge.adapters as adapters_pkg
+from tolokaforge.adapters.base import BaseAdapter, NativeTaskBundle
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.cli.main import cli
+
+pytestmark = pytest.mark.unit
+
+
+class _StubConversionAdapter(NativeAdapter):
+    """Minimal conversion-capable adapter.
+
+    Subclasses the concrete NativeAdapter (so all abstract methods are
+    satisfied) and overrides only what ``convert`` needs.
+    """
+
+    def __init__(self, params: dict | None = None):
+        # NativeAdapter.__init__ requires a tasks_glob; we override discovery
+        # anyway, so any placeholder is fine.
+        super().__init__({"tasks_glob": "unused/**", **(params or {})})
+        self.shared_calls: list = []
+
+    def get_task_ids(self) -> list[str]:
+        return ["t1", "t2"]
+
+    def convert_to_native(self, task_id: str) -> NativeTaskBundle:
+        return NativeTaskBundle(
+            task_config={"name": f"Task {task_id}", "category": "tool_use"},
+            grading_config={"combine": {"method": "weighted", "pass_threshold": 1.0}},
+            fixtures={"tools": [{"name": "noop"}]},
+            metadata={"source_adapter": "stub"},
+        )
+
+    def write_shared_resources(self, output_dir: Path, bundle: NativeTaskBundle) -> None:
+        # A real shared-resources writer owns creating its target directory
+        # (e.g. the old _domain/ writer did mkdir(parents=True)).
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        self.shared_calls.append(out)
+        (out / "_shared_marker").write_text("ok", encoding="utf-8")
+
+
+class _NoSharedAdapter(_StubConversionAdapter):
+    """Conversion adapter that does NOT emit shared resources (default no-op)."""
+
+    write_shared_resources = BaseAdapter.write_shared_resources
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+def test_convert_writes_native_bundles(runner, tmp_path, monkeypatch):
+    stub = _StubConversionAdapter()
+    # convert() does `from tolokaforge.adapters import get_adapter` at call time,
+    # so patching the module attribute is sufficient.
+    monkeypatch.setattr(adapters_pkg, "get_adapter", lambda name, params: stub)
+
+    out = tmp_path / "out"
+    result = runner.invoke(
+        cli,
+        ["adapter", "convert", "--name", "stub", "--tasks-glob", "x/**", "--output", str(out)],
+    )
+
+    assert result.exit_code == 0, result.output
+    for tid in ("t1", "t2"):
+        assert (out / tid / "task.yaml").exists()
+        assert (out / tid / "grading.yaml").exists()
+        assert (out / tid / "fixtures" / "tools.json").exists()
+        assert yaml.safe_load((out / tid / "task.yaml").read_text())["task_id"] == tid
+
+    # shared-resources hook runs exactly once (with the first bundle)
+    assert len(stub.shared_calls) == 1
+    assert (out / "_shared_marker").exists()
+
+
+def test_convert_works_without_shared_resources(runner, tmp_path, monkeypatch):
+    stub = _NoSharedAdapter()
+    monkeypatch.setattr(adapters_pkg, "get_adapter", lambda name, params: stub)
+
+    out = tmp_path / "out"
+    result = runner.invoke(
+        cli,
+        ["adapter", "convert", "--name", "stub", "--tasks-glob", "x/**", "--output", str(out)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (out / "t1" / "task.yaml").exists()
+    # default hook is a no-op → no shared artifacts emitted
+    assert not (out / "_shared_marker").exists()

--- a/tests/unit/test_bundle_writer.py
+++ b/tests/unit/test_bundle_writer.py
@@ -1,0 +1,80 @@
+"""Unit tests for the native bundle writer (tolokaforge.adapters.bundle_writer).
+
+``tolokaforge adapter convert`` imports this module at runtime, so it must exist
+and serialise a NativeTaskBundle to the native on-disk layout.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters.base import NativeTaskBundle
+from tolokaforge.adapters.bundle_writer import write_bundle
+
+pytestmark = pytest.mark.unit
+
+
+def _sample_bundle() -> NativeTaskBundle:
+    return NativeTaskBundle(
+        task_config={"name": "Example", "category": "tool_use"},
+        grading_config={"combine": {"method": "weighted", "pass_threshold": 1.0}},
+        initial_state={"json_db": {"orders": []}},
+        system_prompt="You are a helpful agent.",
+        fixtures={
+            "tools": [{"name": "get_order"}],
+            "golden_actions": [{"tool_name": "get_order", "arguments": {}}],
+            "unstable_fields": [{"table_name": "orders", "field_name": "updated_at"}],
+            "extra_notes": {"hello": "world"},
+        },
+        metadata={"source_adapter": "example", "domain": "demo"},
+    )
+
+
+class TestWriteBundle:
+    def test_writes_full_native_layout(self, tmp_path: Path):
+        task_dir = write_bundle(_sample_bundle(), tmp_path, "task-001")
+
+        assert task_dir == (tmp_path / "task-001").resolve()
+
+        # task.yaml — task_id injected, fields preserved
+        task_yaml = yaml.safe_load((task_dir / "task.yaml").read_text())
+        assert task_yaml["task_id"] == "task-001"
+        assert task_yaml["name"] == "Example"
+
+        # grading.yaml
+        grading = yaml.safe_load((task_dir / "grading.yaml").read_text())
+        assert grading["combine"]["pass_threshold"] == 1.0
+
+        # initial_state.json + system_prompt.md
+        assert json.loads((task_dir / "initial_state.json").read_text()) == {
+            "json_db": {"orders": []}
+        }
+        assert (task_dir / "system_prompt.md").read_text() == "You are a helpful agent."
+
+        # fixtures/
+        fx = task_dir / "fixtures"
+        assert json.loads((fx / "tools.json").read_text()) == [{"name": "get_order"}]
+        assert json.loads((fx / "golden_actions.json").read_text())[0]["tool_name"] == "get_order"
+        assert (
+            json.loads((fx / "unstable_fields.json").read_text())[0]["field_name"] == "updated_at"
+        )
+        assert json.loads((fx / "metadata.json").read_text())["source_adapter"] == "example"
+        # any extra fixture key gets its own JSON file
+        assert json.loads((fx / "extra_notes.json").read_text()) == {"hello": "world"}
+
+    def test_existing_task_id_is_preserved(self, tmp_path: Path):
+        bundle = _sample_bundle()
+        bundle.task_config["task_id"] = "explicit-id"
+        task_dir = write_bundle(bundle, tmp_path, "dir-name")
+        # setdefault: an explicit task_config["task_id"] wins over the dir name
+        assert yaml.safe_load((task_dir / "task.yaml").read_text())["task_id"] == "explicit-id"
+
+    def test_module_is_importable(self):
+        # convert() imports this module at runtime — guard that it exists.
+        import tolokaforge.adapters.bundle_writer as bw
+
+        assert hasattr(bw, "write_bundle")

--- a/tolokaforge/adapters/base.py
+++ b/tolokaforge/adapters/base.py
@@ -410,7 +410,7 @@ class BaseAdapter(ABC):
     def convert_to_native(self, task_id: str) -> NativeTaskBundle:
         """Convert an external task to native TolokaForge format.
 
-        External adapters (Tau, TlkMcpCore, …) override this to produce a
+        Conversion adapters override this to produce a
         :class:`NativeTaskBundle` that can be written to disk with
         :func:`tolokaforge.adapters.bundle_writer.write_bundle`.
 
@@ -429,6 +429,28 @@ class BaseAdapter(ABC):
             NotImplementedError: If the adapter does not support conversion.
         """
         raise NotImplementedError(f"{self.__class__.__name__} does not support convert_to_native()")
+
+    def write_shared_resources(self, output_dir: Path, bundle: NativeTaskBundle) -> None:
+        """Write any shared, cross-task resources to *output_dir*.
+
+        Called once per ``tolokaforge adapter convert`` run, with the first
+        task's :class:`NativeTaskBundle`. The default is a **no-op** — most
+        adapters emit nothing shared.
+
+        Conversion adapters that produce shared resources (for example a
+        ``_domain/`` bundle of libraries, a tool registry, or a knowledge base)
+        override this to materialise them under *output_dir*. The
+        implementation should be idempotent, since it may run alongside
+        per-task :func:`bundle_writer.write_bundle` output in the same
+        directory.
+
+        Args:
+            output_dir: The conversion output root (the same directory that
+                receives the per-task ``{task_id}/`` folders).
+            bundle: The first task's converted bundle, whose ``metadata`` an
+                adapter can use to locate the resources to copy.
+        """
+        return None
 
     def grade(
         self,

--- a/tolokaforge/adapters/bundle_writer.py
+++ b/tolokaforge/adapters/bundle_writer.py
@@ -1,0 +1,121 @@
+"""Serialise a NativeTaskBundle to disk as a native task directory.
+
+Usage::
+
+    from tolokaforge.adapters.base import NativeTaskBundle
+    from tolokaforge.adapters.bundle_writer import write_bundle
+
+    bundle = adapter.convert_to_native(task_id)
+    task_dir = write_bundle(bundle, output_dir=Path("converted"), task_id=task_id)
+
+This module owns the *generic* native-format serialisation only. Adapters that
+need to emit shared, cross-task resources (e.g. a ``_domain/`` bundle) do so by
+overriding :meth:`tolokaforge.adapters.base.BaseAdapter.write_shared_resources`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tolokaforge.adapters.base import NativeTaskBundle
+from tolokaforge.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def write_bundle(
+    bundle: NativeTaskBundle,
+    output_dir: Path,
+    task_id: str,
+) -> Path:
+    """Write a :class:`NativeTaskBundle` to disk as a native task directory.
+
+    Creates the following structure under *output_dir*::
+
+        {output_dir}/{task_id}/
+        ├── task.yaml
+        ├── grading.yaml
+        ├── initial_state.json
+        ├── system_prompt.md
+        └── fixtures/
+            ├── tools.json
+            ├── golden_actions.json
+            ├── unstable_fields.json
+            └── metadata.json
+
+    Args:
+        bundle: The conversion result to serialise.
+        output_dir: Parent directory that will contain the task folder.
+        task_id: Used as the directory name; also injected into
+                 ``task_config["task_id"]`` if missing.
+
+    Returns:
+        Absolute :class:`Path` to the created ``{task_id}/`` directory.
+    """
+    task_dir = Path(output_dir) / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+
+    # Ensure task_id is present in task_config
+    task_config = dict(bundle.task_config)
+    task_config.setdefault("task_id", task_id)
+
+    # Write task.yaml
+    _write_yaml(task_dir / "task.yaml", task_config)
+
+    # Write grading.yaml
+    _write_yaml(task_dir / "grading.yaml", bundle.grading_config)
+
+    # Write initial_state.json
+    _write_json(task_dir / "initial_state.json", bundle.initial_state)
+
+    # Write system_prompt.md
+    (task_dir / "system_prompt.md").write_text(bundle.system_prompt or "", encoding="utf-8")
+
+    # Write fixtures directory
+    fixtures_dir = task_dir / "fixtures"
+    fixtures_dir.mkdir(parents=True, exist_ok=True)
+
+    # Separate well-known fixture keys from the rest
+    tools = bundle.fixtures.get("tools", [])
+    golden_actions = bundle.fixtures.get("golden_actions", [])
+    unstable_fields = bundle.fixtures.get("unstable_fields", [])
+
+    _write_json(fixtures_dir / "tools.json", tools)
+    _write_json(fixtures_dir / "golden_actions.json", golden_actions)
+    _write_json(fixtures_dir / "unstable_fields.json", unstable_fields)
+    _write_json(fixtures_dir / "metadata.json", bundle.metadata)
+
+    # Write any additional fixture keys (not tools/golden_actions/unstable_fields)
+    extra_keys = set(bundle.fixtures.keys()) - {"tools", "golden_actions", "unstable_fields"}
+    for key in sorted(extra_keys):
+        _write_json(fixtures_dir / f"{key}.json", bundle.fixtures[key])
+
+    logger.info(
+        "Wrote native task bundle",
+        task_id=task_id,
+        path=str(task_dir),
+    )
+    return task_dir.resolve()
+
+
+def _write_yaml(path: Path, data: Any) -> None:
+    """Write *data* as YAML, preserving key order."""
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.dump(
+            data,
+            fh,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+
+
+def _write_json(path: Path, data: Any) -> None:
+    """Write *data* as pretty-printed JSON."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False, default=str)
+        fh.write("\n")

--- a/tolokaforge/cli/adapter_commands.py
+++ b/tolokaforge/cli/adapter_commands.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import click
@@ -25,7 +24,11 @@ def adapter():
 
 
 @adapter.command()
-@click.option("--name", required=True, help="Adapter name (tau, tlk_mcp_core)")
+@click.option(
+    "--name",
+    required=True,
+    help="Adapter name (e.g. native, terminal_bench, or an installed conversion adapter)",
+)
 @click.option("--tasks-glob", required=True, help="Glob pattern for source tasks")
 @click.option("--output", required=True, type=click.Path(), help="Output directory")
 @click.option("--adapter-params", default="{}", help="JSON string of extra adapter params")
@@ -44,7 +47,7 @@ def convert(
         logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
     from tolokaforge.adapters import get_adapter
-    from tolokaforge.adapters.bundle_writer import write_bundle, write_domain_bundle
+    from tolokaforge.adapters.bundle_writer import write_bundle
 
     # Parse extra adapter params
     try:
@@ -89,27 +92,15 @@ def convert(
         try:
             bundle = adapter_inst.convert_to_native(task_id)
 
-            # Write shared domain bundle once (from first task's metadata)
-            if not domain_written and bundle.metadata.get("source_adapter") == "tlk_mcp_core":
+            # Write any shared, cross-task resources once. Adapters opt in by
+            # overriding write_shared_resources (default is a no-op); e.g. a
+            # conversion adapter may emit a shared _domain/ bundle here.
+            # Non-fatal: a failure warns but does not abort the conversion.
+            if not domain_written:
                 try:
-                    docindex_path = bundle.metadata.get("docindex_path", "")
-                    write_domain_bundle(
-                        mcp_core_src=Path(bundle.metadata["mcp_core_src"]),
-                        tools_library_src=Path(bundle.metadata["tools_library_src"]),
-                        tool_registry=bundle.metadata["tool_registry"],
-                        system_prompt=bundle.metadata.get("system_prompt", ""),
-                        domain_manifest={
-                            "domain": bundle.metadata.get("domain"),
-                            "adapter": "tlk_mcp_core",
-                            "converted_at": datetime.now().isoformat(),
-                        },
-                        output_dir=output_path / "_domain",
-                        allowed_toolsets=set(bundle.metadata.get("allowed_toolsets", [])) or None,
-                        docindex_src=Path(docindex_path) if docindex_path else None,
-                    )
-                    console.print("  ✓ _domain/ (shared resources)", style="blue")
+                    adapter_inst.write_shared_resources(output_path, bundle)
                 except Exception as exc:
-                    console.print(f"  ⚠ _domain/ write failed: {exc}", style="yellow")
+                    console.print(f"  ⚠ shared resources write failed: {exc}", style="yellow")
                     if verbose:
                         import traceback
 

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -153,7 +153,7 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
-  # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning route.
+  # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on
   # the standard response policy, so it needs neither json_coerce nor


### PR DESCRIPTION
## What & why

`tolokaforge adapter convert` is completely broken in the published package — it crashes for **every** adapter, before doing any work:

```
ModuleNotFoundError: No module named 'tolokaforge.adapters.bundle_writer'
```

`tolokaforge/cli/adapter_commands.py` imports `write_bundle`/`write_domain_bundle` from `tolokaforge.adapters.bundle_writer`, but that module was dropped during the open-source split (commit `3c1636f`) and the CLI import was never updated.

Closes #37.

## Approach — clean split

The old `bundle_writer` had two functions with different natures:
- **`write_bundle()`** — *generic*: serializes the core `NativeTaskBundle` to the native on-disk layout (`task.yaml` / `grading.yaml` / `initial_state.json` / `system_prompt.md` / `fixtures/*.json`). Belongs in core.
- **`write_domain_bundle()`** — *adapter-specific*: copies a particular conversion adapter's own libraries/resources into a `_domain/` bundle. It is not generic and is not needed by the engine, so it does not belong in the core package.

So this PR:
- **Restores `tolokaforge/adapters/bundle_writer.py` with only the generic `write_bundle()`** (+ `_write_yaml`/`_write_json` helpers).
- **Adds a no-op `BaseAdapter.write_shared_resources(output_dir, bundle)` hook.** `convert()` calls it once — replacing a hardcoded adapter-specific `_domain/` branch — so emitting shared, cross-task resources is the adapter's responsibility. Existing adapters inherit the harmless no-op.
- **Generalizes the adapter naming** in the `--name` help text and `docs/CONVERSION_LAYER.md` (only `native` + `terminal_bench` are named).
- **Adds regression tests** that would have caught this.
- **Hygiene:** also drops a stray internal tracking ID left in two unrelated DeepSeek comments (comment-only, no behavior change).

## How this was tested

Automated regression tests (in this PR, run in CI):
- `tests/unit/test_bundle_writer.py` — `write_bundle` writes the full native layout (incl. extra fixture keys), injects `task_id`, preserves an explicit `task_id`, and guards that the module imports.
- `tests/unit/test_adapter_convert_cli.py` — drives `tolokaforge adapter convert` end-to-end via `CliRunner` with a stub conversion adapter (monkeypatching `get_adapter`): asserts bundles are written and the shared-resources hook runs once; plus a case proving the default no-op hook still converts.
- Existing `test_adapters.py` / `test_native_adapter_domain.py` / `test_cli_commands.py` still pass (72) — no regression. `ruff` + `black` clean.

I also verified the wheel ships `tolokaforge/adapters/bundle_writer.py` and that a clean-venv install can `import` it (the original crash).

Manual end-to-end check beyond the stub: installed the built wheel into a clean venv alongside real third-party conversion adapters (registered via the `tolokaforge.adapters` entry-point group) and confirmed they are discovered, the restored `bundle_writer` import they rely on resolves, and `tolokaforge adapter convert` runs *past* the import that previously raised `ModuleNotFoundError` (reaching each adapter's own input validation). Producing full bundles depends on each adapter's external source dataset.

## Follow-up

- A real, automated **end-to-end smoke** (an in-tree demo conversion adapter registered via entry points, driving the real CLI to catch packaging/discovery regressions) is intentionally **kept separate** — tracked in #49.
- Restoring the `_domain/` output for a conversion adapter that needs it is a companion change in that adapter's own package: implement `write_shared_resources` there (a reference implementation lives in this repo's git history at `3c1636f^`). The public `convert` works for any conversion-capable adapter regardless.
