### PR TITLE
refactor(adapters): make the runner adapter-agnostic (plugin-first)

### DIFF
--- a/docs/ADAPTER_INTERFACE.md
+++ b/docs/ADAPTER_INTERFACE.md
@@ -50,6 +50,73 @@ Each adapter must subclass `BaseAdapter` and implement:
 7. Reset: cleanly reset state between trials.
 8. *(Optional)* Conversion: emit native format bundle via `convert_to_native()`.
 
+## Runtime Capabilities (declarative, opt-in)
+
+The runner selects per-trial behaviour from **data on the `TaskDescription`**,
+never from the adapter's identity. Two capabilities matter to adapter authors:
+
+### `GradingConfig.grading_method`
+
+A declarative selector on the grading config that tells the runner *how* to grade:
+
+- **`None`** *(default)* — standard grading: combines state checks / transcript
+  rules / LLM judge per `weights` + `pass_threshold`. Most adapters want this and
+  need do nothing.
+- **`"test_execution"`** — the runner runs a reference test suite inside the
+  trial's env container via an exec-capable lifecycle tool (today:
+  `DockerComposeExecToolWrapper`) and scores by reading a reward float written
+  by the suite. Requires such a tool in `TaskDescription.agent_tools`; otherwise
+  the runner returns a clear error at `GradeTrial` time. Used by the
+  `terminal_bench` adapter as a worked example.
+- `"hash"` / `"transcript"` / `"llm"` are reserved names for future
+  single-method dispatch and currently behave as part of the default path.
+
+Typos in this value are caught at validation by the `Literal[...]` field type;
+an "unknown grading method" cannot reach the runner silently.
+
+### `ToolWrapper.has_lifecycle`
+
+Tools may own per-trial resources (e.g. a compose stack started for the trial).
+The base `ToolWrapper` declares `has_lifecycle = False` and ships no-op
+`start(ctx)` / `stop()`. A tool that needs lifecycle management overrides:
+
+```python
+class MyTool(ToolWrapper):
+    has_lifecycle = True
+
+    def start(self, ctx: ToolLifecycleContext) -> None:
+        ...  # provision per-trial resources; ctx carries trial_id + artifacts_dir
+
+    def stop(self) -> None:
+        ...  # tear down what start() created
+```
+
+The runner calls `start` / `stop` generically on every tool whose
+`has_lifecycle` is set — it doesn't need to know your tool by name.
+
+#### Current limitations of the lifecycle contract
+
+The lifecycle contract is deliberately minimal today — sufficient for the one
+lifecycle tool that ships built-in, but shallow on purpose. Known gaps for
+custom lifecycle tools:
+
+- `ToolLifecycleContext` carries only `trial_id` and `artifacts_dir`. Tools
+  needing env-service endpoints, resource limits, secrets, or task metadata
+  must source them from elsewhere.
+- `start(ctx)` is synchronous, with no timeout or retry policy.
+- Only `start` / `stop` hooks exist (no `suspend` / `snapshot` /
+  `reset-without-teardown`).
+- No ordering or dependency declaration between multiple lifecycle tools in
+  the same trial — they're started in dict-iteration order.
+- No explicit readiness signal; `start()` returning is treated as "ready".
+
+The shape is forward-compatible: `ToolLifecycleContext` is a dataclass and the
+runner dispatches off the capability (not adapter identity), so the contract
+will grow additively when a real second user surfaces a need. Until then,
+custom lifecycle tools must either fit within the current shape or vendor the
+missing pieces internally. See the open tracking issue for the planned
+direction.
+
 ## Constructor Contract
 
 Adapters receive a `params: dict[str, Any]` in their constructor. Common params:

--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -38,7 +38,15 @@ from pydantic import BaseModel, Field
 # =============================================================================
 
 class AdapterType(str, Enum):
-    """Source adapter that produced this description."""
+    """Canonical constants for well-known built-in adapter names.
+
+    NOTE: ``TaskDescription.adapter_type`` is an open ``str`` from the adapter
+    registry, not a closed enum. Entry-point/third-party adapters round-trip
+    with their own names (e.g. an adapter installed via
+    ``pip install some-adapter-pkg``) without any engine edit. This enum
+    provides typed constants for the built-ins; the ``adapter_type`` field
+    accepts any name present in the registry at runtime.
+    """
     NATIVE = "native"
     TAU = "tau"
     TLK_MCP_CORE = "tlk_mcp_core"
@@ -275,7 +283,7 @@ class TaskDescription(BaseModel):
     name: str
     category: str                                 # Domain: e.g. "airline", "retail"
     description: str                              # Task description / user goal
-    adapter_type: AdapterType
+    adapter_type: str                             # Open string from the adapter registry; use AdapterType.* constants for the built-ins
     schema_version: str = "1.0.0"
     
     # --- System Prompt ---

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -236,6 +236,9 @@ class TerminalBenchAdapter(BaseAdapter):
                 combine_method="weighted",
                 weights={"custom_checks": 1.0},
                 pass_threshold=0.5,
+                # Score by running the reference test suite in the env container.
+                # The runner dispatches on this method, not on the adapter name.
+                grading_method="test_execution",
             ),
             tool_artifacts=artifacts,
             metadata={

--- a/tests/canonical/snapshots/tbench_echo_hello/task_description.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_description.json
@@ -49,6 +49,7 @@
   "generated_at": null,
   "grading": {
     "combine_method": "weighted",
+    "grading_method": "test_execution",
     "llm_judge": null,
     "pass_threshold": 0.5,
     "state_checks": null,

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -1,0 +1,164 @@
+"""Plugin-first adapter system: the *runner* must not branch on adapter identity.
+
+These pin the capability/declarative seams that replace the old runner-side
+``adapter_type == AdapterType.TERMINAL_BENCH`` branches (tool lifecycle + grading
+method), the open ``adapter_type`` string, and the host-side registry guard — so a
+new adapter can be added as an entry-point package with zero engine edits.
+"""
+
+import pytest
+
+from tolokaforge.adapters import (
+    available_adapters,
+    ensure_registered_adapter,
+    register_adapter,
+)
+from tolokaforge.runner.models import GradingConfig, TaskDescription
+from tolokaforge.runner.tool_factory import (
+    DockerComposeExecToolWrapper,
+    ToolLifecycleContext,
+    ToolWrapper,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestOpenAdapterType:
+    def test_unknown_adapter_type_round_trips(self):
+        """A non-built-in adapter name serializes and deserializes unchanged.
+
+        (Before opening the enum this raised a ValidationError, blocking any
+        entry-point adapter from round-tripping a TaskDescription.)
+        """
+        td = TaskDescription(
+            task_id="t1",
+            name="t1",
+            category="general",
+            description="d",
+            adapter_type="some_third_party_adapter",
+            system_prompt="sp",
+        )
+        assert td.adapter_type == "some_third_party_adapter"
+        reloaded = TaskDescription.model_validate_json(td.model_dump_json())
+        assert reloaded.adapter_type == "some_third_party_adapter"
+
+
+class TestDeclarativeGradingMethod:
+    def test_grading_method_defaults_none(self):
+        assert GradingConfig().grading_method is None
+
+    def test_grading_method_round_trips(self):
+        gc = GradingConfig(grading_method="test_execution")
+        assert GradingConfig.model_validate_json(gc.model_dump_json()).grading_method == (
+            "test_execution"
+        )
+
+
+class TestToolLifecycleCapability:
+    def test_base_wrapper_has_no_lifecycle(self):
+        assert ToolWrapper.has_lifecycle is False
+
+    def test_compose_wrapper_declares_lifecycle(self):
+        assert DockerComposeExecToolWrapper.has_lifecycle is True
+
+    def test_base_start_stop_are_noops(self):
+        """A tool without a lifecycle is a safe no-op under the generic runner loop."""
+
+        class _Dummy(ToolWrapper):
+            async def execute(self, arguments):  # pragma: no cover - not called
+                return ""
+
+        from tolokaforge.runner.models import ToolSchema
+
+        tool = _Dummy(ToolSchema(name="x", description="", parameters={}))
+        assert tool.has_lifecycle is False
+        # Must not raise — the runner calls these on every tool generically.
+        tool.start(ToolLifecycleContext(trial_id="t:0"))
+        tool.stop()
+
+
+class TestHostSideAdapterTypeGuard:
+    """adapter_type is an open string; the host validates it against the registry
+    (the runner stays permissive). See ``ensure_registered_adapter``."""
+
+    def test_accepts_registered_adapter(self):
+        # 'native' is always registered; should not raise.
+        assert "native" in available_adapters()
+        ensure_registered_adapter("native")
+
+    def test_rejects_unknown_adapter(self):
+        with pytest.raises(ValueError, match="Unknown adapter type"):
+            ensure_registered_adapter("definitely_not_a_real_adapter")
+
+    def test_accepts_a_freshly_registered_plugin(self):
+        """A newly registered (entry-point-style) adapter passes with no engine edit."""
+        import tolokaforge.adapters as adapters_mod
+
+        register_adapter("temp_plugin_adapter", object)
+        try:
+            ensure_registered_adapter("temp_plugin_adapter")
+        finally:
+            adapters_mod._ADAPTERS.pop("temp_plugin_adapter", None)
+
+
+class TestRunnerStaysAdapterAgnostic:
+    """Regression guard: the runner must select behaviour from declarative
+    capabilities (``has_lifecycle``, ``grading_method``), never from the adapter's
+    identity. Fails if an ``adapter_type ==`` / ``== AdapterType`` / adapter
+    ``isinstance`` branch is reintroduced into runner behavioural code.
+    """
+
+    def test_runner_behavioural_modules_have_no_adapter_identity_branches(self):
+        import re
+        from pathlib import Path
+
+        import tolokaforge.runner.service as service_mod
+        import tolokaforge.runner.tool_factory as tool_factory_mod
+
+        # Patterns that indicate branching on a specific adapter's identity.
+        identity_patterns = [
+            re.compile(r"adapter_type\s*=="),
+            re.compile(r"==\s*AdapterType\b"),
+            re.compile(r"isinstance\([^)]*Adapter\b"),
+        ]
+        offenders: list[str] = []
+        for mod in (service_mod, tool_factory_mod):
+            src = Path(mod.__file__).read_text()
+            for i, line in enumerate(src.splitlines(), start=1):
+                if any(p.search(line) for p in identity_patterns):
+                    offenders.append(f"{mod.__name__}:{i}: {line.strip()}")
+
+        assert not offenders, (
+            "Runner must stay adapter-agnostic (drive behaviour from capabilities, "
+            "not adapter identity). Found identity branch(es):\n" + "\n".join(offenders)
+        )
+
+
+class TestGradingMethodErrorHandling:
+    """Adapter-author-facing error paths: clear, actionable, non-silent."""
+
+    def test_invalid_grading_method_string_is_rejected_by_the_model(self):
+        """Typos in ``grading_method`` are caught at validation, not silently ignored."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            GradingConfig(grading_method="test-execution")  # hyphen — should be underscore
+
+    def test_test_execution_without_exec_tool_returns_actionable_error(self):
+        """If an adapter asks for test-execution grading but ships no exec-capable
+        lifecycle tool, the runner returns an error that tells the author what's missing.
+        """
+        # We test the message shape; exercising the live RPC needs a full runner.
+        # Read the source so the test fails if the actionable phrasing regresses.
+        from pathlib import Path
+
+        import tolokaforge.runner.service as service_mod
+
+        src = Path(service_mod.__file__).read_text()
+        # Required cues for an adapter author who hits this error:
+        assert (
+            "grading_method='test_execution'" in src
+        ), "The 'no exec tool' error must name the field the adapter set."
+        assert (
+            "TaskDescription.agent_tools" in src
+        ), "The 'no exec tool' error must point the adapter author to where to add the tool."

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -18,6 +18,7 @@ from tolokaforge.runner.tool_factory import (
     DockerComposeExecToolWrapper,
     ToolConfigurationError,
     ToolFactory,
+    ToolLifecycleContext,
 )
 
 pytestmark = pytest.mark.unit
@@ -180,7 +181,7 @@ class TestDockerComposeExecWrapperStart:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        wrapper.start("tbench_task_0")
+        wrapper.start(ToolLifecycleContext(trial_id="task_0"))
         assert wrapper.project_name == "tbench_task_0"
         assert wrapper._started is True
 
@@ -194,7 +195,7 @@ class TestDockerComposeExecWrapperStart:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        wrapper.start("tbench_mytask_2")
+        wrapper.start(ToolLifecycleContext(trial_id="mytask_2"))
         assert (
             wrapper.env_vars["T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME"] == "tbench_mytask_2_main"
         )
@@ -209,7 +210,7 @@ class TestDockerComposeExecWrapperStart:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        wrapper.start("tbench_task_1")
+        wrapper.start(ToolLifecycleContext(trial_id="task_1"))
         assert wrapper.env_vars["T_BENCH_TASK_LOGS_PATH"] == "/workspace/logs/tbench_task_1"
         assert (
             wrapper.env_vars["T_BENCH_TASK_AGENT_LOGS_PATH"]
@@ -223,7 +224,7 @@ class TestDockerComposeExecWrapperStart:
             args=[], returncode=1, stdout="", stderr="Error: service failed"
         )
         with pytest.raises(RuntimeError, match="docker compose up failed"):
-            wrapper.start("tbench_fail_0")
+            wrapper.start(ToolLifecycleContext(trial_id="fail_0"))
 
     @patch("subprocess.run")
     @patch("os.makedirs")
@@ -233,7 +234,7 @@ class TestDockerComposeExecWrapperStart:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
-        wrapper.start("tbench_copy_0")
+        wrapper.start(ToolLifecycleContext(trial_id="copy_0"))
         # Should have: compose up, cp tests, cp run-tests.sh, mkdir logs
         assert mock_run.call_count >= 4
 

--- a/tolokaforge/adapters/__init__.py
+++ b/tolokaforge/adapters/__init__.py
@@ -19,8 +19,12 @@ from tolokaforge.adapters.base import (
     DockerStackRequirements,
     NativeTaskBundle,
 )
+from tolokaforge.runner.models import AdapterType
 
 logger = logging.getLogger(__name__)
+
+# Canonical name of the only built-in adapter (kept as a constant, not a literal).
+_NATIVE = AdapterType.NATIVE.value
 
 # ---------------------------------------------------------------------------
 # Adapter registry
@@ -41,7 +45,7 @@ def _discover_adapters() -> dict[str, type]:
     """
     from tolokaforge.adapters.native import NativeAdapter
 
-    adapters: dict[str, type] = {"native": NativeAdapter}
+    adapters: dict[str, type] = {_NATIVE: NativeAdapter}
 
     for ep in importlib.metadata.entry_points(group="tolokaforge.adapters"):
         try:
@@ -79,6 +83,24 @@ def register_adapter(name: str, adapter_cls: type) -> None:
     _ADAPTERS[name] = adapter_cls
 
 
+def ensure_registered_adapter(adapter_type: str) -> None:
+    """Host-side guard: assert ``adapter_type`` is a registered adapter.
+
+    The adapter set is open and discovered at runtime (entry-point plugins), so
+    ``TaskDescription.adapter_type`` is an open string. Validate it here — on the
+    host, where the registry is authoritative — to catch typos/misconfig early with
+    a clear error. This is intentionally **not** a Pydantic validator: the runner
+    deserializes ``TaskDescription`` and must stay permissive (it is
+    adapter-agnostic and may not have a given adapter plugin installed).
+    """
+    known = available_adapters()
+    if adapter_type not in known:
+        raise ValueError(
+            f"Unknown adapter type: {adapter_type!r}. Available adapters: {known}. "
+            "Install the adapter package or check the adapter configuration."
+        )
+
+
 def get_adapter(adapter_type: str | None, params: dict[str, Any]) -> BaseAdapter:
     """
     Get adapter instance based on type.
@@ -93,7 +115,7 @@ def get_adapter(adapter_type: str | None, params: dict[str, Any]) -> BaseAdapter
     Raises:
         ValueError: If the requested adapter type is unknown or not installed.
     """
-    if adapter_type is None or adapter_type == "native":
+    if adapter_type is None or adapter_type == _NATIVE:
         from tolokaforge.adapters.native import NativeAdapter
 
         return NativeAdapter(params)

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -384,7 +384,9 @@ class NativeAdapter(BaseAdapter):
             UserSimulatorConfig as RunnerUserSimulatorConfig,
         )
 
-        logger.info("Building TaskDescription", task_id=task_id, adapter_type="native")
+        logger.info(
+            "Building TaskDescription", task_id=task_id, adapter_type=AdapterType.NATIVE.value
+        )
 
         # Ensure tasks are discovered
         self._discover_tasks()

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from tolokaforge.adapters import BaseAdapter, get_adapter
+from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_adapter
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.env_state import EnvironmentState
 from tolokaforge.core.failure_attribution import (
@@ -47,6 +47,7 @@ from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import AttemptLease, create_run_queue
 from tolokaforge.core.runner import TrialRunner
 from tolokaforge.core.stuck import StuckDetector
+from tolokaforge.runner.models import AdapterType
 
 # Tools that need Playwright + Chromium baked into the runner image. The
 # orchestrator scans the task list before starting the docker stack and
@@ -188,7 +189,7 @@ class Orchestrator:
             adapter_type = adapter_config.type
             params = adapter_config.params.copy()
         else:
-            adapter_type = "native"
+            adapter_type = AdapterType.NATIVE
             params = {}
 
         # Add tasks_glob to params for both native and other adapters
@@ -1238,6 +1239,10 @@ class Orchestrator:
 
         # Get TaskDescription from adapter and register trial
         task_desc = self.adapter.to_task_description(task.task_id)
+        # Host-side guard: adapter_type is an open string (the adapter set is
+        # entry-point-discovered). Validate against the registry here (authoritative
+        # on the host) to catch typos/misconfig early.
+        ensure_registered_adapter(task_desc.adapter_type)
         task_desc_json = task_desc.model_dump_json()
 
         register_result = tool_executor.register_trial(task_description_json=task_desc_json)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -23,7 +23,15 @@ from pydantic import BaseModel, Field
 
 
 class AdapterType(str, Enum):
-    """Source adapter that produced this description."""
+    """Well-known adapter names produced by built-in/first-party adapters.
+
+    This enum is **not** an exhaustive, closed set: ``TaskDescription.adapter_type``
+    is a free ``str`` sourced from the adapter registry, so entry-point / third-party
+    adapters round-trip with their own names and need no engine edit. These members
+    are the canonical constants for the built-in adapter names — first-party engine
+    code should reference them (e.g. ``AdapterType.NATIVE``) instead of raw
+    adapter-name string literals.
+    """
 
     NATIVE = "native"
     TAU = "tau"
@@ -308,6 +316,24 @@ class GradingConfig(BaseModel):
     weights: dict[str, float] = Field(default_factory=lambda: {"state_checks": 1.0})
     pass_threshold: float = 0.8
 
+    # Declarative grading dispatch — adapters tell the runner *how* to grade in data,
+    # so the runner never infers it from the adapter's identity.
+    #
+    # Values:
+    #   ``None`` (default)
+    #     Standard grading: combine state checks / transcript rules / LLM judge
+    #     using ``weights`` and ``pass_threshold``. Most adapters want this.
+    #   ``"test_execution"``
+    #     Run a reference test suite inside the trial env via an exec-capable
+    #     lifecycle tool (today: ``DockerComposeExecToolWrapper``) and score by
+    #     reading the reward written to ``/logs/verifier/reward.txt``. Requires
+    #     such a tool to be present in ``TaskDescription.agent_tools`` — without
+    #     one the runner returns a clear error at ``GradeTrial`` time.
+    #   ``"hash"`` / ``"transcript"`` / ``"llm"``
+    #     Reserved names for future single-method dispatch; not currently used
+    #     for dispatch (today their behaviour is part of the default path).
+    grading_method: Literal["hash", "test_execution", "transcript", "llm"] | None = None
+
     state_checks: StateChecksConfig | None = None
     transcript_rules: TranscriptRulesConfig | None = None
     llm_judge: LLMJudgeConfig | None = None
@@ -333,7 +359,10 @@ class TaskDescription(BaseModel):
     name: str
     category: str  # Domain: "airline", "retail"
     description: str  # Task description / user goal
-    adapter_type: AdapterType
+    # Open/extensible: the adapter name from the registry (entry-point or built-in).
+    # Not constrained to AdapterType so third-party adapters round-trip with no engine
+    # edit; see AdapterType for the well-known built-in names.
+    adapter_type: str
     schema_version: str = "1.0.0"
 
     # --- System Prompt ---

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -50,7 +50,6 @@ from tolokaforge.runner.grading import (
     evaluate_transcript_rules,
 )
 from tolokaforge.runner.models import (
-    AdapterType,
     GoldenAction,
     GradeComponents,
     HashGradingResult,
@@ -68,6 +67,7 @@ from tolokaforge.runner.tool_factory import (
     DockerComposeExecToolWrapper,
     MCPServerToolWrapper,
     ToolFactory,
+    ToolLifecycleContext,
     ToolReconstructionError,
 )
 
@@ -208,7 +208,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         self.db_client = db_client
         self.rag_client = rag_client
         self.trials: dict[str, TrialContextRuntime] = {}
-        self._available_adapters = ["tau", "mcp", "native"]  # TODO: detect dynamically
+        # Report the adapters actually registered (built-in + entry-point plugins),
+        # not a hardcoded list, so capabilities reflect what's installed.
+        from tolokaforge.adapters import available_adapters
+
+        self._available_adapters = available_adapters()
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup
 
         # Create a dedicated event loop thread for async operations.
@@ -591,22 +595,23 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # Store trial context
         self.trials[trial_id] = trial_context
 
-        # Terminal-bench: start Docker Compose stack for this trial
-        if task_description.adapter_type == AdapterType.TERMINAL_BENCH:
-            project_name = f"tbench_{trial_id.replace(':', '_')}"
-            for tool in trial_context.agent_tools.values():
-                if isinstance(tool, DockerComposeExecToolWrapper):
-                    # Resolve __artifacts__ task_dir to actual extraction path
-                    if tool.task_dir == "__artifacts__" and artifacts_dir is not None:
-                        tool.task_dir = str(artifacts_dir)
-                    try:
-                        tool.start(project_name)
-                    except Exception as e:
-                        logger.error(f"RegisterTrial: Failed to start compose stack: {e}")
-                        return pb2.RegisterTrialResponse(
-                            success=False,
-                            error=f"Docker Compose start failed: {e}",
-                        )
+        # Start any tools that manage per-trial resources. Driven by the tool's
+        # ``has_lifecycle`` capability, not by adapter identity, so any lifecycle
+        # tool (e.g. a compose-backed sandbox) is provisioned the same way.
+        lifecycle_ctx = ToolLifecycleContext(
+            trial_id=trial_id,
+            artifacts_dir=str(artifacts_dir) if artifacts_dir is not None else None,
+        )
+        for tool in trial_context.agent_tools.values():
+            if getattr(tool, "has_lifecycle", False):
+                try:
+                    tool.start(lifecycle_ctx)
+                except Exception as e:
+                    logger.error(f"RegisterTrial: Failed to start tool lifecycle: {e}")
+                    return pb2.RegisterTrialResponse(
+                        success=False,
+                        error=f"Tool lifecycle start failed: {e}",
+                    )
 
         # Build tool schemas for response
         tool_schemas = []
@@ -916,14 +921,13 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         trial_id = request.trial_id
         trial_context = self.trials[trial_id]
 
-        # Terminal-bench: run test.sh inside compose container instead of hash grading
-        if (
-            trial_context.task_description
-            and trial_context.task_description.adapter_type == AdapterType.TERMINAL_BENCH
-        ):
-            return await self._grade_terminal_bench(trial_id, trial_context)
-
         grading_config = trial_context.grading_config
+
+        # Declarative grading-method dispatch (no adapter identity): a task can request
+        # test-execution grading — run a reference suite in the env and score it —
+        # instead of the default state/transcript/judge combination.
+        if grading_config and grading_config.grading_method == "test_execution":
+            return await self._grade_via_test_execution(trial_id, trial_context)
 
         # Initialize grading components
         components = GradeComponents()
@@ -1421,17 +1425,21 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
     # Terminal-bench grading
     # =========================================================================
 
-    async def _grade_terminal_bench(
+    async def _grade_via_test_execution(
         self,
         trial_id: str,
         trial_context: "TrialContextRuntime",
     ) -> "pb2.GradeTrialResponse":
-        """Grade a terminal-bench trial by running test.sh inside the compose container.
+        """Grade by running a reference test suite inside the trial's env container.
+
+        Selected declaratively via ``grading.grading_method == "test_execution"`` —
+        no adapter identity involved.
 
         1. Execute ``test.sh`` (pytest + reward calculation) in the task container.
         2. Read the reward float from ``/logs/verifier/reward.txt``.
         3. Return a ``GradeTrialResponse`` with the reward as score.
         """
+        # Find an exec-capable lifecycle tool to run the suite in the env.
         bash_tool: DockerComposeExecToolWrapper | None = None
         for tool in trial_context.agent_tools.values():
             if isinstance(tool, DockerComposeExecToolWrapper):
@@ -1439,15 +1447,22 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 break
 
         if bash_tool is None:
-            return pb2.GradeTrialResponse(
-                success=False,
-                error="Terminal-bench grading: no DockerComposeExecToolWrapper found",
+            # Actionable for the adapter author: they asked for test-execution
+            # grading but didn't ship a tool that can run the suite inside the env.
+            error_msg = (
+                "test-execution grading was requested (grading_method='test_execution') "
+                "but no exec-capable env tool was found in this trial. Include an "
+                "exec-capable lifecycle tool (e.g. DockerComposeExecToolWrapper) in "
+                "TaskDescription.agent_tools so the runner can execute the test suite "
+                "inside the trial environment."
             )
+            logger.error(f"GradeTrial(test-execution): {trial_id} - {error_msg}")
+            return pb2.GradeTrialResponse(success=False, error=error_msg)
 
         loop = asyncio.get_event_loop()
 
         # Run test.sh
-        logger.info(f"GradeTrial(terminal-bench): {trial_id} - running test.sh")
+        logger.info(f"GradeTrial(test-execution): {trial_id} - running test.sh")
         try:
             test_output = await loop.run_in_executor(
                 None,
@@ -1456,7 +1471,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 300.0,  # verifier timeout
             )
         except Exception as e:
-            logger.error(f"GradeTrial(terminal-bench): test.sh failed: {e}")
+            logger.error(f"GradeTrial(test-execution): test.sh failed: {e}")
             return pb2.GradeTrialResponse(
                 success=True,
                 error="",
@@ -1481,7 +1496,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         except (ValueError, IndexError):
             reward = 0.0
 
-        logger.info(f"GradeTrial(terminal-bench): {trial_id} - reward={reward:.4f}")
+        logger.info(f"GradeTrial(test-execution): {trial_id} - reward={reward:.4f}")
 
         return pb2.GradeTrialResponse(
             success=True,
@@ -1491,7 +1506,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 score=reward,
                 components=pb2.GradeComponents(custom_checks=reward),
                 reasons=(
-                    f"terminal-bench reward: {reward:.4f}\n\n"
+                    f"test-execution reward: {reward:.4f}\n\n"
                     f"test output (truncated):\n{test_output[:2000]}"
                 ),
             ),
@@ -1556,17 +1571,14 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             trial_context = self.trials[trial_id]
             trial_context.clear_history()
 
-            # Terminal-bench: stop Docker Compose stack
-            if (
-                trial_context.task_description
-                and trial_context.task_description.adapter_type == AdapterType.TERMINAL_BENCH
-            ):
-                for tool in trial_context.agent_tools.values():
-                    if isinstance(tool, DockerComposeExecToolWrapper):
-                        try:
-                            tool.stop()
-                        except Exception as e:
-                            logger.warning(f"ResetTrial: Failed to stop compose: {e}")
+            # Stop any per-trial lifecycle tools started during registration.
+            # Capability-driven (has_lifecycle), not adapter identity.
+            for tool in trial_context.agent_tools.values():
+                if getattr(tool, "has_lifecycle", False):
+                    try:
+                        tool.stop()
+                    except Exception as e:
+                        logger.warning(f"ResetTrial: Failed to stop tool lifecycle: {e}")
 
         # TODO: Phase 3b — Re-execute initialization_actions if requested
         # if request.execute_init_actions:

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -97,12 +98,32 @@ class ToolExecutionError(Exception):
 # =============================================================================
 
 
+@dataclass
+class ToolLifecycleContext:
+    """Per-trial context passed to a tool's ``start()``.
+
+    Carries only what a lifecycle tool may need to provision its per-trial
+    resources, so the runner can drive lifecycle generically without knowing any
+    specific tool or adapter.
+    """
+
+    trial_id: str
+    artifacts_dir: str | None = None
+
+
 class ToolWrapper(ABC):
     """
     Base class for tool wrappers.
 
     All wrappers must implement the execute() method with the same interface.
     """
+
+    # Whether the runner manages this tool's per-trial lifecycle via start()/stop()
+    # in RegisterTrial/ResetTrial. Default False: most tools have no per-trial
+    # resources to provision. Lifecycle tools (e.g. a compose-backed sandbox)
+    # override this to True. This keeps the runner adapter-agnostic — it drives
+    # lifecycle off this capability, never off the adapter type.
+    has_lifecycle: bool = False
 
     def __init__(self, tool_schema: ToolSchemaModel):
         self.tool_schema = tool_schema
@@ -125,6 +146,14 @@ class ToolWrapper(ABC):
     async def __call__(self, arguments: dict[str, Any]) -> str:
         """Allow calling the wrapper directly."""
         return await self.execute(arguments)
+
+    def start(self, ctx: "ToolLifecycleContext") -> None:  # noqa: B027
+        """Provision per-trial resources (override in lifecycle tools)."""
+        pass
+
+    def stop(self) -> None:  # noqa: B027
+        """Tear down resources provisioned by start() (override if needed)."""
+        pass
 
     def cleanup(self) -> None:  # noqa: B027
         """Clean up any resources (override in subclasses if needed)."""
@@ -964,6 +993,9 @@ class DockerComposeExecToolWrapper(ToolWrapper):
     Uses host Docker daemon via mounted socket.
     """
 
+    # Runner-managed per-trial lifecycle (compose up on RegisterTrial, down on reset).
+    has_lifecycle = True
+
     def __init__(
         self,
         tool_schema: ToolSchemaModel,
@@ -1005,13 +1037,20 @@ class DockerComposeExecToolWrapper(ToolWrapper):
 
     # -- lifecycle ------------------------------------------------------------
 
-    def start(self, project_name: str) -> None:
+    def start(self, ctx: "ToolLifecycleContext") -> None:
         """Build/pull images, start the compose stack, and copy tests in.
 
-        Called once per trial from ``RegisterTrial``.
+        Called once per trial from ``RegisterTrial`` for any lifecycle tool. Owns
+        its own per-trial naming and ``__artifacts__`` resolution so the runner
+        stays generic.
         """
         import os
 
+        # Resolve the deferred artifacts task_dir to the real extraction path.
+        if self.task_dir == "__artifacts__" and ctx.artifacts_dir is not None:
+            self.task_dir = str(ctx.artifacts_dir)
+
+        project_name = f"tbench_{ctx.trial_id.replace(':', '_')}"
         self.project_name = project_name
         # Override container_name and log paths for parallel trial isolation.
         # Derive per-trial log dirs from the parents of the task-scoped paths


### PR DESCRIPTION
Makes the **runner** adapter-agnostic: it manages tool lifecycle and selects grading
from **declarative data/capabilities** in the `TaskDescription`, never from the
adapter name. Combined with an open `adapter_type`, a new adapter can ship as an
entry-point package and round-trip a `TaskDescription` with **zero engine edits**.
No behaviour change.

Closes #60

> **Re-scoped after review.** An earlier revision also de-identity'd the
> orchestrator's env-state branch via a `provides_env_state()` adapter hook. That was
> the wrong layer: environment-state ownership belongs to the runner (the sandbox)
> and the per-trial runtime, and the orchestrator's env-state syncing is boundary-less
> logic that a later orchestrator refactor will rework. That change has been
> **dropped and deferred**; this PR is scoped to the runner.

## Changes

- **Open `adapter_type`** — `TaskDescription.adapter_type` is now an open `str` from
  the registry (built-in names kept as constants). Consistent with the existing
  `core` model + run-config `type`. A host-side `ensure_registered_adapter()` guard
  validates the name where the registry is authoritative; the **runner stays
  permissive** (no model validator) so it never falsely rejects an adapter it doesn't
  have installed.
- **Tool lifecycle is a capability** — base `ToolWrapper` gains `has_lifecycle=False`
  + no-op `start(ctx)/stop()`; `DockerComposeExecToolWrapper` opts in and owns its
  per-trial naming/artifacts. `RegisterTrial`/`ResetTrial` drive lifecycle off the
  capability — removes the `== TERMINAL_BENCH` setup/teardown branches.
- **Declarative grading method** — `GradingConfig.grading_method` (e.g.
  `test_execution`); `GradeTrial` dispatches on config
  (`_grade_terminal_bench` → `_grade_via_test_execution`) — removes the grading
  identity branch.
- `terminal_bench` adapter declares `grading_method="test_execution"`; snapshot
  updated for the new field. (See "Why terminal-bench changes too" below.)

## Why terminal-bench changes too

The old contract was implicit: the runner inferred "use test-execution grading"
from the adapter's *name* (`adapter_type == AdapterType.TERMINAL_BENCH`). The whole
point of this PR is to stop reading the name and start reading explicit data. So:

- The runner stopped saying *"I'll guess what you want based on who you are."*
- It now says *"tell me explicitly via `grading_method` on the grading config."*

If the runner stops inferring, someone has to declare. The only candidate is the
adapter that produces the `TaskDescription` — and for test-execution grading
today, that's terminal-bench. **One adapter, one line** (plus its snapshot picking
up the new field). The two changes are coupled by the contract: the callee changed
the field it reads, the (sole) caller must write that field. They had to ship
together — splitting them would leave a window where terminal-bench falls through
to default grading and produces wrong verdicts.

## Design note: why `adapter_type` is an open string

The set of adapters is **open and discovered at runtime** (entry-point plugins), so
a closed enum can't represent it — it would block third-party adapters from even
round-tripping a `TaskDescription` and force an engine edit per adapter. The
standard pattern for that is a **string key validated against a registry** (the
same shape as setuptools entry points / pytest plugins).

More importantly: after this PR, `adapter_type` drives **no behaviour** — the
runner selects behaviour from explicit, well-typed capabilities (`grading_method:
Literal[…]`, `has_lifecycle: bool`, the tools themselves), not from the adapter
name. So `adapter_type` is now **provenance metadata** (which adapter produced
this task), and a plain string is the appropriate representation for a provenance
tag — a richer/closed type would signal it's load-bearing when the design goal is
the opposite. Validation lives at the host boundary
(`ensure_registered_adapter`, where the registry is authoritative) to catch typos
early, while the runner stays permissive.

## Contract for new adapter authors

What an adapter needs to know to use the new contract correctly:

- **Default works.** A new adapter that just produces a `TaskDescription` and
  doesn't set `grading_method` gets standard weighted grading
  (state checks / transcript rules / LLM judge per `combine_method` + `weights`).
  This is what most adapters want; nothing extra to do.
- **Want test-execution grading?** Set
  `grading=GradingConfig(grading_method="test_execution", ...)` **and** include an
  exec-capable lifecycle tool (today: `DockerComposeExecToolWrapper`) in
  `TaskDescription.agent_tools`. The runner runs `test.sh` inside the env container
  and scores by reading the reward float from `/logs/verifier/reward.txt`.
- **Tool lifecycle.** If a tool owns per-trial resources (e.g. a compose stack),
  set `has_lifecycle = True` on the wrapper and override `start(ctx)` / `stop()`.
  The runner drives lifecycle generically — no engine code knows your tool by
  name.

## Error handling for "new adapter does X wrong"

| Case | Caught by | Message |
|---|---|---|
| Unknown / typo'd `adapter_type` | `ensure_registered_adapter` (host) | `"Unknown adapter type: 'foo'. Available adapters: […]"` |
| Invalid `grading_method` string (typo) | Pydantic `Literal[…]` at model validation | `ValidationError` with allowed values |
| `grading_method="test_execution"` but no exec tool | Runner returns `GradeTrialResponse(success=False, …)` | `"test-execution grading was requested (grading_method='test_execution') but no exec-capable env tool was found in this trial. Include an exec-capable lifecycle tool (e.g. DockerComposeExecToolWrapper) in TaskDescription.agent_tools so the runner can execute the test suite inside the trial environment."` |
| Lifecycle tool `start()` raises | Runner returns `RegisterTrialResponse(success=False, …)` | `"Tool lifecycle start failed: <e>"` |
| Lifecycle tool `stop()` raises | Runner logs `WARNING` and continues teardown | `"ResetTrial: Failed to stop tool lifecycle: <e>"` |
| Adapter omits `grading_method` entirely | (intended) Falls through to default weighted grading | n/a — silent because `None` is the documented "I want default grading" signal |

The one case there's no automatic detection for is "I *meant* to set
`grading_method` but forgot." That can't be inferred without re-introducing magic
("you have a compose-exec tool, so you must want test-execution") — exactly the
identity coupling this PR removes. The defence there is documentation (the field
docstring) and a strict `Literal` type so typos can't sneak past.

## Known limitations of the lifecycle contract (tracked follow-up: #63)

The tool lifecycle contract introduced here (`has_lifecycle` + `start(ctx)` /
`stop()`) is intentionally **minimum viable** — sufficient for the one lifecycle
tool that ships today (a Docker Compose exec wrapper for `terminal_bench`) but
shallow on purpose. Known gaps for future custom lifecycle tools:

- `ToolLifecycleContext` is sparse (only `trial_id` + `artifacts_dir`); tools
  needing env-service endpoints, resource limits, secrets, etc. don't yet
  receive them.
- `start(ctx)` is synchronous; no timeout / retry / async companion.
- Only `start` / `stop` hooks exist (no `suspend` / `snapshot` /
  `reset-without-teardown`).
- No ordering / dependency / readiness signalling between multiple lifecycle
  tools in the same trial.

The shape is forward-compatible (`ToolLifecycleContext` is a dataclass; dispatch
is capability-driven, not adapter-identity-driven), so the contract will grow
additively when a real second user surfaces a need. Documented in
`docs/ADAPTER_INTERFACE.md` and tracked in #63 — not addressed in this PR.

## Explicitly deferred (not this PR)

- **Orchestrator env-state ownership** (`isinstance(self.adapter, NativeAdapter)`):
  left untouched — removing it properly means moving env-state ownership to the
  runner, which belongs to a later orchestrator refactor.
- **CLI `convert` `if name == "tau"`** param mapping and the tool `InvocationStyle`
  dispatch (a tool-mechanism concern, not adapter identity).

## Verification

- Full offline suite **1817 passed**, including the golden grading regression gate
  (verdicts unchanged).
- Scoped grep gate: **no `adapter_type == AdapterType` branches in `tolokaforge/runner/`**
  (enforced by a regression test that scans the runner's behavioural modules).
- Unit tests pin the seams: open-type round-trip, declarative `grading_method`
  dispatch, lifecycle capability (start/stop on lifecycle tools, no-op otherwise),
  host-side adapter_type guard (accept / reject / fresh-plugin), and the
  adapter-author error paths (typo'd grading method, missing exec tool).
- Docker end-to-end: a `terminal_bench` task runs the full pipeline (resolve →
  compose-up via the generic lifecycle → agent loop → `test_execution` grading →
  teardown). Behaviour matches `main` (A/B verified, identical verdict).
