### PR TITLE
refactor(output): typed models for run-level aggregate payloads (stage 1)

### DIFF
--- a/tests/canonical/test_run_aggregate_models_snapshot.py
+++ b/tests/canonical/test_run_aggregate_models_snapshot.py
@@ -1,0 +1,308 @@
+"""Byte-identity round-trip for the run-level aggregate Pydantic models.
+
+Stage 1 of TECHDEL-407 — the models in
+:mod:`tolokaforge.core.output.aggregate_models` exist alongside the
+current dict-typed writer surface. This suite proves that the models
+faithfully round-trip every field the metric-calc functions produce
+today, so stages 2 and 3 (function-return migration + consumer
+migration) can rely on the on-wire shape being unchanged.
+
+Each test:
+
+* generates a real dict payload by invoking the production metric-calc
+  function on representative inputs;
+* passes it through the corresponding model
+  (``Model.model_validate(dict).model_dump(by_alias=True, mode="json")``);
+* asserts the dumped dict equals the original dict — same keys, same
+  values, same types.
+
+Anything the current code writes that the model can't round-trip fails
+this suite loudly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from tolokaforge.core.failure_attribution import (
+    attribute_failure,
+    summarize_failure_attributions,
+)
+from tolokaforge.core.metrics import (
+    calculate_aggregate_metrics,
+    calculate_task_metrics,
+)
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    Metrics,
+    TerminationReason,
+    Trajectory,
+    TrialStatus,
+    Usage,
+)
+from tolokaforge.core.output.aggregate_models import (
+    AggregateMetrics,
+    FailureAttribution,
+    FailureRecord,
+    FailureSummary,
+    MetadataSlices,
+    PerTaskMetrics,
+    RunAggregate,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _make_trajectory(
+    task_id: str = "task-1",
+    trial_index: int = 0,
+    *,
+    binary_pass: bool = True,
+    score: float = 1.0,
+    latency_s: float = 12.34,
+    turns: int = 8,
+    tool_calls: int = 5,
+    stuck_detected: bool = False,
+    cost_usd: float | None = 0.021,
+    status: TrialStatus = TrialStatus.COMPLETED,
+    termination_reason: TerminationReason | None = None,
+) -> Trajectory:
+    """Build a Trajectory populated on every field the aggregate path reads.
+
+    Every ``Usage`` field is nonzero so the round-trip catches drops in
+    the ``avg_*`` / ``total_*`` slots. ``binary_pass=False`` (with a
+    non-``COMPLETED`` status) drives the failure-attribution path.
+    """
+    now = datetime.now(tz=UTC)
+    return Trajectory(
+        task_id=task_id,
+        trial_index=trial_index,
+        start_ts=now,
+        end_ts=now,
+        status=status,
+        termination_reason=termination_reason,
+        messages=[],
+        metrics=Metrics(
+            latency_total_s=latency_s,
+            turns=turns,
+            tool_calls=tool_calls,
+            stuck_detected=stuck_detected,
+            cost_usd=cost_usd,
+            usage=Usage(
+                prompt_tokens=1200,
+                completion_tokens=340,
+                reasoning_tokens=80,
+                cached_tokens=200,
+                cache_creation_input_tokens=150,
+                cache_read_input_tokens=90,
+            ),
+        ),
+        grade=Grade(
+            binary_pass=binary_pass,
+            score=score,
+            components=GradeComponents(state_checks=score),
+        ),
+    )
+
+
+def _augment_task_metrics(
+    task_metrics: dict, *, task_id: str, benchmark_type: str = "airline"
+) -> dict:
+    """Mimic the orchestrator's per-row augmentation (see
+    ``orchestrator.py`` around the ``calculate_task_metrics`` call site)."""
+    task_metrics["task_id"] = task_id
+    task_metrics["benchmark_type"] = benchmark_type
+    task_metrics["complexity"] = "simple"
+    task_metrics["expected_failure_modes"] = ["timeout_or_resource"]
+    task_metrics["tags"] = ["domain:airline", "smoke"]
+    return task_metrics
+
+
+def _round_trip(model_cls, payload) -> None:
+    """Validate → dump → assert equal. Failure means either a field drop
+    or a serialisation-order divergence between the model and the source
+    dict.
+
+    ``exclude_unset=True`` on the dump matches the wire behaviour of the
+    current writer path: keys the metric-calc functions did not set are
+    absent from the JSON (e.g. ``success_rate_macro`` on a weighted run,
+    ``success_rate_micro`` on an unweighted one). ``exclude_none`` would
+    over-prune — real ``None`` values (``total_cost_usd`` when no trial
+    reported a cost) must round-trip as ``None``, not drop.
+    """
+    model = model_cls.model_validate(payload)
+    dumped = model.model_dump(by_alias=True, mode="json", exclude_unset=True)
+    assert dumped == payload, (
+        f"{model_cls.__name__} round-trip lost or reshaped fields. "
+        f"expected={payload!r}\n  got={dumped!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PerTaskMetrics
+# ---------------------------------------------------------------------------
+
+
+def test_per_task_metrics_round_trip_from_real_metric_calc() -> None:
+    """A ``PerTaskMetrics`` model round-trips the dict the production
+    ``calculate_task_metrics`` produces (plus the orchestrator's task-id
+    / metadata augmentation)."""
+    trajectories = [
+        _make_trajectory(trial_index=0, binary_pass=True, score=1.0),
+        _make_trajectory(trial_index=1, binary_pass=False, score=0.4),
+        _make_trajectory(trial_index=2, binary_pass=True, score=0.9, stuck_detected=True),
+    ]
+    payload = calculate_task_metrics(trajectories)
+    payload = _augment_task_metrics(payload, task_id="task-1")
+
+    _round_trip(PerTaskMetrics, payload)
+
+
+def test_per_task_metrics_round_trip_with_none_cost() -> None:
+    """When no trial reported a cost, ``total_cost_usd`` / ``avg_cost_usd``
+    are ``None``. The model must preserve ``None`` (not collapse to 0)."""
+    trajectories = [
+        _make_trajectory(trial_index=0, cost_usd=None),
+        _make_trajectory(trial_index=1, cost_usd=None),
+    ]
+    payload = calculate_task_metrics(trajectories)
+    payload = _augment_task_metrics(payload, task_id="task-none-cost")
+
+    assert payload["total_cost_usd"] is None
+    assert payload["avg_cost_usd"] is None
+    _round_trip(PerTaskMetrics, payload)
+
+
+# ---------------------------------------------------------------------------
+# AggregateMetrics + RunAggregate
+# ---------------------------------------------------------------------------
+
+
+def _sample_task_metrics_list() -> list[dict]:
+    """Two task-metric rows fed into aggregate / slice calculators."""
+    t1 = calculate_task_metrics(
+        [_make_trajectory(trial_index=i, binary_pass=(i % 2 == 0)) for i in range(3)]
+    )
+    _augment_task_metrics(t1, task_id="task-1")
+    t2 = calculate_task_metrics(
+        [
+            _make_trajectory(trial_index=0, binary_pass=True),
+            _make_trajectory(trial_index=1, binary_pass=True),
+        ]
+    )
+    _augment_task_metrics(t2, task_id="task-2", benchmark_type="retail")
+    t2["complexity"] = "complex"
+    return [t1, t2]
+
+
+def test_aggregate_metrics_round_trip_weighted() -> None:
+    """Weighted (micro-average) aggregate — populates ``*_micro`` fields,
+    leaves ``*_macro`` un-set (``None``)."""
+    payload = calculate_aggregate_metrics(_sample_task_metrics_list(), weighted=True)
+    _round_trip(AggregateMetrics, payload)
+
+
+def test_aggregate_metrics_round_trip_unweighted() -> None:
+    """Unweighted (macro-average) aggregate — populates ``*_macro`` fields,
+    leaves ``*_micro`` un-set (``None``)."""
+    payload = calculate_aggregate_metrics(_sample_task_metrics_list(), weighted=False)
+    _round_trip(AggregateMetrics, payload)
+
+
+def test_run_aggregate_round_trip_with_schema_version() -> None:
+    """``RunAggregate`` = ``AggregateMetrics`` + the ``schema_version``
+    envelope the orchestrator stamps before writing ``aggregate.json``."""
+    payload = calculate_aggregate_metrics(_sample_task_metrics_list(), weighted=True)
+    payload["schema_version"] = 1
+
+    _round_trip(RunAggregate, payload)
+
+
+# ---------------------------------------------------------------------------
+# MetadataSlices
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_slices_round_trip() -> None:
+    """The four ``by_*`` dictionaries with :class:`AggregateMetrics` slice
+    values. Empty and populated dimensions both round-trip."""
+    tasks = _sample_task_metrics_list()
+    payload = {
+        "by_benchmark_type": {"airline": calculate_aggregate_metrics([tasks[0]], weighted=True)},
+        "by_complexity": {"simple": calculate_aggregate_metrics(tasks, weighted=True)},
+        "by_tag": {"domain:airline": calculate_aggregate_metrics([tasks[0]], weighted=True)},
+        "by_expected_failure_mode": {},
+    }
+
+    _round_trip(MetadataSlices, payload)
+
+
+# ---------------------------------------------------------------------------
+# FailureAttribution
+# ---------------------------------------------------------------------------
+
+
+def test_failure_record_round_trip_from_real_attribution() -> None:
+    """One record produced by ``attribute_failure`` on a failed trajectory."""
+    trajectory = _make_trajectory(
+        binary_pass=False,
+        score=0.0,
+        status=TrialStatus.TIMEOUT,
+        termination_reason=TerminationReason.TIMEOUT,
+    )
+    payload = attribute_failure(trajectory)
+
+    _round_trip(FailureRecord, payload)
+
+
+def test_failure_summary_round_trip_zero_failures() -> None:
+    """Zero-failure branch — ``deterministic_attribution_coverage`` is
+    ``None`` (division-by-zero guarded in the source)."""
+    payload = summarize_failure_attributions([])
+    assert payload["deterministic_attribution_coverage"] is None
+    _round_trip(FailureSummary, payload)
+
+
+def test_failure_summary_round_trip_with_failures() -> None:
+    """Populated summary — attribution records feed the by-class / by-tool
+    counters and drive coverage above 0."""
+    attributions = [
+        attribute_failure(
+            _make_trajectory(
+                trial_index=i,
+                binary_pass=False,
+                status=TrialStatus.TIMEOUT,
+                termination_reason=TerminationReason.TIMEOUT,
+            )
+        )
+        for i in range(3)
+    ]
+    payload = summarize_failure_attributions(attributions)
+
+    _round_trip(FailureSummary, payload)
+
+
+def test_failure_attribution_envelope_round_trip() -> None:
+    """The full ``{summary: ..., failures: [...]}`` envelope the writer
+    persists to ``failure_attribution.json``."""
+    attributions = [
+        attribute_failure(
+            _make_trajectory(
+                task_id=f"task-{i}",
+                trial_index=0,
+                binary_pass=False,
+                status=TrialStatus.TIMEOUT,
+                termination_reason=TerminationReason.TIMEOUT,
+            )
+        )
+        for i in range(2)
+    ]
+    payload = {
+        "summary": summarize_failure_attributions(attributions),
+        "failures": attributions,
+    }
+
+    _round_trip(FailureAttribution, payload)

--- a/tests/canonical/test_run_aggregate_models_snapshot.py
+++ b/tests/canonical/test_run_aggregate_models_snapshot.py
@@ -24,6 +24,7 @@ this suite loudly.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -70,12 +71,17 @@ def _make_trajectory(
     cost_usd: float | None = 0.021,
     status: TrialStatus = TrialStatus.COMPLETED,
     termination_reason: TerminationReason | None = None,
+    tool_log: list[dict[str, Any]] | None = None,
 ) -> Trajectory:
     """Build a Trajectory populated on every field the aggregate path reads.
 
     Every ``Usage`` field is nonzero so the round-trip catches drops in
     the ``avg_*`` / ``total_*`` slots. ``binary_pass=False`` (with a
     non-``COMPLETED`` status) drives the failure-attribution path.
+    ``tool_log`` drives the tool-execution branch of
+    :func:`attribute_failure`, which produces ``evidence`` entries
+    carrying a ``tool`` key — the source of the ``by_tool`` counter in
+    :func:`summarize_failure_attributions`.
     """
     now = datetime.now(tz=UTC)
     return Trajectory(
@@ -86,6 +92,7 @@ def _make_trajectory(
         status=status,
         termination_reason=termination_reason,
         messages=[],
+        tool_log=tool_log or [],
         metrics=Metrics(
             latency_total_s=latency_s,
             turns=turns,
@@ -106,6 +113,28 @@ def _make_trajectory(
             score=score,
             components=GradeComponents(state_checks=score),
         ),
+    )
+
+
+def _make_tool_execution_failure() -> Trajectory:
+    """A tool-execution failure trajectory — ``attribute_failure`` produces
+    an ``evidence`` entry with a ``tool`` key, so the summary's
+    ``by_tool`` counter increments.
+
+    Without this shape every failure path in this suite hits the TIMEOUT
+    branch of ``attribute_failure``, whose evidence carries only a
+    ``termination_reason`` — leaving ``by_tool`` empty and the byte-identity
+    gate blind to a future field-order or type divergence on that dict.
+    """
+    return _make_trajectory(
+        task_id="task-tool-fail",
+        binary_pass=False,
+        score=0.0,
+        status=TrialStatus.FAILED,
+        termination_reason=None,
+        tool_log=[
+            {"tool": "run_python", "success": False, "error": "SyntaxError: unexpected EOF"},
+        ],
     )
 
 
@@ -269,7 +298,14 @@ def test_failure_summary_round_trip_zero_failures() -> None:
 
 def test_failure_summary_round_trip_with_failures() -> None:
     """Populated summary — attribution records feed the by-class / by-tool
-    counters and drive coverage above 0."""
+    counters and drive coverage above 0.
+
+    Mixes TIMEOUT (populates ``by_failure_class['timeout_or_resource']``)
+    with tool-execution failures (populates
+    ``by_failure_class['tool_execution']`` AND ``by_tool[<tool_name>]``)
+    so both counters land non-empty — the previous suite exercised only
+    the TIMEOUT branch and left ``by_tool`` as ``{}`` on every dump.
+    """
     attributions = [
         attribute_failure(
             _make_trajectory(
@@ -279,9 +315,11 @@ def test_failure_summary_round_trip_with_failures() -> None:
                 termination_reason=TerminationReason.TIMEOUT,
             )
         )
-        for i in range(3)
+        for i in range(2)
     ]
+    attributions.append(attribute_failure(_make_tool_execution_failure()))
     payload = summarize_failure_attributions(attributions)
+    assert payload["by_tool"], "guard: by_tool must be non-empty for this test to matter"
 
     _round_trip(FailureSummary, payload)
 

--- a/tests/canonical/test_run_aggregate_models_snapshot.py
+++ b/tests/canonical/test_run_aggregate_models_snapshot.py
@@ -1,11 +1,12 @@
 """Byte-identity round-trip for the run-level aggregate Pydantic models.
 
-Stage 1 of TECHDEL-407 — the models in
-:mod:`tolokaforge.core.output.aggregate_models` exist alongside the
-current dict-typed writer surface. This suite proves that the models
-faithfully round-trip every field the metric-calc functions produce
-today, so stages 2 and 3 (function-return migration + consumer
-migration) can rely on the on-wire shape being unchanged.
+The models in :mod:`tolokaforge.core.output.aggregate_models` exist
+alongside the current dict-typed writer surface. This suite proves the
+models faithfully round-trip every field the production metric-calc
+functions produce today, so a later change that swaps the writer to
+accept the models — or migrates in-process consumers to attribute
+access — can be verified against the same on-disk shape rather than
+being trusted on inspection.
 
 Each test:
 

--- a/tolokaforge/core/output/aggregate_models.py
+++ b/tolokaforge/core/output/aggregate_models.py
@@ -1,0 +1,259 @@
+"""Pydantic models for the four run-level aggregate payloads.
+
+Locks the on-wire shape of ``per_task_metrics.json`` / ``aggregate.json``
+/ ``metadata_slices.json`` / ``failure_attribution.json``. See
+:class:`~tolokaforge.core.output.aggregates.RunAggregateWriter` for the
+writer surface these payloads flow through.
+
+* :class:`PerTaskMetrics` — one row of ``per_task_metrics.json``.
+* :class:`AggregateMetrics` — the shared body of ``aggregate.json`` (via
+  :class:`RunAggregate`) and every slice inside ``metadata_slices.json``.
+* :class:`RunAggregate` — ``AggregateMetrics`` + the ``schema_version``
+  envelope field that ``aggregate.json`` carries at the top level.
+* :class:`MetadataSlices` — the four ``by_*`` slice dictionaries.
+* :class:`FailureAttribution`, :class:`FailureSummary`,
+  :class:`FailureRecord` — the ``failure_attribution.json`` envelope.
+
+Stage 1 of TECHDEL-407: these models exist alongside the current
+dict-typed writer surface. Stage 2 migrates the metric-calc functions
+and the writer Protocol to return / accept them; stage 3 migrates
+in-process consumers to attribute access. Round-trip byte-identity is
+pinned by ``tests/canonical/test_run_aggregate_models_snapshot.py``.
+
+The ``pass@k`` / ``pass_hat@k`` keys aren't valid Python identifiers,
+so they carry :class:`~pydantic.Field` ``alias`` values. Dump with
+``model_dump(by_alias=True, mode="json")`` to produce the wire shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "AggregateMetrics",
+    "FailureAttribution",
+    "FailureRecord",
+    "FailureSummary",
+    "MetadataSlices",
+    "PerTaskMetrics",
+    "RunAggregate",
+]
+
+
+# Fields that appear identically on both PerTaskMetrics and AggregateMetrics —
+# the per-usage-field averages the Metrics.usage dataclass exposes.
+_USAGE_FIELDS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "reasoning_tokens",
+    "cached_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+
+class PerTaskMetrics(BaseModel):
+    """One row of ``per_task_metrics.json`` — a task's aggregate across trials.
+
+    Produced by :func:`~tolokaforge.core.metrics.calculate_task_metrics`
+    and augmented by the orchestrator with the task-identity + metadata
+    fields (``task_id``, ``benchmark_type``, ``complexity``, ``tags``,
+    ``expected_failure_modes``). The union is what lands in the JSON row.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    # Task identity + metadata (added by the orchestrator, not by the
+    # metric-calc function).
+    task_id: str
+    benchmark_type: str | None = None
+    complexity: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    expected_failure_modes: list[str] = Field(default_factory=list)
+
+    # Trial counts + basic success signal.
+    total_trials: int
+    successful_trials: int
+    success_rate: float
+
+    # pass@k / pass_hat@k for k in [1, 5, 10]. ``None`` when the run has
+    # fewer trials than k — mirrors ``calculate_pass_k``.
+    pass_at_1: float | None = Field(default=None, alias="pass@1")
+    pass_at_5: float | None = Field(default=None, alias="pass@5")
+    pass_at_10: float | None = Field(default=None, alias="pass@10")
+    pass_hat_at_1: float | None = Field(default=None, alias="pass_hat@1")
+    pass_hat_at_5: float | None = Field(default=None, alias="pass_hat@5")
+    pass_hat_at_10: float | None = Field(default=None, alias="pass_hat@10")
+
+    # Averages across trials.
+    avg_score: float
+    avg_latency_s: float
+    avg_turns: float
+    avg_tool_calls: float
+
+    # Per-usage-field averages (Metrics.usage — six fields).
+    avg_prompt_tokens: float = 0.0
+    avg_completion_tokens: float = 0.0
+    avg_reasoning_tokens: float = 0.0
+    avg_cached_tokens: float = 0.0
+    avg_cache_creation_input_tokens: float = 0.0
+    avg_cache_read_input_tokens: float = 0.0
+
+    # Cost is ``None`` when no trial reported a cost (unknown-provider case).
+    total_cost_usd: float | None = None
+    avg_cost_usd: float | None = None
+
+    # Per-trial wall-time percentiles.
+    latency_p50_s: float = 0.0
+    latency_p90_s: float = 0.0
+    latency_p99_s: float = 0.0
+
+    # Per-API-call percentiles aggregated across every call in every trial.
+    api_call_latency_p50_s: float = 0.0
+    api_call_latency_p90_s: float = 0.0
+    api_call_latency_p99_s: float = 0.0
+
+    stuck_rate: float = 0.0
+
+
+class AggregateMetrics(BaseModel):
+    """The shared body used both by ``aggregate.json`` (via
+    :class:`RunAggregate`) and by every slice value inside
+    ``metadata_slices.json``.
+
+    Produced by :func:`~tolokaforge.core.metrics.calculate_aggregate_metrics`.
+    Micro vs macro averages are populated depending on whether the
+    aggregate was computed weighted or unweighted; the un-set half stays
+    ``None``.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    total_tasks: int
+    total_trials: int
+
+    # Weighted (micro) averages — set when ``weighted=True``.
+    success_rate_micro: float | None = None
+    avg_score_micro: float | None = None
+
+    # Unweighted (macro) averages — set when ``weighted=False``.
+    success_rate_macro: float | None = None
+    avg_score_macro: float | None = None
+
+    # pass@k macro averages across tasks, plus their pass_hat aliases.
+    pass_at_1_macro: float | None = Field(default=None, alias="pass@1_macro")
+    pass_at_5_macro: float | None = Field(default=None, alias="pass@5_macro")
+    pass_at_10_macro: float | None = Field(default=None, alias="pass@10_macro")
+    pass_hat_at_1_macro: float | None = Field(default=None, alias="pass_hat@1_macro")
+    pass_hat_at_5_macro: float | None = Field(default=None, alias="pass_hat@5_macro")
+    pass_hat_at_10_macro: float | None = Field(default=None, alias="pass_hat@10_macro")
+
+    # Simple cross-task averages.
+    avg_latency_s: float = 0.0
+    avg_turns: float = 0.0
+    avg_tool_calls: float = 0.0
+    stuck_rate: float = 0.0
+
+    # Per-usage-field totals + macro averages.
+    total_prompt_tokens: float = 0.0
+    total_completion_tokens: float = 0.0
+    total_reasoning_tokens: float = 0.0
+    total_cached_tokens: float = 0.0
+    total_cache_creation_input_tokens: float = 0.0
+    total_cache_read_input_tokens: float = 0.0
+    avg_prompt_tokens: float = 0.0
+    avg_completion_tokens: float = 0.0
+    avg_reasoning_tokens: float = 0.0
+    avg_cached_tokens: float = 0.0
+    avg_cache_creation_input_tokens: float = 0.0
+    avg_cache_read_input_tokens: float = 0.0
+
+    total_cost_usd: float | None = None
+    avg_cost_usd: float | None = None
+
+    latency_p50_s_macro: float = 0.0
+    latency_p90_s_macro: float = 0.0
+    latency_p99_s_macro: float = 0.0
+
+
+class RunAggregate(AggregateMetrics):
+    """The top-level ``aggregate.json`` shape — :class:`AggregateMetrics`
+    plus the ``schema_version`` envelope field the orchestrator stamps
+    before writing.
+
+    Slice values inside ``metadata_slices.json`` are :class:`AggregateMetrics`
+    directly; only the top-level artifact carries the envelope.
+    """
+
+    schema_version: int = 1
+
+
+class MetadataSlices(BaseModel):
+    """The ``metadata_slices.json`` envelope — four ``by_*`` dictionaries.
+
+    Each entry maps a slice key (benchmark type, complexity name, tag,
+    or expected failure mode) to the :class:`AggregateMetrics` computed
+    over the tasks in that slice.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    by_benchmark_type: dict[str, AggregateMetrics] = Field(default_factory=dict)
+    by_complexity: dict[str, AggregateMetrics] = Field(default_factory=dict)
+    by_tag: dict[str, AggregateMetrics] = Field(default_factory=dict)
+    by_expected_failure_mode: dict[str, AggregateMetrics] = Field(default_factory=dict)
+
+
+class FailureRecord(BaseModel):
+    """One entry in ``failure_attribution.json``'s ``failures`` list —
+    the output of
+    :func:`~tolokaforge.core.failure_attribution.attribute_failure` for a
+    single failed trajectory.
+
+    ``evidence`` stays as a list of dicts; the entries are heterogeneous
+    (`kind` acts as a tag — ``tool_log`` / ``state_diff`` /
+    ``termination_reason`` / …) and locking the union here would
+    over-constrain the classifier. A future ticket can promote each
+    ``kind`` to its own model.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str
+    trial_index: int
+    status: str
+    termination_reason: str | None = None
+    failure_class: str
+    deterministic: bool
+    confidence: float
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class FailureSummary(BaseModel):
+    """The ``summary`` sub-object of ``failure_attribution.json``.
+
+    Produced by
+    :func:`~tolokaforge.core.failure_attribution.summarize_failure_attributions`.
+    ``deterministic_attribution_coverage`` is ``None`` when the summary
+    describes zero failed attempts (division by zero avoided at source).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    total_failed_attempts: int
+    deterministic_attribution_coverage: float | None = None
+    by_failure_class: dict[str, int] = Field(default_factory=dict)
+    by_tool: dict[str, int] = Field(default_factory=dict)
+
+
+class FailureAttribution(BaseModel):
+    """The ``failure_attribution.json`` envelope — ``{"summary": ...,
+    "failures": [...]}``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: FailureSummary
+    failures: list[FailureRecord] = Field(default_factory=list)

--- a/tolokaforge/core/output/aggregate_models.py
+++ b/tolokaforge/core/output/aggregate_models.py
@@ -94,6 +94,13 @@ class PerTaskMetrics(BaseModel):
     total_cost_usd: float | None = None
     avg_cost_usd: float | None = None
 
+    # Judge-cost split — ``judge_cost_usd`` is the LLM-judge grader's
+    # spend, tracked separately so the agent-vs-judge cost breakdown
+    # survives round-trips. ``total_cost_incl_judge_usd`` = agent +
+    # judge; ``None`` when neither is known.
+    judge_cost_usd: float | None = None
+    total_cost_incl_judge_usd: float | None = None
+
     # Per-trial wall-time percentiles.
     latency_p50_s: float = 0.0
     latency_p90_s: float = 0.0
@@ -161,6 +168,11 @@ class AggregateMetrics(BaseModel):
 
     total_cost_usd: float | None = None
     avg_cost_usd: float | None = None
+
+    # Judge-cost split at the run/slice level — same shape as
+    # ``PerTaskMetrics`` but aggregated across the tasks/slice.
+    judge_cost_usd: float | None = None
+    total_cost_incl_judge_usd: float | None = None
 
     latency_p50_s_macro: float = 0.0
     latency_p90_s_macro: float = 0.0

--- a/tolokaforge/core/output/aggregate_models.py
+++ b/tolokaforge/core/output/aggregate_models.py
@@ -42,18 +42,6 @@ __all__ = [
 ]
 
 
-# Fields that appear identically on both PerTaskMetrics and AggregateMetrics —
-# the per-usage-field averages the Metrics.usage dataclass exposes.
-_USAGE_FIELDS = (
-    "prompt_tokens",
-    "completion_tokens",
-    "reasoning_tokens",
-    "cached_tokens",
-    "cache_creation_input_tokens",
-    "cache_read_input_tokens",
-)
-
-
 class PerTaskMetrics(BaseModel):
     """One row of ``per_task_metrics.json`` — a task's aggregate across trials.
 

--- a/tolokaforge/core/output/aggregate_models.py
+++ b/tolokaforge/core/output/aggregate_models.py
@@ -14,11 +14,12 @@ writer surface these payloads flow through.
 * :class:`FailureAttribution`, :class:`FailureSummary`,
   :class:`FailureRecord` — the ``failure_attribution.json`` envelope.
 
-Stage 1 of TECHDEL-407: these models exist alongside the current
-dict-typed writer surface. Stage 2 migrates the metric-calc functions
-and the writer Protocol to return / accept them; stage 3 migrates
-in-process consumers to attribute access. Round-trip byte-identity is
-pinned by ``tests/canonical/test_run_aggregate_models_snapshot.py``.
+The models exist alongside the current dict-typed writer surface —
+they do not yet flow through the metric-calc functions or the writer
+Protocol. Round-trip byte-identity against the current on-disk shape
+is pinned by ``tests/canonical/test_run_aggregate_models_snapshot.py``,
+so a later change that swaps the writer to accept models can be
+verified against the same wire format.
 
 The ``pass@k`` / ``pass_hat@k`` keys aren't valid Python identifiers,
 so they carry :class:`~pydantic.Field` ``alias`` values. Dump with


### PR DESCRIPTION
## TL;DR

Introduce Pydantic v2 models for the four run-level aggregate JSON payloads (`per_task_metrics.json`, `aggregate.json`, `metadata_slices.json`, `failure_attribution.json`). **No production code path is touched, no behaviour changes.** The value is a canonical round-trip test that pins byte-identity between the model dumps and the current on-disk shape — a wire-format gate that makes the follow-on migration safe.

## Why (architectural context)

The engine has been steadily moving toward the pattern the runtime-architecture roadmap and ADRs 0003–0011 codify: **every data surface that crosses a boundary is a Pydantic model, every behavioural surface is a Protocol.** The per-trial control-plane already lives on `TrialSpec` / `TrialResult`; the run-level control-plane already has the `RunAggregateWriter` Protocol (ADR-0005). The one gap is what those seams carry — the four run-level aggregate payloads are still `dict[str, Any]`, produced by dict-returning metric-calc functions in `metrics.py` and `failure_attribution.py`, and consumed as raw dicts throughout the codebase.

Two consequences that are getting more expensive over time:

- **Downstream dashboards read fields we don't declare.** The only invariant the JSON currently pins is `schema_version: 1` on `aggregate.json`. Every other key is convention. Adding a new field is silent; renaming one is a silent break; drift between the calculator's shape and what the writer emits is caught by nothing except a broken dashboard.
- **The run-level seam is asymmetric with the per-trial seam.** ADR-0003 pins `TrialSpec` / `TrialResult` as typed models on the control↔trial edge; ADR-0005 pins the writer as a Protocol but leaves the payload untyped. That asymmetry means every future refactor at the run-level has to argue about the payload shape from scratch instead of pointing at a model.

Applying the **data-declaration pattern** (a value crossing a boundary is a `BaseModel` with `extra="forbid"`) to these four payloads closes the asymmetry, locks the on-disk shape, and makes shape drift a fail-loud PR-time signal instead of a silent-dashboard-break signal.

## Why this PR does *only* the models, not the migration

The full migration touches three surfaces that all have to move together: the calculator functions in `metrics.py` and `failure_attribution.py`, the writer Protocol + its two implementations in `output/aggregates.py`, and ~150 in-process consumers scattered across the codebase. Landing all three in one PR would ship a large blast-radius change with a hard-to-verify constraint (byte-identical JSON output). If any one field diverges — a `1.0` where the calculator emitted `1`, a key present where the calculator omitted it — downstream dashboards break silently at deploy time, not at review time.

Splitting the work so that **the wire-format gate lands first, in isolation** removes that risk: this PR proves the models round-trip byte-identical against the real calculator output; every subsequent PR that touches the calculators or the writer runs against the same gate. A migration that changes the on-disk shape breaks the round-trip test at the earliest possible moment.

## What ships

- **`tolokaforge/core/output/aggregate_models.py`** (new file) — seven models:
  - **`PerTaskMetrics`** — one row of `per_task_metrics.json`. Task identity + metadata + trial counts + `pass@k` / `pass_hat@k` + averages (score, latency, turns, tool calls, per-usage-field tokens) + cost + wall-time percentiles + per-API-call percentiles + stuck rate + judge-cost split (`judge_cost_usd`, `total_cost_incl_judge_usd`). ~37 fields.
  - **`AggregateMetrics`** — the shared body used both by `aggregate.json` (via `RunAggregate`) and by every slice value inside `metadata_slices.json`. The `success_rate_micro` / `_macro` and `avg_score_micro` / `_macro` fields are `Optional` so the same model round-trips both `weighted=True` and `weighted=False` output of `calculate_aggregate_metrics`. Includes the same judge-cost split (`judge_cost_usd`, `total_cost_incl_judge_usd`) aggregated across the tasks in the run/slice.
  - **`RunAggregate`** — inherits `AggregateMetrics` and adds the `schema_version` envelope the current writer stamps at the top level.
  - **`MetadataSlices`** — the four `by_*` dictionaries (`by_benchmark_type`, `by_complexity`, `by_tag`, `by_expected_failure_mode`), each `dict[str, AggregateMetrics]`.
  - **`FailureAttribution`** / **`FailureSummary`** / **`FailureRecord`** — the `failure_attribution.json` envelope, populated by `attribute_failure` + `summarize_failure_attributions`.
- **`tests/canonical/test_run_aggregate_models_snapshot.py`** (new file) — ten round-trip tests that invoke the production metric-calc functions on representative trajectories, feed the resulting dict through `Model.model_validate(...).model_dump(by_alias=True, mode="json", exclude_unset=True)`, and assert the dumped dict equals the source dict — same keys, same values, same types.

Nothing else is touched — the current writer Protocol still accepts and emits dicts; every producer function still returns dicts.

## Design decisions worth reading

- **`pass@k` / `pass_hat@k` aliases.** These wire keys aren't valid Python identifiers. Handled with `Field(default=None, alias="pass@1")` and dumped via `by_alias=True`. Six such aliases on `PerTaskMetrics`, six on `AggregateMetrics`. `populate_by_name=True` lets tests construct models by either the Python-identifier name or the wire alias for parity.
- **`extra="forbid"` on every model.** This is the whole point — a metric-calc function that grows an undeclared key fails validation at test time instead of shipping to `aggregate.json` and drifting from what the model says the shape is.
- **`exclude_unset=True` on the dump.** Matches the wire behaviour of the current writer path: keys the metric-calc functions did not set are absent from the JSON (e.g. `success_rate_macro` is absent on a weighted run). `exclude_none=True` would over-prune — real `None` values (`total_cost_usd` when no trial reported a cost) must round-trip as `None`, not drop.
- **`RunAggregate` inherits from `AggregateMetrics`** rather than composing. The shared body is exactly the union of every field `calculate_aggregate_metrics` produces; only the top-level artifact carries `schema_version`. Slice values inside `metadata_slices.json` are `AggregateMetrics` directly.
- **Judge-cost fields** (`judge_cost_usd`, `total_cost_incl_judge_usd` on both models) are `float | None = None`, matching `calculate_task_metrics` (`metrics.py:204`) and `calculate_aggregate_metrics` (`metrics.py:336-342`) — both compute `None` when neither an agent cost nor a judge cost is known, and `agent + judge` (with `0.0` for either missing side) otherwise. Added in the rebase against post-open `main`; the fields were introduced to the writer after this PR was first opened.
- **`FailureRecord.evidence: list[dict[str, Any]]`** stays untyped for now. Evidence entries are heterogeneous (`kind` acts as a discriminator — `tool_log` / `state_diff` / `termination_reason` / …); locking a union here would over-constrain the classifier and force every existing evidence emitter through a new type. Documented as a future refinement.

## Fit with the broader typing effort

- **ADR-0003 (`TrialSpec` / `TrialResult`)** pins the per-trial control-plane data. This PR pins the run-level analogue — same data-declaration pattern, applied to the seams it hadn't reached yet.
- **ADR-0005 (`RunAggregateWriter` Protocol)** established the run-level writer *behaviour* seam. Its follow-ups section explicitly flags the untyped payloads; this PR is the model half of that follow-up. The Protocol widening (to accept the models) is deliberately deferred to a follow-on PR so the wire-format gate lands first.
- **ADR-0011 (seam-definition + data-declaration conventions)** codifies exactly this shape: data crossing a JSON boundary is a Pydantic `BaseModel` with `extra="forbid"`; behavioural contracts are Protocols. The models in this PR are the direct application.

## Risk-management posture

The reason this PR is intentionally small is that the *full* refactor — model + calculator returns + writer signature + consumer migration — has real wire-format risk. A byte-order divergence between the current writer's JSON and a future model-based writer's JSON would silently break every downstream dashboard reading the aggregate files. Rather than ship all three surfaces in one PR and rely on human review to catch a shape drift, this PR lands *only* the models and *only* a snapshot test that pins the wire format. That test becomes a CI-level gate for any subsequent PR that migrates a producer, the writer, or a consumer: if the on-disk shape changes for any reason, the round-trip fails at PR time, not at deploy time.

## Follow-up work

- **Migrate the calculators.** `calculate_task_metrics`, `calculate_aggregate_metrics`, `attribute_failure`, `summarize_failure_attributions` return the models instead of dicts. The writer Protocol widens to accept them; `FileAggregateWriter.write_*` dumps via `model_dump(by_alias=True, mode="json", exclude_unset=True)`. The round-trip test from this PR is the wire-format check.
- **Migrate the consumers.** ~150 dict-key access sites (mostly tests, some orchestrator paths) switch to attribute access. Mechanical once the calculators return typed values.
- **Consolidate the duplicated per-usage-field lists.** `metrics.py` currently defines `_usage_fields` and `_agg_usage_fields` — identical six-field tuples across three call sites. Natural to fold when the calculator migration lands, since a drift between them is exactly the class of bug this PR guards against.

## Verification

- `make lint` — green
- `uv run pytest tests/unit tests/canonical -q -m "unit or canonical"` — **2216 passed, 1 skipped** (ten new tests from the byte-identity file, no regressions)

## Refs

Refs #86
