### PR TITLE
feat(runtime): SharedStackRuntimeBackend consumes environment_manifest

### DIFF
--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -127,6 +127,27 @@ class TestInconsistentManifest:
         assert "no-manifest-D" in msg
 
 
+class TestRunWorkerGuard:
+    """Distributed worker mode doesn't currently support env_manifest —
+    the parent's testcontainers-allocated runner address isn't propagated
+    to workers, so a worker joining an env_manifest run would connect to
+    a stale/wrong address. Fail loud instead of silently misroute."""
+
+    def test_extract_helper_flags_env_manifest_runs(self) -> None:
+        """The run_worker guard uses ``_extract_run_env_manifest`` to
+        detect env_manifest runs. Once the helper returns non-None,
+        run_worker raises rather than proceeding with the default
+        EXECUTOR_ADDRESS."""
+        m = _manifest("safe_two_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m)]
+        # Helper returns the manifest; run_worker's guard reads this to
+        # decide whether to fail loud. The guard behaviour itself is a
+        # single ``if`` in run_worker; here we just pin the helper's
+        # non-None contract that the guard depends on.
+        assert orch._extract_run_env_manifest() is not None
+
+
 class TestIsolationDeclarationsPreserved:
     """The helper doesn't need to validate ``isolation`` — that's
     :meth:`_verify_isolation_compatibility`'s job. But it must not

--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -1,0 +1,155 @@
+"""Unit tests for :meth:`Orchestrator._extract_run_env_manifest`.
+
+The Phase 4 shared-stack path materialises exactly one task-declared
+compose file per run. Runs whose tasks declare inconsistent manifests
+would silently pick one (or fail late) — this helper picks up the
+inconsistency at run-start and fails loud.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+
+pytestmark = pytest.mark.unit
+
+
+_FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
+
+
+def _run_config() -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
+    )
+
+
+def _task(task_id: str, manifest: EnvironmentManifest | None) -> Any:
+    """Minimal stand-in for :class:`TaskConfig` — the helper only reads
+    ``.task_id`` and ``.environment_manifest``."""
+    t = MagicMock()
+    t.task_id = task_id
+    t.environment_manifest = manifest
+    return t
+
+
+def _manifest(fixture_name: str = "safe_two_service.yaml") -> EnvironmentManifest:
+    return EnvironmentManifest(compose_file=_FIXTURES / fixture_name)
+
+
+class TestNoManifest:
+    def test_returns_none_when_no_tasks(self) -> None:
+        orch = Orchestrator(_run_config())
+        orch.tasks = []
+        assert orch._extract_run_env_manifest() is None
+
+    def test_returns_none_when_no_task_declares_manifest(self) -> None:
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", None), _task("t2", None)]
+        assert orch._extract_run_env_manifest() is None
+
+
+class TestConsistentManifest:
+    def test_returns_manifest_when_all_tasks_declare_same_compose_file(self) -> None:
+        m = _manifest("safe_two_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m), _task("t2", m)]
+        result = orch._extract_run_env_manifest()
+        assert result is m
+
+    def test_returns_manifest_when_single_task_declares(self) -> None:
+        m = _manifest("safe_one_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("solo", m)]
+        assert orch._extract_run_env_manifest() is m
+
+    def test_two_manifest_instances_with_same_compose_file_are_consistent(self) -> None:
+        """Task authors may construct EnvironmentManifest objects
+        separately per task; identity is by ``compose_file`` path, not
+        Python object identity."""
+        m1 = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
+        m2 = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m1), _task("t2", m2)]
+        # Either instance may be returned — the check is that no error is raised.
+        result = orch._extract_run_env_manifest()
+        assert result is not None
+        assert str(result.compose_file) == str(m1.compose_file)
+
+
+class TestInconsistentManifest:
+    def test_mixed_declared_and_undeclared_raises(self) -> None:
+        m = _manifest()
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("with", m), _task("without", None)]
+        with pytest.raises(RuntimeError, match="mix of tasks with and without"):
+            orch._extract_run_env_manifest()
+
+    def test_different_compose_files_raises(self) -> None:
+        m1 = _manifest("safe_one_service.yaml")
+        m2 = _manifest("safe_two_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m1), _task("t2", m2)]
+        with pytest.raises(RuntimeError, match="different environment_manifest.compose_file"):
+            orch._extract_run_env_manifest()
+
+    def test_error_names_the_offending_tasks(self) -> None:
+        """The error must identify which tasks are on which side of the
+        split so the operator can find them quickly."""
+        m = _manifest()
+        orch = Orchestrator(_run_config())
+        orch.tasks = [
+            _task("has-manifest-A", m),
+            _task("no-manifest-B", None),
+            _task("has-manifest-C", m),
+            _task("no-manifest-D", None),
+        ]
+        with pytest.raises(RuntimeError) as excinfo:
+            orch._extract_run_env_manifest()
+        msg = str(excinfo.value)
+        # Task ids on both sides appear in the message.
+        assert "has-manifest-A" in msg
+        assert "has-manifest-C" in msg
+        assert "no-manifest-B" in msg
+        assert "no-manifest-D" in msg
+
+
+class TestIsolationDeclarationsPreserved:
+    """The helper doesn't need to validate ``isolation`` — that's
+    :meth:`_verify_isolation_compatibility`'s job. But it must not
+    strip or alter the manifest's isolation declaration when returning."""
+
+    def test_per_trial_isolation_survives(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            isolation=TaskIsolation.PER_TRIAL,
+        )
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m)]
+        result = orch._extract_run_env_manifest()
+        assert result is not None
+        assert result.isolation == TaskIsolation.PER_TRIAL
+
+    def test_shared_ok_isolation_survives(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            isolation=TaskIsolation.SHARED_OK,
+        )
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", m)]
+        result = orch._extract_run_env_manifest()
+        assert result is not None
+        assert result.isolation == TaskIsolation.SHARED_OK

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -258,3 +258,50 @@ class TestCloseIdempotency:
 
         backend.close()
         backend.close()  # must not raise
+
+    def test_close_tears_down_compose_even_if_client_close_raises(self, tmp_path: Path) -> None:
+        """If the runner client's close raises (e.g. broken gRPC channel),
+        the compose stack + temp dir must still be cleaned up — otherwise
+        a leaked docker project outlives the run."""
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+        fake_compose = MagicMock()
+        real_temp = tmp_path / "materialised"
+        real_temp.mkdir()
+        fake_client = MagicMock()
+        fake_client.close.side_effect = RuntimeError("gRPC channel broken")
+        backend._compose = fake_compose
+        backend._temp_dir = real_temp
+        backend.runner_client = fake_client
+
+        with pytest.raises(RuntimeError, match="gRPC channel broken"):
+            backend.close()
+
+        # Downstream teardown still ran.
+        fake_compose.stop.assert_called_once_with(down=True)
+        assert not real_temp.exists()
+
+
+class TestMaterialiseIdempotent:
+    """A second ``connect()`` in env_manifest mode must not clobber the
+    running stack. Mirrors ``GrpcRunnerClient.connect``'s
+    ``if self.channel is None`` guard."""
+
+    def test_double_connect_does_not_re_materialise(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+        # Simulate a successful first materialisation.
+        fake_compose = MagicMock()
+        backend._compose = fake_compose
+        backend._temp_dir = tmp_path / "already-there"
+        backend._temp_dir.mkdir()
+        backend._endpoints = EnvEndpoints(db_url="http://x", rag_url=None, runner_url="http://y")
+        backend.runner_client = MagicMock()
+
+        # Second _materialise_manifest is the early-return guard.
+        with patch("tolokaforge.core.shared_stack_runtime.DockerCompose") as mock_docker_compose:
+            backend._materialise_manifest()
+            mock_docker_compose.assert_not_called()
+
+        # State preserved — no clobber.
+        assert backend._compose is fake_compose

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -1,0 +1,260 @@
+"""Unit tests for :class:`SharedStackRuntimeBackend`'s task-declared-stack
+mode.
+
+Covers the Phase 4 extension: when ``env_manifest`` is set at construction,
+the backend materialises the task-declared compose stack **once at
+``connect`` time** for the whole run, resolves endpoints from it, and
+tears it down at ``close``. Contrast with the pre-existing built-in-stack
+mode (``runner_address`` + ``endpoints`` injected at construction), which
+is unchanged and covered by the existing test suite.
+
+Real docker-daemon interaction lives in the docker integration tests; here
+we stub :class:`DockerCompose` and the compose-materialisation primitives
+so the tests run in-process.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_manifest(tmp_path: Path) -> EnvironmentManifest:
+    """Author a minimal valid manifest whose compose file exists on disk.
+
+    ``EnvironmentManifest`` validates that ``compose_file`` exists and
+    parses as a YAML mapping; the fixture here writes a two-service stub
+    (runner + db) that satisfies the manifest validator without needing
+    a real docker daemon."""
+    compose_file = tmp_path / "environment.compose.yaml"
+    compose_file.write_text(
+        "services:\n"
+        "  runner:\n"
+        "    image: tolokaforge-runner:local\n"
+        "    ports:\n"
+        '      - "50051"\n'
+        "  db:\n"
+        "    image: postgres:16\n"
+        "    ports:\n"
+        '      - "5432"\n'
+    )
+    return EnvironmentManifest(compose_file=compose_file, runner_service="runner")
+
+
+class TestBackwardCompatibility:
+    """The built-in-stack mode (no env_manifest) must be unchanged."""
+
+    def test_default_construction_still_works(self) -> None:
+        backend = SharedStackRuntimeBackend()
+        assert backend.runner_client is not None
+        assert backend._endpoints is not None
+        assert backend._env_manifest is None
+        assert backend._compose is None
+
+    def test_endpoints_injection_still_works(self) -> None:
+        endpoints = EnvEndpoints(
+            db_url="http://db.example:8000",
+            rag_url=None,
+            runner_url="http://runner.example:50051",
+        )
+        backend = SharedStackRuntimeBackend(
+            runner_address="runner.example:50051", endpoints=endpoints
+        )
+        assert backend._endpoints is endpoints
+
+
+class TestEnvManifestConstruction:
+    """Construction-time invariants when ``env_manifest`` is set."""
+
+    def test_env_manifest_mode_defers_client_and_endpoints(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="my-run")
+
+        assert backend._env_manifest is manifest
+        assert backend._run_id == "my-run"
+        assert backend.runner_client is None
+        assert backend._endpoints is None
+        assert backend._compose is None
+        assert backend._temp_dir is None
+
+    def test_env_manifest_plus_endpoints_raises(self, tmp_path: Path) -> None:
+        """The two modes are mutually exclusive — passing both is a
+        contract violation, fail loud instead of silently ignoring one."""
+        manifest = _make_manifest(tmp_path)
+        endpoints = EnvEndpoints(db_url="http://x", rag_url=None, runner_url="http://y")
+        with pytest.raises(ValueError, match="env_manifest OR endpoints"):
+            SharedStackRuntimeBackend(env_manifest=manifest, endpoints=endpoints)
+
+
+class TestConnectMaterialises:
+    """``connect`` materialises the task-declared stack, resolves
+    endpoints, then wires the gRPC runner client."""
+
+    def test_connect_materialises_and_populates_state(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+
+        fake_compose = MagicMock()
+        fake_endpoints = EnvEndpoints(
+            db_url="http://localhost:65432",
+            rag_url=None,
+            runner_url="http://localhost:60051",
+        )
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
+                return_value=("localhost", 60051),
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_env_endpoints",
+                return_value=fake_endpoints,
+            ),
+            patch("tolokaforge.core.shared_stack_runtime.GrpcRunnerClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            backend.connect()
+
+        # Materialised state is preserved on the backend for teardown.
+        assert backend._compose is fake_compose
+        assert backend._temp_dir is not None
+        assert backend._endpoints is fake_endpoints
+        assert backend.runner_client is mock_client
+        # runner client was constructed with the resolved host:port.
+        mock_client_cls.assert_called_once_with(runner_address="localhost:60051")
+        mock_client.connect.assert_called_once()
+
+    def test_connect_raises_provision_error_when_runner_missing(self, tmp_path: Path) -> None:
+        """A compose file whose runner_service isn't exposed fails loud
+        (ProvisionError with a message pointing at the runner_service)."""
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+
+        fake_compose = MagicMock()
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
+                return_value=None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"
+            ) as mock_cleanup,
+            pytest.raises(ProvisionError, match="runner_service"),
+        ):
+            backend.connect()
+        # Partial materialisation cleaned up before we raised.
+        mock_cleanup.assert_called_once()
+
+    def test_connect_raises_provision_error_when_db_missing(self, tmp_path: Path) -> None:
+        """A compose file missing the ``db`` service (or its 5432 port)
+        fails loud — same shape as PerTrialRuntimeBackend."""
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+
+        fake_compose = MagicMock()
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
+                return_value=("localhost", 60051),
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_env_endpoints",
+                return_value=None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"
+            ) as mock_cleanup,
+            pytest.raises(ProvisionError, match="db"),
+        ):
+            backend.connect()
+        mock_cleanup.assert_called_once()
+
+    def test_connect_raises_provision_error_on_compose_start_failure(self, tmp_path: Path) -> None:
+        """A docker daemon failure during compose up surfaces as a typed
+        ProvisionError with the underlying cause attached."""
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+
+        fake_compose = MagicMock()
+        fake_compose.start.side_effect = RuntimeError("daemon socket refused")
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"
+            ) as mock_cleanup,
+            pytest.raises(ProvisionError, match="docker compose up failed"),
+        ):
+            backend.connect()
+        mock_cleanup.assert_called_once()
+
+
+class TestCloseIdempotency:
+    """``close`` is safe to call in any state (before materialisation,
+    after materialisation, twice) — the shared-run lifecycle."""
+
+    def test_close_without_materialisation_is_noop(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+        # Never called connect — runner_client and _compose are None.
+        backend.close()  # must not raise
+
+    def test_close_shuts_down_compose_and_removes_temp_dir(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+        # Simulate a successful materialisation state.
+        fake_compose = MagicMock()
+        fake_client = MagicMock()
+        real_temp = tmp_path / "materialised"
+        real_temp.mkdir()
+        backend._compose = fake_compose
+        backend._temp_dir = real_temp
+        backend.runner_client = fake_client
+
+        backend.close()
+
+        fake_client.close.assert_called_once()
+        fake_compose.stop.assert_called_once_with(down=True)
+        assert not real_temp.exists()
+        # State cleared so a second close is a no-op.
+        assert backend._compose is None
+        assert backend._temp_dir is None
+
+    def test_close_twice_is_idempotent(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+        fake_compose = MagicMock()
+        real_temp = tmp_path / "materialised"
+        real_temp.mkdir()
+        backend._compose = fake_compose
+        backend._temp_dir = real_temp
+        backend.runner_client = MagicMock()
+
+        backend.close()
+        backend.close()  # must not raise

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1494,6 +1494,22 @@ class Orchestrator:
 
         runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
 
+        # Workers join an already-materialised run; if the run's tasks declare
+        # env_manifest, the parent orchestrator materialised a task-declared
+        # stack whose runner address is dynamic (testcontainers-allocated),
+        # not the EXECUTOR_ADDRESS a worker reads from its own env. Fail loud
+        # rather than silently connect to a stale/wrong address.
+        run_env_manifest = self._extract_run_env_manifest()
+        if run_env_manifest is not None and self._injected_runtime_backend is None:
+            raise RuntimeError(
+                "Distributed worker mode does not currently support runs with "
+                "environment_manifest. The parent orchestrator materialises a "
+                "task-declared compose stack at a testcontainers-allocated "
+                "address; that address is not propagated to workers. Run the "
+                "orchestrator single-process (no worker split) for env_manifest "
+                "runs, or drop the manifest and use the built-in shared stack."
+            )
+
         runtime_backend: RuntimeBackend
         if self._injected_runtime_backend is not None:
             runtime_backend = self._injected_runtime_backend

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -46,7 +46,12 @@ from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import AttemptLease, create_run_queue
 from tolokaforge.core.runtime import RuntimeBackend
-from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, TrialSpec
+from tolokaforge.core.trial import (
+    DEFAULT_TOOL_TIMEOUT_S,
+    EnvEndpoints,
+    EnvironmentManifest,
+    TrialSpec,
+)
 from tolokaforge.core.trial_executor import TrialExecutor
 from tolokaforge.runner.models import AdapterType, TaskDescription
 
@@ -491,13 +496,63 @@ class Orchestrator:
                 error=result.get("error"),
             )
 
-    def _construct_runtime_backend(self, runner_address: str) -> RuntimeBackend:
+    def _extract_run_env_manifest(self) -> EnvironmentManifest | None:
+        """Return the shared ``environment_manifest`` declared by the run's
+        tasks, or ``None`` if none of them declare one.
+
+        The run's tasks must be consistent: either every task in the run
+        declares the same ``environment_manifest.compose_file`` or none do.
+        Mixed runs (some tasks with, some without; or different compose
+        files across tasks) fail loud — a single ``SharedStackRuntimeBackend``
+        can only materialise one substrate per run, and a mixed declaration
+        signals an ambiguous operator intent.
+        """
+        manifests_by_compose: dict[str, EnvironmentManifest] = {}
+        tasks_by_manifest_status: dict[bool, list[str]] = {True: [], False: []}
+        for task in self.tasks:
+            manifest = task.environment_manifest
+            tasks_by_manifest_status[manifest is not None].append(task.task_id)
+            if manifest is not None:
+                manifests_by_compose[str(manifest.compose_file)] = manifest
+        if not manifests_by_compose:
+            return None
+        if tasks_by_manifest_status[False]:
+            raise RuntimeError(
+                "Run has a mix of tasks with and without environment_manifest — "
+                "SharedStackRuntimeBackend can only materialise one substrate per run. "
+                f"Tasks with manifest: {tasks_by_manifest_status[True]}. "
+                f"Tasks without: {tasks_by_manifest_status[False]}. "
+                "Split into separate runs or declare a consistent manifest for all tasks."
+            )
+        if len(manifests_by_compose) > 1:
+            raise RuntimeError(
+                "Run has tasks declaring different environment_manifest.compose_file "
+                f"values: {sorted(manifests_by_compose)}. A single "
+                "SharedStackRuntimeBackend materialises one substrate for the whole run. "
+                "Split into separate runs or converge on one compose file."
+            )
+        return next(iter(manifests_by_compose.values()))
+
+    def _construct_runtime_backend(
+        self,
+        runner_address: str,
+        env_manifest: EnvironmentManifest | None = None,
+        run_id: str = "run",
+    ) -> RuntimeBackend:
         """Construct the runtime backend from ``config.orchestrator.runtime``.
 
-        ``shared`` (default) → :class:`SharedStackRuntimeBackend` built
-        with :func:`_build_env_endpoints`-resolved URLs; ``per_trial`` →
-        :class:`PerTrialRuntimeBackend`. Called when no backend is
-        injected via ``Orchestrator.__init__(runtime_backend=...)``.
+        ``shared`` (default) → :class:`SharedStackRuntimeBackend`. When
+        ``env_manifest`` is passed the backend materialises the
+        task-declared compose stack once per run at ``connect`` time.
+        When absent, the backend connects to the built-in shared engine
+        at ``runner_address`` with endpoints resolved via
+        :func:`_build_env_endpoints`.
+
+        ``per_trial`` → :class:`PerTrialRuntimeBackend` (env_manifest is
+        consumed per-trial there; ignored here).
+
+        Called when no backend is injected via
+        ``Orchestrator.__init__(runtime_backend=...)``.
         """
         runtime_choice = self.config.orchestrator.runtime
         if runtime_choice == "per_trial":
@@ -513,7 +568,13 @@ class Orchestrator:
             "runtime.backend.selected",
             backend="SharedStackRuntimeBackend",
             source="config" if runtime_choice == "shared" else "default",
+            env_manifest_present=env_manifest is not None,
         )
+        if env_manifest is not None:
+            return SharedStackRuntimeBackend(
+                env_manifest=env_manifest,
+                run_id=run_id,
+            )
         return SharedStackRuntimeBackend(
             runner_address=runner_address,
             endpoints=_build_env_endpoints(runner_address),
@@ -977,6 +1038,11 @@ class Orchestrator:
                 max_requests_per_second=self.config.orchestrator.max_requests_per_second,
             )
 
+        # Task-declared shared-stack manifest (Phase 4): if the run's tasks declare an
+        # environment_manifest, extract the shared manifest here — mixed / divergent
+        # declarations fail loud before we touch docker.
+        run_env_manifest = self._extract_run_env_manifest()
+
         # Auto-start services via ServiceStack if configured
         service_stack = None
         if self.config.orchestrator.auto_start_services:
@@ -1026,10 +1092,16 @@ class Orchestrator:
                     stack_factory = core_stack
                 service_stack = stack_factory(**core_stack_kwargs)
                 per_trial_mode = self.config.orchestrator.runtime == "per_trial"
-                if per_trial_mode:
+                # In per_trial mode OR shared+env_manifest mode the built-in engine
+                # containers go unused — the task-declared compose stack owns the
+                # runner + db-service. The engine images still need to be BUILT so
+                # task compose files can reference the `:local` aliases; skipping
+                # the container-start is the shared-with-per_trial optimisation.
+                task_stack_mode = per_trial_mode or run_env_manifest is not None
+                if task_stack_mode:
                     self.logger.info(
-                        "Preparing Docker engine images (per-trial mode: "
-                        "images built + aliased, containers not started)..."
+                        "Preparing Docker engine images (task-declared-stack mode: "
+                        "images built + aliased, built-in containers not started)..."
                     )
                     service_stack.build_and_prepare()
                     self._ensure_engine_image_local_aliases(service_stack)
@@ -1051,15 +1123,16 @@ class Orchestrator:
 
                 # Connect TypeSense to core stack network so Runner can reach it
                 if hasattr(self, "_typesense_server") and self._typesense_server:
-                    if per_trial_mode:
+                    if task_stack_mode:
                         raise RuntimeError(
-                            "TypeSense KB is enabled but --runtime per_trial does not yet "
-                            "support the TypeSense bridge. The bridge connects TypeSense to "
-                            "the shared 'runner-net' and rewrites the TypeSense config to "
-                            "'typesense:8108' Docker DNS — per-trial runners live on "
-                            "task-side networks and cannot reach that host. Either run with "
-                            "--runtime shared or drop the TypeSense KB block from the run "
-                            "config."
+                            "TypeSense KB is enabled but the run uses a task-declared "
+                            "compose stack (either --runtime per_trial or a run whose tasks "
+                            "declare environment_manifest under --runtime shared). The "
+                            "TypeSense bridge connects TypeSense to the shared 'runner-net' "
+                            "and rewrites the TypeSense config to 'typesense:8108' Docker "
+                            "DNS — task-declared runners live on task-side networks and "
+                            "cannot reach that host. Either drop the TypeSense KB block or "
+                            "drop the task-declared environment_manifest."
                         )
                     self._connect_typesense_to_runner_network(service_stack)
             except Exception as e:
@@ -1077,18 +1150,26 @@ class Orchestrator:
         if self._injected_runtime_backend is not None:
             runtime_backend = self._injected_runtime_backend
         else:
-            runtime_backend = self._construct_runtime_backend(runner_address)
+            runtime_backend = self._construct_runtime_backend(
+                runner_address,
+                env_manifest=run_env_manifest,
+                run_id=run_id,
+            )
         runtime_backend.connect()
         self.logger.info("Runtime backend connected")
         self._verify_isolation_compatibility(runtime_backend)
 
         env_endpoints = _build_env_endpoints(runner_address)
-        if self.config.orchestrator.runtime == "per_trial":
+        if self.config.orchestrator.runtime == "per_trial" or run_env_manifest is not None:
             # Per-trial backend resolves fresh endpoints per trial via
-            # ``endpoints(handle)``. The default values built here would be
-            # phantom values that never reach a trial spec — logging them
-            # here would misdirect log-based diagnosis.
-            self.logger.info("Trial-scoped service endpoints resolved per trial by backend")
+            # ``endpoints(handle)``. Shared+env_manifest resolves them once
+            # at connect time from the materialised stack. In both cases the
+            # default values built here would be phantom values that never
+            # reach a trial spec — logging them here would misdirect
+            # log-based diagnosis.
+            self.logger.info(
+                "Trial-scoped service endpoints resolved by backend from task-declared stack"
+            )
         else:
             self.logger.info(
                 "Resolved trial-scoped service endpoints",

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -17,14 +17,26 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import grpc
+from testcontainers.compose import DockerCompose
 
-from tolokaforge.core.runtime import IsolationMode
-from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints
+from tolokaforge.core.compose_materialisation import (
+    RUNNER_PORT_DEFAULT,
+    cleanup_partial_materialisation,
+    copy_compose_context,
+    make_project_temp_dir,
+    resolve_env_endpoints,
+    resolve_runner_endpoint,
+    shutdown_compose,
+)
+from tolokaforge.core.runtime import IsolationMode, ProvisionError
+from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, EnvironmentManifest
 from tolokaforge.runner import (
     ExecutionStatus,
     runner_pb2,
@@ -679,46 +691,163 @@ class SharedStackRuntimeBackend:
         self,
         runner_address: str = "runner:50051",
         endpoints: EnvEndpoints | None = None,
+        env_manifest: EnvironmentManifest | None = None,
+        run_id: str = "run",
     ):
         """Initialize the shared-stack runtime.
 
-        ``runner_address`` is the gRPC host:port for the shared runner
-        service. ``endpoints`` carries the fully-resolved per-trial URLs
-        (db / rag / runner) the run's shared stack exposes; every call to
-        :meth:`endpoints` returns them verbatim. The orchestrator builds
-        this value once via ``_build_env_endpoints(runner_address)`` and
-        passes it at construction; ``endpoints=None`` is a
-        backwards-compatibility path for callers that construct the
-        backend outside the orchestrator (typically tests) and derives
-        placeholder URLs from ``runner_address`` alone.
+        Two mutually exclusive modes:
+
+        **Built-in-stack mode** (``env_manifest`` is ``None``, the default).
+        The orchestrator's built-in ``ServiceStack`` has already brought up
+        the shared runner + db-service, and its address / endpoints are
+        passed in. ``connect`` just wires the gRPC client to that address.
+
+        **Task-declared-stack mode** (``env_manifest`` is set). The run's
+        tasks declared a shared, task-authored compose file. The backend
+        materialises it **once at ``connect`` time**, resolves endpoints
+        from the materialised stack, and wires the gRPC client to the
+        task-declared runner. Every trial in the run shares that
+        substrate; ``close`` tears it down. ``run_id`` becomes the temp-
+        dir slug so docker compose auto-generates a unique project name
+        per run.
+
+        In built-in mode ``endpoints=None`` derives placeholder URLs from
+        ``runner_address`` alone — a backwards-compat path for callers
+        that construct the backend outside the orchestrator (typically
+        tests).
         """
-        self.runner_client: GrpcRunnerClient = GrpcRunnerClient(runner_address)
-        if endpoints is None:
-            endpoints = EnvEndpoints(
-                db_url=f"http://{runner_address}/db",
-                rag_url=None,
-                runner_url=f"http://{runner_address}",
-            )
-        self._endpoints = endpoints
+        self._env_manifest = env_manifest
+        self._run_id = run_id
+        self._compose: DockerCompose | None = None
+        self._temp_dir: Path | None = None
+
+        if env_manifest is None:
+            # Built-in-stack mode: runner + endpoints known at construction.
+            self.runner_client: GrpcRunnerClient = GrpcRunnerClient(runner_address)
+            if endpoints is None:
+                endpoints = EnvEndpoints(
+                    db_url=f"http://{runner_address}/db",
+                    rag_url=None,
+                    runner_url=f"http://{runner_address}",
+                )
+            self._endpoints: EnvEndpoints = endpoints
+        else:
+            # Task-declared-stack mode: runner + endpoints resolved at connect() time
+            # from the materialised compose. The type hint here is imprecise
+            # (runner_client is None until connect) — an intentional trade to keep
+            # the read-only ``endpoints(handle)`` surface unchanged for callers.
+            self.runner_client = None  # type: ignore[assignment]
+            self._endpoints = None  # type: ignore[assignment]
+            if endpoints is not None:
+                raise ValueError(
+                    "SharedStackRuntimeBackend: pass either env_manifest OR endpoints, "
+                    "not both. env_manifest mode resolves endpoints from the "
+                    "materialised compose stack at connect() time."
+                )
         logger.info("Docker runtime initialized")
 
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         """Connect to Runner service with health check retry.
+
+        In task-declared-stack mode (``env_manifest`` is set) this also
+        materialises the task-declared compose stack once for the whole
+        run and resolves endpoints from it before the gRPC client is
+        wired.
 
         Args:
             timeout: Maximum time to wait for healthy service (seconds)
             retry_interval: Time between health check attempts (seconds)
 
         Raises:
-            ConnectionError: If Runner not healthy after timeout
+            ProvisionError: if the task-declared stack fails to materialise
+                or its declared runner / db service is not exposed.
+            ConnectionError: If Runner not healthy after timeout.
         """
+        if self._env_manifest is not None:
+            self._materialise_manifest()
         self.runner_client.connect(timeout=timeout, retry_interval=retry_interval)
         logger.info("Docker runtime connected")
 
     def close(self):
-        """Close Runner connection"""
-        self.runner_client.close()
+        """Close Runner connection and tear down the task-declared stack
+        (if any). Idempotent: safe to call before ``connect`` or twice."""
+        if self.runner_client is not None:
+            self.runner_client.close()
+        if self._compose is not None:
+            shutdown_compose(self._compose)
+            self._compose = None
+        if self._temp_dir is not None:
+            shutil.rmtree(self._temp_dir, ignore_errors=True)
+            self._temp_dir = None
         logger.info("Docker runtime closed")
+
+    def _materialise_manifest(self) -> None:
+        """Bring up the task-declared compose stack once for the run and
+        wire ``self.runner_client`` + ``self._endpoints`` to it. Called
+        from :meth:`connect` when ``env_manifest`` is set.
+
+        Failure at any stage cleans up any partial materialisation
+        before surfacing a :class:`ProvisionError` — the shared-stack
+        equivalent of PerTrialRuntimeBackend's provision path, but with
+        run scope instead of trial scope.
+        """
+        assert self._env_manifest is not None  # narrowed by caller
+        manifest = self._env_manifest
+
+        temp_dir = make_project_temp_dir(self._run_id)
+        compose: DockerCompose | None = None
+        try:
+            copy_compose_context(manifest.compose_file, temp_dir)
+            compose = DockerCompose(
+                context=str(temp_dir),
+                compose_file_name=manifest.compose_file.name,
+                pull=False,
+                build=False,
+                wait=True,
+            )
+            compose.start()
+        except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise ProvisionError(
+                trial_id=self._run_id,
+                stage="provision",
+                reason=f"docker compose up failed for shared task-declared stack: {exc}",
+            ) from exc
+
+        runner_endpoint = resolve_runner_endpoint(
+            compose, manifest.runner_service, RUNNER_PORT_DEFAULT
+        )
+        if runner_endpoint is None:
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise ProvisionError(
+                trial_id=self._run_id,
+                stage="provision",
+                reason=(
+                    f"runner_service {manifest.runner_service!r} does not expose port "
+                    f"{RUNNER_PORT_DEFAULT} in the shared task-declared compose stack"
+                ),
+            )
+        runner_host, runner_host_port = runner_endpoint
+
+        endpoints = resolve_env_endpoints(compose, runner_host, runner_host_port)
+        if endpoints is None:
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise ProvisionError(
+                trial_id=self._run_id,
+                stage="provision",
+                reason=(
+                    "SharedStackRuntimeBackend requires a compose service named 'db' "
+                    "exposing port 5432; task-declared compose file does not declare "
+                    "one. Endpoint-resolution customisation is a follow-up ticket."
+                ),
+            )
+
+        # Preserve the materialised state on the backend so close() can tear it down.
+        self._compose = compose
+        self._temp_dir = temp_dir
+        self._endpoints = endpoints
+        self.runner_client = GrpcRunnerClient(runner_address=f"{runner_host}:{runner_host_port}")
 
     def health_check(self) -> bool:
         """Check health of Runner service"""

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -722,23 +722,24 @@ class SharedStackRuntimeBackend:
         self._compose: DockerCompose | None = None
         self._temp_dir: Path | None = None
 
+        self.runner_client: GrpcRunnerClient | None
+        self._endpoints: EnvEndpoints | None
         if env_manifest is None:
             # Built-in-stack mode: runner + endpoints known at construction.
-            self.runner_client: GrpcRunnerClient = GrpcRunnerClient(runner_address)
+            self.runner_client = GrpcRunnerClient(runner_address)
             if endpoints is None:
                 endpoints = EnvEndpoints(
                     db_url=f"http://{runner_address}/db",
                     rag_url=None,
                     runner_url=f"http://{runner_address}",
                 )
-            self._endpoints: EnvEndpoints = endpoints
+            self._endpoints = endpoints
         else:
             # Task-declared-stack mode: runner + endpoints resolved at connect() time
-            # from the materialised compose. The type hint here is imprecise
-            # (runner_client is None until connect) — an intentional trade to keep
-            # the read-only ``endpoints(handle)`` surface unchanged for callers.
-            self.runner_client = None  # type: ignore[assignment]
-            self._endpoints = None  # type: ignore[assignment]
+            # from the materialised compose. Both are populated inside
+            # :meth:`_materialise_manifest`.
+            self.runner_client = None
+            self._endpoints = None
             if endpoints is not None:
                 raise ValueError(
                     "SharedStackRuntimeBackend: pass either env_manifest OR endpoints, "
@@ -771,15 +772,23 @@ class SharedStackRuntimeBackend:
 
     def close(self):
         """Close Runner connection and tear down the task-declared stack
-        (if any). Idempotent: safe to call before ``connect`` or twice."""
-        if self.runner_client is not None:
-            self.runner_client.close()
-        if self._compose is not None:
-            shutdown_compose(self._compose)
-            self._compose = None
-        if self._temp_dir is not None:
-            shutil.rmtree(self._temp_dir, ignore_errors=True)
-            self._temp_dir = None
+        (if any). Idempotent: safe to call before ``connect`` or twice.
+
+        A runner-client close failure (e.g. broken gRPC channel) must not
+        prevent the compose stack + temp dir from being cleaned up — the
+        downstream teardown runs in a ``try/finally`` so a leaked docker
+        project doesn't outlive the run.
+        """
+        try:
+            if self.runner_client is not None:
+                self.runner_client.close()
+        finally:
+            if self._compose is not None:
+                shutdown_compose(self._compose)
+                self._compose = None
+            if self._temp_dir is not None:
+                shutil.rmtree(self._temp_dir, ignore_errors=True)
+                self._temp_dir = None
         logger.info("Docker runtime closed")
 
     def _materialise_manifest(self) -> None:
@@ -787,11 +796,20 @@ class SharedStackRuntimeBackend:
         wire ``self.runner_client`` + ``self._endpoints`` to it. Called
         from :meth:`connect` when ``env_manifest`` is set.
 
+        Idempotent: a second call while the stack is up returns without
+        re-materialising, matching :class:`GrpcRunnerClient.connect`'s
+        ``if self.channel is None`` guard. A double-materialisation would
+        leak the first stack + temp dir.
+
         Failure at any stage cleans up any partial materialisation
         before surfacing a :class:`ProvisionError` — the shared-stack
         equivalent of PerTrialRuntimeBackend's provision path, but with
         run scope instead of trial scope.
         """
+        if self._compose is not None:
+            # Already materialised — a second connect() (e.g. after a
+            # transient reconnect) must not clobber the running stack.
+            return
         assert self._env_manifest is not None  # narrowed by caller
         manifest = self._env_manifest
 
@@ -891,12 +909,15 @@ class SharedStackRuntimeBackend:
         """Return the run-wide shared-stack URLs.
 
         Same value for every trial in the run — the shared stack exposes
-        one set of service addresses that all trials share. The
-        orchestrator resolves these via ``_build_env_endpoints`` at
-        construction and passes them via the constructor's ``endpoints``
-        argument. Callers that need per-trial URLs should use a per-trial
-        backend (e.g. ``PerTrialRuntimeBackend``, which resolves real
-        URLs from its per-trial ``ServiceStack``).
+        one set of service addresses that all trials share. In built-in
+        mode the orchestrator resolves these via ``_build_env_endpoints``
+        at construction and passes them via ``endpoints``; in
+        task-declared-stack mode :meth:`_materialise_manifest` resolves
+        them from the materialised compose stack at ``connect`` time.
+        Either way the value is snapshot on the backend by the time this
+        method is called. Callers that need per-trial URLs should use a
+        per-trial backend (e.g. ``PerTrialRuntimeBackend``, which
+        resolves real URLs from its per-trial substrate).
         """
         return self._endpoints
 


### PR DESCRIPTION
## TL;DR

Phase 4 PR 2 of 4. **The load-bearing engine change**: extends \`SharedStackRuntimeBackend\` so a run whose tasks declare an \`environment_manifest\` gets a task-declared compose stack materialised **once per run** — decoupling multi-container capability from per-trial isolation. Before this PR, task-declared compose files were only consumed by \`PerTrialRuntimeBackend\`.

## Why this exists — the design in plain terms

Multi-container capability (\"give the agent a realistic environment: db + backend + frontend + …\") and per-trial isolation (\"every trial gets a fresh substrate\") are **independent concerns**. Before this PR they were entangled: the only way to get a task-declared compose file materialised was to opt into \`--runtime per_trial\`. Tasks that needed a rich environment but were fine sharing state across trials had no path.

The 2×2:

|                        | Built-in stack (engine defaults)                    | Task-declared stack (\`env_manifest\`)                      |
|------------------------|-----------------------------------------------------|-------------------------------------------------------------|
| **Shared** (per run)   | Default today — most existing tasks                 | **What this PR adds** — materialised once per run           |
| **Per-trial**          | Not really used (buys nothing over shared+builtin)  | Shipped in PR #163 — materialised per trial                 |

## Design decisions worth flagging

### 1. Two mutually-exclusive construction modes on the same class

Adding a variant class (\`SharedStackWithManifestBackend\`) was considered and rejected — the Protocol surface is identical, and callers already dispatch on the config, not the class. Keeping one class with two construction modes matches how \`PerTrialRuntimeBackend\` unified per-trial semantics.

- **Built-in mode**: \`runner_address\` + \`endpoints\` passed at construction. \`connect()\` just wires the gRPC client. Unchanged.
- **Task-declared mode**: \`env_manifest\` + \`run_id\` passed at construction. \`connect()\` materialises the compose stack, resolves endpoints, wires the gRPC client. \`close()\` tears it all down.

The two modes are mutually exclusive — passing both raises \`ValueError\` at construction (fail-fast). Documented on the constructor.

### 2. Materialisation at \`connect()\`, not at construction

Moving materialisation into \`connect()\` (rather than \`__init__\`) matches how \`PerTrialRuntimeBackend\` handles per-trial materialisation at \`provision()\`. The Protocol contract is that side effects belong in lifecycle methods, not constructors. Enables error paths (\`ProvisionError\` on daemon failure) to surface at a well-defined seam.

### 3. One manifest per run — divergent declarations fail loud

A single \`SharedStackRuntimeBackend\` materialises one substrate per run. A run whose tasks declare **different** compose files can't be materialised into one shared substrate — the answer is either \"pick one\" (silent, wrong) or \"raise\" (loud, correct). New \`Orchestrator._extract_run_env_manifest()\` helper inspects \`self.tasks\`, returns the single shared manifest if consistent, and raises with the offending task ids if not:

- All tasks declare no manifest → returns \`None\` (default built-in mode).
- All tasks declare the same manifest → returns it.
- Mix of declared and undeclared → \`RuntimeError\` naming both sets.
- Divergent \`compose_file\` values across tasks → \`RuntimeError\` naming all files.

### 4. Reuse compose_materialisation from PR #166

Both backends now call the same primitives (\`make_project_temp_dir\`, \`copy_compose_context\`, \`resolve_runner_endpoint\`, \`resolve_env_endpoints\`, \`shutdown_compose\`, \`cleanup_partial_materialisation\`) from \`tolokaforge/core/compose_materialisation.py\`. Different lifecycle scope (\`run_id\`-based slug for shared, \`trial_id\`-based for per-trial), same mechanics.

### 5. ServiceStack path branches on \`task_stack_mode\`

Introduces a new variable \`task_stack_mode = per_trial_mode OR run_env_manifest is not None\`. When true, the built-in ServiceStack takes the \`build_and_prepare()\` path introduced in PR #163's Step A — build engine images + apply \`:local\` aliases, skip container start. Reason: the task-declared compose owns the runner + db-service; the built-in ones would go unused.

This means shared+env_manifest gets the same efficiency benefit per_trial got in PR #163 (no wasted shared-engine containers).

### 6. TypeSense guard extended, follow-up ticket filed

The TypeSense integration bridges to \`runner-net\` and rewrites the client config to \`typesense:8108\` Docker DNS. That works for shared+built-in only — task-declared runners live on task-side networks and can't reach that DNS. PR #163 added the guard for per_trial; this PR extends it to task_stack_mode (same failure shape). See the **TypeSense note** below.

## TypeSense note (careful territory)

The TypeSense provider layer is currently frozen (a separate ticket tracks unfreezing it; the provider was deleted during OSS cleanup while the surrounding plumbing stayed intact). This PR does **not** touch any TypeSense plumbing:

- Not touched: \`typesense_server.py\`, \`domain_state.py\`, \`TypeSenseConfig\`, \`docker/stacks/typesense.py\`, \`_ensure_typesense_started\`, \`_connect_typesense_to_runner_network\`.
- Touched: the orchestrator's incompatibility guard condition (a two-word change: \`per_trial_mode\` → \`task_stack_mode\`).

**Backward-compat**: users running \`shared + built-in + typesense\` today are unaffected (\`task_stack_mode = False\`, guard doesn't fire).

**New user-observable behaviour**: a new task combining \`env_manifest\` + TypeSense under \`shared\` gets a \`RuntimeError\` explaining why the combination doesn't work, rather than silently getting broken search. Same fail-loud discipline PR #163 established for per_trial+typesense.

A follow-up ticket tracks the full unblock (design options: task-declared TypeSense in the compose file, or per-run bridge to the task-declared network).

## What this PR does NOT do

- No example task exercising the new path — that's Phase 4 PR 3.
- No ADR — Phase 4 PR 4 ships ADR-0018 documenting the shipped state.
- No docker integration smoke test — existing \`PerTrialRuntimeBackend\` integration test is untouched; a matching \`SharedStackRuntimeBackend + env_manifest\` integration test lands with PR 3's task pack.
- No change to any existing task pack.
- No TypeSense plumbing changes.

## Test coverage

- **\`tests/unit/test_shared_stack_runtime_env_manifest.py\`** (11 tests) — construction (both modes, mutual-exclusion), \`connect\` materialisation (with mocked \`DockerCompose\`), \`close\` idempotency, three ProvisionError paths (compose-up failure, missing runner service, missing db).
- **\`tests/unit/test_orchestrator_extract_run_env_manifest.py\`** (10 tests) — no-manifest → None, consistent → returned, mixed / divergent → raise with task ids in the message, isolation declarations round-trip.
- Existing suite unchanged and passing: 1942 unit + 389 canonical before + 21 new = 2375 pass total.

## Test plan

- [x] \`uv run ruff check tolokaforge tests\` clean.
- [x] \`uv run pytest tests/ -m unit -q\` → 1963 pass, 1 skipped.
- [x] \`uv run pytest tests/ -m canonical -q\` → 389 pass.
- [x] New tests: 21 pass.
- [ ] Docker integration smoke (opt-in, manual): can materialise a real multi-service compose end-to-end under \`--runtime shared\` — will validate with PR 3's task pack.
- [ ] Automated Claude review round on this PR.

## Umbrella

- Jira: TECHDEL-466 (Runtime & isolation — Phase 4).
- Milestone: [#4 Runtime & isolation](https://github.com/Toloka/tolokaforge/milestone/4).

## Follows

Phase 4 arc:
1. [#166](https://github.com/Toloka/tolokaforge/pull/166) — extract shared primitives (merged).
2. **This PR** — SharedStackRuntimeBackend consumes env_manifest.
3. Next — example multi-service task exercising this path.
4. Then — ADR-0018 documenting the shipped state.