### PR TITLE
integrate: qwen/qwen3.6-plus

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,50 +381,6 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # -----------------------------------------------------------------
-    # Qwen — preset routes it through the same strict trio as GPT-5.
-    # Reasoning surface is OpenAI-style summary only, no signed blocks,
-    # so thinking capabilities are ``known_unsupported``.
-    # -----------------------------------------------------------------
-    MC(
-        model_id="openrouter__qwen_qwen3.6-plus",
-        provider="openrouter",
-        name="qwen/qwen3.6-plus",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,  # strict-schema dict-map array conversion
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                C.DECIMAL_FIELD_TOOL_CALL,  # same strict sanitizer as GPT-5
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-                # No implicit upstream cache surfaced on the OpenRouter
-                # qwen/* routes.
-                C.IMPLICIT_PROMPT_CACHING,
-            }
-        ),
-    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,6 +381,82 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Qwen 3.6-plus — routed through the model-specific ``qwen_qwen3_6_plus``
+    # preset (a shadow of the family ``qwen`` preset: passthrough schema +
+    # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery) that
+    # swaps the family ``openai`` reasoning codec for the bespoke
+    # ``QwenReasoningCodec``. Integrated via auto-resolve (PR #188) after the
+    # observe baseline flagged ``test_unsigned_thinking_replay`` failing 0/15.
+    #
+    # The codec keeps OpenAI-identical extraction of Qwen's
+    # ``reasoning_content`` summary (THINKING_EMITS_BLOCKS passes, so it is
+    # ``required``) and adds an ``encode_for_replay`` that re-emits the turn-1
+    # reasoning as OpenRouter ``reasoning.text`` — the unsigned envelope
+    # ``test_unsigned_thinking_replay`` round-trips, so UNSIGNED_THINKING_REPLAY
+    # is ``required`` (5/5 on the final reprobe).
+    #
+    # Genuine ceilings (``known_unsupported``): THINKING_REPLAY_ROUNDTRIP —
+    # Qwen emits no signed blocks on turn 1, so the signed-replay contract has
+    # no source; PROMPT_CACHING / IMPLICIT_PROMPT_CACHING — the OpenRouter Qwen
+    # route neither creates an explicit cache entry (no cache_control markers
+    # wired) nor reports any upstream auto-cache read on a 2-call probe.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__qwen_qwen3.6-plus",
+        provider="openrouter",
+        name="qwen/qwen3.6-plus",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+                # Qwen surfaces an OpenAI-style ``reasoning_content`` summary
+                # the codec yields as a structured block — verified 15/15 on
+                # the observe baseline.
+                C.THINKING_EMITS_BLOCKS,
+                # ``QwenReasoningCodec.encode_for_replay`` re-emits the turn-1
+                # reasoning as OpenRouter ``reasoning.text`` so the outgoing
+                # assistant message carries ``reasoning_details`` — the fix
+                # target that went 0/15 (baseline) -> 5/5 (final reprobe).
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # No signed reasoning blocks on turn 1 — the signed-replay
+                # continuity contract has no source. Genuine ceiling; the
+                # unsigned variant (UNSIGNED_THINKING_REPLAY, required above)
+                # is the shape Qwen actually round-trips.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                # Anthropic-style ephemeral cache is not wired on this preset
+                # (cache_policy: none) — call 1 reports 0
+                # cache_creation_input_tokens (baseline 0/15).
+                C.PROMPT_CACHING,
+                # No implicit upstream auto-cache surfaced on the OpenRouter
+                # qwen/qwen3.6-plus route — call 2 reports 0
+                # cache_read_input_tokens on a 2-call ~8 k-token probe
+                # (baseline 0/15).
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -8,7 +8,7 @@
 #   prompt_policy:    none | dict_map_hints
 #   content_policy:   openai | anthropic | nova
 #   response_policy:  standard | unwrap_input | array_dict_map
-#   reasoning_codec:  none | anthropic | openai
+#   reasoning_codec:  none | anthropic | openai | gemini | qwen
 #   cache_policy:     none | anthropic_ephemeral
 #   params:           dict of GenerationParams kwargs
 #
@@ -92,6 +92,31 @@ presets:
     schema_sanitizer: strict
     response_policy: array_dict_map
     reasoning_codec: openai
+
+  # Qwen 3.6-plus — model-specific shadow of the family ``qwen`` preset
+  # (below). Reproduces the family axes verbatim (passthrough schema +
+  # json_coerce response + dict_map_hints prompt) and swaps the reasoning
+  # codec ``openai`` -> ``qwen``. Listed BEFORE the ``qwen`` family glob so
+  # first-match-wins routing picks it up for this model only; every other
+  # ``qwen/*`` route keeps the family preset untouched.
+  #
+  # Why the bespoke codec: the family ``openai`` codec extracts Qwen's
+  # ``reasoning_content`` string fine (THINKING_EMITS_BLOCKS passes) but its
+  # ``encode_for_replay`` is a no-op, so the turn-2 assistant message carries
+  # no ``reasoning_details`` and UNSIGNED_THINKING_REPLAY fails (0/15 baseline).
+  # ``QwenReasoningCodec`` keeps OpenAI-identical extraction and adds an
+  # ``encode_for_replay`` that re-emits the turn-1 reasoning text as OpenRouter
+  # ``reasoning.text`` entries — the exact shape the probe round-trips (5/5
+  # after fix). Signed-replay (Qwen emits no signatures) and prompt caching
+  # (route never creates/reports cache tokens) stay genuine ceilings — see
+  # registry.py ``known_unsupported``. Integrated via auto-resolve (PR #188).
+  qwen_qwen3_6_plus:
+    match:
+      - "qwen/qwen3.6-plus"
+    schema_sanitizer: passthrough
+    response_policy: json_coerce
+    prompt_policy: dict_map_hints
+    reasoning_codec: qwen
 
   qwen:
     # Qwen 3.x emits dict-map arguments as either native dicts (matching the

--- a/tolokaforge/core/llm/__init__.py
+++ b/tolokaforge/core/llm/__init__.py
@@ -38,6 +38,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     AnthropicReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -99,6 +100,7 @@ __all__ = [
     "NoReasoningCodec",
     "AnthropicReasoningCodec",
     "OpenAIReasoningCodec",
+    "QwenReasoningCodec",
     # Usage
     "Usage",
     "UsageExtractor",

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -41,6 +41,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     GeminiReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -106,6 +107,7 @@ _REASONING_CODECS: dict[str, type[ReasoningCodec]] = {
     "anthropic": AnthropicReasoningCodec,
     "openai": OpenAIReasoningCodec,
     "gemini": GeminiReasoningCodec,
+    "qwen": QwenReasoningCodec,
 }
 
 _CACHE_POLICIES: dict[str, type[CachePolicy]] = {


### PR DESCRIPTION
## Integrate `qwen/qwen3.6-plus` (auto-resolve)

**Candidate:** provider `openrouter`, name `qwen/qwen3.6-plus`, model_id
`openrouter__qwen_qwen3.6-plus` (PR #188).

Certifies Qwen 3.6-plus against the integration capability suite and lands the policy the
auto-resolve fix loop proved out.

### Engine change

New **`QwenReasoningCodec`** (`tolokaforge/core/llm/reasoning_codec.py`, registered in
`presets._REASONING_CODECS`, exported from `tolokaforge/core/llm/__init__.py`). Keeps
OpenAI-style extraction of Qwen's `reasoning_content` summary and adds an `encode_for_replay`
that re-emits the turn-1 reasoning as OpenRouter `reasoning.text` — closing the unsigned
thinking-replay gap the `openai` codec left open (its `encode_for_replay` is a no-op).

### Policy

New model-specific preset **`qwen_qwen3_6_plus`** in
`tolokaforge/core/data/model_presets.yaml`, listed before the family `qwen/*` glob so
first-match-wins routing selects it for this model only. It reproduces the family axes
(`passthrough` schema + `json_coerce` response + `dict_map_hints` prompt) and swaps the
reasoning codec `openai` → `qwen`. No other preset is touched; `qwen/qwen3.7-max` and every
other `qwen/*` route keep the family preset.

Certificate added to `tests/integration/llm/registry.py`: **20 required / 3 known_unsupported**.

### Ceilings (`known_unsupported`)

- `THINKING_REPLAY_ROUNDTRIP` — Qwen emits no signed blocks on turn 1.
- `PROMPT_CACHING` — no `cache_control` markers wired (cache_policy: none).
- `IMPLICIT_PROMPT_CACHING` — route surfaces no upstream auto-cache read on a 2-call probe.

### Provenance

Integrated automatically via auto-resolve: the fix loop converged
(`test_unsigned_thinking_replay` 0/15 → 5/5 on the final reprobe) and this PR lands the proven
overlay as the bundled integration.

> ⚠️ **Disposable test branch — do NOT merge.** This branch de-integrated qwen3.6-plus to
> simulate a fresh candidate for the auto-resolve exercise; it is for observation only.
