### PR TITLE
refactor(trial): type env_endpoints with EnvEndpoints Pydantic model

### DIFF
--- a/docs/architecture/adr/0006-typed-env-endpoints.md
+++ b/docs/architecture/adr/0006-typed-env-endpoints.md
@@ -61,6 +61,7 @@ We adopt **Option 1**.
 - **Orchestrator dual-path fallback cleanup.** Three loops in `_run_trial` (`json_db_reset_urls`, `rag_service_urls`, `json_db_sync_urls`) try docker-DNS-name then localhost. These flow from the orchestrator-on-host to services, separate from the runner-perspective URLs on `EnvEndpoints`. Cleanup is its own concern.
 - **`RuntimeBackend` Protocol.** Reads `EnvEndpoints` to know where to send a trial. Next architecture-seam step.
 - **`Conductor` Protocol promoting `TrialRunner`.** Lifts `_run_trial` out of the orchestrator; reads `TrialSpec.env_endpoints` to know its own runner target.
+- **Centralized config / service discovery for multi-machine deployments.** Today each worker reads its own `DB_SERVICE_URL` / `RAG_SERVICE_URL` / `EXECUTOR_ADDRESS` from the environment — fine for 1–2 boxes, friction at 10+. Per-trial routing (orchestrator decides "trial T should target DB-X") is also not expressible. Both belong to the Phase 2+ control-plane / scheduler scope sketched in [`docs/CLOUD_RUNTIME_ARCHITECTURE.md`](../../CLOUD_RUNTIME_ARCHITECTURE.md) §13 and are out of the seam-definition arc; calling them out here so a reader of this ADR sees where the trail goes.
 
 ## Rejected alternatives
 

--- a/docs/architecture/adr/0006-typed-env-endpoints.md
+++ b/docs/architecture/adr/0006-typed-env-endpoints.md
@@ -1,0 +1,76 @@
+# 0006. `EnvEndpoints` — typed runner service URLs on `TrialSpec`
+
+- **Status:** Proposed
+- **Date:** 2026-06-25
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+`TrialSpec` (ADR-0003) shipped with `env_endpoints: dict[str, str]` as a deliberate placeholder — typed as raw key/value strings, defaulted to `{}`, and consumed by nobody. The slot exists so a successor PR can type it in place without revising the surrounding `TrialSpec` shape.
+
+That successor is now needed. Today's runner reads its DB / RAG URLs from server-startup env vars (`DB_SERVICE_URL`, `RAG_SERVICE_URL`) with hardcoded `http://localhost:8000` / `http://localhost:8001` fallbacks. The orchestrator separately resolves the runner gRPC address from `ServiceStack.get_service_url("runner", 50051)`. There is no single, typed surface where the orchestrator declares "these are the URLs this trial should reach" and the runner declares "these are the URLs I read per trial."
+
+The architecture proposal (`docs/CLOUD_RUNTIME_ARCHITECTURE.md` §14 coupling **C2** "localhost runner addr → P1") names this gap as the first follow-on after the control↔trial seam. Without it, a future where the runner is out-of-process — `RuntimeBackend` Protocol, remote `Conductor`, distributed execution — has no contract to flow URLs through.
+
+## Decision Drivers
+
+- **Type one of TrialSpec's last placeholder slots in place.** ADR-0003 was written so this PR is a single-annotation replacement, not a re-shaping.
+- **One source of truth on the wire.** The producer (orchestrator) resolves the URLs once; the consumer (runner) reads the same values per trial. No drift between server-startup defaults and per-trial overrides.
+- **`extra="forbid"` strictness.** The wire format is reviewed at PR time; misspelled fields fail validation rather than being silently dropped. Same convention as `TrialSpec` / `TrialResult`.
+- **Fail-fast.** Required URLs (`db_url`, `runner_url`) raise on missing; `rag_url` is optional because `core_stack` does not include RAG.
+- **No gRPC contract churn.** `trial_spec_json` stays a JSON string in the proto; the nested-model change is transparent to the wire schema.
+
+## Considered Options
+
+1. **Type `env_endpoints` in place with a new `EnvEndpoints` Pydantic model.** The slot already exists; replacing the annotation is a single field change. The orchestrator becomes the producer; the runner gains a typed contract to consume from in a follow-up. **This PR.**
+2. **Add a new top-level field on `TrialSpec` (`endpoints: EnvEndpoints`) and leave the legacy `env_endpoints` dict in place.** Backwards-compatible. Costs a second field and a deprecation window for a feature that has zero readers today.
+3. **Skip the type and just remove the localhost defaults at the runner.** Cheapest. Leaves the orchestrator with no place to declare "this trial's URLs are X"; the runner still depends on its own startup env vars.
+4. **Defer until a remote conductor exists.** Each later seam (`RuntimeBackend`, `Conductor`, remote runner) ends up co-litigating the endpoint shape simultaneously with whatever else it's doing.
+
+## Decision
+
+We adopt **Option 1**.
+
+- Add `EnvEndpoints` to `tolokaforge/core/trial.py` next to `TrialSpec`. Pydantic v2 `BaseModel` with `model_config = {"extra": "forbid"}`. Three fields:
+  - `db_url: str` — required.
+  - `rag_url: str | None = None` — optional (`rag-service` ships in `full_stack` only).
+  - `runner_url: str` — required.
+- `TrialSpec.env_endpoints` annotation flips from `dict[str, str] = Field(default_factory=dict)` to `EnvEndpoints` with no default — the orchestrator is required to supply it.
+- The orchestrator builds an `EnvEndpoints` once per run from a free function (`_build_env_endpoints`) that reads the same env vars the docker stack injects into the runner container (`DB_SERVICE_URL`, `RAG_SERVICE_URL`) and the orchestrator's known runner address. Threaded through `_run_trial` as a kwarg; carried verbatim on every `TrialSpec` the run produces.
+- Canonical contract tests (`tests/canonical/test_trial_spec_contract.py`) update the field assertions and add `test_env_endpoints_is_required`. A new unit test (`tests/unit/test_env_endpoints.py`) pins `EnvEndpoints`'s own shape, optional-`rag_url`, `extra="forbid"`, and JSON round-trip. Orchestrator unit tests (`TestBuildEnvEndpoints`) pin the producer's behaviour.
+
+## Consequences
+
+### Positive
+
+- `TrialSpec.env_endpoints` is now typed end-to-end on the wire. The seam this PR establishes is the contract the next seam-definition steps (`RuntimeBackend`, `Conductor`) read from.
+- Field set is reviewed at PR time, not at consumer-dashboard-breakage time.
+- `extra="forbid"` catches typos.
+- No gRPC `.proto` change; ADR-0003's promise that follow-ons replace placeholders in place is honoured.
+
+### Negative / Trade-offs
+
+- The runner does **not** yet consume `trial_spec.env_endpoints`. Today it still reads URLs from its own server-startup env vars (`DB_SERVICE_URL` / `RAG_SERVICE_URL`) with the docker-stack injection providing the value. Carrying the URLs on the wire is the architectural step; the runner-side consumer (per-trial client construction, removal of the startup defaults) is the next focused PR.
+- Three fields cover today's services only. Engine-internal TypeSense flows through `TaskDescription.search_config` (unchanged); a hypothetical second runner-perspective service in a future stack adds a field then.
+
+### Follow-ups
+
+- **Runner consumer.** `RunnerServiceImpl` builds DB / RAG clients per `RegisterTrial` from `trial_spec.env_endpoints`. Delete `DEFAULT_DB_SERVICE_URL` / `DEFAULT_RAG_SERVICE_URL` from `runner/__main__.py`. Out of scope for this PR (separate ~400 LoC refactor).
+- **Orchestrator dual-path fallback cleanup.** Three loops in `_run_trial` (`json_db_reset_urls`, `rag_service_urls`, `json_db_sync_urls`) try docker-DNS-name then localhost. These flow from the orchestrator-on-host to services, separate from the runner-perspective URLs on `EnvEndpoints`. Cleanup is its own concern.
+- **`RuntimeBackend` Protocol.** Reads `EnvEndpoints` to know where to send a trial. Next architecture-seam step.
+- **`Conductor` Protocol promoting `TrialRunner`.** Lifts `_run_trial` out of the orchestrator; reads `TrialSpec.env_endpoints` to know its own runner target.
+
+## Rejected alternatives
+
+- **Option 2 — keep both `env_endpoints` (dict) and a new typed field.** Backwards-compat for a feature that has zero readers today. Pure cost.
+- **Option 3 — runner-side cleanup only.** Leaves the orchestrator with no typed surface to express "this trial's URLs." Half-measure that defeats the architectural goal.
+- **Option 4 — defer.** Same argument as ADR-0004 and ADR-0005: each later seam ends up re-litigating the endpoint shape under deadline pressure.
+
+## Scope notes
+
+- **Producer side only.** This PR ships the type, the producer (orchestrator), and the contract tests. The runner-side consumer is a separate PR.
+- **TypeSense is engine-internal.** Co-located with the orchestrator; flows through `TaskDescription.search_config`. Not in `EnvEndpoints`.
+- **`executor:50051` literals** in `orchestrator.py` and `docker_runtime.py` are runner-address defaults, not separate-executor URLs. They belong to the `RuntimeBackend` seam, not here.
+- **Dual-path fallback loops** in the orchestrator (`_run_trial`) are dev-mode-only host→service URL lookups, separate from runner-perspective URLs carried on `EnvEndpoints`. Out of scope.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -36,3 +36,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0003](0003-trial-spec-and-trial-result.md) | TrialSpec and TrialResult as the typed control↔trial seam | Proposed |
 | [0004](0004-trial-artifact-writer-seam.md) | `TrialArtifactWriter` as the typed data-plane seam | Proposed |
 | [0005](0005-run-aggregate-writer-seam.md) | `RunAggregateWriter` as the run-level data-plane seam | Proposed |
+| [0006](0006-typed-env-endpoints.md) | `EnvEndpoints` — typed runner service URLs on `TrialSpec` | Proposed |

--- a/tests/canonical/test_trial_spec_contract.py
+++ b/tests/canonical/test_trial_spec_contract.py
@@ -26,7 +26,7 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
 )
-from tolokaforge.core.trial import TrialResult, TrialSpec
+from tolokaforge.core.trial import EnvEndpoints, TrialResult, TrialSpec
 from tolokaforge.runner.models import TaskDescription
 
 pytestmark = pytest.mark.canonical
@@ -47,6 +47,14 @@ def _make_model_config() -> ModelConfig:
     return ModelConfig(name="claude-sonnet-4-6", provider="anthropic")
 
 
+def _make_env_endpoints(rag: bool = False) -> EnvEndpoints:
+    return EnvEndpoints(
+        db_url="http://db.local:8000",
+        rag_url="http://rag.local:8001" if rag else None,
+        runner_url="http://runner.local:50051",
+    )
+
+
 # ---------------------------------------------------------------------------
 # TrialSpec
 # ---------------------------------------------------------------------------
@@ -59,15 +67,29 @@ class TestTrialSpecContract:
             run_id="run_2026_06_18",
             task=_make_task_description(),
             agent_model_config=_make_model_config(),
+            env_endpoints=_make_env_endpoints(),
         )
         # Identity defaults: attempt_id and worker_id have sensible zero values.
         assert spec.attempt_id == 0
         assert spec.worker_id is None
-        # Forward-looking extension points default to empty containers, not None.
-        assert spec.env_endpoints == {}
+        # ``env_endpoints`` is required; the typed model is the contract.
+        assert isinstance(spec.env_endpoints, EnvEndpoints)
+        assert spec.env_endpoints.db_url == "http://db.local:8000"
+        # ``runtime_context`` stays a free-form dict (extension point).
         assert spec.runtime_context == {}
         # Embedded task is the same object (no clone, no transformation).
         assert spec.task.task_id == "airline_001"
+
+    def test_env_endpoints_is_required(self) -> None:
+        """The orchestrator must resolve service URLs before constructing
+        a spec — there is no implicit empty default any longer."""
+        with pytest.raises(ValidationError):
+            TrialSpec(
+                trial_id="airline_001:0",
+                run_id="run_2026_06_18",
+                task=_make_task_description(),
+                agent_model_config=_make_model_config(),
+            )
 
     def test_json_round_trip_is_identity(self) -> None:
         spec = TrialSpec(
@@ -80,7 +102,7 @@ class TestTrialSpecContract:
             user_model_config=_make_model_config(),
             max_turns=20,
             default_tool_timeout_s=45.0,
-            env_endpoints={"db": "http://db.local:8000", "rag": "http://rag.local:8001"},
+            env_endpoints=_make_env_endpoints(rag=True),
             runtime_context={"backend": "local", "pod_class": "ephemeral"},
         )
         reloaded = TrialSpec.model_validate_json(spec.model_dump_json())
@@ -96,6 +118,7 @@ class TestTrialSpecContract:
                     "run_id": "r",
                     "task": _make_task_description().model_dump(),
                     "agent_model_config": _make_model_config().model_dump(),
+                    "env_endpoints": _make_env_endpoints().model_dump(),
                     "this_field_does_not_exist": True,
                 }
             )
@@ -107,6 +130,7 @@ class TestTrialSpecContract:
             run_id="r",
             task=_make_task_description(),
             agent_model_config=_make_model_config(),
+            env_endpoints=_make_env_endpoints(),
         )
         # The set of keys at the top level is the seam. Embedded models can
         # evolve under their own contract tests; this set may not drift

--- a/tests/integration/test_runner_cleanup_trial_grpc.py
+++ b/tests/integration/test_runner_cleanup_trial_grpc.py
@@ -15,7 +15,7 @@ import pytest
 
 from tolokaforge.core.docker_runtime import RunnerClient
 from tolokaforge.core.models import ModelConfig
-from tolokaforge.core.trial import TrialSpec
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.models import TaskDescription
 
@@ -59,6 +59,10 @@ def _trial_spec_json(trial_id: str) -> str:
         run_id="cleanup_e2e_run",
         task=TaskDescription.model_validate(_task_description()),
         agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
     ).model_dump_json()
 
 

--- a/tests/unit/test_env_endpoints.py
+++ b/tests/unit/test_env_endpoints.py
@@ -1,0 +1,82 @@
+"""Pin the ``EnvEndpoints`` Pydantic model shape + behaviour.
+
+`EnvEndpoints` carries the runner-side service URLs on the wire inside
+:class:`tolokaforge.core.trial.TrialSpec`. These tests assert the field
+set, the ``extra="forbid"`` strictness, and JSON round-trip identity so
+shape drift surfaces at PR time.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.trial import EnvEndpoints
+
+pytestmark = pytest.mark.unit
+
+
+class TestEnvEndpointsShape:
+    def test_required_fields_minimal(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db.local:8000",
+            runner_url="http://runner.local:50051",
+        )
+        assert endpoints.db_url == "http://db.local:8000"
+        assert endpoints.runner_url == "http://runner.local:50051"
+        # ``rag_url`` is optional — defaults to ``None`` for stacks without RAG.
+        assert endpoints.rag_url is None
+
+    def test_rag_url_is_optional(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db:8000",
+            rag_url="http://rag:8001",
+            runner_url="http://runner:50051",
+        )
+        assert endpoints.rag_url == "http://rag:8001"
+
+    def test_db_url_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            EnvEndpoints(runner_url="http://runner:50051")
+
+    def test_runner_url_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            EnvEndpoints(db_url="http://db:8000")
+
+    def test_extra_fields_are_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            EnvEndpoints.model_validate(
+                {
+                    "db_url": "http://db:8000",
+                    "runner_url": "http://runner:50051",
+                    "this_field_does_not_exist": "x",
+                }
+            )
+
+    def test_wire_shape_top_level_keys(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db:8000",
+            rag_url="http://rag:8001",
+            runner_url="http://runner:50051",
+        )
+        assert set(endpoints.model_dump().keys()) == {"db_url", "rag_url", "runner_url"}
+
+
+class TestEnvEndpointsRoundTrip:
+    def test_json_round_trip_with_rag(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db:8000",
+            rag_url="http://rag:8001",
+            runner_url="http://runner:50051",
+        )
+        reloaded = EnvEndpoints.model_validate_json(endpoints.model_dump_json())
+        assert reloaded == endpoints
+
+    def test_json_round_trip_without_rag(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db:8000",
+            runner_url="http://runner:50051",
+        )
+        reloaded = EnvEndpoints.model_validate_json(endpoints.model_dump_json())
+        assert reloaded == endpoints
+        assert reloaded.rag_url is None

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1013,3 +1013,56 @@ class TestSerializeModelConfig:
         assert result["agent"]["name"] == "openai/gpt-5.4"
         assert isinstance(result["user"], dict)
         assert result["user"]["name"] == "anthropic/claude-sonnet-4.6"
+
+
+# ===================================================================
+# _build_env_endpoints (free function)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestBuildEnvEndpoints:
+    """The producer of ``TrialSpec.env_endpoints`` — pure resolver that
+    reads the orchestrator's known runner address and the runner-parity
+    env vars (``DB_SERVICE_URL`` / ``RAG_SERVICE_URL``). No service-stack
+    introspection; suitable for both auto-start and external (worker) runs.
+    """
+
+    def test_defaults_match_docker_stack_injection(self, monkeypatch: Any) -> None:
+        """With no env override, ``db_url`` falls back to the URL the docker
+        stack injects into the runner container — so the wire value matches
+        what the runner already sees today."""
+        from tolokaforge.core.orchestrator import _build_env_endpoints
+
+        monkeypatch.delenv("DB_SERVICE_URL", raising=False)
+        monkeypatch.delenv("RAG_SERVICE_URL", raising=False)
+
+        endpoints = _build_env_endpoints("executor:50051")
+
+        assert endpoints.db_url == "http://tolokaforge-db-service:8000"
+        assert endpoints.rag_url is None
+        assert endpoints.runner_url == "http://executor:50051"
+
+    def test_env_overrides_take_precedence(self, monkeypatch: Any) -> None:
+        from tolokaforge.core.orchestrator import _build_env_endpoints
+
+        monkeypatch.setenv("DB_SERVICE_URL", "http://db.example:8000")
+        monkeypatch.setenv("RAG_SERVICE_URL", "http://rag.example:8001")
+
+        endpoints = _build_env_endpoints("runner.example:50051")
+
+        assert endpoints.db_url == "http://db.example:8000"
+        assert endpoints.rag_url == "http://rag.example:8001"
+        assert endpoints.runner_url == "http://runner.example:50051"
+
+    def test_runner_address_with_scheme_passes_through(self) -> None:
+        from tolokaforge.core.orchestrator import _build_env_endpoints
+
+        endpoints = _build_env_endpoints("http://runner.example:50051")
+        assert endpoints.runner_url == "http://runner.example:50051"
+
+    def test_runner_address_https_passes_through(self) -> None:
+        from tolokaforge.core.orchestrator import _build_env_endpoints
+
+        endpoints = _build_env_endpoints("https://runner.example:50051")
+        assert endpoints.runner_url == "https://runner.example:50051"

--- a/tests/unit/test_runner_cleanup_trial.py
+++ b/tests/unit/test_runner_cleanup_trial.py
@@ -14,7 +14,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 from tolokaforge.core.models import ModelConfig
-from tolokaforge.core.trial import TrialSpec
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.models import TaskDescription
 
@@ -52,6 +52,10 @@ def _register(runner_service, mock_grpc_context, trial_id: str, td: dict[str, An
         run_id="test_run",
         task=TaskDescription.model_validate(td),
         agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
     )
     request = pb2.RegisterTrialRequest(
         trial_id=trial_id,

--- a/tests/unit/test_runner_pipeline.py
+++ b/tests/unit/test_runner_pipeline.py
@@ -18,7 +18,7 @@ import pytest
 pytestmark = pytest.mark.unit
 
 from tolokaforge.core.models import ModelConfig
-from tolokaforge.core.trial import TrialSpec
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.models import TaskDescription
 
@@ -36,6 +36,10 @@ def _trial_spec_json(task_dict: dict[str, Any], trial_id: str = "test:0") -> str
         run_id="test_run",
         task=TaskDescription.model_validate(task_dict),
         agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
     ).model_dump_json()
 
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -152,11 +152,6 @@ container at start (`tolokaforge/docker/stacks/core.py`). The orchestrator
 mirrors the value on ``TrialSpec.env_endpoints`` so a future out-of-process
 runner reads its service URLs from the spec instead of its own env."""
 
-_DEFAULT_RAG_SERVICE_URL = "http://tolokaforge-rag-service:8001"
-"""Runner-perspective RAG service URL — companion to ``_DEFAULT_DB_SERVICE_URL``.
-``rag-service`` ships in ``full_stack`` only; the URL is still carried in
-case the runner has its own per-trial RAG configuration."""
-
 
 def _normalise_runner_url(runner_address: str) -> str:
     """Prepend ``http://`` to a bare ``host:port`` runner address, leaving
@@ -169,14 +164,18 @@ def _normalise_runner_url(runner_address: str) -> str:
 def _build_env_endpoints(runner_address: str) -> EnvEndpoints:
     """Resolve the per-trial service URLs for inclusion in :class:`TrialSpec`.
 
-    Sources, in order:
+    Field semantics:
 
-    * ``runner_url`` — derived from the orchestrator's known runner address
-      (the value passed to :class:`DockerRuntime`).
-    * ``db_url`` — ``DB_SERVICE_URL`` env override, else the runner-container
-      default the docker stack injects.
-    * ``rag_url`` — ``RAG_SERVICE_URL`` env override, else ``None`` (the
-      runner-side RAG client is constructed lazily and tolerates absence).
+    * ``runner_url`` — derived from the orchestrator's known runner
+      address (the value passed to :class:`DockerRuntime`). Always set.
+    * ``db_url`` — required on the wire. Reads ``DB_SERVICE_URL`` from
+      the environment if set, otherwise the runner-container default
+      the docker stack injects (``_DEFAULT_DB_SERVICE_URL``).
+    * ``rag_url`` — optional. Reads ``RAG_SERVICE_URL`` from the
+      environment if set, otherwise stays ``None``. ``rag-service``
+      ships in ``full_stack`` only, so a ``core_stack`` run with no
+      override resolves to ``None`` — carrying a hardcoded RAG URL
+      would point at a service that isn't running.
     """
     return EnvEndpoints(
         db_url=os.environ.get("DB_SERVICE_URL", _DEFAULT_DB_SERVICE_URL),

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -50,7 +50,7 @@ from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import AttemptLease, create_run_queue
 from tolokaforge.core.runner import TrialRunner
 from tolokaforge.core.stuck import StuckDetector
-from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialResult, TrialSpec
+from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, TrialResult, TrialSpec
 from tolokaforge.runner.models import AdapterType
 
 # Tools that need Playwright + Chromium baked into the runner image. The
@@ -144,6 +144,45 @@ def _build_resolved_block(model_config: ModelConfig) -> dict[str, Any]:
         "effective_preset": resolve_effective_preset(model_config.name, model_config.provider),
         **resolve_policy_names(capabilities),
     }
+
+
+_DEFAULT_DB_SERVICE_URL = "http://tolokaforge-db-service:8000"
+"""Runner-perspective DB service URL the docker stack injects into the runner
+container at start (`tolokaforge/docker/stacks/core.py`). The orchestrator
+mirrors the value on ``TrialSpec.env_endpoints`` so a future out-of-process
+runner reads its service URLs from the spec instead of its own env."""
+
+_DEFAULT_RAG_SERVICE_URL = "http://tolokaforge-rag-service:8001"
+"""Runner-perspective RAG service URL — companion to ``_DEFAULT_DB_SERVICE_URL``.
+``rag-service`` ships in ``full_stack`` only; the URL is still carried in
+case the runner has its own per-trial RAG configuration."""
+
+
+def _normalise_runner_url(runner_address: str) -> str:
+    """Prepend ``http://`` to a bare ``host:port`` runner address, leaving
+    fully-qualified URLs untouched."""
+    if runner_address.startswith(("http://", "https://")):
+        return runner_address
+    return f"http://{runner_address}"
+
+
+def _build_env_endpoints(runner_address: str) -> EnvEndpoints:
+    """Resolve the per-trial service URLs for inclusion in :class:`TrialSpec`.
+
+    Sources, in order:
+
+    * ``runner_url`` — derived from the orchestrator's known runner address
+      (the value passed to :class:`DockerRuntime`).
+    * ``db_url`` — ``DB_SERVICE_URL`` env override, else the runner-container
+      default the docker stack injects.
+    * ``rag_url`` — ``RAG_SERVICE_URL`` env override, else ``None`` (the
+      runner-side RAG client is constructed lazily and tolerates absence).
+    """
+    return EnvEndpoints(
+        db_url=os.environ.get("DB_SERVICE_URL", _DEFAULT_DB_SERVICE_URL),
+        rag_url=os.environ.get("RAG_SERVICE_URL"),
+        runner_url=_normalise_runner_url(runner_address),
+    )
 
 
 class Orchestrator:
@@ -630,6 +669,14 @@ class Orchestrator:
         docker_runtime.connect()
         self.logger.info("Docker runtime connected")
 
+        env_endpoints = _build_env_endpoints(runner_address)
+        self.logger.info(
+            "Resolved trial-scoped service endpoints",
+            db_url=env_endpoints.db_url,
+            rag_url=env_endpoints.rag_url,
+            runner_url=env_endpoints.runner_url,
+        )
+
         executor_healthy = docker_runtime.health_check()
         self.logger.info("Docker runtime health check", executor_healthy=executor_healthy)
 
@@ -710,6 +757,7 @@ class Orchestrator:
                     request_limiter,
                     attempt_id=lease.retry_count,
                     worker_id=lease_owner,
+                    env_endpoints=env_endpoints,
                 )
                 active_futures[future] = lease
                 return True
@@ -908,10 +956,17 @@ class Orchestrator:
 
         from tolokaforge.core.docker_runtime import DockerRuntime
 
-        docker_runtime = DockerRuntime(
-            runner_address=os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
-        )
+        runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
+        docker_runtime = DockerRuntime(runner_address=runner_address)
         docker_runtime.connect()
+
+        env_endpoints = _build_env_endpoints(runner_address)
+        self.logger.info(
+            "Resolved trial-scoped service endpoints",
+            db_url=env_endpoints.db_url,
+            rag_url=env_endpoints.rag_url,
+            runner_url=env_endpoints.runner_url,
+        )
 
         task_by_id = {task.task_id: task for task in self.tasks}
         run_queue = create_run_queue(
@@ -974,6 +1029,7 @@ class Orchestrator:
                         request_limiter=request_limiter,
                         attempt_id=lease.retry_count,
                         worker_id=lease_owner,
+                        env_endpoints=env_endpoints,
                     )
                     trajectory = trial_result.trajectory
                     self.results.append(trajectory)
@@ -1082,6 +1138,7 @@ class Orchestrator:
         *,
         attempt_id: int = 0,
         worker_id: str | None = None,
+        env_endpoints: EnvEndpoints,
     ) -> TrialResult:
         """Run a single trial with environment state and grading.
 
@@ -1289,6 +1346,7 @@ class Orchestrator:
             user_model_config=user_config,
             max_turns=task.max_turns,
             default_tool_timeout_s=DEFAULT_TOOL_TIMEOUT_S,
+            env_endpoints=env_endpoints,
         )
 
         # The spec is the single source of truth for the timeout; the proto

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -16,6 +16,33 @@ Single source of truth for the producer (orchestrator spec build), the gRPC
 client default, and the runner-side consumer fallback."""
 
 
+class EnvEndpoints(BaseModel):
+    """URLs for trial-scoped environment services the runner talks to.
+
+    Travels on the wire inside :class:`TrialSpec`. The orchestrator
+    resolves the URLs once (from its service-discovery layer) and writes
+    them here; the runner reads the same values per trial without
+    inheriting any host-default. Co-located engine-internal services
+    (TypeSense) do **not** belong here — they flow through
+    ``TaskDescription.search_config``.
+    """
+
+    db_url: str
+    """URL of the per-trial DB service the runner's tool layer calls."""
+
+    rag_url: str | None = None
+    """URL of the RAG service the runner's tool layer calls. ``None``
+    when the run's service stack does not include RAG (e.g.
+    ``core_stack``; ``rag-service`` ships in ``full_stack`` only)."""
+
+    runner_url: str
+    """URL of the runner gRPC endpoint itself. Carried so a future
+    out-of-process conductor reads its target from the spec rather than
+    a host-side default."""
+
+    model_config = {"extra": "forbid"}
+
+
 class TrialSpec(BaseModel):
     """Everything a trial needs to run.
 
@@ -56,9 +83,10 @@ class TrialSpec(BaseModel):
     runner, which falls back to ``DEFAULT_TOOL_TIMEOUT_S``."""
 
     # ---- Extension points ------------------------------------------------
-    env_endpoints: dict[str, str] = Field(default_factory=dict)
-    """URLs for trial-scoped environment services, keyed by service name
-    (``db``, ``rag``, …)."""
+    env_endpoints: EnvEndpoints
+    """URLs for trial-scoped environment services. Required — the producer
+    (orchestrator) resolves them once and the consumer (runner) reads
+    them per trial."""
 
     runtime_context: dict[str, Any] = Field(default_factory=dict)
     """Free-form payload for runtime-backend-specific inputs (e.g. K8s pod
@@ -90,4 +118,4 @@ class TrialResult(BaseModel):
         return cls(trial_id=trial_id, trajectory=trajectory, worker_id=worker_id)
 
 
-__all__ = ["DEFAULT_TOOL_TIMEOUT_S", "TrialSpec", "TrialResult"]
+__all__ = ["DEFAULT_TOOL_TIMEOUT_S", "EnvEndpoints", "TrialResult", "TrialSpec"]

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -36,9 +36,12 @@ class EnvEndpoints(BaseModel):
     ``core_stack``; ``rag-service`` ships in ``full_stack`` only)."""
 
     runner_url: str
-    """URL of the runner gRPC endpoint itself. Carried so a future
-    out-of-process conductor reads its target from the spec rather than
-    a host-side default."""
+    """URL of the runner gRPC endpoint as the orchestrator that produced
+    this spec sees it (e.g. ``http://localhost:55310`` in auto-start
+    mode, ``http://executor:50051`` for workers). Carried on the wire
+    ahead of the remote-conductor design — today's value encodes the
+    writer's local view of the runner; a future out-of-process consumer
+    will need a network-reachable URL, which is on the design backlog."""
 
     model_config = {"extra": "forbid"}
 


### PR DESCRIPTION
## Summary

Types `TrialSpec.env_endpoints` in place with a new `EnvEndpoints` Pydantic model. The slot shipped in PR #74 as a deliberately-untyped placeholder (`dict[str, str] = Field(...)`); this PR replaces the annotation without re-shaping `TrialSpec` or changing the gRPC contract. Producer (orchestrator) lands here; runner-side consumer is the focused follow-up.

## The architecture target this PR serves

The engine has three planes — **control / trial / data**. Each should sit behind a named, typed seam. ADR-0003 explicitly named `EnvEndpoints` as the first follow-on to the control↔trial seam — the wire surface that future out-of-process components (`RuntimeBackend`, `Conductor`, remote runner) read from to know which services to reach.

| Step | Seam | Status |
|---|---|---|
| Control↔Trial | `TrialSpec` / `TrialResult` | Landed (ADR-0003) |
| Trial→Data (per-trial) | `TrialArtifactWriter` | Landed (ADR-0004) |
| Trial→Data (run-level) | `RunAggregateWriter` | Landed (ADR-0005) |
| **Control↔Trial endpoints** | **`EnvEndpoints`** | **This PR (ADR-0006)** |
| Trial execution env | `RuntimeBackend` | Next |
| Per-trial executor | `Conductor` | After RuntimeBackend |

After this PR the wire format every later seam reads is locked: `TrialSpec.env_endpoints: EnvEndpoints` is a Pydantic model with three required-or-optional fields, `extra=\"forbid\"`.

## What changes

### 1. New `EnvEndpoints` model (`tolokaforge/core/trial.py`)

```python
class EnvEndpoints(BaseModel):
    db_url: str
    rag_url: str | None = None  # rag-service ships in full_stack only
    runner_url: str
    model_config = {\"extra\": \"forbid\"}
```

### 2. `TrialSpec.env_endpoints` annotation flips in place

```python
# Before
env_endpoints: dict[str, str] = Field(default_factory=dict)
# After
env_endpoints: EnvEndpoints  # required — no default
```

No new field. No gRPC `.proto` change. The wire payload (`trial_spec_json` as a JSON string in the proto) carries a nested object under `env_endpoints` instead of a flat dict.

### 3. Orchestrator produces `EnvEndpoints` once per run

New free helper `_build_env_endpoints(runner_address)` in `orchestrator.py` reads the orchestrator's known runner address and the same env vars the docker stack injects into the runner container (`DB_SERVICE_URL` / `RAG_SERVICE_URL`), falling back to the docker-stack-injected URLs (`http://tolokaforge-db-service:8000` / nothing for RAG). Threaded through `_run_trial` as a required kwarg; populated on every `TrialSpec`.

Both call sites updated: `run()` (auto-start path) and `run_worker()` (distributed-worker path).

### 4. Tests

- **`tests/unit/test_env_endpoints.py`** *(new)* — 8 tests pin the model's own shape: required fields, optional `rag_url`, `extra=\"forbid\"`, top-level key set, JSON round-trip with and without RAG.
- **`tests/canonical/test_trial_spec_contract.py`** — assertions updated for the typed shape; new `test_env_endpoints_is_required` confirms the slot can no longer default to empty.
- **`tests/unit/test_orchestrator_logic.py::TestBuildEnvEndpoints`** *(new)* — 4 tests pin the producer's behaviour: docker-stack defaults when env unset, env overrides, scheme-passthrough for already-qualified URLs.
- **Runner test fixtures** (`test_runner_pipeline.py`, `test_runner_cleanup_trial.py`, integration `test_runner_cleanup_trial_grpc.py`) updated to pass the required `env_endpoints` kwarg.

### 5. ADR-0006

`docs/architecture/adr/0006-typed-env-endpoints.md` documents the decision in MADR format. Index row added.

## Key decisions

1. **Type in place, no new field.** The `env_endpoints` slot already exists; replacing the annotation is the single-field change ADR-0003 envisioned. No backwards-compat for the dict shape — proven safe because the field has zero readers today.

2. **Three fields, not five.** `db_url` and `rag_url` cover the runner-perspective services in today's stacks. `runner_url` is on the wire for the future out-of-process conductor case. **TypeSense and the executor address stay out** — TypeSense is engine-internal (flows through `TaskDescription.search_config`); `executor:50051` is the runner's own gRPC address, which is `RuntimeBackend`'s concern.

3. **`rag_url` is optional.** `core_stack` doesn't include `rag-service`; only `full_stack` does. Required-`rag_url` would force every minimal-stack run to fake a URL.

4. **Producer-only scope; runner consumer is the next PR.** Threading the type through both producer and consumer in one PR would be ~800–1200 LoC because the runner's DB/RAG clients are server-startup singletons used in ~15 call sites that would need to become trial-scoped. Splitting keeps each PR focused and reviewable. **The runner today still reads URLs from its own env vars** — `EnvEndpoints` is on the wire, but the runner doesn't consume it yet.

5. **`ServiceStack.get_service_url` was not used directly.** The orchestrator runs on the host, so `get_service_url` returns `http://localhost:{port}` — wrong for the runner-perspective URLs we carry on the wire. The helper instead reads the runner-container env defaults (`http://tolokaforge-db-service:8000`, etc.) that the docker stack injects, matching what the runner actually sees today.

## Verification

### Tests + lint

```text
$ uv run ruff check tolokaforge/ tests/
All checks passed!

$ uv run ruff format --check <touched files>
clean

$ uv run pytest tests/ -m canonical -q
201 passed in 12.17s

$ uv run pytest tests/ -m unit -q
1797 passed, 1 skipped in 30.73s

$ uv run pytest tests/unit/test_env_endpoints.py tests/canonical/test_trial_spec_contract.py tests/unit/test_orchestrator_logic.py::TestBuildEnvEndpoints -v
22 passed in 10.61s
```

### Localhost grep audit

```text
$ grep -REn 'localhost|127\.0\.0\.1' tolokaforge/core tolokaforge/runner | \
  grep -v -E '__pycache__|typesense_server|TypeSenseConfig|^.*#'
```

Remaining hits, all out-of-scope per ADR-0006 and explicitly documented as such:

- `core/models.py:376` — `TypeSenseConfig.host` (engine-internal; co-located TypeSense, scope-note in ADR-0006).
- `orchestrator.py:1177, 1207, 1223, 1470` — three dual-path fallback loops in `_run_trial` (host→service URL lookups, separate from the runner-perspective URLs on `EnvEndpoints`; ADR-0006 follow-up).
- `runner/__main__.py:39, 40` — `DEFAULT_DB_SERVICE_URL` / `DEFAULT_RAG_SERVICE_URL` constants (deleted in the runner-consumer follow-up PR).
- `orchestrator.py:650, 653` — comments documenting `get_service_url`'s behaviour, not load-bearing.

### Live smoke — native adapter

`scripts/with_env.sh uv run tolokaforge run --config examples/native/tool_use/run_config.yaml` — 2 trials complete end-to-end, real LLM (Claude Sonnet 4.6, \$0.21 spend). The new \"Resolved trial-scoped service endpoints\" log line emits at the start of the run; every `TrialSpec` sent over gRPC to the runner carries the typed `env_endpoints` payload; RegisterTrial deserializes it successfully (the smoke wouldn't complete otherwise). Four aggregate JSONs structurally identical to pre-PR (same filenames, top-level shapes, envelope keys).

Terminal-bench smoke not run for this PR (per maintainer request mid-iteration). Wire-format validity is end-to-end-confirmed by the native run plus the canonical contract tests; the next focused PR (runner consumer) is where terminal-bench is the meaningful gate.

## Out of scope (deferred — follow-up tickets)

- **Runner-side consumer.** `RunnerServiceImpl` builds DB/RAG clients per `RegisterTrial` from `trial_spec.env_endpoints`. Delete `DEFAULT_DB_SERVICE_URL` / `DEFAULT_RAG_SERVICE_URL` from `runner/__main__.py`. Filed separately.
- **Orchestrator dual-path fallback cleanup** (`_run_trial`'s `json_db_reset_urls` / `rag_service_urls` / `json_db_sync_urls`). Separate concern — these are orchestrator-on-host → service calls, not the runner-perspective URLs on `EnvEndpoints`.
- **TypeSense URL into `EnvEndpoints`.** Only if/when TypeSense moves out-of-process.
- **`executor:50051` literals** in `orchestrator.py` and `docker_runtime.py` — `RuntimeBackend` seam's concern, not `EnvEndpoints`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Full canonical suite green (201 passed)
- [x] Full unit suite green (1797 passed + 1 skipped)
- [x] New `EnvEndpoints` + producer tests green (22 passed)
- [x] Native adapter smoke: 2 trials complete; aggregates structurally identical
- [ ] Terminal-bench live smoke (deferred — runner consumer follow-up is the better gate)