### PR TITLE
fix(pricing): correct GLM 5.1/5.2 to OpenRouter default rates

### DIFF
--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1815,14 +1815,14 @@
       "cache_read": 0.24
     },
     "z-ai/glm-5.1": {
-      "input": 0.975,
-      "output": 4.3,
-      "cache_read": 0.182
+      "input": 0.966,
+      "output": 3.036,
+      "cache_read": 0.1794
     },
     "z-ai/glm-5.2": {
-      "input": 0.93,
-      "output": 3.0,
-      "cache_read": 0.26
+      "input": 0.574,
+      "output": 1.804,
+      "cache_read": 0.1066
     },
     "z-ai/glm-5v-turbo": {
       "input": 1.2,


### PR DESCRIPTION
## What

Correct the GLM 5.1 / GLM 5.2 rates to OpenRouter's default (representative) pricing.

#123 refreshed these two models but pulled the numbers from a single mid-tier provider endpoint (DigitalOcean for 5.1, DeepInfra for 5.2), which sits ~1.6x above the OpenRouter `/models` rate. This aligns both with the rate `pricing-updater` sources for every other model.

| Model | Before (#123) | After (OR default) |
|---|---|---|
| GLM 5.1 | 0.975 / 4.3 | 0.966 / 3.036 |
| GLM 5.2 | 0.93 / 3.0 | 0.574 / 1.804 |

Rates as of 2026-07-05. `cache_read` aligned to the same default provider. No other models touched — Sonnet and the rest are unchanged.

## Why

The table is sourced from the OpenRouter `/models` representative rate (that is what `pricing-updater` writes). Hand-picking one provider's endpoint from `/models/:id/endpoints` is inconsistent across models and, for GLM, inflated the list-price cost estimates by ~1.6x. GLM is open-weights with ~20+ providers spanning a 2.4x range, so the default rate is the defensible reference; closed models such as Sonnet have a single provider and are unaffected.
