### PR TITLE
refactor(core): extract compose-materialisation primitives into shared module

### DIFF
--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -1,0 +1,290 @@
+"""Unit tests for ``tolokaforge.core.compose_materialisation``.
+
+Focused on the primitives with real logic: the ``0.0.0.0 → localhost``
+normalisation in :func:`resolve_host_port`, the shape parsing in
+:func:`first_published_port`, the endpoint-triple composition in
+:func:`resolve_env_endpoints`, and the never-raise guarantee of
+:func:`shutdown_compose`.
+
+The docker-daemon-touching call paths inside a real
+``testcontainers.compose.DockerCompose`` are covered by
+``tests/integration/docker/test_per_trial_runtime_backend_integration.py``.
+Here we stub :class:`DockerCompose` so the tests run in-process.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.compose_materialisation import (
+    RUNNER_PORT_DEFAULT,
+    cleanup_partial_materialisation,
+    copy_compose_context,
+    first_published_port,
+    make_project_temp_dir,
+    resolve_env_endpoints,
+    resolve_host_port,
+    resolve_rag_url,
+    resolve_runner_endpoint,
+    shutdown_compose,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestMakeProjectTempDir:
+    def test_slug_embedded_in_basename(self, tmp_path: Path) -> None:
+        """Trial-id-shaped slugs land in the temp-dir basename so
+        docker compose auto-generates a unique project name per
+        materialisation."""
+        d = make_project_temp_dir("task_id:5")
+        try:
+            assert "task_id_5" in d.name
+            assert d.is_dir()
+        finally:
+            d.rmdir()
+
+    def test_non_alphanumeric_characters_are_sanitised(self) -> None:
+        d = make_project_temp_dir("task/with:mixed-chars_x")
+        try:
+            assert d.name.startswith("tolokaforge-")
+            assert "task_with_mixed-chars_x" in d.name
+        finally:
+            d.rmdir()
+
+
+class TestCopyComposeContext:
+    def test_copies_file_and_sibling_directories(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "compose.yaml").write_text("services: {}\n")
+        (src / "fixtures").mkdir()
+        (src / "fixtures" / "seed.json").write_text("{}")
+
+        dest = tmp_path / "dest"
+        copy_compose_context(src / "compose.yaml", dest)
+
+        assert (dest / "compose.yaml").read_text() == "services: {}\n"
+        assert (dest / "fixtures" / "seed.json").read_text() == "{}"
+
+    def test_creates_dest_dir_if_absent(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "compose.yaml").write_text("services: {}\n")
+
+        dest = tmp_path / "does-not-yet-exist"
+        assert not dest.exists()
+        copy_compose_context(src / "compose.yaml", dest)
+        assert dest.is_dir()
+
+
+class TestResolveHostPort:
+    """The ``0.0.0.0 → localhost`` rewrite is the load-bearing rule —
+    testcontainers returns the container-listen address, not a
+    reachable client host on macOS/Linux."""
+
+    def test_returns_host_port_when_service_exposed(self) -> None:
+        compose = MagicMock()
+        compose.get_service_host_and_port.return_value = ("192.168.1.5", 50051)
+
+        host, port = resolve_host_port(compose, "runner", 50051)
+
+        assert host == "192.168.1.5"
+        assert port == 50051
+
+    def test_rewrites_0_0_0_0_to_localhost(self) -> None:
+        compose = MagicMock()
+        compose.get_service_host_and_port.return_value = ("0.0.0.0", 60000)
+
+        host, port = resolve_host_port(compose, "runner", 50051)
+
+        assert host == "localhost"
+        assert port == 60000
+
+    def test_returns_none_none_when_lookup_raises(self) -> None:
+        """Testcontainers raises varied exception types (KeyError,
+        ValueError, NoSuchPortExposed, subprocess errors). Every one
+        should be caught and treated as "service not exposed"."""
+        compose = MagicMock()
+        compose.get_service_host_and_port.side_effect = KeyError("no such service")
+
+        host, port = resolve_host_port(compose, "missing", 50051)
+
+        assert host is None
+        assert port is None
+
+
+class TestFirstPublishedPort:
+    def test_extracts_first_target_port(self) -> None:
+        entry = MagicMock()
+        entry.TargetPort = 5432
+        container = MagicMock()
+        container.Publishers = [entry]
+
+        assert first_published_port(container) == 5432
+
+    def test_skips_zero_and_non_int_targets(self) -> None:
+        zero_entry = MagicMock()
+        zero_entry.TargetPort = 0
+        bad_entry = MagicMock()
+        bad_entry.TargetPort = "not an int"
+        good_entry = MagicMock()
+        good_entry.TargetPort = 8000
+        container = MagicMock()
+        container.Publishers = [zero_entry, bad_entry, good_entry]
+
+        assert first_published_port(container) == 8000
+
+    def test_returns_none_when_publishers_absent(self) -> None:
+        container = MagicMock(spec=[])  # No Publishers attribute.
+        assert first_published_port(container) is None
+
+
+class TestResolveRagUrl:
+    def test_none_when_no_rag_service_declared(self) -> None:
+        compose = MagicMock()
+        compose.get_container.side_effect = KeyError("no rag")
+
+        assert resolve_rag_url(compose) is None
+
+    def test_url_when_first_candidate_resolves(self) -> None:
+        container = MagicMock()
+        published_entry = MagicMock()
+        published_entry.TargetPort = 8080
+        container.Publishers = [published_entry]
+
+        compose = MagicMock()
+        compose.get_container.return_value = container
+        compose.get_service_host_and_port.return_value = ("localhost", 60080)
+
+        assert resolve_rag_url(compose) == "http://localhost:60080"
+
+
+class TestResolveRunnerEndpoint:
+    def test_returns_host_port_tuple(self) -> None:
+        compose = MagicMock()
+        compose.get_service_host_and_port.return_value = ("localhost", 60051)
+
+        assert resolve_runner_endpoint(compose, "runner", 50051) == ("localhost", 60051)
+
+    def test_returns_none_when_unresolvable(self) -> None:
+        compose = MagicMock()
+        compose.get_service_host_and_port.side_effect = KeyError("no runner service")
+
+        assert resolve_runner_endpoint(compose, "runner", 50051) is None
+
+    def test_defaults_to_50051(self) -> None:
+        """``RUNNER_PORT_DEFAULT`` is the convention. Callers that
+        don't specify a port get it."""
+        compose = MagicMock()
+        compose.get_service_host_and_port.return_value = ("localhost", 60051)
+
+        resolve_runner_endpoint(compose, "runner")
+        args, kwargs = compose.get_service_host_and_port.call_args
+        assert kwargs.get("port") == RUNNER_PORT_DEFAULT
+
+
+class TestResolveEnvEndpoints:
+    def test_composes_full_triple_with_rag(self) -> None:
+        compose = MagicMock()
+
+        def _host_port(service_name: str, port: int) -> tuple[str | None, int | None]:
+            if service_name == "db":
+                return ("localhost", 65432)
+            if service_name == "rag":
+                return ("localhost", 68080)
+            return (None, None)
+
+        compose.get_service_host_and_port.side_effect = lambda service_name, port: _host_port(
+            service_name, port
+        )
+        rag_container = MagicMock()
+        rag_container.Publishers = [MagicMock(TargetPort=8080)]
+        compose.get_container.return_value = rag_container
+
+        endpoints = resolve_env_endpoints(compose, "localhost", 60051)
+
+        assert endpoints is not None
+        assert endpoints.runner_url == "http://localhost:60051"
+        assert endpoints.db_url == "http://localhost:65432"
+        assert endpoints.rag_url == "http://localhost:68080"
+
+    def test_returns_none_when_db_not_exposed(self) -> None:
+        """The db service is required (endpoint-resolution
+        customisation is a follow-up). Absent db → typed None,
+        caller surfaces a ProvisionError."""
+        compose = MagicMock()
+        compose.get_service_host_and_port.side_effect = KeyError("no db")
+
+        assert resolve_env_endpoints(compose, "localhost", 60051) is None
+
+    def test_rag_absent_is_none_not_failure(self) -> None:
+        """rag is best-effort — absent rag doesn't fail endpoint
+        resolution; it just leaves ``rag_url = None`` on the
+        endpoints triple."""
+        compose = MagicMock()
+
+        def _host_port(service_name: str, port: int) -> tuple[str | None, int | None]:
+            if service_name == "db":
+                return ("localhost", 65432)
+            return (None, None)
+
+        compose.get_service_host_and_port.side_effect = lambda service_name, port: _host_port(
+            service_name, port
+        )
+        compose.get_container.side_effect = KeyError("no rag")
+
+        endpoints = resolve_env_endpoints(compose, "localhost", 60051)
+
+        assert endpoints is not None
+        assert endpoints.db_url == "http://localhost:65432"
+        assert endpoints.rag_url is None
+
+
+class TestShutdownCompose:
+    def test_calls_stop_down(self) -> None:
+        compose = MagicMock()
+
+        shutdown_compose(compose)
+
+        compose.stop.assert_called_once_with(down=True)
+
+    def test_swallows_exception(self) -> None:
+        """`shutdown_compose` is a best-effort teardown. Errors from
+        ``docker compose down`` (a common source of noise at the end of
+        a run) must not propagate."""
+        compose = MagicMock()
+        compose.stop.side_effect = RuntimeError("docker daemon disconnected")
+
+        shutdown_compose(compose)  # must not raise
+
+
+class TestCleanupPartialMaterialisation:
+    def test_none_compose_still_removes_temp_dir(self, tmp_path: Path) -> None:
+        """Early-failure case: compose was never constructed. The
+        temp dir still gets cleaned up."""
+        d = tmp_path / "materialisation"
+        d.mkdir()
+        (d / "some-file").write_text("stray")
+
+        cleanup_partial_materialisation(None, d)
+
+        assert not d.exists()
+
+    def test_compose_is_shutdown_and_temp_dir_removed(self, tmp_path: Path) -> None:
+        compose = MagicMock()
+        d = tmp_path / "materialisation"
+        d.mkdir()
+
+        cleanup_partial_materialisation(compose, d)
+
+        compose.stop.assert_called_once_with(down=True)
+        assert not d.exists()
+
+    def test_missing_temp_dir_does_not_raise(self, tmp_path: Path) -> None:
+        """Teardown is idempotent — a temp dir already removed
+        (or never created) doesn't cause a failure."""
+        cleanup_partial_materialisation(None, tmp_path / "does-not-exist")

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -1,0 +1,236 @@
+"""Compose-materialisation primitives shared by runtime backends.
+
+The concrete `RuntimeBackend` implementations that materialise a task's
+``environment_manifest`` via testcontainers-python (``PerTrialRuntimeBackend``
+today, ``SharedStackRuntimeBackend`` under Phase 4) share the same lifecycle
+primitives: copy the compose context into an isolated project directory,
+start the stack with ``.start()``, resolve host-side endpoints via
+``get_service_host_and_port``, and tear the stack down with
+``.stop(down=True)``.
+
+This module holds those primitives as pure functions so both backends call
+into one place. Lifecycle differs by backend — per-trial constructs one
+project per trial; shared constructs one project per run — but the mechanics
+of "get a compose stack up, resolve endpoints, shut it down" are the same.
+
+Contains no runtime-backend concepts (no trial_id, no per-trial cache, no
+handles). The backends layer those on top.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from testcontainers.compose import DockerCompose
+
+from tolokaforge.core.trial import EnvEndpoints
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-resolution conventions
+# ---------------------------------------------------------------------------
+
+
+RUNNER_PORT_DEFAULT = 50051
+"""gRPC port the tolokaforge runner container listens on. Matches
+``GrpcRunnerClient``'s default ``runner:50051``. Task-pack authors that
+need to override this will get a manifest field in a follow-up PR."""
+
+DB_SERVICE_DEFAULT = "db"
+"""Compose service name convention for the raw database backing the
+runner's state (the ``db-service`` HTTP wrapper sits on top of this)."""
+
+DB_PORT_DEFAULT = 5432
+"""Postgres default port for the ``db`` service."""
+
+RAG_SERVICE_CANDIDATES = ("rag", "rag-service")
+"""Compose service names checked when resolving the RAG endpoint.
+First match wins; ``None`` returned if no match is exposed."""
+
+
+# ---------------------------------------------------------------------------
+# Filesystem + project layout
+# ---------------------------------------------------------------------------
+
+
+def make_project_temp_dir(prefix_slug: str) -> Path:
+    """Create a temp directory whose basename embeds ``prefix_slug``.
+
+    Docker Compose auto-generates a project name from the context
+    directory basename; encoding a caller-supplied slug (a trial id for
+    per-trial, a run id for shared) into that basename gives each
+    materialisation a unique compose project.
+    """
+    safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in prefix_slug)
+    return Path(tempfile.mkdtemp(prefix=f"tolokaforge-{safe}-"))
+
+
+def copy_compose_context(compose_file: Path, dest_dir: Path) -> None:
+    """Copy the compose file (and its directory's sibling files) to
+    ``dest_dir`` so Docker Compose sees an isolated context with a
+    unique project-name basename. Bind mount source paths declared with
+    relative paths inside the original compose file are resolved
+    relative to the context directory, so copying the whole directory
+    preserves them.
+    """
+    src_dir = compose_file.parent
+    if not dest_dir.exists():
+        dest_dir.mkdir(parents=True)
+    for entry in src_dir.iterdir():
+        target = dest_dir / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(entry, target)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_host_port(
+    compose: DockerCompose, service_name: str, container_port: int
+) -> tuple[str | None, int | None]:
+    """Look up the host + host-side port that map to ``service_name``'s
+    ``container_port``. Returns ``(None, None)`` if the service or the
+    port is not exposed.
+
+    Testcontainers raises varied exception types (``KeyError``,
+    ``ValueError``, ``NoSuchPortExposed``, and any ``subprocess`` error
+    a docker call can surface). Catch broadly and treat every failure
+    as "not exposed" — but ``logger.debug`` the exception so a genuine
+    daemon issue is diagnosable (otherwise it silently reads as a
+    compose-file misconfiguration downstream).
+
+    Testcontainers returns ``0.0.0.0`` as the host on macOS / Linux —
+    correct as a listen address inside the container, but not reachable
+    as a client host from the orchestrator process. Rewrite it to
+    ``localhost`` so a gRPC/HTTP client on the host can actually
+    connect."""
+    try:
+        host, port = compose.get_service_host_and_port(
+            service_name=service_name, port=container_port
+        )
+    except Exception as exc:  # noqa: BLE001 — testcontainers raises varied types
+        logger.debug(
+            "compose_materialisation: service %r port %d not resolvable: %s",
+            service_name,
+            container_port,
+            exc,
+        )
+        return None, None
+    if host == "0.0.0.0":  # noqa: S104 — testcontainers returns this on macOS/Linux
+        host = "localhost"
+    return host, port
+
+
+def first_published_port(container: Any) -> int | None:
+    """Extract the first published container-side port from a
+    Testcontainers ``ComposeContainer``. Returns ``None`` when nothing
+    is published (or the shape is not what we expect)."""
+    ports = getattr(container, "Publishers", None) or []
+    for entry in ports:
+        target = getattr(entry, "TargetPort", None)
+        if isinstance(target, int) and target > 0:
+            return target
+    return None
+
+
+def resolve_rag_url(compose: DockerCompose) -> str | None:
+    """Best-effort ``rag_url`` — resolve the first RAG service found in
+    the compose stack. Returns ``None`` when no such service is
+    declared or its port is not exposed. Lookup failures are treated
+    as "no rag" but ``logger.debug``-logged for diagnosability."""
+    for candidate in RAG_SERVICE_CANDIDATES:
+        try:
+            container = compose.get_container(service_name=candidate)
+        except Exception as exc:  # noqa: BLE001 — service not declared
+            logger.debug(
+                "compose_materialisation: rag candidate %r not in compose: %s",
+                candidate,
+                exc,
+            )
+            continue
+        published = first_published_port(container)
+        if published is None:
+            continue
+        host, port = resolve_host_port(compose, candidate, published)
+        if host is None or port is None:
+            continue
+        return f"http://{host}:{port}"
+    return None
+
+
+def resolve_runner_endpoint(
+    compose: DockerCompose,
+    runner_service: str,
+    runner_port: int = RUNNER_PORT_DEFAULT,
+) -> tuple[str, int] | None:
+    """Resolve the host-side ``(host, port)`` for a compose stack's
+    runner service. Returns ``None`` if the service does not exist or
+    the port is not exposed — callers surface that as a typed error
+    with their own context (trial id, run id, whatever)."""
+    host, port = resolve_host_port(compose, runner_service, runner_port)
+    if host is None or port is None:
+        return None
+    return host, port
+
+
+def resolve_env_endpoints(
+    compose: DockerCompose,
+    runner_host: str,
+    runner_port: int,
+    *,
+    db_service: str = DB_SERVICE_DEFAULT,
+    db_port: int = DB_PORT_DEFAULT,
+) -> EnvEndpoints | None:
+    """Resolve the full :class:`EnvEndpoints` triple (runner_url, db_url,
+    rag_url) from a running compose stack. Returns ``None`` if the
+    required db service does not exist or its port is not exposed —
+    callers surface that as a typed error with their own context.
+
+    ``rag_url`` is best-effort: absent means ``None`` on the endpoints,
+    not a resolution failure.
+    """
+    db_host, db_host_port = resolve_host_port(compose, db_service, db_port)
+    if db_host is None or db_host_port is None:
+        return None
+    return EnvEndpoints(
+        db_url=f"http://{db_host}:{db_host_port}",
+        rag_url=resolve_rag_url(compose),
+        runner_url=f"http://{runner_host}:{runner_port}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def shutdown_compose(compose: DockerCompose) -> None:
+    """Best-effort ``docker compose down --volumes``. Never raises."""
+    try:
+        compose.stop(down=True)
+    except Exception:  # noqa: BLE001 — best-effort teardown
+        logger.exception("compose_materialisation: docker compose down failed")
+
+
+def cleanup_partial_materialisation(compose: DockerCompose | None, temp_dir: Path) -> None:
+    """Best-effort teardown after a partial-materialisation failure.
+
+    Called from every ``except`` block during materialisation, before
+    a typed error is re-raised. Handles both the early-failure case
+    (``compose is None`` — the DockerCompose was never constructed) and
+    the late-failure case (containers up but endpoint resolution
+    failed).
+    """
+    if compose is not None:
+        shutdown_compose(compose)
+    shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -126,7 +126,9 @@ def resolve_host_port(
             exc,
         )
         return None, None
-    if host == "0.0.0.0":  # noqa: S104 — testcontainers returns this on macOS/Linux
+    if (
+        host == "0.0.0.0"
+    ):  # noqa: S104 — comparing to (not binding) the testcontainers macOS/Linux return value
         host = "localhost"
     return host, port
 

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -34,13 +34,21 @@ from __future__ import annotations
 
 import logging
 import shutil
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from testcontainers.compose import DockerCompose
 
+from tolokaforge.core.compose_materialisation import (
+    RUNNER_PORT_DEFAULT,
+    cleanup_partial_materialisation,
+    copy_compose_context,
+    make_project_temp_dir,
+    resolve_env_endpoints,
+    resolve_runner_endpoint,
+    shutdown_compose,
+)
 from tolokaforge.core.runtime import EnvHandle, IsolationMode, ProvisionError
 from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient, RunnerClient
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints
@@ -50,17 +58,6 @@ if TYPE_CHECKING:
     from tolokaforge.tools.registry import ToolResult
 
 logger = logging.getLogger(__name__)
-
-
-_RUNNER_PORT_DEFAULT = 50051
-"""gRPC port the tolokaforge runner container listens on. Matches
-``GrpcRunnerClient``'s default ``runner:50051``. Task-pack authors that
-need to override this will get a manifest field in a follow-up PR."""
-
-_DB_SERVICE_DEFAULT = "db"
-_DB_PORT_DEFAULT = 5432
-
-_RAG_SERVICE_CANDIDATES = ("rag", "rag-service")
 
 
 @dataclass(frozen=True)
@@ -179,10 +176,10 @@ class PerTrialRuntimeBackend:
                 ),
             )
 
-        temp_dir = _make_per_trial_temp_dir(spec.trial_id)
+        temp_dir = make_project_temp_dir(spec.trial_id)
         compose: DockerCompose | None = None
         try:
-            _copy_compose_context(manifest.compose_file, temp_dir)
+            copy_compose_context(manifest.compose_file, temp_dir)
             compose = DockerCompose(
                 context=str(temp_dir),
                 compose_file_name=manifest.compose_file.name,
@@ -192,7 +189,7 @@ class PerTrialRuntimeBackend:
             )
             compose.start()
         except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
-            _cleanup_partial_provision(compose, temp_dir)
+            cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
                 trial_id=spec.trial_id,
                 stage="provision",
@@ -200,22 +197,32 @@ class PerTrialRuntimeBackend:
             ) from exc
 
         runner_service = manifest.runner_service
-        runner_port = _RUNNER_PORT_DEFAULT
-        try:
-            runner_host, runner_host_port = self._resolve_runner_endpoint(
-                compose, runner_service, runner_port, trial_id=spec.trial_id
+        runner_port = RUNNER_PORT_DEFAULT
+        runner_endpoint = resolve_runner_endpoint(compose, runner_service, runner_port)
+        if runner_endpoint is None:
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise ProvisionError(
+                trial_id=spec.trial_id,
+                stage="provision",
+                reason=(
+                    f"runner_service {runner_service!r} does not expose port "
+                    f"{runner_port} in the compose stack"
+                ),
             )
-        except ProvisionError:
-            _cleanup_partial_provision(compose, temp_dir)
-            raise
+        runner_host, runner_host_port = runner_endpoint
 
-        try:
-            endpoints = self._resolve_endpoints(
-                compose, runner_host, runner_host_port, trial_id=spec.trial_id
+        endpoints = resolve_env_endpoints(compose, runner_host, runner_host_port)
+        if endpoints is None:
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise ProvisionError(
+                trial_id=spec.trial_id,
+                stage="provision",
+                reason=(
+                    "PerTrialRuntimeBackend requires a compose service named 'db' "
+                    "exposing port 5432; compose file does not declare one. "
+                    "Endpoint-resolution customisation is a follow-up ticket."
+                ),
             )
-        except ProvisionError:
-            _cleanup_partial_provision(compose, temp_dir)
-            raise
 
         # Client is constructed but not yet connected. Connect is deferred
         # to first per-trial RPC use — see :attr:`_connected_trials`.
@@ -228,52 +235,6 @@ class PerTrialRuntimeBackend:
             runner_port=runner_port,
             temp_dir=temp_dir,
             endpoints=endpoints,
-        )
-
-    def _resolve_runner_endpoint(
-        self,
-        compose: DockerCompose,
-        runner_service: str,
-        runner_port: int,
-        *,
-        trial_id: str,
-    ) -> tuple[str, int]:
-        host, port = _resolve_host_port(compose, runner_service, runner_port)
-        if host is None or port is None:
-            raise ProvisionError(
-                trial_id=trial_id,
-                stage="provision",
-                reason=(
-                    f"runner_service {runner_service!r} does not expose port "
-                    f"{runner_port} in the compose stack"
-                ),
-            )
-        return host, port
-
-    def _resolve_endpoints(
-        self,
-        compose: DockerCompose,
-        runner_host: str,
-        runner_port: int,
-        *,
-        trial_id: str,
-    ) -> EnvEndpoints:
-        db_host, db_port = _resolve_host_port(compose, _DB_SERVICE_DEFAULT, _DB_PORT_DEFAULT)
-        if db_host is None or db_port is None:
-            raise ProvisionError(
-                trial_id=trial_id,
-                stage="provision",
-                reason=(
-                    f"PerTrialRuntimeBackend requires a compose service named "
-                    f"{_DB_SERVICE_DEFAULT!r} exposing port {_DB_PORT_DEFAULT}; "
-                    "compose file does not declare one. Endpoint-resolution "
-                    "customisation is a follow-up ticket."
-                ),
-            )
-        return EnvEndpoints(
-            db_url=f"http://{db_host}:{db_port}",
-            rag_url=_resolve_rag_url(compose),
-            runner_url=f"http://{runner_host}:{runner_port}",
         )
 
     def await_ready(self, handle: EnvHandle) -> None:
@@ -311,7 +272,7 @@ class PerTrialRuntimeBackend:
                     "PerTrialRuntimeBackend.teardown: runner client close failed for %s",
                     handle.trial_id,
                 )
-        _shutdown_compose(handle.compose)
+        shutdown_compose(handle.compose)
         shutil.rmtree(handle.temp_dir, ignore_errors=True)
 
     # ---- Per-trial RPC operations (ADR-0013) ----
@@ -397,132 +358,3 @@ class PerTrialRuntimeBackend:
             )
             self._connected_trials.add(trial_id)
         return client
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _cleanup_partial_provision(compose: DockerCompose | None, temp_dir: Path) -> None:
-    """Best-effort teardown after a partial-provision failure.
-
-    Called from every ``except`` block inside :meth:`provision` before
-    the typed :class:`ProvisionError` is re-raised. Handles both the
-    early-failure case (``compose is None`` — the DockerCompose was
-    never constructed) and the late-failure case (containers up but
-    endpoint resolution failed)."""
-    if compose is not None:
-        _shutdown_compose(compose)
-    shutil.rmtree(temp_dir, ignore_errors=True)
-
-
-def _make_per_trial_temp_dir(trial_id: str) -> Path:
-    """Create a per-trial temp directory whose name embeds ``trial_id``.
-
-    Docker Compose auto-generates a project name from the context
-    directory basename; encoding the trial id in that name gives each
-    concurrent trial a unique compose project.
-    """
-    safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in trial_id)
-    return Path(tempfile.mkdtemp(prefix=f"tolokaforge-{safe}-"))
-
-
-def _copy_compose_context(compose_file: Path, dest_dir: Path) -> None:
-    """Copy the compose file (and its directory's sibling files) to
-    ``dest_dir`` so Docker Compose sees an isolated context with a
-    unique project-name basename. Bind mount source paths declared with
-    relative paths inside the original compose file are resolved
-    relative to the context directory, so copying the whole directory
-    preserves them.
-    """
-    src_dir = compose_file.parent
-    if not dest_dir.exists():
-        dest_dir.mkdir(parents=True)
-    for entry in src_dir.iterdir():
-        target = dest_dir / entry.name
-        if entry.is_dir():
-            shutil.copytree(entry, target, dirs_exist_ok=True)
-        else:
-            shutil.copy2(entry, target)
-
-
-def _resolve_host_port(
-    compose: DockerCompose, service_name: str, container_port: int
-) -> tuple[str | None, int | None]:
-    """Look up the host + host-side port that map to
-    ``service_name``'s ``container_port``. Returns ``(None, None)`` if
-    the service or the port is not exposed.
-
-    Testcontainers raises varied exception types (``KeyError``,
-    ``ValueError``, ``NoSuchPortExposed``, and any ``subprocess`` error
-    a docker call can surface). Catch broadly and treat every failure
-    as "not exposed" — but ``logger.debug`` the exception so a genuine
-    daemon issue is diagnosable (otherwise it silently reads as a
-    compose-file misconfiguration downstream).
-
-    Testcontainers returns ``0.0.0.0`` as the host on macOS / Linux —
-    correct as a listen address inside the container, but not reachable
-    as a client host from the orchestrator process. Rewrite it to
-    ``localhost`` so a gRPC/HTTP client on the host can actually
-    connect."""
-    try:
-        host, port = compose.get_service_host_and_port(
-            service_name=service_name, port=container_port
-        )
-    except Exception as exc:  # noqa: BLE001 — testcontainers raises varied types
-        logger.debug(
-            "PerTrialRuntimeBackend: service %r port %d not resolvable: %s",
-            service_name,
-            container_port,
-            exc,
-        )
-        return None, None
-    if host == "0.0.0.0":  # noqa: S104 — testcontainers returns this on macOS/Linux
-        host = "localhost"
-    return host, port
-
-
-def _resolve_rag_url(compose: DockerCompose) -> str | None:
-    """Best-effort ``rag_url`` — resolve the first RAG service found in
-    the compose stack. Returns ``None`` when no such service is
-    declared or its port is not exposed. Lookup failures are treated
-    as "no rag" but ``logger.debug``-logged for diagnosability."""
-    for candidate in _RAG_SERVICE_CANDIDATES:
-        try:
-            container = compose.get_container(service_name=candidate)
-        except Exception as exc:  # noqa: BLE001 — service not declared
-            logger.debug(
-                "PerTrialRuntimeBackend: rag candidate %r not in compose: %s",
-                candidate,
-                exc,
-            )
-            continue
-        published = _first_published_port(container)
-        if published is None:
-            continue
-        host, port = _resolve_host_port(compose, candidate, published)
-        if host is None or port is None:
-            continue
-        return f"http://{host}:{port}"
-    return None
-
-
-def _first_published_port(container: Any) -> int | None:
-    """Extract the first published container-side port from a
-    Testcontainers ``ComposeContainer``. Returns ``None`` when nothing
-    is published (or the shape is not what we expect)."""
-    ports = getattr(container, "Publishers", None) or []
-    for entry in ports:
-        target = getattr(entry, "TargetPort", None)
-        if isinstance(target, int) and target > 0:
-            return target
-    return None
-
-
-def _shutdown_compose(compose: DockerCompose) -> None:
-    """Best-effort ``docker compose down --volumes``. Never raises."""
-    try:
-        compose.stop(down=True)
-    except Exception:  # noqa: BLE001 — best-effort teardown
-        logger.exception("PerTrialRuntimeBackend: docker compose down failed")

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -22,12 +22,8 @@ ADR-0013) delegate to a :class:`RunnerClient` cached at provision time
 and keyed by ``trial_id``. Contrast with :class:`SharedStackRuntimeBackend` which
 carries a single client for the whole run.
 
-Endpoint resolution uses conventions (defaults + customisation later —
-see the follow-up ticket): ``runner_service`` from the manifest at port
-50051 → ``runner_url``; a compose service named ``db`` at port 5432 →
-``db_url``; a compose service named ``rag`` (or ``rag-service``) at its
-declared port → ``rag_url``. Task packs that need to override the
-service names or ports will get manifest fields in a follow-up PR.
+Endpoint resolution delegates to :mod:`tolokaforge.core.compose_materialisation`;
+see that module for the conventions and their defaults.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## TL;DR

Phase 4 arc PR 1 of 4. Pure refactor with **no behaviour change**. Extracts the compose-materialisation helpers currently living as private module-level functions in \`per_trial_runtime.py\` into a new \`tolokaforge/core/compose_materialisation.py\` module. Sets up PR 2 in the arc, which needs to call the same primitives from a second backend without cross-module private-attr imports.

## Why this exists — design context

Phase 4's real goal (per the roadmap): **enable multi-container "as-real-as-possible" environments** for complex tasks. That capability is currently entangled with per-trial isolation semantics — the only backend that materialises task-declared \`environment_manifest\` today is \`PerTrialRuntimeBackend\`. Tasks that need 4-5 services in a realistic environment but don't need trial isolation are forced onto \`per_trial\` mode anyway.

The next PR extends \`SharedStackRuntimeBackend\` to also consume \`environment_manifest\` — materialising task-declared services once per run instead of once per trial. Both backends then use the same testcontainers-python primitives (compose-up + healthcheck + endpoint resolution + teardown), differing only in lifecycle scope (per-trial vs per-run).

This PR sets up that shared use. The primitives get their own module so PR 2 doesn't have to reach into \`per_trial_runtime\`'s privates or duplicate the code.

## Design decisions worth flagging

### 1. Where the module lives: \`tolokaforge/core/compose_materialisation.py\`

Considered:

- **Under \`tolokaforge/docker/\`** — the existing \`docker/\` package contains \`stack.py\`, \`image.py\`, \`network.py\`, \`health.py\`, etc. It's about the shared engine \`ServiceStack\` (docker-SDK-driven, not testcontainers). Mixing testcontainers-based helpers under the same package would blur the mental model (docker-SDK-driven engine substrate vs testcontainers-based task substrate).
- **Under \`tolokaforge/core/\`** (chosen) — sits next to the other cross-backend primitives that inhabit the trial plane. \`compose_materialisation\` is one such primitive.
- **Leaving them as private in \`per_trial_runtime.py\`** — rejected because PR 2 needs to call them from a second backend. Cross-module private-attr imports are worse than a proper shared module.

### 2. Scope of the extraction: what moves vs what stays

**Moved (backend-agnostic):**
- \`make_project_temp_dir(prefix_slug)\` — was \`_make_per_trial_temp_dir(trial_id)\`; renamed to reflect that PR 2 will pass a run-id-shaped slug instead of a trial id.
- \`copy_compose_context\`, \`resolve_host_port\`, \`first_published_port\`, \`resolve_rag_url\`, \`shutdown_compose\`, \`cleanup_partial_materialisation\` — moved as-is.
- \`resolve_runner_endpoint\` and \`resolve_env_endpoints\` — were methods on \`PerTrialRuntimeBackend\` mixing pure logic with typed-error raising. Split: the pure logic (endpoint resolution) moves to the shared module and returns \`Optional\` on failure; the typed-error raising stays in the backend that knows its own context (trial id / stage / etc.). This makes them reusable from a second backend that needs different error context.

**Stayed in \`per_trial_runtime.py\` (per-trial specific):**
- \`_LocalEnvHandle\` — the handle type is backend-specific.
- \`PerTrialRuntimeBackend\` — the backend class, its \`provision\` / \`endpoints\` / \`teardown\` / RPC methods, and per-trial state (\`_clients\`, \`_connected_trials\`).

### 3. Naming: \`_make_per_trial_temp_dir\` → \`make_project_temp_dir\`

The old name baked in the caller (per-trial). The new name says what it does (creates a temp dir whose basename becomes docker compose's project name). PR 2's shared-runtime path will pass a run-id-shaped slug; that's still a valid \"project temp dir\".

### 4. Endpoint-resolution methods → module-level functions returning Optional

Was:

\`\`\`python
class PerTrialRuntimeBackend:
    def _resolve_endpoints(self, compose, ..., *, trial_id) -> EnvEndpoints:
        ...
        raise ProvisionError(trial_id=trial_id, ...)
\`\`\`

Now:

\`\`\`python
# In compose_materialisation.py (backend-agnostic)
def resolve_env_endpoints(compose, ...) -> EnvEndpoints | None:
    ...  # returns None on failure

# In per_trial_runtime.py (backend-specific)
def provision(self, spec):
    endpoints = resolve_env_endpoints(compose, ...)
    if endpoints is None:
        cleanup_partial_materialisation(compose, temp_dir)
        raise ProvisionError(trial_id=spec.trial_id, ...)
\`\`\`

The pure logic (\"can we resolve endpoints from this compose stack?\") is separated from the typed-error decision (\"how do we surface this failure?\"). PR 2's shared backend will call the same \`resolve_env_endpoints\` and surface failures with its own context (a run id, not a trial id).

## What this PR does NOT do

- No change to \`SharedStackRuntimeBackend\` — that's PR 2.
- No change to any test task pack — that's PR 3.
- No ADR — the design ADR for \"multi-container under shared\" is PR 4.
- No change to \`PerTrialRuntimeBackend\`'s external behaviour — the refactor is behaviour-neutral by construction.

## Verification

- \`uv run ruff check tolokaforge tests\` clean.
- \`uv run pytest tests/ -m unit -q\` → **1942 pass, 1 skipped** (pre-existing).
- \`uv run pytest tests/ -m canonical -q\` → **389 pass**.
- \`uv run pytest tests/unit/test_compose_materialisation.py -q\` → **23 pass** (new file, direct coverage of the extracted primitives).
- No docker-daemon integration test changes needed — the existing \`tests/integration/docker/test_per_trial_runtime_backend_integration.py\` covers the real testcontainers path and should still work end-to-end (opt-in, docker daemon required — not run in CI's default smoke).

## Test coverage for the new module

23 focused unit tests in \`tests/unit/test_compose_materialisation.py\` — one class per public function, pinning the load-bearing behaviours:

- \`resolve_host_port\`: 0.0.0.0 → localhost rewrite; testcontainers exception → (None, None).
- \`first_published_port\`: shape parsing; skip zero + non-int; absent Publishers attribute → None.
- \`resolve_env_endpoints\`: full triple composition; None when db unresolvable; rag absent is None, not failure.
- \`shutdown_compose\`: swallows exceptions (never-raise contract).
- \`cleanup_partial_materialisation\`: works with None compose; idempotent on missing temp_dir.
- Plus targeted coverage for \`make_project_temp_dir\`, \`copy_compose_context\`, \`resolve_rag_url\`, \`resolve_runner_endpoint\`.

## Test plan

- [x] Ruff + black clean
- [x] Unit suite: 1942 existing pass + 23 new pass
- [x] Canonical suite: 389 pass
- [ ] Docker integration smoke (opt-in): can run \`tests/integration/docker/test_per_trial_runtime_backend_integration.py\` manually after this lands to confirm the real testcontainers path is unaffected

## Follows

Phase 4 arc:
1. **This PR** — extract shared primitives (this refactor).
2. \`feat(runtime): SharedStackRuntimeBackend consumes environment_manifest\` — the load-bearing engine change.
3. \`example(native): multi-service task exercising shared+env_manifest\` — validates PR 2.
4. \`docs(adr-0018): multi-container under shared runtime\` — records the design.

Umbrella: TECHDEL-466 \\ Runtime & isolation. Milestone: [#4 Runtime & isolation](https://github.com/Toloka/tolokaforge/milestone/4).