### PR TITLE
feat(models): add x-ai/grok-4.5 (pricing + capability certificate)

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -679,6 +679,75 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Grok-4.5 — xAI's successor to the 4.x line, routed through the same
+    # ``xai_grok`` preset as grok-4 / grok-4.3 (strict schema sanitiser +
+    # array_dict_map response policy + OpenAI-style reasoning summary). The
+    # resolved policy fingerprint is byte-identical to the grok-4.3 sibling
+    # (schema_sanitizer=strict, response_policy=array_dict_map,
+    # reasoning_codec=openai, cache_policy=none), confirmed via
+    # ``resolve_policy_names``, so no new preset is required.
+    #
+    # Live-certified 2026-07-09 via
+    # ``scripts/with_env.sh uv run pytest tests/integration/llm/ -k grok-4.5``
+    # (17 passed, 5 skipped; final posture 15 required / 5 known_unsupported).
+    # Posture set by the ADD_NEW_MODEL.md § 3 disciplined flow — NOT copied
+    # from a sibling: the grok-4.3 sibling's three non-structural
+    # ``known_unsupported`` entries were flipped to ``required`` as the
+    # hypothesis and re-run live. All three PASS on grok-4.5, so they stay
+    # ``required`` (matching grok-4, not grok-4.3):
+    #
+    #   * MULTI_TURN_ERROR_RECOVERY — grok-4.3 was demoted for a ~17 %
+    #     field-name-as-value hallucination on the retry; grok-4.5 recovers
+    #     reliably (test passed 2026-07-09).
+    #   * ENUM_SLASH_TOLERANCE + RE2_PATTERN_TOLERANCE — grok-4.3's tightened
+    #     tool-schema validator rejected ``/`` enum values and RE2-incompatible
+    #     ``pattern`` regexes; grok-4.5 accepts both, so the xAI validator
+    #     tightening that landed with 4.3 has been relaxed again.
+    #
+    # The five structural entries stay ``known_unsupported`` (all skipped
+    # live): the ``xai_grok`` preset wires the OpenAI reasoning codec (summary
+    # only — no signed blocks, no-op replay) and ``cache_policy=none`` (no
+    # cache_control markers), so THINKING_* and PROMPT_CACHING cannot fire on
+    # this route regardless of model version; IMPLICIT_PROMPT_CACHING keeps the
+    # grok-family observation that no upstream cache is surfaced on the
+    # OpenRouter x-ai/grok-* routes (paired ratchet
+    # ``test_implicit_prompt_caching_unsupported_ratchet`` passed live).
+    MC(
+        model_id="openrouter__x-ai_grok-4.5",
+        provider="openrouter",
+        name="x-ai/grok-4.5",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                # No implicit upstream cache surfaced on the OpenRouter
+                # x-ai/grok-* routes.
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
     # -----------------------------------------------------------------
     # Google Gemini family — routed through the named ``gemini`` preset
     # (see ``model_presets.yaml``) which adds ``GeminiReasoningCodec``

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1730,6 +1730,11 @@
       "output": 2.5,
       "cache_read": 0.2
     },
+    "x-ai/grok-4.5": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
+    },
     "x-ai/grok-build-0.1": {
       "input": 1.0,
       "output": 2.0,


### PR DESCRIPTION
## What

Adds the `x-ai/grok-4.5` model to the benchmarking harness, following the six-step process in [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md).

Two files, both `main`-appropriate (shared cost catalog + shared capability certificate); no eval-specific configs.

## Changes

**1. Pricing** — `tolokaforge/core/data/pricing.json`
```json
"x-ai/grok-4.5": { "input": 2.0, "output": 6.0, "cache_read": 0.5 }
```
Per 1M tokens, USD. Captured from the OpenRouter `/api/v1/models` endpoint on **2026-07-09**; values verified against the API response (`prompt 0.000002`, `completion 0.000006`, `input_cache_read 0.0000005` × 1e6).

**2. Preset** — no change. `x-ai/grok-4.5` falls through to the existing `xai_grok` preset. Confirmed via `resolve_policy_names` that the resolved policy fingerprint is byte-identical to `grok-4.3`: `schema_sanitizer=strict`, `response_policy=array_dict_map`, `reasoning_codec=openai`, `cache_policy=none`.

**3. ModelCertificate** — `tests/integration/llm/registry.py`
`openrouter__x-ai_grok-4.5`, **15 required / 5 known_unsupported**.

Posture set by the § 3 disciplined flow (NOT copied from a sibling): the three non-structural `known_unsupported` entries on `grok-4.3` were flipped to `required` as the hypothesis and re-run live. **All three pass on grok-4.5**, so xAI's 4.3 tool-schema validator tightening has been relaxed again:

| Capability | grok-4.3 | grok-4.5 |
|---|---|---|
| `MULTI_TURN_ERROR_RECOVERY` | known_unsupported (~17% field-name hallucination) | **required** ✅ |
| `ENUM_SLASH_TOLERANCE` | known_unsupported (rejects `/` enums) | **required** ✅ |
| `RE2_PATTERN_TOLERANCE` | known_unsupported (rejects RE2-incompat `pattern`) | **required** ✅ |

The 5 `known_unsupported` are structural to the `xai_grok` preset (OpenAI reasoning codec → no signed blocks / no-op replay; `cache_policy=none` → no explicit cache markers), consistent with grok-4 / grok-4.3: `THINKING_EMITS_BLOCKS`, `THINKING_REPLAY_ROUNDTRIP`, `UNSIGNED_THINKING_REPLAY`, `PROMPT_CACHING`, `IMPLICIT_PROMPT_CACHING`.

Steps 5 (new reasoning format) and 6 (new provider) are N/A — grok-4.5 reuses the OpenAI reasoning codec and runs via OpenRouter.

## Live capability suite (§ 4 — required for merge)

```
$ scripts/with_env.sh uv run pytest tests/integration/llm/ -k grok-4.5 -v --tb=short

collected 673 items / 651 deselected / 22 selected

test_basic_completion.py::...[openrouter__x-ai_grok-4.5] PASSED
test_cost_populated.py::test_cost_usd_populated[...grok-4.5] PASSED
test_decimal_field_tool_call.py::...[...grok-4.5] PASSED
test_dict_map_tool_call.py::...[...grok-4.5] PASSED
test_discriminated_union_tool_call.py::...[...grok-4.5-bare_union] PASSED
test_discriminated_union_tool_call.py::...[...grok-4.5-explicit_discriminator] PASSED
test_enum_slash_tolerance.py::...[...grok-4.5] PASSED
test_implicit_prompt_caching.py::...[...grok-4.5] SKIPPED
test_implicit_prompt_caching_unsupported_ratchet.py::...[...grok-4.5] PASSED
test_lexical_tool_invention.py::...[...grok-4.5] PASSED
test_multi_turn_error_recovery.py::...[...grok-4.5] PASSED
test_multi_turn_tool_use.py::...[...grok-4.5] PASSED
test_progress_after_success.py::...[...grok-4.5] PASSED
test_prompt_caching.py::...[...grok-4.5] SKIPPED
test_re2_pattern_tolerance.py::...[...grok-4.5] PASSED
test_required_fields_complete.py::...[...grok-4.5] PASSED
test_simple_tool_call.py::...[...grok-4.5] PASSED
test_thinking_emits_blocks.py::...[...grok-4.5] SKIPPED
test_thinking_replay_roundtrip.py::...[...grok-4.5] SKIPPED
test_tool_name_discipline.py::...[...grok-4.5] PASSED
test_unsigned_thinking_replay.py::...[...grok-4.5] SKIPPED
test_usage_metrics_populated.py::...[...grok-4.5] PASSED

=========== 17 passed, 5 skipped, 651 deselected in 89.10s (0:01:29) ===========
```

All 5 skips map to declared `known_unsupported` capabilities — no undeclared skips.

## Other verification

- `uv run pytest tests/canonical/test_capability_registry.py` → **9 passed** (unique slug, complete coverage, disjoint required/known_unsupported)
- `uv run pytest tests/unit/test_pricing.py tests/canonical/test_cost_extraction_canon.py` → **41 passed**
- `ruff format --check` + `ruff check` → clean (pre-commit hooks pass)

## Not included

- § 4a smoke eval (one domain through the orchestrator) — requires the external `tasks/` packs and additional API spend; recommended as a follow-up, and eval configs are `main`-excluded anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
