### PR TITLE
chore(python): single-source the Python runtime version from .python-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python 3.12
-      run: uv python install 3.12
+    - name: Set up Python (pinned in .python-version)
+      run: uv python install "$(cat .python-version)"
 
 
     - name: Install dependencies
@@ -91,8 +91,8 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python 3.12
-      run: uv python install 3.12
+    - name: Set up Python (pinned in .python-version)
+      run: uv python install "$(cat .python-version)"
 
 
     - name: Install dependencies
@@ -176,8 +176,8 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python 3.12
-      run: uv python install 3.12
+    - name: Set up Python (pinned in .python-version)
+      run: uv python install "$(cat .python-version)"
 
 
     - name: Install dependencies
@@ -279,8 +279,8 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
-    - name: Set up Python 3.12
-      run: uv python install 3.12
+    - name: Set up Python (pinned in .python-version)
+      run: uv python install "$(cat .python-version)"
 
 
     - name: Install dependencies

--- a/.github/workflows/publish-adapter-terminal-bench.yml
+++ b/.github/workflows/publish-adapter-terminal-bench.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install "$(cat .python-version)"
 
       - name: Build package
         run: uv build --package tolokaforge-adapter-terminal-bench

--- a/.github/workflows/publish-tolokaforge.yml
+++ b/.github/workflows/publish-tolokaforge.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install "$(cat .python-version)"
 
       - name: Build package
         run: uv build

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -25,8 +25,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - name: Set up Python 3.12
-        run: uv python install 3.12
+      - name: Set up Python (pinned in .python-version)
+        run: uv python install "$(cat .python-version)"
 
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install Python
-        run: uv python install 3.12
+        run: uv python install "$(cat .python-version)"
 
       - name: Install commitizen
         run: uv sync --group dev

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -193,7 +193,14 @@ def test_build_image_respects_context_files(monkeypatch, _mock_wheel) -> None:
     # WHEEL_FILENAME must reach docker build. The Dockerfile's ARG default
     # is a placeholder that doesn't match the real wheel on disk, so `COPY
     # ${WHEEL_FILENAME}` fails whenever the harness omits this build arg.
-    assert captured["build_args"] == {"WHEEL_FILENAME": _mock_wheel.path.name}
+    # PYTHON_VERSION is sourced from .python-version so a single upgrade
+    # propagates to every runtime image.
+    from tolokaforge.docker.builder import PYTHON_VERSION
+
+    assert captured["build_args"] == {
+        "WHEEL_FILENAME": _mock_wheel.path.name,
+        "PYTHON_VERSION": PYTHON_VERSION,
+    }
 
 
 def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_wheel) -> None:
@@ -227,13 +234,18 @@ def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_whe
     image = build_image("runner")
     assert image.full_tag == "tolokaforge-runner:cafe1234"
     assert not Path(captured["context"]).exists(), "Temporary build context should be cleaned up"
-    assert captured["build_args"] == {"WHEEL_FILENAME": _mock_wheel.path.name}
+    from tolokaforge.docker.builder import PYTHON_VERSION
+
+    assert captured["build_args"] == {
+        "WHEEL_FILENAME": _mock_wheel.path.name,
+        "PYTHON_VERSION": PYTHON_VERSION,
+    }
 
 
-def test_build_image_passes_no_build_args_when_definition_has_none(monkeypatch) -> None:
-    """Services whose definition has no ``build_args`` entry (e.g. db-service)
-    must receive ``build_args=None`` — not ``{}`` — so the content hash and
-    docker build call are bit-identical to the pre-feature behaviour.
+def test_build_image_passes_python_version_build_arg_for_db_service(monkeypatch) -> None:
+    """Every runtime image receives the pinned Python version as a build arg
+    so ``FROM python:${PYTHON_VERSION}-slim`` resolves from ``.python-version``
+    instead of a per-Dockerfile hardcoded minor version.
     """
     captured: dict[str, object] = {}
 
@@ -252,7 +264,9 @@ def test_build_image_passes_no_build_args_when_definition_has_none(monkeypatch) 
     monkeypatch.setattr(Image, "build", fake_build)
 
     build_image("db-service", force=True)
-    assert captured["build_args"] is None
+    from tolokaforge.docker.builder import PYTHON_VERSION
+
+    assert captured["build_args"] == {"PYTHON_VERSION": PYTHON_VERSION}
 
 
 def test_service_name_for_image_resolves_all_known_services_without_resolving_wheel(

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -39,6 +39,23 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _pinned_python_version() -> str:
+    """Read the pinned Python minor version from ``.python-version``.
+
+    Single source of truth for the runtime Python version — dev, CI,
+    devcontainer, and every runtime Docker image resolve from this file.
+    Passed to Dockerfiles as the ``PYTHON_VERSION`` build arg so
+    ``FROM python:${PYTHON_VERSION}-slim`` follows automatically. The
+    Dockerfiles still default to the current pin so a manual
+    ``docker build`` without the arg produces the same image.
+    """
+    return (repo_root() / ".python-version").read_text().strip()
+
+
+PYTHON_VERSION = _pinned_python_version()
+_PYTHON_BUILD_ARGS: dict[str, str] = {"PYTHON_VERSION": PYTHON_VERSION}
+
+
 # =============================================================================
 # Image Definitions — Single Source of Truth
 # =============================================================================
@@ -64,6 +81,7 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
         "context_files": [
             "tolokaforge/env/json_db_service/",
         ],
+        "build_args": dict(_PYTHON_BUILD_ARGS),
     },
     "runner": {
         "name": "tolokaforge-runner",
@@ -82,6 +100,7 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
         "dockerfile": "tolokaforge/docker/dockerfiles/mock_web.Dockerfile",
         "context": ".",
         "context_files": [],
+        "build_args": dict(_PYTHON_BUILD_ARGS),
     },
 }
 
@@ -107,7 +126,7 @@ def _runner_definition() -> dict[str, Any]:
     return {
         **IMAGE_DEFINITIONS["runner"],
         "context_files": [str(artifact.path)],  # absolute path to the .whl
-        "build_args": {"WHEEL_FILENAME": artifact.path.name},
+        "build_args": {**_PYTHON_BUILD_ARGS, "WHEEL_FILENAME": artifact.path.name},
     }
 
 
@@ -125,7 +144,7 @@ def _rag_definition() -> dict[str, Any]:
             str(artifact.path),  # wheel (absolute → flat copy)
             "tolokaforge/env/rag_service/",  # service files (relative)
         ],
-        "build_args": {"WHEEL_FILENAME": artifact.path.name},
+        "build_args": {**_PYTHON_BUILD_ARGS, "WHEEL_FILENAME": artifact.path.name},
     }
 
 

--- a/tolokaforge/docker/dockerfiles/db_service.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/db_service.Dockerfile
@@ -8,7 +8,8 @@
 #
 # See docs/DB_SERVICE_API.md for the full API specification.
 
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/tolokaforge/docker/dockerfiles/json_db.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/json_db.Dockerfile
@@ -1,5 +1,6 @@
 # JSON DB service
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 

--- a/tolokaforge/docker/dockerfiles/mock_web.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/mock_web.Dockerfile
@@ -1,5 +1,6 @@
 # Mock Web Service
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 

--- a/tolokaforge/docker/dockerfiles/orchestrator.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/orchestrator.Dockerfile
@@ -1,5 +1,6 @@
 # Orchestrator container - has access to env network and coordinates all services
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/tolokaforge/docker/dockerfiles/rag.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/rag.Dockerfile
@@ -3,7 +3,8 @@
 # Per-trial document indexing and search via FastAPI.
 # See tolokaforge/env/rag_service/app.py for the API surface.
 
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 

--- a/tolokaforge/docker/dockerfiles/runner.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/runner.Dockerfile
@@ -10,7 +10,8 @@
 # context by the host-side wheel resolver (tolokaforge.docker.wheel_resolver).
 # The container never clones a repo or reaches PyPI — the wheel is local.
 
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## TL;DR

Move the pinned Python minor version to a single source (`.python-version`) and thread it through every Dockerfile as a `PYTHON_VERSION` build arg. CI workflows now source the version from the same file. Bumping Python is now a one-line change instead of a ~14-spot audit.

## What ships

- **`builder.py`**: reads `.python-version` once at module load; passes `PYTHON_VERSION` in the `build_args` of every `IMAGE_DEFINITIONS` entry and of the wheel-dependent factories `_runner_definition()` / `_rag_definition()`.
- **Runtime Dockerfiles** (4 live + 2 orphan): `runner.Dockerfile`, `db_service.Dockerfile`, `mock_web.Dockerfile`, `rag.Dockerfile`, `json_db.Dockerfile`, `orchestrator.Dockerfile` — each declares `ARG PYTHON_VERSION=3.12` and uses `FROM python:${PYTHON_VERSION}-slim`. The default matches `.python-version` so a bare `docker build` (without the harness passing the arg) still produces the same image.
- **CI workflows** (5 files): `ci.yml`, `release-gate.yml`, `publish-tolokaforge.yml`, `release.yml`, `publish-adapter-terminal-bench.yml` all switch from `uv python install 3.12` to `uv python install "$(cat .python-version)"`.
- **Test update**: `tests/unit/test_docker_build_context.py` — the three tests that pinned `build_args` (`test_build_image_respects_context_files`, `test_build_image_non_force_path_uses_isolated_context`, and the former `test_build_image_passes_no_build_args_when_definition_has_none`) now assert on the new `PYTHON_VERSION` build arg alongside `WHEEL_FILENAME`. The third test's premise flipped (db-service used to have no build_args and now has one), so it's renamed and re-scoped to prove the single-source contract at build-time.

Not touched (intentional): `pyproject.toml` `requires-python = ">=3.10"` and ruff/black `target-version = py310` — those are the OSS-consumer minimum-supported floor and are conceptually separate from the pinned runtime version. Bumping the pin doesn't tighten what consumers must run.

## Why

Three separate Python-version declarations had drifted apart:

- Dev / devcontainer / CI: **3.12** (`.python-version`, `devcontainer.json`, five workflow files)
- `runner.Dockerfile` + `db_service.Dockerfile`: **3.11**
- `mock_web.Dockerfile` + `rag.Dockerfile`: **3.10**
- Orphan Dockerfiles: **3.10**

The engine's Docker path was **running the runner on 3.11 while dev/CI test on 3.12**. That's a silent latent-behavior gap and directly undercuts the "the runner runs the byte-identical engine" contract the architecture depends on. A future Python upgrade would also require finding and editing all ~14 spots — an audit that would inevitably miss some.

The fix has two shapes:

1. **Align now** — every live runtime image runs the version dev + CI test on (3.12). Same interpreter minor, same behavior guarantees, no drift.
2. **Single-source future** — one file (`.python-version`) is the pin. `builder.py` reads it and passes it as a build arg; CI workflows read it directly. A future bump touches one place; every derived surface follows automatically.

The `ARG PYTHON_VERSION=3.12` default on each Dockerfile keeps them independently reproducible — a hand-rolled `docker build` still produces the current pin without needing the harness. This is deliberate: the Dockerfiles remain self-contained artifacts, and the harness just tells them what version to use when it disagrees with the default (it currently doesn't).

## Changes

- `tolokaforge/docker/builder.py` — add `_pinned_python_version()` reader, module-level `PYTHON_VERSION` and `_PYTHON_BUILD_ARGS`; merge into every `IMAGE_DEFINITIONS` entry and both dynamic factories.
- Six Dockerfiles under `tolokaforge/docker/dockerfiles/` — add `ARG PYTHON_VERSION=3.12` before `FROM python:${PYTHON_VERSION}-slim`.
- Five workflows under `.github/workflows/` — source the version from `.python-version` in each `uv python install` step; rename the step to make the source visible.
- `tests/unit/test_docker_build_context.py` — update the three affected assertions to include `PYTHON_VERSION`.

## Verification

- `make lint` — green
- `uv run pytest tests/unit tests/canonical -q -m "unit or canonical"` — **2197 passed, 1 skipped in 26.12s**
- `tests/unit/test_docker_build_context.py` — all 9 tests green with the new assertions

To upgrade Python in the future: edit `.python-version`. That's it. dev, CI, devcontainer venv, and every runtime image follow.