### PR TITLE
chore: remove stray internal tracking ID from code comments

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -868,7 +868,7 @@ _ALL: list[MC] = [
         ),
     ),
     # -----------------------------------------------------------------
-    # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning line on
+    # DeepSeek V3.2-Exp experimental V3.2 reasoning line on
     # the OpenRouter route. Live-certified 2026-06-03 via
     # ``pytest tests/integration/llm/ -k deepseek-v3.2-exp`` (14 passed,
     # 6 skipped). Routes through the dedicated ``deepseek_v32`` preset

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -153,7 +153,7 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
-  # DeepSeek V3.2-Exp (TECHDEL-334) experimental V3.2 reasoning route.
+  # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on
   # the standard response policy, so it needs neither json_coerce nor


### PR DESCRIPTION
## What

Two DeepSeek V3.2-Exp comments carried an internal tracking ID:

- `tolokaforge/core/data/model_presets.yaml`
- `tests/integration/llm/registry.py`

Both comments are reworded to drop the ID; the descriptive text stays.

## Why

Internal tracking IDs don't belong in public source — they're meaningless to OSS readers and go stale. This is a docs/comment-only change; no behavior change.