### PR TITLE
feat(llm): register minimax/minimax-m3 with codec-only preset

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1372,6 +1372,87 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # ------------------------------------------------------------------
+    # MiniMax-M3 (MiniMax via OpenRouter): reasoning model on the M-series
+    # 1M-context line (arena lineup refresh 2026-06). A solid baseline
+    # tool-caller: basic / simple / multi-turn, error-recovery, decimal,
+    # enum-slash, re2, tool-name discipline, lexical invention,
+    # required-fields and progress-after-success all pass live. Routed
+    # codec-only (the ``minimax`` preset sets only the openai reasoning
+    # codec) so its reasoning_content summary lands in the trajectory logs.
+    # Implicit auto-cache is reliable (cache_read priced on OpenRouter; 4/4
+    # clean 2-call probes 2026-06-08), so IMPLICIT_PROMPT_CACHING stays
+    # required (unlike the warmth-dependent DeepSeek route). Like gpt_oss it
+    # has a genuine structured-tool-call gap: it intermittently mis-shapes
+    # typed Dict[str, T] and declines the turn-2 discriminated-union call
+    # (details below), and that gap is NOT schema/stringify-fixable, so both
+    # are known_unsupported rather than papered over. 15 required / 5
+    # known_unsupported. Live-certified 2026-06-08 (pytest
+    # tests/integration/llm/ -k minimax-m3: 15 passed, 6 skipped; the 5
+    # known_unsupported caps yield 6 skips since discriminated_union has 2
+    # parametrisations).
+    # ------------------------------------------------------------------
+    MC(
+        model_id="openrouter__minimax_minimax-m3",
+        provider="openrouter",
+        name="minimax/minimax-m3",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Typed Dict[str, T] tool args are flaky: the model
+                # intermittently emits an array under a literal "item" key
+                # ({"item": [{"sku": ...}, ...]}) instead of a dict keyed by
+                # the map key. Live 2026-06-08: 2/10 fail codec-only, 4/10
+                # fail under openrouter_dict_stringify_recovery, i.e. its
+                # dict_map_hints gave NO reliability lift, and the failure is
+                # native mis-shaping not stringification (json_coerce N/A). So,
+                # like gpt_oss, it routes codec-only and this stays
+                # known_unsupported rather than papered over with a sanitizer
+                # that gives no lift.
+                C.DICT_MAP_TOOL_CALL,
+                # Two-turn discriminated-union calls are likewise unreliable:
+                # 1 of the 2 parametrisations fails on every one of 5 live
+                # runs 2026-06-08 (5/10 param-runs), always "turn 2 returned
+                # no tool call": the model answers turn 2 in prose ("Comment
+                # posted on TCK-...") instead of emitting the union call. A
+                # turn-2 tool-invocation gap, not a schema-dialect one (no
+                # preset fixes it).
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                # No Anthropic-style ephemeral cache markers on this route;
+                # explicit cache_control is not wired for non-Anthropic
+                # OpenRouter routes. The auto-cache surface
+                # (IMPLICIT_PROMPT_CACHING) IS required (see header).
+                # Verified live 2026-06-08.
+                C.PROMPT_CACHING,
+                # Reasoning surfaces only as an unsigned reasoning_content
+                # summary via the openai codec: no signed blocks to replay
+                # and the codec's encode_for_replay path is a no-op. Same
+                # posture as the glm-5.1 / deepseek-v3.2-exp siblings.
+                # Verified live 2026-06-08.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
 ]
 
 

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -254,6 +254,24 @@ presets:
     schema_sanitizer: gemini
     response_policy: array_dict_map
 
+  # MiniMax-M3 (MiniMax via OpenRouter): reasoning model on the M-series
+  # 1M-context line. Codec-only, like ``gpt_oss``: the only non-default
+  # policy is the ``openai`` reasoning codec so the reasoning_content summary
+  # lands in the trajectory logs (observability only; replay is a no-op on
+  # the OpenAI route). It intermittently mis-shapes typed Dict[str, T] /
+  # discriminated unions (native array under a literal "item" key; turn-2
+  # prose instead of the union call): a genuine model gap, NOT
+  # stringification, so the ``json_coerce`` path of
+  # ``openrouter_dict_stringify_recovery`` does not apply and its
+  # dict_map_hints gave no reliability lift (DICT_MAP still flaky ~6/10 live
+  # under it). Both are declared known_unsupported in registry.py rather than
+  # papered over. Live 2026-06-08.
+  minimax:
+    match:
+      - "minimax/minimax-m3*"
+      - "*minimax-m3*"
+    reasoning_codec: openai
+
 providers:
   openrouter:
     params:

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -691,6 +691,11 @@
       "output": 1.2,
       "cache_read": 0.059
     },
+    "minimax/minimax-m3": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
     "mistralai/codestral-2508": {
       "input": 0.3,
       "output": 0.9,


### PR DESCRIPTION
## What

Registers `minimax/minimax-m3` (MiniMax via OpenRouter) for the arena lineup refresh 2026-06. Engine-side only (pricing + preset + capability certificate); eval configs land separately on the tasks repo.

## Changes

- **`tolokaforge/core/data/pricing.json`**: `minimax/minimax-m3` at input $0.30 / output $1.20 / cache_read $0.06 per 1M tokens (OpenRouter API, captured 2026-06-08).
- **`tolokaforge/core/data/model_presets.yaml`**: codec-only `minimax` preset (only `reasoning_codec: openai`, so the reasoning_content summary lands in the trajectory logs). Same shape as `gpt_oss`.
- **`tests/integration/llm/registry.py`**: `ModelCertificate`, 15 required / 5 known_unsupported.

## Live certification

`scripts/with_env.sh uv run pytest tests/integration/llm/ -k minimax-m3 -v`

```
============================= test session starts ==============================
collecting ... collected 544 items / 523 deselected / 21 selected
test_basic_completion.py::test_basic_completion PASSED [  4%]
test_cost_populated.py::test_cost_usd_populated PASSED [  9%]
test_decimal_field_tool_call.py::test_decimal_field_tool_call PASSED [ 14%]
test_dict_map_tool_call.py::test_dict_map_tool_call SKIPPED [ 19%]
test_discriminated_union_tool_call.py::test_discriminated_union_tool_call_two_turns[bare_union] SKIPPED [ 23%]
test_discriminated_union_tool_call.py::test_discriminated_union_tool_call_two_turns[explicit_discriminator] SKIPPED [ 28%]
test_enum_slash_tolerance.py::test_enum_slash_tolerance PASSED [ 33%]
test_implicit_prompt_caching.py::test_implicit_prompt_caching PASSED [ 38%]
test_lexical_tool_invention.py::test_lexical_tool_invention PASSED [ 42%]
test_multi_turn_error_recovery.py::test_multi_turn_error_recovery PASSED [ 47%]
test_multi_turn_tool_use.py::test_multi_turn_tool_use PASSED [ 52%]
test_progress_after_success.py::test_progress_after_success PASSED [ 57%]
test_prompt_caching.py::test_prompt_caching SKIPPED [ 61%]
test_re2_pattern_tolerance.py::test_re2_pattern_tolerance PASSED [ 66%]
test_required_fields_complete.py::test_required_fields_complete PASSED [ 71%]
test_simple_tool_call.py::test_simple_tool_call PASSED [ 76%]
test_thinking_emits_blocks.py::test_thinking_emits_blocks PASSED [ 80%]
test_thinking_replay_roundtrip.py::test_thinking_replay_roundtrip SKIPPED [ 85%]
test_tool_name_discipline.py::test_tool_name_discipline PASSED [ 90%]
test_unsigned_thinking_replay.py::test_unsigned_thinking_replay SKIPPED [ 95%]
test_usage_metrics_populated.py::test_usage_metrics_populated PASSED [100%]
=========== 15 passed, 6 skipped, 523 deselected in 92.16s (0:01:32) ===========
```

## Capability posture (15 required / 5 known_unsupported)

**required** (all pass live): basic/simple/multi-turn tool use, `multi_turn_error_recovery`, `enum_slash_tolerance`, `re2_pattern_tolerance`, `decimal_field_tool_call`, `thinking_emits_blocks`, `implicit_prompt_caching`, usage/cost populated, `tool_name_discipline`, `lexical_tool_invention`, `required_fields_complete`, `progress_after_success`.

`implicit_prompt_caching` is required because cache_read is priced on this OpenRouter route and a clean 2-call probe observes the cache hit reliably (4/4 live), unlike the warmth-dependent DeepSeek route.

**known_unsupported** (each verified live 2026-06-08):

- `dict_map_tool_call` + `discriminated_union_tool_call`: genuine, intermittent structured-tool-call gaps.
  - Dict-map: the model intermittently emits an array under a literal `"item"` key (`{"item": [{"sku": ...}, ...]}`) instead of a dict keyed by the map key. 2/10 fail codec-only, 4/10 fail under the `openrouter_dict_stringify_recovery` preset, so `dict_map_hints` gives no reliability lift.
  - Discriminated-union: 1 of the 2 parametrisations fails on every one of 5 runs (5/10 param-runs), always "turn 2 returned no tool call" (the model answers turn 2 in prose instead of emitting the union call).
  - The failure mode is native mis-shaping / tool invocation, not stringification, so per the `gpt_oss` precedent the model routes codec-only and these stay `known_unsupported` rather than being papered over with a sanitizer that gives no lift.
- `prompt_caching`: no Anthropic ephemeral cache markers on this non-Anthropic route. The implicit auto-cache surface is required instead (see above).
- `thinking_replay_roundtrip` + `unsigned_thinking_replay`: reasoning surfaces only as an unsigned `reasoning_content` summary via the openai codec. No signed blocks to replay and the codec's replay path is a no-op. Same posture as glm-5.1 / deepseek-v3.2-exp.

## Notes

- 6 skipped (not 5): `discriminated_union` runs 2 parametrisations, so the 5 known_unsupported capabilities yield 6 skipped test instances.
- `cost_usd_populated` passes via the pricing.json entry above (litellm fallback to the bundled catalog).
- Smoke eval across the fleet to follow separately on the tasks repo.
