### PR TITLE
feat(output): formalize TrialArtifactWriter as the typed data-plane seam

### DIFF
--- a/docs/architecture/adr/0004-trial-artifact-writer-seam.md
+++ b/docs/architecture/adr/0004-trial-artifact-writer-seam.md
@@ -16,6 +16,8 @@ The engine's architecture has three planes:
 
 Each plane should sit behind a named, typed seam so implementations can swap without engine edits. The control↔trial seam is being typed by `TrialSpec` / `TrialResult` (ADR-0003 lineage); a remote conductor in a different process will read the same payload the in-process one reads today.
 
+> **Numbering note.** ADR-0003 is reserved for the in-review `TrialSpec` / `TrialResult` decision. If that ADR lands under a different number, this file must be renumbered and the index in `README.md` updated.
+
 The data-plane seam is partially built. `tolokaforge/core/output/artifacts.py` already declares `TrialArtifactWriter` as a `typing.Protocol`, and `FileArtifactWriter` is its disk-backed implementation. Several gaps prevent the seam from playing the architectural role the other two planes' contracts do:
 
 1. The Protocol is **not `@runtime_checkable`** — `isinstance(writer, TrialArtifactWriter)` raises `TypeError` even when the writer satisfies every method signature. Other Protocols in the engine (the LLM policy chain — `SystemPromptPolicy`, `ResponsePolicy`, `ReasoningCodec`, …) are runtime-checkable; this one is the outlier.

--- a/docs/architecture/adr/0004-trial-artifact-writer-seam.md
+++ b/docs/architecture/adr/0004-trial-artifact-writer-seam.md
@@ -1,0 +1,82 @@
+# 0004. `TrialArtifactWriter` as the typed data-plane seam
+
+- **Status:** Proposed
+- **Date:** 2026-06-21
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+The engine's architecture has three planes:
+
+- **Control plane** — schedules trials, tracks state.
+- **Trial plane** — runs one trial end-to-end (agent loop, tool calls, grading).
+- **Data plane** — persists per-trial outputs (trajectory, grade, metrics, prompts, tool schemas, logs, environment state) for downstream readers (analytics, dashboards, audit).
+
+Each plane should sit behind a named, typed seam so implementations can swap without engine edits. The control↔trial seam is being typed by `TrialSpec` / `TrialResult` (ADR-0003 lineage); a remote conductor in a different process will read the same payload the in-process one reads today.
+
+The data-plane seam is partially built. `tolokaforge/core/output/artifacts.py` already declares `TrialArtifactWriter` as a `typing.Protocol`, and `FileArtifactWriter` is its disk-backed implementation. Several gaps prevent the seam from playing the architectural role the other two planes' contracts do:
+
+1. The Protocol is **not `@runtime_checkable`** — `isinstance(writer, TrialArtifactWriter)` raises `TypeError` even when the writer satisfies every method signature. Other Protocols in the engine (the LLM policy chain — `SystemPromptPolicy`, `ResponsePolicy`, `ReasoningCodec`, …) are runtime-checkable; this one is the outlier.
+2. The orchestrator's main entry point — `writer.write_trial_bundle(...)` — is on `FileArtifactWriter` but **not declared on the Protocol**. Alternate implementations would have to add it as an undeclared "extra" method or rebuild bundle semantics from the eight per-piece writers.
+3. **Only one implementation exists.** Without a second concrete writer, there's no evidence the Protocol's surface is enough to swap in alternate backends (an in-memory test fixture, an S3 bucket, a remote object store) without engine changes.
+4. **No ADR documents the seam.** A reviewer looking for "where the data-plane contract is decided" finds the Protocol declaration but no statement of intent or alternatives considered.
+
+## Decision Drivers
+
+- **Symmetry across the three planes.** Control↔trial and trial↔runner are typed, runtime-checkable contracts with multiple implementations; the data plane should match.
+- **The Protocol must mirror real callers.** `write_trial_bundle` is the orchestrator's main call site (`orchestrator.py`). A Protocol that omits it lies about the contract.
+- **Plug-in discovery later.** Entry-point-discovered writers (`tolokaforge.artifact_writers`-style) need `isinstance` to work for safe injection.
+- **Fail-fast.** No silent fallbacks if an injected writer is malformed; runtime check is the cleanest line of defence.
+- **Lean code.** Documentation belongs in commits / ADRs, not in source files; the implementation stays small.
+
+## Considered Options
+
+1. **Add `@runtime_checkable`, declare `write_trial_bundle` on the Protocol, ship an `InMemoryArtifactWriter` second implementation, write this ADR.** Closes all four gaps with one focused change.
+2. **Only add `@runtime_checkable`.** Cheapest. Leaves the Protocol↔callers mismatch and the no-second-implementation gap.
+3. **Build an alternate concrete backend now (S3 / GCS) instead of `InMemoryArtifactWriter`.** Proves the seam more thoroughly but requires picking a backend, writing real auth code, and shipping a feature no one has asked for.
+4. **Defer everything until a remote conductor exists and forces the issue.** Deferral has zero cost today but means each follow-on (entry-point discovery, remote object store, async writers) re-litigates the contract simultaneously with whatever else it's doing.
+
+## Decision
+
+We will adopt **Option 1**.
+
+- Add `@runtime_checkable` to the `TrialArtifactWriter` Protocol declaration.
+- Promote `write_trial_bundle(trial_dir, trajectory, task_snapshot, env_state, logger) -> None` from `FileArtifactWriter`-only to a Protocol-declared method. `FileArtifactWriter`'s implementation is unchanged; only the Protocol declaration grows by one method.
+- Add `InMemoryArtifactWriter` — a non-disk implementation that stores each trial's artifacts in `self.trials: dict[Path, TrialArtifactBundle]`. The dataclass holds slots for `trajectory`, `task`, `env`, `metrics`, `grade`, `logs`, `tools_schemas`, `prompts`. Two purposes: (a) prove the Protocol is swappable; (b) serve as a test fixture for code that needs a writer but should not touch the filesystem.
+- Add a canonical contract test (`tests/canonical/test_artifact_writer_contract.py`) that asserts `isinstance(writer, TrialArtifactWriter)` for both implementations and that every Protocol method accepts the same arguments on each.
+
+## Consequences
+
+### Positive
+
+- The data plane has a typed, runtime-checkable seam that matches the orchestrator's actual usage.
+- The three-plane architecture (control / trial / data) now has at least one named, swappable contract per plane.
+- `InMemoryArtifactWriter` is reusable by any test that needs to assert on what was written without YAML round-trips through `tmp_path`.
+- Future plug-in discovery (entry-point-registered writers) can rely on `isinstance` instead of structural-only type checks.
+- An external backend (S3, GCS) can be built against the Protocol with no engine changes — the `InMemoryArtifactWriter` serves as a structural template.
+
+### Negative / Trade-offs
+
+- Adding `write_trial_bundle` to the Protocol is a **breaking change** for any downstream implementer that had already provided a `TrialArtifactWriter` without that method. No known external implementers today; the change is breaking-by-shape only.
+- The `write_trial_bundle` method is partly redundant with the six per-piece writers (it bundles them). Keeping it on the Protocol forces alternate implementations to implement it, but the win — Protocol matches caller usage — outweighs the cost.
+- `InMemoryArtifactWriter` adds a maintenance surface that has to stay in sync with `FileArtifactWriter`'s method signatures. The canonical contract test catches drift.
+
+### Follow-ups
+
+- **Entry-point discovery for writers.** Mirror the `tolokaforge.adapters` pattern with a `tolokaforge.artifact_writers` entry-point group so operators can inject a writer via config.
+- **`RunAggregateWriter` seam (separate from this).** The orchestrator writes post-run aggregates (`per_task_metrics.json`, `aggregate.json`, …) at the run-output root, outside any trial directory. Those are run-level concerns, not per-trial; they belong behind their own seam if/when a non-filesystem run-level destination is needed.
+- **Async variants.** Today's writers are sync; if a remote backend's per-trial write latency starts to matter, an `AsyncTrialArtifactWriter` Protocol can be added without touching the sync one.
+- **Concrete remote backend (S3 / GCS).** User-driven; the seam is now ready for one without engine edits.
+
+## Rejected alternatives
+
+- **Option 2 — only add `@runtime_checkable`.** Leaves `write_trial_bundle` off the Protocol, so the contract still lies about its main caller. Half-measure.
+- **Option 3 — build S3 / GCS now.** Picks a backend before there's a consumer requirement, adds auth + retry concerns this PR shouldn't own. Better as a follow-on once a real need lands.
+- **Option 4 — defer everything.** Each later contract change (remote conductor, plug-in discovery, async writers) ends up co-litigating the data-plane shape simultaneously with whatever else it's doing. Cheaper to settle the seam now while there's only one implementation to migrate.
+
+## Scope notes
+
+- **Per-trial artifacts only.** The orchestrator also writes post-run aggregate JSON files at the run-output root (`per_task_metrics.json`, `aggregate.json`, `metadata_slices.json`, `failure_attribution.json`). Those are out of scope for this seam — they're run-level concerns with different lifecycle and would warrant a separate `RunAggregateWriter` contract.
+- **`FileArtifactWriter` internals are unchanged.** Two methods (`write_tools_schemas`, `write_prompts`) bypass the cached `OutputWriter` and write YAML directly. That asymmetry is pre-existing; cleaning it up is a separate refactor, not a precondition for formalising the Protocol.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -34,3 +34,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions in ADRs | Accepted |
 | [0002](0002-external-model-registry.md) | External model registry — operator-overridable preset data | Proposed |
 | [0003](0003-trial-spec-and-trial-result.md) | TrialSpec and TrialResult as the typed control↔trial seam | Proposed |
+| [0004](0004-trial-artifact-writer-seam.md) | `TrialArtifactWriter` as the typed data-plane seam | Proposed |

--- a/tests/canonical/test_artifact_writer_contract.py
+++ b/tests/canonical/test_artifact_writer_contract.py
@@ -178,7 +178,8 @@ class TestInMemoryWriterBundleSemantics:
         assert bundle.task is snapshot
         assert bundle.trajectory is trajectory
         assert bundle.env is env
-        assert bundle.metrics is trajectory
+        assert bundle.metrics is trajectory.metrics
+        assert isinstance(bundle.metrics, Metrics)
         assert bundle.grade is trajectory.grade
         assert bundle.logs is logger
 
@@ -198,3 +199,26 @@ class TestInMemoryWriterBundleSemantics:
         writer.write_task(Path("x:0"), snapshot)
         snapshot["task_id"] = "y"
         assert writer.trials[Path("x:0")].task["task_id"] == "y"
+
+    def test_write_metrics_stores_metrics_extract_not_whole_trajectory(self) -> None:
+        """``write_metrics`` mirrors the disk-backed writer's behaviour:
+        ``metrics.yaml`` is serialised from ``trajectory.metrics``, so the
+        in-memory bundle stores that same :class:`Metrics` extract, not the
+        whole :class:`Trajectory`."""
+        writer = InMemoryArtifactWriter()
+        trajectory = _make_trajectory()
+        writer.write_metrics(Path("x:0"), trajectory)
+        stored = writer.trials[Path("x:0")].metrics
+        assert isinstance(stored, Metrics)
+        assert stored is trajectory.metrics
+
+    def test_surface_path_forms_bucket_separately(self) -> None:
+        """The in-memory writer keys on ``Path(trial_dir)`` as supplied — it
+        does not ``.resolve()`` (it does not touch the filesystem). Two
+        surface forms of the same logical path bucket into separate trials.
+        Pinned so a future "normalise the key" change has to update this
+        test deliberately."""
+        writer = InMemoryArtifactWriter()
+        writer.write_trajectory(Path("a/b"), _make_trajectory())
+        writer.write_trajectory(Path("./a/b"), _make_trajectory())
+        assert set(writer.trials.keys()) == {Path("a/b"), Path("./a/b")}

--- a/tests/canonical/test_artifact_writer_contract.py
+++ b/tests/canonical/test_artifact_writer_contract.py
@@ -212,6 +212,23 @@ class TestInMemoryWriterBundleSemantics:
         assert isinstance(stored, Metrics)
         assert stored is trajectory.metrics
 
+    def test_write_trial_bundle_skips_grade_when_trajectory_has_none(self) -> None:
+        """Mirrors the disk-backed writer (``OutputWriter.write_all``), which
+        only emits ``grade.yaml`` when ``trajectory.grade`` is non-``None``.
+        The in-memory bundle must leave its ``grade`` slot untouched in the
+        same case so the two writers agree on observable behaviour."""
+        writer = InMemoryArtifactWriter()
+        trajectory = _make_trajectory()
+        trajectory.grade = None
+        writer.write_trial_bundle(
+            Path("x:0"),
+            trajectory,
+            _make_task_snapshot(),
+            _make_env_state(),
+            _FakeStructuredLogger(),  # type: ignore[arg-type]
+        )
+        assert writer.trials[Path("x:0")].grade is None
+
     def test_surface_path_forms_bucket_separately(self) -> None:
         """The in-memory writer keys on ``Path(trial_dir)`` as supplied — it
         does not ``.resolve()`` (it does not touch the filesystem). Two

--- a/tests/canonical/test_artifact_writer_contract.py
+++ b/tests/canonical/test_artifact_writer_contract.py
@@ -161,7 +161,7 @@ class TestInMemoryWriterBundleSemantics:
         assert set(writer.trials.keys()) == {Path("a:0"), Path("b:0")}
         assert isinstance(writer.trials[Path("a:0")], TrialArtifactBundle)
 
-    def test_write_trial_bundle_populates_six_artifacts(self) -> None:
+    def test_write_trial_bundle_populates_bundle_artifacts(self) -> None:
         writer = InMemoryArtifactWriter()
         trajectory = _make_trajectory()
         snapshot = _make_task_snapshot()

--- a/tests/canonical/test_artifact_writer_contract.py
+++ b/tests/canonical/test_artifact_writer_contract.py
@@ -1,0 +1,200 @@
+"""Pin the ``TrialArtifactWriter`` Protocol contract — runtime check + parity."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    Message,
+    Metrics,
+    Trajectory,
+    TrialStatus,
+)
+from tolokaforge.core.output.artifacts import (
+    FileArtifactWriter,
+    InMemoryArtifactWriter,
+    TrialArtifactBundle,
+    TrialArtifactWriter,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _make_trajectory() -> Trajectory:
+    now = datetime.now(UTC)
+    return Trajectory(
+        task_id="airline_001",
+        trial_index=0,
+        start_ts=now,
+        end_ts=now,
+        status=TrialStatus.COMPLETED,
+        messages=[Message(role="assistant", content="done")],
+        metrics=Metrics(),
+        grade=Grade(
+            binary_pass=True,
+            score=1.0,
+            components=GradeComponents(),
+            reasons="ok",
+        ),
+    )
+
+
+def _make_task_snapshot() -> dict[str, Any]:
+    return {"task_id": "airline_001", "category": "airline", "description": "book"}
+
+
+def _make_env_state() -> dict[str, Any]:
+    return {"users": [{"id": "u1", "name": "Alice"}]}
+
+
+class _FakeStructuredLogger:
+    """Minimal stand-in for ``StructuredLogger`` for tests that need to invoke
+    the writers without pulling in the real logging stack. The disk-backed
+    ``OutputWriter.write_logs`` calls ``logger.save_to_file(path)``; the
+    fake honours that contract by emitting a tiny YAML."""
+
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def save_to_file(self, path: Path) -> None:
+        path.write_text("records: []\n", encoding="utf-8")
+
+
+@pytest.fixture
+def writers(tmp_path: Path) -> list[TrialArtifactWriter]:
+    """Both production-shaped writers, ready to receive calls."""
+    return [FileArtifactWriter(), InMemoryArtifactWriter()]
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; both implementations satisfy it
+    via ``isinstance`` (not just by structural type-hint compatibility).
+    """
+
+    def test_file_artifact_writer_passes_isinstance(self) -> None:
+        assert isinstance(FileArtifactWriter(), TrialArtifactWriter)
+
+    def test_in_memory_artifact_writer_passes_isinstance(self) -> None:
+        assert isinstance(InMemoryArtifactWriter(), TrialArtifactWriter)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotAWriter:
+            pass
+
+        assert not isinstance(_NotAWriter(), TrialArtifactWriter)
+
+
+class TestPerTrialMethodParity:
+    """Every Protocol method accepts the same arguments on every implementation."""
+
+    def test_write_trajectory(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        trajectory = _make_trajectory()
+        for i, writer in enumerate(writers):
+            writer.write_trajectory(tmp_path / f"trial_{i}", trajectory)
+
+    def test_write_task(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        snapshot = _make_task_snapshot()
+        for i, writer in enumerate(writers):
+            writer.write_task(tmp_path / f"trial_{i}", snapshot)
+
+    def test_write_env(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        env = _make_env_state()
+        for i, writer in enumerate(writers):
+            writer.write_env(tmp_path / f"trial_{i}", env)
+
+    def test_write_metrics(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        trajectory = _make_trajectory()
+        for i, writer in enumerate(writers):
+            writer.write_metrics(tmp_path / f"trial_{i}", trajectory)
+
+    def test_write_grade(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        grade = _make_trajectory().grade
+        assert grade is not None
+        for i, writer in enumerate(writers):
+            writer.write_grade(tmp_path / f"trial_{i}", grade)
+
+    def test_write_logs(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        logger = _FakeStructuredLogger()
+        for i, writer in enumerate(writers):
+            writer.write_logs(tmp_path / f"trial_{i}", logger)  # type: ignore[arg-type]
+
+    def test_write_tools_schemas(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        schemas = [{"type": "function", "function": {"name": "echo"}}]
+        for i, writer in enumerate(writers):
+            writer.write_tools_schemas(tmp_path / f"trial_{i}", schemas)
+
+    def test_write_prompts(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        for i, writer in enumerate(writers):
+            writer.write_prompts(tmp_path / f"trial_{i}", "sys", "user-sys")
+
+    def test_write_trial_bundle(self, writers: list[TrialArtifactWriter], tmp_path: Path) -> None:
+        trajectory = _make_trajectory()
+        snapshot = _make_task_snapshot()
+        env = _make_env_state()
+        logger = _FakeStructuredLogger()
+        for i, writer in enumerate(writers):
+            writer.write_trial_bundle(
+                tmp_path / f"trial_{i}",
+                trajectory,
+                snapshot,
+                env,
+                logger,  # type: ignore[arg-type]
+            )
+
+
+class TestInMemoryWriterBundleSemantics:
+    """The in-memory writer stores artifacts under ``self.trials[trial_dir]``
+    as a :class:`TrialArtifactBundle`. Tests assert through that surface
+    instead of YAML-parsing files.
+    """
+
+    def test_per_trial_isolation(self) -> None:
+        writer = InMemoryArtifactWriter()
+        writer.write_trajectory(Path("a:0"), _make_trajectory())
+        writer.write_trajectory(Path("b:0"), _make_trajectory())
+        assert set(writer.trials.keys()) == {Path("a:0"), Path("b:0")}
+        assert isinstance(writer.trials[Path("a:0")], TrialArtifactBundle)
+
+    def test_write_trial_bundle_populates_six_artifacts(self) -> None:
+        writer = InMemoryArtifactWriter()
+        trajectory = _make_trajectory()
+        snapshot = _make_task_snapshot()
+        env = _make_env_state()
+        logger = _FakeStructuredLogger()
+        writer.write_trial_bundle(
+            Path("x:0"),
+            trajectory,
+            snapshot,
+            env,
+            logger,  # type: ignore[arg-type]
+        )
+        bundle = writer.trials[Path("x:0")]
+        assert bundle.task is snapshot
+        assert bundle.trajectory is trajectory
+        assert bundle.env is env
+        assert bundle.metrics is trajectory
+        assert bundle.grade is trajectory.grade
+        assert bundle.logs is logger
+
+    def test_overwrites_on_repeat_write(self) -> None:
+        writer = InMemoryArtifactWriter()
+        first = _make_trajectory()
+        second = _make_trajectory()
+        writer.write_trajectory(Path("x:0"), first)
+        writer.write_trajectory(Path("x:0"), second)
+        assert writer.trials[Path("x:0")].trajectory is second
+
+    def test_stores_by_reference_not_by_copy(self) -> None:
+        """Mutating the source after the call surfaces through ``trials`` —
+        matching the disk-backed writer's serialise-at-write-time semantics."""
+        writer = InMemoryArtifactWriter()
+        snapshot: dict[str, Any] = {"task_id": "x"}
+        writer.write_task(Path("x:0"), snapshot)
+        snapshot["task_id"] = "y"
+        assert writer.trials[Path("x:0")].task["task_id"] == "y"

--- a/tolokaforge/core/output/artifacts.py
+++ b/tolokaforge/core/output/artifacts.py
@@ -447,6 +447,9 @@ class InMemoryArtifactWriter:
         bundle.trajectory = trajectory
         bundle.env = env_state
         bundle.metrics = trajectory.metrics
-        if trajectory.grade is not None:
+        # Mirror the disk path's guard exactly (``OutputWriter.write_all``,
+        # output_writer.py) — truthiness, not ``is not None`` — so a future
+        # falsy-but-non-``None`` Grade can't make the two writers diverge.
+        if trajectory.grade:
             bundle.grade = trajectory.grade
         bundle.logs = logger

--- a/tolokaforge/core/output/artifacts.py
+++ b/tolokaforge/core/output/artifacts.py
@@ -39,7 +39,7 @@ from tolokaforge.core.output_writer import OutputWriter
 
 if TYPE_CHECKING:  # pragma: no cover — type-only imports
     from tolokaforge.core.logging import StructuredLogger
-    from tolokaforge.core.models import Grade, Trajectory
+    from tolokaforge.core.models import Grade, Metrics, Trajectory
 
 __all__ = [
     "FileArtifactWriter",
@@ -342,12 +342,16 @@ class TrialArtifactBundle:
     Each attribute holds the most recent value written for that artifact
     name, or ``None`` if the corresponding ``write_*`` method has not been
     called for this trial.
+
+    ``write_trial_bundle`` populates ``task``, ``trajectory``, ``env``,
+    ``metrics``, ``grade``, and ``logs``. ``tools_schemas`` and ``prompts``
+    are only populated by their own per-piece write methods.
     """
 
     trajectory: Trajectory | None = None
     task: dict[str, Any] | None = None
     env: dict[str, Any] | None = None
-    metrics: Trajectory | None = None
+    metrics: Metrics | None = None
     grade: Grade | None = None
     logs: StructuredLogger | None = None
     tools_schemas: list[dict[str, Any]] | None = None
@@ -365,6 +369,14 @@ class InMemoryArtifactWriter:
     copied. Mutating them after the write call is observable through
     :attr:`trials` (matching how :class:`FileArtifactWriter` would serialise
     whatever state existed at write time).
+
+    The bundle key is ``Path(trial_dir)`` as supplied — *not* ``.resolve()``-d.
+    The disk-backed writer resolves trial paths against the filesystem;
+    this writer doesn't touch the filesystem, so two surface forms of the
+    same logical path (``Path("a/b")`` vs ``Path("./a/b")``) bucket into
+    separate trials here even though they'd share an :class:`OutputWriter`
+    cache slot on disk. Tests should pass canonical paths (typically
+    ``tmp_path / ...``) so the divergence doesn't surface.
     """
 
     def __init__(self) -> None:
@@ -390,7 +402,7 @@ class InMemoryArtifactWriter:
         self._bundle(trial_dir).env = env_state
 
     def write_metrics(self, trial_dir: Path, trajectory: Trajectory) -> None:
-        self._bundle(trial_dir).metrics = trajectory
+        self._bundle(trial_dir).metrics = trajectory.metrics
 
     def write_grade(self, trial_dir: Path, grade: Grade) -> None:
         self._bundle(trial_dir).grade = grade
@@ -432,6 +444,6 @@ class InMemoryArtifactWriter:
         bundle.task = task_snapshot
         bundle.trajectory = trajectory
         bundle.env = env_state
-        bundle.metrics = trajectory
+        bundle.metrics = trajectory.metrics
         bundle.grade = trajectory.grade
         bundle.logs = logger

--- a/tolokaforge/core/output/artifacts.py
+++ b/tolokaforge/core/output/artifacts.py
@@ -29,8 +29,9 @@ authoritative on-disk contract.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import yaml
 
@@ -42,7 +43,9 @@ if TYPE_CHECKING:  # pragma: no cover — type-only imports
 
 __all__ = [
     "FileArtifactWriter",
+    "InMemoryArtifactWriter",
     "TrialArtifactWriter",
+    "TrialArtifactBundle",
     "model_id_slug",
 ]
 
@@ -103,12 +106,11 @@ def model_id_slug(provider: str, name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+@runtime_checkable
 class TrialArtifactWriter(Protocol):
-    """Writes per-trial artifacts + per-(task, model) sidecars.
-
-    The orchestrator depends on this Protocol, not
-    :class:`FileArtifactWriter`. Alternative implementations (in-memory for
-    tests, remote-object-store for production, …) satisfy the same contract.
+    """Writes per-trial artifacts. The orchestrator depends on this Protocol;
+    alternative implementations (in-memory, remote object store, …) satisfy
+    the same contract.
     """
 
     def write_trajectory(self, trial_dir: Path, trajectory: Trajectory) -> None:
@@ -165,6 +167,21 @@ class TrialArtifactWriter(Protocol):
         ``Trajectory.system_prompt`` / ``Trajectory.user_system_prompt``
         keys so analytics tools that already read those names keep
         working — only the file moved.
+        """
+        ...
+
+    def write_trial_bundle(
+        self,
+        trial_dir: Path,
+        trajectory: Trajectory,
+        task_snapshot: dict[str, Any],
+        env_state: dict[str, Any],
+        logger: StructuredLogger,
+    ) -> None:
+        """Write the six per-trial bundle artifacts for a trial in one call:
+        ``task.yaml``, ``trajectory.yaml``, ``env.yaml``, ``metrics.yaml``,
+        ``grade.yaml``, ``logs.yaml``. Convenience for the common orchestrator
+        path; equivalent to calling the six individual writers in sequence.
         """
         ...
 
@@ -311,3 +328,110 @@ class FileArtifactWriter:
                 allow_unicode=True,
                 default_flow_style=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# InMemoryArtifactWriter — non-disk implementation, test fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrialArtifactBundle:
+    """The artifacts an :class:`InMemoryArtifactWriter` records for one trial.
+
+    Each attribute holds the most recent value written for that artifact
+    name, or ``None`` if the corresponding ``write_*`` method has not been
+    called for this trial.
+    """
+
+    trajectory: Trajectory | None = None
+    task: dict[str, Any] | None = None
+    env: dict[str, Any] | None = None
+    metrics: Trajectory | None = None
+    grade: Grade | None = None
+    logs: StructuredLogger | None = None
+    tools_schemas: list[dict[str, Any]] | None = None
+    prompts: dict[str, str | None] | None = None
+
+
+class InMemoryArtifactWriter:
+    """In-memory :class:`TrialArtifactWriter`.
+
+    Stores each trial's artifacts in ``self.trials`` keyed by ``trial_dir``.
+    Use as a test fixture when code requires a writer but the assertion is
+    about what was written, not about a filesystem layout.
+
+    The Pydantic / dataclass objects passed in are stored by reference, not
+    copied. Mutating them after the write call is observable through
+    :attr:`trials` (matching how :class:`FileArtifactWriter` would serialise
+    whatever state existed at write time).
+    """
+
+    def __init__(self) -> None:
+        self.trials: dict[Path, TrialArtifactBundle] = {}
+
+    def _bundle(self, trial_dir: Path) -> TrialArtifactBundle:
+        key = Path(trial_dir)
+        if key not in self.trials:
+            self.trials[key] = TrialArtifactBundle()
+        return self.trials[key]
+
+    # ------------------------------------------------------------------
+    # Per-piece writes
+    # ------------------------------------------------------------------
+
+    def write_trajectory(self, trial_dir: Path, trajectory: Trajectory) -> None:
+        self._bundle(trial_dir).trajectory = trajectory
+
+    def write_task(self, trial_dir: Path, task_snapshot: dict[str, Any]) -> None:
+        self._bundle(trial_dir).task = task_snapshot
+
+    def write_env(self, trial_dir: Path, env_state: dict[str, Any]) -> None:
+        self._bundle(trial_dir).env = env_state
+
+    def write_metrics(self, trial_dir: Path, trajectory: Trajectory) -> None:
+        self._bundle(trial_dir).metrics = trajectory
+
+    def write_grade(self, trial_dir: Path, grade: Grade) -> None:
+        self._bundle(trial_dir).grade = grade
+
+    def write_logs(self, trial_dir: Path, logger: StructuredLogger) -> None:
+        self._bundle(trial_dir).logs = logger
+
+    def write_tools_schemas(
+        self,
+        trial_dir: Path,
+        schemas: list[dict[str, Any]],
+    ) -> None:
+        self._bundle(trial_dir).tools_schemas = schemas
+
+    def write_prompts(
+        self,
+        trial_dir: Path,
+        agent_prompt: str | None,
+        user_prompt: str | None,
+    ) -> None:
+        self._bundle(trial_dir).prompts = {
+            "system_prompt": agent_prompt,
+            "user_system_prompt": user_prompt,
+        }
+
+    # ------------------------------------------------------------------
+    # Bundle write
+    # ------------------------------------------------------------------
+
+    def write_trial_bundle(
+        self,
+        trial_dir: Path,
+        trajectory: Trajectory,
+        task_snapshot: dict[str, Any],
+        env_state: dict[str, Any],
+        logger: StructuredLogger,
+    ) -> None:
+        bundle = self._bundle(trial_dir)
+        bundle.task = task_snapshot
+        bundle.trajectory = trajectory
+        bundle.env = env_state
+        bundle.metrics = trajectory
+        bundle.grade = trajectory.grade
+        bundle.logs = logger

--- a/tolokaforge/core/output/artifacts.py
+++ b/tolokaforge/core/output/artifacts.py
@@ -1,15 +1,17 @@
 """Trial artifact writer — Protocol + disk-backed implementation.
 
 The writer composes :class:`tolokaforge.core.output_writer.OutputWriter`
-for the seven per-trial YAML files that make up a trial bundle:
+for the eight per-trial YAML files that make up a trial bundle:
 
 * ``task.yaml`` — frozen task identity + resolved preset fingerprint
 * ``trajectory.yaml`` — full message trace incl. reasoning blocks
 * ``env.yaml`` — final env state snapshot
 * ``metrics.yaml`` — usage / latency / tool-call metrics
-* ``grade.yaml`` — pass / fail + score components
+* ``grade.yaml`` — pass / fail + score components (omitted when the
+  trial has no grade)
 * ``logs.yaml`` — structured trial logs
 * ``tools_schemas.yaml`` — post-policy tool list, what the provider saw
+* ``prompts.yaml`` — per-trial agent + user-simulator system prompts
 
 Every artifact is YAML, every artifact is per-trial — a trial bundle is
 self-contained, no sidecar lookup needed for audit. Disk overhead is
@@ -178,10 +180,10 @@ class TrialArtifactWriter(Protocol):
         env_state: dict[str, Any],
         logger: StructuredLogger,
     ) -> None:
-        """Write the six per-trial bundle artifacts for a trial in one call:
+        """Write the per-trial bundle artifacts for a trial in one call:
         ``task.yaml``, ``trajectory.yaml``, ``env.yaml``, ``metrics.yaml``,
-        ``grade.yaml``, ``logs.yaml``. Convenience for the common orchestrator
-        path; equivalent to calling the six individual writers in sequence.
+        ``grade.yaml`` (when ``trajectory.grade`` is non-``None``), and
+        ``logs.yaml``. Convenience for the common orchestrator path.
         """
         ...
 
@@ -445,5 +447,6 @@ class InMemoryArtifactWriter:
         bundle.trajectory = trajectory
         bundle.env = env_state
         bundle.metrics = trajectory.metrics
-        bundle.grade = trajectory.grade
+        if trajectory.grade is not None:
+            bundle.grade = trajectory.grade
         bundle.logs = logger


### PR DESCRIPTION
## Summary

**Closes the third architectural seam — the data plane.** The engine has a three-plane architecture (control / trial / data); each plane should sit behind a typed, runtime-checkable contract so implementations can swap without engine edits. The control↔trial seam is being typed by `TrialSpec` / `TrialResult` in #74. This PR does the same job for the data plane: the `TrialArtifactWriter` Protocol that persists per-trial outputs (trajectory, grade, metrics, prompts, tool schemas, logs, env state).

After this lands, **the three planes are all behind named, runtime-checkable contracts** with at least one production and one alternate implementation apiece (`FileArtifactWriter` ↔ `InMemoryArtifactWriter` here).

A new ADR documents the seam: [`docs/architecture/adr/0004-trial-artifact-writer-seam.md`](docs/architecture/adr/0004-trial-artifact-writer-seam.md).

## Why now

`tolokaforge/core/output/artifacts.py` **already** declares `TrialArtifactWriter` as a `typing.Protocol` with `FileArtifactWriter` as its disk-backed implementation. The seam exists in spirit but four gaps prevent it from playing the same architectural role the other contracts do:

| Gap | Effect |
|---|---|
| The Protocol is **not `@runtime_checkable`** | `isinstance(writer, TrialArtifactWriter)` raises `TypeError`; only static structural checks work. Other Protocols in the engine (`SystemPromptPolicy`, `ResponsePolicy`, `ReasoningCodec`, …) are runtime-checkable; this one is the outlier. |
| `write_trial_bundle` is on `FileArtifactWriter` but **not on the Protocol** | The orchestrator's main entry point isn't part of the Protocol surface. Alternate implementations have to add it as an undeclared \"extra\" method or rebuild bundle semantics. |
| **Only one implementation exists** | No evidence the Protocol's surface is enough to swap in alternate backends (in-memory test fixture, S3, GCS, …). |
| **No ADR** documents the seam | A reviewer looking for \"where the data-plane contract is decided\" finds the Protocol declaration with no statement of intent or alternatives. |

## What's in this PR

### 1. `@runtime_checkable` on the Protocol

One decorator. Now `isinstance(writer, TrialArtifactWriter)` works — required for any future entry-point-discovered writer the engine wants to safely inject.

### 2. `write_trial_bundle` promoted to the Protocol

The method exists on `FileArtifactWriter` but wasn't declared on the contract. Moving it up means the Protocol's surface matches what the orchestrator actually calls (`write_tools_schemas`, `write_prompts`, `write_trial_bundle`). `FileArtifactWriter`'s implementation is unchanged; only the Protocol declaration grows by one method.

### 3. New `InMemoryArtifactWriter`

A non-disk implementation that stores each trial's artifacts in `self.trials: dict[Path, TrialArtifactBundle]`. The dataclass holds slots for `trajectory`, `task`, `env`, `metrics`, `grade`, `logs`, `tools_schemas`, `prompts`. Two purposes:

- **Proves the Protocol is swappable** — the seam isn't a documentation gesture; you can replace `FileArtifactWriter` with this one and the orchestrator doesn't notice.
- **Test fixture** — code that needs a writer but shouldn't touch disk can use this and assert on `writer.trials[trial_dir].trajectory.status` directly, instead of `tmp_path` + YAML round-trips.

### 4. ADR-0004

`docs/architecture/adr/0004-trial-artifact-writer-seam.md` — `Proposed` status. Documents the four gaps, the four-part fix, considered alternatives (only add `@runtime_checkable`, build a real S3 backend now, defer everything), explicit out-of-scope (RunAggregateWriter, async variants, entry-point discovery), and consequences.

### 5. Canonical contract test

`tests/canonical/test_artifact_writer_contract.py` — 16 tests in three groups:

- **`TestProtocolRuntimeCheck`** — both writers pass `isinstance()`; a random object doesn't.
- **`TestPerTrialMethodParity`** — every Protocol method (9 of them) accepts the same arguments on each implementation.
- **`TestInMemoryWriterBundleSemantics`** — per-trial isolation, bundle population, overwrite-on-repeat, store-by-reference (matching `FileArtifactWriter`'s serialise-at-write-time semantics).

## Key decisions and rationale

### 1. `write_trial_bundle` belongs on the Protocol, not just on `FileArtifactWriter`

The orchestrator's main per-trial output call is `writer.write_trial_bundle(...)`. Keeping it off the Protocol means alternate writers don't satisfy the actual contract the orchestrator uses. Promoting it makes the Protocol match the call sites. Trade-off: alternate writers must implement it, even though they could derive it from the per-piece methods. The win — Protocol matches caller usage — outweighs the cost.

### 2. `InMemoryArtifactWriter` is a real implementation, not a `MagicMock`

A Pydantic-free class with the same method signatures as `FileArtifactWriter`. Stores artifacts in a `TrialArtifactBundle` dataclass per trial. Tests assert through `writer.trials[trial_dir].trajectory` directly. Future S3/GCS implementations can use this as a structural template.

### 3. `@runtime_checkable` is cheap and removes a quiet limitation

One line. Aligns with the LLM policy Protocols already in the codebase. Unblocks future entry-point-discovered writers.

### 4. Scope is per-trial only

The orchestrator also writes post-run aggregate JSON files at the run-output root (`per_task_metrics.json`, `aggregate.json`, `metadata_slices.json`, `failure_attribution.json`). Those are **not** in scope:

- Run-level, not per-trial. The Protocol's signatures all take a `trial_dir`.
- Would warrant a separate `RunAggregateWriter` seam if/when needed.

### 5. `FileArtifactWriter` internals are unchanged

Two of its methods (`write_tools_schemas`, `write_prompts`) bypass the cached `OutputWriter` and write YAML directly. That asymmetry is pre-existing; cleaning it up isn't required to formalise the seam.

## How this fits the architecture arc

| Plane | Contract | Status |
|---|---|---|
| **Control** ↔ **Trial** | `TrialSpec` / `TrialResult` (Pydantic, gRPC wire) | Typed by #74 (in review) |
| **Trial** ↔ **Runner** | `RunnerService` gRPC + `ToolWrapper` ABC + `BaseAdapter` ABC | Typed across earlier PRs (#61, #71, #73) |
| **Data plane** (per-trial artifacts) | `TrialArtifactWriter` Protocol — runtime-checkable, multi-implementation | **This PR** |

After all three land, the engine has named, typed, swappable contracts at every plane boundary. Each subsequent architecture PR (`EnvEndpoints`, `RuntimeBackend`, `Conductor`, eventual remote conductor, control plane / scheduler) plugs into an existing seam rather than inventing one.

This PR is **independent of #74** — different file, different surface, different concern. Either can land first.

## Explicit out-of-scope

- `RunAggregateWriter` Protocol for the post-run JSON files (different lifecycle, separate seam).
- Concrete S3 / GCS backends (user-driven follow-on; the Protocol is now ready).
- Entry-point discovery (`tolokaforge.artifact_writers` group) — `@runtime_checkable` unblocks it for a future PR.
- Async writer variants.
- Refactoring `FileArtifactWriter`'s `write_tools_schemas` / `write_prompts` to go through `OutputWriter` instead of direct `open()`. Pre-existing asymmetry; cleanup-only.

## Breaking change

Adding `write_trial_bundle` to the Protocol declaration is **breaking-by-shape** for any downstream implementer that had provided a `TrialArtifactWriter` without it. No known external implementers today; `FileArtifactWriter` is updated in this repo and `InMemoryArtifactWriter` is new.

## Test plan

- [x] `uv run pytest tests/unit/test_output_artifacts.py tests/canonical/test_artifact_writer_contract.py tests/canonical/test_output_layout.py -v` — **47 passed** (existing 31 layout / artifact tests + 16 new contract tests).
- [x] `uv run pytest tests/ -m unit` — **1763 passed, 1 skipped, 851 deselected**.
- [x] `uv run pytest tests/ -m canonical` — **164 passed, 2451 deselected**. **Golden-trajectory regression gate green** — the gate IS an artifact round-trip, so any shape drift would surface there.
- [x] `uv run ruff check tolokaforge tests scripts tools` — All checks passed.
- [x] `uv run tolokaforge --help` — CLI imports clean.
- [x] **Live `tolokaforge run`** against the `native` adapter on `examples/native/tool_use/`: 2 trials, full pipeline. avg_score=0.62, total_cost_usd=0.14, exit 0.
- [x] **Per-trial output bundle byte-identical to a pre-PR run.** `diff` of the file list against a fresh run on `main` (2026-06-19, 8 YAML files: `env`, `grade`, `logs`, `metrics`, `prompts`, `task`, `tools_schemas`, `trajectory`) → empty. The Protocol change is signature-only; behaviour is identical.

## Files

**New:**
- `docs/architecture/adr/0004-trial-artifact-writer-seam.md`
- `tests/canonical/test_artifact_writer_contract.py`

**Modified:**
- `tolokaforge/core/output/artifacts.py` (class additions + Protocol updates)
- `docs/architecture/adr/README.md` (index)

Total: 4 files, +413 / -6.