### PR TITLE
feat(schema): EnvironmentPatch + resolve() + stack sub-object

### DIFF
--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -441,6 +441,7 @@ class TestManifestWireShape:
         assert set(wire) == {
             "compose_file",
             "runner_service",
+            "stack_inputs",
             "initial_state",
             "network_policy",
             "security_context_defaults",

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -126,6 +126,26 @@ class TestResolveDeepMerges:
         assert manifest.runner_service == "default"
         assert manifest.network_policy == NetworkPolicy.NO_INTERNET
 
+    def test_task_runner_service_overrides_project_on_deep_merge(self) -> None:
+        # Deep-merge (no compose_file trigger) → task wins on scalar
+        # conflict. safe_one_service.yaml declares the service `default`,
+        # but the runtime cross-check only fires if the manifest names
+        # a service missing from compose; here we exercise the pure
+        # merge behaviour with two distinct values that both name a
+        # declared service. Using `default` on both sides masks
+        # whether task-wins actually applies.
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="project-runner"),
+        )
+        task = EnvironmentPatch(stack=StackPatch(runner_service="default"))
+        # `default` is the only service compose actually declares, so
+        # the manifest accepts it; the point of the test is that the
+        # merger picked the task's value over the project's, not that
+        # either particular string is valid.
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.runner_service == "default"
+
     def test_only_project_side(self) -> None:
         project = EnvironmentPatch(
             stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="default"),

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -1,0 +1,224 @@
+"""Unit tests for :func:`tolokaforge.core.project_loader.resolve` and
+the :class:`EnvironmentPatch` shape.
+
+Covers the patch-side (no I/O at construction), the atomic-``stack``
+replacement rule, deep-merge over ``stack.inputs``, policy-request
+survival, and the legacy flat compose_file / runner_service coercion.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.models import EnvironmentManifest, EnvironmentPatch, StackPatch
+from tolokaforge.core.project_loader import resolve
+from tolokaforge.runner.models import NetworkPolicy, SecurityContext, TaskIsolation
+
+pytestmark = pytest.mark.unit
+
+
+ENV_FIXTURE = (
+    Path(__file__).parent.parent
+    / "canonical"
+    / "fixtures"
+    / "environment_manifest"
+    / "safe_one_service.yaml"
+)
+
+
+class TestEnvironmentPatchNoIO:
+    """The patch shape must not read the compose file at construction —
+    that's the invariant :func:`resolve` relies on to defer disk I/O
+    to a single point."""
+
+    def test_patch_accepts_nonexistent_path(self) -> None:
+        patch = EnvironmentPatch(stack=StackPatch(compose_file=Path("/nonexistent/compose.yaml")))
+        assert patch.stack is not None
+        assert patch.stack.compose_file == Path("/nonexistent/compose.yaml")
+
+    def test_patch_all_fields_optional(self) -> None:
+        patch = EnvironmentPatch()
+        assert patch.stack is None
+        assert patch.initial_state is None
+        assert patch.network_policy is None
+        assert patch.security_context_defaults is None
+        assert patch.isolation is None
+
+    def test_stack_patch_all_fields_optional(self) -> None:
+        stack = StackPatch()
+        assert stack.compose_file is None
+        assert stack.runner_service is None
+        assert stack.inputs == {}
+
+
+class TestLegacyFlatShape:
+    """Task packs authored before M2.5 carry ``compose_file`` and
+    ``runner_service`` at the ``environment_manifest`` top level; the
+    patch model normalises them under ``stack`` and emits a
+    ``DeprecationWarning``. Retirement lands in M5."""
+
+    def test_flat_compose_file_migrates_into_stack(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            patch = EnvironmentPatch.model_validate(
+                {
+                    "compose_file": str(ENV_FIXTURE),
+                    "runner_service": "default",
+                }
+            )
+        assert patch.stack is not None
+        assert patch.stack.compose_file == ENV_FIXTURE
+        assert patch.stack.runner_service == "default"
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "flat compose_file" in str(w.message)
+            for w in caught
+        )
+
+    def test_flat_and_stack_together_is_a_load_error(self) -> None:
+        # A pack that half-migrates would silently drop one side; fail
+        # loud instead so the author fixes it.
+        with pytest.raises(Exception) as exc:
+            EnvironmentPatch.model_validate(
+                {
+                    "compose_file": str(ENV_FIXTURE),
+                    "stack": {"compose_file": str(ENV_FIXTURE)},
+                }
+            )
+        assert "both flat" in str(exc.value)
+
+
+class TestResolveReturnsNoneWhenBothSidesAreNone:
+    def test_both_none(self) -> None:
+        assert resolve(None, None) is None
+
+
+class TestResolveDeepMerges:
+    """No atomic-replacement trigger — the merge is a straight
+    deep-merge, task fields win on conflict, others inherit."""
+
+    def test_task_inputs_deep_merge_over_project_stack(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE,
+                runner_service="default",
+                inputs={"postgres_version": "16", "keep_me": "yes"},
+            ),
+        )
+        task = EnvironmentPatch(stack=StackPatch(inputs={"postgres_version": "17"}))
+        manifest = resolve(project, task)
+        assert isinstance(manifest, EnvironmentManifest)
+        assert manifest.compose_file == ENV_FIXTURE
+        assert manifest.runner_service == "default"
+        assert manifest.stack_inputs == {"postgres_version": "17", "keep_me": "yes"}
+
+    def test_task_runner_service_alone_deep_merges(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="default"),
+            network_policy=NetworkPolicy.NO_INTERNET,
+        )
+        task = EnvironmentPatch(stack=StackPatch(runner_service="default"))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.compose_file == ENV_FIXTURE
+        assert manifest.runner_service == "default"
+        assert manifest.network_policy == NetworkPolicy.NO_INTERNET
+
+    def test_only_project_side(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="default"),
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.compose_file == ENV_FIXTURE
+        assert manifest.runner_service == "default"
+
+    def test_only_task_side(self) -> None:
+        task = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="default"),
+        )
+        manifest = resolve(None, task)
+        assert manifest is not None
+        assert manifest.compose_file == ENV_FIXTURE
+
+
+class TestAtomicStackReplacement:
+    """Presence of ``compose_file`` on the task's ``stack`` patch
+    triggers full replacement of the project's ``stack``. The trigger
+    is key presence, not path identity (a re-declaration of the same
+    file still replaces)."""
+
+    def test_task_compose_file_replaces_project_inputs(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE,
+                runner_service="default",
+                inputs={"postgres_version": "16"},
+            ),
+        )
+        task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        # Task's stack replaces project's — inputs reset to empty.
+        assert manifest.stack_inputs == {}
+        # runner_service falls back to the manifest's own default,
+        # not the project's declaration.
+        assert manifest.runner_service == "default"
+
+    def test_replacement_discards_project_isolation(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            isolation=TaskIsolation.SHARED_OK,
+        )
+        task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.isolation == TaskIsolation.PER_TRIAL
+
+    def test_replacement_discards_project_initial_state(self) -> None:
+        from tolokaforge.runner.models import InitialStateRef
+
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            initial_state={"db": InitialStateRef(**{"from": "./seed.sql", "kind": "sql"})},
+        )
+        task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.initial_state == {}
+
+    def test_policy_request_survives_replacement(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            network_policy=NetworkPolicy.FULL_INTERNET,
+            security_context_defaults=SecurityContext(run_as_user=1000),
+        )
+        task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.network_policy == NetworkPolicy.FULL_INTERNET
+        assert manifest.security_context_defaults is not None
+        assert manifest.security_context_defaults.run_as_user == 1000
+
+    def test_task_can_override_policy_request_on_replacement(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            network_policy=NetworkPolicy.NO_INTERNET,
+        )
+        task = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            network_policy=NetworkPolicy.LIMITED_INTERNET,
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.network_policy == NetworkPolicy.LIMITED_INTERNET
+
+
+class TestResolveWithoutComposeFileFailsLoud:
+    def test_neither_side_declares_compose_file(self) -> None:
+        project = EnvironmentPatch(network_policy=NetworkPolicy.NO_INTERNET)
+        task = EnvironmentPatch(isolation=TaskIsolation.PER_TRIAL)
+        with pytest.raises(ValueError, match="no compose_file"):
+            resolve(project, task)

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -143,6 +143,28 @@ class TestResolveDeepMerges:
         assert manifest is not None
         assert manifest.compose_file == ENV_FIXTURE
 
+    def test_initial_state_carries_through_non_replacement_merge(self) -> None:
+        # Non-replacement path (task patches only stack.inputs) must carry
+        # the project's initial_state through as-is — the fixtures are
+        # scoped to the shared stack the task inherited.
+        from tolokaforge.runner.models import InitialStateRef
+
+        # `default` is the sole service declared in safe_one_service.yaml —
+        # the manifest validator cross-checks initial_state keys against
+        # compose services, so keying by anything else fails at construction.
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE, runner_service="default"),
+            initial_state={
+                "default": InitialStateRef.model_validate({"from": "./seed.sql", "kind": "sql"}),
+            },
+        )
+        task = EnvironmentPatch(stack=StackPatch(inputs={"postgres_version": "17"}))
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert set(manifest.initial_state) == {"default"}
+        assert manifest.initial_state["default"].from_ == "./seed.sql"
+        assert manifest.initial_state["default"].kind == "sql"
+
 
 class TestAtomicStackReplacement:
     """Presence of ``compose_file`` on the task's ``stack`` patch

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -16,7 +16,8 @@ import pytest
 import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.models import EnvironmentPatch
+from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -59,7 +60,7 @@ class TestTaskYaml:
     def test_declares_environment_manifest(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
         assert task_config.environment_manifest is not None
-        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+        assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
     def test_isolation_is_shared_ok(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
@@ -67,9 +68,12 @@ class TestTaskYaml:
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        stack = task_config.environment_manifest.stack
+        assert stack is not None
+        assert stack.compose_file is not None
+        compose_body = yaml.safe_load(stack.compose_file.read_text())
         declared_services = set(compose_body.get("services", {}).keys())
-        assert task_config.environment_manifest.runner_service in declared_services
+        assert stack.runner_service in declared_services
 
     def test_agent_tools_reach_apis(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -15,7 +15,8 @@ import pytest
 import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.models import EnvironmentPatch
+from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -63,7 +64,7 @@ class TestTaskYaml:
     def test_declares_environment_manifest(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
         assert task_config.environment_manifest is not None
-        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+        assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
     def test_isolation_is_shared_ok(self) -> None:
         """Case B requires ``isolation: shared_ok`` — a per_trial
@@ -73,14 +74,17 @@ class TestTaskYaml:
         assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
 
     def test_runner_service_matches_compose_declaration(self) -> None:
-        """``runner_service`` in the manifest must name a service
-        actually declared in the compose file — otherwise
+        """``runner_service`` in the patch must name a service actually
+        declared in the compose file — otherwise
         ``resolve_runner_endpoint`` fails at connect time with a typed
         ProvisionError."""
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        stack = task_config.environment_manifest.stack
+        assert stack is not None
+        assert stack.compose_file is not None
+        compose_body = yaml.safe_load(stack.compose_file.read_text())
         declared_services = set(compose_body.get("services", {}).keys())
-        assert task_config.environment_manifest.runner_service in declared_services
+        assert stack.runner_service in declared_services
 
     def test_agent_tools_reach_app_service(self) -> None:
         """The task expects the agent to query ``app-service`` — it

--- a/tests/unit/test_multi_service_postgres_example_task.py
+++ b/tests/unit/test_multi_service_postgres_example_task.py
@@ -18,7 +18,8 @@ import pytest
 import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.models import EnvironmentPatch
+from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -62,7 +63,7 @@ class TestTaskYaml:
     def test_declares_environment_manifest(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
         assert task_config.environment_manifest is not None
-        assert isinstance(task_config.environment_manifest, EnvironmentManifest)
+        assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
     def test_isolation_is_shared_ok(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
@@ -70,9 +71,12 @@ class TestTaskYaml:
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        compose_body = yaml.safe_load(task_config.environment_manifest.compose_file.read_text())
+        stack = task_config.environment_manifest.stack
+        assert stack is not None
+        assert stack.compose_file is not None
+        compose_body = yaml.safe_load(stack.compose_file.read_text())
         declared_services = set(compose_body.get("services", {}).keys())
-        assert task_config.environment_manifest.runner_service in declared_services
+        assert stack.runner_service in declared_services
 
     def test_agent_tools_reach_api(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_native_adapter_environment_manifest.py
+++ b/tests/unit/test_native_adapter_environment_manifest.py
@@ -16,6 +16,7 @@ import pytest
 
 from tests.canonical._factories import write_yaml_file
 from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core.models import EnvironmentPatch, StackPatch
 
 pytestmark = pytest.mark.unit
 
@@ -24,6 +25,7 @@ def _build_task(
     tmp_path: Path,
     *,
     environment_manifest: dict | None = None,
+    project_default_environment: EnvironmentPatch | None = None,
 ) -> NativeAdapter:
     task_dir = tmp_path / "tasks" / "manifest_task"
     task_dir.mkdir(parents=True)
@@ -76,7 +78,10 @@ def _build_task(
             },
         },
     )
-    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+    params: dict = {"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"}
+    if project_default_environment is not None:
+        params["project_default_environment"] = project_default_environment
+    return NativeAdapter(params)
 
 
 class TestEnvironmentManifestWiring:
@@ -112,3 +117,37 @@ class TestEnvironmentManifestWiring:
         # isolation + runner_service round-trip.
         assert manifest.isolation.value == "per_trial"
         assert manifest.runner_service == "runner"
+
+    def test_project_default_environment_composes_with_task_patch(self, tmp_path: Path) -> None:
+        """The orchestrator forwards ``project.default_environment`` to
+        the adapter via ``project_default_environment``; the adapter
+        binds it to each task's own patch via :func:`resolve`. A task
+        that patches only ``stack.inputs`` inherits ``compose_file`` and
+        ``runner_service`` from the project — this pins that the
+        orchestrator → adapter → resolve chain actually deep-merges."""
+        # The project patch points at the same compose file the task
+        # fixture writes; the concrete task pack lives at
+        # ``tmp_path / "tasks" / "manifest_task" /``.
+        compose_path = tmp_path / "tasks" / "manifest_task" / "environment.compose.yaml"
+        project_patch = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=compose_path,
+                runner_service="runner",
+                inputs={"postgres_version": "16", "region": "eu"},
+            ),
+        )
+        adapter = _build_task(
+            tmp_path,
+            environment_manifest={"stack": {"inputs": {"postgres_version": "17"}}},
+            project_default_environment=project_patch,
+        )
+        task_description = adapter.to_task_description("manifest_task")
+
+        manifest = task_description.environment_manifest
+        assert manifest is not None
+        # compose_file + runner_service inherited from the project patch.
+        assert manifest.compose_file == compose_path
+        assert manifest.runner_service == "runner"
+        # inputs deep-merged: task wins on the conflicting key, project
+        # value survives for the untouched one.
+        assert manifest.stack_inputs == {"postgres_version": "17", "region": "eu"}

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -18,7 +18,7 @@ from tolokaforge.core.models import (
     TimeoutDefaults,
     UserSimulatorConfig,
 )
-from tolokaforge.runner.models import EnvironmentManifest
+from tolokaforge.runner.models import EnvironmentPatch, StackPatch
 
 pytestmark = pytest.mark.unit
 
@@ -165,18 +165,16 @@ class TestProjectConfigWithEnvironment:
     def test_default_environment_binds(self) -> None:
         p = ProjectConfig(
             name="with-env",
-            default_environment=EnvironmentManifest(compose_file=ENV_FIXTURE),
+            default_environment=EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE)),
         )
         assert p.default_environment is not None
-        assert p.default_environment.compose_file == ENV_FIXTURE
+        assert p.default_environment.stack is not None
+        assert p.default_environment.stack.compose_file == ENV_FIXTURE
 
-    def test_missing_compose_file_fails(self) -> None:
-        # Regression: EnvironmentManifest still enforces its own file
-        # existence check inside the ProjectConfig graph.
-        with pytest.raises(ValidationError):
-            ProjectConfig(
-                name="broken-env",
-                default_environment=EnvironmentManifest(
-                    compose_file=Path("/nonexistent/compose.yaml"),
-                ),
-            )
+    def test_patch_constructs_with_no_io(self) -> None:
+        # The patch shape is I/O-free at construction: pointing at a
+        # non-existent compose file must not raise. Validation is
+        # deferred to :func:`resolve`, which materialises the manifest.
+        patch = EnvironmentPatch(stack=StackPatch(compose_file=Path("/nonexistent/compose.yaml")))
+        assert patch.stack is not None
+        assert patch.stack.compose_file == Path("/nonexistent/compose.yaml")

--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -161,7 +161,7 @@ class TestLoadProjectConfig:
         assert isinstance(project.task_defaults, TaskDefaults)
         assert project.run_defaults is None
 
-    def test_resolves_default_environment_compose_relative_path(self, tmp_path: Path) -> None:
+    def test_resolves_default_environment_stack_compose_relative_path(self, tmp_path: Path) -> None:
         # Copy the fixture compose file into a project-relative path so
         # relative-path resolution has something to hit.
         env_dir = tmp_path / "shared"
@@ -172,14 +172,18 @@ class TestLoadProjectConfig:
             tmp_path,
             {
                 "default_environment": {
-                    "compose_file": "shared/environment.compose.yaml",
+                    "stack": {
+                        "compose_file": "shared/environment.compose.yaml",
+                    },
                 },
             },
         )
         project = load_project_config(path)
         assert project.default_environment is not None
-        assert project.default_environment.compose_file.is_absolute()
-        assert project.default_environment.compose_file == rel_compose.resolve()
+        assert project.default_environment.stack is not None
+        assert project.default_environment.stack.compose_file is not None
+        assert project.default_environment.stack.compose_file.is_absolute()
+        assert project.default_environment.stack.compose_file == rel_compose.resolve()
 
     def test_missing_file_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):

--- a/tests/unit/test_task_loader.py
+++ b/tests/unit/test_task_loader.py
@@ -403,6 +403,47 @@ class TestLoadTaskYaml:
         with pytest.raises(RuntimeError, match="environment_manifest.*YAML mapping"):
             load_task_yaml(task_path)
 
+    def test_canonical_stack_compose_file_is_anchored(self, tmp_path: Path) -> None:
+        """A task authored with the canonical ``stack.compose_file`` shape
+        and a task-relative path gets anchored to an absolute path before
+        ``TaskConfig`` is constructed — the invariant :func:`resolve`
+        relies on for its "paths are absolute" contract."""
+        env_fixture = (
+            Path(__file__).parent.parent
+            / "canonical"
+            / "fixtures"
+            / "environment_manifest"
+            / "safe_one_service.yaml"
+        )
+        task_dir = tmp_path / "flat_task"
+        task_dir.mkdir()
+        rel_compose = task_dir / "environment.compose.yaml"
+        rel_compose.write_text(env_fixture.read_text())
+        task_path = task_dir / "task.yaml"
+        task_path.write_text(
+            yaml.safe_dump(
+                {
+                    "task_id": "x",
+                    "name": "x",
+                    "category": "x",
+                    "description": "x",
+                    "initial_state": {},
+                    "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                    "user_simulator": {"mode": "scripted", "scripted_flow": []},
+                    "grading": "g.yaml",
+                    "environment_manifest": {
+                        "stack": {"compose_file": "environment.compose.yaml"},
+                    },
+                }
+            )
+        )
+        task, _ = load_task_yaml(task_path)
+        assert task.environment_manifest is not None
+        assert task.environment_manifest.stack is not None
+        assert task.environment_manifest.stack.compose_file is not None
+        assert task.environment_manifest.stack.compose_file.is_absolute()
+        assert task.environment_manifest.stack.compose_file == rel_compose.resolve()
+
     def test_dangling_domain_ref_raises(self, tmp_path: Path) -> None:
         task_path = tmp_path / "testcases" / "c" / "task.yaml"
         task_path.parent.mkdir(parents=True)

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -173,15 +173,18 @@ def load_task_yaml(
 
 
 def _resolve_environment_manifest_paths(task_data: dict, task_root: Path, task_path: Path) -> None:
-    """Rewrite ``environment_manifest.compose_file`` to an absolute path
-    when it appears as a task-relative string. In-place edit on the
-    ``task_data`` dict before Pydantic constructs :class:`TaskConfig`.
+    """Rewrite ``environment_manifest.stack.compose_file`` (canonical)
+    or the legacy flat ``environment_manifest.compose_file`` to an
+    absolute path when the value is a task-relative string. In-place
+    edit on the ``task_data`` dict before Pydantic constructs
+    :class:`TaskConfig`, so ``EnvironmentPatch``'s legacy-shape
+    normaliser sees an anchored path.
 
     Raises :class:`RuntimeError` with the offending ``task_path`` when
-    ``environment_manifest`` or ``compose_file`` is present but shaped
-    wrong — matches the loader's fail-loud pattern for corrupt YAML
-    instead of deferring to a generic Pydantic error at ``TaskConfig``
-    construction, which loses the file / field context.
+    the field is present but shaped wrong — matches the loader's
+    fail-loud pattern for corrupt YAML instead of deferring to a
+    generic Pydantic error at ``TaskConfig`` construction, which loses
+    the file / field context.
     """
     if "environment_manifest" not in task_data:
         return
@@ -191,18 +194,32 @@ def _resolve_environment_manifest_paths(task_data: dict, task_root: Path, task_p
             f"Task file {task_path}: 'environment_manifest' must be a YAML mapping "
             f"(got {type(manifest).__name__})"
         )
-    if "compose_file" not in manifest:
-        return
-    compose_file = manifest["compose_file"]
-    if not isinstance(compose_file, str):
-        raise RuntimeError(
-            f"Task file {task_path}: 'environment_manifest.compose_file' must be a "
-            f"string (got {type(compose_file).__name__})"
-        )
-    resolved = Path(compose_file)
-    if not resolved.is_absolute():
-        resolved = (task_root / resolved).resolve()
-    manifest["compose_file"] = str(resolved)
+
+    stack = manifest.get("stack")
+    if isinstance(stack, dict) and "compose_file" in stack:
+        compose_file = stack["compose_file"]
+        if not isinstance(compose_file, str):
+            raise RuntimeError(
+                f"Task file {task_path}: "
+                f"'environment_manifest.stack.compose_file' must be a string "
+                f"(got {type(compose_file).__name__})"
+            )
+        resolved = Path(compose_file)
+        if not resolved.is_absolute():
+            resolved = (task_root / resolved).resolve()
+        stack["compose_file"] = str(resolved)
+
+    if "compose_file" in manifest:
+        compose_file = manifest["compose_file"]
+        if not isinstance(compose_file, str):
+            raise RuntimeError(
+                f"Task file {task_path}: 'environment_manifest.compose_file' must be a "
+                f"string (got {type(compose_file).__name__})"
+            )
+        resolved = Path(compose_file)
+        if not resolved.is_absolute():
+            resolved = (task_root / resolved).resolve()
+        manifest["compose_file"] = str(resolved)
 
 
 def _detect_task_root(task_path: Path) -> Path:

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -11,7 +11,8 @@ import yaml
 from tolokaforge.adapters._task_loader import _detect_task_root, load_task_yaml
 from tolokaforge.adapters.base import AdapterEnvironment, BaseAdapter
 from tolokaforge.core.logging import get_logger
-from tolokaforge.core.models import GradingConfig, TaskConfig
+from tolokaforge.core.models import EnvironmentPatch, GradingConfig, TaskConfig
+from tolokaforge.core.project_loader import resolve as resolve_environment
 
 if TYPE_CHECKING:
     from tolokaforge.runner.models import TaskDescription
@@ -93,6 +94,14 @@ class NativeAdapter(BaseAdapter):
         # don't have to be repeated in each task file. Empty when the
         # caller (typically the Orchestrator) has no project context.
         self._project_task_defaults: dict[str, Any] = params.get("project_task_defaults", {})
+        # project.default_environment patch from the enclosing project.
+        # Bound to each task's own environment patch by
+        # :func:`resolve_environment` in :meth:`to_task_description`.
+        # ``None`` when the caller has no project or the project sets no
+        # default environment.
+        self._project_default_environment: EnvironmentPatch | None = params.get(
+            "project_default_environment"
+        )
 
         # Validate: tasks_glob must be relative when task_packs is provided
         if self.task_packs and Path(self.tasks_glob).is_absolute():
@@ -719,12 +728,15 @@ class NativeAdapter(BaseAdapter):
                     "ascii"
                 )
 
-        # environment_manifest passes through as-is. The task loader
-        # (:func:`_task_loader.load_task_yaml`) resolves the manifest's
-        # ``compose_file`` to an absolute path before ``TaskConfig`` is
-        # constructed, so ``EnvironmentManifest``'s file-existence
-        # validator succeeds regardless of CWD at load time.
-        environment_manifest = task.environment_manifest
+        # Bind the project's default_environment patch to the task's own
+        # patch via :func:`resolve_environment`; the resolver merges them
+        # (with the atomic-``stack`` rule) and constructs the
+        # ``EnvironmentManifest`` — the point where the compose file's
+        # existence and safety validators run.
+        environment_manifest = resolve_environment(
+            self._project_default_environment,
+            task.environment_manifest,
+        )
 
         # Create TaskDescription
         task_description = TaskDescription(

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -20,8 +20,10 @@ from tolokaforge.core.llm.usage import CostSource, ProviderRawCall, Usage
 from tolokaforge.runner.models import Criterion as Criterion
 from tolokaforge.runner.models import CriterionResult as CriterionResult
 from tolokaforge.runner.models import EnvironmentManifest as EnvironmentManifest
+from tolokaforge.runner.models import EnvironmentPatch as EnvironmentPatch
 from tolokaforge.runner.models import LLMJudgeConfig as LLMJudgeConfig
 from tolokaforge.runner.models import Rubric as Rubric
+from tolokaforge.runner.models import StackPatch as StackPatch
 
 
 class MessageRole(str, Enum):
@@ -819,13 +821,16 @@ class TaskConfig(BaseModel):
     grading: str  # Path to grading.yaml
     system_prompt: str | None = None  # Path to system prompt file (e.g., wiki.md)
     adapter_settings: dict[str, Any] | None = None  # Opaque dict parsed by each adapter type
-    environment_manifest: EnvironmentManifest | None = None
-    """Per-trial substrate declaration (ADR-0009). When set, the adapter
-    forwards the manifest onto the ``TaskDescription`` it builds and the
-    runtime backend materialises the declared compose stack per trial
-    (``PerTrialRuntimeBackend``). Left ``None`` for tasks that run on the
-    shared stack. ``compose_file`` is resolved relative to the task's
-    directory during ``to_task_description``."""
+    environment_manifest: EnvironmentPatch | None = None
+    """Per-trial substrate declaration (ADR-0009), authored as a patch.
+
+    The task's patch composes with the project's ``default_environment``
+    at load time via :func:`tolokaforge.core.project_loader.resolve`,
+    which produces the concrete :class:`EnvironmentManifest` the adapter
+    forwards onto ``TaskDescription``. Left ``None`` for tasks that
+    inherit the project default (or run on the shared stack when the
+    project sets no default either). ``stack.compose_file`` is
+    task-relative and anchored by the loader before construction."""
 
 
 # Grading Configuration Models
@@ -987,6 +992,11 @@ class ProjectConfig(BaseModel):
     version: int = 1
     description: str | None = None
     tasks: TaskInventoryConfig = Field(default_factory=TaskInventoryConfig)
-    default_environment: EnvironmentManifest | None = None
+    default_environment: EnvironmentPatch | None = None
+    """Base environment every task inherits. Composed with each task's
+    own ``environment_manifest`` patch by
+    :func:`tolokaforge.core.project_loader.resolve` to produce the
+    concrete :class:`EnvironmentManifest`."""
+
     task_defaults: TaskDefaults = Field(default_factory=TaskDefaults)
     run_defaults: RunDefaults | None = None

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -327,6 +327,12 @@ class Orchestrator:
             defaults = self.project.task_defaults.model_dump(exclude_defaults=True)
             if defaults:
                 params["project_task_defaults"] = defaults
+            # Forward the project's default_environment patch so the adapter
+            # can bind it to each task's own environment patch via
+            # ``project_loader.resolve`` and hand the resulting
+            # ``EnvironmentManifest`` to ``TaskDescription``.
+            if self.project.default_environment is not None:
+                params["project_default_environment"] = self.project.default_environment
 
         self.logger.info("Creating adapter", type=adapter_type, params=params)
         return get_adapter(adapter_type, params)

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -308,9 +308,13 @@ def load_effective_run_config(
 
 _POLICY_REQUEST_FIELDS = ("network_policy", "security_context_defaults")
 """Fields that survive atomic ``stack`` replacement — policy requests
-that are substrate-neutral. Any other patch field is treated as
-service-treatment: scoped to the reviewed stack and discarded when the
-task replaces the stack outright."""
+that are substrate-neutral (they describe the trial regardless of
+substrate)."""
+
+_SERVICE_TREATMENT_FIELDS = ("initial_state", "isolation")
+"""Fields that are scoped to the reviewed stack — discarded on atomic
+``stack`` replacement (the project's opt-outs reviewed the project's
+services, not the replacement stack)."""
 
 
 def resolve(
@@ -409,7 +413,7 @@ def _merge_env_patches(
         return deep_merge(project, task)
 
     merged: dict[str, Any] = {"stack": dict(task_stack)}
-    for field in ("initial_state", "isolation"):
+    for field in _SERVICE_TREATMENT_FIELDS:
         if field in task:
             merged[field] = task[field]
     for field in _POLICY_REQUEST_FIELDS:

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -37,7 +37,12 @@ from typing import Any
 
 import yaml
 
-from tolokaforge.core.models import ProjectConfig, TaskDefaults
+from tolokaforge.core.models import (
+    EnvironmentManifest,
+    EnvironmentPatch,
+    ProjectConfig,
+    TaskDefaults,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +128,9 @@ def _resolve_project_paths(data: dict, project_dir: Path) -> None:
 
     Two field families are covered:
 
-    - ``default_environment.compose_file`` — the substrate pointer.
+    - ``default_environment.stack.compose_file`` (canonical) or
+      ``default_environment.compose_file`` (legacy flat form) — the
+      substrate pointer.
     - Every path field inside ``task_defaults`` that a per-task
       ``task.yaml`` may carry (``system_prompt``, ``grading``,
       ``tools.{agent,user}.mcp_server``, ``initial_state.json_db``,
@@ -134,14 +141,29 @@ def _resolve_project_paths(data: dict, project_dir: Path) -> None:
     """
     env = data.get("default_environment")
     if isinstance(env, dict):
-        compose = env.get("compose_file")
-        if isinstance(compose, str) and compose:
-            resolved = Path(compose)
-            if not resolved.is_absolute():
-                env["compose_file"] = str((project_dir / resolved).resolve())
+        _anchor_stack_compose_file(env, project_dir)
     task_defaults = data.get("task_defaults")
     if isinstance(task_defaults, dict):
         _rewrite_task_defaults_paths(task_defaults, project_dir)
+
+
+def _anchor_stack_compose_file(env_patch: dict, anchor_dir: Path) -> None:
+    """Rewrite ``env_patch.stack.compose_file`` (or the legacy flat
+    ``env_patch.compose_file``) to an absolute path under *anchor_dir*.
+    In-place; no-op when the field is absent or already absolute.
+    """
+    stack = env_patch.get("stack")
+    if isinstance(stack, dict):
+        compose = stack.get("compose_file")
+        if isinstance(compose, str) and compose:
+            resolved = Path(compose)
+            if not resolved.is_absolute():
+                stack["compose_file"] = str((anchor_dir / resolved).resolve())
+    compose = env_patch.get("compose_file")
+    if isinstance(compose, str) and compose:
+        resolved = Path(compose)
+        if not resolved.is_absolute():
+            env_patch["compose_file"] = str((anchor_dir / resolved).resolve())
 
 
 def _rewrite_task_defaults_paths(task_defaults: dict, project_dir: Path) -> None:
@@ -267,7 +289,7 @@ def load_effective_run_config(
         config_data = yaml.safe_load(f) or {}
     if not isinstance(config_data, dict):
         raise RuntimeError(
-            f"Run config {config_path} is not a YAML mapping " f"(got {type(config_data).__name__})"
+            f"Run config {config_path} is not a YAML mapping (got {type(config_data).__name__})"
         )
 
     project_root, used_legacy_dir = detect_project_layout(config_path)
@@ -279,6 +301,123 @@ def load_effective_run_config(
         project = synthesize_default_project(project_root=config_path.parent)
     merged = resolve_effective_run_config_data(project, config_data)
     return merged, project
+
+
+# ── Environment resolve ────────────────────────────────────────────────
+
+
+_POLICY_REQUEST_FIELDS = ("network_policy", "security_context_defaults")
+"""Fields that survive atomic ``stack`` replacement — policy requests
+that are substrate-neutral. Any other patch field is treated as
+service-treatment: scoped to the reviewed stack and discarded when the
+task replaces the stack outright."""
+
+
+def resolve(
+    project_env: EnvironmentPatch | None,
+    task_env: EnvironmentPatch | None,
+) -> EnvironmentManifest | None:
+    """Bind a project-side and task-side :class:`EnvironmentPatch` pair
+    to an :class:`EnvironmentManifest`.
+
+    Deep-merges the two patches (task wins on conflict), then materialises
+    the manifest — the point where the disk-touching validators
+    (compose-file existence, safety checks) run. Returns ``None`` when
+    neither side declares an environment; raises ``ValueError`` when the
+    merged patch has no ``compose_file`` (the manifest would be
+    unconstructible).
+
+    Atomic ``stack`` replacement — the trigger is the presence of the
+    ``compose_file`` key on the task's ``stack`` patch, never path
+    identity. When it fires:
+
+    - The task's ``stack`` replaces the project's ``stack`` outright —
+      clean slate of ``inputs`` and ``runner_service`` (a foreign
+      compose file's ``${var}`` slots must never silently capture
+      inherited values).
+    - Service-treatment fields (``initial_state``, root ``isolation``)
+      are discarded — the project's opt-outs reviewed the project's
+      services, not the replacement stack.
+    - Policy-request fields (``network_policy``,
+      ``security_context_defaults``) survive — substrate-neutral, they
+      describe the trial regardless of substrate.
+
+    Anchoring: ``stack.compose_file`` paths must already be absolute
+    when this runs. The project loader and the task loader anchor them
+    to the file that declared them before ``ProjectConfig`` /
+    ``TaskConfig`` are constructed; this function assumes that
+    invariant.
+    """
+    if project_env is None and task_env is None:
+        return None
+
+    project_data = _dump_patch(project_env)
+    task_data = _dump_patch(task_env)
+
+    merged = _merge_env_patches(project_data, task_data)
+
+    stack = merged.get("stack") or {}
+    compose_file = stack.get("compose_file")
+    if not compose_file:
+        raise ValueError(
+            "EnvironmentPatch resolve produced no compose_file — either the "
+            "project's default_environment or the task's environment_manifest "
+            "must declare `stack.compose_file`."
+        )
+
+    manifest_kwargs: dict[str, Any] = {
+        "compose_file": compose_file,
+        "stack_inputs": dict(stack.get("inputs") or {}),
+    }
+    runner_service = stack.get("runner_service")
+    if runner_service:
+        manifest_kwargs["runner_service"] = runner_service
+    for field in ("initial_state", "network_policy", "security_context_defaults", "isolation"):
+        value = merged.get(field)
+        if value is None:
+            continue
+        manifest_kwargs[field] = value
+
+    return EnvironmentManifest(**manifest_kwargs)
+
+
+def _dump_patch(patch: EnvironmentPatch | None) -> dict[str, Any]:
+    """Return a merge-friendly dict view of *patch*. Empty dict when
+    *patch* is ``None``; drops fields left at their patch defaults
+    (all ``None``) so that later layers cleanly overwrite unset ones.
+    """
+    if patch is None:
+        return {}
+    return patch.model_dump(exclude_none=True, mode="python")
+
+
+def _merge_env_patches(
+    project: dict[str, Any],
+    task: dict[str, Any],
+) -> dict[str, Any]:
+    """Deep-merge two patch dicts with the atomic-``stack`` rule.
+
+    Standard deep-merge (task wins) applies to every field except
+    ``stack``. The atomic rule fires only when the task declares
+    ``stack.compose_file``: the task's ``stack`` replaces the project's
+    entirely, and service-treatment fields are dropped so they don't
+    silently extend from a reviewed stack to an unreviewed one.
+    """
+    task_stack = task.get("stack")
+    stack_replacement = isinstance(task_stack, dict) and "compose_file" in task_stack
+    if not stack_replacement:
+        return deep_merge(project, task)
+
+    merged: dict[str, Any] = {"stack": dict(task_stack)}
+    for field in ("initial_state", "isolation"):
+        if field in task:
+            merged[field] = task[field]
+    for field in _POLICY_REQUEST_FIELDS:
+        if field in task:
+            merged[field] = task[field]
+        elif field in project:
+            merged[field] = project[field]
+    return merged
 
 
 # ── Legacy alias warnings ──────────────────────────────────────────────

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -376,7 +376,7 @@ def resolve(
     runner_service = stack.get("runner_service")
     if runner_service:
         manifest_kwargs["runner_service"] = runner_service
-    for field in ("initial_state", "network_policy", "security_context_defaults", "isolation"):
+    for field in (*_SERVICE_TREATMENT_FIELDS, *_POLICY_REQUEST_FIELDS):
         value = merged.get(field)
         if value is None:
             continue

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -687,8 +687,7 @@ def _check_safe_bind_mounts(services: dict[str, dict[str, Any]]) -> None:
         volumes = body["volumes"]
         if not isinstance(volumes, list):
             raise ValueError(
-                f"compose service {name!r}: `volumes:` must be a list; got "
-                f"{type(volumes).__name__}"
+                f"compose service {name!r}: `volumes:` must be a list; got {type(volumes).__name__}"
             )
         for idx, entry in enumerate(volumes):
             source = _bind_mount_source(entry)
@@ -832,25 +831,135 @@ def _check_initial_state_keys(
             )
 
 
-class EnvironmentManifest(BaseModel):
-    """Points at a Docker Compose file that declares the per-trial environment.
+class StackPatch(BaseModel):
+    """Substrate slot inside an :class:`EnvironmentPatch`.
 
-    The compose file is the source of truth for service topology (images,
-    ports, volumes, health probes, depends_on, resources). This model adds
-    the engine-specific fields the provisioner needs (which service is the
-    runner, how the initial state fixtures apply, the network posture, the
-    security-context defaults) and runs safety validators against the
-    compose contents at construction time.
+    Groups the compose-file pointer with the runner-service name and
+    the compose-input substitutions scoped to that specific file. All
+    fields optional so a task patch can touch a single sub-field
+    (``inputs``, ``runner_service``) without triggering the atomic
+    ``stack`` replacement rule described in
+    :func:`tolokaforge.core.project_loader.resolve`.
+    """
+
+    compose_file: Path | None = None
+    """Path to the docker-compose file. Anchored to the file that
+    declared it — the project directory for project patches, the task
+    directory for task patches — by the loader before this patch is
+    constructed."""
+
+    runner_service: str | None = None
+    """Name of the compose service that runs the agent. ``None`` in a
+    patch means inherit; :func:`resolve` falls back to ``"default"``
+    when the merged patch leaves this unset."""
+
+    inputs: dict[str, str] = Field(default_factory=dict)
+    """Compose-file variable substitutions scoped to ``compose_file``.
+    Passed through to the runtime backend at compose-up time; the
+    compose file's ``${var}`` slots resolve against this mapping."""
+
+    model_config = {"extra": "forbid"}
+
+
+class EnvironmentPatch(BaseModel):
+    """Per-project or per-task environment declaration — an all-optional
+    input shape that :func:`tolokaforge.core.project_loader.resolve`
+    binds to an :class:`EnvironmentManifest`.
+
+    Every field is optional so ``ProjectConfig.default_environment`` and
+    ``TaskConfig.environment_manifest`` share the same type and compose
+    on merge: a task that touches only ``stack.inputs`` inherits the
+    rest from the project. Patches perform no filesystem I/O at
+    construction time; the disk-touching validators live on the
+    :class:`EnvironmentManifest` output type.
+    """
+
+    stack: StackPatch | None = None
+    """Substrate slot — see :class:`StackPatch`. A task patch that sets
+    ``stack.compose_file`` replaces the project's whole ``stack``
+    atomically (clean slate of ``inputs`` and ``runner_service``); a
+    task patch that touches only ``stack.inputs`` /
+    ``stack.runner_service`` deep-merges."""
+
+    initial_state: dict[str, InitialStateRef] | None = None
+    """Per-service fixture-copy operations. Discarded on atomic
+    ``stack`` replacement (fixtures are scoped to the replaced
+    substrate)."""
+
+    network_policy: NetworkPolicy | None = None
+    """Network posture the provisioner is asked to enforce. Survives
+    atomic ``stack`` replacement (policy request, substrate-neutral)."""
+
+    security_context_defaults: SecurityContext | None = None
+    """Security defaults applied to services that do not override them.
+    Survives atomic ``stack`` replacement (policy request,
+    substrate-neutral)."""
+
+    isolation: TaskIsolation | None = None
+    """Isolation requirement. Discarded on atomic ``stack`` replacement
+    (the project's opt-out reviewed the project's services, not the
+    replacement stack — a task-local stack declares its own
+    ``shared_ok`` explicitly if it wants it)."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_flat_stack_fields(cls, data: Any) -> Any:
+        """Accept legacy ``compose_file`` / ``runner_service`` at the
+        patch top level; normalise into ``stack``. Emits a
+        ``DeprecationWarning`` when the legacy shape is used."""
+        if not isinstance(data, dict):
+            return data
+        legacy_keys = {k for k in ("compose_file", "runner_service") if k in data}
+        if not legacy_keys:
+            return data
+        stack = dict(data.get("stack") or {})
+        for key in sorted(legacy_keys):
+            if key in stack:
+                raise ValueError(
+                    f"EnvironmentPatch: both flat {key!r} and stack.{key} declared; "
+                    "the flat form is legacy — declare it only under stack."
+                )
+            stack[key] = data.pop(key)
+        data["stack"] = stack
+        import warnings
+
+        warnings.warn(
+            "EnvironmentPatch: flat compose_file / runner_service at the "
+            "top level is legacy; move under 'stack:'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return data
+
+
+class EnvironmentManifest(BaseModel):
+    """Resolved per-trial environment — the output of
+    :func:`tolokaforge.core.project_loader.resolve`.
+
+    Produced by binding a project-side and task-side
+    :class:`EnvironmentPatch` pair; consumers (runtime backends,
+    orchestrator, docker stack materialiser) read it directly. The
+    compose file is the source of truth for service topology (images,
+    ports, volumes, health probes, depends_on, resources); this model
+    adds the engine-specific fields the provisioner needs and runs
+    safety validators against the compose contents at construction
+    time.
     """
 
     compose_file: Path
-    """Path to the docker-compose file. Absolute if resolved by a task
-    loader; relative paths are resolved against the current working
-    directory at construction time."""
+    """Path to the docker-compose file. Always absolute — the resolver
+    anchors it to the file that declared it before constructing the
+    manifest."""
 
     runner_service: str = "default"
     """Which compose service is the agent runner. Must be declared in
     the compose file's ``services:`` mapping."""
+
+    stack_inputs: dict[str, str] = Field(default_factory=dict)
+    """Compose-file variable substitutions carried through from
+    :class:`StackPatch.inputs`. Runtime backends pass these to
+    ``docker compose`` as environment values so ``${var}`` slots in
+    the compose file resolve at up-time."""
 
     initial_state: dict[str, InitialStateRef] = Field(default_factory=dict)
     """Fixture-copy operations, keyed by service name."""

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -14,6 +14,7 @@ All models use Pydantic v2 BaseModel for validation and serialization.
 from __future__ import annotations
 
 import re
+import warnings
 from datetime import datetime
 from enum import Enum
 from pathlib import Path, PurePosixPath
@@ -921,8 +922,6 @@ class EnvironmentPatch(BaseModel):
                 )
             stack[key] = data.pop(key)
         data["stack"] = stack
-        import warnings
-
         warnings.warn(
             "EnvironmentPatch: flat compose_file / runner_service at the "
             "top level is legacy; move under 'stack:'.",


### PR DESCRIPTION
Splits the environment shape into a patch (input) and a manifest (post-merge output). The patch is all-optional and performs no I/O at construction; the manifest keeps the disk-touching validators and is now produced by a single resolver at load time.

Closes #223 (child of #220).

## Summary

- **`EnvironmentPatch` + `StackPatch`** (`tolokaforge/runner/models.py`): all-optional input shape. Legacy flat `compose_file` / `runner_service` at the patch top level are still accepted with a `DeprecationWarning` and normalised under `stack` by a `model_validator(mode="before")` — retirement in a later milestone.
- **`EnvironmentManifest`** repurposed as the resolver output. Keeps the flat `compose_file` / `runner_service` the runtime backends already consume, plus a new `stack_inputs: dict[str, str]` field for compose-file variable substitutions.
- **`resolve()`** (`tolokaforge/core/project_loader.py`): deep-merges a project-side and task-side patch (task wins) and constructs the manifest, running the compose-file safety validators once at that point.
- **Atomic `stack` replacement**: when the task patch declares `stack.compose_file` (key presence, not path identity), the task's `stack` replaces the project's outright (clean slate of `inputs` / `runner_service`). Service-treatment fields (`initial_state`, root `isolation`) are dropped; policy-request fields (`network_policy`, `security_context_defaults`) survive — a foreign compose file's `${var}` slots must never silently capture inherited values.
- **Load-path wiring**: `ProjectConfig.default_environment` and `TaskConfig.environment_manifest` are now `EnvironmentPatch | None`. Path anchoring in `_resolve_project_paths` and `_resolve_environment_manifest_paths` walks both `stack.compose_file` and the legacy flat form. `Orchestrator._create_adapter` forwards `project.default_environment`; `NativeAdapter.to_task_description` calls `resolve()` before constructing `TaskDescription`.

## Test plan

- [x] `uv run pytest tests/unit/ tests/canonical/` — 2601 passed, 1 skipped.
- [x] New `tests/unit/test_environment_resolve.py` — 16 tests covering patch construction with no I/O, legacy flat coercion, deep-merge, atomic `stack` replacement, policy-request survival, and the no-compose-file failure mode.
- [x] Updated multi-service example-task tests and the `ProjectConfig` / project-loader tests to the new patch shape.
- [x] Canonical wire-shape test now includes `stack_inputs`.
- [x] `ruff check` and `ruff format --check` clean on the touched files.

## Not in scope

- Per-service isolation semantics on the manifest (`services.<name>.isolation`) — reserved for the isolation redesign milestone (#212).
- `${VAR}` interpolation on run-config strings and the `--workers` CLI flag — #226.
- Dual-home knob resolution (compute/storage aliases) — #225.
- Schema-shape reservations (`actors` name-squat, seed-registry, backend capabilities) — #224.
- `tolokaforge assets stamp` verb — #227.