### PR TITLE
test(adapter-convert): CI smoke pins wheel packaging + real CLI invocation

### DIFF
--- a/tests/canonical/test_adapter_convert_packaging.py
+++ b/tests/canonical/test_adapter_convert_packaging.py
@@ -1,0 +1,123 @@
+"""Packaging + CLI smoke for ``tolokaforge adapter convert``.
+
+Guards two failure modes the in-process tests can't catch:
+
+* A source file (e.g. ``tolokaforge/adapters/bundle_writer.py``) not
+  making it into the built wheel — the exact regression that shipped in
+  GH #37. In-process tests keep passing because the file exists on
+  disk; end-users installing from PyPI hit ``ImportError``.
+* The ``tolokaforge`` console script + entry-point-based adapter
+  discovery failing when invoked as a real subprocess (import ordering,
+  missing dependency at CLI import time, entry-point group name typo).
+
+Both tests run under the ``canonical`` marker so they participate in
+the existing CI smoke job without needing dedicated workflow wiring.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _uv_available() -> bool:
+    """True if the ``uv`` CLI is on PATH — otherwise these tests skip loud."""
+    return shutil.which("uv") is not None
+
+
+@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
+def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
+    """``tolokaforge.adapters.bundle_writer`` must be present in the wheel
+    hatchling produces.
+
+    A structural regression like PR #37 (module omitted from the built
+    wheel because of a hatch config gap) is invisible to any in-process
+    test — the source tree still has the file. The only way to catch it
+    is to build the wheel and look inside.
+    """
+    build_result = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert build_result.returncode == 0, (
+        f"uv build failed (rc={build_result.returncode}):\n"
+        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
+    )
+
+    wheels = sorted(tmp_path.glob("tolokaforge-*.whl"))
+    assert wheels, f"No tolokaforge wheel produced under {tmp_path}"
+    wheel = wheels[-1]
+
+    with zipfile.ZipFile(wheel) as zf:
+        members = set(zf.namelist())
+
+    required = {
+        "tolokaforge/adapters/bundle_writer.py",
+        "tolokaforge/adapters/base.py",
+        "tolokaforge/adapters/native.py",
+        "tolokaforge/adapters/__init__.py",
+        "tolokaforge/cli/adapter_commands.py",
+        "tolokaforge/cli/main.py",
+    }
+    missing = required - members
+    assert not missing, (
+        f"Wheel {wheel.name} is missing modules that adapter convert depends on: "
+        f"{sorted(missing)}. Members starting with 'tolokaforge/adapters/': "
+        f"{sorted(m for m in members if m.startswith('tolokaforge/adapters/'))}"
+    )
+
+
+@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
+def test_adapter_convert_cli_help_runs_via_subprocess() -> None:
+    """``uv run tolokaforge adapter convert --help`` exits 0 and prints usage.
+
+    Proves the installed console script wires, ``tolokaforge.cli.main``
+    imports cleanly, the ``adapter`` subgroup is registered, and every
+    module the CLI reaches at import time (including
+    ``tolokaforge.adapters.bundle_writer``) resolves under the real
+    Python resolver — not a monkeypatched one.
+    """
+    result = subprocess.run(
+        ["uv", "run", "tolokaforge", "adapter", "convert", "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"CLI help failed (rc={result.returncode}):\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "--output" in combined, f"Usage missing --output flag:\n{combined}"
+    assert "--tasks-glob" in combined, f"Usage missing --tasks-glob flag:\n{combined}"
+
+
+def test_bundle_writer_module_imports_cleanly() -> None:
+    """In-process import guard — the module symbols the CLI reaches at
+    call time must resolve. Cheap runtime check that complements the
+    wheel-inspection test above."""
+    import tolokaforge.adapters.bundle_writer as bw
+
+    assert callable(bw.write_bundle), (
+        "tolokaforge.adapters.bundle_writer.write_bundle must be callable — "
+        "the CLI adapter-convert path relies on this symbol."
+    )
+    # sys.modules registration proves the import actually took effect
+    # (rather than a stale cache satisfying attribute lookups).
+    assert "tolokaforge.adapters.bundle_writer" in sys.modules


### PR DESCRIPTION
## TL;DR

Add three canonical tests that catch the failure modes the existing in-process adapter-convert suite can't see: (1) a source module missing from the built wheel, (2) the CLI subprocess crashing on import, (3) `bundle_writer` symbols not resolving. These would have caught the GH #37 regression (module physically absent from the published wheel; in-process tests happily green).

## What ships

New file `tests/canonical/test_adapter_convert_packaging.py` with three tests:

- **`test_bundle_writer_ships_in_the_built_wheel`** — runs `uv build --wheel`, unzips the produced wheel, and asserts every module the CLI reaches at call time is physically present. Currently checks: `bundle_writer.py`, `base.py`, `native.py`, `adapters/__init__.py`, `adapter_commands.py`, `cli/main.py`.
- **`test_adapter_convert_cli_help_runs_via_subprocess`** — spawns `uv run tolokaforge adapter convert --help` in a real subprocess and asserts the help output includes the expected flags. Proves the installed console script wires, the click group resolves, and every module the CLI touches at import time loads under the real Python resolver.
- **`test_bundle_writer_module_imports_cleanly`** — in-process cheap guard that the `write_bundle` symbol is callable and the module lands in `sys.modules`. Complements the wheel-inspection test with a fast path.

Both `uv`-dependent tests skip loudly with `pytest.skip` when the `uv` CLI is not on PATH — no false-negative silent skips.

## Why

The existing regression suite around `tolokaforge adapter convert` (added in PR #48) monkey-patches `get_adapter` and drives the click runner in-process. That's good coverage for the *convert flow logic* but blind to two failure classes:

1. **Wheel-shipping bugs.** A file that exists in the source tree but doesn't make it into the built wheel — because of a `hatch.build.targets.wheel` misconfiguration or a `.gitignore`-adjacent exclusion — will pass every in-process test. The bug only shows up when a user `pip install`s the wheel and the missing module raises `ImportError`. This is exactly what GH #37 was.
2. **CLI-boundary import bugs.** In-process click testing bypasses the actual entry-point script (`tolokaforge = tolokaforge.cli.main:cli` in `pyproject.toml`). A regression in the console-script wiring, a circular import at CLI top-level, or an entry-point group name typo can survive the whole in-process suite.

The three added tests plug both holes: (1) inspects the wheel binary artifact, (2) invokes the CLI the way an end-user would (real subprocess), (3) verifies the module surface the CLI depends on. Together they'd catch any GH #37-shaped regression before it merges.

**No CI workflow change needed.** The existing `test-smoke` job in `ci.yml` runs `pytest -m "unit or canonical"`, so these canonical tests are picked up automatically on every PR. Wall-clock overhead is small: `uv build` takes ~2s in the sandbox measurement below; the subprocess help call ~1s.

## Changes

- `tests/canonical/test_adapter_convert_packaging.py` — new file, three tests, no production-code touch.

## Verification

- `make lint` — green
- `uv run pytest tests/canonical/test_adapter_convert_packaging.py -v` — **3 passed in 2.94s**
- `uv run pytest tests/unit tests/canonical -q -m "unit or canonical"` — **2200 passed, 1 skipped in 28.92s** (three new tests, no regressions)

## Refs

Closes #49