### PR TITLE
integrate: qwen/qwen3.6-plus

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,50 +381,6 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # -----------------------------------------------------------------
-    # Qwen — preset routes it through the same strict trio as GPT-5.
-    # Reasoning surface is OpenAI-style summary only, no signed blocks,
-    # so thinking capabilities are ``known_unsupported``.
-    # -----------------------------------------------------------------
-    MC(
-        model_id="openrouter__qwen_qwen3.6-plus",
-        provider="openrouter",
-        name="qwen/qwen3.6-plus",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,  # strict-schema dict-map array conversion
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                C.DECIMAL_FIELD_TOOL_CALL,  # same strict sanitizer as GPT-5
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-                # No implicit upstream cache surfaced on the OpenRouter
-                # qwen/* routes.
-                C.IMPLICIT_PROMPT_CACHING,
-            }
-        ),
-    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -464,6 +464,78 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Qwen 3.6-plus — Alibaba's Qwen 3.6 generation. Routes through the
+    # dedicated ``qwen3_6_plus`` preset (passthrough schema + ``DictMapHints``
+    # prompt policy + ``JsonCoerceResponse`` recovery), which is identical to
+    # the generic ``qwen`` preset EXCEPT it swaps in the bespoke
+    # ``QwenReasoningCodec`` (reasoning_codec: qwen). That codec's
+    # ``encode_for_replay`` emits the ``reasoning_details`` envelope so turn-1
+    # reasoning text round-trips into the turn-2 request body — the single fix
+    # that makes ``UNSIGNED_THINKING_REPLAY`` a real ``required`` contract for
+    # this model (5/5 on the final auto-resolve reprobe 2026-07-08). Sibling
+    # qwen3.7-max declares that capability ``known_unsupported`` because it
+    # still rides the no-op ``openai`` codec.
+    #
+    # The three ``known_unsupported`` entries are genuine qwen3.6 ceilings, not
+    # missing policy: PROMPT_CACHING / IMPLICIT_PROMPT_CACHING (no upstream
+    # cache accounting on the route — call 1 reports 0 cache_creation and call
+    # 2 reports 0 cache_read across the full reprobe) and
+    # THINKING_REPLAY_ROUNDTRIP (Qwen emits no per-block signature, so the
+    # signed-replay contract has "no signed blocks on turn 1" to assert on).
+    MC(
+        model_id="openrouter__qwen_qwen3.6-plus",
+        provider="openrouter",
+        name="qwen/qwen3.6-plus",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                # Flipped green by the ``qwen`` reasoning codec's replay path
+                # (reasoning_details envelope on the turn-2 request); 5/5 on
+                # the final auto-resolve reprobe 2026-07-08.
+                C.UNSIGNED_THINKING_REPLAY,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Anthropic-style ephemeral cache is not wired on the qwen
+                # preset (cache_policy: none) and the qwen3.6 route surfaces no
+                # cache accounting: ``test_prompt_caching`` requires
+                # ``cache_creation_input_tokens > 0`` on call 1 (0/5 on the
+                # reprobe) and there is no explicit cache_control to trigger it.
+                C.PROMPT_CACHING,
+                # No implicit upstream auto-cache surface: the second identical
+                # call reports ``cache_read_input_tokens == 0`` (0/5 on the
+                # reprobe). Paired with the ratchet test that flips this back to
+                # required the day a clean 2-call probe observes caching.
+                C.IMPLICIT_PROMPT_CACHING,
+                # Qwen emits no signed reasoning blocks on turn 1 ("no signed
+                # blocks on turn 1 — cannot test replay", 0/5 on the reprobe),
+                # so the SIGNED-replay continuity contract has nothing to
+                # assert. The unsigned text round-trip (UNSIGNED_THINKING_REPLAY,
+                # required above) is the shape this route actually satisfies.
+                C.THINKING_REPLAY_ROUNDTRIP,
+            }
+        ),
+    ),
     # -----------------------------------------------------------------
     # xAI Grok — strict schema sanitiser + array-dict-map response
     # policy + OpenAI-style reasoning summary (no signed blocks).

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -8,7 +8,7 @@
 #   prompt_policy:    none | dict_map_hints
 #   content_policy:   openai | anthropic | nova
 #   response_policy:  standard | unwrap_input | array_dict_map
-#   reasoning_codec:  none | anthropic | openai
+#   reasoning_codec:  none | anthropic | openai | gemini | qwen
 #   cache_policy:     none | anthropic_ephemeral
 #   params:           dict of GenerationParams kwargs
 #
@@ -92,6 +92,28 @@ presets:
     schema_sanitizer: strict
     response_policy: array_dict_map
     reasoning_codec: openai
+
+  # Qwen 3.6-plus — same tool-call axes as the generic ``qwen`` preset
+  # below (passthrough schema + json_coerce response + dict_map_hints
+  # prompt) but swaps the reasoning codec from ``openai`` (extract-only,
+  # no-op replay) to the bespoke ``qwen`` codec whose ``encode_for_replay``
+  # emits the ``reasoning_details`` envelope. That single change flips
+  # ``test_unsigned_thinking_replay`` green — turn-1 reasoning text now
+  # round-trips into the turn-2 request body. Declared BEFORE the generic
+  # ``qwen`` preset so first-match-wins routing picks it up for this model
+  # only; every other qwen route keeps the ``openai`` codec until re-tested.
+  # Genuine ceilings kept ``known_unsupported`` in registry.py: prompt_caching
+  # / implicit_prompt_caching (the qwen3.6 route reports no upstream cache
+  # accounting) and thinking_replay_roundtrip (Qwen emits no per-block
+  # signature, so the signed-replay contract has nothing to assert).
+  # Live-observed via auto-resolve 2026-07-08 (candidate PR #182).
+  qwen3_6_plus:
+    match:
+      - "qwen/qwen3.6-plus"
+    schema_sanitizer: passthrough
+    response_policy: json_coerce
+    prompt_policy: dict_map_hints
+    reasoning_codec: qwen
 
   qwen:
     # Qwen 3.x emits dict-map arguments as either native dicts (matching the

--- a/tolokaforge/core/llm/__init__.py
+++ b/tolokaforge/core/llm/__init__.py
@@ -38,6 +38,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     AnthropicReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -99,6 +100,7 @@ __all__ = [
     "NoReasoningCodec",
     "AnthropicReasoningCodec",
     "OpenAIReasoningCodec",
+    "QwenReasoningCodec",
     # Usage
     "Usage",
     "UsageExtractor",

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -41,6 +41,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     GeminiReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -106,6 +107,7 @@ _REASONING_CODECS: dict[str, type[ReasoningCodec]] = {
     "anthropic": AnthropicReasoningCodec,
     "openai": OpenAIReasoningCodec,
     "gemini": GeminiReasoningCodec,
+    "qwen": QwenReasoningCodec,
 }
 
 _CACHE_POLICIES: dict[str, type[CachePolicy]] = {


### PR DESCRIPTION
# Integrate `openrouter / qwen/qwen3.6-plus` (auto-resolve)

Integrates the candidate model **`qwen/qwen3.6-plus`** (provider `openrouter`, model id
`openrouter__qwen_qwen3.6-plus`, candidate PR #182) via the automated observe → resolve loop.

## Engine reference

`QwenReasoningCodec` — `tolokaforge/core/llm/reasoning_codec.py` — extracts Qwen's
`reasoning_content` / `reasoning_details` and, unlike the no-op `openai` codec, replays the
text back through the OpenRouter `reasoning_details` envelope so reasoning survives across
tool-call turns. Registered as the `qwen` reasoning codec in `_REASONING_CODECS` /
`_POLICY_REGISTRIES` and exported from `tolokaforge/core/llm/__init__.py`.

## Policy

New preset **`qwen3_6_plus`** in `tolokaforge/core/data/model_presets.yaml`, declared before
the generic `qwen` preset so first-match-wins scopes it to `qwen/qwen3.6-plus` only. Same
tool-call axes as the generic `qwen` preset (passthrough schema + `json_coerce` response +
`dict_map_hints` prompt), swapping `reasoning_codec: openai` → `reasoning_codec: qwen`. This
flips `UNSIGNED_THINKING_REPLAY` from failing (0/15 baseline) to passing (5/5 final reprobe).
No other preset changed; no shared glob broadened.

Certificate added to `tests/integration/llm/registry.py`: **20 required / 3 known_unsupported**
(full 23-capability coverage).

## Ceilings (`known_unsupported`)

- `PROMPT_CACHING` — qwen preset wires no `cache_control`; route reports 0 cache-creation tokens.
- `IMPLICIT_PROMPT_CACHING` — no upstream auto-cache surface (0 cache-read tokens on the second
  identical call); guarded by the implicit-cache ratchet test.
- `THINKING_REPLAY_ROUNDTRIP` — Qwen emits no per-block signature, so the signed-replay
  contract has nothing to assert.

## Provenance

Integrated automatically via the auto-resolve workflow after the fix loop converged
(`observation/resolve/overlay.yaml` proven, final reprobe green on the fix-target).

> ⚠️ **Disposable test branch — do not merge.** This PR targets `test/observe-qwen3.6-plus`
> and exists to exercise the auto-integration flow against a synthetic candidate. It is not
> intended for `main`.
