### PR TITLE
chore(conductor): delete vestigial POST /index RAG indexing block

### DIFF
--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -304,49 +304,6 @@ class InProcessConductor:
         env_state = EnvironmentState(task_dir, task.initial_state)
         env_state.hydrate()
 
-        # Initialize RAG index if corpus is configured
-        if env_state.rag_corpus_dir:
-            try:
-                import httpx
-
-                rag_service_urls = ["http://rag-service:8001", "http://localhost:8001"]
-
-                corpus_path = str(env_state.rag_corpus_dir)
-                container_corpus_path = None
-                try:
-                    repo_root = Path(__file__).resolve().parents[2]
-                    repo_tolokaforge = repo_root / "tolokaforge"
-                    if env_state.rag_corpus_dir.is_relative_to(repo_tolokaforge):
-                        rel_path = env_state.rag_corpus_dir.relative_to(repo_tolokaforge)
-                        container_corpus_path = str(Path("/app/tolokaforge") / rel_path)
-                except Exception:
-                    container_corpus_path = None
-                indexed = False
-                for rag_service_url in rag_service_urls:
-                    try:
-                        request_path = corpus_path
-                        if "localhost" in rag_service_url and container_corpus_path:
-                            request_path = container_corpus_path
-
-                        with httpx.Client(timeout=10.0) as client:
-                            response = client.post(
-                                f"{rag_service_url}/index",
-                                json={"corpus_path": request_path},
-                            )
-                        if response.status_code == 200:
-                            self.logger.debug(
-                                "Indexed RAG corpus", path=corpus_path, url=rag_service_url
-                            )
-                            indexed = True
-                            break
-                    except Exception:
-                        continue
-
-                if not indexed:
-                    self.logger.warning("Failed to index RAG corpus", path=corpus_path)
-            except Exception as e:
-                self.logger.warning("Could not index RAG corpus", error=str(e))
-
         # Execute initialization_actions to set correct starting state
         if task.initial_state.initialization_actions:
             init_actions = [

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1318,9 +1318,8 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
 
         Binding to the same ``rag_client`` + ``trial_id`` means the judge
         retrieves from the SAME per-trial index by construction: if the agent's
-        ``search_kb`` works the judge's does too, and if it 404s both do. (The
-        host-side global ``/index`` POST and per-trial indexing gating are
-        pre-existing and out of scope here.)
+        ``search_kb`` works the judge's does too, and if it 404s both do.
+        Per-trial indexing gating is a separate concern.
         """
         if self.rag_client is None:
             return None


### PR DESCRIPTION
## TL;DR

Delete a 42-line block in `InProcessConductor.run()` that POSTed to a bare `/index` route the rag-service never exposed. Every call returned 404 and the inner `except Exception` swallowed it, so the intended global index was never populated. Removing the dead code makes the orchestrator↔rag-service coupling honest: per-trial indexing is the only path.

## What ships

- `tolokaforge/core/conductor.py` — the entire `if env_state.rag_corpus_dir: … indexing …` block (lines 307–348 in the pre-PR tree) is gone. Net: `-43 lines`, no additions.

## Why

The rag-service (`tolokaforge/env/rag_service/app.py`) exposes:

- `POST /trials/{trial_id}/index`
- `POST /trials/{trial_id}/search`
- `DELETE /trials/{trial_id}/index`
- legacy `POST /search` (uses a "global" index)

There is **no** bare `POST /index`. The deleted block tried to populate a global index that this route never wired. Because the outer `try:` / inner `except Exception` swallowed the resulting 404s and connection errors, the failure was invisible in production. Two consequences:

1. Any downstream code that assumed a global RAG index existed after trial setup was silently working with an empty index (in practice, none of the shipped adapters read a global index, so the impact is confined to the wasted per-trial HTTP round-trip).
2. The code carried a leaky orchestrator→rag-service coupling that misled readers about the architecture. Per-trial indexing is the actual design.

Filed as GH #108 by @azorej during the judge-KB resolver work (#95 / #102). The other options the issue lists — adding a `POST /index` route to the rag-service, or fixing #107 (native per-trial indexing gated `False`) — are separate concerns and out of scope here. If the global-index concept ever comes back, it should be filed fresh with the current architecture in mind.

## Verification

- `make lint` — green
- `uv run pytest tests/unit tests/canonical -q -m "unit or canonical"` — **2206 passed, 1 skipped**

## Refs

Closes #108