### PR TITLE
feat(devcontainer): add Dev Container config for reproducible dev env

### DIFF
--- a/.devcontainer/.zshrc
+++ b/.devcontainer/.zshrc
@@ -1,0 +1,88 @@
+export PATH="$HOME/.local/bin:$PATH"
+
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+ZSH_THEME="af-magic"
+
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+HYPHEN_INSENSITIVE="true"
+
+zstyle ':omz:update' mode disabled  # disable automatic updates
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
+COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=(git)
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+
+export HISTSIZE=10000
+export SAVEHIST=10000
+export HISTFILE="$HOME/.cache/.zsh_history"
+
+# https://github.com/sharkdp/bat
+alias cat='bat'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,86 @@
+FROM ubuntu:jammy
+
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-o", "nounset", "-o", "xtrace", "-c"]
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
+RUN apt-get update -y && apt-get install -y \
+    curl \
+    wget \
+    jq \
+    git \
+    git-lfs \
+    rsync \
+    apt-transport-https \
+    ca-certificates \
+    gnupg \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-setuptools \
+    python3-wheel \
+    python3-venv \
+    build-essential \
+    libdbus-1-dev libdbus-glib-1-dev \
+    # Dependencies for building Python extensions
+    tk-dev liblzma-dev libssl-dev build-essential zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libffi-dev \
+    # Dependencies for Playwright
+    libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2 \
+    sudo \
+    locales \
+    tzdata \
+    zsh \
+    # https://github.com/BurntSushi/ripgrep
+    ripgrep \
+    # https://github.com/sharkdp/bat
+    bat \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Github cli: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& apt update \
+	&& apt install gh -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js LTS (includes npm and npx) — needed for MCP servers (e.g. @perplexity-ai/mcp-server)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install 'ruff==0.14.4' 'black==25.11.0'
+
+# Set locale
+RUN locale-gen en_US.UTF-8
+
+# Add terminal colors
+RUN echo "PS1='\e[92m\u\e[0m@\e[94m\h\e[0m:\e[35m\w\e[0m# '" >> /root/.bashrc
+
+# Setup non-root user
+ARG USER
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+COPY setup_user.sh setup_terminal.sh .zshrc /devcontainer_bootstrap/
+RUN /devcontainer_bootstrap/setup_user.sh
+
+USER $USER
+
+RUN /devcontainer_bootstrap/setup_terminal.sh
+
+# Pin uv to match the version CI uses (.github/workflows/ci.yml) and stay within
+# [tool.uv] required-version in pyproject.toml. An unpinned install grabs "latest",
+# which drifts outside that range and makes uv refuse to run in the container.
+RUN curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh
+
+# Install Claude Code CLI as the non-root user via the native installer.
+# Installing per-user (to ~/.local/bin, already on PATH) instead of a root/global
+# npm install keeps the binary writable by the user, so background auto-updates and
+# `claude update` work. A root-owned global install cannot self-upgrade.
+RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,6 +77,9 @@ RUN /devcontainer_bootstrap/setup_terminal.sh
 # Pin uv to match the version CI uses (.github/workflows/ci.yml) and stay within
 # [tool.uv] required-version in pyproject.toml. An unpinned install grabs "latest",
 # which drifts outside that range and makes uv refuse to run in the container.
+# Note: ~/.local is overlaid by the ${localWorkspaceFolderBasename}-local named
+# volume at runtime, so bumping this pin requires removing that volume to take
+# effect on an existing container (a fresh rebuild alone won't).
 RUN curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh
 
 # Install Claude Code CLI as the non-root user via the native installer.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "tolokaforge",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "./Dockerfile",
+		"args": {
+			"USER": "codespaces",
+			"DEVCONTAINER_VERSION": "1"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"RooVeterinaryInc.roo-cline",
+				"TomRijndorp.find-it-faster",
+				"aaron-bond.better-comments",
+				"charliermarsh.ruff",
+				"eamodio.gitlens",
+				"github.vscode-github-actions",
+				"ms-python.python",
+				"spmeesseman.vscode-taskexplorer",
+				"yzhang.markdown-all-in-one",
+				"samuelcolvin.jinjahtml"
+			]
+		}
+	},
+	"mounts": [
+		// User cache volume mount
+		"source=${localWorkspaceFolderBasename}-cache,target=/home/codespaces/.cache,type=volume",
+		"source=${localWorkspaceFolderBasename}-local,target=/home/codespaces/.local,type=volume"
+	],
+	"workspaceMount": "source=${localWorkspaceFolder}/,target=${containerWorkspaceFolder},type=bind,consistency=cached",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"initializeCommand": ".devcontainer/pre_init_container.sh",
+	"postCreateCommand": ".devcontainer/post_setup_container.sh codespaces \"${containerWorkspaceFolder}\"",
+	"postAttachCommand": ".devcontainer/post_attach_container.sh",
+
+	// https://containers.dev/features
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "codespaces"
+}

--- a/.devcontainer/post_attach_container.sh
+++ b/.devcontainer/post_attach_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# STANDARD PREAMBLE: BEGIN (do not edit)
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${SCRIPT_DIR}/../scripts/common.sh"
+
+# STANDARD PREAMBLE: END (do not edit)
+
+git config --global core.editor "code --wait"
+
+"${REPO_DIR}/scripts/setup/create_python_venv.sh"

--- a/.devcontainer/post_setup_container.sh
+++ b/.devcontainer/post_setup_container.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# STANDARD PREAMBLE: BEGIN (do not edit)
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${SCRIPT_DIR}/../scripts/common.sh"
+
+# STANDARD PREAMBLE: END (do not edit)
+
+if [ -z ${1+x} ] ; then
+    log_error "Absent argument: {HOST_USER}"
+    exit 1
+fi
+HOST_USER="$1"
+
+if [ -z ${2+x} ] ; then
+    log_error "Absent argument: {WORKSPACE_PATH}"
+    exit 1
+fi
+WORKSPACE_PATH="$2"
+
+sudo chown -R "$HOST_USER":"$HOST_USER" "/home/${HOST_USER}/.cache"
+# Don't try to change owner for git directories
+ls -A "$WORKSPACE_PATH" | egrep -vx '.git(hub)?' | xargs -I{} sudo chown -R "$HOST_USER" "${WORKSPACE_PATH}/{}"
+
+git config --global --add safe.directory "$WORKSPACE_PATH"
+
+# Add GitHub to known_hosts to avoid interactive SSH prompts
+log_info "Adding GitHub to SSH known_hosts"
+mkdir -p ~/.ssh
+ssh-keyscan -H github.com >> ~/.ssh/known_hosts 2>/dev/null || true
+
+# In Codespaces, configure git to use HTTPS instead of SSH for GitHub
+if [ "${CODESPACES:-false}" = "true" ]; then
+    log_info "Running in Codespaces, configuring git to use HTTPS for GitHub"
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
+fi
+
+# Fix Docker credential store if the configured helper is broken.
+# Devcontainer environments sometimes set a credsStore that references
+# docker-credential-secretservice which may not be available, causing
+# all Docker SDK operations (build, pull, images.list) to fail.
+if [ -f "$HOME/.docker/config.json" ]; then
+    CREDS_STORE=$(python3 -c "import json; c=json.load(open('$HOME/.docker/config.json')); print(c.get('credsStore',''))" 2>/dev/null || echo "")
+    if [ -n "$CREDS_STORE" ]; then
+        HELPER="docker-credential-${CREDS_STORE}"
+        if ! command -v "$HELPER" >/dev/null 2>&1 || ! "$HELPER" list >/dev/null 2>&1; then
+            log_warning "Docker credential helper '$HELPER' is not functional — removing credsStore from config"
+            python3 -c "
+import json, pathlib
+p = pathlib.Path('$HOME/.docker/config.json')
+c = json.loads(p.read_text())
+c.pop('credsStore', None)
+p.write_text(json.dumps(c, indent=2) + '\n')
+"
+        fi
+    fi
+fi
+
+cd "$WORKSPACE_PATH"
+
+# Install pre-commit hooks
+log_info "Installing pre-commit hooks"
+uv run pre-commit install
+
+# Initialize Git LFS and pull LFS objects (needed for test fixture data)
+log_info "Initializing Git LFS"
+"${SCRIPT_DIR}/../scripts/setup/init_git_lfs.sh"
+
+uname -a

--- a/.devcontainer/pre_init_container.sh
+++ b/.devcontainer/pre_init_container.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# STANDARD PREAMBLE: BEGIN (do not edit)
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${SCRIPT_DIR}/../scripts/common.sh"
+
+# STANDARD PREAMBLE: END (do not edit)
+
+log_info "Pre-init: begin"
+
+if [[ "${CODESPACES:-false}" = "true" ]]; then
+    log_warning "In a Codespaces. Do nothing"
+    log_info "Pre-init step is skipped!"
+    exit 0
+fi
+
+if command -v ssh-add >/dev/null 2>&1; then
+    if ! RESULT=$(ssh-add -l 2>&1); then
+        log_warning "ssh agent unavailable: $RESULT"
+        log_info "Continuing without host SSH agent."
+        log_info "Generate a new SSH key: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key"
+        log_info "Add the SSH key to the ssh-agent: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent"
+    fi
+else
+    log_warning "ssh-add is not installed on host. Continuing without SSH agent check."
+fi
+
+log_info "Pre-init step is success!"

--- a/.devcontainer/setup_terminal.sh
+++ b/.devcontainer/setup_terminal.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+if [[ "$USER" == "root" ]] ; then
+    export HOME=/root
+else
+    export HOME="/home/${USER}"
+fi
+
+# fix bat: https://github.com/sharkdp/bat?tab=readme-ov-file#on-ubuntu-using-apt
+mkdir -p "$HOME/.local/bin"
+ln -s /usr/bin/batcat "$HOME/.local/bin/bat"
+
+# install oh-my-zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+cp /devcontainer_bootstrap/.zshrc "$HOME/"
+
+# install fzf
+git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
+"$HOME/.fzf/install"

--- a/.devcontainer/setup_user.sh
+++ b/.devcontainer/setup_user.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+if [[ "$USER" == "root" ]] ; then
+    echo "Current user is root. Do nothing"
+    exit 0
+fi
+
+groupadd --gid $USER_GID "$USER"
+useradd --uid $USER_UID --gid $USER_GID -m "$USER"
+
+# Add sudo support.
+echo "$USER" ALL=\(root\) NOPASSWD:ALL > "/etc/sudoers.d/$USER"
+chmod 0440 "/etc/sudoers.d/$USER"
+
+# terminal
+usermod --shell /bin/zsh "$USER"

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ _private/
 converted/
 temp/
 .claude/*
+
+# Devcontainer
+devcontainer-lock.json

--- a/scripts/setup/init_git_lfs.sh
+++ b/scripts/setup/init_git_lfs.sh
@@ -23,8 +23,11 @@ if ! command -v git-lfs &>/dev/null; then
     fi
 fi
 
+# Use --force so a pre-existing pre-push hook (e.g. left over from a prior
+# devcontainer build, since .git persists across rebuilds) is overwritten
+# rather than causing `git lfs install` to abort with exit code 2.
 log_info "Initializing Git LFS..."
-git lfs install --local 2>/dev/null || git lfs install
+git lfs install --local --force 2>/dev/null || git lfs install --force
 
 log_info "Pulling Git LFS objects..."
 git lfs pull


### PR DESCRIPTION
Add a `.devcontainer/` setup (Dockerfile, devcontainer.json, and setup/init scripts) for a reproducible local/Codespaces development environment running as the `codespaces` user with docker-in-docker and cached cache/local volume mounts.

Supporting changes:
- init_git_lfs.sh: use `git lfs install --force` so a pre-existing pre-push hook left in the persisted .git across container rebuilds is overwritten instead of aborting with exit code 2.
- .gitignore: ignore the generated devcontainer-lock.json.