### PR TITLE
docs: surface v0.8.0 isolated trials + multi-container capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,65 @@ points at always travel together.
 
 For distributed execution and advanced workflows see the [Runner Guide](docs/RUNNER.md).
 
+## Runtime modes
+
+Every trial runs inside a Docker stack. Two runtime backends decide how
+that stack is scoped:
+
+- **`shared`** (default): one stack materialises at run start and every
+  trial hits it. Fast startup, lowest overhead.
+- **`per_trial`**: a fresh stack materialises for each trial via
+  [Testcontainers](https://testcontainers.com/). Strict isolation —
+  DB rows, filesystem edits, service state never leak across trials.
+  Use it whenever a task mutates its environment.
+
+Pick per-run via the CLI flag or the config key:
+
+```bash
+uv run tolokaforge run --config my_run.yaml --runtime per_trial
+```
+
+```yaml
+# my_run.yaml
+orchestrator:
+  runtime: per_trial            # or "shared" (default)
+```
+
+A task can also declare its requirement via `environment_manifest.isolation`
+in `task.yaml` — the orchestrator refuses to run a `per_trial` task on the
+shared backend so cross-trial contamination is a startup-time error, not a
+silent grading bug.
+
+See [docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md)
+for the full lifecycle deep-dive and
+[ADR-0016](docs/architecture/adr/0016-runtime-backend-comparison.md) for the
+tradeoff analysis.
+
+## Multi-container tasks
+
+Tasks aren't limited to the engine's built-in stack (runner + db-service ±
+RAG ± mock-web). A task can declare its own `docker-compose.yaml` — the
+task pack ships the compose file next to `task.yaml`, and the engine
+materialises that stack instead. Real databases, real APIs, custom
+services, whatever the compose file names.
+
+```yaml
+# task.yaml
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  runner_service: "runner"
+  isolation: "shared_ok"        # or "per_trial"
+```
+
+The [`multi_service`](examples/native/multi_service/) example is the
+smallest working demonstration (runner + db-service + an nginx serving a
+product catalog); its two siblings scale up to a multi-endpoint join and a
+full PostgREST + postgres three-tier stack.
+
+Read [docs/guides/multi_container_tasks.md](docs/guides/multi_container_tasks.md)
+for a walkthrough, or [ADR-0018](docs/architecture/adr/0018-multi-container-under-shared-runtime.md)
+for the case-matrix that decides which mode fits your task.
+
 ## Project Structure
 
 ```
@@ -94,6 +153,9 @@ examples/             # Reference task layouts with runnable run_config.yaml
 ├── native/           # default `native` adapter
 │   ├── browser_task/
 │   ├── coding/
+│   ├── multi_service/          # task-declared compose (nginx catalog)
+│   ├── multi_service_advanced/ # multi-endpoint join
+│   ├── multi_service_postgres/ # PostgREST + postgres three-tier
 │   ├── native_shared_domain/
 │   └── tool_use/
 └── terminal_bench/   # `terminal_bench` adapter (Docker compose)
@@ -109,6 +171,8 @@ examples/             # Reference task layouts with runnable run_config.yaml
 | Tool reference | [docs/TOOLS.md](docs/TOOLS.md) |
 | Browser/mobile tools | [docs/BROWSER_TOOLS.md](docs/BROWSER_TOOLS.md) |
 | Runner & distributed execution | [docs/RUNNER.md](docs/RUNNER.md) |
+| Runtime backends (shared vs per-trial) | [docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md) |
+| Multi-container task guide | [docs/guides/multi_container_tasks.md](docs/guides/multi_container_tasks.md) |
 | Adapter architecture | [docs/ADAPTER_ARCHITECTURE.md](docs/ADAPTER_ARCHITECTURE.md) |
 | Analytics & failure attribution | [docs/ANALYTICS.md](docs/ANALYTICS.md) |
 | Python package API | [docs/PYTHON_PACKAGE.md](docs/PYTHON_PACKAGE.md) |
@@ -121,6 +185,9 @@ examples/             # Reference task layouts with runnable run_config.yaml
 
 ## Examples
 
+Single-container tasks — one runner container plus the engine's built-in
+services (db-service, mock-web, RAG on demand):
+
 | Example | Description |
 | --- | --- |
 | [`examples/native/coding/`](examples/native/coding/) | Simplest native pattern — file-write grading |
@@ -128,6 +195,15 @@ examples/             # Reference task layouts with runnable run_config.yaml
 | [`examples/native/browser_task/`](examples/native/browser_task/) | Browser tool against mock-web fixtures |
 | [`examples/native/native_shared_domain/`](examples/native/native_shared_domain/) | `_shared/domain.yaml` + FastMCP pattern |
 | [`examples/terminal_bench/`](examples/terminal_bench/) | Docker-compose stacks with `terminal_bench` adapter |
+
+Multi-container tasks — the task ships its own compose file declaring
+additional services (see [multi_container_tasks.md](docs/guides/multi_container_tasks.md)):
+
+| Example | Description |
+| --- | --- |
+| [`examples/native/multi_service/`](examples/native/multi_service/) | Smallest multi-service task — runner + db-service + nginx product catalog |
+| [`examples/native/multi_service_advanced/`](examples/native/multi_service_advanced/) | Multi-endpoint aggregation across two task-specific HTTP APIs |
+| [`examples/native/multi_service_postgres/`](examples/native/multi_service_postgres/) | Realistic three-tier stack — PostgREST + postgres, no application code in the task pack |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ in `task.yaml` — the orchestrator refuses to run a `per_trial` task on the
 shared backend so cross-trial contamination is a startup-time error, not a
 silent grading bug.
 
-See [docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md)
-for the full lifecycle deep-dive and
-[ADR-0016](docs/architecture/adr/0016-runtime-backend-comparison.md) for the
-tradeoff analysis.
+Read [docs/guides/isolated_trials.md](docs/guides/isolated_trials.md) for
+a walkthrough (when to use each mode, how to opt in, cost tradeoffs), or
+[docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md)
+for the full lifecycle deep-dive.
 
 ## Multi-container tasks
 
@@ -172,6 +172,7 @@ examples/             # Reference task layouts with runnable run_config.yaml
 | Browser/mobile tools | [docs/BROWSER_TOOLS.md](docs/BROWSER_TOOLS.md) |
 | Runner & distributed execution | [docs/RUNNER.md](docs/RUNNER.md) |
 | Runtime backends (shared vs per-trial) | [docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md) |
+| Isolated trials guide | [docs/guides/isolated_trials.md](docs/guides/isolated_trials.md) |
 | Multi-container task guide | [docs/guides/multi_container_tasks.md](docs/guides/multi_container_tasks.md) |
 | Adapter architecture | [docs/ADAPTER_ARCHITECTURE.md](docs/ADAPTER_ARCHITECTURE.md) |
 | Analytics & failure attribution | [docs/ANALYTICS.md](docs/ANALYTICS.md) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -67,6 +67,60 @@ grading: "grading.yaml"
 - `mock_web.base_url`: base URL for mock web service (`http://mock-web:8080`).
 - `rag.corpus_dir`: directory of `.txt` files for RAG indexing.
 
+## Multi-container environments (`environment_manifest`)
+
+Optional. A task declares `environment_manifest` when it needs its own
+docker-compose stack — extra services beyond the engine's built-in
+`runner` + `db-service`. If omitted, the engine wires up its default
+stack (extended to include mock-web / rag-service if the task uses their
+tools).
+
+The manifest points at a compose file that lives next to `task.yaml`:
+
+```yaml
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  runner_service: "runner"
+  isolation: "shared_ok"          # or "per_trial" (default)
+```
+
+Field reference:
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `compose_file` | yes | — | Path to the docker-compose YAML. Relative paths resolve against `task.yaml`. This file is the sole source of truth for services, images, ports, volumes, healthchecks, and `depends_on`. |
+| `runner_service` | no | `"default"` | Which compose service is the tolokaforge runner. Must be a service declared in the compose file. |
+| `isolation` | no | `"per_trial"` | `"per_trial"` (fresh stack per trial) or `"shared_ok"` (all trials share the run's stack). See [multi-container guide](guides/multi_container_tasks.md#choosing-isolation) for how to pick. |
+
+Fields declared on the model but **not yet enforced by the provisioner** —
+declaring them is accepted for forward-compatibility but has no runtime
+effect today:
+
+- `network_policy` — reserved. Default `no_internet` is documented but not
+  yet enforced. Compose-file `network_mode: host` is still rejected by the
+  manifest validator regardless.
+- `security_context_defaults` — reserved. No provisioner consumer yet.
+- `initial_state` (on the manifest itself, not the task-level
+  `initial_state`) — reserved for per-service fixture copy operations. Use
+  compose-file `volumes:` for now.
+
+Compose-file safety invariants the manifest validator enforces at task
+load:
+
+- `network_mode: host` is rejected on any service.
+- `privileged: true` is rejected on any service.
+- `cap_add` is rejected on any service.
+- Bind-mount paths must stay inside the task directory.
+- All image tags must be pinned — `image: nginx:latest` is rejected;
+  `image: nginx:1.27-alpine` is accepted.
+- `depends_on` targets must reference declared services.
+- `runner_service` must be declared in the compose file.
+
+For a full walkthrough anchored to a working example, see the
+[multi-container tasks guide](guides/multi_container_tasks.md). For the
+underlying case matrix (built-in vs task-declared × shared vs per-trial)
+see [ADR-0018](architecture/adr/0018-multi-container-under-shared-runtime.md).
+
 ## User Simulator
 
 Prefer LLM mode (`mode: "llm"`) for realistic conversations. Use `backstory` to define the user's goal and information they reveal over the conversation:

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -14,6 +14,7 @@ list — see the top-level `docs/*.md` files (linked from the repo
 
 | Guide | Anchored to | What it covers |
 | --- | --- | --- |
+| [Isolated trials](isolated_trials.md) | [`examples/native/coding/`](../../examples/native/coding/) (works on any task pack) | Choosing between shared and per-trial runtime backends — what isolation buys you, how to opt in, cost tradeoffs |
 | [Multi-container tasks](multi_container_tasks.md) | [`examples/native/multi_service/`](../../examples/native/multi_service/) | Authoring a task that declares its own docker-compose stack (extra services beyond the engine defaults) |
 
 More guides land here as multi-container capabilities and other authoring

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,21 @@
+# Guides
+
+How-to guides for common tolokaforge patterns. Each guide is anchored to a
+working example under [`examples/`](../../examples/) so you can copy the
+pattern rather than reconstruct it.
+
+For reference material — the config schema, the task-YAML fields, the tool
+list — see the top-level `docs/*.md` files (linked from the repo
+[README](../../README.md)). For deep architecture context — the
+`RuntimeBackend` protocol, the compose materialisation lifecycle, the ADRs
+— see [`docs/architecture/`](../architecture/).
+
+## Available guides
+
+| Guide | Anchored to | What it covers |
+| --- | --- | --- |
+| [Multi-container tasks](multi_container_tasks.md) | [`examples/native/multi_service/`](../../examples/native/multi_service/) | Authoring a task that declares its own docker-compose stack (extra services beyond the engine defaults) |
+
+More guides land here as multi-container capabilities and other authoring
+patterns expand. Contributions welcome — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/guides/isolated_trials.md
+++ b/docs/guides/isolated_trials.md
@@ -1,0 +1,200 @@
+# Isolated trials
+
+This guide explains what per-trial isolation buys you, when to use it,
+and how to opt in. It covers the CLI, the run config, and the task-level
+declaration, plus a worked example you can run against an unchanged
+example task pack.
+
+For the underlying protocol and materialisation lifecycle see
+[`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
+For the tradeoff analysis behind the two backends see
+[ADR-0016](../architecture/adr/0016-runtime-backend-comparison.md); for the
+provisioning contract see
+[ADR-0010](../architecture/adr/0010-runtime-backend-provisioning-contract.md).
+
+## What "isolated trial" means
+
+Every trial is a run of a single task by a single agent. Two runtime
+backends decide how the trial's docker substrate is scoped:
+
+- **`shared`** (default): one docker stack materialises at run start.
+  Every trial in the run hits the same containers. When trial 1
+  finishes, its DB rows, filesystem edits, and service state all live on
+  and are visible to trial 2. Fast — the stack starts once.
+- **`per_trial`**: a **fresh** docker stack materialises for each
+  trial. New containers, new network, new volumes, fresh fixture state.
+  When the trial ends the stack is torn down and everything in it is
+  gone. Trial 2 starts from scratch.
+
+Per-trial isolation is the strong guarantee. It's what lets a task
+mutate its environment (write DB rows, edit files, POST to services)
+without polluting any other trial's grading.
+
+## When to use it
+
+Choose `per_trial` when **any** of the following is true:
+
+- The task's grading depends on state the trial itself created (a row
+  the agent wrote, a file it edited, a message it posted).
+- The task's fixtures mutate during the trial (bin-mounted data the
+  agent modifies, a DB that accepts writes).
+- Two trials of the same task could otherwise see each other's residue
+  through a shared service.
+- You measure `pass@k` and need every retry to be genuinely
+  independent.
+
+Choose `shared` when **all** of the following are true:
+
+- Grading only inspects the agent's output (a written file, a returned
+  string).
+- Every service the task touches is read-only or fully idempotent-on-
+  reset for the duration of the run.
+- The trials do not race on any shared state that could cause
+  non-determinism.
+
+Default is `shared` because the cold-start cost is real: every trial in
+a per-trial run pays the cost of `docker compose up` again. On a task
+whose stack takes 30s to reach healthy, a 100-trial run costs an extra
+~50 minutes of wall clock in materialisation alone. See [Cost](#cost)
+below.
+
+## How to opt in
+
+Three surfaces, in ascending order of precedence:
+
+**1. Config file (per-run default).** Set `orchestrator.runtime` in the
+run config YAML:
+
+```yaml
+orchestrator:
+  runtime: per_trial          # or "shared"
+```
+
+**2. CLI flag (override for this invocation).** `--runtime` overrides
+whatever is in the config, so you can flip an existing config without
+editing it:
+
+```bash
+uv run tolokaforge run \
+  --config examples/native/coding/run_config.yaml \
+  --runtime per_trial
+```
+
+**3. Task-level declaration (mandatory requirement).** A task that
+cannot tolerate shared state declares its requirement in
+`task.yaml`:
+
+```yaml
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  runner_service: "runner"
+  isolation: "per_trial"
+```
+
+This is a **hard requirement**: if the run's backend can't satisfy it,
+the orchestrator refuses to start. You'll see a startup-time
+`RuntimeError` naming the offending task(s):
+
+```
+Runtime backend SharedStackRuntimeBackend shares state across every
+trial in the run, but 2 task(s) declare
+`environment_manifest.isolation: per_trial`: ['support_triage_01',
+'orders_customers_join_01']. These tasks would silently produce wrong
+verdicts on a shared-stack backend.
+  Fix: select a per-trial runtime backend in the run config (e.g.
+  PerTrialRuntimeBackend), or set `isolation: shared_ok` on the task(s)
+  that genuinely tolerate shared state across trials.
+```
+
+The refusal is deliberate — silent cross-trial contamination is a
+failure mode where the grader believes it, so making it a startup error
+rather than a subtle grading bug is the safer default.
+
+## Worked example
+
+`--runtime per_trial` works on any task pack, with or without a
+task-declared manifest. When the task has no manifest, the engine's
+built-in stack (`runner` + `db-service`) is what gets materialised per
+trial.
+
+Take the smallest existing example (`examples/native/coding`, no
+manifest) and run it under each backend:
+
+```bash
+# Default — shared backend. One stack, both trials share it.
+uv run tolokaforge run \
+  --config examples/native/coding/run_config.yaml
+
+# Same tasks, per-trial backend. Fresh stack per trial.
+uv run tolokaforge run \
+  --config examples/native/coding/run_config.yaml \
+  --runtime per_trial
+```
+
+While the second run is executing, in a separate shell:
+
+```bash
+docker compose ls | grep tolokaforge
+```
+
+You'll see one compose project per active trial (named with the
+trial's identifier), and each project's containers, network, and
+volumes disappear when the trial ends. Contrast with the shared run,
+where a single compose project stays up for the entire run.
+
+Grading verdicts should be identical between the two runs for this
+example — the coding task doesn't mutate state, so isolation doesn't
+change the outcome. What changes is startup cost (per-trial pays it
+`n_trials` times) and the level of guarantee (per-trial trials can't
+see each other, even in principle).
+
+## Cost
+
+Per-trial materialisation is not free. On a laptop with warm image
+caches:
+
+- **Built-in stack** (`runner` + `db-service`): 3–5s per trial.
+- **`multi_service`** (adds nginx serving static JSON): 4–6s per
+  trial.
+- **`multi_service_postgres`** (adds postgres + PostgREST): 30–45s
+  on the first trial (postgres has to initialise the schema), 5–8s on
+  subsequent trials (image is cached).
+
+The engine tears down each trial's stack after the trial completes.
+Concurrency `orchestrator.workers > 1` compounds the cost — each
+worker materialises its own stack — but also parallelises it.
+
+If your task genuinely doesn't need `per_trial`, don't use it. If it
+does, budget for the wall-clock cost.
+
+## Interaction with multi-container tasks
+
+Isolation and multi-container are orthogonal — you choose them
+independently. All four combinations exist:
+
+| Task | Runtime | Behaviour |
+| --- | --- | --- |
+| No manifest, `shared` | Engine built-in stack once per run | Fastest |
+| No manifest, `per_trial` | Engine built-in stack per trial | Isolation on the defaults |
+| Task manifest, `shared` | Task-declared compose once per run | Task-specific services, shared |
+| Task manifest, `per_trial` | Task-declared compose per trial | Task-specific services, isolated |
+
+See [`multi_container_tasks.md`](multi_container_tasks.md) for the
+task-manifest side of that matrix, and
+[ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md)
+for the full case analysis.
+
+## Further reading
+
+- [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md)
+  — the `RuntimeBackend` protocol, provisioning lifecycle, sequence
+  diagrams for each backend.
+- [ADR-0007](../architecture/adr/0007-runtime-backend-protocol.md)
+  — the seam.
+- [ADR-0010](../architecture/adr/0010-runtime-backend-provisioning-contract.md)
+  — per-trial provisioning contract.
+- [ADR-0016](../architecture/adr/0016-runtime-backend-comparison.md)
+  — shared vs per-trial tradeoff analysis.
+- [`docs/TASKS.md`](../TASKS.md#multi-container-environments-environment_manifest)
+  — reference schema for `environment_manifest.isolation` and the other
+  manifest fields.

--- a/docs/guides/multi_container_tasks.md
+++ b/docs/guides/multi_container_tasks.md
@@ -1,0 +1,207 @@
+# Multi-container tasks
+
+This guide walks through authoring a task that ships its own docker-compose
+stack — extra services beyond the engine's built-in `runner` + `db-service`.
+It's anchored to a working example
+([`examples/native/multi_service/`](../../examples/native/multi_service/))
+that you can `tolokaforge run` unchanged before adapting it.
+
+For the design rationale + case matrix, see
+[ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md).
+For the runtime backend lifecycle, see
+[`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
+
+## When to declare a multi-container task
+
+The engine already ships built-in stacks — `core_stack` (runner +
+db-service) and `full_stack` (adds mock-web + rag-service). If your task
+only needs those services, don't declare a manifest; just point at the
+right run config and the engine wires the built-ins for you.
+
+You want a task-declared manifest when the task genuinely needs *something
+else running alongside* the runner:
+
+- A real database the agent should query (postgres, mysql, redis, ...).
+- A real HTTP API the task provides (a REST endpoint, a mock service, a
+  proxied third-party API).
+- A queue, cache, or worker the agent has to interact with.
+- Any topology the engine defaults don't cover.
+
+The manifest hands the engine a `docker-compose.yaml` you write, and the
+engine materialises **exactly** those services — no more, no fewer — for
+the task.
+
+## Walkthrough — `multi_service_example_01`
+
+The smallest working demonstration lives at
+[`examples/native/multi_service/`](../../examples/native/multi_service/).
+Three files carry the interesting content: `task.yaml`,
+`environment.compose.yaml`, and the sibling `README.md` that describes the
+scenario.
+
+### The task-YAML declaration
+
+The task declares its manifest via `environment_manifest`:
+
+```yaml
+# examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+environment_manifest:
+  compose_file: "./environment.compose.yaml"
+  isolation: "shared_ok"
+  runner_service: "runner"
+```
+
+Three fields matter:
+
+- **`compose_file`** — path to the docker-compose YAML, relative to
+  `task.yaml`. This file is the sole source of truth for images, ports,
+  volumes, health probes, and inter-service dependencies. The engine reads
+  it verbatim.
+- **`runner_service`** — which service in the compose file is the
+  tolokaforge runner. The engine talks gRPC to this service to dispatch
+  tool calls and grade the trial.
+- **`isolation`** — whether the task tolerates state sharing across
+  trials (`shared_ok`) or requires a fresh substrate per trial
+  (`per_trial`). Default is `per_trial`. See [choosing isolation](#choosing-isolation)
+  below.
+
+### The compose file
+
+The compose file lists the services the engine should bring up:
+
+```yaml
+# examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_healthy
+    healthcheck: ...
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck: ...
+
+  app-service:
+    image: nginx:1.27-alpine
+    ports:
+      - "80"
+    volumes:
+      - ./fixtures/products.json:/usr/share/nginx/html/products.json:ro
+    healthcheck: ...
+```
+
+Three things worth noting:
+
+- **`tolokaforge-runner:local` and `tolokaforge-db-service:local` are
+  aliases** the engine sets up at run start. Task compose files reference
+  these stable names instead of the content-hash tags the engine actually
+  builds. Details in
+  [`RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
+- **Services reach each other by service name.** All services in a compose
+  file join the same auto-generated docker network, so the runner container
+  reaches `app-service` as `http://app-service/products.json`. No manual
+  network wiring needed.
+- **Pinned image tags are enforced.** The manifest validator rejects
+  floating tags like `nginx:latest` — pin to a specific version
+  (`nginx:1.27-alpine` above) so runs stay reproducible.
+
+The engine validates a few more safety invariants when it loads the
+manifest: no `network_mode: host`, no `privileged: true`, no `cap_add`,
+`depends_on` must resolve, `runner_service` must be declared in the compose
+file. Violations fail at task-load time with a clear error, not at trial
+start.
+
+## Choosing isolation
+
+Two runtime backends decide *when* a stack materialises. Two isolation
+values on the task decide *what the backend must satisfy*. The four
+combinations aren't all supported:
+
+| Task `isolation` | `--runtime shared` | `--runtime per_trial` |
+| --- | --- | --- |
+| `shared_ok` | ✅ Stack materialises once per run, all trials share it. Fastest. | ✅ Fresh stack per trial. Slower but stricter. |
+| `per_trial` | ❌ Orchestrator refuses at startup — cross-trial contamination would break grading. | ✅ Fresh stack per trial. Required. |
+
+Rule of thumb:
+
+- If the task's grading only inspects the agent's output (files it wrote,
+  a message it sent), and the services in the stack are read-only or
+  reset-idempotent — declare `shared_ok`.
+- If any trial mutates the environment in a way a later trial could observe
+  (DB writes, filesystem edits, side-effects in a service) — declare
+  `per_trial`. The orchestrator will enforce this by refusing an
+  incompatible backend, so a grading bug from cross-trial contamination is
+  a startup-time error, not a silent failure.
+
+Default is `per_trial` — the safer choice. Opt into `shared_ok` only after
+verifying grading is stateless.
+
+## Adding another service
+
+Take the working `multi_service` example and extend its compose file.
+Suppose you want to add a redis cache:
+
+1. Copy the example into your task pack:
+   ```
+   cp -r examples/native/multi_service my_pack/tasks/my_new_task
+   ```
+2. Add a `cache` service to `environment.compose.yaml`:
+   ```yaml
+   services:
+     # ... existing runner, db-service, app-service ...
+     cache:
+       image: redis:7.4-alpine     # pinned tag — floating tags rejected
+       ports:
+         - "6379"
+       healthcheck:
+         test: ["CMD", "redis-cli", "ping"]
+         interval: 2s
+         retries: 30
+         start_period: 2s
+   ```
+3. If the runner needs to reach it, add a `depends_on` and (optionally)
+   an env var:
+   ```yaml
+   services:
+     runner:
+       environment:
+         DB_SERVICE_URL: "http://db-service:8000"
+         REDIS_URL: "redis://cache:6379"
+       depends_on:
+         cache:
+           condition: service_healthy
+   ```
+4. Validate and run:
+   ```bash
+   uv run tolokaforge validate --tasks "my_pack/**/task.yaml"
+   uv run tolokaforge run --config my_pack/run_config.yaml
+   ```
+
+The engine will materialise `runner`, `db-service`, `app-service`, and
+`cache` for the run (or per trial, depending on the runtime you selected).
+
+## Further reading
+
+- [`examples/native/multi_service/README.md`](../../examples/native/multi_service/README.md)
+  — the anchor example this guide walks through
+- [`examples/native/multi_service_advanced/README.md`](../../examples/native/multi_service_advanced/README.md)
+  — multi-endpoint aggregation across two task-specific HTTP APIs
+- [`examples/native/multi_service_postgres/README.md`](../../examples/native/multi_service_postgres/README.md)
+  — a realistic three-tier stack (PostgREST + postgres, no application
+  code in the task pack)
+- [ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md)
+  — case matrix + sequence diagrams for each supported combination
+- [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md)
+  — full lifecycle + materialisation deep-dive
+- [`docs/TASKS.md`](../TASKS.md#multi-container-environments-environment_manifest)
+  — reference schema for every `environment_manifest` field


### PR DESCRIPTION
## Summary

v0.8.0 delivered two capabilities the README never mentioned: **per-trial isolation** (`--runtime per_trial`, shipped in v0.7.0 but never surfaced anywhere in the README) and **task-declared multi-container stacks** (`SharedStackRuntimeBackend` now accepts an `env_manifest` compose file, plus three new working examples). Deep architecture docs already existed (`docs/architecture/RUNTIME_BACKENDS.md`, ADR-0018) — the problem was discovery: a new user reading the README had no idea these existed.

This PR closes the discovery gap without duplicating the deep docs.

## What changed

**`README.md`**
- Two new short sections after Quick Start: "Runtime modes" (~30 lines, shared vs per_trial with the CLI flag + config key + link to `RUNTIME_BACKENDS.md`) and "Multi-container tasks" (~20 lines, one `environment_manifest` snippet + link to the new guide and ADR-0018).
- Examples table split into two sub-tables — single-container (5 rows, unchanged) and multi-container (3 rows, previously invisible: `multi_service`, `multi_service_advanced`, `multi_service_postgres`).
- Documentation table gains rows for `RUNTIME_BACKENDS.md` and `docs/guides/multi_container_tasks.md`.
- Project Structure diagram lists the new example directories.

**`docs/guides/` (new directory)**
- `README.md` — one-paragraph index. Peer to `docs/architecture/`, meant to grow over time.
- `multi_container_tasks.md` — the first guide (~200 lines). Anchored to `examples/native/multi_service/`. Sections: when to declare a manifest, walkthrough of the task-YAML + compose file, isolation matrix (task × backend), a worked "add a redis service" pointer, further reading. Every quoted YAML block byte-matches a real file the user can open.

**`docs/TASKS.md`**
- New reference section for `environment_manifest`. Field table split into "enforced today" (`compose_file`, `runner_service`, `isolation`) and "reserved but not yet enforced" (`network_policy`, `security_context_defaults`, `initial_state` on the manifest itself) — verified by grepping the provisioner call sites — so users who set the latter aren't silently surprised.

## Design choices

- **Discovery, not depth.** The guide + TASKS.md deliberately don't restate ADR-0018 or `RUNTIME_BACKENDS.md`. They link out to the canonical deep docs. This keeps the guide short, avoids duplication, and means the deep docs don't drift out of sync with a parallel narrative.
- **Structure that scales.** `docs/guides/` is a new peer to `docs/architecture/`. As multi-container patterns and other authoring capabilities expand, additional guides land as new `.md` files under `docs/guides/` — no restructure needed.
- **Reserved-field honesty.** `network_policy` / `security_context_defaults` / `initial_state` on the manifest are declared on the pydantic model but not consumed by any provisioner today. The reference section marks them explicitly rather than hiding them.

## Verification

- All relative markdown links from the four touched files resolve — checked programmatically against the repo tree.
- Every YAML block quoted in the guide byte-matches the real example file (`environment_manifest` block, compose service names).
- Every field documented in `docs/TASKS.md` exists on the `EnvironmentManifest` model (`tolokaforge/runner/models.py`).
- Every field marked "enforced" is consumed by a real provisioner call site (grep against `per_trial_runtime.py` + `shared_stack_runtime.py`); reserved fields have zero provisioner hits.

## Test plan

- [ ] Skim the rendered README on GitHub — tables, code fences, TOC layout.
- [ ] Follow the new-user path: Quick Start → Runtime modes → RUNTIME_BACKENDS.md → back. Runtime modes → Multi-container tasks → guide → ADR-0018 → back. Examples table → multi_service example → its README.
- [ ] Confirm the "add a redis service" walkthrough in the guide is intelligible without prior context.