### PR TITLE
fix(ci): pin Claude review action to claude-opus-4-8

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--model claude-opus-4-8'
           direct_prompt: |
             Review this PR against the project's AGENTS.md rules. Flag any
             violation with file path, line number, and a concrete suggested

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-opus-4-8'
+          model: claude-opus-4-8
           direct_prompt: |
             Review this PR against the project's AGENTS.md rules. Flag any
             violation with file path, line number, and a concrete suggested


### PR DESCRIPTION
## Summary

The `claude-code-action@beta` step in `claude-review.yml` did not pin a model, so it relied on the action's internal default. That default model has been retired, causing the workflow to fail with:

```
API Error: 404 not_found_error - model: claude-sonnet-4-20250514
```

This PR pins `model: claude-opus-4-8` on the action so the review workflow uses the current Opus model and isn't subject to the action's default shifting again.

## Why the top-level `model:` input

The first commit on this branch used `claude_args: '--model claude-opus-4-8'`, which is the v1.0 input syntax. This workflow pins `anthropics/claude-code-action@beta`, which is v0.x — that version silently ignored `claude_args` (warning visible in the run log) and the 404 persisted. v0.x exposes `model:` as a direct top-level input (`model`, `anthropic_model`, etc. — confirmed in the run-log warning listing valid inputs).

Second commit on this branch switches to that v0.x input. The latest workflow run on this PR is green, confirming the fix.

## Test plan

- [x] Workflow runs without the 404
- [x] Claude posts a hygiene review comment on this PR