### PR TITLE
feat(orchestrator): make TrialArtifactWriter injectable

### DIFF
--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1326,6 +1326,7 @@ class TestArtifactWriterInjection:
         """The conductor constructed by ``_build_conductor`` receives the
         same writer the orchestrator was given — not a fresh
         :class:`FileArtifactWriter`."""
+        from tolokaforge.core.conductor import InMemoryConductor
         from tolokaforge.core.orchestrator import Orchestrator
         from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 
@@ -1334,8 +1335,6 @@ class TestArtifactWriterInjection:
 
         def factory(**kwargs):
             captured.update(kwargs)
-            from tolokaforge.core.conductor import InMemoryConductor
-
             return InMemoryConductor()
 
         orch = Orchestrator(
@@ -1346,10 +1345,10 @@ class TestArtifactWriterInjection:
         orch.adapter = MagicMock()
 
         orch._build_conductor(
-            agent_client=MagicMock(),
-            docker_runtime=MagicMock(),
+            agent_client=None,
+            docker_runtime=None,
             output_dir=tmp_path,
-            request_limiter=MagicMock(),
+            request_limiter=None,
         )
 
         assert captured["artifact_writer"] is writer

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1295,6 +1295,67 @@ class TestRuntimeBackendInjection:
 
 
 # ===================================================================
+# Orchestrator(artifact_writer=...) kwarg
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestArtifactWriterInjection:
+    """The ``artifact_writer`` kwarg accepts any :class:`TrialArtifactWriter`
+    impl. The orchestrator stores the injected instance and uses it
+    instead of constructing :class:`FileArtifactWriter`.
+    """
+
+    def test_kwarg_default_is_file_writer(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.output.artifacts import FileArtifactWriter
+
+        orch = Orchestrator(_make_run_config())
+        assert isinstance(orch._artifact_writer, FileArtifactWriter)
+
+    def test_kwarg_stores_injected_instance(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
+
+        writer = InMemoryArtifactWriter()
+        orch = Orchestrator(_make_run_config(), artifact_writer=writer)
+
+        assert orch._artifact_writer is writer
+
+    def test_injected_writer_threads_to_conductor(self, tmp_path: Path) -> None:
+        """The conductor constructed by ``_build_conductor`` receives the
+        same writer the orchestrator was given — not a fresh
+        :class:`FileArtifactWriter`."""
+        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
+
+        writer = InMemoryArtifactWriter()
+        captured: dict = {}
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            from tolokaforge.core.conductor import InMemoryConductor
+
+            return InMemoryConductor()
+
+        orch = Orchestrator(
+            _make_run_config(),
+            artifact_writer=writer,
+            conductor_factory=factory,
+        )
+        orch.adapter = MagicMock()
+
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            docker_runtime=MagicMock(),
+            output_dir=tmp_path,
+            request_limiter=MagicMock(),
+        )
+
+        assert captured["artifact_writer"] is writer
+
+
+# ===================================================================
 # Orchestrator(conductor_factory=...) kwarg
 # ===================================================================
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -38,7 +38,7 @@ from tolokaforge.core.models import (
     TypeSenseConfig,
 )
 from tolokaforge.core.output.aggregates import FileAggregateWriter, RunAggregateWriter
-from tolokaforge.core.output.artifacts import FileArtifactWriter
+from tolokaforge.core.output.artifacts import FileArtifactWriter, TrialArtifactWriter
 from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import AttemptLease, create_run_queue
@@ -170,6 +170,7 @@ class Orchestrator:
         run_aggregate_writer: RunAggregateWriter | None = None,
         runtime_backend: RuntimeBackend | None = None,
         conductor_factory: Callable[..., Conductor] | None = None,
+        artifact_writer: TrialArtifactWriter | None = None,
     ):
         self.config = config
         self.resume = resume
@@ -182,7 +183,9 @@ class Orchestrator:
         # Shared artifact writer — every per-trial write goes through it
         # so the orchestrator stays decoupled from filesystem details and
         # alternative writers (in-memory tests, remote stores) can plug in.
-        self._artifact_writer: FileArtifactWriter = FileArtifactWriter()
+        self._artifact_writer: TrialArtifactWriter = (
+            artifact_writer if artifact_writer is not None else FileArtifactWriter()
+        )
         # Run-level analogue: the four post-run aggregate JSONs go through
         # this writer instead of inline ``json.dump`` calls. Injectable so
         # tests / alternate backends (remote object store, in-memory) can


### PR DESCRIPTION
## Summary

Closes #87. Closes the asymmetry across the four writer/executor injection seams: `RunAggregateWriter`, `RuntimeBackend`, and `conductor_factory` are already injectable on `Orchestrator.__init__`; `TrialArtifactWriter` was the last one still hard-bound to `FileArtifactWriter()`.

## Note on PR base

Stacks on `feat/conductor-protocol` (PR #101) because the `_build_conductor` injection-threading test asserts the conductor factory receives the writer — and `_build_conductor` only exists on that branch. Trivial rebase onto main once #101 merges.

## What changes

```python
def __init__(
    self,
    config: RunConfig,
    ...
    run_aggregate_writer: RunAggregateWriter | None = None,
    runtime_backend: RuntimeBackend | None = None,
    conductor_factory: Callable[..., Conductor] | None = None,
    artifact_writer: TrialArtifactWriter | None = None,   # NEW
):
    ...
    self._artifact_writer: TrialArtifactWriter = (
        artifact_writer if artifact_writer is not None else FileArtifactWriter()
    )
```

Default-path callers see no behaviour change. Tests can substitute the already-existing `InMemoryArtifactWriter` without monkey-patching.

## Tests

New `TestArtifactWriterInjection` class in `tests/unit/test_orchestrator_logic.py`:
- `test_kwarg_default_is_file_writer` — kwarg default constructs `FileArtifactWriter`.
- `test_kwarg_stores_injected_instance` — injected instance is stored on `self._artifact_writer`.
- `test_injected_writer_threads_to_conductor` — `_build_conductor` passes the injected writer to the conductor factory (not a fresh `FileArtifactWriter`).

## Verification

```
$ uv run ruff check tolokaforge tests
All checks passed!

$ uv run pytest tests/ -m unit -q
1872 passed, 1 skipped

$ uv run pytest tests/ -m canonical -q
228 passed

$ scripts/with_env.sh uv run tolokaforge run --config examples/native/tool_use/run_config.yaml
✓ Run complete!
Aggregate Results (total_trials=2, ..., total_cost_usd=0.319, ...)
```

## Test plan

- [x] `ruff check` clean
- [x] Full canonical suite green (228 passed)
- [x] Full unit suite green (1872 passed, 1 skipped — +3 new injection tests)
- [x] Native adapter smoke ($0.32, 2 trials end-to-end via the default `FileArtifactWriter`)
- [x] Closes #87
