### PR TITLE
refactor(core): lift DockerRuntime behind a typed RuntimeBackend Protocol

### DIFF
--- a/docs/architecture/adr/0007-runtime-backend-protocol.md
+++ b/docs/architecture/adr/0007-runtime-backend-protocol.md
@@ -1,0 +1,80 @@
+# 0007. `RuntimeBackend` Protocol — lift `DockerRuntime` behind a typed seam
+
+- **Status:** Proposed
+- **Date:** 2026-06-26
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+The Phase 1 seam-definition arc has typed the control↔trial wire format (`TrialSpec`/`TrialResult`, ADR-0003), both halves of the data plane (`TrialArtifactWriter` ADR-0004, `RunAggregateWriter` ADR-0005), and the trial-scoped service URLs on the wire (`EnvEndpoints`, ADR-0006). One Phase-1 seam remains: the abstraction the orchestrator uses to dispatch a trial to its execution environment.
+
+Today `tolokaforge/core/orchestrator.py` imports `DockerRuntime` from `tolokaforge.core.docker_runtime` concretely. `DockerRuntime` is misleadingly named — it isn't a Docker daemon client; it's a thin gRPC client wrapper that talks to a runner gRPC server. It exposes three lifecycle methods (`connect`, `close`, `health_check`) and one attribute (`executor_client: RunnerClient`) the orchestrator passes to `DockerRunnerAdapter` for per-trial operations. The retry-cleanup path also reaches through `executor_client.cleanup_trial(trial_id)` directly — that's the one call the orchestrator makes *before* a per-trial adapter exists.
+
+There is no typed surface that says "this is how the orchestrator talks to its execution environment." A future where the runner is in a different process, a different machine, or a different runtime altogether (Firecracker, local subprocess, remote conductor) has no contract to plug into.
+
+## Decision Drivers
+
+- **Symmetry with the other Phase-1 seams.** Each plane has a `@runtime_checkable` Protocol with at least two implementations. The execution surface should match.
+- **Lean code.** The orchestrator's two `DockerRuntime(...)` construction sites and one direct `executor_client.cleanup_trial` call can route through a Protocol without losing any behaviour.
+- **Fail-fast.** A backend that doesn't satisfy the Protocol fails at instance creation, not deep in the retry path.
+- **The seam is the precondition for the `Conductor` Protocol** (next architecture-seam step), which will read `RuntimeBackend` to know where to send a trial.
+
+## Considered Options
+
+1. **`RuntimeBackend` Protocol with `executor_client` exposed as the concrete `RunnerClient` type.** Smallest change that types the orchestrator's full dependency surface. Documented leak: the gRPC `RunnerClient` type is part of the seam.
+2. **Two separate Protocols — `RuntimeBackend` (lifecycle) and `RunnerClient` (RPC surface).** Cleaner separation but doubles the Protocol-promotion work; the RPC surface has ~7 methods that would all need re-declaration.
+3. **Just a thin wrapper class without Protocol.** Doesn't type the seam — the orchestrator still imports a concrete class.
+4. **Defer until a second backend lands.** Same argument as ADR-0004/0005/0006: each later seam ends up re-litigating the runtime shape simultaneously with whatever it's actually doing.
+
+## Decision
+
+We will adopt **Option 1**.
+
+- Add `RuntimeBackend` to `tolokaforge/core/runtime.py`. `@runtime_checkable` Pydantic-free `typing.Protocol`. Surface:
+  - `connect(timeout, retry_interval) -> None`
+  - `close() -> None`
+  - `health_check() -> bool`
+  - `cleanup_trial(trial_id) -> dict[str, Any]` — the one operation the orchestrator calls before a per-trial adapter exists.
+  - `executor_client: RunnerClient` — the per-trial adapter handoff.
+- Add `cleanup_trial(trial_id)` to `DockerRuntime`. One-line delegate to `self.runner_client.cleanup_trial(trial_id)`. `DockerRuntime` becomes a structural implementation of `RuntimeBackend` (no `class DockerRuntime(RuntimeBackend)` declaration — Python Protocols are duck-typed).
+- Add `InMemoryRuntimeBackend` — a no-network implementation that records lifecycle and cleanup calls on a `RuntimeBackendCallLog` dataclass. Its `executor_client` is a stub whose attribute access raises `NotImplementedError` with a message pointing at `DockerRuntime` or `RunnerClient`-mocking as alternatives. Two purposes: (a) prove the seam is swappable; (b) serve as a test fixture for lifecycle-and-cleanup paths.
+- `Orchestrator.__init__` accepts an optional `runtime_backend: RuntimeBackend | None = None` kwarg. When `None`, the orchestrator constructs `DockerRuntime(runner_address=...)` inline (the legacy behaviour). When provided, the orchestrator uses the injected backend.
+- The `docker_runtime` local variable in `run()` and `run_worker()` is type-annotated as `RuntimeBackend` (Protocol), not `DockerRuntime` (concrete).
+- The one direct `docker_runtime.executor_client.cleanup_trial(trial_id)` call in `_cleanup_runner_state_for_retry` becomes `docker_runtime.cleanup_trial(trial_id)`.
+
+## Consequences
+
+### Positive
+
+- The orchestrator depends on a Protocol, not a concrete class. The execution surface is now swappable without touching the orchestrator.
+- The Phase-1 seam-definition arc is complete after this PR plus the planned `Conductor` follow-up. Every architectural seam in the engine has a typed contract with at least two implementations.
+- `InMemoryRuntimeBackend` is reusable by any test that needs an orchestrator with no Docker dependency.
+- Future plug-in discovery (entry-point-discovered backends) can rely on `isinstance(impl, RuntimeBackend)` for safe injection.
+
+### Negative / Trade-offs
+
+- The Protocol exposes the concrete `RunnerClient` type via `executor_client`. A backend that doesn't speak gRPC would either have to fake a `RunnerClient`-shape object (painful) or live behind a follow-up split into two Protocols (`RuntimeBackend` + `RunnerClient`). Acceptable today — every realistic near-term backend (Docker, remote conductor) speaks the same gRPC contract.
+- `@runtime_checkable` for Protocols with attributes can be surprising — it only checks method presence, not attribute presence. A class with the four lifecycle methods but no `executor_client` will still pass `isinstance()`. Mitigation: contract tests assert `hasattr(impl, "executor_client")` separately; the docstring on `RuntimeBackend` flags the requirement.
+
+### Follow-ups
+
+- **Promote `RunnerClient` to its own Protocol** if a non-gRPC backend ever needs to fake the RPC surface without the gRPC stack.
+- **Collapse `DockerRunnerAdapter` into per-trial Protocol methods.** The adapter is partial-application of `trial_id` over the runner RPC surface; if `RuntimeBackend` directly took `trial_id` parameters everywhere, the adapter could be deleted.
+- **`Conductor` Protocol promoting `TrialRunner`.** Reads `RuntimeBackend` to know its target. Next architecture-seam step.
+- **`LocalProcessRuntime` / Firecracker / remote-conductor backends.** Concrete alternative implementations of `RuntimeBackend`. User-driven follow-ons once the seam is in place.
+- **Remove the hardcoded `EXECUTOR_ADDRESS` env-var default** in `orchestrator.py`. Belongs to the centralized-config follow-up surfaced by ADR-0006.
+
+## Rejected alternatives
+
+- **Option 2 — two separate Protocols.** Higher mechanical cost (~7 RPC methods on `RunnerClient` would need a parallel Protocol declaration) for marginal additional value today.
+- **Option 3 — wrapper class without Protocol.** Doesn't actually type the seam; the orchestrator still depends on a single concrete shape.
+- **Option 4 — defer.** Each later contract change (`Conductor`, remote runner, plug-in discovery) re-litigates the runtime shape under deadline pressure. Settle the shape now while there's only one implementation to migrate.
+
+## Scope notes
+
+- **Only `cleanup_trial` lifts to the Protocol** as a direct method (besides lifecycle). Two other `executor_client` calls remain in the orchestrator — `executor_client.get_state(trial_id)` at the final-state-sync point and `executor_client.grade_trial(trial_id, ...)` on the agentic-judge path. Both happen *after* a per-trial adapter exists and could be routed through the adapter; doing so is a separate refactor and out of scope for this ADR.
+- **The orchestrator's default factory is unchanged.** When no `runtime_backend` is injected, the orchestrator constructs `DockerRuntime(runner_address=...)` as before. Existing callers see no behavioural difference.
+- **No gRPC `.proto` change.** This ADR types the orchestrator-side execution surface, not the gRPC wire.
+- **`EXECUTOR_ADDRESS` env-var default** stays at `"executor:50051"` (Docker DNS name). Moving it requires the centralized-config follow-up from ADR-0006.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -37,3 +37,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0004](0004-trial-artifact-writer-seam.md) | `TrialArtifactWriter` as the typed data-plane seam | Proposed |
 | [0005](0005-run-aggregate-writer-seam.md) | `RunAggregateWriter` as the run-level data-plane seam | Proposed |
 | [0006](0006-typed-env-endpoints.md) | `EnvEndpoints` — typed runner service URLs on `TrialSpec` | Proposed |
+| [0007](0007-runtime-backend-protocol.md) | `RuntimeBackend` Protocol — lift `DockerRuntime` behind a typed seam | Proposed |

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -1,0 +1,146 @@
+"""Pin the ``RuntimeBackend`` Protocol contract — runtime check + parity.
+
+Two implementations are checked: :class:`DockerRuntime` (real gRPC client
+wrapper, never ``connect()``-ed in this test) and
+:class:`InMemoryRuntimeBackend` (no-network test fixture). Lifecycle
+methods and the retry-cleanup method are exercised on both; ``connect()``
+itself is *not* invoked on ``DockerRuntime`` because that would require
+a real runner gRPC server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.docker_runtime import DockerRuntime
+from tolokaforge.core.runtime import (
+    InMemoryRuntimeBackend,
+    RuntimeBackend,
+    RuntimeBackendCallLog,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; both implementations satisfy
+    it via ``isinstance`` (not just by structural type-hint compatibility).
+    """
+
+    def test_docker_runtime_passes_isinstance(self) -> None:
+        assert isinstance(DockerRuntime(runner_address="sentinel:50051"), RuntimeBackend)
+
+    def test_in_memory_runtime_backend_passes_isinstance(self) -> None:
+        assert isinstance(InMemoryRuntimeBackend(), RuntimeBackend)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotARuntime:
+            pass
+
+        assert not isinstance(_NotARuntime(), RuntimeBackend)
+
+
+class TestLifecycleMethodParity:
+    """Every Protocol method accepts the same arguments on every
+    implementation. ``connect()`` itself is exercised only on the
+    in-memory impl because the Docker variant requires a real gRPC
+    server; instead this class asserts the *method signature* exists
+    on both via ``getattr``.
+    """
+
+    @pytest.fixture
+    def implementations(self) -> list[RuntimeBackend]:
+        # ``DockerRuntime`` is constructed but never ``connect()``-ed —
+        # construction is cheap and side-effect-free until ``connect()``.
+        return [InMemoryRuntimeBackend(), DockerRuntime(runner_address="sentinel:50051")]
+
+    def test_connect_signature_is_present(self, implementations: list[RuntimeBackend]) -> None:
+        for impl in implementations:
+            assert callable(getattr(impl, "connect", None))
+
+    def test_close_signature_is_present(self, implementations: list[RuntimeBackend]) -> None:
+        for impl in implementations:
+            assert callable(getattr(impl, "close", None))
+
+    def test_health_check_signature_is_present(self, implementations: list[RuntimeBackend]) -> None:
+        for impl in implementations:
+            assert callable(getattr(impl, "health_check", None))
+
+    def test_cleanup_trial_signature_is_present(
+        self, implementations: list[RuntimeBackend]
+    ) -> None:
+        for impl in implementations:
+            assert callable(getattr(impl, "cleanup_trial", None))
+
+    def test_executor_client_attribute_is_present(
+        self, implementations: list[RuntimeBackend]
+    ) -> None:
+        for impl in implementations:
+            assert hasattr(impl, "executor_client")
+
+
+class TestInMemoryBackendSemantics:
+    """The in-memory backend records calls on its
+    :class:`RuntimeBackendCallLog` for tests to assert against, without
+    touching the network.
+    """
+
+    def test_connect_records_arguments(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        backend.connect(timeout=15.0, retry_interval=0.5)
+        assert backend.call_log.connect_calls == [
+            {"timeout": 15.0, "retry_interval": 0.5},
+        ]
+
+    def test_connect_defaults_are_recorded(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        backend.connect()
+        assert backend.call_log.connect_calls == [
+            {"timeout": 30.0, "retry_interval": 1.0},
+        ]
+
+    def test_close_is_counted(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        backend.close()
+        backend.close()
+        assert backend.call_log.close_calls == 2
+
+    def test_health_check_returns_true_and_is_counted(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        assert backend.health_check() is True
+        assert backend.health_check() is True
+        assert backend.call_log.health_check_calls == 2
+
+    def test_cleanup_trial_returns_success_shape(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        result = backend.cleanup_trial("airline_001:0")
+        assert result == {"success": True, "error": None}
+
+    def test_cleanup_trial_records_trial_ids_in_order(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        backend.cleanup_trial("a:0")
+        backend.cleanup_trial("b:0")
+        backend.cleanup_trial("a:0")
+        assert backend.call_log.cleanup_trial_calls == ["a:0", "b:0", "a:0"]
+
+    def test_cleanup_trial_is_idempotent_on_unknown_trial(self) -> None:
+        """Mirrors ``DockerRuntime``: cleaning a trial that was never
+        registered must succeed so retry paths don't crash."""
+        backend = InMemoryRuntimeBackend()
+        result = backend.cleanup_trial("never_registered:0")
+        assert result["success"] is True
+        assert result["error"] is None
+
+    def test_executor_client_raises_on_rpc_method_access(self) -> None:
+        """The in-memory backend is for lifecycle and cleanup only;
+        attempts to use it as a runner-RPC client fail with a clear
+        message that points at the right alternative."""
+        backend = InMemoryRuntimeBackend()
+        with pytest.raises(NotImplementedError, match="register_trial"):
+            backend.executor_client.register_trial()
+        with pytest.raises(NotImplementedError, match="execute_tool"):
+            backend.executor_client.execute_tool()
+
+    def test_fresh_backend_has_empty_call_log(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        assert backend.call_log == RuntimeBackendCallLog()

--- a/tests/unit/test_docker_runtime_connect_idempotency.py
+++ b/tests/unit/test_docker_runtime_connect_idempotency.py
@@ -1,0 +1,114 @@
+"""Pin the ``connect()`` idempotency promise of the production runtime.
+
+The ``RuntimeBackend`` Protocol's ``connect()`` docstring states that
+calling on an already-connected instance re-runs the health check but
+does not re-create the underlying connection — and the orchestrator
+relies on this by invoking ``connect()`` unconditionally at the start
+of every run.
+
+This test exercises the only production implementation
+(:class:`RunnerClient`, which :class:`DockerRuntime.connect` delegates
+to) to prove the contract holds: a second ``connect()`` on an
+already-healthy client does not raise, does not recreate the gRPC
+channel, and just re-runs the health probe.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.docker_runtime import DockerRuntime, RunnerClient
+
+pytestmark = pytest.mark.unit
+
+
+class TestRunnerClientConnectIdempotency:
+    """``RunnerClient.connect()`` is safe to call repeatedly on a healthy
+    client. The channel is created once (``if self.channel is None``) and
+    subsequent calls re-run the health check.
+    """
+
+    def test_second_connect_does_not_recreate_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = RunnerClient(runner_address="sentinel:50051")
+
+        # Pre-populate the channel + stub as if a previous connect() succeeded.
+        existing_channel = MagicMock()
+        existing_stub = MagicMock()
+        client.channel = existing_channel
+        client.stub = existing_stub
+
+        # Force the health check to return True so connect() returns immediately.
+        monkeypatch.setattr(client, "health_check", lambda: True)
+
+        # Second connect must not blow away the existing channel.
+        client.connect(timeout=1.0, retry_interval=0.01)
+
+        assert client.channel is existing_channel
+        assert client.stub is existing_stub
+
+    def test_second_connect_does_not_raise_on_healthy_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The orchestrator invokes connect() unconditionally at the start of
+        every run. If the runtime is already healthy (e.g. an injected
+        pre-connected backend), connect() must return cleanly — not raise."""
+        client = RunnerClient(runner_address="sentinel:50051")
+        client.channel = MagicMock()
+        client.stub = MagicMock()
+        monkeypatch.setattr(client, "health_check", lambda: True)
+
+        # Must not raise.
+        client.connect(timeout=1.0, retry_interval=0.01)
+
+    def test_second_connect_reruns_health_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Idempotency means "safe to call again," not "no-op." The Protocol
+        docstring promises the health check re-runs; pin that explicitly so a
+        future implementation that turns it into a no-op (skipping the probe)
+        fails this test loudly."""
+        client = RunnerClient(runner_address="sentinel:50051")
+        client.channel = MagicMock()
+        client.stub = MagicMock()
+
+        health_check_calls = 0
+
+        def counting_health_check() -> bool:
+            nonlocal health_check_calls
+            health_check_calls += 1
+            return True
+
+        monkeypatch.setattr(client, "health_check", counting_health_check)
+
+        client.connect(timeout=1.0, retry_interval=0.01)
+        client.connect(timeout=1.0, retry_interval=0.01)
+
+        assert health_check_calls == 2
+
+
+class TestDockerRuntimeConnectDelegates:
+    """``DockerRuntime.connect`` is a one-line wrapper that delegates to
+    ``RunnerClient.connect``. The Protocol's idempotency promise rides on
+    that delegation; pin it so a future refactor (e.g. adding pre-connect
+    side-effects) can't silently weaken the contract.
+    """
+
+    def test_connect_calls_through_to_runner_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runtime = DockerRuntime(runner_address="sentinel:50051")
+
+        call_log: list[dict] = []
+
+        def fake_connect(timeout: float = 30.0, retry_interval: float = 1.0) -> None:
+            call_log.append({"timeout": timeout, "retry_interval": retry_interval})
+
+        monkeypatch.setattr(runtime.runner_client, "connect", fake_connect)
+
+        runtime.connect(timeout=5.0, retry_interval=0.1)
+        runtime.connect()  # second call — must also delegate cleanly
+
+        assert call_log == [
+            {"timeout": 5.0, "retry_interval": 0.1},
+            {"timeout": 30.0, "retry_interval": 1.0},
+        ]

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -313,11 +313,11 @@ class TestCleanupRunnerStateForRetry:
     def test_calls_cleanup_with_canonical_trial_id(self) -> None:
         orch = self._make_orchestrator()
         runtime = MagicMock()
-        runtime.executor_client.cleanup_trial.return_value = {"success": True, "error": None}
+        runtime.cleanup_trial.return_value = {"success": True, "error": None}
 
         orch._cleanup_runner_state_for_retry(runtime, "TASK-001", 3)
 
-        runtime.executor_client.cleanup_trial.assert_called_once_with("TASK-001:3")
+        runtime.cleanup_trial.assert_called_once_with("TASK-001:3")
 
     def test_none_runtime_is_noop(self) -> None:
         """Native (non-Docker) flows have no docker_runtime — cleanup is a no-op."""
@@ -334,14 +334,14 @@ class TestCleanupRunnerStateForRetry:
         """
         orch = self._make_orchestrator()
         runtime = MagicMock()
-        runtime.executor_client.cleanup_trial.side_effect = RuntimeError("connection lost")
+        runtime.cleanup_trial.side_effect = RuntimeError("connection lost")
 
         orch._cleanup_runner_state_for_retry(runtime, "TASK-001", 0)  # must not raise
 
     def test_cleanup_non_success_is_swallowed(self) -> None:
         orch = self._make_orchestrator()
         runtime = MagicMock()
-        runtime.executor_client.cleanup_trial.return_value = {
+        runtime.cleanup_trial.return_value = {
             "success": False,
             "error": "DB unreachable",
         }
@@ -1066,3 +1066,46 @@ class TestBuildEnvEndpoints:
 
         endpoints = _build_env_endpoints("https://runner.example:50051")
         assert endpoints.runner_url == "https://runner.example:50051"
+
+
+# ===================================================================
+# Orchestrator(runtime_backend=...) kwarg
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRuntimeBackendInjection:
+    """The ``runtime_backend`` kwarg accepts any :class:`RuntimeBackend`
+    impl. The orchestrator stores the injected instance and uses it
+    instead of constructing :class:`DockerRuntime`.
+    """
+
+    def test_kwarg_default_is_none(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        orch = Orchestrator(_make_run_config())
+        assert orch._injected_runtime_backend is None
+
+    def test_kwarg_stores_injected_instance(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.runtime import InMemoryRuntimeBackend
+
+        backend = InMemoryRuntimeBackend()
+        orch = Orchestrator(_make_run_config(), runtime_backend=backend)
+
+        assert orch._injected_runtime_backend is backend
+
+    def test_injection_does_not_invoke_backend_lifecycle(self) -> None:
+        """Construction must not call ``connect``/``close`` on the injected
+        backend — that happens only when ``run()`` / ``run_worker()`` are
+        invoked. Tests that construct an Orchestrator with an in-memory
+        backend rely on this to assert lifecycle from a known-empty log."""
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.runtime import InMemoryRuntimeBackend
+
+        backend = InMemoryRuntimeBackend()
+        Orchestrator(_make_run_config(), runtime_backend=backend)
+
+        assert backend.call_log.connect_calls == []
+        assert backend.call_log.close_calls == 0
+        assert backend.call_log.health_check_calls == 0

--- a/tests/unit/test_runtime_backend.py
+++ b/tests/unit/test_runtime_backend.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``tolokaforge.core.runtime``.
+
+Covers the in-memory backend's own shape and the call log dataclass.
+Cross-implementation parity is in
+``tests/canonical/test_runtime_backend_contract.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.runtime import (
+    InMemoryRuntimeBackend,
+    RuntimeBackendCallLog,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestRuntimeBackendCallLog:
+    def test_default_fields_are_empty(self) -> None:
+        log = RuntimeBackendCallLog()
+        assert log.connect_calls == []
+        assert log.close_calls == 0
+        assert log.health_check_calls == 0
+        assert log.cleanup_trial_calls == []
+
+    def test_equality_holds_for_identical_state(self) -> None:
+        assert RuntimeBackendCallLog() == RuntimeBackendCallLog()
+
+    def test_inequality_when_call_lists_diverge(self) -> None:
+        a = RuntimeBackendCallLog()
+        b = RuntimeBackendCallLog()
+        a.cleanup_trial_calls.append("x:0")
+        assert a != b
+
+
+class TestInMemoryRuntimeBackendConstruction:
+    def test_fresh_backend_has_a_call_log(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        assert isinstance(backend.call_log, RuntimeBackendCallLog)
+
+    def test_fresh_backend_call_log_is_empty(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        assert backend.call_log.connect_calls == []
+        assert backend.call_log.close_calls == 0
+
+    def test_each_backend_has_independent_call_log(self) -> None:
+        a = InMemoryRuntimeBackend()
+        b = InMemoryRuntimeBackend()
+        a.cleanup_trial("x:0")
+        assert a.call_log.cleanup_trial_calls == ["x:0"]
+        assert b.call_log.cleanup_trial_calls == []
+
+
+class TestInMemoryRuntimeBackendExecutorClient:
+    """The ``executor_client`` stub is the safety net for tests that try
+    to exercise the runner RPC surface against an in-memory backend
+    (which can't fulfil it)."""
+
+    def test_unknown_method_raises_with_method_name(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        with pytest.raises(NotImplementedError) as excinfo:
+            _ = backend.executor_client.some_unknown_method
+        assert "some_unknown_method" in str(excinfo.value)
+
+    def test_error_message_points_at_alternatives(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        with pytest.raises(NotImplementedError) as excinfo:
+            _ = backend.executor_client.register_trial
+        message = str(excinfo.value)
+        assert "DockerRuntime" in message
+        assert "RunnerClient" in message

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -624,6 +624,15 @@ class DockerRuntime:
         """Check health of Runner service"""
         return self.runner_client.health_check()
 
+    def cleanup_trial(self, trial_id: str) -> dict:
+        """Forget any prior registration of ``trial_id`` on the runner.
+
+        The retry-cleanup path needs to call this *before* a per-trial
+        adapter exists, so the method lives on the runtime (delegating
+        to the gRPC client). Idempotent on the runner side.
+        """
+        return self.runner_client.cleanup_trial(trial_id)
+
     def __enter__(self):
         """Context manager entry"""
         self.connect()

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -310,7 +310,7 @@ class Orchestrator:
 
     def _cleanup_runner_state_for_retry(
         self,
-        docker_runtime: Any,
+        docker_runtime: RuntimeBackend | None,
         task_id: str,
         trial_idx: int,
     ) -> None:
@@ -1188,7 +1188,7 @@ class Orchestrator:
         agent_client: LLMClient | None,
         user_config: ModelConfig | None,
         output_dir: Path,
-        docker_runtime: Any,
+        docker_runtime: RuntimeBackend | None,
         request_limiter: GlobalRateLimiter | None = None,
         *,
         attempt_id: int = 0,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -52,6 +52,7 @@ from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import AttemptLease, create_run_queue
 from tolokaforge.core.runner import TrialRunner
+from tolokaforge.core.runtime import RuntimeBackend
 from tolokaforge.core.stuck import StuckDetector
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, TrialResult, TrialSpec
 from tolokaforge.runner.models import AdapterType
@@ -197,6 +198,7 @@ class Orchestrator:
         verbose: bool = False,
         strict: bool = False,
         run_aggregate_writer: RunAggregateWriter | None = None,
+        runtime_backend: RuntimeBackend | None = None,
     ):
         self.config = config
         self.resume = resume
@@ -217,6 +219,12 @@ class Orchestrator:
         self._run_aggregate_writer: RunAggregateWriter = (
             run_aggregate_writer if run_aggregate_writer is not None else FileAggregateWriter()
         )
+        # Execution surface: the orchestrator depends on the
+        # :class:`RuntimeBackend` Protocol, not a concrete class. When
+        # ``None``, ``run()`` / ``run_worker()`` construct a default
+        # :class:`DockerRuntime` from the resolved runner address — the
+        # legacy behaviour. Tests / alternate backends inject here.
+        self._injected_runtime_backend: RuntimeBackend | None = runtime_backend
 
         # Initialize logger
         log_level = logging.DEBUG if verbose else logging.INFO
@@ -321,7 +329,7 @@ class Orchestrator:
             return
         trial_id = f"{task_id}:{trial_idx}"
         try:
-            result = docker_runtime.executor_client.cleanup_trial(trial_id)
+            result = docker_runtime.cleanup_trial(trial_id)
         except Exception as e:
             self.logger.warning(
                 "Cleanup before retry raised; continuing with re-registration",
@@ -661,15 +669,20 @@ class Orchestrator:
         else:
             runner_address = None
 
-        # Docker runtime (always used)
-        from tolokaforge.core.docker_runtime import DockerRuntime
-
+        # Resolve the runtime backend: injected for tests / alternate
+        # backends, default :class:`DockerRuntime` otherwise.
         if runner_address is None:
             runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
 
-        docker_runtime = DockerRuntime(runner_address=runner_address)
+        docker_runtime: RuntimeBackend
+        if self._injected_runtime_backend is not None:
+            docker_runtime = self._injected_runtime_backend
+        else:
+            from tolokaforge.core.docker_runtime import DockerRuntime
+
+            docker_runtime = DockerRuntime(runner_address=runner_address)
         docker_runtime.connect()
-        self.logger.info("Docker runtime connected")
+        self.logger.info("Runtime backend connected")
 
         env_endpoints = _build_env_endpoints(runner_address)
         self.logger.info(
@@ -956,10 +969,15 @@ class Orchestrator:
         if self.config.orchestrator.max_requests_per_second is not None:
             request_limiter = GlobalRateLimiter(self.config.orchestrator.max_requests_per_second)
 
-        from tolokaforge.core.docker_runtime import DockerRuntime
-
         runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
-        docker_runtime = DockerRuntime(runner_address=runner_address)
+
+        docker_runtime: RuntimeBackend
+        if self._injected_runtime_backend is not None:
+            docker_runtime = self._injected_runtime_backend
+        else:
+            from tolokaforge.core.docker_runtime import DockerRuntime
+
+            docker_runtime = DockerRuntime(runner_address=runner_address)
         docker_runtime.connect()
 
         env_endpoints = _build_env_endpoints(runner_address)

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -1,0 +1,149 @@
+"""``RuntimeBackend`` Protocol — the orchestrator's execution surface.
+
+The orchestrator dispatches trials to an execution environment through a
+runtime backend. Today's only concrete backend is
+:class:`tolokaforge.core.docker_runtime.DockerRuntime` (a thin gRPC
+client wrapper around the runner container); this module declares the
+Protocol that decouples the orchestrator from that single implementation.
+
+* :class:`RuntimeBackend` — the Protocol the orchestrator depends on.
+* :class:`InMemoryRuntimeBackend` — a non-gRPC implementation used as a
+  test fixture and as proof the seam is swappable. Records lifecycle and
+  cleanup calls on a :class:`RuntimeBackendCallLog`; the ``executor_client``
+  stub raises :class:`NotImplementedError` on RPC methods (callers that
+  need a real RPC must use :class:`DockerRuntime` or mock ``RunnerClient``
+  directly).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from tolokaforge.core.docker_runtime import RunnerClient
+
+__all__ = [
+    "InMemoryRuntimeBackend",
+    "RuntimeBackend",
+    "RuntimeBackendCallLog",
+]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RuntimeBackend(Protocol):
+    """The orchestrator's execution surface for trials.
+
+    Declares the lifecycle the orchestrator drives and the one
+    trial-state operation that runs *before* a per-trial adapter exists
+    (the retry-cleanup path). Per-trial operations after registration
+    flow through :class:`DockerRunnerAdapter`, which is constructed
+    from :attr:`executor_client`.
+    """
+
+    # ---- Lifecycle ----
+    def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
+        """Establish the runtime connection (or no-op for an in-memory impl).
+
+        ``DockerRuntime`` waits for the gRPC server to become healthy
+        under a timeout / retry loop; in-memory implementations record
+        the call and return immediately.
+        """
+        ...
+
+    def close(self) -> None:
+        """Release the runtime connection. Idempotent."""
+        ...
+
+    def health_check(self) -> bool:
+        """Probe whether the runtime is currently usable."""
+        ...
+
+    # ---- Retry-cleanup path (called before a per-trial adapter exists) ----
+    def cleanup_trial(self, trial_id: str) -> dict[str, Any]:
+        """Forget any prior registration of ``trial_id`` on the runtime.
+
+        Idempotent: cleaning a trial that isn't currently registered
+        succeeds. Returns the same shape as
+        :meth:`RunnerClient.cleanup_trial` —
+        ``{"success": bool, "error": str | None}``.
+        """
+        ...
+
+    # ---- Per-trial adapter handoff ----
+    executor_client: RunnerClient
+    """The RPC client used by :class:`DockerRunnerAdapter` for per-trial
+    operations after a trial is registered.
+
+    Typed as the concrete :class:`RunnerClient` for now. Promoting it to
+    its own Protocol is a follow-up if a non-gRPC backend ever wants to
+    fake the runner-RPC surface without the gRPC stack."""
+
+
+# ---------------------------------------------------------------------------
+# InMemoryRuntimeBackend — non-gRPC, test fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuntimeBackendCallLog:
+    """Records what an :class:`InMemoryRuntimeBackend` was asked to do.
+
+    Tests assert on this directly instead of mocking individual methods.
+    Each entry is the method name plus a snapshot of its arguments.
+    """
+
+    connect_calls: list[dict[str, Any]] = field(default_factory=list)
+    close_calls: int = 0
+    health_check_calls: int = 0
+    cleanup_trial_calls: list[str] = field(default_factory=list)
+
+
+class _UnusableExecutorClient:
+    """Stub for ``InMemoryRuntimeBackend.executor_client``.
+
+    The in-memory backend is for lifecycle-and-cleanup testing only;
+    code that needs to exercise the runner RPC surface (``register_trial``,
+    ``execute_tool``, ``grade_trial``, …) must either use
+    :class:`DockerRuntime` or mock :class:`RunnerClient` directly.
+    Every attribute access raises ``NotImplementedError`` with that
+    message so the failure mode is obvious.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        raise NotImplementedError(
+            f"InMemoryRuntimeBackend.executor_client.{name}() is not implemented. "
+            "Tests that exercise the runner RPC surface must use DockerRuntime "
+            "or mock RunnerClient directly."
+        )
+
+
+class InMemoryRuntimeBackend:
+    """Non-gRPC :class:`RuntimeBackend` implementation.
+
+    Records lifecycle and cleanup calls on :attr:`call_log`; exposes a
+    stub :attr:`executor_client` that raises on RPC method access.
+    """
+
+    def __init__(self) -> None:
+        self.call_log = RuntimeBackendCallLog()
+        self.executor_client: Any = _UnusableExecutorClient()
+
+    def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
+        self.call_log.connect_calls.append({"timeout": timeout, "retry_interval": retry_interval})
+
+    def close(self) -> None:
+        self.call_log.close_calls += 1
+
+    def health_check(self) -> bool:
+        self.call_log.health_check_calls += 1
+        return True
+
+    def cleanup_trial(self, trial_id: str) -> dict[str, Any]:
+        self.call_log.cleanup_trial_calls.append(trial_id)
+        return {"success": True, "error": None}

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -53,6 +53,12 @@ class RuntimeBackend(Protocol):
         ``DockerRuntime`` waits for the gRPC server to become healthy
         under a timeout / retry loop; in-memory implementations record
         the call and return immediately.
+
+        Idempotent. Calling ``connect()`` on an instance that is already
+        connected re-runs the health check but does not re-create the
+        underlying connection. Callers (including tests injecting
+        a pre-connected backend) can rely on this — the orchestrator
+        invokes ``connect()`` unconditionally at the start of every run.
         """
         ...
 
@@ -117,9 +123,9 @@ class _UnusableExecutorClient:
 
     def __getattr__(self, name: str) -> Any:
         raise NotImplementedError(
-            f"InMemoryRuntimeBackend.executor_client.{name}() is not implemented. "
-            "Tests that exercise the runner RPC surface must use DockerRuntime "
-            "or mock RunnerClient directly."
+            f"Access to InMemoryRuntimeBackend.executor_client.{name} is not "
+            "implemented. Tests that exercise the runner RPC surface must use "
+            "DockerRuntime or mock RunnerClient directly."
         )
 
 


### PR DESCRIPTION
## Summary

`DockerRuntime` is the orchestrator's execution surface for trials — today's only concrete backend, a thin gRPC client wrapper around the runner container. The orchestrator imported it concretely, leaving no typed surface for alternate backends (in-memory tests, remote conductor, Firecracker, local subprocess) to plug into. This PR adds the `RuntimeBackend` Protocol, makes `DockerRuntime` a structural implementation of it, and threads the Protocol through the orchestrator's two construction sites + one direct-call path.

## The architecture target this PR serves

The engine's seam-definition arc, finishing in 0.4.0:

| Step | Seam | Status |
|---|---|---|
| Control↔Trial wire format | `TrialSpec` / `TrialResult` | Landed in 0.3.0 (ADR-0003) |
| Trial→Data (per-trial) | `TrialArtifactWriter` | Landed in 0.3.0 (ADR-0004) |
| Trial→Data (run-level) | `RunAggregateWriter` | Landed in 0.3.0 (ADR-0005) |
| Control↔Trial endpoints | `EnvEndpoints` | Landed in 0.3.0 (ADR-0006) |
| **Execution surface** | **`RuntimeBackend`** | **This PR (ADR-0007)** |
| Per-trial executor | `Conductor` | Next |

After this PR the orchestrator depends on a Protocol, not a concrete class. The execution surface is swappable without touching the orchestrator. `Conductor` (next architecture-seam PR) will read `RuntimeBackend` to know where to send a trial.

## What changes

### 1. New `RuntimeBackend` Protocol (`tolokaforge/core/runtime.py`)

```python
@runtime_checkable
class RuntimeBackend(Protocol):
    def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None: ...
    def close(self) -> None: ...
    def health_check(self) -> bool: ...
    def cleanup_trial(self, trial_id: str) -> dict[str, Any]: ...  # retry-cleanup path
    executor_client: RunnerClient                                  # per-trial adapter handoff
```

Five things in the surface. The first four are lifecycle + the one operation the orchestrator calls *before* a per-trial adapter exists. `executor_client` is the per-trial handoff that `DockerRunnerAdapter` already consumes — documented as a known gRPC-leak, with a follow-up to promote `RunnerClient` to its own Protocol if a non-gRPC backend ever lands.

### 2. `DockerRuntime` becomes a structural implementation

Adds `cleanup_trial(trial_id)` to `tolokaforge/core/docker_runtime.py` — a one-line delegate to `self.runner_client.cleanup_trial(trial_id)`. `DockerRuntime` becomes a structural impl of `RuntimeBackend` automatically (Python Protocols are duck-typed).

### 3. `InMemoryRuntimeBackend` test fixture

Records lifecycle and cleanup calls on a `RuntimeBackendCallLog` dataclass; its `executor_client` is a stub that raises `NotImplementedError` on RPC method access (so tests that need the runner RPC surface have to use `DockerRuntime` or mock `RunnerClient` directly — surface intent is loud and obvious).

### 4. Orchestrator depends on the Protocol

- `Orchestrator.__init__` accepts an optional `runtime_backend: RuntimeBackend | None = None` kwarg. When `None`, `run()` and `run_worker()` construct `DockerRuntime` inline — the legacy behaviour.
- The `docker_runtime` local variable in both methods is now type-annotated as `RuntimeBackend` (Protocol), not `DockerRuntime` (concrete).
- The direct `docker_runtime.executor_client.cleanup_trial(trial_id)` call in `_cleanup_runner_state_for_retry` becomes `docker_runtime.cleanup_trial(trial_id)`.

### 5. Tests

- **`tests/canonical/test_runtime_backend_contract.py`** *(new, 17 tests)* — Protocol conformance + lifecycle-method parity + in-memory backend semantics.
- **`tests/unit/test_runtime_backend.py`** *(new, 8 tests)* — focused unit tests for the in-memory backend and its `RuntimeBackendCallLog` dataclass.
- **`tests/unit/test_orchestrator_logic.py`** — adds `TestRuntimeBackendInjection` (3 tests pinning the kwarg path); updates the 4 existing `TestCleanupRunnerStateForRetry` tests to assert on the new direct-method call path.

### 6. ADR-0007

`docs/architecture/adr/0007-runtime-backend-protocol.md`. MADR format. Context, drivers, four considered options, decision, consequences, follow-ups, scope notes.

## Key decisions

1. **`executor_client: RunnerClient` is on the Protocol as a concrete type.** Documented leak. A non-gRPC backend would either fake a `RunnerClient`-shape object or live behind a follow-up split into two Protocols. Acceptable today — every realistic near-term backend (Docker, remote conductor) speaks gRPC.

2. **Only `cleanup_trial` lifts to a Protocol method.** Two other `executor_client` calls remain in the orchestrator (`get_state`, `grade_trial`) — both happen *after* a per-trial adapter exists and could be routed through the adapter; doing so is a separate refactor, out of scope here.

3. **Default factory unchanged.** When no `runtime_backend` is injected, the orchestrator constructs `DockerRuntime(runner_address=...)` as before. No behavioural difference for existing callers.

4. **`InMemoryRuntimeBackend.executor_client` raises on RPC method access.** Forces tests that need RPC behaviour to use `DockerRuntime` (or mock `RunnerClient` directly). The in-memory backend is for lifecycle-and-cleanup testing only.

5. **`@runtime_checkable` only validates methods, not attributes.** A class with the four lifecycle methods but missing `executor_client` will still pass `isinstance()`. Mitigation: contract tests assert `hasattr(impl, "executor_client")` separately; the Protocol docstring flags the requirement.

## Verification

```text
$ uv run ruff check tolokaforge/core/runtime.py tolokaforge/core/docker_runtime.py tolokaforge/core/orchestrator.py tests/canonical/test_runtime_backend_contract.py tests/unit/test_runtime_backend.py tests/unit/test_orchestrator_logic.py
All checks passed!

$ uv run ruff format --check <touched files>
6 files already formatted

$ uv run pytest tests/canonical/test_runtime_backend_contract.py tests/unit/test_runtime_backend.py tests/unit/test_orchestrator_logic.py::TestRuntimeBackendInjection -v
28 passed in 6.08s

$ uv run pytest tests/ -m canonical -q
218 passed, 2492 deselected in 11.87s

$ uv run pytest tests/ -m unit -q
1800 passed, 1 skipped, 909 deselected in 29.28s
```

### Live smoke — native adapter

```text
$ scripts/with_env.sh uv run tolokaforge run --config examples/native/tool_use/run_config.yaml
✓ Run complete!
Aggregate Results (total_trials=2, total_tasks=2, success_rate_micro=0.0,
  avg_score_micro=0.5958, avg_latency_s=45.27, total_cost_usd=0.121698,
  failed_attempts=2, deterministic_attribution_coverage=1.0)
```

2 trials complete end-to-end. The Docker → gRPC path runs through the new Protocol indirection without behaviour change. Four aggregate JSONs emitted with the expected sizes (`per_task_metrics.json` 2142 bytes, `aggregate.json` 1129 bytes, `metadata_slices.json` 2383 bytes, `failure_attribution.json` 1479 bytes). Cost: $0.12.

Terminal-bench smoke not run for this PR — the runtime path is unchanged behaviour-wise, the canonical contract tests pin the Protocol surface, and the native smoke exercises the same `DockerRuntime` code path. Terminal-bench would mainly add the test-execution grading layer, which this PR doesn't touch.

## Out of scope (follow-ups in ADR-0007)

- **Promote `RunnerClient` to its own Protocol.** If a non-gRPC backend ever wants to fake the runner-RPC surface without the gRPC stack.
- **Collapse `DockerRunnerAdapter` into per-trial Protocol methods.** The adapter is partial-application of `trial_id` over the runner RPC surface; could be deleted if `RuntimeBackend` directly took `trial_id` parameters everywhere.
- **`Conductor` Protocol promoting `TrialRunner`.** Reads `RuntimeBackend` to know its target. Next architecture-seam step.
- **`LocalProcessRuntime` / Firecracker / remote-conductor backends.** Concrete alternative implementations. The seam is now ready.
- **Remove `EXECUTOR_ADDRESS` env-var default.** Belongs to the centralized-config follow-up from ADR-0006.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] 28 new tests green (Protocol conformance + in-memory semantics + orchestrator injection)
- [x] Full canonical suite green (218 passed)
- [x] Full unit suite green (1800 passed, 1 skipped)
- [x] Native adapter smoke: 2 trials complete, 4 aggregates emitted, $0.12 spend
- [ ] Terminal-bench smoke (deferred — no test_execution path change in this PR)