### PR TITLE
feat(cli): shared display layer — Console/THEME/make_progress/make_live (#276)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,7 @@ Full six-step process: [`docs/ADD_NEW_MODEL.md`](docs/ADD_NEW_MODEL.md).
 | Configuration | `docs/CONFIG.md` |
 | Docker / Runner | `docs/RUNNER.md` |
 | Adapters | `docs/ADAPTERS.md` |
+| CLI | `docs/CLI.md` |
 | Future plans | `docs/FUTURE_DEVELOPMENT.md` |
 | API reference | `docs/API.md` |
 | Troubleshooting | `docs/TROUBLESHOOTING.md` |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,77 @@
+# CLI reference
+
+This document describes the tolokaforge CLI's shared building blocks. Per-command usage lives in `--help` output.
+
+## Display layer
+
+Every module under `tolokaforge/cli/` renders human-facing output through `tolokaforge.cli._display`. The module owns four public names — `console`, `THEME`, `make_progress`, and `make_live` — and no CLI file may construct its own `rich.Console`. A canonical test (`tests/canonical/test_cli_display_invariants.py`) fails CI if a new module slips in an ad-hoc `Console(...)`.
+
+### Why a shared surface
+
+The CLI splits into five modules (`main.py`, `adapter_commands.py`, `assets_commands.py`, `config_commands.py`, `docker_commands.py`). Routing them all through one `Console` guarantees a single theme, a single stream posture (stderr, soft-wrapped), and one place to change progress plumbing when downstream milestone work adds a Live panel, a `--display` toggle, and a `runs list` table.
+
+### `console`
+
+```python
+from tolokaforge.cli._display import console
+
+console.print("[success]✓ done[/success]")
+```
+
+`console` writes to **stderr** with `soft_wrap=True` and the semantic palette installed. Stderr is the default because the CLI reserves stdout for the machine-parseable artifact path a later stage will introduce; today no CLI command writes to stdout via Rich. Soft-wrapping preserves long paths and digests in narrow CI terminals.
+
+Use `console.print(...)` for one-shot lines. Use the factories below when you need progress bars or a persistent Live region.
+
+### `THEME` — semantic token palette
+
+`THEME` is a `rich.theme.Theme` mapping seven tokens to Rich styles. Prefer semantic markup (`[success]…[/success]`) over ad-hoc colour markup (`[green]…[/green]`) so future palette tuning propagates automatically.
+
+| Token     | Style              | When to use                                                     |
+|-----------|--------------------|-----------------------------------------------------------------|
+| `info`    | `cyan`             | Hints and status lines.                                         |
+| `warn`    | `yellow`           | Warnings that don't abort the command.                          |
+| `error`   | `bold red`         | Errors — louder than default red so the user cannot miss them.  |
+| `success` | `green`            | Success markers (`✓`, completion summaries).                    |
+| `muted`   | `dim`              | Secondary detail — file paths, digests, ids.                    |
+| `cost`    | `bold magenta`     | Money and token counts.                                         |
+| `link`    | `underline cyan`   | `file://` URLs and other openable references.                   |
+
+All styles use Rich standard names (no truecolor hex) so terminals without full-colour support degrade cleanly.
+
+### `make_progress(...)`
+
+Factory returning a `rich.progress.Progress` bound to the shared console with the CLI's default column set: `SpinnerColumn`, description, `BarColumn`, `MofNCompleteColumn`, `TaskProgressColumn`, `TimeElapsedColumn`, `TimeRemainingColumn`.
+
+```python
+from tolokaforge.cli._display import make_progress
+
+with make_progress() as progress:
+    task = progress.add_task("Grading trials", total=42)
+    for trial in trials:
+        run(trial)
+        progress.advance(task)
+```
+
+Pass `columns=[...]` to override the default set entirely. Pass `disable=True` to render nothing (useful when a caller multiplexes output via a Live region). `redirect_stdout` / `redirect_stderr` default to `True` — set them to `False` when a caller manages its own stream capture.
+
+### `make_live(...)`
+
+Factory returning a `rich.live.Live` bound to the shared console. Use it when a region of the terminal needs to update in place (dashboards, run summaries).
+
+```python
+from rich.text import Text
+from tolokaforge.cli._display import make_live
+
+with make_live(Text("Starting…")) as live:
+    live.update(Text("Working…"))
+```
+
+Defaults: `refresh_per_second=4.0`, `transient=False`, `screen=False`, `vertical_overflow="ellipsis"`.
+
+### Choosing between `console.print`, `make_progress`, and `make_live`
+
+- **One-shot line** (banner, error, single result): `console.print(...)`.
+- **Iteration with a known total** (per-trial grading, batch uploads): `make_progress()`.
+- **Persistent status region that repaints in place** (multi-line dashboard, live cost tracker): `make_live()`.
+
+Nested progress inside a Live region is supported by Rich — pass the same `console` (the default) and Rich cooperates automatically.

--- a/docs/plans/2026-07-14-issue-276-a1-shared-display-layer.md
+++ b/docs/plans/2026-07-14-issue-276-a1-shared-display-layer.md
@@ -1,0 +1,186 @@
+# Plan: A1 — Shared display layer for the CLI
+
+Issue: Toloka/tolokaforge#276 (milestone: Terminal DX, umbrella #297)
+Branch: `feat/issue-276-a1-shared-display-layer` (branches off `feat/terminal-dx`, PR targets `feat/terminal-dx`)
+
+## Context
+
+Every CLI module today instantiates its own `Console()` — four places today (`main.py:50`, `docker_commands.py:15`, `adapter_commands.py:18`, `config_commands.py:22`) plus a fifth in `assets_commands.py` (a stdout/stderr split with `soft_wrap=True` — `assets_commands.py:27, 34`). Nothing shares a theme; nothing shares progress or Live plumbing (neither exists yet in `tolokaforge/cli/`). This is the foundation issue for the Terminal DX milestone: B1 (Rich Live progress panel), B2 (`--display` toggle), C1 (`runs list` Rich tables), C3 (Textual TUI), D1 (`init` wizard prompts), and D4 (`doctor` health table) all consume the shared surface introduced here. Downstream A4 (#280) turns the stderr-by-default posture into `stdout=artifact, stderr=progress`.
+
+Evidence:
+
+- `grep -Rn "Console()" tolokaforge/cli/` → 4 hits (`main.py:50`, `docker_commands.py:15`, `adapter_commands.py:18`, `config_commands.py:22`).
+- `grep -Rn "Console(" tolokaforge/cli/` → 6 hits (adds `assets_commands.py:27` `Console(soft_wrap=True)` and `assets_commands.py:34` `Console(stderr=True, soft_wrap=True)`).
+- `grep -Rn "rich.progress\|rich.live\|from rich.progress\|from rich.live" tolokaforge/` → zero hits. Progress and Live are net-new.
+- `pyproject.toml`: `rich>=13.0.0` — already present. No new dependency.
+- Existing test surface: `tests/unit/test_cli_commands.py`, `tests/unit/test_cli_assets.py`, `tests/unit/test_cli_status.py`, `tests/unit/test_adapter_convert_cli.py`, `tests/unit/test_validate_rubric_migration.py` — Click `CliRunner` invocations that assert on `result.output` / `result.stderr`.
+
+## Goal
+
+One module, `tolokaforge/cli/_display.py`, is the CLI's single source for terminal output primitives:
+
+- `console` — a shared `rich.Console` with `stderr=True`, `soft_wrap=True`, and `THEME` installed. Every CLI module imports it instead of instantiating its own.
+- `THEME` — a Rich `Theme` mapping seven semantic tokens (`info`, `warn`, `error`, `success`, `muted`, `cost`, `link`) to concrete Rich styles chosen to read cleanly on dark terminals and remain legible on light ones.
+- `make_progress(...)` — factory returning a preconfigured `rich.progress.Progress` bound to the shared console with an opinionated column set for benchmark runs (spinner + description + bar + m/n + elapsed + remaining). Accepts kwargs (`transient`, `disable`, `refresh_per_second`, `columns`, `auto_refresh`, `redirect_stdout`, `redirect_stderr`) that B1/B2 need. `redirect_stdout` / `redirect_stderr` pass through to Rich's defaults (True) — B1 will call with `False` to keep the orchestrator's log stream unbuffered while the panel is live.
+- `make_live(...)` — factory returning a preconfigured `rich.live.Live` bound to the shared console. Accepts the kwargs B1's `LiveRunDisplay` will need (`renderable`, `refresh_per_second`, `transient`, `screen`, `auto_refresh`, `vertical_overflow`, `redirect_stdout`, `redirect_stderr`).
+
+After migration, `grep -R "Console(" tolokaforge/cli/` returns exactly one hit — the constructor call inside `_display.py`. A test locks this invariant.
+
+## Non-goals
+
+- **Migrating call-site markup to semantic tokens.** Existing `[bold blue]`, `[cyan]`, `[green]`, `[red]`, `[yellow]` markup stays as-is — those are valid Rich style expressions and remain visually identical whether the console has a theme installed or not. Semantic-token adoption is a separate, incremental follow-up (or done as it becomes natural in B1/D4).
+- **`--display` toggle plumbing (B2).** `make_progress(disable=…)` and `make_live(...)` expose the kwargs B2 will call — B2 wires the CLI flag and the auto-selection. A1 does not add a `--display` flag.
+- **Structured logging (A3) or `stdout=artifact` (A4).** A1 defaults `console` to stderr because A4 depends on it, but A1 does not touch `core/logging.py` handlers, does not add `--verbose` / `--quiet`, and does not carve out a stdout channel for `validate`/`status`/`run`'s final artifact path. Those are #279 and #280.
+- **Textual TUI primitives.** `tolokaforge/tui/` (C3) is a separate package with its own Textual `App`. A1 stays in `rich`.
+- **New dependencies.** `rich` is already present. No `questionary`, no `textual`, no anything else.
+
+## Target module surface
+
+```python
+# tolokaforge/cli/_display.py
+
+from rich.console import Console
+from rich.live import Live
+from rich.progress import Progress, ProgressColumn
+from rich.theme import Theme
+
+THEME: Theme  # keys: info, warn, error, success, muted, cost, link
+
+console: Console  # stderr=True, soft_wrap=True, theme=THEME
+
+def make_progress(
+    *,
+    console: Console | None = None,
+    transient: bool = False,
+    disable: bool = False,
+    columns: Sequence[ProgressColumn] | None = None,
+    refresh_per_second: float = 10.0,
+    auto_refresh: bool = True,
+    redirect_stdout: bool = True,
+    redirect_stderr: bool = True,
+) -> Progress: ...
+
+def make_live(
+    renderable: RenderableType | None = None,
+    *,
+    console: Console | None = None,
+    refresh_per_second: float = 4.0,
+    transient: bool = False,
+    screen: bool = False,
+    auto_refresh: bool = True,
+    vertical_overflow: str = "ellipsis",
+    redirect_stdout: bool = True,
+    redirect_stderr: bool = True,
+) -> Live: ...
+```
+
+Default column set for `make_progress` (locked by test): `SpinnerColumn`, `TextColumn("[progress.description]{task.description}")`, `BarColumn`, `MofNCompleteColumn`, `TaskProgressColumn`, `TimeElapsedColumn`, `TimeRemainingColumn`.
+
+Default theme (locked by test — freeze the palette so drift fails loud):
+
+| Token     | Style              | Rationale                                                        |
+|-----------|--------------------|------------------------------------------------------------------|
+| `info`    | `cyan`             | Hints and status lines. Matches today's `[cyan]` sites.          |
+| `warn`    | `yellow`           | Warnings. Matches today's `[yellow]`.                            |
+| `error`   | `bold red`         | Errors. Louder than default red — user must not miss.            |
+| `success` | `green`            | ✓ lines. Matches today's `[green]`.                              |
+| `muted`   | `dim`              | Secondary detail (paths, ids). Rich `dim` style.                 |
+| `cost`    | `bold magenta`     | Money and token counts (B1 status bar).                          |
+| `link`    | `underline cyan`   | `file://` URLs (A5 banner, C1 `runs open`).                      |
+
+All styles are Rich standard names (no truecolor hex) so terminals without full-color support render them acceptably.
+
+`console` construction — locked by test — is: `Console(stderr=True, soft_wrap=True, theme=THEME)`. `soft_wrap=True` matches the current `assets_commands.py` posture (prevents mid-word wrapping of paths and digests in narrow CI terminals) and is a no-op for short lines everywhere else.
+
+## Stages
+
+### Stage 1: Introduce `_display.py` + module tests
+
+- **Contract:**
+  - New file `tolokaforge/cli/_display.py` exporting the four public names above.
+  - Every kwarg listed in the signatures is honoured; `make_progress` / `make_live` default `console` to the module's shared `console` when `None`.
+  - `THEME` contains exactly seven keys (`info`, `warn`, `error`, `success`, `muted`, `cost`, `link`) with the styles pinned above.
+  - `console.stderr is True`, `console.soft_wrap is True`, and `THEME` is installed (`console.get_style("info")` resolves to a `Style` equivalent to `Style.parse("cyan")`).
+- **Behaviour to lock (unit tests in `tests/unit/test_cli_display.py`):**
+  - `test_console_writes_to_stderr` — `console.stderr is True` and `console.file is sys.stderr`.
+  - `test_console_has_soft_wrap` — `console.soft_wrap is True`.
+  - `test_theme_defines_semantic_tokens` — `THEME.styles.keys() >= {"info","warn","error","success","muted","cost","link"}` and every token resolves via `console.get_style(name)`.
+  - `test_theme_palette_frozen` — each token's `Style` equals the pinned parse (e.g. `console.get_style("error") == Style.parse("bold red")`). One assertion per token; regression net if someone silently retunes the palette.
+  - `test_make_progress_uses_shared_console` — `make_progress().console is console`.
+  - `test_make_progress_default_columns` — the returned `Progress.columns` include, in order, `SpinnerColumn`, `TextColumn`, `BarColumn`, `MofNCompleteColumn`, `TaskProgressColumn`, `TimeElapsedColumn`, `TimeRemainingColumn` (identity by class).
+  - `test_make_progress_disable_kwarg` — `make_progress(disable=True).disable is True`.
+  - `test_make_progress_transient_kwarg` — `make_progress(transient=True).live.transient is True` (or equivalent — Rich exposes it via `Progress.live`).
+  - `test_make_progress_custom_columns_override_default` — passing `columns=[SpinnerColumn()]` yields exactly one column.
+  - `test_make_live_uses_shared_console` — `make_live().console is console`.
+  - `test_make_live_defaults` — `refresh_per_second == 4.0`, `transient is False`, `screen is False`, `auto_refresh is True`, `vertical_overflow == "ellipsis"`.
+  - `test_make_live_accepts_renderable` — a `Text("hello")` renderable passed positionally is stored as `Live.renderable`.
+- **Compatibility:** internal only. `_display.py` is a private CLI helper module (leading underscore); no user-facing surface changes yet.
+- **Deliverable:** `tolokaforge/cli/_display.py` and `tests/unit/test_cli_display.py`. Nothing else edited.
+- **Validation:** `uv run pytest tests/unit/test_cli_display.py -v` passes; `uv run ruff check tolokaforge/cli/_display.py tests/unit/test_cli_display.py` clean; `uv run ruff format --check` clean.
+- **Doc updates:** none in this stage (module is not yet consumed).
+
+### Stage 2: Migrate every CLI module to the shared console + update existing tests
+
+- **Contract:**
+  - No `Console(` instantiation anywhere in `tolokaforge/cli/**/*.py` outside `_display.py`.
+  - Every CLI module imports `console` from `tolokaforge.cli._display`.
+  - `main.py` keeps `from rich.console import Console` only if the `Console` symbol is still used as a type annotation on `_print_runtime_banner(*, console: Console, ...)`; otherwise drops the import.
+  - `assets_commands.py`'s `err_console` is deleted; all its output — success paths and error paths alike — goes through the shared `console`, which now writes to stderr uniformly. The docstring comment block explaining the stdout/stderr split is rewritten to describe the new single-stream posture (A4 will re-carve stdout later; this stage does not).
+  - Rich output routing changes from stdout to stderr across the board. Text markup on call sites (`[bold blue]`, `[cyan]`, `[green]`, `[red]`, `[yellow]`, etc.) is untouched — output is byte-for-byte identical when captured with mixed streams.
+- **Behaviour to lock (unit tests):**
+  - Existing `CliRunner(mix_stderr=False)` tests that currently assert Rich-emitted text on `result.output` are updated to assert on `result.stderr`. Tests that assert Click-emitted text (help output, argument-validation errors) continue to check `result.output`. Concrete migrations:
+    - `tests/unit/test_cli_commands.py`:
+      - `TestValidateCommand.test_validate_nonexistent_glob` — `"0 valid" in result.stderr`.
+      - `TestConfigCommands.test_config_validate_empty_dir` — `"No YAML files found" in result.stderr`.
+      - `TestConfigCommands.test_config_validate_non_mapping_yaml` — `"mapping" in result.stderr.lower()`.
+    - `tests/unit/test_cli_assets.py` (this is the widest change — assets was the only module that already split streams):
+      - Success paths: `"wrote 1 digest"`, `"already current"`, `"stale"`, `"match"`, `"nothing to stamp"`, `"strip on write"`, `"sha256:placeholder → …"` — all migrate from `result.output` to `result.stderr`.
+      - Error paths: `"shared/seeds/missing.sql"`, `"does not exist"`, `"must be a mapping"`, `"No project.yaml"` — already on `result.stderr` in current tests, unchanged.
+      - `test_fresh_digest_written_and_idempotent`'s mtime idempotency assertion (`project_yaml.stat().st_mtime_ns == mtime_after_first`) is unaffected — no stream involved.
+    - `tests/unit/test_validate_rubric_migration.py` — `test_validate_rejects_legacy_rubric_str`, `test_validate_rejects_legacy_model_ref`, `test_validate_accepts_structured_rubric`: `result.output` → `result.stderr` for the Rich-emitted validate output.
+    - `tests/unit/test_cli_status.py` — uses `CliRunner()` with mixed streams (`mix_stderr` default True), so `result.output` already contains combined stdout+stderr; **no change needed**. Regression-check as-is.
+    - `tests/unit/test_adapter_convert_cli.py` — asserts `result.exit_code == 0, result.output` (uses `.output` only as the failure-diagnostic message, not as behaviour); no functional change needed. Leave as-is.
+- **Compatibility:** internal only. This is not a compatibility surface — no task-pack contract, no run-config schema, no gRPC message, no published Python API touched. `AGENTS.md` Core Rule 5 does not gate this.
+- **Deliverable:** edits to
+  - `tolokaforge/cli/main.py` (line 10 import; line 50 removes `console = Console()`; imports shared `console`).
+  - `tolokaforge/cli/docker_commands.py` (lines 12, 15).
+  - `tolokaforge/cli/adapter_commands.py` (lines 16, 18).
+  - `tolokaforge/cli/config_commands.py` (lines 13, 22).
+  - `tolokaforge/cli/assets_commands.py` (lines 19, 21–34: single-console posture, docstring rewrite).
+  - `tests/unit/test_cli_commands.py`, `tests/unit/test_cli_assets.py`, `tests/unit/test_validate_rubric_migration.py`.
+- **Validation:**
+  - `uv run pytest tests/unit/test_cli_commands.py tests/unit/test_cli_assets.py tests/unit/test_cli_status.py tests/unit/test_validate_rubric_migration.py tests/unit/test_adapter_convert_cli.py -v` — all green.
+  - `grep -Rn "Console(" tolokaforge/cli/ | grep -v "_display.py"` — zero hits.
+  - `uv run ruff check tolokaforge/cli tests/unit` clean; format check clean.
+  - Manual visual smoke (implementer runs, quotes output in PR body): `uv run tolokaforge --help`, `uv run tolokaforge run --help`, `uv run tolokaforge config validate --config examples/native/tool_use/run_config.yaml 2>&1 | tee /tmp/a1-smoke.log` — confirm no visible regression versus the pre-migration output.
+- **Behaviour change to call out in PR body:** `tolokaforge assets stamp` currently splits streams (success → stdout, errors → stderr). After Stage 2 all its output goes to stderr, uniform with the rest of the CLI. Callers piping success output should switch to `2>&1 | …` until A4 (#280) re-carves a stdout channel for machine-parseable artifact paths. Landed 2026-07-11 in `525a33f` — external usage low, but call it out so downstream consumers can adjust.
+- **Doc updates:** none in this stage; documentation ships in Stage 3.
+
+### Stage 3: Grep-guard invariant test + `docs/CLI.md` display-layer section
+
+- **Contract:**
+  - A canonical test codifies the "no `Console(` outside `_display.py`" invariant so future regressions fail in CI.
+  - `docs/CLI.md` (new) documents the shared display layer as the CLI's public convention for future contributors.
+- **Behaviour to lock (canonical test in `tests/canonical/test_cli_display_invariants.py`, `@pytest.mark.canonical`):**
+  - `test_no_ad_hoc_console_in_cli` — walk `tolokaforge/cli/**/*.py`; for each file except `_display.py` and `__init__.py`, assert no line matches the regex `\bConsole\s*\(`. Failure message names the offending file and line so a future author sees exactly where they slipped up.
+  - `test_display_module_exports_public_surface` — `import tolokaforge.cli._display as d; assert hasattr(d, "console") and hasattr(d, "THEME") and callable(d.make_progress) and callable(d.make_live)`. Pins the surface so a rename fails here rather than at every call site.
+- **Compatibility:** internal only.
+- **Deliverable:**
+  - `tests/canonical/test_cli_display_invariants.py`.
+  - `docs/CLI.md` — new file with a `## Display layer` section describing `_display.py`'s purpose, the semantic-token palette, and when to use `make_progress` / `make_live` versus raw `Console.print`. Written as the current state of the CLI (per AGENTS.md Core Rule 8) — no "previously X" framing. Titles the file so that later milestone issues (B1/B2/…) can append their own sections without a rename.
+- **Validation:**
+  - `uv run pytest tests/canonical/test_cli_display_invariants.py -v` green.
+  - `uv run pytest tests/unit -m unit -x` and `uv run pytest tests/canonical -m canonical -x` — full unit + canonical suites green (ensures Stage 2's tests still pass alongside the new guard).
+  - `uv run ruff check` clean.
+- **Doc updates:** creates `docs/CLI.md`. Also runs `rg "\bConsole\(" tolokaforge/ tests/ docs/` and confirms every remaining hit is either `_display.py` itself, a test that asserts on the invariant, or a non-CLI subsystem (the `RichHandler` reference in `tolokaforge/docker/logging.py:702–705` is unrelated logging config — leave alone).
+
+## Discovered issues
+
+- **Fix in this PR:** None. The CLI modules audited are otherwise clean of A1-adjacent smells.
+- **Filed as issues:** None. The one adjacent-but-separate observation — `assets_commands.py`'s stdout/stderr split is a UX pattern the rest of the CLI should adopt for pipeline-friendly output — is already the explicit scope of #280 (A4) in the milestone. No new issue needed.
+
+## Risks / open questions
+
+- **Rich `Progress.live.transient` attribute path.** The Stage 1 test `test_make_progress_transient_kwarg` reaches through Rich's internal `Progress.live` handle. If Rich renames this on a minor bump, the assertion needs to move to a documented public accessor. Mitigation: pin the assertion to whatever public API Rich 15.x (per `uv.lock`) exposes at implementation time — verified `Progress.live.transient` works today; if a future bump ever drops it, fall back to a render-capture behavioural test that asserts the transient behaviour end-to-end. Not a blocker.
+- **Mixed-stream Click behaviour under `mix_stderr=False`.** Modern Click (≥8.2) has deprecated the `mix_stderr` parameter; today's tests still use it and it still works on the version pinned in `uv.lock`. If a future Click upgrade drops it, those tests will need to be rewritten independently of this issue. Out of scope for A1; noted so an implementer isn't surprised.
+- **Interaction with A4 (#280).** A4 will introduce a dedicated stdout channel for `run`/`prepare`'s final artifact path and for `validate`/`status`'s human-readable output. That will likely add a second export to `_display.py` (`stdout_console`, or a `write_artifact_path()` helper). A1 does not preempt that decision — Stage 2 unifies everything onto stderr so A4 has a single starting point.

--- a/tests/canonical/test_cli_display_invariants.py
+++ b/tests/canonical/test_cli_display_invariants.py
@@ -1,0 +1,60 @@
+"""Canonical invariants for the shared CLI display layer.
+
+Two guards keep future contributors on the shared path:
+
+* ``test_no_ad_hoc_console_in_cli`` walks ``tolokaforge/cli/**/*.py`` and
+  asserts that no module outside :mod:`tolokaforge.cli._display` constructs
+  its own ``rich.Console`` — every CLI surface routes through the shared
+  instance so theme, stream posture, and progress plumbing stay uniform.
+* ``test_display_module_exports_public_surface`` pins the public names
+  ``console``, ``THEME``, ``make_progress``, and ``make_live`` so a rename
+  fails here rather than at every call site.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+CLI_DIR = Path(__file__).resolve().parents[2] / "tolokaforge" / "cli"
+_EXEMPT_FILES = frozenset({"_display.py", "__init__.py"})
+_CONSOLE_CALL = re.compile(r"\bConsole\s*\(")
+
+
+def test_no_ad_hoc_console_in_cli() -> None:
+    """Every CLI module routes through ``tolokaforge.cli._display.console``.
+
+    Any ``Console(...)`` construction outside ``_display.py`` breaks the
+    shared-theme invariant B1/B2/C1/D1/D4 build on. The failure message
+    names every offending ``file:line`` so the fix is obvious.
+    """
+
+    offenders: list[str] = []
+    for path in sorted(CLI_DIR.rglob("*.py")):
+        if path.name in _EXEMPT_FILES:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _CONSOLE_CALL.search(line):
+                offenders.append(
+                    f"{path.relative_to(CLI_DIR.parent.parent)}:{lineno}: {line.strip()}"
+                )
+
+    assert not offenders, (
+        "Ad-hoc rich.Console constructions found in tolokaforge/cli/ — "
+        "import `console` from `tolokaforge.cli._display` instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_display_module_exports_public_surface() -> None:
+    """The four public names of ``_display`` must stay stable."""
+
+    import tolokaforge.cli._display as display
+
+    assert hasattr(display, "console"), "missing shared `console`"
+    assert hasattr(display, "THEME"), "missing `THEME`"
+    assert callable(getattr(display, "make_progress", None)), "`make_progress` not callable"
+    assert callable(getattr(display, "make_live", None)), "`make_live` not callable"

--- a/tests/unit/test_cli_assets.py
+++ b/tests/unit/test_cli_assets.py
@@ -107,20 +107,20 @@ class TestAssetsStampWriteMode:
         expected = compute_seed_digest(seed)
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
-        assert result.exit_code == 0, result.output
-        assert "wrote 1 digest" in result.output
+        assert result.exit_code == 0, result.stderr
+        assert "wrote 1 digest" in result.stderr
 
         rewritten = yaml.safe_load(project_yaml.read_text())
         assert rewritten["assets"]["seeds"]["base"]["digest"] == expected
 
         # Idempotent: re-running against the now-stamped file is a
-        # no-op that says so and doesn't touch the file. Rich is
-        # configured with ``soft_wrap=True`` so the phrase stays on
-        # one line even in narrow CI terminals.
+        # no-op that says so and doesn't touch the file. The shared
+        # console is configured with ``soft_wrap=True`` so the phrase
+        # stays on one line even in narrow CI terminals.
         mtime_after_first = project_yaml.stat().st_mtime_ns
         result2 = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result2.exit_code == 0
-        assert "already current" in result2.output
+        assert "already current" in result2.stderr
         assert project_yaml.stat().st_mtime_ns == mtime_after_first
 
     def test_bare_string_shorthand_coerced_to_dict_with_digest(
@@ -183,9 +183,9 @@ class TestAssetsStampWriteMode:
         )
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 0, result.stderr
         # One digest changed, one already correct → wrote 1.
-        assert "wrote 1 digest" in result.output
+        assert "wrote 1 digest" in result.stderr
 
         rewritten = yaml.safe_load(project_yaml.read_text())["assets"]["seeds"]
         assert rewritten["a"]["digest"] == digest_a  # unchanged
@@ -224,8 +224,8 @@ class TestAssetsStampCheckMode:
 
         mtime_before = project_yaml.stat().st_mtime_ns
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
-        assert result.exit_code == 0, result.output
-        assert "match" in result.output
+        assert result.exit_code == 0, result.stderr
+        assert "match" in result.stderr
         assert project_yaml.stat().st_mtime_ns == mtime_before
 
     def test_check_stale_digest_exits_one_with_diff(
@@ -236,11 +236,11 @@ class TestAssetsStampCheckMode:
 
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
         assert result.exit_code != 0
-        assert "stale" in result.output
+        assert "stale" in result.stderr
         # Both the OLD (placeholder) and the computed NEW digest must
         # appear in the diff, structured as ``old → new``. A regression
         # to only-print-one would slip past a looser assertion.
-        assert f"sha256:placeholder → {expected_new}" in result.output
+        assert f"sha256:placeholder → {expected_new}" in result.stderr
 
 
 class TestAssetsStampMissingFile:
@@ -270,10 +270,9 @@ class TestAssetsStampMissingFile:
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result.exit_code != 0
-        # Errors route through ``err_console`` (stderr) — uniform with
-        # every other fatal-error path in the module. The offending
-        # path must appear on stderr so the author knows exactly which
-        # reference to fix.
+        # All CLI output routes through the shared stderr console, so
+        # the offending path lands on stderr and the author sees
+        # exactly which reference to fix.
         assert "shared/seeds/missing.sql" in result.stderr
         assert "does not exist" in result.stderr
 
@@ -307,8 +306,7 @@ class TestAssetsStampCheckWithMissingFile:
 
         result = runner.invoke(cli, ["assets", "stamp", "--check", str(tmp_path)])
         assert result.exit_code != 0
-        # Fatal errors route to stderr (see err_console in
-        # assets_commands.py).
+        # All CLI output routes through the shared stderr console.
         assert "shared/seeds/missing.sql" in result.stderr
 
 
@@ -331,7 +329,7 @@ class TestAssetsStampProjectResolution:
 
         result = runner.invoke(cli, ["assets", "stamp", str(empty)])
         assert result.exit_code != 0
-        # Fatal errors route to stderr.
+        # All CLI output routes through the shared stderr console.
         assert "No project.yaml" in result.stderr
 
 
@@ -347,8 +345,8 @@ class TestAssetsStampMalformedShapeFailsLoud:
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result.exit_code != 0
-        # ``click.ClickException`` writes to stderr, and the fixture
-        # is ``mix_stderr=False`` — check the split stream.
+        # ``click.ClickException`` writes to stderr; the fixture uses
+        # ``mix_stderr=False`` so the split stream is inspectable.
         assert "assets" in result.stderr
         assert "must be a mapping" in result.stderr
 
@@ -401,8 +399,8 @@ class TestAssetsStampCommentDetection:
         )
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
-        assert result.exit_code == 0, result.output
-        assert "strip on write" in result.output
+        assert result.exit_code == 0, result.stderr
+        assert "strip on write" in result.stderr
 
     def test_whole_line_comment_triggers_warning(self, runner: CliRunner, tmp_path: Path) -> None:
         seed = tmp_path / "shared" / "seeds" / "base.sql"
@@ -420,8 +418,8 @@ class TestAssetsStampCommentDetection:
         )
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
-        assert result.exit_code == 0, result.output
-        assert "strip on write" in result.output
+        assert result.exit_code == 0, result.stderr
+        assert "strip on write" in result.stderr
 
 
 class TestAssetsStampNoSeeds:
@@ -433,7 +431,7 @@ class TestAssetsStampNoSeeds:
 
         result = runner.invoke(cli, ["assets", "stamp", str(tmp_path)])
         assert result.exit_code == 0
-        assert "nothing to stamp" in result.output
+        assert "nothing to stamp" in result.stderr
 
 
 class TestAssetsStampHelpText:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -81,7 +81,7 @@ class TestValidateCommand:
         # Glob pattern matching no files → 0 valid, 0 invalid
         result = runner.invoke(cli, ["validate", "--tasks", str(tmp_path / "*.xyz")])
         assert result.exit_code == 0
-        assert "0 valid" in result.output
+        assert "0 valid" in result.stderr
 
     def test_validate_valid_task_yaml(self, runner: CliRunner, tmp_path: Path) -> None:
         """Validate a minimal valid task.yaml file."""
@@ -99,7 +99,7 @@ class TestValidateCommand:
 
         result = runner.invoke(cli, ["validate", "--tasks", str(task_file)])
         # Either valid or shows validation result
-        assert result.exit_code == 0 or "invalid" in result.output.lower()
+        assert result.exit_code == 0 or "invalid" in result.stderr.lower()
 
     def test_validate_invalid_yaml(self, runner: CliRunner, tmp_path: Path) -> None:
         """Validate a file with invalid YAML."""
@@ -107,11 +107,12 @@ class TestValidateCommand:
         task_file.write_text("not: valid: yaml: [broken")
 
         result = runner.invoke(cli, ["validate", "--tasks", str(task_file)])
-        # Should handle the error gracefully
+        # Should handle the error gracefully — Rich output routes to
+        # stderr via the shared display console.
         assert (
-            "invalid" in result.output.lower()
+            "invalid" in result.stderr.lower()
             or result.exit_code != 0
-            or "0 valid" in result.output
+            or "0 valid" in result.stderr
         )
 
 
@@ -217,7 +218,7 @@ class TestConfigCommands:
         """Validating an empty directory → no YAML files found."""
         result = runner.invoke(cli, ["config", "validate", "--config", str(tmp_path)])
         assert result.exit_code != 0
-        assert "No YAML files found" in result.output
+        assert "No YAML files found" in result.stderr
 
     def test_config_validate_invalid_yaml(self, runner: CliRunner, tmp_path: Path) -> None:
         """Config validate with invalid YAML content."""
@@ -225,10 +226,11 @@ class TestConfigCommands:
         cfg_file.write_text("[not: valid: yaml: [")
 
         result = runner.invoke(cli, ["config", "validate", "--config", str(cfg_file)])
-        # Either shows error or fails
+        # Either shows error or fails — Rich output routes to stderr
+        # via the shared display console.
         assert (
-            "parse" in result.output.lower()
-            or "error" in result.output.lower()
+            "parse" in result.stderr.lower()
+            or "error" in result.stderr.lower()
             or result.exit_code != 0
         )
 
@@ -238,7 +240,7 @@ class TestConfigCommands:
         cfg_file.write_text("- item1\n- item2\n")
 
         result = runner.invoke(cli, ["config", "validate", "--config", str(cfg_file)])
-        assert "mapping" in result.output.lower() or result.exit_code != 0
+        assert "mapping" in result.stderr.lower() or result.exit_code != 0
 
 
 # ===================================================================

--- a/tests/unit/test_cli_display.py
+++ b/tests/unit/test_cli_display.py
@@ -1,0 +1,113 @@
+"""Unit tests locking the shared CLI display layer contract.
+
+Every assertion here maps to a documented invariant in
+``tolokaforge/cli/_display.py`` — if a test fails, the surface changed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.style import Style
+from rich.text import Text
+
+from tolokaforge.cli._display import THEME, console, make_live, make_progress
+
+pytestmark = pytest.mark.unit
+
+
+def test_console_writes_to_stderr() -> None:
+    assert console.stderr is True
+    assert console.file is sys.stderr
+
+
+def test_console_has_soft_wrap() -> None:
+    assert console.soft_wrap is True
+
+
+def test_theme_defines_semantic_tokens() -> None:
+    required = {"info", "warn", "error", "success", "muted", "cost", "link"}
+    assert set(THEME.styles.keys()) >= required
+    for token in required:
+        resolved = console.get_style(token)
+        assert isinstance(resolved, Style), f"token {token!r} did not resolve to a Style"
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("info", "cyan"),
+        ("warn", "yellow"),
+        ("error", "bold red"),
+        ("success", "green"),
+        ("muted", "dim"),
+        ("cost", "bold magenta"),
+        ("link", "underline cyan"),
+    ],
+)
+def test_theme_palette_frozen(token: str, expected: str) -> None:
+    assert console.get_style(token) == Style.parse(expected)
+
+
+def test_make_progress_uses_shared_console() -> None:
+    assert make_progress().console is console
+
+
+def test_make_progress_default_columns() -> None:
+    expected_classes = [
+        SpinnerColumn,
+        TextColumn,
+        BarColumn,
+        MofNCompleteColumn,
+        TaskProgressColumn,
+        TimeElapsedColumn,
+        TimeRemainingColumn,
+    ]
+    progress = make_progress()
+    actual_classes = [type(col) for col in progress.columns]
+    assert actual_classes == expected_classes
+
+
+def test_make_progress_disable_kwarg() -> None:
+    assert make_progress(disable=True).disable is True
+
+
+def test_make_progress_transient_kwarg() -> None:
+    assert make_progress(transient=True).live.transient is True
+
+
+def test_make_progress_custom_columns_override_default() -> None:
+    progress = make_progress(columns=[SpinnerColumn()])
+    assert len(progress.columns) == 1
+    assert isinstance(progress.columns[0], SpinnerColumn)
+
+
+def test_make_live_uses_shared_console() -> None:
+    assert make_live().console is console
+
+
+def test_make_live_defaults() -> None:
+    live = make_live()
+    assert live.refresh_per_second == 4.0
+    assert live.transient is False
+    # Rich stores the ``screen`` init kwarg on the private ``_screen`` field;
+    # no public accessor exists on Live in rich 15.x.
+    assert live._screen is False
+    assert live.auto_refresh is True
+    assert live.vertical_overflow == "ellipsis"
+
+
+def test_make_live_accepts_renderable() -> None:
+    renderable = Text("hello")
+    live = make_live(renderable)
+    assert live.renderable is renderable

--- a/tests/unit/test_cli_display.py
+++ b/tests/unit/test_cli_display.py
@@ -92,6 +92,31 @@ def test_make_progress_custom_columns_override_default() -> None:
     assert isinstance(progress.columns[0], SpinnerColumn)
 
 
+def test_make_progress_default_kwargs() -> None:
+    progress = make_progress()
+    assert progress.live.transient is False
+    assert progress.live.auto_refresh is True
+    assert progress.live.refresh_per_second == 10.0
+    # Rich stores redirect_stdout/redirect_stderr on Live's private fields
+    # (same class of internal-accessor risk documented for Progress.live.transient).
+    assert progress.live._redirect_stdout is True
+    assert progress.live._redirect_stderr is True
+
+
+def test_make_progress_redirect_kwargs_passthrough() -> None:
+    progress = make_progress(redirect_stdout=False, redirect_stderr=False)
+    assert progress.live._redirect_stdout is False
+    assert progress.live._redirect_stderr is False
+
+
+def test_make_progress_auto_refresh_kwarg() -> None:
+    assert make_progress(auto_refresh=False).live.auto_refresh is False
+
+
+def test_make_progress_refresh_per_second_kwarg() -> None:
+    assert make_progress(refresh_per_second=2.5).live.refresh_per_second == 2.5
+
+
 def test_make_live_uses_shared_console() -> None:
     assert make_live().console is console
 
@@ -105,6 +130,14 @@ def test_make_live_defaults() -> None:
     assert live._screen is False
     assert live.auto_refresh is True
     assert live.vertical_overflow == "ellipsis"
+    assert live._redirect_stdout is True
+    assert live._redirect_stderr is True
+
+
+def test_make_live_redirect_kwargs_passthrough() -> None:
+    live = make_live(redirect_stdout=False, redirect_stderr=False)
+    assert live._redirect_stdout is False
+    assert live._redirect_stderr is False
 
 
 def test_make_live_accepts_renderable() -> None:

--- a/tests/unit/test_validate_rubric_migration.py
+++ b/tests/unit/test_validate_rubric_migration.py
@@ -68,9 +68,10 @@ def test_validate_rejects_legacy_rubric_str(tmp_path: Path):
 
     result = CliRunner(mix_stderr=False).invoke(cli, ["validate", "--tasks", str(task_file)])
 
-    # validate reports per-task pass/fail to stdout and exits 0; the task must be
-    # flagged invalid with the migration message naming rubric + the new shape.
-    out = result.output
+    # validate reports per-task pass/fail via the shared stderr console and
+    # exits 0; the task must be flagged invalid with the migration message
+    # naming rubric + the new shape.
+    out = result.stderr
     assert "1 valid, 0 invalid" not in out
     assert "0 valid, 1 invalid" in out
     assert "rubric is now a structured Rubric" in out
@@ -101,7 +102,7 @@ def test_validate_rejects_legacy_model_ref(tmp_path: Path):
 
     result = CliRunner(mix_stderr=False).invoke(cli, ["validate", "--tasks", str(task_file)])
 
-    out = result.output
+    out = result.stderr
     assert "0 valid, 1 invalid" in out
     assert "model_ref moved to the run config" in out
 
@@ -128,7 +129,7 @@ def test_validate_accepts_structured_rubric(tmp_path: Path):
     )
 
     result = CliRunner(mix_stderr=False).invoke(cli, ["validate", "--tasks", str(task_file)])
-    assert "1 valid, 0 invalid" in result.output
+    assert "1 valid, 0 invalid" in result.stderr
 
 
 def test_validate_grading_yaml_rejects_removed_output_schema(tmp_path: Path):

--- a/tolokaforge/cli/_display.py
+++ b/tolokaforge/cli/_display.py
@@ -1,0 +1,124 @@
+"""Shared display primitives for the tolokaforge CLI.
+
+Every CLI module imports :data:`console` from here instead of instantiating
+its own ``rich.Console`` — one theme, one stream posture, one place to change.
+
+Public surface:
+
+- :data:`THEME` — semantic-token palette (``info``, ``warn``, ``error``,
+  ``success``, ``muted``, ``cost``, ``link``).
+- :data:`console` — shared ``rich.Console`` writing to stderr with soft wrap
+  and :data:`THEME` installed.
+- :func:`make_progress` — factory for ``rich.progress.Progress`` bound to
+  :data:`console` with the CLI's default column set.
+- :func:`make_live` — factory for ``rich.live.Live`` bound to :data:`console`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rich.console import Console, RenderableType
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    ProgressColumn,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.theme import Theme
+
+THEME = Theme(
+    {
+        "info": "cyan",
+        "warn": "yellow",
+        "error": "bold red",
+        "success": "green",
+        "muted": "dim",
+        "cost": "bold magenta",
+        "link": "underline cyan",
+    }
+)
+
+_SHARED_CONSOLE = Console(stderr=True, soft_wrap=True, theme=THEME)
+console = _SHARED_CONSOLE
+
+
+def _default_progress_columns() -> list[ProgressColumn]:
+    return [
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+    ]
+
+
+def make_progress(
+    *,
+    console: Console | None = None,
+    transient: bool = False,
+    disable: bool = False,
+    columns: Sequence[ProgressColumn] | None = None,
+    refresh_per_second: float = 10.0,
+    auto_refresh: bool = True,
+    redirect_stdout: bool = True,
+    redirect_stderr: bool = True,
+) -> Progress:
+    """Return a ``Progress`` bound to the shared console.
+
+    ``columns`` overrides the default column set entirely. Passing ``None``
+    yields the CLI's opinionated set: spinner, description, bar, m/n,
+    percent, elapsed, remaining.
+    """
+
+    target_console = console if console is not None else _SHARED_CONSOLE
+    resolved_columns = list(columns) if columns is not None else _default_progress_columns()
+    return Progress(
+        *resolved_columns,
+        console=target_console,
+        transient=transient,
+        disable=disable,
+        refresh_per_second=refresh_per_second,
+        auto_refresh=auto_refresh,
+        redirect_stdout=redirect_stdout,
+        redirect_stderr=redirect_stderr,
+    )
+
+
+def make_live(
+    renderable: RenderableType | None = None,
+    *,
+    console: Console | None = None,
+    refresh_per_second: float = 4.0,
+    transient: bool = False,
+    screen: bool = False,
+    auto_refresh: bool = True,
+    vertical_overflow: str = "ellipsis",
+    redirect_stdout: bool = True,
+    redirect_stderr: bool = True,
+) -> Live:
+    """Return a ``Live`` bound to the shared console."""
+
+    target_console = console if console is not None else _SHARED_CONSOLE
+    return Live(
+        renderable,
+        console=target_console,
+        refresh_per_second=refresh_per_second,
+        transient=transient,
+        screen=screen,
+        auto_refresh=auto_refresh,
+        vertical_overflow=vertical_overflow,
+        redirect_stdout=redirect_stdout,
+        redirect_stderr=redirect_stderr,
+    )
+
+
+__all__ = ["THEME", "console", "make_live", "make_progress"]

--- a/tolokaforge/cli/_display.py
+++ b/tolokaforge/cli/_display.py
@@ -72,11 +72,15 @@ def make_progress(
     redirect_stdout: bool = True,
     redirect_stderr: bool = True,
 ) -> Progress:
-    """Return a ``Progress`` bound to the shared console.
+    """Return a ``Progress`` bound to the module's shared console.
 
     ``columns`` overrides the default column set entirely. Passing ``None``
     yields the CLI's opinionated set: spinner, description, bar, m/n,
     percent, elapsed, remaining.
+
+    The default ``console`` is early-bound at import time — reassigning
+    ``_display.console`` afterwards does not reach this default; pass
+    ``console=`` explicitly to redirect.
     """
 
     target_console = console if console is not None else _SHARED_CONSOLE
@@ -105,7 +109,12 @@ def make_live(
     redirect_stdout: bool = True,
     redirect_stderr: bool = True,
 ) -> Live:
-    """Return a ``Live`` bound to the shared console."""
+    """Return a ``Live`` bound to the module's shared console.
+
+    The default ``console`` is early-bound at import time — reassigning
+    ``_display.console`` afterwards does not reach this default; pass
+    ``console=`` explicitly to redirect.
+    """
 
     target_console = console if console is not None else _SHARED_CONSOLE
     return Live(

--- a/tolokaforge/cli/adapter_commands.py
+++ b/tolokaforge/cli/adapter_commands.py
@@ -13,9 +13,8 @@ import sys
 from pathlib import Path
 
 import click
-from rich.console import Console
 
-console = Console()
+from tolokaforge.cli._display import console
 
 
 @click.group()

--- a/tolokaforge/cli/assets_commands.py
+++ b/tolokaforge/cli/assets_commands.py
@@ -16,22 +16,8 @@ import sys
 from pathlib import Path
 
 import click
-from rich.console import Console
 
-# ``soft_wrap=True`` disables rich's terminal-width wrapping. Without
-# it, narrow CI terminals wrap paths mid-word (``missing.sql`` →
-# ``miss\ning.sql``), which breaks substring assertions in tests and
-# obscures the offending path in human-readable output. Paths and
-# digests are the primary error surface here; keeping them intact
-# matters more than fitting to terminal width.
-console = Console(soft_wrap=True)
-
-# Errors go to stderr, success messages go to stdout. Two consoles
-# keep the routing uniform without repeatedly threading ``file=``
-# through every call site — the alternative (mix of ``sys.exit`` +
-# ``ClickException``) split the surface across streams depending on
-# the failure mode.
-err_console = Console(stderr=True, soft_wrap=True)
+from tolokaforge.cli._display import console
 
 _COMMENT_LINE_PATTERN = re.compile(r"(?:^|\s)#")
 """Match ``#`` at the start of a line OR preceded by whitespace.
@@ -89,7 +75,7 @@ def stamp(project_path: Path, check_only: bool) -> None:
 
     project_yaml = _resolve_project_yaml(project_path)
     if project_yaml is None:
-        err_console.print(
+        console.print(
             f"[red]No project.yaml found at or above {project_path!s}[/red]",
         )
         sys.exit(1)
@@ -97,7 +83,7 @@ def stamp(project_path: Path, check_only: bool) -> None:
     project_dir = project_yaml.parent
     raw = yaml.safe_load(project_yaml.read_text()) or {}
     if not isinstance(raw, dict):
-        err_console.print(f"[red]{project_yaml} is not a YAML mapping[/red]")
+        console.print(f"[red]{project_yaml} is not a YAML mapping[/red]")
         sys.exit(1)
 
     seeds_container = _extract_seeds(raw)
@@ -131,11 +117,11 @@ def stamp(project_path: Path, check_only: bool) -> None:
     # files are both reported before we exit.
     if path_less_entries or missing_files:
         for name in path_less_entries:
-            err_console.print(
+            console.print(
                 f"[red]{project_yaml}: assets.seeds.{name} has no `path` field[/red]",
             )
         for name, path in missing_files:
-            err_console.print(
+            console.print(
                 f"[red]{project_yaml}: assets.seeds.{name}.path does not exist: {path}[/red]",
             )
         sys.exit(1)
@@ -187,11 +173,9 @@ def _extract_seeds(raw: dict) -> dict | None:
     ``assets`` block with no ``seeds`` key).
 
     Malformed shapes (present but not a mapping) raise
-    ``click.ClickException`` (which routes to stderr per Click's
-    contract) naming the offending key — a ``--check`` in CI must
-    not report green on a file that will blow up at load time.
-    Absent is different from present-but-broken. Matches the
-    stderr routing of every other fatal error in this module.
+    ``click.ClickException`` naming the offending key — a ``--check``
+    in CI must not report green on a file that will blow up at load
+    time. Absent is different from present-but-broken.
     """
     if "assets" not in raw:
         return None

--- a/tolokaforge/cli/config_commands.py
+++ b/tolokaforge/cli/config_commands.py
@@ -10,16 +10,14 @@ import glob
 from pathlib import Path
 
 import click
-from rich.console import Console
 
+from tolokaforge.cli._display import console
 from tolokaforge.core.config_validator import Severity, validate_run_config
 from tolokaforge.core.llm.presets import (
     resolve_overlay_path,
     validate_overlay_file,
 )
 from tolokaforge.core.project_loader import load_effective_run_config
-
-console = Console()
 
 
 @click.group()

--- a/tolokaforge/cli/docker_commands.py
+++ b/tolokaforge/cli/docker_commands.py
@@ -9,10 +9,9 @@ Uses lazy imports to avoid requiring docker dependency at CLI registration time.
 from __future__ import annotations
 
 import click
-from rich.console import Console
 from rich.table import Table
 
-console = Console()
+from tolokaforge.cli._display import console
 
 
 @click.group()

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -9,6 +9,7 @@ import click
 import yaml
 from rich.console import Console
 
+from tolokaforge.cli._display import console
 from tolokaforge.core.engine_run_state import read_persisted_presets_file
 from tolokaforge.core.llm.presets import (
     resolve_overlay_path,
@@ -47,8 +48,6 @@ _secrets.export_to_environ(
     ]
 )
 
-console = Console()
-
 
 def _print_runtime_banner(*, console: Console, runtime_choice: str, source: str) -> None:
     """Print a loud banner naming the selected runtime backend and the
@@ -63,8 +62,7 @@ def _print_runtime_banner(*, console: Console, runtime_choice: str, source: str)
     }.get(runtime_choice, runtime_choice)
     isolation_line = {
         "shared": (
-            "one docker-compose stack shared across every trial (fastest, "
-            "no cross-trial isolation)"
+            "one docker-compose stack shared across every trial (fastest, no cross-trial isolation)"
         ),
         "per_trial": (
             "one docker-compose stack per trial via Testcontainers "


### PR DESCRIPTION
## Summary

Closes #276.

A1 keystone for milestone 11 (Terminal DX, umbrella #297). Introduces `tolokaforge/cli/_display.py` as the CLI's single source for terminal output primitives — a stderr-by-default `Console`, a frozen 7-token `THEME`, and `make_progress` / `make_live` factories with kwargs shaped for downstream milestone consumers (B1 Rich Live panel, B2 `--display` toggle, C1 runs list, C3 Textual TUI, D1 init wizard, D4 doctor).

- Palette (frozen, standard Rich style names for max terminal compatibility): `info=cyan`, `warn=yellow`, `error=bold red`, `success=green`, `muted=dim`, `cost=bold magenta`, `link=underline cyan`.
- Every CLI module (`main`, `docker_commands`, `adapter_commands`, `config_commands`, `assets_commands`) now imports the shared `console` instead of instantiating its own; a canonical grep-guard test locks that invariant.
- Factories expose the kwargs B1 will need — `redirect_stdout` / `redirect_stderr` / `auto_refresh` — so the panel can suppress Rich's default stream redirection when running alongside the orchestrator's log emitter.
- New `docs/CLI.md` documents the display layer as the CLI's public convention for future contributors; linked from AGENTS.md's Detailed Documentation index.

## Behavior change to note

`tolokaforge assets stamp` previously split streams (success → stdout, errors → stderr). It now routes all output to stderr, uniform with the rest of the CLI. Callers piping its success output should switch to `2>&1 | ...` until A4 (#280) re-carves a stdout channel for machine-parseable artifact paths. Landed 2026-07-11 in `525a33f` — external usage low, but calling it out so downstream consumers can adjust.

## Commits (5)

- `6a46860` docs(plans): add A1 shared display layer plan
- `10ca903` feat(cli): shared display layer (_display.py)
- `c629eec` refactor(cli): route all CLI modules through _display.console
- `254d9ed` test(cli): canonical grep guard + CLI.md display-layer docs
- `aad8e04` chore(cli): lock make_progress/make_live pass-through kwargs + docstring + AGENTS link

## Test plan

- [x] `uv run pytest tests/unit/test_cli_display.py -v` — 23 tests, all green (behaviour-locks every factory kwarg + palette token).
- [x] `uv run pytest tests/canonical/test_cli_display_invariants.py -v` — 2 tests, all green (grep-guard + public-surface).
- [x] Full unit suite: 2315 passed, 1 skipped.
- [x] Full canonical suite: 402 passed.
- [x] `grep -Rn "Console(" tolokaforge/cli/ | grep -v "_display.py"` — 0 hits.
- [x] Manual smoke: `tolokaforge --help`, `tolokaforge run --help`, `tolokaforge config validate --config examples/native/tool_use/run_config.yaml` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)