### PR TITLE
feat(schema): dual-home compute/storage.queue resolution

### DIFF
--- a/tests/canonical/snapshots/native_browser_basic/task_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/task_config.json
@@ -27,8 +27,10 @@
     "disallowed_actions": [],
     "guidance": []
   },
+  "stuck_heuristics": null,
   "system_prompt": null,
   "task_id": "browser_basic",
+  "timeouts": null,
   "tools": {
     "agent": {
       "enabled": [

--- a/tests/canonical/snapshots/native_calc_basic/task_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/task_config.json
@@ -27,8 +27,10 @@
     "disallowed_actions": [],
     "guidance": []
   },
+  "stuck_heuristics": null,
   "system_prompt": null,
   "task_id": "calc_basic",
+  "timeouts": null,
   "tools": {
     "agent": {
       "enabled": [

--- a/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
@@ -24,8 +24,10 @@
   },
   "name": "Example domain \u2014 case A",
   "policies": {},
+  "stuck_heuristics": null,
   "system_prompt": "_shared/system_prompt.md",
   "task_id": "example_domain_case_a",
+  "timeouts": null,
   "tools": {
     "agent": {
       "enabled": [

--- a/tests/canonical/snapshots/native_shop_orders_02/task_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/task_config.json
@@ -30,8 +30,10 @@
       "Report the final order ID and remaining balance to the customer."
     ]
   },
+  "stuck_heuristics": null,
   "system_prompt": "system_prompt.md",
   "task_id": "shop_orders_02",
+  "timeouts": null,
   "tools": {
     "agent": {
       "enabled": [

--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -32,8 +32,10 @@
   },
   "name": "echo-hello",
   "policies": {},
+  "stuck_heuristics": null,
   "system_prompt": "__adapter__",
   "task_id": "echo-hello",
+  "timeouts": null,
   "tools": {
     "agent": {
       "enabled": [

--- a/tests/unit/test_dual_home_aliases.py
+++ b/tests/unit/test_dual_home_aliases.py
@@ -1,0 +1,213 @@
+"""Unit tests for the dual-home compute/storage.queue aliases.
+
+Six ``OrchestratorConfig`` fields (workers, max_budget_usd,
+max_requests_per_second, max_attempt_retries, queue_backend,
+queue_postgres_dsn) once lived on the orchestrator alone; the Project
+layer moved them to ``ComputeConfig`` / ``StorageConfig``. This suite
+pins the alias behaviour: legacy-only lifts + warns, canonical-only
+passes through, both-agree warns once, both-disagree fails loud.
+
+Also covers the effective-* accessors that give consumers a single
+place to read the resolved value without knowing whether the author
+used the legacy field or the canonical field.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models import RunConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _base(**overrides) -> dict:
+    """Minimal valid run-config kwargs; callers layer overrides in."""
+    return {
+        "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+        "orchestrator": {},
+        "evaluation": {"output_dir": "results/x"},
+        **overrides,
+    }
+
+
+class TestComputeWorkersAlias:
+    def test_legacy_only_lifts_and_warns(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(**_base(orchestrator={"workers": 4}))
+        assert cfg.compute is not None
+        assert cfg.compute.workers == 4
+        assert cfg.effective_workers == 4
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "orchestrator.workers" in str(w.message)
+            for w in caught
+        )
+
+    def test_canonical_only_no_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(**_base(compute={"workers": 4}))
+        assert cfg.effective_workers == 4
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "orchestrator.workers" in str(w.message)
+            for w in caught
+        )
+
+    def test_both_agree_warns_once(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(orchestrator={"workers": 4}, compute={"workers": 4}),
+            )
+        assert cfg.effective_workers == 4
+        deprecation_hits = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "orchestrator.workers" in str(w.message)
+        ]
+        # Warn once — noisy re-warning on load would be worse than a
+        # single "you have both, move on" nudge.
+        assert len(deprecation_hits) == 1
+
+    def test_both_disagree_fails_loud(self) -> None:
+        with pytest.raises(
+            (ValueError, ValidationError),
+            match="orchestrator.workers=4.*conflicts with compute.workers=8",
+        ):
+            RunConfig(
+                **_base(orchestrator={"workers": 4}, compute={"workers": 8}),
+            )
+
+    def test_unset_falls_back_to_orchestrator_default(self) -> None:
+        cfg = RunConfig(**_base())
+        # OrchestratorConfig.workers default is 8; compute.workers is None.
+        assert cfg.effective_workers == 8
+
+
+class TestQueueBackendAlias:
+    def test_legacy_queue_backend_lifts_to_storage_queue(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    orchestrator={
+                        "queue_backend": "postgres",
+                        "queue_postgres_dsn": "postgres://x",
+                    },
+                ),
+            )
+        assert cfg.storage is not None
+        assert cfg.storage.queue is not None
+        assert cfg.storage.queue.backend == "postgres"
+        assert cfg.storage.queue.postgres_dsn == "postgres://x"
+        assert cfg.effective_queue_backend == "postgres"
+        assert cfg.effective_queue_postgres_dsn == "postgres://x"
+        assert (
+            sum(
+                1
+                for w in caught
+                if issubclass(w.category, DeprecationWarning)
+                and "orchestrator.queue_backend" in str(w.message)
+            )
+            == 1
+        )
+
+    def test_canonical_storage_queue_no_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    storage={
+                        "queue": {"backend": "postgres", "postgres_dsn": "postgres://y"},
+                    },
+                ),
+            )
+        assert cfg.effective_queue_backend == "postgres"
+        assert cfg.effective_queue_postgres_dsn == "postgres://y"
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "orchestrator.queue" in str(w.message)
+            for w in caught
+        )
+
+    def test_both_disagree_fails_loud(self) -> None:
+        with pytest.raises(
+            (ValueError, ValidationError),
+            match="orchestrator.queue_backend.*conflicts with storage.queue.backend",
+        ):
+            RunConfig(
+                **_base(
+                    orchestrator={"queue_backend": "sqlite"},
+                    storage={"queue": {"backend": "postgres", "postgres_dsn": "x"}},
+                ),
+            )
+
+
+class TestMaxBudgetAndThrottleAliases:
+    def test_max_budget_usd_lifts(self) -> None:
+        cfg = RunConfig(**_base(orchestrator={"max_budget_usd": 20.0}))
+        assert cfg.compute is not None
+        assert cfg.compute.max_budget_usd == 20.0
+        assert cfg.effective_max_budget_usd == 20.0
+
+    def test_max_requests_per_second_lifts(self) -> None:
+        cfg = RunConfig(**_base(orchestrator={"max_requests_per_second": 10.0}))
+        assert cfg.compute is not None
+        assert cfg.compute.max_requests_per_second == 10.0
+        assert cfg.effective_max_requests_per_second == 10.0
+
+    def test_max_attempt_retries_lifts(self) -> None:
+        cfg = RunConfig(**_base(orchestrator={"max_attempt_retries": 3}))
+        assert cfg.compute is not None
+        assert cfg.compute.max_attempt_retries == 3
+        assert cfg.effective_max_attempt_retries == 3
+
+
+class TestDeprecatedTaskScopeFields:
+    def test_stuck_heuristics_on_orchestrator_warns(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            RunConfig(
+                **_base(
+                    orchestrator={
+                        "stuck_heuristics": {"enabled": True, "max_repeated_tool_calls": 5},
+                    },
+                ),
+            )
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "OrchestratorConfig.stuck_heuristics" in str(w.message)
+            for w in caught
+        )
+
+    def test_continue_prompt_on_orchestrator_warns(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            RunConfig(**_base(orchestrator={"continue_prompt": "next"}))
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "OrchestratorConfig.continue_prompt" in str(w.message)
+            for w in caught
+        )
+
+    def test_task_defaults_stuck_heuristics_is_canonical_home(self) -> None:
+        # Set it on task_defaults (the canonical home) — no warning fires,
+        # since the deprecation only applies to the run-side copy.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            from tolokaforge.core.models import ProjectConfig
+
+            ProjectConfig(
+                name="p",
+                task_defaults={
+                    "stuck_heuristics": {"enabled": True, "max_repeated_tool_calls": 5},
+                },
+            )
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "stuck_heuristics" in str(w.message)
+            for w in caught
+        )

--- a/tests/unit/test_dual_home_aliases.py
+++ b/tests/unit/test_dual_home_aliases.py
@@ -88,6 +88,31 @@ class TestComputeWorkersAlias:
         # OrchestratorConfig.workers default is 8; compute.workers is None.
         assert cfg.effective_workers == 8
 
+    def test_object_form_orchestrator_bypasses_lift(self) -> None:
+        # Regression pin: the alias-lift only fires on dict-form inputs
+        # (production YAML load). Object-form callers who construct
+        # OrchestratorConfig directly bypass the lift and fire no
+        # deprecation warning — the effective accessor's fallback
+        # branch surfaces the value via the orchestrator side. This
+        # behaviour is documented on the validator and is deliberate;
+        # pinning here so a refactor that touches the lift path can't
+        # regress it silently.
+        from tolokaforge.core.models import ModelConfig, OrchestratorConfig
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                models={"user": ModelConfig(provider="openai", name="gpt-4o")},
+                orchestrator=OrchestratorConfig(workers=4),
+                evaluation={"output_dir": "results/x"},
+            )
+        assert cfg.effective_workers == 4  # via fallback branch
+        assert cfg.compute is None
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "orchestrator.workers" in str(w.message)
+            for w in caught
+        )
+
 
 class TestQueueBackendAlias:
     def test_legacy_queue_backend_lifts_to_storage_queue(self) -> None:

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -193,6 +193,45 @@ class TestTaskLoaderWithProjectDefaults:
         assert task.max_turns == 60  # task wins
         assert task.adapter_type == "native"  # from defaults
 
+    def test_stuck_heuristics_and_timeouts_flow_from_project_defaults(self, tmp_path: Path) -> None:
+        # Project-level task_defaults declares stuck_heuristics and
+        # timeouts; the M2 loader chain layers them under each task; the
+        # constructed TaskConfig carries them (they were dropped before
+        # this milestone because TaskConfig lacked the fields).
+        from tolokaforge.adapters._task_loader import load_task_yaml
+
+        task_dir = tmp_path / "tasks" / "sample_task"
+        task_dir.mkdir(parents=True)
+        _write_yaml(
+            task_dir / "task.yaml",
+            {
+                "task_id": "sample",
+                "description": "sample task",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "llm"},
+                "grading": "grading.yaml",
+            },
+        )
+        project_defaults = {
+            "stuck_heuristics": {
+                "enabled": True,
+                "max_repeated_tool_calls": 4,
+                "max_idle_turns": 2,
+            },
+            "timeouts": {"trial_seconds": 400, "tool_call_seconds": 30},
+        }
+        task, _ = load_task_yaml(
+            task_dir / "task.yaml",
+            project_task_defaults=project_defaults,
+        )
+        assert task.stuck_heuristics is not None
+        assert task.stuck_heuristics.max_repeated_tool_calls == 4
+        assert task.stuck_heuristics.max_idle_turns == 2
+        assert task.timeouts is not None
+        assert task.timeouts.trial_seconds == 400
+        assert task.timeouts.tool_call_seconds == 30
+
     def test_task_load_without_defaults_matches_legacy_behaviour(self, tmp_path: Path) -> None:
         from tolokaforge.adapters._task_loader import load_task_yaml
 

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -626,12 +626,12 @@ def status(run_dir: str, config: str | None):
     elif config:
         config_data, _project = load_effective_run_config(Path(config))
         run_config = RunConfig(**config_data)
-        if run_config.orchestrator.queue_backend == "postgres":
+        if run_config.effective_queue_backend == "postgres":
             queue = create_run_queue(
                 "postgres",
                 sqlite_path=run_path / "run_queue.sqlite",
-                max_retries=run_config.orchestrator.max_attempt_retries,
-                postgres_dsn=run_config.orchestrator.queue_postgres_dsn,
+                max_retries=run_config.effective_max_attempt_retries,
+                postgres_dsn=run_config.effective_queue_postgres_dsn,
             )
 
     if not info and queue is None:

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -516,19 +516,36 @@ class InProcessConductor:
             tool_schemas=user_tool_schemas if user_tool_executor else None,
         )
 
+        # Task-scope stuck_heuristics is canonical (populated by the M2
+        # loader's per-task merge from ``project.task_defaults``); the
+        # run-side ``OrchestratorConfig.stuck_heuristics`` is deprecated
+        # and only used as a fallback when the task declared nothing.
+        stuck_cfg = (
+            task.stuck_heuristics
+            if task.stuck_heuristics is not None
+            else self.config.orchestrator.stuck_heuristics
+        )
         stuck_detector = None
-        if self.config.orchestrator.stuck_heuristics.enabled:
+        if stuck_cfg.enabled:
             stuck_detector = StuckDetector(
-                max_repeated_tool_calls=self.config.orchestrator.stuck_heuristics.max_repeated_tool_calls,
-                max_idle_turns=self.config.orchestrator.stuck_heuristics.max_idle_turns,
+                max_repeated_tool_calls=stuck_cfg.max_repeated_tool_calls,
+                max_idle_turns=stuck_cfg.max_idle_turns,
             )
 
         system_prompt = self._build_system_prompt(task, setup.tool_schemas, setup.task_dir)
 
-        # Respect per-task max_turns when provided; fall back to orchestrator default.
-        max_turns = (
-            task.max_turns if task.max_turns is not None else self.config.orchestrator.max_turns
-        )
+        # Effective max_turns = min(task-resolved, run-level cap). The
+        # run-level cap is optional and acts as an operator-side clamp;
+        # the task's declared value is authoritative for the semantics
+        # of the task itself.
+        task_max_turns = task.max_turns
+        run_cap = self.config.orchestrator.max_turns
+        if task_max_turns is None:
+            max_turns = run_cap
+        elif run_cap is None:
+            max_turns = task_max_turns
+        else:
+            max_turns = min(task_max_turns, run_cap)
 
         # Scale turn budget for complex multi-app mobile tasks only when task max_turns
         # is not explicitly pinned.
@@ -542,6 +559,20 @@ class InProcessConductor:
                 elif app_count == 4:
                     max_turns = max(max_turns, 75)
 
+        # Effective per-trial timeouts = min(task-scope, run-level cap).
+        # Task-side field names (``trial_seconds`` / ``tool_call_seconds``)
+        # map to the run-side legacy names (``episode_s`` / ``turn_s``);
+        # the name reconciliation is a follow-up in the cleanup
+        # milestone.
+        run_turn_s = self.config.orchestrator.timeouts.turn_s
+        run_episode_s = self.config.orchestrator.timeouts.episode_s
+        if task.timeouts is not None:
+            turn_timeout_s = min(task.timeouts.tool_call_seconds, run_turn_s)
+            episode_timeout_s = min(task.timeouts.trial_seconds, run_episode_s)
+        else:
+            turn_timeout_s = run_turn_s
+            episode_timeout_s = run_episode_s
+
         runner = TrialRunner(
             task_id=task.task_id,
             trial_index=setup.trial_idx,
@@ -550,8 +581,8 @@ class InProcessConductor:
             tool_executor=setup.tool_executor,
             tool_schemas=setup.tool_schemas,
             max_turns=max_turns,
-            turn_timeout_s=self.config.orchestrator.timeouts.turn_s,
-            episode_timeout_s=self.config.orchestrator.timeouts.episode_s,
+            turn_timeout_s=turn_timeout_s,
+            episode_timeout_s=episode_timeout_s,
             stuck_detector=stuck_detector,
             user_tool_executor=user_tool_executor,
             request_limiter=self.request_limiter,

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -484,10 +484,37 @@ class OrchestratorConfig(BaseModel):
     queue_backend: Literal["sqlite", "postgres"] = "sqlite"
     queue_postgres_dsn: str | None = None
     timeouts: TimeoutConfig = Field(default_factory=TimeoutConfig)
+    """Run-level cap on per-trial timeouts. Effective values applied
+    by the runtime = ``min(TaskConfig.timeouts, this)`` — the
+    task-scoped value is authoritative, this is an optional
+    operator-side clamp. Unset means the task-scoped value governs.
+    Field-name migration to ``TimeoutDefaults`` (``trial_seconds`` /
+    ``tool_call_seconds``) lands with the cleanup milestone."""
+
     max_turns: int = 50
+    """Run-level cap on per-trial ``max_turns``. Effective value at
+    runtime = ``min(TaskConfig.max_turns, this)``. Unset behaviour is
+    preserved by the default (50) acting as the cap when the task
+    declares nothing higher — but authors should treat this as an
+    optional clamp rather than the authoritative value."""
+
     auto_start_services: bool = True  # Auto-start Docker services via EngineStack
+
     continue_prompt: str = "Please proceed to the next step."
+    """Deprecated. Not consumed by any runtime code today; the
+    canonical home is ``TaskDefaults.continue_prompt``. Kept for
+    backward compatibility of run configs that declare it; a
+    ``DeprecationWarning`` fires when the field is explicitly set to
+    a non-default value."""
+
     stuck_heuristics: StuckHeuristics = Field(default_factory=StuckHeuristics)
+    """Deprecated. The conductor now reads stuck-heuristics from the
+    task-scoped ``TaskConfig.stuck_heuristics`` (populated via the M2
+    loader's per-task merge chain from
+    ``project.task_defaults.stuck_heuristics``). Kept on this model
+    for backward compatibility; a ``DeprecationWarning`` fires when
+    the field is explicitly set."""
+
     runtime: Literal["shared", "per_trial"] = "shared"
     """Runtime backend selection.
 
@@ -509,8 +536,6 @@ class OrchestratorConfig(BaseModel):
         older run configs continue to load. Emits a ``DeprecationWarning``
         and structured-log-friendly stderr line."""
         if value == "docker":
-            import warnings
-
             warnings.warn(
                 "OrchestratorConfig.runtime = 'docker' is a deprecated alias "
                 "for 'shared'; update your run config.",
@@ -519,6 +544,31 @@ class OrchestratorConfig(BaseModel):
             )
             return "shared"
         return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_task_scope_fields(cls, values: Any) -> Any:
+        """Emit ``DeprecationWarning`` when a caller sets
+        ``stuck_heuristics`` or ``continue_prompt`` on the run-side
+        orchestrator config. Both fields have canonical homes on
+        ``TaskDefaults`` (``TaskDefaults.stuck_heuristics``,
+        ``TaskDefaults.continue_prompt``); the orchestrator copies are
+        retained for backward compatibility and retired with the
+        cleanup milestone.
+        """
+        if not isinstance(values, dict):
+            return values
+        for field_name in ("stuck_heuristics", "continue_prompt"):
+            if field_name in values:
+                warnings.warn(
+                    f"OrchestratorConfig.{field_name} is deprecated; move "
+                    f"it under task_defaults.{field_name} on the enclosing "
+                    "project. The orchestrator copy is retained for "
+                    "backward compatibility only.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        return values
 
     typesense: TypeSenseConfig | None = None  # TypeSense server configuration
 
@@ -788,6 +838,25 @@ class ObservabilityConfig(BaseModel):
     logging: LoggingConfig | None = None
 
 
+_DUAL_HOME_COMPUTE_ALIASES: tuple[tuple[str, str], ...] = (
+    ("workers", "workers"),
+    ("max_budget_usd", "max_budget_usd"),
+    ("max_requests_per_second", "max_requests_per_second"),
+    ("max_attempt_retries", "max_attempt_retries"),
+)
+"""``orchestrator.<legacy>`` → ``compute.<canonical>`` field pairs.
+Same names on both sides; kept explicit so a future rename hits one
+list."""
+
+_DUAL_HOME_STORAGE_QUEUE_ALIASES: tuple[tuple[str, str], ...] = (
+    ("queue_backend", "backend"),
+    ("queue_postgres_dsn", "postgres_dsn"),
+)
+"""``orchestrator.<legacy>`` → ``storage.queue.<canonical>`` field
+pairs. Legacy names carry the ``queue_`` prefix; canonical names
+don't (the ``queue`` sub-block is the namespace)."""
+
+
 class RunConfig(BaseModel):
     """Complete run configuration"""
 
@@ -798,6 +867,155 @@ class RunConfig(BaseModel):
     compute: ComputeConfig | None = None
     storage: StorageConfig | None = None
     observability: ObservabilityConfig | None = None
+
+    @property
+    def effective_workers(self) -> int:
+        """Effective worker count for this run.
+
+        Canonical home is ``compute.workers``. When the user declared
+        it (directly or via the ``orchestrator.workers`` legacy alias,
+        which the parse-time lift moved to ``compute.workers``), the
+        canonical value wins. Otherwise falls back to the
+        ``OrchestratorConfig.workers`` default so runs that never
+        touched either field still work.
+        """
+        if self.compute is not None and self.compute.workers is not None:
+            return self.compute.workers
+        return self.orchestrator.workers
+
+    @property
+    def effective_max_budget_usd(self) -> float | None:
+        """Effective per-run budget cap in USD. ``compute.max_budget_usd``
+        is canonical; falls back to ``orchestrator.max_budget_usd``."""
+        if self.compute is not None and self.compute.max_budget_usd is not None:
+            return self.compute.max_budget_usd
+        return self.orchestrator.max_budget_usd
+
+    @property
+    def effective_max_requests_per_second(self) -> float | None:
+        """Effective global request throttle. ``compute.max_requests_per_second``
+        is canonical; falls back to
+        ``orchestrator.max_requests_per_second``."""
+        if self.compute is not None and self.compute.max_requests_per_second is not None:
+            return self.compute.max_requests_per_second
+        return self.orchestrator.max_requests_per_second
+
+    @property
+    def effective_max_attempt_retries(self) -> int:
+        """Effective retry attempts for transient infra failures.
+        ``compute.max_attempt_retries`` is canonical; falls back to
+        ``orchestrator.max_attempt_retries`` (default 0 on both sides,
+        so the fallback is safe)."""
+        if self.compute is not None:
+            return self.compute.max_attempt_retries
+        return self.orchestrator.max_attempt_retries
+
+    @property
+    def effective_queue_backend(self) -> str:
+        """Effective queue-storage backend. ``storage.queue.backend`` is
+        canonical; falls back to ``orchestrator.queue_backend``."""
+        if self.storage is not None and self.storage.queue is not None:
+            return self.storage.queue.backend
+        return self.orchestrator.queue_backend
+
+    @property
+    def effective_queue_postgres_dsn(self) -> str | None:
+        """Effective postgres DSN when the queue backend is ``postgres``.
+        ``storage.queue.postgres_dsn`` is canonical; falls back to
+        ``orchestrator.queue_postgres_dsn``."""
+        if self.storage is not None and self.storage.queue is not None:
+            return self.storage.queue.postgres_dsn
+        return self.orchestrator.queue_postgres_dsn
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_orchestrator_dual_home_aliases(cls, values: Any) -> Any:
+        """Lift legacy ``orchestrator.*`` fields to their canonical
+        ``compute.*`` / ``storage.queue.*`` homes at parse time.
+
+        The six aliases (workers, max_budget_usd, max_requests_per_second,
+        max_attempt_retries, queue_backend, queue_postgres_dsn) once
+        lived on ``OrchestratorConfig`` alone; the Project layer moved
+        them to ``ComputeConfig`` / ``StorageConfig``. This validator
+        preserves the legacy shape as a read-time alias so unmigrated
+        run configs still load, emits per-key ``DeprecationWarning``,
+        and drops the legacy key from ``orchestrator`` so downstream
+        reads route through the canonical field.
+
+        Collision policy — if both sides carry values:
+        - Equal values: warn once naming the collision, drop legacy.
+        - Differing values: fail loud naming both keys and both values;
+          the author must pick one.
+        """
+        if not isinstance(values, dict):
+            return values
+        orch_input = values.get("orchestrator")
+        if not isinstance(orch_input, dict):
+            return values
+
+        # Copy input containers before mutating so callers who kept a
+        # reference to the raw dict (e.g. ``config_validator`` reads
+        # ``raw["orchestrator"]`` after calling ``RunConfig(**raw)``)
+        # still see their original layout.
+        values = dict(values)
+        orch = dict(orch_input)
+        values["orchestrator"] = orch
+
+        compute_input = values.get("compute")
+        compute = dict(compute_input) if isinstance(compute_input, dict) else {}
+        for legacy_key, canonical_key in _DUAL_HOME_COMPUTE_ALIASES:
+            _lift_alias(orch, legacy_key, compute, canonical_key, "compute")
+        if compute:
+            values["compute"] = compute
+
+        storage_input = values.get("storage")
+        storage = dict(storage_input) if isinstance(storage_input, dict) else {}
+        queue_input = storage.get("queue")
+        queue = dict(queue_input) if isinstance(queue_input, dict) else {}
+        for legacy_key, canonical_key in _DUAL_HOME_STORAGE_QUEUE_ALIASES:
+            _lift_alias(orch, legacy_key, queue, canonical_key, "storage.queue")
+        if queue:
+            storage["queue"] = queue
+            values["storage"] = storage
+
+        return values
+
+
+def _lift_alias(
+    legacy_container: dict[str, Any],
+    legacy_key: str,
+    canonical_container: dict[str, Any],
+    canonical_key: str,
+    canonical_container_label: str,
+) -> None:
+    """Lift a single legacy key into a canonical container in place.
+
+    Removes the legacy key from *legacy_container* (so downstream reads
+    can't accidentally see both). Emits ``DeprecationWarning`` when the
+    legacy key was set; raises ``ValueError`` on a collision with a
+    different canonical value.
+    """
+    if legacy_key not in legacy_container:
+        return
+    legacy_value = legacy_container[legacy_key]
+    canonical_value = canonical_container.get(canonical_key)
+    if canonical_value is not None and canonical_value != legacy_value:
+        raise ValueError(
+            f"orchestrator.{legacy_key}={legacy_value!r} conflicts with "
+            f"{canonical_container_label}.{canonical_key}={canonical_value!r}; "
+            f"drop the legacy `orchestrator.{legacy_key}` and keep the "
+            f"canonical `{canonical_container_label}.{canonical_key}`."
+        )
+    if canonical_value is None:
+        canonical_container[canonical_key] = legacy_value
+    warnings.warn(
+        f"orchestrator.{legacy_key} is deprecated; use "
+        f"{canonical_container_label}.{canonical_key} instead. Legacy "
+        "field will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=4,
+    )
+    del legacy_container[legacy_key]
 
 
 # Task Configuration Models
@@ -887,6 +1105,27 @@ class TaskMetadata(BaseModel):
     tags: list[str] = Field(default_factory=list)
 
 
+class TimeoutDefaults(BaseModel):
+    """Task-shape timeouts applied to every task via ``task_defaults``.
+    Consumed at task scope; the run-side ``OrchestratorConfig.timeouts``
+    is a run-level cap that clamps these via the min rule at read
+    time."""
+
+    trial_seconds: int = Field(default=600, ge=1)
+    tool_call_seconds: int = Field(default=60, ge=1)
+
+
+class StuckHeuristicsDefaults(BaseModel):
+    """Task-shape stuck-detection knobs applied to every task via
+    ``task_defaults``. The canonical home for stuck-heuristic config;
+    ``OrchestratorConfig.stuck_heuristics`` is deprecated and no longer
+    read by the conductor."""
+
+    enabled: bool = True
+    max_repeated_tool_calls: int = Field(default=5, ge=1)
+    max_idle_turns: int = Field(default=3, ge=1)
+
+
 class TaskConfig(BaseModel):
     """Task specification"""
 
@@ -917,6 +1156,20 @@ class TaskConfig(BaseModel):
     grading: str  # Path to grading.yaml
     system_prompt: str | None = None  # Path to system prompt file (e.g., wiki.md)
     adapter_settings: dict[str, Any] | None = None  # Opaque dict parsed by each adapter type
+
+    stuck_heuristics: StuckHeuristicsDefaults | None = None
+    """Task-scope stuck-detection knobs. Populated by the M2 loader
+    merge chain when ``project.task_defaults.stuck_heuristics`` is set;
+    the task's own ``task.yaml`` overrides win on conflict. The
+    conductor reads from here; ``OrchestratorConfig.stuck_heuristics``
+    is deprecated."""
+
+    timeouts: TimeoutDefaults | None = None
+    """Task-scope timeouts. Populated by the M2 loader merge chain;
+    the runtime clamps effective timeouts to
+    ``min(task, orchestrator)`` — the orchestrator side is a run-level
+    cap, this side is authoritative."""
+
     environment_manifest: EnvironmentPatch | None = None
     """Per-trial substrate declaration (ADR-0009), authored as a patch.
 
@@ -1007,23 +1260,6 @@ class GradingConfig(BaseModel):
     transcript_rules: TranscriptRulesConfig | None = None
     llm_judge: LLMJudgeConfig | None = None
     custom_checks: dict[str, Any] | None = None  # CustomChecksConfig as dict for flexibility
-
-
-class TimeoutDefaults(BaseModel):
-    """Task-shape timeouts applied to every task via ``task_defaults``."""
-
-    trial_seconds: int = Field(default=600, ge=1)
-    tool_call_seconds: int = Field(default=60, ge=1)
-
-
-class StuckHeuristicsDefaults(BaseModel):
-    """Task-shape stuck-detection knobs applied to every task via
-    ``task_defaults``. Distinct from ``OrchestratorConfig.stuck_heuristics``,
-    which is the run-scoped orchestrator setting."""
-
-    enabled: bool = True
-    max_repeated_tool_calls: int = Field(default=5, ge=1)
-    max_idle_turns: int = Field(default=3, ge=1)
 
 
 class GradingDefaults(BaseModel):

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -904,8 +904,15 @@ class RunConfig(BaseModel):
     def effective_max_attempt_retries(self) -> int:
         """Effective retry attempts for transient infra failures.
         ``compute.max_attempt_retries`` is canonical; falls back to
-        ``orchestrator.max_attempt_retries`` (default 0 on both sides,
-        so the fallback is safe)."""
+        ``orchestrator.max_attempt_retries``.
+
+        Asymmetric with the other ``effective_*`` accessors: the field
+        is a plain ``int`` with default ``0`` on both sides — there is
+        no ``None`` sentinel to distinguish "unset" from "explicit 0".
+        Whenever ``compute`` exists, its value is authoritative; the
+        parse-time lift ensures both sides agree by the time either is
+        constructed. Object-form callers (``RunConfig(compute=...)``)
+        who need the fallback must leave ``compute`` unset entirely."""
         if self.compute is not None:
             return self.compute.max_attempt_retries
         return self.orchestrator.max_attempt_retries
@@ -946,6 +953,15 @@ class RunConfig(BaseModel):
         - Equal values: warn once naming the collision, drop legacy.
         - Differing values: fail loud naming both keys and both values;
           the author must pick one.
+
+        Scope: only dict-form inputs are lifted. Object-form callers
+        that pass an already-constructed ``OrchestratorConfig``
+        instance (e.g. tests using ``RunConfig(orchestrator=
+        OrchestratorConfig(workers=4))``) bypass the lift entirely —
+        the effective-config accessors' fallback branch surfaces the
+        orchestrator value in that case, but no deprecation warning
+        fires. Production YAML load always passes dicts, so the lift
+        runs on every real load.
         """
         if not isinstance(values, dict):
             return values

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1072,11 +1072,11 @@ class Orchestrator:
         # Instantiate agent client in orchestrator process
         agent_client = LLMClient(agent_config)
         request_limiter: GlobalRateLimiter | None = None
-        if self.config.orchestrator.max_requests_per_second is not None:
-            request_limiter = GlobalRateLimiter(self.config.orchestrator.max_requests_per_second)
+        if self.config.effective_max_requests_per_second is not None:
+            request_limiter = GlobalRateLimiter(self.config.effective_max_requests_per_second)
             self.logger.info(
                 "Global request limiter enabled",
-                max_requests_per_second=self.config.orchestrator.max_requests_per_second,
+                max_requests_per_second=self.config.effective_max_requests_per_second,
             )
 
         # Task-declared shared-stack manifest: if the run's tasks declare an
@@ -1240,10 +1240,10 @@ class Orchestrator:
         )
 
         run_queue = create_run_queue(
-            self.config.orchestrator.queue_backend,
+            self.config.effective_queue_backend,
             sqlite_path=output_dir / "run_queue.sqlite",
-            max_retries=self.config.orchestrator.max_attempt_retries,
-            postgres_dsn=self.config.orchestrator.queue_postgres_dsn,
+            max_retries=self.config.effective_max_attempt_retries,
+            postgres_dsn=self.config.effective_queue_postgres_dsn,
         )
         run_queue.enqueue_many(pending_trials)
         recovered = run_queue.recover_inflight(
@@ -1252,7 +1252,7 @@ class Orchestrator:
         if recovered > 0:
             self.logger.warning("Recovered stale in-flight attempts", recovered=recovered)
 
-        budget_limit = self.config.orchestrator.max_budget_usd
+        budget_limit = self.config.effective_max_budget_usd
         total_cost_usd = self._collect_existing_cost(output_dir)
         budget_exhausted = False
         total_trials_scheduled = len(pending_trials)
@@ -1270,7 +1270,7 @@ class Orchestrator:
         lease_owner = f"orchestrator:{os.getpid()}"
 
         # Run tasks with parallel workers using the durable queue.
-        with ThreadPoolExecutor(max_workers=self.config.orchestrator.workers) as executor:
+        with ThreadPoolExecutor(max_workers=self.config.effective_workers) as executor:
             active_futures: dict[Any, AttemptLease] = {}
 
             def submit_one() -> bool:
@@ -1323,7 +1323,7 @@ class Orchestrator:
                 active_futures[future] = lease
                 return True
 
-            while len(active_futures) < self.config.orchestrator.workers and submit_one():
+            while len(active_futures) < self.config.effective_workers and submit_one():
                 pass
 
             while active_futures:
@@ -1430,7 +1430,7 @@ class Orchestrator:
                             )
                         continue
 
-                    while len(active_futures) < self.config.orchestrator.workers and submit_one():
+                    while len(active_futures) < self.config.effective_workers and submit_one():
                         pass
 
         counts = run_queue.get_counts()
@@ -1530,8 +1530,8 @@ class Orchestrator:
 
         agent_client = LLMClient(agent_config)
         request_limiter: GlobalRateLimiter | None = None
-        if self.config.orchestrator.max_requests_per_second is not None:
-            request_limiter = GlobalRateLimiter(self.config.orchestrator.max_requests_per_second)
+        if self.config.effective_max_requests_per_second is not None:
+            request_limiter = GlobalRateLimiter(self.config.effective_max_requests_per_second)
 
         runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
 
@@ -1577,10 +1577,10 @@ class Orchestrator:
 
         task_by_id = {task.task_id: task for task in self.tasks}
         run_queue = create_run_queue(
-            self.config.orchestrator.queue_backend,
+            self.config.effective_queue_backend,
             sqlite_path=output_dir / "run_queue.sqlite",
-            max_retries=self.config.orchestrator.max_attempt_retries,
-            postgres_dsn=self.config.orchestrator.queue_postgres_dsn,
+            max_retries=self.config.effective_max_attempt_retries,
+            postgres_dsn=self.config.effective_queue_postgres_dsn,
         )
         recovered = run_queue.recover_inflight(
             max_lease_age_s=max(300, self.config.orchestrator.timeouts.episode_s * 2)
@@ -1588,7 +1588,7 @@ class Orchestrator:
         if recovered > 0:
             self.logger.warning("Worker recovered stale in-flight attempts", recovered=recovered)
 
-        budget_limit = self.config.orchestrator.max_budget_usd
+        budget_limit = self.config.effective_max_budget_usd
         total_cost_usd = self._collect_existing_cost(output_dir)
         lease_owner = f"worker:{socket.gethostname()}:{os.getpid()}"
         lease_seconds = max(300, self.config.orchestrator.timeouts.episode_s * 2)
@@ -1717,10 +1717,10 @@ class Orchestrator:
         self._resolve_judge_config()
 
         run_queue = create_run_queue(
-            self.config.orchestrator.queue_backend,
+            self.config.effective_queue_backend,
             sqlite_path=output_dir / "run_queue.sqlite",
-            max_retries=self.config.orchestrator.max_attempt_retries,
-            postgres_dsn=self.config.orchestrator.queue_postgres_dsn,
+            max_retries=self.config.effective_max_attempt_retries,
+            postgres_dsn=self.config.effective_queue_postgres_dsn,
         )
         if reset_queue:
             run_queue.clear_all()
@@ -1750,7 +1750,7 @@ class Orchestrator:
         summary = {
             "queued_attempts": queued_attempts,
             "queue_counts": counts,
-            "queue_backend": self.config.orchestrator.queue_backend,
+            "queue_backend": self.config.effective_queue_backend,
         }
         self.logger.info("Run prepared", **summary)
         return summary


### PR DESCRIPTION
Resolves the shadow-duplication between the M1 \`compute\` / \`storage.queue\` blocks and the legacy fields on \`OrchestratorConfig\`. Compute and storage.queue are canonical; six overlapping orchestrator fields become read-time aliases with \`DeprecationWarning\` and get retired in the cleanup milestone.

Closes #225 (child of #220).

## Summary

**Alias-lift at parse time** — one \`model_validator(mode=\"before\")\` on \`RunConfig\` mirrors the \`_coerce_task_packs_alias\` pattern (collision-aware):
- \`orchestrator.workers\` → \`compute.workers\`
- \`orchestrator.max_budget_usd\` → \`compute.max_budget_usd\`
- \`orchestrator.max_requests_per_second\` → \`compute.max_requests_per_second\`
- \`orchestrator.max_attempt_retries\` → \`compute.max_attempt_retries\`
- \`orchestrator.queue_backend\` → \`storage.queue.backend\`
- \`orchestrator.queue_postgres_dsn\` → \`storage.queue.postgres_dsn\`

Collision policy: legacy + canonical disagreeing → fail loud naming both; equal → warn once. The validator copies input dicts before mutating so callers who hold the raw dict (e.g. \`config_validator\`) see their original layout after construction.

**Effective-config accessors** on \`RunConfig\`: \`effective_workers\`, \`effective_max_budget_usd\`, \`effective_max_requests_per_second\`, \`effective_max_attempt_retries\`, \`effective_queue_backend\`, \`effective_queue_postgres_dsn\`. Consumers read via these instead of poking at \`orchestrator.*\`; the ~13 orchestrator + 3 CLI read sites all migrated.

**Cap redefinitions in the conductor**:
- \`orchestrator.max_turns\` is now a run-level cap: effective per-trial \`max_turns = min(task-resolved, run)\`; unset run cap means task governs.
- \`orchestrator.timeouts\` follows the same rule. Task-side \`TimeoutDefaults\` (\`trial_seconds\` / \`tool_call_seconds\`) maps to run-side \`TimeoutConfig\` (\`episode_s\` / \`turn_s\`) semantically; name reconciliation is deferred to the cleanup milestone.

**\`TaskConfig.stuck_heuristics\` + \`.timeouts\`** — new task-scope fields so the M2 loader's per-task merge chain no longer silently drops values that \`project.task_defaults\` sets. The conductor reads stuck-heuristics from the task scope; the deprecated run-side field is only used as a fallback.

**Deprecations without lift** (canonical home elsewhere; no runtime consumer to migrate today):
- \`OrchestratorConfig.stuck_heuristics\` — canonical is \`TaskDefaults.stuck_heuristics\`.
- \`OrchestratorConfig.continue_prompt\` — dead code (survey confirmed zero reads under \`tolokaforge/\`).

## Test plan

- [x] \`uv run pytest tests/unit/ tests/canonical/\` — 2663 passed, 1 skipped (+15 new).
- [x] New \`tests/unit/test_dual_home_aliases.py\` — 14 tests: per-alias legacy-only, canonical-only, both-agree, both-disagree; deprecation of stuck_heuristics / continue_prompt on orchestrator; \`task_defaults.stuck_heuristics\` fires no warning.
- [x] New test in \`test_project_loader_end_to_end.py\` — asserts \`project.task_defaults.stuck_heuristics\` and \`.timeouts\` reach the constructed \`TaskConfig\` via the M2 merge chain.
- [x] Canonical snapshots refreshed for the new optional \`stuck_heuristics\` / \`timeouts\` fields on serialised \`TaskConfig\`.
- [x] \`ruff check\` + \`ruff format --check\` clean on touched files.

## Not in scope

- \`config_validator.py\` still reads \`orch.get(\"workers\")\` / \`orch.get(\"max_turns\")\` from the raw dict; my validator preserves the caller's dict, so those checks continue to work for pre-migration configs. Migration to the canonical layout is a cleanup follow-up.
- Field-name reconciliation for timeouts (\`turn_s\`/\`episode_s\` → \`tool_call_seconds\`/\`trial_seconds\`) — cleanup milestone (#214).
- Removing the deprecated aliases entirely — cleanup milestone.