### PR TITLE
refactor(grading): relocate LLM-judge model from rubric to run config

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,6 +27,15 @@ models:
     provider: "openai"
     name: "gpt-4o-mini"
     temperature: 0.3
+  # Optional: read-only rubric judge model. Required only when a selected task
+  # grades with `llm_judge` — the run aborts up front if a rubric task is
+  # selected but `judge` is absent (no default, no fallback to the agent model).
+  # Keep it separate from `agent` to avoid self-grading bias; temperature 0.0
+  # for determinism.
+  judge:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4.6"
+    temperature: 0.0
 
 orchestrator:
   workers: 4
@@ -61,6 +70,7 @@ evaluation:
 ```
 
 Notes:
+- `models.judge` is the optional run-level read-only rubric judge model (no default); the run fails loud up front if a selected task grades with `llm_judge` but `models.judge` is absent.
 - `models.agent.capabilities` overrides auto-detected model capabilities. Auto-detection (via `ModelCapabilities.for_model()`) covers most models; use overrides for A/B comparisons or to fix edge cases. Available fields: `dict_map_prompt_hints` (inject system prompt hints for dict-map parameters), `supports_typed_dict_maps`, `supports_schema_extras`, `fixed_temperature`, `supports_seed`, `unwrap_input_key`, `reasoning_via_extra_body`. See [Model Capability Presets](#model-capability-presets) below.
 - PyPI wheels exclude `tasks/**`; configure benchmark content via `evaluation.task_packs`.
 - `runtime: docker` is the only supported runtime; it uses the executor service and environment containers.
@@ -309,8 +319,8 @@ transcript_rules:
     required_tools: ["browser"]
     disallowed_tools: []
 
-llm_judge:
-  model_ref: "openrouter/anthropic/claude-sonnet-4.5"   # required; a separate fixed judge model
+llm_judge:                                 # the judge MODEL is set once per run
+                                           # under models.judge — NOT here
   rubric:                                  # structured Rubric (NOT free text)
     reference: |                           # optional author-written ground truth
       The correct order total is $42.50 with apple_pay.
@@ -327,9 +337,12 @@ llm_judge:
 ```
 
 The rubric is a structured `Rubric` (per-criterion scoring + a required gate),
-not a free-text blob; the old `rubric: "<text>"` shape and the `output_schema`
-field were removed. See [GRADING.md](GRADING.md#llm-judge-rubric-grading) for the
-judge mechanism, the two weighting layers, and the fail-loud ERRORED status.
+not a free-text blob; the old `rubric: "<text>"` shape, the `output_schema`
+field, and the per-task judge-model field were all removed. The judge **model**
+is now a run-level role (`models.judge`, see above) — separate from the agent
+under test, with no default and no fallback. See
+[GRADING.md](GRADING.md#llm-judge-rubric-grading) for the judge mechanism, the
+two weighting layers, and the fail-loud ERRORED status.
 
 ## Environment Variables
 

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -78,7 +78,6 @@ grading:
   weights: { state_checks: 0.5, llm_judge: 0.5 }
   pass_threshold: 0.8
   llm_judge:
-    model_ref: openrouter/anthropic/claude-sonnet-4.5   # required; a separate fixed judge model
     rubric:
       reference: |                # optional, author-written ground truth shown to the judge
         Correct refund is $328.50 (base fare minus 24h-cancellation fee).
@@ -98,11 +97,17 @@ grading:
 
 ### How the judge works
 
-* **A separate, fixed judge model.** `model_ref` is required and independent of
-  the agent under test — this prevents self-grading bias and keeps the judge
-  constant across agent comparisons. The judge builds its own LLM client via the
-  agent's provider-correct capability path (so tool schemas/calls are correct
-  for any provider).
+* **A separate, run-level judge model.** The judge model is configured once per
+  run under `models.judge` (the run config — sibling to `models.agent` and
+  `models.user`), **not** in the per-task grading block. It is independent of the
+  agent under test — this prevents self-grading bias and keeps the judge constant
+  across agent comparisons — while a provider switch is a one-line run-config edit
+  rather than an N-task change. There is **no default and no fallback to the agent
+  model**: if a selected task uses an `llm_judge` component but the run config has
+  no `models.judge`, the orchestrator aborts the run up front, before any trial
+  executes (AGENTS.md rule 1). The judge builds its own LLM client via the agent's
+  provider-correct capability path (so tool schemas/calls are correct for any
+  provider).
 * **Author-written reference channel.** The judge sees only the rubric's
   `reference` and per-criterion `expected` — author-written *for grading*. The
   deterministic oracle (`golden_actions`, `expected_hash`, `jsonpath_checks`) is
@@ -261,7 +266,7 @@ Tasks used for RL training need grading that produces a meaningful signal — no
 
 - **Use `state_checks` (weight 1.0) for deterministic tasks.** State checks are objective and reproducible. They verify that the agent actually changed the environment correctly.
 - **Reserve `llm_judge` for genuinely subjective tasks.** An LLM judge giving 0.7 for "attempted the task" masks real failures. Don't use it as padding.
-- **CI portability:** public examples may use `mock/mock-judge` so CI can run without live judge inference; for real evaluations replace it with your production judge model.
+- **CI portability:** the judge model is a run-level role (`models.judge`), so CI can point it at `mock/mock-judge` to run without live judge inference; for real evaluations set `models.judge` to your production judge model. (No per-task edit is needed — switch the whole run in one place.)
 - **Check specific values, not just existence.** Assert `equals: "Large (14\")"` instead of just checking the path exists. Assert `equals: "apple_pay"` instead of checking that any payment method was set.
 - **Set `pass_threshold` to allow partial differentiation.** With 6 checks at `pass_threshold: 0.8`, an agent that gets 5/6 still passes but scores lower than 6/6. This provides gradient signal.
 

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -129,6 +129,9 @@ model_config:
       response_policy: "standard"
       reasoning_codec: "none"
       cache_policy: "none"
+  judge: null                               # run-level rubric judge (models.judge);
+                                            # null when unconfigured, else a full
+                                            # role block with its own resolved.*
 ```
 
 ### `model_config.<role>.resolved.*` (Stage 7, P6)
@@ -151,6 +154,11 @@ Computed by the orchestrator at trial-start via
 stateful [`GenerationParams`](../tolokaforge/core/llm/params_policy.py)
 dataclass, not a single-named policy. Callers needing the full parameter
 block read the `agent.capabilities` block directly.
+
+The `judge` role (the run-level read-only rubric judge, `models.judge`) is
+recorded symmetrically with `agent` / `user` — its own role block plus a
+`resolved.*` fingerprint — so every grade bundle records which judge produced
+it. It is `null` when the run configures no judge.
 
 ## `trials/{task_id}/{trial_index}/trajectory.yaml`
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -139,8 +139,7 @@ transcript_rules:
     required_tools: ["db_update"]
     disallowed_tools: ["bash"]
 
-llm_judge:
-  model_ref: "openrouter/anthropic/claude-sonnet-4.5"  # required; a separate fixed judge model
+llm_judge:                                 # judge MODEL is run-level (models.judge), not here
   rubric:                                  # structured Rubric (NOT free text)
     reference: |                           # optional author-written ground truth shown to the judge
       Correct refund is $328.50 (base fare minus 24h-cancellation fee).
@@ -158,11 +157,14 @@ llm_judge:
 ```
 
 `grading.llm_judge.rubric` is a structured `Rubric`, not a free-text blob; the
-old `rubric: "<text>"` shape and the `output_schema` field were removed (the
-judge's structured-output schema is derived from the rubric's criteria). See
-[GRADING.md](GRADING.md#llm-judge-rubric-grading) for the judge mechanism, the
-two weighting layers, the required-gate semantics, and the fail-loud ERRORED
-status.
+old `rubric: "<text>"` shape, the `output_schema` field, and the per-task
+judge-model field were all removed (the judge's structured-output schema is
+derived from the rubric's criteria). The judge **model** is configured once per run under
+`models.judge` (an optional `ModelConfig` role beside `agent` / `user`) and rides
+each trial as `TrialSpec.judge_model_config`; there is no default and no fallback
+to the agent model. See [GRADING.md](GRADING.md#llm-judge-rubric-grading) for the
+judge mechanism, the two weighting layers, the required-gate semantics, and the
+fail-loud ERRORED status.
 
 ### Environment Variables
 
@@ -288,13 +290,17 @@ from tolokaforge.core.grading.combine import GradingEngine
 
 engine = GradingEngine(
     grading_config: GradingConfig,
-    judge_model: ModelConfig | None = None,
     task_domain: str = "general",
     task_dir: Path | None = None,
 )
 
 grade = engine.grade_trajectory(trajectory: Trajectory, final_env_state: dict)
 # Returns: Grade with binary_pass, score, components, reasons, state_diff
+# (deterministic components only — GradingEngine does NOT run the rubric judge)
+#
+# The rubric judge runs Runner-side (see core/grading/judge.run_rubric_judge),
+# taking the run-level judge ModelConfig carried on TrialSpec.judge_model_config
+# (sourced from RunConfig.models["judge"]).
 ```
 
 ---

--- a/docs/RUBRIC_GRADING_DESIGN.md
+++ b/docs/RUBRIC_GRADING_DESIGN.md
@@ -33,7 +33,7 @@ orchestrator ──RegisterTrial──▶ runner            (TaskDescription inc
 orchestrator ──GradeTrial─────▶ runner._grade_trial_async
                                   ├─ state checks / transcript rules
                                   └─ rubric judge:  run_rubric_judge(...)
-                                        ├─ LLMClient(model_ref) via build_capabilities  (separate fixed judge model)
+                                        ├─ LLMClient(judge_model_config) via build_capabilities  (run-level models.judge)
                                         ├─ ToolCallingLoop (no user sim; stop on submit_report; max_turns + wall-time)
                                         │     read-only tools: get_db_state/query_db, search_kb, read_file, submit_report
                                         ├─ parse_submit_report  → list[CriterionResult]   (fail loud)
@@ -73,7 +73,7 @@ bridge back to the runner event loop with `run_coroutine_threadsafe(...)`.
 | **Judge runs in the runner** | DB + workspace live there; matches what the live code already did. Concurrency handled by raising the `GradeTrial` timeout (300→600s) + a per-judge `max_turns`/wall-time budget, not by moving host-side. |
 | **One shared loop** | The judge is "the agent loop run as a solo grader." Avoids a third near-duplicate loop; the old `_grade_agentic` and `GradingEngine` judge path were deleted. |
 | **Harness-owned read-only tools** (not the agent's tools filtered by `category`) | `category` is stamped `"compute"` for all native task tools, so a filter excludes nothing — untrustworthy. A fixed read-only allowlist is safe and modality-correct without a DB clone. |
-| **Separate fixed judge model via `build_capabilities`** | An agentic tool-calling judge needs the preset/policy machinery (schema sanitizers, reasoning codecs) — raw `litellm.completion` mangles tool calls for Gemini/GPT-5/etc. A fixed model (independent of the agent under test) avoids self-grading bias. |
+| **Run-level judge model via `build_capabilities`** | An agentic tool-calling judge needs the preset/policy machinery (schema sanitizers, reasoning codecs) — raw `litellm.completion` mangles tool calls for Gemini/GPT-5/etc. The model is a run-level role (`RunConfig.models["judge"]`, carried on `TrialSpec.judge_model_config`), separate from the agent under test to avoid self-grading bias, with no default and no fallback — a fleet-wide provider switch is a one-line run-config edit. |
 | **Fail loud → `JudgeStatus.ERRORED`** | Any judge malfunction (no `submit_report`, retry exhaustion, budget/turn exhaustion, crash) yields ERRORED with **no score**; the `llm_judge` component stays at the `-1.0` sentinel (excluded from the combine), never 0.0/0.5. |
 | **Structured output via `submit_report`** | The tool's arg schema is generated from the rubric and validated with Pydantic (bounded re-prompt, then ERRORED). No MCP — the loop is in-process. A flat arg object (per-criterion keyed by id) avoids nested-schema dialect gaps. |
 | **Author-written reference channel** (`rubric.reference`, `criterion.expected`) | The judge needs the correct answer to grade reference-dependent criteria — but it is given an author-written reference, **not** the deterministic oracle (`golden_actions`/`expected_hash`/`jsonpath_checks`), which would bias toward the golden path and double-count state checks. |

--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -266,9 +266,12 @@ class LLMJudgeConfig(BaseModel):
     """LLM-based grading configuration.
 
     The judge's structured-output schema is derived from the rubric's criteria;
-    the old `rubric: str` and `output_schema` fields were removed.
+    the old `rubric: str` and `output_schema` fields were removed. The judge
+    MODEL is no longer pinned here — it moved to the run config under
+    `models.judge` (an optional ModelConfig role) and rides each trial as
+    `TrialSpec.judge_model_config`. There is no default and no fallback to the
+    agent model.
     """
-    model_ref: str                                # "openrouter/anthropic/claude-sonnet-4.5"
     rubric: Rubric                                # structured rubric (see above)
 
 

--- a/examples/native/native_shared_domain/README.md
+++ b/examples/native/native_shared_domain/README.md
@@ -63,8 +63,9 @@ can't fully capture.
 
 The rubric carries an author-written `reference` (the four notes' ground-truth
 content) shown to the judge — this is the *grading* reference channel, not
-`golden_actions`. The judge model is `openrouter/openai/gpt-4.1-mini` (cheap but
-capable; `gpt-4o-mini` loops and never submits).
+`golden_actions`. The judge model is configured at the run level under
+`models.judge` (here `openrouter/openai/gpt-4.1-mini` — cheap but capable;
+`gpt-4o-mini` loops and never submits), separate from the agent under test.
 
 The judge grades from the **transcript + reference**: the criteria score the
 agent's written reply, which only the transcript carries. (The judge's read-only

--- a/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_gated/grading.yaml
+++ b/examples/native/native_shared_domain/dataset/notes/testcases/add_note_duplicate_check_gated/grading.yaml
@@ -24,8 +24,6 @@ combine:
   pass_threshold: 0.75
 
 llm_judge:
-  # Cheap but capable judge that reliably terminates on agentic grading.
-  model_ref: "openrouter/openai/gpt-4.1-mini"
   rubric:
     reference: |
       The notes app already contains a note titled "Team stand-up" with body

--- a/examples/native/native_shared_domain/dataset/notes/testcases/summarize_notes_rubric/grading.yaml
+++ b/examples/native/native_shared_domain/dataset/notes/testcases/summarize_notes_rubric/grading.yaml
@@ -28,9 +28,6 @@ transcript_rules:
       compare_args: []
 
 llm_judge:
-  # Cheap but capable judge. gpt-4o-mini loops and never submits; 4.1-mini
-  # reliably terminates on agentic grading.
-  model_ref: "openrouter/openai/gpt-4.1-mini"
   rubric:
     reference: |
       The user has exactly four saved notes; a correct summary must cover all of

--- a/examples/native/native_shared_domain/run_config.yaml
+++ b/examples/native/native_shared_domain/run_config.yaml
@@ -1,6 +1,11 @@
-# Native shared-domain example — two notes-app testcases that share one
+# Native shared-domain example — notes-app testcases that share one
 # _shared/ directory. Run with:
 #   scripts/with_env.sh uv run tolokaforge run --config examples/native/native_shared_domain/run_config.yaml
+#
+# Three model roles: the `agent` under test, the `user` simulator, and the
+# read-only rubric `judge` (used by the testcases that grade with llm_judge).
+# The judge is a run-level model — separate from the agent under test — so a
+# provider switch is a one-line edit here, not a per-task change.
 models:
   agent:
     provider: "openrouter"
@@ -11,6 +16,10 @@ models:
     provider: "openrouter"
     name: "anthropic/claude-sonnet-4-6"
     temperature: 0.2
+  judge:
+    provider: "openrouter"
+    name: "openai/gpt-4.1-mini"
+    temperature: 0.0
 
 orchestrator:
   workers: 1

--- a/examples/native/native_shared_domain/run_config_gate_demo.yaml
+++ b/examples/native/native_shared_domain/run_config_gate_demo.yaml
@@ -7,6 +7,10 @@
 # criterion → gate_failed → binary_pass=false, even though the graded
 # `note_saved` / `clarity` criteria still score (see grade.yaml criterion_results).
 #
+# The read-only rubric `judge` is a run-level model (models.judge), separate
+# from the cheap agent under test — it must reliably terminate on agentic
+# grading (gpt-4o-mini loops and never submits; 4.1-mini terminates).
+#
 # Run with:
 #   scripts/with_env.sh uv run tolokaforge run --config examples/native/native_shared_domain/run_config_gate_demo.yaml
 models:
@@ -19,6 +23,10 @@ models:
     provider: "openrouter"
     name: "anthropic/claude-sonnet-4-6"
     temperature: 0.2
+  judge:
+    provider: "openrouter"
+    name: "openai/gpt-4.1-mini"
+    temperature: 0.0
 
 orchestrator:
   workers: 1

--- a/tests/canonical/test_trial_spec_contract.py
+++ b/tests/canonical/test_trial_spec_contract.py
@@ -143,6 +143,7 @@ class TestTrialSpecContract:
             "task",
             "agent_model_config",
             "user_model_config",
+            "judge_model_config",
             "max_turns",
             "default_tool_timeout_s",
             "env_endpoints",

--- a/tests/integration/test_rubric_judge_live.py
+++ b/tests/integration/test_rubric_judge_live.py
@@ -19,7 +19,11 @@ import os
 
 import pytest
 
-from tolokaforge.core.grading.judge import JudgeStatus, run_rubric_judge
+from tolokaforge.core.grading.judge import (
+    JudgeStatus,
+    model_config_from_ref,
+    run_rubric_judge,
+)
 from tolokaforge.runner.models import Rubric
 
 pytestmark = [
@@ -124,7 +128,7 @@ def _rubric() -> Rubric:
 def test_rubric_judge_live_passes_good_transcript():
     result = run_rubric_judge(
         rubric=_rubric(),
-        model_ref=_MODEL_REF,
+        model_config=model_config_from_ref(_MODEL_REF),
         agent_system_prompt=_AGENT_SYSTEM_PROMPT,
         transcript=_TRANSCRIPT,
         db_reader=_DictDBReader(_DB_STATE),
@@ -158,7 +162,7 @@ def test_rubric_judge_live_gate_fails_when_refund_missing():
     ]
     result = run_rubric_judge(
         rubric=_rubric(),
-        model_ref=_MODEL_REF,
+        model_config=model_config_from_ref(_MODEL_REF),
         agent_system_prompt=_AGENT_SYSTEM_PROMPT,
         transcript=transcript,
         db_reader=_DictDBReader(pending_state),

--- a/tests/unit/grading/test_judge.py
+++ b/tests/unit/grading/test_judge.py
@@ -14,10 +14,15 @@ import pytest
 from tolokaforge.core.grading.judge import JudgeStatus, run_rubric_judge
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
-from tolokaforge.core.models import ToolCall
+from tolokaforge.core.models import ModelConfig, ToolCall
 from tolokaforge.runner.models import Rubric
 
 pytestmark = pytest.mark.unit
+
+# The judge now takes a run-level ModelConfig. These tests inject a scripted
+# ``llm_client`` so the config is never used to build a real client; it is
+# supplied only to satisfy the required signature.
+_JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +127,7 @@ def test_terminates_on_submit_report_and_scores():
 
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="You are a refund agent.",
         transcript=[{"role": "user", "content": "refund me"}],
         db_reader=FakeDBReader(),
@@ -156,7 +161,7 @@ def test_inspects_db_then_submits():
 
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="policy",
         transcript=[{"role": "user", "content": "hi"}],
         db_reader=reader,
@@ -174,7 +179,7 @@ def test_db_tools_absent_when_no_reader():
     client = ScriptedClient([[("submit_report", _submit_args(refund_done=True))]])
     run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=None,
@@ -199,7 +204,7 @@ def test_malformed_submit_report_reprompts_then_errors():
 
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -223,7 +228,7 @@ def test_malformed_then_valid_recovers():
     )
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -239,7 +244,7 @@ def test_weighted_score_and_criterion_results():
     client = ScriptedClient([[("submit_report", _submit_args(refund_done=True, tone=0.4))]])
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -257,7 +262,7 @@ def test_failed_required_criterion_gates_regardless_of_weighted_score():
     client = ScriptedClient([[("submit_report", _submit_args(refund_done=False, tone=1.0))]])
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -279,7 +284,7 @@ def test_usage_is_recorded():
     )
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -299,7 +304,7 @@ def test_turn_exhaustion_without_submit_report_errors():
     client = ScriptedClient([[("get_db_state", {})]] * 50)
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -323,7 +328,7 @@ def test_judge_loop_crash_errors_not_scores():
 
     result = run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="",
         transcript=[],
         db_reader=FakeDBReader(),
@@ -346,7 +351,7 @@ def test_agent_system_prompt_injected_into_opening_context():
     client = CapturingClient([[("submit_report", _submit_args(refund_done=True))]])
     run_rubric_judge(
         rubric=rubric,
-        model_ref="openai/gpt-4o-mini",
+        model_config=_JUDGE_MODEL,
         agent_system_prompt="SECRET-AGENT-POLICY-MARKER",
         transcript=[{"role": "user", "content": "do the thing"}],
         db_reader=FakeDBReader(),

--- a/tests/unit/grading/test_llm_judge_runner.py
+++ b/tests/unit/grading/test_llm_judge_runner.py
@@ -35,7 +35,7 @@ def test_combine_components_includes_llm_judge_when_score_set():
     cfg = {
         "combine_method": "weighted",
         "weights": {"llm_judge": 1.0},
-        "llm_judge": {"model_ref": "x"},
+        "llm_judge": {"rubric": {"criteria": [{"id": "a", "description": "d"}]}},
     }
     score, _ = combine_grade_components(components, cfg)
     assert score == pytest.approx(0.6)
@@ -77,14 +77,18 @@ def test_build_grade_reasons_includes_judge_text():
 
 
 def test_native_adapter_serializes_llm_judge():
-    """A structured rubric round-trips through the runner GradingConfig wire shape."""
+    """A structured rubric round-trips through the runner GradingConfig wire shape.
+
+    The judge *model* no longer lives on this block — it relocated to the run
+    config (models.judge) and rides ``TrialSpec.judge_model_config``. This pins
+    that the grading payload now carries ONLY the rubric, with no ``model_ref``.
+    """
     from tolokaforge.runner.models import GradingConfig, LLMJudgeConfig
 
     cfg = GradingConfig(
         combine_method="weighted",
         weights={"llm_judge": 1.0},
         llm_judge=LLMJudgeConfig(
-            model_ref="openai/gpt-4o-mini",
             rubric={
                 "reference": "Correct refund is $328.50.",
                 "criteria": [
@@ -101,7 +105,7 @@ def test_native_adapter_serializes_llm_judge():
         ),
     )
     payload = cfg.model_dump()
-    assert payload["llm_judge"]["model_ref"] == "openai/gpt-4o-mini"
+    assert "model_ref" not in payload["llm_judge"]
     assert payload["llm_judge"]["rubric"]["criteria"][0]["id"] == "refund_amount"
 
     reconstructed = GradingConfig.model_validate(payload)
@@ -111,3 +115,34 @@ def test_native_adapter_serializes_llm_judge():
     assert crit.id == "refund_amount"
     assert crit.required is True
     assert crit.expected == "$328.50"
+
+
+def test_judge_model_rides_on_trial_spec():
+    """The judge model is now a run-level ModelConfig carried on the TrialSpec —
+    symmetric with the agent and user models — and survives the gRPC JSON wire."""
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+    from tolokaforge.runner.models import TaskDescription
+
+    judge_model = ModelConfig(
+        provider="openrouter", name="anthropic/claude-sonnet-4.6", temperature=0.0
+    )
+    spec = TrialSpec(
+        trial_id="t:0",
+        run_id="r",
+        task=TaskDescription(
+            task_id="t",
+            name="t",
+            category="test",
+            description="d",
+            adapter_type="native",
+            system_prompt="sys",
+        ),
+        agent_model_config=ModelConfig(provider="openrouter", name="agent"),
+        judge_model_config=judge_model,
+        env_endpoints=EnvEndpoints(db_url="http://db", runner_url="http://runner"),
+    )
+
+    rehydrated = TrialSpec.model_validate_json(spec.model_dump_json())
+    assert rehydrated.judge_model_config == judge_model
+    assert rehydrated.judge_model_config.temperature == 0.0

--- a/tests/unit/test_native_adapter_rubric_mapping.py
+++ b/tests/unit/test_native_adapter_rubric_mapping.py
@@ -55,7 +55,6 @@ def test_structured_rubric_maps_into_runner_llm_judge(tmp_path: Path):
                 "pass_threshold": 0.8,
             },
             "llm_judge": {
-                "model_ref": "openai/gpt-4o-mini",
                 "rubric": {
                     "reference": "Correct refund is $328.50.",
                     "criteria": [
@@ -83,7 +82,6 @@ def test_structured_rubric_maps_into_runner_llm_judge(tmp_path: Path):
 
     judge = task_desc.grading.llm_judge
     assert judge is not None
-    assert judge.model_ref == "openai/gpt-4o-mini"
     assert judge.rubric.reference == "Correct refund is $328.50."
 
     by_id = {c.id: c for c in judge.rubric.criteria}
@@ -108,7 +106,6 @@ def test_legacy_rubric_str_in_task_grading_is_rejected(tmp_path: Path):
         {
             "combine": {"method": "weighted", "weights": {"llm_judge": 1.0}},
             "llm_judge": {
-                "model_ref": "openai/gpt-4o-mini",
                 "rubric": "free-text rubric blob",
                 "output_schema": {"type": "object"},
             },
@@ -116,4 +113,25 @@ def test_legacy_rubric_str_in_task_grading_is_rejected(tmp_path: Path):
     )
 
     with pytest.raises(ValueError, match="rubric is now a structured Rubric"):
+        adapter.to_task_description("rubric_task")
+
+
+def test_legacy_model_ref_in_task_grading_is_rejected(tmp_path: Path):
+    """The judge model moved to the run config; a lingering ``model_ref`` fails loud."""
+    adapter = _build_task(
+        tmp_path,
+        {
+            "combine": {"method": "weighted", "weights": {"llm_judge": 1.0}},
+            "llm_judge": {
+                "model_ref": "openai/gpt-4o-mini",
+                "rubric": {
+                    "criteria": [
+                        {"id": "a", "description": "d", "kind": "binary", "weight": 1.0},
+                    ],
+                },
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="model_ref moved to the run config"):
         adapter.to_task_description("rubric_task")

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1014,6 +1014,58 @@ class TestSerializeModelConfig:
         assert isinstance(result["user"], dict)
         assert result["user"]["name"] == "anthropic/claude-sonnet-4.6"
 
+    def test_serialize_records_judge_role_with_resolved_fingerprint(self) -> None:
+        """A configured judge role is recorded in the bundle like agent/user —
+        carrying provider/name and a ``resolved`` preset fingerprint — so every
+        grade bundle records which judge produced it."""
+        orch = MagicMock()
+        orch.config.models = {
+            "agent": ModelConfig(provider="openrouter", name="openai/gpt-5.4"),
+            "judge": ModelConfig(
+                provider="openrouter", name="openai/gpt-4.1-mini", temperature=0.0
+            ),
+        }
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        result = Orchestrator._serialize_model_config(orch)
+
+        assert result["judge"] is not None
+        assert result["judge"]["provider"] == "openrouter"
+        assert result["judge"]["name"] == "openai/gpt-4.1-mini"
+        # The resolved preset fingerprint must be present (same shape as agent/user).
+        assert "resolved" in result["judge"]
+        assert "effective_preset" in result["judge"]["resolved"]
+
+    def test_serialize_judge_is_null_when_unconfigured(self) -> None:
+        """No judge role configured → ``judge`` key present and null (consistent
+        with how an absent user is recorded), with no resolved fingerprint."""
+        orch = MagicMock()
+        orch.config.models = {
+            "agent": ModelConfig(provider="openrouter", name="openai/gpt-5.4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        }
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        result = Orchestrator._serialize_model_config(orch)
+
+        assert result["judge"] is None
+
+    def test_serialize_judge_arg_overrides_and_is_recorded(self) -> None:
+        """The explicit ``judge_config`` arg (the resolved run-level judge passed
+        from the trial build) is recorded, mirroring the agent/user arg path."""
+        orch = MagicMock()
+        orch.config.models = {
+            "agent": ModelConfig(provider="openrouter", name="openai/gpt-5.4"),
+            "judge": ModelConfig(provider="openrouter", name="openai/gpt-4.1-mini"),
+        }
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        judge = ModelConfig(provider="openrouter", name="openai/gpt-4.1-mini", temperature=0.0)
+        result = Orchestrator._serialize_model_config(orch, judge_config=judge)
+
+        assert result["judge"]["name"] == "openai/gpt-4.1-mini"
+        assert "resolved" in result["judge"]
+
 
 # ===================================================================
 # _build_env_endpoints (free function)
@@ -1066,3 +1118,111 @@ class TestBuildEnvEndpoints:
 
         endpoints = _build_env_endpoints("https://runner.example:50051")
         assert endpoints.runner_url == "https://runner.example:50051"
+
+
+# ===================================================================
+# Up-front judge-model gate (fail loud, no hidden default)
+# ===================================================================
+
+
+def _task_description_with_judge(task_id: str, *, has_judge: bool):
+    """Build a TaskDescription whose grading does / does not declare an llm_judge."""
+    from tolokaforge.runner.models import (
+        GradingConfig,
+        LLMJudgeConfig,
+        Rubric,
+        TaskDescription,
+    )
+
+    llm_judge = None
+    if has_judge:
+        llm_judge = LLMJudgeConfig(
+            rubric=Rubric(
+                criteria=[{"id": "c", "description": "d", "kind": "binary", "weight": 1.0}]
+            )
+        )
+    return TaskDescription(
+        task_id=task_id,
+        name=task_id,
+        category="test",
+        description="d",
+        adapter_type="native",
+        system_prompt="sys",
+        grading=GradingConfig(llm_judge=llm_judge),
+    )
+
+
+def _orchestrator_with_tasks(config: RunConfig, judge_flags: dict[str, bool]):
+    """Construct an Orchestrator with stubbed tasks + adapter for the gate test."""
+    from tolokaforge.core.orchestrator import Orchestrator
+
+    orch = Orchestrator(config)
+    orch.tasks = [_make_task_config(tid) for tid in judge_flags]
+    adapter = MagicMock()
+    adapter.to_task_description.side_effect = lambda tid: _task_description_with_judge(
+        tid, has_judge=judge_flags[tid]
+    )
+    orch.adapter = adapter
+    return orch
+
+
+@pytest.mark.unit
+class TestJudgeModelGate:
+    """The run must abort up front when a task needs an llm_judge but none is set.
+
+    This is the load-bearing relocation guarantee: the judge model lives at the
+    run level (models.judge), there is no default and no fallback to the agent
+    model, and the failure surfaces BEFORE any trial executes (in the gate the
+    run loop calls before scheduling).
+    """
+
+    def test_missing_judge_model_aborts_and_names_offending_task(self) -> None:
+        config = _make_run_config()  # models has agent only, no judge
+        orch = _orchestrator_with_tasks(config, {"TASK-needs-judge": True, "TASK-no-judge": False})
+
+        with pytest.raises(ValueError) as excinfo:
+            orch._resolve_judge_config()
+
+        message = str(excinfo.value)
+        assert "TASK-needs-judge" in message
+        # The non-judge task must NOT be flagged.
+        assert "TASK-no-judge" not in message
+        assert "models.judge" in message
+
+    def test_judge_model_present_returns_it_no_abort(self) -> None:
+        judge = ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6")
+        config = _make_run_config(
+            models={"agent": ModelConfig(provider="openai", name="gpt-4"), "judge": judge}
+        )
+        orch = _orchestrator_with_tasks(config, {"TASK-needs-judge": True})
+
+        assert orch._resolve_judge_config() == judge
+
+    def test_no_judge_task_no_judge_model_is_allowed(self) -> None:
+        config = _make_run_config()  # no judge model
+        orch = _orchestrator_with_tasks(config, {"TASK-no-judge": False})
+
+        # No task needs a judge, so the absence of models.judge is fine.
+        assert orch._resolve_judge_config() is None
+
+    def test_run_worker_aborts_before_any_trial_dispatch(self, tmp_path: Path) -> None:
+        """Pin the gate's PLACEMENT: the abort happens before a single trial is
+        dispatched. ``_run_trial`` and the Docker runtime are stubbed so that if a
+        refactor moved the gate below the scheduling loop, the trial stub would be
+        invoked and this test would fail instead of silently passing.
+        """
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        config = _make_run_config()  # agent only, no judge model
+        orch = _orchestrator_with_tasks(config, {"TASK-needs-judge": True})
+
+        with (
+            patch.object(Orchestrator, "_run_trial") as run_trial,
+            patch("tolokaforge.core.docker_runtime.DockerRuntime") as docker_runtime,
+        ):
+            with pytest.raises(ValueError, match="TASK-needs-judge"):
+                orch.run_worker(tmp_path)
+
+        # No trial was dispatched, and the run never reached Docker setup.
+        run_trial.assert_not_called()
+        docker_runtime.assert_not_called()

--- a/tests/unit/test_validate_rubric_migration.py
+++ b/tests/unit/test_validate_rubric_migration.py
@@ -60,7 +60,6 @@ def test_validate_rejects_legacy_rubric_str(tmp_path: Path):
           weights:
             llm_judge: 1.0
         llm_judge:
-          model_ref: "openai/gpt-4o-mini"
           rubric: "Grade the reply for correctness and tone."
           output_schema:
             type: object
@@ -78,6 +77,35 @@ def test_validate_rejects_legacy_rubric_str(tmp_path: Path):
     assert "criteria:" in out
 
 
+def test_validate_rejects_legacy_model_ref(tmp_path: Path):
+    """The judge model relocated to the run config (models.judge); a stray
+    ``llm_judge.model_ref`` in grading.yaml must fail validate with a migration
+    message that names where the model now lives."""
+    task_file = _write_task(
+        tmp_path / "legacy_model_ref",
+        """
+        combine:
+          method: weighted
+          weights:
+            llm_judge: 1.0
+        llm_judge:
+          model_ref: "openai/gpt-4o-mini"
+          rubric:
+            criteria:
+              - id: refund_amount
+                description: "Reply quotes the correct refund amount"
+                kind: binary
+                weight: 1.0
+        """,
+    )
+
+    result = CliRunner(mix_stderr=False).invoke(cli, ["validate", "--tasks", str(task_file)])
+
+    out = result.output
+    assert "0 valid, 1 invalid" in out
+    assert "model_ref moved to the run config" in out
+
+
 def test_validate_accepts_structured_rubric(tmp_path: Path):
     task_file = _write_task(
         tmp_path / "structured_rubric",
@@ -87,7 +115,6 @@ def test_validate_accepts_structured_rubric(tmp_path: Path):
           weights:
             llm_judge: 1.0
         llm_judge:
-          model_ref: "openai/gpt-4o-mini"
           rubric:
             reference: "Correct refund is $328.50."
             criteria:
@@ -111,7 +138,6 @@ def test_validate_grading_yaml_rejects_removed_output_schema(tmp_path: Path):
         textwrap.dedent(
             """
             llm_judge:
-              model_ref: "openai/gpt-4o-mini"
               rubric:
                 criteria:
                   - id: a

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -2,7 +2,7 @@
 
 This module is the single entry point for turning a ``task.yaml`` path into a
 validated :class:`TaskConfig`. It exists so that every code path that loads a
-task — :class:`NativeAdapter`, :class:`FrozenMcpCoreAdapter`, the
+task — :class:`NativeAdapter`, the ``tlk_mcp_core`` adapter, the
 ``tolokaforge validate`` CLI, and ``tolokaforge adapter validate`` — applies
 the same domain-layout merge.
 
@@ -85,8 +85,11 @@ def validate_grading_yaml(grading_path: Path) -> None:
     # The rubric migration lives on the canonical LLMJudgeConfig, so validate the
     # llm_judge block directly — independent of the surrounding grading schema,
     # which varies by adapter.
+    # Validate when a rubric is present (the new gate) or when the relocated
+    # ``model_ref`` lingers (so its loud migration error surfaces at validate
+    # time rather than only at run time).
     llm_judge = grading_data.get("llm_judge")
-    if isinstance(llm_judge, dict) and llm_judge.get("model_ref"):
+    if isinstance(llm_judge, dict) and (llm_judge.get("rubric") or "model_ref" in llm_judge):
         from tolokaforge.runner.models import LLMJudgeConfig
 
         LLMJudgeConfig(**llm_judge)

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -619,9 +619,12 @@ class NativeAdapter(BaseAdapter):
         # reference), not free text. The old ``rubric: str`` / ``output_schema``
         # shape is rejected by ``Rubric``/``LLMJudgeConfig`` (extra="forbid"),
         # surfacing a migration error during validate.
+        # Gate on rubric presence — the judge model moved to the run config
+        # (models.judge), so ``model_ref`` no longer exists on this block. A
+        # lingering ``model_ref`` is rejected loudly by ``LLMJudgeConfig``.
         llm_judge_config = None
         llm_judge_data = grading_data.get("llm_judge", {}) if grading_data else {}
-        if llm_judge_data and llm_judge_data.get("model_ref"):
+        if llm_judge_data and llm_judge_data.get("rubric"):
             from tolokaforge.runner.models import LLMJudgeConfig as RunnerLLMJudgeConfig
 
             llm_judge_config = RunnerLLMJudgeConfig(**llm_judge_data)
@@ -759,7 +762,7 @@ class NativeAdapter(BaseAdapter):
             [{"name": "...", "description": "...", "parameters": { ... }}]
 
         The ``inputSchema`` field returned by MCP becomes ``parameters`` in the
-        stored/returned format, matching what ``FrozenMcpCoreAdapter`` uses.
+        stored/returned format, matching what the ``tlk_mcp_core`` adapter uses.
 
         Args:
             mcp_server_path: Absolute path to ``mcp_server.py``.
@@ -831,7 +834,7 @@ class NativeAdapter(BaseAdapter):
         Resolution order:
 
         1. ``task_dir/fixtures/tools.json`` — pre-generated static file (fastest,
-           avoids subprocess overhead, matches ``FrozenMcpCoreAdapter`` pattern).
+           avoids subprocess overhead, matches the ``tlk_mcp_core`` adapter pattern).
         2. Live MCP query via ``tools/list`` — used when the static file does not
            exist yet; result is written back to ``fixtures/tools.json`` so that
            subsequent runs are fast.

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -131,6 +131,11 @@ def _activate_presets_overlay(
     help="Override user simulator model (e.g., anthropic/claude-sonnet-4.6). Uses OpenRouter as provider.",
 )
 @click.option(
+    "--judge-model",
+    default=None,
+    help="Set the read-only rubric judge model (e.g., anthropic/claude-sonnet-4.6). Uses OpenRouter as provider, temperature 0.",
+)
+@click.option(
     "--presets-file",
     "presets_file",
     type=click.Path(exists=True, dir_okay=False),
@@ -147,6 +152,7 @@ def run(
     verbose: bool,
     strict: bool,
     user_model: str | None,
+    judge_model: str | None,
     presets_file: str | None,
 ):
     """Run benchmark with specified configuration"""
@@ -171,6 +177,20 @@ def run(
             "temperature": DEFAULT_USER_MODEL_TEMPERATURE,
         }
         console.print(f"[cyan]User model override: {user_model_override}[/cyan]")
+
+    # Apply judge model: CLI flag > env var > YAML config (models.judge).
+    # Temperature is pinned to 0 for grading determinism (the judge does not
+    # honour a non-zero temperature yet). The YAML path is primary and parses
+    # with no loader change; this flag is the ergonomic override mirroring
+    # --user-model.
+    judge_model_override = judge_model or os.environ.get("JUDGE_MODEL")
+    if judge_model_override:
+        config_data.setdefault("models", {})["judge"] = {
+            "provider": DEFAULT_USER_MODEL_PROVIDER,
+            "name": judge_model_override,
+            "temperature": 0.0,
+        }
+        console.print(f"[cyan]Judge model: {judge_model_override}[/cyan]")
 
     run_config = RunConfig(**config_data)
 

--- a/tolokaforge/core/grading/judge.py
+++ b/tolokaforge/core/grading/judge.py
@@ -8,9 +8,10 @@ malfunction."*
 Design (locked decisions, see the plan):
 
 * **Separate fixed judge model.** The judge constructs its own
-  :class:`~tolokaforge.core.llm.client.LLMClient` from the rubric's ``model_ref``
-  via the agent's ``build_capabilities`` path (so tool schemas/calls are
-  provider-correct for Gemini / GPT-5 / …). API keys are read through
+  :class:`~tolokaforge.core.llm.client.LLMClient` from the run-level
+  ``ModelConfig`` (``RunConfig.models["judge"]``) via the agent's
+  ``build_capabilities`` path (so tool schemas/calls are provider-correct for
+  Gemini / GPT-5 / …). API keys are read through
   :class:`SecretManager` inside ``LLMClient`` — never ``os.environ`` here.
 * **Harness-owned read-only allowlist.** NOT the agent's tools, NO category
   filter, NO DB clone. The judge gets read-only DB tools, ``search_kb`` when the
@@ -384,8 +385,13 @@ def _build_judge_registry(
     return registry
 
 
-def _model_config_from_ref(model_ref: str) -> ModelConfig:
+def model_config_from_ref(model_ref: str) -> ModelConfig:
     """Split a ``model_ref`` into ``provider`` / ``name`` (first ``/`` only).
+
+    Boundary helper for the only places that still carry the judge model as a
+    string — the CLI ``--judge-model`` flag and the ``rubric-calibrator``
+    ``--model-ref`` option. The judge's own runtime path takes a full
+    ``ModelConfig`` (run-level), never a string.
 
     Matches ``BaseAdapter.grade`` and ``LLMClient._format_model_name``: e.g.
     ``openrouter/anthropic/claude-sonnet-4.5`` → provider ``openrouter``, name
@@ -407,7 +413,7 @@ def _model_config_from_ref(model_ref: str) -> ModelConfig:
 def run_rubric_judge(
     *,
     rubric: Rubric,
-    model_ref: str,
+    model_config: ModelConfig,
     agent_system_prompt: str,
     transcript: list[dict[str, Any]],
     db_reader: DBReader | None = None,
@@ -430,7 +436,8 @@ def run_rubric_judge(
     numeric score. There is no path that returns ``0.0`` / ``0.5`` on failure.
 
     ``llm_client`` may be injected for tests (a scripted ``LoopLLMClient`` /
-    fake); production passes ``None`` and the judge builds one from ``model_ref``.
+    fake); production passes ``None`` and the judge builds one from the
+    run-level ``model_config``.
     """
     logger = logger or get_logger("rubric_judge")
     metrics = _JudgeMetricsSink()
@@ -439,7 +446,7 @@ def run_rubric_judge(
     if llm_client is not None:
         client = llm_client  # type: ignore[assignment]
     else:
-        client = LLMClient(_model_config_from_ref(model_ref))
+        client = LLMClient(model_config)
 
     registry = _build_judge_registry(
         rubric,
@@ -581,5 +588,6 @@ __all__ = [
     "JudgeResult",
     "JudgeStatus",
     "JudgeUsage",
+    "model_config_from_ref",
     "run_rubric_judge",
 ]

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -509,6 +509,40 @@ class Orchestrator:
 
         self.logger.info("Tasks loaded", count=len(self.tasks), adapter=type(self.adapter).__name__)
 
+    def _resolve_judge_config(self) -> ModelConfig | None:
+        """Resolve the run-level judge model and fail loud on the missing-judge case.
+
+        The judge model lives at the run level (``models.judge``), symmetric with
+        the agent and user models. There is NO default and NO fallback to the
+        agent model (self-grading bias). If any selected task declares an
+        ``llm_judge`` grading component but ``models.judge`` is absent, the run is
+        rejected here — before any trial executes — naming the offending tasks
+        (AGENTS.md rule 1).
+
+        Assumes every adapter populates ``to_task_description().grading.llm_judge``
+        for rubric tasks; only ``NativeAdapter`` implements rubric grading today,
+        so non-native adapters simply surface no offending tasks here.
+        """
+        judge_config = self.config.models.get("judge")
+        if judge_config is not None:
+            return judge_config
+
+        assert self.adapter is not None
+        offending = [
+            task.task_id
+            for task in self.tasks
+            if self.adapter.to_task_description(task.task_id).grading.llm_judge is not None
+        ]
+        if offending:
+            raise ValueError(
+                "These selected tasks use an llm_judge grading component but the run "
+                "config has no judge model: "
+                f"{', '.join(sorted(offending))}. Add a judge model to the run config "
+                "under models.judge (provider/name), e.g. "
+                "`models: {judge: {provider: openrouter, name: anthropic/claude-sonnet-4.6}}`."
+            )
+        return None
+
     def run(self) -> None:
         """Execute all tasks with configured trials"""
         # Add timestamp to output directory for unique runs
@@ -581,11 +615,16 @@ class Orchestrator:
                 user_model="openrouter/anthropic/claude-sonnet-4.6",
             )
 
-        # Log model configuration for both roles
+        # Resolve the run-level judge model and reject the run up front if any
+        # selected task needs a judge but none is configured (fail loud).
+        judge_config = self._resolve_judge_config()
+
+        # Log model configuration for all roles
         self.logger.info(
             "Model configuration",
             agent_model=f"{agent_config.provider}/{agent_config.name}",
             user_model=f"{user_config.provider}/{user_config.name}",
+            judge_model=(f"{judge_config.provider}/{judge_config.name}" if judge_config else None),
         )
 
         # Instantiate agent client in orchestrator process
@@ -760,6 +799,7 @@ class Orchestrator:
                     attempt_id=lease.retry_count,
                     worker_id=lease_owner,
                     env_endpoints=env_endpoints,
+                    judge_config=judge_config,
                 )
                 active_futures[future] = lease
                 return True
@@ -944,11 +984,16 @@ class Orchestrator:
                 user_model="openrouter/anthropic/claude-sonnet-4.6",
             )
 
-        # Log model configuration for both roles
+        # Resolve the run-level judge model and reject the run up front if any
+        # selected task needs a judge but none is configured (fail loud).
+        judge_config = self._resolve_judge_config()
+
+        # Log model configuration for all roles
         self.logger.info(
             "Model configuration",
             agent_model=f"{agent_config.provider}/{agent_config.name}",
             user_model=f"{user_config.provider}/{user_config.name}",
+            judge_model=(f"{judge_config.provider}/{judge_config.name}" if judge_config else None),
         )
 
         agent_client = LLMClient(agent_config)
@@ -1032,6 +1077,7 @@ class Orchestrator:
                         attempt_id=lease.retry_count,
                         worker_id=lease_owner,
                         env_endpoints=env_endpoints,
+                        judge_config=judge_config,
                     )
                     trajectory = trial_result.trajectory
                     self.results.append(trajectory)
@@ -1100,6 +1146,11 @@ class Orchestrator:
             self.load_tasks()
         if not self.tasks:
             raise ValueError("No tasks found to enqueue")
+
+        # Reject up front (at enqueue time) if any task needs a judge but none is
+        # configured — otherwise a misconfigured distributed run reports success
+        # here and then every worker dies identically at grade time.
+        self._resolve_judge_config()
 
         run_queue = create_run_queue(
             self.config.orchestrator.queue_backend,
@@ -1176,6 +1227,7 @@ class Orchestrator:
         attempt_id: int = 0,
         worker_id: str | None = None,
         env_endpoints: EnvEndpoints,
+        judge_config: ModelConfig | None = None,
     ) -> TrialResult:
         """Run a single trial with environment state and grading.
 
@@ -1381,6 +1433,7 @@ class Orchestrator:
             task=task_desc,
             agent_model_config=agent_client.config,
             user_model_config=user_config,
+            judge_model_config=judge_config,
             max_turns=task.max_turns,
             default_tool_timeout_s=DEFAULT_TOOL_TIMEOUT_S,
             env_endpoints=env_endpoints,
@@ -1761,7 +1814,7 @@ class Orchestrator:
             "tools": task.tools.model_dump(mode="json"),
             "policies": task.policies,
             "model_config": self._serialize_model_config(
-                agent_config=agent_config, user_config=user_config
+                agent_config=agent_config, user_config=user_config, judge_config=judge_config
             ),
         }
 
@@ -1787,6 +1840,7 @@ class Orchestrator:
         self,
         agent_config: ModelConfig | None = None,
         user_config: ModelConfig | None = None,
+        judge_config: ModelConfig | None = None,
     ) -> dict[str, Any]:
         """Serialize model config for trial output.
 
@@ -1797,40 +1851,61 @@ class Orchestrator:
         tools diff this across runs to detect config drift without having to
         re-match the preset YAML.
 
-        When callers (e.g. tests) omit *agent_config* / *user_config*, the
-        method falls back to the values declared on ``self.config.models``.
-        The ``resolved:`` block is computed against the same identity.
+        The ``judge`` role (the run-level read-only rubric judge) is recorded the
+        same way as ``agent`` / ``user`` so every grade bundle records which judge
+        produced it — the judge model is a mutable per-run knob. ``judge`` is
+        ``null`` when the run configures no judge.
+
+        When callers (e.g. tests) omit *agent_config* / *user_config* /
+        *judge_config*, the method falls back to the values declared on
+        ``self.config.models``. The ``resolved:`` block is computed against the
+        same identity.
         """
         result: dict[str, Any] = {}
 
         resolved_agent_config = agent_config
         resolved_user_config = user_config
+        resolved_judge_config = judge_config
 
         models = self.config.models
         if isinstance(models, dict):
             agent = models.get("agent", {})
             user = models.get("user")
+            judge = models.get("judge")
             result["agent"] = agent if isinstance(agent, dict) else agent.model_dump(mode="json")
             result["user"] = (
                 (user if isinstance(user, dict) else user.model_dump(mode="json")) if user else None
+            )
+            result["judge"] = (
+                (judge if isinstance(judge, dict) else judge.model_dump(mode="json"))
+                if judge
+                else None
             )
             if resolved_agent_config is None and not isinstance(agent, dict):
                 resolved_agent_config = agent
             if resolved_user_config is None and user is not None and not isinstance(user, dict):
                 resolved_user_config = user
+            if resolved_judge_config is None and judge is not None and not isinstance(judge, dict):
+                resolved_judge_config = judge
         else:
             result["agent"] = models.agent.model_dump(mode="json")
             result["user"] = models.user.model_dump(mode="json") if models.user else None
+            judge = getattr(models, "judge", None)
+            result["judge"] = judge.model_dump(mode="json") if judge else None
             if resolved_agent_config is None:
                 resolved_agent_config = models.agent
             if resolved_user_config is None and models.user is not None:
                 resolved_user_config = models.user
+            if resolved_judge_config is None and judge is not None:
+                resolved_judge_config = judge
 
         # Stage 7 — resolved fingerprint per role.
         if resolved_agent_config is not None:
             result["agent"]["resolved"] = _build_resolved_block(resolved_agent_config)
         if resolved_user_config is not None and result.get("user"):
             result["user"]["resolved"] = _build_resolved_block(resolved_user_config)
+        if resolved_judge_config is not None and result.get("judge"):
+            result["judge"]["resolved"] = _build_resolved_block(resolved_judge_config)
 
         return result
 

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -78,6 +78,10 @@ class TrialSpec(BaseModel):
     user_model_config: ModelConfig | None = None
     """LLM config for the user simulator when the task drives one."""
 
+    judge_model_config: ModelConfig | None = None
+    """LLM config for the read-only rubric judge. None when no selected task uses
+    an llm_judge grading component."""
+
     max_turns: int | None = None
     """Optional per-trial turn cap override; ``None`` defers to the engine default."""
 

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -421,10 +421,11 @@ class LLMJudgeConfig(BaseModel):
     Canonical home for the judge config that crosses both the YAML grading block
     and the gRPC wire (serialized inside ``TrialSpec.task.grading``). The
     ``output_schema`` field was dropped — the judge's structured-output schema is
-    derived from the rubric's criteria (Stage 3), not author-specified.
+    derived from the rubric's criteria (Stage 3), not author-specified. The
+    judge *model* is no longer pinned here: it lives at the run level under
+    ``RunConfig.models["judge"]`` and rides ``TrialSpec.judge_model_config``.
     """
 
-    model_ref: str  # "openrouter/anthropic/claude-sonnet-4.5"
     rubric: Rubric  # Structured grading rubric
 
     model_config = {"extra": "forbid"}
@@ -432,14 +433,20 @@ class LLMJudgeConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_legacy_rubric_shape(cls, data: Any) -> Any:
-        """Fail loud with a migration message on the old free-text rubric shape.
+        """Fail loud with a migration message on legacy llm_judge shapes.
 
-        ``rubric: str`` and the now-removed ``output_schema`` field were the
-        pre-Stage-2 contract. Rubric grading never worked end-to-end, so this is
-        an intentional, non-back-compatible break (see docs/RUBRIC_GRADING_DESIGN.md).
+        The free-text ``rubric: str`` blob, the removed ``output_schema`` field,
+        and the relocated ``model_ref`` field are all pre-relocation contracts.
+        Rubric grading never worked end-to-end, so this is an intentional,
+        non-back-compatible break (see docs/RUBRIC_GRADING_DESIGN.md).
         """
         if not isinstance(data, dict):
             return data
+        if "model_ref" in data:
+            raise ValueError(
+                "grading.llm_judge.model_ref moved to the run config under "
+                "models.judge; remove it from grading.yaml."
+            )
         if isinstance(data.get("rubric"), str):
             raise ValueError(
                 "grading.llm_judge.rubric is now a structured Rubric, not free "

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -34,7 +34,7 @@ import grpc
 from pydantic import ValidationError
 
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, run_rubric_judge
-from tolokaforge.core.models import CriterionResult, LLMJudgeConfig
+from tolokaforge.core.models import CriterionResult, LLMJudgeConfig, ModelConfig
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner import runner_pb2_grpc
@@ -110,6 +110,7 @@ class TrialContextRuntime:
         trial_id: str,
         task_description: TaskDescription,
         default_timeout: float = 30.0,
+        judge_model_config: ModelConfig | None = None,
     ):
         self.trial_id = trial_id
         self.task_description = task_description
@@ -117,6 +118,10 @@ class TrialContextRuntime:
         self.user_tools: dict[str, Callable] = {}
         self.tool_call_history: list[ToolCallRecord] = []
         self.default_timeout = default_timeout
+        # Run-level LLM config for the read-only rubric judge, carried from the
+        # TrialSpec. None when no selected task uses an llm_judge component; the
+        # orchestrator validates up front that it is present whenever a rubric is.
+        self.judge_model_config = judge_model_config
 
     @property
     def grading_config(self):
@@ -454,6 +459,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             trial_id=trial_id,
             task_description=task_description,
             default_timeout=request.default_tool_timeout_s or DEFAULT_TOOL_TIMEOUT_S,
+            judge_model_config=trial_spec.judge_model_config,
         )
 
         # Initialize DB Service with initial_state (FAIL FAST)
@@ -1208,10 +1214,23 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # File readers only when a real workspace exists on this runner.
         workspace_dir = self._judge_workspace_dir(trial_context)
 
+        # The judge model is a run-level config that rides the TrialSpec. The
+        # orchestrator validates up front that it is present whenever any selected
+        # task declares an llm_judge component, so reaching here without it is a
+        # contract violation — fail loud (AGENTS.md rule 1), never invent a model
+        # or silently skip grading.
+        judge_model_config = trial_context.judge_model_config
+        if judge_model_config is None:
+            raise ValueError(
+                f"Trial {trial_id} has an llm_judge rubric but no judge ModelConfig on "
+                "its TrialSpec (judge_model_config is None). The run config must set "
+                "models.judge; the orchestrator should have rejected this run up front."
+            )
+
         def _run() -> JudgeResult:
             return run_rubric_judge(
                 rubric=llm_judge_config.rubric,
-                model_ref=llm_judge_config.model_ref,
+                model_config=judge_model_config,
                 agent_system_prompt=agent_system_prompt,
                 transcript=transcript,
                 db_reader=_LoopBridgeDBReader(),

--- a/tools/rubric-calibrator/src/rubric_calibrator/runner.py
+++ b/tools/rubric-calibrator/src/rubric_calibrator/runner.py
@@ -27,6 +27,7 @@ from tolokaforge.core.grading.judge import (
     JudgeResult,
     JudgeStatus,
     JudgeUsage,
+    model_config_from_ref,
     run_rubric_judge,
 )
 
@@ -126,9 +127,11 @@ def judge_fixture(
     db_reader = DictDBReader(fixture.final_db_state) if fixture.final_db_state else None
     workspace_dir = fixture.workspace_path(fixture_file) if fixture_file else None
 
+    # The calibrator's CLI surface keeps a string ``--model-ref``; convert it to
+    # a run-level ModelConfig at this boundary (the judge no longer takes a ref).
     kwargs: dict[str, Any] = {
         "rubric": fixture.rubric,
-        "model_ref": model_ref,
+        "model_config": model_config_from_ref(model_ref),
         "agent_system_prompt": fixture.agent_system_prompt,
         "transcript": fixture.transcript,
         "db_reader": db_reader,
@@ -191,7 +194,8 @@ def run_calibration(
 
     ``on_fixture_done(outcome)`` is an optional progress callback. ``llm_client``
     is shared across fixtures when injected (scripted tests); production passes
-    ``None`` so each judge builds its own client from ``model_ref``.
+    ``None`` so each judge builds its own client from the ``ModelConfig`` derived
+    from ``model_ref`` at the judge boundary.
     """
     outcomes: list[FixtureOutcome] = []
     all_observations: list[CriterionObservation] = []


### PR DESCRIPTION
## Why

The LLM-judge model was pinned per-task in `grading.llm_judge.model_ref`. That made a provider switch an N-file edit and left the judge asymmetric with the agent/user models, which are run-level (`RunConfig.models`). This relocates the judge model to run-level `RunConfig.models["judge"]`, carried on `TrialSpec.judge_model_config`, so:

- the judge is a first-class run-level model, symmetric with agent/user;
- a provider switch is a one-line run-config edit;
- the rubric goes back to describing **what** to grade, not **which model** grades it.

Follows the design discussion: the judge stays a *separate, fixed* model (independent of the agent under test — no self-grading bias), it just becomes a run-level knob instead of a per-task field.

## What changed

- **`LLMJudgeConfig` drops `model_ref`** — the rubric is now model-agnostic. A stray `model_ref` is rejected with a clear migration message pointing to `models.judge`.
- **Fail loud, no hidden default** — the orchestrator aborts a run *before any trial executes* if a selected task declares an `llm_judge` component but `models.judge` is absent (gated in `run`, `run_worker`, and `prepare_run`, naming the offending tasks). The runner guards the same contract. No fallback to the agent model.
- **`run_rubric_judge` takes a `ModelConfig`**; `model_config_from_ref` is the public boundary helper for string inputs (CLI `--judge-model` / `JUDGE_MODEL`, the rubric-calibrator).
- **Auditability** — each trial bundle now records the `judge` role (+ resolved preset fingerprint) in `model_config`, symmetric with agent/user, so every grade records which judge produced it.
- **No proto/gRPC change** — the judge model rides the existing `TrialSpec.trial_spec_json`.
- Docs (`GRADING.md`, `CONFIG.md`, `REFERENCE.md`, `RUBRIC_GRADING_DESIGN.md`, `TASK_DESCRIPTION_SCHEMA.md`, `OUTPUT_FORMAT.md`), the two example run configs, and the rubric-calibrator updated. Also fixed a stale doc reference to a fictional `GradingEngine(judge_model=…)` param and stale `FrozenMcpCoreAdapter` mentions.

## Migration

A task that previously set `grading.llm_judge.model_ref` must remove it and the run config must set `models.judge`:

```yaml
models:
  agent: { provider: openrouter, name: anthropic/claude-sonnet-4.6 }
  user:  { provider: openrouter, name: anthropic/claude-sonnet-4.6 }
  judge: { provider: openrouter, name: openai/gpt-4.1-mini }
```

Rubric grading is recent (#94) and no shipped task depended on the old shape; `tolokaforge validate` fails loud with the migration message on the old field.

## Calibration

`tools/rubric-calibrator` is kept working (adapted to the new signature via the boundary helper). No harness-level calibration gate was ever enforced, so nothing was removed; revisit calibration later, possibly above the harness.

## Testing

- `ruff check` clean; unit **1799 passed**; canonical **201 passed**; live integration `test_rubric_judge_live.py` **2 passed** (real OpenRouter).
- New behavior tests: the up-front fail-loud gate **and its placement** (asserts no trial dispatch occurs when `models.judge` is missing), judge model riding the `TrialSpec` wire, migration rejection, and the judge role in the serialized bundle.
- Live gate-demo run confirms the relocated judge runs and the REQUIRED-criterion gate still fires (`binary_pass: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)