### PR TITLE
fix(db-service): support JSONPath filter expressions in /query

### DIFF
--- a/tests/integration/test_rubric_judge_live.py
+++ b/tests/integration/test_rubric_judge_live.py
@@ -214,3 +214,91 @@ def test_rubric_judge_live_gate_fails_when_refund_missing():
     assert result.gate_failed is True
     assert "refund_issued" in result.failed_required_ids
     assert result.binary_pass is False
+
+
+class _RealDbServiceReader:
+    """Read-only DBReader backed by the REAL json_db_service via its HTTP API.
+
+    Unlike ``_DictDBReader`` (which evaluates JSONPath locally with
+    ``jsonpath_ng.ext``), this drives the actual service ``/query`` endpoint, so
+    the judge's queries hit the same parser production uses. Mirrors the
+    production ``DBServiceClient`` contract: a non-200 response raises, which
+    ``QueryDbTool`` surfaces to the judge as a tool error. Every query is
+    recorded so the test can assert the real parser never rejected one.
+
+    This is the seam the bug in PR #157 slipped through: the old live test used
+    an in-memory reader, so a DB-service-side JSONPath parser bug was invisible.
+    """
+
+    def __init__(self, test_client, trial_id: str):
+        self._client = test_client
+        self._trial_id = trial_id
+        self.queries: list[tuple[str, int, str]] = []  # (jsonpath, status, detail)
+
+    def get_state(self, tables=None):
+        params = {"tables": ",".join(tables)} if tables else {}
+        resp = self._client.get(f"/trials/{self._trial_id}/state", params=params)
+        resp.raise_for_status()
+        return resp.json()["data"]
+
+    def query(self, jsonpath):
+        resp = self._client.post(f"/trials/{self._trial_id}/query", json={"jsonpath": jsonpath})
+        detail = "" if resp.status_code == 200 else resp.json().get("detail", resp.text)
+        self.queries.append((jsonpath, resp.status_code, detail))
+        if resp.status_code != 200:
+            raise RuntimeError(f"query_db failed: {detail}")
+        return {"results": resp.json()["results"]}
+
+
+@pytest.mark.skipif(_MODEL_REF is None, reason="No OPENROUTER_API_KEY / OPENAI_API_KEY set")
+def test_rubric_judge_live_against_real_db_service(db_test_client):
+    """End-to-end: real LLM judge driving the REAL DB service query endpoint.
+
+    Regression guard for PR #157 — the judge's natural "look up an entity by id"
+    move (``$.orders[?(@.id=="...")]``) must succeed against the real service.
+    The previous live test backed the judge with an in-memory reader, so a
+    service-side parser bug (base ``jsonpath_ng`` rejecting filter expressions)
+    reached production undetected.
+    """
+    trial_id = "judge_live_dbsvc"
+    # Several orders so the judge filters by id rather than dumping the table.
+    tables = {
+        "orders": [
+            {"id": "o_1001", "status": "refunded", "refund_amount": 328.50},
+            {"id": "o_1002", "status": "pending", "refund_amount": 0.0},
+            {"id": "o_1003", "status": "shipped", "refund_amount": 0.0},
+        ]
+    }
+    init = db_test_client.post(f"/trials/{trial_id}/init", json={"tables": tables})
+    assert init.status_code == 200, init.text
+
+    reader = _RealDbServiceReader(db_test_client, trial_id)
+    result = run_rubric_judge(
+        rubric=_rubric(),
+        model_config=model_config_from_ref(_MODEL_REF),
+        agent_system_prompt=_AGENT_SYSTEM_PROMPT,
+        transcript=_TRANSCRIPT,
+        db_reader=reader,
+        max_turns=10,
+        episode_timeout_s=180,
+    )
+
+    # The judge grades correctly against the real service (o_1001 is refunded).
+    assert result.status is JudgeStatus.COMPLETED, result.reasons
+    assert result.gate_failed is False
+
+    # The load-bearing guard (never flaky): no query the judge issued was
+    # rejected by the real parser. Under the pre-#157 bug, every `[?(...)]`
+    # filter returned 400 "Unexpected character: ?" — this would fail.
+    parse_failures = [q for q in reader.queries if q[1] != 200]
+    assert not parse_failures, f"real DB service rejected judge queries: {parse_failures}"
+
+    # Deterministic belt-and-suspenders: exercise a filter expression through the
+    # real service directly, so the regression is caught even on a run where the
+    # model happened to only use `[*]` wildcards.
+    direct = db_test_client.post(
+        f"/trials/{trial_id}/query",
+        json={"jsonpath": '$.orders[?(@.id=="o_1001")].status'},
+    )
+    assert direct.status_code == 200, direct.text
+    assert direct.json()["results"] == ["refunded"]

--- a/tests/unit/test_json_db_service_query.py
+++ b/tests/unit/test_json_db_service_query.py
@@ -1,0 +1,71 @@
+"""Regression tests for the DB service ``/query`` JSONPath endpoint.
+
+The rubric judge's natural first move is to look up an entity by id, e.g.
+``$.orders[?(@.id=="PO-K7V3")]``. Under the base ``jsonpath_ng`` parser this
+failed with "Unexpected character: ?", so the judge fell back to dumping whole
+tables via ``[*]`` and filtering mentally — roughly doubling its tool calls and
+inflating context (PR #151 client feedback, v0.6.0). The endpoint now uses the
+extended parser, which supports filter expressions while remaining a strict
+superset of the wildcard/index grammar that already worked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _init(client, trial_id: str, tables: dict) -> None:
+    resp = client.post(f"/trials/{trial_id}/init", json={"tables": tables})
+    assert resp.status_code == 200, resp.text
+
+
+def test_query_supports_jsonpath_filter_expression(db_test_client):
+    _init(
+        db_test_client,
+        "t_filter",
+        {
+            "orders": [
+                {"id": "PO-K7V3", "status": "open"},
+                {"id": "PO-ZZZ9", "status": "closed"},
+            ]
+        },
+    )
+    resp = db_test_client.post(
+        "/trials/t_filter/query",
+        json={"jsonpath": '$.orders[?(@.id=="PO-K7V3")]'},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["results"][0]["status"] == "open"
+
+
+def test_query_filter_on_nested_field(db_test_client):
+    _init(
+        db_test_client,
+        "t_nested",
+        {"orders": [{"id": "A", "qty": 1}, {"id": "B", "qty": 5}]},
+    )
+    resp = db_test_client.post(
+        "/trials/t_nested/query",
+        json={"jsonpath": "$.orders[?(@.qty>3)].id"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"] == ["B"]
+
+
+def test_query_wildcard_still_works(db_test_client):
+    # The extended parser must not regress the wildcard/index grammar.
+    _init(
+        db_test_client,
+        "t_wild",
+        {"orders": [{"id": "A", "status": "open"}, {"id": "B", "status": "closed"}]},
+    )
+    resp = db_test_client.post(
+        "/trials/t_wild/query",
+        json={"jsonpath": "$.orders[*].status"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert sorted(resp.json()["results"]) == ["closed", "open"]

--- a/tolokaforge/core/grading/judge_tools.py
+++ b/tolokaforge/core/grading/judge_tools.py
@@ -105,8 +105,11 @@ class QueryDbTool(Tool):
         super().__init__(
             name="query_db",
             description=(
-                "Query the final database state with a JSONPath expression "
-                "(e.g. '$.orders[*].status'). Returns matching values. Read-only."
+                "Query the final database state with a JSONPath expression, "
+                "including filter expressions to look up a specific row — e.g. "
+                "'$.orders[?(@.id==\"PO-1\")]' to fetch one order by id, or "
+                "'$.orders[*].status' for a whole column. Returns matching values. "
+                "Read-only."
             ),
             policy=_read_only_policy(),
         )

--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -17,7 +17,7 @@ from threading import Lock
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse  # .ext: supports filter exprs, superset of base grammar
 from pydantic import BaseModel, Field, PrivateAttr
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Why (client feedback on v0.6.0)

The diff-first judge works as intended (reads the diff, then verifies final state, then submits), but the client caught a real, repeating defect:

> The judge's `query_db` tool doesn't support JSONPath filter expressions. Its natural first move is to look up an entity by id — `$.tau_manufacturing_order[?(@.order_id=="PO-K7V3")]` — and **every** such query fails with `Query failed: … Unexpected character: ?`. The judge then falls back to dumping the whole table (`[*]`) and filters mentally. **26 of 50** `query_db` calls failed this way (~half; 100% consistent — every `[?(...)]` fails, every `[*]` succeeds).

**Impact:** ~doubles the judge's tool calls (fail → retry), and the `[*]` fallback dumps entire tables into the judge's context — inflating token cost and, on a large table, risking crowding out the relevant row. Not a correctness problem in that run (small DBs recovered every time), but a real efficiency/robustness defect.

## Root cause

`tolokaforge/env/json_db_service/app.py` imported `from jsonpath_ng import parse` — the **base** grammar, which has no filter support. `Unexpected character: ?` is its signature failure on `[?(...)]`.

## Fix

Switch the `/query` endpoint to `from jsonpath_ng.ext import parse` — the **extended** parser, a strict superset that supports filter expressions while keeping every wildcard/index query working. It's the same parser `runner/grading.py` already uses for jsonpath checks, so this aligns the two evaluation paths.

Also updated the `query_db` tool description to demonstrate a filter lookup (`$.orders[?(@.id=="PO-1")]`) instead of the `[*]` wildcard, nudging the judge toward the one-row path.

## Testing

New `tests/unit/test_json_db_service_query.py` (via the real service TestClient):
- filter-by-id returns exactly the matching row (the previously-failing case)
- numeric nested filter (`[?(@.qty>3)]`)
- wildcard still works (no regression to the base grammar)

345 db/grading unit tests pass; lint + format clean.

## Deploy note

The DB service runs in a container built from `db_service.Dockerfile` — the image must be rebuilt for this to take effect in real runs (unit tests exercise the app in-process, so they validate the fix directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2tL5u2pYEWPt6u78rX632