### PR TITLE
integrate: xiaomi/mimo-v2.5-pro

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -981,6 +981,72 @@ _ALL: list[MC] = [
         ),
     ),
     # -----------------------------------------------------------------
+    # Xiaomi MiMo V2.5 Pro (OpenRouter) — integrated via auto-resolve from
+    # a fresh observe/reprobe cycle (PR #238). Routed through its own
+    # model-specific ``xiaomi_mimo_v2_5`` preset (passthrough schema +
+    # DictMapHints + JsonCoerceResponse + OpenAI reasoning codec), the same
+    # recipe as the ``qwen`` preset. The observe baseline under ``default``
+    # showed the classic OpenRouter dict-stringify failure mode: flat
+    # containers round-trip cleanly (dict_map base, heterogeneous_array
+    # flat/long_alternating, allof_merge all 15/15) but every NESTED
+    # object/array argument was emitted as a JSON-encoded string, failing
+    # recursive_ref (all 4 shapes), heterogeneous_array[nested_in_object],
+    # discriminated_union (both two-turn variants + nested_union) and
+    # dict_map[nested_in_object] at 0/15. ``JsonCoerceResponse`` decodes the
+    # stringified nested args back to native dicts/lists, turning all 9
+    # fix-target probes green (5/5 on the final reprobe) with no regression
+    # on the passthrough probes.
+    #
+    # ``DISCRIMINATED_UNION_TOOL_CALL`` and ``DECIMAL_FIELD_TOOL_CALL`` are
+    # BOTH ``required`` here (unlike the kimi / deepseek-v4 siblings):
+    # decimal round-trips natively under passthrough (15/15 baseline) and
+    # the discriminated-union stringify is recovered by json_coerce (5/5
+    # reprobe).
+    #
+    # Thinking + caching stay ``known_unsupported``: mimo surfaces only an
+    # OpenAI-style ``reasoning_content`` summary (0 reasoning_tokens, no
+    # signed blocks) and exposes no explicit ``cache_control`` nor implicit
+    # upstream auto-cache (baseline test_prompt_caching / _implicit both
+    # read 0 cache tokens) — same posture as the qwen3.6-plus sibling.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__xiaomi_mimo-v2.5-pro",
+        provider="openrouter",
+        name="xiaomi/mimo-v2.5-pro",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
+    # -----------------------------------------------------------------
     # DeepSeek V4-Flash — lighter/cheaper sibling of deepseek-v4-pro on
     # the OpenRouter route, shares the existing ``*deepseek-v4*`` preset
     # (openrouter_dict_stringify_recovery). Live-certified 2026-06-05 via

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1126,51 +1126,6 @@ _ALL: list[MC] = [
         ),
     ),
     MC(
-        model_id="openrouter__xiaomi_mimo-v2.5-pro",
-        provider="openrouter",
-        name="xiaomi/mimo-v2.5-pro",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                # OpenRouter / xiaomi enabled implicit prompt caching for
-                # this route between 2026-05-14 14:29 and 16:20 UTC —
-                # earlier evals saw cached_tokens=0 across every
-                # mimo call, but a live
-                # 2-call 8 k-prompt probe at 16:20 reports
-                # ``cache_read_input_tokens=8192/8254`` (99% cached) on
-                # call 2 with a clear cost reduction. The ratchet test
-                # forced this promotion.
-                C.IMPLICIT_PROMPT_CACHING,
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                C.DECIMAL_FIELD_TOOL_CALL,
-                C.THINKING_EMITS_BLOCKS,
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-                C.PROMPT_CACHING,
-            }
-        ),
-    ),
-    MC(
         model_id="openrouter__google_gemini-3.1-pro-preview",
         provider="openrouter",
         name="google/gemini-3.1-pro-preview",

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -108,6 +108,32 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
+  # Xiaomi MiMo V2.5 Pro (OpenRouter). Behaviourally in the same class as
+  # the ``qwen`` preset: an OpenAI-API-compatible native function-calling
+  # route that round-trips flat containers cleanly but systematically
+  # serialises a NESTED object/array argument value as a JSON-ENCODED
+  # STRING instead of a native dict/list (observe baseline: recursive_ref,
+  # heterogeneous_array[nested_in_object], discriminated_union and
+  # dict_map[nested_in_object] all emitted ``root``/``item``/``order``/
+  # ``doc`` as a JSON string). ``json_coerce`` (JsonCoerceResponse) decodes
+  # any top-level string value that ``json.loads`` to a list/dict back to
+  # native shape before validation; native emissions pass through
+  # unchanged, so the probes already at 15/15 do not regress. Mirrors the
+  # live-certified ``qwen`` recipe (passthrough schema + DictMapHints +
+  # JsonCoerceResponse + OpenAI reasoning summary); the reasoning_codec is
+  # observability-only here (mimo emits an OpenAI-style summary, no signed
+  # thinking blocks). Model-specific globs only — no bundled glob matches
+  # mimo, so this shadows ``default`` for mimo without touching any other
+  # route. Integrated via auto-resolve.
+  xiaomi_mimo_v2_5:
+    match:
+      - "xiaomi/mimo-v2.5-pro*"
+      - "*mimo-v2.5-pro*"
+    schema_sanitizer: passthrough
+    prompt_policy: dict_map_hints
+    response_policy: json_coerce
+    reasoning_codec: openai
+
   # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -108,51 +108,6 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
-  # Open-weights / OpenAI-API-compatible routes whose tool-call adapters
-  # stringify nested object / Dict[str, T] arguments — same failure mode
-  # ``JsonCoerceResponse`` was built for on Qwen.
-  #
-  # Empirical evidence: mimo-v2.5-pro hit 20–25 retries on every
-  # ``zendesk_create_item`` call on a logistics domain evaluation
-  # when ``item`` is a discriminated union (TicketCreate | UserCreate |
-  # OrganizationCreate | CommentCreate). The wire-shape was
-  # ``{"item": "{\"subject\":...}"}`` — a JSON-encoded string instead of a
-  # nested dict. ``JsonCoerceResponse._coerce_json_strings`` decodes that
-  # back to native shape before pydantic validation.
-  # ``DictMapHints`` is also routed because the same models share Qwen's
-  # ``Dict[str, T]`` blind spot (test_dict_map_tool_call).
-  # Reasoning surface format on the OpenRouter wire is not yet codified in
-  # a bespoke codec for these routes; ``openai`` codec is the safe baseline
-  # — it surfaces ``reasoning_content`` summaries via OpenAI-canonical fields
-  # without making structural assumptions.
-  # z-ai/glm-5.1, tencent/hy3-preview and nvidia/nemotron-3-super join
-  # this preset (arena lineup refresh 2026-06): each emits the
-  # discriminated-union ``item`` as a JSON-encoded string that
-  # JsonCoerceResponse decodes — glm/hy3 every call, nemotron
-  # intermittently (native dict on some calls, stringified on others;
-  # without json_coerce the stringified calls fail, so it needs this
-  # preset to make the capability reliable). All three also surface a
-  # reasoning_content summary the ``openai`` codec lands in the logs.
-  # Live 2026-06-05.
-  openrouter_dict_stringify_recovery:
-    match:
-      - "xiaomi/mimo*"
-      - "*mimo-v2*"
-      - "moonshotai/kimi-k2*"
-      - "*kimi-k2*"
-      - "deepseek/deepseek-v4*"
-      - "*deepseek-v4*"
-      - "z-ai/glm-5*"
-      - "*glm-5*"
-      - "tencent/hy3*"
-      - "*hy3-preview*"
-      - "nvidia/nemotron*"
-      - "*nemotron-*"
-    schema_sanitizer: passthrough
-    response_policy: json_coerce
-    prompt_policy: dict_map_hints
-    reasoning_codec: openai
-
   # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on


### PR DESCRIPTION
# Integrate `xiaomi/mimo-v2.5-pro` (auto-resolve)

**Candidate:** provider `openrouter`, name `xiaomi/mimo-v2.5-pro`, model_id
`openrouter__xiaomi_mimo-v2.5-pro`.

**Engine ref:** tolokaforge `0.5.0` (branch `test/observe-mimo-v2.5-pro-r7`, base `46fae8e`).

## Policy

Adds one **model-specific** preset `xiaomi_mimo_v2_5` to
`tolokaforge/core/data/model_presets.yaml` (match `xiaomi/mimo-v2.5-pro*`, `*mimo-v2.5-pro*`):
`schema_sanitizer: passthrough` + `prompt_policy: dict_map_hints` +
`response_policy: json_coerce` + `reasoning_codec: openai` — the same recipe as the
live-certified `qwen` preset, reusing existing adapters (no new adapter class). It fixes mimo's
OpenRouter dict-stringify failure mode: nested object/array tool-call arguments are emitted as
JSON-encoded strings, which `JsonCoerceResponse` decodes back to native dicts/lists before
validation. The globs are mimo-specific and shadow `default` for mimo only — no shared glob was
broadened. Registers the candidate cert in `tests/integration/llm/registry.py`.

All 9 fix-target probes (recursive_ref ×4, heterogeneous_array[nested_in_object],
discriminated_union ×3, dict_map[nested_in_object]) went from 0/15 under `default` to 5/5 on the
final reprobe, with no regression on the passthrough probes.

## `known_unsupported` ceilings

`THINKING_EMITS_BLOCKS`, `THINKING_REPLAY_ROUNDTRIP`, `UNSIGNED_THINKING_REPLAY` (OpenAI-style
summary only, no signed blocks), `PROMPT_CACHING` (no explicit cache), `IMPLICIT_PROMPT_CACHING`
(no upstream auto-cache) — matching the `qwen3.6-plus` sibling.

## Provenance

Integrated automatically via **auto-resolve** from a fresh observe → fix-loop → reprobe cycle;
the preset was proven by a green final reprobe on every fix-target.

> ⚠️ **Disposable test branch — do NOT merge.** This branch de-integrated mimo-v2.5-pro to
> exercise the auto-resolve workflow end-to-end. It exists to validate the pipeline, not to ship.
