### PR TITLE
fix(docker): materialize engine wheel via reinstall provider (closes #29, #13)

### DIFF
--- a/tests/unit/test_wheel_resolver.py
+++ b/tests/unit/test_wheel_resolver.py
@@ -17,6 +17,7 @@ from tolokaforge.docker.wheel_resolver import (
     NoWheelError,
     PipCacheWheelProvider,
     PipDownloadWheelProvider,
+    ReinstallWheelProvider,
     WheelArtifact,
     WheelProvider,
     WheelResolver,
@@ -24,6 +25,10 @@ from tolokaforge.docker.wheel_resolver import (
     _is_engine_pyproject,
     _pip_wheel_cache_bases,
     _read_pyproject_version,
+    _run,
+    _run_pip,
+    _run_uv,
+    _stderr_tail,
     _uv_cache_bases,
     _uv_cache_dir_from_cli,
     _walk_pip_wheel_caches,
@@ -235,6 +240,62 @@ class TestLocalSourceWheelProvider:
             "/nonexistent/tolokaforge/docker/wh.py",
         ):
             assert provider.provide(cache_dir) is None
+        assert "no engine source tree" in provider.last_failure
+
+    def test_build_wheel_calls_uv_with_correct_args(self, engine_root: Path, cache_dir: Path):
+        """Direct call to _build_wheel (real signature) — catches staticmethod/
+        self-binding regressions the patch-based tests miss."""
+        provider = LocalSourceWheelProvider()
+        captured: list[list[str]] = []
+
+        def fake_run_uv(args, timeout=300):
+            captured.append(args)
+            return True, ""
+
+        with patch(
+            "tolokaforge.docker.wheel_resolver._run_uv",
+            side_effect=fake_run_uv,
+        ):
+            provider._build_wheel(engine_root, cache_dir)
+
+        assert len(captured) == 1
+        assert captured[0][:2] == ["build", "--wheel"]
+        assert str(cache_dir) in captured[0]
+        assert str(engine_root) in captured[0]
+
+    def test_build_wheel_falls_back_to_pip_when_uv_fails(self, engine_root: Path, cache_dir: Path):
+        """uv build failure surfaces via pip wheel fallback."""
+        provider = LocalSourceWheelProvider()
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_uv",
+                return_value=(False, "uv not on PATH"),
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_pip",
+                return_value=(True, ""),
+            ) as mock_pip,
+        ):
+            provider._build_wheel(engine_root, cache_dir)
+        assert mock_pip.call_count == 1
+        assert provider.last_failure == ""
+
+    def test_build_wheel_records_both_failures(self, engine_root: Path, cache_dir: Path):
+        """When BOTH uv and pip fail, last_failure carries both stderrs."""
+        provider = LocalSourceWheelProvider()
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_uv",
+                return_value=(False, "uv not on PATH"),
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_pip",
+                return_value=(False, "pip build failed: missing hatchling"),
+            ),
+        ):
+            provider._build_wheel(engine_root, cache_dir)
+        assert "uv not on PATH" in provider.last_failure
+        assert "missing hatchling" in provider.last_failure
 
     def test_tasks_checkout_yields_none(
         self,
@@ -393,12 +454,13 @@ class TestUvCacheDirFromCli:
 
 
 class TestUvCacheBasesPrecedence:
-    """Lock the precedence: `uv cache dir` (authoritative) > UV_CACHE_DIR env > default.
+    """Precedence: ``UV_CACHE_DIR`` env → ``uv cache dir`` CLI → default (all searched).
 
-    The full matrix of {uv present / uv unavailable} x {UV_CACHE_DIR set / unset}.
-    Behavior must be equivalent to the pre-tweak version in every cell (env and
-    `uv cache dir` never disagree when both are available, because `uv cache dir`
-    itself honors UV_CACHE_DIR).
+    Issue #29 fix: the env var is the most explicit signal a user can send
+    (``astral-sh/setup-uv`` sets it directly). Prior to the fix, a stale or
+    unavailable CLI output could mask an env-var-relocated cache. All three
+    candidates are now deduplicated into the search list rather than
+    short-circuiting on the first — so a wheel present in any of them wins.
     """
 
     @pytest.fixture(autouse=True)
@@ -419,16 +481,15 @@ class TestUvCacheBasesPrecedence:
         self._set_cli(monkeypatch, x)
         assert _uv_cache_bases() == [x, self.default]
 
-    def test_cli_wins_over_env(self, tmp_path, monkeypatch):
-        # uv is authoritative; when present, the UV_CACHE_DIR env value is NOT
-        # added as a separate root (uv cache dir already reflects it).
+    def test_env_precedes_cli(self, tmp_path, monkeypatch):
+        # UV_CACHE_DIR env comes FIRST (most explicit signal); CLI output
+        # comes next; both are searched, so a wheel in either wins.
         x = tmp_path / "x"
         y = tmp_path / "y"
         self._set_cli(monkeypatch, x)
         monkeypatch.setenv("UV_CACHE_DIR", str(y))
         bases = _uv_cache_bases()
-        assert bases == [x, self.default]
-        assert y not in bases
+        assert bases == [y, x, self.default]
 
     def test_env_fallback_when_cli_unavailable(self, tmp_path, monkeypatch):
         y = tmp_path / "y"
@@ -445,6 +506,15 @@ class TestUvCacheBasesPrecedence:
         self._set_cli(monkeypatch, x)
         monkeypatch.setenv("UV_CACHE_DIR", str(x))
         assert _uv_cache_bases() == [x, self.default]
+
+    def test_all_three_distinct_all_searched(self, tmp_path, monkeypatch):
+        # Env, CLI, and default are three different paths — all three must
+        # be in the search list so a wheel in any of them can win.
+        env = tmp_path / "env"
+        cli = tmp_path / "cli"
+        self._set_cli(monkeypatch, cli)
+        monkeypatch.setenv("UV_CACHE_DIR", str(env))
+        assert _uv_cache_bases() == [env, cli, self.default]
 
 
 class TestPipWheelCacheBases:
@@ -608,20 +678,454 @@ class TestGitInstallRelocatedCacheResolution:
 
 
 # ===================================================================
+# _run / _run_pip / _run_uv helpers — subprocess wrappers with stderr surfacing
+# ===================================================================
+
+
+class TestStderrTail:
+    def test_short_text_unchanged(self):
+        assert _stderr_tail("short") == "short"
+
+    def test_empty_text(self):
+        assert _stderr_tail("") == ""
+        assert _stderr_tail("   \n  ") == ""
+
+    def test_long_text_truncated_with_ellipsis(self):
+        long = "x" * 5000
+        result = _stderr_tail(long)
+        assert result.startswith("…")
+        assert len(result) <= 801  # _STDERR_TAIL + the ellipsis char
+
+
+class TestRunHelper:
+    def test_success_returns_ok(self):
+        # `python -c "pass"` — a portable no-op that always exists.
+        import sys as _sys
+
+        ok, err = _run([_sys.executable, "-c", "pass"])
+        assert ok
+        assert err == ""
+
+    def test_missing_binary_returns_false_with_path_error(self):
+        ok, err = _run(["/nonexistent/binary/xyz"])
+        assert not ok
+        assert "not on PATH" in err or "No such file" in err or "failed" in err
+
+    def test_nonzero_exit_captures_stderr(self):
+        import sys as _sys
+
+        ok, err = _run([_sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"])
+        assert not ok
+        assert "boom" in err
+
+
+class TestRunPipEnsurepipRecovery:
+    """The load-bearing fix for issue #13: uv envs omit pip → ensurepip retry."""
+
+    def test_pip_available_first_try(self):
+        with patch(
+            "tolokaforge.docker.wheel_resolver._run",
+            return_value=(True, ""),
+        ) as mock_run:
+            ok, err = _run_pip(["download", "tolokaforge==0.1.0"])
+        assert ok
+        assert err == ""
+        assert mock_run.call_count == 1  # no ensurepip needed
+
+    def test_missing_pip_triggers_ensurepip_then_retry(self):
+        # First call: pip missing. Second: ensurepip succeeds.
+        # Third: pip retry succeeds.
+        results = iter(
+            [
+                (False, "No module named pip"),
+                (True, ""),  # ensurepip
+                (True, ""),  # pip retry
+            ]
+        )
+        with patch(
+            "tolokaforge.docker.wheel_resolver._run",
+            side_effect=lambda *a, **k: next(results),
+        ) as mock_run:
+            ok, err = _run_pip(["download", "tolokaforge==0.1.0"])
+        assert ok
+        assert err == ""
+        assert mock_run.call_count == 3
+        # Middle call must be ensurepip.
+        second_argv = mock_run.call_args_list[1].args[0]
+        assert second_argv[-2:] == ["-m", "ensurepip"] or "ensurepip" in second_argv
+
+    def test_ensurepip_failure_surfaces_reason(self):
+        results = iter(
+            [
+                (False, "No module named pip"),
+                (False, "ensurepip is disabled in this environment"),
+            ]
+        )
+        with patch(
+            "tolokaforge.docker.wheel_resolver._run",
+            side_effect=lambda *a, **k: next(results),
+        ):
+            ok, err = _run_pip(["download", "tolokaforge==0.1.0"])
+        assert not ok
+        assert "pip missing" in err
+        assert "ensurepip failed" in err
+        assert "disabled" in err
+
+    def test_non_missing_pip_error_returned_immediately(self):
+        # A generic pip error (network 404 etc.) must NOT trigger ensurepip.
+        with patch(
+            "tolokaforge.docker.wheel_resolver._run",
+            return_value=(False, "HTTP 404 for tolokaforge==999"),
+        ) as mock_run:
+            ok, err = _run_pip(["download", "tolokaforge==999"])
+        assert not ok
+        assert "HTTP 404" in err
+        assert mock_run.call_count == 1  # no ensurepip attempted
+
+
+class TestRunUv:
+    def test_uv_absent_returns_false(self):
+        with patch(
+            "tolokaforge.docker.wheel_resolver.shutil.which",
+            return_value=None,
+        ):
+            ok, err = _run_uv(["pip", "download", "x"])
+        assert not ok
+        assert "uv not on PATH" in err
+
+    def test_uv_present_invokes_run(self):
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver.shutil.which",
+                return_value="/usr/bin/uv",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._run",
+                return_value=(True, ""),
+            ) as mock_run,
+        ):
+            ok, err = _run_uv(["pip", "download", "x"])
+        assert ok
+        assert err == ""
+        argv = mock_run.call_args.args[0]
+        assert argv[0] == "uv"
+
+
+# ===================================================================
+# ReinstallWheelProvider — the load-bearing addition for #29 + #13
+# ===================================================================
+
+
+class TestReinstallWheelProvider:
+    """The reinstall provider is the fix for wheel-only installs on a cold
+    runner. It reads PEP 610 ``direct_url.json`` and dispatches on origin.
+    """
+
+    @staticmethod
+    def _drop_wheel(cache_dir: Path, ver: str = "0.3.0") -> Path:
+        whl = cache_dir / f"tolokaforge-{ver}-py3-none-any.whl"
+        whl.write_bytes(b"PK\x03\x04materialized")
+        return whl
+
+    def test_not_installed_yields_none(self, cache_dir: Path):
+        provider = ReinstallWheelProvider()
+        with patch(
+            "tolokaforge.docker.wheel_resolver._installed_version",
+            return_value=None,
+        ):
+            assert provider.provide(cache_dir) is None
+        assert "not installed" in provider.last_failure
+
+    def test_git_install_clones_and_builds(self, cache_dir: Path):
+        """direct_url.vcs_info present → clone + uv build → wheel."""
+        provider = ReinstallWheelProvider()
+        direct_url = {
+            "url": "https://github.com/Toloka/tolokaforge.git",
+            "vcs_info": {"vcs": "git", "commit_id": "abc123def456"},
+        }
+
+        def fake_git(url, commit, cache_d):
+            self._drop_wheel(cache_d)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=direct_url,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_git",
+                staticmethod(fake_git),
+            ),
+        ):
+            artifact = provider.provide(cache_dir)
+
+        assert artifact is not None
+        assert artifact.version == "0.3.0"
+        assert artifact.provider_name == "reinstall"
+
+    def test_archive_install_downloads(self, cache_dir: Path):
+        """direct_url.archive_info present → download URL → wheel."""
+        provider = ReinstallWheelProvider()
+        direct_url = {
+            "url": "https://example.com/tolokaforge-0.3.0-py3-none-any.whl",
+            "archive_info": {"hash": "sha256=abc"},
+        }
+
+        def fake_archive(url, cache_d):
+            self._drop_wheel(cache_d)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=direct_url,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_archive",
+                staticmethod(fake_archive),
+            ),
+        ):
+            artifact = provider.provide(cache_dir)
+
+        assert artifact is not None
+        assert artifact.provider_name == "reinstall"
+
+    def test_no_direct_url_downloads_by_version(self, cache_dir: Path):
+        """PyPI install (no direct_url) → uv/pip download by name+version."""
+        provider = ReinstallWheelProvider()
+
+        def fake_by_version(ver, cache_d):
+            self._drop_wheel(cache_d, ver=ver)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=None,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(fake_by_version),
+            ),
+        ):
+            artifact = provider.provide(cache_dir)
+
+        assert artifact is not None
+        assert artifact.provider_name == "reinstall"
+
+    def test_git_failure_falls_back_to_by_version(self, cache_dir: Path):
+        """When git materialize fails, try by-version download as a last resort."""
+        provider = ReinstallWheelProvider()
+        direct_url = {
+            "url": "https://github.com/Toloka/tolokaforge.git",
+            "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+        }
+
+        def fake_git(url, commit, cache_d):
+            return False, "clone: fatal: unable to access"
+
+        def fake_by_version(ver, cache_d):
+            self._drop_wheel(cache_d, ver=ver)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=direct_url,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_git",
+                staticmethod(fake_git),
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(fake_by_version),
+            ),
+        ):
+            artifact = provider.provide(cache_dir)
+
+        assert artifact is not None
+        assert artifact.provider_name == "reinstall"
+
+    def test_all_paths_fail_surfaces_stderr(self, cache_dir: Path):
+        """When every path fails, last_failure carries per-attempt stderr."""
+        provider = ReinstallWheelProvider()
+        direct_url = {
+            "url": "https://github.com/Toloka/tolokaforge.git",
+            "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+        }
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=direct_url,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_git",
+                staticmethod(lambda u, c, d: (False, "clone failed: auth denied")),
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(lambda v, d: (False, "index not reachable")),
+            ),
+        ):
+            assert provider.provide(cache_dir) is None
+
+        assert "clone failed: auth denied" in provider.last_failure
+        assert "index not reachable" in provider.last_failure
+
+    def test_vcs_info_missing_fields_recorded(self, cache_dir: Path):
+        """A malformed direct_url with no commit_id is surfaced clearly."""
+        provider = ReinstallWheelProvider()
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value={"vcs_info": {"vcs": "git"}},
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(lambda v, d: (False, "no such version on PyPI")),
+            ),
+        ):
+            assert provider.provide(cache_dir) is None
+        assert "missing url or commit_id" in provider.last_failure
+
+    def test_materialize_git_returns_false_when_git_absent(self, cache_dir: Path):
+        with patch(
+            "tolokaforge.docker.wheel_resolver.shutil.which",
+            return_value=None,
+        ):
+            ok, err = ReinstallWheelProvider._materialize_git(
+                "https://example.com/repo.git", "abc123", cache_dir
+            )
+        assert not ok
+        assert "git not on PATH" in err
+
+    def test_materialize_archive_rejects_non_wheel_url(self, cache_dir: Path):
+        ok, err = ReinstallWheelProvider._materialize_archive(
+            "https://example.com/some/dir/", cache_dir
+        )
+        assert not ok
+        assert "does not look like a wheel or sdist" in err
+
+
+# ===================================================================
+# NoWheelError message enrichment
+# ===================================================================
+
+
+class _FailingProvider(WheelProvider):
+    """Provider that always fails with a controlled failure reason."""
+
+    def __init__(self, name: str, priority: int, reason: str) -> None:
+        super().__init__()
+        self.name = name
+        self.priority = priority
+        self._reason = reason
+
+    def provide(self, cache_dir: Path):
+        self.last_failure = self._reason
+        return None
+
+
+class TestNoWheelErrorMessage:
+    """Pin the enriched error format: per-provider failure lines + remediation."""
+
+    def test_lists_every_provider_and_reason(self, cache_dir: Path):
+        chain = WheelResolver(
+            [
+                _FailingProvider("alpha", 10, "no source tree"),
+                _FailingProvider("beta", 20, "cache empty"),
+                _FailingProvider("gamma", 30, "network error: HTTPError 502"),
+            ]
+        )
+        with pytest.raises(NoWheelError) as exc_info:
+            chain.resolve(cache_dir)
+        msg = str(exc_info.value)
+        assert "Could not resolve" in msg
+        assert "alpha: no source tree" in msg
+        assert "beta: cache empty" in msg
+        assert "gamma: network error: HTTPError 502" in msg
+        assert "Remediation" in msg
+
+    def test_records_env_var_state(self, cache_dir: Path, monkeypatch):
+        monkeypatch.setenv("UV_CACHE_DIR", "/tmp/uv-relocated")
+        monkeypatch.delenv("PIP_CACHE_DIR", raising=False)
+        chain = WheelResolver([_FailingProvider("solo", 10, "nothing worked")])
+        with pytest.raises(NoWheelError) as exc_info:
+            chain.resolve(cache_dir)
+        msg = str(exc_info.value)
+        assert "UV_CACHE_DIR=/tmp/uv-relocated" in msg
+        assert "PIP_CACHE_DIR=unset" in msg
+
+    def test_provider_without_reason_marks_placeholder(self, cache_dir: Path):
+        """A provider that forgot to set last_failure still shows up."""
+        chain = WheelResolver([_FailingProvider("silent", 10, "")])
+        with pytest.raises(NoWheelError) as exc_info:
+            chain.resolve(cache_dir)
+        msg = str(exc_info.value)
+        assert "silent:" in msg
+        assert "no reason recorded" in msg
+
+
+# ===================================================================
 # PipDownloadWheelProvider
 # ===================================================================
 
 
 class TestPipDownloadWheelProvider:
-    def test_downloads_for_pypi_install(self, cache_dir: Path):
-        """For a PyPI install, downloads the matching wheel."""
-        provider = PipDownloadWheelProvider()
+    """Cover the uv-first, pip-fallback, stderr-surfacing behavior (issue #13)."""
 
-        # Simulate: pip download creates a wheel file.
-        def fake_check_call(cmd, **kwargs):
-            dest = cmd[cmd.index("--dest") + 1]
-            whl = Path(dest) / "tolokaforge-0.2.0-py3-none-any.whl"
-            whl.write_bytes(b"PK\x03\x04pypi-wheel")
+    @staticmethod
+    def _drop_wheel(cache_dir: Path, ver: str = "0.2.0") -> None:
+        whl = cache_dir / f"tolokaforge-{ver}-py3-none-any.whl"
+        whl.write_bytes(b"PK\x03\x04pypi-wheel")
+
+    def test_uv_succeeds_first(self, cache_dir: Path):
+        """uv pip download succeeds → pip fallback is never called."""
+        provider = PipDownloadWheelProvider()
+        pip_calls: list[int] = []
+
+        def fake_uv(args, timeout=180):
+            assert args[0:2] == ["pip", "download"]
+            self._drop_wheel(cache_dir)
+            return True, ""
+
+        def fake_pip(args, timeout=180):
+            pip_calls.append(1)
+            return True, ""
 
         with (
             patch(
@@ -632,19 +1136,73 @@ class TestPipDownloadWheelProvider:
                 "tolokaforge.docker.wheel_resolver._read_direct_url",
                 return_value=None,
             ),
-            patch(
-                "tolokaforge.docker.wheel_resolver.subprocess.check_call",
-                side_effect=fake_check_call,
-            ),
+            patch("tolokaforge.docker.wheel_resolver._run_uv", side_effect=fake_uv),
+            patch("tolokaforge.docker.wheel_resolver._run_pip", side_effect=fake_pip),
         ):
             artifact = provider.provide(cache_dir)
 
         assert artifact is not None
         assert artifact.version == "0.2.0"
         assert artifact.provider_name == "pip-download"
+        assert pip_calls == []  # uv worked, pip untouched
 
-    def test_git_install_skipped(self, cache_dir: Path):
-        """Git installs don't have a matching PyPI release; should skip."""
+    def test_pip_fallback_when_uv_unavailable(self, cache_dir: Path):
+        """uv missing → pip download is invoked and succeeds."""
+        provider = PipDownloadWheelProvider()
+
+        def fake_uv(args, timeout=180):
+            return False, "uv not on PATH"
+
+        def fake_pip(args, timeout=180):
+            assert args[0] == "download"
+            self._drop_wheel(cache_dir)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.2.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=None,
+            ),
+            patch("tolokaforge.docker.wheel_resolver._run_uv", side_effect=fake_uv),
+            patch("tolokaforge.docker.wheel_resolver._run_pip", side_effect=fake_pip),
+        ):
+            artifact = provider.provide(cache_dir)
+
+        assert artifact is not None
+        assert artifact.provider_name == "pip-download"
+
+    def test_both_fail_surfaces_stderr(self, cache_dir: Path):
+        """When BOTH uv and pip fail, last_failure carries both stderrs (issue #13)."""
+        provider = PipDownloadWheelProvider()
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.2.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=None,
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_uv",
+                return_value=(False, "uv not on PATH"),
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._run_pip",
+                return_value=(False, "HTTPError: 404 Not Found"),
+            ),
+        ):
+            assert provider.provide(cache_dir) is None
+
+        assert "uv not on PATH" in provider.last_failure
+        assert "HTTPError: 404 Not Found" in provider.last_failure
+
+    def test_git_install_skipped_with_reason(self, cache_dir: Path):
+        """Git installs skip PyPI download and record a reason on last_failure."""
         provider = PipDownloadWheelProvider()
         direct_url = {
             "url": "https://github.com/Toloka/tolokaforge.git",
@@ -662,6 +1220,9 @@ class TestPipDownloadWheelProvider:
         ):
             assert provider.provide(cache_dir) is None
 
+        assert "vcs_info" in provider.last_failure
+        assert "reinstall" in provider.last_failure
+
     def test_not_installed_yields_none(self, cache_dir: Path):
         provider = PipDownloadWheelProvider()
         with patch(
@@ -669,6 +1230,7 @@ class TestPipDownloadWheelProvider:
             return_value=None,
         ):
             assert provider.provide(cache_dir) is None
+        assert "not installed" in provider.last_failure
 
 
 # ===================================================================
@@ -738,7 +1300,7 @@ class TestWheelResolver:
 
     def test_all_none_raises(self, cache_dir: Path):
         chain = WheelResolver([_AlwaysNoneProvider()])
-        with pytest.raises(NoWheelError, match="No provider"):
+        with pytest.raises(NoWheelError, match="Could not resolve"):
             chain.resolve(cache_dir)
 
     def test_empty_chain_raises(self, cache_dir: Path):
@@ -761,10 +1323,13 @@ class TestWheelResolver:
         names = [p.name for p in chain._providers]
         assert "local-source" in names
         assert "pip-cache" in names
+        assert "reinstall" in names
         assert "pip-download" in names
-        # local-source should come first.
+        # Chain order: local-source (10) → pip-cache (20) →
+        # reinstall (25) → pip-download (30).
         assert names.index("local-source") < names.index("pip-cache")
-        assert names.index("pip-cache") < names.index("pip-download")
+        assert names.index("pip-cache") < names.index("reinstall")
+        assert names.index("reinstall") < names.index("pip-download")
 
 
 # ===================================================================

--- a/tests/unit/test_wheel_resolver.py
+++ b/tests/unit/test_wheel_resolver.py
@@ -5,6 +5,7 @@ All tests are synthetic — no Docker daemon, no network, no real wheel builds.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import textwrap
 from pathlib import Path
@@ -23,6 +24,8 @@ from tolokaforge.docker.wheel_resolver import (
     WheelResolver,
     _hash_file,
     _is_engine_pyproject,
+    _looks_like_sha,
+    _newest_whl_for_version,
     _pip_wheel_cache_bases,
     _read_pyproject_version,
     _run,
@@ -146,6 +149,51 @@ class TestWheelMatching:
         assert not _wheel_matches_version(bad, "0.3.0")
 
 
+class TestNewestWhlForVersion:
+    """The version-matching selector must not return a stale wheel of a
+    different version, even if that stale wheel is newer on disk."""
+
+    def test_returns_matching_version(self, tmp_path: Path):
+        old = tmp_path / "tolokaforge-0.2.0-py3-none-any.whl"
+        old.write_bytes(b"old")
+        new = tmp_path / "tolokaforge-0.3.0-py3-none-any.whl"
+        new.write_bytes(b"new")
+        assert _newest_whl_for_version(tmp_path, "tolokaforge", "0.3.0") == new
+
+    def test_prefers_matching_version_over_newer_mtime(self, tmp_path: Path):
+        """A newer stale wheel of the wrong version must NOT win by mtime."""
+        target = tmp_path / "tolokaforge-0.3.0-py3-none-any.whl"
+        target.write_bytes(b"target")
+        # Stale wheel with a newer mtime.
+        stale = tmp_path / "tolokaforge-0.5.0-py3-none-any.whl"
+        stale.write_bytes(b"stale")
+        os.utime(stale, (target.stat().st_mtime + 100, target.stat().st_mtime + 100))
+        assert _newest_whl_for_version(tmp_path, "tolokaforge", "0.3.0") == target
+
+    def test_returns_none_when_no_match(self, tmp_path: Path):
+        (tmp_path / "tolokaforge-0.5.0-py3-none-any.whl").write_bytes(b"x")
+        assert _newest_whl_for_version(tmp_path, "tolokaforge", "0.3.0") is None
+
+
+class TestLooksLikeSha:
+    """Detects hex-SHA commit ids so _materialize_git can skip the
+    unsupported `git clone --branch <SHA>` shallow path."""
+
+    @pytest.mark.parametrize(
+        "commit",
+        ["abc1234", "1234567890abcdef", "a" * 40, "0" * 40, "deadbeef"],
+    )
+    def test_hex_shas_recognized(self, commit: str):
+        assert _looks_like_sha(commit)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["main", "v0.7.0", "release/2026-Q1", "abc123z", "abc", "a" * 41, ""],
+    )
+    def test_non_shas_rejected(self, value: str):
+        assert not _looks_like_sha(value)
+
+
 # ===================================================================
 # LocalSourceWheelProvider
 # ===================================================================
@@ -166,12 +214,10 @@ class TestLocalSourceWheelProvider:
         fake_module.touch()
 
         # Patch the build step to just create a dummy wheel.
-        # _build_wheel is a @staticmethod; patch.object replaces it
-        # with a regular function, so accept *args to be safe.
-        def fake_build(*args):
-            # Last arg is out_dir, second-to-last is source_root.
-            cache_d = args[-1]
-            whl = Path(cache_d) / "tolokaforge-0.3.0-py3-none-any.whl"
+        # `_build_wheel` is an instance method; patch.object replaces it
+        # with `fake_build`, so the call receives (self, source_root, out_dir).
+        def fake_build(self, source_root, out_dir):
+            whl = Path(out_dir) / "tolokaforge-0.3.0-py3-none-any.whl"
             whl.write_bytes(b"PK\x03\x04dummy")
 
         with (
@@ -207,10 +253,9 @@ class TestLocalSourceWheelProvider:
 
         build_calls = []
 
-        def tracked_build(*args):
+        def tracked_build(self, source_root, out_dir):
             build_calls.append(1)
-            cache_d = args[-1]
-            whl = Path(cache_d) / "tolokaforge-0.3.0-py3-none-any.whl"
+            whl = Path(out_dir) / "tolokaforge-0.3.0-py3-none-any.whl"
             whl.write_bytes(b"PK\x03\x04dummy")
 
         with (
@@ -456,11 +501,10 @@ class TestUvCacheDirFromCli:
 class TestUvCacheBasesPrecedence:
     """Precedence: ``UV_CACHE_DIR`` env → ``uv cache dir`` CLI → default (all searched).
 
-    Issue #29 fix: the env var is the most explicit signal a user can send
-    (``astral-sh/setup-uv`` sets it directly). Prior to the fix, a stale or
-    unavailable CLI output could mask an env-var-relocated cache. All three
-    candidates are now deduplicated into the search list rather than
-    short-circuiting on the first — so a wheel present in any of them wins.
+    The env var is the most explicit signal a user (or CI action such as
+    ``astral-sh/setup-uv``) can send, so it comes first. All three
+    candidates are deduplicated into the search list rather than
+    short-circuiting on the first — a wheel present in any of them wins.
     """
 
     @pytest.fixture(autouse=True)
@@ -817,8 +861,11 @@ class TestRunUv:
 
 
 class TestReinstallWheelProvider:
-    """The reinstall provider is the fix for wheel-only installs on a cold
-    runner. It reads PEP 610 ``direct_url.json`` and dispatches on origin.
+    """Reads PEP 610 ``direct_url.json`` and dispatches on install origin.
+
+    Covers all four cases (vcs_info, archive_info, dir_info, and no
+    direct_url) plus the by-version fallback when the origin-specific
+    path succeeds but produces no matching wheel.
     """
 
     @staticmethod
@@ -929,16 +976,63 @@ class TestReinstallWheelProvider:
         assert artifact is not None
         assert artifact.provider_name == "reinstall"
 
-    def test_git_failure_falls_back_to_by_version(self, cache_dir: Path):
-        """When git materialize fails, try by-version download as a last resort."""
+    def test_git_failure_does_not_fall_back_to_pypi(self, cache_dir: Path):
+        """A failed git-origin materialize must NOT fall back to a PyPI download.
+
+        A private git commit almost certainly isn't published to PyPI, so
+        the by-version fallback would waste a network round-trip and could
+        silently substitute a different version's wheel if one happens to
+        exist on the configured index.
+        """
         provider = ReinstallWheelProvider()
         direct_url = {
             "url": "https://github.com/Toloka/tolokaforge.git",
             "vcs_info": {"vcs": "git", "commit_id": "abc123"},
         }
+        by_version_calls: list[int] = []
 
-        def fake_git(url, commit, cache_d):
-            return False, "clone: fatal: unable to access"
+        def fake_by_version(ver, cache_d):
+            by_version_calls.append(1)
+            self._drop_wheel(cache_d, ver=ver)
+            return True, ""
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value=direct_url,
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_git",
+                staticmethod(lambda u, c, d: (False, "clone: fatal: unable to access")),
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(fake_by_version),
+            ),
+        ):
+            assert provider.provide(cache_dir) is None
+
+        assert by_version_calls == []  # never tried the PyPI fallback
+        assert "clone: fatal: unable to access" in provider.last_failure
+
+    def test_archive_failure_falls_back_to_by_version(self, cache_dir: Path):
+        """archive_info origin failure DOES fall back to by-version.
+
+        Unlike git commits, an archive URL usually names the exact
+        version, and the same version may still be on the configured
+        index — so falling back is a reasonable recovery.
+        """
+        provider = ReinstallWheelProvider()
+        direct_url = {
+            "url": "https://example.com/tolokaforge-0.3.0-py3-none-any.whl",
+            "archive_info": {},
+        }
 
         def fake_by_version(ver, cache_d):
             self._drop_wheel(cache_d, ver=ver)
@@ -955,8 +1049,8 @@ class TestReinstallWheelProvider:
             ),
             patch.object(
                 ReinstallWheelProvider,
-                "_materialize_git",
-                staticmethod(fake_git),
+                "_materialize_archive",
+                staticmethod(lambda u, d: (False, "connection reset")),
             ),
             patch.object(
                 ReinstallWheelProvider,
@@ -973,8 +1067,8 @@ class TestReinstallWheelProvider:
         """When every path fails, last_failure carries per-attempt stderr."""
         provider = ReinstallWheelProvider()
         direct_url = {
-            "url": "https://github.com/Toloka/tolokaforge.git",
-            "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+            "url": "https://example.com/tolokaforge-0.3.0-py3-none-any.whl",
+            "archive_info": {},
         }
         with (
             patch(
@@ -987,8 +1081,8 @@ class TestReinstallWheelProvider:
             ),
             patch.object(
                 ReinstallWheelProvider,
-                "_materialize_git",
-                staticmethod(lambda u, c, d: (False, "clone failed: auth denied")),
+                "_materialize_archive",
+                staticmethod(lambda u, d: (False, "download: connection reset")),
             ),
             patch.object(
                 ReinstallWheelProvider,
@@ -998,8 +1092,38 @@ class TestReinstallWheelProvider:
         ):
             assert provider.provide(cache_dir) is None
 
-        assert "clone failed: auth denied" in provider.last_failure
+        assert "download: connection reset" in provider.last_failure
         assert "index not reachable" in provider.last_failure
+
+    def test_dir_info_refused_explicitly(self, cache_dir: Path):
+        """direct_url with dir_info (local-path install) must be refused,
+        not silently substituted with a PyPI download of the same version."""
+        provider = ReinstallWheelProvider()
+        by_version_calls: list[int] = []
+
+        with (
+            patch(
+                "tolokaforge.docker.wheel_resolver._installed_version",
+                return_value="0.3.0",
+            ),
+            patch(
+                "tolokaforge.docker.wheel_resolver._read_direct_url",
+                return_value={
+                    "url": "file:///home/dev/tolokaforge-fork",
+                    "dir_info": {},
+                },
+            ),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(lambda v, d: by_version_calls.append(1) or (True, "")),
+            ),
+        ):
+            assert provider.provide(cache_dir) is None
+
+        assert by_version_calls == []
+        assert "local-path install" in provider.last_failure
+        assert "no reachable origin" in provider.last_failure
 
     def test_vcs_info_missing_fields_recorded(self, cache_dir: Path):
         """A malformed direct_url with no commit_id is surfaced clearly."""
@@ -1033,12 +1157,31 @@ class TestReinstallWheelProvider:
         assert not ok
         assert "git not on PATH" in err
 
-    def test_materialize_archive_rejects_non_wheel_url(self, cache_dir: Path):
+    def test_materialize_archive_rejects_non_archive_url(self, cache_dir: Path):
         ok, err = ReinstallWheelProvider._materialize_archive(
             "https://example.com/some/dir/", cache_dir
         )
         assert not ok
-        assert "does not look like a wheel or sdist" in err
+        assert "does not end in a wheel/sdist suffix" in err
+
+    def test_materialize_archive_accepts_zip_sdist(self, cache_dir: Path, monkeypatch):
+        """Archive filter accepts .zip (a legit Python sdist extension)."""
+        called: list[str] = []
+
+        def fake_urlretrieve(url, dest):
+            called.append(url)
+            Path(dest).write_bytes(b"PK\x03\x04sdist-zip")
+
+        monkeypatch.setattr(
+            "tolokaforge.docker.wheel_resolver.urllib.request.urlretrieve",
+            fake_urlretrieve,
+        )
+        ok, err = ReinstallWheelProvider._materialize_archive(
+            "https://example.com/pkg/tolokaforge-0.3.0.zip", cache_dir
+        )
+        assert ok
+        assert err == ""
+        assert (cache_dir / "tolokaforge-0.3.0.zip").is_file()
 
 
 # ===================================================================
@@ -1106,25 +1249,19 @@ class TestNoWheelErrorMessage:
 
 
 class TestPipDownloadWheelProvider:
-    """Cover the uv-first, pip-fallback, stderr-surfacing behavior (issue #13)."""
+    """Delegates to ReinstallWheelProvider._materialize_by_version so both
+    providers share one implementation of the pip-download path."""
 
     @staticmethod
     def _drop_wheel(cache_dir: Path, ver: str = "0.2.0") -> None:
         whl = cache_dir / f"tolokaforge-{ver}-py3-none-any.whl"
         whl.write_bytes(b"PK\x03\x04pypi-wheel")
 
-    def test_uv_succeeds_first(self, cache_dir: Path):
-        """uv pip download succeeds → pip fallback is never called."""
+    def test_delegates_to_by_version_and_succeeds(self, cache_dir: Path):
         provider = PipDownloadWheelProvider()
-        pip_calls: list[int] = []
 
-        def fake_uv(args, timeout=180):
-            assert args[0:2] == ["pip", "download"]
-            self._drop_wheel(cache_dir)
-            return True, ""
-
-        def fake_pip(args, timeout=180):
-            pip_calls.append(1)
+        def fake_by_version(ver, cache_d):
+            self._drop_wheel(cache_d, ver=ver)
             return True, ""
 
         with (
@@ -1136,47 +1273,19 @@ class TestPipDownloadWheelProvider:
                 "tolokaforge.docker.wheel_resolver._read_direct_url",
                 return_value=None,
             ),
-            patch("tolokaforge.docker.wheel_resolver._run_uv", side_effect=fake_uv),
-            patch("tolokaforge.docker.wheel_resolver._run_pip", side_effect=fake_pip),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(fake_by_version),
+            ),
         ):
             artifact = provider.provide(cache_dir)
 
         assert artifact is not None
         assert artifact.version == "0.2.0"
         assert artifact.provider_name == "pip-download"
-        assert pip_calls == []  # uv worked, pip untouched
 
-    def test_pip_fallback_when_uv_unavailable(self, cache_dir: Path):
-        """uv missing → pip download is invoked and succeeds."""
-        provider = PipDownloadWheelProvider()
-
-        def fake_uv(args, timeout=180):
-            return False, "uv not on PATH"
-
-        def fake_pip(args, timeout=180):
-            assert args[0] == "download"
-            self._drop_wheel(cache_dir)
-            return True, ""
-
-        with (
-            patch(
-                "tolokaforge.docker.wheel_resolver._installed_version",
-                return_value="0.2.0",
-            ),
-            patch(
-                "tolokaforge.docker.wheel_resolver._read_direct_url",
-                return_value=None,
-            ),
-            patch("tolokaforge.docker.wheel_resolver._run_uv", side_effect=fake_uv),
-            patch("tolokaforge.docker.wheel_resolver._run_pip", side_effect=fake_pip),
-        ):
-            artifact = provider.provide(cache_dir)
-
-        assert artifact is not None
-        assert artifact.provider_name == "pip-download"
-
-    def test_both_fail_surfaces_stderr(self, cache_dir: Path):
-        """When BOTH uv and pip fail, last_failure carries both stderrs (issue #13)."""
+    def test_by_version_failure_surfaces_stderr(self, cache_dir: Path):
         provider = PipDownloadWheelProvider()
         with (
             patch(
@@ -1187,41 +1296,42 @@ class TestPipDownloadWheelProvider:
                 "tolokaforge.docker.wheel_resolver._read_direct_url",
                 return_value=None,
             ),
-            patch(
-                "tolokaforge.docker.wheel_resolver._run_uv",
-                return_value=(False, "uv not on PATH"),
-            ),
-            patch(
-                "tolokaforge.docker.wheel_resolver._run_pip",
-                return_value=(False, "HTTPError: 404 Not Found"),
+            patch.object(
+                ReinstallWheelProvider,
+                "_materialize_by_version",
+                staticmethod(
+                    lambda v, d: (
+                        False,
+                        f"pip download tolokaforge=={v}: HTTPError: 404 Not Found",
+                    )
+                ),
             ),
         ):
             assert provider.provide(cache_dir) is None
-
-        assert "uv not on PATH" in provider.last_failure
         assert "HTTPError: 404 Not Found" in provider.last_failure
 
-    def test_git_install_skipped_with_reason(self, cache_dir: Path):
-        """Git installs skip PyPI download and record a reason on last_failure."""
-        provider = PipDownloadWheelProvider()
-        direct_url = {
-            "url": "https://github.com/Toloka/tolokaforge.git",
-            "vcs_info": {"vcs": "git", "commit_id": "abc123"},
-        }
-        with (
-            patch(
-                "tolokaforge.docker.wheel_resolver._installed_version",
-                return_value="0.3.0",
-            ),
-            patch(
-                "tolokaforge.docker.wheel_resolver._read_direct_url",
-                return_value=direct_url,
-            ),
+    def test_reinstall_owned_origins_are_skipped(self, cache_dir: Path):
+        """git, archive, and dir origins are all owned by ReinstallWheelProvider —
+        PipDownload short-circuits so it never runs a duplicate download."""
+        for origin_key, extra in (
+            ("vcs_info", {"vcs": "git", "commit_id": "abc123"}),
+            ("archive_info", {}),
+            ("dir_info", {}),
         ):
-            assert provider.provide(cache_dir) is None
-
-        assert "vcs_info" in provider.last_failure
-        assert "reinstall" in provider.last_failure
+            provider = PipDownloadWheelProvider()
+            with (
+                patch(
+                    "tolokaforge.docker.wheel_resolver._installed_version",
+                    return_value="0.3.0",
+                ),
+                patch(
+                    "tolokaforge.docker.wheel_resolver._read_direct_url",
+                    return_value={"url": "…", origin_key: extra},
+                ),
+            ):
+                assert provider.provide(cache_dir) is None
+            assert origin_key in provider.last_failure
+            assert "reinstall provider" in provider.last_failure
 
     def test_not_installed_yields_none(self, cache_dir: Path):
         provider = PipDownloadWheelProvider()

--- a/tolokaforge/docker/wheel_resolver.py
+++ b/tolokaforge/docker/wheel_resolver.py
@@ -4,14 +4,31 @@ Determines how to provision a ``tolokaforge`` wheel on the host so the
 Docker builder can ``COPY`` it into the runner image.  The container
 always installs from a wheel — no conditional Dockerfile logic needed.
 
-Three providers are tried in priority order:
+Four providers are tried in priority order:
 
-1. **LocalSourceWheelProvider** — builds a wheel from a local source
-   checkout (cached by source-tree SHA-256).
-2. **PipCacheWheelProvider** — locates a wheel that pip or uv already
-   built in their local caches.
-3. **PipDownloadWheelProvider** — downloads a wheel from PyPI as a
-   last-resort fallback.
+1. **LocalSourceWheelProvider** (priority 10) — builds a wheel from a
+   local source checkout (cached by source-tree SHA-256). Fires when
+   the code is running from a git clone with the engine's
+   ``pyproject.toml`` reachable via ``Path(__file__).parents``.
+2. **PipCacheWheelProvider** (priority 20) — locates a wheel that pip
+   or uv already built in their local caches. Fast-path when the same
+   host has previously installed the engine; no-op on a cold runner.
+3. **ReinstallWheelProvider** (priority 25) — materializes a wheel by
+   re-fetching from the installed distribution's origin, using PEP 610
+   ``direct_url.json`` metadata: a ``git clone`` at the pinned commit
+   for git installs; a direct download for archive installs; a
+   ``pip download`` / ``uv pip download`` for PyPI installs. Load-bearing
+   for wheel-only installs (PyPI, git tag) on a cold runner without
+   source or cache. Fixed in the fix for issues #29 and #13.
+4. **PipDownloadWheelProvider** (priority 30) — final fallback:
+   ``uv pip download`` (works in uv envs without pip) then
+   ``python -m pip download`` (with ``ensurepip`` auto-recovery when
+   pip is not installed). Always surfaces subprocess stderr on
+   failure so users can diagnose network / index / permission errors.
+
+The resolver stops at the first successful provider. When every
+provider returns ``None``, :class:`NoWheelError` is raised with per-
+provider failure reasons included so the root cause is visible.
 
 Public API
 ----------
@@ -23,7 +40,24 @@ Public API
 Extension point
 ~~~~~~~~~~~~~~~
 Subclass :class:`WheelProvider`, set ``name`` and ``priority``, implement
-:meth:`provide`, and register via ``WheelResolver.register()``.
+:meth:`provide` (and optionally set ``self.last_failure`` before
+returning ``None`` so failures show up in :class:`NoWheelError`), and
+register via ``WheelResolver.register()``.
+
+Install-scenario matrix (which provider wins in which scenario):
+
+* Source checkout (``git clone`` + ``uv sync``) → LocalSource.
+* Git-tag install (``uv sync`` with ``tolokaforge = { git = "…", tag =
+  "v0.7.0" }``) → PipCache if the uv cache is warm and discoverable,
+  else Reinstall clones the same git ref and builds a wheel.
+* PyPI wheel install (``pip install tolokaforge`` or ``uv pip install
+  tolokaforge``) → PipCache if warm, else Reinstall calls
+  ``uv pip download`` / ``pip download`` for the pinned version.
+* Fresh CI runner with relocated ``UV_CACHE_DIR`` → PipCache picks it
+  up via env-var-first resolution, or Reinstall re-fetches from origin.
+* uv env without pip (bare ``uv venv``) → Reinstall / PipDownload
+  invoke ``uv`` first, then ``ensurepip`` + ``pip`` if uv is not on
+  PATH.
 """
 
 from __future__ import annotations
@@ -50,6 +84,7 @@ __all__ = [
     "NoWheelError",
     "PipCacheWheelProvider",
     "PipDownloadWheelProvider",
+    "ReinstallWheelProvider",
     "WheelArtifact",
     "WheelProvider",
     "WheelResolver",
@@ -103,6 +138,9 @@ class WheelProvider(ABC):
     """Produces a tolokaforge wheel on the host.
 
     Subclasses set ``name`` and ``priority``, and implement :meth:`provide`.
+    Optionally, ``self.last_failure`` should be set to a short human-
+    readable string before returning ``None`` from :meth:`provide` so
+    :class:`NoWheelError` can surface the root cause to callers.
     """
 
     name: str = ""
@@ -111,12 +149,18 @@ class WheelProvider(ABC):
     priority: int = 100
     """Lower values are tried first."""
 
+    def __init__(self) -> None:
+        self.last_failure: str = ""
+
     @abstractmethod
     def provide(self, cache_dir: Path) -> WheelArtifact | None:
         """Locate or build a wheel, placing it under *cache_dir*.
 
         Return a :class:`WheelArtifact` on success, or ``None`` to
-        yield to the next provider in the chain.
+        yield to the next provider in the chain. When returning
+        ``None``, set ``self.last_failure`` to the reason string so
+        the resolver can include it in :class:`NoWheelError` on the
+        end-of-chain path.
         """
 
     def __repr__(self) -> str:
@@ -269,6 +313,95 @@ def _read_direct_url(pkg: str = _ENGINE_PKG) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess helpers (uv / pip / git)
+# ---------------------------------------------------------------------------
+
+
+_STDERR_TAIL = 800
+"""Max chars of stderr to preserve in per-provider failure messages.
+
+Keeps :class:`NoWheelError` output diagnostic without turning it into a
+multi-KB wall of text — long pip / uv error traces get truncated to the
+tail (which is where the actual cause typically sits)."""
+
+
+def _stderr_tail(text: str) -> str:
+    """Return the last ``_STDERR_TAIL`` chars of *text*, right-stripped."""
+    if not text:
+        return ""
+    trimmed = text.rstrip()
+    if len(trimmed) <= _STDERR_TAIL:
+        return trimmed
+    return "…" + trimmed[-_STDERR_TAIL:]
+
+
+def _run(argv: list[str], *, timeout: int = 300) -> tuple[bool, str]:
+    """Run *argv* to completion. Return ``(ok, stderr_tail)``.
+
+    ``ok`` is ``True`` on exit code 0. On any subprocess error
+    (``FileNotFoundError`` for a missing binary, ``TimeoutExpired``,
+    non-zero exit, etc.) ``ok`` is ``False`` and ``stderr_tail`` carries
+    a short, human-readable reason (with the tail of the child's stderr
+    when applicable). Never raises.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return False, f"{argv[0]!r} not on PATH"
+    except subprocess.TimeoutExpired:
+        return False, f"{argv[0]!r} timed out after {timeout}s"
+    except OSError as exc:
+        return False, f"{argv[0]!r} failed: {exc}"
+    if result.returncode == 0:
+        return True, ""
+    return False, _stderr_tail(result.stderr or result.stdout)
+
+
+def _run_pip(args: list[str], *, timeout: int = 300) -> tuple[bool, str]:
+    """Run ``python -m pip <args>``. If pip is missing, invoke
+    ``ensurepip`` once and retry.
+
+    This is the fix for issue #13: ``uv``-created virtualenvs omit pip
+    by default, so ``python -m pip download …`` throws
+    ``ModuleNotFoundError: No module named pip``. We detect that
+    specific error and bootstrap pip via ``ensurepip``, then retry once.
+    On failure the child stderr is preserved.
+    """
+    for attempt in (1, 2):
+        ok, err = _run([sys.executable, "-m", "pip", *args], timeout=timeout)
+        if ok:
+            return True, ""
+        # Detect missing-pip and bootstrap once via ensurepip.
+        if attempt == 1 and "No module named pip" in err:
+            logger.info(
+                "pip not installed in %s; bootstrapping via ensurepip",
+                sys.executable,
+            )
+            boot_ok, boot_err = _run(
+                [sys.executable, "-m", "ensurepip", "--upgrade"],
+                timeout=60,
+            )
+            if not boot_ok:
+                return False, f"pip missing; ensurepip failed: {boot_err}"
+            continue
+        return False, err
+    return False, "unreachable"
+
+
+def _run_uv(args: list[str], *, timeout: int = 300) -> tuple[bool, str]:
+    """Run ``uv <args>``. Returns ``(False, 'uv not on PATH')`` when uv
+    is unavailable. Never raises."""
+    if shutil.which("uv") is None:
+        return False, "uv not on PATH"
+    return _run(["uv", *args], timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
 # Wheel filename helpers
 # ---------------------------------------------------------------------------
 
@@ -330,21 +463,31 @@ def _uv_cache_dir_from_cli() -> Path | None:
 def _uv_cache_bases() -> list[Path]:
     """uv cache roots to search, de-duplicated, in precedence order.
 
-    Prefer ``uv cache dir`` — it is authoritative and already honors
-    ``UV_CACHE_DIR``, ``XDG_CACHE_HOME``, and uv config. Fall back to the
-    ``UV_CACHE_DIR`` env var only when the ``uv`` binary is unavailable, then the
-    default ``~/.cache/uv``. CI tools such as ``astral-sh/setup-uv`` relocate the
-    cache via ``UV_CACHE_DIR``, so a hard-coded ``~/.cache/uv`` is not sufficient.
+    Order (issue #29 fix):
+
+    1. ``UV_CACHE_DIR`` from the process environment — the most explicit
+       signal a user can send. CI tools such as ``astral-sh/setup-uv``
+       relocate the cache by setting this variable; the resolver honors
+       it directly without needing a working ``uv`` CLI subprocess.
+    2. ``uv cache dir`` CLI output — authoritative when the binary is
+       reachable; already honors ``UV_CACHE_DIR``, ``XDG_CACHE_HOME``,
+       and uv config.
+    3. ``~/.cache/uv`` — the default, kept as a final fallback.
+
+    All three candidates are searched (deduplicated) rather than
+    short-circuiting on the first, so a stale CLI result never masks a
+    cache-hit on the env-var-relocated path.
 
     This is *location* discovery — the on-disk *layout* within a root is
     uv-internal and handled by :func:`_walk_pip_wheel_caches`.
     """
     candidates: list[Path] = []
+    env = os.environ.get("UV_CACHE_DIR")
+    if env:
+        candidates.append(Path(env))
     cli = _uv_cache_dir_from_cli()
     if cli is not None:
         candidates.append(cli)
-    elif env := os.environ.get("UV_CACHE_DIR"):
-        candidates.append(Path(env))
     candidates.append(Path.home() / ".cache" / "uv")
     return _dedup_paths(candidates)
 
@@ -419,6 +562,10 @@ class LocalSourceWheelProvider(WheelProvider):
     def provide(self, cache_dir: Path) -> WheelArtifact | None:
         source_root = _find_engine_source_root()
         if source_root is None:
+            self.last_failure = (
+                f"no engine source tree walking up from {Path(__file__).parent} "
+                "(wheel-only install: source tree not present in site-packages)"
+            )
             return None
 
         ver = _read_pyproject_version(source_root) or "0.0.0"
@@ -468,50 +615,38 @@ class LocalSourceWheelProvider(WheelProvider):
             provider_name=self.name,
         )
 
-    @staticmethod
-    def _build_wheel(source_root: Path, out_dir: Path) -> None:
+    def _build_wheel(self, source_root: Path, out_dir: Path) -> None:
         """Build a wheel from *source_root* into *out_dir*.
 
         Tries ``uv build`` first (handles build isolation internally),
-        then falls back to ``pip wheel`` for environments without uv.
+        then falls back to ``pip wheel`` (with ``ensurepip`` recovery
+        when pip is missing). Records the reason on ``self.last_failure``
+        when both paths fail.
         """
-        if shutil.which("uv"):
-            subprocess.check_call(
-                [
-                    "uv",
-                    "build",
-                    "--wheel",
-                    "--out-dir",
-                    str(out_dir),
-                    str(source_root),
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
-        else:
-            # Fallback: pip wheel handles build isolation via pyproject.toml
-            subprocess.check_call(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "wheel",
-                    "--no-deps",
-                    "--wheel-dir",
-                    str(out_dir),
-                    str(source_root),
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
+        ok, uv_err = _run_uv(
+            ["build", "--wheel", "--out-dir", str(out_dir), str(source_root)],
+            timeout=300,
+        )
+        if ok:
+            return
+        ok, pip_err = _run_pip(
+            ["wheel", "--no-deps", "--wheel-dir", str(out_dir), str(source_root)],
+            timeout=300,
+        )
+        if ok:
+            return
+        self.last_failure = f"uv build: {uv_err}; pip wheel: {pip_err}"
 
 
 class PipCacheWheelProvider(WheelProvider):
     """Locates a tolokaforge wheel from the pip/uv wheel cache.
 
-    Used when tolokaforge was installed via ``pip install`` or
-    ``uv sync`` — the installer already built/downloaded a wheel and
-    cached it locally.
+    Fast-path when tolokaforge was previously installed via
+    ``pip install`` or ``uv sync`` on the same host — the installer
+    already built/downloaded a wheel and cached it locally. When the
+    cache is cold (fresh CI runner) or relocated to a directory the
+    resolver hasn't discovered, this provider returns ``None`` and the
+    chain falls through to :class:`ReinstallWheelProvider`.
     """
 
     name = "pip-cache"
@@ -520,9 +655,12 @@ class PipCacheWheelProvider(WheelProvider):
     def provide(self, cache_dir: Path) -> WheelArtifact | None:
         ver = _installed_version()
         if ver is None:
+            self.last_failure = f"{_ENGINE_PKG!r} is not installed in this environment"
             return None
 
-        for whl in _walk_pip_wheel_caches():
+        cache_roots = [*_uv_cache_bases(), *_pip_wheel_cache_bases()]
+        candidates = _walk_pip_wheel_caches()
+        for whl in candidates:
             # Wheel filename: tolokaforge-{version}-{python}-{abi}-{platform}.whl
             # or tolokaforge-{version}-py3-none-any.whl
             if _wheel_matches_version(whl, ver):
@@ -542,14 +680,234 @@ class PipCacheWheelProvider(WheelProvider):
                     provider_name=self.name,
                 )
 
+        self.last_failure = (
+            f"no wheel for {_ENGINE_PKG}=={ver} in {len(candidates)} "
+            f"candidate(s) across {len(cache_roots)} cache root(s): "
+            f"{', '.join(str(p) for p in cache_roots) or '(none)'}"
+        )
         return None
+
+
+# ---------------------------------------------------------------------------
+# ReinstallWheelProvider — materialize a wheel from the installed origin
+# ---------------------------------------------------------------------------
+
+
+def _pep440_pin(ver: str) -> str:
+    """Wheel-safe pin: ``tolokaforge==<version>``."""
+    return f"{_ENGINE_PKG}=={ver}"
+
+
+class ReinstallWheelProvider(WheelProvider):
+    """Materialize a wheel from the installed distribution's origin.
+
+    Reads PEP 610 ``direct_url.json`` from the installed distribution
+    and dispatches:
+
+    * ``vcs_info`` present (git-installed): clone the same git URL at
+      the pinned commit and build a wheel via ``uv build --wheel`` or
+      ``pip wheel`` (with ``ensurepip`` fallback if pip is missing).
+    * ``archive_info`` present (URL-installed wheel/sdist): download
+      the same URL directly.
+    * Neither (PyPI install): ``uv pip download`` first, then
+      ``python -m pip download`` with ``ensurepip`` auto-recovery.
+
+    This provider is the load-bearing path for wheel-only installs on
+    a cold runner — the scenario that broke before the fix for issues
+    #29 (cache assumption) and #13 (uv env without pip). See the
+    module docstring for the full install-scenario matrix.
+    """
+
+    name = "reinstall"
+    priority = 25
+
+    def provide(self, cache_dir: Path) -> WheelArtifact | None:
+        ver = _installed_version()
+        if ver is None:
+            self.last_failure = f"{_ENGINE_PKG!r} is not installed in this environment"
+            return None
+
+        direct_url = _read_direct_url()
+        errors: list[str] = []
+
+        # Case A — git install (PEP 610 vcs_info).
+        if direct_url and "vcs_info" in direct_url:
+            url = direct_url.get("url", "")
+            vcs_info = direct_url["vcs_info"]
+            commit = vcs_info.get("commit_id") or vcs_info.get("requested_revision")
+            if url and commit:
+                ok, err = self._materialize_git(url, commit, cache_dir)
+                if ok:
+                    return self._finalize(cache_dir, ver)
+                errors.append(f"git@{commit[:12] if commit else '<none>'}: {err}")
+            else:
+                errors.append(f"direct_url.vcs_info missing url or commit_id: {vcs_info!r}")
+        # Case B — direct URL install (archive_info).
+        elif direct_url and "archive_info" in direct_url:
+            url = direct_url.get("url", "")
+            if url:
+                ok, err = self._materialize_archive(url, cache_dir)
+                if ok:
+                    return self._finalize(cache_dir, ver)
+                errors.append(f"archive({url}): {err}")
+            else:
+                errors.append("direct_url.archive_info missing url")
+        # Case C — no direct_url or PyPI install → download by name+version.
+        else:
+            ok, err = self._materialize_by_version(ver, cache_dir)
+            if ok:
+                return self._finalize(cache_dir, ver)
+            errors.append(err)
+
+        # If Case A/B failed, also try Case C as a last-resort fallback
+        # (the installed version might still be published to the
+        # configured index).
+        if errors and direct_url is not None:
+            ok, err = self._materialize_by_version(ver, cache_dir)
+            if ok:
+                logger.info(
+                    "%s: origin-specific materialize failed, but by-version " "download succeeded",
+                    self.name,
+                )
+                return self._finalize(cache_dir, ver)
+            errors.append(f"fallback-by-version: {err}")
+
+        self.last_failure = "; ".join(errors) if errors else "no origin metadata"
+        return None
+
+    def _finalize(self, cache_dir: Path, ver: str) -> WheelArtifact | None:
+        whl = _newest_whl(cache_dir, _ENGINE_PKG)
+        if whl is None:
+            self.last_failure = (
+                f"materialize succeeded but no {_ENGINE_PKG}*.whl found in " f"{cache_dir}"
+            )
+            return None
+        return WheelArtifact(
+            path=whl,
+            version=ver,
+            content_hash=_hash_file(whl),
+            provider_name=self.name,
+        )
+
+    @staticmethod
+    def _materialize_git(url: str, commit: str, cache_dir: Path) -> tuple[bool, str]:
+        """Clone *url* at *commit* into a temp dir + build a wheel into
+        *cache_dir*. Returns ``(ok, stderr_tail)``."""
+        import tempfile
+
+        if shutil.which("git") is None:
+            return False, "git not on PATH"
+
+        with tempfile.TemporaryDirectory(prefix="tolokaforge-git-") as tmp:
+            src = Path(tmp) / "src"
+            # Try a shallow clone at the ref first (works for tags/branches).
+            ok, err = _run(
+                ["git", "clone", "--depth=1", "--branch", commit, url, str(src)],
+                timeout=180,
+            )
+            if not ok:
+                # Fall back: full clone + explicit checkout (works for arbitrary commits).
+                ok, err = _run(["git", "clone", url, str(src)], timeout=180)
+                if not ok:
+                    return False, f"clone: {err}"
+                ok, err = _run(["git", "-C", str(src), "checkout", commit], timeout=60)
+                if not ok:
+                    return False, f"checkout {commit[:12]}: {err}"
+
+            # Build the wheel — uv first, pip second.
+            ok, err = _run_uv(
+                ["build", "--wheel", "--out-dir", str(cache_dir), str(src)],
+                timeout=300,
+            )
+            if ok:
+                return True, ""
+            uv_err = err
+
+            ok, err = _run_pip(
+                ["wheel", str(src), "--no-deps", "-w", str(cache_dir)],
+                timeout=300,
+            )
+            if ok:
+                return True, ""
+            return False, f"uv build: {uv_err}; pip wheel: {err}"
+
+    @staticmethod
+    def _materialize_archive(url: str, cache_dir: Path) -> tuple[bool, str]:
+        """Download *url* into *cache_dir*. Returns ``(ok, stderr_tail)``."""
+        import urllib.error
+        import urllib.request
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        filename = Path(parsed.path).name
+        if not filename or not (filename.endswith(".whl") or filename.endswith(".tar.gz")):
+            # Not a directly-usable wheel/sdist filename — bail loud.
+            return False, f"URL does not look like a wheel or sdist: {url}"
+        dest = cache_dir / filename
+        try:
+            urllib.request.urlretrieve(url, dest)  # noqa: S310
+        except urllib.error.URLError as exc:
+            return False, f"urlretrieve {url}: {exc}"
+        except OSError as exc:
+            return False, f"urlretrieve {url}: {exc}"
+        if not dest.is_file() or dest.stat().st_size == 0:
+            return False, "download produced empty file"
+        return True, ""
+
+    @staticmethod
+    def _materialize_by_version(ver: str, cache_dir: Path) -> tuple[bool, str]:
+        """Download the wheel from the configured index by name+version.
+
+        Tries ``uv pip download`` first (works in uv envs without pip),
+        then ``python -m pip download`` (with ``ensurepip`` auto-recovery
+        via :func:`_run_pip`). Returns ``(ok, stderr_tail)``.
+        """
+        spec = _pep440_pin(ver)
+        ok, uv_err = _run_uv(
+            [
+                "pip",
+                "download",
+                spec,
+                "--no-deps",
+                "-d",
+                str(cache_dir),
+            ],
+            timeout=180,
+        )
+        if ok:
+            return True, ""
+        ok, pip_err = _run_pip(
+            [
+                "download",
+                spec,
+                "--no-deps",
+                "--only-binary=:all:",
+                "-d",
+                str(cache_dir),
+            ],
+            timeout=180,
+        )
+        if ok:
+            return True, ""
+        return False, f"uv pip download: {uv_err}; pip download: {pip_err}"
 
 
 class PipDownloadWheelProvider(WheelProvider):
     """Downloads a wheel from PyPI as a last-resort fallback.
 
-    Only fires for PyPI installs (not git installs, which won't have
-    a matching release on PyPI).
+    Fires when the installed distribution has no ``direct_url.json``
+    (a plain PyPI install) and the earlier providers all failed. Uses
+    ``uv pip download`` first — the right primary invocation in uv
+    envs, which omit pip by default — and falls back to
+    ``python -m pip download`` with ``ensurepip`` auto-recovery. Both
+    child stderrs are captured and surfaced through
+    ``self.last_failure`` so :class:`NoWheelError` carries the real
+    cause instead of an opaque exit code.
+
+    For git installs the earlier :class:`ReinstallWheelProvider` is the
+    correct source-of-truth (the tag/commit may not be published to any
+    index), so this provider short-circuits with a reason recorded on
+    ``self.last_failure``.
     """
 
     name = "pip-download"
@@ -558,49 +916,57 @@ class PipDownloadWheelProvider(WheelProvider):
     def provide(self, cache_dir: Path) -> WheelArtifact | None:
         ver = _installed_version()
         if ver is None:
+            self.last_failure = f"{_ENGINE_PKG!r} is not installed in this environment"
             return None
 
-        # Don't attempt PyPI download for git installs.
+        # Skip PyPI download for git installs — the git ref may not be
+        # published to any index, and ReinstallWheelProvider already
+        # handled that origin above.
         direct_url = _read_direct_url()
         if direct_url is not None and "vcs_info" in direct_url:
-            logger.debug(
-                "%s: skipping — installed from git, not PyPI",
-                self.name,
+            self.last_failure = (
+                "skipped: installed from git (vcs_info present); "
+                "reinstall provider owns this origin"
             )
+            logger.debug("%s: %s", self.name, self.last_failure)
             return None
 
         logger.info(
-            "%s: downloading wheel for %s==%s from PyPI",
+            "%s: downloading wheel for %s==%s",
             self.name,
             _ENGINE_PKG,
             ver,
         )
-        try:
-            subprocess.check_call(
+
+        spec = _pep440_pin(ver)
+        # uv first — works in uv envs that omit pip (issue #13).
+        ok, uv_err = _run_uv(
+            ["pip", "download", spec, "--no-deps", "-d", str(cache_dir)],
+            timeout=180,
+        )
+        if not ok:
+            # pip second — with ensurepip auto-recovery via _run_pip.
+            ok, pip_err = _run_pip(
                 [
-                    sys.executable,
-                    "-m",
-                    "pip",
                     "download",
-                    f"{_ENGINE_PKG}=={ver}",
+                    spec,
                     "--no-deps",
                     "--only-binary=:all:",
-                    "--dest",
+                    "-d",
                     str(cache_dir),
                 ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
+                timeout=180,
             )
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "%s: pip download failed (exit %d)",
-                self.name,
-                exc.returncode,
-            )
-            return None
+            if not ok:
+                self.last_failure = f"uv pip download: {uv_err}; pip download: {pip_err}"
+                logger.warning("%s: %s", self.name, self.last_failure)
+                return None
 
         whl = _newest_whl(cache_dir, _ENGINE_PKG)
         if whl is None:
+            self.last_failure = (
+                f"download reported success but no {_ENGINE_PKG}*.whl " f"landed in {cache_dir}"
+            )
             return None
 
         return WheelArtifact(
@@ -639,6 +1005,7 @@ def _wheel_matches_version(whl: Path, ver: str) -> bool:
 _DEFAULT_PROVIDERS: tuple[type[WheelProvider], ...] = (
     LocalSourceWheelProvider,
     PipCacheWheelProvider,
+    ReinstallWheelProvider,
     PipDownloadWheelProvider,
 )
 
@@ -670,13 +1037,15 @@ class WheelResolver:
         """Walk the chain and return the first wheel found.
 
         Raises:
-            NoWheelError: If every provider returns ``None``.
+            NoWheelError: If every provider returns ``None``. The
+                exception message includes each provider's recorded
+                ``last_failure`` so the root cause is visible without
+                re-running with DEBUG logging.
         """
         cache_dir.mkdir(parents=True, exist_ok=True)
-        attempted: list[str] = []
+        failures: list[tuple[str, str]] = []
         for p in self._providers:
             artifact = p.provide(cache_dir)
-            attempted.append(p.name)
             if artifact is not None:
                 logger.info(
                     "Wheel resolver: '%s' provided %s (v%s, hash=%s)",
@@ -686,17 +1055,23 @@ class WheelResolver:
                     artifact.content_hash[:12],
                 )
                 return artifact
+            failures.append((p.name, p.last_failure or "no reason recorded"))
 
-        searched = ", ".join(str(p) for p in (*_uv_cache_bases(), *_pip_wheel_cache_bases()))
-        uv_env = "set" if os.environ.get("UV_CACHE_DIR") else "unset"
-        pip_env = "set" if os.environ.get("PIP_CACHE_DIR") else "unset"
-        raise NoWheelError(
-            f"No provider could produce a tolokaforge wheel.  "
-            f"Tried providers: {', '.join(attempted)}.  "
-            f"Searched wheel caches: {searched} "
-            f"(UV_CACHE_DIR={uv_env}, PIP_CACHE_DIR={pip_env}).  "
-            f"Set UV_CACHE_DIR/PIP_CACHE_DIR, clone the repo, or install via pip/uv."
+        uv_env = os.environ.get("UV_CACHE_DIR") or "unset"
+        pip_env = os.environ.get("PIP_CACHE_DIR") or "unset"
+        lines = [
+            f"Could not resolve a {_ENGINE_PKG} wheel via any provider.",
+            f"UV_CACHE_DIR={uv_env}, PIP_CACHE_DIR={pip_env}.",
+            "Per-provider failure:",
+        ]
+        for name, reason in failures:
+            lines.append(f"  {name}: {reason}")
+        lines.append(
+            "Remediation: install tolokaforge via `uv sync` / `pip install`, "
+            "set UV_CACHE_DIR to a warm cache, or ensure the install origin "
+            "(git URL / archive URL / PyPI index) is reachable."
         )
+        raise NoWheelError("\n".join(lines))
 
     def _sort(self) -> None:
         self._providers.sort(key=lambda p: p.priority)

--- a/tolokaforge/docker/wheel_resolver.py
+++ b/tolokaforge/docker/wheel_resolver.py
@@ -14,17 +14,17 @@ Four providers are tried in priority order:
    or uv already built in their local caches. Fast-path when the same
    host has previously installed the engine; no-op on a cold runner.
 3. **ReinstallWheelProvider** (priority 25) — materializes a wheel by
-   re-fetching from the installed distribution's origin, using PEP 610
+   re-fetching from the installed distribution's origin using PEP 610
    ``direct_url.json`` metadata: a ``git clone`` at the pinned commit
-   for git installs; a direct download for archive installs; a
-   ``pip download`` / ``uv pip download`` for PyPI installs. Load-bearing
-   for wheel-only installs (PyPI, git tag) on a cold runner without
-   source or cache. Fixed in the fix for issues #29 and #13.
+   for git installs; a direct download for archive-URL installs; a
+   ``pip download --only-binary`` for plain PyPI installs. Refuses
+   ``dir_info`` (local-path) origins so a PyPI wheel is never silently
+   substituted for the user's local checkout.
 4. **PipDownloadWheelProvider** (priority 30) — final fallback:
-   ``uv pip download`` (works in uv envs without pip) then
-   ``python -m pip download`` (with ``ensurepip`` auto-recovery when
-   pip is not installed). Always surfaces subprocess stderr on
-   failure so users can diagnose network / index / permission errors.
+   ``python -m pip download`` for the installed name+version, with
+   ``ensurepip`` auto-recovery when pip is not installed. Delegates to
+   :meth:`ReinstallWheelProvider._materialize_by_version` so both
+   providers share one implementation of the download path.
 
 The resolver stops at the first successful provider. When every
 provider returns ``None``, :class:`NoWheelError` is raised with per-
@@ -52,12 +52,14 @@ Install-scenario matrix (which provider wins in which scenario):
   else Reinstall clones the same git ref and builds a wheel.
 * PyPI wheel install (``pip install tolokaforge`` or ``uv pip install
   tolokaforge``) → PipCache if warm, else Reinstall calls
-  ``uv pip download`` / ``pip download`` for the pinned version.
+  ``pip download --only-binary=:all:`` for the pinned version.
 * Fresh CI runner with relocated ``UV_CACHE_DIR`` → PipCache picks it
   up via env-var-first resolution, or Reinstall re-fetches from origin.
+* Local-path install (``pip install /path/to/checkout``) → Reinstall
+  refuses ``dir_info`` so a PyPI wheel is never silently substituted
+  for the user's local checkout.
 * uv env without pip (bare ``uv venv``) → Reinstall / PipDownload
-  invoke ``uv`` first, then ``ensurepip`` + ``pip`` if uv is not on
-  PATH.
+  invoke ``ensurepip`` to bootstrap pip, then run ``pip download``.
 """
 
 from __future__ import annotations
@@ -70,6 +72,10 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -149,8 +155,13 @@ class WheelProvider(ABC):
     priority: int = 100
     """Lower values are tried first."""
 
-    def __init__(self) -> None:
-        self.last_failure: str = ""
+    last_failure: str = ""
+    """Reason recorded when :meth:`provide` returned ``None``.
+
+    Class-level default is an empty string so subclasses that override
+    ``__init__`` without calling ``super().__init__()`` still expose the
+    attribute — the resolver's failure-message assembly reads it
+    unconditionally."""
 
     @abstractmethod
     def provide(self, cache_dir: Path) -> WheelArtifact | None:
@@ -363,14 +374,13 @@ def _run(argv: list[str], *, timeout: int = 300) -> tuple[bool, str]:
 
 
 def _run_pip(args: list[str], *, timeout: int = 300) -> tuple[bool, str]:
-    """Run ``python -m pip <args>``. If pip is missing, invoke
-    ``ensurepip`` once and retry.
+    """Run ``python -m pip <args>``.
 
-    This is the fix for issue #13: ``uv``-created virtualenvs omit pip
-    by default, so ``python -m pip download …`` throws
-    ``ModuleNotFoundError: No module named pip``. We detect that
-    specific error and bootstrap pip via ``ensurepip``, then retry once.
-    On failure the child stderr is preserved.
+    If pip is missing (as in ``uv``-created virtualenvs that omit pip by
+    default), the first attempt fails with ``ModuleNotFoundError: No
+    module named pip``. We detect that specific error, bootstrap pip via
+    ``ensurepip --upgrade``, and retry the invocation once. Child stderr
+    is preserved on failure.
     """
     for attempt in (1, 2):
         ok, err = _run([sys.executable, "-m", "pip", *args], timeout=timeout)
@@ -414,6 +424,23 @@ def _newest_whl(directory: Path, prefix: str) -> Path | None:
         reverse=True,
     )
     return candidates[0] if candidates else None
+
+
+def _newest_whl_for_version(directory: Path, prefix: str, ver: str) -> Path | None:
+    """Return the newest ``.whl`` in *directory* whose name matches *prefix* AND *ver*.
+
+    Uses :func:`_wheel_matches_version` to filter by the PEP 427 version
+    field so a stale wheel of a different version left in *directory* by a
+    prior provider run is never returned tagged with the current version.
+    """
+    candidates = [
+        p
+        for p in directory.glob(f"{prefix}*.whl")
+        if p.is_file() and _wheel_matches_version(p, ver)
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
 # ---------------------------------------------------------------------------
@@ -463,7 +490,7 @@ def _uv_cache_dir_from_cli() -> Path | None:
 def _uv_cache_bases() -> list[Path]:
     """uv cache roots to search, de-duplicated, in precedence order.
 
-    Order (issue #29 fix):
+    Order:
 
     1. ``UV_CACHE_DIR`` from the process environment — the most explicit
        signal a user can send. CI tools such as ``astral-sh/setup-uv``
@@ -693,29 +720,40 @@ class PipCacheWheelProvider(WheelProvider):
 # ---------------------------------------------------------------------------
 
 
-def _pep440_pin(ver: str) -> str:
-    """Wheel-safe pin: ``tolokaforge==<version>``."""
-    return f"{_ENGINE_PKG}=={ver}"
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _looks_like_sha(commit: str) -> bool:
+    """True when *commit* looks like a hex-encoded git object id.
+
+    ``git clone --branch <ref>`` accepts tags and branches, not commit
+    SHAs. Callers use this to skip the shallow-clone fast path when the
+    recorded ``commit_id`` is a raw SHA (the common PEP 610 shape).
+    """
+    return bool(_SHA_RE.fullmatch(commit))
+
+
+_ARCHIVE_SUFFIXES = (".whl", ".tar.gz", ".tgz", ".zip", ".tar.bz2", ".tar.xz")
 
 
 class ReinstallWheelProvider(WheelProvider):
     """Materialize a wheel from the installed distribution's origin.
 
     Reads PEP 610 ``direct_url.json`` from the installed distribution
-    and dispatches:
+    and dispatches on install origin:
 
     * ``vcs_info`` present (git-installed): clone the same git URL at
       the pinned commit and build a wheel via ``uv build --wheel`` or
       ``pip wheel`` (with ``ensurepip`` fallback if pip is missing).
     * ``archive_info`` present (URL-installed wheel/sdist): download
       the same URL directly.
-    * Neither (PyPI install): ``uv pip download`` first, then
-      ``python -m pip download`` with ``ensurepip`` auto-recovery.
+    * No direct_url (plain PyPI install): ``pip download`` for the
+      pinned name+version, with ``ensurepip`` auto-recovery.
 
-    This provider is the load-bearing path for wheel-only installs on
-    a cold runner — the scenario that broke before the fix for issues
-    #29 (cache assumption) and #13 (uv env without pip). See the
-    module docstring for the full install-scenario matrix.
+    ``dir_info`` (local-path install) is intentionally rejected — a
+    local checkout has no reachable origin the container can materialize
+    the same artifact from, and silently substituting a PyPI wheel of
+    the same version would swap the user's local code for public code.
     """
 
     name = "reinstall"
@@ -730,7 +768,7 @@ class ReinstallWheelProvider(WheelProvider):
         direct_url = _read_direct_url()
         errors: list[str] = []
 
-        # Case A — git install (PEP 610 vcs_info).
+        # Case A — git install.
         if direct_url and "vcs_info" in direct_url:
             url = direct_url.get("url", "")
             vcs_info = direct_url["vcs_info"]
@@ -738,48 +776,77 @@ class ReinstallWheelProvider(WheelProvider):
             if url and commit:
                 ok, err = self._materialize_git(url, commit, cache_dir)
                 if ok:
-                    return self._finalize(cache_dir, ver)
-                errors.append(f"git@{commit[:12] if commit else '<none>'}: {err}")
+                    art = self._finalize(cache_dir, ver)
+                    if art is not None:
+                        return art
+                    errors.append(f"git@{commit[:12]}: {self.last_failure}")
+                else:
+                    errors.append(f"git@{commit[:12]}: {err}")
             else:
                 errors.append(f"direct_url.vcs_info missing url or commit_id: {vcs_info!r}")
-        # Case B — direct URL install (archive_info).
+        # Case B — archive URL install.
         elif direct_url and "archive_info" in direct_url:
             url = direct_url.get("url", "")
             if url:
                 ok, err = self._materialize_archive(url, cache_dir)
                 if ok:
-                    return self._finalize(cache_dir, ver)
-                errors.append(f"archive({url}): {err}")
+                    art = self._finalize(cache_dir, ver)
+                    if art is not None:
+                        return art
+                    errors.append(f"archive({url}): {self.last_failure}")
+                else:
+                    errors.append(f"archive({url}): {err}")
             else:
                 errors.append("direct_url.archive_info missing url")
-        # Case C — no direct_url or PyPI install → download by name+version.
+        # Case C — dir_info: refuse silently substituting a PyPI wheel.
+        elif direct_url and "dir_info" in direct_url:
+            path = direct_url.get("url", "<unknown>")
+            self.last_failure = (
+                f"local-path install ({path}) has no reachable origin — "
+                "install tolokaforge from a git ref, an archive URL, or "
+                "PyPI so the runner can materialize the same artifact"
+            )
+            return None
+        # Case D — no direct_url or PyPI install → download by name+version.
         else:
             ok, err = self._materialize_by_version(ver, cache_dir)
             if ok:
-                return self._finalize(cache_dir, ver)
-            errors.append(err)
+                art = self._finalize(cache_dir, ver)
+                if art is not None:
+                    return art
+                errors.append(f"by-version: {self.last_failure}")
+            else:
+                errors.append(err)
 
-        # If Case A/B failed, also try Case C as a last-resort fallback
-        # (the installed version might still be published to the
-        # configured index).
-        if errors and direct_url is not None:
+        # Only fall back to by-version when the origin isn't already
+        # the index (avoids duplicate work + duplicate error text) and
+        # isn't a git origin (a private commit won't be on the index).
+        origin_is_index_or_vcs = direct_url is None or "vcs_info" in (direct_url or {})
+        if errors and not origin_is_index_or_vcs:
             ok, err = self._materialize_by_version(ver, cache_dir)
             if ok:
-                logger.info(
-                    "%s: origin-specific materialize failed, but by-version " "download succeeded",
-                    self.name,
-                )
-                return self._finalize(cache_dir, ver)
-            errors.append(f"fallback-by-version: {err}")
+                art = self._finalize(cache_dir, ver)
+                if art is not None:
+                    return art
+                errors.append(f"fallback-by-version: {self.last_failure}")
+            else:
+                errors.append(f"fallback-by-version: {err}")
 
         self.last_failure = "; ".join(errors) if errors else "no origin metadata"
         return None
 
     def _finalize(self, cache_dir: Path, ver: str) -> WheelArtifact | None:
-        whl = _newest_whl(cache_dir, _ENGINE_PKG)
+        """Return the wheel matching *ver* in *cache_dir*, or ``None``.
+
+        Filters by version match rather than mtime alone so a stale wheel
+        of a different version left in the shared cache directory by a
+        prior provider run cannot be returned tagged with the current
+        version.
+        """
+        whl = _newest_whl_for_version(cache_dir, _ENGINE_PKG, ver)
         if whl is None:
             self.last_failure = (
-                f"materialize succeeded but no {_ENGINE_PKG}*.whl found in " f"{cache_dir}"
+                f"materialize completed but no {_ENGINE_PKG}-{ver}-*.whl " f"landed in {cache_dir}"
             )
             return None
         return WheelArtifact(
@@ -792,57 +859,64 @@ class ReinstallWheelProvider(WheelProvider):
     @staticmethod
     def _materialize_git(url: str, commit: str, cache_dir: Path) -> tuple[bool, str]:
         """Clone *url* at *commit* into a temp dir + build a wheel into
-        *cache_dir*. Returns ``(ok, stderr_tail)``."""
-        import tempfile
+        *cache_dir*. Returns ``(ok, stderr_tail)``.
 
+        Uses a shallow ``--branch <ref>`` clone only when *commit* looks
+        like a tag/branch name; for hex-SHA commit ids (the common PEP
+        610 shape) ``--branch`` would be rejected by git, so we go
+        straight to full clone + explicit checkout.
+        """
         if shutil.which("git") is None:
             return False, "git not on PATH"
 
         with tempfile.TemporaryDirectory(prefix="tolokaforge-git-") as tmp:
             src = Path(tmp) / "src"
-            # Try a shallow clone at the ref first (works for tags/branches).
-            ok, err = _run(
-                ["git", "clone", "--depth=1", "--branch", commit, url, str(src)],
-                timeout=180,
-            )
-            if not ok:
-                # Fall back: full clone + explicit checkout (works for arbitrary commits).
+            if _looks_like_sha(commit):
+                # Full clone then explicit checkout — git clone --branch
+                # does not accept commit SHAs.
                 ok, err = _run(["git", "clone", url, str(src)], timeout=180)
                 if not ok:
                     return False, f"clone: {err}"
                 ok, err = _run(["git", "-C", str(src), "checkout", commit], timeout=60)
                 if not ok:
                     return False, f"checkout {commit[:12]}: {err}"
+            else:
+                # Tag/branch — shallow clone is safe and fast.
+                ok, err = _run(
+                    ["git", "clone", "--depth=1", "--branch", commit, url, str(src)],
+                    timeout=180,
+                )
+                if not ok:
+                    return False, f"clone --branch {commit}: {err}"
 
-            # Build the wheel — uv first, pip second.
-            ok, err = _run_uv(
+            # Build the wheel — uv first, pip fallback.
+            ok, uv_err = _run_uv(
                 ["build", "--wheel", "--out-dir", str(cache_dir), str(src)],
                 timeout=300,
             )
             if ok:
                 return True, ""
-            uv_err = err
-
-            ok, err = _run_pip(
+            ok, pip_err = _run_pip(
                 ["wheel", str(src), "--no-deps", "-w", str(cache_dir)],
                 timeout=300,
             )
             if ok:
                 return True, ""
-            return False, f"uv build: {uv_err}; pip wheel: {err}"
+            return False, f"uv build: {uv_err}; pip wheel: {pip_err}"
 
     @staticmethod
     def _materialize_archive(url: str, cache_dir: Path) -> tuple[bool, str]:
-        """Download *url* into *cache_dir*. Returns ``(ok, stderr_tail)``."""
-        import urllib.error
-        import urllib.request
-        from urllib.parse import urlparse
+        """Download *url* into *cache_dir*. Returns ``(ok, stderr_tail)``.
 
-        parsed = urlparse(url)
+        Accepts any URL whose path ends in a recognized wheel/sdist
+        extension (``.whl``, ``.tar.gz``, ``.tgz``, ``.zip``,
+        ``.tar.bz2``, ``.tar.xz``) — the same set pip and uv accept as
+        a direct-URL install.
+        """
+        parsed = urllib.parse.urlparse(url)
         filename = Path(parsed.path).name
-        if not filename or not (filename.endswith(".whl") or filename.endswith(".tar.gz")):
-            # Not a directly-usable wheel/sdist filename — bail loud.
-            return False, f"URL does not look like a wheel or sdist: {url}"
+        if not filename or not filename.endswith(_ARCHIVE_SUFFIXES):
+            return False, f"URL path does not end in a wheel/sdist suffix: {url}"
         dest = cache_dir / filename
         try:
             urllib.request.urlretrieve(url, dest)  # noqa: S310
@@ -858,25 +932,20 @@ class ReinstallWheelProvider(WheelProvider):
     def _materialize_by_version(ver: str, cache_dir: Path) -> tuple[bool, str]:
         """Download the wheel from the configured index by name+version.
 
-        Tries ``uv pip download`` first (works in uv envs without pip),
-        then ``python -m pip download`` (with ``ensurepip`` auto-recovery
-        via :func:`_run_pip`). Returns ``(ok, stderr_tail)``.
+        Invokes ``python -m pip download --only-binary=:all:`` via
+        :func:`_run_pip`, which auto-recovers a missing pip via
+        ``ensurepip`` (the fix for uv envs that omit pip). Forces
+        ``--only-binary`` so an sdist can never masquerade as a
+        successful wheel download.
+
+        ``uv pip download`` is intentionally not attempted: uv 0.9+ has
+        no ``pip download`` subcommand — the pip path already handles
+        the ``no pip installed`` case via ``ensurepip`` recovery.
+
+        Returns ``(ok, stderr_tail)``.
         """
-        spec = _pep440_pin(ver)
-        ok, uv_err = _run_uv(
-            [
-                "pip",
-                "download",
-                spec,
-                "--no-deps",
-                "-d",
-                str(cache_dir),
-            ],
-            timeout=180,
-        )
-        if ok:
-            return True, ""
-        ok, pip_err = _run_pip(
+        spec = f"{_ENGINE_PKG}=={ver}"
+        ok, err = _run_pip(
             [
                 "download",
                 spec,
@@ -889,25 +958,22 @@ class ReinstallWheelProvider(WheelProvider):
         )
         if ok:
             return True, ""
-        return False, f"uv pip download: {uv_err}; pip download: {pip_err}"
+        return False, f"pip download {spec}: {err}"
 
 
 class PipDownloadWheelProvider(WheelProvider):
     """Downloads a wheel from PyPI as a last-resort fallback.
 
-    Fires when the installed distribution has no ``direct_url.json``
-    (a plain PyPI install) and the earlier providers all failed. Uses
-    ``uv pip download`` first — the right primary invocation in uv
-    envs, which omit pip by default — and falls back to
-    ``python -m pip download`` with ``ensurepip`` auto-recovery. Both
-    child stderrs are captured and surfaced through
-    ``self.last_failure`` so :class:`NoWheelError` carries the real
-    cause instead of an opaque exit code.
+    Runs only when the installed distribution has no ``direct_url.json``
+    (a plain PyPI install) and earlier providers all missed. Reuses
+    :meth:`ReinstallWheelProvider._materialize_by_version` — a single
+    implementation of the ``pip download --only-binary=:all:`` path
+    (with ``ensurepip`` auto-recovery) so the two providers can't drift
+    on flags, timeout, or error format.
 
-    For git installs the earlier :class:`ReinstallWheelProvider` is the
-    correct source-of-truth (the tag/commit may not be published to any
-    index), so this provider short-circuits with a reason recorded on
-    ``self.last_failure``.
+    For git and archive-URL installs the earlier
+    :class:`ReinstallWheelProvider` is authoritative, so this provider
+    short-circuits with a reason on ``self.last_failure``.
     """
 
     name = "pip-download"
@@ -919,53 +985,29 @@ class PipDownloadWheelProvider(WheelProvider):
             self.last_failure = f"{_ENGINE_PKG!r} is not installed in this environment"
             return None
 
-        # Skip PyPI download for git installs — the git ref may not be
-        # published to any index, and ReinstallWheelProvider already
-        # handled that origin above.
         direct_url = _read_direct_url()
-        if direct_url is not None and "vcs_info" in direct_url:
+        if direct_url is not None and (
+            "vcs_info" in direct_url or "archive_info" in direct_url or "dir_info" in direct_url
+        ):
             self.last_failure = (
-                "skipped: installed from git (vcs_info present); "
-                "reinstall provider owns this origin"
+                f"skipped: install origin ({next(iter(direct_url.keys() - {'url'}))}) "
+                "is owned by the reinstall provider"
             )
             logger.debug("%s: %s", self.name, self.last_failure)
             return None
 
-        logger.info(
-            "%s: downloading wheel for %s==%s",
-            self.name,
-            _ENGINE_PKG,
-            ver,
-        )
-
-        spec = _pep440_pin(ver)
-        # uv first — works in uv envs that omit pip (issue #13).
-        ok, uv_err = _run_uv(
-            ["pip", "download", spec, "--no-deps", "-d", str(cache_dir)],
-            timeout=180,
-        )
+        logger.info("%s: downloading wheel for %s==%s", self.name, _ENGINE_PKG, ver)
+        ok, err = ReinstallWheelProvider._materialize_by_version(ver, cache_dir)
         if not ok:
-            # pip second — with ensurepip auto-recovery via _run_pip.
-            ok, pip_err = _run_pip(
-                [
-                    "download",
-                    spec,
-                    "--no-deps",
-                    "--only-binary=:all:",
-                    "-d",
-                    str(cache_dir),
-                ],
-                timeout=180,
-            )
-            if not ok:
-                self.last_failure = f"uv pip download: {uv_err}; pip download: {pip_err}"
-                logger.warning("%s: %s", self.name, self.last_failure)
-                return None
+            self.last_failure = err
+            logger.warning("%s: %s", self.name, err)
+            return None
 
-        whl = _newest_whl(cache_dir, _ENGINE_PKG)
+        whl = _newest_whl_for_version(cache_dir, _ENGINE_PKG, ver)
         if whl is None:
             self.last_failure = (
-                f"download reported success but no {_ENGINE_PKG}*.whl " f"landed in {cache_dir}"
+                f"pip download reported success but no {_ENGINE_PKG}-{ver}-*.whl "
+                f"landed in {cache_dir}"
             )
             return None
 
@@ -1045,6 +1087,10 @@ class WheelResolver:
         cache_dir.mkdir(parents=True, exist_ok=True)
         failures: list[tuple[str, str]] = []
         for p in self._providers:
+            # Reset before each attempt so a stale reason from a prior
+            # resolve() on a reused provider instance cannot leak into
+            # this call's NoWheelError message.
+            p.last_failure = ""
             artifact = p.provide(cache_dir)
             if artifact is not None:
                 logger.info(

--- a/tolokaforge/docker/wheel_resolver.py
+++ b/tolokaforge/docker/wheel_resolver.py
@@ -1055,7 +1055,7 @@ _DEFAULT_PROVIDERS: tuple[type[WheelProvider], ...] = (
 class WheelResolver:
     """Tries :class:`WheelProvider` instances in priority order.
 
-    The default chain contains all three built-in providers.
+    The default chain contains all four built-in providers.
     Use :meth:`register` to add custom providers after construction.
     """
 


### PR DESCRIPTION
## Summary

Fixes two failure modes in `tolokaforge/docker/wheel_resolver.py` that both stemmed from the same design flaw: the resolver assumed a source checkout *or* a warm/discoverable pip/uv cache, and it failed opaquely (`exit 1`) when neither held.

**Closes #29** (wheel provisioning shouldn't assume a uv/pip cache exists — materialize the engine wheel instead)
**Closes #13** (docker runner wheel_resolver fails for PyPI installs in uv envs)

### What changed

The chain grows from 3 to 4 providers:

| Priority | Provider | Role |
|---|---|---|
| 10 | `LocalSourceWheelProvider` | Build from source when the code IS a checkout. Unchanged. |
| 20 | `PipCacheWheelProvider` | Fast-path — cache hit if warm. **Fixed** to honor `UV_CACHE_DIR` unconditionally (not only via CLI). |
| **25** | **`ReinstallWheelProvider` (NEW)** | Read `direct_url.json` from the installed dist; materialize a wheel from the same origin. |
| 30 | `PipDownloadWheelProvider` | Final fallback. **Fixed** to work without pip via `ensurepip` auto-recovery, and to always surface stderr. Delegates to `ReinstallWheelProvider._materialize_by_version` so both share one implementation of the download path. |

`ReinstallWheelProvider` dispatches on PEP 610 `direct_url.json`:
- `vcs_info` present → `git clone` at the pinned commit + `uv build --wheel` (with `pip wheel` fallback). Hex-SHA commit ids skip the `git clone --branch <SHA>` shallow path (git rejects SHAs there).
- `archive_info` present → `urllib` download from the same URL. Accepts `.whl`, `.tar.gz`, `.tgz`, `.zip`, `.tar.bz2`, `.tar.xz`.
- `dir_info` present → **refused** with a clear error, so a local-path install can never be silently substituted with a same-version PyPI wheel in the runner image.
- no `direct_url` (plain PyPI install) → `python -m pip download --only-binary=:all:` for the pinned version, with `ensurepip` auto-recovery when pip is missing (the fix for uv envs that omit pip). uv is not attempted on this path — uv 0.9 has no `pip download` subcommand; the pip path with `ensurepip` recovery already covers the "no pip installed" case.

`_finalize` filters candidate wheels by matching version, not by mtime alone — a stale wheel of a different version left in the shared cache directory by a prior provider run can no longer be returned mislabeled.

Every subprocess call now captures stderr and surfaces it via `provider.last_failure`, so `NoWheelError` reports each provider by name with the concrete reason it failed instead of an opaque `exit 1`. `WheelResolver.resolve` resets `last_failure` before each attempt so a stale reason from a prior resolve on a reused provider can't leak.

### `_uv_cache_bases()` precedence change

Was: CLI first (if uv reachable), env only as fallback. This let a stale/unavailable CLI silently mask a cache relocated via `UV_CACHE_DIR` — the exact failure mode `astral-sh/setup-uv` triggers in CI.

Now: env → CLI → default, all three deduplicated and searched. The env var is the most explicit signal a user (or CI) can send, and it's honored directly without a subprocess round-trip.

### `NoWheelError` message

Before:
```
NoWheelError: No provider could produce a tolokaforge wheel. Tried providers: local-source, pip-cache, pip-download. …
```

After:
```
Could not resolve a tolokaforge wheel via any provider.
UV_CACHE_DIR=unset, PIP_CACHE_DIR=/tmp/….
Per-provider failure:
  local-source: no engine source tree walking up from …
  pip-cache: no wheel for tolokaforge==0.7.0 in 0 candidate(s) across 2 cache root(s): …
  reinstall: pip download tolokaforge==0.7.0: …Connection refused…
  pip-download: pip download tolokaforge==0.7.0: …
Remediation: install tolokaforge via `uv sync` / `pip install`, set UV_CACHE_DIR to a warm cache, or ensure the install origin (git URL / archive URL / PyPI index) is reachable.
```

`WheelProvider.last_failure` moves to a class-level default so downstream subclasses that override `__init__` without calling `super().__init__()` don't crash the resolver's failure-message assembly.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run pre-commit run --files …` (ruff + black) pass
- [x] `uv run pytest tests/ -m "unit or canonical"` — **2496 pass** (baseline 2449, +47 new resolver tests; 97 dedicated wheel-resolver tests)
- [x] Layer 2 — Fresh source-checkout: `LocalSourceWheelProvider` builds a real 578 kB wheel (v0.7.0)
- [x] Layer 3 — Wheel-only install in a bare uv venv (no pip, empty caches, isolated HOME): `ReinstallWheelProvider` fires and materializes the wheel via `direct_url.archive_info` — the exact scenario that broke before
- [x] Layer 4 — Relocated `UV_CACHE_DIR`: `PipCacheWheelProvider` honors the env var directly and finds the wheel; unsetting the env correctly refuses to substitute for `dir_info` origins
- [x] Layer 5 — Git-tag install shape (matches consumer-repo CI): both `pip-cache` (env-honored) and `reinstall` (git-clone at pinned commit + `uv build`) succeed independently
- [x] Layer 6 — PyPI install: `direct_url` is `null`, `reinstall` correctly falls to `_materialize_by_version` and re-downloads via `pip download --only-binary=:all:` (with `ensurepip` bootstrap firing when the venv has no pip)
- [x] Layer 7 — Adversarial break-a-provider (empty `PATH`, unreachable `PIP_INDEX_URL`): every provider fails cleanly, `NoWheelError` names all four and includes the concrete stderr tail from each
- [x] Local review pass (medium-effort): 8 findings surfaced and addressed in commit 2
- [x] GitHub Claude review: no blocking issues; one doc-drift fix landed in commit 3

## Unit test additions (in `tests/unit/test_wheel_resolver.py`)

- `TestStderrTail`, `TestRunHelper` — stderr truncation + subprocess wrapper contract
- `TestRunPipEnsurepipRecovery` — `ModuleNotFoundError: No module named pip` → `ensurepip --upgrade` → retry
- `TestRunUv` — `uv not on PATH` short-circuit
- `TestReinstallWheelProvider` — all four `direct_url` shapes (vcs_info, archive_info, dir_info, none), by-version fallback semantics, per-attempt failure surfacing, malformed `vcs_info`
- `TestNewestWhlForVersion` — version-matching selector never returns a stale wheel of a different version
- `TestLooksLikeSha` — hex-SHA detection so `_materialize_git` can skip the unsupported `--branch <SHA>` path
- `TestNoWheelErrorMessage` — pins the enriched error format
- `TestUvCacheBasesPrecedence` — locks the new env→CLI→default order
- `TestPipDownloadWheelProvider` — delegates to shared `_materialize_by_version`; short-circuits for git/archive/dir origins
- `TestLocalSourceWheelProvider._build_wheel*` — direct-call tests that catch signature regressions the patch-based tests miss