### PR TITLE
refactor(runtime): promote RunnerClient to a Protocol; rename concrete to GrpcRunnerClient

### DIFF
--- a/tests/canonical/test_runner_client_contract.py
+++ b/tests/canonical/test_runner_client_contract.py
@@ -1,0 +1,126 @@
+"""Pin the ``RunnerClient`` Protocol contract.
+
+The Protocol declares the runner-RPC surface any
+:class:`RuntimeBackend.executor_client` must expose. Six per-trial RPCs
+plus a lifecycle probe. The concrete :class:`GrpcRunnerClient` (the
+only production impl today) is checked here for structural conformance;
+a canonical stub proves the shape is genuinely swappable and pins the
+method signatures against silent drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.docker_runtime import GrpcRunnerClient, RunnerClient
+from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S
+from tolokaforge.tools.registry import ToolResult
+
+pytestmark = pytest.mark.canonical
+
+
+class _StubRunnerClient:
+    """Minimal structural implementation used to prove the Protocol is
+    satisfiable without the gRPC stack."""
+
+    def register_trial(
+        self,
+        trial_id: str,
+        trial_spec_json: str,
+        default_tool_timeout_s: float = DEFAULT_TOOL_TIMEOUT_S,
+    ) -> dict:
+        return {
+            "success": True,
+            "error": None,
+            "tool_schemas": [],
+            "num_agent_tools": 0,
+            "num_user_tools": 0,
+        }
+
+    def execute_tool(
+        self,
+        trial_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float = 30.0,
+        executor: str = "agent",
+    ) -> ToolResult:
+        return ToolResult(success=True, output="", error=None)
+
+    def grade_trial(
+        self,
+        trial_id: str,
+        llm_messages_json: str | None = None,
+        grading_components: list[str] | None = None,
+    ) -> dict:
+        return {"success": True, "error": None, "grade": None}
+
+    def get_state(
+        self,
+        trial_id: str,
+        include_unstable: bool = True,
+        tables: list[str] | None = None,
+    ) -> dict:
+        return {"success": True, "error": None, "state_json": "{}"}
+
+    def reset_trial(self, trial_id: str, execute_init_actions: bool = False) -> dict:
+        return {"success": True, "error": None}
+
+    def cleanup_trial(self, trial_id: str) -> dict:
+        return {"success": True, "error": None}
+
+    def health_check(self) -> bool:
+        return True
+
+
+def test_grpc_runner_client_satisfies_protocol() -> None:
+    """The production gRPC client structurally satisfies the Protocol."""
+    client = GrpcRunnerClient.__new__(GrpcRunnerClient)  # no gRPC channel needed
+    assert isinstance(client, RunnerClient)
+
+
+def test_stub_runner_client_satisfies_protocol() -> None:
+    """A non-gRPC stub satisfies the Protocol — proof the seam is swappable."""
+    assert isinstance(_StubRunnerClient(), RunnerClient)
+
+
+def test_mock_without_methods_fails_protocol() -> None:
+    """A ``MagicMock`` with the seven attributes still satisfies (they're
+    all magic-attributed), but an object with only some of the methods
+    should fail the runtime check."""
+
+    class _Partial:
+        def register_trial(self, *args: Any, **kwargs: Any) -> dict:
+            return {}
+
+    assert not isinstance(_Partial(), RunnerClient)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "register_trial",
+        "execute_tool",
+        "grade_trial",
+        "get_state",
+        "reset_trial",
+        "cleanup_trial",
+        "health_check",
+    ],
+)
+def test_protocol_surface_pins_expected_methods(method_name: str) -> None:
+    """The seven methods callers depend on are declared on the Protocol.
+
+    Guards against a future edit accidentally dropping a method from the
+    Protocol without a corresponding removal at every call site."""
+    assert hasattr(RunnerClient, method_name)
+
+
+def test_protocol_is_runtime_checkable() -> None:
+    """``@runtime_checkable`` — callers can ``isinstance(x, RunnerClient)``
+    when validating an injected backend without type-check plumbing."""
+    stub = MagicMock(spec=_StubRunnerClient())
+    assert isinstance(stub, RunnerClient)

--- a/tests/canonical/test_runner_client_contract.py
+++ b/tests/canonical/test_runner_client_contract.py
@@ -87,10 +87,10 @@ def test_stub_runner_client_satisfies_protocol() -> None:
     assert isinstance(_StubRunnerClient(), RunnerClient)
 
 
-def test_mock_without_methods_fails_protocol() -> None:
-    """A ``MagicMock`` with the seven attributes still satisfies (they're
-    all magic-attributed), but an object with only some of the methods
-    should fail the runtime check."""
+def test_partial_impl_fails_protocol_check() -> None:
+    """An object that implements only some of the required methods must
+    fail ``isinstance(..., RunnerClient)`` — the check has real teeth
+    beyond just accepting anything that walks like a duck."""
 
     class _Partial:
         def register_trial(self, *args: Any, **kwargs: Any) -> dict:

--- a/tests/integration/test_docker_grading.py
+++ b/tests/integration/test_docker_grading.py
@@ -23,13 +23,13 @@ class TestDockerGradingVerification:
 
     def test_docker_containers_healthy(self, runner_container, json_db_container):
         """Verify Docker containers are running and healthy."""
-        from tolokaforge.core.docker_runtime import RunnerClient
+        from tolokaforge.core.docker_runtime import GrpcRunnerClient
 
         host = runner_container.get_container_host_ip()
         port = runner_container.get_exposed_port(50051)
         runner_address = f"{host}:{port}"
 
-        client = RunnerClient(runner_address)
+        client = GrpcRunnerClient(runner_address)
         client.connect(timeout=10)
 
         health = client.health_check_detailed()

--- a/tests/integration/test_docker_grading_jsonpath.py
+++ b/tests/integration/test_docker_grading_jsonpath.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import pytest
 
-from tolokaforge.core.docker_runtime import RunnerClient
+from tolokaforge.core.docker_runtime import GrpcRunnerClient
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 
@@ -84,18 +84,18 @@ def _task_description(jsonpath_checks: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 @pytest.fixture
-def runner_client(runner_container) -> RunnerClient:
+def runner_client(runner_container) -> GrpcRunnerClient:
     """RunnerClient connected to the testcontainer Runner over gRPC."""
     host = runner_container.get_container_host_ip()
     port = runner_container.get_exposed_port(50051)
-    client = RunnerClient(runner_address=f"{host}:{port}")
+    client = GrpcRunnerClient(runner_address=f"{host}:{port}")
     client.connect()
     yield client
     client.close()
 
 
 def _register_and_grade(
-    runner_client: RunnerClient,
+    runner_client: GrpcRunnerClient,
     trial_id: str,
     jsonpath_checks: list[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -115,7 +115,7 @@ def _register_and_grade(
 class TestDbJsonpathGradingOverGrpc:
     """Validate PR #80's DB JSONPath state grading against the real wire protocol."""
 
-    def test_db_state_checks_graded_against_live_db(self, runner_client: RunnerClient) -> None:
+    def test_db_state_checks_graded_against_live_db(self, runner_client: GrpcRunnerClient) -> None:
         """``path:`` assertions are evaluated against the registered DB state, with
         PASS/FAIL verdicts and actionable mismatch reasons surfaced under ``State:``."""
         checks = [
@@ -161,7 +161,7 @@ class TestDbJsonpathGradingOverGrpc:
         assert grade["components"]["state_checks"] == pytest.approx(0.6)
         assert grade["binary_pass"] is False
 
-    def test_unknown_operator_fails_loud_over_grpc(self, runner_client: RunnerClient) -> None:
+    def test_unknown_operator_fails_loud_over_grpc(self, runner_client: GrpcRunnerClient) -> None:
         """Parity with the core native grader (PR #66): a ``path:`` assertion with no
         recognized operator must FAIL loudly through the RPC, not silently pass."""
         checks = [

--- a/tests/integration/test_runner_cleanup_trial_grpc.py
+++ b/tests/integration/test_runner_cleanup_trial_grpc.py
@@ -13,7 +13,7 @@ from typing import Any
 import grpc
 import pytest
 
-from tolokaforge.core.docker_runtime import RunnerClient
+from tolokaforge.core.docker_runtime import GrpcRunnerClient, RunnerClient
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
@@ -71,7 +71,7 @@ def runner_client(runner_container) -> RunnerClient:
     """RunnerClient connected to the testcontainer Runner over gRPC."""
     host = runner_container.get_container_host_ip()
     port = runner_container.get_exposed_port(50051)
-    client = RunnerClient(runner_address=f"{host}:{port}")
+    client = GrpcRunnerClient(runner_address=f"{host}:{port}")
     client.connect()
     yield client
     client.close()

--- a/tests/unit/test_docker_runtime_connect_idempotency.py
+++ b/tests/unit/test_docker_runtime_connect_idempotency.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tolokaforge.core.docker_runtime import DockerRuntime, RunnerClient
+from tolokaforge.core.docker_runtime import DockerRuntime, GrpcRunnerClient
 
 pytestmark = pytest.mark.unit
 
@@ -33,7 +33,7 @@ class TestRunnerClientConnectIdempotency:
     def test_second_connect_does_not_recreate_channel(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        client = RunnerClient(runner_address="sentinel:50051")
+        client = GrpcRunnerClient(runner_address="sentinel:50051")
 
         # Pre-populate the channel + stub as if a previous connect() succeeded.
         existing_channel = MagicMock()
@@ -56,7 +56,7 @@ class TestRunnerClientConnectIdempotency:
         """The orchestrator invokes connect() unconditionally at the start of
         every run. If the runtime is already healthy (e.g. an injected
         pre-connected backend), connect() must return cleanly — not raise."""
-        client = RunnerClient(runner_address="sentinel:50051")
+        client = GrpcRunnerClient(runner_address="sentinel:50051")
         client.channel = MagicMock()
         client.stub = MagicMock()
         monkeypatch.setattr(client, "health_check", lambda: True)
@@ -69,7 +69,7 @@ class TestRunnerClientConnectIdempotency:
         docstring promises the health check re-runs; pin that explicitly so a
         future implementation that turns it into a no-op (skipping the probe)
         fails this test loudly."""
-        client = RunnerClient(runner_address="sentinel:50051")
+        client = GrpcRunnerClient(runner_address="sentinel:50051")
         client.channel = MagicMock()
         client.stub = MagicMock()
 

--- a/tests/unit/test_grade_criterion_results_roundtrip.py
+++ b/tests/unit/test_grade_criterion_results_roundtrip.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tolokaforge.core.docker_runtime import RunnerClient
+from tolokaforge.core.docker_runtime import GrpcRunnerClient
 from tolokaforge.core.models import (
     CriterionResult,
     Grade,
@@ -98,7 +98,7 @@ def test_proto_grade_criterion_results_round_trip():
     )
     response = runner_pb2.GradeTrialResponse(success=True, grade=proto_grade)
 
-    client = RunnerClient.__new__(RunnerClient)
+    client = GrpcRunnerClient.__new__(GrpcRunnerClient)
     client.stub = MagicMock()
     client.stub.GradeTrial.return_value = response
 
@@ -123,7 +123,7 @@ def test_proto_grade_without_criterion_results_yields_none():
     proto_grade = runner_pb2.Grade(binary_pass=False, score=0.0)
     response = runner_pb2.GradeTrialResponse(success=True, grade=proto_grade)
 
-    client = RunnerClient.__new__(RunnerClient)
+    client = GrpcRunnerClient.__new__(GrpcRunnerClient)
     client.stub = MagicMock()
     client.stub.GradeTrial.return_value = response
 
@@ -170,7 +170,7 @@ def test_proto_grade_judge_report_round_trip():
     )
     response = runner_pb2.GradeTrialResponse(success=True, grade=proto_grade)
 
-    client = RunnerClient.__new__(RunnerClient)
+    client = GrpcRunnerClient.__new__(GrpcRunnerClient)
     client.stub = MagicMock()
     client.stub.GradeTrial.return_value = response
 

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -5,8 +5,9 @@ Tolokaforge inside Docker. The agent loop stays inside the orchestrator
 process, so only Runner connectivity is handled here.
 
 This module provides:
-- RunnerClient: gRPC client for Host ↔ Runner communication
-- DockerRuntime: High-level wrapper for Docker runtime management
+- RunnerClient: Protocol for the runner-RPC surface callers depend on.
+- GrpcRunnerClient: concrete gRPC implementation of RunnerClient.
+- DockerRuntime: High-level wrapper for Docker runtime management.
 
 See docs/GRPC_PROTOCOL.md for the full protocol specification.
 """
@@ -17,7 +18,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import grpc
 
@@ -36,6 +37,61 @@ if TYPE_CHECKING:  # pragma: no cover — type-only imports for provisioning sur
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RunnerClient(Protocol):
+    """The runner-RPC surface any :class:`RuntimeBackend` implementation
+    must expose through :attr:`RuntimeBackend.executor_client`.
+
+    Seven methods — six per-trial RPCs plus a lifecycle probe — cover
+    every call site downstream of ``DockerRunnerAdapter``. A non-gRPC
+    backend (in-process subprocess, remote conductor over a different
+    transport) satisfies this Protocol structurally without pulling in
+    the gRPC stack. :class:`GrpcRunnerClient` is the sole production
+    implementation.
+    """
+
+    def register_trial(
+        self,
+        trial_id: str,
+        trial_spec_json: str,
+        default_tool_timeout_s: float = DEFAULT_TOOL_TIMEOUT_S,
+    ) -> dict: ...
+
+    def execute_tool(
+        self,
+        trial_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float = 30.0,
+        executor: str = "agent",
+    ) -> ToolResult: ...
+
+    def grade_trial(
+        self,
+        trial_id: str,
+        llm_messages_json: str | None = None,
+        grading_components: list[str] | None = None,
+    ) -> dict: ...
+
+    def get_state(
+        self,
+        trial_id: str,
+        include_unstable: bool = True,
+        tables: list[str] | None = None,
+    ) -> dict: ...
+
+    def reset_trial(self, trial_id: str, execute_init_actions: bool = False) -> dict: ...
+
+    def cleanup_trial(self, trial_id: str) -> dict: ...
+
+    def health_check(self) -> bool: ...
+
+
 def _proto_score_to_optional(value: float) -> float | None:
     """Convert proto sentinel -1.0 to None for unconfigured grade components.
 
@@ -46,7 +102,7 @@ def _proto_score_to_optional(value: float) -> float | None:
     return None if value < 0 else value
 
 
-class RunnerClient:
+class GrpcRunnerClient:
     """Client for communicating with Runner service via gRPC
 
     This client implements the Host side of the Host ↔ Runner protocol
@@ -72,7 +128,7 @@ class RunnerClient:
         self.runner_address = runner_address
         self.channel: grpc.Channel | None = None
         self.stub: runner_pb2_grpc.RunnerServiceStub | None = None
-        logger.info(f"RunnerClient initialized with address: {runner_address}")
+        logger.info(f"GrpcRunnerClient initialized with address: {runner_address}")
 
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         """Establish connection to Runner service with health check retry.
@@ -581,7 +637,7 @@ class RunnerClient:
 
 
 # Backward compatibility alias
-ExecutorClient = RunnerClient
+ExecutorClient = GrpcRunnerClient
 
 
 @dataclass(frozen=True)
@@ -598,7 +654,7 @@ class _SharedStackHandle:
 class DockerRuntime:
     """Docker runtime manager - coordinates Runner connectivity
 
-    This is a high-level wrapper that manages the RunnerClient lifecycle.
+    This is a high-level wrapper that manages the GrpcRunnerClient lifecycle.
     Use as a context manager for automatic connection management.
 
     Example:
@@ -615,9 +671,12 @@ class DockerRuntime:
         Args:
             runner_address: gRPC address for Runner service
         """
-        self.runner_client = RunnerClient(runner_address)
-        # Keep executor_client as alias for backward compatibility
-        self.executor_client = self.runner_client
+        self.runner_client: GrpcRunnerClient = GrpcRunnerClient(runner_address)
+        # Keep executor_client as alias for backward compatibility. Typed
+        # as the concrete gRPC impl (not the Protocol) so downstream code
+        # can still reach ``runner_address`` and other implementation
+        # attributes when needed.
+        self.executor_client: GrpcRunnerClient = self.runner_client
         logger.info("Docker runtime initialized")
 
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:

--- a/tolokaforge/core/docker_runtime.py
+++ b/tolokaforge/core/docker_runtime.py
@@ -5,7 +5,8 @@ Tolokaforge inside Docker. The agent loop stays inside the orchestrator
 process, so only Runner connectivity is handled here.
 
 This module provides:
-- RunnerClient: Protocol for the runner-RPC surface callers depend on.
+- RunnerClient: Protocol declaring the seven-method runner-RPC surface
+  (six per-trial RPCs plus a lifecycle health probe) callers depend on.
 - GrpcRunnerClient: concrete gRPC implementation of RunnerClient.
 - DockerRuntime: High-level wrapper for Docker runtime management.
 

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -190,9 +190,11 @@ class RuntimeBackend(Protocol):
     """The RPC client used by :class:`DockerRunnerAdapter` for per-trial
     operations after a trial is registered.
 
-    Typed as the concrete :class:`RunnerClient` for now. Promoting it to
-    its own Protocol is a follow-up if a non-gRPC backend ever wants to
-    fake the runner-RPC surface without the gRPC stack."""
+    Typed as the :class:`RunnerClient` Protocol so a non-gRPC backend can
+    satisfy the RuntimeBackend contract without pulling in the gRPC
+    stack. :class:`DockerRuntime` sets this to a :class:`GrpcRunnerClient`
+    instance; ``InMemoryRuntimeBackend`` sets it to a stub that raises on
+    any RPC method access."""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

The `RuntimeBackend` Protocol's `executor_client` attribute is now typed against a runtime-checkable `RunnerClient` Protocol (seven RPC methods) instead of the concrete gRPC class. The gRPC implementation is renamed `GrpcRunnerClient`. This closes the documented gRPC-leak in `RuntimeBackend` — a non-gRPC backend can satisfy the executor-client contract structurally, without importing `grpc` at all.

## What ships

- **New Protocol**: `RunnerClient` (`tolokaforge/core/docker_runtime.py`) — `@runtime_checkable`, declares six per-trial RPCs (`register_trial`, `execute_tool`, `grade_trial`, `get_state`, `reset_trial`, `cleanup_trial`) plus `health_check`.
- **Concrete renamed**: the previous `class RunnerClient` is now `class GrpcRunnerClient`. Backward-compat alias `ExecutorClient = GrpcRunnerClient` preserved.
- **`RuntimeBackend.executor_client`**: typed as the `RunnerClient` Protocol (the docstring updated to note this is now real, not aspirational).
- **`DockerRuntime.executor_client`**: typed as the concrete `GrpcRunnerClient` — production callers that reach for implementation attributes (`runner_address`, `channel`, `stub`) still typecheck cleanly.
- **New canonical contract test**: `tests/canonical/test_runner_client_contract.py` — proves `GrpcRunnerClient` satisfies the Protocol, proves a non-gRPC stub does too, and parameter-pins the seven method names so a future edit that drops one from the Protocol fails the suite loudly.
- **Test call-site migration**: tests that instantiated the concrete class now use `GrpcRunnerClient` (four test files touched).

## Why

`RuntimeBackend` was designed as the seam between the orchestrator and the execution environment (ADR-0007). But the seam still leaked: `executor_client: RunnerClient` named the concrete gRPC class as the type of the handoff, so any future backend that didn't want to import `grpc` was forced to fake a `RunnerClient`-shaped object anyway. This is exactly the pattern ADR-0011 (seam-definition conventions) codifies against: **the seam's attribute types must be Protocols or value objects, not concrete classes.**

Promoting `RunnerClient` to a Protocol removes the leak. The Protocol declares only the surface callers actually depend on — the seven methods `DockerRunnerAdapter` and the orchestrator's grading path reach for. The concrete gRPC implementation lives on unchanged behind `GrpcRunnerClient`. Any future backend — in-process subprocess, Firecracker microVM, remote conductor over a different transport — satisfies the executor-client contract by implementing seven methods, without inheriting from anything and without importing `grpc`.

This is the same seam-definition pattern PR #96 (RuntimeBackend), PR #101 (Conductor), and PR #134 (OrchestratorDeps / ConductorContext) established. It's mechanical relative to that pattern; the win is on the type-checker side and on documenting the contract, not on new behaviour.

## Changes

- `tolokaforge/core/docker_runtime.py` — add `RunnerClient` Protocol; rename concrete class `RunnerClient` → `GrpcRunnerClient`; update `DockerRuntime` to instantiate `GrpcRunnerClient` and type `executor_client: GrpcRunnerClient`; keep `ExecutorClient = GrpcRunnerClient` alias.
- `tolokaforge/core/runtime.py` — update the docstring on `RuntimeBackend.executor_client` to reflect that the Protocol promotion has landed (was a stated follow-up).
- `tests/canonical/test_runner_client_contract.py` — new file pinning the Protocol surface.
- `tests/unit/test_grade_criterion_results_roundtrip.py`, `tests/unit/test_docker_runtime_connect_idempotency.py`, `tests/integration/test_docker_grading.py`, `tests/integration/test_docker_grading_jsonpath.py` — instantiate the renamed `GrpcRunnerClient` where they previously constructed `RunnerClient(...)` (a Protocol isn't instantiable).

No production caller needed source changes — `DockerRunnerAdapter.__init__` accepts `runner_client: RunnerClient` and only uses methods declared on the new Protocol, so it typechecks cleanly against either the Protocol or the concrete class.

## Verification

- `make lint` — green
- `make format-check` — green on the seven modified files
- `uv run pytest tests/unit tests/canonical -q -m "unit or canonical"` — **2208 passed, 1 skipped in 26.84s** (11 new tests come from the canonical contract file)

## Refs

Closes #105