### PR TITLE
feat(schema): actor/seed/capability reservations + task-schema relaxation

### DIFF
--- a/tests/canonical/snapshots/native_browser_basic/task_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/task_config.json
@@ -1,4 +1,5 @@
 {
+  "actors": null,
   "adapter_settings": null,
   "adapter_type": "native",
   "category": "test",

--- a/tests/canonical/snapshots/native_calc_basic/task_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/task_config.json
@@ -1,4 +1,5 @@
 {
+  "actors": null,
   "adapter_settings": null,
   "adapter_type": "native",
   "category": "test",

--- a/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
@@ -1,4 +1,5 @@
 {
+  "actors": null,
   "adapter_settings": null,
   "adapter_type": "native",
   "category": "tool_use",

--- a/tests/canonical/snapshots/native_shop_orders_02/task_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/task_config.json
@@ -1,4 +1,5 @@
 {
+  "actors": null,
   "adapter_settings": null,
   "adapter_type": "native",
   "category": "tool_use",

--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -1,4 +1,5 @@
 {
+  "actors": null,
   "adapter_settings": {
     "compose_file": "<ROOT>/tests/data/terminal_bench_tasks/echo-hello/docker-compose.yaml",
     "difficulty": "easy",

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -442,6 +442,28 @@ class TestActorRosterSubsetOfModels:
         merged, _ = load_effective_run_config(run_cfg)
         assert merged == {}
 
+    def test_llm_actor_fails_when_models_is_empty(self, tmp_path: Path) -> None:
+        # Boundary case: `models: {}` is a valid mapping but has no
+        # entries. An llm actor still fails loud — pinning it explicitly
+        # so the "missing" branch isn't confused with a shape-error
+        # branch by a future refactor.
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "task_defaults": {
+                    "actors": {"user": {"mode": "llm", "persona": "curious"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {"models": {}})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError, match="not declared under `models`"):
+            load_effective_run_config(run_cfg)
+
     def test_malformed_models_block_is_a_load_error(self, tmp_path: Path) -> None:
         # A typo where `models:` is a list (or any non-mapping) would
         # confuse the roster check downstream — surface the shape error

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -369,6 +369,121 @@ class TestSchemaAliasCollision:
         )
 
 
+class TestActorRosterSubsetOfModels:
+    """The roster check runs after ``project.run_defaults`` merges into
+    the selected run config — the only point where both ``actors`` and
+    ``models`` are visible together."""
+
+    def test_llm_actor_present_in_models_passes(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "task_defaults": {
+                    "actors": {"user": {"mode": "llm", "persona": "curious"}},
+                },
+                "run_defaults": {
+                    "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {"models": {"user": {"provider": "openai", "name": "gpt-4o"}}})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert "user" in merged["models"]
+
+    def test_llm_actor_missing_from_models_fails_loud(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "task_defaults": {
+                    "actors": {"user": {"mode": "llm", "persona": "curious"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {"models": {"judge": {"provider": "openai", "name": "gpt-4o"}}})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError, match="not declared under `models`"):
+            load_effective_run_config(run_cfg)
+
+    def test_scripted_actor_does_not_require_model(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "task_defaults": {
+                    "actors": {"user": {"mode": "scripted"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        # Scripted actors don't need a matching model entry — must not raise.
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged.get("models", {}) == {}
+
+    def test_no_actors_declared_is_no_op(self, tmp_path: Path) -> None:
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged == {}
+
+
+class TestProjectAssetsPathAnchoring:
+    """``assets.seeds.<name>.path`` and bare-string shorthand entries
+    resolve to absolute paths under the project directory."""
+
+    def test_dict_form_relative_path_anchored(self, tmp_path: Path) -> None:
+        # A seed file that must exist so downstream consumers can find it.
+        seed = tmp_path / "shared" / "seeds" / "base.sql"
+        seed.parent.mkdir(parents=True)
+        seed.write_text("-- fixture\n")
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "assets": {
+                    "seeds": {
+                        "base": {
+                            "path": "shared/seeds/base.sql",
+                            "kind": "sql_dump",
+                        },
+                    },
+                },
+            },
+        )
+        project = load_project_config(tmp_path / "project.yaml")
+        assert project.assets is not None
+        assert project.assets.seeds["base"].path == seed.resolve()
+
+    def test_bare_string_shorthand_relative_anchored(self, tmp_path: Path) -> None:
+        seed = tmp_path / "shared" / "seeds" / "base.sql"
+        seed.parent.mkdir(parents=True)
+        seed.write_text("-- fixture\n")
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {"name": "p", "assets": {"seeds": {"base": "shared/seeds/base.sql"}}},
+        )
+        project = load_project_config(tmp_path / "project.yaml")
+        assert project.assets is not None
+        assert project.assets.seeds["base"].path == seed.resolve()
+        assert project.assets.seeds["base"].kind == "sql_dump"
+
+
 class TestDeepMergeIsSingleImpl:
     """`deep_merge` in the project loader is the single implementation
     the task loader imports — no shadow copy in `_task_loader.py`."""

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -442,6 +442,27 @@ class TestActorRosterSubsetOfModels:
         merged, _ = load_effective_run_config(run_cfg)
         assert merged == {}
 
+    def test_malformed_models_block_is_a_load_error(self, tmp_path: Path) -> None:
+        # A typo where `models:` is a list (or any non-mapping) would
+        # confuse the roster check downstream — surface the shape error
+        # at the check site with the offending type in the message.
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "task_defaults": {
+                    "actors": {"user": {"mode": "llm", "persona": "curious"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(run_cfg, {"models": ["not", "a", "mapping"]})
+
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError, match="`models`.*must be a mapping"):
+            load_effective_run_config(run_cfg)
+
 
 class TestProjectAssetsPathAnchoring:
     """``assets.seeds.<name>.path`` and bare-string shorthand entries

--- a/tests/unit/test_schema_reservations.py
+++ b/tests/unit/test_schema_reservations.py
@@ -81,6 +81,24 @@ class TestActorsMapReservation:
                 actors={"agent": ActorSpec(mode="llm")},
             )
 
+    def test_task_config_accepts_user_actor(self) -> None:
+        # Positive counterpart to the reserved-name rejection — a task
+        # override with a non-reserved actor name parses cleanly. The
+        # runtime binding of ``actors.user`` back to today's simulator
+        # lives in the actor-rename milestone; here we only pin that
+        # the shape parses at the task layer, matching TaskDefaults.
+        t = TaskConfig(
+            task_id="x",
+            description="y",
+            initial_state=InitialStateConfig(),
+            tools=ToolsConfig(),
+            user_simulator=UserSimulatorConfig(),
+            grading="grading.yaml",
+            actors={"user": ActorSpec(mode="llm", persona="task-local")},
+        )
+        assert t.actors is not None
+        assert t.actors["user"].persona == "task-local"
+
 
 # ── ComputeConfig.capabilities ──────────────────────────────────
 
@@ -151,6 +169,23 @@ class TestSeedRef:
     def test_extra_keys_rejected(self) -> None:
         with pytest.raises(ValidationError):
             SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump", "unknown": 1})
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["sql_dump", "filesystem_dir", "redis_dump", "bare"],
+    )
+    def test_all_seed_kinds_accepted_in_dict_form(self, kind: str) -> None:
+        # Pin the full vocabulary — a future refactor that narrows the
+        # Literal type without updating the reset-recipe milestone
+        # would silently strip authoring options for existing packs.
+        s = SeedRef.model_validate({"path": f"/abs/x.{kind[:3]}", "kind": kind})
+        assert s.kind == kind
+
+    def test_bare_string_extension_lookup_is_case_insensitive(self) -> None:
+        # Extension inference uses .suffix.lower(); pin the case-fold so
+        # a Windows-authored fixture path like `Foo.SQL` still parses.
+        s = SeedRef.model_validate("/abs/Foo.SQL")
+        assert s.kind == "sql_dump"
 
 
 class TestAssetsConfig:

--- a/tests/unit/test_schema_reservations.py
+++ b/tests/unit/test_schema_reservations.py
@@ -1,0 +1,231 @@
+"""Unit tests for M2.5 #224 schema-shape reservations.
+
+Name-squats: the ``actors`` map, ``ComputeConfig.capabilities``
+entries, and ``assets.seeds`` typed registry. Also covers the
+task-schema relaxation (``TaskConfig`` minimal shape) and the
+``SecurityContext`` type widening.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models import (
+    ActorSpec,
+    AssetsConfig,
+    ComputeConfig,
+    InitialStateConfig,
+    ProjectConfig,
+    SeedRef,
+    TaskConfig,
+    TaskDefaults,
+    ToolsConfig,
+    UserSimulatorConfig,
+)
+from tolokaforge.runner.models import SecurityContext
+
+pytestmark = pytest.mark.unit
+
+
+# ── ActorSpec / actors map ──────────────────────────────────────
+
+
+class TestActorSpec:
+    def test_all_fields_optional(self) -> None:
+        spec = ActorSpec()
+        assert spec.mode is None
+        assert spec.persona is None
+        assert spec.backstory is None
+        assert spec.scripted_flow is None
+
+    def test_forbids_unknown_sub_keys(self) -> None:
+        # `tools` and `service` are reserved by the design; using them
+        # today is a load error so a pack cannot repurpose the name.
+        with pytest.raises(ValidationError):
+            ActorSpec(tools=["bash"])  # type: ignore[call-arg]
+        with pytest.raises(ValidationError):
+            ActorSpec(service="runner")  # type: ignore[call-arg]
+
+    def test_accepts_documented_fields(self) -> None:
+        spec = ActorSpec(mode="llm", persona="curious engineer", backstory="…")
+        assert spec.mode == "llm"
+        assert spec.persona == "curious engineer"
+
+
+class TestActorsMapReservation:
+    def test_task_defaults_accepts_user_actor(self) -> None:
+        td = TaskDefaults(actors={"user": ActorSpec(mode="llm", persona="p")})
+        assert td.actors is not None
+        assert td.actors["user"].persona == "p"
+
+    def test_task_defaults_rejects_agent_name(self) -> None:
+        with pytest.raises(ValidationError, match="reserved"):
+            TaskDefaults(actors={"agent": ActorSpec(mode="llm")})
+
+    def test_task_defaults_rejects_judge_name(self) -> None:
+        with pytest.raises(ValidationError, match="reserved"):
+            TaskDefaults(actors={"judge": ActorSpec(mode="llm")})
+
+    def test_task_config_rejects_reserved_actor_name(self) -> None:
+        with pytest.raises(ValidationError, match="reserved"):
+            TaskConfig(
+                task_id="x",
+                description="y",
+                initial_state=InitialStateConfig(),
+                tools=ToolsConfig(),
+                user_simulator=UserSimulatorConfig(),
+                grading="grading.yaml",
+                actors={"agent": ActorSpec(mode="llm")},
+            )
+
+
+# ── ComputeConfig.capabilities ──────────────────────────────────
+
+
+class TestComputeCapabilities:
+    def test_default_is_empty_list(self) -> None:
+        cc = ComputeConfig()
+        assert cc.capabilities == []
+
+    def test_bare_string_entries_accepted(self) -> None:
+        cc = ComputeConfig(capabilities=["net.isolation", "compose.exec"])
+        assert cc.capabilities == ["net.isolation", "compose.exec"]
+
+    def test_dict_entries_with_params_accepted(self) -> None:
+        cc = ComputeConfig(
+            capabilities=[{"k8s.cilium": {"policy_engine": "hubble"}}],
+        )
+        assert cc.capabilities == [{"k8s.cilium": {"policy_engine": "hubble"}}]
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty capability name"):
+            ComputeConfig(capabilities=[""])
+
+    def test_multi_key_dict_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="exactly one key"):
+            ComputeConfig(capabilities=[{"a": {}, "b": {}}])
+
+    def test_non_dict_params_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be a mapping"):
+            ComputeConfig(capabilities=[{"name": "not-a-dict"}])  # type: ignore[list-item]
+
+    def test_non_string_non_dict_entry_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be a string or a"):
+            ComputeConfig(capabilities=[42])  # type: ignore[list-item]
+
+
+# ── SeedRef + AssetsConfig ──────────────────────────────────────
+
+
+class TestSeedRef:
+    def test_full_dict_form(self) -> None:
+        s = SeedRef.model_validate(
+            {"path": "/abs/foo.sql", "kind": "sql_dump", "digest": "sha256:aaaa"},
+        )
+        assert s.path == Path("/abs/foo.sql")
+        assert s.kind == "sql_dump"
+        assert s.digest == "sha256:aaaa"
+
+    def test_bare_string_infers_kind_from_sql_extension(self) -> None:
+        s = SeedRef.model_validate("/abs/foo.sql")
+        assert s.path == Path("/abs/foo.sql")
+        assert s.kind == "sql_dump"
+
+    def test_bare_string_infers_kind_from_rdb_extension(self) -> None:
+        s = SeedRef.model_validate("/abs/dump.rdb")
+        assert s.kind == "redis_dump"
+
+    def test_bare_string_unknown_extension_rejected(self) -> None:
+        # A ``.zip`` seed could be a filesystem_dir or a bare — ambiguous;
+        # force the author to declare the full form.
+        with pytest.raises(ValidationError, match="cannot infer kind"):
+            SeedRef.model_validate("/abs/thing.zip")
+
+    def test_digest_optional(self) -> None:
+        s = SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump"})
+        assert s.digest is None
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump", "unknown": 1})
+
+
+class TestAssetsConfig:
+    def test_empty_default(self) -> None:
+        ac = AssetsConfig()
+        assert ac.seeds == {}
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssetsConfig(seeds={}, unknown_field=1)  # type: ignore[call-arg]
+
+
+class TestProjectConfigAssets:
+    def test_assets_defaults_to_none(self) -> None:
+        p = ProjectConfig(name="p")
+        assert p.assets is None
+
+    def test_assets_seeds_populate(self) -> None:
+        p = ProjectConfig(
+            name="p",
+            assets=AssetsConfig(
+                seeds={"baseline": SeedRef(path=Path("/abs/x.sql"), kind="sql_dump")}
+            ),
+        )
+        assert p.assets is not None
+        assert set(p.assets.seeds) == {"baseline"}
+
+
+# ── TaskConfig relaxation ───────────────────────────────────────
+
+
+class TestTaskConfigMinimal:
+    def test_task_id_plus_description_is_enough(self) -> None:
+        t = TaskConfig(
+            task_id="x",
+            description="y",
+            initial_state=InitialStateConfig(),
+            tools=ToolsConfig(),
+            user_simulator=UserSimulatorConfig(),
+            grading="grading.yaml",
+        )
+        assert t.task_id == "x"
+        assert t.name is None
+        assert t.category is None
+
+    def test_name_still_set_when_provided(self) -> None:
+        t = TaskConfig(
+            task_id="x",
+            name="Nice Name",
+            category="cat",
+            description="y",
+            initial_state=InitialStateConfig(),
+            tools=ToolsConfig(),
+            user_simulator=UserSimulatorConfig(),
+            grading="grading.yaml",
+        )
+        assert t.name == "Nice Name"
+        assert t.category == "cat"
+
+
+# ── SecurityContext type widening ───────────────────────────────
+
+
+class TestSecurityContextTypeWidening:
+    def test_numeric_uid_accepted(self) -> None:
+        sc = SecurityContext(run_as_user=1000, run_as_group=1000)
+        assert sc.run_as_user == 1000
+        assert sc.run_as_group == 1000
+
+    def test_username_string_accepted(self) -> None:
+        sc = SecurityContext(run_as_user="toloka", run_as_group="toloka")
+        assert sc.run_as_user == "toloka"
+        assert sc.run_as_group == "toloka"
+
+    def test_defaults_still_none(self) -> None:
+        sc = SecurityContext()
+        assert sc.run_as_user is None
+        assert sc.run_as_group is None

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -4,6 +4,7 @@ import dataclasses
 import warnings
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, Any, Literal, Self, get_args
 
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
@@ -622,6 +623,51 @@ class ComputeConfig(BaseModel):
     max_attempt_retries: int = Field(default=0, ge=0)
     local_docker: LocalDockerComputeConfig | None = None
 
+    capabilities: list[Any] = Field(default_factory=list)
+    """Backend-capability declarations. Each entry is either a bare
+    ``"name"`` string or a ``{"name": {params}}`` mapping with a single
+    key. Field is typed ``list[Any]`` so :meth:`_validate_capability_entries`
+    can emit context-rich errors (Pydantic's built-in union resolution
+    reports the failure against every union arm, which reads badly for
+    authors). Registry lookup and admission gate land with the isolation
+    redesign; this field reserves the shape so packs can start
+    declaring capabilities against the eventual registry vocabulary."""
+
+    @field_validator("capabilities")
+    @classmethod
+    def _validate_capability_entries(cls, value: list[Any]) -> list[Any]:
+        for idx, entry in enumerate(value):
+            if isinstance(entry, str):
+                if not entry:
+                    raise ValueError(
+                        f"ComputeConfig.capabilities[{idx}]: bare-string entry "
+                        "must be a non-empty capability name."
+                    )
+                continue
+            if isinstance(entry, dict):
+                if len(entry) != 1:
+                    raise ValueError(
+                        f"ComputeConfig.capabilities[{idx}]: dict entry must have "
+                        f"exactly one key (the capability name); got {sorted(entry)!r}."
+                    )
+                ((name, params),) = entry.items()
+                if not isinstance(name, str) or not name:
+                    raise ValueError(
+                        f"ComputeConfig.capabilities[{idx}]: capability name must "
+                        f"be a non-empty string; got {name!r}."
+                    )
+                if not isinstance(params, dict):
+                    raise ValueError(
+                        f"ComputeConfig.capabilities[{idx}]: params for capability "
+                        f"{name!r} must be a mapping; got {type(params).__name__}."
+                    )
+                continue
+            raise ValueError(
+                f"ComputeConfig.capabilities[{idx}]: entry must be a string or a "
+                f"single-key dict; got {type(entry).__name__}."
+            )
+        return value
+
 
 class LocalStorageConfig(BaseModel):
     """Local-filesystem storage backend for artifacts or logs.
@@ -793,6 +839,46 @@ class UserSimulatorConfig(BaseModel):
     scripted_flow: list[dict[str, str]] | None = None
 
 
+_RESERVED_ACTOR_NAMES = frozenset({"agent", "judge"})
+"""Actor names reserved for future actors. ``actors.user`` is the
+counterpart actor today; ``actors.agent`` / ``actors.judge`` are
+reserved so a pack cannot use the names for something else in the
+meantime."""
+
+
+class ActorSpec(BaseModel):
+    """Single entry inside the ``actors`` map.
+
+    Fields mirror the shape :class:`UserSimulatorConfig` carries today —
+    binding ``actors.user`` to the simulator's config lands with the
+    canonical rename. Sub-keys ``tools`` and ``service`` are reserved
+    by the design for future actor types; using them today is a load
+    error (``extra="forbid"``).
+    """
+
+    mode: Literal["scripted", "llm"] | None = None
+    persona: str | None = None
+    backstory: str | None = None
+    scripted_flow: list[dict[str, str]] | None = None
+
+    model_config = {"extra": "forbid"}
+
+
+def _validate_actors_map(
+    value: dict[str, ActorSpec] | None,
+) -> dict[str, ActorSpec] | None:
+    """Reject reserved actor names on any ``actors`` map."""
+    if value is None:
+        return value
+    reserved = _RESERVED_ACTOR_NAMES & set(value)
+    if reserved:
+        raise ValueError(
+            f"actors: name(s) {sorted(reserved)!r} are reserved for future "
+            "actors and cannot be declared today."
+        )
+    return value
+
+
 class TaskMetadata(BaseModel):
     """Optional metadata used for analytics slicing."""
 
@@ -805,8 +891,13 @@ class TaskConfig(BaseModel):
     """Task specification"""
 
     task_id: str
-    name: str
-    category: str
+    name: str | None = None
+    """Display name. Optional — falls back to ``task_id`` in the adapter."""
+
+    category: str | None = None
+    """Legacy grouping label. Optional — project-level association
+    replaces the informational role this served for reporting."""
+
     description: str
     adapter_type: str = "native"  # Adapter runtime type (native, tlk_mcp_core, tau, …)
     max_turns: int | None = None  # Optional per-task turn cap override
@@ -814,6 +905,11 @@ class TaskConfig(BaseModel):
     initial_state: InitialStateConfig
     tools: ToolsConfig
     user_simulator: UserSimulatorConfig
+    actors: dict[str, ActorSpec] | None = None
+    """Task-level actor overrides. Reserved at the parse layer; runtime
+    binding lands with the canonical rename. Reserved actor names
+    (``agent``, ``judge``) rejected at load time — same rule as
+    :class:`TaskDefaults`."""
     metadata: TaskMetadata = Field(default_factory=TaskMetadata)
     policies: dict[str, Any] = Field(
         default_factory=dict
@@ -831,6 +927,13 @@ class TaskConfig(BaseModel):
     inherit the project default (or run on the shared stack when the
     project sets no default either). ``stack.compose_file`` is
     task-relative and anchored by the loader before construction."""
+
+    @field_validator("actors")
+    @classmethod
+    def _reject_reserved_actor_names(
+        cls, value: dict[str, ActorSpec] | None
+    ) -> dict[str, ActorSpec] | None:
+        return _validate_actors_map(value)
 
 
 # Grading Configuration Models
@@ -942,6 +1045,12 @@ class TaskDefaults(BaseModel):
     max_turns: int | None = Field(default=None, ge=1)
     system_prompt: str | None = None
     user_simulator: UserSimulatorConfig | None = None
+    actors: dict[str, ActorSpec] | None = None
+    """Named actor map. ``actors.user`` is the counterpart actor today
+    (co-existing with ``user_simulator`` until the canonical rename);
+    ``actors.agent`` and ``actors.judge`` are reserved and rejected at
+    load time. Runtime binding lands with the rename milestone."""
+
     policies: dict[str, Any] = Field(default_factory=dict)
     metadata: TaskMetadata | None = None
     adapter_settings: dict[str, Any] = Field(default_factory=dict)
@@ -950,6 +1059,13 @@ class TaskDefaults(BaseModel):
     timeouts: TimeoutDefaults | None = None
     stuck_heuristics: StuckHeuristicsDefaults | None = None
     continue_prompt: str | None = None
+
+    @field_validator("actors")
+    @classmethod
+    def _reject_reserved_actor_names(
+        cls, value: dict[str, ActorSpec] | None
+    ) -> dict[str, ActorSpec] | None:
+        return _validate_actors_map(value)
 
 
 class RunDefaults(BaseModel):
@@ -965,6 +1081,81 @@ class RunDefaults(BaseModel):
     observability: ObservabilityConfig | None = None
     orchestrator: OrchestratorConfig | None = None
     models: dict[str, ModelConfig] = Field(default_factory=dict)
+
+
+SeedKind = Literal["sql_dump", "filesystem_dir", "redis_dump", "bare"]
+"""Vocabulary for the reset-seed kinds :class:`SeedRef` accepts.
+
+``sql_dump`` (postgres/sqlite dumps), ``filesystem_dir`` (copy into a
+service workspace), ``redis_dump`` (RDB snapshots), ``bare`` (raw file,
+no interpretation). Kind selection binds an overlay recipe with the
+isolation-redesign milestone."""
+
+
+_SEED_KIND_BY_EXTENSION: dict[str, SeedKind] = {
+    ".sql": "sql_dump",
+    ".rdb": "redis_dump",
+}
+"""File-extension → seed kind. Ambiguous / unknown extensions require
+the full ``{path, kind}`` shape."""
+
+
+class SeedRef(BaseModel):
+    """One entry in ``assets.seeds`` — a named baseline that reset
+    recipes and initial-state fixtures reference by name.
+
+    Two authoring shapes both parse: the full ``{path, kind, digest?}``
+    dict, or a bare string path (kind inferred from the extension when
+    unambiguous). ``digest`` verification lands with the reset-recipe
+    milestone; this milestone reserves the field."""
+
+    path: Path
+    """Location of the seed file. Anchored to the project directory by
+    the loader before this model is constructed."""
+
+    kind: SeedKind
+    """How the seed is applied. Values that require file-format-specific
+    handling map to matching kinds; ``bare`` covers raw files that a
+    later recipe consumes verbatim."""
+
+    digest: str | None = None
+    """``sha256:...`` content hash. Optional today; the reset-recipe
+    milestone verifies it at load time so a swap without stamping the
+    digest fails loud."""
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_bare_string_shorthand(cls, data: Any) -> Any:
+        """A bare string coerces to ``{path: <s>}`` with ``kind``
+        inferred from the file extension. Ambiguous / unknown
+        extensions are load-time errors — the author must switch to
+        the full form."""
+        if not isinstance(data, str):
+            return data
+        raw = data
+        ext = Path(raw).suffix.lower()
+        inferred = _SEED_KIND_BY_EXTENSION.get(ext)
+        if inferred is None:
+            raise ValueError(
+                f"SeedRef: cannot infer kind from path {raw!r} "
+                f"(extension {ext!r} not in "
+                f"{sorted(_SEED_KIND_BY_EXTENSION)!r}). Declare the full "
+                "form: {path: ..., kind: ...}."
+            )
+        return {"path": raw, "kind": inferred}
+
+
+class AssetsConfig(BaseModel):
+    """Project-level asset registry.
+
+    Currently only ``seeds`` — a name → :class:`SeedRef` map — is
+    modelled. Additional asset categories land as the design grows."""
+
+    seeds: dict[str, SeedRef] = Field(default_factory=dict)
+
+    model_config = {"extra": "forbid"}
 
 
 class TaskDiscoveryConfig(BaseModel):
@@ -997,6 +1188,10 @@ class ProjectConfig(BaseModel):
     own ``environment_manifest`` patch by
     :func:`tolokaforge.core.project_loader.resolve` to produce the
     concrete :class:`EnvironmentManifest`."""
+
+    assets: AssetsConfig | None = None
+    """Project-level asset registry. Only ``seeds`` is modelled today;
+    reset-recipe binding lands with the isolation redesign."""
 
     task_defaults: TaskDefaults = Field(default_factory=TaskDefaults)
     run_defaults: RunDefaults | None = None

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -142,9 +142,40 @@ def _resolve_project_paths(data: dict, project_dir: Path) -> None:
     env = data.get("default_environment")
     if isinstance(env, dict):
         _anchor_stack_compose_file(env, project_dir)
+    assets = data.get("assets")
+    if isinstance(assets, dict):
+        _anchor_seed_paths(assets, project_dir)
     task_defaults = data.get("task_defaults")
     if isinstance(task_defaults, dict):
         _rewrite_task_defaults_paths(task_defaults, project_dir)
+
+
+def _anchor_seed_paths(assets_data: dict, project_dir: Path) -> None:
+    """Rewrite every ``assets.seeds.<name>`` entry so its path is
+    absolute under *project_dir*. Handles both authoring shapes: the
+    full ``{path, kind, ...}`` dict and the bare-string shorthand.
+    In-place; no-op when ``seeds`` is absent or an entry is already
+    absolute.
+
+    Runs before Pydantic constructs :class:`SeedRef`, so the model
+    receives an anchored path. Bare-string shorthand is preserved as a
+    string here — :class:`SeedRef`'s ``mode="before"`` normaliser
+    coerces it to the dict form after anchoring.
+    """
+    seeds = assets_data.get("seeds")
+    if not isinstance(seeds, dict):
+        return
+    for name, entry in seeds.items():
+        if isinstance(entry, str):
+            resolved = Path(entry)
+            if not resolved.is_absolute():
+                seeds[name] = str((project_dir / resolved).resolve())
+        elif isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str) and path:
+                resolved = Path(path)
+                if not resolved.is_absolute():
+                    entry["path"] = str((project_dir / resolved).resolve())
 
 
 def _anchor_stack_compose_file(env_patch: dict, anchor_dir: Path) -> None:
@@ -300,7 +331,41 @@ def load_effective_run_config(
     else:
         project = synthesize_default_project(project_root=config_path.parent)
     merged = resolve_effective_run_config_data(project, config_data)
+    validate_actor_roster_subset_of_models(project, merged)
     return merged, project
+
+
+def validate_actor_roster_subset_of_models(
+    project: ProjectConfig,
+    merged_run_config: dict[str, Any],
+) -> None:
+    """Every ``actors.<name>`` declaration with ``mode == "llm"`` must
+    have a matching entry in the resolved ``models`` dict.
+
+    Raises ``ValueError`` naming the missing model(s). Runs after
+    ``project.run_defaults`` merges into the selected run config —
+    that's the only point where a project-side actor roster and the
+    run-side model roster are both visible.
+
+    A ``None`` roster (project sets no ``actors``) is a no-op. Actor
+    entries without ``mode == "llm"`` are ignored — scripted actors
+    don't need a model. This is a schema-time cross-check; runtime
+    binding lives in the actor rename milestone.
+    """
+    actors = project.task_defaults.actors
+    if not actors:
+        return
+    models = merged_run_config.get("models") or {}
+    if not isinstance(models, dict):
+        return
+    missing = sorted(
+        name for name, spec in actors.items() if spec.mode == "llm" and name not in models
+    )
+    if missing:
+        raise ValueError(
+            f"Actor roster references models {missing!r} that are not declared "
+            f"under `models`; declared: {sorted(models)!r}."
+        )
 
 
 # ── Environment resolve ────────────────────────────────────────────────

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -342,10 +342,22 @@ def validate_actor_roster_subset_of_models(
     """Every ``actors.<name>`` declaration with ``mode == "llm"`` must
     have a matching entry in the resolved ``models`` dict.
 
+    "Matching entry" means the actor's map-key must appear as a key in
+    ``models`` — e.g. an actor at ``actors.user`` with ``mode: llm``
+    requires ``models.user`` to be declared. ``ActorSpec`` has no
+    ``.model`` field today; the by-key match is the only decidable
+    semantic. If a future milestone adds an explicit
+    ``actors.<name>.model`` reference the check should follow that.
+
     Raises ``ValueError`` naming the missing model(s). Runs after
     ``project.run_defaults`` merges into the selected run config —
     that's the only point where a project-side actor roster and the
     run-side model roster are both visible.
+
+    Scope: this check covers ``project.task_defaults.actors`` only.
+    Task-level ``TaskConfig.actors`` overrides bypass it — enforcement
+    for task-level actors will land alongside the runtime binding
+    (the ``actors.user`` ↔ user-simulator rename milestone).
 
     A ``None`` roster (project sets no ``actors``) is a no-op. Actor
     entries without ``mode == "llm"`` are ignored — scripted actors

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -357,7 +357,11 @@ def validate_actor_roster_subset_of_models(
         return
     models = merged_run_config.get("models") or {}
     if not isinstance(models, dict):
-        return
+        raise ValueError(
+            f"`models` in the resolved run config must be a mapping; got "
+            f"{type(models).__name__}. Fix the `models:` block before the "
+            "actor roster can be checked."
+        )
     missing = sorted(
         name for name, spec in actors.items() if spec.mode == "llm" and name not in models
     )

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -570,11 +570,15 @@ class SecurityContext(BaseModel):
     these to every service that does not override them in the compose file.
     """
 
-    run_as_user: int | None = None
-    """UID the container process runs as. ``None`` defers to the image default."""
+    run_as_user: int | str | None = None
+    """UID or username the container process runs as. ``None`` defers to
+    the image default. A username (e.g. ``"toloka"``) is resolved to a
+    numeric UID by the substrate at materialisation time — some
+    substrates (k8s ``runAsUser``) require the numeric form."""
 
-    run_as_group: int | None = None
-    """GID the container process runs as. ``None`` defers to the image default."""
+    run_as_group: int | str | None = None
+    """GID or group name the container process runs as. ``None`` defers
+    to the image default. Same resolution rules as ``run_as_user``."""
 
     read_only_root_filesystem: bool = False
     """When ``True``, the container's root filesystem is mounted read-only.


### PR DESCRIPTION
Schema-only. Zero behaviour change. Name-squats the shapes later milestones will fill in, and demotes over-required fields on \`TaskConfig\`.

Closes #224 (child of #220).

## Summary

- **`actors` map on `TaskDefaults` + `TaskConfig`** — new \`ActorSpec\` model mirroring today's \`UserSimulatorConfig\` fields (all optional, \`extra=\"forbid\"\` so sub-keys \`tools\`/\`service\` are rejected today). Map-level validator rejects reserved names \`agent\` and \`judge\`.
- **Roster ⊆ models cross-check** — \`validate_actor_roster_subset_of_models\` runs from \`load_effective_run_config\` after the project × run-config merge. Every \`actors.<name>\` with \`mode == \"llm\"\` must have a matching entry in \`models\`; scripted actors are exempt.
- **\`ComputeConfig.capabilities: list[Any]\`** — accepts bare-string entries or single-key \`{\"name\": {params}}\` dicts. Custom \`field_validator\` emits context-rich errors instead of Pydantic's union-resolution noise. No registry / admission gate this PR.
- **Typed seed-registry** — new \`SeedRef\` (full \`{path, kind, digest?}\` form + bare-string shorthand with kind inferred from \`.sql\`/\`.rdb\`; other extensions require the full form) and \`AssetsConfig\` on \`ProjectConfig.assets\`. Digest verification lands with reset recipes.
- **Path anchoring for seeds** — \`_resolve_project_paths\` walks \`assets.seeds.<name>.path\` (dict + bare-string) so seed paths are absolute after load.
- **\`TaskConfig.name\` and \`.category\` demoted** to \`str | None = None\`. Minimal task = \`task_id + description\`. Existing consumers already fall back defensively.
- **\`SecurityContext.run_as_user\` / \`run_as_group\`** widened to \`int | str | None\` — usernames like \`\"toloka\"\` are common; the substrate resolves to numeric UID at materialisation.

## Test plan

- [x] \`uv run pytest tests/unit/ tests/canonical/\` — 2640 passed, 1 skipped (+35 new).
- [x] New \`tests/unit/test_schema_reservations.py\` — 29 tests covering ActorSpec, actors reservation, ComputeConfig capabilities, SeedRef shorthand + full form + ambiguous extension, AssetsConfig, ProjectConfig.assets, minimal TaskConfig, SecurityContext widening.
- [x] Roster ⊆ models tests added to \`test_project_loader_end_to_end.py\` (positive, negative, scripted-exempt, no-actors no-op).
- [x] Asset-path anchoring tests (dict form + bare-string shorthand).
- [x] Manual: \`load_project_config('examples/native/example-microservices-pack/project.yaml')\` populates \`assets.seeds.app_baseline\` (with sha256 digest) and \`task_defaults.actors.user\`. Both were silently dropped before this PR.
- [x] Canonical snapshots refreshed for the new optional \`actors\` field on serialised \`TaskConfig\`.
- [x] \`ruff check\` + \`ruff format --check\` clean on touched files.

## Not in scope

- Binding \`actors.user\` to today's \`user_simulator\` runtime — both co-exist during the deprecation window; the rename lands with the strict-schema milestone (#213).
- Capability registry lookup / admission gate — isolation redesign (#212).
- Seed digest verification + reset-recipe binding — #212.
- Retiring \`TaskConfig.user_simulator\` — cleanup milestone (#214), after the release window.