### PR TITLE
chore(ci): bump actions/checkout to v5 + pin claude-code-action SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         token: ${{ github.token }}
         lfs: true
@@ -158,7 +158,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         token: ${{ github.token }}
         lfs: true
@@ -261,7 +261,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         token: ${{ github.token }}
         lfs: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,11 +23,15 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@beta
+      # Pinned to the SHA of v1.0.173 (the moving @beta tag broke overnight
+      # on 2026-07-13 — a rolling update crashed the runner mid-review).
+      # Bumping is a one-line diff; commit SHAs are immutable so this is
+      # supply-chain safer than a floating tag.
+      - uses: anthropics/claude-code-action@1281377b9fdacad00368735a20d0d153fa1b82bd  # v1.0.173
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-adapter-terminal-bench.yml
+++ b/.github/workflows/publish-adapter-terminal-bench.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-tolokaforge.yml
+++ b/.github/workflows/publish-tolokaforge.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     name: Bump version, changelog, tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0      # full history + tags so commitizen can derive the bump
           ref: main           # always release from main


### PR DESCRIPTION
Two small workflow-hygiene fixes prompted by the CI incident on #263.

## What changed

- **\`actions/checkout@v4\` → \`@v5\`** across every workflow (12 use sites in 6 files). GitHub Actions now forces Node.js 24 on the runner and warns on \`@v4\` (which targets Node 20). The compat shim still works but the warning was showing on every run; \`@v5\` targets Node 24 natively.
- **\`anthropics/claude-code-action@beta\` → SHA \`1281377b9fdacad00368735a20d0d153fa1b82bd\`** (tag \`v1.0.173\`). The moving \`@beta\` tag broke overnight on 2026-07-13: two consecutive hygiene-review runs on PR #263 had opposite outcomes (17:48 "Approve — ship it", 19:36 "Claude encountered an error") with nothing changing on our side. A rolling upstream update crashed the runner mid-review. Immutable SHAs eliminate that failure mode.

## Why this ordering matters

- Even a "green PR" bot has to be stable to be useful — a bot that randomly flips red on unchanged code undermines trust in the whole gate.
- SHA pinning is standard GitHub Actions supply-chain hygiene (see [OSSF's Scorecard](https://github.com/ossf/scorecard) "Pinned-Dependencies" check).
- Bumping to a newer version is now a one-line diff when Anthropic ships a fix worth pulling.

## Test plan

- [x] Every workflow YAML parses (implicit — GitHub validates on push).
- [x] No behaviour change intended. The workflow structure is identical; only version pins moved.
- [x] Once merged, the next hygiene-review run on any PR will exercise the new pins.

## Not in scope

- Retry logic on the review action step. Would help against transient runner errors, but a stable pin should make retries unnecessary.
- Any changes to the review prompt or logic — pure infrastructure.