### PR TITLE
integrate: xiaomi/mimo-v2.5-pro

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1126,51 +1126,6 @@ _ALL: list[MC] = [
         ),
     ),
     MC(
-        model_id="openrouter__xiaomi_mimo-v2.5-pro",
-        provider="openrouter",
-        name="xiaomi/mimo-v2.5-pro",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                # OpenRouter / xiaomi enabled implicit prompt caching for
-                # this route between 2026-05-14 14:29 and 16:20 UTC —
-                # earlier evals saw cached_tokens=0 across every
-                # mimo call, but a live
-                # 2-call 8 k-prompt probe at 16:20 reports
-                # ``cache_read_input_tokens=8192/8254`` (99% cached) on
-                # call 2 with a clear cost reduction. The ratchet test
-                # forced this promotion.
-                C.IMPLICIT_PROMPT_CACHING,
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.DECIMAL_FIELD_TOOL_CALL,
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-            }
-        ),
-    ),
-    MC(
         model_id="openrouter__google_gemini-3.1-pro-preview",
         provider="openrouter",
         name="google/gemini-3.1-pro-preview",

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -108,51 +108,6 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
-  # Open-weights / OpenAI-API-compatible routes whose tool-call adapters
-  # stringify nested object / Dict[str, T] arguments — same failure mode
-  # ``JsonCoerceResponse`` was built for on Qwen.
-  #
-  # Empirical evidence: mimo-v2.5-pro hit 20–25 retries on every
-  # ``zendesk_create_item`` call on a logistics domain evaluation
-  # when ``item`` is a discriminated union (TicketCreate | UserCreate |
-  # OrganizationCreate | CommentCreate). The wire-shape was
-  # ``{"item": "{\"subject\":...}"}`` — a JSON-encoded string instead of a
-  # nested dict. ``JsonCoerceResponse._coerce_json_strings`` decodes that
-  # back to native shape before pydantic validation.
-  # ``DictMapHints`` is also routed because the same models share Qwen's
-  # ``Dict[str, T]`` blind spot (test_dict_map_tool_call).
-  # Reasoning surface format on the OpenRouter wire is not yet codified in
-  # a bespoke codec for these routes; ``openai`` codec is the safe baseline
-  # — it surfaces ``reasoning_content`` summaries via OpenAI-canonical fields
-  # without making structural assumptions.
-  # z-ai/glm-5.1, tencent/hy3-preview and nvidia/nemotron-3-super join
-  # this preset (arena lineup refresh 2026-06): each emits the
-  # discriminated-union ``item`` as a JSON-encoded string that
-  # JsonCoerceResponse decodes — glm/hy3 every call, nemotron
-  # intermittently (native dict on some calls, stringified on others;
-  # without json_coerce the stringified calls fail, so it needs this
-  # preset to make the capability reliable). All three also surface a
-  # reasoning_content summary the ``openai`` codec lands in the logs.
-  # Live 2026-06-05.
-  openrouter_dict_stringify_recovery:
-    match:
-      - "xiaomi/mimo*"
-      - "*mimo-v2*"
-      - "moonshotai/kimi-k2*"
-      - "*kimi-k2*"
-      - "deepseek/deepseek-v4*"
-      - "*deepseek-v4*"
-      - "z-ai/glm-5*"
-      - "*glm-5*"
-      - "tencent/hy3*"
-      - "*hy3-preview*"
-      - "nvidia/nemotron*"
-      - "*nemotron-*"
-    schema_sanitizer: passthrough
-    response_policy: json_coerce
-    prompt_policy: dict_map_hints
-    reasoning_codec: openai
-
   # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on


### PR DESCRIPTION
Restart round on the Slack-enabled + privacy-scrubbed + open_object feat (fb4bcd2). Simulates a fresh candidate (de-integration deletes this model cert/preset/policy). Disposable test branch; never merged.