### PR TITLE
Add langfuse-uploader: post-hoc trajectory uploader to Langfuse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,6 +350,7 @@ required-version = ">=0.9.5,<0.10"
 [tool.uv.workspace]
 members = [
     "tools/dev-mcp",
+    "tools/langfuse-uploader",
     "tools/pricing-updater",
     "tools/rubric-calibrator",
     "external_adapters/tolokaforge-adapter-terminal-bench",

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -9,6 +9,7 @@ Each subdirectory is a **uv workspace member** — an independent Python package
 | Tool | Entry Point | Purpose |
 |------|-------------|---------|
 | `dev-mcp` | `dev-mcp` | Dev MCP server for AI agent interaction (tests, lint, format, etc.) |
+| `langfuse-uploader` | `langfuse-uploader` | Upload trial bundles into Langfuse as traces |
 | `pricing-updater` | `pricing-updater` | Fetch and update LLM pricing data |
 
 ## Adding a New Tool

--- a/tools/langfuse-uploader/README.md
+++ b/tools/langfuse-uploader/README.md
@@ -1,0 +1,76 @@
+# langfuse-uploader
+
+Upload tolokaforge trial bundles into [Langfuse](https://langfuse.com) so runs can be
+explored as traces: per-turn generations with token/cost usage, tool-call spans,
+grades as scores, and screenshots as media.
+
+## Quickstart
+
+```bash
+export LANGFUSE_HOST=https://your-langfuse-host
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+
+# upload a finished run
+uv run langfuse-uploader upload results/<run-name>
+
+# or poll while a run is in progress (state kept in <run_dir>/.langfuse_uploaded.json)
+uv run langfuse-uploader watch results/<run-name>
+```
+
+API keys come from the target Langfuse project (Project Settings → API Keys). The keys
+select the project traces land in, so pointing the same command at another environment
+(dev vs prod) is purely a matter of env values — no code or flag changes.
+
+## Mapping
+
+| tolokaforge | Langfuse |
+|---|---|
+| run (`results/<run-name>`) | session (`sessionId`) + tag |
+| trial (`trials/<task_id>/<trial_index>/`) | trace |
+| assistant message | generation (usage/cost per turn from `metrics.usage.calls`) |
+| tool message | span (input = tool-call arguments, output = tool result) |
+| `grade.yaml` | scores (`binary_pass`, `score` + reasons, `component:*`) |
+| `metrics.yaml` totals | trace metadata |
+| base64 image blocks | Langfuse media (uploaded via the media API) |
+
+Trace, observation and score ids are deterministic (`uuid5` over `--run-tag` / `--label` /
+task id / trial index): re-running the uploader over the same run updates existing traces
+instead of duplicating them. Bump `--run-tag` to force fresh traces.
+
+## Options
+
+| Option | Env | Default | Purpose |
+|---|---|---|---|
+| `--host` | `LANGFUSE_HOST` | — | Langfuse base URL |
+| — | `LANGFUSE_PUBLIC_KEY` | — | project public key |
+| — | `LANGFUSE_SECRET_KEY` | — | project secret key |
+| `--label` | — | run dir name | grouping label in trace names/tags |
+| `--session` | — | run dir name | Langfuse session id |
+| `--run-tag` | — | `v1` | trace id namespace |
+| `--media-put-via` | `LANGFUSE_MEDIA_PUT_VIA` | — | `host:port` override for presigned media PUTs |
+| `--interval` (watch) | — | `15` | poll interval, seconds |
+
+Notes:
+
+- Credentials are read from the environment only (never CLI arguments), so they don't
+  leak into shell history or process lists.
+- Ingestion batches are chunked to stay under the Langfuse request body limit (~4.5 MB).
+- Base64 images are uploaded through the Langfuse media API and replaced with reference
+  tokens; if a media upload fails, the block is replaced with a small placeholder and the
+  trial upload continues.
+- `--media-put-via` is only needed when the presigned upload URL points at an object-store
+  hostname not reachable from your machine (e.g. an in-cluster store) — route it through a
+  port-forward while the signed `Host` header is preserved.
+
+## CI
+
+```yaml
+- name: Upload trajectories to Langfuse
+  if: always()
+  env:
+    LANGFUSE_HOST: ${{ vars.LANGFUSE_HOST }}
+    LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+    LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+  run: uv run langfuse-uploader upload results/${{ env.RUN_NAME }} --label ${{ github.workflow }}
+```

--- a/tools/langfuse-uploader/README.md
+++ b/tools/langfuse-uploader/README.md
@@ -53,8 +53,9 @@ instead of duplicating them. Bump `--run-tag` to force fresh traces.
 
 Notes:
 
-- Credentials are read from the environment only (never CLI arguments), so they don't
-  leak into shell history or process lists.
+- Credentials are resolved through the repo's `SecretManager` (`tolokaforge.secrets`:
+  `.env` first, then the process environment) and never accepted as CLI arguments, so
+  they don't leak into shell history or process lists.
 - Ingestion batches are chunked to stay under the Langfuse request body limit (~4.5 MB).
 - Base64 images are uploaded through the Langfuse media API and replaced with reference
   tokens; if a media upload fails, the block is replaced with a small placeholder and the

--- a/tools/langfuse-uploader/pyproject.toml
+++ b/tools/langfuse-uploader/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "langfuse-uploader"
+version = "0.1.0"
+description = "Upload tolokaforge trial bundles into Langfuse as traces"
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6.0.1",
+    "typer>=0.12.5,<0.13",
+    "click>=8.0.0,<8.2.0",
+    "rich>=13.0.0",
+]
+
+[project.scripts]
+langfuse-uploader = "langfuse_uploader.cli:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tools/langfuse-uploader/pyproject.toml
+++ b/tools/langfuse-uploader/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Upload tolokaforge trial bundles into Langfuse as traces"
 requires-python = ">=3.10"
 dependencies = [
+    "tolokaforge",
     "pyyaml>=6.0.1",
     "typer>=0.12.5,<0.13",
     "click>=8.0.0,<8.2.0",

--- a/tools/langfuse-uploader/src/langfuse_uploader/__init__.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/__init__.py
@@ -1,0 +1,1 @@
+"""Langfuse uploader — ship tolokaforge trial bundles into Langfuse as traces."""

--- a/tools/langfuse-uploader/src/langfuse_uploader/__main__.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m langfuse_uploader``."""
+
+from .cli import app
+
+app()

--- a/tools/langfuse-uploader/src/langfuse_uploader/cli.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -49,10 +48,14 @@ def _default_run_name(run_dir: Path) -> str:
 
 
 def _client(host: str | None, media_put_via: str | None) -> LangfuseClient:
-    host = host or os.environ.get("LANGFUSE_HOST")
-    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
-    secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
-    media_put_via = media_put_via or os.environ.get("LANGFUSE_MEDIA_PUT_VIA")
+    # all secret reads go through SecretManager (repo hard rule); .env then env fallback
+    from tolokaforge.secrets import init_default
+
+    secrets = init_default()
+    host = host or secrets.get_secret("LANGFUSE_HOST")
+    public_key = secrets.get_secret("LANGFUSE_PUBLIC_KEY")
+    secret_key = secrets.get_secret("LANGFUSE_SECRET_KEY")
+    media_put_via = media_put_via or secrets.get_secret("LANGFUSE_MEDIA_PUT_VIA")
     missing = [
         name
         for name, value in [
@@ -99,6 +102,9 @@ def _upload_trials(
         if result.error:
             console.print(f"      [red]{result.error[:300]}[/red]")
     console.print(f"[bold]{ok}/{len(trials)} ok[/bold]")
+    for warning in client.warnings:
+        console.print(f"  [yellow]WARN[/yellow] {warning}")
+    client.warnings.clear()
     return done
 
 

--- a/tools/langfuse-uploader/src/langfuse_uploader/cli.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/cli.py
@@ -1,0 +1,158 @@
+"""CLI for langfuse-uploader."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from .uploader import LangfuseClient, discover_trials, upload_trial
+
+app = typer.Typer(help="Upload tolokaforge trial bundles into Langfuse as traces.")
+console = Console()
+
+RUN_DIR_ARG = typer.Argument(
+    ..., help="Run output dir (results/<run-name>) or a single trial bundle dir"
+)
+LABEL_OPT = typer.Option(
+    None, "--label", "-l", help="Grouping label used in trace names/tags (default: run dir name)"
+)
+SESSION_OPT = typer.Option(
+    None, "--session", "-s", help="Langfuse session id for the run (default: run dir name)"
+)
+RUN_TAG_OPT = typer.Option(
+    "v1", "--run-tag", help="Trace id namespace; bump to re-upload as fresh traces"
+)
+HOST_OPT = typer.Option(None, "--host", help="Langfuse base URL (default: env LANGFUSE_HOST)")
+MEDIA_PUT_VIA_OPT = typer.Option(
+    None,
+    "--media-put-via",
+    help=(
+        "Advanced: 'host:port' to route presigned media PUTs (e.g. a kubectl port-forward) "
+        "when the object store hostname is not reachable from this machine "
+        "(default: env LANGFUSE_MEDIA_PUT_VIA)"
+    ),
+)
+
+
+def _default_run_name(run_dir: Path) -> str:
+    """Run name for default label/session; for a single trial dir, walk up to the run dir."""
+    resolved = run_dir.resolve()
+    if (resolved / "trajectory.yaml").exists() and resolved.parent.parent.name == "trials":
+        return resolved.parent.parent.parent.name or "tolokaforge"
+    return resolved.name or "tolokaforge"
+
+
+def _client(host: str | None, media_put_via: str | None) -> LangfuseClient:
+    host = host or os.environ.get("LANGFUSE_HOST")
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY")
+    media_put_via = media_put_via or os.environ.get("LANGFUSE_MEDIA_PUT_VIA")
+    missing = [
+        name
+        for name, value in [
+            ("LANGFUSE_HOST (or --host)", host),
+            ("LANGFUSE_PUBLIC_KEY", public_key),
+            ("LANGFUSE_SECRET_KEY", secret_key),
+        ]
+        if not value
+    ]
+    if missing:
+        console.print(f"[red]❌ Missing configuration: {', '.join(missing)}[/red]")
+        raise typer.Exit(1)
+    assert host and public_key and secret_key
+    return LangfuseClient(
+        host=host, public_key=public_key, secret_key=secret_key, media_put_via=media_put_via
+    )
+
+
+def _upload_trials(
+    client: LangfuseClient, trials: list[Path], *, label: str, session: str, run_tag: str
+) -> set[str]:
+    """Upload each trial; returns dirs that completed (successfully or with ingest errors)."""
+    done: set[str] = set()
+    ok = 0
+    for trial_dir in trials:
+        try:
+            result = upload_trial(client, trial_dir, label=label, session=session, run_tag=run_tag)
+        except Exception as exc:
+            console.print(f"  [red]FAIL[/red] {trial_dir}: {exc}")
+            continue
+        if result.status == "empty":
+            console.print(f"  [yellow]SKIP[/yellow] {trial_dir}: no trajectory.yaml")
+            continue
+        done.add(str(trial_dir))
+        ok += result.status == "ok"
+        marker = "[green]OK [/green]" if result.status == "ok" else "[red]ERR[/red]"
+        media = f" media={result.media_uploaded}" if result.media_uploaded else ""
+        if result.media_failed:
+            media += f" media_failed={result.media_failed}"
+        console.print(
+            f"  {marker} {trial_dir.parent.name}/{trial_dir.name}"
+            f" events={result.events}{media} trace={result.trace_id}"
+        )
+        if result.error:
+            console.print(f"      [red]{result.error[:300]}[/red]")
+    console.print(f"[bold]{ok}/{len(trials)} ok[/bold]")
+    return done
+
+
+@app.command()
+def upload(
+    run_dir: Path = RUN_DIR_ARG,
+    label: str | None = LABEL_OPT,
+    session: str | None = SESSION_OPT,
+    run_tag: str = RUN_TAG_OPT,
+    host: str | None = HOST_OPT,
+    media_put_via: str | None = MEDIA_PUT_VIA_OPT,
+) -> None:
+    """Upload all trial bundles under RUN_DIR."""
+    client = _client(host, media_put_via)
+    trials = discover_trials(run_dir)
+    if not trials:
+        console.print(f"[yellow]No trial bundles found under {run_dir}[/yellow]")
+        raise typer.Exit(1)
+    run_name = _default_run_name(run_dir)
+    label = label or run_name
+    session = session or run_name
+    console.print(f"[bold]{len(trials)} trial(s)[/bold] → label={label} session={session}")
+    _upload_trials(client, trials, label=label, session=session, run_tag=run_tag)
+
+
+@app.command()
+def watch(
+    run_dir: Path = RUN_DIR_ARG,
+    label: str | None = LABEL_OPT,
+    session: str | None = SESSION_OPT,
+    run_tag: str = RUN_TAG_OPT,
+    host: str | None = HOST_OPT,
+    media_put_via: str | None = MEDIA_PUT_VIA_OPT,
+    interval: int = typer.Option(15, "--interval", help="Poll interval in seconds"),
+) -> None:
+    """Poll RUN_DIR and upload new trial bundles as they appear (Ctrl-C to stop)."""
+    client = _client(host, media_put_via)
+    run_name = _default_run_name(run_dir)
+    label = label or run_name
+    session = session or run_name
+    state_path = run_dir / ".langfuse_uploaded.json"
+    seen: set[str] = set(json.loads(state_path.read_text())) if state_path.exists() else set()
+    console.print(
+        f"Watching {run_dir} every {interval}s — already uploaded: {len(seen)} (Ctrl-C to stop)"
+    )
+    while True:
+        pending = [t for t in discover_trials(run_dir) if str(t) not in seen]
+        if pending:
+            console.print(f"[dim]{datetime.now():%H:%M:%S}[/dim] {len(pending)} new trial(s)")
+            seen |= _upload_trials(client, pending, label=label, session=session, run_tag=run_tag)
+            state_path.write_text(json.dumps(sorted(seen)))
+        time.sleep(interval)
+
+
+def main() -> None:
+    """Entrypoint."""
+    app()

--- a/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
@@ -22,11 +22,12 @@ import base64
 import hashlib
 import http.client
 import json
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -72,6 +73,8 @@ class LangfuseClient:
     # object store hostname inside the URL is not directly reachable from this machine.
     media_put_via: str | None = None
     timeout: float = 60.0
+    # non-fatal issues accumulated during upload; drained and printed by the CLI
+    warnings: list[str] = field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
         self.host = self.host.rstrip("/")
@@ -121,8 +124,9 @@ class LangfuseClient:
                         "uploadHttpError": None,
                     },
                 )
-            except Exception:
-                pass  # confirmation is best-effort; the bytes are already stored
+            except urllib.error.URLError as exc:
+                # confirmation is best-effort — the bytes are already stored
+                self.warnings.append(f"media {media_id}: confirmation PATCH failed: {exc}")
         if not media_id:
             return None
         return f"@@@langfuseMedia:type={content_type}|id={media_id}|source=bytes@@@"

--- a/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
@@ -1,0 +1,449 @@
+"""Map tolokaforge trial bundles to Langfuse ingestion events and upload them.
+
+A trial bundle is the directory ``<run_dir>/trials/<task_id>/<trial_index>/`` produced by
+``tolokaforge run``, containing ``trajectory.yaml``, ``metrics.yaml`` and ``grade.yaml``.
+
+Mapping:
+    run               -> Langfuse session (``sessionId``) + tags
+    trial             -> trace
+    assistant message -> generation (per-turn usage from ``metrics.usage.calls``)
+    tool message      -> span
+    grade             -> scores
+    metrics           -> trace metadata
+
+Trace, observation and score ids are deterministic (uuid5 over run tag / label / task id /
+trial index), so re-uploading the same trial updates the existing trace instead of
+duplicating it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.client
+import json
+import urllib.parse
+import urllib.request
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Namespace for deterministic trace/observation/score ids.
+_UUID_NS = uuid.UUID("00000000-0000-0000-0000-00000000f00d")
+
+# Langfuse rejects ingestion bodies over ~4.5 MB (server-side cap); flush batches well below it.
+MAX_BATCH_BYTES = 3_500_000
+
+# (trace_id, observation_id, field, content_type, raw_bytes) -> media reference token or None.
+MediaHandler = Callable[[str, str, str, str, bytes], "str | None"]
+
+
+def deterministic_id(*parts: object) -> str:
+    return str(uuid.uuid5(_UUID_NS, ":".join(str(part) for part in parts)))
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _normalize_ts(value: object) -> str | None:
+    if not value:
+        return None
+    text = str(value)
+    # Bundle timestamps carry no timezone marker -> treat them as UTC.
+    return text if text.endswith("Z") or "+" in text else text + "Z"
+
+
+@dataclass
+class LangfuseClient:
+    """Minimal stdlib-only client for the Langfuse public REST API (Basic auth)."""
+
+    host: str
+    public_key: str
+    secret_key: str
+    # "host:port" override for presigned media PUTs (e.g. a kubectl port-forward) when the
+    # object store hostname inside the URL is not directly reachable from this machine.
+    media_put_via: str | None = None
+    timeout: float = 60.0
+
+    def __post_init__(self) -> None:
+        self.host = self.host.rstrip("/")
+
+    def api(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        data = json.dumps(body).encode() if body is not None else None
+        request = urllib.request.Request(f"{self.host}{path}", data=data, method=method)
+        token = base64.b64encode(f"{self.public_key}:{self.secret_key}".encode()).decode()
+        request.add_header("Authorization", f"Basic {token}")
+        if data:
+            request.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            raw = response.read()
+        return json.loads(raw) if raw else {}
+
+    def upload_media(
+        self, trace_id: str, observation_id: str, field: str, content_type: str, raw: bytes
+    ) -> str | None:
+        """Register media, PUT the bytes to the presigned URL, confirm the upload.
+
+        Returns the LangfuseMedia reference token, or None when no media id was issued.
+        """
+        sha256 = base64.b64encode(hashlib.sha256(raw).digest()).decode()
+        created = self.api(
+            "POST",
+            "/api/public/media",
+            {
+                "traceId": trace_id,
+                "observationId": observation_id,
+                "field": field,
+                "contentType": content_type,
+                "contentLength": len(raw),
+                "sha256Hash": sha256,
+            },
+        )
+        media_id = created.get("mediaId")
+        upload_url = created.get("uploadUrl")  # absent when these bytes are already stored
+        if media_id and upload_url:
+            status = self._put_presigned(upload_url, content_type, sha256, raw)
+            try:
+                self.api(
+                    "PATCH",
+                    f"/api/public/media/{media_id}",
+                    {
+                        "uploadedAt": datetime.now(timezone.utc).isoformat(),
+                        "uploadHttpStatus": status,
+                        "uploadHttpError": None,
+                    },
+                )
+            except Exception:
+                pass  # confirmation is best-effort; the bytes are already stored
+        if not media_id:
+            return None
+        return f"@@@langfuseMedia:type={content_type}|id={media_id}|source=bytes@@@"
+
+    def _put_presigned(self, url: str, content_type: str, sha256: str, raw: bytes) -> int:
+        parsed = urllib.parse.urlparse(url)
+        if self.media_put_via:
+            via_host, _, via_port = self.media_put_via.partition(":")
+            connect_host, connect_port = via_host, int(via_port)
+        else:
+            connect_host = parsed.hostname or ""
+            connect_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        conn_cls = (
+            http.client.HTTPSConnection if parsed.scheme == "https" else http.client.HTTPConnection
+        )
+        conn = conn_cls(connect_host, connect_port, timeout=120)
+        try:
+            path = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+            # The signature covers the original Host header, so send it explicitly even when
+            # media_put_via routes the TCP connection elsewhere.
+            conn.putrequest("PUT", path, skip_host=True, skip_accept_encoding=True)
+            conn.putheader("Host", parsed.netloc)
+            conn.putheader("Content-Type", content_type)
+            conn.putheader("x-amz-checksum-sha256", sha256)
+            conn.putheader("Content-Length", str(len(raw)))
+            conn.endheaders()
+            conn.send(raw)
+            return conn.getresponse().status
+        finally:
+            conn.close()
+
+
+@dataclass
+class TrialStats:
+    media_uploaded: int = 0
+    media_failed: int = 0
+
+
+def _replace_media(
+    obj: Any,
+    trace_id: str,
+    observation_id: str,
+    field: str,
+    media_handler: MediaHandler | None,
+    stats: TrialStats,
+) -> Any:
+    """Recursively replace base64 image blocks with Langfuse media reference tokens.
+
+    Without a handler (or when the upload fails) the block becomes a small placeholder, so
+    raw base64 payloads never end up in the ingestion body.
+    """
+    if isinstance(obj, dict):
+        source = obj.get("source")
+        if (
+            obj.get("type") == "image"
+            and isinstance(source, dict)
+            and source.get("type") == "base64"
+            and source.get("data")
+        ):
+            content_type = source.get("media_type", "image/png")
+            if media_handler is not None:
+                try:
+                    raw = base64.b64decode(source["data"])
+                    token = media_handler(trace_id, observation_id, field, content_type, raw)
+                    if token:
+                        stats.media_uploaded += 1
+                        return token
+                except Exception as exc:
+                    stats.media_failed += 1
+                    return {
+                        "type": "image",
+                        "note": f"media upload failed: {exc}",
+                        "media_type": content_type,
+                    }
+            return {"type": "image", "note": "media stripped", "media_type": content_type}
+        return {
+            key: _replace_media(value, trace_id, observation_id, field, media_handler, stats)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [
+            _replace_media(item, trace_id, observation_id, field, media_handler, stats)
+            for item in obj
+        ]
+    return obj
+
+
+def build_trial_events(
+    trajectory: dict[str, Any],
+    metrics: dict[str, Any],
+    grade: dict[str, Any],
+    *,
+    label: str,
+    session: str,
+    run_tag: str = "v1",
+    media_handler: MediaHandler | None = None,
+    stats: TrialStats | None = None,
+    fallback_task_id: str = "unknown",
+) -> tuple[list[dict[str, Any]], str]:
+    """Build the Langfuse ingestion event batch for one trial bundle."""
+    stats = stats if stats is not None else TrialStats()
+    task_id = str(trajectory.get("task_id", fallback_task_id))
+    trial_index = trajectory.get("trial_index", 0)
+    trace_id = deterministic_id(run_tag, label, task_id, trial_index)
+    start = _normalize_ts(trajectory.get("start_ts"))
+    end = _normalize_ts(trajectory.get("end_ts"))
+    messages = trajectory.get("messages") or []
+    tool_calls_by_id = {
+        call.get("id"): (call.get("name"), call.get("arguments"))
+        for message in messages
+        for call in (message.get("tool_calls") or [])
+    }
+    usage_calls = (metrics.get("usage") or {}).get("calls") or []
+    events: list[dict[str, Any]] = []
+
+    def add_event(event_type: str, body: dict[str, Any]) -> None:
+        events.append(
+            {
+                "id": str(uuid.uuid4()),
+                "type": event_type,
+                "timestamp": start or "1970-01-01T00:00:00Z",
+                "body": body,
+            }
+        )
+
+    metric_keys = (
+        "turns",
+        "api_calls",
+        "tool_calls",
+        "tool_success_rate",
+        "tokens_input",
+        "tokens_output",
+        "cost_usd",
+        "latency_total_s",
+    )
+    add_event(
+        "trace-create",
+        {
+            "id": trace_id,
+            "name": f"{label}/{task_id[:12]}",
+            "timestamp": start,
+            "sessionId": session,
+            "input": next((m.get("content") for m in messages if m.get("role") == "user"), None),
+            "output": next(
+                (
+                    m.get("content")
+                    for m in reversed(messages)
+                    if m.get("role") == "assistant" and m.get("content")
+                ),
+                None,
+            ),
+            "tags": [
+                "tolokaforge",
+                label,
+                f"status:{trajectory.get('status')}",
+                f"pass:{grade.get('binary_pass')}",
+            ],
+            "metadata": {key: metrics.get(key) for key in metric_keys}
+            | {
+                "task_id": task_id,
+                "trial_index": trial_index,
+                "status": trajectory.get("status"),
+                "termination_reason": trajectory.get("termination_reason"),
+            },
+        },
+    )
+
+    context: list[dict[str, Any]] = []
+    assistant_turn = 0
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        started = _normalize_ts(message.get("ts")) or start
+        ended = _normalize_ts(messages[index + 1].get("ts")) if index + 1 < len(messages) else end
+        blocks = message.get("content_blocks")
+        if role == "assistant":
+            observation_id = deterministic_id(trace_id, "gen", index)
+            output: Any = {
+                "content": message.get("content"),
+                "tool_calls": message.get("tool_calls"),
+            }
+            if blocks:
+                output["content_blocks"] = _replace_media(
+                    blocks, trace_id, observation_id, "output", media_handler, stats
+                )
+            body = {
+                "id": observation_id,
+                "traceId": trace_id,
+                "name": f"assistant turn {index}",
+                "startTime": started,
+                "endTime": ended or started,
+                "input": context[-6:],
+                "output": output,
+                "metadata": {"reasoning": message.get("reasoning")},
+            }
+            call = usage_calls[assistant_turn] if assistant_turn < len(usage_calls) else None
+            if call:
+                body["usageDetails"] = {
+                    "input": call.get("prompt_tokens"),
+                    "output": call.get("completion_tokens"),
+                }
+                if call.get("cost_usd") is not None:
+                    body["costDetails"] = {"total": call["cost_usd"]}
+            assistant_turn += 1
+            add_event("generation-create", body)
+        elif role == "tool":
+            observation_id = deterministic_id(trace_id, "tool", index)
+            name, arguments = tool_calls_by_id.get(message.get("tool_call_id"), (None, None))
+            output = (
+                _replace_media(blocks, trace_id, observation_id, "output", media_handler, stats)
+                if blocks
+                else message.get("content")
+            )
+            add_event(
+                "span-create",
+                {
+                    "id": observation_id,
+                    "traceId": trace_id,
+                    "name": f"tool: {name or 'unknown'}",
+                    "startTime": started,
+                    "endTime": ended or started,
+                    "input": arguments,
+                    "output": output,
+                },
+            )
+        context.append({"role": role, "content": (message.get("content") or "")[:2000]})
+
+    def add_score(name: str, value: float, data_type: str, comment: str | None = None) -> None:
+        add_event(
+            "score-create",
+            {
+                "id": deterministic_id(trace_id, "score", name),
+                "traceId": trace_id,
+                "name": name,
+                "value": value,
+                "dataType": data_type,
+                "comment": comment,
+            },
+        )
+
+    if grade.get("binary_pass") is not None:
+        add_score("binary_pass", 1 if grade["binary_pass"] else 0, "BOOLEAN")
+    if grade.get("score") is not None:
+        add_score("score", float(grade["score"]), "NUMERIC", str(grade.get("reasons") or "")[:900])
+    for name, value in (grade.get("components") or {}).items():
+        if isinstance(value, (int, float)):
+            add_score(f"component:{name}", float(value), "NUMERIC")
+
+    return events, trace_id
+
+
+def iter_batches(
+    events: list[dict[str, Any]], max_bytes: int = MAX_BATCH_BYTES
+) -> Iterator[list[dict[str, Any]]]:
+    """Split events into ingestion batches whose serialized size stays under max_bytes."""
+    batch: list[dict[str, Any]] = []
+    size = 0
+    for event in events:
+        event_size = len(json.dumps(event).encode()) + 1
+        if batch and size + event_size > max_bytes:
+            yield batch
+            batch, size = [], 0
+        batch.append(event)
+        size += event_size
+    if batch:
+        yield batch
+
+
+def discover_trials(root: Path) -> list[Path]:
+    """Trial bundle dirs under a run output dir; a trial dir itself is also accepted."""
+    if (root / "trajectory.yaml").exists():
+        return [root]
+    return sorted(path.parent for path in root.glob("trials/*/*/trajectory.yaml"))
+
+
+@dataclass
+class TrialResult:
+    trial_dir: Path
+    status: str  # "ok" | "error" | "empty"
+    trace_id: str | None = None
+    events: int = 0
+    media_uploaded: int = 0
+    media_failed: int = 0
+    error: str | None = None
+
+
+def upload_trial(
+    client: LangfuseClient,
+    trial_dir: Path,
+    *,
+    label: str,
+    session: str,
+    run_tag: str = "v1",
+) -> TrialResult:
+    """Upload one trial bundle. Media failures are tolerated; transport errors raise."""
+    trajectory = load_yaml(trial_dir / "trajectory.yaml")
+    if not trajectory:
+        return TrialResult(trial_dir, "empty")
+    metrics = load_yaml(trial_dir / "metrics.yaml")
+    grade = load_yaml(trial_dir / "grade.yaml")
+    stats = TrialStats()
+    events, trace_id = build_trial_events(
+        trajectory,
+        metrics,
+        grade,
+        label=label,
+        session=session,
+        run_tag=run_tag,
+        media_handler=client.upload_media,
+        stats=stats,
+        fallback_task_id=trial_dir.parent.name,
+    )
+    errors: list[Any] = []
+    for batch in iter_batches(events):
+        response = client.api("POST", "/api/public/ingestion", {"batch": batch})
+        errors.extend(response.get("errors") or [])
+    return TrialResult(
+        trial_dir,
+        "ok" if not errors else "error",
+        trace_id=trace_id,
+        events=len(events),
+        media_uploaded=stats.media_uploaded,
+        media_failed=stats.media_failed,
+        error=json.dumps(errors[:1]) if errors else None,
+    )

--- a/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
+++ b/tools/langfuse-uploader/src/langfuse_uploader/uploader.py
@@ -253,11 +253,18 @@ def build_trial_events(
         "api_calls",
         "tool_calls",
         "tool_success_rate",
-        "tokens_input",
-        "tokens_output",
         "cost_usd",
         "latency_total_s",
     )
+    # Token totals live at metrics.tokens_{input,output} in some runs and under metrics.usage
+    # (prompt_tokens/completion_tokens) in others; fall back so the trace-level totals are populated.
+    usage = metrics.get("usage") or {}
+    tokens_input = metrics.get("tokens_input")
+    if tokens_input is None:
+        tokens_input = usage.get("prompt_tokens")
+    tokens_output = metrics.get("tokens_output")
+    if tokens_output is None:
+        tokens_output = usage.get("completion_tokens")
     add_event(
         "trace-create",
         {
@@ -282,6 +289,8 @@ def build_trial_events(
             ],
             "metadata": {key: metrics.get(key) for key in metric_keys}
             | {
+                "tokens_input": tokens_input,
+                "tokens_output": tokens_output,
                 "task_id": task_id,
                 "trial_index": trial_index,
                 "status": trajectory.get("status"),

--- a/tools/langfuse-uploader/tests/test_uploader.py
+++ b/tools/langfuse-uploader/tests/test_uploader.py
@@ -95,6 +95,25 @@ class TestBuildTrialEvents:
         assert body["metadata"]["task_id"] == "task-alpha"
         assert body["timestamp"] == "2026-01-01T00:00:00Z"  # naive ts treated as UTC
 
+    def test_trace_token_totals_from_top_level(self) -> None:
+        events, _ = build()
+        meta = events[0]["body"]["metadata"]
+        assert meta["tokens_input"] == 100
+        assert meta["tokens_output"] == 20
+
+    def test_trace_token_totals_fall_back_to_usage(self) -> None:
+        # partner runs carry no top-level tokens_{input,output}; totals live under metrics.usage
+        metrics = {
+            "turns": 1,
+            "usage": {"prompt_tokens": 512, "completion_tokens": 64, "calls": []},
+        }
+        events, _ = build_trial_events(
+            make_trajectory(), metrics, GRADE, label="demo", session="run-1"
+        )
+        meta = events[0]["body"]["metadata"]
+        assert meta["tokens_input"] == 512
+        assert meta["tokens_output"] == 64
+
     def test_generations_and_spans(self) -> None:
         events, _ = build()
         generations = [e for e in events if e["type"] == "generation-create"]

--- a/tools/langfuse-uploader/tests/test_uploader.py
+++ b/tools/langfuse-uploader/tests/test_uploader.py
@@ -1,0 +1,290 @@
+"""Tests for langfuse_uploader — trial bundle mapping, media handling, batching, discovery."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from langfuse_uploader.cli import app as cli_app
+from langfuse_uploader.uploader import (
+    LangfuseClient,
+    TrialStats,
+    build_trial_events,
+    discover_trials,
+    iter_batches,
+    upload_trial,
+)
+from typer.testing import CliRunner
+
+pytestmark = pytest.mark.unit
+
+
+def make_trajectory(**overrides) -> dict:
+    trajectory = {
+        "task_id": "task-alpha",
+        "trial_index": 0,
+        "status": "completed",
+        "termination_reason": "final_answer",
+        "start_ts": "2026-01-01T00:00:00",
+        "end_ts": "2026-01-01T00:01:00",
+        "messages": [
+            {"role": "user", "content": "count files", "ts": "2026-01-01T00:00:00"},
+            {
+                "role": "assistant",
+                "content": None,
+                "ts": "2026-01-01T00:00:10",
+                "tool_calls": [
+                    {"id": "call-1", "name": "shell", "arguments": {"cmd": "ls | wc -l"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "3", "ts": "2026-01-01T00:00:20"},
+            {"role": "assistant", "content": "There are 3 files.", "ts": "2026-01-01T00:00:30"},
+        ],
+    }
+    trajectory.update(overrides)
+    return trajectory
+
+
+METRICS = {
+    "turns": 2,
+    "api_calls": 2,
+    "tool_calls": 1,
+    "tool_success_rate": 1.0,
+    "tokens_input": 100,
+    "tokens_output": 20,
+    "cost_usd": 0.01,
+    "latency_total_s": 60.0,
+    "usage": {
+        "calls": [
+            {"prompt_tokens": 40, "completion_tokens": 5, "cost_usd": 0.004},
+            {"prompt_tokens": 60, "completion_tokens": 15, "cost_usd": 0.006},
+        ]
+    },
+}
+
+GRADE = {
+    "binary_pass": True,
+    "score": 0.9,
+    "reasons": "solved it",
+    "components": {"state_checks": 1.0, "notes": "n/a"},
+}
+
+
+def build(trajectory: dict | None = None, **kwargs):
+    return build_trial_events(
+        trajectory or make_trajectory(), METRICS, GRADE, label="demo", session="run-1", **kwargs
+    )
+
+
+class TestBuildTrialEvents:
+    def test_trace_event(self) -> None:
+        events, trace_id = build()
+        trace = events[0]
+        assert trace["type"] == "trace-create"
+        body = trace["body"]
+        assert body["id"] == trace_id
+        assert body["name"] == "demo/task-alpha"
+        assert body["sessionId"] == "run-1"
+        assert body["input"] == "count files"
+        assert body["output"] == "There are 3 files."
+        assert {"tolokaforge", "demo", "status:completed", "pass:True"} <= set(body["tags"])
+        assert body["metadata"]["cost_usd"] == 0.01
+        assert body["metadata"]["task_id"] == "task-alpha"
+        assert body["timestamp"] == "2026-01-01T00:00:00Z"  # naive ts treated as UTC
+
+    def test_generations_and_spans(self) -> None:
+        events, _ = build()
+        generations = [e for e in events if e["type"] == "generation-create"]
+        spans = [e for e in events if e["type"] == "span-create"]
+        assert len(generations) == 2
+        assert generations[0]["body"]["usageDetails"] == {"input": 40, "output": 5}
+        assert generations[0]["body"]["costDetails"] == {"total": 0.004}
+        assert generations[1]["body"]["usageDetails"] == {"input": 60, "output": 15}
+        assert len(spans) == 1
+        assert spans[0]["body"]["name"] == "tool: shell"
+        assert spans[0]["body"]["input"] == {"cmd": "ls | wc -l"}
+        assert spans[0]["body"]["output"] == "3"
+
+    def test_scores(self) -> None:
+        events, _ = build()
+        scores = {e["body"]["name"]: e["body"] for e in events if e["type"] == "score-create"}
+        assert scores["binary_pass"]["value"] == 1
+        assert scores["binary_pass"]["dataType"] == "BOOLEAN"
+        assert scores["score"]["value"] == 0.9
+        assert scores["score"]["comment"] == "solved it"
+        assert scores["component:state_checks"]["value"] == 1.0
+        assert "component:notes" not in scores  # non-numeric components are skipped
+
+    def test_ids_are_deterministic(self) -> None:
+        first, trace_a = build()
+        second, trace_b = build()
+        assert trace_a == trace_b
+        assert [e["body"]["id"] for e in first] == [e["body"]["id"] for e in second]
+        _, trace_c = build(run_tag="v2")
+        assert trace_c != trace_a
+
+
+def image_block() -> dict:
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": base64.b64encode(b"fake-png").decode(),
+        },
+    }
+
+
+def trajectory_with_image() -> dict:
+    trajectory = make_trajectory()
+    trajectory["messages"][2]["content_blocks"] = [image_block(), {"type": "text", "text": "hi"}]
+    return trajectory
+
+
+class TestMedia:
+    def test_handler_token_replaces_block(self) -> None:
+        calls = []
+
+        def handler(trace_id, observation_id, field, content_type, raw):
+            calls.append((field, content_type, raw))
+            return "@@@langfuseMedia:type=image/png|id=m1|source=bytes@@@"
+
+        stats = TrialStats()
+        events, _ = build(trajectory_with_image(), media_handler=handler, stats=stats)
+        span = next(e for e in events if e["type"] == "span-create")
+        assert span["body"]["output"][0].startswith("@@@langfuseMedia:")
+        assert span["body"]["output"][1] == {"type": "text", "text": "hi"}
+        assert calls == [("output", "image/png", b"fake-png")]
+        assert stats.media_uploaded == 1
+
+    def test_handler_failure_is_fail_open(self) -> None:
+        def handler(*args):
+            raise RuntimeError("boom")
+
+        stats = TrialStats()
+        events, _ = build(trajectory_with_image(), media_handler=handler, stats=stats)
+        span = next(e for e in events if e["type"] == "span-create")
+        assert span["body"]["output"][0]["note"] == "media upload failed: boom"
+        assert stats.media_failed == 1
+
+    def test_no_handler_strips_base64(self) -> None:
+        events, _ = build(trajectory_with_image())
+        span = next(e for e in events if e["type"] == "span-create")
+        assert span["body"]["output"][0] == {
+            "type": "image",
+            "note": "media stripped",
+            "media_type": "image/png",
+        }
+        assert base64.b64encode(b"fake-png").decode() not in json.dumps(events)
+
+
+class TestIterBatches:
+    def test_splits_and_preserves_order(self) -> None:
+        events = [{"id": str(i), "payload": "x" * 1000} for i in range(10)]
+        batches = list(iter_batches(events, max_bytes=3000))
+        assert len(batches) > 1
+        assert [e["id"] for batch in batches for e in batch] == [str(i) for i in range(10)]
+        assert all(len(json.dumps(batch).encode()) <= 3200 for batch in batches)
+
+    def test_single_oversized_event_still_yields(self) -> None:
+        events = [{"payload": "x" * 5000}]
+        assert list(iter_batches(events, max_bytes=100)) == [events]
+
+
+def write_bundle(trial_dir: Path, trajectory: dict) -> None:
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    (trial_dir / "trajectory.yaml").write_text(yaml.safe_dump(trajectory))
+    (trial_dir / "metrics.yaml").write_text(yaml.safe_dump(METRICS))
+    (trial_dir / "grade.yaml").write_text(yaml.safe_dump(GRADE))
+
+
+class TestDiscoverTrials:
+    def test_run_dir_layout(self, tmp_path: Path) -> None:
+        write_bundle(tmp_path / "trials" / "task-a" / "0", make_trajectory())
+        write_bundle(tmp_path / "trials" / "task-b" / "1", make_trajectory(task_id="task-b"))
+        found = discover_trials(tmp_path)
+        assert [(p.parent.name, p.name) for p in found] == [("task-a", "0"), ("task-b", "1")]
+
+    def test_single_trial_dir(self, tmp_path: Path) -> None:
+        write_bundle(tmp_path, make_trajectory())
+        assert discover_trials(tmp_path) == [tmp_path]
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        assert discover_trials(tmp_path) == []
+
+
+def recording_client(errors: list | None = None) -> tuple[LangfuseClient, list]:
+    client = LangfuseClient(host="http://localhost:3000", public_key="pk", secret_key="sk")
+    posted: list = []
+
+    def fake_api(method, path, body=None):
+        posted.append((method, path, body))
+        return {"successes": body["batch"], "errors": errors or []}
+
+    client.api = fake_api  # type: ignore[method-assign]
+    return client, posted
+
+
+class TestUploadTrial:
+    def test_posts_ingestion_batches(self, tmp_path: Path) -> None:
+        write_bundle(tmp_path, make_trajectory())
+        client, posted = recording_client()
+        result = upload_trial(client, tmp_path, label="demo", session="run-1")
+        assert result.status == "ok"
+        assert all(path == "/api/public/ingestion" for _, path, _ in posted)
+        assert sum(len(body["batch"]) for _, _, body in posted) == result.events
+
+    def test_ingestion_errors_reported(self, tmp_path: Path) -> None:
+        write_bundle(tmp_path, make_trajectory())
+        client, _ = recording_client(errors=[{"id": "e1", "message": "bad event"}])
+        result = upload_trial(client, tmp_path, label="demo", session="run-1")
+        assert result.status == "error"
+        assert "bad event" in (result.error or "")
+
+    def test_missing_trajectory_is_empty(self, tmp_path: Path) -> None:
+        client, posted = recording_client()
+        result = upload_trial(client, tmp_path, label="demo", session="run-1")
+        assert result.status == "empty"
+        assert posted == []
+
+
+class TestDefaultRunName:
+    def test_run_dir_uses_own_name(self, tmp_path: Path) -> None:
+        from langfuse_uploader.cli import _default_run_name
+
+        run_dir = tmp_path / "run-42"
+        write_bundle(run_dir / "trials" / "task-a" / "0", make_trajectory())
+        assert _default_run_name(run_dir) == "run-42"
+
+    def test_single_trial_dir_walks_up_to_run(self, tmp_path: Path) -> None:
+        from langfuse_uploader.cli import _default_run_name
+
+        trial_dir = tmp_path / "run-42" / "trials" / "task-a" / "0"
+        write_bundle(trial_dir, make_trajectory())
+        assert _default_run_name(trial_dir) == "run-42"
+
+    def test_dot_resolves_to_real_name(self, tmp_path: Path, monkeypatch) -> None:
+        from langfuse_uploader.cli import _default_run_name
+
+        run_dir = tmp_path / "run-42"
+        run_dir.mkdir()
+        monkeypatch.chdir(run_dir)
+        assert _default_run_name(Path(".")) == "run-42"
+
+
+class TestCli:
+    def test_help_lists_commands(self) -> None:
+        result = CliRunner().invoke(cli_app, ["--help"])
+        assert result.exit_code == 0
+        assert "upload" in result.output
+        assert "watch" in result.output
+
+    def test_upload_requires_credentials(self, tmp_path: Path, monkeypatch) -> None:
+        for var in ("LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        result = CliRunner().invoke(cli_app, ["upload", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "Missing configuration" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1590,6 +1590,7 @@ dependencies = [
     { name = "click" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "tolokaforge" },
     { name = "typer" },
 ]
 
@@ -1598,6 +1599,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0,<8.2.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "tolokaforge", editable = "." },
     { name = "typer", specifier = ">=0.12.5,<0.13" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "dev-mcp",
+    "langfuse-uploader",
     "pricing-updater",
     "rubric-calibrator",
     "tolokaforge",
@@ -1579,6 +1580,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "langfuse-uploader"
+version = "0.1.0"
+source = { editable = "tools/langfuse-uploader" }
+dependencies = [
+    { name = "click" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.0.0,<8.2.0" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "typer", specifier = ">=0.12.5,<0.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

New workspace package `tools/langfuse-uploader` — a CLI that uploads completed tolokaforge trial bundles into a [Langfuse](https://langfuse.com) instance as traces.

## Why

Trajectories produced by tolokaforge runs (`trials/{task}/{trial}/trajectory.yaml` + artifacts) are currently only browsable as files. Pushing them into Langfuse gives search, timelines, token/cost stats, scores and shareable trace views without changing the harness itself: the uploader is strictly post-hoc and reads the stable trial-bundle layout.

## How it works

- `langfuse-uploader upload <run-dir>` — one-shot upload of every trial bundle under the run; idempotent (deterministic trace ids derived from run/task/trial), safe to re-run.
- `langfuse-uploader watch <run-dir>` — same, but tails a directory while a run is in progress.
- Mapping: trial → trace; assistant turns → generations (with model + token usage, incl. fallback to `metrics.usage.*`); tool calls/logs → spans; grades → scores; screenshots/artifacts → media attachments.
- Configuration via standard Langfuse SDK env vars: `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`.

## Testing

- 22 unit tests over the mapper/CLI (fixtures follow the trial-bundle schema).
- Verified end-to-end against a live Langfuse v3 instance: 36/36 real trial bundles uploaded, token totals and scores intact.