### PR TITLE
feat(models): add tencent/hy3 (Hunyuan 3 GA)

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1609,6 +1609,69 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # HY3 (Tencent Hunyuan 3 GA via OpenRouter) — the released successor to
+    # the hy3-preview sibling below. Routes through the same shared
+    # ``openrouter_dict_stringify_recovery`` preset; the resolved policy
+    # fingerprint is byte-identical to hy3-preview (passthrough schema +
+    # dict_map_hints + json_coerce response + openai reasoning codec,
+    # cache_policy=none), confirmed via ``resolve_policy_names``, so no new
+    # preset is required.
+    #
+    # Live-certified 2026-07-10 via
+    # ``scripts/with_env.sh uv run pytest tests/integration/llm/ -k 'hy3 and not preview'``
+    # (18 passed, 3 skipped; final posture 17 required / 3 known_unsupported).
+    # Posture set by the ADD_NEW_MODEL.md § 3 disciplined flow — NOT copied
+    # from the preview sibling: the three non-structural ``known_unsupported``
+    # entries the preview holds were flipped to ``required`` as the hypothesis
+    # and re-run live. All three PASS on the GA release, so the GA is strictly
+    # stronger than the preview and they stay ``required``:
+    #
+    #   * DECIMAL_FIELD_TOOL_CALL — preview intermittently returned no tool
+    #     call (~2/5 runs); GA emits the Decimal call reliably.
+    #   * DISCRIMINATED_UNION_TOOL_CALL — preview intermittently renamed the
+    #     branch field (``title`` for ``subject``, ~1/5 runs); GA round-trips
+    #     both turns cleanly (json_coerce handles any stringified args).
+    #   * IMPLICIT_PROMPT_CACHING — preview's cold 2-call probe read 0; GA
+    #     surfaces cache_read on call 2.
+    #
+    # The three structural entries stay ``known_unsupported`` (all skipped
+    # live): the openai reasoning codec is summary-only (no signed blocks,
+    # no-op replay → THINKING_REPLAY_ROUNDTRIP / UNSIGNED_THINKING_REPLAY) and
+    # ``cache_policy=none`` attaches no cache_control markers (PROMPT_CACHING).
+    MC(
+        model_id="openrouter__tencent_hy3",
+        provider="openrouter",
+        name="tencent/hy3",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                C.PROMPT_CACHING,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
     # HY3-Preview (Tencent Hunyuan 3 via OpenRouter). Routes through the
     # shared ``openrouter_dict_stringify_recovery`` preset (json_coerce
     # decodes its stringified tool args; the openai codec surfaces its

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -1635,6 +1635,11 @@
       "input": 0.14,
       "output": 0.57
     },
+    "tencent/hy3": {
+      "input": 0.14,
+      "output": 0.58,
+      "cache_read": 0.035
+    },
     "tencent/hy3-preview": {
       "input": 0.063,
       "output": 0.21,


### PR DESCRIPTION
## What

Adds **`tencent/hy3`** (Tencent Hunyuan 3, GA) — the released, non-preview successor to the already-integrated `tencent/hy3-preview` — following [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md).

Two files, both `main`-appropriate; no eval-specific configs. (Note: `tencent/hy3:free` exists on OpenRouter but is the free-tier alias, out of scope.)

## Changes

**1. Pricing** — `tolokaforge/core/data/pricing.json` (per 1M tokens, USD; captured from OpenRouter `/api/v1/models` on **2026-07-10**, verified against the API)
```json
"tencent/hy3": { "input": 0.14, "output": 0.58, "cache_read": 0.035 }
```

**2. Preset** — no change. `tencent/hy3` falls through to the existing `openrouter_dict_stringify_recovery` preset (matches `tencent/hy3*`). Confirmed via `resolve_policy_names` that the resolved fingerprint is byte-identical to `hy3-preview`: `schema_sanitizer=passthrough`, `prompt_policy=dict_map_hints`, `response_policy=json_coerce`, `reasoning_codec=openai`, `cache_policy=none`.

**3. ModelCertificate** — `tests/integration/llm/registry.py`
`openrouter__tencent_hy3`, **17 required / 3 known_unsupported**.

Posture set by the § 3 disciplined flow (NOT copied): started from the `hy3-preview` sibling, flipped its three non-structural `known_unsupported` entries to `required`, and re-ran live. **All three pass on the GA** — it is strictly stronger than the preview:

| Capability | hy3-preview | hy3 (GA) |
|---|---|---|
| `DECIMAL_FIELD_TOOL_CALL` | known_unsupported (intermittent "no tool call") | **required** ✅ |
| `DISCRIMINATED_UNION_TOOL_CALL` | known_unsupported (intermittent field-rename) | **required** ✅ |
| `IMPLICIT_PROMPT_CACHING` | known_unsupported (cold probe read 0) | **required** ✅ |

The 3 structural `known_unsupported` (`PROMPT_CACHING`, `THINKING_REPLAY_ROUNDTRIP`, `UNSIGNED_THINKING_REPLAY`) are inherent to the preset wiring (OpenAI reasoning codec is summary-only / no-op replay; `cache_policy=none` attaches no cache_control markers) — same as the preview.

Steps 5 (new reasoning format) and 6 (new provider) are N/A.

## Live capability suite (§ 4 — required for merge)

```
$ scripts/with_env.sh uv run pytest tests/integration/llm/ -k 'hy3 and not preview'

test_basic_completion ................... PASSED
test_simple_tool_call ................... PASSED
test_multi_turn_tool_use ............... PASSED
test_multi_turn_error_recovery ......... PASSED
test_enum_slash_tolerance .............. PASSED
test_re2_pattern_tolerance ............. PASSED
test_dict_map_tool_call ................ PASSED
test_discriminated_union_tool_call ..... PASSED (bare_union + explicit_discriminator)
test_decimal_field_tool_call ........... PASSED
test_thinking_emits_blocks ............. PASSED
test_implicit_prompt_caching ........... PASSED
test_usage_metrics_populated ........... PASSED
test_cost_usd_populated ................ PASSED
test_tool_name_discipline .............. PASSED
test_lexical_tool_invention ............ PASSED
test_required_fields_complete .......... PASSED
test_progress_after_success ............ PASSED
test_prompt_caching .................... SKIPPED
test_thinking_replay_roundtrip ......... SKIPPED
test_unsigned_thinking_replay .......... SKIPPED

========== 18 passed, 3 skipped, 651 deselected in 530.35s (0:08:50) ==========
```

All 3 skips map to declared `known_unsupported` capabilities — no undeclared skips.

## Other verification

- `uv run pytest tests/canonical/test_capability_registry.py` → **9 passed**
- `uv run pytest tests/unit/test_pricing.py` → **35 passed**
- `ruff format --check` + `ruff check` → clean (pre-commit hooks pass)

## Not included

- § 4a smoke eval — requires external `tasks/` packs + additional spend; recommended as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
