### PR TITLE
feat(llm): register z-ai/glm-5.2 and moonshotai/kimi-k2.7-code (cert + pricing)

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -841,6 +841,51 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Kimi-K2.7-Code (Moonshot AI via OpenRouter). Same moonshotai/kimi-k2
+    # family + shared ``openrouter_dict_stringify_recovery`` preset as kimi-k2.6,
+    # so this cert MIRRORS the kimi-k2.6 sibling (13 required / 7
+    # known_unsupported) as the integration starting point. NOT yet
+    # live-certified: the code-specialised variant may behave differently
+    # (tool-call or reasoning surface), so verify against the live route and
+    # promote/demote what it refutes when the model is first evaluated (same
+    # approach as the nemotron-3-ultra integration, #65).
+    MC(
+        model_id="openrouter__moonshotai_kimi-k2.7-code",
+        provider="openrouter",
+        name="moonshotai/kimi-k2.7-code",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                # kimi-k2.6 emits the discriminated-union arg shape correctly as
+                # a native dict but does not follow a turn-2 switch to a different
+                # variant; mirrored here pending the k2.7-code live check.
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+            }
+        ),
+    ),
     MC(
         model_id="openrouter__deepseek_deepseek-v4-pro",
         provider="openrouter",
@@ -1205,6 +1250,49 @@ _ALL: list[MC] = [
                 # Reasoning surfaces only as an unsigned summary via the
                 # openai codec: no signed blocks to replay, and the codec's
                 # replay path is a no-op. Verified live 2026-06-05.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
+    # GLM-5.2 (Zhipu / Z.AI via OpenRouter). Same z-ai/glm-5 family + shared
+    # ``openrouter_dict_stringify_recovery`` preset as glm-5.1, so this cert
+    # MIRRORS the glm-5.1 sibling (17 required / 3 known_unsupported) as the
+    # integration starting point. NOT yet live-certified: verify against the
+    # live route, and demote any capability it refutes, when the model is
+    # first evaluated (same approach as the nemotron-3-ultra integration, #65).
+    MC(
+        model_id="openrouter__z-ai_glm-5.2",
+        provider="openrouter",
+        name="z-ai/glm-5.2",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # No Anthropic-style ephemeral cache markers on this route.
+                C.PROMPT_CACHING,
+                # Reasoning surfaces only as an unsigned summary via the openai
+                # codec (no signed blocks to replay; the codec replay is a no-op).
                 C.THINKING_REPLAY_ROUNDTRIP,
                 C.UNSIGNED_THINKING_REPLAY,
             }

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -871,6 +871,11 @@
       "output": 3.49,
       "cache_read": 0.25
     },
+    "moonshotai/kimi-k2.7-code": {
+      "input": 0.74,
+      "output": 3.5,
+      "cache_read": 0.15
+    },
     "morph/morph-v3-fast": {
       "input": 0.8,
       "output": 1.2
@@ -1807,6 +1812,11 @@
       "input": 0.98,
       "output": 3.08,
       "cache_read": 0.182
+    },
+    "z-ai/glm-5.2": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "z-ai/glm-5v-turbo": {
       "input": 1.2,


### PR DESCRIPTION
## What

Engine integration for two new arena-lineup models:

| Model | Pricing (in / out / cache_read per M) | Ctx | Cert |
|---|---|---|---|
| `z-ai/glm-5.2` | $1.4 / $4.4 / $0.26 | 1M | mirrors `glm-5.1` (17 required / 3 known_unsupported) |
| `moonshotai/kimi-k2.7-code` | $0.74 / $3.5 / $0.15 | 256k | mirrors `kimi-k2.6` (13 required / 7 known_unsupported) |

- **Cert** (`tests/integration/llm/registry.py`): each mirrors its closest sibling in the same family.
- **Pricing** (`tolokaforge/core/data/pricing.json`): real OpenRouter rates (fetched 2026-06-18).
- **Preset**: no change. Both are already covered by the existing `openrouter_dict_stringify_recovery` globs (`z-ai/glm-5*`, `moonshotai/kimi-k2*`).

## Methodology

Same approach as the nemotron-3-ultra integration (#65): the certs **mirror the closest sibling** as the integration starting point and are **not yet live-certified**. Verify against the live route, and demote/promote any capability it refutes, when the models are first evaluated. The `kimi-k2.7-code` "-code" variant in particular may differ from `kimi-k2.6` on tool-call / reasoning surfaces.

## Verification (offline)

- `tests/canonical/test_capability_registry.py` + `tests/unit/llm/test_capability_certificate.py`: **19 passed** (unique slugs, model_id/slug agreement, capability partition).
- Full `tests/unit/llm/`: **428 passed**.
- Registry imports clean; 28 certs total (+2), no duplicate `model_id`, required/known_unsupported disjoint for both.
- Runtime resolution confirmed: both names resolve to pricing + the `openrouter_dict_stringify_recovery` preset.
- `pricing.json` valid JSON.

Live cert + the eval (smoke to full) will validate capability accuracy.

TECHDEL-378, TECHDEL-379
