### PR TITLE
integrate: qwen/qwen3.6-plus

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,6 +381,75 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Qwen 3.6-plus — auto-resolve integration (PR #208). Pinned to its
+    # own ``qwen3_6_plus_candidate`` preset, whose axes are identical to
+    # the family-wide ``qwen`` preset (passthrough schema + ``DictMapHints``
+    # prompt policy + ``JsonCoerceResponse`` recovery + OpenAI-style
+    # reasoning summary). The observe run surfaced four failures, all
+    # GENUINE ceilings (zero preset-fixable fix-targets):
+    #   * PROMPT_CACHING / IMPLICIT_PROMPT_CACHING — the OpenRouter/Qwen
+    #     route returns 0 cache tokens (prompt_tokens ~8.3k, cache_read 0
+    #     across all 15 reps); no policy fabricates an upstream cache hit.
+    #   * THINKING_REPLAY_ROUNDTRIP — Qwen emits only a reasoning_content
+    #     summary, no signed blocks, so turn 1 yields zero signed entries.
+    #   * UNSIGNED_THINKING_REPLAY — OpenAIReasoningCodec.encode_for_replay
+    #     is a no-op by design; turn-2 payload carries no reasoning_details.
+    # THINKING_EMITS_BLOCKS passes the observe probe only via the weak
+    # summary path, so it is kept ``known_unsupported`` here (a human gate
+    # may promote it as the qwen3.7-max sibling did).
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__qwen_qwen3.6-plus",
+        provider="openrouter",
+        name="qwen/qwen3.6-plus",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # No explicit Anthropic-ephemeral cache and no implicit
+                # upstream auto-cache on the OpenRouter qwen/* route — call 1
+                # created 0 cache_creation_input_tokens and call 2 read 0
+                # cache_read_input_tokens across all 15 reps.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                # OpenAI-style reasoning summary only — no signed blocks on
+                # the wire, so the signed-replay continuity contract has
+                # nothing to assert on (turn 1 emits zero signed entries).
+                C.THINKING_REPLAY_ROUNDTRIP,
+                # OpenAIReasoningCodec.encode_for_replay is a no-op for this
+                # preset — turn-2 payload omits ``reasoning_details``. A
+                # future bespoke Qwen reasoning codec would flip this.
+                C.UNSIGNED_THINKING_REPLAY,
+                # Passes the observe probe only via the weak reasoning_content
+                # summary path, not signed structured blocks — kept
+                # known_unsupported pending a human gate (qwen3.7-max promoted
+                # its richer surface; 3.6-plus's is the summary only).
+                C.THINKING_EMITS_BLOCKS,
+            }
+        ),
+    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -381,50 +381,6 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # -----------------------------------------------------------------
-    # Qwen — preset routes it through the same strict trio as GPT-5.
-    # Reasoning surface is OpenAI-style summary only, no signed blocks,
-    # so thinking capabilities are ``known_unsupported``.
-    # -----------------------------------------------------------------
-    MC(
-        model_id="openrouter__qwen_qwen3.6-plus",
-        provider="openrouter",
-        name="qwen/qwen3.6-plus",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,  # strict-schema dict-map array conversion
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                C.DECIMAL_FIELD_TOOL_CALL,  # same strict sanitizer as GPT-5
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-                # No implicit upstream cache surfaced on the OpenRouter
-                # qwen/* routes.
-                C.IMPLICIT_PROMPT_CACHING,
-            }
-        ),
-    ),
     # Qwen 3.7 Max — Alibaba's flagship Qwen 3.7 generation. Routes
     # through the same ``qwen`` preset as 3.6-plus (passthrough schema +
     # ``DictMapHints`` prompt policy + ``JsonCoerceResponse`` recovery +

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -93,6 +93,23 @@ presets:
     response_policy: array_dict_map
     reasoning_codec: openai
 
+  # qwen3.6-plus candidate (auto-resolve, PR #208). Pins this specific model
+  # to the proven, family-wide qwen policy (identical axes to the ``qwen``
+  # preset below that also serves qwen3.7-max) so its certificate and any
+  # reprobe run under the correct preset rather than the bare ``default``.
+  # Declared BEFORE the generic ``qwen`` glob so first-match-wins routing
+  # picks this candidate-specific entry. All four observe failures were
+  # genuine ceilings (no fix-targets), so this composes shipped classes only
+  # — no engine change. See observation/resolve/ for the integration record.
+  qwen3_6_plus_candidate:
+    match:
+      - "qwen/qwen3.6-plus"
+      - "qwen/qwen3.6-plus*"
+    schema_sanitizer: passthrough   # dict-map hints/schema/docs stay aligned
+    prompt_policy: dict_map_hints    # Qwen Dict[str, T] blind-spot hint
+    response_policy: json_coerce     # recover stringified-JSON nested args
+    reasoning_codec: openai          # surface reasoning_content summary
+
   qwen:
     # Qwen 3.x emits dict-map arguments as either native dicts (matching the
     # task docs + DictMapHints) or stringified JSON. The pre-bugfix ``strict``


### PR DESCRIPTION
# Integrate qwen/qwen3.6-plus (auto-resolve)

**Candidate:** `openrouter` / `qwen/qwen3.6-plus` (`openrouter__qwen_qwen3.6-plus`)
**Engine ref:** `676fe9b`

## Policy

Adds preset **`qwen3_6_plus_candidate`** to `tolokaforge/core/data/model_presets.yaml`, pinning
this model to the proven, family-wide `qwen` policy (same axes that serve `qwen3.7-max`), declared
before the generic `qwen` glob so first-match-wins picks the candidate-specific entry:

- `schema_sanitizer: passthrough`
- `prompt_policy: dict_map_hints`
- `response_policy: json_coerce`
- `reasoning_codec: openai`

Composes shipped policy classes only — **no engine change, no new adapter class**. Adds the
certificate to `tests/integration/llm/registry.py` (18 required / 5 `known_unsupported`).

## Ceilings (`known_unsupported`)

All four observe failures are genuine ceilings — zero preset-fixable fix-targets:

- `PROMPT_CACHING`, `IMPLICIT_PROMPT_CACHING` — the OpenRouter/Qwen route returns 0 cache tokens.
- `THINKING_REPLAY_ROUNDTRIP` — summary-only reasoning, no signed blocks on turn 1.
- `UNSIGNED_THINKING_REPLAY` — `OpenAIReasoningCodec.encode_for_replay` is a no-op.
- `THINKING_EMITS_BLOCKS` — passes only via the weak summary path; kept `known_unsupported`
  pending a human gate.

All 18 required capabilities passed 15/15 at the observe baseline; the 6 variant probes passed
6/6.

## Provenance

Integrated via **auto-resolve** (observe → resolve → finalize). See `observation/resolve/` for the
overlay, decision, and integration record.

> ⚠️ This is a disposable test branch (`test/observe-qwen3.6-plus-r5`) used to exercise the
> auto-resolve flow on a fresh candidate. **Do not merge.**
