### PR TITLE
feat(metrics): roll up judge cost at task and run level

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -12,7 +12,14 @@ from tolokaforge.core.metrics import (
     calculate_task_metrics,
     compute_pass_at_k,
 )
-from tolokaforge.core.models import Grade, GradeComponents, JudgeUsage, Metrics, Trajectory
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    JudgeStatus,
+    JudgeUsage,
+    Metrics,
+    Trajectory,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -195,9 +202,35 @@ class TestJudgeCost:
         assert m["total_cost_incl_judge_usd"] == pytest.approx(0.03)
 
     def test_aggregate_rolls_up_judge_cost_across_tasks(self):
-        task_a = calculate_task_metrics([self._trial(0, 0.01, 0.005)])
+        # A multi-trial task in one group so the rollup can't pass by treating
+        # per-task totals as per-trial (sum-of-task-totals, not an average).
+        task_a = calculate_task_metrics([self._trial(0, 0.01, 0.005), self._trial(1, 0.01, 0.005)])
         task_b = calculate_task_metrics([self._trial(0, 0.02, 0.005)])
         agg = calculate_aggregate_metrics([task_a, task_b])
-        assert agg["total_cost_usd"] == pytest.approx(0.03)
-        assert agg["judge_cost_usd"] == pytest.approx(0.01)
-        assert agg["total_cost_incl_judge_usd"] == pytest.approx(0.04)
+        assert agg["total_cost_usd"] == pytest.approx(0.04)  # 0.01+0.01+0.02
+        assert agg["judge_cost_usd"] == pytest.approx(0.015)  # 3 × 0.005
+        assert agg["total_cost_incl_judge_usd"] == pytest.approx(0.055)
+
+    def test_mixed_judge_and_no_judge_trials_in_one_task(self):
+        # Only trials that actually ran a judge contribute to judge_cost_usd.
+        trajectories = [self._trial(0, 0.01, 0.005), self._trial(1, 0.02, None)]
+        m = calculate_task_metrics(trajectories)
+        assert m["total_cost_usd"] == pytest.approx(0.03)
+        assert m["judge_cost_usd"] == pytest.approx(0.005)
+        assert m["total_cost_incl_judge_usd"] == pytest.approx(0.035)
+
+    def test_zero_judge_cost_counted_not_treated_as_absent(self):
+        # A real 0.0 judge cost must not be conflated with "no judge ran" (None).
+        m = calculate_task_metrics([self._trial(0, 0.01, 0.0)])
+        assert m["judge_cost_usd"] == 0.0
+        assert m["judge_cost_usd"] is not None
+        assert m["total_cost_incl_judge_usd"] == pytest.approx(0.01)
+
+    def test_errored_judge_cost_is_still_counted(self):
+        # An ERRORED judge still spent tokens; its cost must roll up (metrics are
+        # judge-status-agnostic — they sum whatever judge_usage.cost_usd exists).
+        traj = self._trial(0, 0.01, 0.003)
+        traj.grade.judge_status = JudgeStatus.ERRORED
+        m = calculate_task_metrics([traj])
+        assert m["judge_cost_usd"] == pytest.approx(0.003)
+        assert m["total_cost_incl_judge_usd"] == pytest.approx(0.013)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,12 +6,13 @@ import pytest
 
 from tolokaforge.core.llm.usage import ProviderRawCall, Usage
 from tolokaforge.core.metrics import (
+    calculate_aggregate_metrics,
     calculate_latency_percentiles,
     calculate_pass_k,
     calculate_task_metrics,
     compute_pass_at_k,
 )
-from tolokaforge.core.models import Grade, GradeComponents, Metrics, Trajectory
+from tolokaforge.core.models import Grade, GradeComponents, JudgeUsage, Metrics, Trajectory
 
 pytestmark = pytest.mark.unit
 
@@ -155,3 +156,48 @@ class TestExtendedMetrics:
         assert metrics["api_call_latency_p50_s"] == pytest.approx(3.0)
         assert metrics["api_call_latency_p90_s"] > metrics["api_call_latency_p50_s"]
         assert metrics["api_call_latency_p99_s"] >= metrics["api_call_latency_p90_s"]
+
+
+@pytest.mark.unit
+class TestJudgeCost:
+    """Judge spend is accounted separately from agent cost and rolled up."""
+
+    def _trial(self, idx: int, agent_cost: float, judge_cost: float | None) -> Trajectory:
+        judge_usage = None if judge_cost is None else JudgeUsage(calls=1, cost_usd=judge_cost)
+        return Trajectory(
+            task_id="task_judge_cost",
+            trial_index=idx,
+            start_ts=datetime.now(tz=timezone.utc),
+            end_ts=datetime.now(tz=timezone.utc),
+            messages=[],
+            metrics=Metrics(latency_total_s=1.0, usage=Usage(), cost_usd=agent_cost),
+            grade=Grade(
+                binary_pass=True,
+                score=1.0,
+                components=GradeComponents(),
+                judge_usage=judge_usage,
+            ),
+        )
+
+    def test_task_metrics_separate_agent_and_judge_cost(self):
+        trajectories = [self._trial(0, 0.01, 0.005), self._trial(1, 0.02, 0.005)]
+        m = calculate_task_metrics(trajectories)
+        # total_cost_usd stays agent-only.
+        assert m["total_cost_usd"] == pytest.approx(0.03)
+        assert m["judge_cost_usd"] == pytest.approx(0.01)
+        assert m["total_cost_incl_judge_usd"] == pytest.approx(0.04)
+
+    def test_judge_cost_none_when_no_judge_ran(self):
+        trajectories = [self._trial(0, 0.01, None), self._trial(1, 0.02, None)]
+        m = calculate_task_metrics(trajectories)
+        assert m["judge_cost_usd"] is None
+        # With no judge cost, the combined total equals the agent total.
+        assert m["total_cost_incl_judge_usd"] == pytest.approx(0.03)
+
+    def test_aggregate_rolls_up_judge_cost_across_tasks(self):
+        task_a = calculate_task_metrics([self._trial(0, 0.01, 0.005)])
+        task_b = calculate_task_metrics([self._trial(0, 0.02, 0.005)])
+        agg = calculate_aggregate_metrics([task_a, task_b])
+        assert agg["total_cost_usd"] == pytest.approx(0.03)
+        assert agg["judge_cost_usd"] == pytest.approx(0.01)
+        assert agg["total_cost_incl_judge_usd"] == pytest.approx(0.04)

--- a/tolokaforge/core/metrics.py
+++ b/tolokaforge/core/metrics.py
@@ -191,6 +191,23 @@ def calculate_task_metrics(trajectories: list[Trajectory]) -> dict[str, any]:
         if metrics["total_cost_usd"] is not None and n_total > 0
         else None
     )
+    # Judge spend is separate from the agent trajectory cost: the rubric judge
+    # runs its own LLM in the Runner, so its cost lives on ``grade.judge_usage``,
+    # not ``trajectory.metrics``. ``total_cost_usd`` above is agent-only; surface
+    # judge cost on its own and a combined total so a run's true spend is visible
+    # without parsing every ``grade.yaml`` (issue: run-level judge cost).
+    _judge_costs = [
+        t.grade.judge_usage.cost_usd
+        for t in trajectories
+        if t.grade is not None and t.grade.judge_usage is not None
+    ]
+    metrics["judge_cost_usd"] = sum(_judge_costs) if _judge_costs else None
+    if metrics["total_cost_usd"] is None and metrics["judge_cost_usd"] is None:
+        metrics["total_cost_incl_judge_usd"] = None
+    else:
+        metrics["total_cost_incl_judge_usd"] = (metrics["total_cost_usd"] or 0.0) + (
+            metrics["judge_cost_usd"] or 0.0
+        )
 
     metrics.update(calculate_latency_percentiles([t.metrics.latency_total_s for t in trajectories]))
 
@@ -311,6 +328,18 @@ def calculate_aggregate_metrics(
     agg["avg_cost_usd"] = (
         sum(_known_avg_costs) / n_tasks if _known_avg_costs and n_tasks > 0 else None
     )
+    # Roll up judge spend and the combined total across tasks (agent-only
+    # ``total_cost_usd`` above; judge runs its own LLM in the Runner).
+    _known_judge_costs = [
+        m.get("judge_cost_usd") for m in task_metrics if m.get("judge_cost_usd") is not None
+    ]
+    agg["judge_cost_usd"] = sum(_known_judge_costs) if _known_judge_costs else None
+    _known_total_incl = [
+        m.get("total_cost_incl_judge_usd")
+        for m in task_metrics
+        if m.get("total_cost_incl_judge_usd") is not None
+    ]
+    agg["total_cost_incl_judge_usd"] = sum(_known_total_incl) if _known_total_incl else None
 
     for percentile in ("latency_p50_s", "latency_p90_s", "latency_p99_s"):
         agg[f"{percentile}_macro"] = (

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1502,6 +1502,8 @@ class Orchestrator:
             latency_p90_s=aggregate.get("latency_p90_s"),
             latency_p99_s=aggregate.get("latency_p99_s"),
             total_cost_usd=aggregate.get("total_cost_usd"),
+            judge_cost_usd=aggregate.get("judge_cost_usd"),
+            total_cost_incl_judge_usd=aggregate.get("total_cost_incl_judge_usd"),
             avg_turns=aggregate["avg_turns"],
             avg_tool_calls=aggregate["avg_tool_calls"],
             stuck_rate=aggregate["stuck_rate"],


### PR DESCRIPTION
## Why

The rubric judge runs its own LLM inside the Runner, so its spend is recorded on `grade.judge_usage.cost_usd` (per trial, in `grade.yaml`) — **separate** from `trajectory.metrics.cost_usd`, which is agent-only. Nothing rolled the judge cost up, so:

- the run-level **`total_cost_usd`** (`core/metrics.py`) and the orchestrator's **"Aggregate Results"** log **silently excluded all judge spend**;
- answering "what did grading cost this run?" meant parsing every `grade.yaml` by hand.

On judge-heavy runs (rubric grading on every trial, sometimes a pricier judge model) this understates true spend materially.

## What

Additive, and preserves the (correct) agent-vs-judge separation — `total_cost_usd` stays agent-only so existing consumers don't shift:

- **Per-task** (`calculate_task_metrics`): `judge_cost_usd` (sum of `grade.judge_usage.cost_usd`, `None` when no judge ran) and `total_cost_incl_judge_usd` (agent + judge, None-safe).
- **Run-level** (`calculate_aggregate_metrics`): the same two keys rolled up across tasks.
- **Visibility**: `judge_cost_usd` + `total_cost_incl_judge_usd` added to the orchestrator's "Aggregate Results" log line.

## Testing

- New `TestJudgeCost`: agent/judge separation, `None` when no judge ran, run-level rollup.
- 18 metrics unit tests pass; **43** grading + run-aggregate **canonical** tests pass (layout snapshots assert shapes, not exact key sets — additive keys are safe); lint + format clean.

## Note

This is independent of the `query_db` fix (PR #157) and the diff-first grading (PR #151). It closes the observability gap surfaced while reviewing judge cost accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2tL5u2pYEWPt6u78rX632