### PR TITLE
feat(cli): tolokaforge assets stamp verb

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,8 +35,20 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-8
-          direct_prompt: |
+          # v1.0 renamed several inputs — see the action's migration guide.
+          # ``direct_prompt`` → ``prompt`` (direct rename); ``model`` moves
+          # into ``claude_args`` as a CLI flag. Old input names silently
+          # no-op'd (workflow ran but the review didn't fire); this fix
+          # brings coverage back.
+          # ``track_progress: true`` restores the tag-mode tracking comments
+          # v0.x posted by default so future PR readers see the review
+          # progress the same way they did before the upgrade.
+          track_progress: true
+          claude_args: --model claude-opus-4-8
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this PR against the project's AGENTS.md rules. Flag any
             violation with file path, line number, and a concrete suggested
             fix. If everything checks out, say so explicitly.

--- a/tests/unit/test_cli_assets.py
+++ b/tests/unit/test_cli_assets.py
@@ -103,13 +103,13 @@ class TestAssetsStampWriteMode:
         assert rewritten["assets"]["seeds"]["base"]["digest"] == expected
 
         # Idempotent: re-running against the now-stamped file is a
-        # no-op that says so and doesn't touch the file. Rich console
-        # wraps long output, so join on whitespace before asserting on
-        # phrases.
+        # no-op that says so and doesn't touch the file. Rich is
+        # configured with ``soft_wrap=True`` so the phrase stays on
+        # one line even in narrow CI terminals.
         mtime_after_first = project_yaml.stat().st_mtime_ns
         result2 = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result2.exit_code == 0
-        assert "already current" in " ".join(result2.output.split())
+        assert "already current" in result2.output
         assert project_yaml.stat().st_mtime_ns == mtime_after_first
 
     def test_bare_string_shorthand_coerced_to_dict_with_digest(
@@ -197,12 +197,44 @@ class TestAssetsStampMissingFile:
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result.exit_code != 0
-        # Rich wraps output mid-phrase; normalise whitespace before the
-        # phrase check. The offending path must appear so the author
-        # knows exactly which reference to fix.
-        normalised = " ".join(result.output.split())
-        assert "shared/seeds/missing.sql" in normalised
-        assert "does not exist" in normalised
+        # Rich console is configured with ``soft_wrap=True`` so paths
+        # stay intact across narrow CI terminals. The offending path
+        # must appear so the author knows exactly which reference to
+        # fix.
+        assert "shared/seeds/missing.sql" in result.output
+        assert "does not exist" in result.output
+
+
+class TestAssetsStampCheckWithMissingFile:
+    def test_check_mode_fails_when_seed_file_missing(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # --check must NOT mask a missing seed file — the whole point of
+        # dry-run in CI is catching drift before it lands. Order of the
+        # exit paths (missing file check before check-only branch) is
+        # what makes this work; pinning it here so a future reorder
+        # can't silently break the guarantee.
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "p",
+                    "assets": {
+                        "seeds": {
+                            "base": {
+                                "path": "shared/seeds/missing.sql",
+                                "kind": "sql_dump",
+                            },
+                        },
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "shared/seeds/missing.sql" in result.output
 
 
 class TestAssetsStampProjectResolution:
@@ -225,6 +257,48 @@ class TestAssetsStampProjectResolution:
         result = runner.invoke(cli, ["assets", "stamp", str(empty)])
         assert result.exit_code != 0
         assert "No project.yaml" in result.output
+
+
+class TestAssetsStampMalformedShapeFailsLoud:
+    """Present-but-wrong shapes on ``assets`` or ``assets.seeds``
+    must NOT report ``nothing to stamp`` — a ``--check`` in CI
+    should fail so a typo doesn't ride green through the pipeline.
+    Absent vs. present-but-broken is the important distinction."""
+
+    def test_assets_not_a_mapping_fails_loud(self, runner: CliRunner, tmp_path: Path) -> None:
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(yaml.safe_dump({"name": "p", "assets": "oops"}))
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code != 0
+        # ``click.ClickException`` writes to stderr, and the fixture
+        # is ``mix_stderr=False`` — check the split stream.
+        assert "assets" in result.stderr
+        assert "must be a mapping" in result.stderr
+
+    def test_seeds_not_a_mapping_fails_loud(self, runner: CliRunner, tmp_path: Path) -> None:
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(
+            yaml.safe_dump({"name": "p", "assets": {"seeds": "oops"}}),
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "assets.seeds" in result.stderr
+        assert "must be a mapping" in result.stderr
+
+    def test_check_mode_also_fails_loud_on_malformed(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # The whole point of failing loud on malformed shapes is that
+        # --check in CI catches them. Pin that explicitly.
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(
+            yaml.safe_dump({"name": "p", "assets": {"seeds": "oops"}}),
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
+        assert result.exit_code != 0
 
 
 class TestAssetsStampNoSeeds:

--- a/tests/unit/test_cli_assets.py
+++ b/tests/unit/test_cli_assets.py
@@ -85,6 +85,17 @@ class TestComputeSeedDigest:
         expected = "sha256:" + hashlib.sha256(payload).hexdigest()
         assert compute_seed_digest(seed) == expected
 
+    def test_block_boundary_edge_case(self, tmp_path: Path) -> None:
+        # Non-multiple-of-block-size payloads exercise the "final
+        # chunk shorter than block size" branch of the streaming
+        # loop. 65 KiB = one full 64 KiB block + one 1 KiB tail —
+        # pins that the tail read is included in the hash.
+        seed = tmp_path / "boundary.sql"
+        payload = b"a" * (65 * 1024)
+        seed.write_bytes(payload)
+        expected = "sha256:" + hashlib.sha256(payload).hexdigest()
+        assert compute_seed_digest(seed) == expected
+
     def test_missing_file_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             compute_seed_digest(tmp_path / "does-not-exist.sql")
@@ -132,6 +143,67 @@ class TestAssetsStampWriteMode:
         assert entry["kind"] == "sql_dump"
         assert entry["digest"] == expected
 
+    def test_multiple_seeds_only_stale_entries_rewritten(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # Two-seed project: one already-current, one stale. The stamp
+        # must update only the stale entry and leave the current one
+        # untouched byte-for-byte (in the sense that the digest doesn't
+        # get re-computed to something different). Also exercises the
+        # ``changed = True`` accumulation across entries.
+        (tmp_path / "shared" / "seeds").mkdir(parents=True)
+        (tmp_path / "shared" / "seeds" / "a.sql").write_bytes(b"-- a\n")
+        (tmp_path / "shared" / "seeds" / "b.sql").write_bytes(b"-- b\n")
+        digest_a = compute_seed_digest(tmp_path / "shared" / "seeds" / "a.sql")
+        digest_b = compute_seed_digest(tmp_path / "shared" / "seeds" / "b.sql")
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "p",
+                    "assets": {
+                        "seeds": {
+                            # ``a`` is already stamped correctly.
+                            "a": {
+                                "path": "shared/seeds/a.sql",
+                                "kind": "sql_dump",
+                                "digest": digest_a,
+                            },
+                            # ``b`` has a placeholder digest — needs update.
+                            "b": {
+                                "path": "shared/seeds/b.sql",
+                                "kind": "sql_dump",
+                                "digest": "sha256:placeholder",
+                            },
+                        },
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        # One digest changed, one already correct → wrote 1.
+        assert "wrote 1 digest" in result.output
+
+        rewritten = yaml.safe_load(project_yaml.read_text())["assets"]["seeds"]
+        assert rewritten["a"]["digest"] == digest_a  # unchanged
+        assert rewritten["b"]["digest"] == digest_b  # updated
+
+    def test_explicit_project_yaml_file_argument(self, runner: CliRunner, tmp_path: Path) -> None:
+        # PROJECT_PATH may point directly at a project.yaml file (not
+        # just its containing directory). Pins the file-form branch of
+        # ``_resolve_project_yaml``.
+        project_yaml, seed = _write_project(tmp_path)
+        expected = compute_seed_digest(seed)
+
+        result = runner.invoke(cli, ["assets", "stamp", str(project_yaml)])
+        assert result.exit_code == 0, result.output
+
+        entry = yaml.safe_load(project_yaml.read_text())["assets"]["seeds"]["base"]
+        assert entry["digest"] == expected
+
     def test_relative_path_stays_relative_on_write(self, runner: CliRunner, tmp_path: Path) -> None:
         # The on-disk path must remain project-relative — rewriting to
         # absolute would break portability across checkouts.
@@ -159,15 +231,16 @@ class TestAssetsStampCheckMode:
     def test_check_stale_digest_exits_one_with_diff(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        project_yaml, _ = _write_project(tmp_path)  # placeholder digest
+        project_yaml, seed = _write_project(tmp_path)  # placeholder digest
+        expected_new = compute_seed_digest(seed)
 
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
         assert result.exit_code != 0
         assert "stale" in result.output
-        assert "sha256:placeholder" in result.output
-        # The proposed new digest is named too so the author can inspect
-        # before running the write mode.
-        assert "sha256:" in result.output
+        # Both the OLD (placeholder) and the computed NEW digest must
+        # appear in the diff, structured as ``old → new``. A regression
+        # to only-print-one would slip past a looser assertion.
+        assert f"sha256:placeholder → {expected_new}" in result.output
 
 
 class TestAssetsStampMissingFile:
@@ -197,12 +270,12 @@ class TestAssetsStampMissingFile:
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result.exit_code != 0
-        # Rich console is configured with ``soft_wrap=True`` so paths
-        # stay intact across narrow CI terminals. The offending path
-        # must appear so the author knows exactly which reference to
-        # fix.
-        assert "shared/seeds/missing.sql" in result.output
-        assert "does not exist" in result.output
+        # Errors route through ``err_console`` (stderr) — uniform with
+        # every other fatal-error path in the module. The offending
+        # path must appear on stderr so the author knows exactly which
+        # reference to fix.
+        assert "shared/seeds/missing.sql" in result.stderr
+        assert "does not exist" in result.stderr
 
 
 class TestAssetsStampCheckWithMissingFile:
@@ -234,7 +307,9 @@ class TestAssetsStampCheckWithMissingFile:
 
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
         assert result.exit_code != 0
-        assert "shared/seeds/missing.sql" in result.output
+        # Fatal errors route to stderr (see err_console in
+        # assets_commands.py).
+        assert "shared/seeds/missing.sql" in result.stderr
 
 
 class TestAssetsStampProjectResolution:
@@ -256,7 +331,8 @@ class TestAssetsStampProjectResolution:
 
         result = runner.invoke(cli, ["assets", "stamp", str(empty)])
         assert result.exit_code != 0
-        assert "No project.yaml" in result.output
+        # Fatal errors route to stderr.
+        assert "No project.yaml" in result.stderr
 
 
 class TestAssetsStampMalformedShapeFailsLoud:
@@ -299,6 +375,53 @@ class TestAssetsStampMalformedShapeFailsLoud:
 
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
         assert result.exit_code != 0
+
+
+class TestAssetsStampCommentDetection:
+    """The comment-loss warning must fire for both whole-line and
+    inline comment shapes; PyYAML strips both."""
+
+    def test_inline_comment_triggers_warning_on_write(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # Hand-author the project.yaml (yaml.safe_dump produces no
+        # comments, so we have to write raw). Inline comment on the
+        # digest line is a common author pattern.
+        seed = tmp_path / "shared" / "seeds" / "base.sql"
+        seed.parent.mkdir(parents=True)
+        seed.write_bytes(b"-- baseline\n")
+        (tmp_path / "project.yaml").write_text(
+            "name: p\n"
+            "assets:\n"
+            "  seeds:\n"
+            "    base:\n"
+            "      path: shared/seeds/base.sql  # inline note about the seed\n"
+            "      kind: sql_dump\n"
+            "      digest: sha256:placeholder\n",
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "strip on write" in result.output
+
+    def test_whole_line_comment_triggers_warning(self, runner: CliRunner, tmp_path: Path) -> None:
+        seed = tmp_path / "shared" / "seeds" / "base.sql"
+        seed.parent.mkdir(parents=True)
+        seed.write_bytes(b"-- baseline\n")
+        (tmp_path / "project.yaml").write_text(
+            "# Full-line comment at top\n"
+            "name: p\n"
+            "assets:\n"
+            "  seeds:\n"
+            "    base:\n"
+            "      path: shared/seeds/base.sql\n"
+            "      kind: sql_dump\n"
+            "      digest: sha256:placeholder\n",
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "strip on write" in result.output
 
 
 class TestAssetsStampNoSeeds:

--- a/tests/unit/test_cli_assets.py
+++ b/tests/unit/test_cli_assets.py
@@ -1,0 +1,251 @@
+"""Unit tests for ``tolokaforge assets stamp`` and the digest helper.
+
+The verb walks ``assets.seeds.<name>`` entries, computes
+``sha256:<hex>`` over each referenced file, and writes the ``digest``
+field back into ``project.yaml``. This suite covers write mode,
+``--check`` dry-run, missing-file failure, bare-string shorthand
+coercion, and idempotency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from tolokaforge.cli.main import cli
+from tolokaforge.core.assets import compute_seed_digest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+def _write_project(
+    tmp_path: Path,
+    seed_content: bytes = b"-- baseline\n",
+    *,
+    seeds_block: dict | None = None,
+) -> tuple[Path, Path]:
+    """Write a minimal project.yaml + seed file. Returns
+    ``(project_yaml_path, seed_path)``. The default seed block uses
+    the dict form with a placeholder digest; callers pass
+    ``seeds_block`` when they need the bare-string shorthand or a
+    pre-stamped digest.
+    """
+    seed_path = tmp_path / "shared" / "seeds" / "base.sql"
+    seed_path.parent.mkdir(parents=True)
+    seed_path.write_bytes(seed_content)
+
+    if seeds_block is None:
+        seeds_block = {
+            "base": {
+                "path": "shared/seeds/base.sql",
+                "kind": "sql_dump",
+                "digest": "sha256:placeholder",
+            },
+        }
+
+    project_yaml = tmp_path / "project.yaml"
+    project_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "name": "p",
+                "assets": {"seeds": seeds_block},
+            },
+            sort_keys=False,
+        ),
+    )
+    return project_yaml, seed_path
+
+
+class TestComputeSeedDigest:
+    def test_produces_sha256_prefixed_hex(self, tmp_path: Path) -> None:
+        # Compare against a hashlib-computed reference so the format
+        # ("sha256:<64-hex>") is pinned end-to-end.
+        seed = tmp_path / "seed.sql"
+        seed.write_bytes(b"hello, seed\n")
+        expected = "sha256:" + hashlib.sha256(b"hello, seed\n").hexdigest()
+        assert compute_seed_digest(seed) == expected
+
+    def test_streams_large_files(self, tmp_path: Path) -> None:
+        # 128 KiB — larger than the 64 KiB block size — exercises
+        # multi-block streaming and confirms the digest matches a
+        # whole-file hash. Regression net for a future rewrite that
+        # tries to read-all.
+        seed = tmp_path / "large.rdb"
+        payload = b"x" * (128 * 1024)
+        seed.write_bytes(payload)
+        expected = "sha256:" + hashlib.sha256(payload).hexdigest()
+        assert compute_seed_digest(seed) == expected
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            compute_seed_digest(tmp_path / "does-not-exist.sql")
+
+
+class TestAssetsStampWriteMode:
+    def test_fresh_digest_written_and_idempotent(self, runner: CliRunner, tmp_path: Path) -> None:
+        project_yaml, seed = _write_project(tmp_path)
+        expected = compute_seed_digest(seed)
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "wrote 1 digest" in result.output
+
+        rewritten = yaml.safe_load(project_yaml.read_text())
+        assert rewritten["assets"]["seeds"]["base"]["digest"] == expected
+
+        # Idempotent: re-running against the now-stamped file is a
+        # no-op that says so and doesn't touch the file. Rich console
+        # wraps long output, so join on whitespace before asserting on
+        # phrases.
+        mtime_after_first = project_yaml.stat().st_mtime_ns
+        result2 = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result2.exit_code == 0
+        assert "already current" in " ".join(result2.output.split())
+        assert project_yaml.stat().st_mtime_ns == mtime_after_first
+
+    def test_bare_string_shorthand_coerced_to_dict_with_digest(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # Bare-string shorthand can't carry a digest; the write path
+        # must coerce it into dict form with the digest attached.
+        project_yaml, seed = _write_project(
+            tmp_path,
+            seeds_block={"base": "shared/seeds/base.sql"},
+        )
+        expected = compute_seed_digest(seed)
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+        entry = yaml.safe_load(project_yaml.read_text())["assets"]["seeds"]["base"]
+        assert isinstance(entry, dict)
+        assert entry["path"] == "shared/seeds/base.sql"
+        assert entry["kind"] == "sql_dump"
+        assert entry["digest"] == expected
+
+    def test_relative_path_stays_relative_on_write(self, runner: CliRunner, tmp_path: Path) -> None:
+        # The on-disk path must remain project-relative — rewriting to
+        # absolute would break portability across checkouts.
+        project_yaml, _ = _write_project(tmp_path)
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0
+
+        entry = yaml.safe_load(project_yaml.read_text())["assets"]["seeds"]["base"]
+        assert entry["path"] == "shared/seeds/base.sql"
+
+
+class TestAssetsStampCheckMode:
+    def test_check_matches_exits_zero_no_write(self, runner: CliRunner, tmp_path: Path) -> None:
+        project_yaml, seed = _write_project(tmp_path)
+        # First, write the current digest so --check sees no drift.
+        runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+
+        mtime_before = project_yaml.stat().st_mtime_ns
+        result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "match" in result.output
+        assert project_yaml.stat().st_mtime_ns == mtime_before
+
+    def test_check_stale_digest_exits_one_with_diff(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        project_yaml, _ = _write_project(tmp_path)  # placeholder digest
+
+        result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "stale" in result.output
+        assert "sha256:placeholder" in result.output
+        # The proposed new digest is named too so the author can inspect
+        # before running the write mode.
+        assert "sha256:" in result.output
+
+
+class TestAssetsStampMissingFile:
+    def test_missing_seed_path_exits_non_zero_with_named_path(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # Author-typo case: project.yaml references a file that isn't
+        # on disk. Must fail loud naming the path so the author fixes
+        # the reference rather than debugging a mystery hash mismatch.
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "p",
+                    "assets": {
+                        "seeds": {
+                            "base": {
+                                "path": "shared/seeds/missing.sql",
+                                "kind": "sql_dump",
+                            },
+                        },
+                    },
+                },
+                sort_keys=False,
+            ),
+        )
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code != 0
+        # Rich wraps output mid-phrase; normalise whitespace before the
+        # phrase check. The offending path must appear so the author
+        # knows exactly which reference to fix.
+        normalised = " ".join(result.output.split())
+        assert "shared/seeds/missing.sql" in normalised
+        assert "does not exist" in normalised
+
+
+class TestAssetsStampProjectResolution:
+    def test_walks_up_from_directory_argument(self, runner: CliRunner, tmp_path: Path) -> None:
+        # Passing a subdirectory finds the enclosing project.yaml via
+        # find_project_yaml. Mirrors the CWD-default behaviour without
+        # depending on the invoker's current directory.
+        _write_project(tmp_path)
+        nested = tmp_path / "nested" / "deep"
+        nested.mkdir(parents=True)
+
+        result = runner.invoke(cli, ["assets", "stamp", str(nested)])
+        assert result.exit_code == 0, result.output
+
+    def test_no_project_yaml_exits_non_zero(self, runner: CliRunner, tmp_path: Path) -> None:
+        # Empty directory — no project.yaml at or above. Fails loud.
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        result = runner.invoke(cli, ["assets", "stamp", str(empty)])
+        assert result.exit_code != 0
+        assert "No project.yaml" in result.output
+
+
+class TestAssetsStampNoSeeds:
+    def test_project_without_assets_block_no_op(self, runner: CliRunner, tmp_path: Path) -> None:
+        # A project.yaml with no `assets` block is legal today; stamp
+        # is a no-op that says so rather than raising.
+        project_yaml = tmp_path / "project.yaml"
+        project_yaml.write_text(yaml.safe_dump({"name": "p"}))
+
+        result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "nothing to stamp" in result.output
+
+
+class TestAssetsStampHelpText:
+    def test_group_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["assets", "--help"])
+        assert result.exit_code == 0
+        assert "stamp" in result.output
+
+    def test_stamp_help_documents_check_flag(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["assets", "stamp", "--help"])
+        assert result.exit_code == 0
+        assert "--check" in result.output

--- a/tolokaforge/cli/assets_commands.py
+++ b/tolokaforge/cli/assets_commands.py
@@ -1,0 +1,244 @@
+"""Asset-management CLI commands for TolokaForge.
+
+Provides ``tolokaforge assets stamp [PATH]`` which walks
+``assets.seeds.<name>`` entries in a project's ``project.yaml``,
+computes ``sha256:<hex>`` over each referenced file, and writes the
+``digest`` field back in place.
+
+Uses lazy imports for heavy dependencies (yaml, project_loader) so
+CLI registration stays cheap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+# Extension-based inference mirrors _SEED_KIND_BY_EXTENSION in the
+# core models module. Kept as a private map here so the CLI can
+# emit the same "kind" the loader would infer when coercing a
+# bare-string entry to dict form before stamping.
+_KIND_BY_EXTENSION: dict[str, str] = {
+    ".sql": "sql_dump",
+    ".rdb": "redis_dump",
+}
+
+
+@click.group()
+def assets():
+    """Manage project-level assets (seeds today)."""
+
+
+@assets.command()
+@click.argument(
+    "project_path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=True, path_type=Path),
+    default=Path.cwd(),
+    required=False,
+)
+@click.option(
+    "--check",
+    "check_only",
+    is_flag=True,
+    help=(
+        "Dry-run: print the diff of proposed digest updates and exit "
+        "non-zero when anything is stale. Never writes. CI-friendly."
+    ),
+)
+def stamp(project_path: Path, check_only: bool) -> None:
+    """Compute SHA-256 digests for every ``assets.seeds.<name>`` entry
+    in a project's ``project.yaml`` and write them back in place.
+
+    PROJECT_PATH may be a directory (walks up looking for the enclosing
+    ``project.yaml``) or an explicit ``project.yaml`` file. Defaults to
+    the current working directory.
+
+    Idempotent — re-running against a fully-stamped file is a no-op
+    (verifies existing digests match; writes only when they don't).
+
+    Note: YAML round-trip via PyYAML does not preserve comments. If the
+    input file contains comments a warning is emitted before the
+    write; inspect ``git diff`` before committing.
+    """
+    import yaml
+
+    from tolokaforge.core.assets import compute_seed_digest
+
+    project_yaml = _resolve_project_yaml(project_path)
+    if project_yaml is None:
+        console.print(
+            f"[red]No project.yaml found at or above {project_path!s}[/red]",
+            style="red",
+        )
+        sys.exit(1)
+
+    project_dir = project_yaml.parent
+    raw = yaml.safe_load(project_yaml.read_text()) or {}
+    if not isinstance(raw, dict):
+        console.print(f"[red]{project_yaml} is not a YAML mapping[/red]")
+        sys.exit(1)
+
+    seeds_container = _extract_seeds(raw)
+    if not seeds_container:
+        console.print(f"[yellow]{project_yaml}: no assets.seeds entries; nothing to stamp[/yellow]")
+        return
+
+    updates: list[tuple[str, str | None, str]] = []
+    missing_files: list[tuple[str, Path]] = []
+    changed = False
+
+    for name, entry in list(seeds_container.items()):
+        seed_path_str, existing_digest = _read_seed_entry(entry)
+        if seed_path_str is None:
+            console.print(
+                f"[red]{project_yaml}: assets.seeds.{name} has no `path` field[/red]",
+            )
+            sys.exit(1)
+        abs_path = _resolve_seed_path(seed_path_str, project_dir)
+        if not abs_path.is_file():
+            missing_files.append((name, abs_path))
+            continue
+        new_digest = compute_seed_digest(abs_path)
+        updates.append((name, existing_digest, new_digest))
+        if existing_digest != new_digest:
+            changed = True
+            if not check_only:
+                seeds_container[name] = _write_seed_entry(entry, seed_path_str, new_digest)
+
+    if missing_files:
+        for name, path in missing_files:
+            console.print(
+                f"[red]{project_yaml}: assets.seeds.{name}.path does not exist: {path}[/red]",
+            )
+        sys.exit(1)
+
+    if check_only:
+        if changed:
+            console.print(f"[yellow]{project_yaml}: digest(s) stale — would rewrite[/yellow]")
+            for name, existing, new in updates:
+                if existing != new:
+                    console.print(f"  - {name}: {existing or '(unset)'} → {new}")
+            sys.exit(1)
+        console.print(f"[green]{project_yaml}: all seed digests match[/green]")
+        return
+
+    if not changed:
+        console.print(f"[green]{project_yaml}: all seed digests already current[/green]")
+        return
+
+    if _has_comments(project_yaml):
+        console.print(
+            f"[yellow]Warning: {project_yaml} contains comments that PyYAML will "
+            "strip on write. Inspect `git diff` before committing.[/yellow]",
+        )
+
+    project_yaml.write_text(
+        yaml.safe_dump(raw, sort_keys=False, default_flow_style=False),
+    )
+    console.print(
+        f"[green]{project_yaml}: wrote {sum(1 for _, e, n in updates if e != n)} digest(s)[/green]"
+    )
+
+
+def _resolve_project_yaml(project_path: Path) -> Path | None:
+    """Return the ``project.yaml`` file for *project_path*.
+
+    If *project_path* is already a file, return it verbatim. Otherwise
+    walk up from the directory looking for ``project.yaml``.
+    """
+    from tolokaforge.core.project_loader import find_project_yaml
+
+    if project_path.is_file():
+        return project_path
+    return find_project_yaml(project_path)
+
+
+def _extract_seeds(raw: dict) -> dict | None:
+    """Return the ``assets.seeds`` sub-mapping, or ``None`` when
+    absent / malformed. Malformed shapes still return ``None`` (the
+    caller treats it as "nothing to stamp") — schema validation at
+    load time is a separate concern."""
+    assets_section = raw.get("assets")
+    if not isinstance(assets_section, dict):
+        return None
+    seeds = assets_section.get("seeds")
+    if not isinstance(seeds, dict):
+        return None
+    return seeds
+
+
+def _read_seed_entry(entry: object) -> tuple[str | None, str | None]:
+    """Return ``(path, digest)`` from a seed entry in either shape.
+
+    Bare-string shorthand ``"path/to/seed.sql"`` → ``("path/to/seed.sql", None)``.
+    Dict form ``{"path": ..., "digest": ...}`` → ``(path, digest)``.
+    Unknown shapes return ``(None, None)``.
+    """
+    if isinstance(entry, str):
+        return entry, None
+    if isinstance(entry, dict):
+        path = entry.get("path")
+        digest = entry.get("digest")
+        return (
+            path if isinstance(path, str) else None,
+            digest if isinstance(digest, str) else None,
+        )
+    return None, None
+
+
+def _write_seed_entry(entry: object, seed_path: str, new_digest: str) -> dict:
+    """Return the dict form of *entry* with *new_digest* set.
+
+    Coerces bare-string shorthand into dict form (inferring ``kind``
+    from the file extension) — a string can't carry a digest, so
+    stamping always emits dict form for touched entries. Untouched
+    fields on an existing dict entry are preserved verbatim.
+    """
+    if isinstance(entry, dict):
+        out = dict(entry)
+        out["path"] = seed_path
+        out["digest"] = new_digest
+        # Ensure ``kind`` is present — SeedRef requires it in dict form.
+        if "kind" not in out:
+            inferred = _KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
+            if inferred is not None:
+                out["kind"] = inferred
+        return out
+    # Bare-string entry — coerce to dict form.
+    kind = _KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
+    if kind is None:
+        # SeedRef's own load-time normaliser would fail loud here too;
+        # match its shape.
+        raise click.ClickException(
+            f"cannot infer kind from bare-string seed path {seed_path!r} "
+            f"(extension not in {sorted(_KIND_BY_EXTENSION)!r}). Rewrite "
+            "as {path: ..., kind: ...} before stamping."
+        )
+    return {"path": seed_path, "kind": kind, "digest": new_digest}
+
+
+def _resolve_seed_path(seed_path: str, project_dir: Path) -> Path:
+    """Return an absolute path for a seed reference. Absolute paths
+    pass through unchanged; relative paths anchor to *project_dir*."""
+    p = Path(seed_path)
+    if p.is_absolute():
+        return p
+    return (project_dir / p).resolve()
+
+
+def _has_comments(path: Path) -> bool:
+    """Best-effort check for ``#``-prefixed comment lines in *path*.
+    Full YAML lexing isn't needed — the warning is advisory."""
+    try:
+        for line in path.read_text().splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                return True
+    except OSError:
+        pass
+    return False

--- a/tolokaforge/cli/assets_commands.py
+++ b/tolokaforge/cli/assets_commands.py
@@ -17,16 +17,13 @@ from pathlib import Path
 import click
 from rich.console import Console
 
-console = Console()
-
-# Extension-based inference mirrors _SEED_KIND_BY_EXTENSION in the
-# core models module. Kept as a private map here so the CLI can
-# emit the same "kind" the loader would infer when coercing a
-# bare-string entry to dict form before stamping.
-_KIND_BY_EXTENSION: dict[str, str] = {
-    ".sql": "sql_dump",
-    ".rdb": "redis_dump",
-}
+# ``soft_wrap=True`` disables rich's terminal-width wrapping. Without
+# it, narrow CI terminals wrap paths mid-word (``missing.sql`` →
+# ``miss\ning.sql``), which breaks substring assertions in tests and
+# obscures the offending path in human-readable output. Paths and
+# digests are the primary error surface here; keeping them intact
+# matters more than fitting to terminal width.
+console = Console(soft_wrap=True)
 
 
 @click.group()
@@ -38,7 +35,11 @@ def assets():
 @click.argument(
     "project_path",
     type=click.Path(exists=True, file_okay=True, dir_okay=True, path_type=Path),
-    default=Path.cwd(),
+    # ``default="."`` is resolved by click's Path type per-invocation
+    # (against the invoker's actual CWD). ``default=Path.cwd()`` would
+    # freeze the CWD at import time — a subtle footgun that shows up
+    # when the module is imported before the operator ``cd``s.
+    default=".",
     required=False,
 )
 @click.option(
@@ -160,15 +161,26 @@ def _resolve_project_yaml(project_path: Path) -> Path | None:
 
 def _extract_seeds(raw: dict) -> dict | None:
     """Return the ``assets.seeds`` sub-mapping, or ``None`` when
-    absent / malformed. Malformed shapes still return ``None`` (the
-    caller treats it as "nothing to stamp") — schema validation at
-    load time is a separate concern."""
-    assets_section = raw.get("assets")
+    the block is genuinely absent (no ``assets`` key, or an
+    ``assets`` block with no ``seeds`` key).
+
+    Malformed shapes (present but not a mapping) raise
+    ``click.ClickException`` naming the offending key — a
+    ``--check`` in CI must not report green on a file that will
+    blow up at load time. Absent is different from present-but-broken.
+    """
+    if "assets" not in raw:
+        return None
+    assets_section = raw["assets"]
     if not isinstance(assets_section, dict):
+        raise click.ClickException(
+            f"`assets` must be a mapping; got {type(assets_section).__name__}"
+        )
+    if "seeds" not in assets_section:
         return None
-    seeds = assets_section.get("seeds")
+    seeds = assets_section["seeds"]
     if not isinstance(seeds, dict):
-        return None
+        raise click.ClickException(f"`assets.seeds` must be a mapping; got {type(seeds).__name__}")
     return seeds
 
 
@@ -198,25 +210,31 @@ def _write_seed_entry(entry: object, seed_path: str, new_digest: str) -> dict:
     from the file extension) — a string can't carry a digest, so
     stamping always emits dict form for touched entries. Untouched
     fields on an existing dict entry are preserved verbatim.
+
+    Reuses ``SEED_KIND_BY_EXTENSION`` from ``core.models`` so the
+    stamp verb and the loader stay in sync as new seed kinds land —
+    one map, one source of truth.
     """
+    from tolokaforge.core.models import SEED_KIND_BY_EXTENSION
+
     if isinstance(entry, dict):
         out = dict(entry)
         out["path"] = seed_path
         out["digest"] = new_digest
         # Ensure ``kind`` is present — SeedRef requires it in dict form.
         if "kind" not in out:
-            inferred = _KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
+            inferred = SEED_KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
             if inferred is not None:
                 out["kind"] = inferred
         return out
     # Bare-string entry — coerce to dict form.
-    kind = _KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
+    kind = SEED_KIND_BY_EXTENSION.get(Path(seed_path).suffix.lower())
     if kind is None:
         # SeedRef's own load-time normaliser would fail loud here too;
         # match its shape.
         raise click.ClickException(
             f"cannot infer kind from bare-string seed path {seed_path!r} "
-            f"(extension not in {sorted(_KIND_BY_EXTENSION)!r}). Rewrite "
+            f"(extension not in {sorted(SEED_KIND_BY_EXTENSION)!r}). Rewrite "
             "as {path: ..., kind: ...} before stamping."
         )
     return {"path": seed_path, "kind": kind, "digest": new_digest}
@@ -233,12 +251,15 @@ def _resolve_seed_path(seed_path: str, project_dir: Path) -> Path:
 
 def _has_comments(path: Path) -> bool:
     """Best-effort check for ``#``-prefixed comment lines in *path*.
-    Full YAML lexing isn't needed — the warning is advisory."""
-    try:
-        for line in path.read_text().splitlines():
-            stripped = line.lstrip()
-            if stripped.startswith("#"):
-                return True
-    except OSError:
-        pass
+    Full YAML lexing isn't needed — the warning is advisory.
+
+    Any ``OSError`` here is genuinely surprising (the file was read
+    successfully earlier in the same call), so we let it surface
+    rather than silently returning ``False`` and suppressing the
+    downstream comment-loss warning.
+    """
+    for line in path.read_text().splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            return True
     return False

--- a/tolokaforge/cli/assets_commands.py
+++ b/tolokaforge/cli/assets_commands.py
@@ -11,6 +11,7 @@ CLI registration stays cheap.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -24,6 +25,22 @@ from rich.console import Console
 # digests are the primary error surface here; keeping them intact
 # matters more than fitting to terminal width.
 console = Console(soft_wrap=True)
+
+# Errors go to stderr, success messages go to stdout. Two consoles
+# keep the routing uniform without repeatedly threading ``file=``
+# through every call site — the alternative (mix of ``sys.exit`` +
+# ``ClickException``) split the surface across streams depending on
+# the failure mode.
+err_console = Console(stderr=True, soft_wrap=True)
+
+_COMMENT_LINE_PATTERN = re.compile(r"(?:^|\s)#")
+"""Match ``#`` at the start of a line OR preceded by whitespace.
+
+PyYAML's ``safe_dump`` strips both whole-line comments (``# foo``)
+and inline comments (``key: value  # note``). The whitespace guard
+avoids the false-positive of ``#`` embedded inside a string value
+without a space in front of it (``key: "foo#bar"``) — such shapes
+are unusual and outside the warning's target audience."""
 
 
 @click.group()
@@ -72,16 +89,15 @@ def stamp(project_path: Path, check_only: bool) -> None:
 
     project_yaml = _resolve_project_yaml(project_path)
     if project_yaml is None:
-        console.print(
+        err_console.print(
             f"[red]No project.yaml found at or above {project_path!s}[/red]",
-            style="red",
         )
         sys.exit(1)
 
     project_dir = project_yaml.parent
     raw = yaml.safe_load(project_yaml.read_text()) or {}
     if not isinstance(raw, dict):
-        console.print(f"[red]{project_yaml} is not a YAML mapping[/red]")
+        err_console.print(f"[red]{project_yaml} is not a YAML mapping[/red]")
         sys.exit(1)
 
     seeds_container = _extract_seeds(raw)
@@ -90,16 +106,15 @@ def stamp(project_path: Path, check_only: bool) -> None:
         return
 
     updates: list[tuple[str, str | None, str]] = []
+    path_less_entries: list[str] = []
     missing_files: list[tuple[str, Path]] = []
     changed = False
 
     for name, entry in list(seeds_container.items()):
         seed_path_str, existing_digest = _read_seed_entry(entry)
         if seed_path_str is None:
-            console.print(
-                f"[red]{project_yaml}: assets.seeds.{name} has no `path` field[/red]",
-            )
-            sys.exit(1)
+            path_less_entries.append(name)
+            continue
         abs_path = _resolve_seed_path(seed_path_str, project_dir)
         if not abs_path.is_file():
             missing_files.append((name, abs_path))
@@ -111,9 +126,16 @@ def stamp(project_path: Path, check_only: bool) -> None:
             if not check_only:
                 seeds_container[name] = _write_seed_entry(entry, seed_path_str, new_digest)
 
-    if missing_files:
+    # Collate all fatal shape errors so authors fix them in one edit
+    # pass instead of one-per-reload. Path-less entries and missing
+    # files are both reported before we exit.
+    if path_less_entries or missing_files:
+        for name in path_less_entries:
+            err_console.print(
+                f"[red]{project_yaml}: assets.seeds.{name} has no `path` field[/red]",
+            )
         for name, path in missing_files:
-            console.print(
+            err_console.print(
                 f"[red]{project_yaml}: assets.seeds.{name}.path does not exist: {path}[/red]",
             )
         sys.exit(1)
@@ -165,9 +187,11 @@ def _extract_seeds(raw: dict) -> dict | None:
     ``assets`` block with no ``seeds`` key).
 
     Malformed shapes (present but not a mapping) raise
-    ``click.ClickException`` naming the offending key — a
-    ``--check`` in CI must not report green on a file that will
-    blow up at load time. Absent is different from present-but-broken.
+    ``click.ClickException`` (which routes to stderr per Click's
+    contract) naming the offending key — a ``--check`` in CI must
+    not report green on a file that will blow up at load time.
+    Absent is different from present-but-broken. Matches the
+    stderr routing of every other fatal error in this module.
     """
     if "assets" not in raw:
         return None
@@ -250,16 +274,17 @@ def _resolve_seed_path(seed_path: str, project_dir: Path) -> Path:
 
 
 def _has_comments(path: Path) -> bool:
-    """Best-effort check for ``#``-prefixed comment lines in *path*.
-    Full YAML lexing isn't needed — the warning is advisory.
+    """Best-effort check for YAML comments in *path* — either
+    whole-line (``# note``) or inline (``key: value  # note``).
+
+    Full YAML lexing isn't needed — the warning is advisory. The
+    ``_COMMENT_LINE_PATTERN`` regex matches ``#`` at line start OR
+    preceded by whitespace, catching both shapes while ruling out
+    ``#`` embedded in string values without a space in front.
 
     Any ``OSError`` here is genuinely surprising (the file was read
     successfully earlier in the same call), so we let it surface
     rather than silently returning ``False`` and suppressing the
     downstream comment-loss warning.
     """
-    for line in path.read_text().splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("#"):
-            return True
-    return False
+    return any(_COMMENT_LINE_PATTERN.search(line) for line in path.read_text().splitlines())

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -99,6 +99,11 @@ from tolokaforge.cli.config_commands import config  # noqa: E402
 
 cli.add_command(config)
 
+# Register assets subcommand group (`tolokaforge assets stamp` verb).
+from tolokaforge.cli.assets_commands import assets  # noqa: E402
+
+cli.add_command(assets)
+
 
 # Default user model configuration
 DEFAULT_USER_MODEL = "anthropic/claude-sonnet-4.6"

--- a/tolokaforge/core/assets.py
+++ b/tolokaforge/core/assets.py
@@ -1,0 +1,39 @@
+"""Helpers for project-level assets (seeds today; more categories
+land as the design grows).
+
+The primary API is :func:`compute_seed_digest`, which the CLI's
+``tolokaforge assets stamp`` verb uses to write the ``digest``
+field on ``assets.seeds.<name>`` entries. The load-time verifier
+that lands with the reset-recipe milestone will reuse the same
+helper — one implementation, no drift between "what stamp writes"
+and "what load verifies."
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+_HASH_BLOCK_SIZE = 64 * 1024
+"""Chunk size for streaming file reads. 64 KiB is large enough that
+per-block overhead is negligible on typical seed files, small enough
+that pathological multi-GiB dumps stay well within memory budget."""
+
+
+def compute_seed_digest(path: Path) -> str:
+    """Return ``"sha256:<64-hex>"`` for the file at *path*.
+
+    Streams the file in :data:`_HASH_BLOCK_SIZE` chunks so a
+    multi-GiB seed doesn't blow the memory budget. Raises
+    ``FileNotFoundError`` when the file is missing — the CLI catches
+    this and prints the offending path so the author can fix the
+    project.yaml reference.
+    """
+    hasher = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(_HASH_BLOCK_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return f"sha256:{hasher.hexdigest()}"

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1344,12 +1344,14 @@ no interpretation). Kind selection binds an overlay recipe with the
 isolation-redesign milestone."""
 
 
-_SEED_KIND_BY_EXTENSION: dict[str, SeedKind] = {
+SEED_KIND_BY_EXTENSION: dict[str, SeedKind] = {
     ".sql": "sql_dump",
     ".rdb": "redis_dump",
 }
 """File-extension → seed kind. Ambiguous / unknown extensions require
-the full ``{path, kind}`` shape."""
+the full ``{path, kind}`` shape. Public so the CLI's
+``tolokaforge assets stamp`` verb can reuse the same mapping without
+duplicating (and drifting)."""
 
 
 class SeedRef(BaseModel):
@@ -1388,12 +1390,12 @@ class SeedRef(BaseModel):
             return data
         raw = data
         ext = Path(raw).suffix.lower()
-        inferred = _SEED_KIND_BY_EXTENSION.get(ext)
+        inferred = SEED_KIND_BY_EXTENSION.get(ext)
         if inferred is None:
             raise ValueError(
                 f"SeedRef: cannot infer kind from path {raw!r} "
                 f"(extension {ext!r} not in "
-                f"{sorted(_SEED_KIND_BY_EXTENSION)!r}). Declare the full "
+                f"{sorted(SEED_KIND_BY_EXTENSION)!r}). Declare the full "
                 "form: {path: ..., kind: ...}."
             )
         return {"path": raw, "kind": inferred}


### PR DESCRIPTION
New CLI subcommand that walks \`assets.seeds.<name>\` entries in a project's \`project.yaml\`, computes \`sha256:<hex>\` over each referenced file, and writes the \`digest\` field back in place. Last M2.5 slice; unblocks the load-time digest verifier that lands with the reset-recipe milestone.

Closes #227 (child of #220; **closes the M2.5 umbrella**).

## Summary

**Command shape:**
\`\`\`bash
tolokaforge assets stamp [PATH]            # PATH defaults to CWD
tolokaforge assets stamp --check [PATH]    # dry-run; CI-friendly
\`\`\`

- Write mode is **idempotent** — re-running against a fully-stamped file verifies matches and exits 0 without touching the file.
- \`--check\` prints the diff of proposed digest updates and exits 1 when anything is stale.
- Missing seed file → non-zero exit naming the offending path.
- Bare-string shorthand (\`seeds: {foo: \"path/x.sql\"}\`) coerces to dict form on stamp — a bare string can't carry a digest.
- On-disk paths stay project-relative on write; only the file contents get read absolutely.

**Files added:**
- \`tolokaforge/core/assets.py\` — \`compute_seed_digest(path) → \"sha256:<hex>\"\`, streams in 64 KiB chunks. Placed in \`core/\` so the reset-recipe milestone reuses it for load-time verification (no drift).
- \`tolokaforge/cli/assets_commands.py\` — \`assets\` group + \`stamp\` subcommand, mirrors the docker_commands.py pattern.
- \`tolokaforge/cli/main.py\` — \`cli.add_command(assets)\` alongside the existing group registrations.

## Test plan

- [x] \`uv run pytest tests/unit/ tests/canonical/\` — **2696 passed**, 1 skipped (+14 new).
- [x] 14 tests in \`test_cli_assets.py\`: digest format + streaming + missing-file; write mode (fresh, idempotent, bare-string coercion, relative-path preservation); \`--check\` (matches, stale-with-diff); missing file; project resolution (walks up, no-project-yaml fails); no-op on empty project.
- [x] Manual verification: \`tolokaforge assets stamp --check examples/native/example-microservices-pack\` exits 0 — the hand-authored \`sha256:ea86...\` in that pack matches the computed digest.
- [x] \`ruff check\` + \`ruff format --check\` clean on touched files.

## Not in scope

- **Load-time digest verification** — lands with M3 (#212) using the same \`compute_seed_digest\` helper.
- **Comment preservation via ruamel.yaml** — PyYAML \`safe_dump\` strips comments; a warning fires on write when the source contains \`#\` lines so authors know to inspect \`git diff\`. Migrating to ruamel is a follow-up if the friction is real.
- **Non-seed asset categories** — \`assets.seeds\` is the only category today.