### PR TITLE
feat(loader): resolve project.yaml + run_configs base+delta merge

### DIFF
--- a/scripts/generate_task_pack_compose_override.py
+++ b/scripts/generate_task_pack_compose_override.py
@@ -40,9 +40,14 @@ def main() -> int:
         config = yaml.safe_load(f) or {}
 
     evaluation = config.get("evaluation", {}) or {}
-    task_pack_values = evaluation.get("task_packs", []) or []
+    # ``evaluation.projects`` is the canonical field; ``task_packs`` is
+    # accepted here as a deprecated alias for symmetry with the loader's
+    # own alias validator (``EvaluationConfig._coerce_task_packs_alias``).
+    # Reading either lets Docker-mode users migrate the loader side and
+    # the compose-override side in lockstep.
+    task_pack_values = evaluation.get("projects") or evaluation.get("task_packs") or []
     if not isinstance(task_pack_values, list):
-        raise ValueError("evaluation.task_packs must be a list of paths")
+        raise ValueError("evaluation.projects must be a list of paths")
 
     try:
         task_packs = normalize_task_pack_paths([str(p) for p in task_pack_values], config_path)
@@ -68,7 +73,7 @@ def main() -> int:
             f"-f {output_path} --profile test up --build --abort-on-container-exit"
         )
     else:
-        print("No evaluation.task_packs in config; override contains empty task-pack mounts.")
+        print("No evaluation.projects in config; override contains empty task-pack mounts.")
 
     return 0
 

--- a/tests/unit/test_mounts.py
+++ b/tests/unit/test_mounts.py
@@ -29,7 +29,7 @@ def test_normalize_task_pack_paths_raises_for_missing(tmp_path: Path):
     config_path = tmp_path / "run.yaml"
     config_path.write_text("evaluation: {}")
 
-    with pytest.raises(FileNotFoundError, match="Task-pack path does not exist"):
+    with pytest.raises(FileNotFoundError, match="Project path does not exist"):
         normalize_task_pack_paths(["./missing"], config_path)
 
 

--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -18,7 +18,6 @@ from tolokaforge.core.project_loader import (
     find_project_yaml,
     load_project_config,
     resolve_effective_run_config_data,
-    resolve_effective_task_data,
     synthesize_default_project,
     warn_legacy_run_config_dir,
 )
@@ -256,42 +255,3 @@ class TestResolveEffectiveRunConfig:
         run_config = {"orchestrator": {"workers": 4}}
         merged = resolve_effective_run_config_data(project, run_config)
         assert merged is not run_config
-
-
-# ── resolve_effective_task_data ────────────────────────────────────────
-
-
-class TestResolveEffectiveTask:
-    def test_none_project_returns_task_unchanged(self) -> None:
-        task = {"task_id": "t1", "max_turns": 30}
-        assert resolve_effective_task_data(None, task) == task
-
-    def test_empty_defaults_returns_task_unchanged(self) -> None:
-        project = ProjectConfig(name="p")  # task_defaults is empty
-        task = {"task_id": "t1", "max_turns": 30}
-        assert resolve_effective_task_data(project, task) == task
-
-    def test_task_defaults_layered_under_task(self) -> None:
-        project = ProjectConfig(
-            name="p",
-            task_defaults=TaskDefaults(
-                adapter_type="native",
-                max_turns=20,
-                continue_prompt="Continue.",
-            ),
-        )
-        task = {"task_id": "t1", "max_turns": 60}  # task overrides only max_turns
-        merged = resolve_effective_task_data(project, task)
-        assert merged["task_id"] == "t1"
-        assert merged["max_turns"] == 60  # task wins
-        assert merged["adapter_type"] == "native"  # from defaults
-        assert merged["continue_prompt"] == "Continue."  # from defaults
-
-    def test_returns_new_dict(self) -> None:
-        project = ProjectConfig(
-            name="p",
-            task_defaults=TaskDefaults(adapter_type="native"),
-        )
-        task = {"task_id": "t1"}
-        merged = resolve_effective_task_data(project, task)
-        assert merged is not task

--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -1,0 +1,297 @@
+"""Unit tests for the project loader — walk-up, deep-merge, and the
+task/run effective-config resolvers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.models import ProjectConfig, RunDefaults, TaskDefaults
+from tolokaforge.core.project_loader import (
+    CANONICAL_RUN_CONFIGS_DIR,
+    LEGACY_RUN_CONFIG_DIR,
+    PROJECT_FILENAME,
+    deep_merge,
+    detect_project_layout,
+    find_project_yaml,
+    load_project_config,
+    resolve_effective_run_config_data,
+    resolve_effective_task_data,
+    synthesize_default_project,
+    warn_legacy_run_config_dir,
+)
+
+pytestmark = pytest.mark.unit
+
+
+ENV_FIXTURE = (
+    Path(__file__).parent.parent
+    / "canonical"
+    / "fixtures"
+    / "environment_manifest"
+    / "safe_one_service.yaml"
+)
+
+
+# ── deep_merge ─────────────────────────────────────────────────────────
+
+
+class TestDeepMerge:
+    def test_delta_wins_scalars(self) -> None:
+        assert deep_merge({"a": 1, "b": 2}, {"a": 3}) == {"a": 3, "b": 2}
+
+    def test_delta_overrides_nested_dicts(self) -> None:
+        base = {"section": {"x": 1, "y": 2}}
+        delta = {"section": {"y": 20, "z": 30}}
+        assert deep_merge(base, delta) == {"section": {"x": 1, "y": 20, "z": 30}}
+
+    def test_delta_lists_replace(self) -> None:
+        assert deep_merge({"xs": [1, 2, 3]}, {"xs": [9]}) == {"xs": [9]}
+
+    def test_empty_delta_returns_base_copy(self) -> None:
+        base = {"a": 1}
+        result = deep_merge(base, {})
+        assert result == base
+        assert result is not base  # copy, not alias
+
+    def test_empty_base_returns_delta_shape(self) -> None:
+        assert deep_merge({}, {"a": 1, "b": {"c": 2}}) == {"a": 1, "b": {"c": 2}}
+
+    def test_none_delta_scalar_replaces_base(self) -> None:
+        # Explicit None in delta overrides base; that's how a user
+        # unsets a project-level default at task level.
+        assert deep_merge({"key": "base"}, {"key": None}) == {"key": None}
+
+    def test_dict_delta_over_scalar_base(self) -> None:
+        # Delta wins even when the types disagree.
+        assert deep_merge({"key": "scalar"}, {"key": {"nested": 1}}) == {"key": {"nested": 1}}
+
+
+# ── find_project_yaml ──────────────────────────────────────────────────
+
+
+class TestFindProjectYaml:
+    def test_finds_at_start_dir(self, tmp_path: Path) -> None:
+        (tmp_path / PROJECT_FILENAME).write_text("name: p\n")
+        assert find_project_yaml(tmp_path) == (tmp_path / PROJECT_FILENAME).resolve()
+
+    def test_walks_up_from_nested_file(self, tmp_path: Path) -> None:
+        (tmp_path / PROJECT_FILENAME).write_text("name: p\n")
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        run_config = deep / "dev.yaml"
+        run_config.write_text("models: {}\n")
+        assert find_project_yaml(run_config) == (tmp_path / PROJECT_FILENAME).resolve()
+
+    def test_returns_none_when_missing(self, tmp_path: Path) -> None:
+        assert find_project_yaml(tmp_path) is None
+
+    def test_max_depth_caps_the_walk(self, tmp_path: Path) -> None:
+        (tmp_path / PROJECT_FILENAME).write_text("name: p\n")
+        deep = tmp_path
+        for name in ["a", "b", "c", "d"]:
+            deep = deep / name
+            deep.mkdir()
+        # Walk from 4-level-deep with max_depth=1 — shouldn't reach the root.
+        assert find_project_yaml(deep, max_depth=1) is None
+
+
+# ── detect_project_layout ──────────────────────────────────────────────
+
+
+class TestDetectProjectLayout:
+    def test_canonical_layout(self, tmp_path: Path) -> None:
+        (tmp_path / PROJECT_FILENAME).write_text("name: p\n")
+        runs = tmp_path / CANONICAL_RUN_CONFIGS_DIR
+        runs.mkdir()
+        cfg = runs / "dev.yaml"
+        cfg.write_text("models: {}\n")
+        project_root, legacy = detect_project_layout(cfg)
+        assert project_root == tmp_path.resolve()
+        assert legacy is False
+
+    def test_legacy_directory_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / PROJECT_FILENAME).write_text("name: p\n")
+        runs = tmp_path / LEGACY_RUN_CONFIG_DIR
+        runs.mkdir()
+        cfg = runs / "dev.yaml"
+        cfg.write_text("models: {}\n")
+        project_root, legacy = detect_project_layout(cfg)
+        assert project_root == tmp_path.resolve()
+        assert legacy is True
+
+    def test_no_project_yaml(self, tmp_path: Path) -> None:
+        runs = tmp_path / CANONICAL_RUN_CONFIGS_DIR
+        runs.mkdir()
+        cfg = runs / "dev.yaml"
+        cfg.write_text("models: {}\n")
+        project_root, legacy = detect_project_layout(cfg)
+        assert project_root is None
+        assert legacy is False
+
+
+class TestLegacyDirWarning:
+    def test_warn_emits_deprecation_warning(self, tmp_path: Path) -> None:
+        cfg = tmp_path / LEGACY_RUN_CONFIG_DIR / "dev.yaml"
+        cfg.parent.mkdir()
+        cfg.write_text("models: {}\n")
+        with pytest.warns(DeprecationWarning, match="run_configs"):
+            warn_legacy_run_config_dir(cfg)
+
+
+# ── load_project_config ────────────────────────────────────────────────
+
+
+class TestLoadProjectConfig:
+    def _write_project(self, root: Path, extra: dict | None = None) -> Path:
+        content: dict = {"name": "demo", "version": 1}
+        if extra:
+            content.update(extra)
+        path = root / PROJECT_FILENAME
+        with path.open("w") as f:
+            yaml.safe_dump(content, f)
+        return path
+
+    def test_loads_minimal_project(self, tmp_path: Path) -> None:
+        path = self._write_project(tmp_path)
+        project = load_project_config(path)
+        assert project.name == "demo"
+        assert project.version == 1
+        assert isinstance(project.task_defaults, TaskDefaults)
+        assert project.run_defaults is None
+
+    def test_resolves_default_environment_compose_relative_path(self, tmp_path: Path) -> None:
+        # Copy the fixture compose file into a project-relative path so
+        # relative-path resolution has something to hit.
+        env_dir = tmp_path / "shared"
+        env_dir.mkdir()
+        rel_compose = env_dir / "environment.compose.yaml"
+        rel_compose.write_text(ENV_FIXTURE.read_text())
+        path = self._write_project(
+            tmp_path,
+            {
+                "default_environment": {
+                    "compose_file": "shared/environment.compose.yaml",
+                },
+            },
+        )
+        project = load_project_config(path)
+        assert project.default_environment is not None
+        assert project.default_environment.compose_file.is_absolute()
+        assert project.default_environment.compose_file == rel_compose.resolve()
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_project_config(tmp_path / "nope.yaml")
+
+    def test_non_mapping_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / PROJECT_FILENAME
+        path.write_text("- not a mapping\n")
+        with pytest.raises(RuntimeError, match="YAML mapping"):
+            load_project_config(path)
+
+
+# ── synthesize_default_project ─────────────────────────────────────────
+
+
+class TestSynthesizeDefaultProject:
+    def test_returns_minimal_project(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            project = synthesize_default_project(project_root=tmp_path / "my-pack")
+        assert project.name == "my-pack"
+        assert project.run_defaults is None
+        assert isinstance(project.task_defaults, TaskDefaults)
+        # Info line so the fallback is visible.
+        assert any("synthesised" in rec.message for rec in caplog.records)
+
+
+# ── resolve_effective_run_config_data ──────────────────────────────────
+
+
+class TestResolveEffectiveRunConfig:
+    def test_none_project_returns_run_config_unchanged(self) -> None:
+        run_config = {"orchestrator": {"workers": 4}}
+        assert resolve_effective_run_config_data(None, run_config) == run_config
+
+    def test_missing_run_defaults_returns_run_config_unchanged(self) -> None:
+        project = ProjectConfig(name="p")
+        run_config = {"orchestrator": {"workers": 4}}
+        assert resolve_effective_run_config_data(project, run_config) == run_config
+
+    def test_run_defaults_layered_under_run_config(self) -> None:
+        project = ProjectConfig(
+            name="p",
+            run_defaults=RunDefaults.model_validate(
+                {
+                    "compute": {"workers": 2, "max_budget_usd": 20.0},
+                    "storage": {
+                        # postgres_dsn is required alongside backend=postgres
+                        # (validator on QueueStorageConfig), so this exercises
+                        # both a nested override and inheritance of a
+                        # non-schema-default value.
+                        "queue": {
+                            "backend": "postgres",
+                            "postgres_dsn": "postgresql://x@h/db",
+                        },
+                    },
+                }
+            ),
+        )
+        run_config = {"compute": {"workers": 8}}  # only workers overridden
+        merged = resolve_effective_run_config_data(project, run_config)
+        assert merged["compute"]["workers"] == 8  # delta wins
+        assert merged["compute"]["max_budget_usd"] == 20.0  # inherited from defaults
+        assert merged["storage"]["queue"]["backend"] == "postgres"  # inherited
+        assert merged["storage"]["queue"]["postgres_dsn"] == "postgresql://x@h/db"
+
+    def test_returns_new_dict(self) -> None:
+        project = ProjectConfig(
+            name="p",
+            run_defaults=RunDefaults.model_validate({"compute": {"workers": 2}}),
+        )
+        run_config = {"orchestrator": {"workers": 4}}
+        merged = resolve_effective_run_config_data(project, run_config)
+        assert merged is not run_config
+
+
+# ── resolve_effective_task_data ────────────────────────────────────────
+
+
+class TestResolveEffectiveTask:
+    def test_none_project_returns_task_unchanged(self) -> None:
+        task = {"task_id": "t1", "max_turns": 30}
+        assert resolve_effective_task_data(None, task) == task
+
+    def test_empty_defaults_returns_task_unchanged(self) -> None:
+        project = ProjectConfig(name="p")  # task_defaults is empty
+        task = {"task_id": "t1", "max_turns": 30}
+        assert resolve_effective_task_data(project, task) == task
+
+    def test_task_defaults_layered_under_task(self) -> None:
+        project = ProjectConfig(
+            name="p",
+            task_defaults=TaskDefaults(
+                adapter_type="native",
+                max_turns=20,
+                continue_prompt="Continue.",
+            ),
+        )
+        task = {"task_id": "t1", "max_turns": 60}  # task overrides only max_turns
+        merged = resolve_effective_task_data(project, task)
+        assert merged["task_id"] == "t1"
+        assert merged["max_turns"] == 60  # task wins
+        assert merged["adapter_type"] == "native"  # from defaults
+        assert merged["continue_prompt"] == "Continue."  # from defaults
+
+    def test_returns_new_dict(self) -> None:
+        project = ProjectConfig(
+            name="p",
+            task_defaults=TaskDefaults(adapter_type="native"),
+        )
+        task = {"task_id": "t1"}
+        merged = resolve_effective_task_data(project, task)
+        assert merged is not task

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the project loader flow — mirrors what the CLI
+does when it processes ``--config``.
+
+Each scenario writes a small ``project.yaml`` + ``run_configs/*.yaml``
+tree under ``tmp_path`` and drives it through the same resolver chain
+the CLI uses. Fast: no Docker, no LLM, no filesystem outside tmp_path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.models import RunConfig
+from tolokaforge.core.project_loader import (
+    detect_project_layout,
+    load_project_config,
+    resolve_effective_run_config_data,
+    synthesize_default_project,
+    warn_legacy_run_config_dir,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        yaml.safe_dump(data, f)
+
+
+def _drive_cli_loader(config_path: Path) -> RunConfig:
+    """Replay the sequence the CLI uses. Returns the effective RunConfig.
+
+    Kept in sync with ``tolokaforge.cli.main.run``:
+    1. Read the YAML at *config_path*.
+    2. Detect the enclosing project layout.
+    3. Load ``project.yaml`` or synthesise a default.
+    4. Merge ``project.run_defaults`` under the run-config dict.
+    5. Construct ``RunConfig`` from the merged dict.
+    """
+    with config_path.open() as f:
+        config_data = yaml.safe_load(f)
+    project_root, used_legacy_dir = detect_project_layout(config_path)
+    if used_legacy_dir:
+        warn_legacy_run_config_dir(config_path)
+    if project_root is not None:
+        project = load_project_config(project_root / "project.yaml")
+    else:
+        project = synthesize_default_project(project_root=config_path.parent)
+    config_data = resolve_effective_run_config_data(project, config_data)
+    return RunConfig(**config_data)
+
+
+class TestProjectAwareLoad:
+    def test_run_defaults_layered_under_dev_run_config(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "demo",
+                "run_defaults": {
+                    "compute": {"workers": 2, "max_budget_usd": 20.0},
+                    "orchestrator": {"repeats": 1},
+                },
+            },
+        )
+        _write_yaml(
+            tmp_path / "run_configs" / "dev.yaml",
+            {
+                "models": {"agent": {"provider": "openrouter", "name": "test/model"}},
+                "orchestrator": {"repeats": 5},  # override just repeats
+                "evaluation": {"output_dir": "results/dev"},
+            },
+        )
+        run_config = _drive_cli_loader(tmp_path / "run_configs" / "dev.yaml")
+        # Inherited from run_defaults:
+        assert run_config.compute is not None
+        assert run_config.compute.workers == 2
+        assert run_config.compute.max_budget_usd == 20.0
+        # Overridden by delta:
+        assert run_config.orchestrator.repeats == 5
+        # Delta-only fields:
+        assert run_config.evaluation.output_dir == "results/dev"
+
+    def test_run_config_delta_wins_on_nested_conflict(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "demo",
+                "run_defaults": {
+                    "compute": {"workers": 2, "max_budget_usd": 20.0},
+                    "orchestrator": {"repeats": 1},  # required by RunConfig schema
+                },
+            },
+        )
+        _write_yaml(
+            tmp_path / "run_configs" / "nightly.yaml",
+            {
+                "models": {"agent": {"provider": "openrouter", "name": "test/m"}},
+                "compute": {"workers": 16, "max_budget_usd": 200.0},
+                "evaluation": {"output_dir": "results/nightly"},
+            },
+        )
+        run_config = _drive_cli_loader(tmp_path / "run_configs" / "nightly.yaml")
+        assert run_config.compute is not None
+        assert run_config.compute.workers == 16  # delta wins
+        assert run_config.compute.max_budget_usd == 200.0
+        # orchestrator inherits from run_defaults since delta omits it
+        assert run_config.orchestrator.repeats == 1
+
+    def test_run_config_without_project_yaml_uses_synthesised_default(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "run_configs" / "dev.yaml",
+            {
+                "models": {"agent": {"provider": "openrouter", "name": "test/m"}},
+                "orchestrator": {"repeats": 3},
+                "evaluation": {"output_dir": "results/dev"},
+            },
+        )
+        # No project.yaml — loader must synthesise a default silently
+        # (info log, no warning).
+        run_config = _drive_cli_loader(tmp_path / "run_configs" / "dev.yaml")
+        assert run_config.orchestrator.repeats == 3
+        assert run_config.compute is None  # nothing to inject
+
+    def test_legacy_run_config_dir_emits_deprecation_warning(self, tmp_path: Path) -> None:
+        _write_yaml(tmp_path / "project.yaml", {"name": "demo"})
+        _write_yaml(
+            tmp_path / "run_config" / "dev.yaml",  # singular — legacy
+            {
+                "models": {"agent": {"provider": "openrouter", "name": "test/m"}},
+                "orchestrator": {"repeats": 1},
+                "evaluation": {"output_dir": "results/dev"},
+            },
+        )
+        with pytest.warns(DeprecationWarning, match="run_configs"):
+            run_config = _drive_cli_loader(tmp_path / "run_config" / "dev.yaml")
+        assert run_config.evaluation.output_dir == "results/dev"
+
+    def test_canonical_run_configs_dir_no_warning(self, tmp_path: Path) -> None:
+        _write_yaml(tmp_path / "project.yaml", {"name": "demo"})
+        _write_yaml(
+            tmp_path / "run_configs" / "dev.yaml",  # plural — canonical
+            {
+                "models": {"agent": {"provider": "openrouter", "name": "test/m"}},
+                "orchestrator": {"repeats": 1},
+                "evaluation": {"output_dir": "results/dev"},
+            },
+        )
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", DeprecationWarning)
+            _drive_cli_loader(tmp_path / "run_configs" / "dev.yaml")
+
+
+class TestTaskLoaderWithProjectDefaults:
+    """Task-side resolution flowing through the modified ``load_task_yaml``."""
+
+    def test_project_task_defaults_layered_under_task(self, tmp_path: Path) -> None:
+        from tolokaforge.adapters._task_loader import load_task_yaml
+
+        # Minimal task.yaml with only per-task identity + one override.
+        task_dir = tmp_path / "tasks" / "sample_task"
+        task_dir.mkdir(parents=True)
+        _write_yaml(
+            task_dir / "task.yaml",
+            {
+                "task_id": "sample",
+                "name": "Sample",
+                "category": "demo",
+                "description": "sample task",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "llm"},
+                "grading": "grading.yaml",
+                "max_turns": 60,  # task-level override
+            },
+        )
+        # Project supplies max_turns=20 by default; adapter_type=native.
+        project_defaults = {
+            "adapter_type": "native",
+            "max_turns": 20,
+            "continue_prompt": "Continue.",
+        }
+        task, task_dir_out = load_task_yaml(
+            task_dir / "task.yaml",
+            project_task_defaults=project_defaults,
+        )
+        assert task.task_id == "sample"
+        assert task.max_turns == 60  # task wins
+        assert task.adapter_type == "native"  # from defaults
+
+    def test_task_load_without_defaults_matches_pre_m2_behaviour(self, tmp_path: Path) -> None:
+        from tolokaforge.adapters._task_loader import load_task_yaml
+
+        task_dir = tmp_path / "tasks" / "legacy"
+        task_dir.mkdir(parents=True)
+        _write_yaml(
+            task_dir / "task.yaml",
+            {
+                "task_id": "legacy",
+                "name": "Legacy",
+                "category": "demo",
+                "description": "no project.yaml",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "llm"},
+                "grading": "grading.yaml",
+                "adapter_type": "native",
+                "max_turns": 40,
+            },
+        )
+        task, _ = load_task_yaml(task_dir / "task.yaml")
+        assert task.task_id == "legacy"
+        assert task.max_turns == 40

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -193,7 +193,7 @@ class TestTaskLoaderWithProjectDefaults:
         assert task.max_turns == 60  # task wins
         assert task.adapter_type == "native"  # from defaults
 
-    def test_task_load_without_defaults_matches_pre_m2_behaviour(self, tmp_path: Path) -> None:
+    def test_task_load_without_defaults_matches_legacy_behaviour(self, tmp_path: Path) -> None:
         from tolokaforge.adapters._task_loader import load_task_yaml
 
         task_dir = tmp_path / "tasks" / "legacy"
@@ -216,3 +216,165 @@ class TestTaskLoaderWithProjectDefaults:
         task, _ = load_task_yaml(task_dir / "task.yaml")
         assert task.task_id == "legacy"
         assert task.max_turns == 40
+
+    def test_project_defaults_outrank_domain_bundle(self, tmp_path: Path) -> None:
+        """Precedence chain (low → high): domain → project defaults → task.
+
+        Reproduces the specific case where domain sets a field, project
+        sets the same field to a different value, and the task doesn't
+        touch it — project must win.
+        """
+        from tolokaforge.adapters._task_loader import load_task_yaml
+
+        domain_dir = tmp_path / "_shared"
+        domain_dir.mkdir()
+        _write_yaml(
+            domain_dir / "domain.yaml",
+            {
+                "adapter_type": "native",
+                "max_turns": 15,
+                "policies": {"guidance": ["from domain"]},
+            },
+        )
+        task_dir = tmp_path / "testcases" / "case_a"
+        task_dir.mkdir(parents=True)
+        _write_yaml(
+            task_dir / "task.yaml",
+            {
+                "domain": "../../_shared/domain.yaml",
+                "task_id": "case_a",
+                "name": "Case A",
+                "category": "demo",
+                "description": "domain-referring task",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "llm"},
+                "grading": "grading.yaml",
+            },
+        )
+        # Project overrides the same fields the domain set.
+        project_defaults = {
+            "adapter_type": "tlk_mcp_core",  # differs from domain's "native"
+            "max_turns": 50,  # differs from domain's 15
+        }
+        task, _ = load_task_yaml(
+            task_dir / "task.yaml",
+            project_task_defaults=project_defaults,
+        )
+        assert task.adapter_type == "tlk_mcp_core"  # project wins over domain
+        assert task.max_turns == 50  # project wins over domain
+        # Fields set only by domain still survive when project/task are silent.
+        assert task.policies == {"guidance": ["from domain"]}
+
+    def test_task_still_beats_project_and_domain(self, tmp_path: Path) -> None:
+        """Task.yaml is the top of the precedence chain."""
+        from tolokaforge.adapters._task_loader import load_task_yaml
+
+        domain_dir = tmp_path / "_shared"
+        domain_dir.mkdir()
+        _write_yaml(
+            domain_dir / "domain.yaml",
+            {"max_turns": 10},
+        )
+        task_dir = tmp_path / "testcases" / "case_b"
+        task_dir.mkdir(parents=True)
+        _write_yaml(
+            task_dir / "task.yaml",
+            {
+                "domain": "../../_shared/domain.yaml",
+                "task_id": "case_b",
+                "name": "Case B",
+                "category": "demo",
+                "description": "task overrides everything",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "llm"},
+                "grading": "grading.yaml",
+                "max_turns": 99,  # task's own value
+            },
+        )
+        task, _ = load_task_yaml(
+            task_dir / "task.yaml",
+            project_task_defaults={"max_turns": 50},
+        )
+        assert task.max_turns == 99  # task wins over project and domain
+
+
+class TestProjectPathResolution:
+    """`_resolve_project_paths` must rewrite every task-side path field
+    that shows up in project.task_defaults, not just the two the earlier
+    version handled."""
+
+    def test_project_system_prompt_resolved_to_absolute_path(self, tmp_path: Path) -> None:
+        prompt = tmp_path / "shared" / "system.md"
+        prompt.parent.mkdir()
+        prompt.write_text("hi")
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "demo",
+                "task_defaults": {"system_prompt": "shared/system.md"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_project_config
+
+        project = load_project_config(tmp_path / "project.yaml")
+        assert project.task_defaults.system_prompt == str(prompt.resolve())
+
+    def test_project_tools_mcp_server_path_resolved(self, tmp_path: Path) -> None:
+        """A ``tools.agent.mcp_server`` string on task_defaults is a path
+        field per the task loader's declaration; the project loader must
+        resolve it before Pydantic construction so downstream consumers
+        find the file."""
+        mcp = tmp_path / "shared" / "mcp_server.py"
+        mcp.parent.mkdir()
+        mcp.write_text("# stub")
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "demo",
+                "task_defaults": {
+                    "tools": {"agent": {"mcp_server": "shared/mcp_server.py"}},
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_project_config
+
+        project = load_project_config(tmp_path / "project.yaml")
+        assert project.task_defaults.tools is not None
+        assert project.task_defaults.tools.agent["mcp_server"] == str(mcp.resolve())
+
+
+class TestSchemaAliasCollision:
+    """`EvaluationConfig` must emit a clear DeprecationWarning when a
+    caller sets both ``projects`` and ``task_packs``."""
+
+    def test_both_set_projects_wins(self) -> None:
+        import warnings as _warnings
+
+        from tolokaforge.core.models import EvaluationConfig
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            cfg = EvaluationConfig(
+                output_dir="results/x",
+                projects=["a", "b"],
+                task_packs=["c", "d"],
+            )
+        assert cfg.projects == ["a", "b"]
+        assert cfg.task_packs == []
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "both set" in str(w.message)
+            for w in caught
+        )
+
+
+class TestDeepMergeIsSingleImpl:
+    """`deep_merge` in the project loader is the single implementation
+    the task loader imports — no shadow copy in `_task_loader.py`."""
+
+    def test_task_loader_imports_from_project_loader(self) -> None:
+        from tolokaforge.adapters import _task_loader
+        from tolokaforge.core import project_loader
+
+        assert _task_loader.deep_merge is project_loader.deep_merge

--- a/tests/unit/test_task_loader.py
+++ b/tests/unit/test_task_loader.py
@@ -16,9 +16,10 @@ import yaml
 from pydantic import ValidationError
 
 from tolokaforge.adapters._task_loader import (
-    _apply_domain,
     _detect_task_root,
+    _load_domain_dict,
     _rewrite_task_paths,
+    deep_merge,
     load_task_yaml,
 )
 
@@ -142,18 +143,17 @@ class TestDetectTaskRoot:
 
 
 # ---------------------------------------------------------------------------
-# _apply_domain
+# _load_domain_dict + deep_merge
 # ---------------------------------------------------------------------------
 
 
-class TestApplyDomain:
-    def test_no_domain_ref_is_passthrough(self, tmp_path: Path) -> None:
+class TestLoadDomainDict:
+    def test_no_domain_ref_returns_empty(self, tmp_path: Path) -> None:
         task_path = tmp_path / "task.yaml"
         task_data = {"task_id": "x", "category": "tool_use"}
-        out = _apply_domain(task_path, task_data, tmp_path)
-        assert out == {"task_id": "x", "category": "tool_use"}
+        assert _load_domain_dict(task_path, task_data, tmp_path) == {}
 
-    def test_deep_merge_task_wins_on_conflict(self, tmp_path: Path) -> None:
+    def test_loads_domain_yaml_contents(self, tmp_path: Path) -> None:
         domain_path = tmp_path / "dom" / "_shared" / "domain.yaml"
         _write_yaml(
             domain_path,
@@ -164,48 +164,32 @@ class TestApplyDomain:
         )
         task_path = tmp_path / "dom" / "testcases" / "c1" / "task.yaml"
         task_path.parent.mkdir(parents=True)
-        task_data = {
-            "task_id": "c1",
-            "domain": "../../_shared/domain.yaml",
-            "category": "case_override",
-            "tools": {"agent": {"enabled": ["t_case"]}},
-        }
-        merged = _apply_domain(task_path, task_data, tmp_path / "dom")
-        # Scalar conflict: case wins.
-        assert merged["category"] == "case_override"
-        # Nested dict conflict: deep-merge, case-side leaf wins.
-        assert merged["tools"]["agent"]["enabled"] == ["t_case"]
-
-    def test_strips_domain_key(self, tmp_path: Path) -> None:
-        domain_path = tmp_path / "dom" / "_shared" / "domain.yaml"
-        _write_yaml(domain_path, {"category": "x"})
-        task_path = tmp_path / "dom" / "testcases" / "c" / "task.yaml"
-        task_path.parent.mkdir(parents=True)
-        merged = _apply_domain(
+        loaded = _load_domain_dict(
             task_path,
-            {"task_id": "c", "domain": "../../_shared/domain.yaml"},
+            {"domain": "../../_shared/domain.yaml"},
             tmp_path / "dom",
         )
-        assert "domain" not in merged
+        assert loaded == {
+            "category": "domain_default",
+            "tools": {"agent": {"enabled": ["t_domain"]}},
+        }
 
     def test_missing_domain_file_raises(self, tmp_path: Path) -> None:
         task_path = tmp_path / "task.yaml"
         with pytest.raises(RuntimeError, match="Domain file referenced"):
-            _apply_domain(task_path, {"domain": "missing.yaml"}, tmp_path)
+            _load_domain_dict(task_path, {"domain": "missing.yaml"}, tmp_path)
 
     def test_non_mapping_domain_raises(self, tmp_path: Path) -> None:
         bad = tmp_path / "bad.yaml"
         bad.write_text("- just\n- a\n- list\n")
         task_path = tmp_path / "task.yaml"
         with pytest.raises(RuntimeError, match="not a YAML mapping"):
-            _apply_domain(task_path, {"domain": "bad.yaml"}, tmp_path)
+            _load_domain_dict(task_path, {"domain": "bad.yaml"}, tmp_path)
 
     def test_domain_paths_rewritten_to_task_root(self, tmp_path: Path) -> None:
         # Domain-side ``mcp_server: mcp_server.py`` lives at <dom>/_shared/.
-        # The task root is <dom>. After merge the path should resolve to
-        # ``_shared/mcp_server.py`` from the task root frame, not from the
-        # case dir frame — that's the bug surfaced by
-        # test_load_task_yaml_real_example.
+        # After the loader rewrites paths into the task_root frame, the
+        # value must resolve to ``_shared/mcp_server.py`` from that frame.
         domain_dir = tmp_path / "dom" / "_shared"
         domain_dir.mkdir(parents=True)
         (domain_dir / "mcp_server.py").write_text("# stub\n")
@@ -215,14 +199,28 @@ class TestApplyDomain:
         )
         case_dir = tmp_path / "dom" / "testcases" / "c1"
         case_dir.mkdir(parents=True)
-        merged = _apply_domain(
+        loaded = _load_domain_dict(
             case_dir / "task.yaml",
             {"task_id": "c1", "domain": "../../_shared/domain.yaml"},
             tmp_path / "dom",
         )
-        # After merge, the path resolves cleanly from task_root.
-        assert merged["tools"]["agent"]["mcp_server"] == "_shared/mcp_server.py"
-        assert (tmp_path / "dom" / merged["tools"]["agent"]["mcp_server"]).exists()
+        assert loaded["tools"]["agent"]["mcp_server"] == "_shared/mcp_server.py"
+        assert (tmp_path / "dom" / loaded["tools"]["agent"]["mcp_server"]).exists()
+
+
+class TestDeepMerge:
+    """Task-side merge combines domain + task via ``deep_merge`` — task
+    wins on conflict, nested dicts recurse."""
+
+    def test_task_wins_on_scalar_conflict(self) -> None:
+        domain = {"category": "domain_default"}
+        task = {"category": "case_override"}
+        assert deep_merge(domain, task) == {"category": "case_override"}
+
+    def test_nested_dict_deep_merges_with_task_wins(self) -> None:
+        domain = {"tools": {"agent": {"enabled": ["t_domain"]}}}
+        task = {"tools": {"agent": {"enabled": ["t_case"]}}}
+        assert deep_merge(domain, task) == {"tools": {"agent": {"enabled": ["t_case"]}}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_packs.py
+++ b/tests/unit/test_task_packs.py
@@ -18,7 +18,28 @@ def _write_minimal_task_yaml(path: Path, task_id: str) -> None:
         yaml.safe_dump({"task_id": task_id}, f)
 
 
-def test_run_config_parses_task_packs():
+def test_run_config_parses_projects():
+    """Canonical field: evaluation.projects is populated directly."""
+    config_data = {
+        "evaluation": {
+            "projects": ["/tmp/pack_a", "/tmp/pack_b"],
+            "tasks_glob": "**/task.yaml",
+            "output_dir": "output/test",
+        },
+        "models": {
+            "agent": {"provider": "openai", "name": "gpt-4o-mini"},
+        },
+        "orchestrator": {"workers": 1, "repeats": 1},
+    }
+
+    run_config = RunConfig(**config_data)
+    assert run_config.evaluation.projects == ["/tmp/pack_a", "/tmp/pack_b"]
+    assert run_config.evaluation.tasks_glob == "**/task.yaml"
+
+
+def test_run_config_task_packs_alias_still_accepted():
+    """Legacy alias: evaluation.task_packs is coerced into projects with
+    a DeprecationWarning."""
     config_data = {
         "evaluation": {
             "task_packs": ["/tmp/pack_a", "/tmp/pack_b"],
@@ -31,9 +52,10 @@ def test_run_config_parses_task_packs():
         "orchestrator": {"workers": 1, "repeats": 1},
     }
 
-    run_config = RunConfig(**config_data)
-    assert run_config.evaluation.task_packs == ["/tmp/pack_a", "/tmp/pack_b"]
-    assert run_config.evaluation.tasks_glob == "**/task.yaml"
+    with pytest.warns(DeprecationWarning, match="task_packs is deprecated"):
+        run_config = RunConfig(**config_data)
+    assert run_config.evaluation.projects == ["/tmp/pack_a", "/tmp/pack_b"]
+    assert run_config.evaluation.task_packs == []  # drained by the validator
 
 
 def test_native_adapter_discovers_tasks_from_multiple_task_packs(tmp_path: Path):

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -54,6 +54,7 @@ from typing import Any
 import yaml
 
 from tolokaforge.core.models import TaskConfig
+from tolokaforge.core.project_loader import deep_merge
 
 
 def validate_grading_yaml(grading_path: Path) -> None:
@@ -111,11 +112,12 @@ def load_task_yaml(
     Args:
         task_path: Absolute or relative path to ``task.yaml``.
         project_task_defaults: Optional ``project.task_defaults`` dict from
-            the enclosing project. When supplied, it is layered under the
-            adapter's Domain merge and the task's own fields — task fields
-            still win on conflict; project defaults fill in fields the task
-            (and any Domain bundle) leaves unset. Precedence, low to high:
-            adapter Domain bundle → project defaults → task.yaml.
+            the enclosing project. When supplied, it is layered above the
+            adapter's Domain merge and below the task's own fields.
+            Precedence, low to high: adapter Domain bundle → project
+            defaults → task.yaml. Task fields win on conflict; project
+            defaults win over the Domain bundle where they overlap and
+            the task doesn't set the field.
 
     Returns:
         ``(task_config, effective_task_dir)``. ``effective_task_dir`` is the
@@ -144,19 +146,22 @@ def load_task_yaml(
     # merge so we never double-rewrite domain-supplied paths. No-op for the
     # flat layout (task_root == task.yaml parent) so legacy callers see no
     # change. The ``domain`` ref itself is not in ``_PATH_FIELD_REWRITERS``
-    # so this step leaves it untouched for ``_apply_domain`` to consume.
+    # so this step leaves it untouched for ``_load_domain_dict`` to consume.
     if task_root != task_path.parent:
         _rewrite_task_paths(task_data, task_path.parent, task_root)
 
-    task_data = _apply_domain(task_path, task_data, task_root)
+    # Load the adapter's Domain bundle (if any) but don't merge yet — the
+    # merge order matters: `domain` sits below `project_task_defaults`,
+    # which sits below `task.yaml`. Later layers win on conflict.
+    domain_data = _load_domain_dict(task_path, task_data, task_root)
+    task_data.pop("domain", None)
 
-    # Layer project.task_defaults under the task's own fields. Task fields
-    # continue to win on conflict; project defaults fill fields the task
-    # (and any adapter Domain bundle) leaves unset. Applied after the
-    # Domain merge so project defaults sit above adapter defaults in the
-    # precedence chain.
+    # Build the precedence chain from lowest to highest. ``deep_merge``
+    # is delta-wins, so the second argument overrides the first on conflict.
+    base = domain_data
     if project_task_defaults:
-        task_data = _deep_merge_task(project_task_defaults, task_data)
+        base = deep_merge(base, project_task_defaults)
+    task_data = deep_merge(base, task_data)
 
     # Resolve environment_manifest.compose_file to an absolute path
     # against the task root so ``EnvironmentManifest``'s file-existence
@@ -214,17 +219,19 @@ def _detect_task_root(task_path: Path) -> Path:
     return parent
 
 
-def _apply_domain(task_path: Path, task_data: dict, task_root: Path) -> dict:
-    """Deep-merge the ``domain:`` ref into *task_data* if one is present.
+def _load_domain_dict(task_path: Path, task_data: dict, task_root: Path) -> dict:
+    """Return the ``domain:`` ref's contents with paths rewritten into the
+    task-root frame. Returns ``{}`` when the task has no ``domain`` ref.
 
-    Domain-side path fields are rewritten from the domain file's parent dir
-    into the *task_root* frame before merge so downstream callers see one
-    consistent set of paths. The ``domain`` key is stripped from the returned
-    dict.
+    The caller is responsible for merging the returned dict into the
+    task's own dict. Splitting load from merge lets the caller layer
+    additional sources (e.g. ``project.task_defaults``) between the
+    domain bundle and the task's own fields, with the correct
+    precedence.
     """
     domain_ref = task_data.get("domain")
     if not domain_ref or not isinstance(domain_ref, str):
-        return task_data
+        return {}
 
     domain_path = (task_path.parent / domain_ref).resolve()
     if not domain_path.exists():
@@ -249,27 +256,7 @@ def _apply_domain(task_path: Path, task_data: dict, task_root: Path) -> dict:
         )
 
     _rewrite_task_paths(domain_data, domain_path.parent, task_root)
-    merged = _deep_merge_task(domain_data, task_data)
-    merged.pop("domain", None)
-    return merged
-
-
-def _deep_merge_task(domain: dict, task: dict) -> dict:
-    """Deep-merge *domain* into *task*; task values win on conflict.
-
-    Nested dicts merge recursively. Lists and scalars from the task side
-    replace the domain side — split a structure across both files only if its
-    inner values are identical for every case; otherwise keep it whole on one
-    side.
-    """
-    result: dict = dict(domain)
-    for key, val in task.items():
-        existing = result.get(key)
-        if isinstance(existing, dict) and isinstance(val, dict):
-            result[key] = _deep_merge_task(existing, val)
-        else:
-            result[key] = val
-    return result
+    return domain_data
 
 
 def _rewrite_path(value: str, from_dir: Path, to_dir: Path) -> str:

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -95,7 +95,11 @@ def validate_grading_yaml(grading_path: Path) -> None:
         LLMJudgeConfig(**llm_judge)
 
 
-def load_task_yaml(task_path: Path) -> tuple[TaskConfig, Path]:
+def load_task_yaml(
+    task_path: Path,
+    *,
+    project_task_defaults: dict[str, Any] | None = None,
+) -> tuple[TaskConfig, Path]:
     """Read ``task.yaml``, apply any ``domain:`` merge, return the validated config.
 
     All relative-path fields on the returned :class:`TaskConfig` are expressed
@@ -106,6 +110,12 @@ def load_task_yaml(task_path: Path) -> tuple[TaskConfig, Path]:
 
     Args:
         task_path: Absolute or relative path to ``task.yaml``.
+        project_task_defaults: Optional ``project.task_defaults`` dict from
+            the enclosing project. When supplied, it is layered under the
+            adapter's Domain merge and the task's own fields — task fields
+            still win on conflict; project defaults fill in fields the task
+            (and any Domain bundle) leaves unset. Precedence, low to high:
+            adapter Domain bundle → project defaults → task.yaml.
 
     Returns:
         ``(task_config, effective_task_dir)``. ``effective_task_dir`` is the
@@ -139,6 +149,14 @@ def load_task_yaml(task_path: Path) -> tuple[TaskConfig, Path]:
         _rewrite_task_paths(task_data, task_path.parent, task_root)
 
     task_data = _apply_domain(task_path, task_data, task_root)
+
+    # Layer project.task_defaults under the task's own fields. Task fields
+    # continue to win on conflict; project defaults fill fields the task
+    # (and any adapter Domain bundle) leaves unset. Applied after the
+    # Domain merge so project defaults sit above adapter defaults in the
+    # precedence chain.
+    if project_task_defaults:
+        task_data = _deep_merge_task(project_task_defaults, task_data)
 
     # Resolve environment_manifest.compose_file to an absolute path
     # against the task root so ``EnvironmentManifest``'s file-existence

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -88,6 +88,11 @@ class NativeAdapter(BaseAdapter):
         self.tasks_glob = params["tasks_glob"]
         self.base_dir = Path(params.get("base_dir", "."))
         self.task_packs: list[str] = params.get("task_packs", [])
+        # project.task_defaults dict from the enclosing project — layered
+        # under every task.yaml at load time so shared task-level defaults
+        # don't have to be repeated in each task file. Empty when the
+        # caller (typically the Orchestrator) has no project context.
+        self._project_task_defaults: dict[str, Any] = params.get("project_task_defaults", {})
 
         # Validate: tasks_glob must be relative when task_packs is provided
         if self.task_packs and Path(self.tasks_glob).is_absolute():
@@ -180,7 +185,10 @@ class NativeAdapter(BaseAdapter):
             raise ValueError(f"Task {task_id} not found")
 
         task_path = self._task_files[task_id]
-        task, task_dir = load_task_yaml(task_path)
+        task, task_dir = load_task_yaml(
+            task_path,
+            project_task_defaults=self._project_task_defaults or None,
+        )
         self._tasks[task_id] = task
         # Loader is the authority on the effective task dir; refresh the cache
         # populated by _discover_tasks so the two stay consistent. (They agree

--- a/tolokaforge/cli/config_commands.py
+++ b/tolokaforge/cli/config_commands.py
@@ -10,7 +10,6 @@ import glob
 from pathlib import Path
 
 import click
-import yaml
 from rich.console import Console
 
 from tolokaforge.core.config_validator import Severity, validate_run_config
@@ -18,6 +17,7 @@ from tolokaforge.core.llm.presets import (
     resolve_overlay_path,
     validate_overlay_file,
 )
+from tolokaforge.core.project_loader import load_effective_run_config
 
 console = Console()
 
@@ -76,10 +76,14 @@ def validate(config_path: str, strict: bool, presets_file: str | None) -> None:
     for p in sorted(paths):
         console.print(f"\n[bold]Validating:[/bold] {p}")
         try:
-            with open(p) as f:
-                raw = yaml.safe_load(f)
+            # Layer the enclosing project's run_defaults under the file
+            # before validation so a run config that legitimately
+            # delegates required fields to project.run_defaults doesn't
+            # report a schema error the actual `run` subcommand would
+            # never hit.
+            raw, _project = load_effective_run_config(Path(p))
         except Exception as exc:
-            console.print(f"  [red]✗ Failed to parse YAML: {exc}[/red]")
+            console.print(f"  [red]✗ Failed to load config: {exc}[/red]")
             total_errors += 1
             continue
 

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -17,6 +17,13 @@ from tolokaforge.core.llm.presets import (
 )
 from tolokaforge.core.models import RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.project_loader import (
+    detect_project_layout,
+    load_project_config,
+    resolve_effective_run_config_data,
+    synthesize_default_project,
+    warn_legacy_run_config_dir,
+)
 from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import create_run_queue
 from tolokaforge.secrets import init_default, install_global_redactor
@@ -204,6 +211,23 @@ def run(
     with open(config) as f:
         config_data = yaml.safe_load(f)
 
+    # Resolve the enclosing project so ``project.run_defaults`` layers
+    # under the selected run config and ``project.task_defaults`` reaches
+    # the adapter downstream. Packs without ``project.yaml`` get a
+    # synthesised default (transitional — the loader logs an info line so
+    # the fallback is visible).
+    config_path = Path(config).resolve()
+    project_root, used_legacy_dir = detect_project_layout(config_path)
+    if used_legacy_dir:
+        warn_legacy_run_config_dir(config_path)
+    if project_root is not None:
+        project = load_project_config(project_root / "project.yaml")
+    else:
+        # No project.yaml found upstream — synthesise a minimal default so
+        # the rest of the loader treats every pack uniformly.
+        project = synthesize_default_project(project_root=config_path.parent)
+    config_data = resolve_effective_run_config_data(project, config_data)
+
     # Create output directory with timestamp (if not resuming)
     if "output_dir" not in config_data.get("evaluation", {}):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -261,8 +285,11 @@ def run(
     if overlay_path:
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
-    # Create orchestrator with flags
-    orchestrator = Orchestrator(run_config, resume=resume, verbose=verbose, strict=strict)
+    # Create orchestrator with flags. Pass the resolved project so the
+    # adapter picks up project.task_defaults on task load.
+    orchestrator = Orchestrator(
+        run_config, resume=resume, verbose=verbose, strict=strict, project=project
+    )
 
     # Load tasks
     console.print("[bold blue]Loading tasks...[/bold blue]")

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -17,13 +17,7 @@ from tolokaforge.core.llm.presets import (
 )
 from tolokaforge.core.models import RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
-from tolokaforge.core.project_loader import (
-    detect_project_layout,
-    load_project_config,
-    resolve_effective_run_config_data,
-    synthesize_default_project,
-    warn_legacy_run_config_dir,
-)
+from tolokaforge.core.project_loader import load_effective_run_config
 from tolokaforge.core.resume import RunStateManager
 from tolokaforge.core.run_queue import create_run_queue
 from tolokaforge.secrets import init_default, install_global_redactor
@@ -207,26 +201,11 @@ def run(
     """Run benchmark with specified configuration"""
     console.print(f"[bold blue]Loading configuration from {config}...[/bold blue]")
 
-    # Load config
-    with open(config) as f:
-        config_data = yaml.safe_load(f)
-
-    # Resolve the enclosing project so ``project.run_defaults`` layers
-    # under the selected run config and ``project.task_defaults`` reaches
-    # the adapter downstream. Packs without ``project.yaml`` get a
-    # synthesised default (transitional — the loader logs an info line so
-    # the fallback is visible).
-    config_path = Path(config).resolve()
-    project_root, used_legacy_dir = detect_project_layout(config_path)
-    if used_legacy_dir:
-        warn_legacy_run_config_dir(config_path)
-    if project_root is not None:
-        project = load_project_config(project_root / "project.yaml")
-    else:
-        # No project.yaml found upstream — synthesise a minimal default so
-        # the rest of the loader treats every pack uniformly.
-        project = synthesize_default_project(project_root=config_path.parent)
-    config_data = resolve_effective_run_config_data(project, config_data)
+    # Load config with the enclosing project's run_defaults layered under
+    # it. Every subcommand that constructs a RunConfig from disk goes
+    # through the same helper so `run`, `prepare`, `worker`, `status`,
+    # and `config validate` treat the same YAML identically.
+    config_data, project = load_effective_run_config(Path(config))
 
     # Create output directory with timestamp (if not resuming)
     if "output_dir" not in config_data.get("evaluation", {}):
@@ -349,15 +328,16 @@ def prepare(
 ):
     """Prepare a queue-backed run directory for distributed workers."""
     console.print(f"[bold blue]Preparing run from config {config}...[/bold blue]")
-    with open(config) as f:
-        config_data = yaml.safe_load(f)
+    config_data, project = load_effective_run_config(Path(config))
     run_config = RunConfig(**config_data)
 
     overlay_path = _activate_presets_overlay(presets_file, run_config)
     if overlay_path:
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
-    orchestrator = Orchestrator(run_config, resume=False, verbose=verbose, strict=strict)
+    orchestrator = Orchestrator(
+        run_config, resume=False, verbose=verbose, strict=strict, project=project
+    )
     orchestrator.load_tasks()
     summary = orchestrator.prepare_run(Path(run_dir), reset_queue=reset_queue)
 
@@ -405,8 +385,7 @@ def worker(
 ):
     """Run a queue worker process (distributed execution mode)."""
     console.print(f"[bold blue]Loading worker config from {config}...[/bold blue]")
-    with open(config) as f:
-        config_data = yaml.safe_load(f)
+    config_data, project = load_effective_run_config(Path(config))
     run_config = RunConfig(**config_data)
 
     # Worker overlay precedence: --presets-file > ``prepare``-persisted queue
@@ -415,7 +394,9 @@ def worker(
     if overlay_path:
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
-    orchestrator = Orchestrator(run_config, resume=False, verbose=verbose, strict=strict)
+    orchestrator = Orchestrator(
+        run_config, resume=False, verbose=verbose, strict=strict, project=project
+    )
     orchestrator.load_tasks()
     summary = orchestrator.run_worker(Path(run_dir), max_attempts=max_attempts)
 
@@ -643,8 +624,7 @@ def status(run_dir: str, config: str | None):
     if queue_db.exists():
         queue = create_run_queue("sqlite", sqlite_path=queue_db, max_retries=0)
     elif config:
-        with open(config) as f:
-            config_data = yaml.safe_load(f)
+        config_data, _project = load_effective_run_config(Path(config))
         run_config = RunConfig(**config_data)
         if run_config.orchestrator.queue_backend == "postgres":
             queue = create_run_queue(

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1,6 +1,7 @@
 """Pydantic models for configuration and data structures"""
 
 import dataclasses
+import warnings
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any, Literal, Self, get_args
@@ -527,13 +528,56 @@ class HarnessAdapterConfig(BaseModel):
 
 
 class EvaluationConfig(BaseModel):
-    """Evaluation configuration"""
+    """Evaluation configuration.
+
+    ``projects`` lists project roots this run pulls tasks from. When
+    omitted the loader defaults to the enclosing project (the project
+    directory containing the run config file). Legacy configs may use
+    ``task_packs`` — it is accepted here as an alias for ``projects``
+    and coerced with a ``DeprecationWarning``.
+    """
 
     tasks_glob: str = "**/task.yaml"
+    projects: list[str] = Field(default_factory=list)
     task_packs: list[str] = Field(default_factory=list)
     output_dir: str
     cache_images: bool = True
     harness_adapter: HarnessAdapterConfig | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_task_packs_alias(cls, values: Any) -> Any:
+        """Accept ``task_packs`` as a deprecated alias for ``projects``.
+
+        Emits a ``DeprecationWarning`` when the legacy key appears with
+        a non-empty value and no explicit ``projects`` key. When both
+        keys carry values the loader keeps ``projects`` and drops
+        ``task_packs`` (with a warning naming the collision).
+        """
+        if not isinstance(values, dict):
+            return values
+        legacy = values.get("task_packs")
+        canonical = values.get("projects")
+        if not legacy:
+            return values
+        if canonical:
+            warnings.warn(
+                "evaluation.task_packs and evaluation.projects both set; "
+                "projects wins. Drop task_packs from the run config.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            values["task_packs"] = []
+            return values
+        warnings.warn(
+            "evaluation.task_packs is deprecated; use evaluation.projects "
+            "instead. task_packs still accepted as an alias for one release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        values["projects"] = list(legacy)
+        values["task_packs"] = []
+        return values
 
 
 class EngineConfig(BaseModel):

--- a/tolokaforge/core/mounts.py
+++ b/tolokaforge/core/mounts.py
@@ -31,8 +31,9 @@ def normalize_task_pack_paths(task_packs: list[str], config_path: Path) -> list[
 
         if not candidate.exists():
             raise FileNotFoundError(
-                "Task-pack path does not exist: "
-                f"{candidate}. Update evaluation.task_packs or create the path before docker run."
+                "Project path does not exist: "
+                f"{candidate}. Update evaluation.projects or create the path "
+                "before docker run."
             )
 
         normalized.append(candidate)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -39,6 +39,7 @@ from tolokaforge.core.metrics import (
 )
 from tolokaforge.core.models import (
     ModelConfig,
+    ProjectConfig,
     RunConfig,
     TaskConfig,
     TerminationReason,
@@ -226,11 +227,18 @@ class Orchestrator:
         verbose: bool = False,
         strict: bool = False,
         deps: OrchestratorDeps | None = None,
+        project: ProjectConfig | None = None,
     ):
         self.config = config
         self.resume = resume
         self.verbose = verbose
         self.strict = strict
+        # Enclosing project (loaded from ``project.yaml``). Adapter
+        # instantiation reads ``project.task_defaults`` from here so every
+        # task inherits the project-level defaults declared alongside
+        # the pack. ``None`` for callers without a project (e.g. old-
+        # shape packs where the CLI synthesises a default upstream).
+        self.project = project
         self.tasks: list[TaskConfig] = []
         self.results: list[Trajectory] = []
         self.state_manager: RunStateManager | None = None
@@ -294,7 +302,10 @@ class Orchestrator:
 
         # Add tasks_glob to params for both native and other adapters
         params["tasks_glob"] = self.config.evaluation.tasks_glob
-        task_packs = list(self.config.evaluation.task_packs)
+        # evaluation.projects is the canonical field (M2); evaluation.task_packs
+        # is a deprecated alias coerced by EvaluationConfig's validator, so
+        # projects always carries the effective list here.
+        task_packs = list(self.config.evaluation.projects)
 
         # In Docker flows, TASK_PACKS_DIRS can override config paths to container-visible mounts.
         env_task_packs = os.environ.get("TASK_PACKS_DIRS", "").strip()
@@ -306,6 +317,15 @@ class Orchestrator:
         typesense_config = self.config.orchestrator.typesense
         if typesense_config and typesense_config.enabled:
             params["typesense"] = typesense_config.model_dump()
+
+        # Layer project.task_defaults under every task the adapter loads.
+        # Adapters consume this via ``load_task_yaml(project_task_defaults=...)``.
+        # ``exclude_defaults`` drops fields the project author didn't set
+        # so we don't repeat schema defaults inside every task dict.
+        if self.project is not None:
+            defaults = self.project.task_defaults.model_dump(exclude_defaults=True)
+            if defaults:
+                params["project_task_defaults"] = defaults
 
         self.logger.info("Creating adapter", type=adapter_type, params=params)
         return get_adapter(adapter_type, params)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -302,9 +302,10 @@ class Orchestrator:
 
         # Add tasks_glob to params for both native and other adapters
         params["tasks_glob"] = self.config.evaluation.tasks_glob
-        # evaluation.projects is the canonical field (M2); evaluation.task_packs
-        # is a deprecated alias coerced by EvaluationConfig's validator, so
-        # projects always carries the effective list here.
+        # ``evaluation.projects`` is the canonical field; the deprecated
+        # ``evaluation.task_packs`` alias is coerced by
+        # ``EvaluationConfig`` so ``projects`` always carries the
+        # effective list here.
         task_packs = list(self.config.evaluation.projects)
 
         # In Docker flows, TASK_PACKS_DIRS can override config paths to container-visible mounts.

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -1,0 +1,246 @@
+"""Project loader — resolves ``project.yaml`` + ``run_configs/*.yaml`` layering.
+
+Turns a run-config file path into an effective ``RunConfig`` by finding the
+enclosing ``project.yaml`` (walking up from the config file) and deep-merging
+``project.run_defaults`` under the selected run config. Also exposes the
+task-side merge (``project.task_defaults`` under each ``task.yaml``) used by
+the adapter layer.
+
+Public helpers:
+
+- :func:`find_project_yaml` — walk up from a start path looking for
+  ``project.yaml``.
+- :func:`load_project_config` — read + validate a ``project.yaml`` file.
+- :func:`synthesize_default_project` — build a minimal ``ProjectConfig`` for
+  packs that don't ship a ``project.yaml``. Emits an info-level log line so
+  the fallback is visible without being a warning.
+- :func:`deep_merge` — recursive dict merge; delta wins on conflict.
+- :func:`resolve_effective_run_config_data` — apply ``project.run_defaults``
+  under a run-config dict.
+- :func:`resolve_effective_task_data` — apply ``project.task_defaults`` under
+  a task-yaml dict.
+- :func:`detect_project_layout` — resolve the enclosing project root and
+  flag whether the run config sits under the legacy ``run_config/``
+  (singular) directory.
+
+The task-side merge in this module operates on **dicts** so it plugs into
+the existing :mod:`tolokaforge.adapters._task_loader` flow, which merges
+domain / task dicts before Pydantic validation.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tolokaforge.core.models import ProjectConfig, TaskDefaults
+
+logger = logging.getLogger(__name__)
+
+
+# ── Filesystem discovery ────────────────────────────────────────────────
+
+
+PROJECT_FILENAME = "project.yaml"
+CANONICAL_RUN_CONFIGS_DIR = "run_configs"
+LEGACY_RUN_CONFIG_DIR = "run_config"
+
+
+def find_project_yaml(start: Path, *, max_depth: int = 8) -> Path | None:
+    """Walk up from *start* looking for ``project.yaml``.
+
+    Stops after ``max_depth`` levels so an unusual mount layout can't spin.
+    Returns the resolved path to the file, or ``None`` if none was found
+    within the depth budget.
+
+    ``start`` may be a file or a directory; the search begins at
+    ``start.parent`` if it is a file.
+    """
+    start = start.resolve()
+    current = start if start.is_dir() else start.parent
+    for _ in range(max_depth + 1):
+        candidate = current / PROJECT_FILENAME
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:  # filesystem root
+            return None
+        current = current.parent
+    return None
+
+
+def detect_project_layout(config_path: Path) -> tuple[Path | None, bool]:
+    """Given a ``--config`` path, return the enclosing project root and a
+    flag indicating whether the run config sits under the legacy
+    ``run_config/`` (singular) directory.
+
+    - ``project_root`` is the directory containing the discovered
+      ``project.yaml``, or ``None`` if no project was found within the
+      search budget.
+    - ``used_legacy_dir`` is ``True`` when the config path's immediate
+      parent directory is named ``run_config/`` (legacy singular) rather
+      than ``run_configs/`` (canonical plural).
+    """
+    config_path = config_path.resolve()
+    project_yaml = find_project_yaml(config_path)
+    project_root = project_yaml.parent if project_yaml else None
+    used_legacy_dir = config_path.is_file() and config_path.parent.name == LEGACY_RUN_CONFIG_DIR
+    return project_root, used_legacy_dir
+
+
+# ── Load + synthesise ──────────────────────────────────────────────────
+
+
+def load_project_config(path: Path) -> ProjectConfig:
+    """Read and validate a ``project.yaml`` file.
+
+    Raises ``FileNotFoundError`` if the file does not exist, ``RuntimeError``
+    if the YAML is not a mapping, and ``pydantic.ValidationError`` if the
+    contents don't validate against :class:`ProjectConfig`.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(f"project.yaml not found at {path}")
+    with path.open() as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"project.yaml at {path} is not a YAML mapping (got {type(data).__name__})"
+        )
+    # Resolve default_environment.compose_file relative to the project dir
+    # so EnvironmentManifest's validator can locate it regardless of CWD.
+    _resolve_project_paths(data, path.parent)
+    return ProjectConfig(**data)
+
+
+def _resolve_project_paths(data: dict, project_dir: Path) -> None:
+    """Rewrite relative paths in *data* to absolute paths under
+    *project_dir*, in place. No-op if the fields are absent or already
+    absolute.
+    """
+    env = data.get("default_environment")
+    if isinstance(env, dict):
+        compose = env.get("compose_file")
+        if isinstance(compose, str) and compose:
+            resolved = Path(compose)
+            if not resolved.is_absolute():
+                env["compose_file"] = str((project_dir / resolved).resolve())
+    task_defaults = data.get("task_defaults")
+    if isinstance(task_defaults, dict):
+        prompt = task_defaults.get("system_prompt")
+        if isinstance(prompt, str) and prompt:
+            resolved = Path(prompt)
+            if not resolved.is_absolute():
+                task_defaults["system_prompt"] = str((project_dir / resolved).resolve())
+
+
+def synthesize_default_project(
+    *,
+    project_root: Path,
+    task_defaults: TaskDefaults | None = None,
+) -> ProjectConfig:
+    """Return a minimal ``ProjectConfig`` for packs without a
+    ``project.yaml``.
+
+    Emits an info-level log line so operators can see the fallback took
+    effect. Used by the CLI to keep old-shape packs loading while the
+    strict-validation milestone hasn't landed yet.
+    """
+    logger.info(
+        "project.yaml not found under %s; using synthesised default (transitional)",
+        project_root,
+    )
+    return ProjectConfig(
+        name=project_root.name or "synthesised",
+        description=None,
+        task_defaults=task_defaults or TaskDefaults(),
+    )
+
+
+# ── Deep merge ─────────────────────────────────────────────────────────
+
+
+def deep_merge(base: dict[str, Any], delta: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *delta* into *base*; *delta* wins on conflict.
+
+    Nested dicts merge key-by-key. Lists and scalars from *delta* replace
+    the corresponding value in *base* — split a structure across both
+    sides only when its inner values are identical for every case;
+    otherwise keep it whole on one side. Returns a new dict; neither
+    input is mutated.
+    """
+    result: dict[str, Any] = dict(base)
+    for key, val in delta.items():
+        existing = result.get(key)
+        if isinstance(existing, dict) and isinstance(val, dict):
+            result[key] = deep_merge(existing, val)
+        else:
+            result[key] = val
+    return result
+
+
+# ── Effective config resolvers ─────────────────────────────────────────
+
+
+def resolve_effective_run_config_data(
+    project: ProjectConfig | None,
+    run_config_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Layer *project.run_defaults* under *run_config_data*.
+
+    Returns a new dict shaped for ``RunConfig(**...)``. The selected run
+    config's fields win on conflict; anything the run config omits
+    inherits from ``run_defaults``. When *project* is ``None`` or the
+    project declares no ``run_defaults``, *run_config_data* is returned
+    unchanged.
+    """
+    if project is None or project.run_defaults is None:
+        return dict(run_config_data)
+    # ``exclude_defaults`` drops fields whose value equals the schema
+    # default (None for optionals, {} / [] for containers). Every
+    # dropped key therefore adds no information — merging them in
+    # would just repeat the schema default at merge time.
+    base = project.run_defaults.model_dump(exclude_defaults=True)
+    return deep_merge(base, run_config_data)
+
+
+def resolve_effective_task_data(
+    project: ProjectConfig | None,
+    task_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Layer *project.task_defaults* under *task_data*.
+
+    The task fields (``task_data``) win on conflict. Called by
+    :mod:`tolokaforge.adapters._task_loader` after any adapter-side
+    Domain merge and before ``TaskConfig`` validation. When *project* is
+    ``None`` or its ``task_defaults`` are effectively empty, *task_data*
+    is returned unchanged.
+    """
+    if project is None:
+        return dict(task_data)
+    # ``exclude_defaults`` skips fields the project author didn't
+    # override (None for optionals, {} / [] for containers) so we
+    # never merge a schema-default value into the task dict.
+    defaults = project.task_defaults.model_dump(exclude_defaults=True)
+    if not defaults:
+        return dict(task_data)
+    return deep_merge(defaults, task_data)
+
+
+# ── Legacy alias warnings ──────────────────────────────────────────────
+
+
+def warn_legacy_run_config_dir(config_path: Path) -> None:
+    """Emit a ``DeprecationWarning`` when a run config sits under
+    ``run_config/`` (singular) instead of ``run_configs/`` (plural).
+    """
+    warnings.warn(
+        f"Run config {config_path} sits under 'run_config/' (singular); the "
+        f"canonical directory is 'run_configs/' (plural). Rename the "
+        f"directory to remove this warning.",
+        DeprecationWarning,
+        stacklevel=2,
+    )

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -17,15 +17,15 @@ Public helpers:
 - :func:`deep_merge` — recursive dict merge; delta wins on conflict.
 - :func:`resolve_effective_run_config_data` — apply ``project.run_defaults``
   under a run-config dict.
-- :func:`resolve_effective_task_data` — apply ``project.task_defaults`` under
-  a task-yaml dict.
 - :func:`detect_project_layout` — resolve the enclosing project root and
   flag whether the run config sits under the legacy ``run_config/``
   (singular) directory.
 
-The task-side merge in this module operates on **dicts** so it plugs into
-the existing :mod:`tolokaforge.adapters._task_loader` flow, which merges
-domain / task dicts before Pydantic validation.
+The task-side merge is executed inside
+:func:`tolokaforge.adapters._task_loader.load_task_yaml`, which imports
+``deep_merge`` from here and layers the project ``task_defaults`` under
+each task's own fields between the adapter's Domain merge and the
+task-yaml delta.
 """
 
 from __future__ import annotations
@@ -120,6 +120,17 @@ def _resolve_project_paths(data: dict, project_dir: Path) -> None:
     """Rewrite relative paths in *data* to absolute paths under
     *project_dir*, in place. No-op if the fields are absent or already
     absolute.
+
+    Two field families are covered:
+
+    - ``default_environment.compose_file`` — the substrate pointer.
+    - Every path field inside ``task_defaults`` that a per-task
+      ``task.yaml`` may carry (``system_prompt``, ``grading``,
+      ``tools.{agent,user}.mcp_server``, ``initial_state.json_db``,
+      ``initial_state.system_prompt``, ``initial_state.filesystem.copy[].from``).
+      The task loader's ``_PATH_FIELD_REWRITERS`` is the canonical
+      enumeration; this function reuses it so a project-level default
+      resolves the same way a task-level value does.
     """
     env = data.get("default_environment")
     if isinstance(env, dict):
@@ -130,11 +141,28 @@ def _resolve_project_paths(data: dict, project_dir: Path) -> None:
                 env["compose_file"] = str((project_dir / resolved).resolve())
     task_defaults = data.get("task_defaults")
     if isinstance(task_defaults, dict):
-        prompt = task_defaults.get("system_prompt")
-        if isinstance(prompt, str) and prompt:
-            resolved = Path(prompt)
-            if not resolved.is_absolute():
-                task_defaults["system_prompt"] = str((project_dir / resolved).resolve())
+        _rewrite_task_defaults_paths(task_defaults, project_dir)
+
+
+def _rewrite_task_defaults_paths(task_defaults: dict, project_dir: Path) -> None:
+    """Rewrite every path-bearing field inside ``task_defaults`` from a
+    project-relative string to an absolute path under *project_dir*.
+
+    Imports ``_PATH_FIELD_REWRITERS`` from the task loader so the field
+    set stays a single declaration — adding a new task-level path field
+    on that side automatically covers the project-level default here.
+    Silently skips any field whose value is not a relative string.
+    """
+    from tolokaforge.adapters._task_loader import _PATH_FIELD_REWRITERS
+
+    def rewrite(val: str) -> str:
+        resolved = Path(val)
+        if resolved.is_absolute():
+            return val
+        return str((project_dir / resolved).resolve())
+
+    for rewriter in _PATH_FIELD_REWRITERS:
+        rewriter(task_defaults, rewrite)
 
 
 def synthesize_default_project(
@@ -142,15 +170,16 @@ def synthesize_default_project(
     project_root: Path,
     task_defaults: TaskDefaults | None = None,
 ) -> ProjectConfig:
-    """Return a minimal ``ProjectConfig`` for packs without a
-    ``project.yaml``.
+    """Return a minimal ``ProjectConfig`` used when a pack does not ship
+    a ``project.yaml``.
 
-    Emits an info-level log line so operators can see the fallback took
-    effect. Used by the CLI to keep old-shape packs loading while the
-    strict-validation milestone hasn't landed yet.
+    Emits an info-level log line so operators can see the synthesised
+    fallback took effect. Loaders route through here whenever
+    ``find_project_yaml`` returns ``None`` so downstream code always
+    has a ``ProjectConfig`` to consume.
     """
     logger.info(
-        "project.yaml not found under %s; using synthesised default (transitional)",
+        "project.yaml not found under %s; using synthesised default",
         project_root,
     )
     return ProjectConfig(
@@ -207,27 +236,49 @@ def resolve_effective_run_config_data(
     return deep_merge(base, run_config_data)
 
 
-def resolve_effective_task_data(
-    project: ProjectConfig | None,
-    task_data: dict[str, Any],
-) -> dict[str, Any]:
-    """Layer *project.task_defaults* under *task_data*.
+# ── High-level loader entry point ──────────────────────────────────────
 
-    The task fields (``task_data``) win on conflict. Called by
-    :mod:`tolokaforge.adapters._task_loader` after any adapter-side
-    Domain merge and before ``TaskConfig`` validation. When *project* is
-    ``None`` or its ``task_defaults`` are effectively empty, *task_data*
-    is returned unchanged.
+
+def load_effective_run_config(
+    config_path: Path,
+) -> tuple[dict[str, Any], ProjectConfig]:
+    """Load the run-config YAML at *config_path* and layer
+    ``project.run_defaults`` under it.
+
+    Returns ``(config_data, project)``:
+
+    - ``config_data`` is the merged dict, ready to feed into
+      ``RunConfig(**config_data)``.
+    - ``project`` is the enclosing ``ProjectConfig`` (loaded from the
+      discovered ``project.yaml``) or a synthesised default for packs
+      that don't ship one.
+
+    Emits a ``DeprecationWarning`` when the run config sits under the
+    legacy ``run_config/`` (singular) directory.
+
+    Every CLI subcommand that constructs a ``RunConfig`` from disk
+    should route through here so that ``project.run_defaults`` reaches
+    every code path uniformly. Direct ``yaml.safe_load`` + ``RunConfig``
+    construction skips the merge and produces a config that behaves
+    differently between ``run`` and any other subcommand.
     """
-    if project is None:
-        return dict(task_data)
-    # ``exclude_defaults`` skips fields the project author didn't
-    # override (None for optionals, {} / [] for containers) so we
-    # never merge a schema-default value into the task dict.
-    defaults = project.task_defaults.model_dump(exclude_defaults=True)
-    if not defaults:
-        return dict(task_data)
-    return deep_merge(defaults, task_data)
+    config_path = Path(config_path).resolve()
+    with config_path.open() as f:
+        config_data = yaml.safe_load(f) or {}
+    if not isinstance(config_data, dict):
+        raise RuntimeError(
+            f"Run config {config_path} is not a YAML mapping " f"(got {type(config_data).__name__})"
+        )
+
+    project_root, used_legacy_dir = detect_project_layout(config_path)
+    if used_legacy_dir:
+        warn_legacy_run_config_dir(config_path)
+    if project_root is not None:
+        project = load_project_config(project_root / PROJECT_FILENAME)
+    else:
+        project = synthesize_default_project(project_root=config_path.parent)
+    merged = resolve_effective_run_config_data(project, config_data)
+    return merged, project
 
 
 # ── Legacy alias warnings ──────────────────────────────────────────────


### PR DESCRIPTION
Wires the Project abstraction into the loader — stage 2 of the [Project layer v1](https://github.com/Toloka/tolokaforge/milestone/9) rollout.

Closes #211.

## Summary

- **\`project.yaml\` discovery** — walk up from \`--config\` looking for the enclosing project (capped at 8 levels). Missing \`project.yaml\` gets a synthesised default with an info-level log — transitional so old-shape packs keep loading.
- **Base+delta composition** — \`project.run_defaults\` deep-merges under the selected \`run_configs/<name>.yaml\`; \`project.task_defaults\` deep-merges under every task at \`load_task_yaml\` time. Delta wins on conflict at both layers.
- **Legacy aliases with \`DeprecationWarning\`**:
  - \`evaluation.task_packs\` → \`evaluation.projects\` (coerced by a \`mode=\"before\"\` validator on \`EvaluationConfig\`). If both are set, \`projects\` wins.
  - \`run_config/\` (singular) directory accepted; warning names the file and points at \`run_configs/\` (plural).
- **Wiring** — \`tolokaforge/cli/main.py\` runs the discovery + merge before constructing \`RunConfig\`; \`Orchestrator\` accepts an optional \`project\` kwarg; \`_create_adapter\` passes \`project.task_defaults\` (with \`exclude_defaults\`) into the adapter params; \`NativeAdapter\` forwards it into every \`load_task_yaml\` call.

## New module

\`tolokaforge/core/project_loader.py\`:
- \`find_project_yaml\`
- \`detect_project_layout\`
- \`load_project_config\`
- \`synthesize_default_project\`
- \`deep_merge\`
- \`resolve_effective_run_config_data\`
- \`resolve_effective_task_data\`
- \`warn_legacy_run_config_dir\`

## What does NOT land here

- **Docker-driven end-to-end test** of \`example-microservices-pack\` — that pack lives on the design-branch PR (#216); once it's on \`main\` the integration test follows in its own small PR.
- **Strict \`extra=\"forbid\"\` validation** and **example-pack migration** — later milestone.
- **Alias removal** (\`task_packs\`, \`run_config/\`, \`docs/TASK_PACKS.md\`) — final cleanup milestone.
- **\`RunConfig.compute\` vs \`RunConfig.orchestrator\` shadow-duplication cross-check** — deferred to the merge-policy discussion on the M2 tracker (option: use \`model_fields_set\` at the loader to detect which surface the operator explicitly declared).

## Testing

- **28 new unit tests** in \`tests/unit/test_project_loader.py\`: \`deep_merge\`, walk-up discovery, layout detection, project-config loading, synthesis, both effective-config resolvers.
- **7 new end-to-end tests** in \`tests/unit/test_project_loader_end_to_end.py\`: full CLI loader flow against \`tmp_path\` project layouts (\`run_defaults\` inheritance, delta override, synthesised default fallback, legacy \`run_config/\` warning, task-defaults injection through \`load_task_yaml\`).
- \`test_task_packs.py\` updated for the \`projects\`/\`task_packs\` migration and gains a test that the alias emits \`DeprecationWarning\`.
- Full unit + canonical suite: **2582 passed, 1 skipped**. Ruff clean. Black clean.

## Design reference

- Public design: \`docs/architecture/PROJECTS.md\` (on the [design-branch PR](https://github.com/Toloka/tolokaforge/pull/216) until it merges).

## Test plan

- [x] \`uv run ruff check tolokaforge/ tests/\` — clean
- [x] \`uv run pytest tests/unit tests/canonical -q\` — 2582 passed, 1 skipped
- [x] Pre-commit black + ruff hooks — pass