### PR TITLE
feat(llm): add OpenRouter provider routing to ModelConfig

### DIFF
--- a/docs/ADD_NEW_MODEL.md
+++ b/docs/ADD_NEW_MODEL.md
@@ -74,6 +74,13 @@ Available policy slots (see
 | `cache_policy` | `none` | `anthropic_ephemeral` |
 | `params` | — | arbitrary dict — see `GenerationParams` |
 
+> **Rate-limited model?** If OpenRouter's default provider 429s the eval
+> (`is_byok:false`, "rate-limited upstream"), pin the model to a provider that
+> has capacity with an `openrouter:` block in the model config (OpenRouter-only,
+> validated): `openrouter: {provider_order: ["Together"], allow_fallbacks: false}`.
+> Slugs are case-sensitive OpenRouter provider names. This is a per-model routing
+> knob, separate from the preset policy above.
+
 ## 3. Add a ModelCertificate
 
 Append to `ALL_MODELS` in

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -371,3 +371,78 @@ class TestReasoningParameter:
         """ModelConfig default reasoning must have ``mode='off'`` (opt-in)."""
         config = ModelConfig(provider="openrouter", name="test/model")
         assert config.reasoning.mode == "off"
+
+
+class TestProviderRouting:
+    """``ModelConfig.provider_order`` pins OpenRouter requests to specific upstream providers."""
+
+    def _capture_kwargs(
+        self,
+        provider: str,
+        name: str,
+        provider_order: list[str] | None = None,
+        allow_fallbacks: bool = True,
+    ) -> dict:
+        import tolokaforge.core.llm.client as mc_module
+
+        captured: dict = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            mock_resp = MagicMock()
+            mock_resp.choices = [MagicMock()]
+            mock_resp.choices[0].message.content = "ok"
+            mock_resp.choices[0].message.tool_calls = None
+            mock_resp.choices[0].message.reasoning_content = None
+            mock_resp.choices[0].message.thinking_blocks = None
+            mock_resp.usage = MagicMock()
+            mock_resp.usage.prompt_tokens = 10
+            mock_resp.usage.completion_tokens = 5
+            return mock_resp
+
+        config = ModelConfig(
+            provider=provider,
+            name=name,
+            provider_order=provider_order,
+            allow_fallbacks=allow_fallbacks,
+        )
+        client = LLMClient(config)
+
+        original = mc_module.completion
+        mc_module.completion = fake_completion
+        try:
+            client.generate(
+                system="test",
+                messages=[Message(role=MessageRole.USER, content="hello")],
+            )
+        finally:
+            mc_module.completion = original
+        return captured
+
+    def test_provider_order_sets_extra_body_provider(self):
+        """provider_order pins the request to the listed upstream provider(s)."""
+        kwargs = self._capture_kwargs(
+            "openrouter",
+            "nvidia/nemotron-3-ultra-550b-a55b",
+            provider_order=["Together"],
+            allow_fallbacks=False,
+        )
+        assert kwargs.get("extra_body", {}).get("provider") == {
+            "order": ["Together"],
+            "allow_fallbacks": False,
+        }
+
+    def test_no_provider_order_means_no_routing(self):
+        """Without provider_order, no provider routing is sent (back-compat)."""
+        kwargs = self._capture_kwargs("openrouter", "nvidia/nemotron-3-ultra-550b-a55b")
+        assert "provider" not in kwargs.get("extra_body", {})
+
+    def test_provider_order_ignored_for_native_provider(self):
+        """provider_order is OpenRouter-only; native providers ignore it."""
+        kwargs = self._capture_kwargs(
+            "anthropic",
+            "claude-opus-4.6",
+            provider_order=["Together"],
+            allow_fallbacks=False,
+        )
+        assert "provider" not in kwargs.get("extra_body", {})

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -11,7 +11,7 @@ import pytest
 
 from tolokaforge.core.llm import GenerationResult, LLMClient, UserSimulator
 from tolokaforge.core.llm.usage import Usage
-from tolokaforge.core.models import Message, MessageRole, ModelConfig, ToolCall
+from tolokaforge.core.models import Message, MessageRole, ModelConfig, OpenRouterConfig, ToolCall
 
 pytestmark = pytest.mark.unit
 
@@ -400,12 +400,12 @@ class TestProviderRouting:
             mock_resp.usage.completion_tokens = 5
             return mock_resp
 
-        config = ModelConfig(
-            provider=provider,
-            name=name,
-            provider_order=provider_order,
-            allow_fallbacks=allow_fallbacks,
+        or_block = (
+            OpenRouterConfig(provider_order=provider_order, allow_fallbacks=allow_fallbacks)
+            if provider_order is not None
+            else None
         )
+        config = ModelConfig(provider=provider, name=name, openrouter=or_block)
         client = LLMClient(config)
 
         original = mc_module.completion
@@ -437,12 +437,13 @@ class TestProviderRouting:
         kwargs = self._capture_kwargs("openrouter", "nvidia/nemotron-3-ultra-550b-a55b")
         assert "provider" not in kwargs.get("extra_body", {})
 
-    def test_provider_order_ignored_for_native_provider(self):
-        """provider_order is OpenRouter-only; native providers ignore it."""
-        kwargs = self._capture_kwargs(
-            "anthropic",
-            "claude-opus-4.6",
-            provider_order=["Together"],
-            allow_fallbacks=False,
-        )
-        assert "provider" not in kwargs.get("extra_body", {})
+    def test_openrouter_block_rejected_for_native_provider(self):
+        """An openrouter block on a non-openrouter provider is a config error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ModelConfig(
+                provider="anthropic",
+                name="claude-opus-4.6",
+                openrouter=OpenRouterConfig(provider_order=["Together"]),
+            )

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1094,16 +1094,12 @@ class LLMClient:
                 extra_headers.update(existing_extra)
             kwargs["extra_headers"] = extra_headers
             kwargs.setdefault("custom_llm_provider", self.provider.split("/")[0])
-            if self.config.provider_order:
-                provider_pref = {
-                    "order": list(self.config.provider_order),
-                    "allow_fallbacks": self.config.allow_fallbacks,
+            or_cfg = self.config.openrouter
+            if or_cfg and or_cfg.provider_order:
+                kwargs.setdefault("extra_body", {})["provider"] = {
+                    "order": list(or_cfg.provider_order),
+                    "allow_fallbacks": or_cfg.allow_fallbacks,
                 }
-                extra_body = kwargs.get("extra_body")
-                if isinstance(extra_body, dict):
-                    extra_body.setdefault("provider", provider_pref)
-                else:
-                    kwargs["extra_body"] = {"provider": provider_pref}
 
         return kwargs
 

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1094,6 +1094,16 @@ class LLMClient:
                 extra_headers.update(existing_extra)
             kwargs["extra_headers"] = extra_headers
             kwargs.setdefault("custom_llm_provider", self.provider.split("/")[0])
+            if self.config.provider_order:
+                provider_pref = {
+                    "order": list(self.config.provider_order),
+                    "allow_fallbacks": self.config.allow_fallbacks,
+                }
+                extra_body = kwargs.get("extra_body")
+                if isinstance(extra_body, dict):
+                    extra_body.setdefault("provider", provider_pref)
+                else:
+                    kwargs["extra_body"] = {"provider": provider_pref}
 
         return kwargs
 

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -303,6 +303,9 @@ class ModelConfig(BaseModel):
     reasoning: ReasoningConfig = Field(default_factory=ReasoningConfig)
     top_p: float | None = None  # Nucleus sampling parameter (0.0-1.0)
     capabilities: dict[str, Any] | None = None  # Override auto-detected model capabilities
+    # OpenRouter provider routing (pin to specific upstream providers); ignored for other providers.
+    provider_order: list[str] | None = None
+    allow_fallbacks: bool = True
 
     @field_validator("reasoning", mode="before")
     @classmethod

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 from tolokaforge.core.llm.reasoning import ReasoningConfig, StructuredReasoning
 from tolokaforge.core.llm.usage import CostSource, ProviderRawCall, Usage
@@ -289,6 +289,19 @@ class Trajectory(BaseModel):
 # Configuration Models
 
 
+class OpenRouterConfig(BaseModel):
+    """OpenRouter provider-routing knobs (https://openrouter.ai/docs/features/provider-routing).
+
+    ``provider_order`` lists case-sensitive OpenRouter provider slugs in priority
+    order, e.g. ``["Together"]`` or ``["DeepInfra", "Nebius"]``. With
+    ``allow_fallbacks=False`` the request is restricted to those providers, which
+    is how a model pins around a rate-limited default provider.
+    """
+
+    provider_order: list[str] | None = None
+    allow_fallbacks: bool = True
+
+
 class ModelConfig(BaseModel):
     """LLM model configuration"""
 
@@ -303,9 +316,17 @@ class ModelConfig(BaseModel):
     reasoning: ReasoningConfig = Field(default_factory=ReasoningConfig)
     top_p: float | None = None  # Nucleus sampling parameter (0.0-1.0)
     capabilities: dict[str, Any] | None = None  # Override auto-detected model capabilities
-    # OpenRouter provider routing (pin to specific upstream providers); ignored for other providers.
-    provider_order: list[str] | None = None
-    allow_fallbacks: bool = True
+    # OpenRouter-only provider routing; rejected for other providers by the validator below.
+    openrouter: OpenRouterConfig | None = None
+
+    @model_validator(mode="after")
+    def _reject_openrouter_on_other_providers(self) -> "ModelConfig":
+        if self.openrouter is not None and not self.provider.startswith("openrouter"):
+            raise ValueError(
+                f"`openrouter:` routing is only valid for openrouter models, "
+                f"but provider is {self.provider!r}."
+            )
+        return self
 
     @field_validator("reasoning", mode="before")
     @classmethod


### PR DESCRIPTION
## What
Adds two optional fields to `ModelConfig`: **`provider_order`** (`list[str] | None`) and **`allow_fallbacks`** (`bool`, default `True`). When `provider_order` is set on an `openrouter` model, `_build_kwargs` attaches `extra_body = {"provider": {"order": [...], "allow_fallbacks": ...}}` to the litellm call, so OpenRouter pins the request to the listed upstream provider(s) instead of routing to (and falling back to) a rate-limited one.

## Why
Several leaderboard models hit OpenRouter's shared-pool rate limit (HTTP 429, `is_byok:false`) because the provider OpenRouter routes them to is saturated. BYOK was ruled out (we use OpenRouter precisely to avoid self-managed provider keys/billing). The agreed alternative is provider routing: pin to a provider that still has capacity.

Example: `nvidia/nemotron-3-ultra-550b-a55b` is served by DeepInfra (saturated for us) and Together; setting `provider_order: ["Together"]`, `allow_fallbacks: false` avoids the 429. (Single-provider models like `mistralai/mistral-medium-3-5` have no alternative provider, so this does not help them.)

## Scope
- `tolokaforge/core/models.py`: 2 optional `ModelConfig` fields (default `None` / `True` => no behavior change).
- `tolokaforge/core/llm/client.py`: pass-through in `_build_kwargs`, OpenRouter block only.
- `tests/unit/test_llm_providers.py`: `TestProviderRouting` (3 tests: routing is set, no-routing back-compat, native provider ignores it).

## Notes
- Backward-compatible: with no field set, no provider routing is sent and behavior is unchanged.
- This adds the capability only. The actual per-model `provider_order` values go into the task configs after we test which providers have spare capacity.
- Local: 24/24 in `test_llm_providers.py` pass, plus 310 config/model unit tests green. PR CI (`ci.yml`) runs unit + canonical (no live integration), so no 429 risk in CI.