### PR TITLE
feat(presets): operator-overridable preset overlay file

### DIFF
--- a/docs/ADD_NEW_MODEL.md
+++ b/docs/ADD_NEW_MODEL.md
@@ -81,6 +81,47 @@ Available policy slots (see
 > Slugs are case-sensitive OpenRouter provider names. This is a per-model routing
 > knob, separate from the preset policy above.
 
+### Adding a model without an engine release — preset overlay
+
+If the model reuses existing policy classes (which is the common case), you
+don't need to cut a new wheel. Put the same preset entry in a separate YAML
+file and point the engine at it:
+
+```yaml
+# my_overlay.yaml — same schema as model_presets.yaml
+presets:
+  my_provider_new_model:
+    match: ["my-provider/new-model*"]
+    content_policy: anthropic
+    reasoning_codec: anthropic
+    cache_policy: anthropic_ephemeral
+```
+
+Then run:
+
+```bash
+tolokaforge run --config run.yaml --presets-file my_overlay.yaml
+```
+
+Or set the overlay declaratively in `run.yaml` under `engine.presets_file`,
+or via `$TOLOKAFORGE_PRESETS_FILE`. Precedence is CLI > env > config field.
+See [`docs/CONFIG.md`](CONFIG.md#preset-overlay-file-no-engine-release-required)
+and [ADR 0002 — External model registry](architecture/adr/0002-external-model-registry.md).
+
+A few rules the overlay enforces (loud-fail at engine startup, naming the
+overlay path and the offending key):
+
+- Policy-name strings must resolve to existing classes shipped in the engine.
+  Adding a brand-new policy class still requires an engine release.
+- Overlay presets are prepended to the iteration order, so overlapping
+  `match:` globs let you shadow a bundled preset.
+- Same-named overlay presets replace the bundled entry (logged at INFO so the
+  swap is visible).
+
+For distributed runs, the overlay path passed to `tolokaforge prepare` is
+persisted into the run queue's state file. Subsequent `tolokaforge worker`
+invocations pick it up automatically without re-specifying `--presets-file`.
+
 ## 3. Add a ModelCertificate
 
 Append to `ALL_MODELS` in

--- a/docs/ADD_NEW_MODEL.md
+++ b/docs/ADD_NEW_MODEL.md
@@ -103,9 +103,9 @@ Then run:
 tolokaforge run --config run.yaml --presets-file my_overlay.yaml
 ```
 
-Or set the overlay declaratively in `run.yaml` under `engine.presets_file`,
-or via `$TOLOKAFORGE_PRESETS_FILE`. Precedence is CLI > env > config field.
-See [`docs/CONFIG.md`](CONFIG.md#preset-overlay-file-no-engine-release-required)
+Or set the overlay declaratively in `run.yaml` under `engine.presets_file`.
+Precedence is CLI > config field. See
+[`docs/CONFIG.md`](CONFIG.md#preset-overlay-file-no-engine-release-required)
 and [ADR 0002 — External model registry](architecture/adr/0002-external-model-registry.md).
 
 A few rules the overlay enforces (loud-fail at engine startup, naming the

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -196,6 +196,46 @@ presets:
     cache_policy: none             # none | anthropic_ephemeral (Anthropic only)
 ```
 
+### Preset overlay file (no engine release required)
+
+For models that reuse existing policy classes, you don't need to release the
+engine to add or adjust a preset. Point TolokaForge at a second YAML file that
+gets merged onto the bundled `model_presets.yaml` at startup. See
+[ADR 0002 — External model registry](architecture/adr/0002-external-model-registry.md)
+for the rationale and [`docs/ADD_NEW_MODEL.md`](ADD_NEW_MODEL.md) for a
+walkthrough.
+
+Set the overlay path three ways; precedence is **CLI flag > env var > config field**:
+
+1. CLI flag: `--presets-file overlay.yaml` on `run`, `prepare`, `worker`, and
+   `config validate`.
+2. Env var: `TOLOKAFORGE_PRESETS_FILE=/path/to/overlay.yaml`.
+3. Run-config field:
+
+   ```yaml
+   engine:
+     presets_file: ./overlay.yaml   # relative to the working directory
+   ```
+
+The overlay file uses the same schema as `model_presets.yaml`. Overlay
+presets are prepended to the iteration order so first-match-wins lets you
+shadow a bundled preset. Same-named overlay presets *replace* the bundled
+entry (logged at INFO so the replacement is visible). Policy-name strings
+(`schema_sanitizer`, `prompt_policy`, etc.) must resolve to a class already
+shipped in the engine — overlays can compose existing policies but cannot
+introduce new classes. Unknown names raise `ValueError` at startup naming
+both the overlay file and the offending key.
+
+#### Distributed-worker propagation
+
+`tolokaforge prepare --presets-file overlay.yaml ...` persists the resolved
+overlay path into `engine_run_state.json` alongside the run queue. Worker
+subprocesses launched later from the same `--run-dir` pick it up
+automatically — you don't have to thread the flag through every
+`tolokaforge worker` invocation. A worker-side `--presets-file` flag (or
+`$TOLOKAFORGE_PRESETS_FILE`) still wins over the persisted value when both
+are set.
+
 ## Task Specification (`task.yaml`)
 
 ```yaml

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -205,12 +205,13 @@ gets merged onto the bundled `model_presets.yaml` at startup. See
 for the rationale and [`docs/ADD_NEW_MODEL.md`](ADD_NEW_MODEL.md) for a
 walkthrough.
 
-Set the overlay path three ways; precedence is **CLI flag > env var > config field**:
+Set the overlay path two ways; precedence is **CLI flag > config field**:
 
 1. CLI flag: `--presets-file overlay.yaml` on `run`, `prepare`, `worker`, and
-   `config validate`.
-2. Env var: `TOLOKAFORGE_PRESETS_FILE=/path/to/overlay.yaml`.
-3. Run-config field:
+   `config validate`. Use this for one-off overlays — smoke-eval iterations,
+   ablations, anything you don't want to commit alongside the run config.
+2. Run-config field — commit the overlay path next to the run definition
+   when an overlay is part of *what this benchmark is*:
 
    ```yaml
    engine:
@@ -232,9 +233,8 @@ both the overlay file and the offending key.
 overlay path into `engine_run_state.json` alongside the run queue. Worker
 subprocesses launched later from the same `--run-dir` pick it up
 automatically — you don't have to thread the flag through every
-`tolokaforge worker` invocation. A worker-side `--presets-file` flag (or
-`$TOLOKAFORGE_PRESETS_FILE`) still wins over the persisted value when both
-are set.
+`tolokaforge worker` invocation. A worker-side `--presets-file` flag still
+wins over the persisted value when both are set.
 
 ## Task Specification (`task.yaml`)
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -22,7 +22,7 @@ for the design rationale and the canonical litellm surface.
 | [`content_policy.py`](../tolokaforge/core/llm/content_policy.py) | Tool-result content format (OpenAI / Anthropic) |
 | [`response_policy.py`](../tolokaforge/core/llm/response_policy.py) | Tool-call argument post-processing |
 | [`capabilities.py`](../tolokaforge/core/llm/capabilities.py) | `ModelCapabilities` frozen dataclass |
-| [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `$TOLOKAFORGE_PRESETS_FILE`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](architecture/adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
+| [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](architecture/adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
 | [`client.py`](../tolokaforge/core/llm/client.py) | `LLMClient`, `GenerationResult`, `UserSimulator` |
 
 ## `reasoning`

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -22,7 +22,7 @@ for the design rationale and the canonical litellm surface.
 | [`content_policy.py`](../tolokaforge/core/llm/content_policy.py) | Tool-result content format (OpenAI / Anthropic) |
 | [`response_policy.py`](../tolokaforge/core/llm/response_policy.py) | Tool-call argument post-processing |
 | [`capabilities.py`](../tolokaforge/core/llm/capabilities.py) | `ModelCapabilities` frozen dataclass |
-| [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities` |
+| [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `$TOLOKAFORGE_PRESETS_FILE`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](architecture/adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
 | [`client.py`](../tolokaforge/core/llm/client.py) | `LLMClient`, `GenerationResult`, `UserSimulator` |
 
 ## `reasoning`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,258 @@
+# Tolokaforge Architecture
+
+This document is the entry point for the system-level architecture of Tolokaforge. It follows the [arc42](https://arc42.org/) section structure inlined as a single file, with [C4 model](https://c4model.com/) views drawn as Mermaid diagrams that render natively on GitHub.
+
+For deep dives into individual subsystems, follow the links to `docs/*.md` from each section. For decision history and rationale, see [`adr/`](adr/).
+
+> **How to evolve this doc:** keep the diagrams here at C4 Levels 1–2 (Context and Container) and treat them as a *reflection of what the code actually does today* — not what we plan to build. When a building block changes shape or a boundary moves, update the relevant section *and* add an ADR. When you want to propose a future state, add an ADR with status `Proposed`; once accepted, update the diagram in this file. Verify diagrams against the source (`tolokaforge/`) before merging changes here.
+
+---
+
+## 1. Introduction and Goals
+
+Tolokaforge is a benchmarking harness for evaluating tool-using LLM agents. It runs multi-turn agent/user loops against task environments and produces deterministic pass/fail verdicts plus rich telemetry.
+
+### Quality goals
+
+| Goal | What it means in practice |
+|---|---|
+| **Determinism** | Same task + same model + same seed should yield the same verdict. State hashes, snapshot grading, transcript rules. |
+| **Provider-agnostic** | Any LLM reachable via LiteLLM is a first-class citizen. Provider-specific quirks are isolated in per-preset capability policies. |
+| **Isolation** | Tool calls always execute in a separate process — a Docker-hosted Runner gRPC service — so the agent loop never touches tool state directly. |
+| **Honesty over convenience** | Failures surface explicitly. No silent fallbacks; no defaults that hide configuration mistakes. |
+| **Extensibility** | New benchmark formats plug in as adapters without touching the core. |
+
+### Primary stakeholders
+
+- Model evaluators running benchmarks across providers.
+- Task authors writing new benchmark task packs.
+- Researchers analysing trajectories, failure modes, and cost/latency.
+
+---
+
+## 2. Constraints
+
+### Technical
+
+- **Language**: Python (managed via `uv`).
+- **LLM access**: routed through [LiteLLM](https://github.com/BerriAI/litellm) — provider-specific glue is kept out of the core. Per-provider differences live in the LLM-layer preset registry (`tolokaforge/core/llm/presets.py`).
+- **Tools**: built-in Python tools plus [Model Context Protocol](https://modelcontextprotocol.io) servers loaded from task packs. All tool code runs inside the Runner container; the orchestrator only sees the gRPC interface.
+- **Docker is required.** Tool execution, environment state, and grading always run inside a Docker stack containing a **Runner gRPC service** (`tolokaforge/runner/service.py`) and supporting environment services (JSON state DB, plus optional RAG indexer / mock web). The orchestrator auto-starts this stack on `tolokaforge run` (`auto_start_services: true` by default) — there is no in-process tool-execution path.
+- **In-process loop, remote tools.** The agent–user message loop itself (`tolokaforge/core/runner.py:TrialRunner`) and the LLM calls run inside the orchestrator process; every tool call from that loop is dispatched as a gRPC `ExecuteTool` RPC to the Runner service.
+- **Durable attempt queue**: SQLite for single-host runs, optional Postgres for multi-host workers (`tolokaforge/core/run_queue.py`).
+
+### Organisational
+
+- **Open source**: this repository is Apache-2.0; nothing committed here may reference internal-only systems by name.
+- **Secrets**: only `SecretManager` reads credentials. Direct `os.environ` access for any secret is forbidden and CI-enforced. See [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction).
+- **Task packs are external**: benchmark task definitions live in separate repositories (public examples ship under `examples/`; production task packs are loaded via adapter glob from any directory the operator points at).
+
+---
+
+## 3. Context and Scope (C4 Level 1)
+
+```mermaid
+flowchart TB
+    Evaluator["Evaluator / Researcher"]
+    TaskAuthor["Task Author"]
+    Forge["Tolokaforge<br/>(benchmarking harness)"]
+    LiteLLM["LLM Providers via LiteLLM<br/>OpenAI · Anthropic · Google · Bedrock · OpenRouter · ..."]
+    TaskPacks["Task Packs<br/>(external repos, glob-loaded)"]
+    Docker["Docker Engine<br/>(Runner gRPC + env services)"]
+    Results["Result Artifacts<br/>(trajectories, metrics, schemas)"]
+    Queue[("Attempt Queue<br/>SQLite or Postgres")]
+
+    Evaluator -->|runs benchmarks| Forge
+    TaskAuthor -->|authors| TaskPacks
+    Forge -->|loads via adapter| TaskPacks
+    Forge <-->|tool execution, state, grading| Docker
+    Forge <-->|completions, tool schemas| LiteLLM
+    Forge -->|writes| Results
+    Forge <-->|durable attempts, leases| Queue
+```
+
+### Boundaries (what is *not* Tolokaforge)
+
+- **LLM providers** — out of scope; accessed via LiteLLM.
+- **Task content** — out of scope; lives in task pack repos. Tolokaforge defines the *contract* (task schema, tool interface, grading config), not the content.
+- **Result analysis UI** — out of scope; result artifacts are stable YAML/JSON, consumed by downstream tooling (see [`tools/benchmark-analyzer`](../../tools/benchmark-analyzer/)).
+
+---
+
+## 4. Solution Strategy
+
+| Decision | Rationale | Detail |
+|---|---|---|
+| **Adapter plugin architecture for benchmark formats** | Lets external task formats (`native` built-in, `terminal_bench` and other plugins) plug in without forking the core. | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **In-process agent–user loop, Docker-delegated tools/state/grading** | The trial control flow (agent prompt assembly, LLM calls, user simulator, message accumulation) stays in the orchestrator process so it can be debugged and instrumented with normal Python tooling. Everything that touches task state — tool execution, env services, grading — runs inside a Docker stack reached over gRPC, giving sandbox isolation and the same code path on every host. | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **Provider-agnostic LLM layer with per-preset capability policies** | LiteLLM normalises envelopes, but providers diverge on schema dialects, reasoning encodings, caching, and tool naming. A preset registry keeps the quirks out of the orchestrator. | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Single secret abstraction** | One audited code path for every credential read; CI-enforced via static grep. | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
+| **Deterministic grading by default; LLM judges opt-in** | Deterministic verdicts are reproducible and cheap; judge calls are reserved for cases that genuinely need them. | [`docs/GRADING.md`](../GRADING.md) |
+| **Durable attempt queue (SQLite / Postgres) with worker leases** | Lets long runs survive crashes and lets `prepare` + `worker` commands split a run across hosts. | `tolokaforge/core/run_queue.py` |
+
+---
+
+## 5. Building Block View (C4 Level 2 — Container)
+
+```mermaid
+flowchart LR
+    subgraph Process["Orchestrator process"]
+        Adapter["Adapter Layer"]
+        Loop["Orchestrator + TrialRunner<br/>(agent–user loop)"]
+        LLM["LLM Layer<br/>(LiteLLM + presets)"]
+    end
+
+    subgraph DockerStack["Docker stack (required)"]
+        Runner["Runner Service<br/>(gRPC)"]
+        Env["db-service<br/>+ optional rag-service · mock-web"]
+    end
+
+    Adapter --> Loop
+    Loop --> LLM
+    Loop -->|gRPC| Runner
+    Runner <--> Env
+```
+
+Component-level detail (CLI commands, the run-queue client, SecretManager, individual env services) is described in the table below rather than spelled out in the diagram, to keep the container view at C4 Level 2.
+
+### Block responsibilities
+
+| Block | Responsibility | Source | Detail |
+|---|---|---|---|
+| **CLI** | User-facing commands. `run` executes locally end-to-end; `prepare` + `worker` split a run for distributed execution. | `tolokaforge/cli` | — |
+| **Orchestrator + Core** | Loads run config, instantiates the adapter, builds the task list, manages the attempt queue, runs trials, aggregates grades and metrics, writes artifacts. | `tolokaforge/core` (`orchestrator.py`, `grading/`, `metrics.py`, `search/`) | [`docs/RUNNER.md`](../RUNNER.md) |
+| **TrialRunner** | One instance per trial. Owns the agent–user message loop, calls the LLM for both agent and user simulator turns, and dispatches every tool call as a gRPC `ExecuteTool` RPC to the Runner service. | `tolokaforge/core/runner.py` | — |
+| **Adapter Layer** | Resolves a benchmark format into `(TaskConfig, tools, grading, environment, docker_stack_requirements, task_description)`. Built-in `native` plus plugins discovered via the `tolokaforge.adapters` entry-point group. | `tolokaforge/adapters` + `external_adapters/` | [`docs/ADAPTER_ARCHITECTURE.md`](../ADAPTER_ARCHITECTURE.md) |
+| **LLM Layer** | Provider-agnostic completion API on top of LiteLLM. Per-provider presets carry capability policies for schema dialect, reasoning encoding, parameter handling, caching, tool-name discipline. Used by both agent and user-simulator turns. | `tolokaforge/core/llm` | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) |
+| **Runner Service (gRPC)** | The sole tool-execution path. Owns per-trial state, reconstructs tools from a `TaskDescription`, executes tool calls, runs grading. A single service — not split into separate "agent" and "executor" services. Auto-started by the orchestrator (`auto_start_services: true`). | `tolokaforge/runner` | [`docs/RUNNER.md`](../RUNNER.md) · [`docs/GRPC_PROTOCOL.md`](../GRPC_PROTOCOL.md) |
+| **db-service** | JSON state DB accessed by the Runner over HTTP. Namespaced per `(task_id, trial_index)` for parallel isolation. | `tolokaforge/env/json_db_service` | — |
+| **rag-service / mock-web** | Optional support services for RAG tasks and browser-style tasks. | `tolokaforge/env/rag_service`, `tolokaforge/env/mock_web_service` | [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
+| **SecretManager** | Single read path for every credential (API keys, DB URLs, OAuth, signing keys). Subprocess export is the only sanctioned `os.environ` mutation, scoped narrowly. | `tolokaforge/secrets` | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
+| **Run-queue client** | Durable attempt queue. SQLite for single-host runs, Postgres for distributed worker pools. | `tolokaforge/core/run_queue.py` | — |
+
+> **Note on the `tolokaforge/agent/` and `tolokaforge/executor/` packages.** These contain protobuf definitions and `*ServiceServicer` implementations for a planned multi-service decomposition, but they are not currently invoked by the orchestrator (`grep -rn "AgentServiceStub\|ExecutorServiceStub" tolokaforge/` returns no callers). Today only the single **Runner Service** is part of the live architecture. The dormant scaffolding is preserved while a decision about service decomposition is open — when that decision lands, an ADR should record the direction.
+
+### Adapter plugin shape (zoom on the Adapter Layer)
+
+```mermaid
+flowchart TB
+    Config["Run Config<br/>harness_adapter.type = native | terminal_bench | ..."]
+    Disco["Entry-point discovery<br/>group: tolokaforge.adapters"]
+    Base["BaseAdapter (abstract)"]
+    Native["NativeAdapter<br/>(built-in · task.yaml)"]
+    Ext1["External adapter A<br/>(separate package)"]
+    Ext2["External adapter B<br/>(separate package)"]
+
+    Config --> Disco --> Base
+    Base --> Native
+    Base --> Ext1
+    Base --> Ext2
+```
+
+Every adapter implements the same `BaseAdapter` contract — including `get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, `to_task_description` (for Docker Runner registration), and `docker_stack_requirements` (to declare bind-mounts, Docker socket access, or DinD needs). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
+
+### Extension points (where external repos plug in)
+
+Tolokaforge is the harness; the *content* (tasks, domain tools, grading data) lives in repositories outside this one. Four contracts let external repos extend the system without forking the core. Public adapter repos and internal/private task-and-tool repos use the same four contracts.
+
+| Surface | Contract | Lives where |
+|---|---|---|
+| **Task packs** | A directory tree of `task.yaml` files (for the `native` adapter) or whatever format the adapter expects. Resolved via `evaluation.tasks_glob` and `evaluation.task_packs` in the run config. | Any directory the operator points at, in any repo. |
+| **Domain tools (MCP servers)** | Each `task.yaml` may set `tools.agent.mcp_server: "mcp_server.py"` — a path *relative to the task directory* to a Python module that implements the task's tools (typically [FastMCP](https://github.com/modelcontextprotocol/python-sdk)). The harness imports it dynamically. Tools may also be declared as built-ins via `tools.agent.enabled`. | Alongside the task pack, or vendored from a separate tool library and referenced by import path. |
+| **Custom adapters** | A separate Python package that subclasses `BaseAdapter` and registers under `[project.entry-points."tolokaforge.adapters"]`. The harness discovers it on `pip install`. | Independent Python package. `external_adapters/` shows the public pattern. |
+| **Custom secret providers** | A subclass of `SecretProvider` registered with the `SecretManager` chain. Used to integrate Vault, AWS Secrets Manager, or other backends without changing call sites. | Anywhere in your Python environment; wired in at startup. |
+
+These four contracts are the entire integration surface. Anything an external task-and-tool repo wants to do — supply new benchmark content, ship custom tools, register a new task format, swap credential backends — should fit through one of them. If something doesn't, that's a signal the contract needs an ADR-recorded extension.
+
+---
+
+## 6. Runtime View — One Trial
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI
+    participant Loop as Orchestrator + TrialRunner
+    participant LLM as LiteLLM
+    participant Runner as Runner Service (gRPC)
+
+    CLI->>Loop: run config + tasks
+    Loop->>Runner: RegisterTrial(task_description)
+    loop agent–user loop
+        Loop->>LLM: agent completion
+        LLM-->>Loop: response + tool calls
+        Loop->>Runner: ExecuteTool
+        Runner-->>Loop: tool result
+        Loop->>LLM: user simulator reply
+        LLM-->>Loop: user turn
+    end
+    Loop->>Runner: GradeTrial
+    Runner-->>Loop: verdict + metrics
+```
+
+The agent loop, the user-simulator loop, and the LLM calls all happen inside the orchestrator process; every tool call and the final grade go over gRPC to the Runner service. Setup steps (loading config, resolving tasks via the adapter, enqueueing attempts, writing artifacts) bracket the loop but are omitted from the diagram for clarity.
+
+---
+
+## 7. Deployment View
+
+```mermaid
+flowchart TB
+    Orch["Orchestrator process<br/>(TrialRunner + LLM client)"]
+    Q[("Attempt queue · SQLite or Postgres")]
+    Stack["Docker stack on the same host<br/>runner + db-service<br/>+ optional rag-service · mock-web · dind"]
+
+    Orch --> Q
+    Orch <-->|gRPC + HTTP| Stack
+```
+
+The orchestrator process and the Docker stack live on the same host. There is no in-process tool path — Docker is always required. **Distributed runs** share the attempt queue across hosts: one host runs `tolokaforge prepare` to populate a Postgres queue; one or more hosts run `tolokaforge worker`, each instantiating a full orchestrator + Docker stack. There is no central scheduler — coordination is entirely through the queue. See [`docs/RUNNER.md`](../RUNNER.md) for the distributed contract.
+
+---
+
+## 8. Cross-cutting Concepts
+
+| Concern | Where to look |
+|---|---|
+| **Secrets handling** | [AGENTS.md § Secrets — single abstraction](../../AGENTS.md#secrets--single-abstraction) · `tolokaforge/secrets` |
+| **Determinism & state hashing** | [`docs/GRADING.md`](../GRADING.md) · [`docs/GOLDEN_TRIALS.md`](../GOLDEN_TRIALS.md) |
+| **Per-provider capability handling** | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) · [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) |
+| **Tool isolation & sandboxing** | [`docs/SECURITY.md`](../SECURITY.md) · [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
+| **Telemetry & metrics** | [`docs/LOGGING.md`](../LOGGING.md) · [`docs/ANALYTICS.md`](../ANALYTICS.md) |
+| **Result artifact layout** | [`docs/OUTPUT_FORMAT.md`](../OUTPUT_FORMAT.md) |
+| **Configuration reference** | [`docs/CONFIG.md`](../CONFIG.md) · [`docs/REFERENCE.md`](../REFERENCE.md) |
+
+---
+
+## 9. Architecture Decisions
+
+All architecturally significant decisions are recorded as ADRs in [`adr/`](adr/). The index is maintained by appending new ADRs in numerical order — never renumber, never delete. When an ADR is superseded, change its status and link forward to the superseding ADR.
+
+See [`adr/README.md`](adr/README.md) for the process and [`adr/0000-template.md`](adr/0000-template.md) for the template.
+
+---
+
+## 10. Risks and Known Limitations
+
+| Area | Note |
+|---|---|
+| **Provider drift** | Tool-schema dialects and reasoning encodings change without notice. Mitigated by capability tests per preset (see [`docs/LLM_LAYER.md`](../LLM_LAYER.md)) and explicit `ModelCertificate` declarations. |
+| **Multi-turn vs single-turn behaviour gap** | Some model failures only surface in long-context multi-turn runs and pass synthetic single-turn probes. Tracked in [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) #22. |
+| **Dormant gRPC scaffolding** | `tolokaforge/agent/` and `tolokaforge/executor/` packages contain gRPC service implementations that nothing currently calls. Whether to wire them up or remove them is an open decision; an ADR should land before the next significant change to the Runner boundary. See also [`docs/FUTURE_DEVELOPMENT.md`](../FUTURE_DEVELOPMENT.md). |
+| **Container resource accounting** | Sandboxed Runner shares the host; resource accounting is per-process, not cgroup-bounded. |
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Adapter** | Plugin that maps a benchmark format to the harness contract (`BaseAdapter`). |
+| **Task pack** | A directory tree of tasks resolved by an adapter (`task.yaml` for native; format varies per adapter). |
+| **Trial** | One attempt at one task with one model configuration. A run produces `N_tasks × repeats` trials. |
+| **Trajectory** | The full message + tool-call log for one trial, written as `trajectory.yaml`. |
+| **TrialRunner** | The in-process Python class (`tolokaforge/core/runner.py`) that owns one trial's agent–user loop and dispatches every tool call to the Runner Service over gRPC. |
+| **Runner Service** | The gRPC service (`tolokaforge/runner/service.py`) that owns tool execution, environment state, and grading. Runs in a Docker container; always required. Distinct from `TrialRunner`. |
+| **Preset** | Per-provider capability bundle (schema sanitizer, reasoning codec, params policy, cache policy, tool-content policy). |
+| **Grading config** | Declarative spec of how a trajectory and final state are turned into a pass/fail verdict. |
+| **Attempt queue** | Durable record of pending and in-flight trial attempts (SQLite single-host or Postgres distributed); leased by workers. |

--- a/docs/architecture/adr/0000-template.md
+++ b/docs/architecture/adr/0000-template.md
@@ -1,0 +1,49 @@
+# NNNN. Short imperative title
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Deciders:** @handles
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+What problem is this ADR resolving? What forces — technical, organisational, regulatory — make a decision necessary now? Keep this focused on the forces, not the implementation.
+
+## Decision Drivers
+
+- Driver 1 (e.g. quality goal it supports)
+- Driver 2 (e.g. constraint it must respect)
+- Driver 3
+
+## Considered Options
+
+1. **Option A** — one-line summary.
+2. **Option B** — one-line summary.
+3. **Option C** — one-line summary.
+
+## Decision
+
+We will adopt **Option X** because …
+
+## Consequences
+
+### Positive
+
+- …
+
+### Negative / Trade-offs
+
+- …
+
+### Follow-ups
+
+- Code changes required: …
+- Documentation to update: …
+- Tests to add: …
+
+## Links
+
+- Related ADRs:
+- Related code:
+- External references:

--- a/docs/architecture/adr/0001-record-architecture-decisions.md
+++ b/docs/architecture/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,59 @@
+# 0001. Record architecture decisions in ADRs
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Deciders:** Tolokaforge maintainers
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Tolokaforge has accumulated a set of architecturally significant decisions — the adapter plugin model, the gRPC service split, the per-provider preset registry, the single-secret-abstraction rule — that today live implicitly across `AGENTS.md`, scattered `docs/*.md` files, and commit history. New contributors (human and agent) re-derive the rationale every time, and proposed changes can't be cleanly weighed against the original forces because those forces aren't written down.
+
+We need a low-friction, durable place to capture *why* an architectural choice was made, not just *what* it is.
+
+## Decision Drivers
+
+- Decisions must survive the people who made them.
+- Format must be agent-friendly: plain markdown, in-repo, no toolchain.
+- Each decision must be individually addressable (linkable, supersedable).
+- Cost of writing one must be low enough that we actually do it.
+
+## Considered Options
+
+1. **In-repo Markdown ADRs (MADR-style).** One file per decision under `docs/architecture/adr/`, numbered, kept forever.
+2. **Wiki / Notion / Confluence.** Centralised, searchable — but lives outside the repo, drifts from code, hostile to agents reading the codebase.
+3. **Long-form `ARCHITECTURE.md`.** Everything in one file. Simple, but conflates the *current* shape with the *history* of how we got there; status transitions are awkward.
+4. **No formal record.** Continue relying on `AGENTS.md` and commit messages.
+
+## Decision
+
+We will adopt **Option 1: in-repo MADR-style ADRs** under [`docs/architecture/adr/`](.), using the template in [`0000-template.md`](0000-template.md).
+
+Each ADR is a single Markdown file with a monotonically increasing four-digit prefix, never renumbered. Status moves through `Proposed → Accepted → (Deprecated | Superseded by ADR-NNNN)`. The current-state architecture continues to live in [`docs/architecture/README.md`](../README.md); ADRs capture the *transitions and rationale*.
+
+## Consequences
+
+### Positive
+
+- Decisions are version-controlled alongside the code they govern.
+- Agents reading the repo encounter rationale in the same place as architecture diagrams.
+- Superseding a decision is explicit (status flip + forward link) rather than silent drift.
+- No tooling investment required.
+
+### Negative / Trade-offs
+
+- Discipline cost: someone has to remember to write the ADR when a significant decision is made. Mitigated by listing the prompt in `docs/architecture/adr/README.md` and in PR review checklists.
+- ADRs can drift from reality if not maintained — but so can any documentation, and the in-repo location makes drift easier to catch in code review.
+
+### Follow-ups
+
+- Code changes required: none.
+- Documentation to update: link `docs/architecture/README.md` from the top-level `README.md` Documentation table.
+- Tests to add: none.
+- Backfill: significant existing decisions (adapter plugin model, gRPC decomposition, secret abstraction) should be written up as ADRs over time — but not in this PR, to keep this one reviewable.
+
+## Links
+
+- Format reference: [adr.github.io/madr](https://adr.github.io/madr/)
+- Architecture overview: [`docs/architecture/README.md`](../README.md)

--- a/docs/architecture/adr/0002-external-model-registry.md
+++ b/docs/architecture/adr/0002-external-model-registry.md
@@ -1,0 +1,155 @@
+# 0002. External model registry — operator-overridable preset data
+
+- **Status:** Proposed
+- **Date:** 2026-06-17
+- **Deciders:** @cirogam22
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Adding (or adjusting) a model in TolokaForge today requires editing files that
+ship **inside the engine wheel**:
+
+- `tolokaforge/core/data/model_presets.yaml` — preset routing (which existing
+  policy/codec classes a model uses).
+- `tolokaforge/core/data/pricing.json` — per-model price data.
+- The capability declaration consumed by `build_capabilities()` in
+  `tolokaforge/core/llm/presets.py`.
+
+The first two are **data**; the third is **code** only when a *new* policy
+class is required. In practice the policy classes already in tree
+(`StandardResponse`, `AnthropicContent`, `AnthropicEphemeralCache`,
+`AnthropicReasoningCodec`, …) cover most new models. So the typical model
+registration is a pure-data change that nevertheless triggers an engine
+release.
+
+The pain compounds in the eval loop: integration tests pass with the new
+preset → release engine → smoke eval surfaces a model-specific failure pattern
+fixable by re-routing to a different existing policy → release engine again.
+Two engine releases per new model becomes common when custom patterns appear.
+
+The same kind of seam was just opened for **task adapters** by
+[ADR 0001's broader project context — entry-point plugin discovery in
+`tolokaforge.adapters`](../../ADAPTER_ARCHITECTURE.md) and validated at the
+host boundary with `ensure_registered_adapter()`
+(`tolokaforge/adapters/__init__.py:86`). The LLM preset layer is the next
+natural seam.
+
+## Decision Drivers
+
+- Ship pure-data model registrations without an engine release.
+- Preserve loud-fail behaviour for typos and unknown policy names
+  (`AGENTS.md` rule #1).
+- Keep the existing call sites (`build_capabilities`,
+  `resolve_effective_preset`, `resolve_policy_names`) untouched — no new
+  signatures, no new caller obligations.
+- Keep `ModelCapabilities` frozen and deterministic for a given input.
+- Do not commit to a particular distribution mechanism (overlay file vs.
+  entry-point bundle vs. config dir) before there's evidence about which
+  operators actually want.
+
+## Considered Options
+
+1. **Status quo** — every model registration is an engine release.
+2. **Operator-pointed preset overlay file** — engine reads bundled
+   `model_presets.yaml` *plus* an optional second YAML named by the operator
+   (CLI flag, env var, or run-config field). Same schema; merged at load time;
+   policy-class names validated against the in-engine registries at load time.
+   This ADR's proposal.
+3. **Entry-point plugin discovery for preset bundles** — a
+   `tolokaforge.model_presets` entry-point group analogous to
+   `tolokaforge.adapters`. Operators install a `pip` package that ships
+   preset YAML; the engine discovers it on import.
+4. **Sidecar Python module for policy classes** — operator points the engine
+   at a Python module that registers brand-new policy/codec classes into the
+   in-engine registries. Escape hatch for one-off experiments where no
+   existing policy class fits.
+
+## Decision
+
+Adopt **Option 2 — operator-pointed preset overlay file** now. Treat 3 as the
+natural follow-up if operators want shippable preset packages and we see
+evidence of cross-project reuse. Defer 4 until eval data shows custom policy
+*classes* recurring per model often enough to justify the escape hatch
+(otherwise novel policy classes stay engine code, which is the right boundary).
+
+The overlay file:
+
+- Uses the same schema as `model_presets.yaml` (`default:`, `presets:`,
+  `providers:`).
+- Is merged onto the bundled file at engine startup: `default:` and
+  `providers:` are shallow-merged with the overlay winning; `presets:` is
+  prepended so first-match-wins lets operators shadow a bundled preset.
+- Policy-name strings (`schema_sanitizer`, `prompt_policy`, `content_policy`,
+  `response_policy`, `reasoning_codec`, `cache_policy`) must resolve in the
+  in-engine registries (`_SCHEMA_SANITIZERS` … `_CACHE_POLICIES`). Unknown
+  names raise `ValueError` at load time, naming both the offending key and
+  the overlay file path. Same shape as `ensure_registered_adapter()`.
+- Has no effect when unconfigured: behaviour is bit-identical to today, no
+  new code paths run.
+
+The overlay path is resolved with precedence `--presets-file` CLI flag > env
+var `TOLOKAFORGE_PRESETS_FILE` > optional `engine.presets_file` field on
+`RunConfig`. Distributed workers inherit it implicitly — `prepare` persists
+the resolved path into the queue run-state, so `worker` subprocesses pick it
+up without the operator threading the flag manually.
+
+## Consequences
+
+### Positive
+
+- A new model that reuses existing policy classes ships with zero engine code
+  change and zero release. Operator drops a 5-line overlay file alongside
+  their run config, points at it, runs.
+- Smoke-eval policy adjustments (re-route a misbehaving model to a different
+  existing response policy) become same-day fixes instead of release-cycle
+  fixes.
+- The seam mirrors the adapter plugin pattern's externalization step — same
+  loud-fail discipline at the host boundary, same "data + declaration are
+  open; new classes stay engine code" boundary.
+- Forward-compatible: if Option 3 (entry-point plugin discovery) lands later,
+  it can populate the same overlay structure rather than introducing a
+  parallel mechanism.
+
+### Negative / Trade-offs
+
+- A new in-engine policy class still requires editing the in-engine
+  validator (so it knows the new name is allowed in overlays). This is a
+  feature, not a bug — it keeps overlay validation honest — but it must be
+  enforced by a unit test that scans the validator body for every registry's
+  members. Without the test, adding a new policy class while forgetting the
+  validator would silently reject overlays that use it.
+- Module-level overlay state (`set_overlay_path()`) is reset between test
+  cases via fixture; tests that forget the fixture could leak overlay state
+  to neighbours. Documented in the test contract.
+- Pricing data is not externalized here. LiteLLM's
+  `LITELLM_MODEL_COST_MAP_URL` already provides an external pricing path; we
+  do not duplicate it inside the engine. Operators who need to ship new
+  pricing without a release use the LiteLLM mechanism.
+
+### Follow-ups
+
+- Code changes required: overlay loader and validator in
+  `tolokaforge/core/llm/presets.py`; `EngineConfig` on `RunConfig`; CLI
+  flag + env-var precedence; orchestrator persists path into queue run-state.
+- Documentation to update: `docs/CONFIG.md` (new field + precedence +
+  distributed-worker propagation); `docs/ADD_NEW_MODEL.md` (overlay
+  walkthrough); `docs/LLM_LAYER.md` (loader note).
+- Tests to add: overlay load + merge, precedence (shadowing), validation
+  (unknown policy name, malformed YAML, missing file, top-level typo),
+  default/provider merge depth, validator-vs-registries sync, worker
+  propagation, fingerprint round-trip through an overlay.
+
+## Links
+
+- Related ADRs: [0001 — Record architecture decisions in ADRs](0001-record-architecture-decisions.md).
+- Related code:
+  - `tolokaforge/core/llm/presets.py` (loader, registries, validator).
+  - `tolokaforge/adapters/__init__.py:86` (`ensure_registered_adapter`, the
+    host-boundary validation pattern this ADR mirrors).
+- External references:
+  - [GH issue #64 — Decouple model policy/codec layer from engine release cadence](https://github.com/Toloka/tolokaforge/issues/64).
+  - LiteLLM external model cost map:
+    [`LITELLM_MODEL_COST_MAP_URL`](https://docs.litellm.ai/docs/provider_registration/add_model_pricing),
+    [day-0 model sync](https://docs.litellm.ai/docs/proxy/sync_models_github).

--- a/docs/architecture/adr/0002-external-model-registry.md
+++ b/docs/architecture/adr/0002-external-model-registry.md
@@ -89,11 +89,20 @@ The overlay file:
 - Has no effect when unconfigured: behaviour is bit-identical to today, no
   new code paths run.
 
-The overlay path is resolved with precedence `--presets-file` CLI flag > env
-var `TOLOKAFORGE_PRESETS_FILE` > optional `engine.presets_file` field on
-`RunConfig`. Distributed workers inherit it implicitly — `prepare` persists
-the resolved path into the queue run-state, so `worker` subprocesses pick it
-up without the operator threading the flag manually.
+The overlay path is resolved with precedence `--presets-file` CLI flag >
+optional `engine.presets_file` field on `RunConfig`. The CLI flag covers
+one-off overlays (smoke iterations, ablations); the config field covers
+overlays that are part of a benchmark's committed definition. An env-var
+fallback (`TOLOKAFORGE_PRESETS_FILE`) was considered and dropped — its
+primary use case (a fleet of subprocesses sharing one overlay) is already
+covered by `prepare`'s queue-state persistence; the two surviving paths
+cover the rest. If a future workflow surfaces a real need (e.g. CI matrix
+steps that need a session-scoped overlay without threading flags), add it
+then.
+
+Distributed workers inherit it implicitly — `prepare` persists the resolved
+path into the queue run-state, so `worker` subprocesses pick it up without
+the operator threading the flag manually.
 
 ## Consequences
 

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records
+
+This directory records architecturally significant decisions about Tolokaforge. We follow the [Markdown ADR (MADR)](https://adr.github.io/madr/) format, lightly adapted.
+
+## When to write an ADR
+
+Write one when a decision:
+
+- changes a boundary in the [Building Block View](../README.md#5-building-block-view-c4-level-2--container),
+- introduces or removes a cross-cutting rule,
+- locks in a quality trade-off (e.g. determinism vs. flexibility, isolation vs. simplicity),
+- or replaces an earlier ADR.
+
+Day-to-day implementation choices that don't affect the system shape do *not* need an ADR — a clear PR description is enough.
+
+## How to write one
+
+1. Copy [`0000-template.md`](0000-template.md) to `NNNN-kebab-case-title.md`, where `NNNN` is the next free number. **Never renumber existing ADRs.**
+2. Fill in the sections. Keep "Context" focused on the forces that drove the decision, not the implementation.
+3. Open the PR with status `Proposed`. Flip to `Accepted` when merged.
+4. If a later decision overrides this one, set the old ADR's status to `Superseded by ADR-NNNN` and add the back-link in the new ADR's "Decision Drivers".
+
+## Statuses
+
+- `Proposed` — under discussion in a PR.
+- `Accepted` — merged and in effect.
+- `Deprecated` — no longer applies, but not replaced by anything specific.
+- `Superseded by ADR-NNNN` — replaced; keep the old file as historical record.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions in ADRs | Accepted |
+| [0002](0002-external-model-registry.md) | External model registry — operator-overridable preset data | Proposed |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,19 @@ import yaml
 from tolokaforge.core.llm.presets import set_overlay_path
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def overlay_isolation():
     """Guard module-level preset-overlay state against test leakage.
 
-    Any test that calls :func:`tolokaforge.core.llm.presets.set_overlay_path`
-    (directly or transitively via ``build_capabilities`` / the CLI helper)
-    must take this fixture so the next test starts from a clean slate.
+    Autouse: every test in the suite gets the teardown, regardless of whether
+    the test author remembered to take the fixture. The preset overlay path
+    lives in module state (:data:`tolokaforge.core.llm.presets._OVERLAY_PATH`),
+    so a test that installs an overlay and forgets to reset would silently
+    leak into the next test in collection order — a classic discipline-based
+    isolation footgun.
+
+    Teardown cost for tests that never touch the overlay is negligible: one
+    function call that sets a module global to ``None``.
     """
     yield
     set_overlay_path(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,38 @@
 """Pytest configuration and shared fixtures for test suite."""
 
 import os
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
+import yaml
+
+from tolokaforge.core.llm.presets import set_overlay_path
+
+
+@pytest.fixture
+def overlay_isolation():
+    """Guard module-level preset-overlay state against test leakage.
+
+    Any test that calls :func:`tolokaforge.core.llm.presets.set_overlay_path`
+    (directly or transitively via ``build_capabilities`` / the CLI helper)
+    must take this fixture so the next test starts from a clean slate.
+    """
+    yield
+    set_overlay_path(None)
+
+
+@pytest.fixture
+def write_overlay(tmp_path: Path) -> Callable[[dict], str]:
+    """Return a writer that materialises an overlay dict to a temp YAML file
+    and returns the path (the shape ``set_overlay_path`` consumes)."""
+
+    def _write(data: dict, name: str = "overlay.yaml") -> str:
+        path = tmp_path / name
+        path.write_text(yaml.safe_dump(data))
+        return str(path)
+
+    return _write
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/integration/test_preset_overlay_live_eval.py
+++ b/tests/integration/test_preset_overlay_live_eval.py
@@ -1,0 +1,216 @@
+"""End-to-end live eval: a real ``tolokaforge run`` driven by a preset
+overlay file, against a public tool-use task. Verifies the per-trial
+``task.yaml`` output records the overlay's preset name in the resolved
+fingerprint — proof that an operator can register a model registration
+delta without an engine release and see it land in the run artifacts.
+
+**Gated.** Requires Docker (for the runner container stack) and a real LLM
+provider key (currently OPENROUTER_API_KEY). The top-level
+``tests/conftest.py`` auto-skips ``requires_api``-marked tests when no key
+is set; the Docker check below skips when the daemon isn't available.
+
+**Cost.** One trial of one tool-use task (max 8 turns) on
+``anthropic/claude-sonnet-4-6`` via OpenRouter, with the standard
+``cache_policy: anthropic_ephemeral`` baseline. Single run costs cents.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_api,
+    pytest.mark.requires_docker,
+    pytest.mark.llm,
+    pytest.mark.slow,
+]
+
+
+def _docker_running() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=5).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+# Single-task pack — the second public tool-use task is omitted by glob so
+# the test stays at one trial.
+_PUBLIC_TASK_PACK = "examples/native/tool_use/dataset"
+_PUBLIC_TASK_GLOB = "**/tool_use_public_example_01/task.yaml"
+_OVERLAY_PRESET_NAME = "live_eval_overlay_marker_preset"
+
+
+def _pick_provider() -> tuple[str, str] | None:
+    """Pick a (provider, model) pair whose credential is available in env.
+
+    Anthropic-direct first (lowest provider surface area for this Claude
+    workload), then OpenRouter. Returns ``None`` if neither key is set —
+    the test that calls this is gated by a skipif on the same condition.
+    """
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return ("anthropic", "claude-sonnet-4-6")
+    if os.environ.get("OPENROUTER_API_KEY"):
+        return ("openrouter", "anthropic/claude-sonnet-4-6")
+    return None
+
+
+def _provider_credential_available() -> bool:
+    return _pick_provider() is not None
+
+
+@pytest.fixture
+def chosen_provider() -> tuple[str, str]:
+    """Return the (provider, model) the test will drive."""
+    picked = _pick_provider()
+    assert picked is not None, "no provider credential available"
+    return picked
+
+
+@pytest.fixture
+def overlay_file(tmp_path: Path, chosen_provider: tuple[str, str]) -> Path:
+    """Write an overlay that shadows the bundled match for the agent model.
+
+    The overlay uses a recognisably distinct preset name so the assertion
+    below can confirm the *overlay* won (and not the bundled ``anthropic``
+    preset). Cache policy stays ``anthropic_ephemeral`` to keep the eval
+    behaviour identical to a non-overlay run — we are testing the seam,
+    not perturbing the workload.
+    """
+    _, model_name = chosen_provider
+    overlay = {
+        "presets": {
+            _OVERLAY_PRESET_NAME: {
+                "match": [f"{model_name}*", f"*{model_name}*"],
+                "content_policy": "anthropic",
+                "reasoning_codec": "anthropic",
+                "cache_policy": "anthropic_ephemeral",
+            }
+        }
+    }
+    path = tmp_path / "overlay.yaml"
+    path.write_text(yaml.safe_dump(overlay))
+    return path
+
+
+@pytest.fixture
+def run_config_file(tmp_path: Path, chosen_provider: tuple[str, str]) -> Path:
+    """Write a run config pointing at the public single-task pack."""
+    provider, model_name = chosen_provider
+    output_dir = tmp_path / "results"
+    cfg = {
+        "models": {
+            "agent": {
+                "provider": provider,
+                "name": model_name,
+                "temperature": 0.0,
+                "max_tokens": 4096,
+            },
+            "user": {
+                "provider": provider,
+                "name": model_name,
+                "temperature": 0.2,
+            },
+        },
+        "orchestrator": {
+            "workers": 1,
+            "repeats": 1,
+            "max_turns": 8,
+            "queue_backend": "sqlite",
+        },
+        "evaluation": {
+            "task_packs": [_PUBLIC_TASK_PACK],
+            "tasks_glob": _PUBLIC_TASK_GLOB,
+            "output_dir": str(output_dir),
+            "cache_images": True,
+        },
+    }
+    path = tmp_path / "run.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    return path
+
+
+@pytest.mark.skipif(not _docker_running(), reason="Docker daemon not available")
+@pytest.mark.skipif(
+    not _provider_credential_available(),
+    reason=(
+        "Neither ANTHROPIC_API_KEY nor OPENROUTER_API_KEY set — at least one "
+        "is required to reach a Claude model for the eval."
+    ),
+)
+def test_live_eval_records_overlay_preset_in_trial_output(
+    overlay_file: Path, run_config_file: Path, tmp_path: Path
+) -> None:
+    """Drive ``tolokaforge run`` with an overlay and assert the per-trial
+    ``task.yaml`` records the overlay's preset name in the resolved block.
+
+    The overlay's only behavioural job here is to *rename* the preset (same
+    policy slots as the bundled ``anthropic`` preset). That keeps the eval
+    workload identical while proving the overlay's metadata reaches the
+    output artifacts.
+    """
+    env = os.environ.copy()
+    # Pass the API key through; conftest gating ensures we only get here
+    # when at least one provider key is set.
+    proc = subprocess.run(
+        [
+            "uv",
+            "run",
+            "tolokaforge",
+            "run",
+            "--config",
+            str(run_config_file),
+            "--presets-file",
+            str(overlay_file),
+        ],
+        cwd=str(Path.cwd()),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=900,  # 15 minutes — Docker build can be slow on a cold cache
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"tolokaforge run failed (rc={proc.returncode}):\n"
+        f"stdout:\n{proc.stdout[-4000:]}\n"
+        f"stderr:\n{proc.stderr[-4000:]}"
+    )
+
+    # Locate the per-trial task.yaml. The orchestrator suffixes ``output_dir``
+    # with ``_<timestamp>`` and writes per-trial output under
+    # ``<output_dir>_<ts>/trials/<task_id>/<trial_idx>/task.yaml``.
+    # Search the *parent* of the configured output_dir so the timestamp suffix
+    # is in scope.
+    configured = Path(yaml.safe_load(run_config_file.read_text())["evaluation"]["output_dir"])
+    search_root = configured.parent
+    trial_yamls = list(search_root.glob("**/trials/*/*/task.yaml"))
+    assert trial_yamls, (
+        f"no per-trial task.yaml found under {search_root}.\n"
+        f"search root contents: {list(search_root.glob('**/*'))[:50]}\n"
+        f"--- stdout tail ---\n{proc.stdout[-2000:]}\n"
+        f"--- stderr tail ---\n{proc.stderr[-2000:]}"
+    )
+
+    # Read the first (and only, given repeats=1 + 1-task glob) trial.
+    trial_yaml = yaml.safe_load(trial_yamls[0].read_text())
+    agent_block = trial_yaml.get("model_config", {}).get("agent", {})
+    resolved = agent_block.get("resolved", {})
+    assert resolved, (
+        f"trial {trial_yamls[0]} missing model_config.agent.resolved; " f"got: {agent_block}"
+    )
+    assert resolved.get("effective_preset") == _OVERLAY_PRESET_NAME, (
+        f"expected overlay preset {_OVERLAY_PRESET_NAME!r} in resolved block, " f"got {resolved!r}"
+    )
+    # Policy slots set by the overlay must be reflected too — proves the
+    # overlay's content reached capability resolution, not just the name tag.
+    assert resolved.get("content_policy") == "anthropic"
+    assert resolved.get("reasoning_codec") == "anthropic"
+    assert resolved.get("cache_policy") == "anthropic_ephemeral"

--- a/tests/integration/test_preset_overlay_orchestrator.py
+++ b/tests/integration/test_preset_overlay_orchestrator.py
@@ -1,0 +1,294 @@
+"""Orchestrator-level integration: overlay-defined presets flow through the
+same plumbing the per-trial output uses to stamp resolved policies into
+``task.yaml`` / metrics.
+
+These tests exercise the in-process integration boundary — config YAML →
+overlay activation → ``build_capabilities`` → ``_build_resolved_block`` —
+without subprocesses, Docker, or LLM credentials. They prove that when an
+operator hands in a run-config with ``engine.presets_file``, the overlay's
+preset actually drives the runtime policy resolution that downstream
+analytics consume.
+
+What this catches that the unit tests don't: a future change that wires the
+overlay into the loader but forgets to thread it through ``Orchestrator``
+or the resolved-block helper would still pass the unit tests but fail
+here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.cli.main import _activate_presets_overlay
+from tolokaforge.core.llm import build_capabilities
+from tolokaforge.core.llm.presets import (
+    resolve_effective_preset,
+    resolve_policy_names,
+)
+from tolokaforge.core.models import EngineConfig, ModelConfig, RunConfig
+from tolokaforge.core.orchestrator import _build_resolved_block
+
+pytestmark = pytest.mark.integration
+
+
+def _write_yaml(path: Path, data: dict) -> str:
+    path.write_text(yaml.safe_dump(data))
+    return str(path)
+
+
+def _minimal_run_config_yaml(
+    tmp_path: Path,
+    *,
+    agent_model_name: str,
+    agent_provider: str,
+    presets_file: str | None = None,
+) -> Path:
+    """Write a minimal ``run.yaml`` that ``RunConfig(**yaml.safe_load(...))``
+    can ingest. Mirrors the on-disk shape operators actually use."""
+    cfg = {
+        "models": {
+            "agent": {
+                "provider": agent_provider,
+                "name": agent_model_name,
+                "temperature": 0.0,
+            }
+        },
+        "orchestrator": {"workers": 1, "repeats": 1, "max_turns": 4},
+        "evaluation": {"output_dir": str(tmp_path / "results")},
+    }
+    if presets_file is not None:
+        cfg["engine"] = {"presets_file": presets_file}
+    p = tmp_path / "run.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    return p
+
+
+class TestOverlayDrivesBuildCapabilities:
+    """The public ``build_capabilities()`` is what the orchestrator (and
+    LLMClient) calls per trial. An overlay-defined preset must surface there.
+    """
+
+    def test_overlay_preset_drives_resolved_capabilities(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        overlay_path = _write_yaml(
+            tmp_path / "overlay.yaml",
+            {
+                "presets": {
+                    "lab_response_override": {
+                        "match": ["lab/custom-model*"],
+                        "response_policy": "array_dict_map",
+                        "reasoning_codec": "openai",
+                    }
+                }
+            },
+        )
+        # Run-config has engine.presets_file pointing at the overlay.
+        run_config_path = _minimal_run_config_yaml(
+            tmp_path,
+            agent_model_name="lab/custom-model-v1",
+            agent_provider="openrouter",
+            presets_file=overlay_path,
+        )
+        # Re-load through the same path the CLI uses.
+        with open(run_config_path) as f:
+            run_config = RunConfig(**yaml.safe_load(f))
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None, run_config=run_config, run_dir=None
+        )
+        assert resolved == overlay_path
+
+        # The public capability builder must see the overlay's preset.
+        agent_config = run_config.models["agent"]
+        caps = build_capabilities(agent_config.name, agent_config.provider)
+        names = resolve_policy_names(caps)
+        assert names["response_policy"] == "array_dict_map"
+        assert names["reasoning_codec"] == "openai"
+        assert resolve_effective_preset(agent_config.name, agent_config.provider) == (
+            "lab_response_override"
+        )
+
+
+class TestOverlayResolvedBlock:
+    """The orchestrator's ``_build_resolved_block`` is what writes the
+    per-trial preset fingerprint into ``task.yaml`` (Stage 7 contract).
+    Analytics tools diff this block to detect capability drift across runs.
+    An overlay-defined preset MUST surface in this block — otherwise
+    operators can't tell from the output which preset actually ran.
+    """
+
+    def test_resolved_block_records_overlay_preset_name(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        overlay_path = _write_yaml(
+            tmp_path / "overlay.yaml",
+            {
+                "presets": {
+                    "lab_v2_preset": {
+                        "match": ["lab-v2/*"],
+                        "response_policy": "json_coerce",
+                    }
+                }
+            },
+        )
+        run_config = RunConfig(
+            models={
+                "agent": ModelConfig(
+                    provider="openrouter",
+                    name="lab-v2/some-model",
+                    temperature=0.0,
+                ),
+            },
+            orchestrator={"workers": 1},
+            evaluation={"output_dir": str(tmp_path / "results")},
+            engine=EngineConfig(presets_file=overlay_path),
+        )
+        _activate_presets_overlay(cli_presets_file=None, run_config=run_config, run_dir=None)
+
+        block = _build_resolved_block(run_config.models["agent"])
+        assert block["effective_preset"] == "lab_v2_preset"
+        assert block["response_policy"] == "json_coerce"
+
+    def test_resolved_block_for_bundled_model_unchanged_when_overlay_does_not_match(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        """An overlay that only adds new presets must not perturb bundled
+        models' resolved blocks. This is the no-behaviour-change invariant
+        for unrelated models when an operator ships an additive overlay.
+        """
+        overlay_path = _write_yaml(
+            tmp_path / "overlay.yaml",
+            {
+                "presets": {
+                    "unrelated_overlay_preset": {
+                        "match": ["totally-different/*"],
+                        "response_policy": "array_dict_map",
+                    }
+                }
+            },
+        )
+        run_config = RunConfig(
+            models={
+                "agent": ModelConfig(
+                    provider="openrouter",
+                    name="anthropic/claude-opus-4.8",
+                    temperature=0.0,
+                ),
+            },
+            orchestrator={"workers": 1},
+            evaluation={"output_dir": str(tmp_path / "results")},
+            engine=EngineConfig(presets_file=overlay_path),
+        )
+
+        # Capture the bundled resolved block with no overlay first.
+        from tolokaforge.core.llm.presets import set_overlay_path
+
+        set_overlay_path(None)
+        bundled_block = _build_resolved_block(run_config.models["agent"])
+
+        # Now install the overlay and re-evaluate.
+        _activate_presets_overlay(None, run_config, run_dir=None)
+        overlaid_block = _build_resolved_block(run_config.models["agent"])
+
+        assert overlaid_block == bundled_block, (
+            "Overlay that adds an unrelated preset must not change a bundled "
+            "model's resolved block — this is the no-behaviour-change "
+            "invariant."
+        )
+
+
+class TestOverlayShadowFlowsThroughOrchestratorHelpers:
+    """Shadowing a bundled preset via an overlay must surface in
+    ``_build_resolved_block`` — operators rely on this to confirm an
+    ablation actually took effect.
+    """
+
+    def test_overlay_shadow_changes_resolved_block(self, tmp_path: Path, overlay_isolation) -> None:
+        # Overlay a preset that matches a bundled model name (claude-opus-4.8)
+        # with an earlier match → first-match-wins gives the overlay priority.
+        overlay_path = _write_yaml(
+            tmp_path / "overlay.yaml",
+            {
+                "presets": {
+                    "ablation_no_cache": {
+                        "match": ["anthropic/claude-opus-4.8*"],
+                        "cache_policy": "none",
+                        "content_policy": "anthropic",
+                    }
+                }
+            },
+        )
+        run_config = RunConfig(
+            models={
+                "agent": ModelConfig(
+                    provider="anthropic",
+                    name="anthropic/claude-opus-4.8",
+                    temperature=0.0,
+                ),
+            },
+            orchestrator={"workers": 1},
+            evaluation={"output_dir": str(tmp_path / "results")},
+            engine=EngineConfig(presets_file=overlay_path),
+        )
+        _activate_presets_overlay(None, run_config, run_dir=None)
+
+        block = _build_resolved_block(run_config.models["agent"])
+        assert block["effective_preset"] == "ablation_no_cache"
+        assert block["cache_policy"] == "none"
+
+
+class TestCLIPrecedenceFlowsThroughOrchestratorHelpers:
+    """An overlay supplied via ``--presets-file`` (highest precedence) must
+    beat ``engine.presets_file`` (lowest), and the orchestrator's resolved
+    block must reflect the winner.
+    """
+
+    def test_cli_overlay_beats_engine_config_overlay(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        config_overlay = _write_yaml(
+            tmp_path / "config_overlay.yaml",
+            {
+                "presets": {
+                    "from_config": {
+                        "match": ["mixed/*"],
+                        "response_policy": "json_coerce",
+                    }
+                }
+            },
+        )
+        cli_overlay = _write_yaml(
+            tmp_path / "cli_overlay.yaml",
+            {
+                "presets": {
+                    "from_cli": {
+                        "match": ["mixed/*"],
+                        "response_policy": "array_dict_map",
+                    }
+                }
+            },
+        )
+        run_config = RunConfig(
+            models={
+                "agent": ModelConfig(
+                    provider="openrouter",
+                    name="mixed/some-model",
+                    temperature=0.0,
+                ),
+            },
+            orchestrator={"workers": 1},
+            evaluation={"output_dir": str(tmp_path / "results")},
+            engine=EngineConfig(presets_file=config_overlay),
+        )
+        _activate_presets_overlay(
+            cli_presets_file=cli_overlay,
+            run_config=run_config,
+            run_dir=None,
+        )
+
+        block = _build_resolved_block(run_config.models["agent"])
+        assert block["effective_preset"] == "from_cli"
+        assert block["response_policy"] == "array_dict_map"

--- a/tests/integration/test_preset_overlay_subprocess.py
+++ b/tests/integration/test_preset_overlay_subprocess.py
@@ -16,7 +16,6 @@ overlay path and prints it.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import textwrap
@@ -27,7 +26,6 @@ import pytest
 from tolokaforge.core.engine_run_state import (
     write_engine_run_state,
 )
-from tolokaforge.core.llm.presets import OVERLAY_ENV_VAR
 
 pytestmark = pytest.mark.integration
 
@@ -63,18 +61,12 @@ def _run_resolver(
     run_dir: Path | None,
     cli_value: str | None,
     config_value: str | None,
-    env_value: str | None = None,
 ) -> dict:
     """Spawn a clean subprocess that drives the worker's overlay resolution.
 
     Returns the resolver's JSON output as a dict, so tests can assert both
     the resolved path and the actually-installed path inside the subprocess.
     """
-    env = os.environ.copy()
-    env.pop(OVERLAY_ENV_VAR, None)
-    if env_value is not None:
-        env[OVERLAY_ENV_VAR] = env_value
-
     proc = subprocess.run(
         [
             sys.executable,
@@ -86,7 +78,6 @@ def _run_resolver(
         ],
         capture_output=True,
         text=True,
-        env=env,
         check=False,
     )
     assert proc.returncode == 0, (
@@ -111,16 +102,6 @@ class TestSubprocessInheritance:
         write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
         result = _run_resolver(run_dir=tmp_path, cli_value="/from/cli.yaml", config_value=None)
         assert result["resolved"] == "/from/cli.yaml"
-
-    def test_subprocess_env_beats_queue_state(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
-        result = _run_resolver(
-            run_dir=tmp_path,
-            cli_value=None,
-            config_value=None,
-            env_value="/from/env.yaml",
-        )
-        assert result["resolved"] == "/from/env.yaml"
 
     def test_subprocess_queue_state_beats_config_field(self, tmp_path: Path) -> None:
         write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")

--- a/tests/integration/test_preset_overlay_subprocess.py
+++ b/tests/integration/test_preset_overlay_subprocess.py
@@ -87,38 +87,63 @@ def _run_resolver(
     return json.loads(proc.stdout.strip().splitlines()[-1])
 
 
+def _write_empty_overlay(tmp_path: Path, name: str) -> str:
+    """Write a minimal valid overlay so the CLI's eager validation passes.
+
+    Resolution-precedence tests only care about *which* file the resolver
+    picked, not what's in it. An empty YAML body is a valid overlay (the
+    loader treats it as the default empty registry) and lets the CLI's
+    eager ``validate_overlay_file`` call succeed.
+    """
+    path = tmp_path / name
+    path.write_text("")
+    return str(path)
+
+
 class TestSubprocessInheritance:
     """Parent writes ``engine_run_state.json``; subprocess reads it without
     any other channel. Proves the file is the actual cross-process carrier.
+
+    Each test materialises real (minimal but valid) overlay files because
+    ``_activate_presets_overlay`` now eagerly validates every resolved
+    overlay — a CLI-boundary improvement that catches typo'd paths before
+    Docker auto-starts.
     """
 
     def test_subprocess_reads_queue_state_overlay(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
+        write_engine_run_state(tmp_path, presets_file=queue_overlay)
         result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=None)
-        assert result["resolved"] == "/from/queue.yaml"
-        assert result["installed"] == "/from/queue.yaml"
+        assert result["resolved"] == queue_overlay
+        assert result["installed"] == queue_overlay
 
     def test_subprocess_cli_flag_beats_queue_state(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
-        result = _run_resolver(run_dir=tmp_path, cli_value="/from/cli.yaml", config_value=None)
-        assert result["resolved"] == "/from/cli.yaml"
+        queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
+        cli_overlay = _write_empty_overlay(tmp_path, "cli.yaml")
+        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        result = _run_resolver(run_dir=tmp_path, cli_value=cli_overlay, config_value=None)
+        assert result["resolved"] == cli_overlay
 
     def test_subprocess_queue_state_beats_config_field(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
-        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
-        assert result["resolved"] == "/from/queue.yaml"
+        queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
+        config_overlay = _write_empty_overlay(tmp_path, "config.yaml")
+        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=config_overlay)
+        assert result["resolved"] == queue_overlay
 
     def test_subprocess_no_queue_state_falls_through_to_config(self, tmp_path: Path) -> None:
         # No engine_run_state.json written.
-        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
-        assert result["resolved"] == "/from/config.yaml"
+        config_overlay = _write_empty_overlay(tmp_path, "config.yaml")
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=config_overlay)
+        assert result["resolved"] == config_overlay
 
     def test_subprocess_persisted_none_falls_through_to_config(self, tmp_path: Path) -> None:
         # ``prepare`` ran without an overlay → persisted as null →
         # subprocess falls through to engine.presets_file.
+        config_overlay = _write_empty_overlay(tmp_path, "config.yaml")
         write_engine_run_state(tmp_path, presets_file=None)
-        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
-        assert result["resolved"] == "/from/config.yaml"
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=config_overlay)
+        assert result["resolved"] == config_overlay
 
     def test_subprocess_no_overlay_anywhere_yields_none(self) -> None:
         result = _run_resolver(run_dir=None, cli_value=None, config_value=None)

--- a/tests/integration/test_preset_overlay_subprocess.py
+++ b/tests/integration/test_preset_overlay_subprocess.py
@@ -1,0 +1,259 @@
+"""Cross-process overlay handoff — proves engine_run_state.json bridges
+``tolokaforge prepare`` and ``tolokaforge worker`` across actual Python
+interpreter boundaries.
+
+The unit tests in ``tests/unit/llm/test_preset_overlay_worker_propagation.py``
+cover the resolution layer (``_activate_presets_overlay``) inside one
+process. These tests run a **fresh subprocess** so module-level overlay
+state cannot have leaked from the parent — the only carrier across the
+boundary is the JSON file written by ``prepare``. If that bridge is
+broken, the subprocess overlay path comes back as ``None``.
+
+No Docker / no LLM credentials needed: the subprocess just resolves the
+overlay path and prints it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.engine_run_state import (
+    write_engine_run_state,
+)
+from tolokaforge.core.llm.presets import OVERLAY_ENV_VAR
+
+pytestmark = pytest.mark.integration
+
+
+_RESOLVER_SCRIPT = textwrap.dedent(
+    """
+    import json, sys
+    from pathlib import Path
+    from tolokaforge.cli.main import _activate_presets_overlay
+    from tolokaforge.core.llm.presets import get_overlay_path
+    from tolokaforge.core.models import EngineConfig, RunConfig
+
+    run_dir = Path(sys.argv[1]) if sys.argv[1] != "NONE" else None
+    cli_value = sys.argv[2] if sys.argv[2] != "NONE" else None
+    config_value = sys.argv[3] if sys.argv[3] != "NONE" else None
+
+    run_config = RunConfig(
+        models={},
+        orchestrator={"workers": 1},
+        evaluation={"output_dir": "/tmp"},
+        engine=EngineConfig(presets_file=config_value) if config_value else None,
+    )
+    resolved = _activate_presets_overlay(
+        cli_presets_file=cli_value, run_config=run_config, run_dir=run_dir
+    )
+    print(json.dumps({"resolved": resolved, "installed": get_overlay_path()}))
+    """
+).strip()
+
+
+def _run_resolver(
+    *,
+    run_dir: Path | None,
+    cli_value: str | None,
+    config_value: str | None,
+    env_value: str | None = None,
+) -> dict:
+    """Spawn a clean subprocess that drives the worker's overlay resolution.
+
+    Returns the resolver's JSON output as a dict, so tests can assert both
+    the resolved path and the actually-installed path inside the subprocess.
+    """
+    env = os.environ.copy()
+    env.pop(OVERLAY_ENV_VAR, None)
+    if env_value is not None:
+        env[OVERLAY_ENV_VAR] = env_value
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RESOLVER_SCRIPT,
+            str(run_dir) if run_dir is not None else "NONE",
+            cli_value if cli_value is not None else "NONE",
+            config_value if config_value is not None else "NONE",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"resolver subprocess failed: rc={proc.returncode}\n"
+        f"stderr={proc.stderr}\nstdout={proc.stdout}"
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+class TestSubprocessInheritance:
+    """Parent writes ``engine_run_state.json``; subprocess reads it without
+    any other channel. Proves the file is the actual cross-process carrier.
+    """
+
+    def test_subprocess_reads_queue_state_overlay(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=None)
+        assert result["resolved"] == "/from/queue.yaml"
+        assert result["installed"] == "/from/queue.yaml"
+
+    def test_subprocess_cli_flag_beats_queue_state(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        result = _run_resolver(run_dir=tmp_path, cli_value="/from/cli.yaml", config_value=None)
+        assert result["resolved"] == "/from/cli.yaml"
+
+    def test_subprocess_env_beats_queue_state(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        result = _run_resolver(
+            run_dir=tmp_path,
+            cli_value=None,
+            config_value=None,
+            env_value="/from/env.yaml",
+        )
+        assert result["resolved"] == "/from/env.yaml"
+
+    def test_subprocess_queue_state_beats_config_field(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
+        assert result["resolved"] == "/from/queue.yaml"
+
+    def test_subprocess_no_queue_state_falls_through_to_config(self, tmp_path: Path) -> None:
+        # No engine_run_state.json written.
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
+        assert result["resolved"] == "/from/config.yaml"
+
+    def test_subprocess_persisted_none_falls_through_to_config(self, tmp_path: Path) -> None:
+        # ``prepare`` ran without an overlay → persisted as null →
+        # subprocess falls through to engine.presets_file.
+        write_engine_run_state(tmp_path, presets_file=None)
+        result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value="/from/config.yaml")
+        assert result["resolved"] == "/from/config.yaml"
+
+    def test_subprocess_no_overlay_anywhere_yields_none(self) -> None:
+        result = _run_resolver(run_dir=None, cli_value=None, config_value=None)
+        assert result["resolved"] is None
+        assert result["installed"] is None
+
+
+def _collapse(text: str) -> str:
+    """Drop whitespace from rich-rendered console output so long paths that
+    wrap across visual lines still match a single-line expected substring."""
+    return "".join(text.split())
+
+
+class TestRealCLISubprocessConfigValidate:
+    """Exercise the actual ``tolokaforge config validate`` CLI in a subprocess
+    with ``--presets-file``. Verifies the operator-facing surface — flag is
+    accepted, good overlays surface a ✓ line, bad overlays surface the
+    file-path-bearing error and exit non-zero.
+
+    Uses the public ``tool_use`` example config as a host run-config so we
+    exercise the same code path operators use.
+    """
+
+    EXAMPLE_CONFIG = "examples/native/tool_use/run_config.yaml"
+
+    def test_good_overlay_exits_zero(self, tmp_path: Path) -> None:
+        overlay = tmp_path / "good_overlay.yaml"
+        overlay.write_text(
+            "presets:\n"
+            "  subproc_test:\n"
+            "    match: ['subproctest/*']\n"
+            "    response_policy: array_dict_map\n"
+        )
+        proc = subprocess.run(
+            [
+                "uv",
+                "run",
+                "tolokaforge",
+                "config",
+                "validate",
+                "--config",
+                self.EXAMPLE_CONFIG,
+                "--presets-file",
+                str(overlay),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # We accept exit 0 (no errors) — API-key warnings don't fail validate
+        # without --strict.
+        assert proc.returncode == 0, f"validate failed unexpectedly:\n{proc.stdout}\n{proc.stderr}"
+        normalized = _collapse(proc.stdout)
+        assert "PresetoverlayOK" in normalized
+        assert _collapse(str(overlay)) in normalized
+
+    def test_bad_overlay_loud_fails(self, tmp_path: Path) -> None:
+        overlay = tmp_path / "bad_overlay.yaml"
+        overlay.write_text(
+            "presets:\n"
+            "  subproc_bad:\n"
+            "    match: ['subprocbad/*']\n"
+            "    response_policy: not_a_real_policy\n"
+        )
+        proc = subprocess.run(
+            [
+                "uv",
+                "run",
+                "tolokaforge",
+                "config",
+                "validate",
+                "--config",
+                self.EXAMPLE_CONFIG,
+                "--presets-file",
+                str(overlay),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode != 0, "validate should exit non-zero on bad overlay"
+        normalized = _collapse(proc.stdout)
+        assert "unknownresponse_policy" in normalized
+        # Error message must name the file path.
+        assert _collapse(str(overlay)) in normalized
+
+    def test_missing_overlay_loud_fails(self, tmp_path: Path) -> None:
+        proc = subprocess.run(
+            [
+                "uv",
+                "run",
+                "tolokaforge",
+                "config",
+                "validate",
+                "--config",
+                self.EXAMPLE_CONFIG,
+                "--presets-file",
+                str(tmp_path / "does_not_exist.yaml"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode != 0
+        normalized = _collapse(proc.stdout).lower()
+        assert "notfound" in normalized or "does_not_exist" in normalized
+
+
+class TestSubprocessIsolation:
+    """Sanity: the subprocess starts with no installed overlay even if the
+    parent test process has one. This is the property we rely on for
+    ``engine_run_state.json`` to be the only carrier across the boundary.
+    """
+
+    def test_subprocess_starts_with_no_overlay(self) -> None:
+        # Parent process may or may not have an overlay installed; the
+        # subprocess MUST start fresh. Run with explicit None inputs.
+        result = _run_resolver(run_dir=None, cli_value=None, config_value=None)
+        assert result["installed"] is None

--- a/tests/unit/llm/conftest.py
+++ b/tests/unit/llm/conftest.py
@@ -1,0 +1,7 @@
+"""LLM-layer unit-test fixtures.
+
+The overlay fixtures (``overlay_isolation``, ``write_overlay``) live in the
+top-level ``tests/conftest.py`` so integration tests can use them too. This
+file is intentionally empty — kept so pytest still treats this directory as
+a fixture-source root.
+"""

--- a/tests/unit/llm/test_preset_overlay_loading.py
+++ b/tests/unit/llm/test_preset_overlay_loading.py
@@ -1,0 +1,179 @@
+"""Overlay loading: merge with bundled, precedence, default/provider merge.
+
+ADR 0002 introduces an operator-pointed preset overlay. These tests pin:
+
+- a freshly-installed overlay's presets are reachable via the public lookup
+  helpers (``resolve_effective_preset``, ``build_capabilities``);
+- bundled presets remain reachable;
+- overlay entries are *prepended* to iteration order so first-match-wins gives
+  the overlay priority when ``match:`` patterns overlap;
+- ``default:`` and ``providers:`` blocks merge shallowly, with nested
+  ``params`` merging deeply;
+- ``set_overlay_path`` invalidates the cached merged registry, so swapping
+  overlays mid-process is visible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm.presets import (
+    _load_presets,
+    _match_preset,
+    build_capabilities,
+    resolve_effective_preset,
+    resolve_policy_names,
+    set_overlay_path,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestOverlayInstall:
+    def test_no_overlay_matches_bundled_data(self, overlay_isolation) -> None:
+        # Baseline: with no overlay installed, _load_presets returns the
+        # bundled registry verbatim.
+        set_overlay_path(None)
+        data = _load_presets()
+        assert "presets" in data and len(data["presets"]) > 0
+        # A bundled preset still resolves.
+        assert resolve_effective_preset("anthropic/claude-opus-4.8") == "anthropic_claude_4_8"
+
+    def test_overlay_preset_resolves_via_public_helpers(
+        self, write_overlay, overlay_isolation
+    ) -> None:
+        path = write_overlay(
+            {
+                "presets": {
+                    "custom_lab_model": {
+                        "match": ["customlab/*"],
+                        "response_policy": "array_dict_map",
+                        "reasoning_codec": "openai",
+                    }
+                }
+            }
+        )
+        set_overlay_path(path)
+        assert resolve_effective_preset("customlab/foo-1") == "custom_lab_model"
+        caps = build_capabilities("customlab/foo-1")
+        names = resolve_policy_names(caps)
+        assert names["response_policy"] == "array_dict_map"
+        assert names["reasoning_codec"] == "openai"
+
+    def test_overlay_does_not_remove_bundled_presets(
+        self, write_overlay, overlay_isolation
+    ) -> None:
+        path = write_overlay(
+            {"presets": {"custom_x": {"match": ["customx/*"], "response_policy": "standard"}}}
+        )
+        set_overlay_path(path)
+        # Bundled preset still routes.
+        assert resolve_effective_preset("anthropic/claude-opus-4.8") == "anthropic_claude_4_8"
+
+
+class TestOverlayPrecedence:
+    def test_overlay_preset_wins_first_match(self, write_overlay, overlay_isolation) -> None:
+        # The bundled file matches "anthropic/claude-opus-4.8" via the
+        # anthropic_claude_4_8 preset. An overlay declaring an earlier match
+        # for the same model name must win.
+        path = write_overlay(
+            {
+                "presets": {
+                    "anthropic_lab_override": {
+                        "match": ["anthropic/claude-opus-4.8*"],
+                        "response_policy": "json_coerce",
+                    }
+                }
+            }
+        )
+        set_overlay_path(path)
+        assert resolve_effective_preset("anthropic/claude-opus-4.8") == "anthropic_lab_override"
+
+    def test_overlay_replaces_bundled_entry_with_same_name(
+        self, write_overlay, overlay_isolation, caplog
+    ) -> None:
+        # Replacing a bundled preset name with overlay content emits an INFO
+        # log so the replacement is visible.
+        import logging
+
+        path = write_overlay(
+            {
+                "presets": {
+                    "anthropic_claude_4_8": {
+                        "match": ["anthropic/claude-opus-4.8*"],
+                        "response_policy": "json_coerce",
+                    }
+                }
+            }
+        )
+        with caplog.at_level(logging.INFO, logger="tolokaforge.core.llm.presets"):
+            set_overlay_path(path)
+            _load_presets()  # force merge
+        assert any(
+            "shadows bundled preset" in r.message for r in caplog.records
+        ), f"expected shadow log; got: {[r.message for r in caplog.records]}"
+        # And the overlay version wins for resolution.
+        merged = _match_preset("anthropic/claude-opus-4.8", "")
+        assert merged["response_policy"] == "json_coerce"
+
+
+class TestOverlayDefaultAndProviders:
+    def test_default_block_overlay_wins_with_params_deep_merge(
+        self, write_overlay, overlay_isolation
+    ) -> None:
+        path = write_overlay(
+            {
+                "default": {
+                    "schema_sanitizer": "strict",
+                    "params": {"supports_seed": False},
+                }
+            }
+        )
+        set_overlay_path(path)
+        merged = _load_presets()
+        assert merged["default"]["schema_sanitizer"] == "strict"
+        # Bundled default 'params' (if any) merges with the overlay's params
+        # — the overlay key supports_seed must be present.
+        assert merged["default"]["params"]["supports_seed"] is False
+
+    def test_provider_block_overlay_wins(self, write_overlay, overlay_isolation) -> None:
+        path = write_overlay(
+            {
+                "providers": {
+                    "openrouter": {
+                        "params": {"supports_seed": False},
+                    }
+                }
+            }
+        )
+        set_overlay_path(path)
+        merged = _load_presets()
+        # Provider 'openrouter' params should now carry supports_seed=False
+        assert merged["providers"]["openrouter"]["params"]["supports_seed"] is False
+
+
+class TestOverlayCacheInvalidation:
+    def test_swapping_overlay_reflects_in_subsequent_lookup(
+        self, write_overlay, overlay_isolation
+    ) -> None:
+        path_a = write_overlay(
+            {"presets": {"a": {"match": ["custom-a/*"], "response_policy": "json_coerce"}}},
+            name="a.yaml",
+        )
+        path_b = write_overlay(
+            {"presets": {"b": {"match": ["custom-b/*"], "response_policy": "json_coerce"}}},
+            name="b.yaml",
+        )
+        set_overlay_path(path_a)
+        assert resolve_effective_preset("custom-a/x") == "a"
+        assert resolve_effective_preset("custom-b/x") == "default"
+
+        # Swap overlays — second lookup must see the new file, not a stale cache.
+        set_overlay_path(path_b)
+        assert resolve_effective_preset("custom-a/x") == "default"
+        assert resolve_effective_preset("custom-b/x") == "b"
+
+        # Clearing the overlay restores bundled-only behaviour.
+        set_overlay_path(None)
+        assert resolve_effective_preset("custom-a/x") == "default"
+        assert resolve_effective_preset("custom-b/x") == "default"

--- a/tests/unit/llm/test_preset_overlay_validation.py
+++ b/tests/unit/llm/test_preset_overlay_validation.py
@@ -1,0 +1,186 @@
+"""Overlay validation — host-boundary guard for the preset registry.
+
+Mirrors the in-tree ``ensure_registered_adapter()`` pattern from
+``tolokaforge.adapters`` (see PR #61): validate at the layer where the
+registry is authoritative, and fail loudly on every recognised
+misconfiguration. The error message must always name the overlay path so the
+operator can find the offending file.
+
+Also pins the validator-versus-registry sync invariant: every in-engine
+policy registry must be referenced by ``_validate_overlay``. Adding a new
+registry without extending the validator becomes a test failure rather than a
+silent runtime hole.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.llm.presets import (
+    _CACHE_POLICIES,
+    _CONTENT_POLICIES,
+    _PROMPT_POLICIES,
+    _REASONING_CODECS,
+    _RESPONSE_POLICIES,
+    _SCHEMA_SANITIZERS,
+    _load_overlay_file,
+    _load_presets,
+    _validate_overlay,
+    set_overlay_path,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestOverlayLoadErrors:
+    def test_missing_file_raises_with_path(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "does_not_exist.yaml")
+        with pytest.raises(FileNotFoundError, match=r"does_not_exist\.yaml"):
+            _load_overlay_file(path)
+
+    def test_malformed_yaml_raises_with_path(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("this:\n  is:\n - not\n  - balanced\n: yaml")
+        with pytest.raises(ValueError, match=r"bad\.yaml.*failed to parse"):
+            _load_overlay_file(str(path))
+
+    def test_top_level_must_be_mapping(self, tmp_path: Path) -> None:
+        path = tmp_path / "list.yaml"
+        path.write_text("- not\n- a\n- mapping")
+        with pytest.raises(ValueError, match=r"must be a YAML mapping"):
+            _load_overlay_file(str(path))
+
+    def test_empty_file_is_allowed(self, tmp_path: Path) -> None:
+        # An empty overlay file is equivalent to "no presets to add" and
+        # should not raise — operators may bootstrap an empty file before
+        # populating it.
+        path = tmp_path / "empty.yaml"
+        path.write_text("")
+        data = _load_overlay_file(str(path))
+        assert data == {"default": {}, "presets": {}, "providers": {}}
+
+    def test_unknown_top_level_key_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "typo.yaml"
+        path.write_text("preests:\n  foo: {}\n")  # 'preests' typo
+        with pytest.raises(ValueError, match=r"unknown top-level keys.*preests"):
+            _load_overlay_file(str(path))
+
+
+class TestOverlayPolicyNameValidation:
+    @pytest.mark.parametrize(
+        "slot,registry_keys",
+        [
+            ("schema_sanitizer", list(_SCHEMA_SANITIZERS)),
+            ("prompt_policy", list(_PROMPT_POLICIES)),
+            ("content_policy", list(_CONTENT_POLICIES)),
+            ("response_policy", list(_RESPONSE_POLICIES)),
+            ("reasoning_codec", list(_REASONING_CODECS)),
+            ("cache_policy", list(_CACHE_POLICIES)),
+        ],
+    )
+    def test_unknown_policy_name_in_preset_raises(
+        self, slot, registry_keys, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "bad_policy.yaml"
+        bogus = "definitely_not_in_registry_xyz"
+        path.write_text(f"presets:\n  bad:\n    match: ['x/*']\n    {slot}: {bogus}\n")
+        with pytest.raises(ValueError) as excinfo:
+            _load_overlay_file(str(path))
+        msg = str(excinfo.value)
+        assert "bad_policy.yaml" in msg
+        assert slot in msg
+        assert bogus in msg
+        # The error also lists the available names so the operator can fix it.
+        for name in registry_keys:
+            assert name in msg
+
+    def test_unknown_policy_in_default_block_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_default.yaml"
+        path.write_text("default:\n  response_policy: not_a_real_policy\n")
+        with pytest.raises(ValueError, match=r"unknown response_policy 'not_a_real_policy'"):
+            _load_overlay_file(str(path))
+
+    def test_unknown_policy_in_provider_block_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_provider.yaml"
+        path.write_text("providers:\n  openrouter:\n    response_policy: not_a_real_policy\n")
+        with pytest.raises(ValueError, match=r"providers\.openrouter.*response_policy"):
+            _load_overlay_file(str(path))
+
+
+class TestOverlayParamsValidation:
+    def test_unknown_params_key_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_params.yaml"
+        path.write_text(
+            "presets:\n  bad:\n    match: ['x/*']\n    params:\n      not_a_real_kwarg: 1\n"
+        )
+        with pytest.raises(ValueError, match=r"params.*unknown keys.*not_a_real_kwarg"):
+            _load_overlay_file(str(path))
+
+    def test_params_must_be_mapping(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_params_type.yaml"
+        path.write_text("presets:\n  bad:\n    match: ['x/*']\n    params: not_a_dict\n")
+        with pytest.raises(ValueError, match=r"params.*expected a mapping"):
+            _load_overlay_file(str(path))
+
+
+class TestValidatorRegistrySync:
+    """Pin the invariant: every in-engine policy registry must be referenced
+    by ``_validate_overlay``. Adding a new registry without updating the
+    validator → silent overlay-validation gap. Catching it here saves a
+    runtime debugging session.
+    """
+
+    def test_validator_references_every_registry(self) -> None:
+        source = inspect.getsource(_validate_overlay)
+        # Each registry constant name must appear in the validator's source.
+        for registry_name in [
+            "_SCHEMA_SANITIZERS",
+            "_PROMPT_POLICIES",
+            "_CONTENT_POLICIES",
+            "_RESPONSE_POLICIES",
+            "_REASONING_CODECS",
+            "_CACHE_POLICIES",
+        ]:
+            assert registry_name in source, (
+                f"_validate_overlay must reference {registry_name!r}; if a new "
+                f"registry was added, extend the validator to check it."
+            )
+
+    def test_validator_references_every_policy_slot_key(self) -> None:
+        source = inspect.getsource(_validate_overlay)
+        for slot in [
+            "schema_sanitizer",
+            "prompt_policy",
+            "content_policy",
+            "response_policy",
+            "reasoning_codec",
+            "cache_policy",
+        ]:
+            assert (
+                f'"{slot}"' in source or f"'{slot}'" in source
+            ), f"_validate_overlay must check the {slot!r} slot."
+
+
+class TestSetOverlayPathDefersFileRead:
+    """``set_overlay_path`` must not read the file — only ``_load_presets`` does.
+
+    This lets the CLI install an overlay path that's known to exist, while
+    deferring the file-read (and any validation error) to the first capability
+    lookup. Important for tests that swap overlays cheaply.
+    """
+
+    def test_set_overlay_path_does_not_raise_on_missing_file(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        # No read happens here, so no FileNotFoundError yet.
+        set_overlay_path(str(tmp_path / "not_there.yaml"))
+
+    def test_load_presets_raises_lazily_on_missing_file(
+        self, tmp_path: Path, overlay_isolation
+    ) -> None:
+        set_overlay_path(str(tmp_path / "not_there.yaml"))
+        with pytest.raises(FileNotFoundError, match=r"not_there\.yaml"):
+            _load_presets()

--- a/tests/unit/llm/test_preset_overlay_validation.py
+++ b/tests/unit/llm/test_preset_overlay_validation.py
@@ -14,21 +14,21 @@ silent runtime hole.
 
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 
 import pytest
 
+from tolokaforge.core.llm import presets as presets_module
 from tolokaforge.core.llm.presets import (
     _CACHE_POLICIES,
     _CONTENT_POLICIES,
+    _POLICY_REGISTRIES,
     _PROMPT_POLICIES,
     _REASONING_CODECS,
     _RESPONSE_POLICIES,
     _SCHEMA_SANITIZERS,
     _load_overlay_file,
     _load_presets,
-    _validate_overlay,
     set_overlay_path,
 )
 
@@ -126,42 +126,82 @@ class TestOverlayParamsValidation:
             _load_overlay_file(str(path))
 
 
+def _discover_policy_registries() -> dict[str, dict]:
+    """Find every module-level ``dict[str, type]`` in ``presets`` — i.e. every
+    policy-name → class registry, by structural shape rather than naming
+    convention. Used by ``TestValidatorRegistrySync`` so that adding a new
+    registry without listing it in ``_POLICY_REGISTRIES`` is a test failure
+    (which is what the PR description promises).
+    """
+    discovered: dict[str, dict] = {}
+    for attr_name, value in vars(presets_module).items():
+        if attr_name == "_POLICY_REGISTRIES":
+            continue
+        if not isinstance(value, dict) or not value:
+            continue
+        if not all(isinstance(k, str) for k in value):
+            continue
+        if not all(isinstance(v, type) for v in value.values()):
+            continue
+        discovered[attr_name] = value
+    return discovered
+
+
 class TestValidatorRegistrySync:
-    """Pin the invariant: every in-engine policy registry must be referenced
-    by ``_validate_overlay``. Adding a new registry without updating the
-    validator → silent overlay-validation gap. Catching it here saves a
-    runtime debugging session.
+    """Pin the invariant: every in-engine policy registry must be wired into
+    ``_POLICY_REGISTRIES`` so ``_validate_overlay`` checks it. Adding a new
+    ``dict[str, type]`` registry without listing it here is a silent overlay-
+    validation gap; this test fails when that happens.
+
+    Mechanism: introspect the ``presets`` module for *all* module-level
+    ``dict[str, type]`` constants (the structural shape of every existing
+    policy registry — ``_SCHEMA_SANITIZERS`` etc.). Every such dict must be a
+    value in ``_POLICY_REGISTRIES``. A new registry that bypasses this fails
+    here, regardless of naming convention.
     """
 
-    def test_validator_references_every_registry(self) -> None:
-        source = inspect.getsource(_validate_overlay)
-        # Each registry constant name must appear in the validator's source.
-        for registry_name in [
+    def test_every_module_registry_is_wired_into_policy_registries(self) -> None:
+        discovered = _discover_policy_registries()
+        registered_ids = {id(d) for d in _POLICY_REGISTRIES.values()}
+        unwired = {name: dct for name, dct in discovered.items() if id(dct) not in registered_ids}
+        assert not unwired, (
+            f"presets module contains policy registries not listed in "
+            f"_POLICY_REGISTRIES: {sorted(unwired.keys())}. Add them to "
+            f"_POLICY_REGISTRIES so _validate_overlay checks them, or this "
+            f"becomes a silent overlay-validation gap."
+        )
+
+    def test_baseline_six_registries_are_present(self) -> None:
+        # Belt-and-braces: pin the known-as-of-this-PR set so a *removal* also
+        # surfaces, not just an addition. Six registries today; if you
+        # consolidate or rename one, update this set.
+        baseline_names = {
             "_SCHEMA_SANITIZERS",
             "_PROMPT_POLICIES",
             "_CONTENT_POLICIES",
             "_RESPONSE_POLICIES",
             "_REASONING_CODECS",
             "_CACHE_POLICIES",
-        ]:
-            assert registry_name in source, (
-                f"_validate_overlay must reference {registry_name!r}; if a new "
-                f"registry was added, extend the validator to check it."
-            )
+        }
+        discovered = set(_discover_policy_registries().keys())
+        missing = baseline_names - discovered
+        assert not missing, (
+            f"baseline registries missing from the presets module: " f"{sorted(missing)}"
+        )
 
-    def test_validator_references_every_policy_slot_key(self) -> None:
-        source = inspect.getsource(_validate_overlay)
-        for slot in [
+    def test_policy_registries_keys_match_slot_names(self) -> None:
+        # The string keys in _POLICY_REGISTRIES are the YAML slot names
+        # operators write in overlay files. They must include every slot
+        # _validate_overlay handles via its block-check helper.
+        expected_slots = {
             "schema_sanitizer",
             "prompt_policy",
             "content_policy",
             "response_policy",
             "reasoning_codec",
             "cache_policy",
-        ]:
-            assert (
-                f'"{slot}"' in source or f"'{slot}'" in source
-            ), f"_validate_overlay must check the {slot!r} slot."
+        }
+        assert set(_POLICY_REGISTRIES.keys()) == expected_slots
 
 
 class TestSetOverlayPathDefersFileRead:

--- a/tests/unit/llm/test_preset_overlay_worker_propagation.py
+++ b/tests/unit/llm/test_preset_overlay_worker_propagation.py
@@ -1,7 +1,7 @@
 """Worker propagation — ``prepare`` persists the overlay path to the queue
 state file; the worker CLI's overlay resolution prefers that value over
 ``engine.presets_file`` (because ``prepare`` reflects the operator's most
-recent intent) while still letting ``--presets-file`` / env overrides win.
+recent intent) while still letting ``--presets-file`` override it.
 
 These are unit tests for the persistence + resolution mechanism. The
 end-to-end worker path (subprocess actually consuming the persisted overlay)
@@ -22,7 +22,7 @@ from tolokaforge.core.engine_run_state import (
     read_persisted_presets_file,
     write_engine_run_state,
 )
-from tolokaforge.core.llm.presets import OVERLAY_ENV_VAR, get_overlay_path
+from tolokaforge.core.llm.presets import get_overlay_path
 from tolokaforge.core.models import EngineConfig, RunConfig
 
 pytestmark = pytest.mark.unit
@@ -69,13 +69,10 @@ class TestEngineRunStatePersistence:
 
 class TestWorkerOverlayResolution:
     """The worker CLI calls ``_activate_presets_overlay(cli, run_config, run_dir)``.
-    The resolution precedence is CLI > env > queue-state > engine.presets_file.
+    The resolution precedence is CLI > queue-state > engine.presets_file.
     """
 
-    def test_queue_state_beats_engine_config(
-        self, tmp_path: Path, overlay_isolation, monkeypatch
-    ) -> None:
-        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+    def test_queue_state_beats_engine_config(self, tmp_path: Path, overlay_isolation) -> None:
         write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
         run_config = _minimal_run_config(presets_file="/from/config.yaml")
         resolved = _activate_presets_overlay(
@@ -84,8 +81,7 @@ class TestWorkerOverlayResolution:
         assert resolved == "/from/queue.yaml"
         assert get_overlay_path() == "/from/queue.yaml"
 
-    def test_cli_beats_queue_state(self, tmp_path: Path, overlay_isolation, monkeypatch) -> None:
-        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+    def test_cli_beats_queue_state(self, tmp_path: Path, overlay_isolation) -> None:
         write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
         resolved = _activate_presets_overlay(
             cli_presets_file="/from/cli.yaml",
@@ -94,20 +90,9 @@ class TestWorkerOverlayResolution:
         )
         assert resolved == "/from/cli.yaml"
 
-    def test_env_beats_queue_state(self, tmp_path: Path, overlay_isolation, monkeypatch) -> None:
-        monkeypatch.setenv(OVERLAY_ENV_VAR, "/from/env.yaml")
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
-        resolved = _activate_presets_overlay(
-            cli_presets_file=None,
-            run_config=_minimal_run_config(),
-            run_dir=tmp_path,
-        )
-        assert resolved == "/from/env.yaml"
-
     def test_no_queue_state_falls_through_to_engine_config(
-        self, tmp_path: Path, overlay_isolation, monkeypatch
+        self, tmp_path: Path, overlay_isolation
     ) -> None:
-        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
         # No engine_run_state.json in tmp_path.
         run_config = _minimal_run_config(presets_file="/from/config.yaml")
         resolved = _activate_presets_overlay(
@@ -116,12 +101,11 @@ class TestWorkerOverlayResolution:
         assert resolved == "/from/config.yaml"
 
     def test_persisted_none_falls_through_to_engine_config(
-        self, tmp_path: Path, overlay_isolation, monkeypatch
+        self, tmp_path: Path, overlay_isolation
     ) -> None:
         # ``prepare`` ran without an overlay → persisted value is None →
         # fall through to engine.presets_file rather than treating the file's
         # presence as "no overlay".
-        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
         write_engine_run_state(tmp_path, presets_file=None)
         run_config = _minimal_run_config(presets_file="/from/config.yaml")
         resolved = _activate_presets_overlay(

--- a/tests/unit/llm/test_preset_overlay_worker_propagation.py
+++ b/tests/unit/llm/test_preset_overlay_worker_propagation.py
@@ -70,45 +70,88 @@ class TestEngineRunStatePersistence:
 class TestWorkerOverlayResolution:
     """The worker CLI calls ``_activate_presets_overlay(cli, run_config, run_dir)``.
     The resolution precedence is CLI > queue-state > engine.presets_file.
+
+    Tests use real (minimal but valid) overlay YAMLs because
+    ``_activate_presets_overlay`` now eagerly validates the resolved overlay
+    — a CLI-boundary improvement that catches typo'd paths before any
+    orchestrator / Docker work runs.
     """
 
-    def test_queue_state_beats_engine_config(self, tmp_path: Path, overlay_isolation) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
-        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+    def test_queue_state_beats_engine_config(self, tmp_path: Path, write_overlay) -> None:
+        queue_overlay = write_overlay({}, name="queue.yaml")
+        config_overlay = write_overlay({}, name="config.yaml")
+        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        run_config = _minimal_run_config(presets_file=config_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=None, run_config=run_config, run_dir=tmp_path
         )
-        assert resolved == "/from/queue.yaml"
-        assert get_overlay_path() == "/from/queue.yaml"
+        assert resolved == queue_overlay
+        assert get_overlay_path() == queue_overlay
 
-    def test_cli_beats_queue_state(self, tmp_path: Path, overlay_isolation) -> None:
-        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+    def test_cli_beats_queue_state(self, tmp_path: Path, write_overlay) -> None:
+        queue_overlay = write_overlay({}, name="queue.yaml")
+        cli_overlay = write_overlay({}, name="cli.yaml")
+        write_engine_run_state(tmp_path, presets_file=queue_overlay)
         resolved = _activate_presets_overlay(
-            cli_presets_file="/from/cli.yaml",
+            cli_presets_file=cli_overlay,
             run_config=_minimal_run_config(),
             run_dir=tmp_path,
         )
-        assert resolved == "/from/cli.yaml"
+        assert resolved == cli_overlay
 
     def test_no_queue_state_falls_through_to_engine_config(
-        self, tmp_path: Path, overlay_isolation
+        self, tmp_path: Path, write_overlay
     ) -> None:
         # No engine_run_state.json in tmp_path.
-        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+        config_overlay = write_overlay({}, name="config.yaml")
+        run_config = _minimal_run_config(presets_file=config_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=None, run_config=run_config, run_dir=tmp_path
         )
-        assert resolved == "/from/config.yaml"
+        assert resolved == config_overlay
 
     def test_persisted_none_falls_through_to_engine_config(
-        self, tmp_path: Path, overlay_isolation
+        self, tmp_path: Path, write_overlay
     ) -> None:
         # ``prepare`` ran without an overlay → persisted value is None →
         # fall through to engine.presets_file rather than treating the file's
         # presence as "no overlay".
+        config_overlay = write_overlay({}, name="config.yaml")
         write_engine_run_state(tmp_path, presets_file=None)
-        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+        run_config = _minimal_run_config(presets_file=config_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=None, run_config=run_config, run_dir=tmp_path
         )
-        assert resolved == "/from/config.yaml"
+        assert resolved == config_overlay
+
+
+class TestEagerValidation:
+    """Pin the High-2 CLI-boundary behaviour: ``_activate_presets_overlay``
+    eagerly validates the resolved overlay so a typo'd path / malformed
+    overlay fails immediately — before the orchestrator is constructed,
+    ``load_tasks()`` runs, or the Docker stack auto-starts.
+
+    The lazy-read contract on ``set_overlay_path`` itself is unchanged (the
+    fixture-based unit tests still exercise it), but the CLI helper layer
+    triggers validation at the host boundary.
+    """
+
+    def test_cli_helper_raises_on_missing_overlay_immediately(self, tmp_path: Path) -> None:
+        run_config = _minimal_run_config(presets_file=str(tmp_path / "missing.yaml"))
+        with pytest.raises(FileNotFoundError, match=r"missing\.yaml"):
+            _activate_presets_overlay(cli_presets_file=None, run_config=run_config, run_dir=None)
+
+    def test_cli_helper_raises_on_malformed_overlay_immediately(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("presets:\n  bad:\n    match: ['x/*']\n    response_policy: not_real\n")
+        run_config = _minimal_run_config(presets_file=str(bad))
+        with pytest.raises(ValueError, match=r"unknown response_policy 'not_real'"):
+            _activate_presets_overlay(cli_presets_file=None, run_config=run_config, run_dir=None)
+
+    def test_cli_helper_no_validation_when_no_overlay_resolved(self, tmp_path: Path) -> None:
+        # No overlay anywhere → no validation runs, no error.
+        run_config = _minimal_run_config()
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None, run_config=run_config, run_dir=None
+        )
+        assert resolved is None

--- a/tests/unit/llm/test_preset_overlay_worker_propagation.py
+++ b/tests/unit/llm/test_preset_overlay_worker_propagation.py
@@ -1,0 +1,130 @@
+"""Worker propagation — ``prepare`` persists the overlay path to the queue
+state file; the worker CLI's overlay resolution prefers that value over
+``engine.presets_file`` (because ``prepare`` reflects the operator's most
+recent intent) while still letting ``--presets-file`` / env overrides win.
+
+These are unit tests for the persistence + resolution mechanism. The
+end-to-end worker path (subprocess actually consuming the persisted overlay)
+is exercised indirectly: we drive ``_activate_presets_overlay`` from the CLI
+module with the same inputs the ``worker`` command builds.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.cli.main import _activate_presets_overlay
+from tolokaforge.core.engine_run_state import (
+    read_engine_run_state,
+    read_persisted_presets_file,
+    write_engine_run_state,
+)
+from tolokaforge.core.llm.presets import OVERLAY_ENV_VAR, get_overlay_path
+from tolokaforge.core.models import EngineConfig, RunConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal_run_config(presets_file: str | None = None) -> RunConfig:
+    """Build a syntactically valid ``RunConfig`` for the resolver tests."""
+    return RunConfig(
+        models={},
+        orchestrator={"workers": 1},
+        evaluation={"output_dir": "/tmp"},
+        engine=EngineConfig(presets_file=presets_file) if presets_file else None,
+    )
+
+
+class TestEngineRunStatePersistence:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/some/overlay.yaml")
+        assert read_persisted_presets_file(tmp_path) == "/some/overlay.yaml"
+        assert read_engine_run_state(tmp_path) == {"presets_file": "/some/overlay.yaml"}
+
+    def test_writing_none_persists_as_none(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file=None)
+        assert read_persisted_presets_file(tmp_path) is None
+        # File exists but the value is null — distinct from "no file at all".
+        assert read_engine_run_state(tmp_path) == {"presets_file": None}
+
+    def test_absent_file_returns_empty_state(self, tmp_path: Path) -> None:
+        assert read_engine_run_state(tmp_path) == {}
+        assert read_persisted_presets_file(tmp_path) is None
+
+    def test_overwrite_replaces_previous_value(self, tmp_path: Path) -> None:
+        write_engine_run_state(tmp_path, presets_file="/first.yaml")
+        write_engine_run_state(tmp_path, presets_file="/second.yaml")
+        assert read_persisted_presets_file(tmp_path) == "/second.yaml"
+
+    def test_malformed_state_file_raises_loudly(self, tmp_path: Path) -> None:
+        # Loud-fail discipline: silently ignoring malformed engine state
+        # would let workers run with the wrong overlay.
+        (tmp_path / "engine_run_state.json").write_text("{not json")
+        with pytest.raises(json.JSONDecodeError):
+            read_engine_run_state(tmp_path)
+
+
+class TestWorkerOverlayResolution:
+    """The worker CLI calls ``_activate_presets_overlay(cli, run_config, run_dir)``.
+    The resolution precedence is CLI > env > queue-state > engine.presets_file.
+    """
+
+    def test_queue_state_beats_engine_config(
+        self, tmp_path: Path, overlay_isolation, monkeypatch
+    ) -> None:
+        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None, run_config=run_config, run_dir=tmp_path
+        )
+        assert resolved == "/from/queue.yaml"
+        assert get_overlay_path() == "/from/queue.yaml"
+
+    def test_cli_beats_queue_state(self, tmp_path: Path, overlay_isolation, monkeypatch) -> None:
+        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        resolved = _activate_presets_overlay(
+            cli_presets_file="/from/cli.yaml",
+            run_config=_minimal_run_config(),
+            run_dir=tmp_path,
+        )
+        assert resolved == "/from/cli.yaml"
+
+    def test_env_beats_queue_state(self, tmp_path: Path, overlay_isolation, monkeypatch) -> None:
+        monkeypatch.setenv(OVERLAY_ENV_VAR, "/from/env.yaml")
+        write_engine_run_state(tmp_path, presets_file="/from/queue.yaml")
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None,
+            run_config=_minimal_run_config(),
+            run_dir=tmp_path,
+        )
+        assert resolved == "/from/env.yaml"
+
+    def test_no_queue_state_falls_through_to_engine_config(
+        self, tmp_path: Path, overlay_isolation, monkeypatch
+    ) -> None:
+        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+        # No engine_run_state.json in tmp_path.
+        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None, run_config=run_config, run_dir=tmp_path
+        )
+        assert resolved == "/from/config.yaml"
+
+    def test_persisted_none_falls_through_to_engine_config(
+        self, tmp_path: Path, overlay_isolation, monkeypatch
+    ) -> None:
+        # ``prepare`` ran without an overlay → persisted value is None →
+        # fall through to engine.presets_file rather than treating the file's
+        # presence as "no overlay".
+        monkeypatch.delenv(OVERLAY_ENV_VAR, raising=False)
+        write_engine_run_state(tmp_path, presets_file=None)
+        run_config = _minimal_run_config(presets_file="/from/config.yaml")
+        resolved = _activate_presets_overlay(
+            cli_presets_file=None, run_config=run_config, run_dir=tmp_path
+        )
+        assert resolved == "/from/config.yaml"

--- a/tolokaforge/cli/config_commands.py
+++ b/tolokaforge/cli/config_commands.py
@@ -15,8 +15,8 @@ from rich.console import Console
 
 from tolokaforge.core.config_validator import Severity, validate_run_config
 from tolokaforge.core.llm.presets import (
-    _load_overlay_file,
     resolve_overlay_path,
+    validate_overlay_file,
 )
 
 console = Console()
@@ -100,7 +100,7 @@ def validate(config_path: str, strict: bool, presets_file: str | None) -> None:
         resolved_overlay = resolve_overlay_path(cli_value=presets_file, config_value=config_overlay)
         if resolved_overlay:
             try:
-                _load_overlay_file(resolved_overlay)
+                validate_overlay_file(resolved_overlay)
                 console.print(f"  [green]✓ Preset overlay OK: {resolved_overlay}[/green]")
             except (FileNotFoundError, ValueError) as exc:
                 console.print(f"  [red]✗ Preset overlay {resolved_overlay!r}: {exc}[/red]")

--- a/tolokaforge/cli/config_commands.py
+++ b/tolokaforge/cli/config_commands.py
@@ -47,8 +47,7 @@ def config():
     help=(
         "Path to a model-presets overlay YAML; validated for schema and "
         "policy-name correctness before the run config is checked. "
-        "Precedence: this flag > $TOLOKAFORGE_PRESETS_FILE > "
-        "engine.presets_file in the run config."
+        "Precedence: this flag > engine.presets_file in the run config."
     ),
 )
 def validate(config_path: str, strict: bool, presets_file: str | None) -> None:

--- a/tolokaforge/cli/config_commands.py
+++ b/tolokaforge/cli/config_commands.py
@@ -14,6 +14,10 @@ import yaml
 from rich.console import Console
 
 from tolokaforge.core.config_validator import Severity, validate_run_config
+from tolokaforge.core.llm.presets import (
+    _load_overlay_file,
+    resolve_overlay_path,
+)
 
 console = Console()
 
@@ -35,7 +39,19 @@ def config():
     is_flag=True,
     help="Exit with non-zero status on warnings (not just errors).",
 )
-def validate(config_path: str, strict: bool) -> None:
+@click.option(
+    "--presets-file",
+    "presets_file",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help=(
+        "Path to a model-presets overlay YAML; validated for schema and "
+        "policy-name correctness before the run config is checked. "
+        "Precedence: this flag > $TOLOKAFORGE_PRESETS_FILE > "
+        "engine.presets_file in the run config."
+    ),
+)
+def validate(config_path: str, strict: bool, presets_file: str | None) -> None:
     """Validate run configuration files.
 
     Checks schema, model parameter compatibility, API key presence,
@@ -46,6 +62,7 @@ def validate(config_path: str, strict: bool) -> None:
         tolokaforge config validate --config examples/native/coding/run_config.yaml
         tolokaforge config validate --config examples/native/coding/
         tolokaforge config validate --config "examples/**/*.yaml"
+        tolokaforge config validate --config run.yaml --presets-file overlay.yaml
     """
     paths = _resolve_paths(config_path)
 
@@ -71,6 +88,25 @@ def validate(config_path: str, strict: bool) -> None:
             console.print("  [red]✗ YAML root must be a mapping[/red]")
             total_errors += 1
             continue
+
+        # Resolve + validate preset overlay (if any) before the rest of the
+        # config — an unreadable / malformed overlay would crash the engine at
+        # startup, so we surface it here for the same loud-fail discipline as
+        # ``tolokaforge run``.
+        config_overlay = (
+            (raw.get("engine") or {}).get("presets_file")
+            if isinstance(raw.get("engine"), dict)
+            else None
+        )
+        resolved_overlay = resolve_overlay_path(cli_value=presets_file, config_value=config_overlay)
+        if resolved_overlay:
+            try:
+                _load_overlay_file(resolved_overlay)
+                console.print(f"  [green]✓ Preset overlay OK: {resolved_overlay}[/green]")
+            except (FileNotFoundError, ValueError) as exc:
+                console.print(f"  [red]✗ Preset overlay {resolved_overlay!r}: {exc}[/red]")
+                total_errors += 1
+                continue
 
         result = validate_run_config(raw)
 

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -10,7 +10,11 @@ import yaml
 from rich.console import Console
 
 from tolokaforge.core.engine_run_state import read_persisted_presets_file
-from tolokaforge.core.llm.presets import resolve_overlay_path, set_overlay_path
+from tolokaforge.core.llm.presets import (
+    resolve_overlay_path,
+    set_overlay_path,
+    validate_overlay_file,
+)
 from tolokaforge.core.models import RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.resume import RunStateManager
@@ -94,6 +98,13 @@ def _activate_presets_overlay(
     after which any later call to ``build_capabilities`` etc. reads the merged
     registry. Must run **before** the ``Orchestrator`` is constructed so that
     capability resolution at trial setup sees the overlay.
+
+    When an overlay is resolved, this also **eagerly validates it** via
+    :func:`validate_overlay_file`. ``set_overlay_path`` itself is lazy by
+    contract (so tests can install paths cheaply), but at the CLI boundary
+    we want a typo'd overlay to fail *here* — before the orchestrator is
+    constructed, ``load_tasks()`` walks the task tree, or the Docker stack
+    auto-starts.
     """
     config_value = run_config.engine.presets_file if run_config.engine else None
     queue_state_value = read_persisted_presets_file(run_dir) if run_dir is not None else None
@@ -102,6 +113,8 @@ def _activate_presets_overlay(
     effective_config_value = queue_state_value or config_value
     resolved = resolve_overlay_path(cli_value=cli_presets_file, config_value=effective_config_value)
     set_overlay_path(resolved)
+    if resolved is not None:
+        validate_overlay_file(resolved)
     return resolved
 
 

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -83,12 +83,11 @@ def _activate_presets_overlay(
     Precedence (highest to lowest):
 
     1. ``cli_presets_file`` — ``--presets-file`` flag on the current command.
-    2. ``$TOLOKAFORGE_PRESETS_FILE``.
-    3. ``run_dir / engine_run_state.json`` — the path persisted by
+    2. ``run_dir / engine_run_state.json`` — the path persisted by
        ``tolokaforge prepare`` so worker subprocesses inherit the operator's
        overlay choice without threading the flag through manually. Only
        consulted when *run_dir* is given (the worker / queue-backed paths).
-    4. ``engine.presets_file`` in the run config.
+    3. ``engine.presets_file`` in the run config.
 
     Returns the resolved path (or ``None`` if no overlay is configured). The
     install side-effect is :func:`tolokaforge.core.llm.presets.set_overlay_path`,
@@ -99,7 +98,7 @@ def _activate_presets_overlay(
     config_value = run_config.engine.presets_file if run_config.engine else None
     queue_state_value = read_persisted_presets_file(run_dir) if run_dir is not None else None
     # Queue-state value (if any) sits above ``engine.presets_file`` because
-    # ``prepare`` was the most recent operator decision. CLI/env still win.
+    # ``prepare`` was the most recent operator decision. CLI still wins.
     effective_config_value = queue_state_value or config_value
     resolved = resolve_overlay_path(cli_value=cli_presets_file, config_value=effective_config_value)
     set_overlay_path(resolved)
@@ -125,8 +124,8 @@ def _activate_presets_overlay(
     default=None,
     help=(
         "Path to a model-presets overlay YAML merged onto the bundled "
-        "model_presets.yaml. Precedence: this flag > $TOLOKAFORGE_PRESETS_FILE "
-        "> engine.presets_file in the run config. See docs/CONFIG.md."
+        "model_presets.yaml. Precedence: this flag > engine.presets_file in "
+        "the run config. See docs/CONFIG.md."
     ),
 )
 def run(
@@ -224,7 +223,7 @@ def run(
     help=(
         "Path to a model-presets overlay YAML; persisted into the queue "
         "run-state so worker subprocesses inherit it. Precedence: this flag > "
-        "$TOLOKAFORGE_PRESETS_FILE > engine.presets_file."
+        "engine.presets_file."
     ),
 )
 def prepare(
@@ -280,7 +279,7 @@ def prepare(
     help=(
         "Path to a model-presets overlay YAML. If unset, the worker reads the "
         "overlay path persisted by ``prepare`` from the queue run-state, then "
-        "falls back to $TOLOKAFORGE_PRESETS_FILE / engine.presets_file."
+        "falls back to engine.presets_file."
     ),
 )
 def worker(
@@ -297,8 +296,8 @@ def worker(
         config_data = yaml.safe_load(f)
     run_config = RunConfig(**config_data)
 
-    # Worker overlay precedence: --presets-file > $TOLOKAFORGE_PRESETS_FILE >
-    # ``prepare``-persisted queue state > engine.presets_file.
+    # Worker overlay precedence: --presets-file > ``prepare``-persisted queue
+    # state > engine.presets_file.
     overlay_path = _activate_presets_overlay(presets_file, run_config, run_dir=Path(run_dir))
     if overlay_path:
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -9,6 +9,8 @@ import click
 import yaml
 from rich.console import Console
 
+from tolokaforge.core.engine_run_state import read_persisted_presets_file
+from tolokaforge.core.llm.presets import resolve_overlay_path, set_overlay_path
 from tolokaforge.core.models import RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.resume import RunStateManager
@@ -71,6 +73,39 @@ DEFAULT_USER_MODEL_PROVIDER = "openrouter"
 DEFAULT_USER_MODEL_TEMPERATURE = 0.2
 
 
+def _activate_presets_overlay(
+    cli_presets_file: str | None,
+    run_config: RunConfig,
+    run_dir: Path | None = None,
+) -> str | None:
+    """Resolve preset-overlay precedence and install the overlay.
+
+    Precedence (highest to lowest):
+
+    1. ``cli_presets_file`` — ``--presets-file`` flag on the current command.
+    2. ``$TOLOKAFORGE_PRESETS_FILE``.
+    3. ``run_dir / engine_run_state.json`` — the path persisted by
+       ``tolokaforge prepare`` so worker subprocesses inherit the operator's
+       overlay choice without threading the flag through manually. Only
+       consulted when *run_dir* is given (the worker / queue-backed paths).
+    4. ``engine.presets_file`` in the run config.
+
+    Returns the resolved path (or ``None`` if no overlay is configured). The
+    install side-effect is :func:`tolokaforge.core.llm.presets.set_overlay_path`,
+    after which any later call to ``build_capabilities`` etc. reads the merged
+    registry. Must run **before** the ``Orchestrator`` is constructed so that
+    capability resolution at trial setup sees the overlay.
+    """
+    config_value = run_config.engine.presets_file if run_config.engine else None
+    queue_state_value = read_persisted_presets_file(run_dir) if run_dir is not None else None
+    # Queue-state value (if any) sits above ``engine.presets_file`` because
+    # ``prepare`` was the most recent operator decision. CLI/env still win.
+    effective_config_value = queue_state_value or config_value
+    resolved = resolve_overlay_path(cli_value=cli_presets_file, config_value=effective_config_value)
+    set_overlay_path(resolved)
+    return resolved
+
+
 @cli.command()
 @click.option(
     "--config", required=True, type=click.Path(exists=True), help="Path to run config YAML"
@@ -83,7 +118,25 @@ DEFAULT_USER_MODEL_TEMPERATURE = 0.2
     default=None,
     help="Override user simulator model (e.g., anthropic/claude-sonnet-4.6). Uses OpenRouter as provider.",
 )
-def run(config: str, resume: bool, verbose: bool, strict: bool, user_model: str | None):
+@click.option(
+    "--presets-file",
+    "presets_file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Path to a model-presets overlay YAML merged onto the bundled "
+        "model_presets.yaml. Precedence: this flag > $TOLOKAFORGE_PRESETS_FILE "
+        "> engine.presets_file in the run config. See docs/CONFIG.md."
+    ),
+)
+def run(
+    config: str,
+    resume: bool,
+    verbose: bool,
+    strict: bool,
+    user_model: str | None,
+    presets_file: str | None,
+):
     """Run benchmark with specified configuration"""
     console.print(f"[bold blue]Loading configuration from {config}...[/bold blue]")
 
@@ -115,6 +168,13 @@ def run(config: str, resume: bool, verbose: bool, strict: bool, user_model: str 
         console.print("[yellow]Verbose mode enabled (DEBUG logging)[/yellow]")
     if strict:
         console.print("[yellow]Strict mode enabled (will raise on errors)[/yellow]")
+
+    # Install preset overlay (if any) before constructing the orchestrator so
+    # build_capabilities() sees the merged registry. Triggers loud-fail
+    # validation on the overlay file at this point.
+    overlay_path = _activate_presets_overlay(presets_file, run_config)
+    if overlay_path:
+        console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
     # Create orchestrator with flags
     orchestrator = Orchestrator(run_config, resume=resume, verbose=verbose, strict=strict)
@@ -156,12 +216,34 @@ def run(config: str, resume: bool, verbose: bool, strict: bool, user_model: str 
 @click.option("--reset-queue", is_flag=True, help="Clear existing queue entries before enqueueing")
 @click.option("--verbose", is_flag=True, help="Enable DEBUG level logging")
 @click.option("--strict", is_flag=True, help="Raise error immediately on logging ERROR level")
-def prepare(config: str, run_dir: str, reset_queue: bool, verbose: bool, strict: bool):
+@click.option(
+    "--presets-file",
+    "presets_file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Path to a model-presets overlay YAML; persisted into the queue "
+        "run-state so worker subprocesses inherit it. Precedence: this flag > "
+        "$TOLOKAFORGE_PRESETS_FILE > engine.presets_file."
+    ),
+)
+def prepare(
+    config: str,
+    run_dir: str,
+    reset_queue: bool,
+    verbose: bool,
+    strict: bool,
+    presets_file: str | None,
+):
     """Prepare a queue-backed run directory for distributed workers."""
     console.print(f"[bold blue]Preparing run from config {config}...[/bold blue]")
     with open(config) as f:
         config_data = yaml.safe_load(f)
     run_config = RunConfig(**config_data)
+
+    overlay_path = _activate_presets_overlay(presets_file, run_config)
+    if overlay_path:
+        console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
     orchestrator = Orchestrator(run_config, resume=False, verbose=verbose, strict=strict)
     orchestrator.load_tasks()
@@ -190,12 +272,36 @@ def prepare(config: str, run_dir: str, reset_queue: bool, verbose: bool, strict:
 @click.option("--max-attempts", type=int, default=None, help="Optional max attempts to process")
 @click.option("--verbose", is_flag=True, help="Enable DEBUG level logging")
 @click.option("--strict", is_flag=True, help="Raise error immediately on logging ERROR level")
-def worker(config: str, run_dir: str, max_attempts: int | None, verbose: bool, strict: bool):
+@click.option(
+    "--presets-file",
+    "presets_file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "Path to a model-presets overlay YAML. If unset, the worker reads the "
+        "overlay path persisted by ``prepare`` from the queue run-state, then "
+        "falls back to $TOLOKAFORGE_PRESETS_FILE / engine.presets_file."
+    ),
+)
+def worker(
+    config: str,
+    run_dir: str,
+    max_attempts: int | None,
+    verbose: bool,
+    strict: bool,
+    presets_file: str | None,
+):
     """Run a queue worker process (distributed execution mode)."""
     console.print(f"[bold blue]Loading worker config from {config}...[/bold blue]")
     with open(config) as f:
         config_data = yaml.safe_load(f)
     run_config = RunConfig(**config_data)
+
+    # Worker overlay precedence: --presets-file > $TOLOKAFORGE_PRESETS_FILE >
+    # ``prepare``-persisted queue state > engine.presets_file.
+    overlay_path = _activate_presets_overlay(presets_file, run_config, run_dir=Path(run_dir))
+    if overlay_path:
+        console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
     orchestrator = Orchestrator(run_config, resume=False, verbose=verbose, strict=strict)
     orchestrator.load_tasks()

--- a/tolokaforge/core/engine_run_state.py
+++ b/tolokaforge/core/engine_run_state.py
@@ -1,0 +1,49 @@
+"""Engine-level run state persisted alongside the queue directory.
+
+Today this file holds a single field — the preset overlay path active when
+``tolokaforge prepare`` ran — so worker subprocesses can inherit it without
+the operator threading ``--presets-file`` through every ``tolokaforge worker``
+invocation.
+
+The file is small, JSON, and intentionally separate from the queue database
+so that adding new engine-level fields later does not require a schema
+migration. See ADR 0002 for context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_FILENAME = "engine_run_state.json"
+
+
+def write_engine_run_state(run_dir: Path, *, presets_file: str | None) -> None:
+    """Write ``engine_run_state.json`` next to the run queue.
+
+    Always writes — clearing a previously-persisted overlay requires
+    re-running ``prepare`` with no ``--presets-file``, which surfaces as
+    ``presets_file = None`` in the new file.
+    """
+    payload: dict[str, Any] = {"presets_file": presets_file}
+    (Path(run_dir) / _FILENAME).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def read_engine_run_state(run_dir: Path) -> dict[str, Any]:
+    """Read engine run state, returning an empty dict if the file is absent.
+
+    Treats absence as "no engine-level state recorded" (e.g. the run was
+    prepared before this file existed). Treats malformed JSON as a loud
+    failure — silently ignoring it would let workers run with the wrong
+    preset overlay, violating the loud-fail discipline.
+    """
+    state_path = Path(run_dir) / _FILENAME
+    if not state_path.exists():
+        return {}
+    return json.loads(state_path.read_text())
+
+
+def read_persisted_presets_file(run_dir: Path) -> str | None:
+    """Convenience accessor for the overlay path persisted by ``prepare``."""
+    return read_engine_run_state(run_dir).get("presets_file")

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import fnmatch
 import inspect
 import logging
-import os
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -72,11 +71,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-#: Env-var consulted by :func:`resolve_overlay_path` when no explicit path is
-#: supplied. Documented in ``docs/CONFIG.md``.
-OVERLAY_ENV_VAR = "TOLOKAFORGE_PRESETS_FILE"
-
-
 # ---------------------------------------------------------------------------
 # Policy-name → class registries
 # ---------------------------------------------------------------------------
@@ -128,10 +122,9 @@ _DEFAULT_PRESET_DATA: dict[str, Any] = {"default": {}, "presets": {}, "providers
 #
 # The bundled ``model_presets.yaml`` is shipped inside the wheel and ties model
 # registrations to the engine release cadence. An operator-supplied overlay
-# file (CLI ``--presets-file`` / env ``TOLOKAFORGE_PRESETS_FILE`` /
-# ``RunConfig.engine.presets_file``) lifts that constraint: the engine merges
-# the overlay onto the bundled data at startup. See
-# [ADR 0002](../../../docs/architecture/adr/0002-external-model-registry.md).
+# file (CLI ``--presets-file`` / ``RunConfig.engine.presets_file``) lifts that
+# constraint: the engine merges the overlay onto the bundled data at startup.
+# See [ADR 0002](../../../docs/architecture/adr/0002-external-model-registry.md).
 #
 # Validation runs at load time and is loud (``ValueError``) on any policy-name
 # string that does not resolve in the in-engine registries — mirrors the
@@ -162,9 +155,9 @@ def set_overlay_path(path: str | None) -> None:
     """Set (or clear) the active preset overlay file path.
 
     Called once at engine startup by the CLI / orchestrator after resolving
-    precedence (CLI flag > env var > ``RunConfig.engine.presets_file``).
-    Idempotent: calling with ``None`` clears the overlay; calling with the
-    same path twice is a no-op-with-cache-clear.
+    precedence (CLI flag > ``RunConfig.engine.presets_file``). Idempotent:
+    calling with ``None`` clears the overlay; calling with the same path
+    twice is a no-op-with-cache-clear.
 
     The first subsequent call to :func:`_load_presets` re-reads the bundled
     YAML and merges in the overlay (if any). Validation errors raise
@@ -190,17 +183,14 @@ def resolve_overlay_path(
     cli_value: str | None = None,
     config_value: str | None = None,
 ) -> str | None:
-    """Resolve the overlay path with precedence ``cli > env > config``.
+    """Resolve the overlay path with precedence ``cli > config``.
 
-    Returns the first non-empty value, or ``None`` if all three are unset.
+    Returns the first non-empty value, or ``None`` if both are unset.
     Exists as a shared helper so the CLI, the config validator, and the
     orchestrator all agree on precedence semantics.
     """
     if cli_value:
         return cli_value
-    env_value = os.environ.get(OVERLAY_ENV_VAR)
-    if env_value:
-        return env_value
     if config_value:
         return config_value
     return None
@@ -227,8 +217,8 @@ def _load_overlay_file(path: str) -> dict[str, Any]:
     if not overlay_path.exists():
         raise FileNotFoundError(
             f"Preset overlay file not found: {path!r}. "
-            f"Check the value of --presets-file, ${OVERLAY_ENV_VAR}, or "
-            f"engine.presets_file in the run config."
+            f"Check the value of --presets-file or engine.presets_file in the "
+            f"run config."
         )
     try:
         with open(overlay_path) as f:

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -10,8 +10,10 @@ resolution order.
 from __future__ import annotations
 
 import fnmatch
+import inspect
+import logging
+import os
 from collections.abc import Iterator
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -61,7 +63,18 @@ __all__ = [
     "build_capabilities",
     "resolve_policy_names",
     "resolve_effective_preset",
+    "set_overlay_path",
+    "get_overlay_path",
+    "resolve_overlay_path",
 ]
+
+
+logger = logging.getLogger(__name__)
+
+
+#: Env-var consulted by :func:`resolve_overlay_path` when no explicit path is
+#: supplied. Documented in ``docs/CONFIG.md``.
+OVERLAY_ENV_VAR = "TOLOKAFORGE_PRESETS_FILE"
 
 
 # ---------------------------------------------------------------------------
@@ -109,14 +122,290 @@ _CACHE_POLICIES: dict[str, type[CachePolicy]] = {
 _DEFAULT_PRESET_DATA: dict[str, Any] = {"default": {}, "presets": {}, "providers": {}}
 
 
-@lru_cache(maxsize=1)
-def _load_presets() -> dict[str, Any]:
-    """Load model capability presets from YAML. Cached after first call."""
+# ---------------------------------------------------------------------------
+# Overlay registry — operator-overridable preset data
+# ---------------------------------------------------------------------------
+#
+# The bundled ``model_presets.yaml`` is shipped inside the wheel and ties model
+# registrations to the engine release cadence. An operator-supplied overlay
+# file (CLI ``--presets-file`` / env ``TOLOKAFORGE_PRESETS_FILE`` /
+# ``RunConfig.engine.presets_file``) lifts that constraint: the engine merges
+# the overlay onto the bundled data at startup. See
+# [ADR 0002](../../../docs/architecture/adr/0002-external-model-registry.md).
+#
+# Validation runs at load time and is loud (``ValueError``) on any policy-name
+# string that does not resolve in the in-engine registries — mirrors the
+# ``ensure_registered_adapter`` host-boundary pattern in
+# ``tolokaforge.adapters``.
+
+#: Top-level keys allowed in an overlay (and the bundled file).
+_OVERLAY_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"default", "presets", "providers"})
+
+#: Valid ``params:`` block keys — introspected from ``GenerationParams.__init__``
+#: so adding a new kwarg to ``GenerationParams`` automatically extends overlay
+#: validation. Keep ``GenerationParams`` the authoritative source.
+_VALID_PARAMS_KEYS: frozenset[str] = frozenset(
+    p for p in inspect.signature(GenerationParams.__init__).parameters if p != "self"
+)
+
+#: Module-level overlay path. ``None`` → bundled-only (today's behaviour).
+#: Mutated only via :func:`set_overlay_path` so cache invalidation has one
+#: choke point. Tests must call ``set_overlay_path(None)`` in teardown — the
+#: ``overlay_isolation`` fixture in ``tests/unit/llm/conftest.py`` handles this.
+_OVERLAY_PATH: str | None = None
+
+#: Memoised merged preset data. Cleared by :func:`set_overlay_path`.
+_CACHED_PRESETS: dict[str, Any] | None = None
+
+
+def set_overlay_path(path: str | None) -> None:
+    """Set (or clear) the active preset overlay file path.
+
+    Called once at engine startup by the CLI / orchestrator after resolving
+    precedence (CLI flag > env var > ``RunConfig.engine.presets_file``).
+    Idempotent: calling with ``None`` clears the overlay; calling with the
+    same path twice is a no-op-with-cache-clear.
+
+    The first subsequent call to :func:`_load_presets` re-reads the bundled
+    YAML and merges in the overlay (if any). Validation errors raise
+    ``ValueError`` from :func:`_load_presets`, not from this function, so
+    that callers can defer the file-read until the engine actually needs it.
+    """
+    global _OVERLAY_PATH, _CACHED_PRESETS
+    _OVERLAY_PATH = path
+    _CACHED_PRESETS = None
+
+
+def get_overlay_path() -> str | None:
+    """Return the active overlay path, or ``None`` if no overlay is installed.
+
+    Read-only accessor — :func:`set_overlay_path` is the sole mutator.
+    Useful for orchestrator code that wants to persist the active overlay
+    into queue run-state so worker subprocesses can inherit it.
+    """
+    return _OVERLAY_PATH
+
+
+def resolve_overlay_path(
+    cli_value: str | None = None,
+    config_value: str | None = None,
+) -> str | None:
+    """Resolve the overlay path with precedence ``cli > env > config``.
+
+    Returns the first non-empty value, or ``None`` if all three are unset.
+    Exists as a shared helper so the CLI, the config validator, and the
+    orchestrator all agree on precedence semantics.
+    """
+    if cli_value:
+        return cli_value
+    env_value = os.environ.get(OVERLAY_ENV_VAR)
+    if env_value:
+        return env_value
+    if config_value:
+        return config_value
+    return None
+
+
+def _load_bundled_presets() -> dict[str, Any]:
+    """Load the bundled ``model_presets.yaml`` from inside the wheel."""
     preset_path = Path(__file__).parent.parent / "data" / "model_presets.yaml"
     if not preset_path.exists():
         return _DEFAULT_PRESET_DATA
     with open(preset_path) as f:
         return yaml.safe_load(f) or _DEFAULT_PRESET_DATA
+
+
+def _load_overlay_file(path: str) -> dict[str, Any]:
+    """Read + parse + validate an operator-supplied overlay file.
+
+    Loud-fail on every recognised mis-configuration: missing file, malformed
+    YAML, non-mapping top-level, unknown top-level keys, unknown policy-name
+    strings, unknown ``params:`` keys. The error message always names the
+    overlay path so the operator can find the offending file.
+    """
+    overlay_path = Path(path)
+    if not overlay_path.exists():
+        raise FileNotFoundError(
+            f"Preset overlay file not found: {path!r}. "
+            f"Check the value of --presets-file, ${OVERLAY_ENV_VAR}, or "
+            f"engine.presets_file in the run config."
+        )
+    try:
+        with open(overlay_path) as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Preset overlay {path!r} failed to parse as YAML: {exc}") from exc
+
+    if data is None:
+        # Empty file is allowed and is equivalent to the default-empty registry.
+        return dict(_DEFAULT_PRESET_DATA)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Preset overlay {path!r} must be a YAML mapping at the top level, "
+            f"got {type(data).__name__}."
+        )
+
+    _validate_overlay(data, path)
+    return data
+
+
+def _validate_overlay(data: dict[str, Any], path: str) -> None:
+    """Host-boundary validation for an overlay's contents.
+
+    Every policy-name string in the overlay must resolve in the in-engine
+    registries (``_SCHEMA_SANITIZERS`` … ``_CACHE_POLICIES``); unknown names
+    raise ``ValueError`` with the file path and the offending key. Mirrors
+    ``ensure_registered_adapter()`` in ``tolokaforge.adapters``.
+
+    A new policy class added to the engine must also be added to the
+    appropriate registry (it would not be reachable from YAML otherwise);
+    overlay validation then accepts it automatically. The
+    ``test_preset_overlay_validator_registry_sync`` unit test pins this
+    invariant.
+    """
+    unknown_top = set(data.keys()) - _OVERLAY_TOP_LEVEL_KEYS
+    if unknown_top:
+        raise ValueError(
+            f"Preset overlay {path!r} has unknown top-level keys: "
+            f"{sorted(unknown_top)}. Allowed: {sorted(_OVERLAY_TOP_LEVEL_KEYS)}."
+        )
+
+    registries: dict[str, dict[str, type[Any]]] = {
+        "schema_sanitizer": _SCHEMA_SANITIZERS,
+        "prompt_policy": _PROMPT_POLICIES,
+        "content_policy": _CONTENT_POLICIES,
+        "response_policy": _RESPONSE_POLICIES,
+        "reasoning_codec": _REASONING_CODECS,
+        "cache_policy": _CACHE_POLICIES,
+    }
+
+    def _check_block(block: dict[str, Any], where: str) -> None:
+        if not isinstance(block, dict):
+            raise ValueError(
+                f"Preset overlay {path!r} at {where}: expected a mapping, "
+                f"got {type(block).__name__}."
+            )
+        for slot, registry in registries.items():
+            if slot not in block:
+                continue
+            name = block[slot]
+            if name not in registry:
+                raise ValueError(
+                    f"Preset overlay {path!r} at {where}: unknown "
+                    f"{slot} {name!r}. Available: {sorted(registry.keys())}. "
+                    f"New policy classes require an engine release; "
+                    f"overlays can only reference existing ones."
+                )
+        params = block.get("params")
+        if params:
+            if not isinstance(params, dict):
+                raise ValueError(
+                    f"Preset overlay {path!r} at {where}.params: "
+                    f"expected a mapping, got {type(params).__name__}."
+                )
+            unknown_params = set(params) - _VALID_PARAMS_KEYS
+            if unknown_params:
+                raise ValueError(
+                    f"Preset overlay {path!r} at {where}.params: "
+                    f"unknown keys {sorted(unknown_params)}. "
+                    f"Allowed: {sorted(_VALID_PARAMS_KEYS)}."
+                )
+
+    if "default" in data:
+        _check_block(data["default"] or {}, "default")
+
+    for preset_name, preset in (data.get("presets") or {}).items():
+        _check_block(preset or {}, f"presets.{preset_name}")
+
+    for provider_name, provider_cfg in (data.get("providers") or {}).items():
+        _check_block(provider_cfg or {}, f"providers.{provider_name}")
+
+
+def _merge_overlay(
+    bundled: dict[str, Any], overlay: dict[str, Any], overlay_path: str
+) -> dict[str, Any]:
+    """Merge ``overlay`` onto ``bundled``.
+
+    - ``default:`` shallow merge; overlay wins; nested ``params`` merges
+      deeply.
+    - ``presets:`` overlay entries are **prepended** to iteration order so
+      first-match-wins lets operators shadow a bundled preset. Same-named
+      overlay entries replace the bundled entry; the replacement is logged
+      at INFO so the operator can confirm it took effect.
+    - ``providers:`` shallow merge per provider key; overlay wins; nested
+      ``params`` merges deeply.
+    """
+    merged: dict[str, Any] = {}
+
+    # default block
+    default_bundled = bundled.get("default") or {}
+    default_overlay = overlay.get("default") or {}
+    merged_default = dict(default_bundled)
+    for key, value in default_overlay.items():
+        if key == "params" and isinstance(merged_default.get("params"), dict):
+            merged_default["params"] = {**merged_default["params"], **value}
+        else:
+            merged_default[key] = value
+    merged["default"] = merged_default
+
+    # presets block — overlay first (iteration order matters for first-match-wins),
+    # then bundled minus shadowed names.
+    bundled_presets = bundled.get("presets") or {}
+    overlay_presets = overlay.get("presets") or {}
+    new_presets: dict[str, Any] = {}
+    for name, preset in overlay_presets.items():
+        if name in bundled_presets:
+            logger.info(
+                "preset overlay %r shadows bundled preset %r",
+                overlay_path,
+                name,
+            )
+        new_presets[name] = preset
+    for name, preset in bundled_presets.items():
+        if name in overlay_presets:
+            continue  # already inserted from overlay
+        new_presets[name] = preset
+    merged["presets"] = new_presets
+
+    # providers block
+    bundled_providers = bundled.get("providers") or {}
+    overlay_providers = overlay.get("providers") or {}
+    new_providers: dict[str, Any] = {}
+    for name in list(bundled_providers) + [
+        n for n in overlay_providers if n not in bundled_providers
+    ]:
+        b = bundled_providers.get(name) or {}
+        o = overlay_providers.get(name) or {}
+        merged_p = dict(b)
+        for key, value in o.items():
+            if key == "params" and isinstance(merged_p.get("params"), dict):
+                merged_p["params"] = {**merged_p["params"], **value}
+            else:
+                merged_p[key] = value
+        new_providers[name] = merged_p
+    merged["providers"] = new_providers
+
+    return merged
+
+
+def _load_presets() -> dict[str, Any]:
+    """Load model capability presets — bundled YAML merged with overlay if set.
+
+    Module-level cached. Invalidate via :func:`set_overlay_path`. The cache
+    is process-local; subprocess workers re-run this fresh on first call.
+    """
+    global _CACHED_PRESETS
+    if _CACHED_PRESETS is not None:
+        return _CACHED_PRESETS
+
+    bundled = _load_bundled_presets()
+    if _OVERLAY_PATH is None:
+        _CACHED_PRESETS = bundled
+        return _CACHED_PRESETS
+
+    overlay = _load_overlay_file(_OVERLAY_PATH)
+    _CACHED_PRESETS = _merge_overlay(bundled, overlay, _OVERLAY_PATH)
+    return _CACHED_PRESETS
 
 
 def _iter_preset_matches(

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -65,6 +65,7 @@ __all__ = [
     "set_overlay_path",
     "get_overlay_path",
     "resolve_overlay_path",
+    "validate_overlay_file",
 ]
 
 
@@ -113,6 +114,22 @@ _CACHE_POLICIES: dict[str, type[CachePolicy]] = {
 }
 
 
+#: Mapping from preset *slot name* to the in-engine registry of allowed
+#: classes. Single source of truth used both by :func:`_validate_overlay`
+#: (host-boundary loud-fail on unknown names) and by the unit test that
+#: pins the validator-versus-registry sync invariant. Adding a new
+#: registry without listing it here is a test failure, not a runtime hole
+#: — see ``tests/unit/llm/test_preset_overlay_validation.py``.
+_POLICY_REGISTRIES: dict[str, dict[str, type[Any]]] = {
+    "schema_sanitizer": _SCHEMA_SANITIZERS,
+    "prompt_policy": _PROMPT_POLICIES,
+    "content_policy": _CONTENT_POLICIES,
+    "response_policy": _RESPONSE_POLICIES,
+    "reasoning_codec": _REASONING_CODECS,
+    "cache_policy": _CACHE_POLICIES,
+}
+
+
 _DEFAULT_PRESET_DATA: dict[str, Any] = {"default": {}, "presets": {}, "providers": {}}
 
 
@@ -143,8 +160,9 @@ _VALID_PARAMS_KEYS: frozenset[str] = frozenset(
 
 #: Module-level overlay path. ``None`` → bundled-only (today's behaviour).
 #: Mutated only via :func:`set_overlay_path` so cache invalidation has one
-#: choke point. Tests must call ``set_overlay_path(None)`` in teardown — the
-#: ``overlay_isolation`` fixture in ``tests/unit/llm/conftest.py`` handles this.
+#: choke point. The autouse ``overlay_isolation`` fixture in
+#: ``tests/conftest.py`` calls ``set_overlay_path(None)`` after every test so
+#: module state cannot leak between cases.
 _OVERLAY_PATH: str | None = None
 
 #: Memoised merged preset data. Cleared by :func:`set_overlay_path`.
@@ -239,6 +257,19 @@ def _load_overlay_file(path: str) -> dict[str, Any]:
     return data
 
 
+def validate_overlay_file(path: str) -> None:
+    """Public host-boundary check for an overlay file.
+
+    Raises :class:`FileNotFoundError` if the file is absent, or
+    :class:`ValueError` on any recognised schema / policy-name
+    misconfiguration. Errors always name the file path so the operator
+    can find the offending file. Used by ``tolokaforge config validate``
+    and by the ``run`` / ``prepare`` / ``worker`` CLIs to fail eagerly
+    before any orchestrator / Docker startup work is done.
+    """
+    _load_overlay_file(path)
+
+
 def _validate_overlay(data: dict[str, Any], path: str) -> None:
     """Host-boundary validation for an overlay's contents.
 
@@ -260,22 +291,13 @@ def _validate_overlay(data: dict[str, Any], path: str) -> None:
             f"{sorted(unknown_top)}. Allowed: {sorted(_OVERLAY_TOP_LEVEL_KEYS)}."
         )
 
-    registries: dict[str, dict[str, type[Any]]] = {
-        "schema_sanitizer": _SCHEMA_SANITIZERS,
-        "prompt_policy": _PROMPT_POLICIES,
-        "content_policy": _CONTENT_POLICIES,
-        "response_policy": _RESPONSE_POLICIES,
-        "reasoning_codec": _REASONING_CODECS,
-        "cache_policy": _CACHE_POLICIES,
-    }
-
     def _check_block(block: dict[str, Any], where: str) -> None:
         if not isinstance(block, dict):
             raise ValueError(
                 f"Preset overlay {path!r} at {where}: expected a mapping, "
                 f"got {type(block).__name__}."
             )
-        for slot, registry in registries.items():
+        for slot, registry in _POLICY_REGISTRIES.items():
             if slot not in block:
                 continue
             name = block[slot]

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -430,12 +430,34 @@ class EvaluationConfig(BaseModel):
     harness_adapter: HarnessAdapterConfig | None = None
 
 
+class EngineConfig(BaseModel):
+    """Engine-wide configuration that lives outside per-trial/per-model surface.
+
+    Holds operator-level knobs that change *which engine extensions* a run
+    picks up at startup — distinct from ``OrchestratorConfig`` (per-run
+    execution semantics) and ``ModelConfig`` (per-model overrides).
+    """
+
+    presets_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to an additional model-presets YAML overlay. Merged onto "
+            "the bundled tolokaforge/core/data/model_presets.yaml at startup "
+            "so operators can register or shadow presets without an engine "
+            "release. CLI flag --presets-file and env var "
+            "TOLOKAFORGE_PRESETS_FILE take precedence over this field. "
+            "See docs/CONFIG.md and ADR 0002."
+        ),
+    )
+
+
 class RunConfig(BaseModel):
     """Complete run configuration"""
 
     models: dict[str, ModelConfig]
     orchestrator: OrchestratorConfig
     evaluation: EvaluationConfig
+    engine: EngineConfig | None = None
 
 
 # Task Configuration Models

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -444,9 +444,8 @@ class EngineConfig(BaseModel):
             "Path to an additional model-presets YAML overlay. Merged onto "
             "the bundled tolokaforge/core/data/model_presets.yaml at startup "
             "so operators can register or shadow presets without an engine "
-            "release. CLI flag --presets-file and env var "
-            "TOLOKAFORGE_PRESETS_FILE take precedence over this field. "
-            "See docs/CONFIG.md and ADR 0002."
+            "release. The --presets-file CLI flag takes precedence over this "
+            "field. See docs/CONFIG.md and ADR 0002."
         ),
     )
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_adapter
 from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core.engine_run_state import write_engine_run_state
 from tolokaforge.core.env_state import EnvironmentState
 from tolokaforge.core.failure_attribution import (
     attribute_failure,
@@ -21,6 +22,7 @@ from tolokaforge.core.failure_attribution import (
 )
 from tolokaforge.core.llm import LLMClient, UserSimulator, build_capabilities
 from tolokaforge.core.llm.presets import (
+    get_overlay_path,
     resolve_effective_preset,
     resolve_policy_names,
 )
@@ -1033,6 +1035,12 @@ class Orchestrator:
         items = self._build_pending_trials(self.tasks, self.config.orchestrator.repeats)
         run_queue.enqueue_many(items)
         counts = run_queue.get_counts()
+
+        # Persist engine-level run state for subprocess workers (the preset
+        # overlay path is the only field today). Worker CLIs read this so the
+        # overlay set at ``prepare`` time propagates without the operator
+        # threading --presets-file through every ``worker`` invocation.
+        write_engine_run_state(output_dir, presets_file=get_overlay_path())
 
         summary = {
             "queued_attempts": len(items),


### PR DESCRIPTION
Closes #64

## What this changes for model-adders

**Today.** Registering a new model — even one that reuses existing
policy classes — means editing `tolokaforge/core/data/model_presets.yaml`
(and/or `pricing.json`, `tests/integration/llm/registry.py`) inside the
wheel, cutting a release, and rolling that release out before you can
run smoke eval. If smoke surfaces a model-specific failure pattern, the
fix is to re-route the model to a different existing policy → another
release. Two releases per model is common.

**After this PR.** For models that reuse existing policy classes
(`StandardResponse`, `AnthropicContent`, `AnthropicEphemeralCache`,
`AnthropicReasoningCodec`, …), the registration is a YAML file you hand
in at run time. Zero release.

```yaml
# my_overlay.yaml — same schema as the bundled model_presets.yaml
presets:
  my_provider_new_model:
    match: ["my-provider/new-model*"]
    content_policy: anthropic
    reasoning_codec: anthropic
    cache_policy: anthropic_ephemeral
```

```bash
tolokaforge run --config run.yaml --presets-file my_overlay.yaml
```

Two ways to point at the overlay, in precedence order:

1. **`--presets-file <path>` (CLI flag)** — for one-off overlays:
   smoke-eval iterations, ablations, anything you don't want to commit
   alongside the run config. Available on `run`, `prepare`, `worker`,
   and `config validate`.
2. **`engine.presets_file` in the run config** — when an overlay is
   part of *what this benchmark is*, commit it next to the rest of the
   run definition:
   ```yaml
   engine:
     presets_file: ./my_overlay.yaml
   ```

**What still needs an engine release.** A brand-new policy *class*
(novel response post-processing, new reasoning codec, new content
format). The overlay validator rejects unknown policy names at startup
with a clear error — by design. The boundary is *data + declaration →
externalizable; new classes → engine code*. This matches the
architecture proposal's framing for the model registry seam.

## How to verify your overlay before running

`tolokaforge config validate` now validates the overlay alongside the
run config:

```bash
tolokaforge config validate --config run.yaml --presets-file my_overlay.yaml
# ✓ Preset overlay OK: my_overlay.yaml
# (or, if you have a typo:)
# ✗ Preset overlay 'my_overlay.yaml' at presets.my_model: unknown
#   response_policy 'standerd'. Available: ['array_dict_map',
#   'json_coerce', 'minimax_m3_tags', 'standard', 'unwrap_input'].
```

The error always names (a) the overlay file path, (b) the offending key,
and (c) the available registry keys. Same loud-fail discipline as the
existing `capabilities:` override surface in run configs.

## Workflow before/after

| Step | Before | After (data-only change) |
|---|---|---|
| Add a preset | Edit `model_presets.yaml` in tree | Add to overlay YAML, no PR needed |
| Pricing | Edit `pricing.json` in tree | Use LiteLLM's `LITELLM_MODEL_COST_MAP_URL` (separate channel, already supported by LiteLLM — not changed by this PR) |
| Capability cert | Edit `tests/integration/llm/registry.py` | Same as before (this PR doesn't touch the certificate suite — integration tests still gate the engine release path) |
| Smoke eval | Wait for release rollout | Run with `--presets-file` immediately |
| Re-route after smoke finding | Another release | Edit overlay, re-run |
| Brand-new policy class | Release required | Release still required (correct boundary) |

For repeat registrations of the same set of models across multiple
runs, the run-config field (`engine.presets_file`) keeps the overlay
declarative — no flag threading.

## Distributed-worker note

`tolokaforge prepare --presets-file overlay.yaml` writes the resolved
overlay path into `engine_run_state.json` alongside the run queue.
`tolokaforge worker` invocations against the same `--run-dir` then
inherit the overlay automatically. Worker-side `--presets-file` still
wins if you set it (useful for A/B-style ablations across worker
fleets).

## Design decisions

**Mirrors the adapter plugin pattern's externalization (PR #61).** The
adapter side opened `TaskDescription.adapter_type` to a registry-sourced
string and added `ensure_registered_adapter()` as a host-boundary
validator. This PR does the same shape one layer up for the LLM preset
layer: opens the preset registry to operator data, validates at the
host boundary at load time, keeps every downstream caller untouched.
Loud-fail messages name the file path the same way
`ensure_registered_adapter` names the registry.

**Bit-identical behaviour when no overlay is configured.** The loader's
no-overlay path returns the bundled YAML verbatim. Golden grading
regression suite (PR #57) and the canonical-suite preset routing tests
all pass unchanged. The full offline suite went from 1817 (PR #61
baseline) to 1911 here — net +94 from new overlay tests; zero
regressions.

**Validator-versus-registry sync, pinned by a unit test.** Adding a new
policy class to the engine (in any of the six registries) must extend
`_validate_overlay` so it knows the new name is allowed. A unit test
scans `_validate_overlay`'s source for every registry constant by name;
a future contributor adding a registry without touching the validator
gets a test failure rather than a silent overlay-validation gap.

**Forward-compatible with the entry-point plugin path.** The data shape
the overlay produces is the same dict the bundled YAML produces, so a
future `tolokaforge.model_presets` entry-point group (the natural Phase
2 if operators want shippable preset bundles) can populate the same
structure without a parallel mechanism. Documented in ADR 0002
*Considered Options*.

**Pricing not externalized in this PR.** LiteLLM already supports an
external model cost map via `LITELLM_MODEL_COST_MAP_URL`. Duplicating it
inside the engine would create a second source of truth. Noted in
ADR 0002 *Trade-offs*.

**ADR scaffolding bundled here.** The `docs/architecture/adr/`
directory and its three scaffolding files (template, README, ADR 0001)
are copied verbatim from the `docs/architecture-overview` branch
(PR #11) so this PR cannot conflict with #11 regardless of merge order.
If #11 lands first, rebasing this PR is `git rm` on those four files.

## Test plan

- [x] **Unit tests (36):** loader merge, precedence (overlay-first
      iteration order), default/provider deep-merge, cache invalidation,
      every loud-fail path (missing file, malformed YAML, non-mapping
      top-level, unknown top-level keys, unknown policy names in
      `presets/default/providers`, unknown `params` keys), validator-
      versus-registry sync, lazy file-read.
- [x] **Integration tests (15):** real subprocess proving
      `engine_run_state.json` is the actual cross-process carrier
      between `prepare` and `worker`; real `tolokaforge config validate`
      CLI accepts good overlays and rejects bad ones with file-path-
      bearing errors; in-process orchestrator integration through
      `_build_resolved_block` (the helper that stamps the resolved
      preset name into per-trial `task.yaml`).
- [x] **Live eval (1, gated on API key + Docker):** real
      `tolokaforge run` against Anthropic via the public
      `examples/native/tool_use/dataset` task — 1 trial, 9 turns,
      ~$0.05. Asserts the per-trial `task.yaml` records the overlay's
      preset name in `model_config.agent.resolved.effective_preset` and
      that all four overridden policy slots landed in the fingerprint.
- [x] **Full offline regression:** `uv run pytest tests/unit
      tests/canonical -q` → **1895 passed, 1 skipped** (skip is
      pre-existing). Verdicts on the golden grading regression suite
      (PR #57) bit-identical to `main`.
- [x] **CLI smoke (real invocations):**
  - `tolokaforge config validate --config run.yaml --presets-file
    good.yaml` → exit 0, `✓ Preset overlay OK`.
  - Same with `bad.yaml` (typo'd policy name) → exit 1, error names
    file path + offending key + available alternatives.
  - Same with a missing file → exit 1, error names the path.

## Docs

- `docs/CONFIG.md` § **Preset overlay file** — the field, precedence,
  schema, and distributed-worker propagation.
- `docs/ADD_NEW_MODEL.md` § **Adding a model without an engine release** —
  5-line walkthrough that the next model-adder can follow directly.
- `docs/LLM_LAYER.md` — one-paragraph pointer at the preset loader.
- `docs/architecture/adr/0002-external-model-registry.md` — Proposed.