### PR TITLE
chore(orchestrator): remove in-process execution-mode residuals

### DIFF
--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -319,12 +319,6 @@ class TestCleanupRunnerStateForRetry:
 
         runtime.cleanup_trial.assert_called_once_with("TASK-001:3")
 
-    def test_none_runtime_is_noop(self) -> None:
-        """Native (non-Docker) flows have no docker_runtime — cleanup is a no-op."""
-        orch = self._make_orchestrator()
-
-        orch._cleanup_runner_state_for_retry(None, "TASK-001", 0)  # must not raise
-
     def test_cleanup_exception_is_swallowed(self) -> None:
         """A stale runner connection must not block the retry attempt itself.
 

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1517,8 +1517,8 @@ class TestArtifactWriterInjection:
         orch.adapter = MagicMock()
 
         orch._build_conductor(
-            agent_client=None,
-            docker_runtime=None,
+            agent_client=MagicMock(),
+            docker_runtime=MagicMock(),
             output_dir=tmp_path,
             request_limiter=None,
         )

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -224,7 +224,7 @@ class InProcessConductor:
         verbose: bool = False,
         strict: bool = False,
         agent_client: LLMClient | None,
-        docker_runtime: RuntimeBackend | None,
+        docker_runtime: RuntimeBackend,
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None = None,
     ) -> None:
@@ -302,9 +302,6 @@ class InProcessConductor:
 
         if agent_client is None:
             raise ValueError("Agent client must be provided for trial execution")
-
-        # Per-trial DB namespace for parallel isolation
-        db_ns = f"{task.task_id}_{trial_idx}"
 
         # Initialize environment state
         env_state = EnvironmentState(task_dir, task.initial_state)
@@ -549,87 +546,47 @@ class InProcessConductor:
         initial_message = task.initial_user_message if task.initial_user_message else ""
         trajectory = runner.run(system_prompt, initial_message)
 
-        # Sync JSON DB state for native tasks (if no MCP server is used)
-        # Skip when Docker runtime is active — state comes from Runner DB service.
-        if (
-            task.initial_state.json_db
-            and not task.tools.agent.get("mcp_server")
-            and not docker_runtime
-        ):
-            try:
-                import httpx
-
-                json_db_sync_urls = [
-                    f"http://json-db:8000/ns/{db_ns}",
-                    f"http://localhost:8000/ns/{db_ns}",
-                ]
-
-                synced = False
-                for sync_url in json_db_sync_urls:
-                    try:
-                        with httpx.Client(timeout=10.0) as client:
-                            response = client.post(f"{sync_url}/query", json={"jsonpath": "$"})
-                        if response.status_code == 200:
-                            results = response.json().get("results", [])
-                            if results:
-                                env_state.db_state = results[0]
-                                env_state._normalize_db_state()
-                                self.logger.debug(
-                                    "Synced json-db state for grading",
-                                    url=sync_url,
-                                    namespace=db_ns,
-                                )
-                                synced = True
-                                break
-                    except Exception:
-                        continue
-
-                if not synced:
-                    self.logger.warning("Failed to sync json-db state")
-            except Exception as e:
-                self.logger.warning("Could not sync json-db state", error=str(e))
-
         # Retrieve final state from the Runner DB service (source of truth).
         # ``adapter_env.data`` is a snapshot from ``create_environment()`` and
         # does not reflect tool-execution changes made through the Runner; the
         # Runner's ``GetState`` RPC syncs the subprocess state to db-service
         # before reading, so the read covers every adapter.
-        if docker_runtime:
-            try:
-                state_result = docker_runtime.executor_client.get_state(trial_id)
-                if state_result.get("success") and state_result.get("state_json"):
-                    import json as _json
+        try:
+            state_result = docker_runtime.executor_client.get_state(trial_id)
+            if state_result.get("success") and state_result.get("state_json"):
+                import json as _json
 
-                    runner_state = _json.loads(state_result["state_json"])
-                    if isinstance(runner_state, dict) and runner_state:
-                        env_state.db_state = runner_state
-                        env_state._normalize_db_state()
-                        self.logger.debug(
-                            "Synced final state from Runner DB service",
-                            tables_count=len(runner_state),
-                            tables_sample=list(runner_state.keys())[:5],
-                        )
-                    else:
-                        self.logger.debug("Runner DB state empty, falling back to adapter env data")
-                        if adapter_env.data:
-                            env_state.db_state = adapter_env.data
-                            env_state._normalize_db_state()
-                else:
+                runner_state = _json.loads(state_result["state_json"])
+                if isinstance(runner_state, dict) and runner_state:
+                    env_state.db_state = runner_state
+                    env_state._normalize_db_state()
                     self.logger.debug(
-                        "Failed to fetch Runner DB state, falling back to adapter env data",
-                        error=state_result.get("error"),
+                        "Synced final state from Runner DB service",
+                        tables_count=len(runner_state),
+                        tables_sample=list(runner_state.keys())[:5],
                     )
+                else:
+                    self.logger.debug("Runner DB state empty, falling back to adapter env data")
                     if adapter_env.data:
                         env_state.db_state = adapter_env.data
                         env_state._normalize_db_state()
-            except Exception as e:
-                self.logger.warning(
-                    "Could not fetch state from Runner, using adapter env data",
-                    error=str(e),
+            else:
+                self.logger.debug(
+                    "Failed to fetch Runner DB state, falling back to adapter env data",
+                    error=state_result.get("error"),
                 )
                 if adapter_env.data:
                     env_state.db_state = adapter_env.data
                     env_state._normalize_db_state()
+        except Exception as e:
+            self.logger.warning(
+                "Could not fetch state from Runner, using adapter env data",
+                error=str(e),
+            )
+            if adapter_env.data:
+                env_state.db_state = adapter_env.data
+                env_state._normalize_db_state()
+
         # Capture final environment state
         final_state = env_state.get_final_state()
         # Pass agent_visible_dir so the agentic judge can read files from disk

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -310,40 +310,6 @@ class InProcessConductor:
         env_state = EnvironmentState(task_dir, task.initial_state)
         env_state.hydrate()
 
-        # Initialize json-db service with initial state (namespaced for parallel isolation)
-        # Skip when Docker runtime is active — the Runner's InMemoryDatabase is the
-        # source of truth, and the standalone json-db service is not started.
-        if env_state.db_state and not docker_runtime:
-            try:
-                import httpx
-
-                json_db_reset_urls = [
-                    f"http://json-db:8000/ns/{db_ns}",
-                    f"http://localhost:8000/ns/{db_ns}",
-                ]
-
-                initialized = False
-                for reset_url in json_db_reset_urls:
-                    try:
-                        with httpx.Client(timeout=10.0) as client:
-                            response = client.post(f"{reset_url}/reset", json=env_state.db_state)
-                        if response.status_code == 200:
-                            self.logger.debug(
-                                "Initialized json-db service",
-                                url=reset_url,
-                                namespace=db_ns,
-                                tables=len(env_state.db_state),
-                            )
-                            initialized = True
-                            break
-                    except Exception:
-                        continue
-
-                if not initialized:
-                    self.logger.warning("Failed to initialize json-db service")
-            except Exception as e:
-                self.logger.warning("Could not initialize json-db service", error=str(e))
-
         # Initialize RAG index if corpus is configured
         if env_state.rag_corpus_dir:
             try:
@@ -623,12 +589,11 @@ class InProcessConductor:
             except Exception as e:
                 self.logger.warning("Could not sync json-db state", error=str(e))
 
-        # Retrieve final state from Runner DB service (source of truth in Docker mode)
-        # The adapter_env.data is a snapshot from create_environment() and does NOT
-        # reflect tool-execution changes made through the Runner.
-        # For native MCP-server tasks the Runner's GetState RPC now syncs the
-        # subprocess state to db-service before reading, so the condition no
-        # longer needs to exclude NativeAdapter.
+        # Retrieve final state from the Runner DB service (source of truth).
+        # ``adapter_env.data`` is a snapshot from ``create_environment()`` and
+        # does not reflect tool-execution changes made through the Runner; the
+        # Runner's ``GetState`` RPC syncs the subprocess state to db-service
+        # before reading, so the read covers every adapter.
         if docker_runtime:
             try:
                 state_result = docker_runtime.executor_client.get_state(trial_id)
@@ -665,20 +630,6 @@ class InProcessConductor:
                 if adapter_env.data:
                     env_state.db_state = adapter_env.data
                     env_state._normalize_db_state()
-        elif adapter_env.data and not isinstance(self.adapter, NativeAdapter):
-            # Non-Docker mode fallback — adapter is source of truth
-            env_state.db_state = adapter_env.data
-            env_state._normalize_db_state()
-            self.logger.debug(
-                "Synced final adapter env data to env_state",
-                tables_count=(len(adapter_env.data) if isinstance(adapter_env.data, dict) else 0),
-                tables_sample=(
-                    list(adapter_env.data.keys())[:5]
-                    if isinstance(adapter_env.data, dict)
-                    else "non-dict"
-                ),
-            )
-
         # Capture final environment state
         final_state = env_state.get_final_state()
         # Pass agent_visible_dir so the agentic judge can read files from disk

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -223,7 +223,7 @@ class InProcessConductor:
         logger: StructuredLogger,
         verbose: bool = False,
         strict: bool = False,
-        agent_client: LLMClient | None,
+        agent_client: LLMClient,
         docker_runtime: RuntimeBackend,
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None = None,
@@ -299,9 +299,6 @@ class InProcessConductor:
 
         # Get task directory from adapter (supports both native and tau)
         task_dir = self.adapter.get_task_dir(task.task_id)
-
-        if agent_client is None:
-            raise ValueError("Agent client must be provided for trial execution")
 
         # Initialize environment state
         env_state = EnvironmentState(task_dir, task.initial_state)
@@ -551,41 +548,39 @@ class InProcessConductor:
         # does not reflect tool-execution changes made through the Runner; the
         # Runner's ``GetState`` RPC syncs the subprocess state to db-service
         # before reading, so the read covers every adapter.
+        runner_state: dict[str, Any] | None = None
         try:
             state_result = docker_runtime.executor_client.get_state(trial_id)
             if state_result.get("success") and state_result.get("state_json"):
                 import json as _json
 
-                runner_state = _json.loads(state_result["state_json"])
-                if isinstance(runner_state, dict) and runner_state:
-                    env_state.db_state = runner_state
-                    env_state._normalize_db_state()
-                    self.logger.debug(
-                        "Synced final state from Runner DB service",
-                        tables_count=len(runner_state),
-                        tables_sample=list(runner_state.keys())[:5],
-                    )
+                decoded = _json.loads(state_result["state_json"])
+                if isinstance(decoded, dict) and decoded:
+                    runner_state = decoded
                 else:
                     self.logger.debug("Runner DB state empty, falling back to adapter env data")
-                    if adapter_env.data:
-                        env_state.db_state = adapter_env.data
-                        env_state._normalize_db_state()
             else:
                 self.logger.debug(
                     "Failed to fetch Runner DB state, falling back to adapter env data",
                     error=state_result.get("error"),
                 )
-                if adapter_env.data:
-                    env_state.db_state = adapter_env.data
-                    env_state._normalize_db_state()
         except Exception as e:
             self.logger.warning(
                 "Could not fetch state from Runner, using adapter env data",
                 error=str(e),
             )
-            if adapter_env.data:
-                env_state.db_state = adapter_env.data
-                env_state._normalize_db_state()
+
+        if runner_state is not None:
+            env_state.db_state = runner_state
+            env_state._normalize_db_state()
+            self.logger.debug(
+                "Synced final state from Runner DB service",
+                tables_count=len(runner_state),
+                tables_sample=list(runner_state.keys())[:5],
+            )
+        elif adapter_env.data:
+            env_state.db_state = adapter_env.data
+            env_state._normalize_db_state()
 
         # Capture final environment state
         final_state = env_state.get_final_state()

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -300,7 +300,7 @@ class Orchestrator:
     def _build_conductor(
         self,
         *,
-        agent_client: LLMClient | None,
+        agent_client: LLMClient,
         docker_runtime: RuntimeBackend,
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -301,7 +301,7 @@ class Orchestrator:
         self,
         *,
         agent_client: LLMClient | None,
-        docker_runtime: RuntimeBackend | None,
+        docker_runtime: RuntimeBackend,
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None,
     ) -> Conductor:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -417,7 +417,7 @@ class Orchestrator:
 
     def _cleanup_runner_state_for_retry(
         self,
-        docker_runtime: RuntimeBackend | None,
+        docker_runtime: RuntimeBackend,
         task_id: str,
         trial_idx: int,
     ) -> None:
@@ -432,8 +432,6 @@ class Orchestrator:
         failing cleanup never blocks the retry attempt itself (the
         re-registration will surface a clearer error if state is unrecoverable).
         """
-        if docker_runtime is None:
-            return
         trial_id = f"{task_id}:{trial_idx}"
         try:
             result = docker_runtime.cleanup_trial(trial_id)


### PR DESCRIPTION
## Summary

Closes #99. Pure deletion of unreachable conditional branches and one orphan local that the runtime-backend Protocol (PR #96) tightened around but didn't remove.

The engine used to ship two trial-execution paths: in-process (orchestrator constructs a runner-like object in the same Python process) and Docker (orchestrator talks to a runner gRPC server in a container). The in-process path was removed; structural residuals — dead conditional branches guarded on `docker_runtime is None` / `not docker_runtime` — survived. PR #96 made every `docker_runtime` parameter non-optional in the typed-Protocol surface, which makes those guards unreachable in every production call site.

## What changes

### Orchestrator

- `_cleanup_runner_state_for_retry` — delete the `if docker_runtime is None: return` guard. Tighten the parameter type from `RuntimeBackend | None` to `RuntimeBackend`.
- `_build_conductor` — tighten `docker_runtime` parameter from `RuntimeBackend | None` to `RuntimeBackend` (the two production call sites in `run()` and `run_worker()` already construct it non-Optional).

### InProcessConductor

- Delete the json-db service **reset** block (early in `run`) guarded on `not docker_runtime`.
- Delete the json-db service **sync** block (later in `run`) guarded on the same predicate — same shape, same dead-branch reasoning.
- Delete the `if docker_runtime:` guard around the final-state read. The body is the live contract on every call; unindent it.
- Delete the `elif adapter_env.data and not isinstance(self.adapter, NativeAdapter)` branch labelled "Non-Docker mode fallback" — unreachable because `docker_runtime` is always truthy when the conductor runs a trial. Rewrite the surrounding comment to describe what the code IS now, not why a NativeAdapter exclusion was historically needed.
- Drop the orphan `db_ns` assignment that was only used by the deleted json-db blocks.
- Tighten `__init__`'s `docker_runtime` parameter from `RuntimeBackend | None` to `RuntimeBackend`.

### Tests

- Delete `TestCleanupRunnerStateForRetry.test_none_runtime_is_noop` — the guard it exercised no longer exists. The remaining three tests in the class continue to pin the live retry behaviour.

## Verification

```
$ uv run ruff check tolokaforge tests
All checks passed!

$ uv run pytest tests/ -m unit -q
1871 passed, 1 skipped

$ uv run pytest tests/ -m canonical -q
228 passed

$ scripts/with_env.sh uv run tolokaforge run --config examples/native/tool_use/run_config.yaml
✓ Run complete!
Aggregate Results (total_trials=2, ..., total_cost_usd=0.16, ...)
```

## Out of scope

The `rag_service_urls = ["http://rag-service:8001", "http://localhost:8001"]` dual-path loop is a judgment-call cleanup candidate from the audit. RAG correctness work surfaced separately (#107, #108, #109, #110) is in flight; leaving the dual-path loop untouched keeps this PR deletion-only and avoids tangling with the in-flight RAG fixes.

## Test plan

- [x] `ruff check` clean
- [x] Full canonical suite green (228 passed)
- [x] Full unit suite green (1871 passed, 1 skipped — `-1` because the dead-guard test was deleted; `+3` from a separate merged PR)
- [x] Native adapter smoke ($0.16, 2 trials, live Docker path unchanged)
- [x] Closes #99
