### PR TITLE
fix(pricing): refresh GLM 5.1/5.2 rates to current OpenRouter list

### DIFF
--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1809,13 +1809,13 @@
       "cache_read": 0.24
     },
     "z-ai/glm-5.1": {
-      "input": 0.98,
-      "output": 3.08,
+      "input": 0.975,
+      "output": 4.3,
       "cache_read": 0.182
     },
     "z-ai/glm-5.2": {
-      "input": 1.4,
-      "output": 4.4,
+      "input": 0.93,
+      "output": 3.0,
       "cache_read": 0.26
     },
     "z-ai/glm-5v-turbo": {


### PR DESCRIPTION
GLM 5.1 and GLM 5.2 list prices in `pricing.json` were stale vs the current OpenRouter rates, which surfaced as a distorted cost gap on the arena leaderboard cost chart.

- `z-ai/glm-5.2`: input $1.40 → $0.93/M, output $4.40 → $3.00/M (the 1.40/4.40 was the launch price; OpenRouter has since lowered it).
- `z-ai/glm-5.1`: output $3.08 → $4.30/M (input ~unchanged, 0.98 → 0.975).

Both values match the current OpenRouter list (verified against the live models API). Targeted edit of the two flagged models only; the rest of the table is unchanged, so a future `pricing-updater update` fetches the same values and leaves these entries stable.