### PR TITLE
integrate: anthropic/claude-haiku-4.5

### DIFF
--- a/.automation/requests/claude-haiku-4.5-r2.json
+++ b/.automation/requests/claude-haiku-4.5-r2.json
@@ -1,0 +1,1 @@
+{"slug":"anthropic/claude-haiku-4.5","round":2,"purpose":"greenfield clean-native agent test"}

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1781,6 +1781,79 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Claude Haiku 4.5 (Anthropic via OpenRouter). Live-certified
+    # 2026-07-13 (r2) via the auto-resolve observe/reprobe loop. Routes
+    # through the dedicated ``anthropic_claude_haiku_4_5`` preset
+    # (model_presets.yaml): same Anthropic content/reasoning/ephemeral-cache
+    # axes as the opus/fable siblings, PLUS ``response_policy: json_coerce``.
+    #
+    # The json_coerce delta is load-bearing: on the plain ``anthropic``
+    # preset (response_policy: standard) Haiku 4.5 failed the
+    # ``explicit_discriminator`` discriminated-union probe 0/15 — it emitted
+    # the top-level ``item`` object as a JSON-encoded string
+    # (``{"kind": "ticket", "subject": ...}``) instead of a native dict.
+    # ``JsonCoerceResponse`` decodes that back to native shape before
+    # pydantic validation; the reprobe under the overlay went 5/5. Because
+    # the union call recovers cleanly, DISCRIMINATED_UNION_TOOL_CALL is
+    # ``required`` here — unlike the opus-4.8 / fable-5 siblings, which stay
+    # on standard response policy and declare it known_unsupported.
+    #
+    # Unlike those siblings, THINKING/CACHE surfaces (THINKING_EMITS_BLOCKS,
+    # THINKING_REPLAY_ROUNDTRIP, UNSIGNED_THINKING_REPLAY, PROMPT_CACHING,
+    # IMPLICIT_PROMPT_CACHING) all passed reliably on this route in the
+    # observe baseline (15/15 each) and are declared ``required``.
+    #
+    # The one ceiling: DECIMAL_FIELD_TOOL_CALL. The $42.50-charge probe
+    # returned "no tool call returned" on 6/15 runs (9/15 pass) — the model
+    # intermittently answers in prose instead of invoking the tool when a
+    # Pydantic ``Decimal`` field is present. That is a model consistency
+    # gap, not a wire quirk json_coerce can recover, so it stays
+    # known_unsupported (a ``required`` capability must pass reliably).
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__anthropic_claude-haiku-4.5",
+        provider="openrouter",
+        name="anthropic/claude-haiku-4.5",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DICT_MAP_TOOL_CALL,
+                # Recovered by json_coerce on the dedicated preset — see
+                # header. 5/5 on the overlay reprobe (0/15 on standard).
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # $42.50-charge probe returned "no tool call returned" on
+                # 6/15 runs (9/15 pass) — a model consistency gap on
+                # Decimal-bearing tool args, not a recoverable wire quirk.
+                # A required capability must pass reliably. See header.
+                C.DECIMAL_FIELD_TOOL_CALL,
+            }
+        ),
+    ),
 ]
 
 

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -66,6 +66,30 @@ presets:
       drop_sampling_when_thinking: true
       reasoning_budget_default: 8000
 
+  # Claude Haiku 4.5 — same Anthropic content/reasoning/cache contract as the
+  # generic ``anthropic`` preset (structured thinking + ephemeral cache), but
+  # with ONE delta: ``response_policy: json_coerce``. On the plain ``anthropic``
+  # preset (response_policy: standard) Haiku 4.5 failed the
+  # ``explicit_discriminator`` discriminated-union probe on every run — it emits
+  # the top-level ``item`` object argument as a JSON-encoded string instead of a
+  # native dict (the classic dict-stringify wire quirk json_coerce already
+  # recovers for Qwen/Kimi/MiniMax). ``JsonCoerceResponse`` decodes that back to
+  # a native dict before validation, and the reprobe went 5/5 green.
+  # Listed BEFORE the generic ``anthropic`` preset so first-match-wins routing
+  # picks this version-specific entry up. Live-certified 2026-07-13 (r2);
+  # see registry.py. DECIMAL_FIELD_TOOL_CALL stays a known_unsupported ceiling
+  # (9/15 "no tool call returned" — a model consistency gap, not a wire quirk).
+  anthropic_claude_haiku_4_5:
+    match:
+      - "anthropic/claude-haiku-4.5*"
+      - "*claude-haiku-4.5*"
+    content_policy: anthropic
+    reasoning_codec: anthropic
+    cache_policy: anthropic_ephemeral
+    response_policy: json_coerce
+    params:
+      supports_seed: false
+
   anthropic:
     match:
       - "anthropic/*"


### PR DESCRIPTION
# Integrate `anthropic/claude-haiku-4.5` (auto-resolve)

**Candidate:** provider `openrouter`, name `anthropic/claude-haiku-4.5`,
model_id `openrouter__anthropic_claude-haiku-4.5`.

**Engine ref:** routed through a new model-scoped preset
`anthropic_claude_haiku_4_5` in `tolokaforge/core/data/model_presets.yaml`.

## Policy

Same Anthropic content/reasoning/ephemeral-cache axes as the opus/fable
siblings, plus one delta — `response_policy: json_coerce`. On the generic
`anthropic` preset (standard response policy) Haiku 4.5 emitted the
discriminated-union `item` argument as a JSON-encoded string instead of a
native dict, failing the `explicit_discriminator` probe 0/15. `JsonCoerceResponse`
decodes that back to native shape; the reprobe went 5/5. No new adapter class
(`json_coerce` is shared with the Qwen/Kimi/MiniMax routes). The certificate is
added to `tests/integration/llm/registry.py` (22 `required`, 1 ceiling), and
pricing is confirmed present in `pricing.json`.

## Ceilings (`known_unsupported`)

- `DECIMAL_FIELD_TOOL_CALL` — 9/15 pass; the model intermittently answers in
  prose ("no tool call returned") when a Pydantic `Decimal` field is present.
  A model consistency gap, not a recoverable wire quirk.

## Provenance

Integrated automatically via the auto-resolve observe/reprobe loop
(convergence on 2026-07-13, r2). **This is a disposable test branch — it must
NOT be merged.**
