### PR TITLE
docs(search): pin core/search/* as the supported adapter-facing contract

### DIFF
--- a/docs/TYPESENSE_INTEGRATION.md
+++ b/docs/TYPESENSE_INTEGRATION.md
@@ -1,421 +1,116 @@
 # TypeSense Integration
 
-TolokaForge provides full TypeSense support for semantic search over knowledge base documents. This feature enables agents to search policy documents, knowledge bases, and other textual content using natural language queries.
+TolokaForge ships the engine-side machinery for running TypeSense-backed search inside a benchmark run. This document describes the **engine/adapter split** for search and the **supported adapter-facing contract**.
 
-## Overview
+## TL;DR
 
-The TypeSense integration bridges TolokaForge adapters with the `mcp_core` TypeSense infrastructure:
+- **The engine owns**: the TypeSense container lifecycle (start, health-check, network-bridge, stop) and a set of small primitives adapters reuse (thread-safe domain-init coordination, result data classes).
+- **Adapters own**: the *provider* — how documents are sourced, what a "domain" means for a given benchmark, and any benchmark-specific dependencies (schemas, registries, etc.).
+- **The engine does not ship a real `TypeSenseClient` abstraction.** Adapters that need a client use the [`typesense`](https://pypi.org/project/typesense/) Python package directly (already a hard dependency of the engine).
 
-- **Standalone Feature**: Can be used by any adapter (Native, internal MCP JSON, Tau)
-- **Automatic Indexing**: Documents in `docindex/` directories are automatically indexed
-- **Semantic Search**: Supports both vector and text-based search
-- **Graceful Degradation**: Falls back to stub behavior when TypeSense server is unavailable
-- **Orchestrator-Managed Server**: Automatic Docker container lifecycle management
-- **Configurable**: Via run config with auto port selection and API key generation
+This split exists because the per-benchmark indexing logic tends to drag in benchmark-specific dependencies (domain registries, schema generators, document loaders). Keeping the provider adapter-side prevents those dependencies from leaking into the public engine.
 
-## Architecture
+## The supported public contract
 
-```
-┌─────────────────┐    ┌──────────────────────┐    ┌─────────────────────┐
-│   Adapter       │    │  TypeSenseProvider   │    │   mcp_core          │
-│                 │    │                      │    │                     │
-│ _init_typesense │────┤ ensure_domain_init   ├────┤ TypesenseIndex     │
-│ (cached)        │    │ (coordinated)        │    │ universal_search_*  │
-│                 │    │ search               │    │                     │
-└─────────────────┘    └──────────────────────┘    └─────────────────────┘
-         │                      │
-         │                      ▼
-         │             ┌──────────────────────┐
-         │             │  DomainStateManager  │
-         │             │  - Per-domain state  │
-         │             │  - Thread-safe       │
-         │             │  - Wait coordination │
-         │             └──────────────────────┘
-         │                      │
-         ▼                      ▼
-       ┌────────────────────────────────────────────────┐
-       │           TypeSense Server                      │
-       │                                                │
-       │  ┌──────────────────────────────────────────┐  │
-       │  │ TypeSenseServerManager (local mode)       │  │
-       │  │ - Auto port selection                    │  │
-       │  │ - Docker foundation layer (ServiceStack) │  │
-       │  │ - Auto API key generation                │  │
-       │  └──────────────────────────────────────────┘  │
-       │                    OR                          │
-       │  ┌──────────────────────────────────────────┐  │
-       │  │ External TypeSense (remote mode)         │  │
-       │  │ - Pre-configured server                  │  │
-       │  └──────────────────────────────────────────┘  │
-       └────────────────────────────────────────────────┘
-```
+The names re-exported by `tolokaforge.core.search` are the **adapter-facing contract**. Removing or renaming one is a breaking change. The current shape:
 
-## Implementation
+| Symbol | Module | Purpose |
+|---|---|---|
+| `DomainState` | `tolokaforge.core.search.domain_state` | Per-domain state object with a thread-safe init claim. |
+| `DomainStateManager` | `tolokaforge.core.search.domain_state` | Get-or-create registry over `DomainState`. |
+| `DomainStatus` | `tolokaforge.core.search.domain_state` | Enum: `PENDING`, `INITIALIZING`, `READY`, `FAILED`. |
+| `SearchResponse` | `tolokaforge.core.search.typesense` | Result envelope (hits, total, query, timing). |
+| `SearchResult` | `tolokaforge.core.search.typesense` | Single hit (id, score, content, highlights). |
 
-### Core Components
+A contract test (`tests/unit/test_search_contract.py`) pins this set; CI fails if a name is removed or renamed without updating the contract.
 
-1. **`tolokaforge/core/search/typesense_provider.py`** - Main TypeSense provider with domain-level caching
-2. **`tolokaforge/core/search/domain_state.py`** - Domain state management for coordinated initialization
-3. **`tolokaforge/core/search/typesense.py`** - Stub interface (backward compatibility)
-4. **`tolokaforge/core/search/__init__.py`** - Module exports
+The **container lifecycle primitives** are in `tolokaforge.core.search.typesense_server` (`TypeSenseServerManager`, `create_typesense_server`) and `tolokaforge.docker.stacks.typesense` (`typesense_service`). These are also part of the supported surface — adapters generally do not start the container themselves (the orchestrator does), but the manager is the canonical entry point for tests and for setups that bypass the orchestrator.
 
-### Provider Configuration
+## Container lifecycle (engine-owned)
+
+The orchestrator owns the TypeSense container per run:
+
+1. On `tolokaforge run`, `Orchestrator._ensure_typesense_started()` calls `create_typesense_server(...)` → `TypeSenseServerManager.start()`.
+2. The manager pulls the image, starts the container via the `tolokaforge.docker` foundation layer (`ServiceStack` + `typesense_service`), and waits for the health endpoint.
+3. The manager bridges the container onto the Runner's Docker network so the Runner can reach it as `typesense:8108` via DNS.
+4. On teardown, `Orchestrator.teardown()` calls `self._typesense_server.stop()` to remove the container and clean up the network bridge.
+
+Adapters do not need to start the container themselves; the orchestrator passes the resolved `host`, `port`, and `api_key` to the adapter via run config.
+
+## How to build a provider (adapter-side)
+
+A provider is whatever the adapter needs to put on top of `core/search/*`. The engine offers two things you usually want to reuse:
+
+1. **`DomainStateManager`** if the provider must coordinate concurrent initialization of the same domain (typical for thread-pooled trial runs).
+2. **`SearchResponse` / `SearchResult`** if the provider exposes results in a structured form rather than passing raw `typesense` dicts up.
+
+For the search client itself, use the [`typesense`](https://pypi.org/project/typesense/) package directly:
 
 ```python
-from tolokaforge.core.search.typesense_provider import create_typesense_provider
+import typesense
 
-provider = create_typesense_provider(
-    enabled=True,              # Enable/disable TypeSense
-    host="127.0.0.1",         # TypeSense server host
-    port=8108,                # TypeSense server port
-    api_key=None,             # API key (uses TYPESENSE_API_KEY env var if None)
-    timeout=30.0,             # Connection timeout
-    use_stub=False            # Force stub implementation
-)
+from tolokaforge.core.search import DomainStateManager, SearchResponse, SearchResult
+from tolokaforge.core.search.typesense_server import TypeSenseServerManager
+
+
+def build_client(host: str, port: int, api_key: str) -> typesense.Client:
+    return typesense.Client({
+        "nodes": [{"host": host, "port": port, "protocol": "http"}],
+        "api_key": api_key,
+        "connection_timeout_seconds": 5,
+    })
 ```
 
-### Document Loading
+A worked end-to-end example — start the manager, build the client, create a collection, index documents, search — lives in [`tests/integration/test_search_no_mcp_core.py`](../tests/integration/test_search_no_mcp_core.py). That test deliberately avoids importing anything benchmark-specific; it is the canonical reference for "what does the minimum integration look like."
 
-Documents are automatically loaded from `docindex/` directories:
+## Concurrency: avoiding duplicate initialization
 
-```
-domain/
-├── docindex/
-│   ├── order_management.md    # ← Indexed automatically  
-│   ├── shipping_returns.md    # ← Indexed automatically
-│   └── customer_service.md    # ← Indexed automatically
-└── testcases/
-    └── *.json
-```
-
-### Search Interface
+If multiple trials run concurrently and each initializes the same domain, you'll race on `create_collection`. The provider should coordinate via `DomainStateManager`:
 
 ```python
-# Initialize for domain
-success = provider.initialize_for_domain("retail_domain", documents)
-
-# Search documents  
-response = provider.search(
-    domain="retail_domain",
-    query="how to return a product", 
-    max_results=5
-)
-
-# Response format
-{
-    "hits": [
-        {
-            "document_id": "returns_policy",
-            "score": 0.95,
-            "content": {
-                "source": "returns_policy.md",
-                "text": "To return a product...",
-                "vector_distance": 0.12
-            }
-        }
-    ],
-    "total_hits": 3,
-    "query": "how to return a product",
-    "search_time_ms": 15.0
-}
+state, _created = manager.get_or_create(domain)
+if state.claim_initialization():
+    try:
+        # only one thread reaches here per domain
+        _index_documents(domain, client)
+        state.set_ready()
+    except Exception:
+        state.set_failed()
+        raise
+state.wait_ready(timeout=30.0)
 ```
 
-## Internal MCP Integration
+`DomainState` handles the `PENDING → INITIALIZING → READY/FAILED` state machine and the wait/notify around it.
 
-The internal MCP adapter automatically initializes TypeSense during environment creation with **domain-level caching**:
+## Why no engine-side `TypeSenseClient`
 
-### Domain-Level Caching
+Prior versions of the engine shipped an abstract `TypeSenseClient` and a `TypeSenseStub` that silently returned empty results. We removed both:
 
-TypeSense initialization is cached per domain to avoid redundant document indexing when running multiple tasks from the same domain:
+- No real implementation existed in-tree, and no adapter implemented the abstract.
+- The stub-returning-empty pattern violates the project's "honesty over convenience" stance — a search that silently returns no results corrupts evaluation rather than failing loudly.
 
-- **Provider Caching**: A single `TypeSenseProvider` instance is cached per adapter
-- **Domain State Coordination**: Uses `DomainStateManager` to ensure only one initialization per domain
-- **Thread-Safe**: Multiple concurrent task executions safely share the cached state
+Adapters that need a real client should use the `typesense` package directly. Adapters that need to test against a fake should mock the `typesense.Client` interface they actually use, not an engine-side abstract.
 
-```python
-# In the internal MCP adapter
-def _get_typesense_provider(self) -> Optional[TypeSenseProvider]:
-    """Get or create TypeSense provider (cached at adapter level)."""
-    with self._provider_lock:
-        if self._typesense_provider is None:
-            self._typesense_provider = create_typesense_provider()
-        return self._typesense_provider
+## Configuration
 
-def _init_typesense(self, task_id: str) -> None:
-    """Initialize TypeSense for knowledge base search (domain-level caching)."""
-    provider = self._get_typesense_provider()
-    if provider is None:
-        return
-    
-    # ensure_domain_initialized handles coordination:
-    # - Only the first caller does actual initialization
-    # - Subsequent callers wait for completion and reuse the result
-    provider.ensure_domain_initialized(
-        domain=self._domain_name,
-        docindex_path=self._domain_path / "docindex",
-    )
-```
-
-### Domain State Lifecycle
-
-The domain initialization follows a state machine:
-
-```
-PENDING → INITIALIZING → READY (success)
-                      → FAILED (error)
-```
-
-- **PENDING**: Initial state, domain not yet initialized
-- **INITIALIZING**: First task is indexing documents
-- **READY**: Documents indexed, subsequent tasks skip re-indexing
-- **FAILED**: Initialization failed, error is propagated
-
-### Database Domain Assignment
-
-For tools to access TypeSense, the database must have a domain attribute:
-
-```python
-# Create database and set domain for TypeSense access
-db = InMemoryDatabase(additional_sources=additional_sources)
-db.domain = self._domain_name  # Required for search_policy tools
-```
-
-## Tool Integration
-
-TypeSense is typically used through `search_policy` tools:
-
-### Example Tool Implementation
-
-```python
-from mcp_core.search import get_typesense_for_domain
-
-class SearchPolicyTool(Tool):
-    def _get_typesense_client(self, db: InMemoryDatabase):
-        """Get TypeSense client for database domain."""
-        domain = getattr(db, 'domain', None)
-        return get_typesense_for_domain(domain) if domain else None
-    
-    async def run(self, db: InMemoryDatabase, request: SearchPolicyInput):
-        client = self._get_typesense_client(db)
-        if client:
-            results = client.universal_search_with_full_text(request.query, [])
-            return SearchPolicyOutput(snippets=results[:request.max_results])
-        else:
-            return SearchPolicyOutput(snippets=[])  # Fallback
-```
-
-## Testing
-
-### Unit Tests
-
-```python
-# tests/unit/test_typesense_provider.py
-def test_document_loading():
-    provider = create_typesense_provider(use_stub=True)
-    documents = provider.load_documents_from_directory(docs_dir)
-    assert len(documents) > 0
-
-def test_search_functionality():
-    provider = create_typesense_provider(use_stub=True) 
-    provider.initialize_for_domain("test", ["sample document"])
-    response = provider.search("test", "sample query")
-    assert response.total_hits >= 0
-```
-
-### Functional Tests
-
-```python
-# tests/functional/test_internal_mcp_typesense.py
-def test_internal_mcp_typesense_integration():
-    adapter = InternalMcpAdapter(params)
-    task_config = adapter.get_task("TC-001")
-    env = adapter.create_environment("TC-001")
-    
-    # Verify TypeSense tools work
-    tools = adapter.get_registry_tools("TC-001", env)
-    search_tool = next(t for t in tools if "search_policy" in t.name)
-    result = search_tool.execute(query="test query")
-    assert result.success
-```
-
-## Server Configuration
-
-TypeSense server can be configured in the run config YAML file under `orchestrator.typesense`:
-
-### Configuration Options
+The orchestrator's TypeSense config is set per run:
 
 ```yaml
 orchestrator:
   typesense:
-    enabled: true          # Enable/disable TypeSense (default: true)
-    mode: local            # "local", "remote", or "disabled"
-    host: "127.0.0.1"      # TypeSense server host (default: 127.0.0.1)
-    port: "auto"           # Port or "auto" for auto-selection (default: "auto")
-    api_key: null          # API key (auto-generated if null for local mode)
-    data_dir: ".cache/typesense"  # Data directory (default: .cache/typesense)
-    image: "typesense/typesense:26.0"  # Docker image (local mode)
-    container_name: "tolokaforge-typesense"  # Container name
-    timeout: 30.0          # Connection timeout in seconds
-    cleanup_on_exit: true  # Remove container on exit (local mode)
+    enabled: true
+    mode: local          # "local" (engine starts a container) | "external"
+    host: 127.0.0.1      # for "external" mode; ignored in "local"
+    port: auto           # "auto" picks a free port and bridges to the runner net
+    api_key: null        # null → engine generates one for "local"
+    timeout: 30.0
 ```
 
-### Mode Options
+Adapters read these from the run config and use them when constructing their provider/client.
 
-- **`local`**: Orchestrator manages a Docker container (auto start/stop)
-- **`remote`**: Connect to an external TypeSense server
-- **`disabled`**: TypeSense is disabled, search_policy returns empty results
+## See also
 
-### Example Configurations
-
-#### Local Mode (Recommended for Development)
-
-```yaml
-orchestrator:
-  typesense:
-    mode: local
-    port: "auto"  # Finds available port automatically
-    # api_key auto-generated
-```
-
-#### Remote Mode (Production)
-
-```yaml
-orchestrator:
-  typesense:
-    mode: remote
-    host: "typesense.example.com"
-    port: 443
-    api_key: "${TYPESENSE_API_KEY}"  # From environment variable
-```
-
-#### Disabled Mode
-
-```yaml
-orchestrator:
-  typesense:
-    enabled: false  # Or mode: disabled
-```
-
-## Deployment
-
-### Development Setup (Manual)
-
-If not using orchestrator-managed server:
-
-1. **Start TypeSense Server**:
-   ```bash
-   docker run -d -p 8108:8108 \
-     -v$(pwd)/typesense-data:/data \
-     typesense/typesense:26.0 \
-     --data-dir /data \
-     --api-key=xyz \
-     --listen-port 8108 \
-     --enable-cors
-   ```
-
-2. **Set API Key**:
-   ```bash
-   export TYPESENSE_API_KEY=xyz
-   ```
-
-3. **Run Tests**:
-   ```bash
-   uv run tolokaforge run --config <your_run_config.yaml>
-   ```
-
-### Development Setup (Orchestrator-Managed)
-
-With `mode: local`, the orchestrator handles everything automatically:
-
-1. **Configure** `.cache/typesense` data directory (added to `.gitignore`)
-2. **Start run** - TypeSense container starts automatically
-3. **Run completes** - Container is cleaned up (if `cleanup_on_exit: true`)
-
-### Production Setup
-
-For production, configure TypeSense server with:
-- Persistent data volumes
-- Proper API key management
-- Network security
-- Backup/restore procedures
-
-## Server Management API
-
-The `TypeSenseServerManager` class provides programmatic control:
-
-```python
-from tolokaforge.core.search.typesense_server import (
-    TypeSenseServerManager,
-    create_typesense_server,
-    find_free_port,
-    generate_api_key,
-)
-
-# Create server manager
-server = create_typesense_server(
-    port="auto",           # Auto-select available port
-    api_key=None,          # Auto-generate API key
-    data_dir=".cache/typesense",
-    container_name="my-typesense",
-)
-
-# Start server
-if server.start():
-    print(f"TypeSense running on {server.host}:{server.port}")
-    print(f"API Key: {server.api_key}")
-    
-    # ... use TypeSense ...
-    
-    # Stop server
-    server.stop()
-
-# Or use as context manager
-with create_typesense_server() as server:
-    # Server is running
-    print(f"Port: {server.port}, Key: {server.api_key}")
-# Server automatically stopped
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **"Connection refused" errors**:
-   - Ensure TypeSense server is running on 127.0.0.1:8108
-   - Check Docker container status: `docker ps`
-
-2. **"Forbidden" API key errors**:
-   - Set TYPESENSE_API_KEY environment variable
-   - Ensure key matches server configuration
-
-3. **"Database has no domain" errors**:
-   - Ensure adapter sets `db.domain` attribute
-   - Check that domain name is properly inferred
-
-4. **Empty search results**:
-   - Verify documents exist in `docindex/` directory
-   - Check TypeSense initialization logs
-   - Confirm documents are .md files with content
-
-5. **Docker not available**:
-   - Docker SDK error: Install with `pip install docker` or `uv add docker`
-   - Docker daemon not running: Start Docker service
-   - Permission issues: Ensure user has Docker access
-
-6. **Port conflicts**:
-   - Use `port: "auto"` to auto-select available port
-   - Check for running TypeSense containers: `docker ps | grep typesense`
-
-7. **Container cleanup issues**:
-   - If container is not removed, manually clean up: `docker rm -f tolokaforge-typesense`
-
-### Logging
-
-Enable debug logging to troubleshoot issues:
-
-```python
-import logging
-logging.getLogger("tolokaforge.core.search.typesense_provider").setLevel(logging.DEBUG)
-logging.getLogger("tolokaforge.core.search.typesense_server").setLevel(logging.DEBUG)
-logging.getLogger("mcp_core.search").setLevel(logging.DEBUG)
-```
+- [`tests/integration/test_search_no_mcp_core.py`](../tests/integration/test_search_no_mcp_core.py) — end-to-end smoke test, no benchmark deps.
+- [`tests/unit/test_search_contract.py`](../tests/unit/test_search_contract.py) — contract pin.
+- [`tolokaforge/core/search/__init__.py`](../tolokaforge/core/search/__init__.py) — the exported surface.
+- [`tolokaforge/core/search/typesense_server.py`](../tolokaforge/core/search/typesense_server.py) — container lifecycle manager.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -89,6 +89,7 @@ flowchart TB
 | **Single secret abstraction** | One audited code path for every credential read; CI-enforced via static grep. | [AGENTS.md § Secrets](../../AGENTS.md#secrets--single-abstraction) |
 | **Deterministic grading by default; LLM judges opt-in** | Deterministic verdicts are reproducible and cheap; judge calls are reserved for cases that genuinely need them. | [`docs/GRADING.md`](../GRADING.md) |
 | **Durable attempt queue (SQLite / Postgres) with worker leases** | Lets long runs survive crashes and lets `prepare` + `worker` commands split a run across hosts. | `tolokaforge/core/run_queue.py` |
+| **Search subsystem split: engine owns container + primitives, adapters own provider** | The TypeSense container lifecycle and a small set of primitives (thread-safe domain-init coordination, result envelopes) live in the engine. The per-benchmark provider — which tends to drag in benchmark-specific dependencies — lives in the adapter. Adapters use the `typesense` Python package directly; the engine does not ship a `TypeSenseClient` abstraction. | [`docs/TYPESENSE_INTEGRATION.md`](../TYPESENSE_INTEGRATION.md) · [ADR 0003](adr/0003-search-subsystem-engine-adapter-split.md) |
 
 ---
 

--- a/docs/architecture/adr/0003-search-subsystem-engine-adapter-split.md
+++ b/docs/architecture/adr/0003-search-subsystem-engine-adapter-split.md
@@ -1,0 +1,138 @@
+# 0003. Search subsystem — engine owns container + primitives, adapters own provider
+
+- **Status:** Accepted
+- **Date:** 2026-06-17
+- **Deciders:** @cirogam22
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+The engine ships modules under `tolokaforge/core/search/` and a TypeSense
+Docker stack under `tolokaforge/docker/stacks/typesense.py`. When the engine
+was open-sourced, the existing `typesense_provider.py` was deleted because it
+imported a benchmark-specific package that was not shippable publicly. The
+provider got re-homed into an adapter; the engine kept the lower-level
+primitives.
+
+The split was correct but **undocumented**. Three consequences followed:
+
+1. A subsequent silent breakage in v0.2.1 — the adapter's `ImportError`
+   fallback masked a deleted symbol, search returned empty results across
+   every search-dependent task, and the failure surfaced only after eval
+   degradation was investigated downstream.
+2. `docs/TYPESENSE_INTEGRATION.md` and the docstring example in
+   `tolokaforge/core/search/typesense_server.py` referenced the deleted
+   provider as if it still existed.
+3. `tolokaforge.core.search.__init__` exposed an abstract
+   `TypeSenseClient` and a `TypeSenseStub` returning empty results — an
+   "honesty over convenience" violation per [`docs/architecture/README.md`
+   §2](../README.md#2-constraints), since nothing implemented the abstract
+   and the stub silently lied about search.
+
+The 0.3.0 exit criterion is *"a TypeSense search task must run with no
+benchmark-specific package installed"*. That makes the split a load-bearing
+contract, not an incidental layout. It needs to be pinned.
+
+## Decision Drivers
+
+- **Honesty over convenience.** No silent fallbacks; no defaults that hide
+  configuration mistakes (overview §2).
+- **Adapter plugin discipline.** Adapter-specific dependencies must not leak
+  into the public engine (overview §4).
+- **Stable adapter boundary.** Adapter authors must be able to depend on a
+  named, tested public surface; renames must fail CI in the engine rather
+  than silently downstream.
+- **Public verifiability.** The "no benchmark-specific package required"
+  property must be exercised in the public CI suite, not just asserted.
+
+## Considered Options
+
+1. **Re-introduce a generic `TypeSenseProvider` in the engine.** Lift the
+   benchmark-independent parts back into `core/search/`. The engine grows a
+   second abstraction adapter authors must learn; the boundary it draws is
+   one that *might* generalise, not one that has.
+2. **Contract pin only.** Document the existing primitives as the public
+   surface, fix stale references, leave providers entirely adapter-side.
+   Smallest possible change.
+3. **Contract pin + public verification (this ADR).** Option 2, plus a
+   public smoke test that drives the contract end-to-end without any
+   benchmark-specific imports, so the exit-bar is verified by CI rather
+   than asserted in prose.
+
+## Decision
+
+Adopt **Option 3**.
+
+- The engine owns container lifecycle (`TypeSenseServerManager`,
+  `create_typesense_server`, `tolokaforge.docker.stacks.typesense`) and a
+  small set of primitives adapters reuse: thread-safe domain-init
+  coordination (`DomainState`, `DomainStateManager`, `DomainStatus`) and
+  the result envelopes (`SearchResponse`, `SearchResult`).
+- The engine deliberately does **not** ship a `TypeSenseClient`
+  abstraction. Adapters that need a client use the `typesense` package
+  directly — already a hard engine dependency. The previously-exported
+  `TypeSenseClient` / `TypeSenseStub` / `create_typesense_client` are
+  removed.
+- The exported surface is the contract. A contract test
+  (`tests/unit/test_search_contract.py`) pins it and asserts the removed
+  abstractions do not re-surface.
+- An integration smoke test (`tests/integration/test_search_no_mcp_core.py`)
+  drives the public surface end-to-end with zero benchmark-specific
+  imports, gating the 0.3.0 exit criterion in CI.
+- The engine/adapter boundary is documented in
+  [`docs/TYPESENSE_INTEGRATION.md`](../../TYPESENSE_INTEGRATION.md), which
+  describes the supported surface, the container-lifecycle ownership, the
+  concurrency primitive, and the canonical reference for a working
+  integration.
+
+## Consequences
+
+### Positive
+
+- The contract is loud: removing or renaming a public symbol fails CI in
+  the engine, not silently in some downstream adapter.
+- The exit bar is verifiable. A reviewer can run one test and confirm the
+  engine has no hidden benchmark-specific dependency in the search path.
+- Adapter authors have a documented, minimal, stable seam to build on
+  without negotiating with the engine team about provider shape.
+- The "no silent fallbacks" rule is upheld — there is no engine-side stub
+  pretending to be a real client.
+
+### Negative / Trade-offs
+
+- Adapter authors must own a small amount of additional code (their
+  provider + their TypeSense client setup) compared to a hypothetical
+  "engine ships a default provider" world. We judged this acceptable
+  because the per-benchmark indexing logic varies enough that an engine
+  default would either be too thin to be useful or would re-import the
+  benchmark-specific dependencies we're trying to keep out.
+- Removing `TypeSenseClient` / `TypeSenseStub` is technically a breaking
+  change for any external consumer that imported them. Grep across the
+  workspace shows zero in-repo callers; external consumers, if any, must
+  switch to using the `typesense` package directly.
+
+### Follow-ups
+
+- Code changes required: `tolokaforge/core/search/__init__.py`
+  (slim `__all__`), `tolokaforge/core/search/typesense.py` (delete
+  abstract + stub + factory; keep data classes),
+  `tolokaforge/core/search/typesense_server.py` (replace stale docstring
+  example).
+- Documentation to update: `docs/TYPESENSE_INTEGRATION.md` (full rewrite),
+  `docs/architecture/README.md` §4 (add Search subsystem row).
+- Tests to add: `tests/unit/test_search_contract.py`,
+  `tests/integration/test_search_no_mcp_core.py`.
+
+## Links
+
+- Related ADRs:
+  [0001 — Record architecture decisions in ADRs](0001-record-architecture-decisions.md),
+  [0002 — External model registry](0002-external-model-registry.md) (same
+  externalisation discipline applied to a different layer).
+- Related code:
+  - [`tolokaforge/core/search/__init__.py`](../../../tolokaforge/core/search/__init__.py) — the exported surface.
+  - [`tolokaforge/core/search/typesense_server.py`](../../../tolokaforge/core/search/typesense_server.py) — container lifecycle.
+  - [`tolokaforge/core/search/domain_state.py`](../../../tolokaforge/core/search/domain_state.py) — concurrency primitives.
+- Documentation:
+  [`docs/TYPESENSE_INTEGRATION.md`](../../TYPESENSE_INTEGRATION.md).

--- a/tests/integration/test_search_no_mcp_core.py
+++ b/tests/integration/test_search_no_mcp_core.py
@@ -1,0 +1,121 @@
+"""End-to-end smoke test for the public search surface.
+
+Drives ``tolokaforge.core.search`` end-to-end using *only* the engine's
+public surface plus the ``typesense`` Python package directly. No
+benchmark-specific imports. This pins the 0.3.0 exit criterion that a
+TypeSense-backed task can run with the public engine alone.
+
+If this test starts depending on a non-engine package, the engine has
+quietly grown a benchmark coupling — fix the coupling rather than the test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.integration
+@pytest.mark.requires_docker
+class TestSearchSurfaceWithoutBenchmarkPackage:
+    """Container → client → index → search, using only the public surface."""
+
+    def test_index_and_search_round_trip(self):
+        from tolokaforge.core.search import SearchResponse, SearchResult
+        from tolokaforge.core.search.typesense_server import (
+            DOCKER_AVAILABLE,
+            create_typesense_server,
+        )
+
+        if not DOCKER_AVAILABLE:
+            pytest.skip("Docker SDK not installed")
+
+        import typesense
+
+        server = create_typesense_server(
+            port="auto",
+            data_dir=".cache/typesense-smoke",
+            container_name="tolokaforge-typesense-smoke",
+        )
+
+        try:
+            started = server.start()
+            if not started:
+                pytest.skip("Could not start TypeSense server")
+
+            client = typesense.Client(
+                {
+                    "nodes": [
+                        {
+                            "host": server.host,
+                            "port": server.port,
+                            "protocol": "http",
+                        }
+                    ],
+                    "api_key": server.api_key,
+                    "connection_timeout_seconds": 5,
+                }
+            )
+
+            collection_name = "smoke_docs"
+            client.collections.create(
+                {
+                    "name": collection_name,
+                    "fields": [
+                        {"name": "title", "type": "string"},
+                        {"name": "body", "type": "string"},
+                    ],
+                }
+            )
+
+            documents = [
+                {
+                    "id": "doc-1",
+                    "title": "Refund policy",
+                    "body": "Customers may request a refund within 30 days of purchase.",
+                },
+                {
+                    "id": "doc-2",
+                    "title": "Shipping",
+                    "body": "Standard shipping arrives in three to five business days.",
+                },
+                {
+                    "id": "doc-3",
+                    "title": "Returns",
+                    "body": "Returned items must be unopened and accompanied by a receipt.",
+                },
+            ]
+            for doc in documents:
+                client.collections[collection_name].documents.create(doc)
+
+            raw = client.collections[collection_name].documents.search(
+                {"q": "refund", "query_by": "title,body"}
+            )
+
+            assert raw["found"] >= 1
+            hit_ids = {hit["document"]["id"] for hit in raw["hits"]}
+            assert "doc-1" in hit_ids
+
+            response = SearchResponse(
+                hits=[
+                    SearchResult(
+                        document_id=hit["document"]["id"],
+                        score=float(hit.get("text_match", 0)),
+                        content=hit["document"],
+                        highlights={
+                            h["field"]: h.get("snippets", []) for h in hit.get("highlights", [])
+                        },
+                    )
+                    for hit in raw["hits"]
+                ],
+                total_hits=raw["found"],
+                query="refund",
+                search_time_ms=float(raw.get("search_time_ms", 0)),
+            )
+
+            assert response.total_hits == raw["found"]
+            assert any(r.document_id == "doc-1" for r in response.hits)
+
+        finally:
+            server.stop()

--- a/tests/unit/test_search_contract.py
+++ b/tests/unit/test_search_contract.py
@@ -1,0 +1,62 @@
+"""Contract test for ``tolokaforge.core.search`` public surface.
+
+The symbols re-exported by ``tolokaforge.core.search.__init__`` are the
+adapter-facing API. Renaming or removing one is a breaking change for any
+adapter that builds a TypeSense-backed provider on top. This test pins
+``__all__`` to its expected shape so an accidental cleanup fails CI here
+rather than silently downstream.
+
+If you add or remove a name, update ``EXPECTED`` and ``docs/TYPESENSE_INTEGRATION.md``
+in the same change.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+
+import pytest
+
+from tolokaforge.core import search as search_pkg
+
+pytestmark = pytest.mark.unit
+
+
+EXPECTED = {
+    "DomainState",
+    "DomainStateManager",
+    "DomainStatus",
+    "SearchResponse",
+    "SearchResult",
+}
+
+
+def test_all_matches_expected_contract():
+    assert set(search_pkg.__all__) == EXPECTED
+
+
+def test_every_exported_name_resolves():
+    for name in search_pkg.__all__:
+        assert hasattr(search_pkg, name), f"{name} listed in __all__ but missing from module"
+
+
+def test_data_classes_are_dataclasses():
+    assert dataclasses.is_dataclass(search_pkg.SearchResponse)
+    assert dataclasses.is_dataclass(search_pkg.SearchResult)
+
+
+def test_domain_status_is_enum_like():
+    assert inspect.isclass(search_pkg.DomainStatus)
+    expected_members = {"PENDING", "INITIALIZING", "READY", "FAILED"}
+    actual = {m for m in dir(search_pkg.DomainStatus) if not m.startswith("_")}
+    assert expected_members.issubset(
+        actual
+    ), f"DomainStatus is missing expected members; have {actual}"
+
+
+def test_no_typesense_client_abstract_resurfaces():
+    for stale in ("TypeSenseClient", "TypeSenseStub", "create_typesense_client"):
+        assert stale not in search_pkg.__all__, (
+            f"{stale} was intentionally removed; do not re-export it. "
+            "If you need a real client, use the typesense package directly."
+        )

--- a/tolokaforge/core/search/__init__.py
+++ b/tolokaforge/core/search/__init__.py
@@ -1,18 +1,30 @@
 """
-Search interfaces for TolokaForge.
+Adapter-facing search primitives.
 
-This module provides abstract interfaces for search backends like TypeSense.
+This package exposes the supported building blocks adapters use to integrate
+TypeSense-backed search with the engine. The engine owns container lifecycle
+(``TypeSenseServerManager`` and ``docker/stacks/typesense.py``) and the
+thread-safe domain-init coordination plumbing (``domain_state``); adapters
+own their own provider — including any benchmark- or domain-specific
+indexing strategy and any benchmark-specific dependencies.
+
+The names exported from this package are the **supported public contract**:
+removing or renaming one is a breaking change. New names land here only
+when an adapter actually needs them.
+
+See ``docs/TYPESENSE_INTEGRATION.md`` for the engine/adapter split and a
+worked example using the ``typesense`` Python package directly.
 """
 
 from .domain_state import DomainState, DomainStateManager, DomainStatus
-from .typesense import TypeSenseClient, TypeSenseStub
+from .typesense import SearchResponse, SearchResult
 
 __all__ = [
-    # Domain state management
+    # Domain init coordination (thread-safe state machine)
     "DomainState",
     "DomainStateManager",
     "DomainStatus",
-    # TypeSense client interfaces
-    "TypeSenseClient",
-    "TypeSenseStub",
+    # Result data classes
+    "SearchResponse",
+    "SearchResult",
 ]

--- a/tolokaforge/core/search/typesense.py
+++ b/tolokaforge/core/search/typesense.py
@@ -1,286 +1,35 @@
 """
-TypeSense search backend interface.
+Search result data classes for the TypeSense subsystem.
 
-This module provides an abstract interface for TypeSense full-text search,
-used primarily by tool-use domains for knowledge base search functionality.
+These are part of the supported adapter-facing surface: an adapter that
+needs to expose TypeSense results in a structured form can import
+``SearchResponse`` and ``SearchResult`` from ``tolokaforge.core.search``.
 
-TODO: Implement actual TypeSense integration when needed.
-Currently provides a stub implementation that returns empty results.
+The engine deliberately does *not* ship a ``TypeSenseClient`` abstraction.
+Adapters wanting a real client should use the ``typesense`` Python package
+directly — it is already a hard dependency of the engine. See
+``docs/TYPESENSE_INTEGRATION.md`` for the engine/adapter split.
 """
 
-import logging
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
 class SearchResult:
-    """A single search result from TypeSense."""
+    """A single search result."""
 
     document_id: str
-    """Unique identifier of the document."""
-
     score: float
-    """Relevance score (higher is better)."""
-
     content: dict[str, Any]
-    """The full document content."""
-
     highlights: dict[str, list[str]] = field(default_factory=dict)
-    """Highlighted snippets matching the query, keyed by field name."""
 
 
 @dataclass
 class SearchResponse:
-    """Response from a TypeSense search query."""
+    """Response from a search query."""
 
     hits: list[SearchResult]
-    """List of matching documents."""
-
     total_hits: int
-    """Total number of matching documents (may be more than returned)."""
-
     query: str
-    """The original query string."""
-
     search_time_ms: float
-    """Time taken for the search in milliseconds."""
-
-
-class TypeSenseClient(ABC):
-    """
-    Abstract interface for TypeSense search operations.
-
-    This interface allows different implementations:
-    - TypeSenseStub: Returns empty results (for testing/development)
-    - TypeSenseLocal: Connects to a local TypeSense instance
-    - TypeSenseCloud: Connects to TypeSense Cloud
-    """
-
-    @abstractmethod
-    def initialize_collection(
-        self,
-        collection_name: str,
-        schema: dict[str, Any],
-        documents_path: Path | None = None,
-    ) -> None:
-        """
-        Initialize a TypeSense collection.
-
-        Args:
-            collection_name: Name of the collection to create/update.
-            schema: TypeSense schema definition for the collection.
-            documents_path: Optional path to a directory containing JSON documents
-                           to index into the collection.
-        """
-        pass
-
-    @abstractmethod
-    def search(
-        self,
-        collection_name: str,
-        query: str,
-        query_by: list[str],
-        filter_by: str | None = None,
-        limit: int = 10,
-        offset: int = 0,
-    ) -> SearchResponse:
-        """
-        Search documents in a collection.
-
-        Args:
-            collection_name: Name of the collection to search.
-            query: The search query string.
-            query_by: List of fields to search in.
-            filter_by: Optional filter expression (TypeSense syntax).
-            limit: Maximum number of results to return.
-            offset: Number of results to skip (for pagination).
-
-        Returns:
-            SearchResponse containing matching documents.
-        """
-        pass
-
-    @abstractmethod
-    def index_document(
-        self,
-        collection_name: str,
-        document: dict[str, Any],
-    ) -> str:
-        """
-        Index a single document into a collection.
-
-        Args:
-            collection_name: Name of the collection.
-            document: The document to index.
-
-        Returns:
-            The document ID.
-        """
-        pass
-
-    @abstractmethod
-    def delete_collection(self, collection_name: str) -> None:
-        """
-        Delete a collection and all its documents.
-
-        Args:
-            collection_name: Name of the collection to delete.
-        """
-        pass
-
-    @abstractmethod
-    def close(self) -> None:
-        """Close the client and release resources."""
-        pass
-
-
-class TypeSenseStub(TypeSenseClient):
-    """
-    Stub implementation of TypeSense that returns empty results.
-
-    This is used when TypeSense is not available or not needed.
-    All search operations return empty results with a warning log.
-
-    TODO: Replace with actual TypeSense implementation when the
-    typesense-python package is integrated.
-    """
-
-    def __init__(self):
-        """Initialize the stub client."""
-        self._collections: dict[str, dict[str, Any]] = {}
-        self._documents: dict[str, list[dict[str, Any]]] = {}
-        logger.warning(
-            "TypeSenseStub initialized - search operations will return empty results. "
-            "TODO: Implement actual TypeSense integration."
-        )
-
-    def initialize_collection(
-        self,
-        collection_name: str,
-        schema: dict[str, Any],
-        documents_path: Path | None = None,
-    ) -> None:
-        """
-        Initialize a collection (stub - stores schema only).
-
-        Args:
-            collection_name: Name of the collection.
-            schema: TypeSense schema definition.
-            documents_path: Path to documents directory (ignored in stub).
-        """
-        self._collections[collection_name] = schema
-        self._documents[collection_name] = []
-
-        if documents_path:
-            logger.info(
-                f"TypeSenseStub: Would index documents from {documents_path} "
-                f"into collection '{collection_name}' (stub - skipping)"
-            )
-
-    def search(
-        self,
-        collection_name: str,
-        query: str,
-        query_by: list[str],
-        filter_by: str | None = None,
-        limit: int = 10,
-        offset: int = 0,
-    ) -> SearchResponse:
-        """
-        Search documents (stub - returns empty results).
-
-        Args:
-            collection_name: Name of the collection.
-            query: The search query.
-            query_by: Fields to search.
-            filter_by: Optional filter (ignored).
-            limit: Max results (ignored).
-            offset: Pagination offset (ignored).
-
-        Returns:
-            Empty SearchResponse.
-        """
-        logger.warning(
-            f"TypeSenseStub: Search in '{collection_name}' for '{query}' "
-            f"returned empty results (stub implementation)"
-        )
-        return SearchResponse(
-            hits=[],
-            total_hits=0,
-            query=query,
-            search_time_ms=0.0,
-        )
-
-    def index_document(
-        self,
-        collection_name: str,
-        document: dict[str, Any],
-    ) -> str:
-        """
-        Index a document (stub - stores in memory).
-
-        Args:
-            collection_name: Name of the collection.
-            document: The document to index.
-
-        Returns:
-            A generated document ID.
-        """
-        if collection_name not in self._documents:
-            self._documents[collection_name] = []
-
-        doc_id = f"stub-{len(self._documents[collection_name])}"
-        document["id"] = doc_id
-        self._documents[collection_name].append(document)
-        return doc_id
-
-    def delete_collection(self, collection_name: str) -> None:
-        """
-        Delete a collection (stub - removes from memory).
-
-        Args:
-            collection_name: Name of the collection.
-        """
-        self._collections.pop(collection_name, None)
-        self._documents.pop(collection_name, None)
-
-    def close(self) -> None:
-        """Close the stub client (no-op)."""
-        pass
-
-
-def create_typesense_client(
-    host: str | None = None,
-    port: int | None = None,
-    api_key: str | None = None,
-    use_stub: bool = True,
-) -> TypeSenseClient:
-    """
-    Factory function to create a TypeSense client.
-
-    Args:
-        host: TypeSense server host (ignored if use_stub=True).
-        port: TypeSense server port (ignored if use_stub=True).
-        api_key: TypeSense API key (ignored if use_stub=True).
-        use_stub: If True, return a stub client that returns empty results.
-
-    Returns:
-        A TypeSenseClient instance.
-
-    TODO: Implement actual TypeSense client when use_stub=False.
-    """
-    if use_stub:
-        return TypeSenseStub()
-
-    # TODO: Implement actual TypeSense client
-    # from typesense import Client
-    # return TypeSenseLocalClient(host, port, api_key)
-    raise NotImplementedError(
-        "Actual TypeSense client not yet implemented. "
-        "Use use_stub=True or implement TypeSenseLocal/TypeSenseCloud."
-    )

--- a/tolokaforge/core/search/typesense_server.py
+++ b/tolokaforge/core/search/typesense_server.py
@@ -70,13 +70,16 @@ class TypeSenseServerManager:
 
     Example:
         ```python
+        import typesense
+
         with TypeSenseServerManager(port="auto") as server:
-            # Server is running, use server.port and server.api_key
-            provider = create_typesense_provider(
-                port=server.port,
-                api_key=server.api_key
-            )
-        # Server automatically stopped
+            client = typesense.Client({
+                "nodes": [{"host": server.host, "port": server.port, "protocol": "http"}],
+                "api_key": server.api_key,
+                "connection_timeout_seconds": 5,
+            })
+            # ... create collections, index documents, search ...
+        # Server automatically stopped on context exit
         ```
 
     Attributes:


### PR DESCRIPTION
## Summary

Pin `tolokaforge.core.search` as the adapter-facing contract for TypeSense-backed search. Bundles the three deliverables from the TypeSense investigation into one PR.

- **Contract pin.** `__all__` now exposes exactly the symbols adapters actually depend on: `DomainState`, `DomainStateManager`, `DomainStatus`, `SearchResponse`, `SearchResult`. The vestigial `TypeSenseClient` / `TypeSenseStub` / `create_typesense_client` are deleted — no in-repo caller existed, and the stub's silent-empty-results pattern violates the "no silent fallbacks" constraint in `docs/architecture/README.md` §2.
- **Stale docstring fix.** The `Example:` block in `typesense_server.py` that referenced the deleted `create_typesense_provider()` is replaced with a working example that uses the `typesense` package directly.
- **Docs rewrite.** `docs/TYPESENSE_INTEGRATION.md` no longer references deleted modules. The new doc describes the engine/adapter split, names the supported public surface, and points at the smoke test as the canonical reference for a working integration.
- **Decision record.** New ADR-0003 captures the engine-owns-container-and-primitives / adapters-own-provider split. Cross-linked from the §4 Solution Strategy table.
- **Contract test.** `tests/unit/test_search_contract.py` pins `__all__` so an accidental cleanup fails CI here rather than silently downstream — exactly the failure mode that bit search in v0.2.1.
- **Public smoke test.** `tests/integration/test_search_no_mcp_core.py` drives the public surface end-to-end (start container → index via `typesense` package → search → assert) with zero benchmark-specific imports. This verifies, in CI, that a TypeSense-backed task can run on the public engine alone.

Net diff: **+431 / -650** across 8 files. Most of the deletions are the vestigial abstract/stub (271 lines) and the stale documentation (358 lines).

## Background

Two issues framed the work:

- #7 asked for a new `TypeSenseProvider` class in the engine.
- #26 pushed back: the engine kept the right things at the open-source split; what's missing is documentation + a contract pin, not a new abstraction.

Investigation across the workspace confirmed the engine's `core/search/*` is already clean (no benchmark-specific imports) and that the right move is to pin what's there rather than grow the surface. The decision and its reasoning are recorded in ADR-0003.

## Test plan

- [x] `pytest tests/unit/test_search_contract.py -v` → 5/5 pass.
- [x] `pytest tests/unit/` (full suite) → 1768 pass, 1 skip.
- [x] `pytest tests/integration/test_search_no_mcp_core.py -v` → passes locally with Docker (start → index → search → assert round-trip green).
- [x] `grep -rn "TypeSenseClient\|TypeSenseStub\|create_typesense_client" --include="*.py"` outside `.venv` returns only the intentional references (docstring + contract test).
- [x] `python -c "from tolokaforge.core.search import *"` succeeds for every name in `__all__`.
- [x] Read the rewritten `TYPESENSE_INTEGRATION.md` end-to-end — no broken links or symbol references.

## Follow-ups (not in this PR)

- Refresh `docs/plans/v0.3.0-implementation-plan.md` once this lands (move PR #61 and #66 to Shipped; mark the search exit-checklist row complete).
- File a separate ticket to repair the matching call-site in any adapter that still imports the deleted public path — see the issue #26 thread for context.

Closes #7. Closes #26.