### PR TITLE
test: golden regression coverage for grading (trajectory + deterministic paths)

### DIFF
--- a/tests/canonical/snapshots/grading_paths/fail_hash_mismatch.json
+++ b/tests/canonical/snapshots/grading_paths/fail_hash_mismatch.json
@@ -1,0 +1,10 @@
+{
+  "binary_pass": false,
+  "components": {
+    "custom_checks": null,
+    "llm_judge": null,
+    "state_checks": 0.0,
+    "transcript_rules": null
+  },
+  "score": 0.0
+}

--- a/tests/canonical/snapshots/grading_paths/jsonpath_partial.json
+++ b/tests/canonical/snapshots/grading_paths/jsonpath_partial.json
@@ -1,0 +1,10 @@
+{
+  "binary_pass": true,
+  "components": {
+    "custom_checks": null,
+    "llm_judge": null,
+    "state_checks": 0.5,
+    "transcript_rules": null
+  },
+  "score": 0.5
+}

--- a/tests/canonical/snapshots/grading_paths/transcript_actions_and_info.json
+++ b/tests/canonical/snapshots/grading_paths/transcript_actions_and_info.json
@@ -1,0 +1,10 @@
+{
+  "binary_pass": false,
+  "components": {
+    "custom_checks": null,
+    "llm_judge": null,
+    "state_checks": null,
+    "transcript_rules": 0.5
+  },
+  "score": 0.5
+}

--- a/tests/canonical/snapshots/grading_paths/weighted_combine.json
+++ b/tests/canonical/snapshots/grading_paths/weighted_combine.json
@@ -1,0 +1,10 @@
+{
+  "binary_pass": true,
+  "components": {
+    "custom_checks": null,
+    "llm_judge": null,
+    "state_checks": 1.0,
+    "transcript_rules": 0.5
+  },
+  "score": 0.8
+}

--- a/tests/canonical/test_golden_trajectory_grading_canon.py
+++ b/tests/canonical/test_golden_trajectory_grading_canon.py
@@ -1,0 +1,62 @@
+"""Golden-trajectory grading regression test.
+
+Pins the *current* grading verdict for a known recorded run so future changes to
+``tolokaforge/core/grading/`` can prove they did not alter verdicts/scores.
+
+This loads a recorded trajectory + final environment state + self-contained
+grading config from the committed ``tau_retail_mini`` project fixture and runs it
+through the existing :class:`GradingEngine`. The fixture's grading config carries a
+pre-computed ``expected_state_hash``, so grading takes the deterministic
+hash-comparison branch in ``combine.py`` — no LLM judge, no custom checks, no
+network, and no Docker. The expected result is read from the committed golden
+``grade.yaml`` rather than hard-coded, so it stays the canonical pin.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.grading.combine import GradingEngine
+from tolokaforge.core.models import GradingConfig, Trajectory
+
+pytestmark = [pytest.mark.canonical, pytest.mark.grading]
+
+# Recorded trial fixture: trajectory + final env state + grading config + golden grade.
+_PROJECT = "tau_retail_mini"
+_TRIAL = Path("output/trials/test_001/0")
+
+
+def _load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def test_golden_trajectory_grading_matches_pinned_verdict(canonical_project_dir):
+    """Grading the recorded trajectory reproduces the committed golden verdict."""
+    trial_dir = canonical_project_dir(_PROJECT) / _TRIAL
+
+    grading_config = GradingConfig(**_load_yaml(trial_dir / "task.yaml")["grading_config"])
+    trajectory = Trajectory.model_validate(_load_yaml(trial_dir / "trajectory.yaml"))
+    final_env_state = _load_yaml(trial_dir / "env.yaml")
+    golden = _load_yaml(trial_dir / "grade.yaml")
+
+    # No judge_model and no task_dir => no LLM judge and no custom checks run.
+    engine = GradingEngine(grading_config=grading_config)
+    grade = engine.grade_trajectory(trajectory, final_env_state)
+
+    assert grade.binary_pass == golden["binary_pass"]
+    assert grade.score == pytest.approx(golden["score"])
+    assert grade.components.state_checks == pytest.approx(golden["components"]["state_checks"])
+    assert grade.components.transcript_rules == golden["components"]["transcript_rules"]
+    assert grade.components.llm_judge == golden["components"]["llm_judge"]
+    assert grade.components.custom_checks == golden["components"]["custom_checks"]
+    assert "hash matches" in grade.reasons
+
+    # Determinism: a second grade with a fresh engine yields the identical verdict.
+    grade2 = GradingEngine(grading_config=grading_config).grade_trajectory(
+        trajectory, final_env_state
+    )
+    assert grade2.score == grade.score
+    assert grade2.binary_pass == grade.binary_pass
+    assert grade2.reasons == grade.reasons

--- a/tests/canonical/test_grading_paths_canon.py
+++ b/tests/canonical/test_grading_paths_canon.py
@@ -1,0 +1,226 @@
+"""Golden coverage for the deterministic grading paths, end-to-end.
+
+The hash path is already pinned by ``test_golden_trajectory_grading_canon.py``.
+This module pins the *other* deterministic paths through the full
+``GradingEngine.grade_trajectory`` pipeline — the parts previously exercised only
+at the component level — so a future grading refactor can prove it didn't change
+verdicts:
+
+- jsonpath partial-credit state checks (``satisfied / total``)
+- transcript ``required_actions`` + ``communicate_info`` (tau2 evaluators, combined
+  multiplicatively with the legacy transcript checker)
+- the weighted-combine normalization across multiple live components
+- a FAIL verdict (``binary_pass=False``)
+
+Determinism notes (verified against the engine source):
+- Scores use no time/random; hashing is canonical (sorted keys). Safe to pin.
+- ``reasons`` strings are NOT pinned: they can embed Python set reprs
+  (tool_expectations), glob ordering, or diff text whose order isn't guaranteed.
+  We snapshot only ``binary_pass`` + ``score`` + ``components`` (the verdict), and
+  round floats to dodge float-repr churn under exact snapshot equality.
+
+No LLM, no network, no Docker: ``GradingEngine`` is built with no ``judge_model``
+and no ``task_dir``, so the judge and custom-checks paths never run.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tolokaforge.core.grading.combine import GradingEngine
+from tolokaforge.core.models import (
+    GradingConfig,
+    Message,
+    MessageRole,
+    ToolCall,
+    Trajectory,
+    TrialStatus,
+)
+
+pytestmark = [pytest.mark.canonical, pytest.mark.grading]
+
+# Fixed timestamps — construction only; they do not feed grading.
+_TS = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def _trajectory(messages: list[Message]) -> Trajectory:
+    return Trajectory(
+        task_id="grading-paths",
+        trial_index=0,
+        start_ts=_TS,
+        end_ts=_TS,
+        status=TrialStatus.COMPLETED,
+        messages=messages,
+    )
+
+
+def _assistant_with_tool(name: str, content: str = "") -> Message:
+    return Message(
+        role=MessageRole.ASSISTANT,
+        content=content,
+        tool_calls=[ToolCall(id=f"call_{name}", name=name, arguments={})],
+    )
+
+
+# --- Scenarios: each returns (grading_config_dict, trajectory, final_env_state) ---
+
+
+def _scenario_jsonpath_partial():
+    """2 of 4 jsonpath assertions satisfied -> state_checks = 0.5 (pass_threshold 0.5)."""
+    config = {
+        "combine": {"method": "weighted", "weights": {"state_checks": 1.0}, "pass_threshold": 0.5},
+        "state_checks": {
+            "jsonpaths": [
+                {"path": "$.db.counter", "equals": 5, "description": "counter is 5"},
+                {"path": "$.db.status", "equals": "done", "description": "status is done"},
+                {"path": "$.db.counter", "equals": 999, "description": "wrong counter (fails)"},
+                {"path": "$.db.missing", "equals": "x", "description": "absent path (fails)"},
+            ],
+        },
+    }
+    traj = _trajectory([Message(role=MessageRole.USER, content="go")])
+    final_env_state = {"db": {"counter": 5, "status": "done"}}
+    return config, traj, final_env_state
+
+
+def _scenario_transcript_actions_and_info():
+    """required_actions 1/2 found (0.5) x communicate_info 1/1 found (1.0) -> transcript 0.5."""
+    config = {
+        "combine": {
+            "method": "weighted",
+            "weights": {"transcript_rules": 1.0},
+            "pass_threshold": 0.75,
+        },
+        "transcript_rules": {
+            "required_actions": [
+                {
+                    "action_id": "a1",
+                    "requestor": "assistant",
+                    "name": "list_products",
+                    "arguments": {},
+                    "compare_args": [],
+                },
+                {
+                    "action_id": "a2",
+                    "requestor": "assistant",
+                    "name": "place_order",
+                    "arguments": {},
+                    "compare_args": [],
+                },
+            ],
+            "communicate_info": [{"info": "ORDER-001", "required": True}],
+        },
+    }
+    traj = _trajectory(
+        [
+            Message(role=MessageRole.USER, content="buy it"),
+            _assistant_with_tool("list_products"),  # matches a1; a2 (place_order) never called
+            Message(role=MessageRole.ASSISTANT, content="All set — your order is ORDER-001."),
+        ]
+    )
+    return config, traj, {}
+
+
+def _scenario_weighted_combine():
+    """state_checks=1.0 (w .6) + transcript=0.5 (w .4) -> (0.6 + 0.2)/1.0 = 0.8."""
+    config = {
+        "combine": {
+            "method": "weighted",
+            "weights": {"state_checks": 0.6, "transcript_rules": 0.4},
+            "pass_threshold": 0.75,
+        },
+        "state_checks": {
+            "jsonpaths": [
+                {"path": "$.db.counter", "equals": 5, "description": "counter is 5"},
+                {"path": "$.db.status", "equals": "done", "description": "status is done"},
+            ],
+        },
+        "transcript_rules": {
+            "required_actions": [
+                {
+                    "action_id": "a1",
+                    "requestor": "assistant",
+                    "name": "list_products",
+                    "arguments": {},
+                    "compare_args": [],
+                },
+                {
+                    "action_id": "a2",
+                    "requestor": "assistant",
+                    "name": "place_order",
+                    "arguments": {},
+                    "compare_args": [],
+                },
+            ],
+        },
+    }
+    traj = _trajectory(
+        [
+            Message(role=MessageRole.USER, content="go"),
+            _assistant_with_tool("list_products"),  # 1 of 2 required actions
+        ]
+    )
+    final_env_state = {"db": {"counter": 5, "status": "done"}}
+    return config, traj, final_env_state
+
+
+def _scenario_fail_hash_mismatch():
+    """Wrong expected_state_hash -> state_checks 0.0 -> binary_pass False."""
+    config = {
+        "combine": {"method": "weighted", "weights": {"state_checks": 1.0}, "pass_threshold": 1.0},
+        "state_checks": {
+            "jsonpaths": [],
+            "hash": {"enabled": True, "weight": 1.0, "expected_state_hash": "0" * 64},
+        },
+    }
+    traj = _trajectory([Message(role=MessageRole.USER, content="go")])
+    final_env_state = {"db": {"counter": 5, "status": "done"}}
+    return config, traj, final_env_state
+
+
+_SCENARIOS = {
+    "jsonpath_partial": _scenario_jsonpath_partial,
+    "transcript_actions_and_info": _scenario_transcript_actions_and_info,
+    "weighted_combine": _scenario_weighted_combine,
+    "fail_hash_mismatch": _scenario_fail_hash_mismatch,
+}
+
+
+def _verdict(grade) -> dict:
+    """Deterministic, snapshot-safe slice of a Grade (no volatile reasons strings)."""
+
+    def r(x):
+        return round(x, 6) if isinstance(x, float) else x
+
+    c = grade.components
+    return {
+        "binary_pass": grade.binary_pass,
+        "score": r(grade.score),
+        "components": {
+            "state_checks": r(c.state_checks),
+            "transcript_rules": r(c.transcript_rules),
+            "llm_judge": r(c.llm_judge),
+            "custom_checks": r(c.custom_checks),
+        },
+    }
+
+
+@pytest.mark.parametrize("name", list(_SCENARIOS))
+def test_grading_path_verdict_is_pinned(name, canon_snapshot):
+    """Each deterministic grading path produces the pinned golden verdict."""
+    config_dict, trajectory, final_env_state = _SCENARIOS[name]()
+    grading_config = GradingConfig(**config_dict)
+
+    # No judge_model, no task_dir => no LLM judge, no custom checks.
+    grade = GradingEngine(grading_config=grading_config).grade_trajectory(
+        trajectory, final_env_state
+    )
+
+    # Determinism: a second fresh engine yields an identical verdict.
+    grade2 = GradingEngine(grading_config=grading_config).grade_trajectory(
+        trajectory, final_env_state
+    )
+    assert _verdict(grade2) == _verdict(grade)
+
+    snap = canon_snapshot("grading_paths")
+    snap.assert_match(_verdict(grade), f"{name}.json")


### PR DESCRIPTION
## What

Adds **golden** regression coverage for the deterministic grading paths, so a
future grading refactor can prove it didn't change verdicts. Two complementary
pieces:

**1. Golden trajectory (hash path)** — `test_golden_trajectory_grading_canon.py`
Runs the recorded `tau_retail_mini/test_001` trial (recorded trajectory + final
env state + grading config) through the existing `GradingEngine` and asserts the
committed golden `grade.yaml` verdict. The config carries a pre-computed
`expected_state_hash`, so it exercises the deterministic hash-comparison path.

**2. Deterministic grading paths** — `test_grading_paths_canon.py`
Drives the full `GradingEngine.grade_trajectory` pipeline over small synthetic
scenarios, pinning paths previously exercised only at the component level:
- **jsonpath partial-credit** — 2 of 4 assertions → `0.5`
- **transcript** `required_actions` × `communicate_info` × legacy checker → `0.5`
  (pins the multiplicative combine)
- **weighted-combine normalization** — state 1.0 (w 0.6) + transcript 0.5 (w 0.4) → `0.8`
- a **FAIL** verdict — hash mismatch → `0.0`, `binary_pass=False`

## How / determinism

Scoring is deterministic (no time/random; canonical sorted-key hashing). For the
synthetic scenarios the snapshots pin **only** `{binary_pass, score, components}`
with floats rounded — raw `reasons` strings are intentionally not pinned because
they can embed Python set reprs (tool_expectations), unsorted glob ordering, or
diff text whose order isn't guaranteed. Snapshot goldens were **recorded** from the
engine via `canon_snapshot` / `--update-canon`, then verified to be clean,
explainable values. Each test also re-grades with a fresh engine and asserts the
verdict is identical.

No LLM, no network, no Docker: the engine is built with no `judge_model` and no
`task_dir`, so the judge and custom-checks paths never run.

## Scope

- Two new canonical test files + 4 snapshot JSONs. No grading logic changed.

## Verification

```
$ uv run pytest tests/canonical/test_golden_trajectory_grading_canon.py tests/canonical/test_grading_paths_canon.py -v
5 passed in 1.38s
```

Deterministic across repeated runs.

Closes #53
