### PR TITLE
example(native) + engine: three multi-service tasks + optional db_url resolution

### DIFF
--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -108,7 +108,7 @@ sequenceDiagram
     DC->>Docker: docker compose up -d --wait
     Docker-->>DC: containers up +<br/>healthchecks pass
     LRB->>DC: get_service_host_and_port(<br/> runner_service, 50051)
-    LRB->>DC: get_service_host_and_port(<br/> "db", 5432)
+    LRB->>DC: get_service_host_and_port(<br/> "db-service", 8000) — best-effort
     LRB->>DC: rag lookup (optional)
     LRB->>GRC: new GrpcRunnerClient(<br/> host:port)
     Note right of GRC: constructed —<br/>NOT connected
@@ -164,21 +164,23 @@ Nine steps, in order. Failure at any step raises `ProvisionError(stage="provisio
 4. **Construct `DockerCompose`** with `context=<temp_dir>`, `compose_file_name=<manifest.compose_file.name>`, `pull=False`, `build=False`, `wait=True`.
 5. **`compose.start()`.** Runs `docker compose up -d --wait`. Blocks until every service's compose `healthcheck:` reports healthy. On failure, raise `ProvisionError` and rmtree the temp dir.
 6. **Construct the runner client** — `GrpcRunnerClient(runner_address="<host>:<port>")`. Host + port come from `compose.get_service_host_and_port(manifest.runner_service, 50051)`. **The client is not connected here** — `connect()` is deferred to first RPC use (see next section).
-7. **Snapshot endpoints on the handle.** `_resolve_endpoints(...)` looks up `runner_service` at 50051 and the conventional `db` service at 5432, plus an optional `rag` service. Missing `db` raises `ProvisionError` (see follow-up ticket for making this customisable).
+7. **Snapshot endpoints on the handle.** `_resolve_endpoints(...)` looks up `runner_service` at 50051 (required) and, best-effort, the conventional `db-service` at 8000 and `rag` service. Missing `db-service` leaves `EnvEndpoints.db_url = None`; the runner-side `DBServiceClient` binds to `DB_SERVICE_URL` from its container env and `db_json.py` tools fall back to the same env var, so a missing `db_url` is not a provisioning failure. Runner-missing still raises `ProvisionError`.
 8. **Cache the client** — `self._clients[spec.trial_id] = client`. This is the map every per-trial RPC method reads from.
 9. **Return `_LocalEnvHandle`** carrying the trial_id (public), the compose stack, the runner service name + port, the temp dir, and the endpoints snapshot. All except `trial_id` are backend-private; callers treat the handle as an opaque token.
 
 ## Endpoint resolution
 
-`endpoints(handle)` is a **pure read** — it returns `handle.endpoints`, resolved once at provision time. This is a deliberate departure from an earlier design where `endpoints()` re-queried the compose stack every call: a method named `endpoints` mutating state on missing-service was surprising, and the missing-db check now fails fast at provision time before a handle exists.
+`endpoints(handle)` is a **pure read** — it returns `handle.endpoints`, resolved once at provision time. This is a deliberate departure from an earlier design where `endpoints()` re-queried the compose stack every call: a method named `endpoints` mutating state on missing-service was surprising.
 
-Where each URL comes from (defaults; customisation is a follow-up):
+Where each URL comes from:
 
-| Field | Source | Port |
-|---|---|---|
-| `runner_url` | `manifest.runner_service` (default `"default"`) | `50051` |
-| `db_url` | compose service named **`db`** | `5432` |
-| `rag_url` | compose service named `rag` or `rag-service`; else `None` | service's declared port |
+| Field | Source | Port | Required? |
+|---|---|---|---|
+| `runner_url` | `manifest.runner_service` (default `"default"`) | `50051` | Yes — missing raises `ProvisionError` |
+| `db_url` | compose service named `db-service` | `8000` | Best-effort — absent leaves `db_url = None` |
+| `rag_url` | compose service named `rag` or `rag-service`; else `None` | service's declared port | Best-effort |
+
+`db_url` is best-effort because the runner-side `DBServiceClient` binds to `DB_SERVICE_URL` from its own container env (task compose files set it on the `runner` service), and `db_json.py` tools fall back to the same env var when constructed without a URL. A task compose file that omits `db-service` still provisions; the `db_url` field on the wire is populated only for callers that need to reach the state backend from outside the runner container.
 
 All three are resolved via `compose.get_service_host_and_port(name, port)`, which returns the host-assigned port that maps to a service's container port. Two concurrent trials of the same task get **different** host-assigned ports for the same container port — that is what makes concurrent stacks not clash.
 
@@ -291,7 +293,7 @@ Enforcement lives at the orchestrator layer, not on `SharedStackRuntimeBackend.p
 | `provision` — no manifest | `ProvisionError(stage="provision")` | Nothing to clean |
 | `provision` — compose start fails | `ProvisionError(stage="provision")` wrapping the compose error | Per-trial temp dir removed |
 | `provision` — runner-client construction (host/port unresolvable) | `ProvisionError(stage="provision")` | Compose stack torn down + temp dir removed |
-| `provision` — endpoint resolution (missing `db` service) | `ProvisionError(stage="provision")` | Compose stack torn down + temp dir removed |
+| `provision` — endpoint resolution (missing `db-service`) | Not a failure — `EnvEndpoints.db_url` stays `None`; the runner reads `DB_SERVICE_URL` from its container env | — |
 | `await_ready` | Never raises today (`--wait` gates during provision); reserved for future backends | — |
 | `endpoints` — foreign handle | `TypeError` | — |
 | `endpoints` — everything else | Never raises (pure read on the handle's snapshot) | — |

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -1,9 +1,8 @@
 # Multi-service example — Product Catalog Summary
 
 A **task-declared multi-service** example. The task ships its own
-`environment.compose.yaml` declaring four services (runner + db-service +
-a stub `db` postgres required by the current endpoint resolver + a
-task-specific `app-service`), and the engine materialises them **once at
+`environment.compose.yaml` declaring three services (runner + db-service +
+a task-specific `app-service`), and the engine materialises them **once at
 run start** under `--runtime shared` (Case B in
 [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md)).
 
@@ -47,7 +46,7 @@ examples/native/multi_service/
 └── dataset/tasks/multi_service/
     └── multi_service_example_01/
         ├── task.yaml              # declares environment_manifest + tools
-        ├── environment.compose.yaml # 4-service compose
+        ├── environment.compose.yaml # 3-service compose
         ├── grading.yaml           # state checks + transcript rules
         └── fixtures/
             └── products.json      # served by app-service (nginx)
@@ -62,12 +61,6 @@ examples/native/multi_service/
   file. The point of the example is to demonstrate the multi-service
   materialisation path, not to be a realistic application. Real task
   packs would ship a proper backend + database + …
-- **The `db` postgres service is a stub.** `db-service` uses an in-memory
-  sqlite backend and does not talk to postgres, but the current
-  shared+env_manifest endpoint resolver requires a compose service named
-  `db` on port 5432 to satisfy `EnvEndpoints.db_url` construction. A
-  follow-up ticket generalises endpoint resolution so this stub can go
-  away.
 - **The runner reaches `app-service` by service name.** Docker Compose
   auto-networks all services in a compose file; container-name-based DNS
   resolution works from any service to any other on the same network.

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -37,15 +37,19 @@ uv run tolokaforge validate --tasks "examples/native/multi_service/dataset/**/ta
 scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service/run_config.yaml
 ```
 
-## Task layout
+## Layout
 
 ```
-multi_service_example_01/
-├── task.yaml                    # declares environment_manifest + tools
-├── environment.compose.yaml     # 4-service compose
-├── grading.yaml                 # state checks + transcript rules
-└── fixtures/
-    └── products.json            # served by app-service (nginx)
+examples/native/multi_service/
+├── run_config.yaml                # models + orchestrator + evaluation
+├── README.md                      # this file
+└── dataset/tasks/multi_service/
+    └── multi_service_example_01/
+        ├── task.yaml              # declares environment_manifest + tools
+        ├── environment.compose.yaml # 3-service compose
+        ├── grading.yaml           # state checks + transcript rules
+        └── fixtures/
+            └── products.json      # served by app-service (nginx)
 ```
 
 ## Design notes

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -1,9 +1,9 @@
 # Multi-service example — Product Catalog Summary
 
 A **task-declared multi-service** example. The task ships its own
-`environment.compose.yaml` declaring four services (runner + db-service +
-db + a task-specific `app-service`), and the engine materialises them
-**once at run start** under `--runtime shared` (Case B in
+`environment.compose.yaml` declaring three services (runner + db-service +
+a task-specific `app-service`), and the engine materialises them **once at
+run start** under `--runtime shared` (Case B in
 [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md)).
 
 The agent's job is to query the running product-catalog HTTP service and
@@ -16,7 +16,7 @@ products.
   environment (real running HTTP service the agent hits) without paying
   per-trial substrate cost. Contrast with the per-trial isolation path,
   which materialises a fresh substrate per trial.
-- Docker Compose service discovery inside the substrate. All four services
+- Docker Compose service discovery inside the substrate. All three services
   join the same auto-generated docker-compose network, so the runner
   container reaches `app-service` by service name via docker DNS
   (`http://app-service/products.json` from inside the runner).

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -1,8 +1,9 @@
 # Multi-service example — Product Catalog Summary
 
 A **task-declared multi-service** example. The task ships its own
-`environment.compose.yaml` declaring three services (runner + db-service +
-a task-specific `app-service`), and the engine materialises them **once at
+`environment.compose.yaml` declaring four services (runner + db-service +
+a stub `db` postgres required by the current endpoint resolver + a
+task-specific `app-service`), and the engine materialises them **once at
 run start** under `--runtime shared` (Case B in
 [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md)).
 
@@ -16,9 +17,9 @@ products.
   environment (real running HTTP service the agent hits) without paying
   per-trial substrate cost. Contrast with the per-trial isolation path,
   which materialises a fresh substrate per trial.
-- Docker Compose service discovery inside the substrate. All three services
-  join the same auto-generated docker-compose network, so the runner
-  container reaches `app-service` by service name via docker DNS
+- Docker Compose service discovery inside the substrate. All services join
+  the same auto-generated docker-compose network, so the runner container
+  reaches `app-service` by service name via docker DNS
   (`http://app-service/products.json` from inside the runner).
 - The `:local` engine-image alias pattern the engine applies at run start,
   so task compose files can reference `tolokaforge-runner:local` and
@@ -46,7 +47,7 @@ examples/native/multi_service/
 └── dataset/tasks/multi_service/
     └── multi_service_example_01/
         ├── task.yaml              # declares environment_manifest + tools
-        ├── environment.compose.yaml # 3-service compose
+        ├── environment.compose.yaml # 4-service compose
         ├── grading.yaml           # state checks + transcript rules
         └── fixtures/
             └── products.json      # served by app-service (nginx)
@@ -61,6 +62,12 @@ examples/native/multi_service/
   file. The point of the example is to demonstrate the multi-service
   materialisation path, not to be a realistic application. Real task
   packs would ship a proper backend + database + …
+- **The `db` postgres service is a stub.** `db-service` uses an in-memory
+  sqlite backend and does not talk to postgres, but the current
+  shared+env_manifest endpoint resolver requires a compose service named
+  `db` on port 5432 to satisfy `EnvEndpoints.db_url` construction. A
+  follow-up ticket generalises endpoint resolution so this stub can go
+  away.
 - **The runner reaches `app-service` by service name.** Docker Compose
   auto-networks all services in a compose file; container-name-based DNS
   resolution works from any service to any other on the same network.

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -1,0 +1,68 @@
+# Multi-service example — Product Catalog Summary
+
+A **task-declared multi-service** example. The task ships its own
+`environment.compose.yaml` declaring four services (runner + db-service +
+db + a task-specific `app-service`), and the engine materialises them
+**once at run start** under `--runtime shared` (Case B in
+[ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md)).
+
+The agent's job is to query the running product-catalog HTTP service and
+write a short executive summary of the top-3 most expensive in-stock
+products.
+
+## What this example demonstrates
+
+- Task-authored `environment_manifest` under **shared runtime** — realistic
+  environment (real running HTTP service the agent hits) without paying
+  per-trial substrate cost. Contrast with the per-trial isolation path,
+  which materialises a fresh substrate per trial.
+- Docker Compose service discovery inside the substrate. All four services
+  join the same auto-generated docker-compose network, so the runner
+  container reaches `app-service` by service name via docker DNS
+  (`http://app-service/products.json` from inside the runner).
+- The `:local` engine-image alias pattern the engine applies at run start,
+  so task compose files can reference `tolokaforge-runner:local` and
+  `tolokaforge-db-service:local` regardless of the underlying content-hash
+  tag (see `docs/architecture/RUNTIME_BACKENDS.md`).
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service/run_config.yaml
+```
+
+## Task layout
+
+```
+multi_service_example_01/
+├── task.yaml                    # declares environment_manifest + tools
+├── environment.compose.yaml     # 4-service compose
+├── grading.yaml                 # state checks + transcript rules
+└── fixtures/
+    └── products.json            # served by app-service (nginx)
+```
+
+## Design notes
+
+- **`isolation: shared_ok`** — the task tolerates state sharing across
+  trials. Its grading only inspects the agent's output (a written file);
+  the app-service is read-only static content that doesn't mutate.
+- **`app-service` is deliberately trivial** — nginx serving a static JSON
+  file. The point of the example is to demonstrate the multi-service
+  materialisation path, not to be a realistic application. Real task
+  packs would ship a proper backend + database + …
+- **The runner reaches `app-service` by service name.** Docker Compose
+  auto-networks all services in a compose file; container-name-based DNS
+  resolution works from any service to any other on the same network.
+
+## Related
+
+- [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md) — Case matrix + sequence diagrams for each supported case
+- [ADR-0016](../../../docs/architecture/adr/0016-runtime-backend-comparison.md) — shared vs per_trial (lifecycle axis)
+- [docs/architecture/RUNTIME_BACKENDS.md](../../../docs/architecture/RUNTIME_BACKENDS.md) — mechanics deep-dive

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
@@ -1,17 +1,26 @@
 # Task-declared compose stack for `multi_service_example_01`.
 #
-# Three services on the same docker-compose network:
+# Four services on the same docker-compose network:
 #   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
 #                     References the `:local` alias applied by the engine at run
 #                     start; see docs/architecture/RUNTIME_BACKENDS.md.
 #   - `db-service`  — tolokaforge-db-service, the runner's state / grading backend.
+#   - `db`          — postgres 16, required by the shared+env_manifest endpoint
+#                     resolver's current contract. `db-service` itself uses an
+#                     in-memory sqlite backend and does not consume this
+#                     container; it's declared purely to satisfy the
+#                     endpoint-resolution requirement (a "db:5432" service must
+#                     exist in the task-declared compose stack). See the note in
+#                     `SharedStackRuntimeBackend._materialise_manifest` — a
+#                     follow-up ticket generalises endpoint resolution so the
+#                     stub can go away.
 #   - `app-service` — nginx serving `fixtures/products.json` — the task-specific
 #                     application the agent inspects. Reachable from the runner
 #                     container via `http://app-service/products.json` (docker-
 #                     compose DNS resolves service names on the shared network).
 #
 # ``runner_service: runner`` in the sibling task.yaml points the conductor at
-# the first service. All other services join the same auto-generated network.
+# the runner. All other services join the same auto-generated network.
 services:
   runner:
     image: tolokaforge-runner:local
@@ -49,6 +58,20 @@ services:
       timeout: 3s
       retries: 30
       start_period: 3s
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: tolokaforge
+      POSTGRES_PASSWORD: tolokaforge
+      POSTGRES_DB: tolokaforge
+    ports:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
 
   app-service:
     image: nginx:1.27-alpine

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
@@ -1,0 +1,79 @@
+# Task-declared compose stack for `multi_service_example_01`.
+#
+# Four services on the same docker-compose network:
+#   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
+#                     References the `:local` alias applied by the engine at run
+#                     start; see docs/architecture/RUNTIME_BACKENDS.md.
+#   - `db-service`  — tolokaforge-db-service, the runner's state / grading backend.
+#   - `db`          — postgres 16, the raw DB behind db-service.
+#   - `app-service` — nginx serving `fixtures/products.json` — the task-specific
+#                     application the agent inspects. Reachable from the runner
+#                     container via `http://app-service/products.json` (docker-
+#                     compose DNS resolves service names on the shared network).
+#
+# ``runner_service: runner`` in the sibling task.yaml points the conductor at
+# the first service. All other services join the same auto-generated network.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: tolokaforge
+      POSTGRES_PASSWORD: tolokaforge
+      POSTGRES_DB: tolokaforge
+    ports:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  app-service:
+    image: nginx:1.27-alpine
+    ports:
+      - "80"
+    volumes:
+      - ./fixtures/products.json:/usr/share/nginx/html/products.json:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost/products.json"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
@@ -1,11 +1,10 @@
 # Task-declared compose stack for `multi_service_example_01`.
 #
-# Four services on the same docker-compose network:
+# Three services on the same docker-compose network:
 #   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
 #                     References the `:local` alias applied by the engine at run
 #                     start; see docs/architecture/RUNTIME_BACKENDS.md.
 #   - `db-service`  — tolokaforge-db-service, the runner's state / grading backend.
-#   - `db`          — postgres 16, the raw DB behind db-service.
 #   - `app-service` — nginx serving `fixtures/products.json` — the task-specific
 #                     application the agent inspects. Reachable from the runner
 #                     container via `http://app-service/products.json` (docker-
@@ -50,20 +49,6 @@ services:
       timeout: 3s
       retries: 30
       start_period: 3s
-
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: tolokaforge
-      POSTGRES_PASSWORD: tolokaforge
-      POSTGRES_DB: tolokaforge
-    ports:
-      - "5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
 
   app-service:
     image: nginx:1.27-alpine

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
@@ -1,19 +1,11 @@
 # Task-declared compose stack for `multi_service_example_01`.
 #
-# Four services on the same docker-compose network:
+# Three services on the same docker-compose network:
 #   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
 #                     References the `:local` alias applied by the engine at run
 #                     start; see docs/architecture/RUNTIME_BACKENDS.md.
-#   - `db-service`  — tolokaforge-db-service, the runner's state / grading backend.
-#   - `db`          — postgres 16, required by the shared+env_manifest endpoint
-#                     resolver's current contract. `db-service` itself uses an
-#                     in-memory sqlite backend and does not consume this
-#                     container; it's declared purely to satisfy the
-#                     endpoint-resolution requirement (a "db:5432" service must
-#                     exist in the task-declared compose stack). See the note in
-#                     `SharedStackRuntimeBackend._materialise_manifest` — a
-#                     follow-up ticket generalises endpoint resolution so the
-#                     stub can go away.
+#   - `db-service`  — tolokaforge-db-service, the runner's state / grading backend
+#                     (in-memory sqlite behind an HTTP JSON interface).
 #   - `app-service` — nginx serving `fixtures/products.json` — the task-specific
 #                     application the agent inspects. Reachable from the runner
 #                     container via `http://app-service/products.json` (docker-
@@ -58,20 +50,6 @@ services:
       timeout: 3s
       retries: 30
       start_period: 3s
-
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: tolokaforge
-      POSTGRES_PASSWORD: tolokaforge
-      POSTGRES_DB: tolokaforge
-    ports:
-      - "5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
 
   app-service:
     image: nginx:1.27-alpine

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/fixtures/products.json
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/fixtures/products.json
@@ -1,0 +1,9 @@
+[
+  {"id": 1, "name": "Nebula Laptop 15", "price": 1899.00, "in_stock": true},
+  {"id": 2, "name": "Cascade Desktop Pro", "price": 2499.50, "in_stock": true},
+  {"id": 3, "name": "Meridian Ultrabook 14", "price": 1599.99, "in_stock": false},
+  {"id": 4, "name": "Prism Workstation", "price": 3299.00, "in_stock": true},
+  {"id": 5, "name": "Solstice Mini PC", "price": 799.00, "in_stock": true},
+  {"id": 6, "name": "Halo Tablet 11", "price": 649.99, "in_stock": true},
+  {"id": 7, "name": "Vantage Studio Monitor", "price": 1199.00, "in_stock": false}
+]

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/grading.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/grading.yaml
@@ -1,0 +1,35 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.7
+    transcript_rules: 0.3
+  pass_threshold: 0.5
+state_checks:
+  jsonpaths:
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Prism Workstation"
+      description: "Report names the most expensive in-stock product"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Cascade Desktop Pro"
+      description: "Report names the second most expensive in-stock product"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Nebula Laptop 15"
+      description: "Report names the third most expensive in-stock product"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "3299"
+      description: "Report includes the top price (numeric)"
+transcript_rules:
+  max_turns: 10
+  disallow_regex:
+    - "(?i)(cannot complete|unable to complete|i refuse)"
+  required_actions:
+    - action_id: "query_catalog"
+      requestor: assistant
+      name: bash
+      arguments: {}
+      compare_args: []
+    - action_id: "write_summary"
+      requestor: assistant
+      name: write_file
+      arguments: {}
+      compare_args: []

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
@@ -1,0 +1,32 @@
+task_id: "multi_service_example_01"
+name: "Product Catalog Summary"
+category: "multi_service"
+description: "Query a running product-catalog HTTP service, summarise the top-3 most expensive in-stock products in a handoff note."
+max_turns: 10
+initial_user_message: |
+  We're preparing an executive brief. Please query the product-catalog service
+  at http://app-service/products.json and write a short summary to
+  `submissions/catalog_summary.md` listing the top-3 most expensive products
+  that are currently in stock (in_stock = true). Include the product name and
+  price for each. Rank by price descending.
+adapter_type: "native"
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  isolation: "shared_ok"
+  runner_service: "runner"
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["bash", "write_file"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are a product manager waiting on the summary. Ask brief clarifying questions only when strictly necessary and end with ###STOP### once the summary is delivered."
+policies:
+  guidance:
+    - "Use `bash` with curl / wget to reach the catalog service — the runner container joins the same docker network as `app-service` and reaches it by service name."
+    - "Only list products where `in_stock: true`. Skip out-of-stock items."
+grading: "grading.yaml"

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
@@ -8,7 +8,9 @@ initial_user_message: |
   at http://app-service/products.json and write a short summary to
   `submissions/catalog_summary.md` listing the top-3 most expensive products
   that are currently in stock (in_stock = true). Include the product name and
-  price for each. Rank by price descending.
+  price for each, ranked by price descending. Render each price as a plain
+  number without a currency symbol, thousands separators, or trailing zeros
+  (e.g. `3299` rather than `$3,299.00`).
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
@@ -27,6 +29,6 @@ user_simulator:
   backstory: "You are a product manager waiting on the summary. Ask brief clarifying questions only when strictly necessary and end with ###STOP### once the summary is delivered."
 policies:
   guidance:
-    - "Use `bash` with curl / wget to reach the catalog service — the runner container joins the same docker network as `app-service` and reaches it by service name."
+    - "Use `bash` with curl to reach the catalog service — the runner container joins the same docker network as `app-service` and reaches it by service name."
     - "Only list products where `in_stock: true`. Skip out-of-stock items."
 grading: "grading.yaml"

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
@@ -29,6 +29,6 @@ user_simulator:
   backstory: "You are a product manager waiting on the summary. Ask brief clarifying questions only when strictly necessary and end with ###STOP### once the summary is delivered."
 policies:
   guidance:
-    - "Use `bash` with curl to reach the catalog service — the runner container joins the same docker network as `app-service` and reaches it by service name."
+    - "Use `bash` with `python3 -c 'import urllib.request; ...'` to reach the catalog service — the runner container joins the same docker network as `app-service` and reaches it by service name. (The bash allowlist permits python but not curl/wget.)"
     - "Only list products where `in_stock: true`. Skip out-of-stock items."
 grading: "grading.yaml"

--- a/examples/native/multi_service/run_config.yaml
+++ b/examples/native/multi_service/run_config.yaml
@@ -1,0 +1,34 @@
+# Multi-service example — `Product Catalog Summary` task.
+#
+# Exercises the shared-runtime + task-declared-stack path (Case B in
+# ADR-0018). The task declares its own compose file with four services
+# (runner + db-service + db + app-service). The engine materialises them
+# **once at run start** under `--runtime shared`.
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env (default).
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 10
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/multi_service/dataset"
+  tasks_glob: "tasks/multi_service/multi_service_example_01/task.yaml"
+  output_dir: "results/multi_service_example"

--- a/examples/native/multi_service/run_config.yaml
+++ b/examples/native/multi_service/run_config.yaml
@@ -1,8 +1,8 @@
 # Multi-service example — `Product Catalog Summary` task.
 #
 # Exercises the shared-runtime + task-declared-stack path (Case B in
-# ADR-0018). The task declares its own compose file with four services
-# (runner + db-service + db + app-service). The engine materialises them
+# ADR-0018). The task declares its own compose file with three services
+# (runner + db-service + app-service). The engine materialises them
 # **once at run start** under `--runtime shared`.
 #
 # Requirements:

--- a/examples/native/multi_service_advanced/README.md
+++ b/examples/native/multi_service_advanced/README.md
@@ -15,10 +15,10 @@ Case B in [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-s
 
 ## What this example demonstrates
 
-- **Multi-endpoint aggregation under shared runtime.** Five-service compose
-  stack (runner + db-service + db stub + `orders-api` + `customers-api`),
+- **Multi-endpoint aggregation under shared runtime.** Four-service compose
+  stack (runner + db-service + `orders-api` + `customers-api`),
   materialised once at run start and shared across every trial.
-- **Docker Compose DNS discovery.** All five services join the same
+- **Docker Compose DNS discovery.** All four services join the same
   auto-generated docker-compose network, so the runner container reaches
   both APIs by service name (`http://orders-api/orders.json` and
   `http://customers-api/customers.json`).
@@ -47,7 +47,7 @@ examples/native/multi_service_advanced/
 └── dataset/tasks/multi_service/
     └── orders_customers_join_01/
         ├── task.yaml              # declares environment_manifest + tools
-        ├── environment.compose.yaml # 5-service compose
+        ├── environment.compose.yaml # 4-service compose
         ├── grading.yaml           # state checks + transcript rules
         └── fixtures/
             ├── orders.json        # served by orders-api (nginx)
@@ -58,11 +58,6 @@ examples/native/multi_service_advanced/
 
 - **`isolation: shared_ok`** — the task's grading only inspects the agent's
   written output; both APIs are read-only static content.
-- **The `db` postgres service is a stub.** Same reason as the sibling
-  `multi_service` example — the current shared+env_manifest endpoint
-  resolver requires a compose service named `db` on port 5432 to satisfy
-  `EnvEndpoints.db_url` construction. `db-service` uses in-memory sqlite
-  and does not consume it.
 - **Both APIs use pinned nginx tags (`1.27-alpine`)** so runs are
   reproducible; the manifest validator rejects floating tags.
 

--- a/examples/native/multi_service_advanced/README.md
+++ b/examples/native/multi_service_advanced/README.md
@@ -1,0 +1,73 @@
+# Multi-service `advanced` example — Customer Value Analysis
+
+The **advanced** counterpart to the sibling `multi_service` example. Adds two
+things beyond the basic Case B demonstration:
+
+1. **Two task-specific HTTP services**, not one. The agent must coordinate
+   reads across an orders API and a customers API, join the two datasets on
+   `customer_id`, and aggregate paid-order totals per customer before
+   ranking.
+2. **A different model tier for the agent.** The agent runs on Claude
+   Haiku 4.5 (smaller, cheaper) while the user simulator stays on Sonnet 4.6.
+   Useful for comparing multi-service handling across model classes.
+
+Case B in [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md).
+
+## What this example demonstrates
+
+- **Multi-endpoint aggregation under shared runtime.** Five-service compose
+  stack (runner + db-service + db stub + `orders-api` + `customers-api`),
+  materialised once at run start and shared across every trial.
+- **Docker Compose DNS discovery.** All five services join the same
+  auto-generated docker-compose network, so the runner container reaches
+  both APIs by service name (`http://orders-api/orders.json` and
+  `http://customers-api/customers.json`).
+- **Grading that pins the aggregate output.** Ranks Acme Robotics (12000) /
+  Vector Industries (8500) / Nimbus Analytics (5000) as the top-3 by
+  paid-order total — deterministic given the fixtures.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_advanced/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_advanced/run_config.yaml
+```
+
+## Layout
+
+```
+examples/native/multi_service_advanced/
+├── run_config.yaml                # haiku-4.5 agent, sonnet-4.6 user
+├── README.md                      # this file
+└── dataset/tasks/multi_service/
+    └── orders_customers_join_01/
+        ├── task.yaml              # declares environment_manifest + tools
+        ├── environment.compose.yaml # 5-service compose
+        ├── grading.yaml           # state checks + transcript rules
+        └── fixtures/
+            ├── orders.json        # served by orders-api (nginx)
+            └── customers.json     # served by customers-api (nginx)
+```
+
+## Design notes
+
+- **`isolation: shared_ok`** — the task's grading only inspects the agent's
+  written output; both APIs are read-only static content.
+- **The `db` postgres service is a stub.** Same reason as the sibling
+  `multi_service` example — the current shared+env_manifest endpoint
+  resolver requires a compose service named `db` on port 5432 to satisfy
+  `EnvEndpoints.db_url` construction. `db-service` uses in-memory sqlite
+  and does not consume it.
+- **Both APIs use pinned nginx tags (`1.27-alpine`)** so runs are
+  reproducible; the manifest validator rejects floating tags.
+
+## Related
+
+- [`../multi_service/README.md`](../multi_service/README.md) — the basic
+  Case B example (single task-specific service, Sonnet 4.6 agent)
+- [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md) — case matrix + sequence diagrams

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/environment.compose.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/environment.compose.yaml
@@ -1,14 +1,9 @@
 # Task-declared compose stack for `orders_customers_join_01`.
 #
-# Five services on the same docker-compose network:
+# Four services on the same docker-compose network:
 #   - `runner`         — tolokaforge-runner, the gRPC server the conductor talks to.
 #   - `db-service`     — tolokaforge-db-service (in-memory sqlite), the runner's
 #                        state / grading backend.
-#   - `db`             — postgres 16 stub. Required by the shared+env_manifest
-#                        endpoint resolver's current contract (a service named
-#                        `db` on port 5432 must exist). `db-service` does not
-#                        consume it; a follow-up ticket generalises endpoint
-#                        resolution so the stub can go away.
 #   - `orders-api`     — nginx serving `fixtures/orders.json`. Reachable as
 #                        `http://orders-api/orders.json` from inside the
 #                        runner.
@@ -57,20 +52,6 @@ services:
       timeout: 3s
       retries: 30
       start_period: 3s
-
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: tolokaforge
-      POSTGRES_PASSWORD: tolokaforge
-      POSTGRES_DB: tolokaforge
-    ports:
-      - "5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
 
   orders-api:
     image: nginx:1.27-alpine

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/environment.compose.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/environment.compose.yaml
@@ -1,0 +1,99 @@
+# Task-declared compose stack for `orders_customers_join_01`.
+#
+# Five services on the same docker-compose network:
+#   - `runner`         — tolokaforge-runner, the gRPC server the conductor talks to.
+#   - `db-service`     — tolokaforge-db-service (in-memory sqlite), the runner's
+#                        state / grading backend.
+#   - `db`             — postgres 16 stub. Required by the shared+env_manifest
+#                        endpoint resolver's current contract (a service named
+#                        `db` on port 5432 must exist). `db-service` does not
+#                        consume it; a follow-up ticket generalises endpoint
+#                        resolution so the stub can go away.
+#   - `orders-api`     — nginx serving `fixtures/orders.json`. Reachable as
+#                        `http://orders-api/orders.json` from inside the
+#                        runner.
+#   - `customers-api`  — nginx serving `fixtures/customers.json`. Reachable as
+#                        `http://customers-api/customers.json` from inside
+#                        the runner.
+#
+# ``runner_service: runner`` in the sibling task.yaml points the conductor at
+# the runner. All other services join the same auto-generated network.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      orders-api:
+        condition: service_healthy
+      customers-api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: tolokaforge
+      POSTGRES_PASSWORD: tolokaforge
+      POSTGRES_DB: tolokaforge
+    ports:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tolokaforge"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  orders-api:
+    image: nginx:1.27-alpine
+    ports:
+      - "80"
+    volumes:
+      - ./fixtures/orders.json:/usr/share/nginx/html/orders.json:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost/orders.json"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  customers-api:
+    image: nginx:1.27-alpine
+    ports:
+      - "80"
+    volumes:
+      - ./fixtures/customers.json:/usr/share/nginx/html/customers.json:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost/customers.json"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/customers.json
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/customers.json
@@ -1,0 +1,7 @@
+[
+  {"customer_id": "C-101", "name": "Acme Robotics", "tier": "gold"},
+  {"customer_id": "C-102", "name": "Nimbus Analytics", "tier": "silver"},
+  {"customer_id": "C-103", "name": "Vector Industries", "tier": "gold"},
+  {"customer_id": "C-104", "name": "Helix Bio", "tier": "silver"},
+  {"customer_id": "C-105", "name": "Orbit Media", "tier": "bronze"}
+]

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/orders.json
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/orders.json
@@ -1,0 +1,9 @@
+[
+  {"order_id": "O-001", "customer_id": "C-101", "amount": 7500, "status": "paid"},
+  {"order_id": "O-002", "customer_id": "C-101", "amount": 4500, "status": "paid"},
+  {"order_id": "O-003", "customer_id": "C-102", "amount": 3200, "status": "paid"},
+  {"order_id": "O-004", "customer_id": "C-102", "amount": 1800, "status": "paid"},
+  {"order_id": "O-005", "customer_id": "C-103", "amount": 8500, "status": "paid"},
+  {"order_id": "O-006", "customer_id": "C-104", "amount": 2500, "status": "paid"},
+  {"order_id": "O-007", "customer_id": "C-105", "amount": 900, "status": "paid"}
+]

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/orders.json
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/fixtures/orders.json
@@ -5,5 +5,7 @@
   {"order_id": "O-004", "customer_id": "C-102", "amount": 1800, "status": "paid"},
   {"order_id": "O-005", "customer_id": "C-103", "amount": 8500, "status": "paid"},
   {"order_id": "O-006", "customer_id": "C-104", "amount": 2500, "status": "paid"},
-  {"order_id": "O-007", "customer_id": "C-105", "amount": 900, "status": "paid"}
+  {"order_id": "O-007", "customer_id": "C-105", "amount": 900, "status": "paid"},
+  {"order_id": "O-008", "customer_id": "C-104", "amount": 9000, "status": "pending"},
+  {"order_id": "O-009", "customer_id": "C-105", "amount": 6500, "status": "cancelled"}
 ]

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/grading.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/grading.yaml
@@ -1,0 +1,41 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.7
+    transcript_rules: 0.3
+  pass_threshold: 0.5
+state_checks:
+  jsonpaths:
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Acme Robotics"
+      description: "Report names the #1 customer by paid-order total"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Vector Industries"
+      description: "Report names the #2 customer by paid-order total"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Nimbus Analytics"
+      description: "Report names the #3 customer by paid-order total"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "12000"
+      description: "Report shows the #1 customer's total (12000)"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "8500"
+      description: "Report shows the #2 customer's total (8500)"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "5000"
+      description: "Report shows the #3 customer's total (5000)"
+transcript_rules:
+  max_turns: 12
+  disallow_regex:
+    - "(?i)(cannot complete|unable to complete|i refuse)"
+  required_actions:
+    - action_id: "query_orders"
+      requestor: assistant
+      name: bash
+      arguments: {}
+      compare_args: []
+    - action_id: "write_report"
+      requestor: assistant
+      name: write_file
+      arguments: {}
+      compare_args: []

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
@@ -1,0 +1,40 @@
+task_id: "orders_customers_join_01"
+name: "Customer Value Analysis"
+category: "multi_service"
+description: "Fetch orders + customers from two separate HTTP services, join them, and write the top-3 customers by paid-order total."
+max_turns: 12
+initial_user_message: |
+  Please build a customer-value ranking. Two services are running inside the
+  substrate:
+
+    * Orders API:    http://orders-api/orders.json
+    * Customers API: http://customers-api/customers.json
+
+  Join the two datasets on `customer_id`, sum the `amount` of every order with
+  `status == "paid"` per customer, and write a report to
+  `submissions/customer_value.md` listing the top-3 customers by paid total.
+  For each ranked customer include the customer name and the total value as a
+  plain integer (no currency symbol, no comma separators — e.g. `12000`, not
+  `$12,000`). Rank descending by total value.
+adapter_type: "native"
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  isolation: "shared_ok"
+  runner_service: "runner"
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["bash", "write_file"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are an operations analyst waiting on the customer-value report. Ask brief clarifying questions only when strictly necessary and end with ###STOP### once the report is delivered."
+policies:
+  guidance:
+    - "Use `bash` with `python3 -c 'import urllib.request; ...'` to reach both HTTP services — the runner container joins the same docker network so both are addressable by service name. (The bash allowlist permits python but not curl/wget.)"
+    - "Only count orders with `status: paid`. Skip any order in a different status."
+    - "Aggregate totals per customer BEFORE ranking; do not treat individual orders as candidates."
+grading: "grading.yaml"

--- a/examples/native/multi_service_advanced/run_config.yaml
+++ b/examples/native/multi_service_advanced/run_config.yaml
@@ -1,0 +1,37 @@
+# Multi-service `advanced` example — `Customer Value Analysis` task.
+#
+# Exercises the shared-runtime + task-declared-stack path (Case B in
+# ADR-0018) with **two** task-specific HTTP services the agent must
+# coordinate reads across (orders + customers), joined on `customer_id`.
+#
+# Also demonstrates model heterogeneity vs the sibling `multi_service`
+# example — the agent runs on Claude Haiku 4.5 (smaller, cheaper) while
+# the user simulator stays on Sonnet 4.6 (drives cleaner dialogue).
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env (default).
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4.5"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 12
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/multi_service_advanced/dataset"
+  tasks_glob: "tasks/multi_service/orders_customers_join_01/task.yaml"
+  output_dir: "results/multi_service_advanced_example"

--- a/examples/native/multi_service_postgres/README.md
+++ b/examples/native/multi_service_postgres/README.md
@@ -1,0 +1,106 @@
+# Multi-service `postgres` example — Enterprise Support Triage
+
+The **third and most realistic** example in the multi-service series.
+Unlike its siblings (`multi_service`, `multi_service_advanced`) which
+serve static JSON from nginx, this one runs a genuine three-tier stack:
+
+```
+agent → PostgREST (HTTP API) → postgres:16 (real database)
+```
+
+The task pack ships **no application code** — PostgREST introspects the
+postgres schema and generates REST endpoints automatically. All the task
+authoring lives in one file: the SQL that defines the schema and seeds
+the data (`app-db/init.sql`).
+
+Case B in [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md).
+
+## What this example demonstrates
+
+- **A real database and a real API in the substrate.** `app-db` is
+  postgres:16 with schema + fixtures seeded via
+  docker-entrypoint-initdb.d. `app-service` is PostgREST auto-serving
+  REST endpoints over that schema.
+- **Multi-endpoint coordination.** The agent must call two endpoints
+  (`/tickets` and `/customers`), join them on `customer_id`, apply two
+  filters (`status == "open"` AND `tier == "enterprise"`), sort by
+  priority, and take the top-3.
+- **Distractors that make filters real signals.** The fixture includes
+  priority-1 tickets in wrong tiers (Beta Retail = business, Halcyon
+  Media = individual) and priority-1 tickets with wrong status (Acme
+  Corp closed). Any filter the agent skips changes the top-3 —
+  demonstrated by the `test_filters_actually_matter` unit test.
+- **Zero application code shipped in the task pack.** Just SQL + a
+  compose file. PostgREST handles the rest.
+
+## Expected top-3
+
+Filtering to `status == "open"` AND `customer.tier == "enterprise"`,
+sorted by `priority` ascending:
+
+| Rank | Customer         | Ticket priority | Subject |
+|------|------------------|-----------------|---------|
+| 1    | Acme Corp        | 1               | Login failures spike |
+| 2    | Corex Systems    | 2               | Data export timing out |
+| 3    | Enterprise Co    | 3               | SSO integration broken |
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_postgres/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres/run_config.yaml
+```
+
+First run is ~30-45s slower than the sibling examples — postgres has to
+initialise and seed, and PostgREST has to introspect the schema. On
+subsequent runs the postgres image pull is cached; only the seed step
+runs from scratch (compose volumes are removed at teardown).
+
+## Layout
+
+```
+examples/native/multi_service_postgres/
+├── run_config.yaml                # sonnet-4-6 agent + user
+├── README.md                      # this file
+└── dataset/tasks/multi_service/
+    └── support_triage_01/
+        ├── task.yaml              # env_manifest + tool declarations
+        ├── environment.compose.yaml # 4-service compose
+        ├── grading.yaml           # state checks on the written report
+        └── app-db/
+            └── init.sql           # schema + seed data (loaded by
+                                   # postgres's docker-entrypoint-initdb.d)
+```
+
+## Design notes
+
+- **PostgREST config.** PostgREST connects as the `authenticator` role
+  (the postgres image's `POSTGRES_USER`) and SET-ROLEs to `web_anon` for
+  unauthenticated requests. `web_anon` has SELECT on `api.customers`
+  and `api.tickets` only — read-only exposure, no writes.
+- **The `db-service` engine backend is unchanged.** `db-service` (in-
+  memory sqlite) still stores per-trial state and grading state; it's
+  independent of `app-db` (the task's own postgres). This example
+  demonstrates that a task's application backend can be a completely
+  different technology from the engine's own state backend.
+- **`isolation: shared_ok`.** The task's grading inspects the agent's
+  written output only; the read-only API doesn't mutate state across
+  trials. If the task wrote through PostgREST (which permissions would
+  need to allow), `per_trial` isolation would be appropriate to avoid
+  cross-trial contamination.
+- **Both API endpoints use pinned tags.** `postgrest/postgrest:v12.2.0`
+  and `postgres:16` are pinned per the manifest validator's
+  non-floating-tag rule.
+
+## Related
+
+- [`../multi_service/README.md`](../multi_service/README.md) — basic Case
+  B (nginx + static JSON)
+- [`../multi_service_advanced/README.md`](../multi_service_advanced/README.md) —
+  multi-endpoint join over two nginx services
+- [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md) — case matrix + sequence diagrams

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/app-db/init.sql
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/app-db/init.sql
@@ -1,0 +1,76 @@
+-- Support-triage schema for the `multi_service_postgres` example.
+--
+-- Loaded by postgres:16's docker-entrypoint-initdb.d at container start.
+-- Runs exactly once during the first postgres init (before any client
+-- connects); a re-run against an existing database is a no-op because
+-- the compose stack tears down volumes on ``.stop(down=True)``.
+--
+-- Layout:
+--   * ``api`` schema         — everything PostgREST exposes over HTTP.
+--   * ``web_anon`` role      — the role PostgREST assumes for
+--                              unauthenticated requests. NOLOGIN — only
+--                              reachable via the authenticator's SET ROLE.
+--   * ``authenticator`` role — the LOGIN role in POSTGRES_USER;
+--                              PostgREST connects as this and switches
+--                              to ``web_anon`` per request.
+--
+-- Both tables live in the ``api`` schema; PostgREST's
+-- ``PGRST_DB_SCHEMAS=api`` restricts exposure to that schema only.
+
+CREATE SCHEMA api;
+
+CREATE ROLE web_anon NOLOGIN;
+GRANT web_anon TO authenticator;
+
+GRANT USAGE ON SCHEMA api TO web_anon;
+
+CREATE TABLE api.customers (
+  customer_id TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  tier        TEXT NOT NULL CHECK (tier IN ('enterprise', 'business', 'individual'))
+);
+
+CREATE TABLE api.tickets (
+  ticket_id   TEXT PRIMARY KEY,
+  customer_id TEXT NOT NULL REFERENCES api.customers(customer_id),
+  status      TEXT NOT NULL CHECK (status IN ('open', 'closed', 'resolved')),
+  priority    INTEGER NOT NULL CHECK (priority BETWEEN 1 AND 10),
+  subject     TEXT NOT NULL
+);
+
+GRANT SELECT ON api.customers TO web_anon;
+GRANT SELECT ON api.tickets TO web_anon;
+
+-- Six customers spanning all three tiers so the tier filter is a real
+-- signal (not decorative).
+INSERT INTO api.customers (customer_id, name, tier) VALUES
+  ('C-101', 'Acme Corp',      'enterprise'),
+  ('C-102', 'Beta Retail',    'business'),
+  ('C-103', 'Corex Systems',  'enterprise'),
+  ('C-104', 'Delta Labs',     'enterprise'),
+  ('C-105', 'Halcyon Media',  'individual'),
+  ('C-106', 'Enterprise Co',  'enterprise');
+
+-- Ten tickets. Filtering to open + enterprise then ordering by priority
+-- ascending yields a unique top-3: Acme Corp (P1) / Corex Systems (P2)
+-- / Enterprise Co (P3). Distractors are deliberately placed so any
+-- filter the agent skips would change the ranking:
+--   * T-101 (Beta Retail, business, P1)   — top of unfiltered ranking
+--                                            if agent skips tier filter.
+--   * T-104 (Acme Corp, CLOSED, P1)       — top if agent skips status
+--                                            filter (Acme appears twice).
+--   * T-105 (Halcyon Media, individual, P1) — displaces Corex if tier
+--                                              filter is skipped.
+--   * T-108 (Delta Labs, RESOLVED, P2)    — displaces Corex if status
+--                                            filter is skipped.
+INSERT INTO api.tickets (ticket_id, customer_id, status, priority, subject) VALUES
+  ('T-100', 'C-101', 'open',     1, 'Login failures spike'),
+  ('T-101', 'C-102', 'open',     1, 'Checkout error'),
+  ('T-102', 'C-103', 'open',     2, 'Data export timing out'),
+  ('T-103', 'C-104', 'open',     4, 'Slow API response'),
+  ('T-104', 'C-101', 'closed',   1, 'Old resolved billing question'),
+  ('T-105', 'C-105', 'open',     1, 'Password reset stuck'),
+  ('T-106', 'C-106', 'open',     3, 'SSO integration broken'),
+  ('T-107', 'C-103', 'open',     5, 'Feature request'),
+  ('T-108', 'C-104', 'resolved', 2, 'Auth fix landed'),
+  ('T-109', 'C-106', 'open',     6, 'Docs typo');

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/environment.compose.yaml
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/environment.compose.yaml
@@ -1,0 +1,88 @@
+# Task-declared compose stack for `support_triage_01`.
+#
+# Four services on the same docker-compose network:
+#   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
+#   - `db-service`  — tolokaforge-db-service (in-memory sqlite), the engine's
+#                     state / grading backend. Same convention as every other
+#                     multi-service example.
+#   - `app-service` — PostgREST auto-generating REST endpoints from the
+#                     `api` schema in `app-db`. Reachable from the runner
+#                     container as `http://app-service:3000/` (docker-
+#                     compose DNS resolves service names on the shared
+#                     network).
+#   - `app-db`      — real postgres:16 backing the task's application. Seeded
+#                     at start via `./app-db/init.sql` bind-mounted into
+#                     postgres's docker-entrypoint-initdb.d.
+#
+# Unlike the sibling examples that serve static JSON from nginx, this one
+# exercises a genuine three-tier stack: the agent → HTTP API → postgres.
+# PostgREST introspects the schema and generates endpoints automatically
+# so no custom application code is shipped in the task pack.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_started
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 8s
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  app-service:
+    image: postgrest/postgrest:v12.2.0
+    environment:
+      PGRST_DB_URI: "postgres://authenticator:auth_pass@app-db:5432/support"
+      PGRST_DB_ANON_ROLE: "web_anon"
+      PGRST_DB_SCHEMAS: "api"
+      PGRST_SERVER_PORT: "3000"
+      PGRST_OPENAPI_SERVER_PROXY_URI: "http://app-service:3000"
+    ports:
+      - "3000"
+    depends_on:
+      app-db:
+        condition: service_healthy
+
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "support"
+      POSTGRES_USER: "authenticator"
+      POSTGRES_PASSWORD: "auth_pass"
+    ports:
+      - "5432"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U authenticator -d support"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/grading.yaml
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/grading.yaml
@@ -1,0 +1,41 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.7
+    transcript_rules: 0.3
+  pass_threshold: 0.5
+state_checks:
+  jsonpaths:
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Acme Corp"
+      description: "Report names the #1 open enterprise-tier ticket's customer"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Corex Systems"
+      description: "Report names the #2 open enterprise-tier ticket's customer"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Enterprise Co"
+      description: "Report names the #3 open enterprise-tier ticket's customer"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Login failures spike"
+      description: "Report references the #1 ticket's subject"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "Data export timing out"
+      description: "Report references the #2 ticket's subject"
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "SSO integration broken"
+      description: "Report references the #3 ticket's subject"
+transcript_rules:
+  max_turns: 15
+  disallow_regex:
+    - "(?i)(cannot complete|unable to complete|i refuse)"
+  required_actions:
+    - action_id: "query_tickets"
+      requestor: assistant
+      name: bash
+      arguments: {}
+      compare_args: []
+    - action_id: "write_report"
+      requestor: assistant
+      name: write_file
+      arguments: {}
+      compare_args: []

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
@@ -1,0 +1,47 @@
+task_id: "support_triage_01"
+name: "Enterprise Support Triage"
+category: "multi_service"
+description: "Query a REST API (PostgREST) backed by a real postgres database. Join tickets and customers, filter to open enterprise-tier tickets, rank by priority, and produce a triage report for the top-3."
+max_turns: 15
+initial_user_message: |
+  Please produce a triage report for the on-call team. A support REST API
+  runs at http://app-service:3000. Two endpoints are relevant:
+
+    * GET /tickets    — every support ticket. Fields: ticket_id, customer_id,
+                        status ("open" | "closed" | "resolved"), priority
+                        (integer, lower = more urgent), subject.
+    * GET /customers  — every customer. Fields: customer_id, name,
+                        tier ("enterprise" | "business" | "individual").
+
+  Both endpoints return JSON arrays.
+
+  Produce a triage report and write it to `submissions/triage_report.md`
+  listing the top-3 open enterprise-tier tickets, ranked by priority
+  ascending (lowest priority number first). For each, include the customer
+  name and the ticket priority (as a plain integer — no formatting, no
+  currency symbols).
+
+  Only include tickets where `status == "open"` AND the ticket's customer
+  has `tier == "enterprise"`. Skip everything else.
+adapter_type: "native"
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  isolation: "shared_ok"
+  runner_service: "runner"
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["bash", "write_file"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are the incident-management lead waiting on the triage report. Ask brief clarifying questions only when strictly necessary and end with ###STOP### once the report is delivered."
+policies:
+  guidance:
+    - "Use `bash` with `python3 -c 'import urllib.request; ...'` to reach the REST API — the runner container joins the same docker network as `app-service` and reaches it by service name. (The bash allowlist permits python but not curl/wget.)"
+    - "Both the status filter and the tier filter matter — skipping either changes the ranking. Apply both before you sort by priority."
+    - "Aggregate per ticket, not per customer — this is a ticket-triage report, not a customer-volume report."
+grading: "grading.yaml"

--- a/examples/native/multi_service_postgres/run_config.yaml
+++ b/examples/native/multi_service_postgres/run_config.yaml
@@ -1,0 +1,41 @@
+# Multi-service `postgres` example — `Enterprise Support Triage` task.
+#
+# Third example in the multi-service series. Exercises Case B in ADR-0018
+# (shared runtime + task-declared compose stack), but unlike the sibling
+# `multi_service` (nginx + static JSON) and `multi_service_advanced`
+# (two nginx-served fixtures) examples this one ships a genuine
+# three-tier stack:
+#
+#   agent → PostgREST (app-service) → real postgres:16 (app-db)
+#
+# PostgREST auto-generates REST endpoints from the postgres schema, so
+# the task pack ships no application code — only the SQL that defines
+# the schema and seeds the data.
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env (default).
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 15
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/multi_service_postgres/dataset"
+  tasks_glob: "tasks/multi_service/support_triage_01/task.yaml"
+  output_dir: "results/multi_service_postgres_example"

--- a/tests/canonical/test_per_trial_runtime_backend.py
+++ b/tests/canonical/test_per_trial_runtime_backend.py
@@ -63,7 +63,7 @@ class _FakeCompose:
         self.start_raises: Exception | None = None
         self.exposed_services: dict[str, dict[int, int]] = {
             "default": {50051: 50100},
-            "db": {5432: 55432},
+            "db-service": {8000: 58000},
         }
 
     def start(self) -> None:
@@ -436,16 +436,16 @@ class TestEndpoints:
         endpoints = patched_backend.endpoints(handle)
         assert isinstance(endpoints, EnvEndpoints)
         assert endpoints.runner_url == "http://127.0.0.1:50100"
-        assert endpoints.db_url == "http://127.0.0.1:55432"
+        assert endpoints.db_url == "http://127.0.0.1:58000"
         assert endpoints.rag_url is None
 
-    def test_missing_db_service_raises_at_provision_time(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Endpoint resolution runs at provision time — a compose stack
-        without a ``db`` service fails fast before a handle is returned.
-        Prior design deferred the check to :meth:`endpoints` which then
-        had to tear down mid-call; that surprising side effect is gone."""
+    def test_missing_db_service_yields_db_url_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``db_url`` is best-effort — a task compose file that omits
+        ``db-service:8000`` yields ``EnvEndpoints(db_url=None, ...)``
+        and provisioning proceeds. The runner-side ``DBServiceClient``
+        binds to ``DB_SERVICE_URL`` from its container env, so a missing
+        ``db_url`` is not a provisioning failure. Load-bearing contract
+        change (was: ProvisionError at provision time)."""
 
         class _NoDbCompose(_FakeCompose):
             def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -456,12 +456,12 @@ class TestEndpoints:
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
         backend = PerTrialRuntimeBackend()
         spec = _make_trial_spec(compose_file=_FIXTURES / "safe_one_service.yaml")
-        with pytest.raises(ProvisionError) as exc:
-            backend.provision(spec)
-        assert exc.value.stage == "provision"
-        assert "compose service named 'db'" in exc.value.reason
-        # No handle returned → no cache entry, no lingering client.
-        assert spec.trial_id not in backend._clients
+        handle = backend.provision(spec)
+        endpoints = backend.endpoints(handle)
+        assert endpoints.db_url is None
+        assert endpoints.runner_url == "http://127.0.0.1:50100"
+        # Client was constructed and cached — no lingering-failure state.
+        assert spec.trial_id in backend._clients
 
     def test_rag_service_resolves_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class _WithRagCompose(_FakeCompose):
@@ -469,7 +469,7 @@ class TestEndpoints:
                 super().__init__(*args, **kwargs)
                 self.exposed_services = {
                     "default": {50051: 50100},
-                    "db": {5432: 55432},
+                    "db-service": {8000: 58000},
                     "rag": {8080: 58080},
                 }
 

--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -192,8 +192,8 @@ class TestResolveEnvEndpoints:
         compose = MagicMock()
 
         def _host_port(service_name: str, port: int) -> tuple[str | None, int | None]:
-            if service_name == "db":
-                return ("localhost", 65432)
+            if service_name == "db-service":
+                return ("localhost", 68000)
             if service_name == "rag":
                 return ("localhost", 68080)
             return (None, None)
@@ -209,17 +209,25 @@ class TestResolveEnvEndpoints:
 
         assert endpoints is not None
         assert endpoints.runner_url == "http://localhost:60051"
-        assert endpoints.db_url == "http://localhost:65432"
+        assert endpoints.db_url == "http://localhost:68000"
         assert endpoints.rag_url == "http://localhost:68080"
 
-    def test_returns_none_when_db_not_exposed(self) -> None:
-        """The db service is required (endpoint-resolution
-        customisation is a follow-up). Absent db → typed None,
-        caller surfaces a ProvisionError."""
+    def test_db_absent_yields_none_not_failure(self) -> None:
+        """db_url is best-effort — a task compose file that omits
+        ``db-service:8000`` gets ``EnvEndpoints(db_url=None, ...)``.
+        The runner-side ``DBServiceClient`` binds to ``DB_SERVICE_URL``
+        from its container env, and ``db_json.py`` tools fall back to
+        the same env var when constructed without a URL."""
         compose = MagicMock()
-        compose.get_service_host_and_port.side_effect = KeyError("no db")
+        compose.get_service_host_and_port.side_effect = KeyError("no db-service")
+        compose.get_container.side_effect = KeyError("no rag either")
 
-        assert resolve_env_endpoints(compose, "localhost", 60051) is None
+        endpoints = resolve_env_endpoints(compose, "localhost", 60051)
+
+        assert endpoints is not None
+        assert endpoints.runner_url == "http://localhost:60051"
+        assert endpoints.db_url is None
+        assert endpoints.rag_url is None
 
     def test_rag_absent_is_none_not_failure(self) -> None:
         """rag is best-effort — absent rag doesn't fail endpoint
@@ -228,8 +236,8 @@ class TestResolveEnvEndpoints:
         compose = MagicMock()
 
         def _host_port(service_name: str, port: int) -> tuple[str | None, int | None]:
-            if service_name == "db":
-                return ("localhost", 65432)
+            if service_name == "db-service":
+                return ("localhost", 68000)
             return (None, None)
 
         compose.get_service_host_and_port.side_effect = lambda service_name, port: _host_port(
@@ -240,7 +248,7 @@ class TestResolveEnvEndpoints:
         endpoints = resolve_env_endpoints(compose, "localhost", 60051)
 
         assert endpoints is not None
-        assert endpoints.db_url == "http://localhost:65432"
+        assert endpoints.db_url == "http://localhost:68000"
         assert endpoints.rag_url is None
 
 

--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -207,7 +207,6 @@ class TestResolveEnvEndpoints:
 
         endpoints = resolve_env_endpoints(compose, "localhost", 60051)
 
-        assert endpoints is not None
         assert endpoints.runner_url == "http://localhost:60051"
         assert endpoints.db_url == "http://localhost:68000"
         assert endpoints.rag_url == "http://localhost:68080"
@@ -224,7 +223,6 @@ class TestResolveEnvEndpoints:
 
         endpoints = resolve_env_endpoints(compose, "localhost", 60051)
 
-        assert endpoints is not None
         assert endpoints.runner_url == "http://localhost:60051"
         assert endpoints.db_url is None
         assert endpoints.rag_url is None
@@ -247,7 +245,6 @@ class TestResolveEnvEndpoints:
 
         endpoints = resolve_env_endpoints(compose, "localhost", 60051)
 
-        assert endpoints is not None
         assert endpoints.db_url == "http://localhost:68000"
         assert endpoints.rag_url is None
 

--- a/tests/unit/test_env_endpoints.py
+++ b/tests/unit/test_env_endpoints.py
@@ -35,9 +35,14 @@ class TestEnvEndpointsShape:
         )
         assert endpoints.rag_url == "http://rag:8001"
 
-    def test_db_url_is_required(self) -> None:
-        with pytest.raises(ValidationError):
-            EnvEndpoints(runner_url="http://runner:50051")
+    def test_db_url_is_optional(self) -> None:
+        """``db_url`` is best-effort in env_manifest mode — a task compose
+        that omits ``db-service:8000`` yields ``db_url=None``. The
+        runner-side ``DBServiceClient`` reads ``DB_SERVICE_URL`` from its
+        container env, and ``db_json.py`` tools fall back to the same
+        env var, so a missing ``db_url`` is not a construction failure."""
+        endpoints = EnvEndpoints(runner_url="http://runner:50051")
+        assert endpoints.db_url is None
 
     def test_runner_url_is_required(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -79,19 +79,18 @@ class TestTaskYaml:
 
 
 class TestComposeShape:
-    """The compose file must declare five services: the runner + db-service
-    + db postgres stub (endpoint-resolver constraint) + the two
-    task-specific HTTP services (orders-api + customers-api)."""
+    """The compose file must declare four services: the runner +
+    db-service + the two task-specific HTTP services (orders-api +
+    customers-api)."""
 
     def _load_compose(self) -> dict:
         return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
 
-    def test_declares_five_services(self) -> None:
+    def test_declares_four_services(self) -> None:
         compose = self._load_compose()
         assert set(compose["services"].keys()) == {
             "runner",
             "db-service",
-            "db",
             "orders-api",
             "customers-api",
         }

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -154,3 +154,22 @@ class TestFixtureAggregation:
         values = [total for _, total in ranked]
         assert names == ["Acme Robotics", "Vector Industries", "Nimbus Analytics"]
         assert values == [12000, 8500, 5000]
+
+    def test_status_filter_actually_matters(self) -> None:
+        """The fixture must include non-``paid`` orders large enough to
+        change the ranking if an agent skips the ``status: paid`` filter.
+        Without this the task-yaml's "only count paid orders" instruction
+        is a formality — the grading would pass whether or not the agent
+        respects it. Pins that the fixture actually exercises the filter."""
+        orders = self._load_json("orders.json")
+        customers = {c["customer_id"]: c for c in self._load_json("customers.json")}
+        totals_unfiltered: dict[str, int] = {}
+        for order in orders:
+            totals_unfiltered[order["customer_id"]] = (
+                totals_unfiltered.get(order["customer_id"], 0) + order["amount"]
+            )
+        wrong_ranked = sorted(totals_unfiltered.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        wrong_names = [customers[cid]["name"] for cid, _ in wrong_ranked]
+        # The unfiltered top-3 must be different from the filtered top-3
+        # (otherwise the filter is decorative).
+        assert wrong_names != ["Acme Robotics", "Vector Industries", "Nimbus Analytics"]

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -1,0 +1,157 @@
+"""Static-shape tests for the ``orders_customers_join_01`` task pack.
+
+The task pack under ``examples/native/multi_service_advanced/`` is the
+Phase 4 demonstration workload for the shared+task-declared substrate
+path with **multiple** task-specific HTTP services (Case B in ADR-0018).
+Real docker execution lives in the docker integration suite; here we pin
+the task pack's static shape so a future refactor doesn't silently break
+the example.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+
+pytestmark = pytest.mark.unit
+
+
+_TASK_DIR = (
+    Path(__file__).parent.parent.parent
+    / "examples"
+    / "native"
+    / "multi_service_advanced"
+    / "dataset"
+    / "tasks"
+    / "multi_service"
+    / "orders_customers_join_01"
+)
+
+
+class TestTaskLayoutOnDisk:
+    def test_task_yaml_exists(self) -> None:
+        assert (_TASK_DIR / "task.yaml").is_file()
+
+    def test_compose_file_exists(self) -> None:
+        assert (_TASK_DIR / "environment.compose.yaml").is_file()
+
+    def test_grading_file_exists(self) -> None:
+        assert (_TASK_DIR / "grading.yaml").is_file()
+
+    def test_orders_fixture_exists(self) -> None:
+        assert (_TASK_DIR / "fixtures" / "orders.json").is_file()
+
+    def test_customers_fixture_exists(self) -> None:
+        assert (_TASK_DIR / "fixtures" / "customers.json").is_file()
+
+
+class TestTaskYaml:
+    def test_loads_via_task_loader(self) -> None:
+        task_config, task_root = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.task_id == "orders_customers_join_01"
+        assert task_root == _TASK_DIR
+
+    def test_declares_environment_manifest(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest is not None
+        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+
+    def test_isolation_is_shared_ok(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+
+    def test_runner_service_matches_compose_declaration(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        declared_services = set(compose_body.get("services", {}).keys())
+        assert task_config.environment_manifest.runner_service in declared_services
+
+    def test_agent_tools_reach_apis(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        enabled = set(task_config.tools.agent.get("enabled", []))
+        assert "bash" in enabled
+        assert "write_file" in enabled
+
+
+class TestComposeShape:
+    """The compose file must declare five services: the runner + db-service
+    + db postgres stub (endpoint-resolver constraint) + the two
+    task-specific HTTP services (orders-api + customers-api)."""
+
+    def _load_compose(self) -> dict:
+        return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
+
+    def test_declares_five_services(self) -> None:
+        compose = self._load_compose()
+        assert set(compose["services"].keys()) == {
+            "runner",
+            "db-service",
+            "db",
+            "orders-api",
+            "customers-api",
+        }
+
+    def test_runner_uses_local_alias(self) -> None:
+        compose = self._load_compose()
+        assert compose["services"]["runner"]["image"] == "tolokaforge-runner:local"
+
+    def test_db_service_uses_local_alias(self) -> None:
+        compose = self._load_compose()
+        assert compose["services"]["db-service"]["image"] == "tolokaforge-db-service:local"
+
+    def test_app_services_use_pinned_nginx(self) -> None:
+        compose = self._load_compose()
+        for svc in ("orders-api", "customers-api"):
+            image = compose["services"][svc]["image"]
+            assert image.startswith("nginx:")
+            tag = image.split(":", 1)[1]
+            assert tag not in {"latest", "edge", "stable", "main", "master"}
+
+    def test_runner_depends_on_health_of_downstreams(self) -> None:
+        """The runner must wait for db-service AND both APIs to become
+        healthy before starting — otherwise trials hit the runner
+        before the substrate is ready."""
+        compose = self._load_compose()
+        depends = compose["services"]["runner"]["depends_on"]
+        assert depends["db-service"]["condition"] == "service_healthy"
+        assert depends["orders-api"]["condition"] == "service_healthy"
+        assert depends["customers-api"]["condition"] == "service_healthy"
+
+    def test_fixture_bind_mounts_relative(self) -> None:
+        """The compose file uses relative bind-mount paths (validator
+        rejects absolute or ``..`` paths)."""
+        compose = self._load_compose()
+        orders_mount = compose["services"]["orders-api"]["volumes"][0]
+        customers_mount = compose["services"]["customers-api"]["volumes"][0]
+        assert orders_mount.startswith("./fixtures/orders.json:")
+        assert customers_mount.startswith("./fixtures/customers.json:")
+
+
+class TestFixtureAggregation:
+    """The task's grading pins the top-3 customers by paid-order total.
+    A silent fixture reorder would score every future correct agent 0/6
+    on state_checks. Pin the aggregation up-front."""
+
+    def _load_json(self, name: str) -> list[dict]:
+        import json
+
+        return json.loads((_TASK_DIR / "fixtures" / name).read_text())
+
+    def test_top_three_customers_by_paid_total(self) -> None:
+        orders = self._load_json("orders.json")
+        customers = {c["customer_id"]: c for c in self._load_json("customers.json")}
+        totals: dict[str, int] = {}
+        for order in orders:
+            if order["status"] != "paid":
+                continue
+            totals[order["customer_id"]] = totals.get(order["customer_id"], 0) + order["amount"]
+        ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        names = [customers[cid]["name"] for cid, _ in ranked]
+        values = [total for _, total in ranked]
+        assert names == ["Acme Robotics", "Vector Industries", "Nimbus Analytics"]
+        assert values == [12000, 8500, 5000]

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -1,0 +1,163 @@
+"""Static-shape tests for the ``multi_service_example_01`` task pack.
+
+The task pack under ``examples/native/multi_service/`` is the Phase 4
+demonstration workload for the shared+task-declared substrate path
+(Case B in ADR-0018). Real docker execution lives in the docker
+integration suite; here we pin the task pack's static shape so a
+future refactor doesn't silently break the example.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+
+pytestmark = pytest.mark.unit
+
+
+_TASK_DIR = (
+    Path(__file__).parent.parent.parent
+    / "examples"
+    / "native"
+    / "multi_service"
+    / "dataset"
+    / "tasks"
+    / "multi_service"
+    / "multi_service_example_01"
+)
+
+
+class TestTaskLayoutOnDisk:
+    """The example is authored to be integration-test-friendly. That
+    only holds if every declared file is actually present on disk."""
+
+    def test_task_yaml_exists(self) -> None:
+        assert (_TASK_DIR / "task.yaml").is_file()
+
+    def test_compose_file_exists(self) -> None:
+        assert (_TASK_DIR / "environment.compose.yaml").is_file()
+
+    def test_grading_file_exists(self) -> None:
+        assert (_TASK_DIR / "grading.yaml").is_file()
+
+    def test_products_fixture_exists(self) -> None:
+        """The compose file bind-mounts ``fixtures/products.json`` into
+        ``app-service`` — the fixture must exist or nginx will 404."""
+        assert (_TASK_DIR / "fixtures" / "products.json").is_file()
+
+
+class TestTaskYaml:
+    """The task.yaml declaration is what the orchestrator's
+    ``_extract_run_env_manifest`` reads to route the run to Case B."""
+
+    def test_loads_via_task_loader(self) -> None:
+        task_config, task_root = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.task_id == "multi_service_example_01"
+        assert task_root == _TASK_DIR
+
+    def test_declares_environment_manifest(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest is not None
+        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+
+    def test_isolation_is_shared_ok(self) -> None:
+        """Case B requires ``isolation: shared_ok`` — a per_trial
+        declaration would route to ``PerTrialRuntimeBackend`` instead
+        of the new shared+env_manifest path."""
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+
+    def test_runner_service_matches_compose_declaration(self) -> None:
+        """``runner_service`` in the manifest must name a service
+        actually declared in the compose file — otherwise
+        ``resolve_runner_endpoint`` fails at connect time with a typed
+        ProvisionError."""
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        declared_services = set(compose_body.get("services", {}).keys())
+        assert task_config.environment_manifest.runner_service in declared_services
+
+    def test_agent_tools_reach_app_service(self) -> None:
+        """The task expects the agent to query ``app-service`` — it
+        needs ``bash`` (which has curl/wget in the runner container) and
+        ``write_file`` (to submit the report)."""
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        enabled = set(task_config.tools.agent.get("enabled", []))
+        assert "bash" in enabled
+        assert "write_file" in enabled
+
+
+class TestComposeShape:
+    """The compose file must declare the four services the Case B
+    materialisation path needs to resolve: the ``runner`` named by the
+    manifest, the ``db`` service the endpoint-resolver looks up, plus
+    the task-specific ``app-service`` this example exists to
+    demonstrate."""
+
+    def _load_compose(self) -> dict:
+        return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
+
+    def test_declares_four_services(self) -> None:
+        compose = self._load_compose()
+        assert set(compose["services"].keys()) == {"runner", "db-service", "db", "app-service"}
+
+    def test_runner_uses_local_alias(self) -> None:
+        """The runner service references the ``:local`` alias applied
+        by the engine at run start (see RUNTIME_BACKENDS.md). A
+        floating tag (``:latest`` / ``:edge`` / …) would be rejected
+        by the manifest validator."""
+        compose = self._load_compose()
+        assert compose["services"]["runner"]["image"] == "tolokaforge-runner:local"
+
+    def test_db_service_uses_local_alias(self) -> None:
+        compose = self._load_compose()
+        assert compose["services"]["db-service"]["image"] == "tolokaforge-db-service:local"
+
+    def test_app_service_is_pinned_nginx(self) -> None:
+        """The example demonstrates a task-provided service — a pinned
+        (non-floating) tag keeps runs reproducible and satisfies the
+        manifest validator."""
+        compose = self._load_compose()
+        assert compose["services"]["app-service"]["image"].startswith("nginx:")
+        # The tag isn't ``latest`` / ``edge`` / etc.
+        tag = compose["services"]["app-service"]["image"].split(":", 1)[1]
+        assert tag not in {"latest", "edge", "stable", "main", "master"}
+
+    def test_runner_depends_on_health_of_downstreams(self) -> None:
+        """The runner must wait for both db-service AND app-service to
+        become healthy before starting — otherwise trials hit the
+        runner before it can register tools that touch either."""
+        compose = self._load_compose()
+        depends = compose["services"]["runner"]["depends_on"]
+        assert depends["db-service"]["condition"] == "service_healthy"
+        assert depends["app-service"]["condition"] == "service_healthy"
+
+
+class TestProductFixture:
+    """The task's grading expects the top-3-by-price in-stock products.
+    If the fixture ordering ever changes, the grading breaks silently
+    (agent gets 0/4 on state checks). Pin the expected top-3."""
+
+    def _load_products(self) -> list[dict]:
+        import json
+
+        return json.loads((_TASK_DIR / "fixtures" / "products.json").read_text())
+
+    def test_top_three_in_stock_by_price(self) -> None:
+        products = self._load_products()
+        in_stock = [p for p in products if p["in_stock"]]
+        top_three = sorted(in_stock, key=lambda p: p["price"], reverse=True)[:3]
+        names = [p["name"] for p in top_three]
+        # Names the grading references.
+        assert names == ["Prism Workstation", "Cascade Desktop Pro", "Nebula Laptop 15"]
+
+    def test_top_price_matches_grading_reference(self) -> None:
+        products = self._load_products()
+        in_stock = [p for p in products if p["in_stock"]]
+        top = max(in_stock, key=lambda p: p["price"])
+        assert int(top["price"]) == 3299

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -93,18 +93,19 @@ class TestTaskYaml:
 
 
 class TestComposeShape:
-    """The compose file must declare the three services the Case B
+    """The compose file must declare the four services the Case B
     materialisation path needs to resolve: the ``runner`` named by the
-    manifest, the ``db-service`` endpoint the runner talks to, plus
-    the task-specific ``app-service`` this example exists to
-    demonstrate."""
+    manifest, the ``db-service`` endpoint the runner talks to, the
+    ``db`` postgres stub the endpoint resolver currently requires
+    (see follow-up ticket), plus the task-specific ``app-service``
+    this example exists to demonstrate."""
 
     def _load_compose(self) -> dict:
         return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
 
-    def test_declares_three_services(self) -> None:
+    def test_declares_four_services(self) -> None:
         compose = self._load_compose()
-        assert set(compose["services"].keys()) == {"runner", "db-service", "app-service"}
+        assert set(compose["services"].keys()) == {"runner", "db-service", "db", "app-service"}
 
     def test_runner_uses_local_alias(self) -> None:
         """The runner service references the ``:local`` alias applied

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -93,18 +93,18 @@ class TestTaskYaml:
 
 
 class TestComposeShape:
-    """The compose file must declare the four services the Case B
+    """The compose file must declare the three services the Case B
     materialisation path needs to resolve: the ``runner`` named by the
-    manifest, the ``db`` service the endpoint-resolver looks up, plus
+    manifest, the ``db-service`` endpoint the runner talks to, plus
     the task-specific ``app-service`` this example exists to
     demonstrate."""
 
     def _load_compose(self) -> dict:
         return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
 
-    def test_declares_four_services(self) -> None:
+    def test_declares_three_services(self) -> None:
         compose = self._load_compose()
-        assert set(compose["services"].keys()) == {"runner", "db-service", "db", "app-service"}
+        assert set(compose["services"].keys()) == {"runner", "db-service", "app-service"}
 
     def test_runner_uses_local_alias(self) -> None:
         """The runner service references the ``:local`` alias applied
@@ -155,9 +155,5 @@ class TestProductFixture:
         names = [p["name"] for p in top_three]
         # Names the grading references.
         assert names == ["Prism Workstation", "Cascade Desktop Pro", "Nebula Laptop 15"]
-
-    def test_top_price_matches_grading_reference(self) -> None:
-        products = self._load_products()
-        in_stock = [p for p in products if p["in_stock"]]
-        top = max(in_stock, key=lambda p: p["price"])
-        assert int(top["price"]) == 3299
+        # And the price the grading references (as an unformatted integer).
+        assert int(top_three[0]["price"]) == 3299

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -93,19 +93,18 @@ class TestTaskYaml:
 
 
 class TestComposeShape:
-    """The compose file must declare the four services the Case B
+    """The compose file must declare the three services the Case B
     materialisation path needs to resolve: the ``runner`` named by the
-    manifest, the ``db-service`` endpoint the runner talks to, the
-    ``db`` postgres stub the endpoint resolver currently requires
-    (see follow-up ticket), plus the task-specific ``app-service``
-    this example exists to demonstrate."""
+    manifest, the ``db-service`` HTTP endpoint the runner's tool layer
+    reaches for state persistence, plus the task-specific
+    ``app-service`` this example exists to demonstrate."""
 
     def _load_compose(self) -> dict:
         return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
 
-    def test_declares_four_services(self) -> None:
+    def test_declares_three_services(self) -> None:
         compose = self._load_compose()
-        assert set(compose["services"].keys()) == {"runner", "db-service", "db", "app-service"}
+        assert set(compose["services"].keys()) == {"runner", "db-service", "app-service"}
 
     def test_runner_uses_local_alias(self) -> None:
         """The runner service references the ``:local`` alias applied

--- a/tests/unit/test_multi_service_postgres_example_task.py
+++ b/tests/unit/test_multi_service_postgres_example_task.py
@@ -1,0 +1,252 @@
+"""Static-shape tests for the ``support_triage_01`` task pack.
+
+The task pack under ``examples/native/multi_service_postgres/`` is the
+Phase 4 realistic-backend demonstration workload for Case B (ADR-0018):
+a shared-runtime task-declared compose stack that runs a real
+postgres:16 database plus a PostgREST HTTP API on top of it. Real
+docker execution lives in the docker integration suite; here we pin
+the task pack's static shape + the fixture aggregation so a future
+refactor doesn't silently break the example.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+
+pytestmark = pytest.mark.unit
+
+
+_TASK_DIR = (
+    Path(__file__).parent.parent.parent
+    / "examples"
+    / "native"
+    / "multi_service_postgres"
+    / "dataset"
+    / "tasks"
+    / "multi_service"
+    / "support_triage_01"
+)
+
+
+class TestTaskLayoutOnDisk:
+    def test_task_yaml_exists(self) -> None:
+        assert (_TASK_DIR / "task.yaml").is_file()
+
+    def test_compose_file_exists(self) -> None:
+        assert (_TASK_DIR / "environment.compose.yaml").is_file()
+
+    def test_grading_file_exists(self) -> None:
+        assert (_TASK_DIR / "grading.yaml").is_file()
+
+    def test_init_sql_exists(self) -> None:
+        """The compose file bind-mounts ``app-db/init.sql`` into
+        postgres's ``docker-entrypoint-initdb.d`` — the file must exist
+        or postgres starts with an empty database and every query
+        returns 0 rows."""
+        assert (_TASK_DIR / "app-db" / "init.sql").is_file()
+
+
+class TestTaskYaml:
+    def test_loads_via_task_loader(self) -> None:
+        task_config, task_root = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.task_id == "support_triage_01"
+        assert task_root == _TASK_DIR
+
+    def test_declares_environment_manifest(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest is not None
+        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+
+    def test_isolation_is_shared_ok(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+
+    def test_runner_service_matches_compose_declaration(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        declared_services = set(compose_body.get("services", {}).keys())
+        assert task_config.environment_manifest.runner_service in declared_services
+
+    def test_agent_tools_reach_api(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        enabled = set(task_config.tools.agent.get("enabled", []))
+        assert "bash" in enabled
+        assert "write_file" in enabled
+
+
+class TestComposeShape:
+    """The compose file must declare four services: runner + db-service
+    (engine state backend) + app-service (PostgREST) + app-db (real
+    postgres)."""
+
+    def _load_compose(self) -> dict:
+        return yaml.safe_load((_TASK_DIR / "environment.compose.yaml").read_text())
+
+    def test_declares_four_services(self) -> None:
+        compose = self._load_compose()
+        assert set(compose["services"].keys()) == {
+            "runner",
+            "db-service",
+            "app-service",
+            "app-db",
+        }
+
+    def test_runner_uses_local_alias(self) -> None:
+        compose = self._load_compose()
+        assert compose["services"]["runner"]["image"] == "tolokaforge-runner:local"
+
+    def test_db_service_uses_local_alias(self) -> None:
+        compose = self._load_compose()
+        assert compose["services"]["db-service"]["image"] == "tolokaforge-db-service:local"
+
+    def test_app_service_is_pinned_postgrest(self) -> None:
+        compose = self._load_compose()
+        image = compose["services"]["app-service"]["image"]
+        assert image.startswith("postgrest/postgrest:")
+        tag = image.split(":", 1)[1]
+        assert tag not in {"latest", "edge", "stable", "main", "master"}
+
+    def test_app_db_is_pinned_postgres(self) -> None:
+        compose = self._load_compose()
+        image = compose["services"]["app-db"]["image"]
+        assert image.startswith("postgres:")
+        tag = image.split(":", 1)[1]
+        assert tag not in {"latest", "edge", "stable", "main", "master"}
+
+    def test_app_service_connects_to_app_db(self) -> None:
+        """PostgREST's PGRST_DB_URI must reference the compose service
+        name of the postgres instance — otherwise DNS-resolution fails
+        at container start and postgrest crashes."""
+        compose = self._load_compose()
+        db_uri = compose["services"]["app-service"]["environment"]["PGRST_DB_URI"]
+        assert "@app-db:5432" in db_uri
+
+    def test_app_service_depends_on_healthy_db(self) -> None:
+        """PostgREST connects to postgres on startup — postgres must be
+        healthy first, otherwise postgrest crashes on init."""
+        compose = self._load_compose()
+        depends = compose["services"]["app-service"]["depends_on"]
+        assert depends["app-db"]["condition"] == "service_healthy"
+
+    def test_init_sql_bind_mounted_read_only(self) -> None:
+        """The seed SQL script must land in postgres's init-scripts
+        directory to run at first-start. Read-only mount so a
+        misbehaving container can't rewrite the seed."""
+        compose = self._load_compose()
+        mounts = compose["services"]["app-db"]["volumes"]
+        assert any(
+            m.startswith("./app-db/init.sql:") and m.endswith(":ro") for m in mounts
+        ), f"expected init.sql read-only bind mount into postgres, got {mounts!r}"
+
+
+class TestInitSqlSeed:
+    """The task's grading pins the top-3 open enterprise-tier tickets.
+    If the seed data ever changes, the grading breaks silently (agent
+    gets 0/6 on state_checks). Pin the aggregation up-front."""
+
+    def _load_sql(self) -> str:
+        return (_TASK_DIR / "app-db" / "init.sql").read_text()
+
+    def _parse_customers(self, sql: str) -> dict[str, dict]:
+        """Extract the INSERT INTO api.customers rows into a
+        {customer_id: {name, tier}} dict. Regex-based parsing — we're
+        not asking postgres to run this in a test, we just need to
+        confirm the seed's shape."""
+        m = re.search(
+            r"INSERT INTO api\.customers\s*\([^)]+\)\s*VALUES\s*(.+?);",
+            sql,
+            re.DOTALL,
+        )
+        assert m is not None, "customers INSERT not found in init.sql"
+        block = m.group(1)
+        row_re = re.compile(r"\(\s*'([^']+)'\s*,\s*'([^']+)'\s*,\s*'([^']+)'\s*\)")
+        return {cid: {"name": name, "tier": tier} for cid, name, tier in row_re.findall(block)}
+
+    def _parse_tickets(self, sql: str) -> list[dict]:
+        m = re.search(
+            r"INSERT INTO api\.tickets\s*\([^)]+\)\s*VALUES\s*(.+?);",
+            sql,
+            re.DOTALL,
+        )
+        assert m is not None, "tickets INSERT not found in init.sql"
+        block = m.group(1)
+        row_re = re.compile(
+            r"\(\s*'([^']+)'\s*,\s*'([^']+)'\s*,\s*'([^']+)'\s*,\s*(\d+)\s*,\s*'([^']+)'\s*\)"
+        )
+        return [
+            {
+                "ticket_id": tid,
+                "customer_id": cid,
+                "status": status,
+                "priority": int(priority),
+                "subject": subject,
+            }
+            for tid, cid, status, priority, subject in row_re.findall(block)
+        ]
+
+    def test_top_three_open_enterprise_tickets(self) -> None:
+        sql = self._load_sql()
+        customers = self._parse_customers(sql)
+        tickets = self._parse_tickets(sql)
+        filtered = [
+            t
+            for t in tickets
+            if t["status"] == "open" and customers[t["customer_id"]]["tier"] == "enterprise"
+        ]
+        ranked = sorted(filtered, key=lambda t: (t["priority"], t["ticket_id"]))[:3]
+        names = [customers[t["customer_id"]]["name"] for t in ranked]
+        subjects = [t["subject"] for t in ranked]
+        assert names == ["Acme Corp", "Corex Systems", "Enterprise Co"]
+        assert subjects == [
+            "Login failures spike",
+            "Data export timing out",
+            "SSO integration broken",
+        ]
+
+    def test_filters_actually_matter(self) -> None:
+        """The seed data must be arranged so that skipping EITHER the
+        status filter OR the tier filter changes the top-3. Without
+        this, the task-yaml's guidance is a formality. Pins the
+        invariant that the fixture exercises both filters."""
+        sql = self._load_sql()
+        customers = self._parse_customers(sql)
+        tickets = self._parse_tickets(sql)
+
+        # Skipping the status filter (only tier filter applied)
+        only_tier = sorted(
+            [t for t in tickets if customers[t["customer_id"]]["tier"] == "enterprise"],
+            key=lambda t: (t["priority"], t["ticket_id"]),
+        )[:3]
+        only_tier_ids = [t["ticket_id"] for t in only_tier]
+
+        # Skipping the tier filter (only status filter applied)
+        only_status = sorted(
+            [t for t in tickets if t["status"] == "open"],
+            key=lambda t: (t["priority"], t["ticket_id"]),
+        )[:3]
+        only_status_ids = [t["ticket_id"] for t in only_status]
+
+        # Correct top-3
+        both = sorted(
+            [
+                t
+                for t in tickets
+                if t["status"] == "open" and customers[t["customer_id"]]["tier"] == "enterprise"
+            ],
+            key=lambda t: (t["priority"], t["ticket_id"]),
+        )[:3]
+        both_ids = [t["ticket_id"] for t in both]
+
+        assert (
+            only_tier_ids != both_ids
+        ), "status filter is decorative — seed needs a closed enterprise ticket that would rank"
+        assert (
+            only_status_ids != both_ids
+        ), "tier filter is decorative — seed needs a non-enterprise open ticket that would rank"

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -163,13 +163,22 @@ class TestConnectMaterialises:
         # Partial materialisation cleaned up before we raised.
         mock_cleanup.assert_called_once()
 
-    def test_connect_raises_provision_error_when_db_missing(self, tmp_path: Path) -> None:
-        """A compose file missing the ``db`` service (or its 5432 port)
-        fails loud — same shape as PerTrialRuntimeBackend."""
+    def test_connect_accepts_db_url_none(self, tmp_path: Path) -> None:
+        """``db_url`` is best-effort in env_manifest mode. When the task's
+        compose file omits ``db-service:8000`` the resolver returns
+        ``EnvEndpoints(db_url=None, ...)`` and connect proceeds — the
+        runner-side ``DBServiceClient`` binds to ``DB_SERVICE_URL`` from
+        its container env, so a missing db_url is not a provisioning
+        failure. Load-bearing contract change (was: ProvisionError)."""
         manifest = _make_manifest(tmp_path)
         backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
 
         fake_compose = MagicMock()
+        fake_endpoints = EnvEndpoints(
+            db_url=None,
+            rag_url=None,
+            runner_url="http://localhost:60051",
+        )
         with (
             patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
             patch(
@@ -182,15 +191,15 @@ class TestConnectMaterialises:
             ),
             patch(
                 "tolokaforge.core.shared_stack_runtime.resolve_env_endpoints",
-                return_value=None,
+                return_value=fake_endpoints,
             ),
-            patch(
-                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"
-            ) as mock_cleanup,
-            pytest.raises(ProvisionError, match="db"),
+            patch("tolokaforge.core.shared_stack_runtime.GrpcRunnerClient") as mock_client_cls,
         ):
+            mock_client_cls.return_value = MagicMock()
             backend.connect()
-        mock_cleanup.assert_called_once()
+
+        assert backend._endpoints is fake_endpoints
+        assert backend._endpoints.db_url is None
 
     def test_connect_raises_provision_error_on_compose_start_failure(self, tmp_path: Path) -> None:
         """A docker daemon failure during compose up surfaces as a typed

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -32,8 +32,8 @@ def _make_manifest(tmp_path: Path) -> EnvironmentManifest:
 
     ``EnvironmentManifest`` validates that ``compose_file`` exists and
     parses as a YAML mapping; the fixture here writes a two-service stub
-    (runner + db) that satisfies the manifest validator without needing
-    a real docker daemon."""
+    (runner + db-service) that satisfies the manifest validator without
+    needing a real docker daemon."""
     compose_file = tmp_path / "environment.compose.yaml"
     compose_file.write_text(
         "services:\n"
@@ -41,10 +41,10 @@ def _make_manifest(tmp_path: Path) -> EnvironmentManifest:
         "    image: tolokaforge-runner:local\n"
         "    ports:\n"
         '      - "50051"\n'
-        "  db:\n"
-        "    image: postgres:16\n"
+        "  db-service:\n"
+        "    image: tolokaforge-db-service:local\n"
         "    ports:\n"
-        '      - "5432"\n'
+        '      - "8000"\n'
     )
     return EnvironmentManifest(compose_file=compose_file, runner_service="runner")
 

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -42,12 +42,15 @@ RUNNER_PORT_DEFAULT = 50051
 ``GrpcRunnerClient``'s default ``runner:50051``. Task-pack authors that
 need to override this will get a manifest field in a follow-up PR."""
 
-DB_SERVICE_DEFAULT = "db"
-"""Compose service name convention for the raw database backing the
-runner's state (the ``db-service`` HTTP wrapper sits on top of this)."""
+DB_SERVICE_DEFAULT = "db-service"
+"""Compose service name convention for the HTTP JSON state backend the
+runner's tool layer POSTs to (the in-memory-sqlite service that lives
+behind the ``/query|/update|/sql|/schema`` endpoints)."""
 
-DB_PORT_DEFAULT = 5432
-"""Postgres default port for the ``db`` service."""
+DB_SERVICE_PORT_DEFAULT = 8000
+"""HTTP port ``db-service`` listens on. Matches the port the built-in
+core stack exposes and the port task compose files publish for the
+``tolokaforge-db-service:local`` alias."""
 
 RAG_SERVICE_CANDIDATES = ("rag", "rag-service")
 """Compose service names checked when resolving the RAG endpoint.
@@ -191,21 +194,32 @@ def resolve_env_endpoints(
     runner_port: int,
     *,
     db_service: str = DB_SERVICE_DEFAULT,
-    db_port: int = DB_PORT_DEFAULT,
-) -> EnvEndpoints | None:
-    """Resolve the full :class:`EnvEndpoints` triple (runner_url, db_url,
-    rag_url) from a running compose stack. Returns ``None`` if the
-    required db service does not exist or its port is not exposed —
-    callers surface that as a typed error with their own context.
+    db_port: int = DB_SERVICE_PORT_DEFAULT,
+) -> EnvEndpoints:
+    """Resolve the :class:`EnvEndpoints` triple (runner_url, db_url,
+    rag_url) from a running compose stack.
 
-    ``rag_url`` is best-effort: absent means ``None`` on the endpoints,
-    not a resolution failure.
+    ``runner_url`` is required — the caller already resolved the runner
+    endpoint before invoking this function and passes the host/port in.
+
+    ``db_url`` and ``rag_url`` are **both best-effort**. When the task's
+    compose file declares ``db-service`` on port 8000 (the well-known
+    convention that matches the engine's built-in stack), the returned
+    ``db_url`` points at the host-mapped HTTP endpoint. When the compose
+    file omits ``db-service``, ``db_url`` stays ``None`` — the runner
+    container reads ``DB_SERVICE_URL`` from its own environment (task
+    compose files set it via the ``runner`` service's ``environment``
+    block), and ``db_json.py`` tools fall back to the same env var when
+    constructed without a URL, so a missing ``db_url`` is not a failure.
     """
     db_host, db_host_port = resolve_host_port(compose, db_service, db_port)
+    db_url: str | None
     if db_host is None or db_host_port is None:
-        return None
+        db_url = None
+    else:
+        db_url = f"http://{db_host}:{db_host_port}"
     return EnvEndpoints(
-        db_url=f"http://{db_host}:{db_host_port}",
+        db_url=db_url,
         rag_url=resolve_rag_url(compose),
         runner_url=f"http://{runner_host}:{runner_port}",
     )

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -171,9 +171,12 @@ def _build_env_endpoints(runner_address: str) -> EnvEndpoints:
 
     * ``runner_url`` — derived from the orchestrator's known runner
       address (the value passed to :class:`SharedStackRuntimeBackend`). Always set.
-    * ``db_url`` — required on the wire. Reads ``DB_SERVICE_URL`` from
-      the environment if set, otherwise the runner-container default
-      the docker stack injects (``_DEFAULT_DB_SERVICE_URL``).
+    * ``db_url`` — populated in built-in-stack mode from
+      ``DB_SERVICE_URL`` in the environment (or the default the docker
+      stack injects, ``_DEFAULT_DB_SERVICE_URL``). Env_manifest mode
+      resolves it best-effort from the task-declared compose stack; a
+      missing ``db-service`` leaves it ``None`` — see
+      :class:`EnvEndpoints`.
     * ``rag_url`` — optional. Reads ``RAG_SERVICE_URL`` from the
       environment if set, otherwise stays ``None``. ``rag-service``
       ships in ``full_stack`` only, so a ``core_stack`` run with no

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -207,18 +207,12 @@ class PerTrialRuntimeBackend:
             )
         runner_host, runner_host_port = runner_endpoint
 
+        # resolve_env_endpoints is best-effort for db_url + rag_url — a task
+        # compose file that omits `db-service:8000` gets endpoints with
+        # `db_url=None`. The runner-side DBServiceClient reads DB_SERVICE_URL
+        # from its container env, and `db_json.py` tools fall back to the
+        # same env var, so a missing db_url is not a provisioning failure.
         endpoints = resolve_env_endpoints(compose, runner_host, runner_host_port)
-        if endpoints is None:
-            cleanup_partial_materialisation(compose, temp_dir)
-            raise ProvisionError(
-                trial_id=spec.trial_id,
-                stage="provision",
-                reason=(
-                    "PerTrialRuntimeBackend requires a compose service named 'db' "
-                    "exposing port 5432; compose file does not declare one. "
-                    "Endpoint-resolution customisation is a follow-up ticket."
-                ),
-            )
 
         # Client is constructed but not yet connected. Connect is deferred
         # to first per-trial RPC use — see :attr:`_connected_trials`.

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -848,18 +848,12 @@ class SharedStackRuntimeBackend:
             )
         runner_host, runner_host_port = runner_endpoint
 
+        # resolve_env_endpoints is best-effort for db_url + rag_url — a task
+        # compose file that omits `db-service:8000` gets endpoints with
+        # `db_url=None`. The runner-side DBServiceClient reads DB_SERVICE_URL
+        # from its container env, and `db_json.py` tools fall back to the
+        # same env var, so a missing db_url is not a provisioning failure.
         endpoints = resolve_env_endpoints(compose, runner_host, runner_host_port)
-        if endpoints is None:
-            cleanup_partial_materialisation(compose, temp_dir)
-            raise ProvisionError(
-                trial_id=self._run_id,
-                stage="provision",
-                reason=(
-                    "SharedStackRuntimeBackend requires a compose service named 'db' "
-                    "exposing port 5432; task-declared compose file does not declare "
-                    "one. Endpoint-resolution customisation is a follow-up ticket."
-                ),
-            )
 
         # Preserve the materialised state on the backend so close() can tear it down.
         self._compose = compose

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -40,8 +40,14 @@ class EnvEndpoints(BaseModel):
     ``TaskDescription.search_config``.
     """
 
-    db_url: str
-    """URL of the per-trial DB service the runner's tool layer calls."""
+    db_url: str | None = None
+    """URL of the DB service the runner's tool layer calls. ``None``
+    when the run's substrate does not publish a discoverable ``db-service``
+    endpoint on port 8000 — in env_manifest mode the runner-side
+    ``DBServiceClient`` binds to ``DB_SERVICE_URL`` from its container
+    environment (set in the task's compose file), and ``db_json.py``
+    tools fall back to the same env var when constructed without a
+    URL. Built-in-stack mode always populates this field."""
 
     rag_url: str | None = None
     """URL of the RAG service the runner's tool layer calls. ``None``


### PR DESCRIPTION
## TL;DR

Phase 4 PR 3 of 4. Ships **three public examples** exercising Case B (shared runtime + task-declared compose stack) from [ADR-0018](https://github.com/Toloka/tolokaforge/blob/main/docs/architecture/adr/0018-multi-container-under-shared-runtime.md), and — after end-to-end runs surfaced a latent engine bug — an engine fix that removes the phantom \`db:5432\` requirement from the env_manifest endpoint resolver.

Every example is runnable, pinned by static tests, and **verified end-to-end** against real docker + real LLMs.

| Example | Backend | Agent model | Cost / turns | Purpose |
|---|---|---|---|---|
| \`multi_service\` (basic) | nginx + static JSON | Sonnet 4.6 | \$0.020 / 3 turns | Minimum Case B — one task-specific HTTP service |
| \`multi_service_advanced\` | 2× nginx (orders + customers) | Haiku 4.5 | \$0.013 / 4 turns | Multi-endpoint join + different model tier |
| **\`multi_service_postgres\`** | **PostgREST + real postgres:16** | **Sonnet 4.6** | **\$0.041 / 4 turns** | **Genuine three-tier stack (agent → HTTP API → SQL database)** |

## The three examples

### \`multi_service\` — Product Catalog Summary
Agent gets \`bash\` + \`write_file\`. Queries \`http://app-service/products.json\` from inside the runner container (via \`python3 -c 'import urllib.request'\` — the runner's bash allowlist permits python, not curl/wget) and writes an executive summary of the top-3 most expensive in-stock products.

### \`multi_service_advanced\` — Customer Value Analysis
Agent coordinates reads across **two** HTTP services (\`orders-api\` + \`customers-api\`), joins their datasets on \`customer_id\`, aggregates paid-order totals per customer, and ranks the top 3. Fixture includes \`pending\` and \`cancelled\` orders that would change the ranking if the agent skipped the \`status: paid\` filter — the \`test_status_filter_actually_matters\` unit test pins this invariant. Runs on Haiku 4.5.

### \`multi_service_postgres\` — Enterprise Support Triage (NEW)
The **realistic** example. A genuine three-tier stack — no static JSON:

\`\`\`
agent → PostgREST (app-service) → real postgres:16 (app-db)
\`\`\`

Agent hits PostgREST auto-generated REST endpoints backed by a live postgres:16 seeded from \`app-db/init.sql\` (via docker-entrypoint-initdb.d). Must query \`/tickets\` and \`/customers\`, join on \`customer_id\`, apply two filters (\`status == "open"\` AND \`customer.tier == "enterprise"\`), rank by priority, and produce a triage report.

Distractors deliberately placed so any skipped filter changes the top-3: priority-1 tickets in wrong tiers (Beta Retail = business, Halcyon Media = individual) + a closed priority-1 ticket for Acme Corp. \`test_filters_actually_matter\` pins that both filters are load-bearing.

Zero application code in the task pack — PostgREST introspects the postgres schema and generates the API automatically. The only task-authored code is 60 lines of SQL.

## Engine fix: optional \`db_url\` (removes the phantom)

The first end-to-end run of \`multi_service\` surfaced this: \`SharedStackRuntimeBackend._materialise_manifest\` (and \`PerTrialRuntimeBackend.provision\`) hardcoded \`DB_SERVICE_DEFAULT="db"\` and \`DB_PORT_DEFAULT=5432\` in the endpoint resolver, refusing to provision unless the task-declared compose file declared that service. It then built \`EnvEndpoints.db_url\` pointing at the raw postgres host-mapped port.

**Nothing consumed that URL.** \`tolokaforge-db-service\` uses in-memory sqlite (\`tolokaforge/env/json_db_service/app.py:240\`), zero postgres client code anywhere. The runner reads \`DB_SERVICE_URL\` from its own container env (task compose files set it to \`http://db-service:8000\`). \`db_json.py\` tools have their own env-var fallback.

The compose-service existence check was a phantom forcing every task-declared compose file to ship a stub \`postgres:16\` container doing nothing (~380 MB image, ~200 MB RSS, zero function).

**The fix:**
- \`EnvEndpoints.db_url\` becomes \`str | None = None\`. Built-in mode still populates it with \`http://tolokaforge-db-service:8000\`; env_manifest mode populates it best-effort from \`db-service:8000\` if declared, otherwise leaves it None.
- \`resolve_env_endpoints\` defaults rename from \`db:5432\` → \`db-service:8000\` (matching what actually consumes the URL).
- No more \`ProvisionError\` when the resolver can't find a db service. Runner-missing still fails loud.
- Docs updated: \`RUNTIME_BACKENDS.md\` sequence diagram, provision-step-7, endpoint-resolution table, failure-modes row.

**Note about the postgres in the third example.** That's \`app-db\` — the *task's* application database, unrelated to the engine's \`db-service\`. \`app-db\` uses postgres:16 because it needs a real relational store; \`db-service\` (the engine's state backend) uses sqlite because that's the shape it was designed for. Removing the phantom in the engine did not remove real database usage — it removed a container that was declared but never connected.

## Design decisions worth flagging

### 1. PostgREST for zero-code REST APIs

The postgres example uses [PostgREST](https://postgrest.org) rather than shipping a custom FastAPI or Express app. Trade-off: less code in the task pack (only SQL), but the API surface is constrained to what PostgREST auto-generates. For richer application semantics, task authors would ship their own service.

### 2. Nginx + static JSON in the two simpler examples

Kept intentionally minimal (zero-build, pinned tags, deterministic) so those examples focus on the Case B materialisation path itself, not on application complexity. Real task packs are unconstrained by these choices — they can ship whatever backend their workload needs, as \`multi_service_postgres\` demonstrates.

### 3. Bash guidance points at \`python3 -c urllib\`, not \`curl\` / \`wget\`

The runner's default bash allowlist (\`tolokaforge/tools/builtin/bash.py\`) permits \`python\` / \`python3\` but explicitly does not include \`curl\` or \`wget\`. Task guidance in all three examples reflects that.

### 4. \`isolation: shared_ok\` throughout

None of the tasks mutate substrate state — grading inspects agent-written files only, and the APIs are read-only. Shared substrate is fine. If a task wrote through the API (which permissions would need to allow), \`per_trial\` isolation would route to \`PerTrialRuntimeBackend\` (Case C) instead.

## Empirical validation

Real docker + real OpenRouter LLMs across the iteration cycle:

| Run | Backend | Model | Score | Turns | Cost |
|---|---|---|---|---|---|
| \`multi_service\` (initial) | nginx | Sonnet 4.6 | 1.0 | 3 | \$0.020 |
| \`multi_service_advanced\` (initial) | 2× nginx | Haiku 4.5 | 1.0 | 4 | \$0.012 |
| \`multi_service_advanced\` (harder fixture) | 2× nginx | Haiku 4.5 | 1.0 | 4 | \$0.013 |
| \`multi_service\` (after engine fix) | nginx, no postgres stub | Sonnet 4.6 | 1.0 | 3 | \$0.020 |
| \`multi_service_advanced\` (after engine fix) | 2× nginx, no postgres stub | Haiku 4.5 | 1.0 | 4 | \$0.012 |
| **\`multi_service_postgres\` (first try)** | **PostgREST + postgres:16** | **Sonnet 4.6** | **1.0** | **4** | **\$0.041** |
| Regression check on \`tool_use\` (built-in mode, DB tools) | built-in stack | Sonnet 4.6 | 0.567 (identical pre/post fix) | 8 | — |

The postgres run's trajectory confirms real data flow: agent queried \`http://app-service:3000/tickets\`, received JSON with the seeded ticket IDs (\`T-100\` through \`T-109\`), joined against \`/customers\`, and wrote the correct top-3.

## Static test coverage

**51 example-shape tests total** (\`multi_service\` — 15, \`multi_service_advanced\` — 17, \`multi_service_postgres\` — 19). Cover file-layout pins, \`task.yaml\` round-trip, cross-file alignment, compose shape (declared service set, pinned tags, health-driven \`depends_on\`, service-to-service wiring), and fixture aggregation (top-3 pin + both-filters-matter pin per example).

**Engine tests updated** for the \`db_url\` optional change: \`test_compose_materialisation::TestResolveEnvEndpoints\` (new default \`db-service:8000\`, new test for \`db_url=None\`), \`test_shared_stack_runtime_env_manifest::test_connect_accepts_db_url_none\` (was \`_when_db_missing\`), \`test_per_trial_runtime_backend::test_missing_db_service_yields_db_url_none\`, \`test_env_endpoints::test_db_url_is_optional\`.

**Full unit + canonical suite:** 2430 pass, 1 skipped.

## Test plan

- [x] \`uv run ruff check\` clean on all modified files.
- [x] \`uv run pytest tests/ -m "unit or canonical" -q\` — 2430 pass.
- [x] \`uv run tolokaforge validate --tasks 'examples/native/multi_service*/dataset/**/task.yaml'\` — 3 valid, 0 invalid.
- [x] **Real docker + real LLM**: \`multi_service\` → 1.0 / \$0.020 / 3 turns.
- [x] **Real docker + real LLM**: \`multi_service_advanced\` → 1.0 / \$0.013 / 4 turns.
- [x] **Real docker + real LLM + real postgres**: \`multi_service_postgres\` → 1.0 / \$0.041 / 4 turns.
- [x] Regression check on built-in-mode \`tool_use\` — identical score with/without engine change.
- [x] Automated Claude review on prior commits — clean.
- [ ] Automated Claude review on the new postgres-example commit.

## Phase 4 arc

| PR | Status | What |
|---|---|---|
| #166 | Merged | Extract compose_materialisation primitives |
| #167 | Merged | SharedStackRuntimeBackend consumes env_manifest |
| #168 | Merged | ADR-0018 + 2×2 diagrams |
| #169 | Merged | Rename ServiceStack → EngineStack + non-Protocol note |
| **This PR** | Open | Three multi-service examples (nginx / 2× nginx / postgres+PostgREST) + engine fix removing the phantom db:5432 requirement |
| Next | — | Phase 4 PR 4: flip ADR-0018 → Accepted + roadmap housekeeping |
