### PR TITLE
integrate: xiaomi/mimo-v2.5-pro

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1126,51 +1126,6 @@ _ALL: list[MC] = [
         ),
     ),
     MC(
-        model_id="openrouter__xiaomi_mimo-v2.5-pro",
-        provider="openrouter",
-        name="xiaomi/mimo-v2.5-pro",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                # OpenRouter / xiaomi enabled implicit prompt caching for
-                # this route between 2026-05-14 14:29 and 16:20 UTC —
-                # earlier evals saw cached_tokens=0 across every
-                # mimo call, but a live
-                # 2-call 8 k-prompt probe at 16:20 reports
-                # ``cache_read_input_tokens=8192/8254`` (99% cached) on
-                # call 2 with a clear cost reduction. The ratchet test
-                # forced this promotion.
-                C.IMPLICIT_PROMPT_CACHING,
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.DECIMAL_FIELD_TOOL_CALL,
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-            }
-        ),
-    ),
-    MC(
         model_id="openrouter__google_gemini-3.1-pro-preview",
         provider="openrouter",
         name="google/gemini-3.1-pro-preview",

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1125,6 +1125,73 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Xiaomi MiMo V2.5 Pro (via OpenRouter) — integrated via auto-resolve
+    # (candidate PR #186). Routes through the model-specific
+    # ``xiaomi_mimo_v2_5_pro`` preset (passthrough schema + JsonCoerceResponse
+    # + GeminiReasoningCodec + reasoning_via_extra_body). Two composed fixes:
+    #
+    #   * json_coerce recovers mimo's stringified object tool-args (``item`` /
+    #     ``root`` / ``doc`` / ``order`` / ``envelope`` / ``message`` arrive as
+    #     JSON-encoded strings). This makes RECURSIVE_REF_TOOL_CALL,
+    #     HETEROGENEOUS_ARRAY_TOOL_CALL, DICT_MAP_TOOL_CALL and
+    #     DISCRIMINATED_UNION_TOOL_CALL all ``required`` (each failed 0/15 on
+    #     the default preset, then passed 5/5 on the final reprobe).
+    #   * the gemini reasoning codec surfaces mimo's unsigned OpenRouter
+    #     reasoning, promoting THINKING_EMITS_BLOCKS + UNSIGNED_THINKING_REPLAY
+    #     to ``required`` (both 0/15 -> 5/5).
+    #
+    # Ceilings (from the resolve decision, genuine gaps, NOT papered over):
+    #   * THINKING_REPLAY_ROUNDTRIP — needs a real per-block signature mimo
+    #     cannot emit; the unsigned replay contract is covered by
+    #     UNSIGNED_THINKING_REPLAY above.
+    #   * PROMPT_CACHING — the provider returns 0 cache_creation_input_tokens
+    #     (no explicit cache_control surface); IMPLICIT_PROMPT_CACHING covers
+    #     the auto-cache surface and is ``required``.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__xiaomi_mimo-v2.5-pro",
+        provider="openrouter",
+        name="xiaomi/mimo-v2.5-pro",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Needs a real per-block signature mimo cannot emit; the
+                # unsigned replay contract is covered by
+                # UNSIGNED_THINKING_REPLAY (required above).
+                C.THINKING_REPLAY_ROUNDTRIP,
+                # Provider returns 0 cache_creation_input_tokens (no explicit
+                # cache_control surface); IMPLICIT_PROMPT_CACHING covers the
+                # auto-cache surface and is required above.
+                C.PROMPT_CACHING,
+            }
+        ),
+    ),
     MC(
         model_id="openrouter__google_gemini-3.1-pro-preview",
         provider="openrouter",

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -108,51 +108,6 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
-  # Open-weights / OpenAI-API-compatible routes whose tool-call adapters
-  # stringify nested object / Dict[str, T] arguments — same failure mode
-  # ``JsonCoerceResponse`` was built for on Qwen.
-  #
-  # Empirical evidence: mimo-v2.5-pro hit 20–25 retries on every
-  # ``zendesk_create_item`` call on a logistics domain evaluation
-  # when ``item`` is a discriminated union (TicketCreate | UserCreate |
-  # OrganizationCreate | CommentCreate). The wire-shape was
-  # ``{"item": "{\"subject\":...}"}`` — a JSON-encoded string instead of a
-  # nested dict. ``JsonCoerceResponse._coerce_json_strings`` decodes that
-  # back to native shape before pydantic validation.
-  # ``DictMapHints`` is also routed because the same models share Qwen's
-  # ``Dict[str, T]`` blind spot (test_dict_map_tool_call).
-  # Reasoning surface format on the OpenRouter wire is not yet codified in
-  # a bespoke codec for these routes; ``openai`` codec is the safe baseline
-  # — it surfaces ``reasoning_content`` summaries via OpenAI-canonical fields
-  # without making structural assumptions.
-  # z-ai/glm-5.1, tencent/hy3-preview and nvidia/nemotron-3-super join
-  # this preset (arena lineup refresh 2026-06): each emits the
-  # discriminated-union ``item`` as a JSON-encoded string that
-  # JsonCoerceResponse decodes — glm/hy3 every call, nemotron
-  # intermittently (native dict on some calls, stringified on others;
-  # without json_coerce the stringified calls fail, so it needs this
-  # preset to make the capability reliable). All three also surface a
-  # reasoning_content summary the ``openai`` codec lands in the logs.
-  # Live 2026-06-05.
-  openrouter_dict_stringify_recovery:
-    match:
-      - "xiaomi/mimo*"
-      - "*mimo-v2*"
-      - "moonshotai/kimi-k2*"
-      - "*kimi-k2*"
-      - "deepseek/deepseek-v4*"
-      - "*deepseek-v4*"
-      - "z-ai/glm-5*"
-      - "*glm-5*"
-      - "tencent/hy3*"
-      - "*hy3-preview*"
-      - "nvidia/nemotron*"
-      - "*nemotron-*"
-    schema_sanitizer: passthrough
-    response_policy: json_coerce
-    prompt_policy: dict_map_hints
-    reasoning_codec: openai
-
   # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -238,6 +238,40 @@ presets:
     reasoning_codec: openai
     response_policy: minimax_m3_tags
 
+  # Xiaomi MiMo V2.5 Pro (via OpenRouter) — model-specific recovery preset
+  # created by auto-resolve (candidate PR #186). Two shipped-class fixes
+  # composed in one entry:
+  #   * response_policy: json_coerce (Family A, dict-stringify recovery) —
+  #     mimo emits object-valued tool args as JSON-encoded strings (``root``,
+  #     ``doc``, ``order``, ``envelope``, ``message``, ``item`` all arrive as
+  #     ``str``). Schema is the default ``passthrough``, so no array pivot is
+  #     needed; ``json_coerce`` decodes the top-level ``{`` / ``[`` strings
+  #     back to native dicts before pydantic validation. Recovers, does not
+  #     reshape. Fixes the recursive_ref / discriminated_union /
+  #     heterogeneous_array / dict_map nested-in-object tool calls.
+  #   * reasoning_codec: gemini (Family B, reasoning not surfaced) — mimo is
+  #     reasoning-native (reasoning_tokens>0) and the ``providers.openrouter``
+  #     override already sends ``extra_body.reasoning``, so the request is
+  #     correct; only the codec was missing (default ``none`` discards the
+  #     reasoning). The gemini codec is the unsigned OpenRouter
+  #     ``reasoning_details`` parser: it surfaces reasoning.text/summary and
+  #     replays reasoning_details without a per-block signature, so
+  #     THINKING_EMITS_BLOCKS + UNSIGNED_THINKING_REPLAY pass.
+  # ``reasoning_via_extra_body`` is already true via ``providers.openrouter``;
+  # pinned here so the entry is self-contained. This is a NARROW,
+  # model-specific match (mimo-v2.5-pro only) — it deliberately does not
+  # restore the broad shared glob. Ceilings live in registry.py:
+  # THINKING_REPLAY_ROUNDTRIP (needs a real per-block signature mimo cannot
+  # emit) and PROMPT_CACHING (provider returns 0 cache_creation_input_tokens).
+  xiaomi_mimo_v2_5_pro:
+    match:
+      - "xiaomi/mimo-v2.5-pro*"
+      - "*mimo-v2.5-pro*"
+    response_policy: json_coerce
+    reasoning_codec: gemini
+    params:
+      reasoning_via_extra_body: true
+
 providers:
   openrouter:
     params:


### PR DESCRIPTION
## Integrate `xiaomi/mimo-v2.5-pro` (auto-resolve)

**Candidate:** provider `openrouter`, name `xiaomi/mimo-v2.5-pro`
(`openrouter__xiaomi_mimo-v2.5-pro`)
**Engine ref:** `dd61443`

Integrated via **auto-resolve**: the fix loop converged and the final reprobe
went green (5/5) on every fix-target, so the proven policy is landed as the
model's integration.

### Policy

A single **model-specific** preset entry `xiaomi_mimo_v2_5_pro` in
`tolokaforge/core/data/model_presets.yaml` (matches `xiaomi/mimo-v2.5-pro*`
only — no shared glob broadened, no new adapter class):

- `response_policy: json_coerce` — decodes mimo's stringified object tool-args
  (`item`/`root`/`doc`/`order`/`envelope`/`message` arriving as JSON strings)
  back to native dicts before validation. Fixes the recursive_ref /
  discriminated_union / heterogeneous_array / dict_map nested-in-object calls.
- `reasoning_codec: gemini` — surfaces mimo's unsigned OpenRouter reasoning
  (`reasoning_details`), promoting `THINKING_EMITS_BLOCKS` and
  `UNSIGNED_THINKING_REPLAY`.
- `params.reasoning_via_extra_body: true` — pinned for self-containment (already
  true via `providers.openrouter`).

Cert added to `tests/integration/llm/registry.py`: 21 `required` /
2 `known_unsupported`.

### Ceilings (`known_unsupported`)

- `THINKING_REPLAY_ROUNDTRIP` — needs a per-block signature mimo cannot emit
  (unsigned replay is covered by `UNSIGNED_THINKING_REPLAY`, required).
- `PROMPT_CACHING` — provider returns `0 cache_creation_input_tokens`; the
  implicit auto-cache surface (`IMPLICIT_PROMPT_CACHING`) is required instead.

---

> ⚠️ **Disposable test branch — DO NOT MERGE.** `test/observe-mimo-v2.5-pro-r2`
> exists to exercise the observe → resolve → integrate flow end-to-end (the
> mimo cert + preset were deliberately de-integrated in `dd61443` to simulate a
> fresh candidate). This PR is the auto-resolve output, not a real integration.
