### PR TITLE
feat(schema): add ProjectConfig, TaskDefaults, RunDefaults + compute/storage/observability blocks

### DIFF
--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -1,8 +1,4 @@
-"""Unit tests for the ProjectConfig / TaskDefaults schema.
-
-Stage-1 scope: models only. No loader wiring, no strict validation.
-See docs/architecture/PROJECTS.md.
-"""
+"""Unit tests for the ProjectConfig / TaskDefaults schema."""
 
 from __future__ import annotations
 
@@ -110,6 +106,14 @@ class TestTaskDefaultsFields:
         )
         assert gd.combine is not None
         assert gd.combine.pass_threshold == 0.7
+
+    def test_grading_defaults_accepts_partial_combine(self) -> None:
+        # A project can declare only pass_threshold without enumerating
+        # every weight — weights defaults to an empty dict.
+        gd = GradingDefaults(combine=GradingCombineConfig(pass_threshold=0.9))
+        assert gd.combine is not None
+        assert gd.combine.pass_threshold == 0.9
+        assert gd.combine.weights == {}
 
     def test_policies_and_adapter_settings_are_dicts(self) -> None:
         td = TaskDefaults(

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -24,6 +24,8 @@ from tolokaforge.core.models import (
 )
 from tolokaforge.runner.models import EnvironmentManifest
 
+pytestmark = pytest.mark.unit
+
 ENV_FIXTURE = (
     Path(__file__).parent.parent
     / "canonical"

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -1,0 +1,176 @@
+"""Unit tests for the ProjectConfig / TaskDefaults schema.
+
+Stage-1 scope: models only. No loader wiring, no strict validation.
+See docs/architecture/PROJECTS.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models import (
+    GradingCombineConfig,
+    GradingDefaults,
+    ProjectConfig,
+    StuckHeuristicsDefaults,
+    TaskDefaults,
+    TaskDiscoveryConfig,
+    TaskInventoryConfig,
+    TimeoutDefaults,
+    UserSimulatorConfig,
+)
+from tolokaforge.runner.models import EnvironmentManifest
+
+ENV_FIXTURE = (
+    Path(__file__).parent.parent
+    / "canonical"
+    / "fixtures"
+    / "environment_manifest"
+    / "safe_one_service.yaml"
+)
+
+
+class TestTaskDiscoveryDefaults:
+    def test_default_glob(self) -> None:
+        cfg = TaskDiscoveryConfig()
+        assert cfg.glob == "tasks/**/task.yaml"
+
+    def test_custom_glob(self) -> None:
+        cfg = TaskDiscoveryConfig(glob="benchmarks/**/task.yaml")
+        assert cfg.glob == "benchmarks/**/task.yaml"
+
+    def test_inventory_defaults(self) -> None:
+        inv = TaskInventoryConfig()
+        assert inv.discovery.glob == "tasks/**/task.yaml"
+
+
+class TestTaskDefaultsFields:
+    def test_all_fields_optional(self) -> None:
+        td = TaskDefaults()
+        assert td.adapter_type is None
+        assert td.max_turns is None
+        assert td.system_prompt is None
+        assert td.user_simulator is None
+        assert td.policies == {}
+        assert td.metadata is None
+        assert td.adapter_settings == {}
+        assert td.tools is None
+        assert td.grading_defaults is None
+        assert td.timeouts is None
+        assert td.stuck_heuristics is None
+        assert td.continue_prompt is None
+
+    def test_max_turns_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TaskDefaults(max_turns=0)
+
+    def test_user_simulator_nested(self) -> None:
+        td = TaskDefaults(
+            user_simulator=UserSimulatorConfig(mode="llm", persona="curious engineer")
+        )
+        assert td.user_simulator is not None
+        assert td.user_simulator.persona == "curious engineer"
+
+    def test_timeout_defaults_nested(self) -> None:
+        td = TaskDefaults(timeouts=TimeoutDefaults(trial_seconds=1200, tool_call_seconds=90))
+        assert td.timeouts is not None
+        assert td.timeouts.trial_seconds == 1200
+        assert td.timeouts.tool_call_seconds == 90
+
+    def test_timeout_defaults_reject_non_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TimeoutDefaults(trial_seconds=0)
+        with pytest.raises(ValidationError):
+            TimeoutDefaults(tool_call_seconds=0)
+
+    def test_stuck_heuristics_defaults(self) -> None:
+        sh = StuckHeuristicsDefaults()
+        assert sh.enabled is True
+        assert sh.max_repeated_tool_calls == 5
+        assert sh.max_idle_turns == 3
+
+    def test_stuck_heuristics_reject_non_positive_counts(self) -> None:
+        with pytest.raises(ValidationError):
+            StuckHeuristicsDefaults(max_repeated_tool_calls=0)
+        with pytest.raises(ValidationError):
+            StuckHeuristicsDefaults(max_idle_turns=0)
+
+    def test_grading_defaults_wraps_combine(self) -> None:
+        gd = GradingDefaults(
+            combine=GradingCombineConfig(
+                method="weighted",
+                weights={"state_checks": 0.5, "llm_judge": 0.5},
+                pass_threshold=0.7,
+            )
+        )
+        assert gd.combine is not None
+        assert gd.combine.pass_threshold == 0.7
+
+    def test_policies_and_adapter_settings_are_dicts(self) -> None:
+        td = TaskDefaults(
+            policies={"max_tool_calls_per_turn": 10},
+            adapter_settings={"bundle_path": "./domain"},
+        )
+        assert td.policies == {"max_tool_calls_per_turn": 10}
+        assert td.adapter_settings == {"bundle_path": "./domain"}
+
+
+class TestProjectConfigMinimal:
+    def test_minimal_project(self) -> None:
+        p = ProjectConfig(name="minimal-eval")
+        assert p.name == "minimal-eval"
+        assert p.version == 1
+        assert p.description is None
+        assert p.tasks.discovery.glob == "tasks/**/task.yaml"
+        assert p.default_environment is None
+        assert isinstance(p.task_defaults, TaskDefaults)
+        assert p.run_defaults is None
+
+    def test_project_requires_name(self) -> None:
+        with pytest.raises(ValidationError):
+            ProjectConfig()  # type: ignore[call-arg]
+
+    def test_project_version_default_is_one(self) -> None:
+        p = ProjectConfig(name="v-check")
+        assert p.version == 1
+
+    def test_project_with_populated_task_defaults(self) -> None:
+        p = ProjectConfig(
+            name="populated",
+            description="A populated project",
+            task_defaults=TaskDefaults(
+                adapter_type="native",
+                max_turns=20,
+                continue_prompt="Continue.",
+                timeouts=TimeoutDefaults(trial_seconds=600, tool_call_seconds=60),
+                stuck_heuristics=StuckHeuristicsDefaults(),
+            ),
+        )
+        assert p.description == "A populated project"
+        assert p.task_defaults.adapter_type == "native"
+        assert p.task_defaults.max_turns == 20
+        assert p.task_defaults.continue_prompt == "Continue."
+
+
+class TestProjectConfigWithEnvironment:
+    def test_default_environment_binds(self) -> None:
+        p = ProjectConfig(
+            name="with-env",
+            default_environment=EnvironmentManifest(compose_file=ENV_FIXTURE),
+        )
+        assert p.default_environment is not None
+        assert p.default_environment.compose_file == ENV_FIXTURE
+
+    def test_missing_compose_file_fails(self) -> None:
+        # Regression: EnvironmentManifest still enforces its own file
+        # existence check inside the ProjectConfig graph.
+        with pytest.raises(ValidationError):
+            ProjectConfig(
+                name="broken-env",
+                default_environment=EnvironmentManifest(
+                    compose_file=Path("/nonexistent/compose.yaml"),
+                ),
+            )

--- a/tests/unit/test_run_defaults_schema.py
+++ b/tests/unit/test_run_defaults_schema.py
@@ -1,8 +1,4 @@
-"""Unit tests for RunDefaults + Compute/Storage/Observability schemas.
-
-Stage-1 scope: models only. The loader that consumes these lands in
-the next milestone. See docs/architecture/PROJECTS.md.
-"""
+"""Unit tests for RunDefaults + Compute/Storage/Observability schemas."""
 
 from __future__ import annotations
 
@@ -38,7 +34,7 @@ class TestComputeConfig:
         assert c.workers is None
         assert c.max_budget_usd is None
         assert c.max_requests_per_second is None
-        assert c.max_attempt_retries is None
+        assert c.max_attempt_retries == 0
         assert c.local_docker is None
 
     def test_rejects_unknown_provider(self) -> None:
@@ -98,9 +94,31 @@ class TestStorageConfig:
         assert q.backend == "postgres"
         assert q.postgres_dsn == "postgresql://x@h/db"
 
+    def test_queue_postgres_requires_dsn(self) -> None:
+        with pytest.raises(ValidationError, match="postgres_dsn"):
+            QueueStorageConfig(backend="postgres")
+        with pytest.raises(ValidationError, match="postgres_dsn"):
+            QueueStorageConfig(backend="postgres", postgres_dsn="")
+
     def test_queue_rejects_unknown_backend(self) -> None:
         with pytest.raises(ValidationError):
             QueueStorageConfig(backend="redis")  # type: ignore[arg-type]
+
+    def test_artifacts_union_discriminated_by_type(self) -> None:
+        # Mixed tag: type=local with an s3-only field. The discriminator
+        # must reject rather than silently pick LocalStorageConfig and
+        # drop the extra field.
+        with pytest.raises(ValidationError):
+            StorageConfig.model_validate(
+                {"artifacts": {"type": "local", "path": "/tmp", "bucket": "wrong-mix"}}
+            )
+
+    def test_artifacts_union_selects_by_type_tag(self) -> None:
+        s = StorageConfig.model_validate(
+            {"artifacts": {"type": "s3", "bucket": "b", "prefix": "p"}}
+        )
+        assert isinstance(s.artifacts, S3StorageConfig)
+        assert s.artifacts.bucket == "b"
 
 
 class TestObservabilityConfig:
@@ -120,15 +138,27 @@ class TestObservabilityConfig:
         assert t.exporter == "otlp"
         assert t.endpoint == "http://collector:4317"
 
+    def test_tracing_otlp_requires_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="endpoint"):
+            TracingConfig(exporter="otlp")
+
     def test_metrics_prometheus(self) -> None:
         m = MetricsConfig(exporter="prometheus", endpoint="http://prom:9090")
         assert m.exporter == "prometheus"
+
+    def test_metrics_prometheus_requires_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="endpoint"):
+            MetricsConfig(exporter="prometheus")
 
     def test_logging_defaults(self) -> None:
         lg = LoggingConfig()
         assert lg.level == "INFO"
         assert lg.exporter == "stdout"
         assert lg.endpoint is None
+
+    def test_logging_otlp_requires_endpoint(self) -> None:
+        with pytest.raises(ValidationError, match="endpoint"):
+            LoggingConfig(exporter="otlp")
 
     def test_logging_level_rejects_unknown(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/test_run_defaults_schema.py
+++ b/tests/unit/test_run_defaults_schema.py
@@ -1,0 +1,200 @@
+"""Unit tests for RunDefaults + Compute/Storage/Observability schemas.
+
+Stage-1 scope: models only. The loader that consumes these lands in
+the next milestone. See docs/architecture/PROJECTS.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models import (
+    ComputeConfig,
+    EngineConfig,
+    EvaluationConfig,
+    LocalDockerComputeConfig,
+    LocalStorageConfig,
+    LoggingConfig,
+    MetricsConfig,
+    ModelConfig,
+    ObservabilityConfig,
+    OrchestratorConfig,
+    QueueStorageConfig,
+    RunConfig,
+    RunDefaults,
+    S3StorageConfig,
+    StorageConfig,
+    TracingConfig,
+)
+
+
+class TestComputeConfig:
+    def test_default_provider_is_local_docker(self) -> None:
+        c = ComputeConfig()
+        assert c.provider == "local-docker"
+        assert c.workers is None
+        assert c.max_budget_usd is None
+        assert c.max_requests_per_second is None
+        assert c.max_attempt_retries is None
+        assert c.local_docker is None
+
+    def test_rejects_unknown_provider(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(provider="kubernetes")  # type: ignore[arg-type]
+
+    def test_workers_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(workers=0)
+
+    def test_budget_non_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(max_budget_usd=-1.0)
+        ComputeConfig(max_budget_usd=0.0)  # zero is allowed
+
+    def test_rate_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(max_requests_per_second=0.0)
+
+    def test_retries_non_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(max_attempt_retries=-1)
+        ComputeConfig(max_attempt_retries=0)  # zero is allowed
+
+    def test_provider_sub_block_binds(self) -> None:
+        c = ComputeConfig(local_docker=LocalDockerComputeConfig())
+        assert c.local_docker is not None
+
+
+class TestStorageConfig:
+    def test_defaults_all_none(self) -> None:
+        s = StorageConfig()
+        assert s.artifacts is None
+        assert s.logs is None
+        assert s.queue is None
+
+    def test_local_artifacts(self) -> None:
+        s = StorageConfig(artifacts=LocalStorageConfig(path="./results"))
+        assert s.artifacts is not None
+        assert s.artifacts.type == "local"
+        assert s.artifacts.path == "./results"
+
+    def test_s3_artifacts(self) -> None:
+        s = StorageConfig(artifacts=S3StorageConfig(bucket="team-toloka", prefix="nightly"))
+        assert s.artifacts is not None
+        assert s.artifacts.type == "s3"
+        assert s.artifacts.bucket == "team-toloka"
+        assert s.artifacts.prefix == "nightly"
+
+    def test_queue_defaults(self) -> None:
+        q = QueueStorageConfig()
+        assert q.backend == "sqlite"
+        assert q.postgres_dsn is None
+
+    def test_queue_postgres(self) -> None:
+        q = QueueStorageConfig(backend="postgres", postgres_dsn="postgresql://x@h/db")
+        assert q.backend == "postgres"
+        assert q.postgres_dsn == "postgresql://x@h/db"
+
+    def test_queue_rejects_unknown_backend(self) -> None:
+        with pytest.raises(ValidationError):
+            QueueStorageConfig(backend="redis")  # type: ignore[arg-type]
+
+
+class TestObservabilityConfig:
+    def test_defaults_all_none(self) -> None:
+        o = ObservabilityConfig()
+        assert o.tracing is None
+        assert o.metrics is None
+        assert o.logging is None
+
+    def test_tracing_defaults_to_none_exporter(self) -> None:
+        t = TracingConfig()
+        assert t.exporter == "none"
+        assert t.endpoint is None
+
+    def test_tracing_otlp(self) -> None:
+        t = TracingConfig(exporter="otlp", endpoint="http://collector:4317")
+        assert t.exporter == "otlp"
+        assert t.endpoint == "http://collector:4317"
+
+    def test_metrics_prometheus(self) -> None:
+        m = MetricsConfig(exporter="prometheus", endpoint="http://prom:9090")
+        assert m.exporter == "prometheus"
+
+    def test_logging_defaults(self) -> None:
+        lg = LoggingConfig()
+        assert lg.level == "INFO"
+        assert lg.exporter == "stdout"
+        assert lg.endpoint is None
+
+    def test_logging_level_rejects_unknown(self) -> None:
+        with pytest.raises(ValidationError):
+            LoggingConfig(level="VERBOSE")  # type: ignore[arg-type]
+
+
+class TestRunDefaults:
+    def test_all_fields_optional(self) -> None:
+        r = RunDefaults()
+        assert r.compute is None
+        assert r.storage is None
+        assert r.observability is None
+        assert r.orchestrator is None
+        assert r.models == {}
+
+    def test_populated(self) -> None:
+        r = RunDefaults(
+            compute=ComputeConfig(workers=4, max_budget_usd=20.0),
+            storage=StorageConfig(artifacts=LocalStorageConfig(path="./out")),
+            observability=ObservabilityConfig(logging=LoggingConfig(level="DEBUG")),
+        )
+        assert r.compute is not None and r.compute.workers == 4
+        assert r.storage is not None and r.storage.artifacts is not None
+        assert r.observability is not None and r.observability.logging is not None
+
+
+class TestRunConfigNewFields:
+    """RunConfig gets three optional new blocks; unset means None so
+    every existing pack loads unchanged."""
+
+    def _minimal_kwargs(self) -> dict[str, object]:
+        return {
+            "models": {
+                "agent": ModelConfig(provider="openrouter", name="test/model"),
+                "user": ModelConfig(provider="openrouter", name="test/model"),
+                "judge": ModelConfig(provider="openrouter", name="test/model"),
+            },
+            "orchestrator": OrchestratorConfig(),
+            "evaluation": EvaluationConfig(output_dir="results/x"),
+        }
+
+    def test_new_blocks_default_to_none(self) -> None:
+        rc = RunConfig(**self._minimal_kwargs())
+        assert rc.compute is None
+        assert rc.storage is None
+        assert rc.observability is None
+
+    def test_engine_still_optional(self) -> None:
+        rc = RunConfig(**self._minimal_kwargs())
+        assert rc.engine is None
+
+    def test_new_blocks_bind_when_provided(self) -> None:
+        rc = RunConfig(
+            **self._minimal_kwargs(),
+            compute=ComputeConfig(workers=8),
+            storage=StorageConfig(
+                queue=QueueStorageConfig(backend="sqlite"),
+            ),
+            observability=ObservabilityConfig(tracing=TracingConfig(exporter="none")),
+        )
+        assert rc.compute is not None and rc.compute.workers == 8
+        assert rc.storage is not None and rc.storage.queue is not None
+        assert rc.observability is not None and rc.observability.tracing is not None
+
+    def test_engine_config_still_binds(self) -> None:
+        rc = RunConfig(
+            **self._minimal_kwargs(),
+            engine=EngineConfig(presets_file="/tmp/x.yaml"),
+        )
+        assert rc.engine is not None
+        assert rc.engine.presets_file == "/tmp/x.yaml"

--- a/tests/unit/test_run_defaults_schema.py
+++ b/tests/unit/test_run_defaults_schema.py
@@ -28,6 +28,8 @@ from tolokaforge.core.models import (
     TracingConfig,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestComputeConfig:
     def test_default_provider_is_local_docker(self) -> None:

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -3,7 +3,7 @@
 import dataclasses
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Literal, get_args
+from typing import Annotated, Any, Literal, Self, get_args
 
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
@@ -556,6 +556,146 @@ class EngineConfig(BaseModel):
     )
 
 
+class LocalDockerComputeConfig(BaseModel):
+    """Configuration for the ``local-docker`` compute provider."""
+
+
+class ComputeConfig(BaseModel):
+    """Compute substrate + parallelism + budget selection for a run.
+
+    ``provider`` selects the runtime substrate; the sub-block matching
+    the provider (e.g. ``local_docker``) carries provider-specific
+    settings. When another provider is registered it shows up as a new
+    ``Literal`` value on ``provider`` plus its own sub-block.
+    """
+
+    provider: Literal["local-docker"] = "local-docker"
+    workers: int | None = Field(default=None, ge=1)
+    max_budget_usd: float | None = Field(default=None, ge=0.0)
+    max_requests_per_second: float | None = Field(default=None, gt=0.0)
+    max_attempt_retries: int = Field(default=0, ge=0)
+    local_docker: LocalDockerComputeConfig | None = None
+
+
+class LocalStorageConfig(BaseModel):
+    """Local-filesystem storage backend for artifacts or logs.
+
+    Extras rejected so a mis-tagged input (e.g. ``bucket`` on a
+    ``type=local`` block) fails loud instead of dropping the stray
+    field. The discriminator on ``StorageBackend`` selects this variant
+    by ``type``; extras=forbid makes the selection safe.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    type: Literal["local"] = "local"
+    path: str
+
+
+class S3StorageConfig(BaseModel):
+    """S3 storage backend for artifacts or logs.
+
+    Extras rejected — same rationale as :class:`LocalStorageConfig`.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    type: Literal["s3"] = "s3"
+    bucket: str
+    prefix: str | None = None
+
+
+# Discriminated union over the ``type`` tag so mixed-tag inputs fail
+# loud instead of silently dropping the fields of the losing variant.
+StorageBackend = Annotated[LocalStorageConfig | S3StorageConfig, Field(discriminator="type")]
+
+
+class QueueStorageConfig(BaseModel):
+    """Queue backend for orchestrator state.
+
+    ``backend='postgres'`` requires ``postgres_dsn`` — enforced by
+    ``_require_postgres_dsn`` so a partial declaration fails at load
+    instead of falling back silently.
+    """
+
+    backend: Literal["sqlite", "postgres"] = "sqlite"
+    postgres_dsn: str | None = None
+
+    @model_validator(mode="after")
+    def _require_postgres_dsn(self) -> Self:
+        if self.backend == "postgres" and not self.postgres_dsn:
+            raise ValueError("QueueStorageConfig.backend='postgres' requires postgres_dsn.")
+        return self
+
+
+class StorageConfig(BaseModel):
+    """Where a run's artifacts, logs, and queue state live."""
+
+    artifacts: StorageBackend | None = None
+    logs: StorageBackend | None = None
+    queue: QueueStorageConfig | None = None
+
+
+class TracingConfig(BaseModel):
+    """Tracing exporter selection.
+
+    A non-default ``exporter`` requires an ``endpoint``; ``none`` (the
+    default) does not.
+    """
+
+    exporter: Literal["none", "otlp"] = "none"
+    endpoint: str | None = None
+
+    @model_validator(mode="after")
+    def _require_endpoint_when_active(self) -> Self:
+        if self.exporter != "none" and not self.endpoint:
+            raise ValueError(f"TracingConfig.exporter={self.exporter!r} requires endpoint.")
+        return self
+
+
+class MetricsConfig(BaseModel):
+    """Metrics exporter selection.
+
+    A non-default ``exporter`` requires an ``endpoint``; ``none`` (the
+    default) does not.
+    """
+
+    exporter: Literal["none", "prometheus"] = "none"
+    endpoint: str | None = None
+
+    @model_validator(mode="after")
+    def _require_endpoint_when_active(self) -> Self:
+        if self.exporter != "none" and not self.endpoint:
+            raise ValueError(f"MetricsConfig.exporter={self.exporter!r} requires endpoint.")
+        return self
+
+
+class LoggingConfig(BaseModel):
+    """Logging exporter selection.
+
+    ``exporter='otlp'`` requires an ``endpoint``; ``stdout`` (the
+    default) does not.
+    """
+
+    level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
+    exporter: Literal["stdout", "otlp"] = "stdout"
+    endpoint: str | None = None
+
+    @model_validator(mode="after")
+    def _require_endpoint_when_active(self) -> Self:
+        if self.exporter == "otlp" and not self.endpoint:
+            raise ValueError(f"LoggingConfig.exporter={self.exporter!r} requires endpoint.")
+        return self
+
+
+class ObservabilityConfig(BaseModel):
+    """Tracing, metrics, and logging exporters for a run."""
+
+    tracing: TracingConfig | None = None
+    metrics: MetricsConfig | None = None
+    logging: LoggingConfig | None = None
+
+
 class RunConfig(BaseModel):
     """Complete run configuration"""
 
@@ -563,12 +703,9 @@ class RunConfig(BaseModel):
     orchestrator: OrchestratorConfig
     evaluation: EvaluationConfig
     engine: EngineConfig | None = None
-    # Project layer schema foundations. Optional this stage — the loader
-    # is not yet wired to consume them. Semantic wiring lands in the next
-    # milestone. See docs/architecture/PROJECTS.md.
-    compute: "ComputeConfig | None" = None
-    storage: "StorageConfig | None" = None
-    observability: "ObservabilityConfig | None" = None
+    compute: ComputeConfig | None = None
+    storage: StorageConfig | None = None
+    observability: ObservabilityConfig | None = None
 
 
 # Task Configuration Models
@@ -698,10 +835,15 @@ class TranscriptRulesConfig(BaseModel):
 
 
 class GradingCombineConfig(BaseModel):
-    """Grading combination configuration"""
+    """Grading combination configuration.
+
+    ``weights`` defaults to an empty dict so a project-level defaults
+    block may declare only a partial view (e.g. ``pass_threshold`` alone).
+    Consumers that require weights validate presence at use-site.
+    """
 
     method: str = "weighted"
-    weights: dict[str, float]
+    weights: dict[str, float] = Field(default_factory=dict)
     pass_threshold: float = 0.8
 
 
@@ -713,98 +855,6 @@ class GradingConfig(BaseModel):
     transcript_rules: TranscriptRulesConfig | None = None
     llm_judge: LLMJudgeConfig | None = None
     custom_checks: dict[str, Any] | None = None  # CustomChecksConfig as dict for flexibility
-
-
-# ── Project layer — schema foundations ─────────────────────────────────
-# Models introduced by the Project abstraction. Semantics-only in this
-# stage: the loader is not yet wired to consume them.
-# See docs/architecture/PROJECTS.md.
-
-
-class LocalDockerComputeConfig(BaseModel):
-    """Provider-specific configuration for the ``local-docker`` compute
-    provider. Reserved shape — no provider-specific fields at this stage."""
-
-
-class ComputeConfig(BaseModel):
-    """Compute substrate + parallelism + budget selection for a run.
-
-    ``provider`` selects the runtime substrate; the sub-block matching the
-    provider (e.g. ``local_docker``) carries provider-specific settings.
-    Additional providers land as future ``Literal`` values plus their own
-    sub-block — the schema shape stays stable across substrates.
-    """
-
-    provider: Literal["local-docker"] = "local-docker"
-    workers: int | None = Field(default=None, ge=1)
-    max_budget_usd: float | None = Field(default=None, ge=0.0)
-    max_requests_per_second: float | None = Field(default=None, gt=0.0)
-    max_attempt_retries: int | None = Field(default=None, ge=0)
-    local_docker: LocalDockerComputeConfig | None = None
-
-
-class LocalStorageConfig(BaseModel):
-    """Local-filesystem storage backend for artifacts or logs."""
-
-    type: Literal["local"] = "local"
-    path: str
-
-
-class S3StorageConfig(BaseModel):
-    """S3 storage backend for artifacts or logs."""
-
-    type: Literal["s3"] = "s3"
-    bucket: str
-    prefix: str | None = None
-
-
-ArtifactsStorage = LocalStorageConfig | S3StorageConfig
-LogsStorage = LocalStorageConfig | S3StorageConfig
-
-
-class QueueStorageConfig(BaseModel):
-    """Queue backend for orchestrator state."""
-
-    backend: Literal["sqlite", "postgres"] = "sqlite"
-    postgres_dsn: str | None = None
-
-
-class StorageConfig(BaseModel):
-    """Where a run's artifacts, logs, and queue state live."""
-
-    artifacts: ArtifactsStorage | None = None
-    logs: LogsStorage | None = None
-    queue: QueueStorageConfig | None = None
-
-
-class TracingConfig(BaseModel):
-    """Tracing exporter selection."""
-
-    exporter: Literal["none", "otlp"] = "none"
-    endpoint: str | None = None
-
-
-class MetricsConfig(BaseModel):
-    """Metrics exporter selection."""
-
-    exporter: Literal["none", "prometheus"] = "none"
-    endpoint: str | None = None
-
-
-class LoggingConfig(BaseModel):
-    """Logging exporter selection."""
-
-    level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
-    exporter: Literal["stdout", "otlp"] = "stdout"
-    endpoint: str | None = None
-
-
-class ObservabilityConfig(BaseModel):
-    """Tracing, metrics, and logging exporters for a run."""
-
-    tracing: TracingConfig | None = None
-    metrics: MetricsConfig | None = None
-    logging: LoggingConfig | None = None
 
 
 class TimeoutDefaults(BaseModel):
@@ -896,8 +946,3 @@ class ProjectConfig(BaseModel):
     default_environment: EnvironmentManifest | None = None
     task_defaults: TaskDefaults = Field(default_factory=TaskDefaults)
     run_defaults: RunDefaults | None = None
-
-
-# Resolve forward references on RunConfig now that ComputeConfig,
-# StorageConfig, and ObservabilityConfig are defined.
-RunConfig.model_rebuild()

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -563,6 +563,12 @@ class RunConfig(BaseModel):
     orchestrator: OrchestratorConfig
     evaluation: EvaluationConfig
     engine: EngineConfig | None = None
+    # Project layer schema foundations. Optional this stage — the loader
+    # is not yet wired to consume them. Semantic wiring lands in the next
+    # milestone. See docs/architecture/PROJECTS.md.
+    compute: "ComputeConfig | None" = None
+    storage: "StorageConfig | None" = None
+    observability: "ObservabilityConfig | None" = None
 
 
 # Task Configuration Models
@@ -707,3 +713,191 @@ class GradingConfig(BaseModel):
     transcript_rules: TranscriptRulesConfig | None = None
     llm_judge: LLMJudgeConfig | None = None
     custom_checks: dict[str, Any] | None = None  # CustomChecksConfig as dict for flexibility
+
+
+# ── Project layer — schema foundations ─────────────────────────────────
+# Models introduced by the Project abstraction. Semantics-only in this
+# stage: the loader is not yet wired to consume them.
+# See docs/architecture/PROJECTS.md.
+
+
+class LocalDockerComputeConfig(BaseModel):
+    """Provider-specific configuration for the ``local-docker`` compute
+    provider. Reserved shape — no provider-specific fields at this stage."""
+
+
+class ComputeConfig(BaseModel):
+    """Compute substrate + parallelism + budget selection for a run.
+
+    ``provider`` selects the runtime substrate; the sub-block matching the
+    provider (e.g. ``local_docker``) carries provider-specific settings.
+    Additional providers land as future ``Literal`` values plus their own
+    sub-block — the schema shape stays stable across substrates.
+    """
+
+    provider: Literal["local-docker"] = "local-docker"
+    workers: int | None = Field(default=None, ge=1)
+    max_budget_usd: float | None = Field(default=None, ge=0.0)
+    max_requests_per_second: float | None = Field(default=None, gt=0.0)
+    max_attempt_retries: int | None = Field(default=None, ge=0)
+    local_docker: LocalDockerComputeConfig | None = None
+
+
+class LocalStorageConfig(BaseModel):
+    """Local-filesystem storage backend for artifacts or logs."""
+
+    type: Literal["local"] = "local"
+    path: str
+
+
+class S3StorageConfig(BaseModel):
+    """S3 storage backend for artifacts or logs."""
+
+    type: Literal["s3"] = "s3"
+    bucket: str
+    prefix: str | None = None
+
+
+ArtifactsStorage = LocalStorageConfig | S3StorageConfig
+LogsStorage = LocalStorageConfig | S3StorageConfig
+
+
+class QueueStorageConfig(BaseModel):
+    """Queue backend for orchestrator state."""
+
+    backend: Literal["sqlite", "postgres"] = "sqlite"
+    postgres_dsn: str | None = None
+
+
+class StorageConfig(BaseModel):
+    """Where a run's artifacts, logs, and queue state live."""
+
+    artifacts: ArtifactsStorage | None = None
+    logs: LogsStorage | None = None
+    queue: QueueStorageConfig | None = None
+
+
+class TracingConfig(BaseModel):
+    """Tracing exporter selection."""
+
+    exporter: Literal["none", "otlp"] = "none"
+    endpoint: str | None = None
+
+
+class MetricsConfig(BaseModel):
+    """Metrics exporter selection."""
+
+    exporter: Literal["none", "prometheus"] = "none"
+    endpoint: str | None = None
+
+
+class LoggingConfig(BaseModel):
+    """Logging exporter selection."""
+
+    level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
+    exporter: Literal["stdout", "otlp"] = "stdout"
+    endpoint: str | None = None
+
+
+class ObservabilityConfig(BaseModel):
+    """Tracing, metrics, and logging exporters for a run."""
+
+    tracing: TracingConfig | None = None
+    metrics: MetricsConfig | None = None
+    logging: LoggingConfig | None = None
+
+
+class TimeoutDefaults(BaseModel):
+    """Task-shape timeouts applied to every task via ``task_defaults``."""
+
+    trial_seconds: int = Field(default=600, ge=1)
+    tool_call_seconds: int = Field(default=60, ge=1)
+
+
+class StuckHeuristicsDefaults(BaseModel):
+    """Task-shape stuck-detection knobs applied to every task via
+    ``task_defaults``. Distinct from ``OrchestratorConfig.stuck_heuristics``,
+    which is the run-scoped orchestrator setting."""
+
+    enabled: bool = True
+    max_repeated_tool_calls: int = Field(default=5, ge=1)
+    max_idle_turns: int = Field(default=3, ge=1)
+
+
+class GradingDefaults(BaseModel):
+    """Grading defaults applied to every task via ``task_defaults``. A
+    task's own ``grading.yaml.combine`` deep-merges on top."""
+
+    combine: GradingCombineConfig | None = None
+
+
+class TaskDefaults(BaseModel):
+    """Base task-level configuration inherited by every task in a project.
+
+    Applied at loader time; ``task.yaml`` deltas deep-merge on top with
+    task fields winning on conflict. Every field is optional — omitting a
+    field means the engine default (or an adapter default) applies.
+    """
+
+    adapter_type: str | None = None
+    max_turns: int | None = Field(default=None, ge=1)
+    system_prompt: str | None = None
+    user_simulator: UserSimulatorConfig | None = None
+    policies: dict[str, Any] = Field(default_factory=dict)
+    metadata: TaskMetadata | None = None
+    adapter_settings: dict[str, Any] = Field(default_factory=dict)
+    tools: ToolsConfig | None = None
+    grading_defaults: GradingDefaults | None = None
+    timeouts: TimeoutDefaults | None = None
+    stuck_heuristics: StuckHeuristicsDefaults | None = None
+    continue_prompt: str | None = None
+
+
+class RunDefaults(BaseModel):
+    """Base run-level configuration inherited by every ``run_configs/*.yaml``.
+
+    Applied at loader time; per-invocation run-config files deep-merge on
+    top. Every field is optional — a project without ``run_defaults`` acts
+    as if every run config were a standalone declaration.
+    """
+
+    compute: ComputeConfig | None = None
+    storage: StorageConfig | None = None
+    observability: ObservabilityConfig | None = None
+    orchestrator: OrchestratorConfig | None = None
+    models: dict[str, ModelConfig] = Field(default_factory=dict)
+
+
+class TaskDiscoveryConfig(BaseModel):
+    """Where the loader finds task files under the project directory."""
+
+    glob: str = "tasks/**/task.yaml"
+
+
+class TaskInventoryConfig(BaseModel):
+    """Task discovery configuration on the Project."""
+
+    discovery: TaskDiscoveryConfig = Field(default_factory=TaskDiscoveryConfig)
+
+
+class ProjectConfig(BaseModel):
+    """Top-level Project spec — a ``project.yaml`` at a pack root.
+
+    Holds identity, task discovery, the default environment every task
+    inherits, and two labelled base blocks: ``task_defaults`` (base for
+    tasks) and ``run_defaults`` (base for run configs). See
+    ``docs/architecture/PROJECTS.md``.
+    """
+
+    name: str
+    version: int = 1
+    description: str | None = None
+    tasks: TaskInventoryConfig = Field(default_factory=TaskInventoryConfig)
+    default_environment: EnvironmentManifest | None = None
+    task_defaults: TaskDefaults = Field(default_factory=TaskDefaults)
+    run_defaults: RunDefaults | None = None
+
+
+# Resolve forward references on RunConfig now that ComputeConfig,
+# StorageConfig, and ObservabilityConfig are defined.
+RunConfig.model_rebuild()


### PR DESCRIPTION
Adds the Pydantic models that back the Project abstraction — stage 1 of the [Project layer v1](https://github.com/Toloka/tolokaforge/milestone/9) rollout.

Closes #210.

## Summary

- \`ProjectConfig\` — top-level \`project.yaml\` spec: identity, \`tasks.discovery\`, \`default_environment\`, \`task_defaults\`, \`run_defaults\`.
- \`TaskDefaults\` — base task-level config; every field optional so \`task.yaml\` deltas overlay cleanly in the next milestone's loader.
- \`RunDefaults\` — base run-level config; every field optional so \`run_configs/<name>.yaml\` deltas overlay cleanly.
- \`ComputeConfig\` / \`StorageConfig\` / \`ObservabilityConfig\` — new optional blocks on \`RunConfig\`. All default to \`None\` so existing configs load unchanged.
- \`compute.provider\` is \`Literal[\"local-docker\"]\` with a per-provider sub-block (\`local_docker\`). Shape is designed so additional substrates (e.g. Kubernetes) slot in later as new \`Literal\` values + their own sub-block — no schema break.

## What does NOT land here

- **Loader wiring** — the loader that reads \`project.yaml\` and merges base+delta comes in the next PR.
- **Strict \`extra=\"forbid\"\` validation** — lands in a later milestone alongside example-pack migration.
- **New runtime behaviour** — no changes to the orchestrator, backends, or isolation model.

## Testing

- 43 new unit tests across \`tests/unit/test_project_config.py\` and \`tests/unit/test_run_defaults_schema.py\`.
- Every pre-existing unit test (2139) and canonical test (400) still passes.
- \`ruff check\` and \`ruff format --check\` clean.

## Kubernetes forward-compat

The \`compute.provider\` + provider-specific sub-block pattern is chosen so a future Kubernetes backend lands as one new \`Literal\` value plus a \`compute.kubernetes\` sub-block. Neither the schema nor the runtime backend Protocol needs to change to accommodate it.

## Design reference

- Design: [\`docs/architecture/PROJECTS.md\`](https://github.com/Toloka/tolokaforge/blob/design/project-manifest-extension/docs/architecture/PROJECTS.md) (on the \`design/project-manifest-extension\` review branch until it merges).

## Test plan

- [x] \`uv run ruff check tolokaforge/ tests/\` — clean
- [x] \`uv run ruff format --check tolokaforge/core/models.py tests/unit/test_project_config.py tests/unit/test_run_defaults_schema.py\` — clean
- [x] \`uv run pytest tests/unit tests/canonical -q\` — 2582 passed, 1 skipped