### PR TITLE
integrate: qwen/qwen3.6-plus

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,50 +381,6 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # -----------------------------------------------------------------
-    # Qwen — preset routes it through the same strict trio as GPT-5.
-    # Reasoning surface is OpenAI-style summary only, no signed blocks,
-    # so thinking capabilities are ``known_unsupported``.
-    # -----------------------------------------------------------------
-    MC(
-        model_id="openrouter__qwen_qwen3.6-plus",
-        provider="openrouter",
-        name="qwen/qwen3.6-plus",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,  # strict-schema dict-map array conversion
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                C.DECIMAL_FIELD_TOOL_CALL,  # same strict sanitizer as GPT-5
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-                # No implicit upstream cache surfaced on the OpenRouter
-                # qwen/* routes.
-                C.IMPLICIT_PROMPT_CACHING,
-            }
-        ),
-    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,6 +381,76 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Qwen 3.6-plus — auto-resolve integration (2026-07-08). Routed through
+    # the model-specific ``qwen_qwen3_6_plus_candidate`` preset (passthrough
+    # schema + ``DictMapHints`` prompt policy + ``JsonCoerceResponse``
+    # recovery + the new ``QwenReasoningCodec``). The candidate observed clean
+    # on every tool-call / metrics probe under the qwen axes; the ONE fix
+    # target was UNSIGNED_THINKING_REPLAY — the stock ``openai`` codec extracts
+    # Qwen's ``reasoning_content`` summary but its ``encode_for_replay`` is a
+    # no-op, so turn-2 dropped the reasoning text. ``QwenReasoningCodec`` adds
+    # the OpenRouter ``reasoning_details`` / ``reasoning.text`` unsigned replay
+    # path, flipping the capability green (5/5 final reprobe).
+    #
+    # Caching (no upstream cache_read/creation tokens on this route) and the
+    # signed thinking surfaces (no signatures on the wire, summary-only
+    # reasoning) are genuine ceilings for the OpenRouter Qwen route, declared
+    # ``known_unsupported`` below. This is NOT the pre-de-integration posture:
+    # the old cert routed via the strict trio and declared the thinking family
+    # + both caches unsupported; the new codec promotes UNSIGNED_THINKING_REPLAY.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__qwen_qwen3.6-plus",
+        provider="openrouter",
+        name="qwen/qwen3.6-plus",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.DICT_MAP_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.LEXICAL_TOOL_INVENTION,
+                C.TOOL_NAME_DISCIPLINE,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                # Fix target: the new QwenReasoningCodec emits the OpenRouter
+                # reasoning_details / reasoning.text envelope on replay, so the
+                # turn-2 assistant dict carries the turn-1 reasoning text.
+                # 5/5 on the final reprobe (2026-07-08).
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # No explicit ``cache_control`` markers wired on the qwen
+                # preset — call 1 creates 0 cache_creation_input_tokens.
+                C.PROMPT_CACHING,
+                # No implicit upstream auto-cache surfaced on this OpenRouter
+                # Qwen route — call 2 reads 0 cache_read_input_tokens across
+                # all 15 baseline runs.
+                C.IMPLICIT_PROMPT_CACHING,
+                # Summary-only reasoning: turn 1 emits zero signed blocks, so
+                # the signed-block contract has nothing to assert on.
+                C.THINKING_EMITS_BLOCKS,
+                # Companion of the above — signed-replay continuity has no
+                # source signature to round-trip. The UNSIGNED text contract
+                # (required above) is the shape this route actually honours.
+                C.THINKING_REPLAY_ROUNDTRIP,
+            }
+        ),
+    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -8,7 +8,7 @@
 #   prompt_policy:    none | dict_map_hints
 #   content_policy:   openai | anthropic | nova
 #   response_policy:  standard | unwrap_input | array_dict_map
-#   reasoning_codec:  none | anthropic | openai
+#   reasoning_codec:  none | anthropic | openai | gemini | qwen
 #   cache_policy:     none | anthropic_ephemeral
 #   params:           dict of GenerationParams kwargs
 #
@@ -92,6 +92,31 @@ presets:
     schema_sanitizer: strict
     response_policy: array_dict_map
     reasoning_codec: openai
+
+  # qwen/qwen3.6-plus — model-specific composite that reproduces the shipped
+  # ``qwen`` axes (passthrough schema + json_coerce response + dict_map_hints
+  # prompt — all green on every tool-call probe during observe) and swaps ONLY
+  # the reasoning codec ``openai`` → ``qwen``. The ``openai`` codec extracts
+  # Qwen's ``reasoning_content`` summary but its ``encode_for_replay`` is a
+  # no-op, so reasoning text is dropped on turn 2 and
+  # ``test_unsigned_thinking_replay`` fails (the outgoing assistant dict
+  # carries no ``reasoning_details``). ``QwenReasoningCodec`` keeps the summary
+  # extract and adds the unsigned-text replay path (OpenRouter
+  # ``reasoning_details`` / ``type=reasoning.text``), flipping
+  # UNSIGNED_THINKING_REPLAY green (5/5 reprobe, 2026-07-08).
+  #
+  # MUST stay declared BEFORE the family-wide ``qwen`` preset below: preset
+  # routing is first-match-wins in declaration order, and ``qwen/*`` would
+  # otherwise win and re-apply the ``openai`` codec. Caching + signed thinking
+  # replay stay genuine ceilings for this route (see registry.py
+  # known_unsupported).
+  qwen_qwen3_6_plus_candidate:
+    match:
+      - "qwen/qwen3.6-plus"
+    schema_sanitizer: passthrough
+    response_policy: json_coerce
+    prompt_policy: dict_map_hints
+    reasoning_codec: qwen
 
   qwen:
     # Qwen 3.x emits dict-map arguments as either native dicts (matching the

--- a/tolokaforge/core/llm/__init__.py
+++ b/tolokaforge/core/llm/__init__.py
@@ -38,6 +38,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     AnthropicReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -99,6 +100,7 @@ __all__ = [
     "NoReasoningCodec",
     "AnthropicReasoningCodec",
     "OpenAIReasoningCodec",
+    "QwenReasoningCodec",
     # Usage
     "Usage",
     "UsageExtractor",

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -41,6 +41,7 @@ from tolokaforge.core.llm.reasoning_codec import (
     GeminiReasoningCodec,
     NoReasoningCodec,
     OpenAIReasoningCodec,
+    QwenReasoningCodec,
     ReasoningCodec,
 )
 from tolokaforge.core.llm.response_policy import (
@@ -106,6 +107,7 @@ _REASONING_CODECS: dict[str, type[ReasoningCodec]] = {
     "anthropic": AnthropicReasoningCodec,
     "openai": OpenAIReasoningCodec,
     "gemini": GeminiReasoningCodec,
+    "qwen": QwenReasoningCodec,
 }
 
 _CACHE_POLICIES: dict[str, type[CachePolicy]] = {

--- a/tolokaforge/core/llm/reasoning_codec.py
+++ b/tolokaforge/core/llm/reasoning_codec.py
@@ -34,6 +34,7 @@ __all__ = [
     "AnthropicReasoningCodec",
     "OpenAIReasoningCodec",
     "GeminiReasoningCodec",
+    "QwenReasoningCodec",
 ]
 
 
@@ -465,3 +466,114 @@ class GeminiReasoningCodec:
             f"only ``thinking`` and ``redacted_thinking`` blocks round-trip "
             "through the Gemini reasoning_details envelope."
         )
+
+
+class QwenReasoningCodec:
+    """Extract / replay reasoning for the Qwen family over OpenRouter.
+
+    Qwen (like OpenAI / Grok) surfaces reasoning as an unstructured
+    ``reasoning_content`` summary string — no per-block ``signature`` and,
+    on the common OpenRouter route, no
+    ``provider_specific_fields.reasoning_details`` envelope. The stock
+    ``openai`` codec therefore *extracts* that summary fine, but its
+    ``encode_for_replay`` is a no-op, so the reasoning *text* is dropped on
+    the next turn and multi-turn reasoning continuity
+    (:attr:`Capability.UNSIGNED_THINKING_REPLAY`) is lost — the outgoing
+    assistant message carries no ``reasoning_details``.
+
+    This codec keeps the OpenAI-style *extract* (summary → one ``thinking``
+    block) but adds the unsigned-text *replay* path: on the way out it emits
+    the OpenRouter ``reasoning_details`` envelope (``type="reasoning.text"``)
+    carrying the turn-1 text verbatim, which OpenRouter forwards to the
+    upstream Qwen route so reasoning context survives the turn boundary.
+
+    Signed replay stays out of scope: Qwen emits no signatures, so
+    :attr:`Capability.THINKING_REPLAY_ROUNDTRIP` remains unsupported — only
+    the unsigned text contract is honoured here.
+
+    When a route DOES surface structured ``reasoning_details``
+    (``reasoning.text`` entries), those win over the summary, so the codec
+    never fabricates a block on top of real structured data.
+
+    Loud-fail discipline: an unknown structured block type raises
+    :class:`ValueError` rather than silently dropping data.
+    """
+
+    _OPENROUTER_TEXT_TYPE = "reasoning.text"
+
+    def extract(self, response_message: Any) -> StructuredReasoning | None:
+        details = self._reasoning_details(response_message)
+        summary = getattr(response_message, "reasoning_content", None) or None
+
+        if not details and not summary:
+            return None
+
+        if details:
+            blocks = tuple(self._detail_to_block(raw) for raw in details)
+            return StructuredReasoning(
+                blocks=blocks,
+                summary=_dedup_summary(blocks, summary),
+                transport="openrouter",
+            )
+
+        # Summary-only route (the common Qwen shape): normalise the
+        # ``reasoning_content`` string into a single text block so the replay
+        # path has verbatim text to round-trip. ``summary`` would 1:1 mirror
+        # the block text, so ``_dedup_summary`` drops it.
+        block = ReasoningBlock(type="thinking", text=summary or "")
+        return StructuredReasoning(
+            blocks=(block,),
+            summary=_dedup_summary((block,), summary),
+            transport="openrouter",
+        )
+
+    @staticmethod
+    def _reasoning_details(response_message: Any) -> list[Any]:
+        """Pull ``provider_specific_fields.reasoning_details`` defensively.
+
+        PSF may be ``None``, a dict, or an attribute-bearing object; any
+        non-list ``reasoning_details`` yields ``[]`` so callers' ``not``
+        checks behave.
+        """
+        psf = getattr(response_message, "provider_specific_fields", None)
+        if psf is None:
+            return []
+        if isinstance(psf, dict):
+            details = psf.get("reasoning_details")
+        else:
+            details = getattr(psf, "reasoning_details", None)
+        if isinstance(details, list):
+            return details
+        return []
+
+    def _detail_to_block(self, raw: Any) -> ReasoningBlock:
+        if not isinstance(raw, dict):
+            raise ValueError(f"Qwen reasoning_details entry must be dict, got {type(raw).__name__}")
+        block_type = raw.get("type")
+        if block_type != self._OPENROUTER_TEXT_TYPE:
+            raise ValueError(
+                f"Unknown Qwen reasoning_details type: {block_type!r}; "
+                f"expected {self._OPENROUTER_TEXT_TYPE!r}"
+            )
+        return ReasoningBlock(
+            type="thinking",
+            text=raw.get("text", "") or "",
+            # Qwen does not emit signatures — preserve None explicitly.
+            signature=raw.get("signature"),
+        )
+
+    def encode_for_replay(self, reasoning: StructuredReasoning) -> dict[str, Any]:
+        """Emit the OpenRouter ``reasoning_details`` text envelope for replay.
+
+        Only text-bearing blocks round-trip; a Qwen turn without reasoning
+        text yields no envelope (``{}``), matching the no-op contract of the
+        other codecs when there is nothing to replay.
+        """
+        entries = [
+            {"type": self._OPENROUTER_TEXT_TYPE, "text": block.text}
+            for block in reasoning.blocks
+            if block.text
+        ]
+        if not entries:
+            return {}
+        return {"reasoning_details": entries}


### PR DESCRIPTION
# Integrate `qwen/qwen3.6-plus` (auto-resolve)

**Candidate:** `openrouter` / `qwen/qwen3.6-plus` (`openrouter__qwen_qwen3.6-plus`) — PR #194.
**Engine ref:** this branch (`test/observe-qwen3.6-plus-r3`).

## Policy

- **Preset** `qwen_qwen3_6_plus_candidate` (`tolokaforge/core/data/model_presets.yaml`), declared
  before the family `qwen` preset so first-match-wins routes this model to it. Axes: `passthrough`
  schema + `json_coerce` response + `dict_map_hints` prompt (unchanged from the qwen family) with the
  reasoning codec swapped `openai` → `qwen`.
- **Adapter** `QwenReasoningCodec` (`tolokaforge/core/llm/reasoning_codec.py`, wired into
  `_REASONING_CODECS` + `__init__.py`) — adds the OpenRouter `reasoning_details` /
  `type=reasoning.text` unsigned-text replay path the `openai` codec lacked, restoring turn-to-turn
  reasoning continuity. This flips `UNSIGNED_THINKING_REPLAY` green (0/15 → 5/5 final reprobe).
- **Cert** in `tests/integration/llm/registry.py`: 19 required / 4 known_unsupported.

## Ceilings (`known_unsupported`)

`PROMPT_CACHING`, `IMPLICIT_PROMPT_CACHING` (no cache tokens on this OpenRouter Qwen route),
`THINKING_EMITS_BLOCKS`, `THINKING_REPLAY_ROUNDTRIP` (summary-only reasoning, no signed blocks).

---

Integrated via auto-resolve. **Disposable test branch — DO NOT MERGE.**
