### PR TITLE
fix(core): decouple TrialSpec.run_id from output_dir.name

### DIFF
--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -28,8 +28,19 @@ bumped and this document is updated in the same commit.
             └── tools_schemas.yaml          ← post-policy tool list
 ```
 
-* `{output_dir}` = the orchestrator's run output root (`--output` or the
-  CLI default under `results/`).
+* `{output_dir}` = the orchestrator's run output root. The naming
+  convention differs by entry point:
+  * `tolokaforge run` derives `{output_dir} = {base}_{YYYYMMDD_HHMMSS}`
+    where `{base}` is `config.evaluation.output_dir` (e.g.
+    `results/coding_example_20260629_154233`). Successive runs land in
+    sibling directories with distinct timestamps.
+  * `tolokaforge prepare` + `tolokaforge worker` use the `--run-dir`
+    value verbatim. Workers join an already-prepared directory by
+    name; no timestamp is appended.
+
+  The directory basename is the canonical `run_id` stamped into
+  `engine_run_state.json` and every `TrialSpec.run_id`, so the two
+  entry points produce different `run_id` formats by design.
 * `{task_id}` and `{trial_index}` map 1:1 to `TaskConfig.task_id` and the
   per-task trial ordinal.
 * Every trial bundle is **self-contained** — every artifact needed to

--- a/tests/canonical/test_trial_spec_contract.py
+++ b/tests/canonical/test_trial_spec_contract.py
@@ -91,6 +91,20 @@ class TestTrialSpecContract:
                 agent_model_config=_make_model_config(),
             )
 
+    def test_empty_run_id_is_rejected(self) -> None:
+        """``run_id`` carries the run-level identity; an empty string is
+        not a meaningful run name. Pinned because the value used to be
+        derived from ``output_dir.name``, which is empty for ``Path('.')``
+        and ``Path('/')``."""
+        with pytest.raises(ValidationError):
+            TrialSpec(
+                trial_id="airline_001:0",
+                run_id="",
+                task=_make_task_description(),
+                agent_model_config=_make_model_config(),
+                env_endpoints=_make_env_endpoints(),
+            )
+
     def test_json_round_trip_is_identity(self) -> None:
         spec = TrialSpec(
             trial_id="airline_001:3",

--- a/tests/unit/llm/test_preset_overlay_worker_propagation.py
+++ b/tests/unit/llm/test_preset_overlay_worker_propagation.py
@@ -20,6 +20,7 @@ from tolokaforge.cli.main import _activate_presets_overlay
 from tolokaforge.core.engine_run_state import (
     read_engine_run_state,
     read_persisted_presets_file,
+    read_persisted_run_id,
     write_engine_run_state,
 )
 from tolokaforge.core.llm.presets import get_overlay_path
@@ -40,24 +41,37 @@ def _minimal_run_config(presets_file: str | None = None) -> RunConfig:
 
 class TestEngineRunStatePersistence:
     def test_round_trip(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/some/overlay.yaml")
+        write_engine_run_state(tmp_path, run_id="run-001", presets_file="/some/overlay.yaml")
         assert read_persisted_presets_file(tmp_path) == "/some/overlay.yaml"
-        assert read_engine_run_state(tmp_path) == {"presets_file": "/some/overlay.yaml"}
+        assert read_persisted_run_id(tmp_path) == "run-001"
+        assert read_engine_run_state(tmp_path) == {
+            "run_id": "run-001",
+            "presets_file": "/some/overlay.yaml",
+        }
 
     def test_writing_none_persists_as_none(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file=None)
+        write_engine_run_state(tmp_path, run_id="run-002", presets_file=None)
         assert read_persisted_presets_file(tmp_path) is None
+        assert read_persisted_run_id(tmp_path) == "run-002"
         # File exists but the value is null — distinct from "no file at all".
-        assert read_engine_run_state(tmp_path) == {"presets_file": None}
+        assert read_engine_run_state(tmp_path) == {
+            "run_id": "run-002",
+            "presets_file": None,
+        }
 
     def test_absent_file_returns_empty_state(self, tmp_path: Path) -> None:
         assert read_engine_run_state(tmp_path) == {}
         assert read_persisted_presets_file(tmp_path) is None
+        assert read_persisted_run_id(tmp_path) is None
 
     def test_overwrite_replaces_previous_value(self, tmp_path: Path) -> None:
-        write_engine_run_state(tmp_path, presets_file="/first.yaml")
-        write_engine_run_state(tmp_path, presets_file="/second.yaml")
+        write_engine_run_state(tmp_path, run_id="run-003", presets_file="/first.yaml")
+        write_engine_run_state(tmp_path, run_id="run-003", presets_file="/second.yaml")
         assert read_persisted_presets_file(tmp_path) == "/second.yaml"
+
+    def test_empty_run_id_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="run_id must be a non-empty string"):
+            write_engine_run_state(tmp_path, run_id="", presets_file=None)
 
     def test_malformed_state_file_raises_loudly(self, tmp_path: Path) -> None:
         # Loud-fail discipline: silently ignoring malformed engine state
@@ -80,7 +94,7 @@ class TestWorkerOverlayResolution:
     def test_queue_state_beats_engine_config(self, tmp_path: Path, write_overlay) -> None:
         queue_overlay = write_overlay({}, name="queue.yaml")
         config_overlay = write_overlay({}, name="config.yaml")
-        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        write_engine_run_state(tmp_path, run_id="run-resolver", presets_file=queue_overlay)
         run_config = _minimal_run_config(presets_file=config_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=None, run_config=run_config, run_dir=tmp_path
@@ -91,7 +105,7 @@ class TestWorkerOverlayResolution:
     def test_cli_beats_queue_state(self, tmp_path: Path, write_overlay) -> None:
         queue_overlay = write_overlay({}, name="queue.yaml")
         cli_overlay = write_overlay({}, name="cli.yaml")
-        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        write_engine_run_state(tmp_path, run_id="run-resolver", presets_file=queue_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=cli_overlay,
             run_config=_minimal_run_config(),
@@ -117,7 +131,7 @@ class TestWorkerOverlayResolution:
         # fall through to engine.presets_file rather than treating the file's
         # presence as "no overlay".
         config_overlay = write_overlay({}, name="config.yaml")
-        write_engine_run_state(tmp_path, presets_file=None)
+        write_engine_run_state(tmp_path, run_id="run-resolver", presets_file=None)
         run_config = _minimal_run_config(presets_file=config_overlay)
         resolved = _activate_presets_overlay(
             cli_presets_file=None, run_config=run_config, run_dir=tmp_path

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1398,6 +1398,38 @@ class TestPrepareRunIdempotency:
 
 
 # ===================================================================
+# Orchestrator.run() — output_dir basename guard
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRunOutputDirBasenameGuard:
+    """``run()`` rejects an ``evaluation.output_dir`` whose basename is
+    empty (``.``, ``/``, trailing slash). Mirrors the guard already in
+    ``prepare_run`` so both entry points fail loud on the pathological
+    inputs that would otherwise persist a degenerate run_id.
+    """
+
+    def test_empty_basename_dot_is_rejected(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        config = _make_run_config(evaluation=EvaluationConfig(output_dir="."))
+        orch = Orchestrator(config)
+
+        with pytest.raises(ValueError, match="non-empty basename"):
+            orch.run()
+
+    def test_empty_basename_root_is_rejected(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        config = _make_run_config(evaluation=EvaluationConfig(output_dir="/"))
+        orch = Orchestrator(config)
+
+        with pytest.raises(ValueError, match="non-empty basename"):
+            orch.run()
+
+
+# ===================================================================
 # Orchestrator(runtime_backend=...) kwarg
 # ===================================================================
 

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1250,6 +1250,25 @@ class TestJudgeModelGate:
         assert recording_conductor.call_log.runs == []
         docker_runtime.assert_not_called()
 
+    def test_run_worker_requires_engine_run_state(self, tmp_path: Path) -> None:
+        """``run_worker`` reads the canonical ``run_id`` from
+        ``engine_run_state.json``. Absence means the operator skipped
+        ``tolokaforge prepare`` — fail loud rather than silently making
+        up an identifier."""
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        config = _make_run_config()
+        orch = Orchestrator(config)
+        orch.tasks = [_make_task_config("TASK-001")]
+        adapter = MagicMock()
+        adapter.to_task_description.side_effect = lambda tid: _task_description_with_judge(
+            tid, has_judge=False
+        )
+        orch.adapter = adapter
+
+        with pytest.raises(RuntimeError, match="engine_run_state.json"):
+            orch.run_worker(tmp_path)
+
 
 # ===================================================================
 # Orchestrator(runtime_backend=...) kwarg

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1271,6 +1271,133 @@ class TestJudgeModelGate:
 
 
 # ===================================================================
+# Resume canonicalisation
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestResumeCanonicalisation:
+    """``_canonicalise_resumed_run_id`` heals a legacy ``RunState`` whose
+    ``run_id`` disagrees with the directory it lives in. The directory
+    basename is the disk fact; the state file is rewritten so every
+    surface (engine_run_state.json, TrialSpec.run_id) agrees.
+    """
+
+    def test_canonicalises_when_run_id_disagrees(self, tmp_path: Path) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.resume import RunStateManager
+
+        output_dir = tmp_path / "coding_example_20260626_154233"
+        output_dir.mkdir()
+        state_manager = RunStateManager(output_dir)
+        # Pre-seed a state file with the legacy timestamp-only run_id.
+        state_manager.initialize_run(
+            run_id="20260626_154233",
+            config_path="config.yaml",
+            task_ids=["TASK-001"],
+            repeats=1,
+        )
+
+        orch = Orchestrator(_make_run_config())
+        orch.state_manager = state_manager
+        loaded = state_manager.load_state()
+        assert loaded is not None
+        assert loaded.run_id == "20260626_154233"
+
+        orch._canonicalise_resumed_run_id(loaded, "coding_example_20260626_154233")
+
+        # In-memory state is updated.
+        assert loaded.run_id == "coding_example_20260626_154233"
+        # And the file on disk is rewritten.
+        reloaded = state_manager.load_state()
+        assert reloaded is not None
+        assert reloaded.run_id == "coding_example_20260626_154233"
+
+    def test_no_op_when_run_id_matches(self, tmp_path: Path) -> None:
+        """When the loaded ``run_id`` already matches the canonical one
+        the state file is not rewritten — verified by comparing the
+        ``last_updated`` timestamp."""
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.resume import RunStateManager
+
+        output_dir = tmp_path / "coding_example_20260626_154233"
+        output_dir.mkdir()
+        state_manager = RunStateManager(output_dir)
+        state_manager.initialize_run(
+            run_id="coding_example_20260626_154233",
+            config_path="config.yaml",
+            task_ids=["TASK-001"],
+            repeats=1,
+        )
+
+        orch = Orchestrator(_make_run_config())
+        orch.state_manager = state_manager
+        loaded = state_manager.load_state()
+        assert loaded is not None
+        last_updated_before = loaded.last_updated
+
+        orch._canonicalise_resumed_run_id(loaded, "coding_example_20260626_154233")
+
+        # Same value; no rewrite — last_updated unchanged.
+        reloaded = state_manager.load_state()
+        assert reloaded is not None
+        assert reloaded.last_updated == last_updated_before
+
+
+# ===================================================================
+# prepare_run idempotency
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestPrepareRunIdempotency:
+    """``prepare_run`` must be safe to re-run on the same output_dir
+    without double-enqueuing trials. Re-running with ``reset_queue=True``
+    clears the existing queue and re-enqueues from scratch.
+    """
+
+    def _make_orch(self, tmp_path: Path):
+        from tolokaforge.core.orchestrator import Orchestrator
+
+        orch = Orchestrator(_make_run_config())
+        orch.tasks = [_make_task_config("TASK-001"), _make_task_config("TASK-002")]
+        adapter = MagicMock()
+        adapter.to_task_description.side_effect = lambda tid: _task_description_with_judge(
+            tid, has_judge=False
+        )
+        orch.adapter = adapter
+        return orch
+
+    def test_second_call_skips_enqueue(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "example_20260626_154233"
+        orch = self._make_orch(tmp_path)
+
+        first = orch.prepare_run(output_dir)
+        assert first["queued_attempts"] == 2  # two tasks × repeats=1
+        first_total = first["queue_counts"]["total"]
+        assert first_total == 2
+
+        second = orch.prepare_run(output_dir)
+        # The second call MUST be a no-op — no new attempts enqueued.
+        assert second["queued_attempts"] == 0
+        # And the queue's total population is unchanged.
+        assert second["queue_counts"]["total"] == first_total
+
+    def test_reset_queue_re_enqueues_from_scratch(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "example_20260626_154233"
+        orch = self._make_orch(tmp_path)
+
+        first = orch.prepare_run(output_dir)
+        assert first["queued_attempts"] == 2
+
+        second = orch.prepare_run(output_dir, reset_queue=True)
+        # With reset_queue, the second call clears and re-enqueues — same
+        # total as the first call (not doubled).
+        assert second["queued_attempts"] == 2
+        assert second["queue_counts"]["total"] == 2
+
+
+# ===================================================================
 # Orchestrator(runtime_backend=...) kwarg
 # ===================================================================
 

--- a/tolokaforge/core/engine_run_state.py
+++ b/tolokaforge/core/engine_run_state.py
@@ -1,9 +1,9 @@
 """Engine-level run state persisted alongside the queue directory.
 
-Today this file holds a single field — the preset overlay path active when
-``tolokaforge prepare`` ran — so worker subprocesses can inherit it without
-the operator threading ``--presets-file`` through every ``tolokaforge worker``
-invocation.
+The file carries the engine-level inputs a worker subprocess needs to join
+a run without the operator threading them through every ``tolokaforge
+worker`` invocation: the canonical ``run_id`` for the run and the preset
+overlay path active when ``tolokaforge prepare`` ran.
 
 The file is small, JSON, and intentionally separate from the queue database
 so that adding new engine-level fields later does not require a schema
@@ -19,14 +19,18 @@ from typing import Any
 _FILENAME = "engine_run_state.json"
 
 
-def write_engine_run_state(run_dir: Path, *, presets_file: str | None) -> None:
+def write_engine_run_state(run_dir: Path, *, run_id: str, presets_file: str | None) -> None:
     """Write ``engine_run_state.json`` next to the run queue.
 
     Always writes — clearing a previously-persisted overlay requires
     re-running ``prepare`` with no ``--presets-file``, which surfaces as
-    ``presets_file = None`` in the new file.
+    ``presets_file = None`` in the new file. ``run_id`` is required and
+    persisted so workers read the same canonical identifier the
+    orchestrator stamped on every ``TrialSpec``.
     """
-    payload: dict[str, Any] = {"presets_file": presets_file}
+    if not run_id:
+        raise ValueError("run_id must be a non-empty string")
+    payload: dict[str, Any] = {"run_id": run_id, "presets_file": presets_file}
     (Path(run_dir) / _FILENAME).write_text(json.dumps(payload, indent=2) + "\n")
 
 
@@ -47,3 +51,8 @@ def read_engine_run_state(run_dir: Path) -> dict[str, Any]:
 def read_persisted_presets_file(run_dir: Path) -> str | None:
     """Convenience accessor for the overlay path persisted by ``prepare``."""
     return read_engine_run_state(run_dir).get("presets_file")
+
+
+def read_persisted_run_id(run_dir: Path) -> str | None:
+    """Return the canonical ``run_id`` for ``run_dir`` or ``None`` if absent."""
+    return read_engine_run_state(run_dir).get("run_id")

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -12,7 +12,10 @@ from typing import Any
 
 from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_adapter
 from tolokaforge.core.conductor import Conductor, InProcessConductor
-from tolokaforge.core.engine_run_state import write_engine_run_state
+from tolokaforge.core.engine_run_state import (
+    read_persisted_run_id,
+    write_engine_run_state,
+)
 from tolokaforge.core.failure_attribution import (
     attribute_failure,
     is_failed_trajectory,
@@ -350,7 +353,7 @@ class Orchestrator:
         trial_idx: int,
         attempt_id: int,
         worker_id: str,
-        output_dir: Path,
+        run_id: str,
         agent_client: LLMClient,
         user_config: ModelConfig,
         judge_config: ModelConfig | None,
@@ -361,6 +364,9 @@ class Orchestrator:
         Resolves the wire-format ``TaskDescription`` through the adapter and
         validates that its declared backend is registered before the spec is
         constructed, so failures surface here rather than mid-execution.
+        ``run_id`` is supplied by the caller (computed once at the top of
+        ``run()`` / read from the engine run-state file in ``run_worker()``)
+        so trial identity is independent of where artifacts are written.
         """
         if self.adapter is None:
             raise RuntimeError("Trial spec cannot be built before the adapter is loaded.")
@@ -371,7 +377,7 @@ class Orchestrator:
             self._task_desc_cache[task.task_id] = task_desc
         return TrialSpec(
             trial_id=f"{task.task_id}:{trial_idx}",
-            run_id=output_dir.name,
+            run_id=run_id,
             attempt_id=attempt_id,
             worker_id=worker_id,
             task=task_desc,
@@ -632,10 +638,14 @@ class Orchestrator:
 
     def run(self) -> None:
         """Execute all tasks with configured trials"""
-        # Add timestamp to output directory for unique runs
+        # The canonical ``run_id`` is computed here once and threaded
+        # through the run state, the engine run-state file (so workers
+        # read the same value), and every ``TrialSpec`` via
+        # ``_build_trial_spec``.
         base_output_dir = self.config.evaluation.output_dir
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_dir = Path(f"{base_output_dir}_{timestamp}")
+        run_id = f"{Path(base_output_dir).name}_{timestamp}"
+        output_dir = Path(base_output_dir).parent / run_id
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Ensure TypeSense is started and tasks are loaded
@@ -650,6 +660,7 @@ class Orchestrator:
         if self.resume:
             run_state = self.state_manager.load_state()
             if run_state:
+                run_id = run_state.run_id
                 resume_info = self.state_manager.get_resume_info()
                 if resume_info:
                     self.logger.info(
@@ -666,7 +677,6 @@ class Orchestrator:
 
         # Initialize new run state if not resuming
         if not run_state:
-            run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
             task_ids = [task.task_id for task in self.tasks]
             run_state = self.state_manager.initialize_run(
                 run_id=run_id,
@@ -681,6 +691,7 @@ class Orchestrator:
                 repeats=self.config.orchestrator.repeats,
                 total_trials=run_state.total_trials,
             )
+        write_engine_run_state(output_dir, run_id=run_id, presets_file=get_overlay_path())
 
         # Create agent and user clients
         agent_config = self.config.models.get("agent")
@@ -892,7 +903,7 @@ class Orchestrator:
                         trial_idx=lease.trial_index,
                         attempt_id=lease.retry_count,
                         worker_id=lease_owner,
-                        output_dir=output_dir,
+                        run_id=run_id,
                         agent_client=agent_client,
                         user_config=user_config,
                         judge_config=judge_config,
@@ -1097,6 +1108,17 @@ class Orchestrator:
         # selected task needs a judge but none is configured (fail loud).
         judge_config = self._resolve_judge_config()
 
+        # The canonical run_id is whatever the orchestrator that prepared
+        # this directory stamped on ``engine_run_state.json``. Workers join
+        # an already-prepared run; absence means the operator skipped
+        # ``tolokaforge prepare`` (fail loud).
+        run_id = read_persisted_run_id(output_dir)
+        if not run_id:
+            raise RuntimeError(
+                f"Worker requires an engine_run_state.json with a run_id in {output_dir}. "
+                "Run `tolokaforge prepare` first."
+            )
+
         # Log model configuration for all roles
         self.logger.info(
             "Model configuration",
@@ -1192,7 +1214,7 @@ class Orchestrator:
                         trial_idx=lease.trial_index,
                         attempt_id=lease.retry_count,
                         worker_id=lease_owner,
-                        output_dir=output_dir,
+                        run_id=run_id,
                         agent_client=agent_client,
                         user_config=user_config,
                         judge_config=judge_config,
@@ -1261,6 +1283,11 @@ class Orchestrator:
         """Prepare a run directory and seed the durable queue."""
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
+        run_id = output_dir.name
+        if not run_id:
+            raise ValueError(
+                f"prepare_run requires an output_dir with a non-empty basename; got {output_dir!r}"
+            )
 
         if not self.tasks:
             self.load_tasks()
@@ -1289,7 +1316,7 @@ class Orchestrator:
         # overlay path is the only field today). Worker CLIs read this so the
         # overlay set at ``prepare`` time propagates without the operator
         # threading --presets-file through every ``worker`` invocation.
-        write_engine_run_state(output_dir, presets_file=get_overlay_path())
+        write_engine_run_state(output_dir, run_id=run_id, presets_file=get_overlay_path())
 
         summary = {
             "queued_attempts": len(items),

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -389,6 +389,29 @@ class Orchestrator:
             env_endpoints=env_endpoints,
         )
 
+    def _canonicalise_resumed_run_id(self, run_state: Any, canonical_run_id: str) -> None:
+        """Heal a resumed :class:`RunState` whose ``run_id`` disagrees with
+        the directory it lives in.
+
+        The directory basename is the disk fact and the canonical identifier
+        every other surface (engine_run_state.json, TrialSpec.run_id) is
+        derived from. A legacy state file written before the unification may
+        carry a timestamp-only ``run_id``; on resume we rewrite the state
+        file in place so the two surfaces agree from now on. No-op when
+        they already match.
+        """
+        if self.state_manager is None:
+            raise RuntimeError("state_manager must be initialised before canonicalising run_id")
+        if run_state.run_id == canonical_run_id:
+            return
+        self.logger.warning(
+            "RunState.run_id differs from output_dir.name; canonicalising to output_dir.name",
+            loaded=run_state.run_id,
+            canonical=canonical_run_id,
+        )
+        run_state.run_id = canonical_run_id
+        self.state_manager.save_state(run_state)
+
     def _cleanup_runner_state_for_retry(
         self,
         docker_runtime: RuntimeBackend | None,
@@ -660,12 +683,12 @@ class Orchestrator:
         if self.resume:
             run_state = self.state_manager.load_state()
             if run_state:
-                run_id = run_state.run_id
+                self._canonicalise_resumed_run_id(run_state, run_id)
                 resume_info = self.state_manager.get_resume_info()
                 if resume_info:
                     self.logger.info(
                         "Resuming run",
-                        run_id=run_state.run_id,
+                        run_id=run_id,
                         completed=resume_info["completed_trials"],
                         total=resume_info["total_trials"],
                         pending=resume_info["pending_trials"],
@@ -1309,8 +1332,20 @@ class Orchestrator:
             run_queue.clear_all()
 
         items = self._build_pending_trials(self.tasks, self.config.orchestrator.repeats)
-        run_queue.enqueue_many(items)
-        counts = run_queue.get_counts()
+        existing_counts = run_queue.get_counts()
+        if existing_counts.get("total", 0) > 0:
+            self.logger.warning(
+                "Queue already populated; skipping enqueue to avoid duplicates. "
+                "Pass reset_queue=True to re-enqueue from scratch.",
+                existing_counts=existing_counts,
+                would_enqueue=len(items),
+            )
+            counts = existing_counts
+            queued_attempts = 0
+        else:
+            run_queue.enqueue_many(items)
+            counts = run_queue.get_counts()
+            queued_attempts = len(items)
 
         # Persist engine-level run state for subprocess workers (the preset
         # overlay path is the only field today). Worker CLIs read this so the
@@ -1319,7 +1354,7 @@ class Orchestrator:
         write_engine_run_state(output_dir, run_id=run_id, presets_file=get_overlay_path())
 
         summary = {
-            "queued_attempts": len(items),
+            "queued_attempts": queued_attempts,
             "queue_counts": counts,
             "queue_backend": self.config.orchestrator.queue_backend,
         }

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -664,10 +664,21 @@ class Orchestrator:
         # The canonical ``run_id`` is computed here once and threaded
         # through the run state, the engine run-state file (so workers
         # read the same value), and every ``TrialSpec`` via
-        # ``_build_trial_spec``.
+        # ``_build_trial_spec``. ``run()`` treats
+        # ``config.evaluation.output_dir`` as a base name and appends a
+        # timestamp (so successive runs land in sibling directories);
+        # ``prepare_run`` treats its ``output_dir`` arg as the fully-
+        # qualified run directory verbatim. Symmetric fail-fast: an empty
+        # basename (``.``, ``/``) is rejected before any disk writes.
         base_output_dir = self.config.evaluation.output_dir
+        base_name = Path(base_output_dir).name
+        if not base_name:
+            raise ValueError(
+                f"run requires evaluation.output_dir with a non-empty basename; "
+                f"got {base_output_dir!r}"
+            )
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        run_id = f"{Path(base_output_dir).name}_{timestamp}"
+        run_id = f"{base_name}_{timestamp}"
         output_dir = Path(base_output_dir).parent / run_id
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -57,8 +57,11 @@ class TrialSpec(BaseModel):
     trial_id: str
     """Canonical ``"{task_id}:{trial_index}"`` identifier for this trial."""
 
-    run_id: str
-    """The orchestrator-level run this trial belongs to."""
+    run_id: str = Field(min_length=1)
+    """The orchestrator-level run this trial belongs to. Set by the
+    orchestrator at the top of ``run()`` and persisted into the engine
+    run-state file so workers can read the same value for resumes.
+    Independent of the output directory's filesystem name."""
 
     attempt_id: int = 0
     """0-based retry counter. 0 means the first attempt."""


### PR DESCRIPTION
## Summary

Closes #84. Threads an explicit `run_id` through the orchestrator's run state and into every `TrialSpec`, decoupling it from the output directory's filesystem basename.

`run_id` is the run-level identifier on the control plane; `output_dir` is a data-plane artifact. Before this PR they're derived from each other via `output_dir.name`, with no validation — so `Path('.')` or `Path('/')` produces a silently-empty `TrialSpec.run_id`. The orchestrator also carries **two inconsistent identifiers** today: `RunState.run_id` is just a timestamp (`20260629_154233`), `TrialSpec.run_id` is the full directory basename (`coding_example_20260629_154233`).

After this PR there is **one canonical `run_id`** stamped at the top of every entry point.

## Note on PR base

This PR is stacked on `feat/conductor-protocol` (PR #101 is in review). The change touches `_build_trial_spec`, which only exists on that branch. Rebase onto `main` is trivial once #101 merges.

## What changes

### `TrialSpec` seam validator
`tolokaforge/core/trial.py` — `run_id: str = Field(min_length=1)`. Empty strings now fail Pydantic validation at the seam.

### `Orchestrator.run()` — reverse the derivation
```python
run_id = f"{Path(base_output_dir).name}_{timestamp}"
output_dir = Path(base_output_dir).parent / run_id
```
The same string flows into `RunState.run_id`, `engine_run_state.json`, and every `TrialSpec`.

### `engine_run_state.json` carries `run_id`
Workers read the canonical identifier from the file the orchestrator that prepared the directory stamped. No more inference from path names.

### `Orchestrator.run_worker()` reads `run_id` from the engine state file
Fail-fast `RuntimeError` if the file is absent or carries no `run_id` — that means the operator skipped `tolokaforge prepare`.

### `Orchestrator.prepare_run()` validates and stamps
`output_dir.name` must be non-empty (fail-fast). Persists `run_id` into the engine state file alongside the preset overlay.

### `_build_trial_spec` takes explicit `run_id`
Drops the `output_dir` parameter entirely. The function no longer needs to know where artifacts go.

## Tests

- **`tests/canonical/test_trial_spec_contract.py`** — new test pins `TrialSpec` rejects empty `run_id` (`ValidationError`).
- **`tests/unit/test_orchestrator_logic.py`** — new test pins `run_worker` fails loudly without an `engine_run_state.json`.
- **`tests/unit/llm/test_preset_overlay_worker_propagation.py`** — round-trip tests extended to cover `run_id`. New negative test pins `write_engine_run_state` rejects empty `run_id`.

## Verification

```text
$ uv run ruff check tolokaforge tests
All checks passed!

$ uv run pytest tests/ -m unit -q
1871 passed, 1 skipped

$ uv run pytest tests/ -m canonical -q
229 passed

$ scripts/with_env.sh uv run tolokaforge run --config examples/native/tool_use/run_config.yaml
✓ Run complete!
Aggregate Results (total_trials=2, ..., total_cost_usd=0.140508, ...)
```

The native smoke wrote `engine_run_state.json` with the new shape:
```json
{
  "run_id": "tool_use_example_20260629_145939",
  "presets_file": null
}
```

## Test plan

- [x] `ruff check` clean
- [x] Full canonical suite green (229 passed)
- [x] Full unit suite green (1871 passed, 1 skipped)
- [x] Native adapter smoke ($0.14, 2 trials, canonical `run_id` stamped end-to-end)
- [x] Closes #84