### PR TITLE
fix(docker): unblock clean runner/rag-service builds and integration tests

### DIFF
--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -12,7 +12,11 @@ from unittest.mock import patch
 
 import pytest
 
-from tolokaforge.docker.builder import build_image, get_image_definition
+from tolokaforge.docker.builder import (
+    build_image,
+    get_image_definition,
+    service_name_for_image,
+)
 from tolokaforge.docker.image import Image
 from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
 from tolokaforge.docker.wheel_resolver import WheelArtifact
@@ -249,6 +253,21 @@ def test_build_image_passes_no_build_args_when_definition_has_none(monkeypatch) 
 
     build_image("db-service", force=True)
     assert captured["build_args"] is None
+
+
+@pytest.mark.usefixtures("_mock_wheel")
+def test_service_name_for_image_resolves_all_known_services() -> None:
+    """Reverse lookup must cover dynamically-resolved services too.
+
+    Integration test fixtures rely on this to auto-build runner / rag-service
+    images on a cold machine; iterating only ``IMAGE_DEFINITIONS`` misses them
+    because they are resolved via ``_runner_definition`` / ``_rag_definition``.
+    """
+    assert service_name_for_image("tolokaforge-db-service") == "db-service"
+    assert service_name_for_image("tolokaforge-mock-web") == "mock-web"
+    assert service_name_for_image("tolokaforge-runner") == "runner"
+    assert service_name_for_image("tolokaforge-rag-service") == "rag-service"
+    assert service_name_for_image("tolokaforge-does-not-exist") is None
 
 
 def test_start_service_builds_with_isolated_context_when_skipping_build_images(

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -255,14 +255,25 @@ def test_build_image_passes_no_build_args_when_definition_has_none(monkeypatch) 
     assert captured["build_args"] is None
 
 
-@pytest.mark.usefixtures("_mock_wheel")
-def test_service_name_for_image_resolves_all_known_services() -> None:
-    """Reverse lookup must cover dynamically-resolved services too.
+def test_service_name_for_image_resolves_all_known_services_without_resolving_wheel(
+    monkeypatch,
+) -> None:
+    """Reverse lookup must (a) cover dynamically-resolved services too and
+    (b) never invoke the wheel resolver as a side effect.
 
-    Integration test fixtures rely on this to auto-build runner / rag-service
-    images on a cold machine; iterating only ``IMAGE_DEFINITIONS`` misses them
-    because they are resolved via ``_runner_definition`` / ``_rag_definition``.
+    Iterating ``IMAGE_DEFINITIONS`` only misses runner / rag-service (they're
+    resolved via ``_runner_definition`` / ``_rag_definition``); calling
+    ``get_image_definition`` for every candidate, conversely, would invoke
+    ``resolve_wheel()`` for runner / rag-service even when looking up an
+    unrelated service like db-service — propagating wheel-build failures from
+    an unrelated lookup. The implementation must do neither.
     """
+
+    def fail_resolve_wheel(*args, **kwargs):
+        raise AssertionError("resolve_wheel must not be called during a name lookup")
+
+    monkeypatch.setattr("tolokaforge.docker.builder.resolve_wheel", fail_resolve_wheel)
+
     assert service_name_for_image("tolokaforge-db-service") == "db-service"
     assert service_name_for_image("tolokaforge-mock-web") == "mock-web"
     assert service_name_for_image("tolokaforge-runner") == "runner"

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -152,14 +152,14 @@ def test_runner_build_context_contains_wheel() -> None:
     assert context_files[0].endswith(".whl")
 
 
-@pytest.mark.usefixtures("_mock_wheel")
-def test_build_image_respects_context_files(monkeypatch) -> None:
+def test_build_image_respects_context_files(monkeypatch, _mock_wheel) -> None:
     """build_image() should place the resolved wheel in the Docker context."""
     captured = {}
 
     def fake_build(dockerfile, context, build_args=None, name=None, client=None):
         captured["dockerfile"] = dockerfile
         captured["context"] = context
+        captured["build_args"] = build_args
         root = Path(context)
 
         # The wheel should be in the build context root.
@@ -186,19 +186,23 @@ def test_build_image_respects_context_files(monkeypatch) -> None:
     image = build_image("runner", force=True)
     assert image.full_tag == "tolokaforge-runner:deadbeef"
     assert not Path(captured["context"]).exists(), "Temporary build context should be cleaned up"
+    # WHEEL_FILENAME must reach docker build. The Dockerfile's ARG default
+    # is a placeholder that doesn't match the real wheel on disk, so `COPY
+    # ${WHEEL_FILENAME}` fails whenever the harness omits this build arg.
+    assert captured["build_args"] == {"WHEEL_FILENAME": _mock_wheel.path.name}
 
 
-@pytest.mark.usefixtures("_mock_wheel")
-def test_build_image_non_force_path_uses_isolated_context(monkeypatch) -> None:
+def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_wheel) -> None:
     """The cached (non-force) path must also assemble the isolated context.
 
     Production builds go through ``ImageRegistry.get_or_build``.
     """
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
     def fake_get_or_build(self, *, name, dockerfile, context, build_args=None):  # noqa: ARG001
         captured["dockerfile"] = dockerfile
         captured["context"] = context
+        captured["build_args"] = build_args
         root = Path(context)
         # Wheel should be present in the isolated context.
         assert list(root.glob("tolokaforge-*.whl"))
@@ -219,6 +223,32 @@ def test_build_image_non_force_path_uses_isolated_context(monkeypatch) -> None:
     image = build_image("runner")
     assert image.full_tag == "tolokaforge-runner:cafe1234"
     assert not Path(captured["context"]).exists(), "Temporary build context should be cleaned up"
+    assert captured["build_args"] == {"WHEEL_FILENAME": _mock_wheel.path.name}
+
+
+def test_build_image_passes_no_build_args_when_definition_has_none(monkeypatch) -> None:
+    """Services whose definition has no ``build_args`` entry (e.g. db-service)
+    must receive ``build_args=None`` — not ``{}`` — so the content hash and
+    docker build call are bit-identical to the pre-feature behaviour.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_build(dockerfile, context, build_args=None, name=None, client=None):
+        captured["build_args"] = build_args
+        return Image(
+            name=name or "test",
+            tag="deadbeef",
+            image_id="dummy",
+            dockerfile=dockerfile,
+            context=context,
+            context_hash="deadbeef",
+            build_args=build_args or {},
+        )
+
+    monkeypatch.setattr(Image, "build", fake_build)
+
+    build_image("db-service", force=True)
+    assert captured["build_args"] is None
 
 
 def test_start_service_builds_with_isolated_context_when_skipping_build_images(

--- a/tests/utils/containers.py
+++ b/tests/utils/containers.py
@@ -44,16 +44,13 @@ def _check_image_available(image_name: str) -> None:
         pytest.skip(f"Docker not available: {exc}")
         return
 
-    # Image not found — try to build it from the project's Dockerfiles
-    from tolokaforge.docker.builder import IMAGE_DEFINITIONS
+    # Image not found — try to build it from the project's Dockerfiles.
+    # service_name_for_image covers both static (IMAGE_DEFINITIONS) and
+    # dynamically-resolved services (runner, rag-service).
+    from tolokaforge.docker.builder import service_name_for_image
 
-    # Resolve image name (without tag) to service name
     base_name = image_name.split(":")[0]
-    service_name = None
-    for svc, defn in IMAGE_DEFINITIONS.items():
-        if defn["name"] == base_name:
-            service_name = svc
-            break
+    service_name = service_name_for_image(base_name)
 
     if service_name is None:
         pytest.skip(f"Docker image '{image_name}' not found and no build definition exists for it")

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import shutil
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +42,19 @@ def repo_root() -> Path:
 # =============================================================================
 # Image Definitions — Single Source of Truth
 # =============================================================================
+#
+# Every service the project knows about appears in IMAGE_DEFINITIONS. Each
+# entry holds the static facts (name, dockerfile, context) and, when the
+# Dockerfile needs no host-side resolution, the static context_files too.
+#
+# Services whose build context depends on the wheel resolver (currently
+# ``runner`` and ``rag-service``) declare only their static fields here, and
+# pair with a factory (``_runner_definition`` / ``_rag_definition``) that
+# augments the static base with ``context_files`` and ``build_args`` at call
+# time. ``get_image_definition`` routes to that factory; everything that only
+# needs the static facts (reverse lookups, service enumeration, group
+# membership) reads IMAGE_DEFINITIONS directly and never triggers wheel
+# resolution as a side effect.
 
 IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
     "db-service": {
@@ -51,8 +65,18 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
             "tolokaforge/env/json_db_service/",
         ],
     },
-    # "runner" is resolved dynamically — see get_image_definition().
-    # "rag-service" is also resolved dynamically (needs wheel + service files).
+    "runner": {
+        "name": "tolokaforge-runner",
+        "dockerfile": "tolokaforge/docker/dockerfiles/runner.Dockerfile",
+        "context": ".",
+        # context_files + build_args added by _runner_definition() at call time
+    },
+    "rag-service": {
+        "name": "tolokaforge-rag-service",
+        "dockerfile": "tolokaforge/docker/dockerfiles/rag.Dockerfile",
+        "context": ".",
+        # context_files + build_args added by _rag_definition() at call time
+    },
     "mock-web": {
         "name": "tolokaforge-mock-web",
         "dockerfile": "tolokaforge/docker/dockerfiles/mock_web.Dockerfile",
@@ -61,35 +85,34 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
 }
 
+# Factories that augment a static base entry with wheel-resolver-dependent
+# fields. Keyed by service name; absent for services whose full definition
+# fits in IMAGE_DEFINITIONS verbatim.
+_DYNAMIC_DEFINITIONS: dict[str, Callable[[], dict[str, Any]]] = {}
+
 # Service groups for selective building
 CORE_IMAGES: list[str] = ["db-service", "runner"]
 EXTENDED_IMAGES: list[str] = ["rag-service", "mock-web"]
 
-_ALL_KNOWN_SERVICES = {"db-service", "runner", "rag-service", "mock-web"}
+_ALL_KNOWN_SERVICES = frozenset(IMAGE_DEFINITIONS)
 
 
 def _runner_definition() -> dict[str, Any]:
-    """Build the runner image definition dynamically via the wheel resolver.
+    """Augment the runner base entry with the resolved wheel.
 
-    The resolver produces a wheel on the host; the Dockerfile installs it.
-    The only file in the build context (besides the Dockerfile) is the wheel.
+    The Dockerfile installs the wheel produced by ``resolve_wheel()``; the
+    only file in the build context (besides the Dockerfile) is that wheel.
     """
     artifact = resolve_wheel()
     return {
-        "name": "tolokaforge-runner",
-        "dockerfile": "tolokaforge/docker/dockerfiles/runner.Dockerfile",
-        "context": ".",
-        "context_files": [
-            str(artifact.path),  # absolute path to the .whl
-        ],
-        "build_args": {
-            "WHEEL_FILENAME": artifact.path.name,
-        },
+        **IMAGE_DEFINITIONS["runner"],
+        "context_files": [str(artifact.path)],  # absolute path to the .whl
+        "build_args": {"WHEEL_FILENAME": artifact.path.name},
     }
 
 
 def _rag_definition() -> dict[str, Any]:
-    """Build the rag-service image definition dynamically.
+    """Augment the rag-service base entry with the resolved wheel + service files.
 
     The rag service needs both the tolokaforge wheel (for
     ``import tolokaforge.secrets``) and its own service files
@@ -97,32 +120,31 @@ def _rag_definition() -> dict[str, Any]:
     """
     artifact = resolve_wheel()
     return {
-        "name": "tolokaforge-rag-service",
-        "dockerfile": "tolokaforge/docker/dockerfiles/rag.Dockerfile",
-        "context": ".",
+        **IMAGE_DEFINITIONS["rag-service"],
         "context_files": [
             str(artifact.path),  # wheel (absolute → flat copy)
             "tolokaforge/env/rag_service/",  # service files (relative)
         ],
-        "build_args": {
-            "WHEEL_FILENAME": artifact.path.name,
-        },
+        "build_args": {"WHEEL_FILENAME": artifact.path.name},
     }
 
 
-def get_image_definition(service_name: str) -> dict[str, Any]:
-    """Return the image definition for *service_name*.
+_DYNAMIC_DEFINITIONS["runner"] = _runner_definition
+_DYNAMIC_DEFINITIONS["rag-service"] = _rag_definition
 
-    ``runner`` and ``rag-service`` are built dynamically via the wheel
-    resolver; all other entries come from the static dict.
+
+def get_image_definition(service_name: str) -> dict[str, Any]:
+    """Return the full image definition for *service_name*.
+
+    For services with a dynamic factory, that factory is called (it may
+    invoke ``resolve_wheel()``); otherwise the static entry is returned
+    as-is.
 
     Raises:
         KeyError: If *service_name* is not a known service.
     """
-    if service_name == "runner":
-        return _runner_definition()
-    if service_name == "rag-service":
-        return _rag_definition()
+    if service_name in _DYNAMIC_DEFINITIONS:
+        return _DYNAMIC_DEFINITIONS[service_name]()
     if service_name in IMAGE_DEFINITIONS:
         return IMAGE_DEFINITIONS[service_name]
     raise KeyError(f"Unknown service '{service_name}'. Available: {sorted(_ALL_KNOWN_SERVICES)}")
@@ -131,12 +153,12 @@ def get_image_definition(service_name: str) -> dict[str, Any]:
 def service_name_for_image(image_name: str) -> str | None:
     """Return the service whose definition produces ``image_name`` (without tag).
 
-    Searches both static (``IMAGE_DEFINITIONS``) and dynamically-resolved
-    (``runner``, ``rag-service``) services uniformly. Returns ``None`` if no
-    known service matches.
+    Reads IMAGE_DEFINITIONS directly — every service's image name lives there
+    as a static field, even for services with a dynamic factory, so no wheel
+    resolution is triggered as a side effect of an unrelated lookup.
     """
-    for svc in _ALL_KNOWN_SERVICES:
-        if get_image_definition(svc)["name"] == image_name:
+    for svc, defn in IMAGE_DEFINITIONS.items():
+        if defn["name"] == image_name:
             return svc
     return None
 

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -215,6 +215,7 @@ def build_image(
     """
     definition = get_image_definition(service_name)
     context_files = definition.get("context_files", [])
+    build_args = definition.get("build_args")
 
     if context_files:
         build_context = assemble_build_context(
@@ -230,6 +231,7 @@ def build_image(
                     dockerfile=str(dockerfile_path),
                     context=str(build_context),
                     name=definition["name"],
+                    build_args=build_args,
                 )
 
             if registry is None:
@@ -239,6 +241,7 @@ def build_image(
                 name=definition["name"],
                 dockerfile=str(dockerfile_path),
                 context=str(build_context),
+                build_args=build_args,
             )
         finally:
             shutil.rmtree(build_context, ignore_errors=True)
@@ -249,6 +252,7 @@ def build_image(
             dockerfile=definition["dockerfile"],
             context=definition["context"],
             name=definition["name"],
+            build_args=build_args,
         )
 
     if registry is None:
@@ -258,6 +262,7 @@ def build_image(
         name=definition["name"],
         dockerfile=definition["dockerfile"],
         context=definition["context"],
+        build_args=build_args,
     )
 
 

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -128,6 +128,19 @@ def get_image_definition(service_name: str) -> dict[str, Any]:
     raise KeyError(f"Unknown service '{service_name}'. Available: {sorted(_ALL_KNOWN_SERVICES)}")
 
 
+def service_name_for_image(image_name: str) -> str | None:
+    """Return the service whose definition produces ``image_name`` (without tag).
+
+    Searches both static (``IMAGE_DEFINITIONS``) and dynamically-resolved
+    (``runner``, ``rag-service``) services uniformly. Returns ``None`` if no
+    known service matches.
+    """
+    for svc in _ALL_KNOWN_SERVICES:
+        if get_image_definition(svc)["name"] == image_name:
+            return svc
+    return None
+
+
 def build_all_images(
     core_only: bool = False,
     force: bool = False,

--- a/tolokaforge/docker/dockerfiles/rag.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/rag.Dockerfile
@@ -15,8 +15,10 @@ RUN pip install --no-cache-dir -r service-requirements.txt
 
 # Install the tolokaforge package from a pre-built wheel so service code
 # can ``import tolokaforge.secrets`` for the global log redactor.
-# The wheel is placed in the build context by the host-side wheel resolver.
-ARG WHEEL_FILENAME=tolokaforge-0.0.0-py3-none-any.whl
+# The wheel is placed in the build context by the host-side wheel resolver;
+# WHEEL_FILENAME has no default so a missing --build-arg fails loudly at
+# this layer rather than silently `COPY`ing the wrong filename later.
+ARG WHEEL_FILENAME
 COPY ${WHEEL_FILENAME} /tmp/
 RUN pip install --no-cache-dir "/tmp/${WHEEL_FILENAME}" \
     && rm -f "/tmp/${WHEEL_FILENAME}"

--- a/tolokaforge/docker/dockerfiles/runner.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/runner.Dockerfile
@@ -38,8 +38,10 @@ WORKDIR /app
 
 # Install tolokaforge from the wheel the host resolver placed in the context.
 # WHEEL_FILENAME is passed as a build arg by the wheel resolver so we don't
-# rely on shell glob expansion inside Docker.
-ARG WHEEL_FILENAME=tolokaforge-0.0.0-py3-none-any.whl
+# rely on shell glob expansion inside Docker. No default — a missing
+# --build-arg fails loudly at this layer rather than silently `COPY`ing the
+# wrong filename later.
+ARG WHEEL_FILENAME
 COPY ${WHEEL_FILENAME} /tmp/
 RUN pip install --no-cache-dir "/tmp/${WHEEL_FILENAME}[docker]" \
     && rm -f "/tmp/${WHEEL_FILENAME}"


### PR DESCRIPTION
## Summary

Issue #82 reports a single symptom — "Docker integration tests skip and a clean build of `runner` / `rag-service` fails" — that turned out to have **three distinct root causes**, all in the runner/rag-service build path. This PR fixes all three.

### Bug 1 — `build_image()` drops `build_args`

`build_image()` in `tolokaforge/docker/builder.py` constructed a definition that included `build_args` (`WHEEL_FILENAME=tolokaforge-0.2.11-py3-none-any.whl` for `runner` and `rag-service`) but **dropped that dict at all four** `Image.build` / `ImageRegistry.get_or_build` call sites. The Dockerfile's placeholder default then took over and `COPY ${WHEEL_FILENAME}` failed for every project version other than `0.0.0`.

**Fix:** forward `definition.get("build_args")` at all four call sites. Strengthen the two runner tests to assert `WHEEL_FILENAME` reaches the build layer (derived from `_mock_wheel.path.name`, not hardcoded). Add `test_build_image_passes_no_build_args_when_definition_has_none` to pin the `None` direction.

### Bug 2 — `_check_image_available` reverse lookup misses dynamic services

While running the issue's test-plan items, integration tests **kept skipping with the same message** even with bug 1 fixed. `_check_image_available` (in `tests/utils/containers.py`) iterates `IMAGE_DEFINITIONS` to map an image name back to a service name, but `runner` and `rag-service` were deliberately absent from that dict — they're resolved dynamically via `_runner_definition` / `_rag_definition`. The lookup never found them and skipped **before ever calling `build_image()`**.

**Fix:** add `service_name_for_image()` in `builder.py` as the natural reverse-lookup API; refactor `IMAGE_DEFINITIONS` to be the actual single source of truth its comment block promised (every service's static fields live there; dynamic services pair with a factory registered in `_DYNAMIC_DEFINITIONS` that augments the static base with wheel-dependent fields). Pin the no-side-effect property with `test_service_name_for_image_resolves_all_known_services_without_resolving_wheel`, which patches `resolve_wheel` to raise on call.

### Bug 3 — misleading `WHEEL_FILENAME` placeholder default in the Dockerfiles

Both `runner.Dockerfile` and `rag.Dockerfile` declared `ARG WHEEL_FILENAME=tolokaforge-0.0.0-py3-none-any.whl`. That default is the AGENTS.md rule #1 silent-fallback smell that let bug 1 lurk: instead of failing loudly when `--build-arg` was missing, builds would silently substitute the `0.0.0` placeholder and then fail far away at `COPY` with "stat tolokaforge-0.0.0-...: file does not exist" — pointing at no real wheel and no real caller.

**Fix:** drop the default. The ARG stays declared (still a public contract), but a missing `--build-arg` now produces a failure that mentions `${WHEEL_FILENAME}` in the failing instruction. Verified locally: `docker build --file runner.Dockerfile .` (no `--build-arg`) fails loudly with the unresolved variable visible in the error; harness path (`tolokaforge docker build --service runner --force`) still succeeds.

## Verification

- [x] `uv run pytest tests/unit/test_docker_build_context.py` — 9 passed (was 7 before, +2 new + 2 strengthened)
- [x] `uv run ruff check` + `ruff format --check` on touched files — clean
- [x] **E2E repro from the issue, on `main`**: `tolokaforge docker build --service runner --force` fails at Step 6/17 with `COPY tolokaforge-0.0.0-py3-none-any.whl: file does not exist` (matches issue verbatim)
- [x] **E2E on this branch**: same command succeeds, both `runner` and `rag-service` build from zero cache (all 22 cached tags removed first), `import tolokaforge` inside the runner image reports version `0.2.11`
- [x] **Integration test previously skipping**: `tests/integration/test_docker_services.py::TestDockerE2E::test_complete_trial_execution` now passes (~3 min) — runner+rag containers auto-build on demand as the fixture docstring promised
- [x] **Bare docker build without `--build-arg`** (rule #1 verification): fails loudly with `${WHEEL_FILENAME}` referenced in the failing line; pre-fix it failed with a misleading "stat tolokaforge-0.0.0-...: file does not exist"

Closes #82.
Closes #90.