### PR TITLE
docs(agents): document the implicit type-system choices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,26 @@ Recommended MCP servers for AI agents working on this project:
 | CLI argument parsing | `typer` |
 | Retry logic | `tenacity` |
 
+### Type system choices
+
+Pick by what the type is *for*, not by habit. Pydantic is for cross-boundary data — using it for in-process values or behavioural contracts adds validation overhead with no payoff.
+
+| Use case | Choice |
+|---|---|
+| Polymorphism / behaviour contract (anything that "implements this can plug in") | `typing.Protocol` (preferred — duck-typed) or `abc.ABC` |
+| Internal value object passed between methods in one process | `@dataclasses.dataclass(frozen=True)` |
+| Enumeration of named values | `class Foo(str, Enum)` |
+| Data that crosses a serialisation boundary (gRPC, JSON file, YAML config, output bundle, snapshot) | Pydantic v2 `BaseModel` with `model_config = {"extra": "forbid"}` |
+
+How this looks in the engine today:
+
+- `BaseAdapter`, `ToolWrapper`, the LLM policy interfaces (`SystemPromptPolicy`, `ToolSchemaSanitizer`, `ResponsePolicy`, `ReasoningCodec`, …), `RunQueue` — `Protocol` or `ABC`.
+- `ToolLifecycleContext`, `AttemptLease` — `@dataclass(frozen=True)`.
+- `AdapterType`, `InvocationStyle`, `TrialStatus`, `ExecutionStatus` — `str, Enum`.
+- `TaskDescription`, `ToolSchema`, `ToolSource`, `ModelConfig`, `Trajectory`, `Grade`, `Metrics`, `GradingConfig`, `TrialSpec`, `TrialResult` — Pydantic `BaseModel` (`extra="forbid"`).
+
+When extending an existing contract, follow the existing choice unless you have an explicit reason to change it (e.g. a previously in-process value object now needs to serialise — promote it to Pydantic in a dedicated PR with the rationale).
+
 ### uv Workspace Rules
 
 - **DO NOT** use `[project.optional-dependencies]` in workspace member packages


### PR DESCRIPTION
## Why

The engine has a consistent four-way pick for new types — `Protocol`/`ABC` for behaviour contracts, `@dataclass(frozen=True)` for internal value objects, `str, Enum` for named-value sets, Pydantic `BaseModel` for cross-boundary data — but the convention was never written down. Every new contract has been triggering the same *"should this be Pydantic or a dataclass?"* conversation from scratch, and reviewers have been answering it case-by-case rather than pointing at a rule.

## What this PR adds

A short \"Type system choices\" subsection under \`AGENTS.md\` § Preferred Libraries that:

1. States the rule (Pydantic is for cross-boundary data; in-process values use `dataclass`; behaviour contracts use `Protocol`).
2. Tables each use case → choice.
3. Lists the engine's existing types in each bucket so a contributor can see the rule in action without grep:
   - `Protocol` / `ABC` — `BaseAdapter`, `ToolWrapper`, LLM policy interfaces, `RunQueue`.
   - `@dataclass(frozen=True)` — `ToolLifecycleContext`, `AttemptLease`.
   - `str, Enum` — `AdapterType`, `InvocationStyle`, `TrialStatus`, `ExecutionStatus`.
   - Pydantic — `TaskDescription`, `ToolSchema`, `ModelConfig`, `Trajectory`, `Grade`, `Metrics`, `TrialSpec`, `TrialResult`, …
4. One guidance line on extending existing contracts: follow the existing choice unless there's an explicit reason to change it; a promotion (e.g. dataclass → Pydantic) gets its own dedicated PR with rationale.

## Why now

The conversation that prompted this came up while reviewing #74: that PR introduces `TrialSpec` / `TrialResult` as Pydantic models, which looked inconsistent with #61 / #71 / #73 (where new contracts used `ABC`, `dataclass`, or an `Enum` member). On inspection it's not inconsistent — those earlier PRs introduced behaviour contracts and value objects, not cross-boundary data. But the rule wasn't documented anywhere, so the question recurs. This PR ends that.

## Out of scope

- No code changes. All types in the codebase already follow the rule.
- No ADR — the rule is small and concrete enough to live in `AGENTS.md` next to the existing `typer` / `tenacity` guidance. Promoting it to an ADR is overkill.
- Orthogonal to #74; can land independently.

## Files

`AGENTS.md` — single subsection added, +20 lines, no changes to other sections.