### PR TITLE
Support DB JSONPath checks in Docker runner grading

### DIFF
--- a/tests/integration/test_docker_grading_jsonpath.py
+++ b/tests/integration/test_docker_grading_jsonpath.py
@@ -1,0 +1,184 @@
+"""End-to-end integration tests for DB JSONPath state grading over real gRPC.
+
+These tests exercise the path added in PR #80: the Docker runner's ``GradeTrial``
+RPC now grades ``path:``-style JSONPath assertions against the trial's structured
+DB state (``$.db.*``), not just ``path_glob:`` file checks. The flow under test is
+
+    RegisterTrial (loads initial_state.tables into the DB service)
+        -> GradeTrial RPC
+            -> service fetches db_client.get_stable_state(trial_id)
+            -> grading.evaluate_jsonpath_checks routes path: -> state checks
+            -> grade.reasons carries "State: PASS/FAIL ..." segments
+
+Unlike the unit tests in ``tests/unit/test_runner_jsonpath_grading.py`` (which call
+the evaluators directly), these drive the same transport the orchestrator uses in
+production and assert on the grade the runner container actually returns. They are
+deterministic: the DB state is the registered ``initial_state`` (no mutations, no
+LLM), so the verdicts are pinned.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.docker_runtime import RunnerClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+
+def _task_description(jsonpath_checks: list[dict[str, Any]]) -> dict[str, Any]:
+    """A trial whose DB holds one known ``orders`` row, graded by ``jsonpath_checks``.
+
+    Only ``state_checks.jsonpath_checks`` is configured (hash grading disabled and
+    no transcript rules), so the combined ``state_checks`` component equals the
+    JSONPath score — making the expected score easy to pin.
+    """
+    return {
+        "task_id": "jsonpath_state_e2e",
+        "name": "JSONPath State Grading E2E",
+        "category": "test",
+        "description": "Grade $.db.* assertions through the runner GradeTrial RPC",
+        "adapter_type": "native",
+        "system_prompt": "You are a test assistant.",
+        "initial_state": {
+            "tables": {
+                "orders": [
+                    {
+                        "id": "O-1",
+                        "status": "confirmed",
+                        "quantity": 3,
+                        "note": "Priority RUSH order",
+                    }
+                ]
+            },
+            "schemas": [
+                {
+                    "table_name": "orders",
+                    "fields": {
+                        "id": "string",
+                        "status": "string",
+                        "quantity": "integer",
+                        "note": "string",
+                    },
+                    "primary_key": "id",
+                }
+            ],
+            "unstable_fields": [],
+        },
+        "agent_tools": [],
+        "user_tools": [],
+        "grading": {
+            "combine_method": "weighted",
+            "weights": {"state_checks": 1.0},
+            "pass_threshold": 0.99,
+            "state_checks": {
+                "hash_enabled": False,
+                "golden_actions": [],
+                "jsonpath_checks": jsonpath_checks,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def runner_client(runner_container) -> RunnerClient:
+    """RunnerClient connected to the testcontainer Runner over gRPC."""
+    host = runner_container.get_container_host_ip()
+    port = runner_container.get_exposed_port(50051)
+    client = RunnerClient(runner_address=f"{host}:{port}")
+    client.connect()
+    yield client
+    client.close()
+
+
+def _register_and_grade(
+    runner_client: RunnerClient,
+    trial_id: str,
+    jsonpath_checks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Register a trial with the given checks, grade it, clean up, return the grade."""
+    td_json = json.dumps(_task_description(jsonpath_checks))
+    registered = runner_client.register_trial(trial_id=trial_id, task_description_json=td_json)
+    assert registered["success"] is True, registered["error"]
+    try:
+        result = runner_client.grade_trial(trial_id=trial_id)
+    finally:
+        runner_client.cleanup_trial(trial_id=trial_id)
+    assert result["success"] is True, result["error"]
+    assert result["grade"] is not None, "grade missing from successful GradeTrial response"
+    return result["grade"]
+
+
+class TestDbJsonpathGradingOverGrpc:
+    """Validate PR #80's DB JSONPath state grading against the real wire protocol."""
+
+    def test_db_state_checks_graded_against_live_db(self, runner_client: RunnerClient) -> None:
+        """``path:`` assertions are evaluated against the registered DB state, with
+        PASS/FAIL verdicts and actionable mismatch reasons surfaced under ``State:``."""
+        checks = [
+            {
+                "path": "$.db.orders[0].status",
+                "equals": "confirmed",
+                "description": "status is confirmed",
+            },
+            {
+                "path": "$.db.orders[0].status",
+                "equals": "cancelled",
+                "description": "status is cancelled",
+            },
+            {"path": "$.db.orders[0].quantity", "equals": 3, "description": "quantity is three"},
+            {
+                "path": "$.db.orders[0].note",
+                "contains_ci": "rush",
+                "description": "note mentions rush",
+            },
+            {"path": "$.db.orders[0].missing", "equals": "x", "description": "absent field"},
+        ]
+
+        grade = _register_and_grade(runner_client, "jsonpath_state_e2e:0", checks)
+        reasons = grade["reasons"]
+
+        # The new state route fired (not the file route).
+        assert "State:" in reasons, reasons
+
+        # Passing assertions of both operator kinds, including a non-string equals
+        # that proves the int round-tripped through the DB service intact.
+        assert "PASS: status is confirmed" in reasons, reasons
+        assert "PASS: quantity is three" in reasons, reasons
+        assert "PASS: note mentions rush" in reasons, reasons
+
+        # Failing assertion reports the actual value pulled from the DB.
+        assert "FAIL: status is cancelled" in reasons, reasons
+        assert "got 'confirmed'" in reasons, reasons
+
+        # Missing path is a loud failure, not a silent skip.
+        assert "Path not found" in reasons, reasons
+
+        # 3 of 5 assertions pass; state_checks is the only weighted component.
+        assert grade["components"]["state_checks"] == pytest.approx(0.6)
+        assert grade["binary_pass"] is False
+
+    def test_unknown_operator_fails_loud_over_grpc(self, runner_client: RunnerClient) -> None:
+        """Parity with the core native grader (PR #66): a ``path:`` assertion with no
+        recognized operator must FAIL loudly through the RPC, not silently pass."""
+        checks = [
+            {
+                "path": "$.db.orders[0].status",
+                "op": "gte",
+                "expected": 5,
+                "description": "bogus operator",
+            },
+        ]
+
+        grade = _register_and_grade(runner_client, "jsonpath_state_e2e:1", checks)
+        reasons = grade["reasons"]
+
+        assert "no recognized operator" in reasons, reasons
+        assert "bogus operator" in reasons, reasons
+        # The supported operators are named so the task author can fix the assertion.
+        assert "equals" in reasons, reasons
+        assert grade["components"]["state_checks"] == pytest.approx(0.0)
+        assert grade["binary_pass"] is False

--- a/tests/unit/test_runner_jsonpath_grading.py
+++ b/tests/unit/test_runner_jsonpath_grading.py
@@ -15,7 +15,9 @@ import pytest
 from tolokaforge.runner.grading import (
     build_grade_reasons,
     combine_grade_components,
+    evaluate_jsonpath_checks,
     evaluate_jsonpath_file_checks,
+    evaluate_jsonpath_state_checks,
 )
 
 pytestmark = pytest.mark.unit
@@ -130,6 +132,77 @@ def test_partial_pass_score(tmp_path: Path):
     assert score == 0.5
 
 
+def test_state_jsonpath_checks_grade_db_state():
+    state = {
+        "db": {
+            "orders": [
+                {
+                    "status": "confirmed",
+                    "items": [{"product_id": "hub-flex-7-silver", "quantity": 1}],
+                }
+            ]
+        }
+    }
+    checks = [
+        {
+            "path": "$.db.orders[-1].status",
+            "equals": "confirmed",
+            "description": "order is confirmed",
+        },
+        {
+            "path": "$.db.orders[-1].items[0].product_id",
+            "equals": "hub-flex-7-silver",
+            "description": "exact product selected",
+        },
+    ]
+
+    score, reasons = evaluate_jsonpath_state_checks(checks, state)
+
+    assert score == 1.0
+    assert "PASS: order is confirmed" in reasons
+    assert "PASS: exact product selected" in reasons
+
+
+def test_state_jsonpath_checks_fail_on_wrong_value():
+    state = {"db": {"orders": [{"status": "cancelled"}]}}
+    checks = [
+        {
+            "path": "$.db.orders[-1].status",
+            "equals": "confirmed",
+            "description": "order is confirmed",
+        }
+    ]
+
+    score, reasons = evaluate_jsonpath_state_checks(checks, state)
+
+    assert score == 0.0
+    assert "FAIL: order is confirmed" in reasons
+
+
+def test_mixed_jsonpath_checks_keep_file_compatibility(tmp_path: Path):
+    target = tmp_path / "answer.md"
+    target.write_text("approved")
+    state = {"db": {"orders": [{"status": "confirmed"}]}}
+    checks = [
+        {
+            "path_glob": str(target),
+            "contains_ci": "approved",
+            "description": "file artifact check",
+        },
+        {
+            "path": "$.db.orders[-1].status",
+            "equals": "confirmed",
+            "description": "state check",
+        },
+    ]
+
+    score, reasons = evaluate_jsonpath_checks(checks, state=state)
+
+    assert score == 1.0
+    assert "Files: PASS: file artifact check" in reasons
+    assert "State: PASS: state check" in reasons
+
+
 def test_combine_components_uses_jsonpath_when_hash_absent():
     components = {"hash_score": -1.0, "jsonpath_score": 0.75, "transcript_score": -1.0}
     grading_config = {
@@ -160,7 +233,7 @@ def test_build_reasons_includes_jsonpath_when_score_set():
         "transcript_score": -1.0,
     }
     text = build_grade_reasons(components)
-    assert "Files: PASS: A; FAIL: B" in text
+    assert "JSONPath: PASS: A; FAIL: B" in text
 
 
 class TestRunnerSideAssertionsWithoutPathGlobFailLoud:

--- a/tests/unit/test_runner_jsonpath_grading.py
+++ b/tests/unit/test_runner_jsonpath_grading.py
@@ -179,6 +179,29 @@ def test_state_jsonpath_checks_fail_on_wrong_value():
     assert "FAIL: order is confirmed" in reasons
 
 
+def test_state_jsonpath_unknown_operator_fails_loud():
+    """Parity with the core native grader (PR #66): a ``path:`` assertion with
+    no recognized operator (here a typo'd ``op:``/``expected:``) must FAIL with
+    an actionable reason, not silently pass as an existence check."""
+    state = {"db": {"orders": [{"status": "cancelled"}]}}
+    checks = [
+        {
+            "path": "$.db.orders[-1].status",
+            "op": "gte",
+            "expected": 5,
+            "description": "bogus operator",
+        }
+    ]
+
+    score, reasons = evaluate_jsonpath_state_checks(checks, state)
+
+    assert score == 0.0
+    assert "no recognized operator" in reasons
+    assert "bogus operator" in reasons
+    # The supported operators are named so the author can fix the assertion.
+    assert "equals" in reasons
+
+
 def test_mixed_jsonpath_checks_keep_file_compatibility(tmp_path: Path):
     target = tmp_path / "answer.md"
     target.write_text("approved")

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -15,6 +15,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from jsonpath_ng.ext import parse
+
 from tolokaforge.runner.models import (
     StateDiff,
     TableDiff,
@@ -536,6 +538,154 @@ def evaluate_jsonpath_file_checks(
     return score, reasons
 
 
+def _contains(haystack: Any, needle: Any, ci: bool = False) -> bool:
+    if isinstance(haystack, str) and isinstance(needle, str):
+        return needle.casefold() in haystack.casefold() if ci else needle in haystack
+    if isinstance(haystack, list | tuple | set):
+        return any(_contains(item, needle, ci=ci) for item in haystack)
+    if isinstance(haystack, dict):
+        return any(_contains(value, needle, ci=ci) for value in haystack.values())
+    if ci and isinstance(haystack, str) and isinstance(needle, str):
+        return haystack.casefold() == needle.casefold()
+    return haystack == needle
+
+
+def evaluate_jsonpath_state_checks(
+    checks: list[dict[str, Any]],
+    state: dict[str, Any],
+) -> tuple[float, str]:
+    """
+    Evaluate JSONPath assertions against the trial's structured DB state.
+
+    This is the state-oriented counterpart to evaluate_jsonpath_file_checks().
+    It supports the same JSONPath assertion shape used by the core native
+    grader: path + one of equals, equals_ci, contains, contains_ci.
+    """
+    if not checks:
+        return -1.0, ""
+
+    passed = 0
+    total = len(checks)
+    reasons_parts: list[str] = []
+
+    for check in checks:
+        path = check.get("path")
+        description = check.get("description", path or "JSONPath state check")
+        if not path:
+            reasons_parts.append(f"FAIL: Missing path — {description}")
+            continue
+
+        operators = [
+            ("equals", check.get("equals")),
+            ("equals_ci", check.get("equals_ci")),
+            ("contains", check.get("contains")),
+            ("contains_ci", check.get("contains_ci")),
+        ]
+        active = [(name, expected) for name, expected in operators if expected is not None]
+        if len(active) > 1:
+            reasons_parts.append(f"FAIL: Multiple operators at {path} — {description}")
+            continue
+
+        try:
+            matches = [match.value for match in parse(path).find(state)]
+        except Exception as exc:
+            reasons_parts.append(f"FAIL: Invalid JSONPath {path}: {exc} — {description}")
+            continue
+
+        if not matches:
+            reasons_parts.append(f"FAIL: Path not found {path} — {description}")
+            continue
+
+        if not active:
+            passed += 1
+            reasons_parts.append(f"PASS: {description}")
+            continue
+
+        op_name, expected = active[0]
+        found = False
+        for value in matches:
+            if op_name == "equals" and value == expected:
+                found = True
+                break
+            if op_name == "equals_ci" and isinstance(value, str) and isinstance(expected, str):
+                if value.casefold() == expected.casefold():
+                    found = True
+                    break
+            if op_name == "contains" and _contains(value, expected):
+                found = True
+                break
+            if op_name == "contains_ci" and _contains(value, expected, ci=True):
+                found = True
+                break
+
+        if found:
+            passed += 1
+            reasons_parts.append(f"PASS: {description}")
+        else:
+            reasons_parts.append(
+                f"FAIL: {description} ({path}: expected {op_name} {expected!r}, got {matches[0]!r})"
+            )
+
+    score = passed / total if total > 0 else 0.0
+    reasons = "; ".join(reasons_parts)
+    return score, reasons
+
+
+def evaluate_jsonpath_checks(
+    checks: list[dict[str, Any]],
+    state: dict[str, Any] | None = None,
+) -> tuple[float, str]:
+    """
+    Evaluate mixed JSONPath checks.
+
+    Checks with path_glob remain file-content checks for backwards
+    compatibility. Checks with path are evaluated against structured DB state.
+    """
+    if not checks:
+        return -1.0, ""
+
+    file_checks: list[dict[str, Any]] = []
+    state_checks: list[dict[str, Any]] = []
+    invalid_checks: list[dict[str, Any]] = []
+
+    for check in checks:
+        if check.get("path_glob") is not None and check.get("path") is None:
+            file_checks.append(check)
+        elif check.get("path") is not None:
+            state_checks.append(check)
+        else:
+            invalid_checks.append(check)
+
+    passed = 0.0
+    total = len(checks)
+    reasons_parts: list[str] = []
+
+    if file_checks:
+        file_score, file_reasons = evaluate_jsonpath_file_checks(file_checks)
+        if file_score >= 0:
+            passed += file_score * len(file_checks)
+        if file_reasons:
+            reasons_parts.append(f"Files: {file_reasons}")
+
+    if state_checks:
+        if state is None:
+            reasons_parts.append("State: FAIL: DB state unavailable for JSONPath checks")
+        else:
+            state_score, state_reasons = evaluate_jsonpath_state_checks(state_checks, state)
+            if state_score >= 0:
+                passed += state_score * len(state_checks)
+            if state_reasons:
+                reasons_parts.append(f"State: {state_reasons}")
+
+    for check in invalid_checks:
+        description = check.get("description", "JSONPath check")
+        reasons_parts.append(f"FAIL: Missing path/path_glob — {description}")
+
+    score = passed / total if total > 0 else 0.0
+    reasons = "; ".join(reasons_parts)
+    return score, reasons
+
+
 def combine_grade_components(
     components: dict[str, Any], grading_config: dict[str, Any]
 ) -> tuple[float, bool]:
@@ -692,11 +842,11 @@ def build_grade_reasons(
     if jsonpath_score >= 0:
         jsonpath_reasons = components.get("jsonpath_reasons", "")
         if jsonpath_reasons:
-            reasons.append(f"Files: {jsonpath_reasons}")
+            reasons.append(f"JSONPath: {jsonpath_reasons}")
         elif jsonpath_score == 1.0:
-            reasons.append("Files: all jsonpath checks passed")
+            reasons.append("JSONPath: all checks passed")
         else:
-            reasons.append(f"Files: jsonpath score={jsonpath_score:.2f}")
+            reasons.append(f"JSONPath: score={jsonpath_score:.2f}")
 
     # Transcript rules reason
     transcript_score = components.get("transcript_score", -1.0)

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -545,8 +545,6 @@ def _contains(haystack: Any, needle: Any, ci: bool = False) -> bool:
         return any(_contains(item, needle, ci=ci) for item in haystack)
     if isinstance(haystack, dict):
         return any(_contains(value, needle, ci=ci) for value in haystack.values())
-    if ci and isinstance(haystack, str) and isinstance(needle, str):
-        return haystack.casefold() == needle.casefold()
     return haystack == needle
 
 
@@ -597,8 +595,20 @@ def evaluate_jsonpath_state_checks(
             continue
 
         if not active:
-            passed += 1
-            reasons_parts.append(f"PASS: {description}")
+            # Fail loud — mirrors the core native grader's contract: an
+            # assertion with no recognized operator (a typo'd or unsupported
+            # operator such as ``op:``/``expected:``, or a bare ``path:`` with
+            # no comparison) is an author error, not a passing existence check.
+            # Silently passing it would turn a strict-looking assertion into a
+            # no-op and diverge from host-side grading.
+            unknown_keys = sorted(
+                key for key in check if key not in {"path", "path_glob", "description"}
+            )
+            reasons_parts.append(
+                f"FAIL: no recognized operator at {path} (got keys: {unknown_keys}); "
+                f"supported operators are 'equals', 'equals_ci', 'contains', "
+                f"'contains_ci' — {description}"
+            )
             continue
 
         op_name, expected = active[0]

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -45,7 +45,7 @@ from tolokaforge.runner.grading import (
     build_grade_reasons,
     combine_grade_components,
     compute_state_diff,
-    evaluate_jsonpath_file_checks,
+    evaluate_jsonpath_checks,
     evaluate_llm_judge,
     evaluate_transcript_rules,
 )
@@ -985,19 +985,25 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     error=f"Hash grading failed: {type(e).__name__}: {str(e)}",
                 )
 
-        # A.2) JSONPATH FILE ASSERTIONS (if jsonpath_checks exist)
+        # A.2) JSONPATH ASSERTIONS (if jsonpath_checks exist)
         if state_checks_config and state_checks_config.jsonpath_checks:
             logger.info(
                 f"GradeTrial: {trial_id} - Evaluating "
-                f"{len(state_checks_config.jsonpath_checks)} jsonpath file checks"
+                f"{len(state_checks_config.jsonpath_checks)} jsonpath checks"
             )
-            jsonpath_score, jsonpath_reasons = evaluate_jsonpath_file_checks(
-                state_checks_config.jsonpath_checks
+            stable_state_response = await self.db_client.get_stable_state(trial_id)
+            jsonpath_state = {
+                "db": stable_state_response.data,
+                "tables": stable_state_response.data,
+            }
+            jsonpath_score, jsonpath_reasons = evaluate_jsonpath_checks(
+                state_checks_config.jsonpath_checks,
+                state=jsonpath_state,
             )
             components.jsonpath_score = jsonpath_score
             components.jsonpath_reasons = jsonpath_reasons
             logger.info(
-                f"GradeTrial: {trial_id} - Jsonpath file checks: score={jsonpath_score:.2f}"
+                f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}"
             )
 
         # B) TRANSCRIPT RULES GRADING (if transcript_rules exist)

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -991,20 +991,25 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 f"GradeTrial: {trial_id} - Evaluating "
                 f"{len(state_checks_config.jsonpath_checks)} jsonpath checks"
             )
-            stable_state_response = await self.db_client.get_stable_state(trial_id)
-            jsonpath_state = {
-                "db": stable_state_response.data,
-                "tables": stable_state_response.data,
-            }
+            # Only fetch DB state when at least one assertion targets it via
+            # ``path:``. File-only (``path_glob:``) checks never needed the DB,
+            # so fetching unconditionally would add a round-trip and a new
+            # failure mode for tasks that previously graded without it.
+            jsonpath_checks = state_checks_config.jsonpath_checks
+            jsonpath_state = None
+            if any(check.get("path") is not None for check in jsonpath_checks):
+                stable_state_response = await self.db_client.get_stable_state(trial_id)
+                jsonpath_state = {
+                    "db": stable_state_response.data,
+                    "tables": stable_state_response.data,
+                }
             jsonpath_score, jsonpath_reasons = evaluate_jsonpath_checks(
-                state_checks_config.jsonpath_checks,
+                jsonpath_checks,
                 state=jsonpath_state,
             )
             components.jsonpath_score = jsonpath_score
             components.jsonpath_reasons = jsonpath_reasons
-            logger.info(
-                f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}"
-            )
+            logger.info(f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}")
 
         # B) TRANSCRIPT RULES GRADING (if transcript_rules exist)
         transcript_rules_config = grading_config.transcript_rules


### PR DESCRIPTION
## Summary

This adds structured DB-state JSONPath support to Docker runner grading while preserving the existing file-content JSONPath checks.

Currently, runner `state_checks.jsonpath_checks` are evaluated only as file checks using `path_glob`. That works for artifact assertions, but checks with `path` are interpreted as missing file checks instead of structured state assertions.

This PR:
- keeps existing `path_glob` checks on the current file-content path
- evaluates checks with `path` against stable DB state from `db_client.get_stable_state(trial_id)`
- supports `equals`, `equals_ci`, `contains`, and `contains_ci`
- allows mixed file and DB-state JSONPath checks in one grading config
- changes combined reason text from `Files:` to `JSONPath:` so mixed checks are not mislabeled

## Notes

The state evaluator grades against both `$.db...` and `$.tables...` aliases:

```python
{"db": stable_state, "tables": stable_state}
```

A future cleanup could move JSONPath assertion evaluation into a shared helper so all grading paths use exactly the same implementation.

## Test

```bash
uv run pytest tests/unit/test_runner_jsonpath_grading.py
```

Result: `12 passed`.
