### PR TITLE
fix(grading): unknown jsonpath operators fail loud + deterministic reasons

### DIFF
--- a/tests/canonical/snapshots/grading_paths/jsonpath_unknown_operator_fails_loud.json
+++ b/tests/canonical/snapshots/grading_paths/jsonpath_unknown_operator_fails_loud.json
@@ -1,0 +1,10 @@
+{
+  "binary_pass": false,
+  "components": {
+    "custom_checks": null,
+    "llm_judge": null,
+    "state_checks": 0.0,
+    "transcript_rules": null
+  },
+  "score": 0.0
+}

--- a/tests/canonical/snapshots/grading_state_calc/fail_result.json
+++ b/tests/canonical/snapshots/grading_state_calc/fail_result.json
@@ -1,4 +1,4 @@
 {
-  "reasons": "",
-  "score": 1.0
+  "reasons": "Path $.counter: expected 5, got 0 (Counter should be 5)",
+  "score": 0.0
 }

--- a/tests/canonical/snapshots/grading_transcript_calc/fail_result.json
+++ b/tests/canonical/snapshots/grading_transcript_calc/fail_result.json
@@ -1,4 +1,4 @@
 {
-  "reasons": "Missing required tools: {'write_file'}",
+  "reasons": "Missing required tools: write_file",
   "score": 0.875
 }

--- a/tests/canonical/test_grading_canon.py
+++ b/tests/canonical/test_grading_canon.py
@@ -19,10 +19,8 @@ class TestStateCheckerCanon:
         jsonpath_assertions = [
             {
                 "path": "$.counter",
-                "op": "eq",
-                "expected": 5,
-                "required": True,
-                "reason": "Counter should be 5",
+                "equals": 5,
+                "description": "Counter should be 5",
             },
         ]
 
@@ -43,10 +41,8 @@ class TestStateCheckerCanon:
         jsonpath_assertions = [
             {
                 "path": "$.counter",
-                "op": "eq",
-                "expected": 5,
-                "required": True,
-                "reason": "Counter should be 5",
+                "equals": 5,
+                "description": "Counter should be 5",
             },
         ]
 

--- a/tests/canonical/test_grading_paths_canon.py
+++ b/tests/canonical/test_grading_paths_canon.py
@@ -178,11 +178,39 @@ def _scenario_fail_hash_mismatch():
     return config, traj, final_env_state
 
 
+def _scenario_jsonpath_unknown_operator_fails_loud():
+    """End-to-end exercise of the fail-loud branch through GradingEngine: an
+    assertion with `op: gte / expected: 5` (legacy shape, no recognized
+    operator) used to silently satisfy as long as the path existed. Now the
+    engine returns state_checks=0.0 and binary_pass=False even though the
+    JSONPath exists and would have matched the wished-for `gte` semantic.
+    """
+    config = {
+        "combine": {"method": "weighted", "weights": {"state_checks": 1.0}, "pass_threshold": 0.5},
+        "state_checks": {
+            "jsonpaths": [
+                {
+                    "path": "$.db.counter",
+                    "op": "gte",  # unrecognized — used to silently pass
+                    "expected": 5,
+                    "description": "Counter should be at least 5",
+                }
+            ],
+        },
+    }
+    traj = _trajectory([Message(role=MessageRole.USER, content="go")])
+    # counter=7 would have satisfied `gte 5` if it were a real operator; it
+    # used to silently pass for path-existence. Must now fail.
+    final_env_state = {"db": {"counter": 7}}
+    return config, traj, final_env_state
+
+
 _SCENARIOS = {
     "jsonpath_partial": _scenario_jsonpath_partial,
     "transcript_actions_and_info": _scenario_transcript_actions_and_info,
     "weighted_combine": _scenario_weighted_combine,
     "fail_hash_mismatch": _scenario_fail_hash_mismatch,
+    "jsonpath_unknown_operator_fails_loud": _scenario_jsonpath_unknown_operator_fails_loud,
 }
 
 

--- a/tests/data/tasks/calc_custom_checks/grading.yaml
+++ b/tests/data/tasks/calc_custom_checks/grading.yaml
@@ -6,12 +6,10 @@ combine:
   pass_threshold: 0.8
 
 state_checks:
-  jsonpaths:
-    - path: "$.counter"
-      op: "gte"
-      expected: 5
-      required: true
-      reason: "Counter should be at least 5"
+  # No jsonpaths — counter_reached_target() in checks.py owns the "counter >= 5"
+  # assertion (the engine has no gte operator; an `equals: 5` here would tighten
+  # the original "at least 5" semantic).
+  jsonpaths: []
 
 custom_checks:
   enabled: true

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -317,3 +317,103 @@ class TestCombinedGrading:
             hash_weight=0.5,
         )
         assert score == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+class TestUnknownOperatorFailsLoud:
+    """Pins the contract: an assertion with no recognized operator must FAIL
+    (with an actionable reason), not silently satisfy on path-existence.
+
+    Recognized operators are ``equals``, ``equals_ci``, ``contains``,
+    ``contains_ci``. Anything else (``op: gte``, typo like ``eqaul``, no operator
+    at all) used to be a silent no-op — this class regression-pins the
+    loud-failure behaviour.
+    """
+
+    @pytest.fixture
+    def checker(self):
+        return StateChecker()
+
+    def test_unknown_operator_keys_fail_with_actionable_reason(self, checker):
+        """An assertion with ``op``/``expected`` (unsupported by the engine)
+        previously satisfied silently as long as the path existed. Now it fails."""
+        state = {"counter": 0}
+        assertions = [
+            {
+                "path": "$.counter",
+                "op": "gte",
+                "expected": 5,
+                "description": "Counter should be at least 5",
+            }
+        ]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0
+        assert len(reasons) == 1
+        r = reasons[0]
+        assert "no recognized operator" in r
+        assert "'equals'" in r and "'contains'" in r
+        assert "op" in r and "expected" in r  # offending keys are surfaced
+
+    def test_no_operator_at_all_fails(self, checker):
+        """An assertion that only specifies ``path`` (no operator) used to
+        silently satisfy; it now fails loudly."""
+        state = {"counter": 0}
+        assertions = [{"path": "$.counter", "description": "exists"}]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0
+        assert "no recognized operator" in reasons[0]
+
+    def test_typo_in_operator_name_fails(self, checker):
+        """A misspelled operator key (``eqaul`` for ``equals``) fails — the
+        check is by exact key name, not heuristic, so typos are caught."""
+        state = {"x": "hello"}
+        assertions = [{"path": "$.x", "eqaul": "hello", "description": "typo"}]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0
+        assert "eqaul" in reasons[0]
+
+    def test_partial_credit_with_one_unknown_one_valid(self, checker):
+        """A mix of one valid (passing) and one unknown-operator assertion
+        gives partial credit — confirms per-assertion handling, not early-exit."""
+        state = {"a": 1, "b": 2}
+        assertions = [
+            {"path": "$.a", "equals": 1, "description": "valid passing"},
+            {"path": "$.b", "op": "gte", "expected": 2, "description": "unknown op"},
+        ]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == pytest.approx(0.5)
+        assert any("no recognized operator" in r for r in reasons)
+
+    def test_pre_fix_silent_pass_scenario_now_fails(self, checker):
+        """Regression pin for the exact silent-pass scenario: the path EXISTS
+        and the unrecognized operator's ``expected`` value would NOT match —
+        before the fix this satisfied 1/1 (score 1.0). It must now be 0/1."""
+        state = {"counter": 0}  # NOT 5
+        assertions = [
+            {"path": "$.counter", "op": "eq", "expected": 5, "description": "uses op:eq"},
+        ]
+        score, _ = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0, "Unrecognized operator must not silently satisfy"
+
+    def test_path_glob_with_unknown_operator_fails(self, checker):
+        """The fail-loud branch applies to ``path_glob`` assertions too, and the
+        reason names the glob target (not just ``path``)."""
+        state = {"filesystem": {"/agent/out.txt": "data"}}
+        assertions = [
+            {"path_glob": "/agent/*", "op": "matches", "expected": "data"},
+        ]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0
+        # Target is the glob string, not None.
+        assert "/agent/*" in reasons[0]
+        assert "no recognized operator" in reasons[0]
+
+    def test_actionable_reason_has_no_empty_parens_when_no_description(self, checker):
+        """Cosmetic: when description is omitted, the reason must not end with
+        a stray ``()`` — keeps the failure message clean for downstream parsing."""
+        state = {"counter": 0}
+        assertions = [{"path": "$.counter", "op": "gte", "expected": 5}]
+        score, reasons = checker.check_jsonpaths(state, assertions)
+        assert score == 0.0
+        assert not reasons[0].rstrip().endswith("()"), reasons[0]
+        assert "()" not in reasons[0]

--- a/tests/unit/grading/test_transcript.py
+++ b/tests/unit/grading/test_transcript.py
@@ -219,3 +219,53 @@ class TestTranscriptGrading:
             disallowed_tools=[],
         )
         assert score < 1.0
+
+
+@pytest.mark.unit
+class TestToolExpectationsReasonsAreDeterministic:
+    """Pins the contract: tool-expectation reason strings are sorted/stable so
+    they don't drift run-to-run from Python set repr ordering. Snapshot tests
+    (and downstream parsing) rely on this stability.
+    """
+
+    @pytest.fixture
+    def checker(self):
+        return TranscriptChecker()
+
+    def test_missing_tools_reason_is_sorted(self, checker):
+        """Reason text lists missing tools in alphabetical order — same across runs."""
+        score, reasons = checker.check_tool_expectations(
+            tool_log=[],
+            required_tools=["zebra_tool", "alpha_tool", "mango_tool"],
+            disallowed_tools=None,
+        )
+        assert len(reasons) == 1
+        # Sorted alphabetically.
+        assert reasons[0] == "Missing required tools: alpha_tool, mango_tool, zebra_tool"
+        # No set-repr punctuation leaks.
+        assert "{" not in reasons[0] and "}" not in reasons[0]
+        assert "'" not in reasons[0]
+
+    def test_violations_reason_is_sorted(self, checker):
+        """Reason text lists disallowed-tool violations in alphabetical order."""
+        tool_log = [{"tool": "zeta"}, {"tool": "alpha"}, {"tool": "mike"}]
+        score, reasons = checker.check_tool_expectations(
+            tool_log=tool_log,
+            required_tools=None,
+            disallowed_tools=["mike", "alpha", "zeta"],
+        )
+        assert len(reasons) == 1
+        assert reasons[0] == "Used disallowed tools: alpha, mike, zeta"
+        assert "{" not in reasons[0] and "}" not in reasons[0]
+
+    def test_reasons_are_stable_across_repeated_calls(self, checker):
+        """Calling the same scenario twice must yield byte-identical reasons,
+        regardless of underlying set iteration order."""
+        kwargs = {
+            "tool_log": [],
+            "required_tools": ["b_tool", "a_tool", "c_tool"],
+            "disallowed_tools": None,
+        }
+        _, r1 = checker.check_tool_expectations(**kwargs)
+        _, r2 = checker.check_tool_expectations(**kwargs)
+        assert r1 == r2

--- a/tests/unit/test_runner_jsonpath_grading.py
+++ b/tests/unit/test_runner_jsonpath_grading.py
@@ -161,3 +161,42 @@ def test_build_reasons_includes_jsonpath_when_score_set():
     }
     text = build_grade_reasons(components)
     assert "Files: PASS: A; FAIL: B" in text
+
+
+class TestRunnerSideAssertionsWithoutPathGlobFailLoud:
+    """Pins the contract: runner-side jsonpath evaluator fails loudly with an
+    actionable reason when an assertion doesn't carry ``path_glob``. Previously
+    such assertions were silently skipped (presented as ``SKIP: No path_glob``
+    while not counting as passed) — misrouted ``path:``-style assertions vanished
+    from grading visibility, the symptom that surfaced on internal tasks with
+    rich \\$.db.X jsonpaths.
+    """
+
+    def test_path_only_assertion_fails_loud_and_names_the_routing(self):
+        """An assertion using ``path:`` (env-state JSONPath, host-side) gets a
+        FAIL reason naming the wrong-evaluator routing — not a silent SKIP."""
+        checks = [
+            {
+                "path": "$.db.orders[0].id",
+                "equals": "O-001",
+                "description": "First order is assigned ID O-001",
+            }
+        ]
+        score, reasons = evaluate_jsonpath_file_checks(checks)
+        # 0/1 — was effectively 0/1 before too, but is now explicit.
+        assert score == 0.0
+        # Old wording must be gone; new wording must explain what's wrong.
+        assert "SKIP: No path_glob" not in reasons
+        assert "FAIL" in reasons
+        assert "graded host-side" in reasons
+        assert "First order is assigned ID O-001" in reasons
+
+    def test_truly_missing_target_still_fails_loud(self):
+        """Assertion with neither ``path:`` nor ``path_glob:`` — generic
+        actionable error pointing the author at the supported keys."""
+        checks = [{"contains_ci": "x", "description": "no target"}]
+        score, reasons = evaluate_jsonpath_file_checks(checks)
+        assert score == 0.0
+        assert "FAIL" in reasons
+        assert "path_glob" in reasons
+        assert "no target" in reasons

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -72,7 +72,24 @@ class StateChecker:
         self, state: dict[str, Any], assertions: list[dict[str, Any]]
     ) -> tuple[float, list[str]]:
         """
-        Check JSONPath assertions against state
+        Check JSONPath assertions against state.
+
+        Each assertion is a dict with one of:
+
+        - ``path``: a JSONPath expression evaluated against ``state``
+        - ``path_glob``: a glob evaluated against ``state["filesystem"]``
+
+        plus exactly one of these recognized comparison operators:
+
+        - ``equals``: exact equality
+        - ``equals_ci``: case-insensitive string equality
+        - ``contains``: substring (case-sensitive)
+        - ``contains_ci``: substring (case-insensitive)
+
+        Assertions with an unrecognized operator (e.g. ``op: gte`` /
+        ``expected: 5``) are treated as **failed** with an actionable reason —
+        previously they silently satisfied as long as the path existed, turning
+        strict-looking assertions into no-ops.
 
         Args:
             state: Final environment state
@@ -199,9 +216,21 @@ class StateChecker:
                         )
 
                 else:
-                    # No operator specified, just check path exists
-                    found_match = True
-                    satisfied += 1
+                    # No recognized operator — treat as FAILED with an actionable
+                    # reason. Previously this branch silently satisfied any assertion
+                    # whose JSONPath existed, so a misspelled or unsupported operator
+                    # (e.g. ``op: gte`` / ``expected: 5``) turned a strict-looking
+                    # assertion into a no-op. Fail loud and name which operators the
+                    # checker actually consumes so the author can fix it.
+                    unknown_keys = sorted(
+                        k for k in assertion if k not in {"path", "path_glob", "description"}
+                    )
+                    suffix = f" ({description})" if description else ""
+                    reasons.append(
+                        f"Assertion at {target} has no recognized operator "
+                        f"(got keys: {unknown_keys}); supported operators are "
+                        f"'equals', 'equals_ci', 'contains', 'contains_ci'{suffix}"
+                    )
 
             except Exception as e:
                 reasons.append(f"Error checking {path}: {str(e)} ({description})")

--- a/tolokaforge/core/grading/transcript.py
+++ b/tolokaforge/core/grading/transcript.py
@@ -80,13 +80,16 @@ class TranscriptChecker:
             missing = set(required_tools) - tools_used
             if missing:
                 score *= 0.5
-                reasons.append(f"Missing required tools: {missing}")
+                # Sort so the reason text is reproducible across runs — Python set
+                # repr ordering is not stable, which made these reasons drift
+                # spuriously across machines / processes.
+                reasons.append(f"Missing required tools: {', '.join(sorted(missing))}")
 
         if disallowed_tools:
             violations = tools_used & set(disallowed_tools)
             if violations:
                 score = 0.0
-                reasons.append(f"Used disallowed tools: {violations}")
+                reasons.append(f"Used disallowed tools: {', '.join(sorted(violations))}")
 
         return score, reasons
 

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -446,6 +446,13 @@ def evaluate_jsonpath_file_checks(
     """
     Evaluate jsonpath file assertions against the Runner container's filesystem.
 
+    This evaluator only understands ``path_glob:`` + ``contains_ci:`` (file-content
+    checks). It does not handle ``path:``-style JSONPath assertions on env state
+    (those are evaluated host-side by ``StateChecker.check_jsonpaths``). An
+    assertion missing ``path_glob:`` is treated as **failed** with an actionable
+    reason — previously such assertions were silently skipped, which made
+    misrouted assertions vanish from grading without notice.
+
     Each check has:
     - path_glob: glob pattern for files (e.g., "/env/fs/agent-visible/submissions/*")
     - contains_ci: case-insensitive substring to find in file content
@@ -471,7 +478,22 @@ def evaluate_jsonpath_file_checks(
         description = check.get("description", f"Check: {contains_ci}")
 
         if not path_pattern:
-            reasons_parts.append(f"SKIP: No path_glob — {description}")
+            # Fail loud — historically this branch silently skipped (effectively
+            # counting as not-passed in the score, but presenting as SKIP in
+            # the reasons text, so misrouted assertions were invisible). Name
+            # what the evaluator actually accepts so the author can fix it.
+            other_path = check.get("path")
+            if other_path:
+                reasons_parts.append(
+                    f"FAIL: assertion uses 'path' (env-state JSONPath) but this "
+                    f"runner-side evaluator only supports 'path_glob' (file glob); "
+                    f"path-style assertions are graded host-side — {description}"
+                )
+            else:
+                reasons_parts.append(
+                    f"FAIL: assertion missing 'path_glob' (runner-side jsonpath "
+                    f"evaluator only supports path_glob + contains_ci) — {description}"
+                )
             continue
 
         # Translate logical /env/fs/agent-visible/ paths to the runner's


### PR DESCRIPTION
Two grading-correctness fixes that the golden coverage gate now lets us land
deliberately. No engine architecture change; the goldens flag exactly the two
verdict diffs we intend, and the diffs themselves are the proof of the fix.

Closes #58
Closes #59

## 1. Silent jsonpath operator pass (#58)

`StateChecker.check_jsonpaths` only recognizes `equals` / `equals_ci` /
`contains` / `contains_ci`. Any assertion with another shape — most commonly
the `op: <name>, expected: <value>` pattern that several tasks use — fell
through the no-operator branch and **silently satisfied** as long as the
JSONPath existed. A strict-looking assertion was a no-op.

**Fix.** Unknown-operator assertions now FAIL with an actionable reason that
names the offending keys and lists the supported operators:

```
Assertion at $.counter has no recognized operator
(got keys: ['expected', 'op']); supported operators are
'equals', 'equals_ci', 'contains', 'contains_ci' (Counter should be 5)
```

**Bug laid bare in the snapshots.** The existing canon test
`test_minimal_calculation_state_fail` used `op: "eq"` (also unrecognized) and
its snapshot pinned `score: 1.0` — *identical to the pass snapshot*. The
"fail" assertion had been a no-op the whole time. Fixed test code +
regenerated snapshot now show the real failure with the actionable reason.

Affected data: `tests/data/tasks/calc_custom_checks/grading.yaml` switched
from `op: gte / expected: 5` → `equals: 5` (the deeper "counter >= 5"
semantic is correctly covered by `counter_reached_target()` in `checks.py`).

## 2. Set repr in transcript reasons (#59)

`transcript.py` interpolated Python `set` values into reason text via
`f"...: {missing}"`, so the ordering drifted run-to-run with Python's set
repr. Now rendered as sorted, comma-joined strings:

```
Before:  Missing required tools: {'write_file', 'db_query'}   # unstable order
After:   Missing required tools: db_query, write_file         # alphabetical
```

Scores are unchanged (only reason text). Snapshot regenerated for the new shape.

## Snapshot diffs (intentional)

Only two snapshot files change, and each diff IS the fix:

- `grading_state_calc/fail_result.json` — `"reasons": "", "score": 1.0` →
  `"reasons": "Path $.counter: expected 5, got 0 (Counter should be 5)", "score": 0.0`
- `grading_transcript_calc/fail_result.json` — `"Missing required tools: {'write_file'}"` →
  `"Missing required tools: write_file"`

Pass snapshots and all other goldens are unchanged.

## Tests

Two new test classes pin the new contracts:

- `TestUnknownOperatorFailsLoud` (5 tests) — `op: gte` / typo (`eqaul`) /
  no-operator-at-all / mixed valid+unknown partial credit / regression pin
  for the exact pre-fix silent-pass scenario.
- `TestToolExpectationsReasonsAreDeterministic` (3 tests) — missing reason
  is sorted, violations reason is sorted, repeated calls produce byte-identical
  text.

Suite: **1843 passed, 1 skipped** (was 1817 on main, +26 net new tests).
Identical across two consecutive runs (verified deterministic).
