### PR TITLE
fix(orchestrator): select full_stack when the adapter declares rag-service need

### DIFF
--- a/tests/unit/test_orchestrator_full_stack_detection.py
+++ b/tests/unit/test_orchestrator_full_stack_detection.py
@@ -7,14 +7,21 @@ mock-web or rag-service (#125).
 which adds the two extra services on top. Detection mirrors
 ``_tasks_need_playwright``: scan ``task.tools.agent.enabled`` AND look for
 ``initial_state.mock_web`` / ``initial_state.rag`` declarations.
+
+Adapters whose search signal is not visible in task tool names (e.g. a
+domain-shipped ``docindex/`` knowledge base surfaced as
+``TaskDescription.search.enabled``) declare the rag-service need via
+``DockerStackRequirements.needs_rag_service``; the run-level decision
+(:func:`_run_needs_full_stack`) combines both signals.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from tolokaforge.adapters.base import DockerStackRequirements
 from tolokaforge.core.models import TaskConfig
-from tolokaforge.core.orchestrator import _tasks_need_full_stack
+from tolokaforge.core.orchestrator import _run_needs_full_stack, _tasks_need_full_stack
 
 pytestmark = pytest.mark.unit
 
@@ -75,3 +82,32 @@ def test_no_full_stack_signal_returns_false():
 
 def test_empty_task_list_returns_false():
     assert _tasks_need_full_stack([]) is False
+
+
+def test_adapter_declared_rag_need_triggers_full_stack():
+    """The task-level signals see nothing (plain tools), but the adapter
+    declares search-enabled TaskDescriptions - the run must get the stack
+    that actually provisions rag-service."""
+    reqs = DockerStackRequirements(needs_rag_service=True)
+    assert _run_needs_full_stack([_task(["bash"])], reqs) is True
+
+
+def test_default_requirements_do_not_trigger_full_stack():
+    assert _run_needs_full_stack([_task(["bash"])], DockerStackRequirements()) is False
+
+
+def test_none_requirements_fall_back_to_task_signals():
+    assert _run_needs_full_stack([_task(["bash"])], None) is False
+    assert _run_needs_full_stack([_task(["search_kb"])], None) is True
+
+
+def test_task_signals_still_trigger_with_default_requirements():
+    assert _run_needs_full_stack([_task(["search_kb"])], DockerStackRequirements()) is True
+
+
+def test_needs_rag_service_not_rendered_into_stack_kwargs():
+    """``needs_rag_service`` selects the stack factory; it must NOT leak into
+    ``core_stack(**kwargs)`` / ``full_stack(**kwargs)`` - neither factory
+    accepts it, so a leak would TypeError at stack construction."""
+    reqs = DockerStackRequirements(needs_rag_service=True)
+    assert reqs.to_core_stack_kwargs() == {}

--- a/tolokaforge/adapters/base.py
+++ b/tolokaforge/adapters/base.py
@@ -36,18 +36,33 @@ class DockerStackRequirements:
             Runner so it can drive the host Docker daemon directly.
         enable_dind: Add a Docker-in-Docker sidecar so the Runner can manage
             Docker Compose stacks without touching the host daemon.
+        needs_rag_service: The adapter emits search-enabled TaskDescriptions
+            (``TaskDescription.search.enabled``), so the run must use the
+            stack that actually provisions ``rag-service`` (``full_stack``).
+            The Runner hard-fails ``RegisterTrial`` for search-enabled tasks
+            when no RAG client is configured, and ``core_stack`` deliberately
+            omits ``RAG_SERVICE_URL`` (issue #95: "env present" ==
+            "rag-service running") - so adapters whose search signal is not
+            visible in task tool names or ``initial_state`` (e.g. a
+            domain-shipped ``docindex/`` knowledge base) must declare the
+            need here for the orchestrator's stack selection.
     """
 
     task_pack_mounts: list[Path] = field(default_factory=list)
     extra_runner_binds: list[tuple[Path, str]] = field(default_factory=list)
     mount_docker_socket: bool = False
     enable_dind: bool = False
+    needs_rag_service: bool = False
 
     def to_core_stack_kwargs(self) -> dict[str, Any]:
         """Render to ``core_stack()`` kwargs, omitting empty defaults.
 
         An empty requirements object yields ``{}`` so default callers stay
         unchanged.
+
+        ``needs_rag_service`` is deliberately NOT rendered: it selects the
+        stack factory (``core_stack`` vs ``full_stack``), it is not a stack
+        kwarg - neither factory accepts it.
         """
         kwargs: dict[str, Any] = {}
         if self.task_pack_mounts:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -123,6 +123,26 @@ def _tasks_need_full_stack(tasks: list[Any]) -> bool:
     return False
 
 
+def _run_needs_full_stack(tasks: list[Any], stack_requirements: Any) -> bool:
+    """Return True iff the run needs ``full_stack``.
+
+    Combines the task-level signals (:func:`_tasks_need_full_stack`) with the
+    adapter's declarative stack needs
+    (``DockerStackRequirements.needs_rag_service``). Adapters whose search
+    signal is not visible in task tool names or ``initial_state`` (e.g. a
+    domain-shipped ``docindex/`` knowledge base surfaced as
+    ``TaskDescription.search.enabled``) declare the rag-service need on their
+    :meth:`BaseAdapter.docker_stack_requirements`. The Runner hard-fails
+    ``RegisterTrial`` for search-enabled tasks when no RAG client is
+    configured (``runner/service.py``), so the provisioning decision must
+    follow the same signal the Runner enforces. Duck-typed like its sibling
+    so unit tests can pass lightweight stand-ins.
+    """
+    if stack_requirements is not None and getattr(stack_requirements, "needs_rag_service", False):
+        return True
+    return _tasks_need_full_stack(tasks)
+
+
 _DEFAULT_DB_SERVICE_URL = "http://tolokaforge-db-service:8000"
 """Runner-perspective DB service URL the docker stack injects into the runner
 container at start (`tolokaforge/docker/stacks/core.py`). The orchestrator
@@ -797,15 +817,21 @@ class Orchestrator:
                     )
                     core_stack_kwargs["enable_playwright"] = True
                 # Pick full_stack (db-service + runner + rag-service +
-                # mock-web) when any task talks to mock-web or rag — see
-                # ``_FULL_STACK_TOOL_NAMES`` for the routing matrix.
+                # mock-web) when any task talks to mock-web or rag (see
+                # ``_FULL_STACK_TOOL_NAMES`` for the routing matrix) OR when
+                # the adapter declares a rag-service need
+                # (``DockerStackRequirements.needs_rag_service``).
                 # ``full_stack`` accepts every kwarg ``core_stack`` does,
                 # so the playwright/binds plumbing above still applies.
-                if _tasks_need_full_stack(self.tasks):
+                if _run_needs_full_stack(self.tasks, stack_requirements):
                     self.logger.info(
-                        "Full-stack-dependent task detected (browser/mobile/search_kb or "
-                        "initial_state.mock_web/rag) — using full_stack (db-service + runner "
-                        "+ rag-service + mock-web)"
+                        "Full-stack-dependent run detected (task browser/mobile/search_kb, "
+                        "initial_state.mock_web/rag, or adapter-declared rag-service need) "
+                        "- using full_stack (db-service + runner + rag-service + mock-web)",
+                        adapter_needs_rag_service=bool(
+                            stack_requirements is not None
+                            and getattr(stack_requirements, "needs_rag_service", False)
+                        ),
                     )
                     stack_factory = full_stack
                 else:


### PR DESCRIPTION
## Regression

Since `804246a` (shipped in v0.3.1, "faithful judge KB search", #95/#102) `core_stack` no longer injects `RAG_SERVICE_URL`; only `full_stack` (which actually runs rag-service) sets it. That change is correct on its own (invariant: "env present" == "rag-service running"), but it removed the safety net that had been masking a stack-selection blind spot:

- The selector (`_tasks_need_full_stack`) recognizes only task-level signals: `browser` / `mobile` / `search_kb` tool names and `initial_state.mock_web` / `initial_state.rag`.
- The Runner, however, enforces on the **resolved** `TaskDescription.search.enabled`, which an adapter may derive from signals the selector cannot see - e.g. a domain-shipped `docindex/` knowledge base with domain-named search tools.

On such runs the selector picks `core_stack`, the Runner builds no RAG client, and every search-enabled task hard-fails `RegisterTrial` with `"Search enabled but RAG service not configured"` (`runner/service.py`). Observed as 0 graded trials across all search domains of a downstream eval fleet on v0.4.1; runs on <= v0.2.11 were unaffected because `core_stack` still hardcoded the URL.

## Fix

Provision rag-service exactly when a task actually needs it, using the **existing** adapter-to-stack declarative seam (`DockerStackRequirements`, the same mechanism adapters already use for bind mounts / docker socket / DinD):

- `DockerStackRequirements.needs_rag_service: bool = False` - the adapter declares "my TaskDescriptions are search-enabled".
- `_run_needs_full_stack(tasks, stack_requirements)` combines the task-level signals with the adapter declaration; the orchestrator uses it for the factory choice and logs the adapter trigger.
- `needs_rag_service` is deliberately **not** rendered into `to_core_stack_kwargs()` - it selects the stack factory, it is not a stack kwarg (neither factory accepts it). A unit test pins this so it cannot leak and TypeError at stack construction.

This keeps the #95 invariant intact: `RAG_SERVICE_URL` is still only ever set by `full_stack`, i.e. when rag-service is actually running - the fix makes the provisioning decision follow the same signal the Runner enforces, instead of resurrecting an always-on default.

Behavior is unchanged for adapters that do not opt in (field defaults to False; `None` requirements fall back to the task-level signals).

The frozen-mcp-core adapter (private adapters repo) opts in separately by declaring `needs_rag_service` when its domain ships `docindex/`.

## Tests

```text
$ pytest tests/unit/test_orchestrator_full_stack_detection.py tests/unit/test_full_stack_kwargs.py -q
23 passed in 1.88s
```

New cases:
- adapter-declared need triggers `full_stack` even when task signals see nothing
- default / `None` requirements keep the existing task-signal behavior byte-identical
- `needs_rag_service` does not leak into `core_stack(**kwargs)`

Lint: `ruff check` clean; formatted with black per repo config.
