### PR TITLE
refactor(docker): rename ServiceStack → EngineStack; document scope + non-Protocol

### DIFF
--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -54,6 +54,37 @@ legal but pointless combination (per-trial isolation on a built-in stack buys
 nothing — you pay compose-up cost every trial to get an identical substrate);
 the engine won't refuse to run it, but no task packs opt in.
 
+## Naming note: `EngineStack` is deliberately docker-only and non-Protocol
+
+The engine's built-in service bring-up primitive is called `EngineStack`
+(in `tolokaforge/docker/stack.py`, previously named `ServiceStack`). Two
+deliberate constraints on its shape are worth stating so future readers
+don't try to "generalise" it:
+
+1. **Docker-only.** `EngineStack` drives `docker-py` directly. It is not
+   a substrate-agnostic abstraction. A future Kubernetes / Modal / EC2
+   backend would ship its own engine-bring-up primitive (or not need one
+   at all if that substrate is always task-declared). "Engine" in the
+   class name signals the scope (the engine's built-in services); the
+   docker-mode-ness is signalled by the module path
+   (`tolokaforge/docker/stack.py`).
+2. **Not a Protocol.** `EngineStack` sits below the
+   :class:`RuntimeBackend` seam as a docker-mode implementation detail.
+   The substrate-agnostic seam is `RuntimeBackend` (ADR-0007), and the
+   design doc's D15 plug-in list does not include `EngineStack`. We
+   don't have a second implementation, we don't know the shape of a
+   second implementation (a k8s engine-bring-up might not even look
+   like a compose-shaped stack), and premature abstraction risks
+   locking in the wrong shape. If a second implementation arrives with
+   a demonstrable shape, we Protocol-ise then — that's a 1-hour
+   mechanical refactor when the demand is real, and zero cost to defer.
+
+In the case diagrams below, `EngineStack` appears as an actor only in
+Case A (shared + built-in). Cases B and C use it only as an *image
+builder* via `build_and_prepare()` — the actual substrate materialisation
+happens inside the `RuntimeBackend` implementation via
+testcontainers-`DockerCompose` (see `compose_materialisation.py`).
+
 ## Package composition is a separate concern
 
 This ADR is about **which services live in the substrate** and **when they
@@ -93,7 +124,7 @@ config. That's Phase 7 design territory — out of scope for this ADR.
 
 ### Case A — `shared` + built-in stack (default, unchanged)
 
-The engine's shared substrate. `ServiceStack` brings up `core_stack`
+The engine's shared substrate. `EngineStack` brings up `core_stack`
 (runner + db-service) or `full_stack` (adds mock-web + rag-service based on
 task tools) once at run start. Every trial connects to the same containers.
 
@@ -101,7 +132,7 @@ task tools) once at run start. Every trial connects to the same containers.
 sequenceDiagram
   autonumber
   participant O as Orchestrator
-  participant S as ServiceStack
+  participant S as EngineStack
   participant B as SharedStackRuntimeBackend
   participant R as Runner (engine builtin)
   participant T as Trial
@@ -135,7 +166,7 @@ happens at run end.
 sequenceDiagram
   autonumber
   participant O as Orchestrator
-  participant S as ServiceStack
+  participant S as EngineStack
   participant B as SharedStackRuntimeBackend
   participant DC as DockerCompose (task-declared)
   participant R as Runner (from task compose)
@@ -164,7 +195,7 @@ Key differences from Case A:
   compose file gets `docker compose up`'d when the backend connects.
   Endpoints are resolved *from* the running stack — testcontainers-python
   allocates host ports; the backend reads them back.
-- **`ServiceStack` takes the `build_and_prepare()` path** (build engine
+- **`EngineStack` takes the `build_and_prepare()` path** (build engine
   images + apply `:local` aliases, no built-in container start). The
   engine's runner + db-service go unused; the task's compose owns them via
   `:local` alias references.
@@ -182,7 +213,7 @@ Every trial gets an isolated substrate; teardown happens per trial.
 sequenceDiagram
   autonumber
   participant O as Orchestrator
-  participant S as ServiceStack
+  participant S as EngineStack
   participant B as PerTrialRuntimeBackend
   participant DC as DockerCompose (per-trial)
   participant R as Runner (per trial)

--- a/tests/integration/docker/test_docker_stack.py
+++ b/tests/integration/docker/test_docker_stack.py
@@ -1,6 +1,6 @@
-"""Integration tests for ServiceStack lifecycle.
+"""Integration tests for EngineStack lifecycle.
 
-These tests verify that ServiceStack can create, start, health-check,
+These tests verify that EngineStack can create, start, health-check,
 stop, and destroy containers using the foundation layer.
 
 Requires Docker to be running.
@@ -42,16 +42,16 @@ def simple_dockerfile(tmp_path):
 
 @pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
 class TestDockerStack:
-    """Integration tests for ServiceStack lifecycle."""
+    """Integration tests for EngineStack lifecycle."""
 
     def test_start_stop_single_service(self, simple_dockerfile):
         """Start and stop a single service."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-single-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-single-{uuid.uuid4().hex[:6]}")
         svc = ServiceDefinition(
             name="web",
             image_name="test-stack-web",
@@ -71,11 +71,11 @@ class TestDockerStack:
     def test_dependency_ordering(self, simple_dockerfile):
         """Services start in dependency order."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-deps-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-deps-{uuid.uuid4().hex[:6]}")
 
         svc_a = ServiceDefinition(
             name="base",
@@ -109,11 +109,11 @@ class TestDockerStack:
     def test_profile_filtering(self, simple_dockerfile):
         """Profile filtering includes/excludes services correctly."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-profiles-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-profiles-{uuid.uuid4().hex[:6]}")
 
         core_svc = ServiceDefinition(
             name="core",
@@ -145,11 +145,11 @@ class TestDockerStack:
     def test_auto_port_allocation(self, simple_dockerfile):
         """Auto port allocation assigns unique host ports."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-autoport-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-autoport-{uuid.uuid4().hex[:6]}")
         svc = ServiceDefinition(
             name="auto",
             image_name="test-autoport-svc",
@@ -169,11 +169,11 @@ class TestDockerStack:
     def test_destroy_cleanup(self, simple_dockerfile):
         """Destroy removes all containers and networks."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-cleanup-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-cleanup-{uuid.uuid4().hex[:6]}")
         svc = ServiceDefinition(
             name="cleanup",
             image_name="test-cleanup-svc",
@@ -193,13 +193,13 @@ class TestDockerStack:
         assert len(stack._images) == 0
 
     def test_context_manager(self, simple_dockerfile):
-        """ServiceStack works as a context manager."""
+        """EngineStack works as a context manager."""
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir, dockerfile = simple_dockerfile
 
-        stack = ServiceStack(prefix=f"test-ctxmgr-{uuid.uuid4().hex[:6]}")
+        stack = EngineStack(prefix=f"test-ctxmgr-{uuid.uuid4().hex[:6]}")
         svc = ServiceDefinition(
             name="ctxmgr",
             image_name="test-ctxmgr-svc",
@@ -220,7 +220,7 @@ class TestDockerStack:
         """health_check_all returns status for all services."""
         from tolokaforge.docker.health import HealthProbe
         from tolokaforge.docker.ports import PortConfig
-        from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+        from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
         context_dir = tmp_path / "context"
         context_dir.mkdir()
@@ -254,7 +254,7 @@ class TestDockerStack:
         _prefix = f"test-health-{uuid.uuid4().hex[:6]}"
         # Use fixed host port so health probe URL can reference it directly
         _host_port = 28080
-        stack = ServiceStack(prefix=_prefix)
+        stack = EngineStack(prefix=_prefix)
         svc = ServiceDefinition(
             name="healthsvc",
             image_name="test-health-svc",

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -18,7 +18,7 @@ from tolokaforge.docker.builder import (
     service_name_for_image,
 )
 from tolokaforge.docker.image import Image
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 from tolokaforge.docker.wheel_resolver import WheelArtifact
 
 pytestmark = pytest.mark.unit
@@ -325,7 +325,7 @@ def test_start_service_builds_with_isolated_context_when_skipping_build_images(
         context=".",
         context_files=["pyproject.toml", "README.md", "tolokaforge/"],
     )
-    stack = ServiceStack()
+    stack = EngineStack()
     stack.add_service(svc)
 
     with pytest.raises(_Sentinel):
@@ -343,7 +343,7 @@ def test_start_service_builds_with_isolated_context_when_skipping_build_images(
 def test_build_and_prepare_builds_images_and_networks_without_starting_containers(
     monkeypatch,
 ) -> None:
-    """``ServiceStack.build_and_prepare`` builds every declared image and
+    """``EngineStack.build_and_prepare`` builds every declared image and
     creates every declared network, but skips the container-start phase.
 
     The per-trial substrate path needs the ``:local``-alias hook to find
@@ -398,7 +398,7 @@ def test_build_and_prepare_builds_images_and_networks_without_starting_container
         context_files=["pyproject.toml", "README.md", "tolokaforge/"],
         networks=["runner-net"],
     )
-    stack = ServiceStack()
+    stack = EngineStack()
     stack.add_service(svc_runner)
     stack.add_service(svc_db)
 

--- a/tests/unit/test_orchestrator_engine_image_local_aliases.py
+++ b/tests/unit/test_orchestrator_engine_image_local_aliases.py
@@ -5,7 +5,7 @@ shared stack starts, giving per-trial task compose files stable names
 to reference (the raw content-hash tags change on every source edit
 and would break any external reference).
 
-Uses a fake ``ServiceStack`` / ``Image`` pair so the tests don't touch
+Uses a fake ``EngineStack`` / ``Image`` pair so the tests don't touch
 the Docker daemon or the real image-build path — the hook's contract
 under test is "look up each engine image, apply the alias, log", not
 "actually rebuild an image."
@@ -51,8 +51,8 @@ class _FakeImage:
         self.calls.append((alias_repository, alias_tag))
 
 
-class _FakeServiceStack:
-    """Minimal stand-in for :class:`ServiceStack` — only ``get_image`` is used."""
+class _FakeEngineStack:
+    """Minimal stand-in for :class:`EngineStack` — only ``get_image`` is used."""
 
     def __init__(self, images: dict[str, _FakeImage] | None = None) -> None:
         self._images = images or {}
@@ -70,7 +70,7 @@ class TestEngineImageLocalAliases:
         orch = _make_orchestrator()
         runner_img = _FakeImage()
         db_img = _FakeImage()
-        stack = _FakeServiceStack({"runner": runner_img, "db-service": db_img})
+        stack = _FakeEngineStack({"runner": runner_img, "db-service": db_img})
 
         orch._ensure_engine_image_local_aliases(stack)
 
@@ -84,7 +84,7 @@ class TestEngineImageLocalAliases:
         orch = _make_orchestrator()
         orch.logger = MagicMock()
         runner_img = _FakeImage()
-        stack = _FakeServiceStack({"runner": runner_img})  # no db-service
+        stack = _FakeEngineStack({"runner": runner_img})  # no db-service
 
         orch._ensure_engine_image_local_aliases(stack)
 
@@ -103,7 +103,7 @@ class TestEngineImageLocalAliases:
             "tag", "tolokaforge-runner:hashhash", "daemon rejected the tag"
         )
         db_img = _FakeImage()
-        stack = _FakeServiceStack({"runner": runner_img, "db-service": db_img})
+        stack = _FakeEngineStack({"runner": runner_img, "db-service": db_img})
 
         orch._ensure_engine_image_local_aliases(stack)  # no raise
 
@@ -122,7 +122,7 @@ class TestEngineImageLocalAliases:
         orch = _make_orchestrator()
         runner_img = _FakeImage()
         runner_img.should_raise = AttributeError("get_image returned a wrong-typed object")
-        stack = _FakeServiceStack({"runner": runner_img})
+        stack = _FakeEngineStack({"runner": runner_img})
 
         with pytest.raises(AttributeError, match="wrong-typed object"):
             orch._ensure_engine_image_local_aliases(stack)

--- a/tests/unit/test_service_definition.py
+++ b/tests/unit/test_service_definition.py
@@ -1,4 +1,4 @@
-"""Unit tests for ServiceDefinition, ServiceStatus, and ServiceStack dependency ordering.
+"""Unit tests for ServiceDefinition, ServiceStatus, and EngineStack dependency ordering.
 
 These tests validate the Pydantic models and topological sort logic
 without requiring Docker.
@@ -6,17 +6,17 @@ without requiring Docker.
 
 import pytest
 
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
 pytestmark = pytest.mark.unit
 
 # =============================================================================
-# ServiceStack Dependency Ordering Tests
+# EngineStack Dependency Ordering Tests
 # =============================================================================
 
 
-class TestServiceStackDependencyOrdering:
-    """Tests for ServiceStack._topological_sort() — no Docker required."""
+class TestEngineStackDependencyOrdering:
+    """Tests for EngineStack._topological_sort() — no Docker required."""
 
     @pytest.mark.unit
     def test_no_dependencies(self):
@@ -26,7 +26,7 @@ class TestServiceStackDependencyOrdering:
             "b": ServiceDefinition(name="b", image_name="img-b"),
             "c": ServiceDefinition(name="c", image_name="img-c"),
         }
-        order = ServiceStack._topological_sort(services)
+        order = EngineStack._topological_sort(services)
         assert set(order) == {"a", "b", "c"}
         assert order == ["a", "b", "c"]
 
@@ -38,7 +38,7 @@ class TestServiceStackDependencyOrdering:
             "b": ServiceDefinition(name="b", image_name="img-b", depends_on=["a"]),
             "c": ServiceDefinition(name="c", image_name="img-c", depends_on=["b"]),
         }
-        order = ServiceStack._topological_sort(services)
+        order = EngineStack._topological_sort(services)
         assert order.index("a") < order.index("b")
         assert order.index("b") < order.index("c")
 
@@ -51,7 +51,7 @@ class TestServiceStackDependencyOrdering:
             "c": ServiceDefinition(name="c", image_name="img", depends_on=["a"]),
             "d": ServiceDefinition(name="d", image_name="img", depends_on=["b", "c"]),
         }
-        order = ServiceStack._topological_sort(services)
+        order = EngineStack._topological_sort(services)
         assert order.index("a") < order.index("b")
         assert order.index("a") < order.index("c")
         assert order.index("b") < order.index("d")
@@ -65,7 +65,7 @@ class TestServiceStackDependencyOrdering:
             "b": ServiceDefinition(name="b", image_name="img", depends_on=["a"]),
         }
         with pytest.raises(ValueError, match="Circular dependency"):
-            ServiceStack._topological_sort(services)
+            EngineStack._topological_sort(services)
 
     @pytest.mark.unit
     def test_missing_dependency_raises(self):
@@ -74,21 +74,21 @@ class TestServiceStackDependencyOrdering:
             "a": ServiceDefinition(name="a", image_name="img", depends_on=["nonexistent"]),
         }
         with pytest.raises(ValueError, match="not in the stack"):
-            ServiceStack._topological_sort(services)
+            EngineStack._topological_sort(services)
 
 
 # =============================================================================
-# ServiceStack Service Management Tests
+# EngineStack Service Management Tests
 # =============================================================================
 
 
-class TestServiceStackManagement:
-    """Tests for ServiceStack add/filter methods — no Docker required."""
+class TestEngineStackManagement:
+    """Tests for EngineStack add/filter methods — no Docker required."""
 
     @pytest.mark.unit
     def test_add_service(self):
         """add_service() adds a service to the stack."""
-        stack = ServiceStack()
+        stack = EngineStack()
         svc = ServiceDefinition(name="test", image_name="img")
         stack.add_service(svc)
         assert "test" in stack.services
@@ -97,7 +97,7 @@ class TestServiceStackManagement:
     @pytest.mark.unit
     def test_add_duplicate_raises(self):
         """add_service() raises on duplicate name."""
-        stack = ServiceStack()
+        stack = EngineStack()
         svc = ServiceDefinition(name="test", image_name="img")
         stack.add_service(svc)
         with pytest.raises(ValueError, match="already exists"):
@@ -106,7 +106,7 @@ class TestServiceStackManagement:
     @pytest.mark.unit
     def test_filter_by_profiles_match(self):
         """Profile filtering includes matching and no-profile services."""
-        stack = ServiceStack()
+        stack = EngineStack()
         stack.add_service(ServiceDefinition(name="core-svc", image_name="img", profiles=["core"]))
         stack.add_service(ServiceDefinition(name="rag-svc", image_name="img", profiles=["rag"]))
         stack.add_service(ServiceDefinition(name="always", image_name="img"))

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -481,7 +481,7 @@ class OrchestratorConfig(BaseModel):
     queue_postgres_dsn: str | None = None
     timeouts: TimeoutConfig = Field(default_factory=TimeoutConfig)
     max_turns: int = 50
-    auto_start_services: bool = True  # Auto-start Docker services via ServiceStack
+    auto_start_services: bool = True  # Auto-start Docker services via EngineStack
     continue_prompt: str = "Please proceed to the next step."
     stuck_heuristics: StuckHeuristics = Field(default_factory=StuckHeuristics)
     runtime: Literal["shared", "per_trial"] = "shared"

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -582,7 +582,7 @@ class Orchestrator:
 
     _LOCAL_ALIAS_TAG: str = "local"
     """Stable secondary tag applied to freshly-built engine images after
-    ``ServiceStack.start_all()``. Decoupled from ``tolokaforge.__version__``
+    ``EngineStack.start_all()``. Decoupled from ``tolokaforge.__version__``
     so task compose files referencing ``:local`` don't have to rotate on
     every release. When a public registry lands, task composes will
     reference the published tag directly; ``:local`` stays as the
@@ -1043,13 +1043,13 @@ class Orchestrator:
         # declarations fail loud before we touch docker.
         run_env_manifest = self._extract_run_env_manifest()
 
-        # Auto-start services via ServiceStack if configured
+        # Auto-start services via EngineStack if configured
         service_stack = None
         if self.config.orchestrator.auto_start_services:
             try:
                 from tolokaforge.docker.stacks import core_stack, full_stack
 
-                self.logger.info("Auto-starting Docker services via ServiceStack")
+                self.logger.info("Auto-starting Docker services via EngineStack")
                 stack_requirements = (
                     self.adapter.docker_stack_requirements() if self.adapter is not None else None
                 )
@@ -1106,7 +1106,7 @@ class Orchestrator:
                     service_stack.build_and_prepare()
                     self._ensure_engine_image_local_aliases(service_stack)
                     runner_address = None
-                    self.logger.info("ServiceStack prepared (images ready, no containers started)")
+                    self.logger.info("EngineStack prepared (images ready, no containers started)")
                 else:
                     self.logger.info(
                         "Building Docker images and starting containers "
@@ -1119,7 +1119,7 @@ class Orchestrator:
                     runner_url = service_stack.get_service_url("runner", 50051)
                     # get_service_url returns "http://localhost:{port}" — strip scheme for gRPC
                     runner_address = runner_url.replace("http://", "")
-                    self.logger.info("ServiceStack started", runner_address=runner_address)
+                    self.logger.info("EngineStack started", runner_address=runner_address)
 
                 # Connect TypeSense to core stack network so Runner can reach it
                 if hasattr(self, "_typesense_server") and self._typesense_server:
@@ -1412,7 +1412,7 @@ class Orchestrator:
             runtime_backend.close()
             self.logger.info("Docker runtime closed")
 
-        # Stop TypeSense BEFORE destroying the ServiceStack.
+        # Stop TypeSense BEFORE destroying the EngineStack.
         # TypeSense is connected to runner-net (via _connect_typesense_to_runner_network),
         # so it must be removed from that network before the stack can tear it down.
         if hasattr(self, "_typesense_server") and self._typesense_server:
@@ -1422,13 +1422,13 @@ class Orchestrator:
             except Exception as e:
                 self.logger.warning(f"Failed to stop TypeSense server: {e}")
 
-        # Cleanup ServiceStack if auto-started
+        # Cleanup EngineStack if auto-started
         if service_stack is not None:
             try:
                 service_stack.destroy()
-                self.logger.info("ServiceStack destroyed")
+                self.logger.info("EngineStack destroyed")
             except Exception as e:
-                self.logger.warning("Failed to destroy ServiceStack", error=str(e))
+                self.logger.warning("Failed to destroy EngineStack", error=str(e))
 
         # Generate reports
         self._generate_reports(output_dir)

--- a/tolokaforge/core/search/typesense_server.py
+++ b/tolokaforge/core/search/typesense_server.py
@@ -4,7 +4,7 @@ This module provides orchestrator-managed TypeSense server lifecycle management.
 In local mode, it automatically starts a Docker container before trials run and
 stops it after completion.
 
-Uses the tolokaforge.docker ServiceStack and typesense_service() for container
+Uses the tolokaforge.docker EngineStack and typesense_service() for container
 lifecycle, replacing raw Docker SDK calls.
 """
 
@@ -16,7 +16,7 @@ import httpx
 
 # Check if Docker foundation layer is available
 try:
-    from tolokaforge.docker.stack import ServiceStack  # noqa: F401
+    from tolokaforge.docker.stack import EngineStack  # noqa: F401
 
     DOCKER_AVAILABLE = True
 except ImportError:
@@ -63,7 +63,7 @@ class TypeSenseServerManager:
     """Manages TypeSense server lifecycle using Docker foundation layer.
 
     This class handles starting, stopping, and monitoring a TypeSense Docker
-    container for local development and testing. Uses ServiceStack from the
+    container for local development and testing. Uses EngineStack from the
     tolokaforge.docker foundation layer for container management.
 
     Supports context manager protocol for automatic cleanup.
@@ -138,13 +138,13 @@ class TypeSenseServerManager:
     def start(self) -> bool:
         """Start TypeSense server container.
 
-        Uses ServiceStack and typesense_service() from the foundation layer.
+        Uses EngineStack and typesense_service() from the foundation layer.
 
         Returns:
             True if server started successfully, False otherwise
         """
         try:
-            from tolokaforge.docker.stack import ServiceStack
+            from tolokaforge.docker.stack import EngineStack
             from tolokaforge.docker.stacks.typesense import typesense_service
         except ImportError:
             logger.error(
@@ -200,7 +200,7 @@ class TypeSenseServerManager:
                 ) from pull_err
 
             # Create and start the stack
-            self._stack = ServiceStack(prefix=self.container_name)
+            self._stack = EngineStack(prefix=self.container_name)
             self._stack.add_service(svc_def)
 
             logger.info(

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -699,7 +699,7 @@ class SharedStackRuntimeBackend:
         Two mutually exclusive modes:
 
         **Built-in-stack mode** (``env_manifest`` is ``None``, the default).
-        The orchestrator's built-in ``ServiceStack`` has already brought up
+        The orchestrator's built-in ``EngineStack`` has already brought up
         the shared runner + db-service, and its address / endpoints are
         passed in. ``connect`` just wires the gRPC client to that address.
 

--- a/tolokaforge/docker/__init__.py
+++ b/tolokaforge/docker/__init__.py
@@ -97,7 +97,7 @@ from tolokaforge.docker.network import Network, NetworkError
 from tolokaforge.docker.policy import Capability, ResourcePolicy
 from tolokaforge.docker.ports import PortAllocationError, PortConfig
 from tolokaforge.docker.registry import ImageRegistry
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack, ServiceStatus
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition, ServiceStatus
 from tolokaforge.docker.wait_for_services import (
     ServiceTarget,
     ServiceType,
@@ -160,6 +160,6 @@ __all__ = [
     "ServiceWaitError",
     # Service stack
     "ServiceDefinition",
-    "ServiceStack",
+    "EngineStack",
     "ServiceStatus",
 ]

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -9,7 +9,7 @@ This is the primary orchestration layer that replaces docker-compose.yaml and
 bash Docker management scripts.
 
 Example:
-    >>> from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+    >>> from tolokaforge.docker.stack import ServiceDefinition, EngineStack
     >>> from tolokaforge.docker import HealthProbe, PortConfig, Mount
     >>>
     >>> svc = ServiceDefinition(
@@ -19,7 +19,7 @@ Example:
     ...     ports=[PortConfig(container_port=8000, host_port=8000)],
     ...     health_probe=HealthProbe.http("http://localhost:8000/health"),
     ... )
-    >>> stack = ServiceStack()
+    >>> stack = EngineStack()
     >>> stack.add_service(svc)
     >>> stack.start_all(wait=True)
     >>> stack.stop_all()
@@ -52,7 +52,7 @@ class ServiceDefinition(BaseModel):
 
     A ServiceDefinition captures all the configuration needed to build
     an image, create a container, and start a service. It is declarative
-    and immutable — the ServiceStack uses it to orchestrate lifecycle.
+    and immutable — the EngineStack uses it to orchestrate lifecycle.
 
     Attributes:
         name: Unique service name (used as container name prefix).
@@ -182,15 +182,42 @@ class ServiceStatus(BaseModel):
     }
 
 
-class ServiceStack(BaseModel):
-    """Manages a collection of ServiceDefinitions with lifecycle orchestration.
+class EngineStack(BaseModel):
+    """Local-dev / docker-mode primitive for the engine's built-in services.
 
-    ServiceStack is the primary replacement for docker-compose.yaml. It handles:
-    - Image building via ImageRegistry (with content-hash caching)
+    Manages a collection of :class:`ServiceDefinition`s (the engine's runner,
+    db-service, and optionally mock-web + rag-service) with lifecycle
+    orchestration on ``docker-py``. Concretely:
+
+    - Image building via ``ImageRegistry`` (with content-hash caching)
     - Network creation (idempotent)
-    - Topological sort of services by depends_on
+    - Topological sort of services by ``depends_on``
     - Container creation, start, health wait
     - Ordered stop and destroy
+
+    **Scope and non-scope.** ``EngineStack`` is deliberately docker-specific
+    and engine-specific:
+
+    - **Docker-specific**: it drives ``docker-py`` directly. It is not a
+      substrate-agnostic abstraction. A future Kubernetes or Modal backend
+      would ship its own engine-bring-up primitive (or not need one at all
+      if that substrate is always task-declared) — it would NOT extend or
+      subclass ``EngineStack``.
+    - **Engine-specific**: it materialises the engine's *built-in* services
+      (``core_stack`` = runner + db-service, ``full_stack`` adds mock-web +
+      rag-service). Task-declared services (from
+      ``environment_manifest.compose_file``) are materialised elsewhere via
+      testcontainers-``DockerCompose`` inside the concrete
+      :class:`RuntimeBackend` implementations (see
+      ``tolokaforge/core/compose_materialisation.py``).
+
+    **Not a Protocol.** ``EngineStack`` is intentionally not lifted behind a
+    Protocol/seam. The substrate-agnostic seam is :class:`RuntimeBackend`
+    (ADR-0007); ``EngineStack`` sits below that layer as a docker-mode
+    implementation detail used by the orchestrator's Case A path (shared
+    runtime + built-in stack) and as the engine-image builder for the
+    ``:local`` alias hook Cases B and C consume. See ADR-0018 for the full
+    case matrix and the deliberate non-Protocol rationale.
 
     Supports context manager protocol for automatic cleanup.
 
@@ -200,7 +227,7 @@ class ServiceStack(BaseModel):
         prefix: Prefix for container and network names.
 
     Example:
-        >>> stack = ServiceStack()
+        >>> stack = EngineStack()
         >>> stack.add_service(db_service_def)
         >>> stack.add_service(runner_def)
         >>> with stack:
@@ -941,7 +968,7 @@ class ServiceStack(BaseModel):
 
     # ── Context Manager ─────────────────────────────────────────────────
 
-    def __enter__(self) -> ServiceStack:
+    def __enter__(self) -> EngineStack:
         """Start all services when entering context."""
         self.start_all()
         return self

--- a/tolokaforge/docker/stacks/__init__.py
+++ b/tolokaforge/docker/stacks/__init__.py
@@ -1,6 +1,6 @@
 """Predefined service stacks for TolokaForge.
 
-Provides factory functions that return pre-configured ServiceStack instances
+Provides factory functions that return pre-configured EngineStack instances
 for common deployment scenarios.
 
 Available stacks:

--- a/tolokaforge/docker/stacks/core.py
+++ b/tolokaforge/docker/stacks/core.py
@@ -20,7 +20,7 @@ from tolokaforge.docker.health import HealthProbe
 from tolokaforge.docker.mount import Mount
 from tolokaforge.docker.policy import Capability, ResourcePolicy
 from tolokaforge.docker.ports import PortConfig
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 from tolokaforge.docker.wheel_resolver import resolve_wheel
 
 
@@ -34,7 +34,7 @@ def core_stack(
     extra_runner_binds: list[tuple[Path, str]] | None = None,
     mount_docker_socket: bool = False,
     rag_service_url: str | None = None,
-) -> ServiceStack:
+) -> EngineStack:
     """Create a core service stack with DB service and Runner.
 
     Args:
@@ -66,9 +66,9 @@ def core_stack(
             value, keeping "env present" == "rag-service running".
 
     Returns:
-        ServiceStack configured with db-service and runner.
+        EngineStack configured with db-service and runner.
     """
-    stack = ServiceStack(config=config or DockerConfig())
+    stack = EngineStack(config=config or DockerConfig())
 
     # Build health probe only when the host port is known upfront.
     # When auto-allocated, _start_service will construct the probe

--- a/tolokaforge/docker/stacks/full.py
+++ b/tolokaforge/docker/stacks/full.py
@@ -21,7 +21,7 @@ from tolokaforge.docker.config import DockerConfig
 from tolokaforge.docker.health import HealthProbe
 from tolokaforge.docker.mount import Mount
 from tolokaforge.docker.ports import PortConfig
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 from tolokaforge.docker.stacks.core import core_stack
 from tolokaforge.docker.wheel_resolver import resolve_wheel
 
@@ -37,7 +37,7 @@ def full_stack(
     task_pack_mounts: list[Path] | None = None,
     extra_runner_binds: list[tuple[Path, str]] | None = None,
     mount_docker_socket: bool = False,
-) -> ServiceStack:
+) -> EngineStack:
     """Create a full service stack with all services.
 
     Includes:
@@ -59,7 +59,7 @@ def full_stack(
         mount_docker_socket: Forwarded to ``core_stack``.
 
     Returns:
-        ServiceStack configured with all services.
+        EngineStack configured with all services.
     """
     stack = core_stack(
         config=config,

--- a/tolokaforge/docker/stacks/test.py
+++ b/tolokaforge/docker/stacks/test.py
@@ -15,12 +15,12 @@ from __future__ import annotations
 from tolokaforge.docker.config import DockerConfig
 from tolokaforge.docker.policy import Capability, ResourcePolicy
 from tolokaforge.docker.ports import PortConfig
-from tolokaforge.docker.stack import ServiceDefinition, ServiceStack
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
 
 
 def test_stack(
     config: DockerConfig | None = None,
-) -> ServiceStack:
+) -> EngineStack:
     """Create a test service stack with auto-allocated ports.
 
     All host ports are "auto" to avoid conflicts in CI environments.
@@ -29,9 +29,9 @@ def test_stack(
         config: Optional DockerConfig. Uses defaults if None.
 
     Returns:
-        ServiceStack configured for testing.
+        EngineStack configured for testing.
     """
-    stack = ServiceStack(
+    stack = EngineStack(
         config=config or DockerConfig(),
         prefix="tolokaforge-test",
     )

--- a/tolokaforge/docker/stacks/typesense.py
+++ b/tolokaforge/docker/stacks/typesense.py
@@ -1,4 +1,4 @@
-"""TypeSense service definition for use with ServiceStack.
+"""TypeSense service definition for use with EngineStack.
 
 Provides a factory function that creates a ServiceDefinition for
 a TypeSense search server, replacing raw Docker SDK usage in
@@ -6,10 +6,10 @@ typesense_server.py.
 
 Example:
     >>> from tolokaforge.docker.stacks.typesense import typesense_service
-    >>> from tolokaforge.docker.stack import ServiceStack
+    >>> from tolokaforge.docker.stack import EngineStack
     >>>
     >>> svc = typesense_service(port=8108, api_key="test-key")
-    >>> stack = ServiceStack()
+    >>> stack = EngineStack()
     >>> stack.add_service(svc)
     >>> stack.start_all()
 """


### PR DESCRIPTION
## Summary

Renames \`ServiceStack\` → \`EngineStack\` and documents two deliberate constraints on its shape.

**Why now.** In [PR #168](https://github.com/Toloka/tolokaforge/pull/168)'s ADR-0018 discussion, Ciro flagged that \`ServiceStack\` reads as a substrate-agnostic \"generic stack of services\" primitive when the implementation is actually docker-only AND engine-scoped:

- **Docker-only** — drives \`docker-py\` directly.
- **Engine-scoped** — only ever materialises the engine's built-in services (\`core_stack\` = runner + db-service; \`full_stack\` adds mock-web + rag-service). Arbitrary user-defined services from \`environment_manifest.compose_file\` are materialised elsewhere (via testcontainers-\`DockerCompose\` inside the concrete \`RuntimeBackend\` implementations).

The old name did zero work — could have been labelled \`Foo\` and meant the same thing.

## The rename

- Class: \`ServiceStack\` → \`EngineStack\`. \"Engine\" signals the scope; docker-mode-ness is signalled by the module path (\`tolokaforge/docker/stack.py\`). Same convention as our RuntimeBackend classes.
- Test-internal classes: \`_FakeServiceStack\` → \`_FakeEngineStack\`, \`TestServiceStack*\` → \`TestEngineStack*\`.
- Log messages, docstrings, and comments in every file that mentioned it (~15 files touched, ~85 references renamed).
- No behaviour change.

## Docstring — deliberate scope

The class docstring now states explicitly what \`EngineStack\` is NOT:

- **Not substrate-agnostic**. A future Kubernetes / Modal backend would ship its own engine-bring-up primitive (or not need one at all if that substrate is always task-declared) — it would not extend or subclass \`EngineStack\`.
- **Not a Protocol**. Sits below the \`RuntimeBackend\` seam as a docker-mode implementation detail. The substrate-agnostic seam is \`RuntimeBackend\` (ADR-0007). D15 in the design doc lists what we plugin-ise; \`EngineStack\` is deliberately not on that list.

## ADR-0018 update

Adds a **\"Naming note: \`EngineStack\` is deliberately docker-only and non-Protocol\"** section to ADR-0018. Captures the same rationale in the public architecture record so future contributors have a durable reference.

Key line: **we don't have a second implementation, we don't know the shape of one, and premature abstraction risks locking in the wrong shape**. If a second engine-stack impl arrives with a demonstrable shape (e.g. a k8s engine-bring-up), Protocol-ising is a 1-hour mechanical refactor when the demand is real. Zero cost to defer.

## Why \`EngineStack\` (not \`DockerEngineStack\` or \`BuiltinStack\`)

Considered:
- \`DockerEngineStack\` — \"docker\" appears twice (module path + class name). Redundant.
- \`BuiltinStack\` — accurate but the name ties to the current dichotomy (built-in vs env_manifest). If we ever add a third composition mode, the name gets awkward.
- \`EngineStack\` — signals the scope (the engine's stack) without redundant/temporary framing. Chosen.

## Test coverage

- 2378 unit + canonical tests pass (unchanged from post-PR #167 baseline).
- No new tests — pure rename, existing tests exercise the renamed class as before.
- Lint clean.

## Test plan

- [x] \`uv run ruff check tolokaforge tests\` clean
- [x] \`uv run pytest tests/ -m unit -q\` → 1965+21 = 1986 unit pass (matches pre-rename)
- [x] \`uv run pytest tests/ -m canonical -q\` → 389 canonical pass
- [ ] Automated Claude review round

## Umbrella

Jira: TECHDEL-466 (Runtime & isolation — Phase 4). Milestone: [#4 Runtime & isolation](https://github.com/Toloka/tolokaforge/milestone/4).