### PR TITLE
refactor(core): EnvironmentManifest as compose-as-source-of-truth

### DIFF
--- a/docs/architecture/adr/0009-environment-manifest.md
+++ b/docs/architecture/adr/0009-environment-manifest.md
@@ -1,240 +1,239 @@
-# 0009. `EnvironmentManifest` — typed schema for per-trial multicontainer environments
+# 0009. `EnvironmentManifest` — compose-as-source-of-truth for per-trial environments
 
 - **Status:** Proposed
-- **Date:** 2026-06-30
+- **Date:** 2026-07-02
 - **Deciders:** @CiroGamboa
 - **Supersedes:** —
 - **Superseded by:** —
 
 ## Context and Problem Statement
 
-The engine's typed-seam arc is complete: every plane has a `@runtime_checkable` Protocol with at least two implementations. The next architectural arc is **per-trial environment isolation** — a task that needs `db + backend + frontend` (or even `db + rag`) should run in its own isolated stack, not share one stack across every trial of the run.
+Multi-service tasks (agent + database + tool services) need per-trial environment isolation: each trial gets its own containers, its own bind mounts, its own initial state. The engine's current shared-stack path — one docker-compose project shared across every trial in a run — makes cross-trial state contamination structural. It also caps concurrency at one trial per stack.
 
-Today there is no typed declaration of what a task's world looks like. Tasks fall back to a small set of hard-coded stack templates (`core_stack`, `full_stack`) selected by tool declarations; the orchestrator brings the shared stack up once at the start of a run and tears it down at the end. That choice predates per-trial isolation and locks the engine to a single-substrate, shared-stack model.
+Solving that requires the engine to know, for a given task, what its environment looks like. Not just "which containers" — but also which service is the agent's runner, which fixtures to apply before the run starts, what network posture to enforce, and what security defaults to apply to every service.
 
-We need a typed, declarative schema that:
-
-- expresses any multi-service environment a task could need,
-- does not bake in any one substrate's grammar (so non-local substrates remain a future option without re-design),
-- is the same wire format every runtime backend reads.
-
-That schema is the **environment manifest**. This ADR proposes it.
+That declaration is what this ADR defines: `EnvironmentManifest`, a small Pydantic wrapper that points at a Docker Compose file, adds the engine-specific fields the provisioner needs, and applies safety validators against the loaded compose contents at construction time.
 
 ## Architecture context — picture before prose
 
 ### Today: one stack, shared across trials
 
 ```
-┌──────────────────────────────────────────────┐
-│            Run-wide shared stack             │
-│  (one ServiceStack, lives for the whole run) │
-│                                              │
-│  ┌──────┐  ┌────┐  ┌─────┐  ┌──────────────┐ │
-│  │runner│  │ db │  │ rag │  │  typesense   │ │
-│  └──────┘  └────┘  └─────┘  └──────────────┘ │
-└──────────────────────────────────────────────┘
-            ▲   ▲   ▲   ▲   ▲
-            │   │   │   │   │
-        trials 1, 2, 3, 4, 5 (all share one stack)
+                          Orchestrator
+                                │
+                                ▼
+                     ServiceStack (shared)
+                    ┌───────┬───────┬───────┐
+                    │  db   │ runner│  rag  │
+                    └───────┴───────┴───────┘
+                        ▲       ▲       ▲
+                        │       │       │
+                    trial 0 trial 1 trial 2   (all trials share the same containers)
 ```
 
 ### Next: one isolated stack per trial, declared by a manifest
 
 ```
-   ┌─── trial 1 ────┐  ┌─── trial 2 ────┐  ┌─── trial 3 ────┐
-   │ ┌────┐ ┌────┐  │  │ ┌────┐ ┌────┐  │  │ ┌────┐ ┌────┐  │
-   │ │runr│ │ db │  │  │ │runr│ │ db │  │  │ │runr│ │ db │  │
-   │ └────┘ └────┘  │  │ └────┘ └────┘  │  │ └────┘ └────┘  │
-   └────────────────┘  └────────────────┘  └────────────────┘
-            ▲                  ▲                  ▲
-            │                  │                  │
-            └──────── EnvironmentManifest ────────┘
-                              │
-                              ▼
-        ┌─────────────────────────────────────────┐
-        │  RuntimeBackend.provision(spec)         │
-        │  ─── compiles manifest into substrate ─ │
-        │                                         │
-        │   • LocalRuntimeBackend → per-trial     │
-        │     docker-compose project              │
-        │   • DockerRuntime → shared stack        │
-        │     (no-op compat path)                 │
-        └─────────────────────────────────────────┘
+              Orchestrator
+                     │
+                     ▼
+    ┌────────────┬────────────┬────────────┐
+    ▼            ▼            ▼            ▼
+ stack 0     stack 1     stack 2     stack N
+ ┌──────┐   ┌──────┐   ┌──────┐   ┌──────┐
+ │  db  │   │  db  │   │  db  │   │  db  │
+ │runner│   │runner│   │runner│   │runner│
+ └──────┘   └──────┘   └──────┘   └──────┘
+    ▲          ▲          ▲          ▲
+    │          │          │          │
+ trial 0    trial 1    trial 2    trial N
 ```
 
-The manifest is **the wire format between task declarations and runtime backends.**
+The manifest is the declarative side of this arc; the runtime backend (ADR-0010) is the consuming side.
 
 ## Decision Drivers
 
-- **Borrow, don't reinvent.** The compose convention used by Inspect AI is an established shape with documented semantics; aligning with it saves design effort and gives operators a familiar surface.
-- **Substrate-agnostic.** The schema does not bake in compose-only grammar. Today the only consumer is `LocalRuntimeBackend` (docker-compose). Other substrates can be added later without breaking the wire format — but the design does not commit to any specific non-local substrate, and adding one is an independent decision recorded in its own ADR.
-- **Determinism precondition.** Images pinned; readiness gate explicit; initial state declared, not inferred.
-- **Strict schema.** `extra="forbid"` everywhere so silent field additions cannot drift the wire format.
-- **Validation-first.** Land the schema and its tests **before** any runtime backend consumes it, so the contract can iterate against a Pydantic model (cheap) rather than against a deployed backend (expensive).
-- **No mandatory migration.** Existing tasks must keep running unchanged. The new field is optional and opt-in.
+- **The compose file is already the industry-standard artefact for declaring a multi-service environment.** Task authors know Docker Compose. Tooling (`docker compose config`, IDE integrations, `docker compose up`) works out of the box. Adjacent agent-eval harnesses that solve the same problem (Inspect AI in particular) consume compose files directly.
+- **Substrate portability.** Docker Compose translates to Kubernetes Pods via industry-standard tooling (`kompose`, Testcontainers' k8s module) and to remote sandbox platforms via their own SDKs. Adopting compose as the source-of-truth avoids building a parallel schema that would then need those same translators anyway.
+- **Safety belongs to the wrapper, not the substrate.** The engine's safety controls (path-traversal guards on bind mount sources, rejection of `network_mode: host`, rejection of `privileged: true`, rejection of `cap_add`) are engine concerns, not compose concerns. Encoding them as load-time validators against the compose contents keeps the substrate agnostic and the safety story ours to enforce.
+- **Ecosystem interop.** Tasks whose sandbox spec is already a compose file (Inspect AI's docker sandbox convention, community task packs) run natively with zero adapter code.
+- **Iterate cheaply until validated.** The manifest lands as `Proposed`; contract tests pin every safety validator against fixture compose files. Status flips to `Accepted` once a real workload runs end-to-end on a per-trial backend (ADR-0010's follow-up work).
 
 ## Considered Options
 
-1. **Typed Pydantic manifest borrowing Inspect AI's compose convention.** First service = default / runner; others addressed by name; health probes typed by protocol (`tcp` / `http`); `extra="forbid"` round-trip-pinned by a canonical contract test. **This ADR.**
-2. **Roll our own schema from scratch.** Maximum freedom, but no precedent to align with; every operator who has used Inspect AI would have to relearn it.
-3. **Use docker-compose YAML directly as the manifest.** Zero translation effort today, but locks the wire format to docker-compose grammar — any other substrate would need a parallel format.
-4. **Defer until a runtime backend needs it.** The runtime backend cannot land without something to consume; deferring just reorders the same work into a more constrained position.
+1. **Compose file as source-of-truth; `EnvironmentManifest` is a Pydantic wrapper adding engine-specific fields and safety validators.** *This ADR.*
+2. **Field-by-field Pydantic schema that re-encodes compose semantics.** Every compose field (`services`, `ports`, `volumes`, `depends_on`, `health`, `resources`) becomes a Pydantic type owned by the engine. Rejected: pays a translation tax at every backend (Pydantic → compose → docker) and diverges from every neighbour in the agent-eval space that reads compose directly.
+3. **Python-code environment definitions (METR task-standard's approach).** Task authors write a `TaskFamily` class with `install()` / `start()` / `teardown()` methods. Rejected: sacrifices the ability to statically analyse environments (which our safety-validator layer requires) and diverges from the compose ecosystem tooling.
 
 ## Decision
 
-We adopt **Option 1**.
+We adopt **Option 1**. `EnvironmentManifest` is:
 
-Concretely:
+```python
+class EnvironmentManifest(BaseModel):
+    model_config = {"extra": "forbid"}
 
-- Add `EnvironmentManifest` and its supporting models (`ServiceSpec`, `HealthProbe`, `PortSpec`, `VolumeMount`, `Resources`, `InitialStateRef`, `DependsOn`, `SecurityContext`) to `tolokaforge/runner/models.py` — alongside `TaskDescription`, which carries the new field. All `extra="forbid"`. The models are re-exported from `tolokaforge/core/trial.py` for callers that work against the trial-spec surface; placing them next to `TaskDescription` avoids a circular import (the manifest is a field on `TaskDescription`).
-- `EnvironmentManifest`'s top-level surface: `services: list[ServiceSpec]` (non-empty, first service = default / runner), optional `initial_state: dict[str, InitialStateRef]`, optional `resources: Resources | None` (manifest-level defaults).
-- `ServiceSpec` carries a per-service `resources: Resources | None` override — provisioners fall back to the manifest-level defaults when a service declares none.
-- `HealthProbe` carries `kind: Literal["tcp", "http"]` plus `port` plus optional `path` (required iff `kind == "http"`), plus `initial_delay_seconds` (startup grace window) alongside `interval_seconds` / `timeout_seconds` / `retries`. No raw `HEALTHCHECK CMD` strings — the typed-by-protocol shape is provisioner-agnostic.
-- `Resources` uses **Kubernetes-style quantity strings** — `cpu: "2" | "500m"`, `memory: "4Gi" | "512Mi"`. This is a documented external standard we are borrowing the grammar from (so we don't invent our own parser); it does not commit us to running on Kubernetes.
-- `VolumeMount` carries an explicit `kind: Literal["named", "bind"]` (default `"bind"`) so the provisioner does not have to infer named-volume vs path from `source`'s shape.
-- `InitialStateRef` carries `kind: Literal["sql", "copy", "script"]` (default `"copy"`) so the provisioner knows how to apply the fixture — SQL pipe, file copy, or script exec — instead of inferring from a filename extension. `from_` is rejected when empty.
-- `DependsOn` exists as a structured form for `depends_on` entries: `condition: Literal["service_started", "service_healthy"]`. `ServiceSpec.depends_on: list[str | DependsOn]` — string entries are shorthand for `DependsOn(service=name, condition="service_started")`.
-- `ServiceSpec.image` is required and validated against a deny-list of floating tags (`latest`, `main`, `master`, `edge`, `stable`, `dev`, `develop`, `nightly`, `head`, case-insensitive) plus a parser that correctly handles registry-with-port image references (`registry.example.com:5000/foo` without a tag is rejected). `@sha256:` digests are accepted.
-- `ServiceSpec.name` is a lowercase DNS label (`^[a-z]([-a-z0-9]*[a-z0-9])?$`) capped at 63 characters (RFC 1123).
-- **`VolumeMount.source` (when `kind="bind"`) and `InitialStateRef.from_` are validated as safe relative paths** — non-empty, not absolute, with no `..` segments. A manifest cannot bind-mount the host's `/etc` into a trial container; it cannot reference a fixture outside the task pack root. Named-volume sources are unaffected (they are identifiers, not paths).
-- **`EnvironmentManifest.network: Literal["isolated", "external"] = "isolated"`** declares the network posture the provisioner is asked to enforce. Default `isolated` means the per-trial network has no outbound path to the public internet or to other trials' projects; `external` is the explicit opt-in for tasks that legitimately need outbound access. The schema declares the posture; provisioners enforce it.
-- **`ServiceSpec.security_context: SecurityContext | None`** declares per-container security policy — `run_as_user`, `run_as_group`, `read_only_root_filesystem`, `no_new_privileges`, `capabilities_drop`, `capabilities_add`. Same declare-in-schema / provisioner-enforces-later pattern used for `network`, `read_only`, `resources`. Defaults chosen deliberately: `no_new_privileges=True` and `capabilities_drop=["ALL"]` are the safer starting posture; other fields default `None` / `False` / empty so a service that does not declare a `security_context` sees no behaviour change from the runtime backend's default.
-- `EnvironmentManifest` carries cross-service validators: `services` non-empty, names unique within the manifest, every `depends_on` reference (in either form) resolves to a service in the same manifest, every `initial_state` key resolves to a service in the same manifest.
-- `tolokaforge/runner/models.py:TaskDescription.environment_manifest: EnvironmentManifest | None = None` — net-new optional field. No prior field is being superseded.
-- `tests/canonical/test_environment_manifest_contract.py` pins the JSON wire shape (snapshot), the `extra="forbid"` round-trip, and every cross-field validator.
-- ADR status stays `Proposed` until a real complex workload exercises the schema end-to-end. The follow-up arc flips it to `Accepted`.
+    compose_file: Path
+    """Path to the docker-compose file. Absolute if resolved by a task
+    loader; relative paths are resolved against the current working
+    directory at construction time."""
 
-The manifest carries no runtime behaviour in this PR — no provisioner reads it yet. That is intentional: lock the schema with tests before any backend consumer locks it into runtime decisions.
+    runner_service: str = "default"
+    """Which compose service is the agent runner. Must be declared in
+    the compose file's `services:` mapping."""
+
+    initial_state: dict[str, InitialStateRef] = {}
+    """Fixture-copy operations, keyed by service name."""
+
+    network_policy: NetworkPolicy = NetworkPolicy.NO_INTERNET
+    """Network posture the provisioner is asked to enforce."""
+
+    security_context_defaults: SecurityContext | None = None
+    """Applied by the provisioner to every service that does not override
+    the equivalent settings in the compose file."""
+```
+
+Load-time safety validators run against the loaded compose contents. Failing any of them raises `ValidationError` at construction:
+
+- **Bind mount sources** — reject `..` segments and absolute paths (both short-form `SOURCE:TARGET` and long-form `{type: bind, source: ...}` syntaxes).
+- **`network_mode: host`** — rejected outright. The manifest's `network_policy` is the only network-posture surface.
+- **`privileged: true`** — rejected outright.
+- **`cap_add`** — rejected outright. If a task genuinely needs added capabilities, they belong on the manifest's `SecurityContext.capabilities_add` — a location the provisioner can reason about and log.
+
+Cross-field checks:
+
+- `runner_service` must be a service declared in the compose file.
+- Every key in `initial_state` must reference a declared compose service.
+
+### `NetworkPolicy` — permission-string network model
+
+Three literal states, following METR task-standard's permission-string convention:
+
+| Value | Semantics |
+|---|---|
+| `no_internet` (default) | Services reach each other on the per-trial network only. No egress to the public internet; no reachability across per-trial projects. |
+| `limited_internet` | Egress permitted for a provisioner-defined allowlist. No cross-trial reachability. The allowlist is a provisioner concern, not a schema concern. |
+| `full_internet` | Unrestricted egress. Still no cross-trial reachability. |
+
+Extending to a fourth mode (e.g. `dns_only`) is a permission-string addition; no consumer breaks.
+
+### `SecurityContext` — defaults applied by the provisioner
+
+`SecurityContext` declares per-container security policy. On the manifest it appears as `security_context_defaults` — the provisioner applies each declared field to every compose service that does not already set the equivalent. Task authors who want per-service policy set it in the compose file (`security_opt`, `user`, `read_only`, `cap_drop`, `cap_add` — subject to the safety validators).
+
+### `InitialStateRef` — how a fixture applies to a service
+
+```python
+class InitialStateRef(BaseModel):
+    from_: str          # relative path to the fixture (validated: no absolute, no `..`)
+    kind: Literal["sql", "copy", "script"] = "copy"
+```
+
+- `sql` — piped through the service's SQL client.
+- `copy` — written to a well-known path inside the service's container.
+- `script` — executed inside the service's container.
+
+Applied by the provisioner before `await_ready` returns.
+
+### Two-file task authoring model
+
+```yaml
+# task.yaml
+task_id: my_task
+name: My Task
+category: general
+description: ...
+adapter_type: native
+system_prompt: ...
+environment_manifest:
+  compose_file: ./environment/compose.yaml
+  runner_service: default
+  network_policy: no_internet
+  initial_state:
+    db:
+      from: ./fixtures/db-seed.sql
+      kind: sql
+
+# environment/compose.yaml   (pure Docker Compose)
+services:
+  db:
+    image: postgres:16
+    healthcheck: { test: ["CMD-SHELL", "pg_isready"] }
+  default:
+    image: tolokaforge/runner:0.5.0
+    depends_on:
+      db: { condition: service_healthy }
+```
 
 ## Impact on existing tasks
 
-**This PR changes nothing about today's run behaviour.** It adds a schema; no code path reads it. Full canonical + unit suites stay green.
-
-The longer-term picture is worth being explicit about — it shapes how adapter packs plan their adoption.
-
 ### Per-trial isolation is the universal architectural goal
 
-The current shared-stack model (one run-wide `ServiceStack`; trials are distinguished only by `trial_id` in URLs) is on the architectural deprecation list — it is a known coupling point regardless of how many services a task uses. Even single-container tasks share the runner across trials today, which leaves room for cross-trial state contamination and constrains how aggressively trials can run in parallel. The direction this arc is moving toward is **one isolated stack per trial for every task**, irrespective of topology size. Multi-service tasks are the forcing function; single-container tasks ride the same machinery.
-
-That direction is delivered by the runtime backend that consumes this manifest, not by this PR.
+Every task in the engine — not just multi-service ones — moves to per-trial isolation. Single-container tasks get a one-service manifest; the underlying infrastructure changes even where the task's declared shape is minimal.
 
 ### What happens to existing tasks across the arc
 
-- **In this PR:** nothing. The shared-stack path runs every task exactly as on `main`.
-- **When the per-trial runtime backend lands (later PR):** runtime-backend selection is config-driven. The shared-stack path remains the default; tasks that opt into the per-trial backend run with isolation; tasks that do not opt in keep their existing path.
-- **Long term:** the per-trial path is the recommended target. Adapter packs adopt the manifest on their own schedule by adding an `environment_manifest` to their `TaskDescription` — even a one-service manifest is enough to give a single-container task its own isolated container per trial.
+- Tasks that do not declare an `environment_manifest` continue to run on the shared-stack path (`DockerRuntime`, unchanged). No behavioural change from this ADR.
+- Tasks that opt into a manifest run through the per-trial provisioning path (ADR-0010 + `LocalRuntimeBackend`, follow-up PR). The manifest is validated at load time; unsafe configurations fail before any container starts.
 
 ### Does a task need a manifest to "comply"?
 
-- **In this PR and the near term:** no. The shared-stack path keeps working; the schema is optional and opt-in. Adapter packs adopt the manifest on their own schedule, not a flag day.
-- **To gain per-trial isolation today:** declare a manifest. Even a one-service manifest is enough; the runtime backend that consumes it will give that task its own isolated stack per trial.
-- **Longer term:** per-trial isolation may become the required path. Once it has been proven on real workloads and the per-trial backend is the default, the shared-stack path is a candidate for deprecation. **That decision is not made by this ADR.** A future ADR — with its own deprecation window, migration guide, and communication ahead of any breaking change — will decide whether and when "running with a manifest" becomes mandatory. Adapter packs treating manifest adoption as eventual rather than optional is the safer planning posture.
-
-Today there is no mandatory migration and no engine-side breakage. The schema's design intentionally keeps the door open to making it required later, so anyone planning adapter-pack work knows that "adopt the manifest" is the direction of travel, not a permanent opt-in.
+No. The manifest is opt-in. A task with no `environment_manifest` continues to work under the shared-stack semantics. Task authors adopt the manifest when they want per-trial isolation.
 
 ## Safety boundaries
 
-The manifest is the typed declaration of the **boundary an agent's trial runs inside**. Three properties are worth stating explicitly so reviewers and adapter authors share the same mental model.
-
-**Grading runs outside the trial container.** Every grader the engine ships (rubric judge, state-hash, assertions, transcript rules) executes in the runner / orchestrator process, never inside the trial's services. The agent loop inside the trial cannot reach the grader's code, the tests it evaluates, or the report it produces. The manifest does not change this — the grader is structurally beyond an agent's reach by where it runs, not by what the schema declares.
-
-**The schema declares; the provisioner enforces.** `read_only`, `network`, and `resources` are properties the schema documents; the runtime backend that consumes the manifest is responsible for honouring them. The schema's job is to make the intended posture explicit and auditable; the provisioner's job is to materialise that posture in containers, networks, and policies. A manifest that declares `read_only: true` on a fixture mount is still only safe if the provisioner refuses to ignore it — that's why these are named follow-ups for the provisioner ADR, not just task-side declarations.
-
-**Per-trial isolation bounds an agent's blast radius.** Today's shared-stack path partitions trials only by `trial_id` in URLs; per-trial isolation puts each trial in its own compose project with its own network and its own ephemeral volumes. The manifest's job is to make that boundary declarative and consistent across runtime backends so the same task runs with the same posture whether the provisioner is local docker-compose or a future substrate.
-
-The schema-side guards in this ADR (path-traversal validation on bind sources and initial-state references, network-mode default of `isolated`, image-pinning, `extra="forbid"`) reduce the surface area through which a malformed or hostile manifest could weaken those boundaries. They do not replace the provisioner-side enforcement that lands later — but they catch the cheap failure modes (typos, careless authoring, drift) at task-load time instead of at trial-run time.
+- **Grading runs outside the trial container.** The grader (rubric judge, transcript checker, state-hash comparator) executes in the runner-side worker thread; the agent cannot reach the grader's code. This is a load-bearing safety property distinct from container isolation, and it is preserved unchanged by this ADR.
+- **Safety validators are load-time, not runtime-time.** A manifest that would let a service escape the per-trial boundary (`network_mode: host`, `privileged: true`, `cap_add`, `..` in a bind mount source) fails to load. Provisioning cannot start.
+- **The manifest declares; the provisioner enforces.** The manifest is the declaration surface. ADR-0010's `RuntimeBackend` provisioning contract requires the provisioner to honour every declared field, or to fail `provision` if it cannot. Silent degradation is a contract violation.
 
 ## Industry precedents studied
 
-The schema is the result of an explicit review of how other agent-evaluation harnesses declare their environments. Three projects shaped the choices here; one is the primary precedent we copied from, one is a future-integration option we deliberately left room for, and one informed a single targeted choice (image pinning).
-
 ### Inspect AI (UK AI Safety Institute) — primary precedent
 
-[inspect.aisi.org.uk/sandboxing](https://inspect.aisi.org.uk/sandboxing.html). The UK AISI's open evaluation framework is the clearest existing example of the two pillars this ADR formalises:
+Inspect AI's docker sandbox provider consumes a `compose.yaml` file verbatim, resolves service topology from the compose file's `services:` mapping, and layers a small config layer for provider-specific fields (a `default` service convention, cleanup semantics). This ADR adopts the same shape: compose is the source of truth; the wrapper adds engine-specific fields.
 
-- **Sandbox-provider abstraction.** Inspect ships `docker` and `local` built in, plus `k8s`, Daytona, Modal, EC2, and Proxmox as separate provider packages. The eval runs unchanged across them — substrate is a swap, not a rewrite. This is the same shape our `RuntimeBackend` Protocol (ADR-0007) commits to.
-- **Per-sample isolation.** "Each sample gets its own sandbox instance, even if the sandbox is defined at task level" — validates per-trial isolation as the right unit.
-- **Compose-based environment convention.** Inspect's `docker` provider reads a `compose.yaml` where the **first listed service is the default** (the one the harness talks to), **others are addressed by name**, and shared volumes wire inter-container comms.
+### METR task-standard — permission-string network model
 
-What we adopted directly: the compose convention (first-service-default, address-by-name), per-sample isolation as the model, and the protocol typing of health probes (`tcp` / `http`) instead of raw command strings. An operator who has used Inspect can read our manifest without learning anything new; an Inspect task could in principle be ported by renaming fields.
+METR's `manifest.yaml` uses permission strings for network access (`no_internet` / `limited_internet` / `full_internet`) rather than a boolean or a specific-substrate literal. This ADR's `NetworkPolicy` follows that convention: extensible without breaking callers, and readable at a glance without needing to know the substrate.
 
-### Kubernetes Agent Sandbox — studied as a future integration
+### Testcontainers — the library that consumes the manifest
 
-[agent-sandbox.sigs.k8s.io](https://agent-sandbox.sigs.k8s.io). A formal Kubernetes SIG-Apps subproject (launched late 2025) that standardises agent-execution primitives on Kubernetes. We studied it as the candidate path for any future at-scale backend; we did **not** commit to it, but we made schema choices that keep the integration cheap if/when it happens.
+Testcontainers Python's `testcontainers.compose.DockerCompose` module consumes a compose file directly. Adopting compose as source-of-truth means the concrete `LocalRuntimeBackend` (ADR-0010 follow-up) is a thin adapter over Testcontainers — no Pydantic-to-compose translator to own.
 
-What Agent Sandbox offers:
+### SWE-bench — layered image caching, not manifest
 
-- **A `Sandbox` CRD** — a declarative, controller-managed pod with stable identity and persistent storage. Replaces the hand-rolled "StatefulSet of size 1 + headless Service + PVC" pattern.
-- **Warm pools** (`SandboxWarmPool` + `SandboxTemplate` + `SandboxClaim`) — pre-provisioned isolated pods claimed on demand, with reported sub-200 ms allocation latency.
-- **Pluggable isolation** via Kubernetes's standard `runtimeClassName` — **gVisor** (userspace kernel) or **Kata** (per-pod micro-VM) for kernel/network isolation of untrusted agent + task code on shared infrastructure.
-
-Why this ADR does not commit to it:
-
-- **Pre-1.0.** The project is still maturing (v0.4.x as of writing); APIs may change; warm-pool design is still under upstream discussion. Adopting now means tracking a moving target.
-- **Multi-container gap.** Core Sandbox models a **single container per sandbox**; a realistic trial often needs N services (db + backend + frontend + …). Multi-container topology is an open extension point — not free, would need composition work on our side.
-- **Local must always work.** The `local` runtime backend has to work without a cluster; committing to a specific at-scale substrate is reversible only if it stays optional.
-
-What we did instead — cheap insurance:
-
-- `Resources.cpu` / `memory` use Kubernetes-style quantity strings (`"500m"`, `"4Gi"`). Borrowed grammar; works for compose `deploy.resources.limits` today; would drop straight into pod `resources.requests` if a K8s integration ever lands.
-- `PortSpec` declares only the container port; the runtime backend assigns host-side mapping. Sandbox CRs have no host ports either — services are reached by name on the pod's network namespace. Same shape works both ways.
-- Health probes are typed by protocol (`tcp` / `http`), the same shape Kubernetes readiness/liveness probes use.
-
-Names that would need to land in a separate ADR if we ever pursue this path: `runtimeClassName`, `securityContext`, `NetworkPolicy`. They are out of scope here.
-
-### SWE-bench — targeted influence on image pinning
-
-[swebench.com](https://www.swebench.com/). SWE-bench's instance-image discipline (every instance image pinned to an immutable tag or digest, hierarchy of base → environment → instance images cached aggressively) is the precedent for the strict image-pinning rule on `ServiceSpec.image`. We borrowed the rule; the layered-cache pattern is a named follow-up (see below), not in this ADR.
+SWE-bench's harness uses a 3-tier image hierarchy (base → environment → instance) for build-time caching. That is a build-time optimisation, not a schema concern, and it composes with any manifest that declares images with pinned tags or digests.
 
 ## Consequences
 
 ### Positive
 
-- The boundary between task-side declaration and runtime-side execution is now typed.
-- The schema's strict validation (`extra="forbid"`, image pinning, cross-field resolvers) catches malformed manifests at task-load time, not at trial-run time.
-- A canonical contract test pins the JSON wire shape: any silent field addition fails CI before it ships.
-- The shape is familiar to anyone who has used Inspect AI — no novel mental model.
-- Existing tasks are not impacted. The new field is optional and opt-in; the shared-stack path is preserved.
+- Task authors write compose files — an artefact they already know. The engine adds a small typed wrapper on top; the total learning curve is bounded.
+- Every safety-relevant configuration (`network_mode: host`, `privileged: true`, `cap_add`, bind-mount traversal) fails to load. Unsafe manifests never reach a provisioner.
+- Compose files run through `docker compose config` for structural validation, through IDE integrations for authoring, and through `docker compose up` for standalone testing. Zero-cost interop with the surrounding ecosystem.
+- The concrete `LocalRuntimeBackend` consumes the compose file directly via Testcontainers. No engine-owned Pydantic-to-compose translator.
+- Alignment with Inspect AI's docker sandbox convention makes ecosystem interop trivial: an Inspect-authored compose sandbox spec runs through `EnvironmentManifest` with no adapter code.
 
 ### Negative / Trade-offs
 
-- The manifest carries no runtime behaviour in this PR — the value is purely contract definition until a provisioner consumes it. Acceptable: the alternative (ship schema + provisioner together) doubles the diff and removes the "iterate schema cheaply" property.
-- `extra="forbid"` is intentionally strict. A new field needs a coordinated change: model + validator + canonical snapshot. That is the cost of catching silent drift at CI time.
-- Inspect-AI-compatible field names (`services`, `image`, `depends_on`) are inherited rather than re-invented; some are more verbose than the shortest possible alternative. We accept the verbosity in exchange for the familiarity.
+- Task authors edit two files (`task.yaml` + `environment/compose.yaml`) instead of one. Acceptable — the alternative (one file mixing engine-specific config with compose config) is harder to reason about and diverges from ecosystem convention.
+- Compose is docker-specific. A future Kubernetes backend translates the compose file to a Pod spec at provisioning time (via `kompose`, Testcontainers' k8s module, or a small owned translator). One industry-standard translator vs. two engine-owned translators; still the smaller cost.
+- Author-time type safety on the compose file itself is looser than an all-Pydantic schema would give (compose YAML is a permissive spec). Mitigated by the safety validators, which catch the classes of misconfiguration that matter, and by `docker compose config`.
 
 ### Follow-ups
 
-- **`RuntimeBackend` Protocol extension** (the provisioning surface that consumes the manifest). Separate PR.
-- **`LocalRuntimeBackend`** — the first concrete consumer.
-- **Layered image hierarchy / build cache.** Build-time optimisation, not a schema concern. Surfaces as `ServiceSpec.build` once we have a layered base-image story.
-- **Streaming log surface.** Belongs on `RuntimeBackend.stream_logs`, not on the manifest.
-- **Flip this ADR's status to `Accepted`** once a complex workload validates the schema end-to-end.
-
-#### Architectural-consistency follow-ups
-
-Not specific to this manifest, but surfaced by the pattern-audit this ADR triggered — filed so the discipline they codify applies uniformly to future components:
-
-- **[Architectural conventions ADR](https://github.com/Toloka/tolokaforge/issues/130).** Codify the two patterns Phase 1 established — seam-definition (Protocol + ≥2 impls + `InMemory*` fixture + contract test) and data-declaration (Pydantic + `extra="forbid"` + snapshot test) — so new components adopt the same shape rather than each contributor picking their own.
-- **[Judge Protocol lift](https://github.com/Toloka/tolokaforge/issues/131).** The rubric judge is a one-implementation top-level function today; lifting it to a `Judge` Protocol (with `LLMJudge` + `InMemoryJudge`) matches the seam-definition pattern used by `RuntimeBackend`, `Conductor`, and the artifact writers. Unlocks deterministic replay, cross-check ensemble, and adversarial-content variants without ad-hoc forks. Coordination with the Judge maintainer; sequenced after their active follow-up PRs.
-
-#### Deferred safety follow-ups
-
-Named here so a future reader does not have to re-derive what was considered and consciously deferred from this ADR:
-
-- **Per-trial secret scoping.** The current `SecretManager` is a runner-wide singleton bootstrapped from a single environment variable; every trial in a run sees the same secret pool. Per-trial secret scoping is a control-plane concern (which trial sees which credentials), not a manifest concern. Separate ADR when secret-leakage isolation becomes a hard requirement.
-- **Grader / agent boundary inside the trial container.** Today's grader runs in the runner / orchestrator process — outside any trial container, with its own isolated `ToolRegistry` the agent has no path to reach. The schema therefore does not need to carve out a separate grading service. If a future runtime backend ever runs the grader beside the agent (e.g. inheriting a benchmark harness convention), the manifest will need an optional `grading_service` field with stricter mounts and a read-only artifact path the agent cannot write to. Not in scope today. Complementary architectural work — lifting the judge itself to a Protocol — is tracked separately (see [Judge Protocol lift](https://github.com/Toloka/tolokaforge/issues/131) in the architectural-consistency follow-ups above).
-- **Trusted-output declaration / instruction-hierarchy hardening.** When the engine evaluates agents against adversarial-content scenarios (manifest-declared services that emit fake CI logs, fake issue comments, etc.), the manifest may need a way to mark which service outputs the agent should treat as authoritative vs untrusted. Out of scope until such evaluations exist in the engine.
+- **`LocalRuntimeBackend`** — the first concrete provisioner. Consumes `manifest.compose_file` directly via `testcontainers.compose.DockerCompose`.
+- **`NetworkPolicy.LIMITED_INTERNET` allowlist mechanism** — provisioner-defined; separate ADR when the first workload requires it.
+- **`K8sRuntimeBackend` design ADR** — filed when the K8s backend becomes concrete work.
 
 ## Rejected alternatives
 
-- **Option 2 — roll our own schema.** No precedent alignment; every operator pays a relearning tax.
-- **Option 3 — docker-compose YAML directly.** Locks the wire format to one substrate's grammar; no other consumer could ever read the same document.
-- **Option 4 — defer.** Just reorders the work. The runtime backend cannot land without something to consume.
+- **Field-by-field Pydantic schema re-encoding compose.** Owning `ServiceSpec` / `PortSpec` / `VolumeMount` / `HealthProbe` / `Resources` / `DependsOn` as Pydantic types. Rejected — pays a translation tax at every backend, diverges from every neighbour that reads compose directly, and gives no safety guarantee that a compose-file wrapper cannot give equivalently.
+- **METR-style Python code environment definitions.** Task authors write `TaskFamily` classes with lifecycle methods. Rejected — sacrifices static analysability, which the safety-validator layer requires, and diverges from compose tooling.
+- **One-file authoring (compose file with `x-tolokaforge:` extension carrying engine config).** Considered; rejected because it mixes engine-specific config with compose config in a single artefact, obscuring which fields the engine controls and which are pure compose semantics.
 
 ## Scope notes
 
-- **Net-new field.** `TaskDescription.environment_manifest` is brand new — there is no prior `docker_stack_requirements` field on `TaskDescription` to supersede. The shared-stack path (`core_stack` / `full_stack` templates selected by tool declarations) is preserved as the default until a backend honours the new field.
-- **Optional field, opt-in adoption.** `environment_manifest: EnvironmentManifest | None = None`. Tasks without a manifest continue to run on the existing shared-stack path. Adapter packs adopt the manifest on their own schedule.
-- **No runtime behaviour change.** No code path constructs or consumes the manifest in this PR. The contract test exercises serialization, deserialization, and every validator — that is the scope of "Proposed" status.
-- **Health probes are typed-by-protocol, not raw command strings.** A `command: list[str]` field would compile only to one healthcheck flavour. Typed `kind: tcp|http` + `port` + optional `path` is provisioner-agnostic.
-- **Initial state references are paths.** `InitialStateRef.from_` is a string path interpreted relative to the task pack root. The provisioner is responsible for resolving the path and applying the fixture; the manifest just names it and declares the kind of application (sql / copy / script).
+- **Status.** `Proposed`. Flips to `Accepted` when a real workload runs end-to-end on a per-trial backend (ADR-0010's follow-up).
+- **Contract tests are canonical.** `tests/canonical/test_environment_manifest_contract.py` pins every safety validator against fixture compose files (`tests/canonical/fixtures/environment_manifest/*.yaml`). Any silent drift fails CI.
+- **The manifest does not cache compose contents.** Every `manifest.load_compose()` re-reads from disk. Backends that need per-trial variants (per-project prefix, etc.) do so at provision time.

--- a/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
+++ b/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
@@ -106,7 +106,7 @@ class RuntimeBackend(Protocol):
 ```
 
 - **`provision(spec)`** — reads `spec.task.environment_manifest`, materialises its services (or fails `ProvisionError`), returns an `EnvHandle` the backend understands. When `environment_manifest is None`, the backend materialises the shared-stack view (backwards-compat path).
-- **`await_ready(handle)`** — blocks until all services in the handle pass their `HealthProbe`s. Raises `ProvisionError` on health-probe timeout (before returning; not silently after).
+- **`await_ready(handle)`** — blocks until every compose service in the handle passes its `healthcheck:` probe. Raises `ProvisionError` on probe timeout (before returning; not silently after).
 - **`endpoints(handle)`** — resolves per-trial URLs for the runner + declared services. Returns a fully populated `EnvEndpoints` (ADR-0006). Does not block; readiness is `await_ready`'s job.
 - **`teardown(handle)`** — stops containers, removes per-trial network, releases any lease the backend holds. **Idempotent** — calling on an already-torn-down handle is a no-op, not an error. **Best-effort** — logs but does not raise if a container was already gone.
 
@@ -144,21 +144,22 @@ class ProvisionError(Exception):
 
 ### Enforcement obligations
 
-A `RuntimeBackend` implementation is contractually obligated to honour these manifest declarations. Failure to enforce any of them at `provision` time — not later, not silently — is a contract violation:
+A `RuntimeBackend` implementation is contractually obligated to honour every declaration in the manifest and the compose file it points at. Failure to enforce any of them at `provision` time — not later, not silently — is a contract violation:
 
-| Manifest field | Provisioner obligation |
+| Declared where | Provisioner obligation |
 |---|---|
-| `EnvironmentManifest.network` = `isolated` | No egress to the public internet; no reachability across per-trial projects. Enforce via substrate-native network isolation. |
-| `EnvironmentManifest.network` = `external` | Egress permitted; still no cross-trial reachability. |
-| `ServiceSpec.security_context` | Every declared field applied to the container (`run_as_user`, `read_only_root_filesystem`, `no_new_privileges`, capability drops/adds). Fail `ProvisionError` if any declared field cannot be enforced by the substrate. |
-| `ServiceSpec.resources` / manifest-level `Resources` | CPU / memory caps applied at the container level. Per-service overrides manifest-level defaults. |
-| `VolumeMount.read_only` | Bind or named mount honours the flag. |
-| `ServiceSpec.health` + `HealthProbe.initial_delay_seconds` | `await_ready` respects the delay before the first probe. |
-| `ServiceSpec.depends_on` (in either form) | Startup ordering; `service_healthy` waits on the probe passing. |
-| `EnvironmentManifest.initial_state` | Fixture applied per its `kind` (`sql` / `copy` / `script`) before `await_ready` returns. |
-| `ServiceSpec.image` pinning | Substrate honours the exact tag or digest; no automatic tag resolution. |
+| `EnvironmentManifest.network_policy` = `no_internet` | No egress to the public internet; no reachability across per-trial projects. Enforce via substrate-native network isolation. |
+| `EnvironmentManifest.network_policy` = `limited_internet` | Egress permitted for the provisioner-defined allowlist; no cross-trial reachability. |
+| `EnvironmentManifest.network_policy` = `full_internet` | Unrestricted egress; still no cross-trial reachability. |
+| `EnvironmentManifest.security_context_defaults` | Every declared field applied to each compose service that does not set the equivalent explicitly (`run_as_user`, `read_only_root_filesystem`, `no_new_privileges`, capability drops / adds). Fail `ProvisionError` if the substrate cannot enforce a declared field. |
+| `EnvironmentManifest.initial_state` | Fixture applied per its `kind` (`sql` / `copy` / `script`) to the named compose service before `await_ready` returns. |
+| Compose service `deploy.resources` / `mem_limit` / `cpus` | Container-level CPU / memory caps enforced as declared. |
+| Compose service `volumes:` with `:ro` short-form or `read_only: true` long-form | Bind or named mount honours the read-only flag. |
+| Compose service `healthcheck:` block | `await_ready` respects `start_period`, `interval`, `timeout`, `retries` before returning. |
+| Compose service `depends_on` (short-form list or long-form mapping) | Startup ordering enforced; `condition: service_healthy` waits on the probe passing. |
+| Compose service `image:` pinning (validated at manifest load-time) | Substrate honours the exact tag or digest; no automatic tag resolution. |
 
-**Rule of thumb: if the substrate cannot enforce a declared property, `provision` raises `ProvisionError` at task-load time. No provisioner may silently drop, downgrade, or ignore a declaration.**
+**Rule of thumb: if the substrate cannot enforce a declared property, `provision` raises `ProvisionError` — not later, not silently. No provisioner may silently drop, downgrade, or ignore a declaration.**
 
 ### Lifecycle ownership
 

--- a/docs/architecture/adr/0011-seam-and-declaration-conventions.md
+++ b/docs/architecture/adr/0011-seam-and-declaration-conventions.md
@@ -67,13 +67,13 @@ Use for a typed shape that crosses a serialization or task-boundary. Every occur
 |---|---|---|---|
 | Trial wire format | `TrialSpec`, `TrialResult` | `test_trial_spec_contract.py` | [0003](0003-trial-spec-and-trial-result.md) |
 | Trial-scoped service URLs | `EnvEndpoints` | *(embedded in `TrialSpec` snapshot)* | [0006](0006-typed-env-endpoints.md) |
-| Multi-service environment | `EnvironmentManifest` + `ServiceSpec` + `HealthProbe` + `PortSpec` + `VolumeMount` + `Resources` + `InitialStateRef` + `DependsOn` + `SecurityContext` | `test_environment_manifest_contract.py` | [0009](0009-environment-manifest.md) |
+| Per-trial environment | `EnvironmentManifest` + `InitialStateRef` + `NetworkPolicy` + `SecurityContext` (points at a Docker Compose file; safety validators run against loaded compose contents) | `test_environment_manifest_contract.py` | [0009](0009-environment-manifest.md) |
 | Rubric grading | `Rubric`, `Criterion`, `CriterionResult`, `LLMJudgeConfig` | *(embedded in `TaskDescription` + grading tests)* | — |
 
 ### Naming discipline
 
 - **`*Config` suffix** for models whose purpose is *behaviour configuration* — e.g. `LLMJudgeConfig`, `SearchConfig`, `UserSimulatorConfig`, `GradingConfig`, `TranscriptRulesConfig`. These carry knobs that select or shape a runtime component's behaviour.
-- **No suffix** for models whose purpose is *data-shape declaration* — e.g. `ServiceSpec`, `HealthProbe`, `Resources`, `EnvEndpoints`, `TrialSpec`, `Rubric`. These describe a structure, not a set of choices.
+- **No suffix** for models whose purpose is *data-shape declaration* — e.g. `EnvironmentManifest`, `InitialStateRef`, `SecurityContext`, `EnvEndpoints`, `TrialSpec`, `Rubric`. These describe a structure, not a set of choices.
 
 The distinction is descriptive of what the codebase already does; it is not a new convention. New models should follow whichever suffix matches their role.
 

--- a/docs/architecture/adr/0011-seam-and-declaration-conventions.md
+++ b/docs/architecture/adr/0011-seam-and-declaration-conventions.md
@@ -70,6 +70,16 @@ Use for a typed shape that crosses a serialization or task-boundary. Every occur
 | Per-trial environment | `EnvironmentManifest` + `InitialStateRef` + `NetworkPolicy` + `SecurityContext` (points at a Docker Compose file; safety validators run against loaded compose contents) | `test_environment_manifest_contract.py` | [0009](0009-environment-manifest.md) |
 | Rubric grading | `Rubric`, `Criterion`, `CriterionResult`, `LLMJudgeConfig` | *(embedded in `TaskDescription` + grading tests)* | — |
 
+**Pattern B addendum — typed wrapper over an external artifact.** A strict Pydantic wrapper may reference an external artifact (a Docker Compose file, a Kubernetes Pod spec, etc.) via a `Path` (or equivalent locator) field, provided:
+
+- The wrapper's engine-specific fields remain strict with `extra="forbid"`, and every field the wrapper itself declares is either a typed Pydantic type or a locator (never an untyped dict that carries structured meaning).
+- The wrapper's `model_validator` inspects the artifact's contents at construction and rejects unsafe patterns. Every safety guarantee is a load-time check, not a runtime hope.
+- The artifact's shape has its own governing external spec (Docker Compose, Kubernetes, OCI, etc.). The wrapper does NOT re-encode the external spec as Pydantic types — that is the translation tax this pattern is written to avoid.
+- Safety-validator behaviour is pinned by fixture-driven canonical tests (one fixture artifact per unsafe pattern, plus at least one safe fixture the wrapper accepts).
+- Any cached in-memory representation of the parsed artifact lives on the model as a `PrivateAttr` (not a field). `PrivateAttr` values do not appear in the wire format and do not count as an untyped-dict escape hatch.
+
+**Example:** `EnvironmentManifest` (ADR-0009) points at a `compose.yaml` file. The wrapper's five engine-specific fields (`compose_file`, `runner_service`, `initial_state`, `network_policy`, `security_context_defaults`) are strict Pydantic; the compose file is validated by safety helpers (`_check_no_host_network`, `_check_no_privileged`, `_check_no_cap_add`, `_check_safe_bind_mounts`, `_check_pinned_images`, `_check_depends_on_resolves`) at construction; the parsed contents are cached on the model via a `PrivateAttr` and returned verbatim by `load_compose()`.
+
 ### Naming discipline
 
 - **`*Config` suffix** for models whose purpose is *behaviour configuration* — e.g. `LLMJudgeConfig`, `SearchConfig`, `UserSimulatorConfig`, `GradingConfig`, `TranscriptRulesConfig`. These carry knobs that select or shape a runtime component's behaviour.

--- a/tests/canonical/fixtures/environment_manifest/safe_one_service.yaml
+++ b/tests/canonical/fixtures/environment_manifest/safe_one_service.yaml
@@ -1,0 +1,3 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0

--- a/tests/canonical/fixtures/environment_manifest/safe_two_service.yaml
+++ b/tests/canonical/fixtures/environment_manifest/safe_two_service.yaml
@@ -1,0 +1,13 @@
+services:
+  db:
+    image: postgres:16
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+  default:
+    image: tolokaforge/runner:0.5.0
+    depends_on:
+      db:
+        condition: service_healthy

--- a/tests/canonical/fixtures/environment_manifest/unsafe_bare_image.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_bare_image.yaml
@@ -1,0 +1,3 @@
+services:
+  default:
+    image: postgres

--- a/tests/canonical/fixtures/environment_manifest/unsafe_bind_absolute.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_bind_absolute.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    volumes:
+      - /etc/passwd:/passwd:ro

--- a/tests/canonical/fixtures/environment_manifest/unsafe_bind_env_var.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_bind_env_var.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    volumes:
+      - ${TASK_ROOT}/data:/target

--- a/tests/canonical/fixtures/environment_manifest/unsafe_bind_tilde.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_bind_tilde.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    volumes:
+      - ~/data:/target

--- a/tests/canonical/fixtures/environment_manifest/unsafe_bind_traversal.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_bind_traversal.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    volumes:
+      - ../etc/passwd:/passwd:ro

--- a/tests/canonical/fixtures/environment_manifest/unsafe_cap_add.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_cap_add.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    cap_add:
+      - SYS_ADMIN

--- a/tests/canonical/fixtures/environment_manifest/unsafe_floating_tag.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_floating_tag.yaml
@@ -1,0 +1,3 @@
+services:
+  default:
+    image: postgres:latest

--- a/tests/canonical/fixtures/environment_manifest/unsafe_host_network.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_host_network.yaml
@@ -1,0 +1,4 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    network_mode: host

--- a/tests/canonical/fixtures/environment_manifest/unsafe_missing_depends_on.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_missing_depends_on.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    depends_on:
+      - db_typo

--- a/tests/canonical/fixtures/environment_manifest/unsafe_privileged.yaml
+++ b/tests/canonical/fixtures/environment_manifest/unsafe_privileged.yaml
@@ -1,0 +1,4 @@
+services:
+  default:
+    image: tolokaforge/runner:0.5.0
+    privileged: true

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -165,6 +165,17 @@ class TestEnvironmentManifestConstruction:
         content = m.load_compose()
         assert set(content["services"]) == {"db", "default"}
 
+    def test_load_compose_returns_cached_snapshot(self, tmp_path: Path) -> None:
+        """The manifest snapshots the compose file at construction time.
+        Later edits to the file on disk are not reflected — callers see the
+        content the safety validators inspected."""
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres:16\n")
+        m = EnvironmentManifest(compose_file=compose)
+        assert m.load_compose()["services"] == {"default": {"image": "postgres:16"}}
+        compose.write_text("services:\n  changed:\n    image: postgres:16\n")
+        assert m.load_compose()["services"] == {"default": {"image": "postgres:16"}}
+
 
 # ---------------------------------------------------------------------------
 # EnvironmentManifest — safety validators against loaded compose contents
@@ -199,7 +210,7 @@ class TestComposeSafetyValidators:
             EnvironmentManifest(compose_file=_fixture("unsafe_host_network.yaml"))
 
     def test_privileged_true_is_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="privileged: true"):
+        with pytest.raises(ValidationError, match="privileged"):
             EnvironmentManifest(compose_file=_fixture("unsafe_privileged.yaml"))
 
     def test_cap_add_is_rejected(self) -> None:
@@ -213,6 +224,104 @@ class TestComposeSafetyValidators:
     def test_bind_mount_with_absolute_path_is_rejected(self) -> None:
         with pytest.raises(ValidationError, match="relative path"):
             EnvironmentManifest(compose_file=_fixture("unsafe_bind_absolute.yaml"))
+
+    def test_bind_mount_with_env_var_expansion_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="shell-expansion"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_bind_env_var.yaml"))
+
+    def test_bind_mount_with_tilde_prefix_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="home-directory"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_bind_tilde.yaml"))
+
+    def test_privileged_true_string_is_rejected(self, tmp_path: Path) -> None:
+        """A quoted `\"true\"` parses as a string but must still fail the
+        safety check — otherwise a bare-string edit slips a privileged
+        container past the validator."""
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            'services:\n  default:\n    image: postgres:16\n    privileged: "true"\n'
+        )
+        with pytest.raises(ValidationError, match="privileged"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_privileged_integer_one_is_rejected(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres:16\n    privileged: 1\n")
+        with pytest.raises(ValidationError, match="privileged"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_privileged_false_is_accepted(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres:16\n    privileged: false\n")
+        EnvironmentManifest(compose_file=compose)  # must not raise
+
+    def test_floating_image_tag_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="floating tag"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_floating_tag.yaml"))
+
+    def test_bare_image_reference_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="explicit tag or digest"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_bare_image.yaml"))
+
+    @pytest.mark.parametrize(
+        "tag",
+        ["latest", "main", "master", "edge", "stable", "dev", "develop", "nightly", "head"],
+    )
+    def test_every_floating_tag_variant_is_rejected(self, tag: str, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(f"services:\n  default:\n    image: postgres:{tag}\n")
+        with pytest.raises(ValidationError, match="floating tag"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_sha256_digest_reference_is_accepted(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        digest = "sha256:" + "a" * 64
+        compose.write_text(f"services:\n  default:\n    image: postgres@{digest}\n")
+        EnvironmentManifest(compose_file=compose)  # must not raise
+
+    def test_malformed_digest_is_rejected(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres@sha256:short\n")
+        with pytest.raises(ValidationError, match="digest"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_build_only_service_is_accepted(self, tmp_path: Path) -> None:
+        """A service that declares `build:` instead of `image:` is exempt
+        from the pinning check — no tag to pin."""
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    build: ./ctx\n")
+        EnvironmentManifest(compose_file=compose)  # must not raise
+
+    def test_depends_on_undeclared_service_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not declared in the compose file"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_missing_depends_on.yaml"))
+
+    def test_depends_on_long_form_undeclared_service_is_rejected(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "services:\n"
+            "  default:\n"
+            "    image: tolokaforge/runner:0.5.0\n"
+            "    depends_on:\n"
+            "      db_typo:\n"
+            "        condition: service_healthy\n"
+        )
+        with pytest.raises(ValidationError, match="not declared in the compose file"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_depends_on_scalar_is_rejected(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres:16\n    depends_on: 5\n")
+        with pytest.raises(ValidationError, match="must be a list or a mapping"):
+            EnvironmentManifest(compose_file=compose)
+
+    def test_volumes_scalar_is_rejected(self, tmp_path: Path) -> None:
+        """A non-list `volumes:` value must fail explicitly rather than be
+        silently swallowed as empty."""
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  default:\n    image: postgres:16\n    volumes: ''\n")
+        with pytest.raises(ValidationError, match="must be a list"):
+            EnvironmentManifest(compose_file=compose)
 
     def test_named_volume_reference_is_accepted(self, tmp_path: Path) -> None:
         compose = tmp_path / "compose.yaml"

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -1,224 +1,96 @@
-"""Pin the JSON wire shape and validators of ``EnvironmentManifest``.
+"""Pin the ``EnvironmentManifest`` contract — compose-as-source-of-truth.
 
-The manifest is the typed declaration of a task's multi-service environment;
-this module pins every field, every default, and every cross-field validator
-so a silent change to either fails CI.
+The manifest is a lean Pydantic wrapper over a Docker Compose file: the
+compose file declares service topology (images, ports, volumes, health
+probes, depends_on, resources), and the manifest adds engine-specific
+fields (runner-service selection, initial-state fixtures, network policy,
+security-context defaults) plus safety validators that run against the
+loaded compose contents at construction time.
+
+Wire-shape snapshot pins the top-level manifest surface; fixture-driven
+tests pin each safety validator against a real compose file.
 """
 
 from __future__ import annotations
 
-import json
-from typing import Any
+from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
-from tolokaforge.runner.models import (
-    DependsOn,
+from tolokaforge.core.trial import (
     EnvironmentManifest,
-    HealthProbe,
     InitialStateRef,
-    PortSpec,
-    Resources,
+    NetworkPolicy,
     SecurityContext,
-    ServiceSpec,
-    TaskDescription,
-    VolumeMount,
 )
+from tolokaforge.runner.models import TaskDescription
 
 pytestmark = pytest.mark.canonical
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+FIXTURES = Path(__file__).parent / "fixtures" / "environment_manifest"
 
 
-def _make_minimal_service(name: str = "runner") -> ServiceSpec:
-    return ServiceSpec(name=name, image="tolokaforge/runner:0.5.0")
-
-
-def _make_minimal_manifest() -> EnvironmentManifest:
-    return EnvironmentManifest(services=[_make_minimal_service()])
+def _fixture(name: str) -> Path:
+    path = FIXTURES / name
+    assert path.is_file(), f"missing fixture: {path}"
+    return path
 
 
 # ---------------------------------------------------------------------------
-# HealthProbe
-# ---------------------------------------------------------------------------
-
-
-class TestHealthProbeContract:
-    def test_tcp_probe_defaults(self) -> None:
-        probe = HealthProbe(kind="tcp", port=5432)
-        assert probe.path is None
-        assert probe.initial_delay_seconds == 0
-        assert probe.interval_seconds == 5
-        assert probe.timeout_seconds == 3
-        assert probe.retries == 10
-
-    def test_http_probe_requires_path(self) -> None:
-        with pytest.raises(ValidationError, match="path is required"):
-            HealthProbe(kind="http", port=8080)
-
-    def test_tcp_probe_rejects_path(self) -> None:
-        with pytest.raises(ValidationError, match="not allowed"):
-            HealthProbe(kind="tcp", port=5432, path="/healthz")
-
-    def test_initial_delay_seconds_round_trip(self) -> None:
-        probe = HealthProbe(
-            kind="http",
-            port=8080,
-            path="/healthz",
-            initial_delay_seconds=30,
-            interval_seconds=10,
-            timeout_seconds=2,
-            retries=20,
-        )
-        assert HealthProbe.model_validate_json(probe.model_dump_json()) == probe
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            HealthProbe.model_validate({"kind": "tcp", "port": 5432, "extra": "no"})
-
-
-# ---------------------------------------------------------------------------
-# PortSpec
-# ---------------------------------------------------------------------------
-
-
-class TestPortSpecContract:
-    def test_default_protocol_is_tcp(self) -> None:
-        spec = PortSpec(container_port=80)
-        assert spec.protocol == "tcp"
-
-    def test_udp_accepted(self) -> None:
-        spec = PortSpec(container_port=53, protocol="udp")
-        assert spec.protocol == "udp"
-
-    def test_invalid_protocol_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            PortSpec.model_validate({"container_port": 80, "protocol": "sctp"})
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            PortSpec.model_validate({"container_port": 80, "host_port": 8080})
-
-
-# ---------------------------------------------------------------------------
-# VolumeMount
-# ---------------------------------------------------------------------------
-
-
-class TestVolumeMountContract:
-    def test_minimal_mount_defaults_to_bind(self) -> None:
-        mount = VolumeMount(source="fixtures/seed.sql", target="/seed.sql")
-        assert mount.kind == "bind"
-        assert mount.read_only is False
-
-    def test_named_volume_round_trip(self) -> None:
-        mount = VolumeMount(kind="named", source="pgdata", target="/var/lib/postgresql/data")
-        assert VolumeMount.model_validate_json(mount.model_dump_json()) == mount
-
-    def test_unknown_kind_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            VolumeMount.model_validate({"kind": "tmpfs", "source": "a", "target": "/b"})
-
-    @pytest.mark.parametrize(
-        "bad_source",
-        ["..", "../escape", "a/../b", "/etc/passwd", "/", ""],
-    )
-    def test_bind_source_rejects_unsafe_paths(self, bad_source: str) -> None:
-        with pytest.raises(ValidationError):
-            VolumeMount(kind="bind", source=bad_source, target="/in/container")
-
-    def test_named_source_skips_path_traversal_check(self) -> None:
-        # Named volume identifiers are not paths; path-traversal guard does not apply.
-        mount = VolumeMount(kind="named", source="../pgdata", target="/data")
-        assert mount.kind == "named"
-        assert mount.source == "../pgdata"
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            VolumeMount.model_validate({"source": "a", "target": "/b", "mode": "rw"})
-
-
-# ---------------------------------------------------------------------------
-# Resources
-# ---------------------------------------------------------------------------
-
-
-class TestResourcesContract:
-    def test_empty_resources_allowed(self) -> None:
-        r = Resources()
-        assert r.cpu is None
-        assert r.memory is None
-
-    def test_k8s_quantity_strings_accepted(self) -> None:
-        r = Resources(cpu="500m", memory="512Mi")
-        assert r.cpu == "500m"
-        assert r.memory == "512Mi"
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            Resources.model_validate({"cpu": "2", "gpu": "1"})
-
-
-# ---------------------------------------------------------------------------
-# InitialStateRef
+# InitialStateRef — retained model
 # ---------------------------------------------------------------------------
 
 
 class TestInitialStateRefContract:
-    def test_round_trip_via_alias_defaults_to_copy(self) -> None:
-        ref = InitialStateRef.model_validate({"from": "fixtures/orders.sql"})
-        assert ref.from_ == "fixtures/orders.sql"
-        assert ref.kind == "copy"
+    def test_alias_from_round_trips(self) -> None:
+        ref = InitialStateRef.model_validate({"from": "./fixtures/seed.sql", "kind": "sql"})
+        assert ref.from_ == "./fixtures/seed.sql"
         dumped = ref.model_dump(by_alias=True)
-        assert dumped == {"from": "fixtures/orders.sql", "kind": "copy"}
+        assert dumped == {"from": "./fixtures/seed.sql", "kind": "sql"}
+
+    def test_default_kind_is_copy(self) -> None:
+        ref = InitialStateRef.model_validate({"from": "./fixtures/blob"})
+        assert ref.kind == "copy"
 
     @pytest.mark.parametrize("kind", ["sql", "copy", "script"])
-    def test_all_kinds_accepted(self, kind: str) -> None:
-        ref = InitialStateRef.model_validate({"from": "x", "kind": kind})
+    def test_all_kinds_are_accepted(self, kind: str) -> None:
+        ref = InitialStateRef.model_validate({"from": "./x", "kind": kind})
         assert ref.kind == kind
 
-    def test_unknown_kind_rejected(self) -> None:
+    def test_empty_from_is_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            InitialStateRef.model_validate({"from": "x", "kind": "exec"})
-
-    def test_empty_from_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="non-empty"):
             InitialStateRef.model_validate({"from": ""})
 
-    @pytest.mark.parametrize(
-        "bad_from",
-        ["..", "../escape.sql", "a/../b.sql", "/etc/passwd", "/"],
-    )
-    def test_from_rejects_unsafe_paths(self, bad_from: str) -> None:
+    @pytest.mark.parametrize("bad", ["../escape", "../../escape", "/etc/passwd"])
+    def test_unsafe_from_is_rejected(self, bad: str) -> None:
         with pytest.raises(ValidationError):
-            InitialStateRef.model_validate({"from": bad_from})
+            InitialStateRef.model_validate({"from": bad})
 
-    def test_extra_field_rejected(self) -> None:
+    def test_extra_fields_are_forbidden(self) -> None:
         with pytest.raises(ValidationError):
-            InitialStateRef.model_validate({"from": "a.sql", "format": "sql"})
+            InitialStateRef.model_validate({"from": "./x", "unknown": True})
 
 
 # ---------------------------------------------------------------------------
-# DependsOn
+# SecurityContext — retained; used by the manifest as security_context_defaults
 # ---------------------------------------------------------------------------
 
 
 class TestSecurityContextContract:
-    def test_defaults_favour_safer_posture(self) -> None:
-        sc = SecurityContext()
-        assert sc.run_as_user is None
-        assert sc.run_as_group is None
-        assert sc.read_only_root_filesystem is False
-        assert sc.no_new_privileges is True
-        assert sc.capabilities_drop == ["ALL"]
-        assert sc.capabilities_add == []
+    def test_safer_posture_by_default(self) -> None:
+        ctx = SecurityContext()
+        assert ctx.no_new_privileges is True
+        assert ctx.capabilities_drop == ["ALL"]
+        assert ctx.capabilities_add == []
+        assert ctx.read_only_root_filesystem is False
+        assert ctx.run_as_user is None
+        assert ctx.run_as_group is None
 
-    def test_full_construction_round_trip(self) -> None:
-        sc = SecurityContext(
+    def test_round_trip_preserves_every_field(self) -> None:
+        ctx = SecurityContext(
             run_as_user=1000,
             run_as_group=1000,
             read_only_root_filesystem=True,
@@ -226,446 +98,253 @@ class TestSecurityContextContract:
             capabilities_drop=["ALL"],
             capabilities_add=["NET_BIND_SERVICE"],
         )
-        assert SecurityContext.model_validate_json(sc.model_dump_json()) == sc
+        reloaded = SecurityContext.model_validate_json(ctx.model_dump_json())
+        assert reloaded == ctx
 
-    def test_extra_field_rejected(self) -> None:
+    def test_extra_fields_are_forbidden(self) -> None:
         with pytest.raises(ValidationError):
-            SecurityContext.model_validate(
-                {"run_as_user": 1000, "seccomp_profile": "runtime/default"}
-            )
-
-    def test_per_service_assignment(self) -> None:
-        svc = ServiceSpec(
-            name="runner",
-            image="tolokaforge/runner:0.5.0",
-            security_context=SecurityContext(run_as_user=1000, read_only_root_filesystem=True),
-        )
-        assert svc.security_context is not None
-        assert svc.security_context.run_as_user == 1000
-        assert svc.security_context.read_only_root_filesystem is True
-
-    def test_service_default_is_none(self) -> None:
-        svc = ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0")
-        assert svc.security_context is None
-
-    def test_uid_type_is_unbounded_int(self) -> None:
-        # int | None accepts any int; the runtime backend is responsible for
-        # rejecting nonsensical UIDs. Confirmed with a small-int case.
-        sc = SecurityContext(run_as_user=0)
-        assert sc.run_as_user == 0
-
-
-class TestDependsOnContract:
-    def test_minimal_construction_defaults_to_started(self) -> None:
-        dep = DependsOn(service="db")
-        assert dep.condition == "service_started"
-
-    def test_service_healthy_accepted(self) -> None:
-        dep = DependsOn(service="db", condition="service_healthy")
-        assert dep.condition == "service_healthy"
-
-    def test_unknown_condition_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            DependsOn.model_validate({"service": "db", "condition": "service_completed"})
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            DependsOn.model_validate({"service": "db", "restart": True})
+            SecurityContext.model_validate({"unknown": True})
 
 
 # ---------------------------------------------------------------------------
-# ServiceSpec
+# NetworkPolicy — permission-string enum
 # ---------------------------------------------------------------------------
 
 
-class TestServiceSpecContract:
-    def test_minimal_construction(self) -> None:
-        svc = _make_minimal_service()
-        assert svc.command is None
-        assert svc.env == {}
-        assert svc.ports == []
-        assert svc.volumes == []
-        assert svc.depends_on == []
-        assert svc.health is None
-        assert svc.resources is None
+class TestNetworkPolicyContract:
+    @pytest.mark.parametrize(
+        "value",
+        [NetworkPolicy.NO_INTERNET, NetworkPolicy.LIMITED_INTERNET, NetworkPolicy.FULL_INTERNET],
+    )
+    def test_member_values_are_permission_strings(self, value: NetworkPolicy) -> None:
+        assert value.value in {"no_internet", "limited_internet", "full_internet"}
+
+    def test_string_construction(self) -> None:
+        assert NetworkPolicy("no_internet") is NetworkPolicy.NO_INTERNET
+        assert NetworkPolicy("full_internet") is NetworkPolicy.FULL_INTERNET
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentManifest — happy-path construction + defaults
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentManifestConstruction:
+    def test_minimal_construction_defaults(self) -> None:
+        m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
+        assert m.runner_service == "default"
+        assert m.initial_state == {}
+        assert m.network_policy is NetworkPolicy.NO_INTERNET
+        assert m.security_context_defaults is None
 
     def test_full_construction_round_trip(self) -> None:
-        svc = ServiceSpec(
-            name="db",
-            image="postgres:16",
-            command=["postgres", "-c", "shared_buffers=256MB"],
-            env={"POSTGRES_PASSWORD": "dev"},
-            ports=[PortSpec(container_port=5432)],
-            volumes=[VolumeMount(kind="named", source="pgdata", target="/var/lib/postgresql/data")],
-            depends_on=[],
-            health=HealthProbe(kind="tcp", port=5432, initial_delay_seconds=15),
-            resources=Resources(cpu="2", memory="4Gi"),
+        compose_file = _fixture("safe_two_service.yaml")
+        m = EnvironmentManifest(
+            compose_file=compose_file,
+            runner_service="default",
+            initial_state={
+                "db": InitialStateRef.model_validate({"from": "./fixtures/seed.sql", "kind": "sql"})
+            },
+            network_policy=NetworkPolicy.FULL_INTERNET,
+            security_context_defaults=SecurityContext(run_as_user=1000),
         )
-        assert ServiceSpec.model_validate_json(svc.model_dump_json()) == svc
+        reloaded = EnvironmentManifest.model_validate_json(m.model_dump_json())
+        assert reloaded == m
 
-    def test_per_service_resources_override(self) -> None:
-        svc = ServiceSpec(
-            name="runner",
-            image="tolokaforge/runner:0.5.0",
-            resources=Resources(cpu="500m", memory="256Mi"),
-        )
-        assert svc.resources is not None
-        assert svc.resources.cpu == "500m"
-
-    def test_depends_on_accepts_string_shorthand(self) -> None:
-        svc = ServiceSpec(
-            name="backend",
-            image="ghcr.io/example/api:v1.2.3",
-            depends_on=["db"],
-        )
-        # String entries stay as strings on the wire (shorthand for service_started).
-        assert svc.depends_on == ["db"]
-
-    def test_depends_on_accepts_structured_form(self) -> None:
-        svc = ServiceSpec(
-            name="backend",
-            image="ghcr.io/example/api:v1.2.3",
-            depends_on=[DependsOn(service="db", condition="service_healthy")],
-        )
-        assert isinstance(svc.depends_on[0], DependsOn)
-        assert svc.depends_on[0].condition == "service_healthy"
-
-    def test_depends_on_mixed_round_trip(self) -> None:
-        svc = ServiceSpec(
-            name="backend",
-            image="ghcr.io/example/api:v1.2.3",
-            depends_on=["db", DependsOn(service="cache", condition="service_healthy")],
-        )
-        rehydrated = ServiceSpec.model_validate_json(svc.model_dump_json())
-        assert rehydrated == svc
-
-    # ---- image-pinning ----
-
-    def test_latest_tag_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="floating tag"):
-            ServiceSpec(name="runner", image="tolokaforge/runner:latest")
-
-    def test_latest_tag_case_insensitive(self) -> None:
-        with pytest.raises(ValidationError, match="floating tag"):
-            ServiceSpec(name="runner", image="tolokaforge/runner:LATEST")
-
-    @pytest.mark.parametrize("tag", ["main", "master", "edge", "stable", "dev", "nightly", "head"])
-    def test_other_floating_tags_rejected(self, tag: str) -> None:
-        with pytest.raises(ValidationError, match="floating tag"):
-            ServiceSpec(name="svc", image=f"example/svc:{tag}")
-
-    def test_bare_image_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="explicit tag or digest"):
-            ServiceSpec(name="runner", image="tolokaforge/runner")
-
-    def test_registry_with_port_but_no_tag_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="explicit tag or digest"):
-            ServiceSpec(name="runner", image="registry.example.com:5000/foo")
-
-    def test_registry_with_port_and_tag_accepted(self) -> None:
-        svc = ServiceSpec(name="runner", image="registry.example.com:5000/foo:1.2.3")
-        assert svc.image == "registry.example.com:5000/foo:1.2.3"
-
-    def test_empty_tag_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="non-empty"):
-            ServiceSpec(name="runner", image="example/svc:")
-
-    def test_sha_digest_accepted(self) -> None:
-        svc = ServiceSpec(
-            name="runner",
-            image="tolokaforge/runner@sha256:" + "0" * 64,
-        )
-        assert svc.image.startswith("tolokaforge/runner@sha256:")
-
-    def test_digest_with_tag_accepted(self) -> None:
-        # Docker permits tag + digest; digest takes precedence and is always pinned.
-        svc = ServiceSpec(
-            name="runner",
-            image="example/svc:1.2.3@sha256:" + "0" * 64,
-        )
-        assert "@sha256:" in svc.image
-
-    def test_sha512_digest_accepted(self) -> None:
-        svc = ServiceSpec(name="runner", image="example/svc@sha512:" + "0" * 128)
-        assert "@sha512:" in svc.image
-
-    @pytest.mark.parametrize(
-        "bad_image",
-        [
-            "repo@sha256:zzz",  # not hex
-            "repo@sha256:" + "0" * 63,  # one char short
-            "repo@sha256:" + "0" * 65,  # one char long
-            "repo@sha512:" + "0" * 64,  # sha512 must be 128 hex
-            "repo@md5:" + "0" * 32,  # unsupported algorithm
-            "repo@:" + "0" * 64,  # missing algorithm
-            "repo@sha256:",  # empty digest
-        ],
-    )
-    def test_malformed_digest_rejected(self, bad_image: str) -> None:
-        with pytest.raises(ValidationError, match="well-formed"):
-            ServiceSpec(name="runner", image=bad_image)
-
-    # ---- name validation ----
-
-    @pytest.mark.parametrize(
-        "bad_name",
-        [
-            "Runner",  # uppercase
-            "-leading-dash",
-            "trailing-dash-",
-            "with_underscore",
-            "with.dot",
-            "",
-        ],
-    )
-    def test_invalid_dns_label_rejected(self, bad_name: str) -> None:
+    def test_extra_fields_are_forbidden(self) -> None:
         with pytest.raises(ValidationError):
-            ServiceSpec(name=bad_name, image="tolokaforge/runner:0.5.0")
-
-    def test_dns_label_length_cap_63(self) -> None:
-        ok = "a" + "b" * 62  # 63 chars total
-        ServiceSpec(name=ok, image="example/svc:1.0")
-        too_long = "a" + "b" * 63  # 64 chars
-        with pytest.raises(ValidationError, match="at most 63 characters"):
-            ServiceSpec(name=too_long, image="example/svc:1.0")
-
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ServiceSpec.model_validate(
-                {"name": "runner", "image": "tolokaforge/runner:0.5.0", "restart": "always"}
+            EnvironmentManifest.model_validate(
+                {
+                    "compose_file": str(_fixture("safe_one_service.yaml")),
+                    "unknown": True,
+                }
             )
+
+    def test_load_compose_returns_parsed_dict(self) -> None:
+        m = EnvironmentManifest(compose_file=_fixture("safe_two_service.yaml"))
+        content = m.load_compose()
+        assert set(content["services"]) == {"db", "default"}
 
 
 # ---------------------------------------------------------------------------
-# EnvironmentManifest — cross-service validators + wire shape
+# EnvironmentManifest — safety validators against loaded compose contents
 # ---------------------------------------------------------------------------
 
 
-class TestEnvironmentManifestContract:
-    def test_minimal_manifest(self) -> None:
-        manifest = _make_minimal_manifest()
-        assert manifest.initial_state == {}
-        assert manifest.resources is None
+class TestComposeSafetyValidators:
+    def test_missing_compose_file_is_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValidationError, match="does not exist"):
+            EnvironmentManifest(compose_file=tmp_path / "nonexistent.yaml")
 
-    def test_empty_services_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="non-empty"):
-            EnvironmentManifest(services=[])
+    def test_non_mapping_yaml_is_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "list.yaml"
+        bad.write_text("- one\n- two\n")
+        with pytest.raises(ValidationError, match="YAML mapping"):
+            EnvironmentManifest(compose_file=bad)
 
-    def test_duplicate_service_names_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="duplicate name"):
+    def test_missing_services_key_is_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "no_services.yaml"
+        bad.write_text("version: '3'\n")
+        with pytest.raises(ValidationError, match="`services:`"):
+            EnvironmentManifest(compose_file=bad)
+
+    def test_empty_services_is_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "empty_services.yaml"
+        bad.write_text("services: {}\n")
+        with pytest.raises(ValidationError, match="`services:`"):
+            EnvironmentManifest(compose_file=bad)
+
+    def test_network_mode_host_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="network_mode: host"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_host_network.yaml"))
+
+    def test_privileged_true_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="privileged: true"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_privileged.yaml"))
+
+    def test_cap_add_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="cap_add"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_cap_add.yaml"))
+
+    def test_bind_mount_with_dotdot_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"\.\."):
+            EnvironmentManifest(compose_file=_fixture("unsafe_bind_traversal.yaml"))
+
+    def test_bind_mount_with_absolute_path_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="relative path"):
+            EnvironmentManifest(compose_file=_fixture("unsafe_bind_absolute.yaml"))
+
+    def test_named_volume_reference_is_accepted(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "volumes:\n  data: {}\nservices:\n  default:\n"
+            "    image: postgres:16\n    volumes:\n      - data:/var/lib/data\n"
+        )
+        m = EnvironmentManifest(compose_file=compose)
+        assert m.load_compose()["services"]["default"]["volumes"] == ["data:/var/lib/data"]
+
+    def test_long_form_bind_mount_is_validated(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "services:\n  default:\n    image: postgres:16\n"
+            "    volumes:\n      - type: bind\n        source: ../escape\n"
+            "        target: /data\n"
+        )
+        with pytest.raises(ValidationError, match=r"\.\."):
+            EnvironmentManifest(compose_file=compose)
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentManifest — cross-field validation
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCrossFieldValidation:
+    def test_runner_service_must_exist_in_compose(self) -> None:
+        with pytest.raises(ValidationError, match="not declared in the compose file"):
             EnvironmentManifest(
-                services=[
-                    _make_minimal_service("runner"),
-                    _make_minimal_service("runner"),
-                ]
+                compose_file=_fixture("safe_one_service.yaml"),
+                runner_service="does_not_exist",
             )
 
-    def test_depends_on_string_must_resolve(self) -> None:
-        with pytest.raises(ValidationError, match="unknown service"):
-            EnvironmentManifest(
-                services=[
-                    ServiceSpec(
-                        name="runner",
-                        image="tolokaforge/runner:0.5.0",
-                        depends_on=["nonexistent"],
-                    ),
-                ]
-            )
-
-    def test_depends_on_dependson_form_must_resolve(self) -> None:
-        with pytest.raises(ValidationError, match="unknown service"):
-            EnvironmentManifest(
-                services=[
-                    ServiceSpec(
-                        name="runner",
-                        image="tolokaforge/runner:0.5.0",
-                        depends_on=[
-                            DependsOn(service="ghost", condition="service_healthy"),
-                        ],
-                    ),
-                ]
-            )
-
-    def test_initial_state_keys_must_resolve(self) -> None:
+    def test_initial_state_keys_must_match_declared_services(self) -> None:
         with pytest.raises(ValidationError, match="does not match any declared service"):
             EnvironmentManifest(
-                services=[_make_minimal_service("runner")],
-                initial_state={"db": InitialStateRef.model_validate({"from": "fixture.sql"})},
+                compose_file=_fixture("safe_two_service.yaml"),
+                initial_state={
+                    "not_a_service": InitialStateRef.model_validate(
+                        {"from": "./fixtures/seed.sql"}
+                    ),
+                },
             )
 
-    def test_extra_field_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            EnvironmentManifest.model_validate(
-                {
-                    "services": [{"name": "runner", "image": "tolokaforge/runner:0.5.0"}],
-                    "version": "1.0",
-                }
-            )
-
-    # ---- network mode (safety default) ----
-
-    def test_network_defaults_to_isolated(self) -> None:
-        manifest = _make_minimal_manifest()
-        assert manifest.network == "isolated"
-
-    @pytest.mark.parametrize("mode", ["isolated", "external"])
-    def test_network_modes_accepted(self, mode: str) -> None:
-        manifest = EnvironmentManifest(services=[_make_minimal_service()], network=mode)
-        assert manifest.network == mode
-
-    def test_unknown_network_mode_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            EnvironmentManifest.model_validate(
-                {
-                    "services": [{"name": "runner", "image": "tolokaforge/runner:0.5.0"}],
-                    "network": "bridge",
-                }
-            )
-
-    def test_canonical_wire_shape(self) -> None:
-        """Pin the JSON wire shape of a fully-populated manifest. Any
-        intentional field addition or default change must update this
-        snapshot in the same PR."""
-        manifest = EnvironmentManifest(
-            services=[
-                ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0"),
-                ServiceSpec(
-                    name="db",
-                    image="postgres:16",
-                    env={"POSTGRES_PASSWORD": "dev"},
-                    ports=[PortSpec(container_port=5432)],
-                    health=HealthProbe(kind="tcp", port=5432, initial_delay_seconds=15),
-                    resources=Resources(cpu="2", memory="2Gi"),
-                ),
-                ServiceSpec(
-                    name="backend",
-                    image="ghcr.io/example/api:v1.2.3",
-                    depends_on=["db", DependsOn(service="cache", condition="service_healthy")],
-                    health=HealthProbe(kind="http", port=8080, path="/healthz"),
-                ),
-                ServiceSpec(name="cache", image="redis:7"),
-            ],
+    def test_initial_state_keys_are_accepted_when_they_match(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
             initial_state={
-                "db": InitialStateRef.model_validate({"from": "fixtures/seed.sql", "kind": "sql"}),
+                "db": InitialStateRef.model_validate({"from": "./fixtures/seed.sql", "kind": "sql"})
             },
-            resources=Resources(cpu="2", memory="4Gi"),
         )
-        actual = json.loads(manifest.model_dump_json(by_alias=True))
-        expected: dict[str, Any] = {
-            "services": [
-                {
-                    "name": "runner",
-                    "image": "tolokaforge/runner:0.5.0",
-                    "command": None,
-                    "env": {},
-                    "ports": [],
-                    "volumes": [],
-                    "depends_on": [],
-                    "health": None,
-                    "resources": None,
-                    "security_context": None,
-                },
-                {
-                    "name": "db",
-                    "image": "postgres:16",
-                    "command": None,
-                    "env": {"POSTGRES_PASSWORD": "dev"},
-                    "ports": [{"container_port": 5432, "protocol": "tcp"}],
-                    "volumes": [],
-                    "depends_on": [],
-                    "health": {
-                        "kind": "tcp",
-                        "port": 5432,
-                        "path": None,
-                        "initial_delay_seconds": 15,
-                        "interval_seconds": 5,
-                        "timeout_seconds": 3,
-                        "retries": 10,
-                    },
-                    "resources": {"cpu": "2", "memory": "2Gi"},
-                    "security_context": None,
-                },
-                {
-                    "name": "backend",
-                    "image": "ghcr.io/example/api:v1.2.3",
-                    "command": None,
-                    "env": {},
-                    "ports": [],
-                    "volumes": [],
-                    "depends_on": [
-                        "db",
-                        {"service": "cache", "condition": "service_healthy"},
-                    ],
-                    "health": {
-                        "kind": "http",
-                        "port": 8080,
-                        "path": "/healthz",
-                        "initial_delay_seconds": 0,
-                        "interval_seconds": 5,
-                        "timeout_seconds": 3,
-                        "retries": 10,
-                    },
-                    "resources": None,
-                    "security_context": None,
-                },
-                {
-                    "name": "cache",
-                    "image": "redis:7",
-                    "command": None,
-                    "env": {},
-                    "ports": [],
-                    "volumes": [],
-                    "depends_on": [],
-                    "health": None,
-                    "resources": None,
-                    "security_context": None,
-                },
-            ],
-            "initial_state": {"db": {"from": "fixtures/seed.sql", "kind": "sql"}},
-            "resources": {"cpu": "2", "memory": "4Gi"},
-            "network": "isolated",
-        }
-        assert actual == expected
-
-    def test_round_trip_preserves_manifest(self) -> None:
-        manifest = EnvironmentManifest(
-            services=[
-                ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0"),
-                ServiceSpec(name="db", image="postgres:16", depends_on=[]),
-            ],
-        )
-        rehydrated = EnvironmentManifest.model_validate_json(
-            manifest.model_dump_json(by_alias=True)
-        )
-        assert rehydrated == manifest
+        assert "db" in m.initial_state
 
 
 # ---------------------------------------------------------------------------
-# TaskDescription embedding
+# Wire-shape snapshot — top-level manifest fields
+# ---------------------------------------------------------------------------
+
+
+class TestManifestWireShape:
+    def test_canonical_wire_shape(self) -> None:
+        """Lock the JSON shape callers see over the wire. Adding, removing, or
+        renaming a top-level manifest field must update this test — that is
+        what makes it canonical."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            runner_service="default",
+            initial_state={
+                "db": InitialStateRef.model_validate({"from": "./fixtures/seed.sql", "kind": "sql"})
+            },
+            network_policy=NetworkPolicy.NO_INTERNET,
+            security_context_defaults=SecurityContext(),
+        )
+        wire = m.model_dump(mode="json")
+        assert set(wire) == {
+            "compose_file",
+            "runner_service",
+            "initial_state",
+            "network_policy",
+            "security_context_defaults",
+        }
+        assert wire["runner_service"] == "default"
+        assert wire["network_policy"] == "no_internet"
+        assert wire["initial_state"] == {"db": {"from_": "./fixtures/seed.sql", "kind": "sql"}}
+        assert wire["security_context_defaults"] == {
+            "run_as_user": None,
+            "run_as_group": None,
+            "read_only_root_filesystem": False,
+            "no_new_privileges": True,
+            "capabilities_drop": ["ALL"],
+            "capabilities_add": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# TaskDescription embedding — optional, defaults to None
 # ---------------------------------------------------------------------------
 
 
 class TestTaskDescriptionEmbedding:
-    def test_default_manifest_is_none(self) -> None:
-        td = TaskDescription(
+    def _task(self, manifest: EnvironmentManifest | None = None) -> TaskDescription:
+        return TaskDescription(
             task_id="t1",
-            name="x",
-            category="general",
-            description="x",
+            name="t1",
+            category="test",
+            description="d",
             adapter_type="native",
-            system_prompt="x",
+            system_prompt="",
+            environment_manifest=manifest,
         )
-        assert td.environment_manifest is None
 
-    def test_manifest_round_trip_through_task_description(self) -> None:
-        td = TaskDescription(
-            task_id="t1",
-            name="x",
-            category="general",
-            description="x",
-            adapter_type="native",
-            system_prompt="x",
-            environment_manifest=_make_minimal_manifest(),
-        )
-        rehydrated = TaskDescription.model_validate_json(td.model_dump_json(by_alias=True))
-        assert rehydrated.environment_manifest == td.environment_manifest
+    def test_manifest_defaults_to_none(self) -> None:
+        assert self._task().environment_manifest is None
+
+    def test_manifest_round_trips_through_task_description(self) -> None:
+        m = EnvironmentManifest(compose_file=_fixture("safe_two_service.yaml"))
+        task = self._task(m)
+        reloaded = TaskDescription.model_validate_json(task.model_dump_json())
+        assert reloaded.environment_manifest is not None
+        assert reloaded.environment_manifest.compose_file == m.compose_file
+        assert reloaded.environment_manifest.runner_service == "default"
+
+
+def test_fixtures_are_parseable() -> None:
+    """Sanity: pyyaml can parse every fixture, and each has a services mapping.
+    Guards against accidental fixture drift outside the safety-validator tests.
+    """
+    for path in FIXTURES.iterdir():
+        if path.suffix != ".yaml":
+            continue
+        with path.open() as f:
+            content = yaml.safe_load(f)
+        assert isinstance(content, dict), f"{path.name}: not a mapping"
+        assert isinstance(content.get("services"), dict), f"{path.name}: no services mapping"

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -14,6 +14,8 @@ The lower half of the file pins the ADR-0010 provisioning surface:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tests.canonical._factories import make_env_endpoints, make_task_description
@@ -26,8 +28,10 @@ from tolokaforge.core.runtime import (
     RuntimeBackend,
     RuntimeBackendCallLog,
 )
-from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, ServiceSpec, TrialSpec
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 from tolokaforge.runner.models import TaskDescription
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "environment_manifest"
 
 pytestmark = pytest.mark.canonical
 
@@ -192,12 +196,11 @@ def _make_trial_spec(
 
 
 def _make_two_service_manifest() -> EnvironmentManifest:
-    return EnvironmentManifest(
-        services=[
-            ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0"),
-            ServiceSpec(name="db", image="postgres:16"),
-        ],
-    )
+    return EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
+
+
+def _make_one_service_manifest() -> EnvironmentManifest:
+    return EnvironmentManifest(compose_file=_FIXTURES / "safe_one_service.yaml")
 
 
 class TestProvisioningProtocolConformance:
@@ -267,10 +270,7 @@ class TestProvisionLifecycle:
 
     def test_partial_startup_only_fires_when_service_present(self) -> None:
         backend = InMemoryRuntimeBackend(fail_provision_after_service="db")
-        manifest = EnvironmentManifest(
-            services=[ServiceSpec(name="runner", image="tolokaforge/runner:0.5.0")]
-        )
-        handle = backend.provision(_make_trial_spec(manifest=manifest))
+        handle = backend.provision(_make_trial_spec(manifest=_make_one_service_manifest()))
         assert handle.trial_id == "task-1:0"
 
 

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -305,7 +305,7 @@ class InMemoryRuntimeBackend:
         handle = _InMemoryEnvHandle(trial_id=trial_id)
         manifest = spec.task.environment_manifest
         if self._fail_provision_after_service is not None and manifest is not None:
-            service_names = [s.name for s in manifest.services]
+            service_names = set(manifest.load_compose().get("services", {}))
             if self._fail_provision_after_service in service_names:
                 # Best-effort teardown of anything materialised so far.
                 self.teardown(handle)

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -305,7 +305,7 @@ class InMemoryRuntimeBackend:
         handle = _InMemoryEnvHandle(trial_id=trial_id)
         manifest = spec.task.environment_manifest
         if self._fail_provision_after_service is not None and manifest is not None:
-            service_names = set(manifest.load_compose().get("services", {}))
+            service_names = set(manifest.load_compose()["services"])
             if self._fail_provision_after_service in service_names:
                 # Best-effort teardown of anything materialised so far.
                 self.teardown(handle)

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -13,21 +13,12 @@ from pydantic import BaseModel, Field
 
 from tolokaforge.core.models import ModelConfig, Trajectory
 from tolokaforge.runner.models import (
-    DependsOn,
-    DependsOnCondition,
     EnvironmentManifest,
-    HealthProbe,
-    HealthProbeKind,
     InitialStateKind,
     InitialStateRef,
-    NetworkMode,
-    PortSpec,
-    Resources,
+    NetworkPolicy,
     SecurityContext,
-    ServiceSpec,
     TaskDescription,
-    VolumeKind,
-    VolumeMount,
 )
 
 DEFAULT_TOOL_TIMEOUT_S = 30.0
@@ -151,21 +142,12 @@ class TrialResult(BaseModel):
 
 __all__ = [
     "DEFAULT_TOOL_TIMEOUT_S",
-    "DependsOn",
-    "DependsOnCondition",
     "EnvEndpoints",
     "EnvironmentManifest",
-    "HealthProbe",
-    "HealthProbeKind",
     "InitialStateKind",
     "InitialStateRef",
-    "NetworkMode",
-    "PortSpec",
-    "Resources",
+    "NetworkPolicy",
     "SecurityContext",
-    "ServiceSpec",
     "TrialResult",
     "TrialSpec",
-    "VolumeKind",
-    "VolumeMount",
 ]

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -20,7 +20,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 # =============================================================================
 # Enums (from TASK_DESCRIPTION_SCHEMA.md)
@@ -520,11 +520,23 @@ InitialStateKind = Literal["sql", "copy", "script"]
 
 def _check_safe_relative_path(value: str, field_label: str) -> None:
     """Raise ``ValueError`` unless ``value`` is a non-empty relative path with
-    no ``..`` segments. Used to keep manifest-declared paths inside the task
-    pack root.
+    no ``..`` segments, no shell-expansion sequences, and no home-directory
+    expansion. Used to keep manifest-declared paths inside the task pack root.
     """
     if not value:
         raise ValueError(f"{field_label} must be a non-empty path.")
+    if "$" in value:
+        raise ValueError(
+            f"{field_label} contains a shell-expansion sequence ({value!r}); "
+            "not allowed — expansion happens at provision time and escapes "
+            "the load-time safety check."
+        )
+    if value.startswith("~"):
+        raise ValueError(
+            f"{field_label} starts with '~' ({value!r}); home-directory "
+            "expansion happens at provision time and escapes the load-time "
+            "safety check."
+        )
     path = PurePosixPath(value)
     if path.is_absolute():
         raise ValueError(f"{field_label} must be a relative path; got absolute {value!r}.")
@@ -621,11 +633,16 @@ def _check_no_host_network(services: dict[str, dict[str, Any]]) -> None:
 
 def _check_no_privileged(services: dict[str, dict[str, Any]]) -> None:
     for name, body in services.items():
-        if body.get("privileged") is True:
-            raise ValueError(
-                f"compose service {name!r} sets `privileged: true`; not allowed "
-                "under the manifest's safety contract."
-            )
+        privileged = body.get("privileged")
+        if privileged is None or privileged is False:
+            continue
+        # Reject any truthy or non-bool value; catches `privileged: true`,
+        # `privileged: "true"` (quoted string), `privileged: 1`, and stray
+        # non-bool declarations that YAML would parse to a truthy value.
+        raise ValueError(
+            f"compose service {name!r} declares `privileged: {privileged!r}`; not "
+            "allowed under the manifest's safety contract."
+        )
 
 
 def _check_no_cap_add(services: dict[str, dict[str, Any]]) -> None:
@@ -641,14 +658,116 @@ def _check_no_cap_add(services: dict[str, dict[str, Any]]) -> None:
 
 def _check_safe_bind_mounts(services: dict[str, dict[str, Any]]) -> None:
     for name, body in services.items():
-        volumes = body.get("volumes") or []
+        if "volumes" not in body:
+            continue
+        volumes = body["volumes"]
         if not isinstance(volumes, list):
-            raise ValueError(f"compose service {name!r}: `volumes:` must be a list")
+            raise ValueError(
+                f"compose service {name!r}: `volumes:` must be a list; got "
+                f"{type(volumes).__name__}"
+            )
         for idx, entry in enumerate(volumes):
             source = _bind_mount_source(entry)
             if source is None:
                 continue
             _check_safe_relative_path(source, f"compose service {name!r} volumes[{idx}].source")
+
+
+_FLOATING_IMAGE_TAGS = frozenset(
+    {
+        "latest",
+        "main",
+        "master",
+        "edge",
+        "stable",
+        "dev",
+        "develop",
+        "nightly",
+        "head",
+    }
+)
+
+_IMAGE_DIGEST_RE = re.compile(r"^(?:sha256:[a-fA-F0-9]{64}|sha512:[a-fA-F0-9]{128})$")
+
+
+def _image_tag_or_digest(image: str) -> tuple[str | None, str | None]:
+    """Return ``(tag, digest)`` from a docker image reference. Either may be
+    ``None``. When a digest is set, the tag is reported as ``None`` even if a
+    tag is also present in the reference (digest takes precedence)."""
+    if "@" in image:
+        _, digest = image.rsplit("@", 1)
+        return None, digest
+    last_segment = image.rsplit("/", 1)[-1]
+    if ":" not in last_segment:
+        return None, None
+    return last_segment.split(":", 1)[1], None
+
+
+def _check_pinned_images(services: dict[str, dict[str, Any]]) -> None:
+    """Reject floating tags (:latest, :main, :master, :edge, :stable, :dev,
+    :develop, :nightly, :head) and bare image references; require an
+    immutable tag or a ``sha256`` / ``sha512`` digest. Compose services that
+    declare ``build:`` instead of ``image:`` are exempt (no tag to check)."""
+    for name, body in services.items():
+        image = body.get("image")
+        if image is None:
+            continue
+        if not isinstance(image, str) or not image:
+            raise ValueError(
+                f"compose service {name!r}: `image:` must be a non-empty string; got {image!r}"
+            )
+        tag, digest = _image_tag_or_digest(image)
+        if digest is not None:
+            if not _IMAGE_DIGEST_RE.fullmatch(digest):
+                raise ValueError(
+                    f"compose service {name!r}: image digest must be a well-formed "
+                    f"`sha256:<64-hex>` or `sha512:<128-hex>` reference; got {image!r}."
+                )
+            continue
+        if tag is None:
+            raise ValueError(
+                f"compose service {name!r}: `image: {image!r}` must include an "
+                "explicit tag or digest for reproducibility."
+            )
+        if tag == "":
+            raise ValueError(
+                f"compose service {name!r}: image tag must be non-empty; got {image!r}."
+            )
+        if tag.lower() in _FLOATING_IMAGE_TAGS:
+            raise ValueError(
+                f"compose service {name!r}: `image: {image!r}` uses a floating tag "
+                f"({tag!r}); pin to an immutable tag or a digest for reproducibility."
+            )
+
+
+def _check_depends_on_resolves(services: dict[str, dict[str, Any]]) -> None:
+    """Every service named in a ``depends_on`` entry must be declared in
+    the compose file. Supports both short form (list of service names) and
+    long form (mapping from service name to a condition dict)."""
+    for name, body in services.items():
+        deps = body.get("depends_on")
+        if deps is None:
+            continue
+        if isinstance(deps, list):
+            dep_names = deps
+        elif isinstance(deps, dict):
+            dep_names = list(deps.keys())
+        else:
+            raise ValueError(
+                f"compose service {name!r}: `depends_on:` must be a list or a "
+                f"mapping; got {type(deps).__name__}"
+            )
+        for dep in dep_names:
+            if not isinstance(dep, str):
+                raise ValueError(
+                    f"compose service {name!r}: `depends_on` entries must be strings; got {dep!r}"
+                )
+            if dep not in services:
+                raise ValueError(
+                    f"compose service {name!r}: `depends_on: {dep!r}` references a "
+                    f"service not declared in the compose file; declared services "
+                    f"are {sorted(services)!r}."
+                )
 
 
 def _bind_mount_source(entry: Any) -> str | None:
@@ -721,6 +840,10 @@ class EnvironmentManifest(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    _compose_content: dict[str, Any] = PrivateAttr(default_factory=dict)
+    """Parsed compose file contents cached at construction time. Populated
+    by the model_validator; returned verbatim from :meth:`load_compose`."""
+
     @model_validator(mode="after")
     def _load_and_validate_compose(self) -> EnvironmentManifest:
         if not self.compose_file.is_file():
@@ -740,17 +863,20 @@ class EnvironmentManifest(BaseModel):
         _check_no_privileged(services)
         _check_no_cap_add(services)
         _check_safe_bind_mounts(services)
+        _check_pinned_images(services)
+        _check_depends_on_resolves(services)
         _check_runner_service_declared(services, self.runner_service)
         _check_initial_state_keys(services, self.initial_state)
+        self._compose_content = content
         return self
 
     def load_compose(self) -> dict[str, Any]:
-        """Return the parsed compose file. Callers re-read from disk each
-        time; the manifest does not cache."""
-        with self.compose_file.open() as f:
-            content = yaml.safe_load(f)
-        assert isinstance(content, dict)
-        return content
+        """Return the parsed compose file cached at construction time.
+
+        The manifest snapshots the compose file when the validator runs;
+        callers get the same content the safety validators inspected. Later
+        edits to the compose file on disk are not reflected."""
+        return self._compose_content
 
 
 # =============================================================================

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
+import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 # =============================================================================
@@ -361,7 +362,6 @@ class Rubric(BaseModel):
               another criterion's derived ``"<id>_justification"`` key;
           (d) every id matches ``^[A-Za-z][A-Za-z0-9_]*$`` (identifier-safe).
         """
-        import re
 
         ids = [c.id for c in self.criteria]
 
@@ -511,70 +511,17 @@ class GradingConfig(BaseModel):
 
 
 # =============================================================================
-# EnvironmentManifest — typed schema for multi-service environments
+# EnvironmentManifest — Docker Compose as source of truth
 # =============================================================================
 
 
-HealthProbeKind = Literal["tcp", "http"]
-
-
-class HealthProbe(BaseModel):
-    """Readiness probe for a service, typed by protocol."""
-
-    kind: HealthProbeKind
-    """``"tcp"`` opens a socket; ``"http"`` issues a GET."""
-
-    port: int
-    """Container port to probe."""
-
-    path: str | None = None
-    """HTTP path. Required when ``kind == "http"``; must be unset for ``"tcp"``."""
-
-    initial_delay_seconds: int = 0
-    """Seconds to wait after container start before the first probe attempt."""
-
-    interval_seconds: int = 5
-    """Seconds between probe attempts."""
-
-    timeout_seconds: int = 3
-    """Seconds a single probe attempt may run before it counts as failed."""
-
-    retries: int = 10
-    """Failed attempts (after the initial delay) before the service is unhealthy."""
-
-    model_config = {"extra": "forbid"}
-
-    @model_validator(mode="after")
-    def _path_consistent_with_kind(self) -> HealthProbe:
-        if self.kind == "http" and not self.path:
-            raise ValueError("HealthProbe.path is required when kind == 'http'.")
-        if self.kind == "tcp" and self.path is not None:
-            raise ValueError("HealthProbe.path is not allowed when kind == 'tcp'.")
-        return self
-
-
-class PortSpec(BaseModel):
-    """A container port declaration. The runtime backend assigns the host port."""
-
-    container_port: int
-    protocol: Literal["tcp", "udp"] = "tcp"
-
-    model_config = {"extra": "forbid"}
-
-
-VolumeKind = Literal["named", "bind"]
+InitialStateKind = Literal["sql", "copy", "script"]
 
 
 def _check_safe_relative_path(value: str, field_label: str) -> None:
     """Raise ``ValueError`` unless ``value`` is a non-empty relative path with
     no ``..`` segments. Used to keep manifest-declared paths inside the task
     pack root.
-
-    POSIX-targeted (uses ``PurePosixPath``) because the runtime backends in
-    scope (docker-compose Linux containers) interpret paths as POSIX. A
-    Windows-style ``..\\escape`` is not flagged on POSIX; that is correct for
-    the substrates we target, and would need a separate guard if the engine
-    ever runs on a non-POSIX provisioner.
     """
     if not value:
         raise ValueError(f"{field_label} must be a non-empty path.")
@@ -583,46 +530,6 @@ def _check_safe_relative_path(value: str, field_label: str) -> None:
         raise ValueError(f"{field_label} must be a relative path; got absolute {value!r}.")
     if any(part == ".." for part in path.parts):
         raise ValueError(f"{field_label} must not contain '..' segments; got {value!r}.")
-
-
-class VolumeMount(BaseModel):
-    """A volume mounted into a service container."""
-
-    kind: VolumeKind = "bind"
-    """``"named"`` — ``source`` is a named volume identifier.
-    ``"bind"`` — ``source`` is a path relative to the task pack root."""
-
-    source: str
-    """Volume name (when ``kind == "named"``) or path (when ``kind == "bind"``).
-    Bind sources are validated as relative, ``..``-free paths."""
-
-    target: str
-    """Path inside the container."""
-
-    read_only: bool = False
-
-    model_config = {"extra": "forbid"}
-
-    @model_validator(mode="after")
-    def _bind_source_stays_inside_task_pack(self) -> VolumeMount:
-        if self.kind == "bind":
-            _check_safe_relative_path(self.source, "VolumeMount.source (bind)")
-        return self
-
-
-class Resources(BaseModel):
-    """Resource limits / requests as Kubernetes quantity strings."""
-
-    cpu: str | None = None
-    """E.g. ``"2"`` or ``"500m"``."""
-
-    memory: str | None = None
-    """E.g. ``"4Gi"`` or ``"512Mi"``."""
-
-    model_config = {"extra": "forbid"}
-
-
-InitialStateKind = Literal["sql", "copy", "script"]
 
 
 class InitialStateRef(BaseModel):
@@ -646,7 +553,9 @@ class InitialStateRef(BaseModel):
 
 
 class SecurityContext(BaseModel):
-    """Per-container security policy declarations."""
+    """Per-container security policy declarations. The provisioner applies
+    these to every service that does not override them in the compose file.
+    """
 
     run_as_user: int | None = None
     """UID the container process runs as. ``None`` defers to the image default."""
@@ -672,197 +581,176 @@ class SecurityContext(BaseModel):
     model_config = {"extra": "forbid"}
 
 
-NetworkMode = Literal["isolated", "external"]
+class NetworkPolicy(str, Enum):
+    """Network posture the provisioner is asked to enforce for a trial."""
+
+    NO_INTERNET = "no_internet"
+    """Services reach each other on the per-trial network only. No egress
+    to the public internet, no reachability across per-trial projects."""
+
+    LIMITED_INTERNET = "limited_internet"
+    """Egress permitted for a provisioner-defined allowlist. No cross-trial
+    reachability. The allowlist is a provisioner concern, not a schema one."""
+
+    FULL_INTERNET = "full_internet"
+    """Unrestricted egress. Still no cross-trial reachability."""
 
 
-DependsOnCondition = Literal["service_started", "service_healthy"]
+def _compose_services(content: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    services = content.get("services")
+    if not isinstance(services, dict) or not services:
+        raise ValueError("compose file must declare a non-empty top-level `services:` mapping")
+    for name, body in services.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"compose service names must be non-empty strings; got {name!r}")
+        if not isinstance(body, dict):
+            raise ValueError(
+                f"compose service {name!r} must be a mapping; got {type(body).__name__}"
+            )
+    return services
 
 
-class DependsOn(BaseModel):
-    """Service dependency with a wait condition.
+def _check_no_host_network(services: dict[str, dict[str, Any]]) -> None:
+    for name, body in services.items():
+        if body.get("network_mode") == "host":
+            raise ValueError(
+                f"compose service {name!r} sets `network_mode: host`; not allowed "
+                "under the manifest's network-isolation contract."
+            )
 
-    String entries in ``ServiceSpec.depends_on`` are shorthand for
-    ``DependsOn(service=name, condition="service_started")``.
+
+def _check_no_privileged(services: dict[str, dict[str, Any]]) -> None:
+    for name, body in services.items():
+        if body.get("privileged") is True:
+            raise ValueError(
+                f"compose service {name!r} sets `privileged: true`; not allowed "
+                "under the manifest's safety contract."
+            )
+
+
+def _check_no_cap_add(services: dict[str, dict[str, Any]]) -> None:
+    for name, body in services.items():
+        cap_add = body.get("cap_add")
+        if cap_add:
+            raise ValueError(
+                f"compose service {name!r} sets `cap_add: {cap_add!r}`; not allowed "
+                "under the manifest's safety contract (start from ALL-dropped, "
+                "declare additions via SecurityContext.capabilities_add if needed)."
+            )
+
+
+def _check_safe_bind_mounts(services: dict[str, dict[str, Any]]) -> None:
+    for name, body in services.items():
+        volumes = body.get("volumes") or []
+        if not isinstance(volumes, list):
+            raise ValueError(f"compose service {name!r}: `volumes:` must be a list")
+        for idx, entry in enumerate(volumes):
+            source = _bind_mount_source(entry)
+            if source is None:
+                continue
+            _check_safe_relative_path(source, f"compose service {name!r} volumes[{idx}].source")
+
+
+def _bind_mount_source(entry: Any) -> str | None:
+    """Return the bind-mount source path from a compose volume entry, or
+    ``None`` if the entry is a named volume / not a bind mount.
     """
-
-    service: str
-    """Name of another service declared in the same manifest."""
-
-    condition: DependsOnCondition = "service_started"
-    """``"service_started"`` waits only for the container to start.
-    ``"service_healthy"`` also waits for the service's ``HealthProbe`` to pass."""
-
-    model_config = {"extra": "forbid"}
-
-
-_VALID_SERVICE_NAME_RE = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
-_MAX_DNS_LABEL_LENGTH = 63
-
-_FLOATING_IMAGE_TAGS = frozenset(
-    {
-        "latest",
-        "main",
-        "master",
-        "edge",
-        "stable",
-        "dev",
-        "develop",
-        "nightly",
-        "head",
-    }
-)
-
-# Accept the two algorithms in common use; reject malformed lengths and any
-# unknown algorithm string. Hex is case-insensitive (Docker normalises to lower).
-_IMAGE_DIGEST_RE = re.compile(r"^(?:sha256:[a-fA-F0-9]{64}|sha512:[a-fA-F0-9]{128})$")
+    if isinstance(entry, str):
+        # Short form: "SOURCE:TARGET[:MODE]". Bind if SOURCE contains a path separator
+        # or starts with `.` / `/`; otherwise it's a named volume reference.
+        source = entry.split(":", 1)[0]
+        if source.startswith((".", "/")) or "/" in source:
+            return source
+        return None
+    if isinstance(entry, dict):
+        if entry.get("type") == "bind":
+            source = entry.get("source")
+            if isinstance(source, str):
+                return source
+    return None
 
 
-def _image_tag_or_digest(image: str) -> tuple[str | None, str | None]:
-    """Return ``(tag, digest)`` from a docker image reference.
-
-    Either may be ``None``. The digest (if any) takes precedence — when the
-    digest is set, the tag is reported as ``None`` even if a tag is also
-    present in the reference.
-    """
-    if "@" in image:
-        head, digest = image.rsplit("@", 1)
-        return None, digest
-    last_segment = image.rsplit("/", 1)[-1]
-    if ":" not in last_segment:
-        return None, None
-    return last_segment.split(":", 1)[1], None
+def _check_runner_service_declared(services: dict[str, dict[str, Any]], runner: str) -> None:
+    if runner not in services:
+        raise ValueError(
+            f"EnvironmentManifest.runner_service = {runner!r} is not declared in the "
+            f"compose file; declared services are {sorted(services)!r}."
+        )
 
 
-class ServiceSpec(BaseModel):
-    """One service in an environment manifest."""
-
-    name: str
-    """Unique within the manifest. Lowercase DNS label up to 63 characters."""
-
-    image: str
-    """Container image with an immutable tag or a ``@sha256:`` digest.
-    Floating tags (``:latest``, ``:main``, ``:edge``, ``:stable``, ``:dev``,
-    ``:develop``, ``:nightly``, ``:head``) are rejected."""
-
-    command: list[str] | None = None
-    env: dict[str, str] = Field(default_factory=dict)
-    ports: list[PortSpec] = Field(default_factory=list)
-    volumes: list[VolumeMount] = Field(default_factory=list)
-    depends_on: list[str | DependsOn] = Field(default_factory=list)
-    """Other services this one depends on. String entries are shorthand for
-    ``DependsOn(service=name, condition="service_started")``."""
-
-    health: HealthProbe | None = None
-    resources: Resources | None = None
-    """Per-service overrides for the manifest-level ``resources`` defaults."""
-
-    security_context: SecurityContext | None = None
-    """Per-container security policy. ``None`` means the container runs with
-    the runtime backend's default posture."""
-
-    model_config = {"extra": "forbid"}
-
-    @field_validator("name")
-    @classmethod
-    def _name_is_valid_dns_label(cls, v: str) -> str:
-        if len(v) > _MAX_DNS_LABEL_LENGTH:
+def _check_initial_state_keys(
+    services: dict[str, dict[str, Any]], initial_state: dict[str, InitialStateRef]
+) -> None:
+    for key in initial_state:
+        if key not in services:
             raise ValueError(
-                f"ServiceSpec.name must be at most {_MAX_DNS_LABEL_LENGTH} "
-                f"characters (RFC 1123 DNS label); got {len(v)}."
+                f"EnvironmentManifest.initial_state has key {key!r} that does not "
+                f"match any declared service; compose declares {sorted(services)!r}."
             )
-        if not _VALID_SERVICE_NAME_RE.fullmatch(v):
-            raise ValueError(
-                f"ServiceSpec.name must be a lowercase DNS label "
-                f"(matching ^[a-z]([-a-z0-9]*[a-z0-9])?$); got {v!r}."
-            )
-        return v
-
-    @field_validator("image")
-    @classmethod
-    def _image_is_pinned(cls, v: str) -> str:
-        if not v:
-            raise ValueError("ServiceSpec.image must not be empty.")
-        tag, digest = _image_tag_or_digest(v)
-        if digest is not None:
-            if not _IMAGE_DIGEST_RE.fullmatch(digest):
-                raise ValueError(
-                    f"ServiceSpec.image digest must be a well-formed "
-                    f"`sha256:<64-hex>` or `sha512:<128-hex>` reference; "
-                    f"got {v!r}."
-                )
-            return v
-        if tag is None:
-            raise ValueError(
-                f"ServiceSpec.image must include an explicit tag or " f"digest; got {v!r}."
-            )
-        if tag == "":
-            raise ValueError(f"ServiceSpec.image tag must be non-empty; got {v!r}.")
-        if tag.lower() in _FLOATING_IMAGE_TAGS:
-            raise ValueError(
-                f"ServiceSpec.image must be pinned to an immutable tag or "
-                f"digest; floating tag {tag!r} is not deterministic."
-            )
-        return v
-
-
-def _dep_service_name(dep: str | DependsOn) -> str:
-    return dep if isinstance(dep, str) else dep.service
 
 
 class EnvironmentManifest(BaseModel):
-    """Typed declaration of a task's multi-service environment."""
+    """Points at a Docker Compose file that declares the per-trial environment.
 
-    services: list[ServiceSpec]
-    """Non-empty. The first entry is the default / runner service."""
+    The compose file is the source of truth for service topology (images,
+    ports, volumes, health probes, depends_on, resources). This model adds
+    the engine-specific fields the provisioner needs (which service is the
+    runner, how the initial state fixtures apply, the network posture, the
+    security-context defaults) and runs safety validators against the
+    compose contents at construction time.
+    """
+
+    compose_file: Path
+    """Path to the docker-compose file. Absolute if resolved by a task
+    loader; relative paths are resolved against the current working
+    directory at construction time."""
+
+    runner_service: str = "default"
+    """Which compose service is the agent runner. Must be declared in
+    the compose file's ``services:`` mapping."""
 
     initial_state: dict[str, InitialStateRef] = Field(default_factory=dict)
-    """Keyed by service name. Each value declares a fixture the provisioner
-    applies to that service before the readiness gate."""
+    """Fixture-copy operations, keyed by service name."""
 
-    resources: Resources | None = None
-    """Manifest-level resource defaults applied when a service declares no
-    ``resources`` of its own."""
+    network_policy: NetworkPolicy = NetworkPolicy.NO_INTERNET
+    """Network posture the provisioner is asked to enforce."""
 
-    network: NetworkMode = "isolated"
-    """Network posture the provisioner is asked to enforce.
-    ``"isolated"`` — services reach each other on the per-trial network only;
-    no path out to the public internet or to other trials.
-    ``"external"`` — services may reach the public internet (still no path to
-    other trials). Opt in explicitly; the safe default is ``"isolated"``."""
+    security_context_defaults: SecurityContext | None = None
+    """Applied by the provisioner to every service that does not override
+    the equivalent settings in the compose file."""
 
     model_config = {"extra": "forbid"}
 
     @model_validator(mode="after")
-    def _validate_cross_service_references(self) -> EnvironmentManifest:
-        if not self.services:
-            raise ValueError("EnvironmentManifest.services must be non-empty.")
-
-        names = [s.name for s in self.services]
-        seen: set[str] = set()
-        for name in names:
-            if name in seen:
-                raise ValueError(f"EnvironmentManifest.services has duplicate name {name!r}.")
-            seen.add(name)
-
-        for service in self.services:
-            for dep in service.depends_on:
-                dep_name = _dep_service_name(dep)
-                if dep_name not in seen:
-                    raise ValueError(
-                        f"ServiceSpec({service.name!r}).depends_on references "
-                        f"unknown service {dep_name!r}; manifest declares "
-                        f"{sorted(seen)!r}."
-                    )
-
-        for state_key in self.initial_state:
-            if state_key not in seen:
-                raise ValueError(
-                    f"EnvironmentManifest.initial_state has key {state_key!r} "
-                    f"that does not match any declared service; manifest "
-                    f"declares {sorted(seen)!r}."
-                )
-
+    def _load_and_validate_compose(self) -> EnvironmentManifest:
+        if not self.compose_file.is_file():
+            raise ValueError(
+                f"EnvironmentManifest.compose_file does not exist or is not a "
+                f"file: {self.compose_file}"
+            )
+        with self.compose_file.open() as f:
+            content = yaml.safe_load(f)
+        if not isinstance(content, dict):
+            raise ValueError(
+                f"EnvironmentManifest.compose_file must be a YAML mapping; got "
+                f"{type(content).__name__}"
+            )
+        services = _compose_services(content)
+        _check_no_host_network(services)
+        _check_no_privileged(services)
+        _check_no_cap_add(services)
+        _check_safe_bind_mounts(services)
+        _check_runner_service_declared(services, self.runner_service)
+        _check_initial_state_keys(services, self.initial_state)
         return self
+
+    def load_compose(self) -> dict[str, Any]:
+        """Return the parsed compose file. Callers re-read from disk each
+        time; the manifest does not cache."""
+        with self.compose_file.open() as f:
+            content = yaml.safe_load(f)
+        assert isinstance(content, dict)
+        return content
 
 
 # =============================================================================


### PR DESCRIPTION
## TL;DR

Docker Compose is now the source of truth for per-trial environment topology. `EnvironmentManifest` becomes a lean Pydantic wrapper that points at a `compose.yaml` file, adds the engine-specific fields the provisioner needs, and applies safety validators against the loaded compose contents at construction time.

Retires the field-by-field Pydantic schema (`ServiceSpec`, `PortSpec`, `VolumeMount`, `HealthProbe`, `Resources`, `DependsOn`) that re-encoded compose semantics. Aligns with Inspect AI's docker sandbox convention, unblocks a `LocalRuntimeBackend` (follow-up PR) that wraps `testcontainers.compose.DockerCompose` directly, and eliminates the translation tax the previous schema would have paid at every backend.

Closes #138.

---

## What ships

### Manifest surface

- **ADR-0009 rewritten** — presents the compose-as-source-of-truth design. Status stays `Proposed`. Industry precedents cited (Inspect AI as primary neighbour, METR task-standard for the `NetworkPolicy` permission-string model, Testcontainers as the follow-up local-backend library, SWE-bench for build-time image caching).
- **Retire the field-by-field Pydantic schema** — `ServiceSpec`, `PortSpec`, `VolumeMount`, `HealthProbe`, `Resources`, `DependsOn`, and their type aliases + image-pinning helpers deleted from `tolokaforge/runner/models.py`.
- **New lean `EnvironmentManifest`**:

  ```python
  class EnvironmentManifest(BaseModel):
      model_config = {"extra": "forbid"}
      compose_file: Path
      runner_service: str = "default"
      initial_state: dict[str, InitialStateRef] = {}
      network_policy: NetworkPolicy = NetworkPolicy.NO_INTERNET
      security_context_defaults: SecurityContext | None = None
  ```

- **`NetworkPolicy` enum** — permission-string semantics (`no_internet` / `limited_internet` / `full_internet`), following METR task-standard's convention.
- **Compose contents cached at construction** via a `PrivateAttr`. `load_compose()` returns the snapshot; the manifest does not re-read the file per call.
- Retained models: `SecurityContext` (used as `security_context_defaults`), `InitialStateRef`, `InitialStateKind`.

### Load-time safety validators (all run against the parsed compose contents)

- Reject `network_mode: host` on any service.
- Reject `privileged` on any service — accepts only explicit `false` / absent; catches truthy variants (`true`, `"true"` quoted-string, integer `1`, arbitrary truthy strings) that would slip past an identity check.
- Reject `cap_add` on any service.
- Reject unsafe bind-mount sources: `..` segments, absolute paths, `${VAR}` shell-expansion, and `~` home-directory prefixes (both short-form `SOURCE:TARGET` and long-form `{type: bind, source: ...}` syntaxes).
- Reject `volumes:` values that are not a list (no silent `or []` swallowing).
- Reject unpinned images: floating tags (`:latest`, `:main`, `:master`, `:edge`, `:stable`, `:dev`, `:develop`, `:nightly`, `:head`), bare-image references, and malformed digests. Accept immutable tags and `sha256:<64-hex>` / `sha512:<128-hex>` digests. Services that declare `build:` instead of `image:` are exempt (no tag to pin).
- Reject `depends_on` entries that reference services not declared in the compose file (both short-form list and long-form mapping).
- `runner_service` must resolve to a declared compose service.
- Every key in `initial_state` must reference a declared compose service.

### Tests

- **`tests/canonical/test_environment_manifest_contract.py`** — 63 fixture-driven tests pinning every validator against real compose files. `test_fixtures_are_parseable` guards fixture drift.
- **`tests/canonical/fixtures/environment_manifest/`** — 12 fixtures: `safe_one_service.yaml`, `safe_two_service.yaml`, and one per unsafe pattern (`unsafe_privileged.yaml`, `unsafe_host_network.yaml`, `unsafe_cap_add.yaml`, `unsafe_bind_absolute.yaml`, `unsafe_bind_traversal.yaml`, `unsafe_bind_env_var.yaml`, `unsafe_bind_tilde.yaml`, `unsafe_floating_tag.yaml`, `unsafe_bare_image.yaml`, `unsafe_missing_depends_on.yaml`).
- **`tests/canonical/test_runtime_backend_contract.py`** — provisioning tests retargeted to build manifests via `compose_file`. `InMemoryRuntimeBackend.provision()`'s failure-simulation logic reads services from the cached compose snapshot.

### Doc alignment

- **ADR-0010** — enforcement obligations table rewritten to reference the current surface: `EnvironmentManifest.network_policy` / `security_context_defaults` / `initial_state` on the manifest; compose-file properties (`deploy.resources`, `volumes:` with `:ro`, `healthcheck:`, `depends_on`, `image:`) for the substrate side. `await_ready` description updated to reference compose `healthcheck:` probes.
- **ADR-0011** — data-declaration examples row updated; naming-discipline bullet cites live models; new **Pattern B addendum — typed wrapper over an external artifact** codifies the hybrid pattern the new manifest exercises.

---

## Task authoring model

```yaml
# task.yaml
task_id: my_task
name: My Task
category: general
description: ...
adapter_type: native
system_prompt: ...
environment_manifest:
  compose_file: ./environment/compose.yaml
  runner_service: default
  network_policy: no_internet
  initial_state:
    db:
      from: ./fixtures/db-seed.sql
      kind: sql

# environment/compose.yaml   (pure Docker Compose — nothing engine-specific here)
services:
  db:
    image: postgres:16
    healthcheck: { test: ["CMD-SHELL", "pg_isready"] }
  default:
    image: tolokaforge/runner:0.5.0
    depends_on:
      db: { condition: service_healthy }
```

Two files per task; each stays within its own domain (engine-specific config vs. pure compose).

---

## Why this shape

Three concrete architectural wins over the retired field-by-field schema:

1. **No translation tax.** The concrete `LocalRuntimeBackend` (follow-up PR) consumes the compose file directly via `testcontainers.compose.DockerCompose`. No Pydantic-to-compose translator to own.
2. **Ecosystem interop.** Tasks whose sandbox spec is already a compose file (Inspect AI's docker sandbox convention) run natively with zero adapter code.
3. **Substrate portability.** A future K8s backend translates the compose file via industry-standard tooling (`kompose`, Testcontainers' k8s module) — one industry-owned translator instead of two engine-owned translators.

Safety validators stay ours: the engine's safety controls (path-traversal guards, rejection of `network_mode: host` / `privileged` / `cap_add`, unpinned-image rejection, `${VAR}` / `~` expansion guards) are engine concerns, encoded as load-time validators over the compose contents rather than as fields in a competing schema.

---

## What this PR does NOT change

- **No changes to `DockerRuntime` or the shared-stack path.** Tasks that do not declare an `environment_manifest` continue to run unchanged.
- **No `LocalRuntimeBackend`.** That is the follow-up PR and it consumes `manifest.compose_file` directly via Testcontainers Python. Concrete substrate work does not gate this schema change.
- **No `Conductor` / `Orchestrator` wiring changes.** Those land after `LocalRuntimeBackend`.

---

## Verification

```
$ uv run ruff check tolokaforge tests
All checks passed!

$ uv run pytest tests/canonical/test_environment_manifest_contract.py -q
63 passed

$ uv run pytest tests/canonical/test_runtime_backend_contract.py -q
45 passed

$ uv run pytest tests/ -m canonical -q
320 passed

$ uv run pytest tests/ -m unit -q
1871 passed, 1 skipped
```

Net -382 LoC on the branch (retiring the field-by-field Pydantic models + related tests outweighs the new validators + fixture YAMLs + Pattern B addendum).

---

## What's next

`LocalRuntimeBackend` — the first concrete provisioner. Thin adapter over `testcontainers.compose.DockerCompose` that consumes `manifest.compose_file` directly. Once that PR merges and validates the design end-to-end, ADR-0009 flips from `Proposed` to `Accepted`.