### PR TITLE
feat(grading): diff-first default state view for the rubric judge

### DIFF
--- a/tests/integration/test_rubric_judge_live.py
+++ b/tests/integration/test_rubric_judge_live.py
@@ -153,6 +153,45 @@ def test_rubric_judge_live_passes_good_transcript():
 
 
 @pytest.mark.skipif(_MODEL_REF is None, reason="No OPENROUTER_API_KEY / OPENAI_API_KEY set")
+def test_rubric_judge_live_with_state_diff_injected():
+    """The diff-first default: a rendered initial→final diff is injected as the
+    judge's primary view. Exercises the ``state_diff`` param through the real
+    provider path (real tool schemas / model), on top of the deterministic
+    injection pinned by ``test_judge.py::test_state_diff_injected_into_opening_context``.
+    """
+    from tolokaforge.core.grading.state_diff import render_state_diff
+
+    initial = {"orders": [{"id": "o_1001", "status": "pending", "refund_amount": 0.0}]}
+    state_diff = render_state_diff(
+        initial,
+        _DB_STATE,
+        primary_keys={"orders": "id"},
+    )
+    # Sanity: the renderer produced the transition the judge should grade on.
+    assert "status:" in state_diff and "refunded" in state_diff
+
+    result = run_rubric_judge(
+        rubric=_rubric(),
+        model_config=model_config_from_ref(_MODEL_REF),
+        agent_system_prompt=_AGENT_SYSTEM_PROMPT,
+        transcript=_TRANSCRIPT,
+        db_reader=_DictDBReader(_DB_STATE),
+        state_diff=state_diff,
+        max_turns=10,
+        episode_timeout_s=180,
+    )
+
+    # Passing the diff must not break the live path: judge completes, gate holds,
+    # and the diff is captured verbatim into the judge's own transcript (the
+    # inject+persist contract — the opening message is message[0]).
+    assert result.status is JudgeStatus.COMPLETED, result.reasons
+    assert result.gate_failed is False
+    assert result.score is not None and result.score >= 0.7
+    opening = result.transcript[0]["content"]
+    assert "STATE CHANGES" in opening
+
+
+@pytest.mark.skipif(_MODEL_REF is None, reason="No OPENROUTER_API_KEY / OPENAI_API_KEY set")
 def test_rubric_judge_live_gate_fails_when_refund_missing():
     # Final state shows the order still pending — the required criterion fails.
     pending_state = {"orders": [{"id": "o_1001", "status": "pending", "refund_amount": 0.0}]}

--- a/tests/unit/grading/test_judge.py
+++ b/tests/unit/grading/test_judge.py
@@ -702,6 +702,29 @@ def test_agent_system_prompt_injected_into_opening_context():
     assert "do the thing" in captured["first_user"]
 
 
+def test_state_diff_injected_into_opening_context():
+    """The initial→final state diff is injected as the judge's primary view."""
+    rubric = _binary_rubric()
+    captured: dict = {}
+
+    class CapturingClient(ScriptedClient):
+        def generate(self, system, messages, tools, tool_choice="auto"):
+            captured.setdefault("first_user", messages[0].content)
+            return super().generate(system, messages, tools, tool_choice)
+
+    client = CapturingClient([[("submit_report", _submit_args(refund_done=True))]])
+    run_rubric_judge(
+        rubric=rubric,
+        model_config=_JUDGE_MODEL,
+        agent_system_prompt="",
+        transcript=[{"role": "user", "content": "do the thing"}],
+        db_reader=FakeDBReader(),
+        state_diff="STATE-DIFF-MARKER: orders: 1 modified",
+        llm_client=client,
+    )
+    assert "STATE-DIFF-MARKER" in captured["first_user"]
+
+
 def test_input_surface_excludes_oracle_fields():
     """Narrow input surface: there is no parameter through which golden_actions /
     expected_hash / jsonpath_checks could leak into the judge."""

--- a/tests/unit/grading/test_llm_judge_runner.py
+++ b/tests/unit/grading/test_llm_judge_runner.py
@@ -146,3 +146,79 @@ def test_judge_model_rides_on_trial_spec():
     rehydrated = TrialSpec.model_validate_json(spec.model_dump_json())
     assert rehydrated.judge_model_config == judge_model
     assert rehydrated.judge_model_config.temperature == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _build_judge_state_diff — the diff-first default's runner-side seam
+# ---------------------------------------------------------------------------
+
+
+def _trial_context(initial_state):
+    """A minimal stand-in exposing only what _build_judge_state_diff reads."""
+    import types
+
+    task_desc = types.SimpleNamespace(initial_state=initial_state)
+    return types.SimpleNamespace(task_description=task_desc)
+
+
+class _FakeDBClient:
+    """Async db_client returning a fixed final state."""
+
+    def __init__(self, data):
+        self._data = data
+
+    async def get_state(self, trial_id, tables=None):
+        import types
+
+        return types.SimpleNamespace(data=self._data)
+
+
+async def test_build_judge_state_diff_none_when_no_db_client():
+    import types
+
+    from tolokaforge.runner.models import InitialStateConfig
+    from tolokaforge.runner.service import RunnerServiceImpl
+
+    fake_self = types.SimpleNamespace(db_client=None)
+    tc = _trial_context(InitialStateConfig(tables={"orders": [{"id": 1}]}))
+    out = await RunnerServiceImpl._build_judge_state_diff(fake_self, "trial", tc)
+    assert out is None
+
+
+async def test_build_judge_state_diff_none_when_no_initial_tables():
+    import types
+
+    from tolokaforge.runner.models import InitialStateConfig
+    from tolokaforge.runner.service import RunnerServiceImpl
+
+    fake_self = types.SimpleNamespace(db_client=_FakeDBClient({"orders": []}))
+    tc = _trial_context(InitialStateConfig(tables={}))
+    out = await RunnerServiceImpl._build_judge_state_diff(fake_self, "trial", tc)
+    assert out is None
+
+
+async def test_build_judge_state_diff_renders_modified_row():
+    import types
+
+    from tolokaforge.runner.models import InitialStateConfig, TableSchema
+    from tolokaforge.runner.service import RunnerServiceImpl
+
+    initial = InitialStateConfig(
+        tables={"orders": [{"id": 1, "status": "open"}]},
+        schemas=[
+            TableSchema(
+                table_name="orders",
+                fields={"id": "integer", "status": "string"},
+                primary_key="id",
+            )
+        ],
+    )
+    fake_self = types.SimpleNamespace(
+        db_client=_FakeDBClient({"orders": [{"id": 1, "status": "shipped"}]})
+    )
+    out = await RunnerServiceImpl._build_judge_state_diff(
+        fake_self, "trial", _trial_context(initial)
+    )
+    assert out is not None
+    assert "orders: 1 modified" in out
+    assert 'status: "open" → "shipped"' in out

--- a/tests/unit/grading/test_state_diff.py
+++ b/tests/unit/grading/test_state_diff.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from tolokaforge.core.grading.state_diff import render_state_diff
+
+pytestmark = pytest.mark.unit
 
 
 def test_no_changes_reports_untouched_explicitly() -> None:

--- a/tests/unit/grading/test_state_diff.py
+++ b/tests/unit/grading/test_state_diff.py
@@ -1,0 +1,157 @@
+"""Unit tests for the judge's ``initial → final`` state-diff renderer."""
+
+from __future__ import annotations
+
+from tolokaforge.core.grading.state_diff import render_state_diff
+
+
+def test_no_changes_reports_untouched_explicitly() -> None:
+    state = {"orders": [{"id": 1, "status": "open"}]}
+    out = render_state_diff(state, state)
+    assert "No changes detected" in out
+    assert out.startswith("===== STATE CHANGES")
+    assert out.rstrip().endswith("===== END STATE CHANGES =====")
+
+
+def test_added_row_by_declared_pk() -> None:
+    initial = {"refunds": []}
+    final = {"refunds": [{"id": 88, "order_id": 42, "amount": 10.0}]}
+    out = render_state_diff(initial, final, primary_keys={"refunds": "id"})
+    assert "refunds: 1 added" in out
+    assert '"id": 88' in out
+    assert "removed" not in out
+
+
+def test_removed_row() -> None:
+    initial = {"orders": [{"id": 1}, {"id": 2}]}
+    final = {"orders": [{"id": 1}]}
+    out = render_state_diff(initial, final, primary_keys={"orders": "id"})
+    assert "orders: 1 removed" in out
+    assert '"id": 2' in out
+
+
+def test_modified_row_shows_only_changed_fields() -> None:
+    initial = {"orders": [{"id": 1, "status": "pending", "total": 5}]}
+    final = {"orders": [{"id": 1, "status": "shipped", "total": 5}]}
+    out = render_state_diff(initial, final, primary_keys={"orders": "id"})
+    assert "orders: 1 modified" in out
+    assert 'status: "pending" → "shipped"' in out
+    # An unchanged field must not appear in the per-field diff.
+    assert "total:" not in out
+
+
+def test_star_id_heuristic_when_no_declared_pk() -> None:
+    initial = {"lines": [{"order_id": 1, "qty": 1}]}
+    final = {"lines": [{"order_id": 1, "qty": 3}]}
+    out = render_state_diff(initial, final)  # no primary_keys passed
+    assert "lines: 1 modified" in out
+    assert "order_id=1" in out
+    assert "qty: 1 → 3" in out
+
+
+def test_whole_record_fallback_when_no_usable_key() -> None:
+    initial = {"notes": [{"text": "a"}]}
+    final = {"notes": [{"text": "b"}]}
+    out = render_state_diff(initial, final)
+    # No id/_id field and no declared pk → set matching: added + removed, never modified.
+    assert "1 added" in out
+    assert "1 removed" in out
+    assert "modified" not in out
+
+
+def test_unstable_fields_are_suppressed() -> None:
+    initial = {"tickets": [{"id": 1, "status": "open", "updated_at": "t0"}]}
+    final = {"tickets": [{"id": 1, "status": "open", "updated_at": "t1"}]}
+    out = render_state_diff(
+        initial,
+        final,
+        primary_keys={"tickets": "id"},
+        unstable_fields={("tickets", "updated_at")},
+    )
+    # Only the unstable field changed → treated as no change.
+    assert "No changes detected" in out
+    assert "updated_at" not in out
+
+
+def test_unstable_field_change_does_not_mask_real_change() -> None:
+    initial = {"tickets": [{"id": 1, "status": "open", "updated_at": "t0"}]}
+    final = {"tickets": [{"id": 1, "status": "closed", "updated_at": "t1"}]}
+    out = render_state_diff(
+        initial,
+        final,
+        primary_keys={"tickets": "id"},
+        unstable_fields={("tickets", "updated_at")},
+    )
+    assert 'status: "open" → "closed"' in out
+    assert "updated_at" not in out
+
+
+def test_unchanged_tables_are_listed() -> None:
+    initial = {
+        "orders": [{"id": 1, "status": "open"}],
+        "customers": [{"id": 9, "name": "x"}],
+    }
+    final = {
+        "orders": [{"id": 1, "status": "shipped"}],
+        "customers": [{"id": 9, "name": "x"}],
+    }
+    out = render_state_diff(initial, final, primary_keys={"orders": "id", "customers": "id"})
+    assert "orders: 1 modified" in out
+    assert "Unchanged tables (1): customers" in out
+
+
+def test_pk_flagged_unstable_still_matches_as_modified() -> None:
+    """A PK that is ALSO an unstable field (id / auto_id) must still key rows.
+
+    Regression: previously the PK was stripped as noise before matching, so an
+    in-place edit rendered as add+remove and the field-level change was lost.
+    """
+    initial = {"tickets": [{"id": 1, "status": "open", "subject": "help"}]}
+    final = {"tickets": [{"id": 1, "status": "solved", "subject": "help"}]}
+    out = render_state_diff(
+        initial,
+        final,
+        primary_keys={"tickets": "id"},
+        unstable_fields={("tickets", "id")},
+    )
+    assert "tickets: 1 modified" in out
+    assert 'status: "open" → "solved"' in out
+    assert "added" not in out and "removed" not in out
+
+
+def test_keyless_fallback_preserves_multiplicity() -> None:
+    """Removing one of two identical keyless rows must show as a removal.
+
+    Regression: set-based matching collapsed duplicates, hiding the removal.
+    """
+    initial = {"events": [{"kind": "ping"}, {"kind": "ping"}]}
+    final = {"events": [{"kind": "ping"}]}
+    out = render_state_diff(initial, final)
+    assert "1 removed" in out
+    assert "added" not in out
+
+
+def test_int_and_float_pk_are_the_same_row() -> None:
+    initial = {"orders": [{"id": 1, "status": "open"}]}
+    final = {"orders": [{"id": 1.0, "status": "shipped"}]}
+    out = render_state_diff(initial, final, primary_keys={"orders": "id"})
+    assert "orders: 1 modified" in out
+    assert 'status: "open" → "shipped"' in out
+    assert "added" not in out and "removed" not in out
+
+
+def test_tiny_max_chars_never_exceeds_budget_grossly() -> None:
+    # Pathological max_chars must not crash or wildly overshoot (budget guard).
+    initial = {"t": []}
+    final = {"t": [{"id": 1, "blob": "x" * 100}]}
+    out = render_state_diff(initial, final, primary_keys={"t": "id"}, max_chars=10)
+    assert out.rstrip().endswith("===== END STATE CHANGES =====")
+
+
+def test_truncation_is_flagged_not_silent() -> None:
+    initial = {"t": []}
+    final = {"t": [{"id": i, "blob": "x" * 100} for i in range(50)]}
+    out = render_state_diff(initial, final, primary_keys={"t": "id"}, max_chars=300)
+    assert "truncated" in out
+    assert out.rstrip().endswith("===== END STATE CHANGES =====")
+    assert len(out) <= 300 + 200  # cap plus the flag/footer allowance

--- a/tolokaforge/core/grading/judge.py
+++ b/tolokaforge/core/grading/judge.py
@@ -332,22 +332,55 @@ def _serialize_judge_transcript(messages: list[Message]) -> tuple[dict[str, Any]
     return tuple(out)
 
 
-def _build_opening_message(agent_system_prompt: str, transcript: list[dict[str, Any]]) -> str:
-    """Inject the agent's policy (system prompt) + transcript into the judge context."""
+def _build_opening_message(
+    agent_system_prompt: str,
+    transcript: list[dict[str, Any]],
+    state_diff: str | None = None,
+) -> str:
+    """Inject the agent's policy (system prompt) + transcript into the judge context.
+
+    When a ``state_diff`` is supplied (the ``initial → final`` delta of the DB
+    state — exactly what the agent changed), it is injected as the judge's
+    default view of the outcome. It is deliberately NOT the trial-vs-golden diff:
+    it reveals nothing about the expected answer, only the agent's own edits. The
+    judge is steered to read the diff first and reach for ``get_db_state`` /
+    ``query_db`` only to confirm post-conditions the diff does not settle.
+    """
     policy_block = (
         f"The agent under evaluation operated under this policy / system prompt:\n"
         f"---\n{agent_system_prompt.strip()}\n---\n\n"
         if agent_system_prompt and agent_system_prompt.strip()
         else ""
     )
+    if state_diff and state_diff.strip():
+        state_block = (
+            "Below is a diff of the database state the agent changed "
+            "(initial → final): the rows it added, removed, or modified, plus "
+            "which tables it left untouched. Use it as your starting point for "
+            "what the agent did.\n"
+            f"{state_diff.strip()}\n\n"
+        )
+        closing = (
+            "The diff shows changes, not the complete final state. For criteria "
+            "about what must NOT change, invariants, absence, or the quality of a "
+            "full final value, inspect the relevant state directly with query_db "
+            "(or get_db_state as a last resort). Then grade each criterion and "
+            "call submit_report."
+        )
+    else:
+        state_block = ""
+        closing = (
+            "Use your read-only tools to inspect the final state, then grade each "
+            "criterion and call submit_report."
+        )
     return (
         f"{policy_block}"
         "Here is the full transcript of the agent's interaction:\n"
         "===== TRANSCRIPT =====\n"
         f"{_format_transcript(transcript)}\n"
         "===== END TRANSCRIPT =====\n\n"
-        "Use your read-only tools to inspect the final state, then grade each "
-        "criterion and call submit_report."
+        f"{state_block}"
+        f"{closing}"
     )
 
 
@@ -451,6 +484,7 @@ def run_rubric_judge(
     kb_search: KnowledgeSearch | None = None,
     extra_read_tools: list[Tool] | None = None,
     workspace_dir: Path | None = None,
+    state_diff: str | None = None,
     max_turns: int = DEFAULT_JUDGE_MAX_TURNS,
     episode_timeout_s: int = DEFAULT_JUDGE_EPISODE_TIMEOUT_S,
     submit_report_retries: int = DEFAULT_SUBMIT_REPORT_RETRIES,
@@ -459,8 +493,11 @@ def run_rubric_judge(
 ) -> JudgeResult:
     """Run the read-only agentic rubric judge and return its verdict.
 
-    Narrow input surface: ``{agent_system_prompt, transcript, rubric, read-tools}``
-    only. Never receives the deterministic-oracle fields of ``GradingConfig``.
+    Narrow input surface: ``{agent_system_prompt, transcript, rubric, read-tools,
+    state_diff}`` only. Never receives the deterministic-oracle fields of
+    ``GradingConfig``. ``state_diff`` is the ``initial → final`` delta of the
+    agent's own edits (not the trial-vs-golden diff) — it reveals nothing about
+    the expected answer, so it does not bias the judge.
 
     Fail-loud: any judge malfunction — repeated malformed ``submit_report`` past
     ``submit_report_retries``, turn / wall-time exhaustion, or an LLM/tool error
@@ -508,7 +545,7 @@ def run_rubric_judge(
     messages: list[Message] = [
         Message(
             role=MessageRole.USER,
-            content=_build_opening_message(agent_system_prompt, transcript),
+            content=_build_opening_message(agent_system_prompt, transcript, state_diff),
         )
     ]
     rubric_brief = _build_rubric_brief(rubric)

--- a/tolokaforge/core/grading/judge_tools.py
+++ b/tolokaforge/core/grading/judge_tools.py
@@ -60,9 +60,12 @@ class GetDbStateTool(Tool):
         super().__init__(
             name="get_db_state",
             description=(
-                "Read the final database state of the trial. Optionally pass a list "
-                "of table names to narrow the result; omit to return all tables. "
-                "Read-only."
+                "LAST RESORT — returns the ENTIRE final database state as raw JSON, "
+                "which can be very large and is truncated at a fixed size. Prefer the "
+                "initial → final state diff already provided in your instructions, and "
+                "use query_db for specific values. Only call this when you must see a "
+                "whole table the diff does not cover; pass a list of table names to "
+                "narrow the result. Read-only."
             ),
             policy=_read_only_policy(),
         )

--- a/tolokaforge/core/grading/state_diff.py
+++ b/tolokaforge/core/grading/state_diff.py
@@ -1,0 +1,284 @@
+"""Render a compact, human-readable ``initial → final`` state diff for the judge.
+
+The rubric judge historically inspected the trial's final DB state by dumping it
+whole (``get_db_state``) — a large, noisy JSON blob that is expensive on context
+and hard for both the model and a human reviewer to read. This module produces
+the *diff-first default*: a compact summary of exactly what the agent **changed**
+between the pre-run initial state and the final state, injected into the judge's
+opening message (and, because that message is part of the judge transcript,
+persisted verbatim into ``judge_trajectory.yaml``).
+
+Crucially this is the **initial → final** delta — the agent's own edits — NOT the
+trial-vs-golden diff (``runner/grading.py:compute_state_diff``). The golden diff
+reveals the expected answer and is deliberately withheld from the judge to avoid
+path-matching bias (see ``plans/rubric_grading.md`` Decisions #7/#8). An
+initial→final delta leaks nothing about the oracle: it only says what the agent
+did, which is the thing most rubrics actually grade.
+
+The renderer is intentionally dependency-free — it takes plain dicts and returns
+a string — so it is trivially unit-testable and carries no coupling to the runner
+models. The caller (``runner/service.py``) extracts primary keys and unstable
+fields from the trial's ``InitialStateConfig`` and passes them in as plain data.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from typing import Any
+
+__all__ = ["render_state_diff"]
+
+#: Overall cap on the rendered diff so a pathological change set can't blow the
+#: judge's context window. Truncation is always flagged, never silent — matching
+#: ``judge_tools._MAX_OUTPUT_CHARS``.
+_MAX_OUTPUT_CHARS = 50_000
+
+#: Per-table cap on how many added / removed rows are shown in full before the
+#: rest collapse to a count. Modified rows are always shown (they carry the
+#: field-level old→new that is the whole point of a diff) up to the same cap.
+_MAX_ROWS_PER_CATEGORY = 20
+
+
+def _fmt_value(value: Any) -> str:
+    """Format a single field value unambiguously (``null``, quoted strings, …)."""
+    return json.dumps(value, default=str, ensure_ascii=False, sort_keys=True)
+
+
+def _fmt_record(record: dict[str, Any]) -> str:
+    """Format a whole record as compact one-line JSON with stable key order."""
+    return json.dumps(record, default=str, ensure_ascii=False, sort_keys=True)
+
+
+def _pk_key(value: Any) -> str:
+    """Canonical hashable key for PK matching.
+
+    Normalizes numbers so an integer and its float twin key the same row
+    (``1`` and ``1.0`` — JSON round-tripping through the DB readily flips one to
+    the other, and for a primary key they denote the same entity). ``bool`` is
+    kept distinct from ``int`` (Python treats ``True == 1``, which we do not want
+    for a key). All other values fall back to the unambiguous JSON form.
+    """
+    if isinstance(value, bool):
+        return f"bool:{value}"
+    if isinstance(value, (int, float)):
+        return f"num:{float(value)!r}"
+    return _fmt_value(value)
+
+
+def _strip_unstable(
+    record: dict[str, Any], table: str, unstable: set[tuple[str, str]]
+) -> dict[str, Any]:
+    """Drop noise fields (auto-ids, timestamps, …) so the diff shows real edits."""
+    if not unstable:
+        return record
+    return {k: v for k, v in record.items() if (table, k) not in unstable}
+
+
+def _resolve_pk(
+    before: list[dict[str, Any]],
+    after: list[dict[str, Any]],
+    declared_pk: str | None,
+) -> str | None:
+    """Pick a usable primary-key field for row matching, or ``None``.
+
+    A field is usable when, on **each side independently**, every row carries it
+    non-null and uniquely. Uniqueness is checked per side (not on the combined
+    rows) — a key shared by a before-row and an after-row is exactly the match we
+    want, not a duplicate. Prefers the declared schema PK, then ``id``, then the
+    first ``*_id`` field. Returns ``None`` when no field reliably keys the rows —
+    the caller then degrades to whole-record set matching (added/removed only).
+    """
+
+    def usable(field: str) -> bool:
+        for side in (before, after):
+            seen: set[str] = set()
+            for r in side:
+                if field not in r or r[field] is None:
+                    return False
+                key = _pk_key(r[field])
+                if key in seen:
+                    return False
+                seen.add(key)
+        return True
+
+    if declared_pk and usable(declared_pk):
+        return declared_pk
+    sample = before or after
+    if not sample:
+        return declared_pk or None
+    candidates = ["id"] + sorted(f for f in sample[0] if f.endswith("_id") and f != "id")
+    for field in candidates:
+        if usable(field):
+            return field
+    return None
+
+
+def _field_diffs(before: dict[str, Any], after: dict[str, Any]) -> list[str]:
+    """Field-level ``name: old → new`` fragments for changed fields only."""
+    frags: list[str] = []
+    for field in sorted(set(before) | set(after)):
+        old, new = before.get(field), after.get(field)
+        if old != new:
+            frags.append(f"{field}: {_fmt_value(old)} → {_fmt_value(new)}")
+    return frags
+
+
+def _diff_table(
+    initial_rows: list[dict[str, Any]],
+    final_rows: list[dict[str, Any]],
+    *,
+    table: str,
+    declared_pk: str | None,
+    unstable: set[tuple[str, str]],
+) -> tuple[list[str], list[str], list[tuple[str, list[str]]]]:
+    """Return (added, removed, modified) for one table.
+
+    ``added`` / ``removed`` are formatted record strings; ``modified`` is a list
+    of ``(row_label, field_diff_fragments)``. Row matching is done on the **raw**
+    records so a primary key that is itself flagged unstable (``id`` with
+    ``reason="auto_id"`` is common) still correlates rows; unstable fields are
+    stripped only for the displayed record and the field-level diff, so
+    non-deterministic noise never shows up as a change. Output is sorted for
+    determinism.
+    """
+
+    def strip(r: dict[str, Any]) -> dict[str, Any]:
+        return _strip_unstable(r, table, unstable)
+
+    # Resolve the PK on RAW rows (before stripping): the PK field must be present
+    # to key rows, even when it is registered as an unstable (auto-id) field.
+    pk = _resolve_pk(initial_rows, final_rows, declared_pk)
+
+    if pk is None:
+        # No reliable key: fall back to whole-record (post-strip) matching with
+        # MULTISET semantics so removing one of two identical rows is not lost to
+        # set collapse. Only added / removed can be reported, never modifications.
+        before_counts = Counter(_fmt_record(strip(r)) for r in initial_rows)
+        after_counts = Counter(_fmt_record(strip(r)) for r in final_rows)
+        added = sorted((after_counts - before_counts).elements())
+        removed = sorted((before_counts - after_counts).elements())
+        return added, removed, []
+
+    before_by_pk = {_pk_key(r[pk]): r for r in initial_rows}
+    after_by_pk = {_pk_key(r[pk]): r for r in final_rows}
+
+    added = sorted(
+        _fmt_record(strip(row)) for key, row in after_by_pk.items() if key not in before_by_pk
+    )
+    removed = sorted(
+        _fmt_record(strip(row)) for key, row in before_by_pk.items() if key not in after_by_pk
+    )
+    modified: list[tuple[str, list[str]]] = []
+    for key in before_by_pk.keys() & after_by_pk.keys():
+        before_row, after_row = before_by_pk[key], after_by_pk[key]
+        frags = _field_diffs(strip(before_row), strip(after_row))
+        if frags:
+            # Label from the actual PK value (not the internal match key), and
+            # from the final row so it reflects the surviving entity.
+            modified.append((f"{pk}={_fmt_value(after_row[pk])}", frags))
+    modified.sort(key=lambda m: m[0])
+
+    return added, removed, modified
+
+
+def render_state_diff(
+    initial: dict[str, list[dict[str, Any]]],
+    final: dict[str, list[dict[str, Any]]],
+    *,
+    primary_keys: dict[str, str] | None = None,
+    unstable_fields: set[tuple[str, str]] | None = None,
+    max_chars: int = _MAX_OUTPUT_CHARS,
+) -> str:
+    """Render the ``initial → final`` state delta as a compact diff block.
+
+    Args:
+        initial: pre-run state, ``table -> [records]``.
+        final: final state after the agent's run, ``table -> [records]``.
+        primary_keys: declared ``table -> pk field`` (from the task schemas);
+            used to match rows across the two states. Falls back to an
+            ``id`` / ``*_id`` heuristic, then to whole-record matching.
+        unstable_fields: ``(table, field)`` pairs to exclude as noise
+            (auto-ids, timestamps, LLM-generated content) so the diff shows
+            only meaningful edits — the same set used for stable-hash grading.
+        max_chars: overall cap; detail beyond it collapses with a flag.
+
+    Returns:
+        A ``===== STATE CHANGES … =====`` block. When nothing changed, the body
+        is a single explicit "No changes" line so the judge can distinguish
+        "agent correctly changed nothing" from "diff unavailable".
+    """
+    primary_keys = primary_keys or {}
+    unstable_fields = unstable_fields or set()
+
+    lines: list[str] = []
+    changed_tables = 0
+    unchanged: list[str] = []
+
+    for table in sorted(set(initial) | set(final)):
+        added, removed, modified = _diff_table(
+            initial.get(table, []),
+            final.get(table, []),
+            table=table,
+            declared_pk=primary_keys.get(table),
+            unstable=unstable_fields,
+        )
+        if not (added or removed or modified):
+            unchanged.append(table)
+            continue
+
+        changed_tables += 1
+        counts = []
+        if added:
+            counts.append(f"{len(added)} added")
+        if removed:
+            counts.append(f"{len(removed)} removed")
+        if modified:
+            counts.append(f"{len(modified)} modified")
+        lines.append(f"{table}: {', '.join(counts)}")
+
+        for label, frags in modified[:_MAX_ROWS_PER_CATEGORY]:
+            lines.append(f"  ~ {label}: {'; '.join(frags)}")
+        if len(modified) > _MAX_ROWS_PER_CATEGORY:
+            lines.append(f"  ~ … ({len(modified) - _MAX_ROWS_PER_CATEGORY} more modified)")
+
+        for row in added[:_MAX_ROWS_PER_CATEGORY]:
+            lines.append(f"  + {row}")
+        if len(added) > _MAX_ROWS_PER_CATEGORY:
+            lines.append(f"  + … ({len(added) - _MAX_ROWS_PER_CATEGORY} more added)")
+
+        for row in removed[:_MAX_ROWS_PER_CATEGORY]:
+            lines.append(f"  - {row}")
+        if len(removed) > _MAX_ROWS_PER_CATEGORY:
+            lines.append(f"  - … ({len(removed) - _MAX_ROWS_PER_CATEGORY} more removed)")
+
+    header = "===== STATE CHANGES (what the agent changed: initial → final) ====="
+    footer = "===== END STATE CHANGES ====="
+
+    body: list[str]
+    if changed_tables == 0:
+        body = ["No changes detected in any table (agent left the state untouched)."]
+    else:
+        body = list(lines)
+        if unchanged:
+            body.append(f"Unchanged tables ({len(unchanged)}): {', '.join(unchanged)}")
+
+    rendered = "\n".join([header, *body, footer])
+    if len(rendered) > max_chars:
+        # Trim the detail lines, keeping header/footer and a truncation flag. Use
+        # query_db / get_db_state to inspect anything the diff had to drop.
+        budget = max(0, max_chars - len(header) - len(footer) - 120)
+        kept: list[str] = []
+        running = 0
+        for line in body:
+            if running + len(line) + 1 > budget:
+                break
+            kept.append(line)
+            running += len(line) + 1
+        kept.append(
+            "… (state diff truncated — use query_db / get_db_state to inspect "
+            "the remaining changes)"
+        )
+        rendered = "\n".join([header, *kept, footer])
+
+    return rendered

--- a/tolokaforge/core/grading/state_diff.py
+++ b/tolokaforge/core/grading/state_diff.py
@@ -11,7 +11,7 @@ persisted verbatim into ``judge_trajectory.yaml``).
 Crucially this is the **initial → final** delta — the agent's own edits — NOT the
 trial-vs-golden diff (``runner/grading.py:compute_state_diff``). The golden diff
 reveals the expected answer and is deliberately withheld from the judge to avoid
-path-matching bias (see ``plans/rubric_grading.md`` Decisions #7/#8). An
+path-matching bias (see ``docs/RUBRIC_GRADING_DESIGN.md`` Decisions #7/#8). An
 initial→final delta leaks nothing about the oracle: it only says what the agent
 did, which is the thing most rubrics actually grade.
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -36,6 +36,7 @@ from pydantic import ValidationError
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, run_rubric_judge
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
+from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.models import CriterionResult, LLMJudgeConfig, ModelConfig
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
@@ -1290,6 +1291,30 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 "models.judge; the orchestrator should have rejected this run up front."
             )
 
+        # Diff-first default: hand the judge the initial → final state delta (the
+        # agent's own edits) as its primary view of the outcome, instead of it
+        # dumping the whole final DB via get_db_state. This is NOT the
+        # trial-vs-golden diff (that would leak the oracle and bias grading, see
+        # rubric_grading.md #7/#8) — it reveals only what the agent changed.
+        # Persisted for free: the opening message it lands in is captured into
+        # judge_trajectory.yaml. Computed here on the loop thread where both
+        # states are in hand.
+        #
+        # This is an aid to the judge, not a grade component: if building it
+        # fails (DB read hiccup, unexpected state shape), degrade to no diff
+        # rather than failing the whole grade — the judge still has its read-only
+        # tools, and the hash / jsonpath components already computed must not be
+        # discarded. The judge's OWN fail-loud contract still governs grading;
+        # this only guards the optional context we hand it.
+        try:
+            state_diff_text = await self._build_judge_state_diff(trial_id, trial_context)
+        except Exception as exc:  # noqa: BLE001 — optional context, never fail the grade
+            logger.warning(
+                "Failed to build judge state diff; grading without it "
+                f"(trial_id={trial_id}, error={exc})"
+            )
+            state_diff_text = None
+
         def _run() -> JudgeResult:
             return run_rubric_judge(
                 rubric=llm_judge_config.rubric,
@@ -1300,9 +1325,37 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 kb_search=kb_search,
                 extra_read_tools=extra_read_tools,
                 workspace_dir=workspace_dir,
+                state_diff=state_diff_text,
             )
 
         return await loop.run_in_executor(None, _run)
+
+    async def _build_judge_state_diff(
+        self, trial_id: str, trial_context: TrialContextRuntime
+    ) -> str | None:
+        """Render the ``initial → final`` DB state diff for the judge, or ``None``.
+
+        Returns ``None`` when there is no DB client or no initial-state tables for
+        this trial (e.g. non-DB tasks) — the judge then falls back to its
+        read-only tools. Otherwise fetches the raw final state (the same shape
+        ``get_db_state`` returns) and diffs it against the pre-run initial tables,
+        matching rows by declared primary key and dropping ``unstable_fields`` as
+        noise so the diff shows only meaningful edits.
+        """
+        db_client = self.db_client
+        task_desc = trial_context.task_description
+        initial_state = task_desc.initial_state if task_desc else None
+        if db_client is None or initial_state is None or not initial_state.tables:
+            return None
+        final_state = (await db_client.get_state(trial_id)).data
+        primary_keys = {s.table_name: s.primary_key for s in initial_state.schemas}
+        unstable_fields = {(u.table_name, u.field_name) for u in initial_state.unstable_fields}
+        return render_state_diff(
+            initial_state.tables,
+            final_state,
+            primary_keys=primary_keys,
+            unstable_fields=unstable_fields,
+        )
 
     def _resolve_judge_kb_search(
         self, trial_id: str, agent_tools: dict[str, Callable]

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1295,7 +1295,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # agent's own edits) as its primary view of the outcome, instead of it
         # dumping the whole final DB via get_db_state. This is NOT the
         # trial-vs-golden diff (that would leak the oracle and bias grading, see
-        # rubric_grading.md #7/#8) — it reveals only what the agent changed.
+        # docs/RUBRIC_GRADING_DESIGN.md #7/#8) — it reveals only what the agent changed.
         # Persisted for free: the opening message it lands in is captured into
         # judge_trajectory.yaml. Computed here on the loop thread where both
         # states are in hand.


### PR DESCRIPTION
## Why

The rubric judge inspects the final DB state through read-only tools, and in practice reflexively calls `get_db_state()` — dumping the **entire** final DB as JSON (truncated at 50k chars, sometimes silently incomplete). It's large, noisy, and hard for both the model and a human reviewer to read. Most rubrics actually grade *what the agent changed*, not the whole end state.

## What

Compute the **initial → final** state delta (the agent's own edits) and inject it into the judge's opening message as its primary view; keep `get_db_state`/`query_db` as a last resort.

Crucially this is **not** the trial-vs-golden diff. Per `plans/rubric_grading.md` #7/#8 the judge must never see the oracle (that causes path-matching bias). An initial→final delta reveals only what the agent did, so it leaks nothing about the expected answer. Persistence is free: the opening message is captured into `judge_trajectory.yaml` by `_serialize_judge_transcript`.

### Changes
- **New pure renderer** `core/grading/state_diff.py` — per-table added/removed/modified with field-level `old → new`, an explicit *"Unchanged tables"* line (so "correctly left untouched" is visible, not silent), unstable-field suppression, and size-capped output.
- **Robust row matching** — declared PK → `id`/`*_id` heuristic → whole-record **multiset** fallback. Matching runs on **raw** records so a PK that is itself an `auto_id` unstable field still correlates rows (unstable fields are stripped only for display). Numeric PK normalization so an int and its float twin key the same row.
- **Runner** `_build_judge_state_diff` computes the diff on the loop thread; on failure it **degrades to no diff** rather than failing the whole grade (the judge keeps its tools; already-computed hash/jsonpath components survive).
- **Prompt** — `get_db_state` reworded to a last-resort signal; opening-message framing steers the judge to inspect full state for invariant / absence / full-value criteria.

## Design review

An independent adversarial critic reviewed this. It confirmed the **oracle-leak constraint holds** (and verified the golden snapshot is restored before the judge runs). It found real correctness bugs — all fixed here with regression tests:
- PK-as-`auto_id` was stripped before matching → modifies rendered as add/remove (and could silently drop rows via set-collapse).
- int/float PK churn.
- fail-loud on this presentational input would have discarded other grade components → now degrades gracefully.

## Testing
- **52** grading unit tests (incl. the auto_id-PK, duplicate-row multiplicity, and int/float PK regressions).
- **43** grading canonical/snapshot tests — no pipeline regression.
- **3** live judge integration tests (real LLM), including a new case that renders a real diff and asserts it reaches the judge.
- **`native_shared_domain` example** end-to-end (real Docker db-service + runner + LLMs): diff verified in `judge_trajectory.yaml` for both the no-change case (`No changes detected... left the state untouched`) and the write case (`notes: 1 added + {...}`).

## Follow-ups (out of scope)
- Whether diff-first improves grading *accuracy* (not just cost/readability) warrants a real eval comparison.
- Rubric-scoped state extraction / precomputed per-criterion checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2tL5u2pYEWPt6u78rX632