### PR TITLE
integrate: moonshotai/kimi-k2-thinking

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -930,6 +930,80 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Kimi K2 Thinking (Moonshot AI via OpenRouter) — the reasoning
+    # sibling of the kimi-k2 line, and NOT a copy of the kimi-k2.6 /
+    # k2.7-code posture. It routes through its OWN ``moonshotai_kimi_k2_thinking``
+    # preset (default + openrouter overlay + ``reasoning_codec: gemini``),
+    # because K2 Thinking returns UNSIGNED ``reasoning.text`` blocks over the
+    # OpenRouter ``reasoning_details`` envelope — the Gemini Pro archetype the
+    # ``GeminiReasoningCodec`` decodes. That codec is why this cert diverges
+    # from the non-thinking kimi siblings in four ways (all re-run live per
+    # docs/ADD_NEW_MODEL.md, not copied):
+    #
+    #   * THINKING_EMITS_BLOCKS + UNSIGNED_THINKING_REPLAY are REQUIRED here
+    #     (known_unsupported on k2.6/k2.7-code): the gemini codec surfaces the
+    #     reasoning_details blocks and round-trips them back out. Baseline on
+    #     the ``default`` preset was 0/15 on both; final reprobe 5/5 each.
+    #   * DISCRIMINATED_UNION_TOOL_CALL + DECIMAL_FIELD_TOOL_CALL pass natively
+    #     on the passthrough schema (both known_unsupported on the k2.6
+    #     sibling): the base two-turn union probe passes and the Decimal-field
+    #     probe emits a clean structured call.
+    #
+    # THINKING_REPLAY_ROUNDTRIP stays known_unsupported — that contract
+    # asserts a SIGNED replay block, and Kimi's reasoning is unsigned (genuine
+    # ceiling, not preset-fixable). Both caching surfaces stay
+    # known_unsupported: no ``cache_control`` markers wired (PROMPT_CACHING)
+    # and the OpenRouter route surfaces 0 cache_read_input_tokens on a clean
+    # 2-call ~8 k-token probe (IMPLICIT_PROMPT_CACHING). Live-certified
+    # 2026-07-13 via auto-resolve (PR #254; disposable test branch).
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__moonshotai_kimi-k2-thinking",
+        provider="openrouter",
+        name="moonshotai/kimi-k2-thinking",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.DICT_MAP_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                # gemini reasoning codec decodes the unsigned reasoning.text
+                # blocks (0/15 on default -> 5/5 final reprobe).
+                C.THINKING_EMITS_BLOCKS,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Signed-replay contract: Kimi's reasoning is UNSIGNED, so
+                # there is no signature to round-trip. UNSIGNED_THINKING_REPLAY
+                # (required above) covers its real replay shape.
+                C.THINKING_REPLAY_ROUNDTRIP,
+                # No Anthropic-style ephemeral cache wired (no cache_control
+                # markers) — call 1 creates 0 cache_creation_input_tokens.
+                C.PROMPT_CACHING,
+                # Clean 2-call ~8 k-token probe reads 0 cache_read_input_tokens
+                # on the OpenRouter moonshotai/kimi-k2-thinking route.
+                C.IMPLICIT_PROMPT_CACHING,
+            }
+        ),
+    ),
     MC(
         model_id="openrouter__deepseek_deepseek-v4-pro",
         provider="openrouter",

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -281,6 +281,28 @@ presets:
     reasoning_codec: openai
     response_policy: minimax_m3_tags
 
+  # Moonshot Kimi K2 Thinking (Moonshot AI via OpenRouter). Unlike the
+  # non-thinking kimi-k2 family, K2 Thinking returns its reasoning over the
+  # OpenRouter ``provider_specific_fields.reasoning_details`` envelope as
+  # UNSIGNED ``reasoning.text`` blocks (no signatures) — the exact archetype
+  # the ``GeminiReasoningCodec`` was built for (Gemini Pro lineage). On the
+  # ``default`` preset (reasoning_codec unset -> none) those blocks decoded to
+  # nothing, sinking test_thinking_emits_blocks + test_unsigned_thinking_replay
+  # at 0/15. Attaching ``reasoning_codec: gemini`` decodes the blocks on
+  # extract and re-emits them as ``reasoning_details`` on replay, landing both.
+  # Everything else is inherited from ``default`` + the ``openrouter`` provider
+  # overlay (passthrough schema, openai content policy, standard response
+  # policy, reasoning_via_extra_body): all tool-call shape probes pass
+  # natively, so no schema/response axis is touched. Signed-block replay
+  # (THINKING_REPLAY_ROUNDTRIP) is a genuine ceiling — Kimi is unsigned — and
+  # neither caching surface fires on this route (see registry.py).
+  # Live-certified 2026-07-13 via auto-resolve (PR #254).
+  moonshotai_kimi_k2_thinking:
+    match:
+      - "moonshotai/kimi-k2-thinking*"
+      - "*kimi-k2-thinking*"
+    reasoning_codec: gemini
+
 providers:
   openrouter:
     params:

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -138,8 +138,6 @@ presets:
     match:
       - "xiaomi/mimo*"
       - "*mimo-v2*"
-      - "moonshotai/kimi-k2*"
-      - "*kimi-k2*"
       - "deepseek/deepseek-v4*"
       - "*deepseek-v4*"
       - "z-ai/glm-5*"


### PR DESCRIPTION
# Integrate `moonshotai/kimi-k2-thinking` (auto-resolve)

**Candidate:** provider `openrouter`, name `moonshotai/kimi-k2-thinking`
(`model_id=openrouter__moonshotai_kimi-k2-thinking`).

**Engine ref:** reuses the existing `GeminiReasoningCodec` — no new adapter
class.

## Policy

One new model-specific preset in `model_presets.yaml`
(`moonshotai_kimi_k2_thinking`, matching `moonshotai/kimi-k2-thinking*` /
`*kimi-k2-thinking*`) that sets `reasoning_codec: gemini`. K2 Thinking
returns unsigned `reasoning.text` blocks over the OpenRouter
`reasoning_details` envelope — the Gemini Pro archetype the codec decodes.
On the `default` preset those blocks decoded to nothing, sinking
`test_thinking_emits_blocks` and `test_unsigned_thinking_replay` at 0/15;
with the codec attached both went 5/5 on the final reprobe. Everything else
is inherited from `default` + the `openrouter` provider overlay (passthrough
schema, openai content policy, standard response policy). No shared glob was
broadened.

Cert added to `tests/integration/llm/registry.py`: **20 required /
3 known_unsupported**. Pricing verified present in `pricing.json`.

## Ceilings (`known_unsupported`)

- `THINKING_REPLAY_ROUNDTRIP` — signed replay; Kimi is unsigned (genuine ceiling).
- `PROMPT_CACHING` — no `cache_control` markers wired.
- `IMPLICIT_PROMPT_CACHING` — 0 `cache_read_input_tokens` on a clean 2-call probe.

## Note

Integrated via **auto-resolve** (the fix loop converged; the last reprobe went
green on every fix-target). ⚠️ This is a **disposable test branch**
(`test/observe-kimi-k2-thinking-r1`) — it **must not be merged**.
