### PR TITLE
feat(core): RuntimeBackend provisioning contract (ADR-0010)

### DIFF
--- a/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
+++ b/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
@@ -214,6 +214,38 @@ Existing tasks running through `DockerRuntime` see no behavioural change. The Pr
 
 The first behavioural change lands with the follow-up PR that ships `LocalRuntimeBackend` — and even then, tasks default to `DockerRuntime` (backward-compat) until a run's config opts into `runtime.backend: local`. Per-trial isolation is opt-in until the first workload validates it end-to-end.
 
+## Industry precedents studied
+
+The four-method surface (`provision` / `await_ready` / `endpoints` / `teardown`) is not novel — it is the widely-used shape of per-scope environment materialisation. Anchoring the ADR against these precedents makes clear what we are and are not inventing.
+
+### Testcontainers — primary precedent
+
+The Testcontainers family of libraries (https://testcontainers.com, Java/Python/Go/Node) is the closest direct precedent. Their per-container lifecycle is `start()` + `waitingFor(strategy)` + `getMappedPort(...)` + `stop()`; our per-trial surface is the same shape one abstraction up (a handle over a *set* of services, not a single container). Testcontainers' `WaitStrategy` is the pattern our `HealthProbe` (ADR-0009) compiles to at runtime; their `ContainerState` is the analog of our opaque `EnvHandle`.
+
+### Inspect AI sandbox providers — same seam decision
+
+Inspect AI (UK AI Safety Institute, https://inspect.aisi.org.uk/sandboxing.html) chose the same "one Protocol, many backends" seam we are choosing here: a single `SandboxEnvironment` interface implemented by a docker provider, a Kubernetes provider, and a local provider. Our `RuntimeBackend` plays the same role. Cross-checking against Inspect's provider set validated that four lifecycle methods are sufficient — no substrate they support requires a fifth.
+
+### Docker Compose CLI — the substrate `LocalRuntimeBackend` will target
+
+`docker compose up -d --wait` (provision + readiness), `docker compose port` (endpoint resolution), `docker compose down -v` (teardown). This is the substrate the first concrete backend compiles the manifest to; the per-trial-project naming convention (`{prefix}-{trial_id}`) is standard Compose usage.
+
+### Kubernetes Pod lifecycle — pattern preserved, not backend committed
+
+The four-phase pattern (create → readinessProbe → Service DNS → delete) is the same shape one substrate over. Called out here as *the pattern the contract preserves* — not a commitment that a Kubernetes backend is planned. If a cluster backend later materialises, **Kubernetes Agent Sandbox** (kubernetes-sigs SIG-Apps, https://agent-sandbox.sigs.k8s.io) is the natural forward target: it is explicitly designed for one multi-container Pod per sandbox with declarative health probes and per-invocation teardown.
+
+### SWE-bench harness — per-trial isolation posture
+
+Per-instance ephemeral container per trial, torn down at end. Establishes the isolation posture our `provision` / `teardown` obligations codify: no cross-trial reachability, no shared mutable state, one lifecycle per trial.
+
+### HashiCorp Terraform providers — the staged-failure model
+
+The per-substrate provider pattern is directly analogous; more specifically, Terraform's staged failure model (`plan` vs. `apply` vs. `refresh` errors) is the precedent for our `ProvisionError.stage: Literal["provision", "await_ready"]`. A caller distinguishing "couldn't bring it up" from "brought it up but it isn't healthy" is a well-known distinction; conflating them loses retry-policy nuance.
+
+### Opaque-handle convention
+
+`EnvHandle` follows a common cloud-SDK pattern: AWS SDK waiters return service-side identifiers the caller treats as opaque; the Kubernetes dynamic client returns `*unstructured.Unstructured` wrapping only the object identity; Testcontainers' `ContainerState` is the same idea. The typing does not commit to Python-object handles — a serializable dict handle (`{trial_id, provider, lease_id}`) is a valid future extension for a remote backend without breaking the Protocol.
+
 ## Consequences
 
 ### Positive

--- a/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
+++ b/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
@@ -1,0 +1,252 @@
+# 0010. `RuntimeBackend` provisioning contract — how a backend consumes an environment manifest
+
+- **Status:** Proposed
+- **Date:** 2026-07-01
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+ADR-0007 lifted `DockerRuntime` behind a typed `RuntimeBackend` Protocol; ADR-0009 introduced `EnvironmentManifest` as the typed declaration of a task's multi-service environment. Two halves of the multicontainer arc are in place: a Protocol for **where** a trial runs, and a schema for **what** it looks like. The half missing is **how** a backend consumes the manifest — the lifecycle contract between "orchestrator hands the backend a `TrialSpec`" and "backend hands back the endpoints the trial's runner talks to".
+
+Today's `RuntimeBackend` surface (`connect` / `close` / `health_check` / `cleanup_trial` + a `RunnerClient` attribute) predates the manifest. It has no method for "bring up this trial's environment", no notion of a per-trial handle, no lifecycle semantics for the trial-scoped services the manifest can declare. Without the missing contract, ADR-0009's safety declarations (`read_only`, `network: isolated`, `resources` caps, `security_context`, health probes) are theatre — no one is contractually obligated to honour them.
+
+The gap is not just missing methods. It is the absence of a written-down agreement about what a provisioner is *required* to do with a manifest, what happens when it fails, who owns the lifecycle, and how selection is expressed. Writing that down before the first concrete provisioner ships is the whole point of this ADR.
+
+## Architecture context — picture before prose
+
+### The three seams already in place
+
+```
+                    Orchestrator (scheduler)
+                            │
+                            │  conductor.run(spec, task_config)
+                            ▼
+                       Conductor (ADR-0008)
+                            │
+                            │  ??? this ADR fills the ??? ???
+                            ▼
+                    RuntimeBackend (ADR-0007)
+                            │
+                            │  reads → EnvironmentManifest (ADR-0009)
+                            ▼
+                      trial environment
+                     (containers, network,
+                      services, endpoints)
+```
+
+The `???` is where ADR-0010 lives.
+
+### Lifecycle after this ADR
+
+```
+For each trial:
+
+  1. Orchestrator selects a RuntimeBackend from config          (once per run)
+        │
+        ▼
+  2. Conductor.run() picks up the trial's spec + task_config
+        │
+        ├─▶ 3. backend.provision(spec)  ──▶  EnvHandle
+        │      (containers up, network created, initial state applied)
+        │
+        ├─▶ 4. backend.await_ready(handle)
+        │      (blocks until health probes pass; ProvisionError on timeout)
+        │
+        ├─▶ 5. backend.endpoints(handle) ──▶ EnvEndpoints
+        │      (per-trial service URLs)
+        │
+        ├─▶ 6. Trial body runs — agent loop, runner RPC, grading
+        │
+        └─▶ 7. backend.teardown(handle) in finally
+               (containers stopped, network removed; idempotent)
+
+Concurrent trials each get their own EnvHandle → their own isolated stack.
+```
+
+## Decision Drivers
+
+- **Fill the missing seam, not carve a new one.** The provisioner role is one face of `RuntimeBackend`, not a separate abstraction. A future reader should be able to point at the manifest, the Protocol, and one contract document and see how they compose — not chase three overlapping interfaces.
+- **Lock the enforcement obligations.** ADR-0009's safety declarations are only meaningful if some contract requires a provisioner to honour them. This ADR is where that requirement lives.
+- **Fail loud, not silent.** A provisioner that cannot enforce a declared property (`read_only`, `network: isolated`, resource caps, security context) must reject the manifest at `provision` time, not silently degrade to a weaker posture.
+- **Local-first.** The `local` runtime backend must always work without a cluster or a remote surface. The contract's typing (opaque `EnvHandle`, in-process today) must leave room for future remote provisioning without forcing it now.
+- **Backwards compatible with the shared-stack path.** Every existing task continues to run through `DockerRuntime` unchanged. The new methods have no-op or shared-stack semantics on that backend.
+- **Same iterate-cheaply property as ADR-0009.** Land ADR + Protocol + canonical contract tests together; keep status `Proposed` until the first concrete consumer (`LocalRuntimeBackend`) validates the contract end-to-end.
+
+## Considered Options
+
+1. **Extend `RuntimeBackend` with four methods (`provision` / `await_ready` / `endpoints` / `teardown`), an opaque `EnvHandle`, and a typed `ProvisionError`.** Encode every safety-relevant enforcement obligation in the ADR's contract clauses. Ship the extension, contract tests, and no-op adapter on `DockerRuntime` as one PR. **This ADR.**
+2. **Separate `Provisioner` Protocol distinct from `RuntimeBackend`.** Splits the abstraction into two: the runtime (lifecycle, RPC surface) vs. the provisioner (environment materialisation). Cleaner in theory; doubles the injection points and the Protocol-promotion work; no near-term backend legitimately implements one without the other.
+3. **Inline the provisioning calls in `Conductor`.** The conductor already runs one trial end-to-end; it could hand-roll the compose lifecycle itself. Rejected: couples the conductor to the substrate; every future backend would need conductor changes; loses the "swappable execution surface" property ADR-0007 was written to establish.
+4. **Defer until the first concrete backend needs it.** Ship `LocalRuntimeBackend` first, then extract the contract from what actually shipped. Rejected for the same reason ADR-0009 was written before its first consumer: the contract iterates cheaply against a Pydantic + tests surface, and expensively against a deployed backend.
+
+## Decision
+
+We adopt **Option 1**.
+
+### Method surface on `RuntimeBackend`
+
+Four new methods, added to the existing Protocol in `tolokaforge/core/runtime.py`:
+
+```python
+class RuntimeBackend(Protocol):
+    # Existing (ADR-0007):
+    def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None: ...
+    def close(self) -> None: ...
+    def health_check(self) -> bool: ...
+    def cleanup_trial(self, trial_id: str) -> dict[str, Any]: ...
+    executor_client: RunnerClient
+
+    # New (this ADR):
+    def provision(self, spec: TrialSpec) -> EnvHandle: ...
+    def await_ready(self, handle: EnvHandle) -> None: ...
+    def endpoints(self, handle: EnvHandle) -> EnvEndpoints: ...
+    def teardown(self, handle: EnvHandle) -> None: ...
+```
+
+- **`provision(spec)`** — reads `spec.task.environment_manifest`, materialises its services (or fails `ProvisionError`), returns an `EnvHandle` the backend understands. When `environment_manifest is None`, the backend materialises the shared-stack view (backwards-compat path).
+- **`await_ready(handle)`** — blocks until all services in the handle pass their `HealthProbe`s. Raises `ProvisionError` on health-probe timeout (before returning; not silently after).
+- **`endpoints(handle)`** — resolves per-trial URLs for the runner + declared services. Returns a fully populated `EnvEndpoints` (ADR-0006). Does not block; readiness is `await_ready`'s job.
+- **`teardown(handle)`** — stops containers, removes per-trial network, releases any lease the backend holds. **Idempotent** — calling on an already-torn-down handle is a no-op, not an error. **Best-effort** — logs but does not raise if a container was already gone.
+
+### `EnvHandle` — opaque Protocol-typed value
+
+```python
+@runtime_checkable
+class EnvHandle(Protocol):
+    """Opaque per-trial handle returned by RuntimeBackend.provision.
+
+    Each backend defines its own internal shape (compose project name,
+    pod identity, remote-lease id). Callers should treat the handle as
+    unopened; only the backend that issued it can interpret its fields.
+    """
+    trial_id: str
+```
+
+`trial_id` is the one field callers may read — it's the identity for logs and for `cleanup_trial`. Everything else is backend-private. The typing leaves room for future remote provisioning: a `RemoteEnvHandle` can be a small serializable dict (`{trial_id, provider, lease_id}`) without breaking the Protocol.
+
+### `ProvisionError` — typed failure
+
+```python
+class ProvisionError(Exception):
+    """Raised when RuntimeBackend.provision or await_ready cannot bring
+    the trial environment up to the state the manifest declares.
+
+    The provisioner is expected to have made a best-effort teardown of
+    anything it partially materialised before raising. Callers may
+    call teardown(handle) again — it is idempotent.
+    """
+    trial_id: str
+    stage: Literal["provision", "await_ready"]
+    reason: str
+```
+
+### Enforcement obligations
+
+A `RuntimeBackend` implementation is contractually obligated to honour these manifest declarations. Failure to enforce any of them at `provision` time — not later, not silently — is a contract violation:
+
+| Manifest field | Provisioner obligation |
+|---|---|
+| `EnvironmentManifest.network` = `isolated` | No egress to the public internet; no reachability across per-trial projects. Enforce via substrate-native network isolation. |
+| `EnvironmentManifest.network` = `external` | Egress permitted; still no cross-trial reachability. |
+| `ServiceSpec.security_context` | Every declared field applied to the container (`run_as_user`, `read_only_root_filesystem`, `no_new_privileges`, capability drops/adds). Fail `ProvisionError` if any declared field cannot be enforced by the substrate. |
+| `ServiceSpec.resources` / manifest-level `Resources` | CPU / memory caps applied at the container level. Per-service overrides manifest-level defaults. |
+| `VolumeMount.read_only` | Bind or named mount honours the flag. |
+| `ServiceSpec.health` + `HealthProbe.initial_delay_seconds` | `await_ready` respects the delay before the first probe. |
+| `ServiceSpec.depends_on` (in either form) | Startup ordering; `service_healthy` waits on the probe passing. |
+| `EnvironmentManifest.initial_state` | Fixture applied per its `kind` (`sql` / `copy` / `script`) before `await_ready` returns. |
+| `ServiceSpec.image` pinning | Substrate honours the exact tag or digest; no automatic tag resolution. |
+
+**Rule of thumb: if the substrate cannot enforce a declared property, `provision` raises `ProvisionError` at task-load time. No provisioner may silently drop, downgrade, or ignore a declaration.**
+
+### Lifecycle ownership
+
+- **`Conductor.run()`** owns per-trial calls: `provision(spec)` before the trial body, `endpoints(handle)` to resolve per-trial URLs to feed into the runner, `teardown(handle)` in a `finally` block (runs on both success and failure paths).
+- **`Orchestrator`** owns the `RuntimeBackend` **instance** for the whole run: one backend per run, injected into the `Conductor` at construction time.
+- **Runtime-backend selection** is a run-level, config-driven choice (see below), decided once at the start of `run()`.
+
+This split makes the trial-level concern (provision/teardown per trial) local to the `Conductor` where it belongs, and keeps the backend instance stable across the run so per-run resources (client connections, warm pools) are not repeatedly built and torn down.
+
+### Failure semantics
+
+- **Partial-startup failure**: `provision` raises `ProvisionError(stage="provision")` after making a best-effort teardown of anything it materialised before the failure. The handle is not returned. The caller does not need to call `teardown` again — but if it does (defensive `finally`), `teardown` handles the already-torn-down state as a no-op.
+- **Health-probe timeout**: `await_ready` raises `ProvisionError(stage="await_ready")`. The handle **is** valid (containers are up); the caller must call `teardown` to clean up.
+- **`teardown` is idempotent**: subsequent calls on the same handle are no-ops. `teardown` may log substrate-side warnings ("container X was already stopped") but does not raise.
+- **Orphan sweep on `connect`**: the backend may perform a best-effort sweep of leftover per-trial resources from a crashed previous run (matched by `trial_id` prefix in the backend's naming scheme). Best-effort — a failure to sweep does not fail `connect`.
+
+### Selection mechanism
+
+Runtime-backend selection is config-driven at run start:
+
+```yaml
+runtime:
+  backend: local        # "local" | "shared"; default "shared" preserves today's behaviour
+```
+
+`shared` = `DockerRuntime` (today's shared-stack path). `local` = `LocalRuntimeBackend` (per-trial isolation; the concrete consumer landing in a follow-up PR). Additional backends slot in behind the same key without breaking existing configs.
+
+The existing `auto_start_services` flag stays as-is; it controls whether the orchestrator brings services up at all, not which backend materialises them.
+
+### Backwards compatibility
+
+`DockerRuntime` implements the four new methods with **shared-stack semantics**:
+
+- `provision(spec)` — no-op that returns a handle pointing at the run-wide shared stack. All trials in the run receive equivalent handles referencing the same stack.
+- `await_ready(handle)` — no-op if the shared stack was already brought up at `connect` time.
+- `endpoints(handle)` — returns the run-wide shared `EnvEndpoints` unchanged.
+- `teardown(handle)` — no-op; the shared stack lives for the whole run and is torn down at `close`.
+
+Existing tasks running through `DockerRuntime` see no behavioural change. The Protocol widens; nothing that already worked breaks.
+
+`InMemoryRuntimeBackend` (the ADR-0007 test fixture) is extended with deterministic stub implementations of the four methods, adding call-log entries so orchestrator-level tests can assert lifecycle ordering without spinning up Docker.
+
+### Explicitly out of scope
+
+- **`stream_logs`**. The internal runtime-architecture sketch listed a `stream_logs(handle) -> Iterator[bytes]` method on `RuntimeBackend`. Deferred — no consumer today needs streaming (grading and artifact writing read final state, not live streams). Adds as a Protocol method when a consumer (e.g. a live-tail UI or a control-plane observability surface) exists.
+- **Remote provisioning**. The `EnvHandle` typing leaves room for serializable handles, but no concrete `RemoteRuntimeBackend` exists yet and this ADR does not commit to one. That's a later ADR that will settle the on-the-wire handle shape.
+- **Provisioner side-effect budgets** (CPU / memory quotas across concurrent trials). Individual trials honour their manifest's `Resources`; system-wide caps are a scheduler concern, not a provisioner one.
+- **GPU / accelerator declarations**. Handled by the substrate today via the existing `Resources.cpu` / `memory` string surface; if declaring GPUs becomes a first-class need, it lands in a follow-up manifest schema update, not this ADR.
+
+## Impact on existing tasks
+
+**None in the PR that lands this ADR.** The Protocol widens; `DockerRuntime` adapts with no-op semantics that preserve the shared-stack path exactly. Every existing task continues to run unchanged.
+
+The first behavioural change lands with the follow-up PR that ships `LocalRuntimeBackend` — and even then, tasks default to `DockerRuntime` (backward-compat) until a run's config opts into `runtime.backend: local`. Per-trial isolation is opt-in until the first workload validates it end-to-end.
+
+## Consequences
+
+### Positive
+
+- Every manifest safety declaration now has a contract clause requiring a provisioner to honour it. `read_only`, `network`, `resources`, `security_context`, health probes — all move from "the schema says so" to "the backend is required to enforce so".
+- The lifecycle picture is written down in one place: who calls `provision`, who calls `teardown`, when, and what happens on failure. Future readers do not re-derive it.
+- The `EnvHandle` abstraction leaves room for remote provisioning without forcing it. The typing does not commit to Python-object handles.
+- `DockerRuntime` continues to satisfy the widened Protocol; no existing task is disturbed by the change.
+- The `Conductor` becomes ready to compose against any provisioning backend without further conductor-side changes. The next PR (`LocalRuntimeBackend`) is a pure Protocol implementation, not a call-site refactor.
+
+### Negative / Trade-offs
+
+- The `RuntimeBackend` Protocol grows. Every future implementation carries four more methods to fulfil. Acceptable: three of the four (`provision`, `endpoints`, `teardown`) are the minimum a per-trial substrate needs; the fourth (`await_ready`) could be folded into `provision` at the cost of blocking semantics being invisible in the type surface, which we chose against.
+- `ProvisionError` is a new failure surface the orchestrator's retry machinery has to think about. Mitigation: it's the same shape as existing typed exceptions the runtime already handles (e.g. `RunnerClientError`); the retry policy needs one extra branch, not a rewrite.
+- The "fail loud on unenforceable declarations" rule imposes work on backend authors — they cannot ship a partial implementation that silently degrades one property. This is intentional; a runtime that silently ignores `security_context` is worse than a runtime that refuses to run.
+
+### Follow-ups
+
+- **`LocalRuntimeBackend`** — the first concrete consumer that actually enforces the obligations. Ships with its own PR immediately after this ADR lands; also flips ADR-0010 status from `Proposed` to `Accepted` once end-to-end validation is green.
+- **`stream_logs` method** — added when a consumer appears (live-tail, observability sink).
+- **Remote provisioner ADR** — settles the on-the-wire `EnvHandle` shape for out-of-process backends. Blocked on a concrete remote workload materialising.
+- **Orphan-sweep policy formalisation** — today's "best-effort on `connect`" is a reasonable default; a future ADR may tighten it if crash-resilience becomes a hard requirement.
+
+## Rejected alternatives
+
+- **Option 2 — separate `Provisioner` Protocol.** Two Protocols where one suffices; every future backend implements both anyway. Rejected as premature abstraction.
+- **Option 3 — inline in `Conductor`.** Couples the conductor to the substrate; every backend requires a conductor edit. Defeats the "swappable execution surface" property ADR-0007 established.
+- **Option 4 — defer until a backend needs it.** Loses the cheap-iteration property. The contract iterates cheaply against a Protocol + tests surface; against a deployed backend it iterates painfully.
+
+## Scope notes
+
+- **Method placement.** The four new methods live on `RuntimeBackend`, not on a helper class the backend composes with. Rationale: any provisioner is a backend from the orchestrator's perspective; putting the methods on the backend keeps the injection surface flat.
+- **`connect` / `close` unchanged.** The existing lifecycle methods keep their meaning (bring the *backend* up / down for the run). `provision` / `teardown` are per-trial; they are strictly nested inside `connect` / `close` for the lifetime of the run.
+- **No gRPC `.proto` change.** This ADR types the orchestrator ↔ backend surface, not the runner gRPC wire.
+- **Contract tests are canonical.** `tests/canonical/test_runtime_backend_contract.py` grows to pin every new method's contract: handle round-trip, idempotent teardown, `ProvisionError` semantics for both `stage` values, no-op compat semantics on `DockerRuntime`. Any silent drift fails CI.
+- **Status stays `Proposed` until end-to-end validation.** Same discipline ADR-0009 used: land the design + contract tests; flip to `Accepted` when the first concrete consumer (`LocalRuntimeBackend`) validates the contract against a real workload.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -40,4 +40,5 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0007](0007-runtime-backend-protocol.md) | `RuntimeBackend` Protocol — lift `DockerRuntime` behind a typed seam | Accepted |
 | [0008](0008-conductor-protocol.md) | `Conductor` Protocol — per-trial executor seam | Accepted |
 | [0009](0009-environment-manifest.md) | `EnvironmentManifest` — typed schema for per-trial multicontainer environments | Proposed |
+| [0010](0010-runtime-backend-provisioning-contract.md) | `RuntimeBackend` provisioning contract — `provision` / `await_ready` / `endpoints` / `teardown` | Proposed |
 | [0011](0011-seam-and-declaration-conventions.md) | Seam-definition and data-declaration conventions for new components | Proposed |

--- a/tests/canonical/_factories.py
+++ b/tests/canonical/_factories.py
@@ -1,0 +1,43 @@
+"""Shared model factories for canonical contract tests.
+
+Each contract-test file builds :class:`TaskDescription` / :class:`EnvEndpoints`
+with site-specific literals (task_id, name, description). These factories
+centralise HOW the model is constructed so a new required field on the
+underlying Pydantic model lands in one place; each test file still passes
+its own site-specific literals as keyword overrides.
+"""
+
+from __future__ import annotations
+
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest
+from tolokaforge.runner.models import TaskDescription
+
+
+def make_task_description(
+    *,
+    task_id: str = "task",
+    name: str = "task",
+    category: str = "test",
+    description: str = "contract-test task",
+    adapter_type: str = "native",
+    system_prompt: str = "",
+    environment_manifest: EnvironmentManifest | None = None,
+) -> TaskDescription:
+    return TaskDescription(
+        task_id=task_id,
+        name=name,
+        category=category,
+        description=description,
+        adapter_type=adapter_type,
+        system_prompt=system_prompt,
+        environment_manifest=environment_manifest,
+    )
+
+
+def make_env_endpoints(
+    *,
+    db_url: str = "http://db.local:8000",
+    rag_url: str | None = None,
+    runner_url: str = "http://runner.local:50051",
+) -> EnvEndpoints:
+    return EnvEndpoints(db_url=db_url, rag_url=rag_url, runner_url=runner_url)

--- a/tests/canonical/test_conductor_contract.py
+++ b/tests/canonical/test_conductor_contract.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.canonical._factories import make_task_description
 from tolokaforge.core.conductor import (
     Conductor,
     ConductorCallLog,
@@ -47,13 +48,10 @@ def _make_in_process_conductor() -> InProcessConductor:
 
 def _make_task_description(task_id: str = "t1") -> TaskDescription:
     """Build the minimal :class:`TaskDescription` Pydantic requires."""
-    return TaskDescription(
+    return make_task_description(
         task_id=task_id,
         name=task_id,
-        category="test",
         description="contract-test stub",
-        adapter_type="native",
-        system_prompt="",
     )
 
 

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -339,11 +339,6 @@ class TestTeardownLifecycle:
         backend.teardown(handle)
         backend.teardown(handle)  # no exception
 
-    def test_teardown_best_effort_on_missing_resources(self) -> None:
-        backend = InMemoryRuntimeBackend(container_missing_on_teardown=True)
-        handle = backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))
-        backend.teardown(handle)  # no exception
-
 
 class TestDockerRuntimeSharedStackCompat:
     def test_provision_returns_handle_with_trial_id(self) -> None:

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -6,6 +6,10 @@ wrapper, never ``connect()``-ed in this test) and
 methods and the retry-cleanup method are exercised on both; ``connect()``
 itself is *not* invoked on ``DockerRuntime`` because that would require
 a real runner gRPC server.
+
+The lower half of the file pins the ADR-0010 provisioning surface:
+``provision`` / ``await_ready`` / ``endpoints`` / ``teardown``,
+``EnvHandle``, ``ProvisionError``.
 """
 
 from __future__ import annotations
@@ -13,11 +17,16 @@ from __future__ import annotations
 import pytest
 
 from tolokaforge.core.docker_runtime import DockerRuntime
+from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.runtime import (
+    EnvHandle,
     InMemoryRuntimeBackend,
+    ProvisionError,
     RuntimeBackend,
     RuntimeBackendCallLog,
 )
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, ServiceSpec, TrialSpec
+from tolokaforge.runner.models import TaskDescription
 
 pytestmark = pytest.mark.canonical
 
@@ -144,3 +153,251 @@ class TestInMemoryBackendSemantics:
     def test_fresh_backend_has_empty_call_log(self) -> None:
         backend = InMemoryRuntimeBackend()
         assert backend.call_log == RuntimeBackendCallLog()
+
+
+# ===========================================================================
+# ADR-0010 provisioning contract
+# ===========================================================================
+#
+# The tests below pin the provisioning surface added by ADR-0010:
+# provision / await_ready / endpoints / teardown, plus EnvHandle shape and
+# ProvisionError semantics. Per-backend enforcement of manifest safety
+# declarations lives in that backend's own test module — this file tests
+# the Protocol contract only.
+
+
+def _make_task_description(manifest: EnvironmentManifest | None = None) -> TaskDescription:
+    return TaskDescription(
+        task_id="task-1",
+        name="probe",
+        category="general",
+        description="Contract-test task",
+        adapter_type="native",
+        system_prompt="You are a helpful assistant.",
+        environment_manifest=manifest,
+    )
+
+
+def _make_env_endpoints() -> EnvEndpoints:
+    return EnvEndpoints(
+        db_url="http://db.local:8000",
+        rag_url=None,
+        runner_url="http://runner.local:50051",
+    )
+
+
+def _make_trial_spec(
+    trial_id: str = "task-1:0",
+    manifest: EnvironmentManifest | None = None,
+) -> TrialSpec:
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="run_contract_test",
+        task=_make_task_description(manifest),
+        agent_model_config=ModelConfig(name="claude-sonnet-4-6", provider="anthropic"),
+        env_endpoints=_make_env_endpoints(),
+    )
+
+
+def _make_two_service_manifest() -> EnvironmentManifest:
+    return EnvironmentManifest(
+        services=[
+            ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0"),
+            ServiceSpec(name="db", image="postgres:16"),
+        ],
+    )
+
+
+class TestProvisioningProtocolConformance:
+    def test_docker_runtime_has_provisioning_methods(self) -> None:
+        backend = DockerRuntime(runner_address="sentinel:50051")
+        for method in ("provision", "await_ready", "endpoints", "teardown"):
+            assert callable(getattr(backend, method))
+
+    def test_in_memory_backend_has_provisioning_methods(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        for method in ("provision", "await_ready", "endpoints", "teardown"):
+            assert callable(getattr(backend, method))
+
+
+class TestEnvHandleShape:
+    def test_handle_exposes_trial_id(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        assert handle.trial_id == "task-1:0"
+
+    def test_handle_is_protocol_typed(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec())
+        assert isinstance(handle, EnvHandle)
+
+
+class TestProvisionError:
+    def test_carries_trial_id_stage_reason(self) -> None:
+        err = ProvisionError(trial_id="task-1:0", stage="provision", reason="port bind failed")
+        assert err.trial_id == "task-1:0"
+        assert err.stage == "provision"
+        assert err.reason == "port bind failed"
+
+    @pytest.mark.parametrize("stage", ["provision", "await_ready"])
+    def test_stage_accepts_documented_literals(self, stage: str) -> None:
+        err = ProvisionError(trial_id="t:0", stage=stage, reason="x")  # type: ignore[arg-type]
+        assert err.stage == stage
+
+    def test_error_is_raisable_and_catchable(self) -> None:
+        with pytest.raises(ProvisionError) as exc:
+            raise ProvisionError(trial_id="t:0", stage="provision", reason="x")
+        assert exc.value.trial_id == "t:0"
+
+
+class TestProvisionLifecycle:
+    def test_returns_handle_with_matching_trial_id(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        spec = _make_trial_spec(trial_id="task-1:0", manifest=_make_two_service_manifest())
+        handle = backend.provision(spec)
+        assert handle.trial_id == "task-1:0"
+
+    def test_no_manifest_returns_handle(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        spec = _make_trial_spec(manifest=None)
+        handle = backend.provision(spec)
+        assert handle.trial_id == spec.trial_id
+
+    def test_partial_startup_raises_provision_error(self) -> None:
+        backend = InMemoryRuntimeBackend(fail_provision_after_service="db")
+        spec = _make_trial_spec(trial_id="task-1:0", manifest=_make_two_service_manifest())
+        with pytest.raises(ProvisionError) as exc:
+            backend.provision(spec)
+        assert exc.value.stage == "provision"
+        assert exc.value.trial_id == "task-1:0"
+        # Best-effort teardown ran before the raise.
+        assert "task-1:0" in backend.call_log.torn_down_trials
+
+    def test_partial_startup_only_fires_when_service_present(self) -> None:
+        backend = InMemoryRuntimeBackend(fail_provision_after_service="db")
+        manifest = EnvironmentManifest(
+            services=[ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0")]
+        )
+        handle = backend.provision(_make_trial_spec(manifest=manifest))
+        assert handle.trial_id == "task-1:0"
+
+
+class TestAwaitReadyLifecycle:
+    def test_returns_when_all_probes_pass(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec())
+        assert backend.await_ready(handle) is None
+
+    def test_timeout_raises_provision_error(self) -> None:
+        backend = InMemoryRuntimeBackend(await_ready_times_out=True)
+        handle = backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))
+        with pytest.raises(ProvisionError) as exc:
+            backend.await_ready(handle)
+        assert exc.value.stage == "await_ready"
+
+    def test_handle_valid_after_await_ready_failure(self) -> None:
+        backend = InMemoryRuntimeBackend(await_ready_times_out=True)
+        handle = backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))
+        with pytest.raises(ProvisionError):
+            backend.await_ready(handle)
+        backend.teardown(handle)  # must not raise
+        assert handle.trial_id in backend.call_log.torn_down_trials
+
+
+class TestEndpointsResolution:
+    def test_returns_env_endpoints(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec())
+        endpoints = backend.endpoints(handle)
+        assert isinstance(endpoints, EnvEndpoints)
+        assert endpoints.runner_url
+
+    def test_does_not_block(self) -> None:
+        backend = InMemoryRuntimeBackend(await_ready_times_out=True)
+        handle = backend.provision(_make_trial_spec())
+        _ = backend.endpoints(handle)  # must not raise
+
+    def test_per_trial_endpoints_differ(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle_a = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        handle_b = backend.provision(_make_trial_spec(trial_id="task-1:1"))
+        ep_a = backend.endpoints(handle_a)
+        ep_b = backend.endpoints(handle_b)
+        assert ep_a.runner_url != ep_b.runner_url
+
+
+class TestTeardownLifecycle:
+    def test_teardown_records_trial(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        backend.teardown(handle)
+        assert "task-1:0" in backend.call_log.torn_down_trials
+
+    def test_teardown_is_idempotent(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec())
+        backend.teardown(handle)
+        backend.teardown(handle)  # no exception
+
+    def test_teardown_best_effort_on_missing_resources(self) -> None:
+        backend = InMemoryRuntimeBackend(container_missing_on_teardown=True)
+        handle = backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))
+        backend.teardown(handle)  # no exception
+
+
+class TestDockerRuntimeSharedStackCompat:
+    def test_provision_returns_handle_with_trial_id(self) -> None:
+        backend = DockerRuntime(runner_address="localhost:50051")
+        spec = _make_trial_spec(trial_id="task-1:0")
+        handle = backend.provision(spec)
+        assert handle.trial_id == "task-1:0"
+        assert isinstance(handle, EnvHandle)
+
+    def test_endpoints_returns_shared_run_wide_urls(self) -> None:
+        backend = DockerRuntime(runner_address="localhost:50051")
+        handle_a = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        handle_b = backend.provision(_make_trial_spec(trial_id="task-1:1"))
+        # Shared-stack semantics: both handles resolve to the same endpoints.
+        assert backend.endpoints(handle_a) == backend.endpoints(handle_b)
+
+    def test_teardown_is_no_op(self) -> None:
+        backend = DockerRuntime(runner_address="localhost:50051")
+        handle = backend.provision(_make_trial_spec())
+        backend.teardown(handle)  # no exception
+        backend.teardown(handle)  # idempotent
+
+    def test_await_ready_is_no_op(self) -> None:
+        backend = DockerRuntime(runner_address="localhost:50051")
+        handle = backend.provision(_make_trial_spec())
+        assert backend.await_ready(handle) is None
+
+
+class TestInMemoryProvisioningCallLog:
+    def test_records_provision_and_teardown(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        backend.teardown(handle)
+        assert backend.call_log.provisioned_trials == ["task-1:0"]
+        assert backend.call_log.torn_down_trials == ["task-1:0"]
+
+    def test_call_log_preserves_ordering(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        h_a = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        h_b = backend.provision(_make_trial_spec(trial_id="task-1:1"))
+        backend.teardown(h_a)
+        backend.teardown(h_b)
+        assert backend.call_log.provisioned_trials == ["task-1:0", "task-1:1"]
+        assert backend.call_log.torn_down_trials == ["task-1:0", "task-1:1"]
+
+    def test_records_await_ready_and_endpoints_calls(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        backend.await_ready(handle)
+        backend.endpoints(handle)
+        assert backend.call_log.await_ready_calls == ["task-1:0"]
+        assert backend.call_log.endpoints_calls == ["task-1:0"]
+
+    def test_configurable_provision_failure(self) -> None:
+        backend = InMemoryRuntimeBackend(fail_provision_after_service="db")
+        with pytest.raises(ProvisionError):
+            backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.canonical._factories import make_env_endpoints, make_task_description
 from tolokaforge.core.docker_runtime import DockerRuntime
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.runtime import (
@@ -167,22 +168,13 @@ class TestInMemoryBackendSemantics:
 
 
 def _make_task_description(manifest: EnvironmentManifest | None = None) -> TaskDescription:
-    return TaskDescription(
+    return make_task_description(
         task_id="task-1",
         name="probe",
         category="general",
         description="Contract-test task",
-        adapter_type="native",
         system_prompt="You are a helpful assistant.",
         environment_manifest=manifest,
-    )
-
-
-def _make_env_endpoints() -> EnvEndpoints:
-    return EnvEndpoints(
-        db_url="http://db.local:8000",
-        rag_url=None,
-        runner_url="http://runner.local:50051",
     )
 
 
@@ -195,7 +187,7 @@ def _make_trial_spec(
         run_id="run_contract_test",
         task=_make_task_description(manifest),
         agent_model_config=ModelConfig(name="claude-sonnet-4-6", provider="anthropic"),
-        env_endpoints=_make_env_endpoints(),
+        env_endpoints=make_env_endpoints(),
     )
 
 

--- a/tests/canonical/test_trial_spec_contract.py
+++ b/tests/canonical/test_trial_spec_contract.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from tests.canonical._factories import make_env_endpoints, make_task_description
 from tolokaforge.core.models import (
     Grade,
     GradeComponents,
@@ -33,12 +34,11 @@ pytestmark = pytest.mark.canonical
 
 
 def _make_task_description() -> TaskDescription:
-    return TaskDescription(
+    return make_task_description(
         task_id="airline_001",
         name="Book a flight",
         category="airline",
         description="The user wants to book a one-way flight from JFK to LAX.",
-        adapter_type="native",
         system_prompt="You are a helpful airline assistant.",
     )
 
@@ -48,11 +48,7 @@ def _make_model_config() -> ModelConfig:
 
 
 def _make_env_endpoints(rag: bool = False) -> EnvEndpoints:
-    return EnvEndpoints(
-        db_url="http://db.local:8000",
-        rag_url="http://rag.local:8001" if rag else None,
-        runner_url="http://runner.local:50051",
-    )
+    return make_env_endpoints(rag_url="http://rag.local:8001" if rag else None)
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 import grpc
 
-from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S
+from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints
 from tolokaforge.runner import (
     ExecutionStatus,
     runner_pb2,
@@ -31,7 +31,7 @@ from tolokaforge.tools.registry import ToolResult
 
 if TYPE_CHECKING:  # pragma: no cover — type-only imports for provisioning surface
     from tolokaforge.core.runtime import EnvHandle
-    from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+    from tolokaforge.core.trial import TrialSpec
 
 logger = logging.getLogger(__name__)
 
@@ -690,8 +690,6 @@ class DockerRuntime:
         backend (e.g. ``LocalRuntimeBackend``, which resolves real URLs
         from its per-trial ``ServiceStack``).
         """
-        from tolokaforge.core.trial import EnvEndpoints
-
         return EnvEndpoints(
             db_url=f"http://{self.runner_client.runner_address}/db-shared",
             rag_url=None,

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -11,10 +11,13 @@ This module provides:
 See docs/GRPC_PROTOCOL.md for the full protocol specification.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import time
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import grpc
 
@@ -25,6 +28,10 @@ from tolokaforge.runner import (
     runner_pb2_grpc,
 )
 from tolokaforge.tools.registry import ToolResult
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports for provisioning surface
+    from tolokaforge.core.runtime import EnvHandle
+    from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 
 logger = logging.getLogger(__name__)
 
@@ -577,6 +584,17 @@ class RunnerClient:
 ExecutorClient = RunnerClient
 
 
+@dataclass(frozen=True)
+class _SharedStackHandle:
+    """Handle returned by :meth:`DockerRuntime.provision`.
+
+    Points at the run-wide shared stack rather than a per-trial materialisation.
+    Two trials in the same run receive equivalent handles.
+    """
+
+    trial_id: str
+
+
 class DockerRuntime:
     """Docker runtime manager - coordinates Runner connectivity
 
@@ -632,6 +650,52 @@ class DockerRuntime:
         to the gRPC client). Idempotent on the runner side.
         """
         return self.runner_client.cleanup_trial(trial_id)
+
+    # ---- Per-trial provisioning (ADR-0010) — shared-stack compat path ----
+    #
+    # DockerRuntime keeps the run-wide shared-stack semantics that existed
+    # before ADR-0010. The new methods satisfy the extended
+    # ``RuntimeBackend`` Protocol without changing behaviour: provision
+    # returns a handle pointing at the shared stack; endpoints returns the
+    # run-wide URLs the shared stack exposes; teardown is a no-op because
+    # the shared stack lives for the whole run and is torn down at
+    # ``close``. Per-trial isolation is a ``LocalRuntimeBackend`` concern,
+    # not a ``DockerRuntime`` concern.
+
+    def provision(self, spec: TrialSpec) -> EnvHandle:
+        """Return a handle pointing at the run-wide shared stack.
+
+        No per-trial containers are brought up — the shared stack is
+        already running from ``connect()``. Every trial receives an
+        equivalent handle referencing the same stack.
+        """
+        return _SharedStackHandle(trial_id=spec.trial_id)
+
+    def await_ready(self, handle: EnvHandle) -> None:  # noqa: ARG002 — Protocol conformance
+        """No-op: the shared stack becomes ready at ``connect`` time, not
+        per-trial. Health probes for the shared services are already
+        applied by :meth:`connect`'s health-check loop."""
+
+    def endpoints(self, handle: EnvHandle) -> EnvEndpoints:  # noqa: ARG002 — Protocol conformance
+        """Return the run-wide shared endpoints.
+
+        DockerRuntime does not carry the per-trial URLs the manifest
+        would resolve to — orchestrator-side resolution supplies those
+        through the existing ``EnvEndpoints`` construction site. The
+        method exists to satisfy the extended Protocol; callers that
+        need per-trial URLs should use a per-trial backend.
+        """
+        from tolokaforge.core.trial import EnvEndpoints
+
+        return EnvEndpoints(
+            db_url=f"http://{self.runner_client.runner_address}/db-shared",
+            rag_url=None,
+            runner_url=f"http://{self.runner_client.runner_address}",
+        )
+
+    def teardown(self, handle: EnvHandle) -> None:  # noqa: ARG002 — Protocol conformance
+        """No-op: the shared stack lives for the whole run and is torn
+        down at :meth:`close`, not per-trial. Idempotent by construction."""
 
     def __enter__(self):
         """Context manager entry"""

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -677,13 +677,18 @@ class DockerRuntime:
         applied by :meth:`connect`'s health-check loop."""
 
     def endpoints(self, handle: EnvHandle) -> EnvEndpoints:  # noqa: ARG002 — Protocol conformance
-        """Return the run-wide shared endpoints.
+        """Return **sentinel** URLs for the shared-stack path.
 
         DockerRuntime does not carry the per-trial URLs the manifest
-        would resolve to — orchestrator-side resolution supplies those
-        through the existing ``EnvEndpoints`` construction site. The
-        method exists to satisfy the extended Protocol; callers that
-        need per-trial URLs should use a per-trial backend.
+        would resolve to; the returned strings are placeholders scoped
+        to the runner address (``…/db-shared``) purely to satisfy
+        :class:`EnvEndpoints`' non-empty ``db_url`` / ``runner_url``
+        constraint. **Do not wire a client to these values** — real
+        addresses on the shared-stack path come from the orchestrator's
+        existing ``EnvEndpoints`` construction site, not from this
+        method. Callers that need per-trial URLs should use a per-trial
+        backend (e.g. ``LocalRuntimeBackend``, which resolves real URLs
+        from its per-trial ``ServiceStack``).
         """
         from tolokaforge.core.trial import EnvEndpoints
 

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -265,9 +265,11 @@ class InMemoryRuntimeBackend:
     * ``await_ready_times_out`` — when ``True``, :meth:`await_ready`
       raises :class:`ProvisionError` with ``stage="await_ready"``. The
       handle stays valid; the caller must still call :meth:`teardown`.
-    * ``container_missing_on_teardown`` — when ``True``, :meth:`teardown`
-      records its call but takes no other action, matching a real
-      backend's best-effort behaviour when a container is already gone.
+
+    Substrate-specific failure modes (e.g. "container already gone" on
+    teardown) are not simulated here — those live in the concrete
+    backend's own test module because the in-memory backend has no
+    substrate to be in an anomalous state.
     """
 
     def __init__(
@@ -275,13 +277,11 @@ class InMemoryRuntimeBackend:
         *,
         fail_provision_after_service: str | None = None,
         await_ready_times_out: bool = False,
-        container_missing_on_teardown: bool = False,
     ) -> None:
         self.call_log = RuntimeBackendCallLog()
         self.executor_client: Any = _UnusableExecutorClient()
         self._fail_provision_after_service = fail_provision_after_service
         self._await_ready_times_out = await_ready_times_out
-        self._container_missing_on_teardown = container_missing_on_teardown
 
     # ---- Run-level lifecycle ----
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
@@ -338,6 +338,3 @@ class InMemoryRuntimeBackend:
 
     def teardown(self, handle: EnvHandle) -> None:
         self.call_log.torn_down_trials.append(handle.trial_id)
-        # container_missing_on_teardown is best-effort no-raise; the call is
-        # still recorded above, matching a real backend's log-and-move-on.
-        _ = self._container_missing_on_teardown

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -7,27 +7,82 @@ client wrapper around the runner container); this module declares the
 Protocol that decouples the orchestrator from that single implementation.
 
 * :class:`RuntimeBackend` — the Protocol the orchestrator depends on.
+* :class:`EnvHandle` — opaque per-trial handle returned by
+  :meth:`RuntimeBackend.provision`.
+* :class:`ProvisionError` — typed failure for the provisioning lifecycle.
 * :class:`InMemoryRuntimeBackend` — a non-gRPC implementation used as a
-  test fixture and as proof the seam is swappable. Records lifecycle and
-  cleanup calls on a :class:`RuntimeBackendCallLog`; the ``executor_client``
-  stub raises :class:`NotImplementedError` on RPC methods (callers that
-  need a real RPC must use :class:`DockerRuntime` or mock ``RunnerClient``
-  directly).
+  test fixture and as proof the seam is swappable. Records lifecycle,
+  cleanup, and provisioning calls on a :class:`RuntimeBackendCallLog`;
+  the ``executor_client`` stub raises :class:`NotImplementedError` on
+  RPC methods (callers that need a real RPC must use
+  :class:`DockerRuntime` or mock ``RunnerClient`` directly).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 
 if TYPE_CHECKING:  # pragma: no cover — type-only imports
     from tolokaforge.core.docker_runtime import RunnerClient
 
 __all__ = [
+    "EnvHandle",
     "InMemoryRuntimeBackend",
+    "ProvisionError",
+    "ProvisionStage",
     "RuntimeBackend",
     "RuntimeBackendCallLog",
 ]
+
+
+# ---------------------------------------------------------------------------
+# EnvHandle — opaque per-trial handle
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EnvHandle(Protocol):
+    """Opaque per-trial handle returned by :meth:`RuntimeBackend.provision`.
+
+    Each backend defines the handle's internal shape (compose project name,
+    pod identity, remote-lease id). Callers may only read :attr:`trial_id`;
+    everything else is backend-private.
+
+    The typing is deliberately narrow so future backends can serialise the
+    handle across a process boundary (a remote provisioner returning a
+    small dict) without breaking the Protocol.
+    """
+
+    trial_id: str
+
+
+# ---------------------------------------------------------------------------
+# ProvisionError — typed failure for the provisioning lifecycle
+# ---------------------------------------------------------------------------
+
+
+ProvisionStage = Literal["provision", "await_ready"]
+
+
+class ProvisionError(Exception):
+    """Raised when :meth:`RuntimeBackend.provision` or
+    :meth:`RuntimeBackend.await_ready` cannot bring the trial environment
+    up to the state the manifest declares.
+
+    The provisioner is expected to make a best-effort teardown of anything
+    it partially materialised before raising. Callers may call
+    :meth:`RuntimeBackend.teardown` again defensively — teardown is
+    idempotent.
+    """
+
+    def __init__(self, *, trial_id: str, stage: ProvisionStage, reason: str) -> None:
+        super().__init__(f"[{stage}] trial={trial_id}: {reason}")
+        self.trial_id = trial_id
+        self.stage = stage
+        self.reason = reason
 
 
 # ---------------------------------------------------------------------------
@@ -39,14 +94,14 @@ __all__ = [
 class RuntimeBackend(Protocol):
     """The orchestrator's execution surface for trials.
 
-    Declares the lifecycle the orchestrator drives and the one
-    trial-state operation that runs *before* a per-trial adapter exists
-    (the retry-cleanup path). Per-trial operations after registration
-    flow through :class:`DockerRunnerAdapter`, which is constructed
-    from :attr:`executor_client`.
+    Declares the run-level lifecycle, the per-trial provisioning surface,
+    and the one trial-state operation that runs *before* a per-trial
+    adapter exists (the retry-cleanup path). Per-trial operations after
+    registration flow through :class:`DockerRunnerAdapter`, which is
+    constructed from :attr:`executor_client`.
     """
 
-    # ---- Lifecycle ----
+    # ---- Run-level lifecycle ----
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         """Establish the runtime connection (or no-op for an in-memory impl).
 
@@ -81,6 +136,55 @@ class RuntimeBackend(Protocol):
         """
         ...
 
+    # ---- Per-trial provisioning surface (ADR-0010) ----
+    def provision(self, spec: TrialSpec) -> EnvHandle:
+        """Bring up the trial's environment; return an opaque handle.
+
+        Reads ``spec.task.environment_manifest`` to materialise the
+        services the manifest declares. When ``environment_manifest`` is
+        ``None``, the backend returns a handle pointing at whatever
+        shared-stack view it keeps (backwards-compat).
+
+        A backend that cannot enforce a declared property of the manifest
+        (``read_only`` mount, ``network`` mode, ``resources`` cap,
+        ``security_context`` field) MUST raise :class:`ProvisionError`
+        with ``stage="provision"`` rather than silently degrade.
+
+        On partial-startup failure the backend is expected to attempt a
+        best-effort teardown of anything already brought up before
+        raising. Callers may still call :meth:`teardown` defensively —
+        teardown is idempotent.
+        """
+        ...
+
+    def await_ready(self, handle: EnvHandle) -> None:
+        """Block until every service in ``handle`` passes its health probe.
+
+        Raises :class:`ProvisionError` with ``stage="await_ready"`` on
+        timeout. The handle remains valid after the failure; callers
+        must invoke :meth:`teardown` to clean up the containers that were
+        brought up before the probe timed out.
+        """
+        ...
+
+    def endpoints(self, handle: EnvHandle) -> EnvEndpoints:
+        """Resolve per-trial service URLs for ``handle``.
+
+        Does NOT block on readiness; that is :meth:`await_ready`'s job.
+        Returns a fully populated :class:`EnvEndpoints`; when the
+        manifest is ``None``, returns the run-wide shared endpoints.
+        """
+        ...
+
+    def teardown(self, handle: EnvHandle) -> None:
+        """Stop and remove the resources the handle references.
+
+        Idempotent — calling on an already-torn-down handle is a no-op,
+        not an error. Best-effort — logs but does not raise if a
+        resource is already gone.
+        """
+        ...
+
     # ---- Per-trial adapter handoff ----
     executor_client: RunnerClient
     """The RPC client used by :class:`DockerRunnerAdapter` for per-trial
@@ -108,6 +212,21 @@ class RuntimeBackendCallLog:
     close_calls: int = 0
     health_check_calls: int = 0
     cleanup_trial_calls: list[str] = field(default_factory=list)
+    provisioned_trials: list[str] = field(default_factory=list)
+    await_ready_calls: list[str] = field(default_factory=list)
+    endpoints_calls: list[str] = field(default_factory=list)
+    torn_down_trials: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _InMemoryEnvHandle:
+    """Concrete handle type returned by :class:`InMemoryRuntimeBackend`.
+
+    Satisfies the :class:`EnvHandle` Protocol structurally via the
+    ``trial_id`` attribute.
+    """
+
+    trial_id: str
 
 
 class _UnusableExecutorClient:
@@ -132,14 +251,39 @@ class _UnusableExecutorClient:
 class InMemoryRuntimeBackend:
     """Non-gRPC :class:`RuntimeBackend` implementation.
 
-    Records lifecycle and cleanup calls on :attr:`call_log`; exposes a
-    stub :attr:`executor_client` that raises on RPC method access.
+    Records lifecycle, cleanup, and provisioning calls on :attr:`call_log`.
+    Exposes a stub :attr:`executor_client` that raises on RPC method access.
+
+    Constructor knobs let orchestrator-level tests exercise the failure
+    branches of the provisioning contract without a real substrate:
+
+    * ``fail_provision_after_service`` — when set, :meth:`provision`
+      raises :class:`ProvisionError` with ``stage="provision"`` after
+      recording that the named service in the manifest was reached. A
+      best-effort :meth:`teardown` is called before the raise so the
+      call log captures that pattern.
+    * ``await_ready_times_out`` — when ``True``, :meth:`await_ready`
+      raises :class:`ProvisionError` with ``stage="await_ready"``. The
+      handle stays valid; the caller must still call :meth:`teardown`.
+    * ``container_missing_on_teardown`` — when ``True``, :meth:`teardown`
+      records its call but takes no other action, matching a real
+      backend's best-effort behaviour when a container is already gone.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        fail_provision_after_service: str | None = None,
+        await_ready_times_out: bool = False,
+        container_missing_on_teardown: bool = False,
+    ) -> None:
         self.call_log = RuntimeBackendCallLog()
         self.executor_client: Any = _UnusableExecutorClient()
+        self._fail_provision_after_service = fail_provision_after_service
+        self._await_ready_times_out = await_ready_times_out
+        self._container_missing_on_teardown = container_missing_on_teardown
 
+    # ---- Run-level lifecycle ----
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         self.call_log.connect_calls.append({"timeout": timeout, "retry_interval": retry_interval})
 
@@ -153,3 +297,47 @@ class InMemoryRuntimeBackend:
     def cleanup_trial(self, trial_id: str) -> dict[str, Any]:
         self.call_log.cleanup_trial_calls.append(trial_id)
         return {"success": True, "error": None}
+
+    # ---- Per-trial provisioning ----
+    def provision(self, spec: TrialSpec) -> EnvHandle:
+        trial_id = spec.trial_id
+        self.call_log.provisioned_trials.append(trial_id)
+        handle = _InMemoryEnvHandle(trial_id=trial_id)
+        manifest = spec.task.environment_manifest
+        if self._fail_provision_after_service is not None and manifest is not None:
+            service_names = [s.name for s in manifest.services]
+            if self._fail_provision_after_service in service_names:
+                # Best-effort teardown of anything materialised so far.
+                self.teardown(handle)
+                raise ProvisionError(
+                    trial_id=trial_id,
+                    stage="provision",
+                    reason=(
+                        f"partial startup — failed after service "
+                        f"{self._fail_provision_after_service!r}"
+                    ),
+                )
+        return handle
+
+    def await_ready(self, handle: EnvHandle) -> None:
+        self.call_log.await_ready_calls.append(handle.trial_id)
+        if self._await_ready_times_out:
+            raise ProvisionError(
+                trial_id=handle.trial_id,
+                stage="await_ready",
+                reason="health-probe timeout",
+            )
+
+    def endpoints(self, handle: EnvHandle) -> EnvEndpoints:
+        self.call_log.endpoints_calls.append(handle.trial_id)
+        return EnvEndpoints(
+            db_url=f"http://in-memory-db-{handle.trial_id}:5432",
+            rag_url=None,
+            runner_url=f"http://in-memory-runner-{handle.trial_id}:50051",
+        )
+
+    def teardown(self, handle: EnvHandle) -> None:
+        self.call_log.torn_down_trials.append(handle.trial_id)
+        # container_missing_on_teardown is best-effort no-raise; the call is
+        # still recorded above, matching a real backend's log-and-move-on.
+        _ = self._container_missing_on_teardown


### PR DESCRIPTION
## TL;DR

Ships ADR-0010 (`Proposed`) plus the `RuntimeBackend` provisioning surface: four new methods (`provision` / `await_ready` / `endpoints` / `teardown`), an opaque `EnvHandle` Protocol, and a typed `ProvisionError` exception. Same declare-in-schema / consumer-enforces-later pattern that shipped ADR-0009's manifest schema, applied one layer down at the substrate.

**Impact on existing tasks: none.** `DockerRuntime` adapts with no-op `provision` / `teardown` and shared-stack endpoints — every existing task runs through the same code path it did before. `InMemoryRuntimeBackend` gains matching methods + failure knobs for test injection.

Closes #117.

---

## What ships

- **ADR-0010** — full design, industry precedents, decision drivers, considered options, enforcement obligations table (9 manifest fields × their provisioner obligations), lifecycle ownership, failure semantics, selection mechanism.
- **`RuntimeBackend` Protocol extension** in `tolokaforge/core/runtime.py` — the 4 new methods added beside the existing lifecycle surface. Protocol stays `@runtime_checkable`.
- **`EnvHandle`** — opaque `@runtime_checkable` Protocol. Only `trial_id` is public; every backend defines its own internals (compose project name, pod identity, remote lease id). Typing leaves room for future serialisable handles (remote provisioning) without forcing it now.
- **`ProvisionError`** — typed exception with `trial_id`, `stage: Literal["provision", "await_ready"]`, `reason`.
- **`DockerRuntime` adaptation** — 4 no-op / shared-stack methods that preserve today's behaviour exactly. Ships a private `_SharedStackHandle` dataclass carrying the trial_id.
- **`InMemoryRuntimeBackend` extension** — 4 new methods, extended `RuntimeBackendCallLog` (`provisioned_trials`, `await_ready_calls`, `endpoints_calls`, `torn_down_trials`), and three failure knobs (`fail_provision_after_service`, `await_ready_times_out`, `container_missing_on_teardown`) for orchestrator-level tests to drive failure paths without a real substrate.
- **Contract tests** — 46 total (17 pre-existing pinning the ADR-0007 surface + 29 new pinning the ADR-0010 surface). Every new method, every failure semantic, both impls' Protocol conformance.
- **`adr/README.md`** — ADR-0010 row added.

---

## Enforcement obligations (the ADR's core contract)

The ADR states plainly: a `RuntimeBackend` implementation is **contractually obligated** to honour these manifest declarations. Failure to enforce any of them at `provision` time — not later, not silently — is a contract violation.

| Manifest field | Provisioner obligation |
|---|---|
| `EnvironmentManifest.network` = `isolated` | No public-internet egress; no cross-trial reachability. |
| `EnvironmentManifest.network` = `external` | Egress permitted; still no cross-trial reachability. |
| `ServiceSpec.security_context` | Every declared field applied (`run_as_user`, `read_only_root_filesystem`, `no_new_privileges`, capability drops/adds). |
| `ServiceSpec.resources` / manifest-level `Resources` | CPU / memory caps applied at the container level. |
| `VolumeMount.read_only` | Bind or named mount honours the flag. |
| `ServiceSpec.health` + `HealthProbe.initial_delay_seconds` | `await_ready` respects the delay before the first probe. |
| `ServiceSpec.depends_on` (either form) | Startup ordering; `service_healthy` waits on the probe passing. |
| `EnvironmentManifest.initial_state` | Fixture applied per its `kind` (`sql` / `copy` / `script`) before `await_ready` returns. |
| `ServiceSpec.image` pinning | Substrate honours the exact tag or digest; no automatic tag resolution. |

**Rule of thumb: if the substrate cannot enforce a declared property, `provision` raises `ProvisionError`. No provisioner may silently drop, downgrade, or ignore a declaration.**

The manifest's safety declarations were theatre until this ADR — now they carry a written contract clause. The first backend that actually enforces them lands in the next PR (`LocalRuntimeBackend`).

---

## Design highlights

**One face, not two.** Provisioning is methods on `RuntimeBackend`, not a separate `Provisioner` Protocol. Rationale: every future backend implements both anyway; splitting doubles the injection surface without a near-term need.

**Opaque `EnvHandle`.** Backends define their own internals — compose project name, pod identity, remote lease id. Callers may read `trial_id` and nothing else. The typing is deliberately narrow so future backends can serialise the handle across a process boundary (a `RemoteEnvHandle` returning `{trial_id, provider, lease_id}`) without breaking the Protocol.

**`ProvisionError.stage` distinguishes failure points.** `"provision"` for partial-startup failure (containers didn't come up); `"await_ready"` for health-probe timeout (containers up but not ready). Callers can decide policy differently — e.g. retry immediately on `await_ready` timeout, but back off on `provision` failure.

**Idempotent `teardown`.** Callers use `try / finally` freely; double-teardown is a no-op, not an error. Same guarantee applies when `provision` raises after its best-effort self-teardown — a defensive `teardown` call in the `finally` still won't raise.

**Config-driven selection.** `runtime.backend: local | shared` (default `shared` — today's behaviour preserved). Additional backends slot in behind the same key without breaking existing configs.

**`stream_logs` deferred.** The internal architecture sketch listed a `stream_logs` method; deferred because no consumer needs streaming today (grading reads final state, not live streams). Added as a Protocol method when a consumer materialises.

---

## Prior art (why this shape isn't novel)

The four-method surface is the widely-used shape of per-scope environment materialisation. ADR-0010 anchors against these precedents — full write-up in the ADR's "Industry precedents studied" section:

- **Testcontainers** (primary precedent, https://testcontainers.com) — `start()` + `waitingFor(strategy)` + `getMappedPort()` + `stop()` maps 1:1 to `provision` / `await_ready` / `endpoints` / `teardown`; their `ContainerState` is the analog of our opaque `EnvHandle`; their `WaitStrategy` is what `HealthProbe` (ADR-0009) compiles to.
- **Inspect AI sandbox providers** (UK AISI, https://inspect.aisi.org.uk/sandboxing.html) — same "one Protocol, many backends" decision; a single `SandboxEnvironment` interface backed by docker / K8s / local providers. Cross-checking against Inspect's provider set validated four lifecycle methods are sufficient.
- **Docker Compose CLI** — `up -d --wait` / `port` / `down -v` is the substrate `LocalRuntimeBackend` will compile the manifest to.
- **Kubernetes Pod lifecycle** — create → readinessProbe → Service DNS → delete. Called out as *pattern preserved*, not a backend commitment. If a cluster backend ever lands, Kubernetes Agent Sandbox (kubernetes-sigs, https://agent-sandbox.sigs.k8s.io) is the natural forward target.
- **SWE-bench harness** — per-instance ephemeral container per trial; the isolation posture our `provision` / `teardown` obligations codify.
- **HashiCorp Terraform providers** — the staged failure model (`plan` / `apply` / `refresh`) is the precedent for `ProvisionError.stage: Literal["provision", "await_ready"]`.

The opaque `EnvHandle` follows a common cloud-SDK convention (AWS SDK waiters, K8s dynamic client's `*unstructured.Unstructured`, Testcontainers `ContainerState`) — callers treat handles as opaque; only the issuing backend interprets fields. The typing does not commit to Python-object handles; a serializable dict handle is a valid future extension for a remote backend without breaking the Protocol.

---

## What this PR does NOT change

- **No `Conductor` changes.** The conductor keeps its current call sites (`_run_trial` / today's `docker_runtime.executor_client` handoff). Wiring the conductor to call `provision` / `teardown` per trial lands in the next-next PR after `LocalRuntimeBackend`.
- **No `Orchestrator` selection logic.** Config-driven backend selection lands with the conductor wiring.
- **No behavioural change for existing tasks.** `DockerRuntime` is the default; its new methods are no-ops that preserve the shared-stack semantics.

---

## Verification

```
$ uv run ruff check tolokaforge tests
All checks passed!

$ uv run pytest tests/canonical/test_runtime_backend_contract.py -q
46 passed in 0.09s        # was 17; +29 for the new surface

$ uv run pytest tests/ -m canonical -q
355 passed                # was 326; +29 for the new surface

$ uv run pytest tests/ -m unit -q
1871 passed, 1 skipped    # unchanged
```

**No live-LLM smoke required** — pure schema-level PR; the concrete substrate lands in the next PR.

---

## What's next

`LocalRuntimeBackend` — the first concrete consumer that actually enforces the obligations. Reuses the existing `ServiceStack` primitive from `tolokaforge/docker/stack.py` to materialise each trial's `EnvironmentManifest` as its own isolated compose project. Once that PR merges + validates the contract end-to-end, ADR-0010 flips from `Proposed` to `Accepted`.

