### PR TITLE
feat(models): add openai/gpt-5.6-terra and openai/gpt-5.6-sol

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -114,6 +114,134 @@ _ALL: list[MC] = [
         ),
     ),
     # -----------------------------------------------------------------
+    # OpenAI GPT-5.6 family (Terra + Sol tiers) — routed through the same
+    # ``openai_gpt5`` preset as gpt-5.4 / gpt-5.5 (strict schema sanitiser +
+    # array_dict_map response policy + OpenAI-style reasoning summary). Both
+    # variants resolve to a policy fingerprint byte-identical to the gpt-5.5
+    # sibling (schema_sanitizer=strict, response_policy=array_dict_map,
+    # reasoning_codec=openai, cache_policy=none), confirmed via
+    # ``resolve_policy_names``, so no new preset is required. OpenRouter
+    # exposes GPT-5.6 only as named tiers (Luna / Terra / Sol, each with a
+    # ``-pro`` reasoning-mode twin); there is no bare ``openai/gpt-5.6``.
+    # Terra ($2.5/$15) and Sol ($5/$30, flagship) are the same underlying
+    # family at different price/quality tiers and returned IDENTICAL live
+    # capability postures, so they share the posture below.
+    #
+    # Live-certified 2026-07-10 via
+    # ``scripts/with_env.sh uv run pytest tests/integration/llm/ -k gpt-5.6``
+    # (first pass: 28 passed, 8 skipped, 6 failed — the 6 fails are the same
+    # 3 capabilities on each variant; final posture 13 required /
+    # 7 known_unsupported per variant). Posture set by the ADD_NEW_MODEL.md
+    # § 3 disciplined flow: the gpt-5.5 sibling posture (16 required /
+    # 4 known_unsupported) was the starting hypothesis, and the THREE
+    # capabilities gpt-5.5 holds as ``required`` but gpt-5.6 refuted live were
+    # demoted (the key divergence from the sibling — NOT a blind copy):
+    #
+    #   * RE2_PATTERN_TOLERANCE — gpt-5.6's endpoint now REJECTS tool schemas
+    #     carrying a RE2-incompatible lookaround ``pattern`` with ``400
+    #     invalid_json_schema: regex lookaround is not supported`` (the error
+    #     names both Azure and OpenAI as rejecting). gpt-5.4/5.5 accept the
+    #     same payload, so this is a gpt-5.6 validator tightening, matching the
+    #     grok-4.3 posture. Production is unaffected:
+    #     ``StrictSchema.strip_re2_incompatible_patterns`` (default True on the
+    #     openai_gpt5 preset) strips the pattern before it reaches the model;
+    #     the raw-probe capability test swaps in PassthroughSchema to reach the
+    #     provider unstripped. Paired ratchet fires if OpenAI relaxes it.
+    #   * DECIMAL_FIELD_TOOL_CALL — intermittently returns NO tool call when a
+    #     Pydantic ``Decimal`` field is present (terra 2/2 fail, sol 1/2 fail
+    #     across two runs 2026-07-10). StrictSchema's Decimal-anyOf collapse
+    #     keeps the schema valid (no 400), so this is a model-behaviour gap,
+    #     not a schema-dialect one; a ``required`` capability must pass
+    #     reliably, so it is demoted. Same failure family as the
+    #     deepseek-v3.2-exp / tencent-hy3 decimal flakiness.
+    #   * IMPLICIT_PROMPT_CACHING — a clean 2-call 8 k-token probe records the
+    #     cache WRITE (cache_write_tokens ~8092) but reads back 0
+    #     cache_read_input_tokens on call 2 (route served by Azure, which does
+    #     not surface the read on a cold back-to-back probe). gpt-5.5's route
+    #     auto-caches; gpt-5.6's does not on this probe. Paired with
+    #     ``test_implicit_prompt_caching_unsupported_ratchet`` so it flips back
+    #     to required the day a 2-call probe observes caching.
+    #
+    # The four structural entries stay ``known_unsupported`` (all skipped
+    # live): the OpenAI reasoning codec surfaces summary-only reasoning (no
+    # signed blocks, no-op replay → THINKING_*), and ``cache_policy=none``
+    # attaches no explicit cache_control markers (PROMPT_CACHING).
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__openai_gpt-5.6-terra",
+        provider="openrouter",
+        name="openai/gpt-5.6-terra",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Structural to the openai_gpt5 preset (openai reasoning codec
+                # + cache_policy=none) — see family header.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                # Demoted from the gpt-5.5 hypothesis after the live run — see
+                # family header for the per-capability evidence.
+                C.RE2_PATTERN_TOLERANCE,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    MC(
+        model_id="openrouter__openai_gpt-5.6-sol",
+        provider="openrouter",
+        name="openai/gpt-5.6-sol",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Identical live posture to the terra sibling (same underlying
+                # family) — see family header for the full evidence.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # -----------------------------------------------------------------
     # Anthropic Claude family — structured thinking blocks + ephemeral
     # cache fully wired. Strict schema sanitisation is NOT applied to
     # Anthropic (preset keeps :class:`PassthroughSchema`), so dict-map /

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1219,6 +1219,16 @@
       "input": 30.0,
       "output": 180.0
     },
+    "openai/gpt-5.6-sol": {
+      "input": 5.0,
+      "output": 30.0,
+      "cache_read": 0.5
+    },
+    "openai/gpt-5.6-terra": {
+      "input": 2.5,
+      "output": 15.0,
+      "cache_read": 0.25
+    },
     "openai/gpt-audio": {
       "input": 2.5,
       "output": 10.0


### PR DESCRIPTION
## What

Adds the **GPT-5.6 Terra** and **GPT-5.6 Sol** tiers to the harness, following [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md). OpenRouter exposes GPT-5.6 only as named tiers (Luna / Terra / Sol, each with a `-pro` reasoning-mode twin) — there is **no bare `openai/gpt-5.6`**. This PR integrates the two requested tiers.

Two files, both `main`-appropriate (shared cost catalog + shared capability certificates); no eval-specific configs.

## Changes

**1. Pricing** — `tolokaforge/core/data/pricing.json` (per 1M tokens, USD; captured from OpenRouter `/api/v1/models` on **2026-07-10**, verified against the API response)
```json
"openai/gpt-5.6-sol":   { "input": 5.0, "output": 30.0, "cache_read": 0.5 },
"openai/gpt-5.6-terra": { "input": 2.5, "output": 15.0, "cache_read": 0.25 }
```

**2. Preset** — no change. Both fall through to the existing `openai_gpt5` preset (matches `openai/gpt-5*`). Confirmed via `resolve_policy_names` that the resolved fingerprint is byte-identical to `gpt-5.5`: `schema_sanitizer=strict`, `response_policy=array_dict_map`, `reasoning_codec=openai`, `cache_policy=none`.

**3. ModelCertificates** — `tests/integration/llm/registry.py`
`openrouter__openai_gpt-5.6-terra` and `openrouter__openai_gpt-5.6-sol`, **13 required / 7 known_unsupported each** (identical live posture — same underlying family at different price/quality tiers).

Posture set by the § 3 disciplined flow (NOT copied): started from the gpt-5.5 sibling (16 req / 4 ku), then demoted the **three** capabilities gpt-5.5 holds as `required` but gpt-5.6 refuted live:

| Capability | Why demoted (live 2026-07-10) |
|---|---|
| `RE2_PATTERN_TOLERANCE` | gpt-5.6 endpoint rejects lookaround `pattern` regexes: `400 invalid_json_schema: regex lookaround is not supported` (Azure **and** OpenAI both reject). gpt-5.4/5.5 accept it → gpt-5.6 validator tightening (grok-4.3 posture). **Production unaffected**: `StrictSchema.strip_re2_incompatible_patterns` (default on, `openai_gpt5`) strips it before it reaches the model; paired ratchet guards for when OpenAI relaxes it. |
| `DECIMAL_FIELD_TOOL_CALL` | Intermittently returns **no tool call** on a Pydantic `Decimal` field (terra 2/2 fail, sol 1/2 fail across two runs). Schema is valid post-sanitise (no 400) → model-behaviour gap; a `required` cap must be reliable. Same family as deepseek-v3.2-exp / tencent-hy3. |
| `IMPLICIT_PROMPT_CACHING` | Cold 2-call 8 k-token probe records the cache **write** (`cache_write_tokens ~8092`) but reads back **0** `cache_read_input_tokens` (route served by Azure). gpt-5.5 auto-caches; gpt-5.6 doesn't on this probe. Paired with `test_implicit_prompt_caching_unsupported_ratchet` to flip back when observed. |

The 4 structural `known_unsupported` (THINKING_EMITS_BLOCKS / THINKING_REPLAY_ROUNDTRIP / UNSIGNED_THINKING_REPLAY / PROMPT_CACHING) match gpt-5.4/5.5 — OpenAI reasoning codec is summary-only (no signed blocks / no-op replay) and `cache_policy=none` (no explicit cache markers).

Steps 5 (new reasoning format) and 6 (new provider) are N/A.

## Live capability suite (§ 4 — required for merge)

First pass (with the gpt-5.5 hypothesis) surfaced the 3 divergences: **28 passed, 8 skipped, 6 failed** (the 6 fails = RE2 + DECIMAL + IMPLICIT_CACHE on each variant). After demoting those 3 to `known_unsupported`, the final posture is fully green:

```
$ scripts/with_env.sh uv run pytest tests/integration/llm/ -k gpt-5.6

========== 32 passed, 14 skipped, 651 deselected in 125.79s (0:02:05) ==========
```

- 14 skipped = 7 `known_unsupported` × 2 variants (no undeclared skips).
- 32 passed includes the RE2 and implicit-cache **ratchet** tests (`..._unsupported_ratchet`) for both variants — they confirm the provider still rejects RE2 patterns / still returns 0 cache-read, i.e. the `known_unsupported` declarations are honest and will trip when the provider behaviour changes.

## Other verification

- `uv run pytest tests/canonical/test_capability_registry.py` → **9 passed** (unique slugs, complete coverage, disjoint required/known_unsupported for both certs)
- `uv run pytest tests/unit/test_pricing.py` → **35 passed**
- `ruff format --check` + `ruff check` → clean (pre-commit hooks pass)

## Not included

- § 4a smoke eval — requires external `tasks/` packs + additional spend; recommended as a follow-up. Eval configs are `main`-excluded anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
