### PR TITLE
feat(output): formalize RunAggregateWriter as the run-level data-plane seam

### DIFF
--- a/docs/architecture/adr/0005-run-aggregate-writer-seam.md
+++ b/docs/architecture/adr/0005-run-aggregate-writer-seam.md
@@ -1,0 +1,89 @@
+# 0005. `RunAggregateWriter` as the run-level data-plane seam
+
+- **Status:** Proposed
+- **Date:** 2026-06-23
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+The engine's architecture has three planes:
+
+- **Control plane** — schedules trials, tracks state.
+- **Trial plane** — runs one trial end-to-end (agent loop, tool calls, grading).
+- **Data plane** — persists run outputs (per-trial artifacts; run-level aggregates) for downstream readers.
+
+ADR-0004 typed the **per-trial** half of the data plane behind `TrialArtifactWriter`. The **run-level** half is still inline disk I/O: `Orchestrator._generate_reports` opens four `*.json` files directly and `json.dump`s into them. There is no seam, no alternative implementation, no contract test pinning what the orchestrator emits at the run-output root.
+
+ADR-0004's `Follow-ups` section explicitly listed this gap:
+
+> `RunAggregateWriter` seam (separate from this). The orchestrator writes post-run aggregates at the run-output root, outside any trial directory. Those are run-level concerns, not per-trial; they belong behind their own seam if/when a non-filesystem run-level destination is needed.
+
+This ADR closes that follow-up. After it lands, every plane has a named, typed, runtime-checkable contract with at least two implementations.
+
+> **Numbering note.** ADR-0003 is reserved for the in-review `TrialSpec` / `TrialResult` decision (the control↔trial seam). If that ADR lands under a different number, this file must be renumbered and the index in `README.md` updated.
+
+## Decision Drivers
+
+- **Symmetry across the three planes.** Per-trial artifacts already sit behind a runtime-checkable Protocol with two implementations. The run-level half should match.
+- **One seam per lifecycle.** Per-trial writes happen *as each trial completes*; run aggregates write *once at the end*. Mixing them in one Protocol would force every backend to handle two different write rhythms (high-rate per-trial vs single-shot run-level).
+- **Lean code.** The four `open() + json.dump()` blocks in `_generate_reports` are five lines apiece, repeat the same serializer kwargs, and obscure the orchestrator's actual responsibility (assembling the dicts). A writer collapses them to one call.
+- **Plug-in discovery later.** Entry-point-discovered backends (`tolokaforge.run_aggregate_writers`-style) need `isinstance` to work for safe injection — same argument as ADR-0004.
+- **Fail-fast.** No silent fallbacks on a malformed writer; runtime check is the cleanest line of defence.
+
+## Considered Options
+
+1. **Add `RunAggregateWriter` Protocol + `FileAggregateWriter` + `InMemoryAggregateWriter`, route the orchestrator's four writes through the bundle method, ship a canonical contract test + an on-disk layout test.** Closes all gaps with one focused change.
+2. **Only add `FileAggregateWriter` (no Protocol, no second impl).** Cheapest — collapses the four `json.dump` blocks behind one class. Leaves the seam unproven (no second backend, no runtime-checkable contract).
+3. **Extend `TrialArtifactWriter` with run-level methods instead of a new Protocol.** Single Protocol, single class hierarchy. Mixes two lifecycles into one contract — every backend now has to handle both rhythms.
+4. **Defer until a non-filesystem backend is requested.** Each later contract change (entry-point discovery, remote object store, async writers, typed Pydantic aggregates) ends up co-litigating the run-level shape simultaneously with whatever else is in flight.
+
+## Decision
+
+We will adopt **Option 1**.
+
+- Add `RunAggregateWriter` as a `@runtime_checkable` `typing.Protocol` in `tolokaforge/core/output/aggregates.py` with five methods: one per-piece writer for each of the four JSON files (`write_per_task_metrics`, `write_aggregate`, `write_metadata_slices`, `write_failure_attribution`) and a `write_run_aggregates` convenience that writes all four.
+- Add `FileAggregateWriter` — the disk-backed implementation. Each method opens `output_dir / "<name>.json"` and `json.dump`s with `indent=2, default=str` — byte-identical to the pre-PR writes the orchestrator did inline.
+- Add `InMemoryAggregateWriter` — a non-disk implementation that records each run's artifacts on a `RunAggregateBundle` dataclass keyed by `output_dir`. Two purposes: (a) prove the Protocol is swappable; (b) serve as a test fixture for code that needs a writer but should not touch the filesystem.
+- Route the orchestrator's four inline writes in `_generate_reports` through a single `self._run_aggregate_writer.write_run_aggregates(...)` call. The dict-assembly logic (`schema_version` injection, failure-attribution envelope, empty-results early return) stays in the orchestrator — the writer is downstream of dict assembly.
+- Add canonical tests:
+  - `tests/canonical/test_run_aggregate_writer_contract.py` — Protocol conformance + parity between the two implementations.
+  - `tests/canonical/test_run_aggregate_layout.py` — on-disk layout assertions (filenames, top-level shape, envelope keys, serializer conventions).
+  - `tests/unit/test_output_run_aggregates.py` — focused unit tests for both writers.
+
+## Consequences
+
+### Positive
+
+- The data plane has *both* halves behind typed, runtime-checkable seams — per-trial and run-level — matching the symmetry of the control / trial planes.
+- The four `open() + json.dump()` blocks in the orchestrator collapse to one writer call. `_generate_reports` is now solely about dict assembly + an envelope; storage is a single delegated line.
+- `InMemoryAggregateWriter` is reusable by any test that needs to assert on what the orchestrator emitted at run-end without JSON-parsing temp files.
+- Future entry-point-registered backends can rely on `isinstance(writer, RunAggregateWriter)` instead of structural-only type checks.
+- An external backend (S3, GCS, analytics service) can be built against the Protocol with no engine changes — `InMemoryAggregateWriter` serves as a structural template.
+
+### Negative / Trade-offs
+
+- The Protocol's surface today (raw `dict[str, Any]` payloads) reflects how the orchestrator builds the aggregates today, not an idealised shape. Typing the four payloads with Pydantic models is worthwhile, but it's a separate ADR with its own breaking-change risk for downstream readers.
+- The four per-piece methods are partly redundant with the `write_run_aggregates` bundle method. Keeping per-piece methods on the Protocol forces alternate implementations to provide them, but the win — Protocol matches both call shapes (bundle for orchestrator, per-piece for ad-hoc tooling) — outweighs the cost.
+- The orchestrator gains a new private attribute (`self._run_aggregate_writer`). Mirrors the existing `self._artifact_writer` precedent.
+
+### Follow-ups
+
+- **Entry-point discovery for run-aggregate writers.** Mirror the `tolokaforge.adapters` pattern with a `tolokaforge.run_aggregate_writers` entry-point group so operators can inject a writer via config.
+- **Typed Pydantic models for the four aggregates.** `per_task_metrics`, `aggregate`, `metadata_slices`, `failure_attribution` today are wide, inconsistent across slices, and produced by metric-calc functions that return `dict[str, Any]`. Typing them is its own ADR.
+- **Async variants.** Today's writers are sync; if a remote backend's run-end write latency starts to matter, an `AsyncRunAggregateWriter` Protocol can be added without touching the sync one.
+- **Concrete remote backend (S3 / GCS).** User-driven; the seam is now ready for one without engine edits.
+- **Streaming / per-trial flushes.** Today's writers are called once at run-end. If a consumer needs progress visibility before the run finishes, a streaming variant is its own design conversation.
+
+## Rejected alternatives
+
+- **Option 2 — only add `FileAggregateWriter` (no Protocol, no second impl).** Collapses the inline writes but leaves the seam undocumented and untestable as a contract. Half-measure.
+- **Option 3 — extend `TrialArtifactWriter`.** Conflates per-trial and run-level lifecycles. A backend tuned for high-rate per-trial writes (e.g. local disk with a cached `OutputWriter` per trial) is the wrong shape for a single-shot run-level upload, and vice versa. Two seams keep each Protocol minimal.
+- **Option 4 — defer.** Each later contract change ends up co-litigating the run-level shape simultaneously with whatever else it's doing. Cheaper to settle the seam now while there's only one implementation to migrate.
+
+## Scope notes
+
+- **Analytics artifacts only.** `run_state.json` (durable resume state, written by `RunStateManager`), `engine_run_state.json`, and `run_queue.sqlite` (the durable attempt queue) all live at the run-output root but are **infrastructure**, not analytics. They belong to the resume/queue layer and stay out of this seam.
+- **`_generate_reports`'s dict-assembly logic is unchanged.** The orchestrator still computes per-task metrics, the aggregate, the metadata slices, and the failure attribution. The writer is only the disk-touching tail. Future ADRs that retype the payloads (Pydantic-modelled aggregates) will live in `metrics.py` / `failure_attribution.py`, not in this seam.
+- **Empty-results early return is preserved.** When `self.results` is empty, `_generate_reports` returns at the top with a warning and **no** aggregate file is written. The writer is never invoked in that case. Behaviour-equivalent with the pre-PR code path.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -33,3 +33,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 |---|---|---|
 | [0001](0001-record-architecture-decisions.md) | Record architecture decisions in ADRs | Accepted |
 | [0002](0002-external-model-registry.md) | External model registry — operator-overridable preset data | Proposed |
+| [0005](0005-run-aggregate-writer-seam.md) | `RunAggregateWriter` as the run-level data-plane seam | Proposed |

--- a/tests/canonical/test_run_aggregate_layout.py
+++ b/tests/canonical/test_run_aggregate_layout.py
@@ -1,0 +1,189 @@
+"""Canonical on-disk layout for the four run-level aggregate JSONs.
+
+Locks the filenames, top-level shape, and envelope keys
+(``schema_version``, ``summary`` / ``failures``) that downstream readers
+depend on. Drift in any of these fails CI loudly.
+
+Exercised through :class:`FileAggregateWriter` directly — the same
+writer the orchestrator calls. Avoids spinning up a real run (Docker,
+adapters, LLM) while still asserting on the bytes the orchestrator
+would emit.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.output.aggregates import FileAggregateWriter
+
+pytestmark = pytest.mark.canonical
+
+
+def _per_task_metrics() -> list[dict[str, Any]]:
+    return [
+        {
+            "task_id": "airline_001",
+            "total_trials": 1,
+            "successful_trials": 1,
+            "success_rate": 1.0,
+            "avg_score": 1.0,
+            "benchmark_type": "airline",
+            "complexity": "simple",
+            "tags": ["domain:airline"],
+            "expected_failure_modes": [],
+        }
+    ]
+
+
+def _aggregate() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "total_tasks": 1,
+        "total_trials": 1,
+        "success_rate_micro": 1.0,
+        "avg_score_micro": 1.0,
+        "avg_latency_s": 12.3,
+    }
+
+
+def _metadata_slices() -> dict[str, dict[str, Any]]:
+    return {
+        "by_benchmark_type": {"airline": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_complexity": {"simple": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_tag": {"domain:airline": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_expected_failure_mode": {},
+    }
+
+
+def _failure_attribution() -> dict[str, Any]:
+    return {
+        "summary": {
+            "total_failed_attempts": 0,
+            "deterministic_attribution_coverage": 1.0,
+            "by_failure_class": {},
+            "by_tool": {},
+        },
+        "failures": [],
+    }
+
+
+@pytest.fixture
+def populated_run_dir(tmp_path: Path) -> Path:
+    """A run-output directory after :class:`FileAggregateWriter` has
+    emitted all four aggregates via the bundle method."""
+    writer = FileAggregateWriter()
+    writer.write_run_aggregates(
+        tmp_path,
+        _per_task_metrics(),
+        _aggregate(),
+        _metadata_slices(),
+        _failure_attribution(),
+    )
+    return tmp_path
+
+
+class TestFilenamesAndDirectoryLayout:
+    """The four aggregates land at the run-output root with the canonical
+    names downstream readers expect."""
+
+    def test_all_four_files_exist(self, populated_run_dir: Path) -> None:
+        for name in (
+            "per_task_metrics.json",
+            "aggregate.json",
+            "metadata_slices.json",
+            "failure_attribution.json",
+        ):
+            assert (populated_run_dir / name).is_file(), f"missing {name}"
+
+    def test_no_unexpected_files_at_run_root(self, populated_run_dir: Path) -> None:
+        """The writer must not emit anything beyond the four declared files."""
+        actual = {p.name for p in populated_run_dir.iterdir() if p.is_file()}
+        assert actual == {
+            "per_task_metrics.json",
+            "aggregate.json",
+            "metadata_slices.json",
+            "failure_attribution.json",
+        }
+
+
+class TestTopLevelShapes:
+    """Each artifact's JSON top-level type is what downstream consumers
+    parse against. Drift here breaks every dashboard / analysis tool."""
+
+    def test_per_task_metrics_is_list(self, populated_run_dir: Path) -> None:
+        payload = json.loads((populated_run_dir / "per_task_metrics.json").read_text())
+        assert isinstance(payload, list)
+        assert len(payload) >= 1
+        assert isinstance(payload[0], dict)
+
+    def test_aggregate_is_dict_with_schema_version(self, populated_run_dir: Path) -> None:
+        payload = json.loads((populated_run_dir / "aggregate.json").read_text())
+        assert isinstance(payload, dict)
+        assert payload["schema_version"] == 1
+
+    def test_metadata_slices_is_dict_with_four_dimensions(self, populated_run_dir: Path) -> None:
+        payload = json.loads((populated_run_dir / "metadata_slices.json").read_text())
+        assert isinstance(payload, dict)
+        assert set(payload.keys()) == {
+            "by_benchmark_type",
+            "by_complexity",
+            "by_tag",
+            "by_expected_failure_mode",
+        }
+
+    def test_failure_attribution_has_summary_and_failures(self, populated_run_dir: Path) -> None:
+        payload = json.loads((populated_run_dir / "failure_attribution.json").read_text())
+        assert isinstance(payload, dict)
+        assert set(payload.keys()) == {"summary", "failures"}
+        assert isinstance(payload["summary"], dict)
+        assert isinstance(payload["failures"], list)
+
+
+class TestSerializerConventions:
+    """The writer must preserve the orchestrator's pre-PR serializer
+    choices: ``indent=2`` for diff-able output, ``default=str`` so
+    Enums / datetimes round-trip to strings without raising."""
+
+    def test_indent_two_produces_pretty_output(self, populated_run_dir: Path) -> None:
+        text = (populated_run_dir / "aggregate.json").read_text()
+        assert "\n  " in text, "indent=2 should produce two-space indented JSON"
+
+    def test_default_str_handles_enum_values(self, tmp_path: Path) -> None:
+        """A non-JSON-native value (Enum) must not raise — it must stringify."""
+
+        class _Status(Enum):
+            FAILED = "failed"
+
+        writer = FileAggregateWriter()
+        writer.write_aggregate(
+            tmp_path,
+            {"schema_version": 1, "worst_status": _Status.FAILED},
+        )
+        payload = json.loads((tmp_path / "aggregate.json").read_text())
+        assert isinstance(payload["worst_status"], str)
+        assert "FAILED" in payload["worst_status"]
+
+    def test_default_str_handles_datetime(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_aggregate(
+            tmp_path,
+            {"schema_version": 1, "started_at": datetime(2026, 1, 1, tzinfo=UTC)},
+        )
+        payload = json.loads((tmp_path / "aggregate.json").read_text())
+        assert payload["started_at"].startswith("2026-01-01")
+
+
+class TestParentDirectoryCreation:
+    """The writer creates ``output_dir`` if it doesn't already exist."""
+
+    def test_creates_missing_parent(self, tmp_path: Path) -> None:
+        nested = tmp_path / "does" / "not" / "exist"
+        assert not nested.exists()
+        FileAggregateWriter().write_aggregate(nested, _aggregate())
+        assert (nested / "aggregate.json").is_file()

--- a/tests/canonical/test_run_aggregate_writer_contract.py
+++ b/tests/canonical/test_run_aggregate_writer_contract.py
@@ -66,7 +66,7 @@ def _make_failure_attribution() -> dict[str, Any]:
 
 
 @pytest.fixture
-def writers(tmp_path: Path) -> list[RunAggregateWriter]:
+def writers() -> list[RunAggregateWriter]:
     """Both production-shaped writers, ready to receive calls."""
     return [FileAggregateWriter(), InMemoryAggregateWriter()]
 

--- a/tests/canonical/test_run_aggregate_writer_contract.py
+++ b/tests/canonical/test_run_aggregate_writer_contract.py
@@ -1,0 +1,193 @@
+"""Pin the ``RunAggregateWriter`` Protocol contract — runtime check + parity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.output.aggregates import (
+    FileAggregateWriter,
+    InMemoryAggregateWriter,
+    RunAggregateBundle,
+    RunAggregateWriter,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _make_per_task_metrics() -> list[dict[str, Any]]:
+    return [
+        {
+            "task_id": "airline_001",
+            "total_trials": 1,
+            "successful_trials": 1,
+            "success_rate": 1.0,
+            "avg_score": 1.0,
+            "benchmark_type": "airline",
+            "complexity": "simple",
+            "tags": ["domain:airline"],
+            "expected_failure_modes": [],
+        }
+    ]
+
+
+def _make_aggregate() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "total_tasks": 1,
+        "total_trials": 1,
+        "success_rate_micro": 1.0,
+        "avg_score_micro": 1.0,
+        "avg_latency_s": 12.3,
+    }
+
+
+def _make_metadata_slices() -> dict[str, dict[str, Any]]:
+    return {
+        "by_benchmark_type": {"airline": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_complexity": {"simple": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_tag": {"domain:airline": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_expected_failure_mode": {},
+    }
+
+
+def _make_failure_attribution() -> dict[str, Any]:
+    return {
+        "summary": {
+            "total_failed_attempts": 0,
+            "deterministic_attribution_coverage": 1.0,
+            "by_failure_class": {},
+            "by_tool": {},
+        },
+        "failures": [],
+    }
+
+
+@pytest.fixture
+def writers(tmp_path: Path) -> list[RunAggregateWriter]:
+    """Both production-shaped writers, ready to receive calls."""
+    return [FileAggregateWriter(), InMemoryAggregateWriter()]
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; both implementations satisfy it
+    via ``isinstance`` (not just by structural type-hint compatibility).
+    """
+
+    def test_file_aggregate_writer_passes_isinstance(self) -> None:
+        assert isinstance(FileAggregateWriter(), RunAggregateWriter)
+
+    def test_in_memory_aggregate_writer_passes_isinstance(self) -> None:
+        assert isinstance(InMemoryAggregateWriter(), RunAggregateWriter)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotAWriter:
+            pass
+
+        assert not isinstance(_NotAWriter(), RunAggregateWriter)
+
+
+class TestPerRunMethodParity:
+    """Every Protocol method accepts the same arguments on every implementation."""
+
+    def test_write_per_task_metrics(
+        self, writers: list[RunAggregateWriter], tmp_path: Path
+    ) -> None:
+        metrics = _make_per_task_metrics()
+        for i, writer in enumerate(writers):
+            writer.write_per_task_metrics(tmp_path / f"run_{i}", metrics)
+
+    def test_write_aggregate(self, writers: list[RunAggregateWriter], tmp_path: Path) -> None:
+        aggregate = _make_aggregate()
+        for i, writer in enumerate(writers):
+            writer.write_aggregate(tmp_path / f"run_{i}", aggregate)
+
+    def test_write_metadata_slices(self, writers: list[RunAggregateWriter], tmp_path: Path) -> None:
+        slices = _make_metadata_slices()
+        for i, writer in enumerate(writers):
+            writer.write_metadata_slices(tmp_path / f"run_{i}", slices)
+
+    def test_write_failure_attribution(
+        self, writers: list[RunAggregateWriter], tmp_path: Path
+    ) -> None:
+        attribution = _make_failure_attribution()
+        for i, writer in enumerate(writers):
+            writer.write_failure_attribution(tmp_path / f"run_{i}", attribution)
+
+    def test_write_run_aggregates(self, writers: list[RunAggregateWriter], tmp_path: Path) -> None:
+        for i, writer in enumerate(writers):
+            writer.write_run_aggregates(
+                tmp_path / f"run_{i}",
+                _make_per_task_metrics(),
+                _make_aggregate(),
+                _make_metadata_slices(),
+                _make_failure_attribution(),
+            )
+
+
+class TestInMemoryWriterBundleSemantics:
+    """The in-memory writer stores aggregates under ``self.runs[output_dir]``
+    as a :class:`RunAggregateBundle`. Tests assert through that surface
+    instead of JSON-parsing files.
+    """
+
+    def test_per_run_isolation(self) -> None:
+        writer = InMemoryAggregateWriter()
+        writer.write_aggregate(Path("run_a"), _make_aggregate())
+        writer.write_aggregate(Path("run_b"), _make_aggregate())
+        assert set(writer.runs.keys()) == {Path("run_a"), Path("run_b")}
+        assert isinstance(writer.runs[Path("run_a")], RunAggregateBundle)
+
+    def test_write_run_aggregates_populates_four_artifacts(self) -> None:
+        writer = InMemoryAggregateWriter()
+        per_task = _make_per_task_metrics()
+        aggregate = _make_aggregate()
+        slices = _make_metadata_slices()
+        attribution = _make_failure_attribution()
+        writer.write_run_aggregates(Path("run_x"), per_task, aggregate, slices, attribution)
+        bundle = writer.runs[Path("run_x")]
+        assert bundle.per_task_metrics is per_task
+        assert bundle.aggregate is aggregate
+        assert bundle.metadata_slices is slices
+        assert bundle.failure_attribution is attribution
+
+    def test_overwrites_on_repeat_write(self) -> None:
+        writer = InMemoryAggregateWriter()
+        first = _make_aggregate()
+        second = _make_aggregate()
+        second["schema_version"] = 2
+        writer.write_aggregate(Path("run_x"), first)
+        writer.write_aggregate(Path("run_x"), second)
+        assert writer.runs[Path("run_x")].aggregate is second
+
+    def test_stores_by_reference_not_by_copy(self) -> None:
+        """Mutating the source after the call surfaces through ``runs`` —
+        matching the disk-backed writer's serialise-at-write-time semantics."""
+        writer = InMemoryAggregateWriter()
+        aggregate: dict[str, Any] = {"schema_version": 1, "total_tasks": 1}
+        writer.write_aggregate(Path("run_x"), aggregate)
+        aggregate["total_tasks"] = 99
+        assert writer.runs[Path("run_x")].aggregate["total_tasks"] == 99
+
+    def test_per_piece_writes_only_populate_their_slot(self) -> None:
+        """``write_aggregate`` should not touch the other three slots."""
+        writer = InMemoryAggregateWriter()
+        writer.write_aggregate(Path("run_x"), _make_aggregate())
+        bundle = writer.runs[Path("run_x")]
+        assert bundle.aggregate is not None
+        assert bundle.per_task_metrics is None
+        assert bundle.metadata_slices is None
+        assert bundle.failure_attribution is None
+
+    def test_surface_path_forms_bucket_separately(self) -> None:
+        """The in-memory writer keys on ``Path(output_dir)`` as supplied — it
+        does not ``.resolve()`` (it does not touch the filesystem). Two
+        surface forms of the same logical path bucket into separate runs.
+        Pinned so a future "normalise the key" change has to update this
+        test deliberately."""
+        writer = InMemoryAggregateWriter()
+        writer.write_aggregate(Path("a/b"), _make_aggregate())
+        writer.write_aggregate(Path("./a/b"), _make_aggregate())
+        assert set(writer.runs.keys()) == {Path("a/b"), Path("./a/b")}

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -635,6 +635,46 @@ class TestGenerateReports:
         assert "summary" in fa
         assert "failures" in fa
 
+    def test_run_aggregate_writer_kwarg_swaps_writer(self, tmp_path: Path) -> None:
+        """The ``run_aggregate_writer`` kwarg accepts any
+        :class:`RunAggregateWriter` impl and routes the four aggregates
+        through it instead of the default disk-backed writer."""
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.output.aggregates import InMemoryAggregateWriter
+
+        writer = InMemoryAggregateWriter()
+        orch = Orchestrator(_make_run_config(), run_aggregate_writer=writer)
+        orch.tasks = [_make_task_config("T1")]
+        orch.results = [_make_trajectory("T1", 0, score=1.0, binary_pass=True)]
+
+        orch._generate_reports(tmp_path)
+
+        # No JSON files on disk — the in-memory writer captured them instead.
+        assert not (tmp_path / "aggregate.json").exists()
+        assert not (tmp_path / "per_task_metrics.json").exists()
+        bundle = writer.runs[tmp_path]
+        assert bundle.aggregate is not None
+        assert bundle.aggregate["schema_version"] == 1
+        assert bundle.per_task_metrics is not None
+        assert len(bundle.per_task_metrics) == 1
+        assert bundle.metadata_slices is not None
+        assert bundle.failure_attribution is not None
+        assert bundle.failure_attribution.keys() == {"summary", "failures"}
+
+    def test_empty_results_does_not_invoke_writer(self, tmp_path: Path) -> None:
+        """The empty-results early-return guard runs before the writer call,
+        so no aggregates are recorded when the run produced zero trials."""
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.output.aggregates import InMemoryAggregateWriter
+
+        writer = InMemoryAggregateWriter()
+        orch = Orchestrator(_make_run_config(), run_aggregate_writer=writer)
+        orch.results = []
+
+        orch._generate_reports(tmp_path)
+
+        assert writer.runs == {}
+
 
 # ===================================================================
 # _create_adapter

--- a/tests/unit/test_output_run_aggregates.py
+++ b/tests/unit/test_output_run_aggregates.py
@@ -1,0 +1,195 @@
+"""``tolokaforge.core.output.aggregates`` unit tests.
+
+Covers:
+
+* :class:`FileAggregateWriter` — per-piece methods write the right JSON
+  to the right filename with the orchestrator's pre-PR serializer
+  conventions (``indent=2``, ``default=str``).
+* :class:`InMemoryAggregateWriter` — per-piece methods populate the
+  matching slot on the run's :class:`RunAggregateBundle`.
+* :func:`write_run_aggregates` — bundle method on both writers writes
+  all four artifacts in one call.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.output.aggregates import (
+    FileAggregateWriter,
+    InMemoryAggregateWriter,
+    RunAggregateBundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Synthetic payloads
+# ---------------------------------------------------------------------------
+
+
+def _per_task_metrics() -> list[dict[str, Any]]:
+    return [
+        {"task_id": "t1", "success_rate": 1.0, "tags": ["x"]},
+        {"task_id": "t2", "success_rate": 0.0, "tags": []},
+    ]
+
+
+def _aggregate() -> dict[str, Any]:
+    return {"schema_version": 1, "total_tasks": 2, "success_rate_micro": 0.5}
+
+
+def _slices() -> dict[str, dict[str, Any]]:
+    return {
+        "by_benchmark_type": {"airline": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_complexity": {},
+        "by_tag": {"x": {"total_tasks": 1, "success_rate_micro": 1.0}},
+        "by_expected_failure_mode": {},
+    }
+
+
+def _attribution() -> dict[str, Any]:
+    return {
+        "summary": {"total_failed_attempts": 1, "deterministic_attribution_coverage": 1.0},
+        "failures": [{"task_id": "t2", "failure_class": "tool_error"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# FileAggregateWriter
+# ---------------------------------------------------------------------------
+
+
+class TestFileAggregateWriterPerPiece:
+    def test_write_per_task_metrics(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_per_task_metrics(tmp_path, _per_task_metrics())
+        target = tmp_path / "per_task_metrics.json"
+        assert target.is_file()
+        assert json.loads(target.read_text()) == _per_task_metrics()
+
+    def test_write_aggregate(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_aggregate(tmp_path, _aggregate())
+        target = tmp_path / "aggregate.json"
+        assert target.is_file()
+        assert json.loads(target.read_text()) == _aggregate()
+
+    def test_write_metadata_slices(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_metadata_slices(tmp_path, _slices())
+        target = tmp_path / "metadata_slices.json"
+        assert target.is_file()
+        assert json.loads(target.read_text()) == _slices()
+
+    def test_write_failure_attribution(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_failure_attribution(tmp_path, _attribution())
+        target = tmp_path / "failure_attribution.json"
+        assert target.is_file()
+        assert json.loads(target.read_text()) == _attribution()
+
+    def test_overwrite_unconditional(self, tmp_path: Path) -> None:
+        """The run-output root is owned by the run; subsequent writes
+        replace prior contents."""
+        writer = FileAggregateWriter()
+        writer.write_aggregate(tmp_path, {"schema_version": 1})
+        writer.write_aggregate(tmp_path, {"schema_version": 2})
+        assert json.loads((tmp_path / "aggregate.json").read_text())["schema_version"] == 2
+
+
+class TestFileAggregateWriterBundle:
+    def test_write_run_aggregates_emits_four_files(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        writer.write_run_aggregates(
+            tmp_path,
+            _per_task_metrics(),
+            _aggregate(),
+            _slices(),
+            _attribution(),
+        )
+        for name in (
+            "per_task_metrics.json",
+            "aggregate.json",
+            "metadata_slices.json",
+            "failure_attribution.json",
+        ):
+            assert (tmp_path / name).is_file(), f"missing {name}"
+
+    def test_bundle_payloads_round_trip(self, tmp_path: Path) -> None:
+        writer = FileAggregateWriter()
+        per_task, aggregate, slices, attribution = (
+            _per_task_metrics(),
+            _aggregate(),
+            _slices(),
+            _attribution(),
+        )
+        writer.write_run_aggregates(tmp_path, per_task, aggregate, slices, attribution)
+        assert json.loads((tmp_path / "per_task_metrics.json").read_text()) == per_task
+        assert json.loads((tmp_path / "aggregate.json").read_text()) == aggregate
+        assert json.loads((tmp_path / "metadata_slices.json").read_text()) == slices
+        assert json.loads((tmp_path / "failure_attribution.json").read_text()) == attribution
+
+
+# ---------------------------------------------------------------------------
+# InMemoryAggregateWriter
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryAggregateWriterPerPiece:
+    def test_write_per_task_metrics(self) -> None:
+        writer = InMemoryAggregateWriter()
+        payload = _per_task_metrics()
+        writer.write_per_task_metrics(Path("r0"), payload)
+        assert writer.runs[Path("r0")].per_task_metrics is payload
+
+    def test_write_aggregate(self) -> None:
+        writer = InMemoryAggregateWriter()
+        payload = _aggregate()
+        writer.write_aggregate(Path("r0"), payload)
+        assert writer.runs[Path("r0")].aggregate is payload
+
+    def test_write_metadata_slices(self) -> None:
+        writer = InMemoryAggregateWriter()
+        payload = _slices()
+        writer.write_metadata_slices(Path("r0"), payload)
+        assert writer.runs[Path("r0")].metadata_slices is payload
+
+    def test_write_failure_attribution(self) -> None:
+        writer = InMemoryAggregateWriter()
+        payload = _attribution()
+        writer.write_failure_attribution(Path("r0"), payload)
+        assert writer.runs[Path("r0")].failure_attribution is payload
+
+    def test_empty_writer_has_no_runs(self) -> None:
+        writer = InMemoryAggregateWriter()
+        assert writer.runs == {}
+
+    def test_bundle_default_all_none(self) -> None:
+        bundle = RunAggregateBundle()
+        assert bundle.per_task_metrics is None
+        assert bundle.aggregate is None
+        assert bundle.metadata_slices is None
+        assert bundle.failure_attribution is None
+
+
+class TestInMemoryAggregateWriterBundle:
+    def test_write_run_aggregates_populates_all_four_slots(self) -> None:
+        writer = InMemoryAggregateWriter()
+        per_task, aggregate, slices, attribution = (
+            _per_task_metrics(),
+            _aggregate(),
+            _slices(),
+            _attribution(),
+        )
+        writer.write_run_aggregates(Path("r0"), per_task, aggregate, slices, attribution)
+        bundle = writer.runs[Path("r0")]
+        assert bundle.per_task_metrics is per_task
+        assert bundle.aggregate is aggregate
+        assert bundle.metadata_slices is slices
+        assert bundle.failure_attribution is attribution

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -43,6 +43,7 @@ from tolokaforge.core.models import (
     TrialStatus,
     TypeSenseConfig,
 )
+from tolokaforge.core.output.aggregates import FileAggregateWriter
 from tolokaforge.core.output.artifacts import FileArtifactWriter
 from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.resume import RunStateManager
@@ -162,6 +163,9 @@ class Orchestrator:
         # so the orchestrator stays decoupled from filesystem details and
         # alternative writers (in-memory tests, remote stores) can plug in.
         self._artifact_writer: FileArtifactWriter = FileArtifactWriter()
+        # Run-level analogue: the four post-run aggregate JSONs go through
+        # this writer instead of inline ``json.dump`` calls.
+        self._run_aggregate_writer: FileAggregateWriter = FileAggregateWriter()
 
         # Initialize logger
         log_level = logging.DEBUG if verbose else logging.INFO
@@ -1874,29 +1878,25 @@ Try to be helpful and always follow the policy."""
                 group, weighted=True
             )
 
-        # Save per-task metrics
-        with open(output_dir / "per_task_metrics.json", "w") as f:
-            json.dump(all_task_metrics, f, indent=2, default=str)
-
         aggregate["schema_version"] = 1
-        # Save aggregate report
-        with open(output_dir / "aggregate.json", "w") as f:
-            json.dump(aggregate, f, indent=2, default=str)
-        with open(output_dir / "metadata_slices.json", "w") as f:
-            json.dump(metadata_slices, f, indent=2, default=str)
 
         # Deterministic failure attribution report
         failure_attributions = [
             attribute_failure(traj) for traj in self.results if is_failed_trajectory(traj)
         ]
         failure_summary = summarize_failure_attributions(failure_attributions)
-        with open(output_dir / "failure_attribution.json", "w") as f:
-            json.dump(
-                {"summary": failure_summary, "failures": failure_attributions},
-                f,
-                indent=2,
-                default=str,
-            )
+        failure_attribution_payload: dict[str, Any] = {
+            "summary": failure_summary,
+            "failures": failure_attributions,
+        }
+
+        self._run_aggregate_writer.write_run_aggregates(
+            output_dir,
+            all_task_metrics,
+            aggregate,
+            metadata_slices,
+            failure_attribution_payload,
+        )
 
         # Log summary
         self.logger.info(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -43,7 +43,7 @@ from tolokaforge.core.models import (
     TrialStatus,
     TypeSenseConfig,
 )
-from tolokaforge.core.output.aggregates import FileAggregateWriter
+from tolokaforge.core.output.aggregates import FileAggregateWriter, RunAggregateWriter
 from tolokaforge.core.output.artifacts import FileArtifactWriter
 from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.resume import RunStateManager
@@ -150,7 +150,12 @@ class Orchestrator:
     """Orchestrates benchmark runs across tasks and trials"""
 
     def __init__(
-        self, config: RunConfig, resume: bool = False, verbose: bool = False, strict: bool = False
+        self,
+        config: RunConfig,
+        resume: bool = False,
+        verbose: bool = False,
+        strict: bool = False,
+        run_aggregate_writer: RunAggregateWriter | None = None,
     ):
         self.config = config
         self.resume = resume
@@ -165,8 +170,12 @@ class Orchestrator:
         # alternative writers (in-memory tests, remote stores) can plug in.
         self._artifact_writer: FileArtifactWriter = FileArtifactWriter()
         # Run-level analogue: the four post-run aggregate JSONs go through
-        # this writer instead of inline ``json.dump`` calls.
-        self._run_aggregate_writer: FileAggregateWriter = FileAggregateWriter()
+        # this writer instead of inline ``json.dump`` calls. Injectable so
+        # tests / alternate backends (remote object store, in-memory) can
+        # substitute without touching the orchestrator.
+        self._run_aggregate_writer: RunAggregateWriter = (
+            run_aggregate_writer if run_aggregate_writer is not None else FileAggregateWriter()
+        )
 
         # Initialize logger
         log_level = logging.DEBUG if verbose else logging.INFO
@@ -1917,7 +1926,7 @@ Try to be helpful and always follow the policy."""
             attribute_failure(traj) for traj in self.results if is_failed_trajectory(traj)
         ]
         failure_summary = summarize_failure_attributions(failure_attributions)
-        failure_attribution_payload: dict[str, Any] = {
+        failure_attribution_payload = {
             "summary": failure_summary,
             "failures": failure_attributions,
         }

--- a/tolokaforge/core/output/__init__.py
+++ b/tolokaforge/core/output/__init__.py
@@ -12,6 +12,14 @@ This package is the boundary between the orchestrator and disk. It defines:
 * :func:`~tolokaforge.core.output.artifacts.model_id_slug` — deterministic
   filesystem-safe ``(provider, name)`` slug used as the ``<model_id>`` part
   of ``results/tools_schemas/<task_id>__<model_id>.json``.
+* :class:`~tolokaforge.core.output.aggregates.RunAggregateWriter` —
+  Protocol covering the four post-run aggregate JSONs at the run-output
+  root (``per_task_metrics.json``, ``aggregate.json``,
+  ``metadata_slices.json``, ``failure_attribution.json``); see ADR-0005.
+* :class:`~tolokaforge.core.output.aggregates.FileAggregateWriter` and
+  :class:`~tolokaforge.core.output.aggregates.InMemoryAggregateWriter` —
+  the disk-backed and in-memory implementations; the latter records
+  payloads on a :class:`RunAggregateBundle`.
 
 See [`docs/OUTPUT_FORMAT.md`](../../../docs/OUTPUT_FORMAT.md) for the full
 on-disk contract.

--- a/tolokaforge/core/output/__init__.py
+++ b/tolokaforge/core/output/__init__.py
@@ -1,28 +1,38 @@
-"""Output artifact writers (Stage 7 / P6).
+"""Output artifact writers — the boundary between the orchestrator and disk.
 
-This package is the boundary between the orchestrator and disk. It defines:
+The package types both halves of the data plane behind runtime-checkable
+Protocols, each with a disk-backed and an in-memory implementation.
 
-* :class:`~tolokaforge.core.output.artifacts.TrialArtifactWriter` —
-  a :class:`typing.Protocol` that the orchestrator depends on (not the
-  concrete class).
-* :class:`~tolokaforge.core.output.artifacts.FileArtifactWriter` —
-  the disk-backed implementation. Composes the existing
-  :class:`tolokaforge.core.output_writer.OutputWriter` for per-trial files
-  and adds the Stage 7 ``results/tools_schemas/`` sidecar writer.
-* :func:`~tolokaforge.core.output.artifacts.model_id_slug` — deterministic
-  filesystem-safe ``(provider, name)`` slug used as the ``<model_id>`` part
-  of ``results/tools_schemas/<task_id>__<model_id>.json``.
+Per-trial seam (see ADR-0004):
+
+* :class:`~tolokaforge.core.output.artifacts.TrialArtifactWriter` — the
+  Protocol the orchestrator depends on for per-trial artifacts.
+* :class:`~tolokaforge.core.output.artifacts.FileArtifactWriter` — the
+  disk-backed implementation; composes
+  :class:`tolokaforge.core.output_writer.OutputWriter` for the eight
+  per-trial YAML files (``task.yaml``, ``trajectory.yaml``,
+  ``env.yaml``, ``metrics.yaml``, ``grade.yaml``, ``logs.yaml``,
+  ``tools_schemas.yaml``, ``prompts.yaml``) inside each trial bundle.
+
+Run-level seam (see ADR-0005):
+
 * :class:`~tolokaforge.core.output.aggregates.RunAggregateWriter` —
   Protocol covering the four post-run aggregate JSONs at the run-output
   root (``per_task_metrics.json``, ``aggregate.json``,
-  ``metadata_slices.json``, ``failure_attribution.json``); see ADR-0005.
+  ``metadata_slices.json``, ``failure_attribution.json``).
 * :class:`~tolokaforge.core.output.aggregates.FileAggregateWriter` and
-  :class:`~tolokaforge.core.output.aggregates.InMemoryAggregateWriter` —
-  the disk-backed and in-memory implementations; the latter records
+  :class:`~tolokaforge.core.output.aggregates.InMemoryAggregateWriter`
+  — the disk-backed and in-memory implementations; the latter records
   payloads on a :class:`RunAggregateBundle`.
 
-See [`docs/OUTPUT_FORMAT.md`](../../../docs/OUTPUT_FORMAT.md) for the full
-on-disk contract.
+Helper:
+
+* :func:`~tolokaforge.core.output.artifacts.model_id_slug` —
+  deterministic filesystem-safe ``(provider, name)`` slug used wherever
+  an artifact path needs a model identifier (cache files, debug dumps).
+
+See [`docs/OUTPUT_FORMAT.md`](../../../docs/OUTPUT_FORMAT.md) for the
+full on-disk contract.
 """
 
 from __future__ import annotations

--- a/tolokaforge/core/output/__init__.py
+++ b/tolokaforge/core/output/__init__.py
@@ -19,6 +19,12 @@ on-disk contract.
 
 from __future__ import annotations
 
+from tolokaforge.core.output.aggregates import (
+    FileAggregateWriter,
+    InMemoryAggregateWriter,
+    RunAggregateBundle,
+    RunAggregateWriter,
+)
 from tolokaforge.core.output.artifacts import (
     FileArtifactWriter,
     TrialArtifactWriter,
@@ -26,7 +32,11 @@ from tolokaforge.core.output.artifacts import (
 )
 
 __all__ = [
+    "FileAggregateWriter",
     "FileArtifactWriter",
+    "InMemoryAggregateWriter",
+    "RunAggregateBundle",
+    "RunAggregateWriter",
     "TrialArtifactWriter",
     "model_id_slug",
 ]

--- a/tolokaforge/core/output/aggregates.py
+++ b/tolokaforge/core/output/aggregates.py
@@ -1,0 +1,269 @@
+"""Run-level aggregate writer — Protocol + disk-backed implementation.
+
+The writer covers the four run-level JSON artifacts produced once per
+run at the run-output root:
+
+* ``per_task_metrics.json`` — per-task metric rows (success rate, pass@k,
+  latency / token / cost aggregates, plus task metadata).
+* ``aggregate.json`` — single run-level aggregate, carries
+  ``schema_version: 1``.
+* ``metadata_slices.json`` — aggregates sliced by benchmark type,
+  complexity, tag, and expected failure mode.
+* ``failure_attribution.json`` — deterministic failure-attribution
+  report: ``{"summary": ..., "failures": [...]}``.
+
+These artifacts live at the run-output root (next to ``trials/``); they
+are the run-level analogue of the per-trial files written by
+:class:`tolokaforge.core.output.artifacts.TrialArtifactWriter`.
+
+* :class:`RunAggregateWriter` — Protocol the orchestrator depends on.
+* :class:`FileAggregateWriter` — disk-backed implementation.
+* :class:`InMemoryAggregateWriter` — non-disk implementation used as a
+  test fixture and as proof the seam is swappable.
+* :class:`RunAggregateBundle` — the per-run record the in-memory writer
+  populates.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "FileAggregateWriter",
+    "InMemoryAggregateWriter",
+    "RunAggregateBundle",
+    "RunAggregateWriter",
+]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RunAggregateWriter(Protocol):
+    """Writes run-level aggregate artifacts. The orchestrator depends on
+    this Protocol; alternative implementations (in-memory, remote object
+    store, …) satisfy the same contract.
+    """
+
+    def write_per_task_metrics(
+        self,
+        output_dir: Path,
+        metrics: list[dict[str, Any]],
+    ) -> None:
+        """Persist ``output_dir/per_task_metrics.json`` from *metrics*."""
+        ...
+
+    def write_aggregate(
+        self,
+        output_dir: Path,
+        aggregate: dict[str, Any],
+    ) -> None:
+        """Persist ``output_dir/aggregate.json`` from *aggregate*.
+
+        Callers are responsible for injecting any envelope fields the
+        artifact carries (e.g. ``schema_version``) before calling.
+        """
+        ...
+
+    def write_metadata_slices(
+        self,
+        output_dir: Path,
+        slices: dict[str, dict[str, Any]],
+    ) -> None:
+        """Persist ``output_dir/metadata_slices.json`` from *slices*.
+
+        *slices* is a ``{slice_dimension: {slice_key: aggregate_dict}}``
+        mapping — one entry per dimension (``by_benchmark_type``,
+        ``by_complexity``, ``by_tag``, ``by_expected_failure_mode``).
+        """
+        ...
+
+    def write_failure_attribution(
+        self,
+        output_dir: Path,
+        attribution: dict[str, Any],
+    ) -> None:
+        """Persist ``output_dir/failure_attribution.json`` from *attribution*.
+
+        *attribution* is the orchestrator-assembled envelope
+        ``{"summary": ..., "failures": [...]}``.
+        """
+        ...
+
+    def write_run_aggregates(
+        self,
+        output_dir: Path,
+        per_task_metrics: list[dict[str, Any]],
+        aggregate: dict[str, Any],
+        metadata_slices: dict[str, dict[str, Any]],
+        failure_attribution: dict[str, Any],
+    ) -> None:
+        """Write the four run-level aggregate artifacts in one call:
+        ``per_task_metrics.json``, ``aggregate.json``,
+        ``metadata_slices.json``, ``failure_attribution.json``.
+        Convenience for the common orchestrator path.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FileAggregateWriter — disk-backed implementation
+# ---------------------------------------------------------------------------
+
+
+def _dump_json(target: Path, payload: object) -> None:
+    """Write *payload* to *target* with the orchestrator's serializer
+    conventions: ``indent=2`` and ``default=str`` so Enums / datetimes /
+    other non-JSON-native values stringify deterministically.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with open(target, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+
+
+class FileAggregateWriter:
+    """Disk-backed :class:`RunAggregateWriter`.
+
+    Each artifact is one JSON file at ``output_dir``. Overwrites
+    unconditionally — the run-output root is owned by this run.
+    """
+
+    def write_per_task_metrics(
+        self,
+        output_dir: Path,
+        metrics: list[dict[str, Any]],
+    ) -> None:
+        _dump_json(Path(output_dir) / "per_task_metrics.json", metrics)
+
+    def write_aggregate(
+        self,
+        output_dir: Path,
+        aggregate: dict[str, Any],
+    ) -> None:
+        _dump_json(Path(output_dir) / "aggregate.json", aggregate)
+
+    def write_metadata_slices(
+        self,
+        output_dir: Path,
+        slices: dict[str, dict[str, Any]],
+    ) -> None:
+        _dump_json(Path(output_dir) / "metadata_slices.json", slices)
+
+    def write_failure_attribution(
+        self,
+        output_dir: Path,
+        attribution: dict[str, Any],
+    ) -> None:
+        _dump_json(Path(output_dir) / "failure_attribution.json", attribution)
+
+    def write_run_aggregates(
+        self,
+        output_dir: Path,
+        per_task_metrics: list[dict[str, Any]],
+        aggregate: dict[str, Any],
+        metadata_slices: dict[str, dict[str, Any]],
+        failure_attribution: dict[str, Any],
+    ) -> None:
+        self.write_per_task_metrics(output_dir, per_task_metrics)
+        self.write_aggregate(output_dir, aggregate)
+        self.write_metadata_slices(output_dir, metadata_slices)
+        self.write_failure_attribution(output_dir, failure_attribution)
+
+
+# ---------------------------------------------------------------------------
+# InMemoryAggregateWriter — non-disk implementation, test fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunAggregateBundle:
+    """The artifacts an :class:`InMemoryAggregateWriter` records for one run.
+
+    Each attribute holds the most recent value written for that artifact
+    name, or ``None`` if the corresponding ``write_*`` method has not
+    been called for this run.
+
+    ``write_run_aggregates`` populates all four slots. Per-piece writers
+    only touch their own slot.
+    """
+
+    per_task_metrics: list[dict[str, Any]] | None = None
+    aggregate: dict[str, Any] | None = None
+    metadata_slices: dict[str, dict[str, Any]] | None = None
+    failure_attribution: dict[str, Any] | None = None
+
+
+class InMemoryAggregateWriter:
+    """In-memory :class:`RunAggregateWriter`.
+
+    Stores each run's aggregates in ``self.runs`` keyed by ``output_dir``.
+    Use as a test fixture when code requires a writer but the assertion
+    is about what was written, not about a filesystem layout.
+
+    Dicts / lists passed in are stored by reference, not copied —
+    matching how :class:`FileAggregateWriter` would serialise whatever
+    state existed at write time.
+
+    The bundle key is ``Path(output_dir)`` as supplied — *not*
+    ``.resolve()``-d. Two surface forms of the same logical path
+    (``Path("a/b")`` vs ``Path("./a/b")``) bucket into separate runs
+    here; tests should pass canonical paths (typically ``tmp_path``) so
+    the divergence doesn't surface.
+    """
+
+    def __init__(self) -> None:
+        self.runs: dict[Path, RunAggregateBundle] = {}
+
+    def _bundle(self, output_dir: Path) -> RunAggregateBundle:
+        key = Path(output_dir)
+        if key not in self.runs:
+            self.runs[key] = RunAggregateBundle()
+        return self.runs[key]
+
+    def write_per_task_metrics(
+        self,
+        output_dir: Path,
+        metrics: list[dict[str, Any]],
+    ) -> None:
+        self._bundle(output_dir).per_task_metrics = metrics
+
+    def write_aggregate(
+        self,
+        output_dir: Path,
+        aggregate: dict[str, Any],
+    ) -> None:
+        self._bundle(output_dir).aggregate = aggregate
+
+    def write_metadata_slices(
+        self,
+        output_dir: Path,
+        slices: dict[str, dict[str, Any]],
+    ) -> None:
+        self._bundle(output_dir).metadata_slices = slices
+
+    def write_failure_attribution(
+        self,
+        output_dir: Path,
+        attribution: dict[str, Any],
+    ) -> None:
+        self._bundle(output_dir).failure_attribution = attribution
+
+    def write_run_aggregates(
+        self,
+        output_dir: Path,
+        per_task_metrics: list[dict[str, Any]],
+        aggregate: dict[str, Any],
+        metadata_slices: dict[str, dict[str, Any]],
+        failure_attribution: dict[str, Any],
+    ) -> None:
+        bundle = self._bundle(output_dir)
+        bundle.per_task_metrics = per_task_metrics
+        bundle.aggregate = aggregate
+        bundle.metadata_slices = metadata_slices
+        bundle.failure_attribution = failure_attribution


### PR DESCRIPTION
## Summary

Adds a typed, runtime-checkable seam for the four run-level aggregate JSONs the orchestrator emits today (`per_task_metrics.json`, `aggregate.json`, `metadata_slices.json`, `failure_attribution.json`). Mirrors the per-trial `TrialArtifactWriter` precedent (ADR-0004).

## The architecture target this PR serves

The engine has three planes — **control / trial / data**. Each should sit behind a named, typed seam so alternative implementations swap without engine edits.

| Plane | Seam | Status |
|---|---|---|
| Control ↔ Trial | `TrialSpec` / `TrialResult` | Landed on `main` (ADR-0003) |
| Trial → Data (per-trial) | `TrialArtifactWriter` | Landed on `main` (ADR-0004) |
| **Trial → Data (run-level)** | **`RunAggregateWriter`** | **This PR (ADR-0005)** |

After this PR, every plane has a typed, runtime-checkable contract with at least two implementations (production + in-memory). The data plane has both halves — per-trial and run-level — behind matching seams. Alternate backends (S3, GCS, a remote analytics service) can plug in without engine edits.

## What changes

### 1. New `RunAggregateWriter` Protocol + two implementations

`tolokaforge/core/output/aggregates.py` declares:

- `RunAggregateWriter` — `@runtime_checkable` `typing.Protocol` with five methods: one per-piece writer for each of the four JSON files plus a `write_run_aggregates` bundle method.
- `FileAggregateWriter` — disk-backed. Each method opens `output_dir / "<name>.json"` and `json.dump`s with `indent=2, default=str` — byte-shape identical to the pre-PR inline writes.
- `InMemoryAggregateWriter` — non-disk; records each run's payloads on a `RunAggregateBundle` dataclass keyed by `output_dir`. Two purposes: (a) prove the seam is swappable; (b) serve as a test fixture for code that needs a writer but should not touch the filesystem.

### 2. Orchestrator integration

`Orchestrator.__init__` now also instantiates `self._run_aggregate_writer: FileAggregateWriter = FileAggregateWriter()` — mirrors the existing `self._artifact_writer` precedent.

`_generate_reports()`'s four inline `open() + json.dump()` blocks collapse to one delegated call:

```python
self._run_aggregate_writer.write_run_aggregates(
    output_dir,
    all_task_metrics,
    aggregate,
    metadata_slices,
    failure_attribution_payload,
)
```

Dict-assembly logic (`schema_version` injection, failure-attribution envelope wrapping, empty-results early-return guard) stays in the orchestrator — the writer is downstream of dict assembly.

### 3. Tests

- `tests/canonical/test_run_aggregate_writer_contract.py` — 14 tests across three classes (Protocol runtime check, per-method parity, in-memory bundle semantics).
- `tests/canonical/test_run_aggregate_layout.py` — 10 tests pinning the on-disk filenames, top-level JSON shape, envelope keys (`schema_version`, `summary`/`failures`), serializer conventions (`indent=2`, `default=str` for Enums + datetimes), and parent-directory creation.
- `tests/unit/test_output_run_aggregates.py` — 14 focused unit tests for both writers.

### 4. ADR-0005

`docs/architecture/adr/0005-run-aggregate-writer-seam.md` documents the decision in MADR format: context, drivers, four considered options (full mirror / `@runtime_checkable` only / S3 backend now / defer), trade-offs, and explicit follow-ups (entry-point discovery, typed Pydantic models for the aggregates, async variants, concrete remote backends).

## Key decisions

1. **Separate Protocol from `TrialArtifactWriter`.** Per-trial and run-level seams have different lifecycles — per-trial writes happen *as each trial completes*; run aggregates write *once at the end*. Mixing them would force every backend to handle two write rhythms.

2. **Raw `dict[str, Any]` payloads, not Pydantic models.** The four aggregates today are wide, inconsistent across slices, and produced by metric-calc functions that return raw dicts. Typing them is a worthwhile follow-up but it's a separate ADR with its own breaking-change risk for downstream readers. Mirrors the per-trial `task_snapshot: dict[str, Any]` convention.

3. **`FileAggregateWriter` is byte-shape identical to the pre-PR writes.** Same `json.dump(..., indent=2, default=str)` kwargs the orchestrator used inline. Smoke validation below.

4. **`InMemoryAggregateWriter` is a real implementation, not a mock.** Same reasoning as `InMemoryArtifactWriter` (ADR-0004): proves the seam is swappable, doubles as a test fixture, no `MagicMock` quirks.

5. **Empty-results early return preserved.** When `self.results` is empty, `_generate_reports` returns at the top with a warning and no aggregate file is written. Writer is never invoked in that case.

## Verification

### Tests + lint (post-merge with `main`)

```text
$ uv run pytest tests/canonical/test_run_aggregate_writer_contract.py tests/canonical/test_run_aggregate_layout.py tests/unit/test_output_run_aggregates.py -q
38 passed in 0.13s

$ uv run pytest tests/ -m canonical -q
200 passed, 2471 deselected in 12.55s

$ uv run pytest tests/ -m unit -q
1777 passed, 1 skipped, 859 deselected in 33.99s

$ uv run ruff check tolokaforge/core/output/aggregates.py tolokaforge/core/output/__init__.py tolokaforge/core/orchestrator.py tests/canonical/test_run_aggregate_writer_contract.py tests/canonical/test_run_aggregate_layout.py tests/unit/test_output_run_aggregates.py
All checks passed!

$ uv run ruff format --check <touched files>
clean
```

### Live smoke — native adapter, byte-shape vs baseline

Ran `tolokaforge run --config examples/native/tool_use/run_config.yaml` against `main` (baseline) and then again on this branch. Compared the four aggregate JSONs.

**Filenames at the run root** — identical:

```text
aggregate.json
failure_attribution.json
metadata_slices.json
per_task_metrics.json
```

**Top-level key sets** — identical for every aggregate. Examples:

- `aggregate.json`: 35 top-level keys including `schema_version`, `success_rate_micro`, `pass@k_macro`, `latency_p{50,90,99}_s`, full token + cost aggregates.
- `metadata_slices.json`: `{by_benchmark_type, by_complexity, by_tag, by_expected_failure_mode}`.
- `failure_attribution.json`: `{summary, failures}`.
- `per_task_metrics.json`: 33-key per-task rows (success rate, pass@k, latency percentiles, token / cost aggregates, task metadata).

**File sizes** within 1–22 bytes of baseline — variation matches LLM sampling stochasticity (different turn counts, different costs); the serializer output shape is identical.

**Per-trial YAMLs unchanged** — `TrialArtifactWriter` path is untouched.

## Out of scope (follow-ups in ADR-0005)

- Entry-point discovery for run-aggregate writers (mirror the `tolokaforge.adapters` pattern with `tolokaforge.run_aggregate_writers`).
- Typed Pydantic models for the four aggregate payloads.
- Async variants (`AsyncRunAggregateWriter`).
- Concrete remote backends (S3, GCS, analytics service).
- Streaming / per-trial flushes of aggregates.
- `run_state.json`, `engine_run_state.json`, `run_queue.sqlite` — durable-state infrastructure, not analytics; stay out of this seam.

## Test plan

- [x] Canonical contract + layout tests green
- [x] Unit tests green
- [x] Full canonical suite green (200 passed)
- [x] Full unit suite green (1777 passed)
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] Live smoke against native adapter: byte-shape identical aggregates vs main
- [x] Rebased on latest `main` (includes #74 + #79)