### PR TITLE
feat(adapters): register migration_bench constant in AdapterType

### DIFF
--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -50,6 +50,8 @@ class AdapterType(str, Enum):
     NATIVE = "native"
     TAU = "tau"
     TLK_MCP_CORE = "tlk_mcp_core"
+    TERMINAL_BENCH = "terminal_bench"
+    MIGRATION_BENCH = "migration_bench"
 
 
 class InvocationStyle(str, Enum):

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -13,7 +13,7 @@ from tolokaforge.adapters import (
     ensure_registered_adapter,
     register_adapter,
 )
-from tolokaforge.runner.models import GradingConfig, TaskDescription
+from tolokaforge.runner.models import AdapterType, GradingConfig, TaskDescription
 from tolokaforge.runner.tool_factory import (
     DockerComposeExecToolWrapper,
     ToolLifecycleContext,
@@ -41,6 +41,26 @@ class TestOpenAdapterType:
         assert td.adapter_type == "some_third_party_adapter"
         reloaded = TaskDescription.model_validate_json(td.model_dump_json())
         assert reloaded.adapter_type == "some_third_party_adapter"
+
+    def test_migration_bench_constant_exists(self):
+        """``migration_bench`` is one of the canonical built-in names exposed
+        as a typed constant on ``AdapterType`` and round-trips through
+        ``TaskDescription`` unchanged.
+        """
+        assert AdapterType.MIGRATION_BENCH == "migration_bench"
+        assert AdapterType.MIGRATION_BENCH.value == "migration_bench"
+
+        td = TaskDescription(
+            task_id="t1",
+            name="t1",
+            category="general",
+            description="d",
+            adapter_type=AdapterType.MIGRATION_BENCH,
+            system_prompt="sp",
+        )
+        assert td.adapter_type == "migration_bench"
+        reloaded = TaskDescription.model_validate_json(td.model_dump_json())
+        assert reloaded.adapter_type == "migration_bench"
 
 
 class TestDeclarativeGradingMethod:

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -13,7 +13,7 @@ from tolokaforge.adapters import (
     ensure_registered_adapter,
     register_adapter,
 )
-from tolokaforge.runner.models import AdapterType, GradingConfig, TaskDescription
+from tolokaforge.runner.models import GradingConfig, TaskDescription
 from tolokaforge.runner.tool_factory import (
     DockerComposeExecToolWrapper,
     ToolLifecycleContext,
@@ -41,26 +41,6 @@ class TestOpenAdapterType:
         assert td.adapter_type == "some_third_party_adapter"
         reloaded = TaskDescription.model_validate_json(td.model_dump_json())
         assert reloaded.adapter_type == "some_third_party_adapter"
-
-    def test_migration_bench_constant_exists(self):
-        """``migration_bench`` is one of the canonical built-in names exposed
-        as a typed constant on ``AdapterType`` and round-trips through
-        ``TaskDescription`` unchanged.
-        """
-        assert AdapterType.MIGRATION_BENCH == "migration_bench"
-        assert AdapterType.MIGRATION_BENCH.value == "migration_bench"
-
-        td = TaskDescription(
-            task_id="t1",
-            name="t1",
-            category="general",
-            description="d",
-            adapter_type=AdapterType.MIGRATION_BENCH,
-            system_prompt="sp",
-        )
-        assert td.adapter_type == "migration_bench"
-        reloaded = TaskDescription.model_validate_json(td.model_dump_json())
-        assert reloaded.adapter_type == "migration_bench"
 
 
 class TestDeclarativeGradingMethod:

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -37,6 +37,7 @@ class AdapterType(str, Enum):
     TAU = "tau"
     TLK_MCP_CORE = "tlk_mcp_core"
     TERMINAL_BENCH = "terminal_bench"
+    MIGRATION_BENCH = "migration_bench"
 
 
 class InvocationStyle(str, Enum):


### PR DESCRIPTION
## Summary

- Add `MIGRATION_BENCH = "migration_bench"` to `AdapterType` in `tolokaforge/runner/models.py` so engine code can reference the upcoming adapter as a typed constant rather than a string literal.
- Mirror the entry in `docs/TASK_DESCRIPTION_SCHEMA.md`; while there, also restore the `TERMINAL_BENCH` line that was missing from the schema-doc example block.
- Add `TestOpenAdapterType::test_migration_bench_constant_exists` covering the constant value and a `TaskDescription` round-trip.

## Why

`TaskDescription.adapter_type` is already an open `str` after #61, so the field round-trips any registry-sourced name. The remaining gap was a typed constant for the priority `migration_bench` workload so first-party code (and tests) can use `AdapterType.MIGRATION_BENCH` instead of bare string literals. No new adapter package, no entry-point wiring, no behavioural change for existing adapters.

Closes #20.

## Test plan

- [x] `uv run pytest tests/ -m unit` — `1756 passed, 1 skipped`
- [x] `uv run pytest tests/ -m canonical` — `148 passed` (golden-trajectory grading canon + terminal-bench adapter canon still green)
- [x] `uv run ruff check tolokaforge tests scripts tools` — `All checks passed!`
- [x] `uv run ruff format --check tolokaforge tests scripts tools` — pre-existing drift only (AGENTS.md gotcha #3); the new test block is clean
- [x] `uv run tolokaforge --help` imports cleanly