### PR TITLE
docs(adr): flip ADR-0018 to Accepted; add example cross-refs

### DIFF
--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -1,7 +1,7 @@
 # 0018. Multi-container capability under shared runtime
 
-- **Status:** Proposed
-- **Date:** 2026-07-03
+- **Status:** Accepted
+- **Date:** 2026-07-04
 - **Deciders:** @CiroGamboa
 - **Supersedes:** —
 - **Superseded by:** —
@@ -322,12 +322,13 @@ flowchart TB
 
 ### Follow-ups
 
-- **`environment_manifest.compose_file` extension flexibility** — the
-  built-in endpoint conventions (`runner_service` from the manifest, `db`
-  at port 5432, `rag`/`rag-service` at declared port) are hard-coded
-  in `compose_materialisation.py`. A future manifest field
-  (`runner_port` / `db_service` / `db_port` / etc.) lets tasks override.
-  Tracked separately.
+- **Task-declared `db_service` / `db_port` overrides** — the well-known
+  endpoint convention now looks for `db-service` at port 8000, matching
+  the HTTP JSON state backend the engine ships (and dropping the earlier
+  phantom `db:5432` postgres requirement). Task compose files that name
+  their state backend differently would need optional manifest fields
+  to override the defaults. Not needed for any current task; deferred
+  until a real use case surfaces.
 - **TypeSense + task-declared substrates** — a dedicated follow-up ticket
   tracks the unblock (design options: task-declared TypeSense in the
   compose file, per-run bridge to the task-declared network, per-trial
@@ -354,3 +355,7 @@ flowchart TB
   - `tolokaforge/core/orchestrator.py` — `_extract_run_env_manifest`, `task_stack_mode`, backend construction
 - Related docs:
   - `docs/architecture/RUNTIME_BACKENDS.md` — mechanics deep-dive
+- Case B examples (all under `examples/native/`):
+  - `multi_service/` — minimum Case B: one task-specific HTTP service (nginx + static JSON)
+  - `multi_service_advanced/` — multi-endpoint join across two task-specific HTTP services + smaller-model tier (Haiku)
+  - `multi_service_postgres/` — three-tier stack (agent → PostgREST → real `postgres:16`); the task's application backend is a genuine relational database

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -46,4 +46,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0014](0014-trial-grader-protocol.md) | `TrialGrader` Protocol — swappable trial-grading strategy | Accepted |
 | [0015](0015-trial-executor-protocol.md) | `TrialExecutor` Protocol — per-trial substrate-lifecycle seam | Accepted |
 | [0016](0016-runtime-backend-comparison.md) | Runtime backend comparison: `shared` vs `per_trial` (lifecycle axis) | Accepted |
-| [0018](0018-multi-container-under-shared-runtime.md) | Multi-container capability under shared runtime (composition axis) | Proposed |
+| [0018](0018-multi-container-under-shared-runtime.md) | Multi-container capability under shared runtime (composition axis) | Accepted |


### PR DESCRIPTION
## TL;DR

Closes out the multi-container-under-shared-runtime work. ADR-0018 has been shipped end-to-end (backend + primitives + three public examples all merged on `main`); this PR flips its status from Proposed to Accepted and sweeps two doc-drift items that came out of the last iteration.

## Changes

- **ADR-0018 status: Proposed → Accepted.** Date updated to today. The design is no longer a proposal — it's the shape of the engine on `main`.
- **ADR index (`docs/architecture/adr/README.md`).** Row updated to `Accepted`.
- **Follow-ups section rewritten.** The "endpoint-resolution flexibility" bullet used to say `db:5432` was hard-coded and would need a manifest override to change. That's no longer accurate — the well-known convention now looks for `db-service:8000` (matching the HTTP JSON state backend the engine actually ships), the phantom `db:5432` requirement is gone, and the *optional* manifest override remains deferred until a real task needs it. Rewrote the bullet to match reality.
- **Case B examples cross-referenced.** Added a `Links → Case B examples` sub-list pointing at the three public examples: `multi_service` (nginx + static JSON), `multi_service_advanced` (multi-endpoint join, Haiku), `multi_service_postgres` (three-tier stack with real `postgres:16`). Readers landing on the ADR can now find the runnable demonstrations.

## What this PR does NOT do

- **No ROADMAP.md update.** That doc is release-triggered per the repo's convention (updated on release cuts, not per-feature merges).
- **No engine code changes.** Pure documentation.

## Test plan

- [x] `docs/architecture/adr/README.md` and `0018-*.md` render correctly (spot-checked table cell + follow-up bullet).
- [x] No `TECHDEL` / `jira` / `implementation-plan` / `cloud_runtime` / `ws[1-9]` leaks (post-flight grep against the PR body clean).
