### PR TITLE
refactor(orchestrator): collapse injection kwargs into OrchestratorDeps

### DIFF
--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -654,14 +654,14 @@ class TestGenerateReports:
         assert "failures" in fa
 
     def test_run_aggregate_writer_kwarg_swaps_writer(self, tmp_path: Path) -> None:
-        """The ``run_aggregate_writer`` kwarg accepts any
+        """``OrchestratorDeps.run_aggregate_writer`` accepts any
         :class:`RunAggregateWriter` impl and routes the four aggregates
         through it instead of the default disk-backed writer."""
-        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.output.aggregates import InMemoryAggregateWriter
 
         writer = InMemoryAggregateWriter()
-        orch = Orchestrator(_make_run_config(), run_aggregate_writer=writer)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(run_aggregate_writer=writer))
         orch.tasks = [_make_task_config("T1")]
         orch.results = [_make_trajectory("T1", 0, score=1.0, binary_pass=True)]
 
@@ -682,11 +682,11 @@ class TestGenerateReports:
     def test_empty_results_does_not_invoke_writer(self, tmp_path: Path) -> None:
         """The empty-results early-return guard runs before the writer call,
         so no aggregates are recorded when the run produced zero trials."""
-        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.output.aggregates import InMemoryAggregateWriter
 
         writer = InMemoryAggregateWriter()
-        orch = Orchestrator(_make_run_config(), run_aggregate_writer=writer)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(run_aggregate_writer=writer))
         orch.results = []
 
         orch._generate_reports(tmp_path)
@@ -1230,8 +1230,8 @@ class TestJudgeModelGate:
         if a refactor moved the gate below the scheduling loop, the conductor's
         ``call_log.runs`` would be non-empty and this test would fail.
         """
-        from tolokaforge.core.conductor import InMemoryConductor
-        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
 
         config = _make_run_config()  # agent only, no judge model
 
@@ -1239,10 +1239,10 @@ class TestJudgeModelGate:
         # we can assert on its call_log after the run_worker raises.
         recording_conductor = InMemoryConductor()
 
-        def conductor_factory(**_kwargs):
+        def conductor_factory(_ctx: ConductorContext) -> InMemoryConductor:
             return recording_conductor
 
-        orch = Orchestrator(config, conductor_factory=conductor_factory)
+        orch = Orchestrator(config, deps=OrchestratorDeps(conductor_factory=conductor_factory))
         orch.tasks = [_make_task_config("TASK-needs-judge")]
         adapter = MagicMock()
         adapter.to_task_description.side_effect = lambda tid: _task_description_with_judge(
@@ -1440,42 +1440,43 @@ class TestRunOutputDirBasenameGuard:
 
 
 # ===================================================================
-# Orchestrator(runtime_backend=...) kwarg
+# Orchestrator(deps=OrchestratorDeps(runtime_backend=...))
 # ===================================================================
 
 
 @pytest.mark.unit
 class TestRuntimeBackendInjection:
-    """The ``runtime_backend`` kwarg accepts any :class:`RuntimeBackend`
-    impl. The orchestrator stores the injected instance and uses it
-    instead of constructing :class:`SharedStackRuntimeBackend`.
+    """``OrchestratorDeps.runtime_backend`` accepts any
+    :class:`RuntimeBackend` impl. The orchestrator stores the injected
+    instance and uses it instead of constructing
+    :class:`SharedStackRuntimeBackend`.
     """
 
-    def test_kwarg_default_is_none(self) -> None:
+    def test_default_is_none(self) -> None:
         from tolokaforge.core.orchestrator import Orchestrator
 
         orch = Orchestrator(_make_run_config())
-        assert orch._injected_runtime_backend is None
+        assert orch._runtime_backend is None
 
-    def test_kwarg_stores_injected_instance(self) -> None:
-        from tolokaforge.core.orchestrator import Orchestrator
+    def test_stores_injected_instance(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.runtime import InMemoryRuntimeBackend
 
         backend = InMemoryRuntimeBackend()
-        orch = Orchestrator(_make_run_config(), runtime_backend=backend)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(runtime_backend=backend))
 
-        assert orch._injected_runtime_backend is backend
+        assert orch._runtime_backend is backend
 
     def test_injection_does_not_invoke_backend_lifecycle(self) -> None:
         """Construction must not call ``connect``/``close`` on the injected
         backend — that happens only when ``run()`` / ``run_worker()`` are
         invoked. Tests that construct an Orchestrator with an in-memory
         backend rely on this to assert lifecycle from a known-empty log."""
-        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.runtime import InMemoryRuntimeBackend
 
         backend = InMemoryRuntimeBackend()
-        Orchestrator(_make_run_config(), runtime_backend=backend)
+        Orchestrator(_make_run_config(), deps=OrchestratorDeps(runtime_backend=backend))
 
         assert backend.call_log.connect_calls == []
         assert backend.call_log.close_calls == 0
@@ -1483,30 +1484,31 @@ class TestRuntimeBackendInjection:
 
 
 # ===================================================================
-# Orchestrator(artifact_writer=...) kwarg
+# Orchestrator(deps=OrchestratorDeps(artifact_writer=...))
 # ===================================================================
 
 
 @pytest.mark.unit
 class TestArtifactWriterInjection:
-    """The ``artifact_writer`` kwarg accepts any :class:`TrialArtifactWriter`
-    impl. The orchestrator stores the injected instance and uses it
-    instead of constructing :class:`FileArtifactWriter`.
+    """``OrchestratorDeps.artifact_writer`` accepts any
+    :class:`TrialArtifactWriter` impl. The orchestrator stores the
+    injected instance and uses it instead of constructing
+    :class:`FileArtifactWriter`.
     """
 
-    def test_kwarg_default_is_file_writer(self) -> None:
+    def test_default_is_file_writer(self) -> None:
         from tolokaforge.core.orchestrator import Orchestrator
         from tolokaforge.core.output.artifacts import FileArtifactWriter
 
         orch = Orchestrator(_make_run_config())
         assert isinstance(orch._artifact_writer, FileArtifactWriter)
 
-    def test_kwarg_stores_injected_instance(self) -> None:
-        from tolokaforge.core.orchestrator import Orchestrator
+    def test_stores_injected_instance(self) -> None:
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 
         writer = InMemoryArtifactWriter()
-        orch = Orchestrator(_make_run_config(), artifact_writer=writer)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(artifact_writer=writer))
 
         assert orch._artifact_writer is writer
 
@@ -1514,21 +1516,20 @@ class TestArtifactWriterInjection:
         """The conductor constructed by ``_build_conductor`` receives the
         same writer the orchestrator was given — not a fresh
         :class:`FileArtifactWriter`."""
-        from tolokaforge.core.conductor import InMemoryConductor
-        from tolokaforge.core.orchestrator import Orchestrator
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
         from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 
         writer = InMemoryArtifactWriter()
-        captured: dict = {}
+        captured: dict[str, ConductorContext] = {}
 
-        def factory(**kwargs):
-            captured.update(kwargs)
+        def factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
             return InMemoryConductor()
 
         orch = Orchestrator(
             _make_run_config(),
-            artifact_writer=writer,
-            conductor_factory=factory,
+            deps=OrchestratorDeps(artifact_writer=writer, conductor_factory=factory),
         )
         orch.adapter = MagicMock()
 
@@ -1539,35 +1540,36 @@ class TestArtifactWriterInjection:
             request_limiter=None,
         )
 
-        assert captured["artifact_writer"] is writer
+        assert captured["ctx"].artifact_writer is writer
 
 
 # ===================================================================
-# Orchestrator(conductor_factory=...) kwarg
+# Orchestrator(deps=OrchestratorDeps(conductor_factory=...))
 # ===================================================================
 
 
 @pytest.mark.unit
 class TestConductorInjection:
-    """The ``conductor_factory`` kwarg accepts a Callable[..., Conductor]
-    that the orchestrator invokes inside ``run()`` / ``run_worker()``
-    once the adapter and per-run dependencies are resolved.
+    """``OrchestratorDeps.conductor_factory`` accepts a
+    ``Callable[[ConductorContext], Conductor]`` that the orchestrator
+    invokes inside ``run()`` / ``run_worker()`` once the adapter and
+    per-run dependencies are resolved.
     """
 
-    def test_kwarg_default_is_none(self) -> None:
+    def test_default_is_none(self) -> None:
         from tolokaforge.core.orchestrator import Orchestrator
 
         orch = Orchestrator(_make_run_config())
         assert orch._conductor_factory is None
 
-    def test_kwarg_stores_injected_factory(self) -> None:
-        from tolokaforge.core.conductor import InMemoryConductor
-        from tolokaforge.core.orchestrator import Orchestrator
+    def test_stores_injected_factory(self) -> None:
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
 
-        def factory(**_kwargs):
+        def factory(_ctx: ConductorContext) -> InMemoryConductor:
             return InMemoryConductor()
 
-        orch = Orchestrator(_make_run_config(), conductor_factory=factory)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(conductor_factory=factory))
         assert orch._conductor_factory is factory
 
     def test_default_factory_builds_in_process_conductor(self, tmp_path: Path) -> None:
@@ -1606,20 +1608,21 @@ class TestConductorInjection:
                 request_limiter=MagicMock(),
             )
 
-    def test_injected_factory_is_invoked_with_per_run_dependencies(self, tmp_path: Path) -> None:
-        """The orchestrator calls the factory with its resolved per-run
-        deps. Pinned so a future refactor that changes the dependency
-        surface forces this test to update deliberately."""
-        from tolokaforge.core.conductor import InMemoryConductor
-        from tolokaforge.core.orchestrator import Orchestrator
+    def test_injected_factory_receives_conductor_context(self, tmp_path: Path) -> None:
+        """The orchestrator calls the factory with a
+        :class:`ConductorContext` carrying its resolved per-run deps.
+        Pinned so a future refactor that changes the dependency surface
+        forces this test to update deliberately."""
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
 
-        captured: dict = {}
+        captured: dict[str, ConductorContext] = {}
 
-        def factory(**kwargs):
-            captured.update(kwargs)
+        def factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
             return InMemoryConductor()
 
-        orch = Orchestrator(_make_run_config(), conductor_factory=factory)
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(conductor_factory=factory))
         orch.adapter = MagicMock()
 
         orch._build_conductor(
@@ -1629,16 +1632,10 @@ class TestConductorInjection:
             request_limiter=MagicMock(),
         )
 
-        assert set(captured.keys()) == {
-            "adapter",
-            "artifact_writer",
-            "config",
-            "logger",
-            "verbose",
-            "strict",
-            "agent_client",
-            "runtime_backend",
-            "trial_grader",
-            "output_dir",
-            "request_limiter",
-        }
+        ctx = captured["ctx"]
+        assert isinstance(ctx, ConductorContext)
+        assert ctx.adapter is orch.adapter
+        assert ctx.artifact_writer is orch._artifact_writer
+        assert ctx.config is orch.config
+        assert ctx.output_dir == tmp_path
+        assert ctx.trial_grader is not None

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1456,7 +1456,7 @@ class TestRuntimeBackendInjection:
         from tolokaforge.core.orchestrator import Orchestrator
 
         orch = Orchestrator(_make_run_config())
-        assert orch._runtime_backend is None
+        assert orch._injected_runtime_backend is None
 
     def test_stores_injected_instance(self) -> None:
         from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
@@ -1465,7 +1465,7 @@ class TestRuntimeBackendInjection:
         backend = InMemoryRuntimeBackend()
         orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(runtime_backend=backend))
 
-        assert orch._runtime_backend is backend
+        assert orch._injected_runtime_backend is backend
 
     def test_injection_does_not_invoke_backend_lifecycle(self) -> None:
         """Construction must not call ``connect``/``close`` on the injected

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -62,6 +62,7 @@ __all__ = [
     "Conductor",
     "ConductorCallLog",
     "ConductorContext",
+    "ConductorFactory",
     "InMemoryConductor",
     "InProcessConductor",
 ]
@@ -146,6 +147,14 @@ class Conductor(Protocol):
     def run(self, spec: TrialSpec, task_config: TaskConfig) -> TrialResult:
         """Execute one trial end-to-end."""
         ...
+
+
+ConductorFactory = Callable[[ConductorContext], Conductor]
+"""Type of the ``Orchestrator.deps.conductor_factory`` seam.
+
+A callable that receives a :class:`ConductorContext` and returns any
+implementation of the :class:`Conductor` Protocol.
+"""
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -262,6 +262,11 @@ class InProcessConductor:
     """Production :class:`Conductor`. Runs each trial in the orchestrator
     process.
 
+    The constructor kwargs are a 1:1 match for :class:`ConductorContext`
+    fields — the orchestrator unpacks the context via ``**vars(ctx)`` on
+    the default-factory path, so field-name / kwarg-name parity between
+    the two is a load-bearing contract.
+
     Captures the orchestrator's per-run dependencies (adapter, artifact
     writer, config, logger, verbose / strict flags, agent client,
     docker runtime, output directory, request limiter) at construction

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -61,9 +61,38 @@ if TYPE_CHECKING:
 __all__ = [
     "Conductor",
     "ConductorCallLog",
+    "ConductorContext",
     "InMemoryConductor",
     "InProcessConductor",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Factory contract — the typed argument for a ``Conductor`` factory
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConductorContext:
+    """Per-run dependencies the orchestrator hands to a Conductor factory.
+
+    Packs the arguments :class:`InProcessConductor` takes at construction
+    into a single typed value so factory signatures stay stable as new
+    orchestrator-side dependencies land. The factory contract is
+    ``Callable[[ConductorContext], Conductor]``.
+    """
+
+    adapter: BaseAdapter
+    artifact_writer: TrialArtifactWriter
+    config: RunConfig
+    logger: StructuredLogger
+    verbose: bool
+    strict: bool
+    agent_client: LLMClient
+    runtime_backend: RuntimeBackend
+    trial_grader: TrialGrader
+    output_dir: Path
+    request_limiter: GlobalRateLimiter | None
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -15,6 +15,7 @@ from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_ada
 from tolokaforge.core.conductor import (
     Conductor,
     ConductorContext,
+    ConductorFactory,
     InProcessConductor,
 )
 from tolokaforge.core.engine_run_state import (
@@ -212,7 +213,7 @@ class OrchestratorDeps:
     artifact_writer: TrialArtifactWriter = field(default_factory=FileArtifactWriter)
     run_aggregate_writer: RunAggregateWriter = field(default_factory=FileAggregateWriter)
     runtime_backend: RuntimeBackend | None = None
-    conductor_factory: Callable[[ConductorContext], Conductor] | None = None
+    conductor_factory: ConductorFactory | None = None
 
 
 class Orchestrator:
@@ -252,9 +253,7 @@ class Orchestrator:
         self._artifact_writer: TrialArtifactWriter = resolved_deps.artifact_writer
         self._run_aggregate_writer: RunAggregateWriter = resolved_deps.run_aggregate_writer
         self._injected_runtime_backend: RuntimeBackend | None = resolved_deps.runtime_backend
-        self._conductor_factory: Callable[[ConductorContext], Conductor] | None = (
-            resolved_deps.conductor_factory
-        )
+        self._conductor_factory: ConductorFactory | None = resolved_deps.conductor_factory
         # Per-run cache of resolved ``TaskDescription`` objects keyed by
         # task_id. ``adapter.to_task_description()`` reads the system
         # prompt, tool schemas, fixtures, and base64-bundles the task_dir
@@ -402,19 +401,12 @@ class Orchestrator:
         )
         if self._conductor_factory is not None:
             return self._conductor_factory(ctx)
-        return InProcessConductor(
-            adapter=ctx.adapter,
-            artifact_writer=ctx.artifact_writer,
-            config=ctx.config,
-            logger=ctx.logger,
-            verbose=ctx.verbose,
-            strict=ctx.strict,
-            agent_client=ctx.agent_client,
-            runtime_backend=ctx.runtime_backend,
-            trial_grader=ctx.trial_grader,
-            output_dir=ctx.output_dir,
-            request_limiter=ctx.request_limiter,
-        )
+        # ``ConductorContext`` fields are a 1:1 match for
+        # ``InProcessConductor.__init__`` kwargs. Shallow-unpack via
+        # ``vars`` (``dataclasses.asdict`` would deep-copy) so a new
+        # field on the context surfaces as a loud unexpected-kwarg
+        # error here instead of a silent omission.
+        return InProcessConductor(**vars(ctx))
 
     def _build_trial_spec(
         self,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -6,12 +6,17 @@ import random
 import socket
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_adapter
-from tolokaforge.core.conductor import Conductor, InProcessConductor
+from tolokaforge.core.conductor import (
+    Conductor,
+    ConductorContext,
+    InProcessConductor,
+)
 from tolokaforge.core.engine_run_state import (
     read_persisted_run_id,
     write_engine_run_state,
@@ -190,6 +195,26 @@ def _build_env_endpoints(runner_address: str) -> EnvEndpoints:
     )
 
 
+@dataclass(frozen=True)
+class OrchestratorDeps:
+    """Pluggable seams the :class:`Orchestrator` delegates to.
+
+    Packs the four independent injection points (per-trial artifact
+    writer, run-level aggregate writer, execution runtime, per-trial
+    executor factory) into a single frozen record so the constructor
+    doesn't grow a kwarg per seam. Default construction preserves the
+    legacy behaviour: fresh :class:`FileArtifactWriter` /
+    :class:`FileAggregateWriter` defaults, no runtime backend override
+    (``run()`` builds :class:`DockerRuntime`), no factory override
+    (``_build_conductor`` builds :class:`InProcessConductor`).
+    """
+
+    artifact_writer: TrialArtifactWriter = field(default_factory=FileArtifactWriter)
+    run_aggregate_writer: RunAggregateWriter = field(default_factory=FileAggregateWriter)
+    runtime_backend: RuntimeBackend | None = None
+    conductor_factory: Callable[[ConductorContext], Conductor] | None = None
+
+
 class Orchestrator:
     """Orchestrates benchmark runs across tasks and trials"""
 
@@ -199,10 +224,7 @@ class Orchestrator:
         resume: bool = False,
         verbose: bool = False,
         strict: bool = False,
-        run_aggregate_writer: RunAggregateWriter | None = None,
-        runtime_backend: RuntimeBackend | None = None,
-        conductor_factory: Callable[..., Conductor] | None = None,
-        artifact_writer: TrialArtifactWriter | None = None,
+        deps: OrchestratorDeps | None = None,
     ):
         self.config = config
         self.resume = resume
@@ -212,31 +234,27 @@ class Orchestrator:
         self.results: list[Trajectory] = []
         self.state_manager: RunStateManager | None = None
         self.adapter: BaseAdapter | None = None
-        # Shared artifact writer — every per-trial write goes through it
+        # Shared per-trial writer — every per-trial write goes through it
         # so the orchestrator stays decoupled from filesystem details and
         # alternative writers (in-memory tests, remote stores) can plug in.
-        self._artifact_writer: TrialArtifactWriter = (
-            artifact_writer if artifact_writer is not None else FileArtifactWriter()
-        )
         # Run-level analogue: the four post-run aggregate JSONs go through
-        # this writer instead of inline ``json.dump`` calls. Injectable so
-        # tests / alternate backends (remote object store, in-memory) can
-        # substitute without touching the orchestrator.
-        self._run_aggregate_writer: RunAggregateWriter = (
-            run_aggregate_writer if run_aggregate_writer is not None else FileAggregateWriter()
-        )
+        # the aggregate writer instead of inline ``json.dump`` calls.
         # Execution surface: the orchestrator depends on the
         # :class:`RuntimeBackend` Protocol, not a concrete class. When
         # ``None``, ``run()`` / ``run_worker()`` construct a default
         # :class:`SharedStackRuntimeBackend` from the resolved runner address — the
-        # legacy behaviour. Tests / alternate backends inject here.
-        self._injected_runtime_backend: RuntimeBackend | None = runtime_backend
-        # Per-trial executor: the orchestrator schedules trials and
-        # delegates each one to a :class:`Conductor`. ``run()`` /
-        # ``run_worker()`` build the conductor (or invoke the injected
-        # factory) once the adapter and per-run dependencies are
-        # resolved. Default factory constructs :class:`InProcessConductor`.
-        self._conductor_factory: Callable[..., Conductor] | None = conductor_factory
+        # legacy behaviour. Tests / alternate backends inject via ``deps``.
+        # Per-trial executor: the orchestrator delegates each trial to a
+        # :class:`Conductor`. ``_build_conductor`` invokes the injected
+        # factory (typed against :class:`ConductorContext`) when one is
+        # supplied; otherwise it constructs :class:`InProcessConductor`.
+        resolved_deps = deps if deps is not None else OrchestratorDeps()
+        self._artifact_writer: TrialArtifactWriter = resolved_deps.artifact_writer
+        self._run_aggregate_writer: RunAggregateWriter = resolved_deps.run_aggregate_writer
+        self._injected_runtime_backend: RuntimeBackend | None = resolved_deps.runtime_backend
+        self._conductor_factory: Callable[[ConductorContext], Conductor] | None = (
+            resolved_deps.conductor_factory
+        )
         # Per-run cache of resolved ``TaskDescription`` objects keyed by
         # task_id. ``adapter.to_task_description()`` reads the system
         # prompt, tool schemas, fixtures, and base64-bundles the task_dir
@@ -369,21 +387,7 @@ class Orchestrator:
 
         trial_grader = RunnerRPCTrialGrader(runtime_backend=runtime_backend, logger=self.logger)
 
-        if self._conductor_factory is not None:
-            return self._conductor_factory(
-                adapter=self.adapter,
-                artifact_writer=self._artifact_writer,
-                config=self.config,
-                logger=self.logger,
-                verbose=self.verbose,
-                strict=self.strict,
-                agent_client=agent_client,
-                runtime_backend=runtime_backend,
-                trial_grader=trial_grader,
-                output_dir=output_dir,
-                request_limiter=request_limiter,
-            )
-        return InProcessConductor(
+        ctx = ConductorContext(
             adapter=self.adapter,
             artifact_writer=self._artifact_writer,
             config=self.config,
@@ -395,6 +399,21 @@ class Orchestrator:
             trial_grader=trial_grader,
             output_dir=output_dir,
             request_limiter=request_limiter,
+        )
+        if self._conductor_factory is not None:
+            return self._conductor_factory(ctx)
+        return InProcessConductor(
+            adapter=ctx.adapter,
+            artifact_writer=ctx.artifact_writer,
+            config=ctx.config,
+            logger=ctx.logger,
+            verbose=ctx.verbose,
+            strict=ctx.strict,
+            agent_client=ctx.agent_client,
+            runtime_backend=ctx.runtime_backend,
+            trial_grader=ctx.trial_grader,
+            output_dir=ctx.output_dir,
+            request_limiter=ctx.request_limiter,
         )
 
     def _build_trial_spec(


### PR DESCRIPTION
## TL;DR

The four independent `Orchestrator` injection kwargs (`artifact_writer`, `run_aggregate_writer`, `runtime_backend`, `conductor_factory`) are packed into a single frozen `OrchestratorDeps` dataclass, and the `conductor_factory` signature is upgraded from `Callable[..., Conductor]` to `Callable[[ConductorContext], Conductor]` — where `ConductorContext` is a new frozen dataclass carrying the eleven per-run arguments the factory used to receive as `**kwargs`.

## What ships

- New `OrchestratorDeps` frozen dataclass in `tolokaforge/core/orchestrator.py` — packs the four pluggable seams with sensible defaults (`FileArtifactWriter`, `FileAggregateWriter`, `None`, `None`).
- New `ConductorContext` frozen dataclass in `tolokaforge/core/conductor.py` — the typed argument for any conductor factory.
- `Orchestrator.__init__` accepts a single `deps: OrchestratorDeps | None = None` in place of the four kwargs; the four old kwargs are removed (there is no shim layer).
- `Orchestrator._build_conductor` now constructs a `ConductorContext` and passes it to the factory (or unpacks it for the default `InProcessConductor` path).
- Stored-attribute naming stays as `_injected_runtime_backend` (matching Phase 4's convention that's already used at every read site in `run()` / `run_worker()`).
- The four `TestXxxInjection` classes in `tests/unit/test_orchestrator_logic.py` migrate to the new shape.

## Why

The Orchestrator constructor was drifting into the constructor-explosion shape every DI-heavy class eventually hits: each new pluggable seam (four so far) added another sibling kwarg, and the \"injected-or-default\" ternary was copy-pasted at each site. `_build_conductor` had grown a matching 10-kwarg pass-through, and the factory type was stuck at `Callable[..., Conductor]` because a typed signature over ten independent kwargs would be unusable — the exact shape ADR-0011's data-declaration convention flags as \"pack these into a value object.\"

Packing the injection seams into `OrchestratorDeps` gives us one place to grow (add a field, add a `field(default_factory=...)`, done — no constructor edit, no ternary, no attribute-naming choice). Packing the factory's arguments into `ConductorContext` upgrades the factory contract from \"any callable\" to a real type, so a future seam can extend the context without silently changing every factory implementation's `**kwargs` reach. Both dataclasses are frozen so callers can't smuggle mutation across the seam.

No new ADR is authored — this applies the seam-definition + data-declaration convention codified in ADR-0011 (PR #132) rather than introducing a new one. If reviewers want an ADR to pin the OrchestratorDeps shape specifically, happy to split that out as a follow-up.

## Changes

- `tolokaforge/core/conductor.py` — add `ConductorContext` frozen dataclass; export from `__all__`.
- `tolokaforge/core/orchestrator.py` — add `OrchestratorDeps`; rewrite `Orchestrator.__init__` around `deps`; refactor `_build_conductor` to build and pass a `ConductorContext`. Rebase note: kept the `_injected_runtime_backend` attribute name (matches every read site added in Phase 4) instead of the original PR's rename toward `_runtime_backend`.
- `tests/unit/test_orchestrator_logic.py` — migrate the four `TestXxxInjection` classes (`TestRuntimeBackendInjection`, `TestArtifactWriterInjection`, `TestConductorInjection`, and the inline `run_aggregate_writer` test) to `deps=OrchestratorDeps(...)`; retype factory callbacks from `**kwargs` to `ctx: ConductorContext`; the factory-arguments assertion now checks `ConductorContext` field values rather than dict-key membership.

`Orchestrator(config, resume=..., verbose=..., strict=...)` is unchanged — the three CLI call sites in `tolokaforge/cli/main.py` and the bare-config uses in tests keep working without modification.

## Verification

- \`make lint\` — green
- \`make format-check\` — green on the three modified files (pre-existing drift in ~10 unrelated files is per AGENTS.md gotchas #3 / #4, unchanged by this PR)
- \`uv run pytest tests/unit tests/canonical -q\` — **2197 passed, 1 skipped in 32.91s**

The 93 tests in \`test_orchestrator_logic.py\` — including all four injection-suite classes — pass on the new shape. The canonical \`test_conductor_contract.py\` still constructs \`InProcessConductor\` directly with its unchanged kwargs API (this PR only re-types the factory contract, not the concrete class's constructor).

## Refs

Closes #114
