### PR TITLE
fix(deps): exclude litellm 1.92.0 due to fastapi import regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     # Core LLM integration
-    "litellm>=1.83.14,<2.0.0",
+    "litellm>=1.83.14,!=1.92.0,<2.0.0",
     # Data validation and schemas
     "pydantic>=2.0.0",
     "pydantic[email]>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4004,7 +4004,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonpath-ng", specifier = ">=1.6.0" },
     { name = "jsonschema", specifier = ">=4.20.0" },
-    { name = "litellm", specifier = ">=1.83.14,<2.0.0" },
+    { name = "litellm", specifier = ">=1.83.14,!=1.92.0,<2.0.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "odata-query", specifier = ">=0.10.0" },


### PR DESCRIPTION
## Summary
- litellm `1.92.0` shipped a real regression: a new module-level `from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup` in `litellm/responses/mcp/litellm_proxy_mcp_handler.py` transitively imports fastapi. Any base-SDK install without the `[proxy]` extra crashes with `ModuleNotFoundError: No module named 'fastapi'` the instant `completion(..., tools=[...])` is called — i.e., every tool-call path in tolokaforge.
- Narrow the pin: `litellm>=1.83.14,<2.0.0` → `litellm>=1.83.14,!=1.92.0,<2.0.0`.
- `uv.lock` regenerated; litellm stays at `1.87.0`.

## Why only `!=1.92.0` and not `!=1.92.*`
Verified the offending line in each upstream tag on GitHub:
- `v1.91.3` — offending import absent (clean).
- `v1.92.0` — offending import newly added.
- `v1.93.0-rc.1` — offending import removed again (upstream fix commit landed).

The fix (PR [BerriAI/litellm#32339](https://github.com/BerriAI/litellm/pull/32339)) merged to `litellm_internal_staging` on 2026-07-07 and is an ancestor of `v1.93.0-rc.1` but **not** of `v1.92.0`. The `v1.92.0` tag was a hand-picked backport release (its commit message: *"backport 11 staging PRs onto patch-1.92.0rc2 for the 1.92.0 stable cut"*) and this fix was one of the PRs not picked. Single-tag process slip, not a broader pattern.

With `!=1.92.0`, resolvers pick `1.91.3` today and will auto-adopt `1.92.1` (when BerriAI ships the patch) or `1.93.0` stable — no follow-up dep bump needed. CI is the safety net.

Upstream tracking: [BerriAI/litellm#32993](https://github.com/BerriAI/litellm/issues/32993).

## Test plan
- [ ] `uv lock --check` passes.
- [ ] `uv sync --group dev` clean.
- [ ] `uv run python -c "import litellm; from litellm import completion; print('ok')"` succeeds.
- [ ] `uv run ruff check` / `ruff format --check` pass.
- [ ] CI (`ci.yml`) green on this branch.
- [ ] Post-release smoke: fresh venv, `pip install tolokaforge==<new-version>`, confirm `pip show litellm | grep Version` is not `1.92.0`.