### PR TITLE
feat(runtime): per-service isolation in default_environment.services (M3 1/5)

### DIFF
--- a/docs/architecture/PROJECTS.md
+++ b/docs/architecture/PROJECTS.md
@@ -264,7 +264,6 @@ tasks:
 default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
-  isolation: "per_trial"
 
 task_defaults:
   adapter_type: "native"
@@ -729,14 +728,13 @@ default_environment:
   # Everything below is substrate-neutral — no compose-isms.
   # Two classes, though: policy REQUESTS (network_policy,
   # security_context_defaults) survive a stack replacement;
-  # service-TREATMENT fields (isolation, services) are scoped to
-  # the reviewed stack and reset with it (see Task override
+  # service-TREATMENT fields (initial_state, services) are scoped
+  # to the reviewed stack and reset with it (see Task override
   # semantics).
-  # `isolation:` is optional. Unset means services without an
-  # entry in `services:` below default to `per_trial` per
-  # ADR-0009. A task can declare `isolation: "shared_ok"` as an
-  # explicit opt-in when its services allow it — per-service
-  # entries still take precedence over this default.
+  # Backend selection is task-driven from `services.<name>.isolation`:
+  # any non-`shared` label (or any unlabelled compose service, which
+  # fills to `ephemeral`) routes the run onto PerTrialRuntimeBackend.
+  # Fully-`shared` task sets route onto SharedStackRuntimeBackend.
   services:                        # scaffolding — per-service semantics live in the
     postgres:                      # manifest, never solely in the substrate file
       isolation: "reset"
@@ -745,7 +743,7 @@ default_environment:
       isolation: "shared"
     backend-api:
       isolation: "shared"
-    # runner: no entry → ephemeral (per_trial default)
+    # runner: no entry → ephemeral
   network_policy: "no_internet"    # closed enum: no_internet | limited_internet |
                                    # full_internet; parameterisation (e.g. egress
                                    # hosts) is finalised before the first major release
@@ -872,19 +870,17 @@ Some fields replace instead of merge:
   `runner_service` (a foreign file's `${var}` slots must never
   silently capture inherited values). Replacement also resets the
   service-*treatment* fields: the project's service-keyed maps
-  (`services` entries, `initial_state`) are discarded, and the
-  root `isolation` falls back to the `per_trial` default even if
-  the project declared `shared_ok` — the project's opt-out was a
-  review of the project's services, and it must not silently
-  extend to a stack nobody reviewed under it. Policy-*request*
-  fields (`network_policy`, `security_context_defaults`) are
-  stack-independent and survive. A task-local stack declares its
-  own `services` entries (and its own `shared_ok`, explicitly) if
-  it needs them. `stack: null` and `stack: {compose_file: null}`
-  are both load errors — a task cannot unset the environment (or
-  its substrate pointer) out from under a project that declares
-  one, and there is no engine-default compose file to fall
-  through to.
+  (`services` entries, `initial_state`) are discarded — the
+  project's per-service opt-outs were a review of the project's
+  services, and they must not silently extend to a stack nobody
+  reviewed under it. The replacement stack's compose services fill
+  with the `ephemeral` default unless the task's own `services`
+  block relabels them. Policy-*request* fields (`network_policy`,
+  `security_context_defaults`) are stack-independent and survive.
+  `stack: null` and `stack: {compose_file: null}` are both load
+  errors — a task cannot unset the environment (or its substrate
+  pointer) out from under a project that declares one, and there
+  is no engine-default compose file to fall through to.
 - **`system_prompt`**: pointing at a different file (or inline
   text) replaces the project prompt entirely; no merge.
 
@@ -1285,7 +1281,6 @@ default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
     runner_service: "runner"
-  isolation: "per_trial"
 
 task_defaults:
   adapter_type: "native"
@@ -1438,9 +1433,9 @@ output path. `nightly.yaml` is longer because nightly differs
 more (S3 storage, OTLP tracing, more workers, more repeats), but
 even it only declares the fields that actually differ; the
 shared local-docker / sqlite-queue boilerplate from
-`run_defaults` (and the project's `per_trial` isolation stance,
-which lives in `default_environment`) doesn't appear in either
-file.
+`run_defaults` (and the project's per-service isolation stance,
+which lives in `default_environment.services`) doesn't appear in
+either file.
 
 ### Scenario C — Cross-model bake-off
 

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -48,11 +48,11 @@ graph TB
     LRB -->|"one client per trial<br/>keyed by trial_id"| T2
 ```
 
-Selection is a run-level choice with two knobs and a safety enforcement:
+Selection is **task-driven** with a deprecated operator override and a safety enforcement:
 
-- **Config**: `orchestrator.runtime: shared | per_trial` in the run config YAML. Default `shared`.
-- **CLI override**: `tolokaforge run --runtime {shared,per_trial}` overrides the config for a single invocation. The banner printed at run start names the backend and the source (`cli-flag` vs `config` vs `default`) so operators can see what actually got chosen.
-- **Task-side enforcement**: every task's `environment_manifest.isolation` declares its requirement (`per_trial` default, `shared_ok` opt-out). The orchestrator refuses to start the run if any task requires `per_trial` and the selected backend is `SharedStackRuntimeBackend` — silent cross-trial state contamination is what this guard prevents. See "Isolation enforcement" below.
+- **Task-side signal (default path)**: the orchestrator resolves the task set and reads each task's `default_environment.services.<name>.isolation` map. Any task whose manifest carries a non-`shared` label (`reset` or `ephemeral`, or an unlabelled compose service that fills to `ephemeral`) forces `PerTrialRuntimeBackend`. When every task with a manifest is fully-`shared` labelled, the selector picks `SharedStackRuntimeBackend`. A task without a manifest contributes no signal.
+- **Deprecated override**: `orchestrator.runtime: shared | per_trial` in the run config YAML (or `tolokaforge run --runtime {shared,per_trial}` on the CLI) bypasses the task-driven signal and forces the named backend. Setting it emits a `DeprecationWarning`; retirement is deferred to a later milestone. The banner printed at run start names the backend and the source (`config-override` vs `tasks`) so operators can see which path fired.
+- **Task-side enforcement**: the orchestrator refuses to start the run if the deprecated override forces `SharedStackRuntimeBackend` against a task set that requires per-trial materialisation — silent cross-trial state contamination is what this guard prevents. It also refuses `ephemeral`-labelled services on a shared backend (they require a compose-down between trials). See "Isolation enforcement" below.
 
 Legacy `orchestrator.runtime: docker` is accepted as a deprecated alias for `shared` with a `DeprecationWarning` at config load.
 
@@ -264,27 +264,31 @@ A second `teardown(handle)` call finds nothing in the cache, exits quickly. Fore
 
 ## Isolation enforcement
 
-Every `EnvironmentManifest` declares a `TaskIsolation` (default `per_trial`, opt-out `shared_ok`). The orchestrator reads this immediately after backend selection and refuses the run if the combination is unsafe.
+Every `EnvironmentManifest` carries a `services: dict[str, ServiceSpec]` map — one entry per compose service, each labelled `shared` / `reset` / `ephemeral`. A compose service missing from the merged map fills with `ephemeral` after resolve. `manifest.requires_per_trial` is true iff any service is non-`shared` (or the map is empty). Backend selection reads that flag; the isolation-enforcement guard runs after backend construction and only fires under the deprecated `orchestrator.runtime` override.
 
 ```mermaid
 flowchart TD
-    Start[Orchestrator.run] --> Backend[Construct RuntimeBackend<br/>per config / CLI override]
-    Backend --> Check{{"For each task in the run:<br/>manifest.isolation ?"}}
-    Check -->|None or shared_ok| OK[Compatible]
-    Check -->|per_trial + PerTrialRuntimeBackend| OK
-    Check -->|per_trial + SharedStackRuntimeBackend| Refuse["Refuse run<br/>RuntimeError names offending tasks<br/>+ two concrete fixes"]
+    Start[Orchestrator.run] --> Select{{"orchestrator.runtime<br/>override set?"}}
+    Select -->|No| Task[Task-driven selector<br/>reads manifest.requires_per_trial<br/>for every task]
+    Select -->|Yes, DeprecationWarning| Backend[Construct forced backend]
+    Task --> Backend
+    Backend --> Check{{"Backend.isolation_mode ?"}}
+    Check -->|PER_TRIAL_STACK| OK[Compatible — any task safe]
+    Check -->|SHARED_STACK| Verify{{"For each task:<br/>manifest.requires_per_trial ?<br/>any ephemeral service ?"}}
+    Verify -->|No non-shared services| OK
+    Verify -->|Yes| Refuse["Refuse run<br/>RuntimeError names offending tasks<br/>+ concrete fixes"]
     OK --> Trials[Run trials]
     Refuse --> Stop[Zero trials executed]
 ```
 
-Fail-loud fix message names both remedies:
+Fail-loud fix message names two remedies:
 
-- Switch the runtime: pass `--runtime per_trial` or set `orchestrator.runtime: per_trial` in the config.
-- Opt the task out: set `environment_manifest.isolation: shared_ok` (only appropriate for genuinely stateless tasks).
+- Drop the deprecated `orchestrator.runtime` override so backend selection is task-driven (the task-driven selector will pick `PerTrialRuntimeBackend` automatically for any task requiring per-trial materialisation).
+- Label every service `isolation: shared` on tasks that genuinely tolerate shared state across trials.
 
 Enforcement lives at the orchestrator layer, not on `SharedStackRuntimeBackend.provision()`. Refusing the run BEFORE any trial starts (rather than trial-by-trial) means the operator sees the whole failure at once instead of watching trials time out or produce garbage verdicts.
 
-`PerTrialRuntimeBackend` accepts every task — per-trial isolation is a superset of shared-stack semantics for correctness purposes. Cost of per-trial provisioning for genuinely stateless tasks is a separate concern (the loud-defaults banner surfaces the cost/benefit trade so operators can pick the right backend for their workload).
+`PerTrialRuntimeBackend` accepts every task — per-trial isolation is a superset of shared-stack semantics for correctness purposes. Cost of per-trial provisioning for genuinely stateless tasks is a separate concern (the task-driven selector routes fully-`shared` task sets onto the shared backend automatically).
 
 ## Failure modes
 
@@ -330,14 +334,14 @@ See also: [ADR-0016](adr/0016-runtime-backend-comparison.md) — resource-use, g
 
 Both satisfy the same `RuntimeBackend` Protocol. Callers depend only on the Protocol — swapping backends is a construction-time choice, not a callsite change.
 
-## Adapter compatibility with `per_trial`
+## Adapter compatibility with per-trial materialisation
 
-`--runtime per_trial` is opt-in per task, gated on `TaskConfig.environment_manifest`. An adapter opts a task into orchestrator-driven per-trial isolation by populating that field on the `TaskConfig` it produces. Tasks without a manifest belong on `SharedStackRuntimeBackend`; pointing `PerTrialRuntimeBackend` at them raises `ProvisionError("… task did not declare one")` at provision time — fail-loud by design, no silent fallback.
+Per-trial materialisation is opt-in per task, gated on `TaskConfig.environment_manifest`. An adapter opts a task into orchestrator-driven per-trial isolation by populating that field on the `TaskConfig` it produces (with at least one service labelled non-`shared`, or an implicit `ephemeral` from an unlabelled compose service). Tasks without a manifest belong on `SharedStackRuntimeBackend`; pointing `PerTrialRuntimeBackend` at them raises `ProvisionError("… task did not declare one")` at provision time — fail-loud by design, no silent fallback.
 
-| Adapter | Populates `environment_manifest` | Compatible with `--runtime per_trial` |
+| Adapter | Populates `environment_manifest` | Compatible with `PerTrialRuntimeBackend` |
 |---|---|---|
 | `native` | Yes — reads it from the task's `task.yaml` when declared. | Yes. Tested end-to-end with `coding_public_example_01`. |
-| `terminal_bench` | No — the adapter synthesises `TaskConfig` from `TerminalBenchTask` metadata and leaves `environment_manifest = None` by design. | No. Terminal-bench tasks run only under `--runtime shared` today. |
+| `terminal_bench` | No — the adapter synthesises `TaskConfig` from `TerminalBenchTask` metadata and leaves `environment_manifest = None` by design. | No. Terminal-bench tasks run only on `SharedStackRuntimeBackend` today. |
 
 **Why terminal-bench sits outside `PerTrialRuntimeBackend`.** Each terminal-bench task already ships its own `docker-compose.yaml`, which the adapter materialises through the `DOCKER_COMPOSE_EXEC` tool style (see `adapter_settings.compose_file` in the produced `TaskDescription`). That gives terminal-bench tasks *adapter-owned* per-task isolation — a fresh container per task, orchestrated inside the tool-invocation path — but it lives one level below the runtime backend seam. From the orchestrator's perspective, terminal-bench tasks look like shared-stack workloads: the engine services (`runner`, `db-service`) come up once for the run, and the adapter handles each task's own container itself.
 

--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -1,7 +1,10 @@
 # 0018. Multi-container capability under shared runtime
 
-- **Status:** Accepted
+- **Status:** Accepted (amended)
 - **Date:** 2026-07-04
+- **Amended:** 2026-07-14 — isolation is per-service in the manifest;
+  backend selection is task-driven; `orchestrator.runtime` is a
+  deprecated override.
 - **Deciders:** @CiroGamboa
 - **Supersedes:** —
 - **Superseded by:** —
@@ -15,6 +18,57 @@ that needed a realistic multi-service environment but were fine sharing state
 across trials had no path. This ADR decouples them by extending
 `SharedStackRuntimeBackend` to consume `environment_manifest` — task-declared
 services get materialised **once per run** under shared semantics.
+
+## Amendment — per-service isolation, task-driven backend selection
+
+The originally-shipped whole-manifest `isolation` field
+(`per_trial` / `shared_ok`) is superseded. Isolation now lives per
+compose service under `default_environment.services.<name>.isolation`
+in the manifest, with the vocabulary `shared` / `reset` /
+`ephemeral`. Services without a manifest entry default to `ephemeral`;
+the overall default per ADR-0009 stays `per_trial` (a manifest with no
+explicit `services` entries is treated as per-trial-requiring).
+
+Backend selection is **task-driven**: the orchestrator resolves the
+task set, reads each task's `EnvironmentManifest.requires_per_trial`
+(true iff any service is not `shared`), and picks
+`PerTrialRuntimeBackend` when any task requires it, otherwise
+`SharedStackRuntimeBackend`. The legacy `orchestrator.runtime` field
+survives as a deprecated operator override — setting it emits a
+`DeprecationWarning`; retirement is deferred to a later milestone.
+The isolation-compatibility guard (`_verify_isolation_compatibility`)
+now only fires under that override path — when an operator forces a
+shared backend against a per-trial-requiring task set (or asks for an
+`ephemeral` service on a shared backend, which cannot be honoured
+without a compose-down between trials).
+
+The 2×2 matrix below is unchanged in shape — cases A / B / C still
+map onto the same cells — but each cell is now reached via the
+task-driven signal derived from the per-service isolation map. Case B
+(shared + task-declared stack) is entered by declaring every service
+`isolation: shared`; case C (per-trial + task-declared stack) by
+declaring at least one `reset` or `ephemeral` service.
+
+Compose files carry **zero isolation semantics**. The manifest is the
+single authority; the compose file is the substrate definition. A
+task can declare its own `services.<name>` entries as a patch on top
+of the project's; the resolver treats a task override of a service as
+an atomic replacement of that service's whole `ServiceSpec` (a stale
+`reset` sibling from the project side can't leak through). Atomic
+`stack` replacement (a task supplying its own `stack.compose_file`)
+still discards the project's service-treatment fields — the project's
+per-service opt-outs reviewed the project's services, not the
+replacement stack.
+
+The substrate-agnostic resolver lives at
+`tolokaforge/runtime/isolation.py` (`resolve_service_isolation`,
+`resolve_service_specs`). It consumes `EnvironmentPatch` inputs only —
+no filesystem I/O — so a future Kubernetes backend consumes the same
+resolved per-service map without any change to the resolver's shape.
+
+See also [ADR-0009](0009-environment-manifest.md); the manifest's
+outer contract is unchanged, only the isolation surface it carries
+moved sub-tree.
 
 ## The two independent axes
 
@@ -200,9 +254,10 @@ Key differences from Case A:
   engine's runner + db-service go unused; the task's compose owns them via
   `:local` alias references.
 - **Every trial sees the same substrate.** State persists across trials.
-  Task authors opt into this by setting `environment_manifest.isolation:
-  shared_ok`; the isolation guard refuses shared+manifest for
-  `isolation: per_trial` declarations.
+  Task authors opt into this by labelling every service
+  `services.<name>.isolation: shared` in the manifest; any `reset` or
+  `ephemeral` label routes the run onto `PerTrialRuntimeBackend` via
+  task-driven selection.
 
 ### Case C — `per_trial` + task-declared stack (already shipped)
 
@@ -255,8 +310,8 @@ flowchart TB
   Q2{Do trials mutate<br/>state that the grader<br/>reads at trial end?}
   Q3{Is the task<br/>state-mutation<br/>trial-scoped?}
   A[Case A<br/>shared + built-in<br/>no env_manifest]
-  B[Case B<br/>shared + env_manifest<br/>isolation: shared_ok]
-  C[Case C<br/>per_trial + env_manifest<br/>isolation: per_trial]
+  B[Case B<br/>shared + env_manifest<br/>every service isolation: shared]
+  C[Case C<br/>per_trial + env_manifest<br/>at least one reset / ephemeral service]
 
   START --> Q1
   Q1 -- No --> A
@@ -279,10 +334,12 @@ flowchart TB
 - **Prefer Case B over Case C when possible.** Case B pays compose-up cost
   once per run; Case C pays it every trial. Case C is only worth its
   overhead when trials genuinely need fresh state that the grader reads.
-- **`isolation: per_trial` is a task-author declaration, not an operator
-  choice.** The task's declaration determines the case; the operator picks
-  the runtime backend and the isolation guard refuses incompatible
-  combinations (shared runtime + per_trial-declared task → fail loud).
+- **Isolation is a task-author declaration, not an operator choice.**
+  The manifest's per-service isolation map determines the case; backend
+  selection is task-driven from that map. The deprecated
+  `orchestrator.runtime` override still wins if set, and the isolation-
+  compatibility guard refuses incompatible overrides (shared runtime
+  forced against a per-trial-requiring task set → fail loud).
 
 ## Consequences
 
@@ -303,9 +360,9 @@ flowchart TB
 ### Negative / Trade-offs
 
 - **Case B ties every trial to the same substrate.** State contamination
-  is the task author's problem to prevent, same as Case A. The
-  `isolation: shared_ok` declaration is a task-author acknowledgment of
-  that responsibility.
+  is the task author's problem to prevent, same as Case A. Labelling
+  every service `isolation: shared` in the manifest is a task-author
+  acknowledgment of that responsibility.
 - **A run whose tasks declare different `environment_manifest.compose_file`
   values cannot be materialised into one shared substrate.** The
   orchestrator's `_extract_run_env_manifest()` helper fails loud at run

--- a/examples/native/multi_service/README.md
+++ b/examples/native/multi_service/README.md
@@ -54,9 +54,11 @@ examples/native/multi_service/
 
 ## Design notes
 
-- **`isolation: shared_ok`** — the task tolerates state sharing across
-  trials. Its grading only inspects the agent's output (a written file);
-  the app-service is read-only static content that doesn't mutate.
+- **Every service labelled `isolation: shared`** — the task tolerates
+  state sharing across trials. Its grading only inspects the agent's
+  output (a written file); the app-service is read-only static content
+  that doesn't mutate. A single non-`shared` label would route the run
+  onto `PerTrialRuntimeBackend`.
 - **`app-service` is deliberately trivial** — nginx serving a static JSON
   file. The point of the example is to demonstrate the multi-service
   materialisation path, not to be a realistic application. Real task

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
@@ -14,8 +14,11 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    app-service: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/examples/native/multi_service_advanced/README.md
+++ b/examples/native/multi_service_advanced/README.md
@@ -56,8 +56,9 @@ examples/native/multi_service_advanced/
 
 ## Design notes
 
-- **`isolation: shared_ok`** — the task's grading only inspects the agent's
-  written output; both APIs are read-only static content.
+- **Every service labelled `isolation: shared`** — the task's grading
+  only inspects the agent's written output; both APIs are read-only
+  static content.
 - **Both APIs use pinned nginx tags (`1.27-alpine`)** so runs are
   reproducible; the manifest validator rejects floating tags.
 

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
@@ -19,8 +19,12 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    orders-api: {isolation: "shared"}
+    customers-api: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/examples/native/multi_service_postgres/README.md
+++ b/examples/native/multi_service_postgres/README.md
@@ -88,11 +88,12 @@ examples/native/multi_service_postgres/
   independent of `app-db` (the task's own postgres). This example
   demonstrates that a task's application backend can be a completely
   different technology from the engine's own state backend.
-- **`isolation: shared_ok`.** The task's grading inspects the agent's
-  written output only; the read-only API doesn't mutate state across
-  trials. If the task wrote through PostgREST (which permissions would
-  need to allow), `per_trial` isolation would be appropriate to avoid
-  cross-trial contamination.
+- **Every service labelled `isolation: shared`.** The task's grading
+  inspects the agent's written output only; the read-only API doesn't
+  mutate state across trials. If the task wrote through PostgREST
+  (which permissions would need to allow), labelling any mutating
+  service `reset` or `ephemeral` would route the run onto
+  `PerTrialRuntimeBackend` to avoid cross-trial contamination.
 - **Both API endpoints use pinned tags.** `postgrest/postgrest:v12.2.0`
   and `postgres:16` are pinned per the manifest validator's
   non-floating-tag rule.

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
@@ -26,8 +26,12 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    app-service: {isolation: "shared"}
+    app-db: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/tests/canonical/test_adapter_convert_packaging.py
+++ b/tests/canonical/test_adapter_convert_packaging.py
@@ -185,6 +185,6 @@ def test_pinned_python_version_reads_cleanly_in_process() -> None:
     value = _pinned_python_version()
     assert value, "_pinned_python_version() returned an empty string"
     repo_root_value = (_REPO_ROOT / ".python-version").read_text().strip()
-    assert value == repo_root_value, (
-        f"_pinned_python_version() returned {value!r} but repo-root pin is " f"{repo_root_value!r}"
-    )
+    assert (
+        value == repo_root_value
+    ), f"_pinned_python_version() returned {value!r} but repo-root pin is {repo_root_value!r}"

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -19,12 +19,12 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from tolokaforge.core.models import ResetSpec, ServiceSpec
 from tolokaforge.core.trial import (
     EnvironmentManifest,
     InitialStateRef,
     NetworkPolicy,
     SecurityContext,
-    TaskIsolation,
 )
 from tolokaforge.runner.models import TaskDescription
 
@@ -126,43 +126,55 @@ class TestNetworkPolicyContract:
 
 
 # ---------------------------------------------------------------------------
-# TaskIsolation — per-task isolation-requirement enum
+# ServiceIsolation — per-service isolation vocabulary
 # ---------------------------------------------------------------------------
 
 
-class TestTaskIsolationContract:
-    @pytest.mark.parametrize(
-        "value",
-        [TaskIsolation.PER_TRIAL, TaskIsolation.SHARED_OK],
-    )
-    def test_member_values_are_isolation_strings(self, value: TaskIsolation) -> None:
-        assert value.value in {"per_trial", "shared_ok"}
+class TestServiceIsolationContract:
+    @pytest.mark.parametrize("value", ["shared", "reset", "ephemeral"])
+    def test_service_spec_accepts_every_label(self, value: str) -> None:
+        if value == "reset":
+            spec = ServiceSpec(isolation=value, reset=ResetSpec(seed="s"))
+        else:
+            spec = ServiceSpec(isolation=value)
+        assert spec.isolation == value
 
-    def test_string_construction(self) -> None:
-        assert TaskIsolation("per_trial") is TaskIsolation.PER_TRIAL
-        assert TaskIsolation("shared_ok") is TaskIsolation.SHARED_OK
+    def test_reset_label_requires_seed(self) -> None:
+        with pytest.raises(ValidationError, match="reset"):
+            ServiceSpec(isolation="reset")
 
-    def test_default_on_manifest_is_per_trial(self) -> None:
-        """Safety default: a manifest that does not opt out requires
-        per-trial isolation. This is the load-bearing invariant that
-        prevents silent cross-trial state contamination."""
+    def test_shared_label_rejects_seed(self) -> None:
+        with pytest.raises(ValidationError, match="cannot carry"):
+            ServiceSpec(isolation="shared", reset=ResetSpec(seed="s"))
+
+    def test_default_empty_manifest_requires_per_trial(self) -> None:
+        """Safety default: a manifest whose services map is empty is
+        treated as per-trial-requiring. Keeps the ADR-0009 invariant
+        under the new schema."""
         m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
-        assert m.isolation is TaskIsolation.PER_TRIAL
+        assert m.services == {}
+        assert m.requires_per_trial is True
 
-    def test_shared_ok_is_accepted(self) -> None:
+    def test_all_shared_services_do_not_require_per_trial(self) -> None:
         m = EnvironmentManifest(
             compose_file=_fixture("safe_one_service.yaml"),
-            isolation=TaskIsolation.SHARED_OK,
+            services={"default": ServiceSpec(isolation="shared")},
         )
-        assert m.isolation is TaskIsolation.SHARED_OK
+        assert m.requires_per_trial is False
 
-    def test_round_trip_preserves_isolation(self) -> None:
+    def test_round_trip_preserves_services(self) -> None:
         m = EnvironmentManifest(
             compose_file=_fixture("safe_two_service.yaml"),
-            isolation=TaskIsolation.SHARED_OK,
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         reloaded = EnvironmentManifest.model_validate_json(m.model_dump_json())
-        assert reloaded.isolation is TaskIsolation.SHARED_OK
+        assert reloaded.services["db"].isolation == "reset"
+        assert reloaded.services["db"].reset is not None
+        assert reloaded.services["db"].reset.seed == "baseline"
+        assert reloaded.services["default"].isolation == "shared"
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +448,10 @@ class TestManifestWireShape:
             },
             network_policy=NetworkPolicy.NO_INTERNET,
             security_context_defaults=SecurityContext(),
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         wire = m.model_dump(mode="json")
         assert set(wire) == {
@@ -445,11 +461,14 @@ class TestManifestWireShape:
             "initial_state",
             "network_policy",
             "security_context_defaults",
-            "isolation",
+            "services",
         }
         assert wire["runner_service"] == "default"
         assert wire["network_policy"] == "no_internet"
-        assert wire["isolation"] == "per_trial"
+        assert wire["services"] == {
+            "db": {"isolation": "reset", "reset": {"seed": "baseline"}},
+            "default": {"isolation": "shared", "reset": None},
+        }
         assert wire["initial_state"] == {"db": {"from_": "./fixtures/seed.sql", "kind": "sql"}}
         assert wire["security_context_defaults"] == {
             "run_as_user": None,

--- a/tests/canonical/test_run_aggregate_models_snapshot.py
+++ b/tests/canonical/test_run_aggregate_models_snapshot.py
@@ -519,10 +519,9 @@ def test_int_valued_aggregate_fields_preserve_int_type() -> None:
         "latency_p50_s_macro",
     ):
         value = getattr(model, field)
-        assert isinstance(value, int) and not isinstance(value, bool), (
-            f"AggregateMetrics.{field}: int input coerced to {type(value).__name__}. "
-            f"Got {value!r}."
-        )
+        assert isinstance(value, int) and not isinstance(
+            value, bool
+        ), f"AggregateMetrics.{field}: int input coerced to {type(value).__name__}. Got {value!r}."
 
     # And rate fields DID stay narrow float — a regression that widens them
     # would be caught by mypy at consumer sites, but a runtime guard here

--- a/tests/integration/test_preset_overlay_live_eval.py
+++ b/tests/integration/test_preset_overlay_live_eval.py
@@ -203,12 +203,12 @@ def test_live_eval_records_overlay_preset_in_trial_output(
     trial_yaml = yaml.safe_load(trial_yamls[0].read_text())
     agent_block = trial_yaml.get("model_config", {}).get("agent", {})
     resolved = agent_block.get("resolved", {})
-    assert resolved, (
-        f"trial {trial_yamls[0]} missing model_config.agent.resolved; " f"got: {agent_block}"
-    )
-    assert resolved.get("effective_preset") == _OVERLAY_PRESET_NAME, (
-        f"expected overlay preset {_OVERLAY_PRESET_NAME!r} in resolved block, " f"got {resolved!r}"
-    )
+    assert (
+        resolved
+    ), f"trial {trial_yamls[0]} missing model_config.agent.resolved; got: {agent_block}"
+    assert (
+        resolved.get("effective_preset") == _OVERLAY_PRESET_NAME
+    ), f"expected overlay preset {_OVERLAY_PRESET_NAME!r} in resolved block, got {resolved!r}"
     # Policy slots set by the overlay must be reflected too — proves the
     # overlay's content reached capability resolution, not just the name tag.
     assert resolved.get("content_policy") == "anthropic"

--- a/tests/unit/llm/test_params_policy_unsupported_effort.py
+++ b/tests/unit/llm/test_params_policy_unsupported_effort.py
@@ -89,9 +89,9 @@ def test_supported_effort_levels_still_emit_normally() -> None:
             seed=None,
             reasoning=ReasoningConfig(mode="adaptive", effort_hint=ok_effort),
         )
-        assert kwargs.get("reasoning_effort") == ok_effort, (
-            f"effort={ok_effort} should emit reasoning_effort={ok_effort}, " f"got {kwargs!r}"
-        )
+        assert (
+            kwargs.get("reasoning_effort") == ok_effort
+        ), f"effort={ok_effort} should emit reasoning_effort={ok_effort}, got {kwargs!r}"
 
 
 def test_empty_unsupported_set_is_default_behaviour() -> None:

--- a/tests/unit/llm/test_preset_overlay_validation.py
+++ b/tests/unit/llm/test_preset_overlay_validation.py
@@ -185,9 +185,9 @@ class TestValidatorRegistrySync:
         }
         discovered = set(_discover_policy_registries().keys())
         missing = baseline_names - discovered
-        assert not missing, (
-            f"baseline registries missing from the presets module: " f"{sorted(missing)}"
-        )
+        assert (
+            not missing
+        ), f"baseline registries missing from the presets module: {sorted(missing)}"
 
     def test_policy_registries_keys_match_slot_names(self) -> None:
         # The string keys in _POLICY_REGISTRIES are the YAML slot names

--- a/tests/unit/test_backend_selection.py
+++ b/tests/unit/test_backend_selection.py
@@ -1,0 +1,326 @@
+"""Unit tests for the task-driven runtime-backend selector.
+
+``Orchestrator._select_backend_from_tasks`` derives the backend choice
+from the resolved task set: any task whose manifest requires per-trial
+materialisation forces ``PerTrialRuntimeBackend``; otherwise
+``SharedStackRuntimeBackend``. ``Orchestrator._resolve_effective_runtime_choice``
+layers the deprecated ``orchestrator.runtime`` override on top so
+operators retain an escape hatch — setting it emits a
+``DeprecationWarning`` once at ``OrchestratorConfig`` construction time.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_task_description
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    ResetSpec,
+    RunConfig,
+    ServiceSpec,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.trial import EnvironmentManifest
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = pytest.mark.unit
+
+
+_FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
+
+
+def _make_run_config(runtime_override: str | None = None) -> RunConfig:
+    kwargs: dict[str, Any] = {"workers": 1, "repeats": 1, "auto_start_services": False}
+    if runtime_override is not None:
+        kwargs["runtime"] = runtime_override
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            orch = OrchestratorConfig(**kwargs)
+    else:
+        orch = OrchestratorConfig(**kwargs)
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=orch,
+        evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
+    )
+
+
+def _make_task_config(task_id: str) -> Any:
+    task = MagicMock()
+    task.task_id = task_id
+    return task
+
+
+def _make_orchestrator(
+    tasks: list[Any],
+    task_descriptions: dict[str, TaskDescription],
+    runtime_override: str | None = None,
+) -> Orchestrator:
+    orch = Orchestrator(_make_run_config(runtime_override))
+    orch.tasks = tasks
+    orch.adapter = MagicMock()
+    orch.adapter.to_task_description.side_effect = lambda tid: task_descriptions[tid]
+    return orch
+
+
+def _manifest_with_services(services: dict[str, ServiceSpec]) -> EnvironmentManifest:
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services=services,
+    )
+
+
+class TestTaskDrivenSelection:
+    """Task-driven signal: read every task's manifest, pick per-trial
+    iff any task requires it."""
+
+    def test_no_tasks_with_manifest_selects_shared(self) -> None:
+        tasks = [_make_task_config("t1"), _make_task_config("t2")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=None),
+            "t2": make_task_description(task_id="t2", environment_manifest=None),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "shared"
+
+    def test_all_shared_manifests_select_shared(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "shared"
+
+    def test_any_reset_service_selects_per_trial(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_any_ephemeral_service_selects_per_trial(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="ephemeral"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_empty_services_manifest_selects_per_trial(self) -> None:
+        """A manifest with no explicit services is per-trial-requiring
+        by the ADR-0009 safety default."""
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=EnvironmentManifest(
+                    compose_file=_FIXTURES / "safe_two_service.yaml",
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_mixed_task_set_any_per_trial_wins(self) -> None:
+        """A run with a mix of per-trial and shared-labelled tasks
+        routes onto per-trial — one per-trial task is enough."""
+        tasks = [_make_task_config("shared"), _make_task_config("stateful")]
+        task_descs = {
+            "shared": make_task_description(
+                task_id="shared",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+            "stateful": make_task_description(
+                task_id="stateful",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+
+class TestPinnedSharedServiceInMixedShape:
+    """A per-trial-eligible run pins one service
+    ``services.<name>.isolation=shared`` in an otherwise ``reset``
+    task set. The selector still picks per-trial; the pinned service's
+    ``shared`` label carries forward into the manifest for the reset
+    dispatcher to honour between trials.
+    """
+
+    def test_pinned_shared_service_selects_per_trial(self) -> None:
+        tasks = [_make_task_config("triage")]
+        task_descs = {
+            "triage": make_task_description(
+                task_id="triage",
+                environment_manifest=_manifest_with_services(
+                    {
+                        # postgres pinned shared: reset dispatcher will
+                        # keep it alive between trials.
+                        "db": ServiceSpec(isolation="shared"),
+                        # worker service requires reset between trials.
+                        "default": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_pinned_shared_service_survives_on_manifest(self) -> None:
+        manifest = _manifest_with_services(
+            {
+                "db": ServiceSpec(isolation="shared"),
+                "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            }
+        )
+        assert manifest.services["db"].isolation == "shared"
+        assert manifest.services["default"].isolation == "reset"
+        assert manifest.requires_per_trial is True
+
+
+class TestOperatorOverride:
+    """Setting ``orchestrator.runtime`` bypasses the task-driven signal
+    and forces the named backend. Setting it emits a
+    ``DeprecationWarning`` at ``OrchestratorConfig`` construction time."""
+
+    def test_setting_runtime_emits_deprecation_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OrchestratorConfig(workers=1, repeats=1, auto_start_services=False, runtime="per_trial")
+        deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation, "expected a DeprecationWarning when runtime is set"
+        assert any(
+            "OrchestratorConfig.runtime is deprecated" in str(w.message) for w in deprecation
+        )
+
+    def test_omitting_runtime_emits_no_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OrchestratorConfig(workers=1, repeats=1, auto_start_services=False)
+        deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation == []
+
+    def test_docker_alias_emits_two_deprecation_warnings(self) -> None:
+        """``docker`` is a legacy alias for ``shared``; it triggers both
+        the alias warning and the outer deprecation warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OrchestratorConfig(workers=1, repeats=1, auto_start_services=False, runtime="docker")
+        messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert any("docker" in m for m in messages)
+        assert any("OrchestratorConfig.runtime is deprecated" in m for m in messages)
+
+    def test_override_forces_per_trial_against_shared_task_set(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs, runtime_override="per_trial")
+        assert orch._resolve_effective_runtime_choice() == "per_trial"
+
+    def test_override_forces_shared_against_per_trial_task_set(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs, runtime_override="shared")
+        assert orch._resolve_effective_runtime_choice() == "shared"
+
+    def test_no_override_falls_back_to_task_driven(self) -> None:
+        tasks = [_make_task_config("t")]
+        task_descs = {
+            "t": make_task_description(
+                task_id="t",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs, runtime_override=None)
+        assert orch._resolve_effective_runtime_choice() == "per_trial"
+
+
+class TestSelectorAdapterGuard:
+    def test_missing_adapter_raises_clear_error(self) -> None:
+        orch = Orchestrator(_make_run_config())
+        orch.tasks = [_make_task_config("t")]
+        orch.adapter = None
+        with pytest.raises(RuntimeError, match="adapter"):
+            orch._select_backend_from_tasks()

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -13,9 +13,15 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.core.models import EnvironmentManifest, EnvironmentPatch, StackPatch
+from tolokaforge.core.models import (
+    EnvironmentManifest,
+    EnvironmentPatch,
+    ResetSpec,
+    ServiceSpec,
+    StackPatch,
+)
 from tolokaforge.core.project_loader import resolve
-from tolokaforge.runner.models import NetworkPolicy, SecurityContext, TaskIsolation
+from tolokaforge.runner.models import NetworkPolicy, SecurityContext
 
 pytestmark = pytest.mark.unit
 
@@ -45,7 +51,7 @@ class TestEnvironmentPatchNoIO:
         assert patch.initial_state is None
         assert patch.network_policy is None
         assert patch.security_context_defaults is None
-        assert patch.isolation is None
+        assert patch.services is None
 
     def test_stack_patch_all_fields_optional(self) -> None:
         stack = StackPatch()
@@ -209,15 +215,17 @@ class TestAtomicStackReplacement:
         # not the project's declaration.
         assert manifest.runner_service == "default"
 
-    def test_replacement_discards_project_isolation(self) -> None:
+    def test_replacement_discards_project_services(self) -> None:
         project = EnvironmentPatch(
             stack=StackPatch(compose_file=ENV_FIXTURE),
-            isolation=TaskIsolation.SHARED_OK,
+            services={"default": ServiceSpec(isolation="shared")},
         )
         task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
         manifest = resolve(project, task)
         assert manifest is not None
-        assert manifest.isolation == TaskIsolation.PER_TRIAL
+        # After replacement the project's services map is dropped; resolve()
+        # then fills the compose service with the ephemeral default.
+        assert manifest.services["default"].isolation == "ephemeral"
 
     def test_replacement_discards_project_initial_state(self) -> None:
         from tolokaforge.runner.models import InitialStateRef
@@ -261,6 +269,158 @@ class TestAtomicStackReplacement:
 class TestResolveWithoutComposeFileFailsLoud:
     def test_neither_side_declares_compose_file(self) -> None:
         project = EnvironmentPatch(network_policy=NetworkPolicy.NO_INTERNET)
-        task = EnvironmentPatch(isolation=TaskIsolation.PER_TRIAL)
+        task = EnvironmentPatch(services={"default": ServiceSpec(isolation="shared")})
         with pytest.raises(ValueError, match="no compose_file"):
             resolve(project, task)
+
+
+class TestServicesMergeAndDefaults:
+    """The per-service map merges deep-by-name (task wins per service);
+    every compose service missing from both sides fills with the
+    ``ephemeral`` default after resolve()."""
+
+    def test_task_service_entry_overrides_project(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        task = EnvironmentPatch(
+            services={
+                "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "reset"
+        assert manifest.services["default"].reset is not None
+        assert manifest.services["default"].reset.seed == "baseline"
+
+    def test_task_service_override_drops_project_reset_sibling(self) -> None:
+        """When project labels a service ``reset`` with a seed and task
+        re-labels the same service ``shared``, the project's ``reset``
+        sibling must not leak through (would fail ServiceSpec's
+        cross-field validator)."""
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            services={
+                "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+        task = EnvironmentPatch(
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "shared"
+        assert manifest.services["default"].reset is None
+
+    def test_project_service_survives_when_task_touches_a_different_service(self) -> None:
+        two_service = ENV_FIXTURE.parent / "safe_two_service.yaml"
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=two_service, runner_service="default"),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        task = EnvironmentPatch(
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "shared"
+        assert manifest.services["db"].isolation == "reset"
+
+    def test_missing_compose_service_defaults_to_ephemeral(self) -> None:
+        two_service = ENV_FIXTURE.parent / "safe_two_service.yaml"
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=two_service, runner_service="default"),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "shared"
+        assert manifest.services["db"].isolation == "ephemeral"
+
+    def test_requires_per_trial_true_when_any_service_non_shared(self) -> None:
+        two_service = ENV_FIXTURE.parent / "safe_two_service.yaml"
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=two_service, runner_service="default"),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="s")),
+            },
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.requires_per_trial is True
+
+    def test_requires_per_trial_false_when_all_services_shared(self) -> None:
+        two_service = ENV_FIXTURE.parent / "safe_two_service.yaml"
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=two_service, runner_service="default"),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="shared"),
+            },
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.requires_per_trial is False
+
+    def test_atomic_stack_replacement_task_services_survive(self) -> None:
+        """Task declares its own ``stack.compose_file`` **and** a
+        ``services`` block: the project's services are discarded (atomic
+        replacement), and the task's per-service entries survive on the
+        replaced stack."""
+        two_service = ENV_FIXTURE.parent / "safe_two_service.yaml"
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        task = EnvironmentPatch(
+            stack=StackPatch(compose_file=two_service, runner_service="default"),
+            services={"db": ServiceSpec(isolation="shared")},
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.compose_file == two_service
+        # Task's services declaration survives.
+        assert manifest.services["db"].isolation == "shared"
+        # Project's "default" declaration is discarded; the compose
+        # service `default` therefore falls back to ephemeral.
+        assert manifest.services["default"].isolation == "ephemeral"
+
+
+class TestServicesSchemaStrictness:
+    """Validation invariants that guard the ``services`` schema at load
+    time — pinning these locks the loud-fail behaviour under future
+    refactors."""
+
+    def test_unknown_isolation_vocab_rejected_at_patch_construction(self) -> None:
+        with pytest.raises(Exception) as exc:
+            EnvironmentPatch.model_validate({"services": {"postgres": {"isolation": "resett"}}})
+        assert "isolation" in str(exc.value)
+
+    def test_unknown_service_name_rejected_at_manifest_construction(self) -> None:
+        # safe_one_service.yaml declares only the compose service `default`.
+        # A manifest that labels a service the compose file does not
+        # declare must fail loud with the compose-declared names in the
+        # error message.
+        with pytest.raises(Exception) as exc:
+            EnvironmentManifest(
+                compose_file=ENV_FIXTURE,
+                services={"nonexistent": ServiceSpec(isolation="shared")},
+            )
+        message = str(exc.value)
+        assert "nonexistent" in message
+        assert "default" in message
+
+    def test_reset_without_seed_rejected(self) -> None:
+        with pytest.raises(Exception) as exc:
+            ServiceSpec(isolation="reset")
+        assert "reset" in str(exc.value)
+
+    def test_shared_with_reset_sibling_rejected(self) -> None:
+        with pytest.raises(Exception) as exc:
+            ServiceSpec(isolation="shared", reset=ResetSpec(seed="baseline"))
+        assert "cannot carry" in str(exc.value)

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -17,7 +17,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -62,9 +61,11 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
+    def test_all_services_labelled_shared(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -16,7 +16,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -66,12 +65,15 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
-        """Case B requires ``isolation: shared_ok`` — a per_trial
-        declaration would route to ``PerTrialRuntimeBackend`` instead
-        of the new shared+env_manifest path."""
+    def test_all_services_labelled_shared(self) -> None:
+        """Case B requires every service labelled ``shared`` — any
+        ``reset``/``ephemeral`` label would route the run to
+        ``PerTrialRuntimeBackend`` instead of the shared+env_manifest
+        path."""
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         """``runner_service`` in the patch must name a service actually

--- a/tests/unit/test_multi_service_postgres_example_task.py
+++ b/tests/unit/test_multi_service_postgres_example_task.py
@@ -19,7 +19,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -65,9 +64,11 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
+    def test_all_services_labelled_shared(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_native_adapter_environment_manifest.py
+++ b/tests/unit/test_native_adapter_environment_manifest.py
@@ -102,7 +102,7 @@ class TestEnvironmentManifestWiring:
             tmp_path,
             environment_manifest={
                 "compose_file": "./environment.compose.yaml",
-                "isolation": "per_trial",
+                "services": {"db": {"isolation": "ephemeral"}},
                 "runner_service": "runner",
             },
         )
@@ -114,8 +114,11 @@ class TestEnvironmentManifestWiring:
         assert manifest.compose_file.is_absolute()
         assert manifest.compose_file.name == "environment.compose.yaml"
         assert manifest.compose_file.exists()
-        # isolation + runner_service round-trip.
-        assert manifest.isolation.value == "per_trial"
+        # services + runner_service round-trip; the compose service
+        # `runner` was not labelled so it fills with ephemeral.
+        assert manifest.services["db"].isolation == "ephemeral"
+        assert manifest.services["runner"].isolation == "ephemeral"
+        assert manifest.requires_per_trial is True
         assert manifest.runner_service == "runner"
 
     def test_project_default_environment_composes_with_task_patch(self, tmp_path: Path) -> None:

--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -18,10 +18,12 @@ from tolokaforge.core.models import (
     EvaluationConfig,
     ModelConfig,
     OrchestratorConfig,
+    ResetSpec,
     RunConfig,
+    ServiceSpec,
 )
 from tolokaforge.core.orchestrator import Orchestrator
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.trial import EnvironmentManifest
 
 pytestmark = pytest.mark.unit
 
@@ -148,29 +150,36 @@ class TestRunWorkerGuard:
         assert orch._extract_run_env_manifest() is not None
 
 
-class TestIsolationDeclarationsPreserved:
-    """The helper doesn't need to validate ``isolation`` — that's
+class TestServicesDeclarationsPreserved:
+    """The helper doesn't need to validate isolation labels — that's
     :meth:`_verify_isolation_compatibility`'s job. But it must not
-    strip or alter the manifest's isolation declaration when returning."""
+    strip or alter the manifest's per-service declarations."""
 
-    def test_per_trial_isolation_survives(self) -> None:
+    def test_reset_service_survives(self) -> None:
         m = EnvironmentManifest(
             compose_file=_FIXTURES / "safe_two_service.yaml",
-            isolation=TaskIsolation.PER_TRIAL,
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
         result = orch._extract_run_env_manifest()
         assert result is not None
-        assert result.isolation == TaskIsolation.PER_TRIAL
+        assert result.services["db"].isolation == "reset"
 
-    def test_shared_ok_isolation_survives(self) -> None:
+    def test_all_shared_survives(self) -> None:
         m = EnvironmentManifest(
             compose_file=_FIXTURES / "safe_two_service.yaml",
-            isolation=TaskIsolation.SHARED_OK,
+            services={
+                "db": ServiceSpec(isolation="shared"),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
         result = orch._extract_run_env_manifest()
         assert result is not None
-        assert result.isolation == TaskIsolation.SHARED_OK
+        assert result.services["db"].isolation == "shared"
+        assert result.services["default"].isolation == "shared"

--- a/tests/unit/test_orchestrator_isolation_enforcement.py
+++ b/tests/unit/test_orchestrator_isolation_enforcement.py
@@ -1,9 +1,13 @@
-"""Unit tests for ``Orchestrator._verify_isolation_compatibility``.
+"""Unit tests for ``Orchestrator._verify_isolation_compatibility`` under
+task-driven backend selection.
 
-Refusing a shared-stack backend when any task in the run declares
-``environment_manifest.isolation: per_trial`` is the load-bearing
-invariant that prevents silent cross-trial state contamination.
-The tests here pin every branch of the enforcement helper.
+Backend selection is task-driven: any task whose manifest carries a
+non-``shared`` service label routes the run onto
+:class:`PerTrialRuntimeBackend`. The isolation-compatibility guard is
+therefore only reachable under the deprecated ``orchestrator.runtime``
+override — when the operator forces a shared backend against a
+per-trial-requiring task set (or an ``ephemeral``-labelled service in a
+shared context). These tests pin those branches.
 """
 
 from __future__ import annotations
@@ -19,12 +23,14 @@ from tolokaforge.core.models import (
     EvaluationConfig,
     ModelConfig,
     OrchestratorConfig,
+    ResetSpec,
     RunConfig,
+    ServiceSpec,
 )
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.trial import EnvironmentManifest
 from tolokaforge.runner.models import TaskDescription
 
 pytestmark = pytest.mark.unit
@@ -42,8 +48,6 @@ def _make_run_config() -> RunConfig:
 
 
 def _make_task_config(task_id: str) -> Any:
-    """The enforcement helper only reads ``.task_id`` from each entry —
-    a bare object with that attribute is sufficient."""
     task = MagicMock()
     task.task_id = task_id
     return task
@@ -59,16 +63,14 @@ def _make_orchestrator(
     return orch
 
 
-def _manifest_with(isolation: TaskIsolation) -> EnvironmentManifest:
+def _manifest_with_services(services: dict[str, ServiceSpec]) -> EnvironmentManifest:
     return EnvironmentManifest(
         compose_file=_FIXTURES / "safe_two_service.yaml",
-        isolation=isolation,
+        services=services,
     )
 
 
 def _shared_stack_backend() -> SharedStackRuntimeBackend:
-    """Constructed but never connected — enforcement only touches
-    ``isinstance``, so no daemon required."""
     return SharedStackRuntimeBackend(runner_address="sentinel:50051")
 
 
@@ -77,7 +79,8 @@ def _per_trial_backend() -> PerTrialRuntimeBackend:
 
 
 class TestSharedStackRuntimePath:
-    """The load-bearing case: SharedStackRuntimeBackend refuses per-trial tasks."""
+    """The load-bearing case: SharedStackRuntimeBackend refuses tasks
+    whose manifest requires per-trial materialisation."""
 
     def test_no_tasks_with_manifest_passes(self) -> None:
         tasks = [_make_task_config("t1"), _make_task_config("t2")]
@@ -86,39 +89,50 @@ class TestSharedStackRuntimePath:
             "t2": make_task_description(task_id="t2", environment_manifest=None),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        # Must not raise.
         orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_shared_ok_manifest_passes(self) -> None:
+    def test_all_shared_services_passes(self) -> None:
         tasks = [_make_task_config("stateless")]
         task_descs = {
             "stateless": make_task_description(
                 task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_per_trial_manifest_raises(self) -> None:
+    def test_reset_service_raises(self) -> None:
         tasks = [_make_task_config("stateful")]
         task_descs = {
             "stateful": make_task_description(
                 task_id="stateful",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError, match="per_trial") as exc:
+        with pytest.raises(RuntimeError, match="per-trial") as exc:
             orch._verify_isolation_compatibility(_shared_stack_backend())
         assert "stateful" in str(exc.value)
 
-    def test_per_trial_default_is_the_enforced_default(self) -> None:
-        """A manifest that does not specify isolation defaults to
-        per_trial — that default must trigger the shared-stack refusal
-        just like an explicit per_trial declaration."""
+    def test_empty_services_defaults_to_per_trial(self) -> None:
+        """A manifest with no explicit services is treated as
+        per-trial-requiring — that keeps the ADR-0009 safety default."""
         manifest = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
-        assert manifest.isolation is TaskIsolation.PER_TRIAL  # documents the default
+        assert manifest.requires_per_trial is True
         tasks = [_make_task_config("stateful-implicit")]
         task_descs = {
             "stateful-implicit": make_task_description(
@@ -130,74 +144,59 @@ class TestSharedStackRuntimePath:
         with pytest.raises(RuntimeError, match="stateful-implicit"):
             orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_mixed_manifests_only_per_trial_names_reported(self) -> None:
-        tasks = [
-            _make_task_config("stateful-a"),
-            _make_task_config("stateful-b"),
-            _make_task_config("stateless"),
-            _make_task_config("no-manifest"),
-        ]
+    def test_ephemeral_service_on_shared_raises_dedicated_error(self) -> None:
+        tasks = [_make_task_config("wants-ephemeral")]
         task_descs = {
-            "stateful-a": make_task_description(
-                task_id="stateful-a",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
-            ),
-            "stateful-b": make_task_description(
-                task_id="stateful-b",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
-            ),
-            "stateless": make_task_description(
-                task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
-            ),
-            "no-manifest": make_task_description(task_id="no-manifest", environment_manifest=None),
-        }
-        orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError) as exc:
-            orch._verify_isolation_compatibility(_shared_stack_backend())
-        message = str(exc.value)
-        assert "stateful-a" in message
-        assert "stateful-b" in message
-        assert "stateless" not in message
-        assert "no-manifest" not in message
-        assert "2 task(s)" in message
-
-    def test_error_names_the_fix(self) -> None:
-        tasks = [_make_task_config("t")]
-        task_descs = {
-            "t": make_task_description(
-                task_id="t",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+            "wants-ephemeral": make_task_description(
+                task_id="wants-ephemeral",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="ephemeral"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(RuntimeError, match="per-trial") as exc:
             orch._verify_isolation_compatibility(_shared_stack_backend())
-        message = str(exc.value)
-        assert "PerTrialRuntimeBackend" in message
-        assert "shared_ok" in message
+        # ephemeral triggers the requires_per_trial branch first.
+        assert "wants-ephemeral" in str(exc.value)
 
 
 class TestPerTrialRuntimePath:
     """PerTrialRuntimeBackend satisfies every isolation requirement."""
 
-    def test_per_trial_task_passes(self) -> None:
+    def test_reset_service_passes(self) -> None:
         tasks = [_make_task_config("stateful")]
         task_descs = {
             "stateful": make_task_description(
                 task_id="stateful",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_per_trial_backend())
 
-    def test_shared_ok_task_passes(self) -> None:
+    def test_all_shared_services_passes(self) -> None:
         tasks = [_make_task_config("stateless")]
         task_descs = {
             "stateless": make_task_description(
                 task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
@@ -211,32 +210,30 @@ class TestPerTrialRuntimePath:
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_per_trial_backend())
 
+    def test_ephemeral_pinned_service_passes(self) -> None:
+        """A task pinning ``services.<name>.isolation=ephemeral`` runs
+        cleanly on the per-trial backend — the guard's ephemeral-on-shared
+        branch does not fire."""
+        tasks = [_make_task_config("wants-ephemeral")]
+        task_descs = {
+            "wants-ephemeral": make_task_description(
+                task_id="wants-ephemeral",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="ephemeral"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        orch._verify_isolation_compatibility(_per_trial_backend())
+
 
 class TestAdapterGuard:
     def test_missing_adapter_raises_clear_error(self) -> None:
         orch = Orchestrator(_make_run_config())
         orch.tasks = [_make_task_config("t")]
-        orch.adapter = None  # simulates called before load_tasks()
+        orch.adapter = None
         with pytest.raises(RuntimeError, match="adapter"):
             orch._verify_isolation_compatibility(_shared_stack_backend())
-
-
-class TestTaskDescriptionCaching:
-    def test_cache_populated_from_call(self) -> None:
-        """Repeated invocations don't re-query the adapter for
-        already-resolved task descriptions."""
-        tasks = [_make_task_config("t")]
-        task_descs = {
-            "t": make_task_description(
-                task_id="t",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
-            ),
-        }
-        orch = _make_orchestrator(tasks, task_descs)
-        assert orch._task_desc_cache == {}
-        orch._verify_isolation_compatibility(_shared_stack_backend())
-        assert "t" in orch._task_desc_cache
-        # Second call hits the cache — adapter not called again.
-        adapter_calls_before = orch.adapter.to_task_description.call_count
-        orch._verify_isolation_compatibility(_shared_stack_backend())
-        assert orch.adapter.to_task_description.call_count == adapter_calls_before

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -63,8 +63,7 @@ def _print_runtime_banner(*, console: Console, runtime_choice: str, source: str)
     }.get(runtime_choice, runtime_choice)
     isolation_line = {
         "shared": (
-            "one docker-compose stack shared across every trial (fastest, "
-            "no cross-trial isolation)"
+            "one docker-compose stack shared across every trial (fastest, no cross-trial isolation)"
         ),
         "per_trial": (
             "one docker-compose stack per trial via Testcontainers "
@@ -186,11 +185,11 @@ def _activate_presets_overlay(
     type=click.Choice(["shared", "per_trial"]),
     default=None,
     help=(
-        "Runtime backend. Overrides orchestrator.runtime in the run config. "
-        "'shared' (default) uses one docker-compose stack across every trial; "
-        "'per_trial' materialises an isolated stack per trial via Testcontainers "
-        "(required by tasks whose environment_manifest declares "
-        "isolation: per_trial). See docs/architecture/RUNTIME_BACKENDS.md."
+        "Deprecated operator override — backend selection is task-driven "
+        "from `default_environment.services.<name>.isolation`. `shared` "
+        "forces `SharedStackRuntimeBackend`; `per_trial` forces "
+        "`PerTrialRuntimeBackend`. Emits a DeprecationWarning; retired in "
+        "a future release. See docs/architecture/RUNTIME_BACKENDS.md."
     ),
 )
 @click.option(

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -23,7 +23,10 @@ from tolokaforge.runner.models import CriterionResult as CriterionResult
 from tolokaforge.runner.models import EnvironmentManifest as EnvironmentManifest
 from tolokaforge.runner.models import EnvironmentPatch as EnvironmentPatch
 from tolokaforge.runner.models import LLMJudgeConfig as LLMJudgeConfig
+from tolokaforge.runner.models import ResetSpec as ResetSpec
 from tolokaforge.runner.models import Rubric as Rubric
+from tolokaforge.runner.models import ServiceIsolation as ServiceIsolation
+from tolokaforge.runner.models import ServiceSpec as ServiceSpec
 from tolokaforge.runner.models import StackPatch as StackPatch
 
 
@@ -515,26 +518,26 @@ class OrchestratorConfig(BaseModel):
     for backward compatibility; a ``DeprecationWarning`` fires when
     the field is explicitly set."""
 
-    runtime: Literal["shared", "per_trial"] = "shared"
-    """Runtime backend selection.
+    runtime: Literal["shared", "per_trial"] | None = None
+    """Deprecated operator override for runtime-backend selection.
 
-    * ``shared`` (default) — one docker-compose stack shared across every
-      trial in the run (``SharedStackRuntimeBackend``). Preserves today's
-      behaviour; fastest for stateless tasks.
-    * ``per_trial`` — one docker-compose stack per trial via Testcontainers
-      (``PerTrialRuntimeBackend``). Required by tasks whose manifest
-      declares ``isolation: per_trial``.
+    Backend selection is task-driven: the orchestrator picks
+    :class:`PerTrialRuntimeBackend` when any task's manifest requires
+    per-trial materialisation, otherwise :class:`SharedStackRuntimeBackend`.
+    Setting this field bypasses the task-driven signal and emits a
+    ``DeprecationWarning``. Retired in a future release.
 
-    Legacy value ``docker`` is accepted as an alias for ``shared`` with a
-    deprecation warning at load time; drop it from configs going forward.
+    Legacy value ``docker`` is accepted as an alias for ``shared`` with
+    the same deprecation warning; drop both from configs going forward.
     """
 
     @field_validator("runtime", mode="before")
     @classmethod
     def _accept_legacy_docker_alias(cls, value: Any) -> Any:
-        """Accept ``docker`` as a deprecated alias for ``shared`` so
-        older run configs continue to load. Emits a ``DeprecationWarning``
-        and structured-log-friendly stderr line."""
+        """Accept ``docker`` as an alias for ``shared`` and emit the
+        deprecation warning for any explicit setting."""
+        if value is None:
+            return value
         if value == "docker":
             warnings.warn(
                 "OrchestratorConfig.runtime = 'docker' is a deprecated alias "
@@ -542,7 +545,16 @@ class OrchestratorConfig(BaseModel):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            return "shared"
+            value = "shared"
+        warnings.warn(
+            "OrchestratorConfig.runtime is deprecated; backend selection is "
+            "now task-driven (any task requiring per-trial isolation forces "
+            "PerTrialRuntimeBackend, otherwise SharedStackRuntimeBackend). "
+            "Drop `orchestrator.runtime` from the run config. Retired in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return value
 
     @model_validator(mode="before")

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -574,33 +574,77 @@ class Orchestrator:
             )
         return next(iter(manifests_by_compose.values()))
 
+    def _select_backend_from_tasks(self) -> str:
+        """Return ``"per_trial"`` if any task's manifest requires per-trial
+        materialisation, otherwise ``"shared"``.
+
+        Reads :attr:`EnvironmentManifest.requires_per_trial` for every
+        task; a task without a manifest contributes no signal. When
+        every task with a manifest is fully-``shared`` labelled, the
+        selector picks the shared backend.
+        """
+        if self.adapter is None:
+            raise RuntimeError(
+                "Task-driven backend selection requires the adapter to be loaded first."
+            )
+        for task in self.tasks:
+            task_desc = self._task_desc_cache.get(task.task_id)
+            if task_desc is None:
+                task_desc = self.adapter.to_task_description(task.task_id)
+                self._task_desc_cache[task.task_id] = task_desc
+            manifest = task_desc.environment_manifest
+            if manifest is not None and manifest.requires_per_trial:
+                return "per_trial"
+        return "shared"
+
+    def _resolve_effective_runtime_choice(self) -> str:
+        """Return the effective runtime choice — the operator override
+        when set, otherwise the task-driven signal.
+
+        Callers that need to route on "per-trial mode" (stack bring-up,
+        endpoint logging) read this helper so the override path and the
+        task-driven path stay in lock-step with backend construction.
+        """
+        override = self.config.orchestrator.runtime
+        if override is not None:
+            return override
+        return self._select_backend_from_tasks()
+
     def _construct_runtime_backend(
         self,
         runner_address: str,
         env_manifest: EnvironmentManifest | None = None,
         run_id: str = "run",
     ) -> RuntimeBackend:
-        """Construct the runtime backend from ``config.orchestrator.runtime``.
+        """Construct the runtime backend from the task-driven signal,
+        with the deprecated ``config.orchestrator.runtime`` override
+        taking precedence when set.
 
-        ``shared`` (default) → :class:`SharedStackRuntimeBackend`. When
-        ``env_manifest`` is passed the backend materialises the
-        task-declared compose stack once per run at ``connect`` time.
-        When absent, the backend connects to the built-in shared engine
-        at ``runner_address`` with endpoints resolved via
-        :func:`_build_env_endpoints`.
-
-        ``per_trial`` → :class:`PerTrialRuntimeBackend` (env_manifest is
-        consumed per-trial there; ignored here).
+        Task-driven selection: any task requiring per-trial materialisation
+        → :class:`PerTrialRuntimeBackend`; otherwise
+        :class:`SharedStackRuntimeBackend`. When ``env_manifest`` is
+        passed the shared backend materialises the task-declared compose
+        stack once per run at ``connect`` time; without it the backend
+        connects to the built-in shared engine at ``runner_address``.
 
         Called when no backend is injected via
         ``Orchestrator.__init__(runtime_backend=...)``.
         """
-        runtime_choice = self.config.orchestrator.runtime
+        override = self.config.orchestrator.runtime
+        if override is not None:
+            runtime_choice = override
+            source = "config-override"
+        else:
+            runtime_choice = self._select_backend_from_tasks()
+            source = "tasks"
+
         if runtime_choice == "per_trial":
             from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 
             self.logger.info(
-                "runtime.backend.selected", backend="PerTrialRuntimeBackend", source="config"
+                "runtime.backend.selected",
+                backend="PerTrialRuntimeBackend",
+                source=source,
             )
             return PerTrialRuntimeBackend()
         from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
@@ -608,7 +652,7 @@ class Orchestrator:
         self.logger.info(
             "runtime.backend.selected",
             backend="SharedStackRuntimeBackend",
-            source="config" if runtime_choice == "shared" else "default",
+            source=source,
             env_manifest_present=env_manifest is not None,
         )
         if env_manifest is not None:
@@ -706,28 +750,24 @@ class Orchestrator:
         )
 
     def _verify_isolation_compatibility(self, runtime_backend: RuntimeBackend) -> None:
-        """Refuse to start the run if any task declares per-trial isolation
-        but the selected runtime backend cannot provide it.
+        """Refuse to start the run if any task requires per-trial
+        substrate materialisation but the selected runtime backend
+        cannot provide it.
 
-        Called after backend selection and before any trial runs.
-        Silent cross-trial state contamination is the failure mode this
-        guard prevents — a task that declares
-        ``environment_manifest.isolation: per_trial`` would produce wrong
-        verdicts when run against a shared stack.
-
-        Reads :attr:`RuntimeBackend.isolation_mode` rather than inspecting
-        the concrete class, so a future backend on a different substrate
-        (Kubernetes, Modal, ...) plugs into this check by setting the
-        attribute correctly.
+        Task-driven backend selection already routes such runs onto
+        :class:`PerTrialRuntimeBackend`; this guard only fires under
+        the deprecated ``orchestrator.runtime`` override path when the
+        operator forces a shared backend against a per-trial-requiring
+        task set. It also catches an ``ephemeral``-labelled service on
+        a shared backend — that isolation label cannot be honoured
+        without a full compose-down cycle.
 
         Raises :class:`RuntimeError` naming the offending tasks and the
         concrete fix.
         """
         from tolokaforge.core.runtime import IsolationMode
-        from tolokaforge.runner.models import TaskIsolation
 
         if runtime_backend.isolation_mode is IsolationMode.PER_TRIAL_STACK:
-            # Any per-trial backend satisfies every isolation requirement.
             return
 
         if self.adapter is None:
@@ -735,7 +775,8 @@ class Orchestrator:
                 "Isolation-compatibility check requires the adapter to be loaded first."
             )
 
-        violations: list[str] = []
+        per_trial_violations: list[str] = []
+        ephemeral_violations: list[tuple[str, list[str]]] = []
         for task in self.tasks:
             task_desc = self._task_desc_cache.get(task.task_id)
             if task_desc is None:
@@ -744,20 +785,34 @@ class Orchestrator:
             manifest = task_desc.environment_manifest
             if manifest is None:
                 continue
-            if manifest.isolation is TaskIsolation.PER_TRIAL:
-                violations.append(task.task_id)
+            if manifest.requires_per_trial:
+                per_trial_violations.append(task.task_id)
+            ephemeral = sorted(
+                name for name, spec in manifest.services.items() if spec.isolation == "ephemeral"
+            )
+            if ephemeral:
+                ephemeral_violations.append((task.task_id, ephemeral))
 
-        if violations:
+        if per_trial_violations:
             raise RuntimeError(
                 f"Runtime backend {type(runtime_backend).__name__} shares state "
-                f"across every trial in the run, but {len(violations)} task(s) "
-                f"declare `environment_manifest.isolation: per_trial`: "
-                f"{sorted(violations)!r}. These tasks would silently produce "
-                "wrong verdicts on a shared-stack backend.\n"
-                "  Fix: select a per-trial runtime backend in the run config "
-                "(e.g. PerTrialRuntimeBackend), or set `isolation: shared_ok` "
-                "on the task(s) that genuinely tolerate shared state across "
-                "trials."
+                f"across every trial in the run, but {len(per_trial_violations)} "
+                f"task(s) require per-trial materialisation via their "
+                f"`services.<name>.isolation` labels: "
+                f"{sorted(per_trial_violations)!r}. These tasks would silently "
+                "produce wrong verdicts on a shared-stack backend.\n"
+                "  Fix: drop the deprecated `orchestrator.runtime` override so "
+                "backend selection is task-driven, or label every service "
+                "`isolation: shared` on the task(s) that genuinely tolerate "
+                "shared state across trials."
+            )
+        if ephemeral_violations:
+            raise RuntimeError(
+                "Shared-stack backend cannot honour `isolation: ephemeral` "
+                "services (they require a compose-down between trials). "
+                f"Offending: {ephemeral_violations!r}. "
+                "Fix: drop the deprecated `orchestrator.runtime` override "
+                "so the task-driven selector picks a per-trial backend."
             )
 
     def _build_pending_trials(
@@ -1132,7 +1187,7 @@ class Orchestrator:
                     self.logger.info("Creating service stack (db-service + runner)")
                     stack_factory = core_stack
                 service_stack = stack_factory(**core_stack_kwargs)
-                per_trial_mode = self.config.orchestrator.runtime == "per_trial"
+                per_trial_mode = self._resolve_effective_runtime_choice() == "per_trial"
                 # In per_trial mode OR shared+env_manifest mode the built-in engine
                 # containers go unused — the task-declared compose stack owns the
                 # runner + db-service. The engine images still need to be BUILT so
@@ -1201,7 +1256,7 @@ class Orchestrator:
         self._verify_isolation_compatibility(runtime_backend)
 
         env_endpoints = _build_env_endpoints(runner_address)
-        if self.config.orchestrator.runtime == "per_trial" or run_env_manifest is not None:
+        if self._resolve_effective_runtime_choice() == "per_trial" or run_env_manifest is not None:
             # Per-trial backend resolves fresh endpoints per trial via
             # ``endpoints(handle)``. Shared+env_manifest resolves them once
             # at connect time from the materialised stack. In both cases the

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -98,8 +98,9 @@ class PerTrialRuntimeBackend:
 
     isolation_mode: IsolationMode = IsolationMode.PER_TRIAL_STACK
     """Every trial gets its own compose project. Advertised to the
-    orchestrator's compatibility check so tasks that declare
-    ``environment_manifest.isolation: per_trial`` are satisfied."""
+    orchestrator's compatibility check so tasks whose manifest carries
+    any non-``shared`` service label (``reset`` / ``ephemeral``) are
+    satisfied."""
 
     connect_timeout: float = 30.0
     """Seconds to wait for a per-trial runner's gRPC server to become

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -45,6 +45,7 @@ from tolokaforge.core.models import (
     ProjectConfig,
     TaskDefaults,
 )
+from tolokaforge.runtime.isolation import resolve_service_specs
 
 logger = logging.getLogger(__name__)
 
@@ -554,10 +555,18 @@ _POLICY_REQUEST_FIELDS = ("network_policy", "security_context_defaults")
 that are substrate-neutral (they describe the trial regardless of
 substrate)."""
 
-_SERVICE_TREATMENT_FIELDS = ("initial_state", "isolation")
-"""Fields that are scoped to the reviewed stack — discarded on atomic
-``stack`` replacement (the project's opt-outs reviewed the project's
-services, not the replacement stack)."""
+_SERVICE_TREATMENT_FIELDS = ("initial_state",)
+"""Fields scoped to the reviewed stack — discarded on atomic
+``stack`` replacement (the project's per-service opt-outs reviewed the
+project's services, not the replacement stack).
+
+``services`` is treated the same way (dropped on atomic replacement)
+but its merge is not a straight deep-merge — it lives on the manifest's
+per-service isolation surface where a task override must atomically
+replace the project's :class:`ServiceSpec` for the same service so a
+stale ``reset`` sibling can't leak through. See
+:func:`_fill_missing_service_defaults` and
+:func:`tolokaforge.runtime.isolation.resolve_service_specs`."""
 
 
 def resolve(
@@ -582,12 +591,17 @@ def resolve(
       clean slate of ``inputs`` and ``runner_service`` (a foreign
       compose file's ``${var}`` slots must never silently capture
       inherited values).
-    - Service-treatment fields (``initial_state``, root ``isolation``)
-      are discarded — the project's opt-outs reviewed the project's
-      services, not the replacement stack.
+    - Service-treatment fields (``initial_state``, ``services``) are
+      discarded — the project's per-service opt-outs reviewed the
+      project's services, not the replacement stack.
     - Policy-request fields (``network_policy``,
       ``security_context_defaults``) survive — substrate-neutral, they
       describe the trial regardless of substrate.
+
+    After manifest construction, every compose service missing from the
+    merged ``services`` map is filled with an ``ephemeral`` default via
+    :func:`tolokaforge.runtime.isolation.resolve_service_specs` so
+    downstream consumers see the complete map.
 
     Anchoring: ``stack.compose_file`` paths must already be absolute
     when this runs. The project loader and the task loader anchor them
@@ -625,7 +639,42 @@ def resolve(
             continue
         manifest_kwargs[field] = value
 
-    return EnvironmentManifest(**manifest_kwargs)
+    manifest = EnvironmentManifest(**manifest_kwargs)
+    _fill_missing_service_defaults(manifest, project_env, task_env)
+    return manifest
+
+
+def _fill_missing_service_defaults(
+    manifest: EnvironmentManifest,
+    project_env: EnvironmentPatch | None,
+    task_env: EnvironmentPatch | None,
+) -> None:
+    """Populate ``manifest.services`` with the merged
+    ``{service_name: ServiceSpec}`` map for every compose service
+    declared in the manifest's compose file.
+
+    On atomic-stack replacement (task supplies its own
+    ``stack.compose_file``) the project's ``services`` map is dropped —
+    the project's per-service opt-outs reviewed the project's services,
+    not the replacement stack. Task-side entries and the ``ephemeral``
+    fallback fill the map.
+    """
+    compose_services = manifest.load_compose().get("services") or {}
+    project_for_defaults = project_env
+    if _is_atomic_stack_replacement(task_env):
+        project_for_defaults = None
+    manifest.services.clear()
+    manifest.services.update(
+        resolve_service_specs(project_for_defaults, task_env, compose_services.keys())
+    )
+
+
+def _is_atomic_stack_replacement(task_env: EnvironmentPatch | None) -> bool:
+    return (
+        task_env is not None
+        and task_env.stack is not None
+        and task_env.stack.compose_file is not None
+    )
 
 
 def _dump_patch(patch: EnvironmentPatch | None) -> dict[str, Any]:

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -683,9 +683,10 @@ class SharedStackRuntimeBackend:
     """
 
     isolation_mode: IsolationMode = IsolationMode.SHARED_STACK
-    """Every trial in the run talks to the same runner container. Read by
-    the orchestrator's compatibility check to refuse runs whose tasks
-    declare ``environment_manifest.isolation: per_trial``."""
+    """Every trial in the run talks to the same runner container. Read
+    by the orchestrator's compatibility check to refuse runs whose tasks
+    require per-trial materialisation (any service labelled ``reset``
+    or ``ephemeral`` in the manifest)."""
 
     def __init__(
         self,

--- a/tolokaforge/core/trial.py
+++ b/tolokaforge/core/trial.py
@@ -17,9 +17,11 @@ from tolokaforge.runner.models import (
     InitialStateKind,
     InitialStateRef,
     NetworkPolicy,
+    ResetSpec,
     SecurityContext,
+    ServiceIsolation,
+    ServiceSpec,
     TaskDescription,
-    TaskIsolation,
 )
 
 DEFAULT_TOOL_TIMEOUT_S = 30.0
@@ -154,8 +156,10 @@ __all__ = [
     "InitialStateKind",
     "InitialStateRef",
     "NetworkPolicy",
+    "ResetSpec",
     "SecurityContext",
-    "TaskIsolation",
+    "ServiceIsolation",
+    "ServiceSpec",
     "TrialResult",
     "TrialSpec",
 ]

--- a/tolokaforge/docker/wheel_resolver.py
+++ b/tolokaforge/docker/wheel_resolver.py
@@ -846,7 +846,7 @@ class ReinstallWheelProvider(WheelProvider):
         whl = _newest_whl_for_version(cache_dir, _ENGINE_PKG, ver)
         if whl is None:
             self.last_failure = (
-                f"materialize completed but no {_ENGINE_PKG}-{ver}-*.whl " f"landed in {cache_dir}"
+                f"materialize completed but no {_ENGINE_PKG}-{ver}-*.whl landed in {cache_dir}"
             )
             return None
         return WheelArtifact(

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -613,28 +613,60 @@ class NetworkPolicy(str, Enum):
     """Unrestricted egress. Still no cross-trial reachability."""
 
 
-class TaskIsolation(str, Enum):
-    """Isolation requirement the task declares to the runtime backend.
+ServiceIsolation = Literal["shared", "reset", "ephemeral"]
+"""Per-service isolation vocabulary.
 
-    A task that mutates state (writes DB rows, applies fixtures, modifies
-    per-trial files) needs a fresh environment per trial to grade
-    correctly. Running such a task on a shared-stack backend produces
-    silent cross-trial contamination — the manifest's declaration lets
-    the orchestrator refuse an incompatible backend before any trial
-    runs.
+* ``shared`` — service persists across trials (state carries over).
+* ``reset`` — service is reset between trials via a seed-backed recipe
+  named by :attr:`ServiceSpec.reset`.
+* ``ephemeral`` — service is torn down and recreated between trials.
+"""
+
+
+class ResetSpec(BaseModel):
+    """Seed pointer for a service labelled ``reset``. Names the entry in
+    the project's ``assets.seeds`` map whose recipe restores the service
+    to a known baseline between trials."""
+
+    seed: str
+    """Name of the seed entry in the project's ``assets.seeds`` map."""
+
+    model_config = {"extra": "forbid"}
+
+
+class ServiceSpec(BaseModel):
+    """Per-service manifest entry — the harness's declaration of how a
+    compose service is treated between trials.
+
+    ``reset`` is required when ``isolation == "reset"`` and forbidden
+    otherwise; :meth:`_check_reset_agrees_with_isolation` enforces the
+    invariant so a stale ``reset`` sibling from a deep merge fails loud
+    at load.
     """
 
-    PER_TRIAL = "per_trial"
-    """Task requires a fresh environment per trial. The orchestrator
-    refuses to run the task on ``SharedStackRuntimeBackend``. Safe
-    default — any task that has a manifest almost certainly wants this
-    (it is why the task declared a manifest in the first place)."""
+    isolation: ServiceIsolation
+    """Per-service isolation label — see :data:`ServiceIsolation`."""
 
-    SHARED_OK = "shared_ok"
-    """Task tolerates running against a stack shared with other trials.
-    Opt-out for stateless tasks that would otherwise pay the per-trial
-    cold-start cost unnecessarily. The orchestrator accepts either
-    backend for these tasks."""
+    reset: ResetSpec | None = None
+    """Reset recipe pointer. Required for ``isolation="reset"``, forbidden
+    for the other labels."""
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def _check_reset_agrees_with_isolation(self) -> ServiceSpec:
+        if self.isolation == "reset" and self.reset is None:
+            raise ValueError(
+                "ServiceSpec: isolation='reset' requires a 'reset.seed' pointer; "
+                "declare `reset: {seed: <name>}` or change isolation."
+            )
+        if self.isolation != "reset" and self.reset is not None:
+            raise ValueError(
+                f"ServiceSpec: isolation={self.isolation!r} cannot carry a 'reset' "
+                "recipe. Either change isolation to 'reset' or drop the 'reset' "
+                "sibling (e.g. `reset: null` on the overriding side)."
+            )
+        return self
 
 
 def _compose_services(content: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -836,6 +868,19 @@ def _check_initial_state_keys(
             )
 
 
+def _check_services_keys(
+    compose_services: dict[str, dict[str, Any]],
+    manifest_services: dict[str, ServiceSpec],
+) -> None:
+    for key in manifest_services:
+        if key not in compose_services:
+            raise ValueError(
+                f"EnvironmentManifest.services has entry {key!r} that does not "
+                f"match any declared compose service; compose declares "
+                f"{sorted(compose_services)!r}."
+            )
+
+
 class StackPatch(BaseModel):
     """Substrate slot inside an :class:`EnvironmentPatch`.
 
@@ -900,11 +945,12 @@ class EnvironmentPatch(BaseModel):
     Survives atomic ``stack`` replacement (policy request,
     substrate-neutral)."""
 
-    isolation: TaskIsolation | None = None
-    """Isolation requirement. Discarded on atomic ``stack`` replacement
-    (the project's opt-out reviewed the project's services, not the
-    replacement stack — a task-local stack declares its own
-    ``shared_ok`` explicitly if it wants it)."""
+    services: dict[str, ServiceSpec] | None = None
+    """Per-service isolation + reset declarations, keyed by compose
+    service name. Discarded on atomic ``stack`` replacement — the
+    project's per-service opt-outs reviewed the project's services,
+    not the replacement stack. Deep-merges over the project side
+    entry-by-entry on non-replacement paths."""
 
     @model_validator(mode="before")
     @classmethod
@@ -974,13 +1020,29 @@ class EnvironmentManifest(BaseModel):
     """Applied by the provisioner to every service that does not override
     the equivalent settings in the compose file."""
 
-    isolation: TaskIsolation = TaskIsolation.PER_TRIAL
-    """Isolation requirement. Defaults to per-trial — the orchestrator
-    refuses to run a per-trial task on ``SharedStackRuntimeBackend``.
-    Set to ``shared_ok`` to opt out for stateless tasks that tolerate
-    a shared stack."""
+    services: dict[str, ServiceSpec] = Field(default_factory=dict)
+    """Per-service isolation + reset declarations, keyed by compose
+    service name. Populated by :func:`tolokaforge.core.project_loader.resolve`
+    which merges the project-side and task-side patches and then fills
+    any compose service missing from the merged map with an
+    ``ephemeral`` default. Consumed by :attr:`requires_per_trial` (for
+    backend selection) and by the runtime backends (for between-trial
+    reset dispatch)."""
 
     model_config = {"extra": "forbid"}
+
+    @property
+    def requires_per_trial(self) -> bool:
+        """True iff at least one service is labelled ``reset`` or
+        ``ephemeral``, or the manifest declares no services at all.
+
+        Read by :meth:`Orchestrator._select_backend_from_tasks` to pick
+        :class:`PerTrialRuntimeBackend` for any run whose tasks need
+        per-trial substrate materialisation.
+        """
+        if not self.services:
+            return True
+        return any(spec.isolation != "shared" for spec in self.services.values())
 
     _compose_content: dict[str, Any] = PrivateAttr(default_factory=dict)
     """Parsed compose file contents cached at construction time. Populated
@@ -1009,6 +1071,7 @@ class EnvironmentManifest(BaseModel):
         _check_depends_on_resolves(services)
         _check_runner_service_declared(services, self.runner_service)
         _check_initial_state_keys(services, self.initial_state)
+        _check_services_keys(services, self.services)
         self._compose_content = content
         return self
 

--- a/tolokaforge/runtime/__init__.py
+++ b/tolokaforge/runtime/__init__.py
@@ -1,0 +1,8 @@
+"""Substrate-agnostic helpers for the runtime layer.
+
+The ``core`` package owns orchestration and lifecycle; ``runtime`` owns
+substrate-neutral utilities that runtime backends and the project loader
+both consume. Modules here must not depend on any concrete backend
+(docker, kubernetes, ...) — they operate on the manifest types declared
+in :mod:`tolokaforge.runner.models`.
+"""

--- a/tolokaforge/runtime/isolation.py
+++ b/tolokaforge/runtime/isolation.py
@@ -1,0 +1,99 @@
+"""Per-service isolation resolver.
+
+Substrate-agnostic helpers that layer a task-side
+:class:`EnvironmentPatch` over a project-side one to produce the merged
+per-service isolation map an :class:`EnvironmentManifest` carries.
+
+Two entry points:
+
+- :func:`resolve_service_isolation` — return the effective
+  :data:`ServiceIsolation` label for a single compose service.
+- :func:`resolve_service_specs` — return the full merged
+  ``{service_name: ServiceSpec}`` map with ``ephemeral`` defaults filled
+  for every compose service missing from both patches.
+
+Both consume :class:`EnvironmentPatch` inputs only — no filesystem I/O,
+no Pydantic construction of :class:`EnvironmentManifest`. The
+project loader calls into these after its dict-level merge; runtime
+backends may call them directly against an already-resolved manifest's
+compose-service list.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from tolokaforge.runner.models import (
+    EnvironmentPatch,
+    ServiceIsolation,
+    ServiceSpec,
+)
+
+_DEFAULT_ISOLATION: ServiceIsolation = "ephemeral"
+"""Fallback label for a compose service that neither the project nor the
+task declares. Mirrors :attr:`EnvironmentManifest.requires_per_trial`'s
+safety default — an unlabelled service opts into fresh-per-trial
+materialisation."""
+
+
+def resolve_service_isolation(
+    project_env: EnvironmentPatch | None,
+    task_env: EnvironmentPatch | None,
+    compose_service: str,
+) -> ServiceIsolation:
+    """Return the effective isolation label for ``compose_service``.
+
+    Precedence: task-side patch wins over project-side patch. When
+    neither side names the service, the helper returns ``ephemeral``
+    (the unlabelled default from ADR-0018's amendment).
+    """
+    task_spec = _service_from_patch(task_env, compose_service)
+    if task_spec is not None:
+        return task_spec.isolation
+    project_spec = _service_from_patch(project_env, compose_service)
+    if project_spec is not None:
+        return project_spec.isolation
+    return _DEFAULT_ISOLATION
+
+
+def resolve_service_specs(
+    project_env: EnvironmentPatch | None,
+    task_env: EnvironmentPatch | None,
+    compose_service_names: Iterable[str],
+) -> dict[str, ServiceSpec]:
+    """Return the merged ``{service_name: ServiceSpec}`` map for every
+    name in *compose_service_names*.
+
+    Task-side entries win over project-side entries per service (deep
+    merge at the map level, not inside a single :class:`ServiceSpec`
+    — a task that overrides a service replaces the project's full
+    :class:`ServiceSpec` for that name so a mismatched ``reset``
+    sibling can't leak through). Services absent from both sides fill
+    with ``ServiceSpec(isolation="ephemeral")``.
+
+    The plural form is what :func:`tolokaforge.core.project_loader.resolve`
+    consumes; :func:`resolve_service_isolation` is the single-service
+    convenience for callers that walk a manifest's already-resolved
+    services map.
+    """
+    resolved: dict[str, ServiceSpec] = {}
+    for name in compose_service_names:
+        task_spec = _service_from_patch(task_env, name)
+        if task_spec is not None:
+            resolved[name] = task_spec
+            continue
+        project_spec = _service_from_patch(project_env, name)
+        if project_spec is not None:
+            resolved[name] = project_spec
+            continue
+        resolved[name] = ServiceSpec(isolation=_DEFAULT_ISOLATION)
+    return resolved
+
+
+def _service_from_patch(
+    patch: EnvironmentPatch | None,
+    compose_service: str,
+) -> ServiceSpec | None:
+    if patch is None or patch.services is None:
+        return None
+    return patch.services.get(compose_service)


### PR DESCRIPTION
## 1. In plain English

If you use `default_environment.services` in a task pack, you can now say per-service how it should be reused across trials: `shared` keeps the container alive, `reset` re-seeds it between trials, and `ephemeral` (the default when a service isn't listed) tears it down and re-provisions it fresh. The runtime backend picks itself based on what the tasks actually ask for — a shared stack when every service is `shared`, per-trial containers when anything requires reset or ephemeral. The old operator-supplied `orchestrator.runtime` knob still works but now emits a deprecation warning; it's an escape hatch, not the primary switch.

---

## 2. Design

- Per-service isolation lives in `default_environment.services.<name>.isolation` with the vocabulary `shared` / `reset` / `ephemeral`. Missing entries default to `ephemeral` — a `_fill_missing_service_defaults` pass runs after patch merge so unlabelled services never leak into selection as `shared`. Tradeoff: authors pay a small documentation-tax to opt into `shared`, but every deployed pack gets a safe default that never keeps stale state across trials by accident.
- Backend selection is derived from the resolved task set (`_select_backend_from_tasks` / `_construct_runtime_backend`). Per-trial iff any task has a non-`shared` service; shared-stack otherwise. Tradeoff: the operator loses the "always pick backend X" knob as a primary API surface — but they keep it as a deprecated escape hatch (`orchestrator.runtime`) that emits `DeprecationWarning` exactly once per run. The upshot is that the choice belongs to whoever wrote the pack, not whoever runs it.
- A substrate-agnostic resolver `tolokaforge/runtime/isolation.py` exposes `resolve_service_isolation(task_env, compose_service)` and the plural form `resolve_service_specs(project_env, task_env, compose_service_names)`. It's pure — no filesystem, no compose I/O, no coupling to Pydantic models beyond the two `EnvironmentPatch` shapes it merges. Tradeoff: an extra module and a small import redirection in `project_loader.resolve`, in exchange for a seam that later reset-recipe execution and environment-identity hashing sub-issues can call without paying compose-file I/O.
- ADR-0018 amendment records the new per-service vocabulary, the task-driven selector, and the deprecation of `orchestrator.runtime`. ADR-0009's outer contract (compose-file as source of truth for the shape of the stack) stays intact.
- Legacy `runtime: docker` alias on `OrchestratorConfig.runtime` continues to resolve to the shared-stack backend, still emitting `DeprecationWarning`. Tradeoff: one more transitional path to describe in docs, worth it to avoid breaking existing operator invocations.

```mermaid
flowchart TD
  A[task manifests] --> B[resolve_service_specs<br/>project + task patches]
  B --> C{any service<br/>not shared?}
  C -- yes --> D[PerTrialRuntimeBackend]
  C -- no --> E[SharedStackRuntimeBackend]
  F[orchestrator.runtime<br/>deprecated override] -.forces.-> D
  F -.forces.-> E
```

---

## 3. Changes

- `tolokaforge/runtime/isolation.py` (new) — `resolve_service_isolation` and `resolve_service_specs`; substrate-agnostic patch-merge with `ephemeral` default fill.
- `tolokaforge/runtime/__init__.py` (new) — re-exports the two helpers.
- `tolokaforge/runner/models.py` — `ServiceSpec` gets `isolation: Literal['shared','reset','ephemeral']` under `extra='forbid'`; `EnvironmentPatch.services` and `EnvironmentManifest.services` carry the per-service map; `_check_services_keys` rejects unknown compose-service names.
- `tolokaforge/core/models.py` — `OrchestratorConfig.runtime` retained as deprecated escape hatch; `runtime: docker` alias preserved; `DeprecationWarning` emitted once at construction.
- `tolokaforge/core/orchestrator.py` — `_select_backend_from_tasks` and `_construct_runtime_backend` now select from resolved tasks; `_verify_isolation_compatibility` covers both per-trial-on-shared and ephemeral-on-shared paths.
- `tolokaforge/core/project_loader.py` — calls into `resolve_service_specs`; the old inline merge + `_fill_missing_service_defaults` pass moves into the shared helper.
- `tolokaforge/core/per_trial_runtime.py`, `tolokaforge/core/shared_stack_runtime.py`, `tolokaforge/core/trial.py` — read the per-service isolation off the resolved manifest.
- `tolokaforge/cli/main.py` — surface the deprecation warning at the CLI boundary; no new flags.
- `docs/architecture/RUNTIME_BACKENDS.md` — replaces whole-manifest `isolation` prose with per-service vocabulary and task-driven selection.
- `docs/architecture/PROJECTS.md` — aligns the pack-authoring section to the new schema.
- `docs/architecture/adr/0018-multi-container-under-shared-runtime.md` — amended with the new vocabulary and selection path.
- `examples/native/multi_service{,_advanced,_postgres}/` — task and README updates onto the new schema.
- `tests/unit/test_backend_selection.py` (new) — mixed-manifest selection, override-with-warning, and mixed-shape (`services.postgres.isolation=shared` inside an otherwise per-trial run) coverage.
- `tests/unit/test_environment_resolve.py` — task-side patch wins over project-side per-service key; unknown vocab fails at patch construction; unknown compose-service name fails after merge; atomic-stack-replacement drops the project's `services` block.
- `tests/unit/test_orchestrator_isolation_enforcement.py` — extended to cover manifest-based per-service labels including the `services.postgres.isolation=shared` inside per-trial case.
- `tests/canonical/test_environment_manifest_contract.py` and adjacent multi-service unit tests — updated to the new schema.

---

## 4. How each linked issue was solved

_Filled at PR-ready time via `gh pr view <n> --json commits` once the branch history stabilises._

### #271 — per-service isolation in default_environment.services

- `29eed78` — Introduce per-service isolation, task-driven backend selection, and the `tolokaforge/runtime/isolation.py` resolver; migrate docs, ADR-0018, examples, and tests.

Umbrella: #212. Sibling sub-issues: #267, #268, #269, #270.

---

## 5. Verification

_Filled after CI settles and the smoke pipeline completes._

- **CI checks.** _pending_.
- **Local verify.** `ruff check` and `ruff format --check` pass; `pytest -m unit` and `pytest -m canonical` still to run on this branch snapshot.
- **Real-task smoke.** _pending_ — will exercise the three `examples/native/multi_service*` packs since the schema landed in their task files.
- **Example-pack sweep.** _pending_.

---

## 6. Boundary

- Does not implement reset-recipe execution — that's #267 (2/5).
- Does not add environment-identity hashing — that's #269 (4/5).
- Does not wire a Kubernetes backend — the resolver is substrate-agnostic on purpose and slots into a K8s backend later.
- Does not introduce a compose-file isolation label reader — no producer of that shape exists in-tree, so the "manifest-wins-over-label" precedence rule has no consumer to bind to. If a label surface is later requested, it merges under the same resolver.
- Does not remove `orchestrator.runtime` — it stays as a `DeprecationWarning`-emitting override; removal is a separate cleanup once no operator invocation depends on it.

---

## 7. Constraints observed

- No AI / Claude attribution in this commit or in this PR body.
- No internal tracker keys, no internal repo names, no internal doc IDs in the commit or the PR body.
- No release bumps (no version, no CHANGELOG entry).
- Umbrella issue linked (#212 — this closes sub-issue #271 of it).
- Lean source comments — every comment in the diff describes what the code IS, not history.
- Lint gate ran before tests.

Closes #271.
Refs #212, #267, #268, #269, #270.
