### PR TITLE
ci: make uv.lock reproducible — relock on release, locked + pinned uv in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,14 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        # Pinned (not "latest") so CI resolves the lockfile with the SAME uv that
+        # generated it. With `uv sync --locked`, a "latest" uv that ever changes
+        # lock resolution/format would fail CI repo-wide on its release day, for
+        # nobody's change. Bump this deliberately alongside a relock. Must stay
+        # within [tool.uv] required-version in pyproject.toml.
+        version: "0.9.5"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
@@ -75,9 +80,14 @@ jobs:
 
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        # Pinned (not "latest") so CI resolves the lockfile with the SAME uv that
+        # generated it. With `uv sync --locked`, a "latest" uv that ever changes
+        # lock resolution/format would fail CI repo-wide on its release day, for
+        # nobody's change. Bump this deliberately alongside a relock. Must stay
+        # within [tool.uv] required-version in pyproject.toml.
+        version: "0.9.5"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
@@ -155,9 +165,14 @@ jobs:
 
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        # Pinned (not "latest") so CI resolves the lockfile with the SAME uv that
+        # generated it. With `uv sync --locked`, a "latest" uv that ever changes
+        # lock resolution/format would fail CI repo-wide on its release day, for
+        # nobody's change. Bump this deliberately alongside a relock. Must stay
+        # within [tool.uv] required-version in pyproject.toml.
+        version: "0.9.5"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
@@ -253,9 +268,14 @@ jobs:
 
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        # Pinned (not "latest") so CI resolves the lockfile with the SAME uv that
+        # generated it. With `uv sync --locked`, a "latest" uv that ever changes
+        # lock resolution/format would fail CI repo-wide on its release day, for
+        # nobody's change. Bump this deliberately alongside a relock. Must stay
+        # within [tool.uv] required-version in pyproject.toml.
+        version: "0.9.5"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Install dependencies
-      run: uv sync --dev
+      run: uv sync --dev --locked
 
     - name: Run pre-commit checks
       run: uv run pre-commit run --all-files --show-diff-on-failure
@@ -87,7 +87,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --dev
+        uv sync --dev --locked
 
     - name: Install Playwright browsers
       run: |
@@ -167,7 +167,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --dev
+        uv sync --dev --locked
 
     - name: Install Playwright browsers
       run: |
@@ -265,7 +265,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --dev
+        uv sync --dev --locked
 
     - name: Install Playwright browsers
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,13 @@ jobs:
           echo "released=true" >> "$GITHUB_OUTPUT"
           echo "new_tag=v$(uv run cz version -p)" >> "$GITHUB_OUTPUT"
 
+      # Belt-and-suspenders: the cz pre_bump_hook (pyproject [tool.commitizen])
+      # relocks uv.lock to the new version and folds it into the bump commit. Assert
+      # there's no leftover drift before we publish the tag.
+      - name: Assert uv.lock is consistent with the bump
+        if: ${{ !inputs.dry_run && steps.bump.outputs.released == 'true' }}
+        run: uv lock --check
+
       # Push the bump commit and its tag in a single atomic update: both refs
       # land or neither does. Avoids leaving a release commit on main with no tag
       # (which would trigger nothing downstream) if the tag push were rejected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,14 @@ dev = [
 # uv is the recommended package manager for this project
 # See: https://docs.astral.sh/uv/
 
+[tool.uv]
+# Keep everyone (CI + every laptop) on a compatible uv so the committed uv.lock is
+# reproducible. uv refuses to run outside this range and tells the dev to align,
+# which prevents "I relocked and now CI's `uv sync --locked` rejects my lock"
+# surprises. A narrow range (not one exact version) avoids forcing a reinstall on
+# every uv patch; the CI pin in .github/workflows/ci.yml lives inside this range.
+required-version = ">=0.9.5,<0.10"
+
 [tool.uv.workspace]
 members = [
     "tools/dev-mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,6 +277,17 @@ major_version_zero = true            # project is pre-1.0/unstable: breaking cha
 bump_message = "chore(release): bump version to $new_version"
 annotated_tag = true
 
+# Keep uv.lock's own `tolokaforge` package version in step with [project] version.
+# cz bump rewrites [project] version but does NOT relock; without this the lockfile
+# would pin the previous version every release. pre_bump_hooks run after the version
+# is written and before cz's commit, so we relock and stage uv.lock — cz then folds
+# it into the same release commit. (cz only auto-stages its own version files, so the
+# explicit `git add` is required.)
+pre_bump_hooks = [
+    "uv lock",
+    "git add -- uv.lock",
+]
+
 # =============================================================================
 # Development Dependencies (PEP 735)
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -3868,7 +3868,7 @@ wheels = [
 
 [[package]]
 name = "tolokaforge"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },


### PR DESCRIPTION
## The problem

Our release workflow runs `cz bump`, which rewrites `[project] version` in
`pyproject.toml` and `CHANGELOG.md`, then commits and tags — **but it never
relocks**. So `uv.lock`'s own `tolokaforge` package entry kept pinning the
*previous* version after every release. Concretely, the lock stayed at `0.2.6`
after the `0.2.7` release.

It went unnoticed because nothing enforced lockfile consistency:

- CI installed with `uv sync --dev` (**unlocked**), so it silently re-resolved a
  stale lock instead of failing.
- Release commits push straight to `main` via deploy key, **bypassing PR CI**.

Left alone, this drift compounds on every release.

## The fix (defense in depth)

**1. Stop it at the source — `pyproject.toml` (`[tool.commitizen]`)**
Add `pre_bump_hooks = ["uv lock", "git add -- uv.lock"]`. commitizen runs these
after writing the new version and before its commit, so the relocked `uv.lock` is
folded into the *same* bump commit. (cz only auto-stages its own version files,
hence the explicit `git add`.) This keeps commitizen the single owner of the
release commit — no workflow surgery on the protected release path.

**2. Guard the release — `release.yml`**
Assert `uv lock --check` right after the bump, before the tag is pushed. Because
releases bypass PR CI, this is the real guarantee for that path: a release can
never publish a drifted lock.

**3. Guard everything else — `ci.yml`**
Install with `uv sync --dev --locked`. Any change that touches dependencies or the
version without relocking now fails CI instead of silently re-resolving.

**4. Make the locked install reproducible — `ci.yml`**
`--locked` is only meaningful if CI uses the *same* uv that generated the lock.
CI was on `version: "latest"`, which would make `uv sync --locked` fail repo-wide
the day a future uv changes lock resolution/format — for nobody's change. That
just trades silent drift for surprise breakage. So we pin `setup-uv` to `0.9.5`
(the uv that generated the lock) and align the action `@v4 → @v7` with the
publish/release workflows. Upgrading uv becomes a deliberate step: bump the pin
and relock together.

**5. Keep local dev aligned — `pyproject.toml` (`[tool.uv]`)**
Add `required-version = ">=0.9.5,<0.10"`. uv refuses to run outside this range and
tells the dev to align, so CI and every laptop use a compatible uv. This prevents
the one friction case below. A narrow range (not one exact version) avoids forcing
a reinstall on every uv patch; the CI pin sits inside it.

**6. Clear today's drift**
Relock `uv.lock` to `0.2.7`.

## Why this shape (reasoning)

- The project's own version lives in `uv.lock` by design (uv workspace locking) —
  there's no flag to omit it. So *relock-on-bump* is the irreducible fix; the only
  real choice is *where* to enforce it. We enforce at the source (the bump hook)
  **and** at the gate (locked CI), from two independent directions.
- This is a standard industry pattern, not a bespoke setup. "Install exactly the
  lockfile in CI, fail otherwise" is `npm ci`, Yarn `--immutable`, pnpm
  `--frozen-lockfile`, Cargo `--locked`, Bundler `--frozen`, Go `-mod=readonly`.
  "Pin the tool itself" is `packageManager`/Corepack, `rust-toolchain.toml`,
  `.ruby-version`, `.tool-versions`. We're doing the uv equivalents.

## What this means for contributors

The lockfile already guarantees everyone installs the *same dependencies*
regardless of their local uv. The new check only changes one case:

| What you do | Effect |
|---|---|
| Run / `uv sync` from the existing lock | No change — installs exactly the lock. |
| Don't touch dependencies | No change — CI passes. |
| Change deps **and** `uv lock` on a mismatched uv | CI's `--locked` flags it. `required-version` keeps you on a compatible uv so this won't happen; if you do hit it, just relock on the pinned uv. |

In short: editing dependencies now requires a relock (intended), and
`required-version` makes sure your uv matches CI's.

## Blast radius on open PRs

Minimal. CI runs on the `pull_request` *merge ref* (PR merged into `main`), so a
branch that doesn't touch `uv.lock`/`pyproject` inherits `main`'s now-consistent
lock and passes `--locked`. Only PRs that themselves edit the lock into an
inconsistent state need a rebase/relock; dependabot's uv PRs auto-rebase.

## Verification

- `uv lock --check` passes on this branch.
- `uv sync --dev --locked` passes locally (simulates CI).
- `cz bump --dry-run` parses the config and computes the next version/tag.
- Ran a **real** local `cz bump --increment patch`: the bump commit included
  `uv.lock` at the new version (proving the hook stages it), then reset locally —
  nothing pushed.
- Local uv (0.9.5) satisfies `required-version`; adding it does not change the lock.
