### PR TITLE
chore(ci): skip Claude review on mechanical PRs via paths-ignore

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,23 @@ name: Claude Code PR Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # Skip the (paid) review for mechanical PRs: model integration /
+    # registration (presets, registry, pricing — e.g. #261, #257, #196),
+    # dependabot lock bumps, docs/ADR edits, and changelog updates.
+    # GitHub skips the run only when EVERY changed file matches this list,
+    # so a PR that also touches real code is still reviewed. Deliberately
+    # NOT ignored: AGENTS.md / CLAUDE.md / README.md (policy the review
+    # enforces) and pyproject.toml (workspace + dependency rules). A review
+    # can always be requested manually on a skipped PR via an `@claude`
+    # comment (the issue_comment trigger has no path filter).
+    paths-ignore:
+      - tolokaforge/core/data/model_presets.yaml
+      - tolokaforge/core/data/pricing.json
+      - tests/integration/llm/registry.py
+      - .automation/requests/**
+      - uv.lock
+      - docs/**
+      - CHANGELOG.md
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
## Why

The Claude Code PR review runs on every PR and re-runs on every push, which burns API budget on mechanical PRs — auto-integration PRs like #261, model registrations, pricing refreshes, dependabot lock bumps, docs edits.

## What

Adds a `paths-ignore` filter to the `pull_request` trigger in `claude-review.yml`:

- `tolokaforge/core/data/model_presets.yaml`
- `tolokaforge/core/data/pricing.json`
- `tests/integration/llm/registry.py`
- `.automation/requests/**`
- `uv.lock`
- `docs/**`
- `CHANGELOG.md`

## Semantics & safety

- GitHub skips the run only when **every** changed file matches the list. Mixed PRs that also touch real code (e.g. #237/#260, which modified `response_policy.py`) are still reviewed.
- **Deliberately not ignored:** `AGENTS.md` / `CLAUDE.md` / `README.md` (the policy the review enforces) and `pyproject.toml` (workspace + dependency review rules).
- The `issue_comment` triggers have no path filter, so an `@claude` comment still summons a review on a skipped PR.
- The `main` ruleset has no required status check on this workflow, so skipped runs can't block merges.

## Impact

Replayed against the last 167 closed PRs (since 2026-04): **60 (36%) would have been skipped**, every one of them mechanical — integrate/registration PRs, pricing refreshes, ADR status flips, dependabot bumps, changelog cuts. Savings compound because each skipped PR also avoids per-push `synchronize` re-reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)