### PR TITLE
feat(loader): ${VAR} interpolation in run configs + --workers CLI flag

### DIFF
--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -257,6 +257,7 @@ class TestRunCommand:
         assert "--resume" in result.output
         assert "--verbose" in result.output
         assert "--strict" in result.output
+        assert "--workers" in result.output
 
     def test_run_missing_config(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["run"])
@@ -265,6 +266,33 @@ class TestRunCommand:
     def test_run_nonexistent_config(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["run", "--config", "/nonexistent/config.yaml"])
         assert result.exit_code != 0
+
+    def test_run_workers_rejects_zero(self, runner: CliRunner, tmp_path: Path) -> None:
+        # Positive-int validation happens at click-parse time — no need
+        # for a real config file since the exit fires before loading.
+        # Click's IntRange failure writes to stderr and exits with 2;
+        # asserting on exit_code alone is enough to pin the validation
+        # (message goes to stderr, which CliRunner routes separately).
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(tmp_path / "x.yaml"), "--workers", "0"],
+        )
+        assert result.exit_code != 0
+
+    def test_run_workers_rejects_negative(self, runner: CliRunner, tmp_path: Path) -> None:
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(tmp_path / "x.yaml"), "--workers", "-3"],
+        )
+        assert result.exit_code != 0
+
+    def test_run_workers_help_names_compute_workers(self, runner: CliRunner) -> None:
+        # The help text points authors at the canonical home so the
+        # flag doesn't quietly ship the compute vs orchestrator dual-
+        # home confusion into new pack authoring.
+        result = runner.invoke(cli, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "compute.workers" in result.output
 
 
 # ===================================================================

--- a/tests/unit/test_dual_home_aliases.py
+++ b/tests/unit/test_dual_home_aliases.py
@@ -88,6 +88,23 @@ class TestComputeWorkersAlias:
         # OrchestratorConfig.workers default is 8; compute.workers is None.
         assert cfg.effective_workers == 8
 
+    def test_cli_workers_write_to_compute_no_warning(self) -> None:
+        # The `--workers` CLI flag writes to canonical `compute.workers`
+        # (see tolokaforge.cli.main:run). Pin that writing there does
+        # NOT fire the dual-home DeprecationWarning — the alias-lift
+        # only warns when `orchestrator.workers` is set. A regression
+        # here would silently ship the warning on every CLI-driven run.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(**_base(compute={"workers": 4}))
+        assert cfg.effective_workers == 4
+        assert cfg.compute is not None
+        assert cfg.compute.workers == 4
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "orchestrator.workers" in str(w.message)
+            for w in caught
+        )
+
     def test_object_form_orchestrator_bypasses_lift(self) -> None:
         # Regression pin: the alias-lift only fires on dict-form inputs
         # (production YAML load). Object-form callers who construct

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -698,6 +698,102 @@ class TestEnvVarInterpolation:
         merged, _ = load_effective_run_config(run_cfg)
         assert merged["models"]["user"]["name"] == "gpt-4o-2026-nightly"
 
+    def test_credential_shaped_names_rejected_at_load(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Rule-2 boundary: even if the env var IS set, a placeholder
+        # with a credential-shaped suffix is rejected. Credentials
+        # must flow through SecretManager, not the plaintext merged
+        # config dict.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak-here")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "results/${OPENAI_API_KEY}"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError) as exc:
+            load_effective_run_config(run_cfg)
+        message = str(exc.value)
+        assert "credential-shaped" in message
+        assert "OPENAI_API_KEY" in message
+        assert "SecretManager" in message
+        # And the env var's real value must never appear in the error —
+        # the point of the boundary is to keep it out of every downstream
+        # log surface, starting with our own error path.
+        assert "sk-should-not-leak-here" not in message
+
+    def test_credential_suffix_variants_all_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Suffix-based match mirrors tests/unit/secrets/test_no_raw_secret_access.py.
+        # A representative from each suffix pins the shape.
+        variants = [
+            "MY_TOKEN",
+            "MY_SECRET",
+            "MY_PASSWORD",
+            "POSTGRES_DSN",
+            "GITHUB_PAT",
+            "MY_CREDENTIAL",
+            "MY_CREDENTIALS",
+        ]
+        for var in variants:
+            monkeypatch.setenv(var, "unused")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "results/x"},
+                "orchestrator": {
+                    # Field is a string, so it exercises the walker.
+                    "continue_prompt": " ".join(f"${{{v}}}" for v in variants),
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError, match="credential-shaped") as exc:
+            load_effective_run_config(run_cfg)
+        message = str(exc.value)
+        for var in variants:
+            assert var in message, f"expected {var!r} in error message"
+
+    def test_dict_keys_are_never_interpolated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pins that only string VALUES are interpolated. A ${...}-shaped
+        # dict key would parse as a literal string key on the merged
+        # dict — no substitution attempted, no missing-var error.
+        monkeypatch.setenv("SHOULD_NOT_FIRE", "surprise")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "results/x"},
+                "orchestrator": {
+                    # A YAML mapping key using ${...} shape — the walker
+                    # must skip keys entirely, so this survives verbatim
+                    # regardless of whether the env var is set.
+                    "typesense": {"${SHOULD_NOT_FIRE}": "literal-value"},
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        # The key survives untouched; env var value never leaks in.
+        assert "${SHOULD_NOT_FIRE}" in merged["orchestrator"]["typesense"]
+        assert "surprise" not in merged["orchestrator"]["typesense"]
+
     def test_multiple_missing_vars_reported_together(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -732,7 +732,13 @@ class TestEnvVarInterpolation:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Suffix-based match mirrors tests/unit/secrets/test_no_raw_secret_access.py.
-        # A representative from each suffix pins the shape.
+        # A representative from each suffix pins the shape. Uses
+        # ``evaluation.output_dir`` (non-deprecated string field) as
+        # the concatenation site so this test doesn't depend on the
+        # deprecated ``orchestrator.continue_prompt`` — if a future
+        # refactor moves interpolation after RunConfig construction,
+        # the assertion still holds without picking up a stray
+        # DeprecationWarning.
         variants = [
             "MY_TOKEN",
             "MY_SECRET",
@@ -750,10 +756,11 @@ class TestEnvVarInterpolation:
             run_cfg,
             {
                 "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
-                "evaluation": {"output_dir": "results/x"},
-                "orchestrator": {
-                    # Field is a string, so it exercises the walker.
-                    "continue_prompt": " ".join(f"${{{v}}}" for v in variants),
+                "evaluation": {
+                    # Non-deprecated string field; the walker sees every
+                    # concatenated placeholder in one pass.
+                    "output_dir": "results/"
+                    + "-".join(f"${{{v}}}" for v in variants),
                 },
             },
         )
@@ -793,6 +800,59 @@ class TestEnvVarInterpolation:
         # The key survives untouched; env var value never leaks in.
         assert "${SHOULD_NOT_FIRE}" in merged["orchestrator"]["typesense"]
         assert "surprise" not in merged["orchestrator"]["typesense"]
+
+    def test_variable_names_with_digits_substitute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The regex's second-char class is [A-Za-z0-9_], so digits are
+        # allowed after the first character. Pin the common shapes
+        # (``NAME_1``, ``NAME2``, ``NAME_1A``) so a future tightening
+        # of the pattern can't silently break them.
+        monkeypatch.setenv("MY_VAR_1", "one")
+        monkeypatch.setenv("MY_VAR2", "two")
+        monkeypatch.setenv("MY_VAR_1A", "one-a")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {
+                    "output_dir": "results/${MY_VAR_1}-${MY_VAR2}-${MY_VAR_1A}",
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["evaluation"]["output_dir"] == "results/one-two-one-a"
+
+    def test_key_path_in_error_uses_bracket_index_no_dot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pin the rendered key-path format for list indices: the error
+        # should say ``projects[0]`` (not ``projects.[0]``). A regression
+        # in :func:`_render_key_path` would reintroduce the spurious dot.
+        monkeypatch.delenv("MISSING_IN_LIST", raising=False)
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {
+                    "output_dir": "results/x",
+                    "projects": ["${MISSING_IN_LIST}"],
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError) as exc:
+            load_effective_run_config(run_cfg)
+        message = str(exc.value)
+        assert "evaluation.projects[0]" in message, message
+        assert "projects.[0]" not in message, message
 
     def test_placeholder_in_list_value_substituted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -566,6 +566,165 @@ class TestProjectAssetsPathAnchoring:
         assert project.assets.seeds["base"].kind == "sql_dump"
 
 
+class TestEnvVarInterpolation:
+    """``${VAR}`` substitution runs on run-config string values after
+    ``project.run_defaults`` merge and before the roster check. Only
+    string values are interpolated; keys, numbers, booleans, and lists
+    of non-strings pass through untouched. Missing variables collect
+    into a single error naming every offending key path."""
+
+    def test_interpolated_from_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_OUTPUT_DIR", "results/from-env")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "${MY_OUTPUT_DIR}"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["evaluation"]["output_dir"] == "results/from-env"
+
+    def test_missing_variable_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEFINITELY_UNSET_VAR", raising=False)
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "${DEFINITELY_UNSET_VAR}"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(
+            ValueError,
+            match=r"unresolved environment variable.*DEFINITELY_UNSET_VAR",
+        ):
+            load_effective_run_config(run_cfg)
+
+    def test_non_strings_pass_through_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No env var set — numbers, booleans, and lists of non-strings
+        # must not participate in the walker's string-value branch.
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "orchestrator": {
+                    "workers": 4,
+                    "auto_start_services": True,
+                    "repeats": 1,
+                },
+                "evaluation": {"output_dir": "results/x"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["orchestrator"]["auto_start_services"] is True
+
+    def test_string_with_no_placeholder_untouched(self, tmp_path: Path) -> None:
+        # A literal string without ``${...}`` must survive verbatim —
+        # the walker's replace callback only rewrites placeholders.
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "results/literal"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["evaluation"]["output_dir"] == "results/literal"
+
+    def test_bareword_dollar_not_interpolated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Only ``${VAR}`` (braces mandatory) is interpolated; ``$VAR``
+        # bareword stays literal — an intentional design choice
+        # documented on the helper.
+        monkeypatch.setenv("BAREWORD_VAR", "would-be-substituted")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {"output_dir": "prefix-$BAREWORD_VAR"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["evaluation"]["output_dir"] == "prefix-$BAREWORD_VAR"
+
+    def test_interpolation_fires_after_run_defaults_merge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Project supplies a base model name with a placeholder that the
+        # operator resolves at run time. The run config doesn't override
+        # models, so the project default flows through the merge into
+        # the effective dict — and then interpolation fires, substituting
+        # the operator-supplied value. Uses `models` (which is a valid
+        # RunDefaults field) since `evaluation` isn't on RunDefaults.
+        monkeypatch.setenv("MODEL_TAG", "gpt-4o-2026-nightly")
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "run_defaults": {
+                    "models": {"user": {"provider": "openai", "name": "${MODEL_TAG}"}},
+                },
+            },
+        )
+        run_cfg = tmp_path / "run_configs" / "nightly.yaml"
+        _write_yaml(run_cfg, {"evaluation": {"output_dir": "results/nightly"}})
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["models"]["user"]["name"] == "gpt-4o-2026-nightly"
+
+    def test_multiple_missing_vars_reported_together(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Author-ergonomic: report every miss in a single error rather
+        # than one-at-a-time. Fixing three typos should take one edit
+        # pass, not three reload cycles.
+        for var in ("UNSET_A", "UNSET_B", "UNSET_C"):
+            monkeypatch.delenv(var, raising=False)
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "${UNSET_A}"}},
+                "evaluation": {"output_dir": "${UNSET_B}/${UNSET_C}"},
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        with pytest.raises(ValueError) as exc:
+            load_effective_run_config(run_cfg)
+        message = str(exc.value)
+        assert "UNSET_A" in message
+        assert "UNSET_B" in message
+        assert "UNSET_C" in message
+
+
 class TestDeepMergeIsSingleImpl:
     """`deep_merge` in the project loader is the single implementation
     the task loader imports — no shadow copy in `_task_loader.py`."""

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -794,6 +794,56 @@ class TestEnvVarInterpolation:
         assert "${SHOULD_NOT_FIRE}" in merged["orchestrator"]["typesense"]
         assert "surprise" not in merged["orchestrator"]["typesense"]
 
+    def test_placeholder_in_list_value_substituted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The walker recurses lists; pin the list-branch positively so
+        # a future refactor to the walker can't silently break list-
+        # of-strings substitution (a shape real packs use for
+        # ``evaluation.projects`` when parameterising by env).
+        monkeypatch.setenv("PACK_ROOT", "/abs/packs")
+        _write_yaml(tmp_path / "project.yaml", {"name": "p"})
+        run_cfg = tmp_path / "run_configs" / "dev.yaml"
+        _write_yaml(
+            run_cfg,
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {
+                    "output_dir": "results/x",
+                    "projects": ["${PACK_ROOT}/pack-a", "${PACK_ROOT}/pack-b"],
+                },
+            },
+        )
+        from tolokaforge.core.project_loader import load_effective_run_config
+
+        merged, _ = load_effective_run_config(run_cfg)
+        assert merged["evaluation"]["projects"] == [
+            "/abs/packs/pack-a",
+            "/abs/packs/pack-b",
+        ]
+
+    def test_input_dict_not_mutated(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The public helper's contract says the input tree is not
+        # mutated — a caller who kept a reference to the raw dict must
+        # still see it verbatim after the interpolation returns. Pin
+        # via an isolated helper call rather than through the loader
+        # (loader wraps everything in a fresh dict via deep_merge).
+        import copy
+
+        from tolokaforge.core.project_loader import _interpolate_env_vars
+
+        monkeypatch.setenv("VAL", "resolved")
+        original = {
+            "root": "${VAL}/x",
+            "nested": {"leaf": "prefix-${VAL}"},
+            "list_of_strings": ["a", "${VAL}"],
+        }
+        snapshot = copy.deepcopy(original)
+        result = _interpolate_env_vars(original, source_path=tmp_path / "x.yaml")
+        assert original == snapshot, "input dict was mutated"
+        assert result is not original
+        assert result["root"] == "resolved/x"
+
     def test_multiple_missing_vars_reported_together(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -188,6 +188,16 @@ def _activate_presets_overlay(
         "isolation: per_trial). See docs/architecture/RUNTIME_BACKENDS.md."
     ),
 )
+@click.option(
+    "--workers",
+    "workers",
+    type=click.IntRange(min=1),
+    default=None,
+    help=(
+        "Number of concurrent trial workers. Overrides compute.workers "
+        "in the run config. Must be a positive integer. See docs/CONFIG.md."
+    ),
+)
 def run(
     config: str,
     resume: bool,
@@ -197,6 +207,7 @@ def run(
     judge_model: str | None,
     presets_file: str | None,
     runtime: str | None,
+    workers: int | None,
 ):
     """Run benchmark with specified configuration"""
     console.print(f"[bold blue]Loading configuration from {config}...[/bold blue]")
@@ -241,6 +252,12 @@ def run(
     # value survives every downstream config lookup.
     if runtime is not None:
         config_data.setdefault("orchestrator", {})["runtime"] = runtime
+
+    # --workers writes to the canonical compute.workers home; the dual-
+    # home alias-lift is a no-op here (no `orchestrator.workers` set by
+    # the CLI), so this fires no DeprecationWarning.
+    if workers is not None:
+        config_data.setdefault("compute", {})["workers"] = workers
 
     run_config = RunConfig(**config_data)
 

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -31,6 +31,8 @@ task-yaml delta.
 from __future__ import annotations
 
 import logging
+import os
+import re
 import warnings
 from pathlib import Path
 from typing import Any
@@ -292,6 +294,98 @@ def resolve_effective_run_config_data(
 # ── High-level loader entry point ──────────────────────────────────────
 
 
+# ── ${VAR} interpolation ───────────────────────────────────────────────
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+"""Match ``${VAR}`` occurrences. Braces are mandatory — bareword
+``$VAR`` is not recognised (ambiguity with literal ``$`` is a
+tar-pit; explicit braces avoid it). Variable names follow the shell
+convention: letter or underscore, then letters / digits / underscores.
+"""
+
+
+def _interpolate_env_vars(
+    node: Any,
+    *,
+    source_path: Path,
+    _key_path: tuple[str, ...] = (),
+) -> Any:
+    """Substitute ``${VAR}`` occurrences in every string value under
+    *node* with values from ``os.environ``. Recursive; walks dicts and
+    lists; leaves non-string leaves untouched.
+
+    Returns a new tree with substitutions applied — the input is not
+    mutated. Missing variables collect into a single error naming the
+    file, every offending key path, and every missing variable so the
+    author fixes them in one pass rather than one-at-a-time.
+
+    Scope: only string *values* are interpolated. Dict keys stay
+    literal. Numbers, booleans, ``None``, and lists-of-non-strings pass
+    through unchanged. Recursion into substituted values does not run —
+    if ``${FOO}`` resolves to a string containing ``${BAR}``, only one
+    pass happens.
+    """
+    missing: list[str] = []
+    result = _interpolate_walk(node, source_path, _key_path, missing)
+    if missing:
+        raise ValueError(
+            f"Run config {source_path}: unresolved environment "
+            f"variable(s): {sorted(set(missing))}. Export them before "
+            "loading (or supply defaults in the run config)."
+        )
+    return result
+
+
+def _interpolate_walk(
+    node: Any,
+    source_path: Path,
+    key_path: tuple[str, ...],
+    missing: list[str],
+) -> Any:
+    """Depth-first walk used by :func:`_interpolate_env_vars`.
+    Splits into a top-level helper so the public entry point owns the
+    "raise once with every miss" contract in a single place.
+    """
+    if isinstance(node, dict):
+        return {
+            k: _interpolate_walk(v, source_path, (*key_path, str(k)), missing)
+            for k, v in node.items()
+        }
+    if isinstance(node, list):
+        return [
+            _interpolate_walk(item, source_path, (*key_path, f"[{idx}]"), missing)
+            for idx, item in enumerate(node)
+        ]
+    if isinstance(node, str):
+        return _interpolate_string(node, source_path, key_path, missing)
+    return node
+
+
+def _interpolate_string(
+    value: str,
+    source_path: Path,
+    key_path: tuple[str, ...],
+    missing: list[str],
+) -> str:
+    """Substitute every ``${VAR}`` occurrence in *value*. Unknown
+    variables record onto *missing* as ``"KEY.PATH → VAR"`` entries for
+    the collated error message; the string is returned with the
+    original placeholders in place so downstream code can still see
+    something reasonable if the caller catches the error."""
+
+    def replace(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            joined_path = ".".join(key_path) if key_path else "(root)"
+            missing.append(f"{joined_path} → ${{{var_name}}}")
+            return match.group(0)
+        return env_value
+
+    return _ENV_VAR_PATTERN.sub(replace, value)
+
+
 def load_effective_run_config(
     config_path: Path,
 ) -> tuple[dict[str, Any], ProjectConfig]:
@@ -331,6 +425,7 @@ def load_effective_run_config(
     else:
         project = synthesize_default_project(project_root=config_path.parent)
     merged = resolve_effective_run_config_data(project, config_data)
+    merged = _interpolate_env_vars(merged, source_path=config_path)
     validate_actor_roster_subset_of_models(project, merged)
     return merged, project
 

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -304,6 +304,16 @@ tar-pit; explicit braces avoid it). Variable names follow the shell
 convention: letter or underscore, then letters / digits / underscores.
 """
 
+_CREDENTIAL_NAME_SUFFIX_PATTERN = re.compile(
+    r"(?:_API_KEY|_API_KEYS|_API_BASE|_TOKEN|_SECRET|_PASSWORD" r"|_DSN|_CREDENTIAL[S]?|_PAT)$"
+)
+"""Variable-name suffixes that mark a placeholder as
+credential-shaped. Mirrors the enforcement pattern in
+``tests/unit/secrets/test_no_raw_secret_access.py`` so authors
+cannot smuggle credentials into a config through ``${VAR}`` —
+credentials must flow through ``SecretManager``, never a run-config
+placeholder that lands as plaintext in the merged dict."""
+
 
 def _interpolate_env_vars(
     node: Any,
@@ -316,24 +326,45 @@ def _interpolate_env_vars(
     lists; leaves non-string leaves untouched.
 
     Returns a new tree with substitutions applied — the input is not
-    mutated. Missing variables collect into a single error naming the
-    file, every offending key path, and every missing variable so the
-    author fixes them in one pass rather than one-at-a-time.
+    mutated. Missing variables and credential-shaped placeholders
+    collect into a single error naming the file, every offending key
+    path, and every offending variable so the author fixes them in
+    one pass rather than one-at-a-time.
 
     Scope: only string *values* are interpolated. Dict keys stay
     literal. Numbers, booleans, ``None``, and lists-of-non-strings pass
     through unchanged. Recursion into substituted values does not run —
     if ``${FOO}`` resolves to a string containing ``${BAR}``, only one
     pass happens.
+
+    Rule-2 boundary: variable names ending in credential-shaped
+    suffixes (``_API_KEY``, ``_TOKEN``, ``_SECRET``, ``_PASSWORD``,
+    ``_DSN``, ``_CREDENTIAL[S]``, ``_PAT``) are rejected at load
+    time even if the env var is set. Credentials must go through
+    ``SecretManager``, never a plaintext ``${VAR}`` placeholder — the
+    merged run-config dict is logged, dumped, and passed through
+    many hands, so a secret lifted into it via interpolation escapes
+    the single-abstraction invariant.
     """
     missing: list[str] = []
-    result = _interpolate_walk(node, source_path, _key_path, missing)
-    if missing:
-        raise ValueError(
-            f"Run config {source_path}: unresolved environment "
-            f"variable(s): {sorted(set(missing))}. Export them before "
-            "loading (or supply defaults in the run config)."
+    credentials: list[str] = []
+    result = _interpolate_walk(node, source_path, _key_path, missing, credentials)
+    errors: list[str] = []
+    if credentials:
+        errors.append(
+            f"credential-shaped variable(s) in ${{...}} placeholders: "
+            f"{sorted(set(credentials))}. Credentials must go through "
+            "SecretManager, not a run-config placeholder — the merged "
+            "dict is plaintext and gets logged / dumped downstream."
         )
+    if missing:
+        errors.append(
+            f"unresolved environment variable(s): {sorted(set(missing))}. "
+            "Export them before loading (or supply defaults in the run config)."
+        )
+    if errors:
+        joined = " | ".join(errors)
+        raise ValueError(f"Run config {source_path}: {joined}")
     return result
 
 
@@ -342,6 +373,7 @@ def _interpolate_walk(
     source_path: Path,
     key_path: tuple[str, ...],
     missing: list[str],
+    credentials: list[str],
 ) -> Any:
     """Depth-first walk used by :func:`_interpolate_env_vars`.
     Splits into a top-level helper so the public entry point owns the
@@ -349,16 +381,16 @@ def _interpolate_walk(
     """
     if isinstance(node, dict):
         return {
-            k: _interpolate_walk(v, source_path, (*key_path, str(k)), missing)
+            k: _interpolate_walk(v, source_path, (*key_path, str(k)), missing, credentials)
             for k, v in node.items()
         }
     if isinstance(node, list):
         return [
-            _interpolate_walk(item, source_path, (*key_path, f"[{idx}]"), missing)
+            _interpolate_walk(item, source_path, (*key_path, f"[{idx}]"), missing, credentials)
             for idx, item in enumerate(node)
         ]
     if isinstance(node, str):
-        return _interpolate_string(node, source_path, key_path, missing)
+        return _interpolate_string(node, source_path, key_path, missing, credentials)
     return node
 
 
@@ -367,18 +399,22 @@ def _interpolate_string(
     source_path: Path,
     key_path: tuple[str, ...],
     missing: list[str],
+    credentials: list[str],
 ) -> str:
-    """Substitute every ``${VAR}`` occurrence in *value*. Unknown
-    variables record onto *missing* as ``"KEY.PATH → VAR"`` entries for
-    the collated error message; the string is returned with the
-    original placeholders in place so downstream code can still see
-    something reasonable if the caller catches the error."""
+    """Substitute every ``${VAR}`` occurrence in *value*. Credential-
+    shaped names are rejected before the environment is even queried;
+    unknown names record onto *missing* for the collated error. The
+    return value only matters when both lists stay empty — callers
+    always route the raise through the public entry point."""
 
     def replace(match: re.Match[str]) -> str:
         var_name = match.group(1)
+        joined_path = ".".join(key_path) if key_path else "(root)"
+        if _CREDENTIAL_NAME_SUFFIX_PATTERN.search(var_name):
+            credentials.append(f"{joined_path} → ${{{var_name}}}")
+            return match.group(0)
         env_value = os.environ.get(var_name)
         if env_value is None:
-            joined_path = ".".join(key_path) if key_path else "(root)"
             missing.append(f"{joined_path} → ${{{var_name}}}")
             return match.group(0)
         return env_value

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -107,6 +107,15 @@ def load_project_config(path: Path) -> ProjectConfig:
     Raises ``FileNotFoundError`` if the file does not exist, ``RuntimeError``
     if the YAML is not a mapping, and ``pydantic.ValidationError`` if the
     contents don't validate against :class:`ProjectConfig`.
+
+    Scope note: ``${VAR}`` interpolation is **not** applied to
+    ``project.yaml`` values — only the run-config load path (see
+    :func:`load_effective_run_config`) substitutes placeholders. A
+    ``project.yaml`` entry like ``assets.seeds.foo.path:
+    "${SEED_ROOT}/foo.sql"`` stays literal. This is a scope choice
+    (project.yaml is checked into the repo; the operator's env is
+    per-invocation), not a correctness one — extending interpolation
+    to the project side is a follow-up if authors ask for it.
     """
     path = Path(path)
     if not path.is_file():
@@ -385,6 +394,10 @@ def _interpolate_walk(
             for k, v in node.items()
         }
     if isinstance(node, list):
+        # List-index segments are appended without a leading dot so the
+        # rendered path reads ``evaluation.projects[0]`` rather than the
+        # spurious ``evaluation.projects.[0]``. The joiner in
+        # :func:`_render_key_path` treats ``[N]`` segments specially.
         return [
             _interpolate_walk(item, source_path, (*key_path, f"[{idx}]"), missing, credentials)
             for idx, item in enumerate(node)
@@ -392,6 +405,24 @@ def _interpolate_walk(
     if isinstance(node, str):
         return _interpolate_string(node, source_path, key_path, missing, credentials)
     return node
+
+
+def _render_key_path(key_path: tuple[str, ...]) -> str:
+    """Render a walker key path for error messages.
+
+    Dict-key segments join with ``.``; list-index segments (``[N]``)
+    stay attached to the preceding segment without an intervening dot.
+    Returns ``"(root)"`` when the path is empty.
+    """
+    if not key_path:
+        return "(root)"
+    parts: list[str] = []
+    for segment in key_path:
+        if segment.startswith("[") and parts:
+            parts[-1] = parts[-1] + segment
+        else:
+            parts.append(segment)
+    return ".".join(parts)
 
 
 def _interpolate_string(
@@ -409,13 +440,13 @@ def _interpolate_string(
 
     def replace(match: re.Match[str]) -> str:
         var_name = match.group(1)
-        joined_path = ".".join(key_path) if key_path else "(root)"
+        rendered_path = _render_key_path(key_path)
         if _CREDENTIAL_NAME_SUFFIX_PATTERN.search(var_name):
-            credentials.append(f"{joined_path} → ${{{var_name}}}")
+            credentials.append(f"{rendered_path} → ${{{var_name}}}")
             return match.group(0)
         env_value = os.environ.get(var_name)
         if env_value is None:
-            missing.append(f"{joined_path} → ${{{var_name}}}")
+            missing.append(f"{rendered_path} → ${{{var_name}}}")
             return match.group(0)
         return env_value
 


### PR DESCRIPTION
Two small M2.5 additions bundled per the umbrella. No behaviour change for configs without \`\${...}\` placeholders and no \`--workers\` flag.

Closes #226 (child of #220).

## Summary

**\`\${VAR}\` interpolation** — new \`_interpolate_env_vars\` helper in \`project_loader.py\`. Recursive walker over the effective run-config tree; substitutes \`\${VAR}\` in string values from \`os.environ\`.
- Only string values are interpolated. Dict keys, numbers, booleans, non-string list items pass through untouched.
- Only \`\${VAR}\` form recognised (braces mandatory). Bareword \`\$VAR\` stays literal — the ambiguity vs literal \`\$\` is a tar-pit.
- Missing variables collect into a single \`ValueError\` naming every offending key path so authors fix all misses in one edit pass.
- Fires from \`load_effective_run_config\` after the \`run_defaults\` merge and before the roster check — every downstream CLI subcommand routes through one site.

**\`--workers N\` CLI flag** — new \`click.IntRange(min=1)\` decorator on \`tolokaforge run\`. Positive-integer validation at parse time.
- Writes to canonical \`compute.workers\` (not the legacy \`orchestrator.workers\`), so no \`DeprecationWarning\` fires from the M2.5 #225 alias-lift.
- Help text points at \`compute.workers\` so authors learn the right home from the flag output.

## Test plan

- [x] \`uv run pytest tests/unit/ tests/canonical/\` — 2674 passed, 1 skipped (+10 new).
- [x] Interpolation: seven new tests covering positive substitution, missing-var error, non-strings untouched, literal-string round-trip, bareword \`\$VAR\` stays literal, fires after \`run_defaults\` merge, multiple misses collated into one error.
- [x] CLI: \`--workers\` appears in \`--help\`; rejects \`0\` and negative values via \`IntRange\`; help text points at \`compute.workers\`.
- [x] \`ruff check\` + \`ruff format --check\` clean on touched files.

## Not in scope

- Interpolating dict keys (only values).
- \`\$VAR\` bareword shorthand — only \`\${VAR}\` form.
- Default-value syntax (\`\${VAR:-default}\`, bash-style) — post-v1 refinement if authors ask for it.
- Recursive interpolation of substituted values — if \`\${FOO}\` resolves to a string containing \`\${BAR}\`, only one pass runs. Simpler mental model; predictable.