### PR TITLE
refactor(runner): drop private-package prefix from MCP_ASYNC import path

### DIFF
--- a/tests/unit/test_tool_factory_import_paths.py
+++ b/tests/unit/test_tool_factory_import_paths.py
@@ -15,6 +15,7 @@ These tests pin both ends of that contract:
 
 from __future__ import annotations
 
+import types
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,13 +25,20 @@ from tolokaforge.runner.tool_factory import ToolFactory, ToolImportError
 
 pytestmark = pytest.mark.unit
 
+# Private package names the public engine has historically been coupled to.
+# The runner must never inject any of these into the import path or error text;
+# they may appear only when the *adapter* itself supplied them.
+FORBIDDEN_PRIVATE_NAMES = ("mcp_tools_library", "mcp_core", "tau_bench")
+
 
 @pytest.fixture
 def factory():
     return ToolFactory(db_client=MagicMock(), trial_id="test:0")
 
 
-def _mcp_async_schema(*, toolset: str, module_path: str, class_name: str = "T") -> ToolSchema:
+def _schema(
+    *, style: InvocationStyle, toolset: str, module_path: str, class_name: str = "T"
+) -> ToolSchema:
     return ToolSchema(
         name="t",
         description="",
@@ -39,7 +47,7 @@ def _mcp_async_schema(*, toolset: str, module_path: str, class_name: str = "T") 
             toolset=toolset,
             module_path=module_path,
             class_name=class_name,
-            invocation_style=InvocationStyle.MCP_ASYNC,
+            invocation_style=style,
         ),
     )
 
@@ -48,35 +56,44 @@ class TestMcpAsyncImportPath:
     """The class-import path: ``{toolset}.{module_path}`` verbatim."""
 
     def test_uses_adapter_supplied_path_unchanged(self, factory, monkeypatch):
-        captured: list[str] = []
+        captured_class: list[str] = []
+        captured_register_arg: list[str] = []
 
         def _fake_import(path):
-            captured.append(path)
+            captured_class.append(path)
             module = MagicMock()
             module.MyTool = type("MyTool", (), {})
             return module
 
         monkeypatch.setattr("tolokaforge.runner.tool_factory.importlib.import_module", _fake_import)
-        # Skip the models-registration side effect; it has its own test below.
-        monkeypatch.setattr(ToolFactory, "_register_toolset_models", lambda self, toolset: None)
+        # Pin the boundary: the registration helper receives ``source.toolset``
+        # verbatim, with no prefix munging by the dispatch.
+        monkeypatch.setattr(
+            ToolFactory,
+            "_register_toolset_models",
+            lambda self, toolset: captured_register_arg.append(toolset),
+        )
 
-        schema = _mcp_async_schema(
+        schema = _schema(
+            style=InvocationStyle.MCP_ASYNC,
             toolset="my_adapter_pkg.zendesk",
             module_path="tools.create_item",
             class_name="MyTool",
         )
         factory._create_wrapper(schema)
 
-        assert captured == ["my_adapter_pkg.zendesk.tools.create_item"]
+        assert captured_class == ["my_adapter_pkg.zendesk.tools.create_item"]
+        assert captured_register_arg == ["my_adapter_pkg.zendesk"]
 
 
-class TestMcpAsyncErrorMessages:
-    """When the configured path is unimportable, the error names exactly what
-    the adapter supplied — not any private root the engine used to prepend.
+class TestTauSyncImportPath:
+    """TAU_SYNC has always used the no-prefix convention; symmetry test that
+    the error-message refactor in this PR didn't drift it from that shape.
     """
 
     def test_unimportable_module_error_names_only_the_configured_path(self, factory):
-        schema = _mcp_async_schema(
+        schema = _schema(
+            style=InvocationStyle.TAU_SYNC,
             toolset="definitely_no_such_pkg_42",
             module_path="x.y",
         )
@@ -85,8 +102,28 @@ class TestMcpAsyncErrorMessages:
 
         msg = str(exc_info.value)
         assert "definitely_no_such_pkg_42.x.y" in msg
-        # Regression guard: no private root may sneak back into the error text.
-        assert "mcp_tools_library" not in msg
+        for forbidden in FORBIDDEN_PRIVATE_NAMES:
+            assert forbidden not in msg, f"Private name {forbidden!r} leaked into TAU_SYNC error"
+
+
+class TestMcpAsyncErrorMessages:
+    """When the configured path is unimportable, the error names exactly what
+    the adapter supplied — not any private root the engine used to prepend.
+    """
+
+    def test_unimportable_module_error_names_only_the_configured_path(self, factory):
+        schema = _schema(
+            style=InvocationStyle.MCP_ASYNC,
+            toolset="definitely_no_such_pkg_42",
+            module_path="x.y",
+        )
+        with pytest.raises(ToolImportError) as exc_info:
+            factory._create_wrapper(schema)
+
+        msg = str(exc_info.value)
+        assert "definitely_no_such_pkg_42.x.y" in msg
+        for forbidden in FORBIDDEN_PRIVATE_NAMES:
+            assert forbidden not in msg, f"Private name {forbidden!r} leaked into MCP_ASYNC error"
 
 
 class TestModelsRegistrationImportPath:
@@ -100,8 +137,6 @@ class TestModelsRegistrationImportPath:
             # Empty module — the registration loop just iterates dir(); a
             # MagicMock would expose unrelated attributes and trigger the
             # FAIL-LOUD branch downstream, so use a real empty namespace.
-            import types
-
             return types.ModuleType(path)
 
         monkeypatch.setattr("tolokaforge.runner.tool_factory.importlib.import_module", _fake_import)
@@ -109,3 +144,20 @@ class TestModelsRegistrationImportPath:
         factory._register_toolset_models("my_adapter_pkg.zendesk")
 
         assert captured == ["my_adapter_pkg.zendesk.models"]
+
+    def test_broken_models_module_propagates_not_swallowed(self, factory, monkeypatch):
+        """A genuine ImportError *inside* a models module (e.g. missing dep)
+        must NOT be silently swallowed at debug level. The fail-quiet path is
+        scoped to ``ModuleNotFoundError`` (the toolset has no models module);
+        any other ImportError surfaces the bug.
+        """
+
+        def _fake_import(path):
+            # Plain ImportError, not ModuleNotFoundError — simulates a models
+            # module that exists but raises during its own imports.
+            raise ImportError("simulated missing transitive dep")
+
+        monkeypatch.setattr("tolokaforge.runner.tool_factory.importlib.import_module", _fake_import)
+
+        with pytest.raises(ImportError, match="simulated missing transitive dep"):
+            factory._register_toolset_models("my_adapter_pkg.zendesk")

--- a/tests/unit/test_tool_factory_import_paths.py
+++ b/tests/unit/test_tool_factory_import_paths.py
@@ -1,0 +1,111 @@
+"""Runner tool factory must not assume a private package layout.
+
+The public engine cannot hardcode any non-public package name into the import
+path it uses for adapter-supplied tools. ``_create_mcp_async_wrapper`` and its
+sibling ``_register_toolset_models`` now import ``{toolset}.{module_path}``
+and ``{toolset}.models`` directly — the adapter supplies the fully-qualified
+package; the runner adds no prefix. This mirrors how ``_create_tau_sync_wrapper``
+has always worked.
+
+These tests pin both ends of that contract:
+  1. the import path the runner *constructs* contains no extra prefix;
+  2. the error path *reports* surfaced via ``ToolImportError`` contains the
+     exact module path the adapter supplied — and crucially nothing else.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.runner.models import InvocationStyle, ToolSchema, ToolSource
+from tolokaforge.runner.tool_factory import ToolFactory, ToolImportError
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def factory():
+    return ToolFactory(db_client=MagicMock(), trial_id="test:0")
+
+
+def _mcp_async_schema(*, toolset: str, module_path: str, class_name: str = "T") -> ToolSchema:
+    return ToolSchema(
+        name="t",
+        description="",
+        parameters={"type": "object", "properties": {}},
+        source=ToolSource(
+            toolset=toolset,
+            module_path=module_path,
+            class_name=class_name,
+            invocation_style=InvocationStyle.MCP_ASYNC,
+        ),
+    )
+
+
+class TestMcpAsyncImportPath:
+    """The class-import path: ``{toolset}.{module_path}`` verbatim."""
+
+    def test_uses_adapter_supplied_path_unchanged(self, factory, monkeypatch):
+        captured: list[str] = []
+
+        def _fake_import(path):
+            captured.append(path)
+            module = MagicMock()
+            module.MyTool = type("MyTool", (), {})
+            return module
+
+        monkeypatch.setattr("tolokaforge.runner.tool_factory.importlib.import_module", _fake_import)
+        # Skip the models-registration side effect; it has its own test below.
+        monkeypatch.setattr(ToolFactory, "_register_toolset_models", lambda self, toolset: None)
+
+        schema = _mcp_async_schema(
+            toolset="my_adapter_pkg.zendesk",
+            module_path="tools.create_item",
+            class_name="MyTool",
+        )
+        factory._create_wrapper(schema)
+
+        assert captured == ["my_adapter_pkg.zendesk.tools.create_item"]
+
+
+class TestMcpAsyncErrorMessages:
+    """When the configured path is unimportable, the error names exactly what
+    the adapter supplied — not any private root the engine used to prepend.
+    """
+
+    def test_unimportable_module_error_names_only_the_configured_path(self, factory):
+        schema = _mcp_async_schema(
+            toolset="definitely_no_such_pkg_42",
+            module_path="x.y",
+        )
+        with pytest.raises(ToolImportError) as exc_info:
+            factory._create_wrapper(schema)
+
+        msg = str(exc_info.value)
+        assert "definitely_no_such_pkg_42.x.y" in msg
+        # Regression guard: no private root may sneak back into the error text.
+        assert "mcp_tools_library" not in msg
+
+
+class TestModelsRegistrationImportPath:
+    """The companion ``{toolset}.models`` import — same no-prefix contract."""
+
+    def test_models_import_uses_adapter_supplied_path_unchanged(self, factory, monkeypatch):
+        captured: list[str] = []
+
+        def _fake_import(path):
+            captured.append(path)
+            # Empty module — the registration loop just iterates dir(); a
+            # MagicMock would expose unrelated attributes and trigger the
+            # FAIL-LOUD branch downstream, so use a real empty namespace.
+            import types
+
+            return types.ModuleType(path)
+
+        monkeypatch.setattr("tolokaforge.runner.tool_factory.importlib.import_module", _fake_import)
+
+        factory._register_toolset_models("my_adapter_pkg.zendesk")
+
+        assert captured == ["my_adapter_pkg.zendesk.models"]

--- a/tests/unit/test_tool_factory_import_paths.py
+++ b/tests/unit/test_tool_factory_import_paths.py
@@ -15,13 +15,19 @@ These tests pin both ends of that contract:
 
 from __future__ import annotations
 
+import sys
+import textwrap
 import types
 from unittest.mock import MagicMock
 
 import pytest
 
 from tolokaforge.runner.models import InvocationStyle, ToolSchema, ToolSource
-from tolokaforge.runner.tool_factory import ToolFactory, ToolImportError
+from tolokaforge.runner.tool_factory import (
+    MCPAsyncToolWrapper,
+    ToolFactory,
+    ToolImportError,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -161,3 +167,97 @@ class TestModelsRegistrationImportPath:
 
         with pytest.raises(ImportError, match="simulated missing transitive dep"):
             factory._register_toolset_models("my_adapter_pkg.zendesk")
+
+
+class TestMcpAsyncEndToEnd:
+    """End-to-end: a real Python package on disk + sys.path + ``importlib``,
+    with no mocks of the import machinery. Proves the engine can load an
+    MCP_ASYNC tool from an adapter-supplied package path without any prefix
+    coupling — the contract this PR establishes, exercised against real code
+    rather than monkeypatched ``import_module``.
+    """
+
+    def test_real_package_loads_with_no_prefix(self, factory, tmp_path, monkeypatch):
+        # Build a tiny tool package on disk:
+        #   tmp/pkg_root/my_adapter_under_test/zendesk/__init__.py
+        #   tmp/pkg_root/my_adapter_under_test/zendesk/tools/__init__.py
+        #   tmp/pkg_root/my_adapter_under_test/zendesk/tools/create_item.py  (class CreateItem)
+        #   tmp/pkg_root/my_adapter_under_test/zendesk/models.py             (no model classes)
+        pkg_root = tmp_path / "pkg_root"
+        zendesk = pkg_root / "my_adapter_under_test" / "zendesk"
+        (zendesk / "tools").mkdir(parents=True)
+        (pkg_root / "my_adapter_under_test" / "__init__.py").write_text("")
+        (zendesk / "__init__.py").write_text("")
+        (zendesk / "tools" / "__init__.py").write_text("")
+        (zendesk / "tools" / "create_item.py").write_text(
+            textwrap.dedent(
+                """
+                class CreateItem:
+                    pass
+                """
+            )
+        )
+        (zendesk / "models.py").write_text("")  # empty: registration is a no-op
+
+        monkeypatch.syspath_prepend(str(pkg_root))
+
+        schema = _schema(
+            style=InvocationStyle.MCP_ASYNC,
+            toolset="my_adapter_under_test.zendesk",
+            module_path="tools.create_item",
+            class_name="CreateItem",
+        )
+        wrapper = factory._create_wrapper(schema)
+
+        # Engine loaded the adapter-supplied path verbatim (no prefix), found
+        # the class, and built a real wrapper.
+        assert isinstance(wrapper, MCPAsyncToolWrapper)
+        assert wrapper.tool_class.__name__ == "CreateItem"
+        assert wrapper.tool_class.__module__ == "my_adapter_under_test.zendesk.tools.create_item"
+
+    def test_no_engine_prefix_means_old_bare_subpackage_now_fails_loudly(
+        self, factory, tmp_path, monkeypatch
+    ):
+        """Pre-PR private adapters set toolset=\"zendesk\" relying on the
+        engine to prepend a private root. After this PR the bare name is
+        imported as-is; if it doesn't exist on sys.path the engine raises
+        ToolImportError naming the exact missing path — the clear signal for
+        adapter authors to migrate. This test pins the failure mode.
+        """
+        # Build the package only under a (real) parent; the bare name "zendesk"
+        # alone is NOT importable.
+        pkg_root = tmp_path / "pkg_root"
+        zendesk = pkg_root / "my_adapter_under_test" / "zendesk"
+        (zendesk / "tools").mkdir(parents=True)
+        (pkg_root / "my_adapter_under_test" / "__init__.py").write_text("")
+        (zendesk / "__init__.py").write_text("")
+        (zendesk / "tools" / "__init__.py").write_text("")
+        (zendesk / "tools" / "create_item.py").write_text("class CreateItem: pass\n")
+        monkeypatch.syspath_prepend(str(pkg_root))
+
+        # Sanity: the qualified name imports
+        import importlib
+
+        importlib.import_module("my_adapter_under_test.zendesk.tools.create_item")
+        # Sanity: the bare name does not
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module("zendesk.tools.create_item")
+        # Drop any stale cache entry for the bare name from prior test runs.
+        sys.modules.pop("zendesk", None)
+        sys.modules.pop("zendesk.tools", None)
+        sys.modules.pop("zendesk.tools.create_item", None)
+
+        # The engine: bare-name adapter shape now fails loudly with the exact
+        # path the adapter supplied — so the author knows what to update.
+        schema = _schema(
+            style=InvocationStyle.MCP_ASYNC,
+            toolset="zendesk",
+            module_path="tools.create_item",
+            class_name="CreateItem",
+        )
+        with pytest.raises(ToolImportError) as exc_info:
+            factory._create_wrapper(schema)
+        msg = str(exc_info.value)
+        assert "zendesk.tools.create_item" in msg
+        for forbidden in FORBIDDEN_PRIVATE_NAMES:
+            assert forbidden not in msg

--- a/tests/unit/test_tool_factory_import_paths.py
+++ b/tests/unit/test_tool_factory_import_paths.py
@@ -15,6 +15,7 @@ These tests pin both ends of that contract:
 
 from __future__ import annotations
 
+import json
 import sys
 import textwrap
 import types
@@ -214,6 +215,83 @@ class TestMcpAsyncEndToEnd:
         assert isinstance(wrapper, MCPAsyncToolWrapper)
         assert wrapper.tool_class.__name__ == "CreateItem"
         assert wrapper.tool_class.__module__ == "my_adapter_under_test.zendesk.tools.create_item"
+
+    async def test_full_pipeline_loads_and_invokes_tool_with_no_engine_prefix(
+        self, factory, tmp_path, monkeypatch
+    ):
+        """The most honest in-repo signal for this PR's change. Build a real
+        adapter-style tool package, route a serialized TaskDescription tool
+        block through ``ToolFactory.reconstruct_tools`` (the public engine
+        entry point), and then **invoke** the resulting wrapper through the
+        live ``MCPAsyncToolWrapper.execute`` path. Surfaces touched, no mocks:
+
+          * pydantic ``ToolSchema`` validation
+          * ``_create_wrapper`` dispatch
+          * ``_create_mcp_async_wrapper`` (real ``importlib.import_module``)
+          * ``_register_toolset_models`` (real importlib; hits the
+            fail-quiet ``ModuleNotFoundError`` branch tightened in this PR
+            because the test package ships no ``models.py``)
+          * ``MCPAsyncToolWrapper`` construction
+          * ``MCPAsyncToolWrapper.execute`` (live, awaited)
+          * the test tool class's real ``run_with_validation``
+
+        Only ``db_client`` is mocked, because the test tool deliberately does
+        not touch the DB. After this PR, the engine constructs the import
+        path verbatim from the adapter-supplied ``toolset`` (no prefix); if
+        the change ever regresses, this test fails at the wrapper step.
+        """
+        # Real MCP-style tool package: my_e2e_adapter_pkg/zendesk_e2e/tools/echo.py
+        pkg_root = tmp_path / "pkg"
+        zendesk = pkg_root / "my_e2e_adapter_pkg" / "zendesk_e2e"
+        (zendesk / "tools").mkdir(parents=True)
+        (pkg_root / "my_e2e_adapter_pkg" / "__init__.py").write_text("")
+        (zendesk / "__init__.py").write_text("")
+        (zendesk / "tools" / "__init__.py").write_text("")
+        (zendesk / "tools" / "echo.py").write_text(
+            textwrap.dedent(
+                """
+                class Echo:
+                    async def run_with_validation(self, db, arguments):
+                        # Mirrors the real MCP runtime contract: take a kwargs
+                        # dict, return a JSON-serializable dict. No DB use, so
+                        # the mocked db_proxy is irrelevant here.
+                        return {"echoed": arguments.get("message"), "count": len(arguments)}
+                """
+            )
+        )
+        # Deliberately NO models.py — exercises the fail-quiet
+        # ``ModuleNotFoundError`` branch that this PR narrowed (improvement #2).
+        monkeypatch.syspath_prepend(str(pkg_root))
+
+        # Serialized TaskDescription tool block, fully-qualified toolset
+        # per the post-PR engine contract.
+        tool_dict = {
+            "name": "echo",
+            "description": "Echo arguments back",
+            "parameters": {
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+            },
+            "source": {
+                "toolset": "my_e2e_adapter_pkg.zendesk_e2e",
+                "module_path": "tools.echo",
+                "class_name": "Echo",
+                "invocation_style": "mcp_async",
+            },
+        }
+
+        # The actual engine pipeline — no mocks of dispatch, import, or
+        # wrapper construction.
+        reconstructed = factory.reconstruct_tools(agent_tools=[tool_dict])
+
+        assert "echo" in reconstructed.agent_tools
+        wrapper = reconstructed.agent_tools["echo"]
+        assert isinstance(wrapper, MCPAsyncToolWrapper)
+        assert wrapper.tool_class.__module__ == ("my_e2e_adapter_pkg.zendesk_e2e.tools.echo")
+
+        # Live invocation — exercises MCPAsyncToolWrapper.execute end-to-end.
+        output = await wrapper.execute({"message": "hello", "extra": 42})
+        assert json.loads(output) == {"echoed": "hello", "count": 2}
 
     def test_no_engine_prefix_means_old_bare_subpackage_now_fails_loudly(
         self, factory, tmp_path, monkeypatch

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -63,7 +63,10 @@ class ToolSource(BaseModel):
     or mounted in the container.
     """
 
-    toolset: str  # Package/directory: "zendesk", "airline", "retail"
+    # Import-rooted Python package name. The runner imports
+    # ``{toolset}.{module_path}`` as-is — the adapter must supply the full
+    # package path (e.g. "my_adapter_pkg.zendesk"); the runner adds no prefix.
+    toolset: str
     module_path: str  # Module within toolset: "tools.create_item"
     class_name: str  # Class/function: "CreateItem", "BookReservation"
     invocation_style: InvocationStyle = InvocationStyle.TAU_SYNC

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -317,7 +317,8 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         if extract_str not in sys.path:
             sys.path.insert(0, extract_str)
 
-        # Also add tools/ subdirectory if it exists (for mcp_tools_library)
+        # Also add tools/ subdirectory if it exists (some adapter layouts place
+        # their tool packages under a 'tools/' folder rather than the artifact root)
         tools_dir = extract_dir / "tools"
         if tools_dir.exists():
             tools_str = str(tools_dir)

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1296,10 +1296,11 @@ class ToolFactory:
 
         FAIL FAST: Raises ToolImportError if module/class cannot be imported.
 
-        Import path: {source.toolset}.{source.module_path}
+        Import path: ``{source.toolset}.{source.module_path}`` — the adapter
+        supplies the fully-qualified package; the runner does no prefixing.
         """
+        module_path = f"{source.toolset}.{source.module_path}"
         try:
-            module_path = f"{source.toolset}.{source.module_path}"
             module = importlib.import_module(module_path)
             tool_class = getattr(module, source.class_name)
 
@@ -1309,14 +1310,11 @@ class ToolFactory:
                 db_proxy=self._sync_proxy,
             )
         except ImportError as e:
-            raise ToolImportError(
-                schema.name, f"Cannot import module '{source.toolset}.{source.module_path}': {e}"
-            )
+            raise ToolImportError(schema.name, f"Cannot import module '{module_path}': {e}")
         except AttributeError as e:
             raise ToolImportError(
                 schema.name,
-                f"Class '{source.class_name}' not found in module "
-                f"'{source.toolset}.{source.module_path}': {e}",
+                f"Class '{source.class_name}' not found in module '{module_path}': {e}",
             )
 
     def _create_mcp_async_wrapper(
@@ -1543,8 +1541,13 @@ class ToolFactory:
             self._registered_toolsets.add(toolset)
             logger.info(f"Registered models for toolset '{toolset}'")
 
-        except ImportError:
-            # No models module - that's OK, some toolsets may not have models
+        except ModuleNotFoundError:
+            # No models module — that's OK, some toolsets may not have one.
+            # Note: ``ModuleNotFoundError`` is a subclass of ``ImportError`` raised
+            # only when the module itself cannot be located. A genuine import error
+            # *inside* an existing models module (e.g. a missing transitive dep)
+            # raises plain ``ImportError`` and will propagate — surfacing the bug
+            # instead of being silently logged at debug level.
             logger.debug(f"No models module found for toolset '{toolset}'")
             self._registered_toolsets.add(toolset)
 

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1327,7 +1327,8 @@ class ToolFactory:
 
         FAIL FAST: Raises ToolImportError if module/class cannot be imported.
 
-        Import path: mcp_tools_library.{source.toolset}.{source.module_path}
+        Import path: ``{source.toolset}.{source.module_path}`` — the adapter
+        supplies the fully-qualified package; the runner does no prefixing.
 
         Note: MCP tools call db methods synchronously inside their async run()
         method, so we pass SyncDBServiceProxy instead of DBServiceProxy.
@@ -1335,8 +1336,8 @@ class ToolFactory:
         Also registers model classes from the toolset with namespaced table names
         so that db.create(Ticket(...)) maps to 'zendesk_tickets' table.
         """
+        module_path = f"{source.toolset}.{source.module_path}"
         try:
-            module_path = f"mcp_tools_library.{source.toolset}.{source.module_path}"
             module = importlib.import_module(module_path)
             tool_class = getattr(module, source.class_name)
 
@@ -1350,15 +1351,11 @@ class ToolFactory:
                 db_proxy=self._sync_proxy,  # MCP tools need sync proxy!
             )
         except ImportError as e:
-            raise ToolImportError(
-                schema.name,
-                f"Cannot import module 'mcp_tools_library.{source.toolset}.{source.module_path}': {e}",
-            )
+            raise ToolImportError(schema.name, f"Cannot import module '{module_path}': {e}")
         except AttributeError as e:
             raise ToolImportError(
                 schema.name,
-                f"Class '{source.class_name}' not found in module "
-                f"'mcp_tools_library.{source.toolset}.{source.module_path}': {e}",
+                f"Class '{source.class_name}' not found in module '{module_path}': {e}",
             )
 
     def _get_id_field_name(self, model_cls: type) -> str | None:
@@ -1430,7 +1427,7 @@ class ToolFactory:
 
         try:
             # Try to import the models module from the toolset
-            models_module_path = f"mcp_tools_library.{toolset}.models"
+            models_module_path = f"{toolset}.models"
             models_module = importlib.import_module(models_module_path)
 
             # Collect all model classes from the module


### PR DESCRIPTION
## Summary

- `_create_mcp_async_wrapper` and `_register_toolset_models` no longer prepend a non-public package name to the import path. The runner now imports `{toolset}.{module_path}` and `{toolset}.models` verbatim — the adapter supplies the fully-qualified Python package, the runner does no prefixing.
- Same convention `_create_tau_sync_wrapper` has always used (`tool_factory.py:1302`); MCP_ASYNC simply adopts it. `_create_tau_sync_wrapper` is refactored in lockstep to the same error-message shape — pure cleanup, no behaviour change.
- `_register_toolset_models` now catches `ModuleNotFoundError` instead of plain `ImportError`. The fail-quiet branch was meant for "this toolset has no models module" only; a real `ImportError` inside an existing models module (missing dep, syntax bug) now propagates instead of being silently logged at debug level. Fail-fast per `AGENTS.md`.
- One stray comment in `runner/service.py` that named the same private package was generalised; behaviour unchanged.
- `ToolSource.toolset` doc comment in `runner/models.py` updated to reflect the import-rooted contract.
- New test module `tests/unit/test_tool_factory_import_paths.py` pins the contract on multiple levels: (a) the import calls use the adapter-supplied path verbatim, (b) the `ToolImportError` text on an unimportable module reports only the configured path (regression guard against any private name sneaking back), (c) a full end-to-end pipeline test that builds a real Python package on disk and invokes the resulting `MCPAsyncToolWrapper` through the live `execute()` path — no mocks of the engine surface.

## Why

The public engine cannot hardcode a non-public package name into the import path it uses for adapter-supplied tools. The prior shape forced every MCP_ASYNC-using adapter to live under one specific subtree; a second adapter with a different package layout could not be loaded without forking the engine. This closes the last private-layout coupling in `runner/tool_factory.py`.

Same plugin-first thread as #61 (runner adapter-agnostic) and #71 (open `AdapterType`).

## Breaking change (private adapter authors only)

Any external adapter that today sets a bare subpackage name in `ToolSource.toolset` for MCP_ASYNC tools — relying on the runner to prepend the old root — must now supply the full Python package path. For example, `toolset="zendesk"` becomes `toolset="my_adapter_pkg.zendesk"` (or whatever the real importable package is).

**Public adapters in this repo are unaffected**: `native` uses `MCP_SERVER`, `terminal-bench` uses `DOCKER_COMPOSE_EXEC`; neither touches the changed code path.

Per the project's fail-fast rule (`AGENTS.md`), there is no deprecation period — the `ImportError` on the old shape is the clear signal. The error message now contains exactly the configured path so private adapter authors see precisely what to update.

Closes #21.

## Test plan

- [x] `uv run pytest tests/unit/test_tool_factory_import_paths.py -v` — `8 passed in 0.10s` (new test module; includes a full-pipeline e2e test that imports + invokes a real Python tool through the live `MCPAsyncToolWrapper.execute` path)
- [x] `uv run pytest tests/ -m unit` — `1763 passed, 1 skipped, 835 deselected` (full unit suite)
- [x] `uv run pytest tests/ -m canonical` — `148 passed, 2451 deselected` (golden-trajectory grading canon + terminal-bench adapter canon still green; DOCKER_COMPOSE_EXEC path untouched)
- [x] `uv run ruff check tolokaforge tests scripts tools` — `All checks passed!`
- [x] `uv run tolokaforge --help` — CLI imports cleanly
- [x] `grep -RIn 'mcp_tools_library' tolokaforge/` — **zero matches** (strongest acceptance signal: the private package name is no longer in the public engine)