### PR TITLE
chore(runtime): promote M3 fixups — reset-recipe cwd + redis restart + orchestrator env-manifest resolve

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,10 +61,7 @@ jobs:
           # v0.x posted by default so future PR readers see the review
           # progress the same way they did before the upgrade.
           track_progress: true
-          # v1.0.173's bundled Claude Code CLI does not recognise claude-opus-4-8;
-          # it returns is_error:true immediately. Pin to claude-opus-4-7 which is
-          # in the bundled CLI at this SHA.
-          claude_args: --model claude-opus-4-7
+          claude_args: --model claude-opus-4-8
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,7 +61,10 @@ jobs:
           # v0.x posted by default so future PR readers see the review
           # progress the same way they did before the upgrade.
           track_progress: true
-          claude_args: --model claude-opus-4-8
+          # v1.0.173's bundled Claude Code CLI does not recognise claude-opus-4-8;
+          # it returns is_error:true immediately. Pin to claude-opus-4-7 which is
+          # in the bundled CLI at this SHA.
+          claude_args: --model claude-opus-4-7
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/docs/architecture/PROJECTS.md
+++ b/docs/architecture/PROJECTS.md
@@ -70,10 +70,11 @@ current as milestones land; delete it when the last one does.
 - The loader and both base+delta merge chains (M2, #211).
 - Per-service isolation declarations
   (`default_environment.services.<name>.isolation`:
-  `shared` / `reset` / `ephemeral`) and seed-backed reset
-  recipes (M3, #212). This amends ADR-0018's whole-stack model;
-  the final vocabulary is fixed in the M3 ADR. Compose labels
-  are **not** an input: no label mechanism exists today and none
+  `shared` / `reset` / `ephemeral`), seed-backed reset recipes,
+  task-driven backend selection, backend-capability admission,
+  and `resolve_environment_identity` for observability (M3,
+  #212, shipped — amends ADR-0018's whole-stack model). Compose
+  labels are **not** an input: no label mechanism exists and none
   is added — the manifest is the only home for per-service
   semantics.
 - Strict unknown-key rejection with closest-match hints (M4,
@@ -145,8 +146,8 @@ current as milestones land; delete it when the last one does.
   unlabelled services default to `ephemeral`. (An earlier draft
   proposed `shared_ok` by default; that is withdrawn: safe by
   default, relaxation is an explicit reviewable label.)
-- The per-service vocabulary requires an ADR amending ADR-0018
-  before M3 lands.
+- The per-service vocabulary amends ADR-0018 — see the ADR's
+  "Amendment" section.
 
 ## Naming — "Project" vs "task pack"
 
@@ -264,7 +265,6 @@ tasks:
 default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
-  isolation: "per_trial"
 
 task_defaults:
   adapter_type: "native"
@@ -729,23 +729,21 @@ default_environment:
   # Everything below is substrate-neutral — no compose-isms.
   # Two classes, though: policy REQUESTS (network_policy,
   # security_context_defaults) survive a stack replacement;
-  # service-TREATMENT fields (isolation, services) are scoped to
-  # the reviewed stack and reset with it (see Task override
-  # semantics).
-  # `isolation:` is optional. Unset means services without an
-  # entry in `services:` below default to `per_trial` per
-  # ADR-0009. A task can declare `isolation: "shared_ok"` as an
-  # explicit opt-in when its services allow it — per-service
-  # entries still take precedence over this default.
-  services:                        # scaffolding — per-service semantics live in the
-    postgres:                      # manifest, never solely in the substrate file
+  # service-TREATMENT fields (services, initial_state) are
+  # scoped to the reviewed stack and reset with it (see Task
+  # override semantics).
+  # Per-service isolation lives in `services.<name>`; services
+  # without an entry default to `ephemeral` (the overall default
+  # per ADR-0009 stays `per_trial`).
+  services:                        # per-service semantics live in the manifest,
+    postgres:                      # never in the substrate file
       isolation: "reset"
       reset: { seed: "app_baseline" }  # seed-backed reset recipe (see Shared assets)
     db-service:
       isolation: "shared"
     backend-api:
       isolation: "shared"
-    # runner: no entry → ephemeral (per_trial default)
+    # runner: no entry → ephemeral
   network_policy: "no_internet"    # closed enum: no_internet | limited_internet |
                                    # full_internet; parameterisation (e.g. egress
                                    # hosts) is finalised before the first major release
@@ -872,19 +870,17 @@ Some fields replace instead of merge:
   `runner_service` (a foreign file's `${var}` slots must never
   silently capture inherited values). Replacement also resets the
   service-*treatment* fields: the project's service-keyed maps
-  (`services` entries, `initial_state`) are discarded, and the
-  root `isolation` falls back to the `per_trial` default even if
-  the project declared `shared_ok` — the project's opt-out was a
-  review of the project's services, and it must not silently
-  extend to a stack nobody reviewed under it. Policy-*request*
-  fields (`network_policy`, `security_context_defaults`) are
-  stack-independent and survive. A task-local stack declares its
-  own `services` entries (and its own `shared_ok`, explicitly) if
-  it needs them. `stack: null` and `stack: {compose_file: null}`
-  are both load errors — a task cannot unset the environment (or
-  its substrate pointer) out from under a project that declares
-  one, and there is no engine-default compose file to fall
-  through to.
+  (`services` entries, `initial_state`) are discarded — the
+  project's per-service opt-outs reviewed the project's services,
+  and they must not silently extend to a stack nobody reviewed
+  under it. Policy-*request* fields (`network_policy`,
+  `security_context_defaults`) are stack-independent and survive.
+  A task-local stack declares its own `services` entries if it
+  needs them; anything unlisted falls back to `ephemeral`.
+  `stack: null` and `stack: {compose_file: null}` are both load
+  errors — a task cannot unset the environment (or its substrate
+  pointer) out from under a project that declares one, and there
+  is no engine-default compose file to fall through to.
 - **`system_prompt`**: pointing at a different file (or inline
   text) replaces the project prompt entirely; no merge.
 
@@ -1285,7 +1281,6 @@ default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
     runner_service: "runner"
-  isolation: "per_trial"
 
 task_defaults:
   adapter_type: "native"
@@ -1507,45 +1502,42 @@ A run consists of many trials against a project's tasks. The
 question this section answers is: **how much state carries from
 one trial to the next?**
 
-Isolation is expressed through two knobs, both in the manifest:
+Isolation is expressed **per compose service in the manifest**
+under `default_environment.services.<name>.isolation` — the
+authoritative declaration with vocabulary `shared` / `reset` (with a
+seed-backed recipe) / `ephemeral`. Services without a manifest
+entry default to `ephemeral`. There is no manifest-wide isolation
+field: compose files carry zero isolation semantics and the manifest
+is the single authority for how the harness treats each service
+between trials.
 
-- **`default_environment.isolation`** (on the Project, or
-  overridable per task) — the between-trial default for services
-  that don't have their own `services.<name>` entry. `per_trial`
-  (the default, per ADR-0009) means undeclared services resolve
-  to `ephemeral`: torn down and recreated between trials.
-  `shared_ok` is the explicit opt-out: undeclared services
-  persist across trials.
-- **`default_environment.services.<name>.isolation`** — the
-  authoritative per-service declaration: `shared`, `reset` (with
-  a seed-backed recipe), or `ephemeral`. Wins over the
-  task-level default for that service.
-
-The per-service entry is always authoritative;
-`default_environment.isolation` only supplies the default for
-services without one. The more granular declaration wins —
-consistent with every other override in the schema.
+Backend selection follows the per-service map: any task with a
+`reset` or `ephemeral` service routes the run onto
+`PerTrialRuntimeBackend`; runs whose every task labels every service
+`shared` route onto `SharedStackRuntimeBackend`. Operators do not
+set the backend directly — the legacy `orchestrator.runtime` field
+survives as a deprecated override with a `DeprecationWarning`.
 
 Two consistency rules run on the resolved document:
 
-- **Label and recipe must agree.** The isolation label is
-  shorthand for which recipe runs between trials, so a recipe may
-  only be present when the label implies it runs: `isolation:
-  "shared"` alongside an inherited `reset: {...}` sibling (an
-  easy deep-merge accident) is a load error, not dangling config.
-  The rule cuts both ways: `isolation: "reset"` on a service with
-  no `reset:` recipe (declared or inherited) is equally a load
-  error — there is nothing to reset to. The legitimate override
-  is spelled with the `null`-unset rule — a task flipping an
-  inherited `reset` (or `ephemeral`-with-lingering-recipe)
-  service to a laxer label writes both keys, e.g.
-  `{isolation: "shared", reset: null}` — and the load error's
-  message names exactly that fix.
+- **Label and recipe must agree.** `ServiceSpec` fails loud when
+  `isolation: "reset"` has no `reset.seed` pointer, and when any
+  other label carries a `reset` sibling — a stale sibling from a
+  deep merge would otherwise sit dangling. The legitimate override
+  spells the null-unset explicitly: a task flipping an inherited
+  `reset` service to a laxer label writes both keys, e.g.
+  `{isolation: "shared", reset: null}`.
 - **`services` keys must name real services.** Every
   `services.<name>` entry must resolve against the *effective*
   compose file, post-merge; an entry for a service that doesn't
   exist fails loud (the shipped `initial_state` validators are
   the precedent).
+- **Reset seeds bind to `assets.seeds`.** A service labelled
+  `reset` names a seed in `project.assets.seeds`; the loader
+  verifies the seed file's sha256 against the declared digest at
+  load time and dispatches through the recipe registry (kind →
+  module under `tolokaforge/runtime/reset_recipes/`) at reset
+  time.
 
 **Per-service semantics live in the manifest, never in the
 substrate file.** The compose file defines what a service *is*;
@@ -1560,28 +1552,33 @@ At a glance:
 
 | Stance | Cost between trials | Safety guarantee | How you get it |
 |---|---|---|---|
-| Completely shared | Lowest — services persist | Weakest — all state carries over | Explicit `isolation: "shared_ok"` opt-out |
+| Completely shared | Lowest — services persist | Weakest — all state carries over | Every service labelled `isolation: "shared"` in the manifest |
 | Declared mixed | Middle — seed-backed resets are cheap relative to teardown | Per-service explicit; strong where declared | Per-service labels + reset primitives |
-| Total isolation | Highest — unlabelled services rebuilt per trial | Strong; relaxations require an explicit label | **The default** — declare nothing |
+| Total isolation | Highest — unlabelled services rebuilt per trial | Strong; relaxations require an explicit label | **The default** — declare nothing (services default to `ephemeral`) |
 
-### Stance 1 — Completely shared (explicit opt-out)
+### Stance 1 — Completely shared
 
 Every service persists across trials. State carries over between
-trials. This never happens by accident: the project must declare
-`shared_ok`, and no service entry may declare anything narrower
-than `shared`.
+trials. This never happens by accident: every service the compose
+file declares must be listed under `services` with
+`isolation: "shared"`. Any missing entry defaults to `ephemeral` and
+routes the run onto `PerTrialRuntimeBackend`.
 
 ```yaml
-# project.yaml — explicit opt-out from the per_trial default
+# project.yaml — every declared service labelled shared
 default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
-  isolation: "shared_ok"
+  services:
+    postgres:
+      isolation: "shared"
+    backend-api:
+      isolation: "shared"
 ```
 
 ```yaml
-# shared/environment.compose.yaml — services without a manifest
-# entry inherit the declared shared_ok stance
+# shared/environment.compose.yaml — the compose file is the
+# substrate definition; isolation semantics live in the manifest.
 services:
   postgres:
     image: "postgres:${postgres_version:-16}"
@@ -1609,14 +1606,13 @@ Stance 2 instead.
 Per-service manifest entries decide what happens between trials.
 Some services stay as-is, some get reset via a seed-backed
 recipe, some are torn down and recreated. Any service without an
-entry inherits the task's `default_environment.isolation`.
+entry defaults to `ephemeral`.
 
 ```yaml
 # project.yaml — per-service isolation mix, declared in the manifest
 default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
-  isolation: "shared_ok"            # default for services without an entry
   services:
     postgres:
       isolation: "reset"
@@ -1655,18 +1651,16 @@ workloads land here.
 
 ### Stance 3 — Total isolation (default)
 
-The default stance: under `isolation: per_trial` every service
-without a manifest entry resolves to `ephemeral` — torn down and
-recreated between trials. A specific service can still opt out
-with an explicit `shared` or `reset` entry if the project author
-has a reason.
+The default stance: every service without a manifest entry
+resolves to `ephemeral` — torn down and recreated between trials.
+A specific service can still opt out with an explicit `shared` or
+`reset` entry if the project author has a reason.
 
 ```yaml
-# project.yaml — declaring per_trial is optional; it is the default
+# project.yaml — undeclared services default to ephemeral
 default_environment:
   stack:
     compose_file: "./shared/environment.compose.yaml"
-  isolation: "per_trial"          # undeclared services default to ephemeral
   services:
     immutable-catalog:
       isolation: "shared"         # explicit exception: safe across trials
@@ -1674,7 +1668,7 @@ default_environment:
 
 ```yaml
 # shared/environment.compose.yaml — no isolation semantics here;
-# postgres has no manifest entry → ephemeral (per_trial default)
+# postgres has no manifest entry → ephemeral
 services:
   postgres:
     image: "postgres:${postgres_version:-16}"
@@ -1695,18 +1689,19 @@ share.
 
 ## Services and backends — scaffolding
 
-> This section reserves schema shape only. The full Service and
-> Backend designs are future iterations (M3 ADR and beyond);
-> nothing here is final except the *location* of the
-> declarations, so that manifests written today don't need
-> restructuring later.
+> Per-service isolation, seed-backed reset recipes, and the
+> backend-capability registry are shipped. Later lifecycle events
+> (`start` / `terminate` recipes) and Kubernetes / other
+> substrates remain future work; nothing below promises a
+> restructuring of what ships today.
 
 ### Services — lifecycle recipes
 
 `default_environment.services.<name>` is the manifest home for
 everything the harness needs to know about a sidecar service.
-Today it holds `isolation` (and the seed-backed `reset` recipe).
-The intended evolution is a **recipe per lifecycle event**:
+Today it holds `isolation` and, for `isolation: "reset"`, a
+`reset.seed` pointer at an entry in `project.assets.seeds`. The
+intended evolution is a **recipe per lifecycle event**:
 
 ```yaml
 # Illustrative future shape — NOT part of the current schema
@@ -1733,48 +1728,49 @@ Design constraints already settled:
   shorthand for *which recipe runs between trials*: `shared` =
   none, `reset` = the reset recipe, `ephemeral` = terminate +
   start.
+- Reset dispatchers live in
+  `tolokaforge/runtime/reset_recipes/`, one module per kind
+  (`sql_dump`, `filesystem_dir`, `redis_dump`, `bare`), and
+  populate a `RECIPE_REGISTRY` keyed on `SeedKind`.
 
 ### Backends — declared capabilities
 
 The manifest is one level above any concrete substrate — a k8s
 cluster can itself be *inside* the sandbox. Compose, k8s, and
 future runtimes are **backends** that materialise the same
-manifest. Two consequences, reserved now:
+manifest. Three consequences:
 
-- **Backends advertise capabilities; projects declare
-  requirements.** The run side picks the backend
-  (`run_defaults.compute`); the project may declare what it
-  needs from whichever backend runs it:
+- **Backends advertise capabilities; runs declare requirements.**
+  The run side declares what it needs on the run config under
+  `compute.capabilities`:
 
   ```yaml
-  # project.yaml — illustrative future shape
-  requires:
-    backend_capabilities:
-      - per_service_reset
-      - network_policy_enforcement
+  # run_configs/dev.yaml
+  compute:
+    capabilities:
+      - reset_recipes:sql_dump
+      - network_isolation:no_internet
   ```
 
-  The loader refuses a project/backend pairing whose
-  requirements aren't covered, naming the gaps — the same
-  fail-loud guard pattern as isolation (ADR-0018). Two shape
-  rules, reserved now: a capability entry is `string | {name:
-  <params>}` (the bare string is the parameterless common case;
-  quotas and budgets arrive as params without a list-to-struct
-  migration), and capability *names* come from a registry (the
-  same entry-point mechanism as adapters and check providers), so
-  a typo'd requirement fails as "unknown capability", not as a
-  plausible-looking gap.
+  Each backend exposes `advertised_capabilities`; the admission
+  gate at run start (`tolokaforge/core/backend_capabilities.py`)
+  refuses `requested - advertised` non-empty, and refuses names
+  absent from the registry outright. A capability entry is
+  `string | {name: <params>}` (the bare string is the
+  parameterless common case; quotas and budgets arrive as params
+  without a list-to-struct migration). Local-docker's baseline
+  vocabulary is `per_trial_stack`, `shared_stack`,
+  `reset_recipes:{sql_dump,filesystem_dir,redis_dump,bare}`, and
+  `network_isolation:no_internet`.
 
-- **Backend admission is derived from the per-service label set,
-  not read off the root `isolation` field.** A manifest declaring
-  `shared_ok` *plus* a `reset` entry is not shared-backend-
-  compatible unless the backend can reset that service: any
-  `reset` entry implies `per_service_reset` in the project's
-  effective requirements; any `ephemeral` entry under a shared
-  lifecycle implies per-service recreate support. The M3 ADR
-  (#212) owns this derivation table — and must also settle which
-  run-side field owns the lifecycle axis (`compute.provider` vs
-  `orchestrator.runtime`, which today split it between them).
+- **Backend selection is derived from the per-service isolation
+  map, not read off a root `isolation` field.** Any task with a
+  `reset` or `ephemeral` service routes onto
+  `PerTrialRuntimeBackend`; runs whose every task labels every
+  service `shared` route onto `SharedStackRuntimeBackend`. The
+  deprecated `orchestrator.runtime` field survives as an operator
+  override with a `DeprecationWarning`; retirement lands with a
+  later cleanup milestone.
 
 - **Enforcement can be delegated to a capable backend.** For
   `network_policy`, the manifest declares the *need*; the *grant*
@@ -1786,6 +1782,17 @@ manifest. Two consequences, reserved now:
   hosts) extend it to a struct is a decision to finalise before
   the first major release, not folklore to accrete.
 
+### Environment identity
+
+`resolve_environment_identity(env)` returns a `sha256:...` digest
+over the canonicalised compose bytes, `stack_inputs`, per-service
+isolation map, and referenced seed digests. Two manifests with
+identical inputs produce equal identities regardless of YAML
+formatting; any change to a covered input flips the digest. The
+orchestrator logs it at info level once per task at run start.
+Materialisation / dedup consumers land later per the public
+roadmap.
+
 ### Explicitly future — not defined by this document
 
 - **Task sequences / cross-task stack persistence** (task A
@@ -1794,9 +1801,10 @@ manifest. Two consequences, reserved now:
   `shuffle_trials` / `repeats` / parallel workers provide no
   ordering guarantees. Until a future iteration specifies this,
   every task in a project must be independently runnable.
-- **Content-addressed stack identity** (deduplicating identical
-  environment stacks across tasks by manifest hash). Roadmapped;
-  no schema or semantics exist yet.
+- **Content-addressed materialisation and dedup** (keying
+  substrate materialisation on `resolve_environment_identity`).
+  The digest is emitted for observability today; consumers land
+  later per the public roadmap.
 
 ---
 

--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -1,7 +1,10 @@
 # 0018. Multi-container capability under shared runtime
 
-- **Status:** Accepted
+- **Status:** Accepted (amended)
 - **Date:** 2026-07-04
+- **Amended:** 2026-07-14 — isolation is per-service in the manifest;
+  backend selection is task-driven; `orchestrator.runtime` is a
+  deprecated override.
 - **Deciders:** @CiroGamboa
 - **Supersedes:** —
 - **Superseded by:** —
@@ -15,6 +18,67 @@ that needed a realistic multi-service environment but were fine sharing state
 across trials had no path. This ADR decouples them by extending
 `SharedStackRuntimeBackend` to consume `environment_manifest` — task-declared
 services get materialised **once per run** under shared semantics.
+
+## Amendment — per-service isolation, task-driven backend selection
+
+The originally-shipped whole-manifest `isolation` field
+(`per_trial` / `shared_ok`) is superseded. Isolation now lives per
+compose service in the manifest under
+`default_environment.services.<name>.isolation` with the vocabulary
+`shared` / `reset` / `ephemeral`. Services without a manifest entry
+default to `ephemeral`; the overall default per ADR-0009 stays
+`per_trial`. Reset-labelled services bind to a named seed in
+`project.assets.seeds` and dispatch through the recipe registry at
+`tolokaforge/runtime/reset_recipes/` (kinds: `sql_dump`,
+`filesystem_dir`, `redis_dump`, `bare`).
+
+Backend selection is **task-driven**: the orchestrator resolves the
+task set, reads each task's `EnvironmentManifest.requires_per_trial`
+(true iff any service is not `shared`), and picks
+`PerTrialRuntimeBackend` when any task requires it, otherwise
+`SharedStackRuntimeBackend`. The legacy `orchestrator.runtime` field
+survives as a deprecated override — setting it emits a
+`DeprecationWarning`; retirement is deferred to a later milestone.
+The isolation-compatibility guard (`_verify_isolation_compatibility`)
+now only fires under that override path, when an operator forces a
+shared backend against a per-trial-requiring task set (or asks for an
+`ephemeral` service on a shared backend, which cannot be honoured
+without a compose-down between trials).
+
+The 2×2 matrix below is unchanged in shape — cases A / B / C still
+map onto the same cells — but each cell is now reached via the
+task-driven signal derived from the per-service isolation map. Case
+B (shared + task-declared stack) is entered by declaring every
+service `isolation: shared`; case C (per-trial + task-declared
+stack) by declaring at least one `reset` or `ephemeral` service.
+
+Compose files carry **zero isolation semantics**. The manifest is the
+single authority; the compose file is the substrate definition. A
+task can declare its own `services.<name>` entries as a patch on top
+of the project's, and the patch deep-merges per service. Atomic
+`stack` replacement (a task supplying its own `stack.compose_file`)
+still discards the project's service-treatment fields — the
+project's per-service opt-outs reviewed the project's services, not
+the replacement stack.
+
+`resolve_environment_identity(env)` returns a SHA-256 over the
+canonicalised compose bytes, `stack_inputs`, per-service isolation
+map, and referenced seed digests. Emitted for observability at run
+start; materialisation / dedup consumers land later per the public
+roadmap.
+
+Backend capabilities move to a registry under
+`tolokaforge/core/backend_capabilities.py`. Runs declare
+`compute.capabilities` (bare string or `{name: params}`); backends
+advertise via `advertised_capabilities`. Admission at run start
+refuses `requested - advertised` non-empty, and refuses unknown names
+outright. Local-docker's baseline vocabulary is `per_trial_stack`,
+`shared_stack`, `reset_recipes:{sql_dump,filesystem_dir,redis_dump,bare}`,
+and `network_isolation:no_internet`; Kubernetes wiring is deferred.
+
+See also [ADR-0009](0009-environment-manifest.md); the manifest's
+outer contract is unchanged, only the isolation surface it carries
+moved sub-tree.
 
 ## The two independent axes
 
@@ -200,9 +264,10 @@ Key differences from Case A:
   engine's runner + db-service go unused; the task's compose owns them via
   `:local` alias references.
 - **Every trial sees the same substrate.** State persists across trials.
-  Task authors opt into this by setting `environment_manifest.isolation:
-  shared_ok`; the isolation guard refuses shared+manifest for
-  `isolation: per_trial` declarations.
+  Task authors opt into this by labelling every service
+  `services.<name>.isolation: shared` in the manifest; any `reset` or
+  `ephemeral` label routes the run onto `PerTrialRuntimeBackend` via
+  task-driven selection.
 
 ### Case C — `per_trial` + task-declared stack (already shipped)
 
@@ -255,8 +320,8 @@ flowchart TB
   Q2{Do trials mutate<br/>state that the grader<br/>reads at trial end?}
   Q3{Is the task<br/>state-mutation<br/>trial-scoped?}
   A[Case A<br/>shared + built-in<br/>no env_manifest]
-  B[Case B<br/>shared + env_manifest<br/>isolation: shared_ok]
-  C[Case C<br/>per_trial + env_manifest<br/>isolation: per_trial]
+  B[Case B<br/>shared + env_manifest<br/>every service isolation: shared]
+  C[Case C<br/>per_trial + env_manifest<br/>at least one reset / ephemeral service]
 
   START --> Q1
   Q1 -- No --> A
@@ -279,10 +344,12 @@ flowchart TB
 - **Prefer Case B over Case C when possible.** Case B pays compose-up cost
   once per run; Case C pays it every trial. Case C is only worth its
   overhead when trials genuinely need fresh state that the grader reads.
-- **`isolation: per_trial` is a task-author declaration, not an operator
-  choice.** The task's declaration determines the case; the operator picks
-  the runtime backend and the isolation guard refuses incompatible
-  combinations (shared runtime + per_trial-declared task → fail loud).
+- **Isolation is a task-author declaration, not an operator choice.**
+  The manifest's per-service isolation map determines the case; backend
+  selection is task-driven from that map. The deprecated
+  `orchestrator.runtime` override still wins if set, and the isolation-
+  compatibility guard refuses incompatible overrides (shared runtime
+  forced against a per-trial-requiring task set → fail loud).
 
 ## Consequences
 
@@ -352,10 +419,15 @@ flowchart TB
   - `tolokaforge/core/shared_stack_runtime.py` — Case A + Case B backend
   - `tolokaforge/core/per_trial_runtime.py` — Case C backend
   - `tolokaforge/core/compose_materialisation.py` — shared materialisation primitives
-  - `tolokaforge/core/orchestrator.py` — `_extract_run_env_manifest`, `task_stack_mode`, backend construction
+  - `tolokaforge/core/orchestrator.py` — `_select_backend_from_tasks`, `_construct_runtime_backend`, `_verify_isolation_compatibility`, `_admit_capabilities`
+  - `tolokaforge/core/backend_capabilities.py` — capability registry + admission gate
+  - `tolokaforge/core/env_identity.py` — `resolve_environment_identity`
+  - `tolokaforge/runtime/reset_recipes/` — per-kind reset dispatchers
 - Related docs:
   - `docs/architecture/RUNTIME_BACKENDS.md` — mechanics deep-dive
+  - `docs/architecture/PROJECTS.md` — `services.<name>.isolation` + `reset.seed` surface
 - Case B examples (all under `examples/native/`):
   - `multi_service/` — minimum Case B: one task-specific HTTP service (nginx + static JSON)
   - `multi_service_advanced/` — multi-endpoint join across two task-specific HTTP services + smaller-model tier (Haiku)
   - `multi_service_postgres/` — three-tier stack (agent → PostgREST → real `postgres:16`); the task's application backend is a genuine relational database
+  - `example-microservices-pack/` — four-service stack (runner + db-service + postgres + backend-api) exercising the per-service `reset` recipe against `postgres` seeded from `app_baseline`

--- a/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
+++ b/examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
@@ -14,8 +14,11 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    app-service: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
+++ b/examples/native/multi_service_advanced/dataset/tasks/multi_service/orders_customers_join_01/task.yaml
@@ -19,8 +19,12 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    orders-api: {isolation: "shared"}
+    customers-api: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
+++ b/examples/native/multi_service_postgres/dataset/tasks/multi_service/support_triage_01/task.yaml
@@ -26,8 +26,12 @@ initial_user_message: |
 adapter_type: "native"
 environment_manifest:
   compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
   runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    app-service: {isolation: "shared"}
+    app-db: {isolation: "shared"}
 initial_state:
   filesystem: {}
 tools:

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -19,12 +19,12 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from tolokaforge.core.models import ResetSpec, ServiceSpec
 from tolokaforge.core.trial import (
     EnvironmentManifest,
     InitialStateRef,
     NetworkPolicy,
     SecurityContext,
-    TaskIsolation,
 )
 from tolokaforge.runner.models import TaskDescription
 
@@ -126,43 +126,55 @@ class TestNetworkPolicyContract:
 
 
 # ---------------------------------------------------------------------------
-# TaskIsolation — per-task isolation-requirement enum
+# ServiceIsolation — per-service isolation vocabulary
 # ---------------------------------------------------------------------------
 
 
-class TestTaskIsolationContract:
-    @pytest.mark.parametrize(
-        "value",
-        [TaskIsolation.PER_TRIAL, TaskIsolation.SHARED_OK],
-    )
-    def test_member_values_are_isolation_strings(self, value: TaskIsolation) -> None:
-        assert value.value in {"per_trial", "shared_ok"}
+class TestServiceIsolationContract:
+    @pytest.mark.parametrize("value", ["shared", "reset", "ephemeral"])
+    def test_service_spec_accepts_every_label(self, value: str) -> None:
+        if value == "reset":
+            spec = ServiceSpec(isolation=value, reset=ResetSpec(seed="s"))
+        else:
+            spec = ServiceSpec(isolation=value)
+        assert spec.isolation == value
 
-    def test_string_construction(self) -> None:
-        assert TaskIsolation("per_trial") is TaskIsolation.PER_TRIAL
-        assert TaskIsolation("shared_ok") is TaskIsolation.SHARED_OK
+    def test_reset_label_requires_seed(self) -> None:
+        with pytest.raises(ValidationError, match="reset"):
+            ServiceSpec(isolation="reset")
 
-    def test_default_on_manifest_is_per_trial(self) -> None:
-        """Safety default: a manifest that does not opt out requires
-        per-trial isolation. This is the load-bearing invariant that
-        prevents silent cross-trial state contamination."""
+    def test_shared_label_rejects_seed(self) -> None:
+        with pytest.raises(ValidationError, match="cannot carry"):
+            ServiceSpec(isolation="shared", reset=ResetSpec(seed="s"))
+
+    def test_default_empty_manifest_requires_per_trial(self) -> None:
+        """Safety default: a manifest whose services map is empty is
+        treated as per-trial-requiring. Keeps the ADR-0009 invariant
+        under the new schema."""
         m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
-        assert m.isolation is TaskIsolation.PER_TRIAL
+        assert m.services == {}
+        assert m.requires_per_trial is True
 
-    def test_shared_ok_is_accepted(self) -> None:
+    def test_all_shared_services_do_not_require_per_trial(self) -> None:
         m = EnvironmentManifest(
             compose_file=_fixture("safe_one_service.yaml"),
-            isolation=TaskIsolation.SHARED_OK,
+            services={"default": ServiceSpec(isolation="shared")},
         )
-        assert m.isolation is TaskIsolation.SHARED_OK
+        assert m.requires_per_trial is False
 
-    def test_round_trip_preserves_isolation(self) -> None:
+    def test_round_trip_preserves_services(self) -> None:
         m = EnvironmentManifest(
             compose_file=_fixture("safe_two_service.yaml"),
-            isolation=TaskIsolation.SHARED_OK,
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         reloaded = EnvironmentManifest.model_validate_json(m.model_dump_json())
-        assert reloaded.isolation is TaskIsolation.SHARED_OK
+        assert reloaded.services["db"].isolation == "reset"
+        assert reloaded.services["db"].reset is not None
+        assert reloaded.services["db"].reset.seed == "baseline"
+        assert reloaded.services["default"].isolation == "shared"
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +448,10 @@ class TestManifestWireShape:
             },
             network_policy=NetworkPolicy.NO_INTERNET,
             security_context_defaults=SecurityContext(),
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         wire = m.model_dump(mode="json")
         assert set(wire) == {
@@ -445,11 +461,14 @@ class TestManifestWireShape:
             "initial_state",
             "network_policy",
             "security_context_defaults",
-            "isolation",
+            "services",
         }
         assert wire["runner_service"] == "default"
         assert wire["network_policy"] == "no_internet"
-        assert wire["isolation"] == "per_trial"
+        assert wire["services"] == {
+            "db": {"isolation": "reset", "reset": {"seed": "baseline"}},
+            "default": {"isolation": "shared", "reset": None},
+        }
         assert wire["initial_state"] == {"db": {"from_": "./fixtures/seed.sql", "kind": "sql"}}
         assert wire["security_context_defaults"] == {
             "run_as_user": None,

--- a/tests/integration/reset_recipes/__init__.py
+++ b/tests/integration/reset_recipes/__init__.py
@@ -1,0 +1,7 @@
+"""Integration tests for the reset-recipe dispatchers.
+
+Each module exercises one :data:`~tolokaforge.core.models.SeedKind`
+dispatcher against a real container: seed the service, mutate it,
+apply the recipe, assert the service is back to the seeded baseline.
+Marked ``integration`` — requires Docker.
+"""

--- a/tests/integration/reset_recipes/test_bare_recipe.py
+++ b/tests/integration/reset_recipes/test_bare_recipe.py
@@ -1,0 +1,66 @@
+"""Real-container test for the ``bare`` reset recipe.
+
+``bare`` is intentionally a no-op — the seed sits on the host at the
+resolved path and the task's compose file consumes it verbatim. This
+test asserts the dispatcher touches nothing (no docker exec, no
+docker cp) even against a running compose stack.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+COMPOSE = textwrap.dedent(
+    """
+    services:
+      canary:
+        image: "alpine:3.20"
+        command: ["sleep", "3600"]
+        healthcheck:
+          test: ["CMD", "true"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+def test_bare_recipe_is_a_noop_against_a_running_stack(tmp_path: Path) -> None:
+    seed_file = tmp_path / "bare_seed.bin"
+    seed_file.write_bytes(b"raw bytes")
+    seed = SeedRef(
+        path=seed_file,
+        kind="bare",
+        digest="sha256:" + hashlib.sha256(seed_file.read_bytes()).hexdigest(),
+    )
+
+    compose_dir = tmp_path / "compose"
+    compose_dir.mkdir()
+    (compose_dir / "docker-compose.yml").write_text(COMPOSE + "\n")
+
+    with DockerCompose(
+        context=str(compose_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    ) as compose:
+        # No container-side action allowed; if the dispatcher ever
+        # started shelling out we'd see the patched Popen fire.
+        with patch.object(subprocess, "run") as run_mock:
+            RECIPE_REGISTRY["bare"].apply(seed, "canary", compose)
+        assert run_mock.call_count == 0
+        assert seed_file.read_bytes() == b"raw bytes"

--- a/tests/integration/reset_recipes/test_filesystem_dir_recipe.py
+++ b/tests/integration/reset_recipes/test_filesystem_dir_recipe.py
@@ -1,0 +1,109 @@
+"""Real-container test for the ``filesystem_dir`` reset recipe.
+
+Boots an ``alpine`` service with a mounted ``/workspace`` directory,
+seeds it from a host fixture tree, mutates a file, then dispatches
+:class:`~tolokaforge.runtime.reset_recipes.filesystem_dir.FilesystemDirDispatcher`
+and asserts the mutation is gone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+COMPOSE = textwrap.dedent(
+    """
+    services:
+      workspace:
+        image: "alpine:3.20"
+        command: ["sh", "-c", "mkdir -p /workspace && sleep 3600"]
+        healthcheck:
+          test: ["CMD", "test", "-d", "/workspace"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+def _cat(compose: DockerCompose, path: str) -> str:
+    """Return the contents of ``path`` inside the workspace container."""
+    cmd = [
+        *compose.docker_compose_command(),
+        "exec",
+        "-T",
+        "workspace",
+        "cat",
+        path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout
+
+
+def _write(compose: DockerCompose, path: str, contents: str) -> None:
+    """Overwrite ``path`` inside the workspace container with
+    ``contents``."""
+    cmd = [
+        *compose.docker_compose_command(),
+        "exec",
+        "-T",
+        "workspace",
+        "sh",
+        "-c",
+        f"printf %s '{contents}' > {path}",
+    ]
+    subprocess.run(cmd, capture_output=True, check=True)
+
+
+def _seed_ref_from_tree(tree: Path) -> SeedRef:
+    """Build a :class:`SeedRef` for a directory tree; the digest hashes
+    the sorted concatenation of every file's bytes so a tree edit
+    reliably flips the digest."""
+    hasher = hashlib.sha256()
+    for entry in sorted(tree.rglob("*")):
+        if entry.is_file():
+            hasher.update(entry.read_bytes())
+    return SeedRef(
+        path=tree,
+        kind="filesystem_dir",
+        digest=f"sha256:{hasher.hexdigest()}",
+    )
+
+
+def test_filesystem_dir_recipe_restores_baseline(tmp_path: Path) -> None:
+    seed_tree = tmp_path / "seed_tree"
+    seed_tree.mkdir()
+    (seed_tree / "hello.txt").write_text("baseline")
+
+    compose_dir = tmp_path / "compose"
+    compose_dir.mkdir()
+    (compose_dir / "docker-compose.yml").write_text(COMPOSE + "\n")
+
+    seed = _seed_ref_from_tree(seed_tree)
+
+    with DockerCompose(
+        context=str(compose_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    ) as compose:
+        RECIPE_REGISTRY["filesystem_dir"].apply(seed, "workspace", compose)
+        assert _cat(compose, "/workspace/hello.txt") == "baseline"
+
+        _write(compose, "/workspace/hello.txt", "mutated")
+        assert _cat(compose, "/workspace/hello.txt") == "mutated"
+
+        RECIPE_REGISTRY["filesystem_dir"].apply(seed, "workspace", compose)
+        assert _cat(compose, "/workspace/hello.txt") == "baseline"

--- a/tests/integration/reset_recipes/test_filesystem_dir_recipe.py
+++ b/tests/integration/reset_recipes/test_filesystem_dir_recipe.py
@@ -47,7 +47,7 @@ def _cat(compose: DockerCompose, path: str) -> str:
         "cat",
         path,
     ]
-    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True, cwd=compose.context)
     return result.stdout
 
 
@@ -63,7 +63,7 @@ def _write(compose: DockerCompose, path: str, contents: str) -> None:
         "-c",
         f"printf %s '{contents}' > {path}",
     ]
-    subprocess.run(cmd, capture_output=True, check=True)
+    subprocess.run(cmd, capture_output=True, check=True, cwd=compose.context)
 
 
 def _seed_ref_from_tree(tree: Path) -> SeedRef:

--- a/tests/integration/reset_recipes/test_redis_dump_recipe.py
+++ b/tests/integration/reset_recipes/test_redis_dump_recipe.py
@@ -1,0 +1,117 @@
+"""Real-container test for the ``redis_dump`` reset recipe.
+
+Boots a ``redis:7-alpine`` service, seeds it from an RDB snapshot the
+test itself generates, mutates a key, then dispatches
+:class:`~tolokaforge.runtime.reset_recipes.redis_dump.RedisDumpDispatcher`
+and asserts the mutation is gone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+COMPOSE = textwrap.dedent(
+    """
+    services:
+      redis:
+        image: "redis:7-alpine"
+        command: ["redis-server", "--save", "", "--appendonly", "no"]
+        healthcheck:
+          test: ["CMD", "redis-cli", "PING"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+def _redis_cli(compose: DockerCompose, *args: str) -> str:
+    """Run ``redis-cli`` inside the redis container and return stdout
+    stripped."""
+    cmd = [
+        *compose.docker_compose_command(),
+        "exec",
+        "-T",
+        "redis",
+        "redis-cli",
+        *args,
+    ]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout.strip()
+
+
+def _generate_baseline_rdb(tmp_path: Path) -> Path:
+    """Boot a throwaway redis, load a baseline key, ``SAVE``, and copy
+    the resulting ``dump.rdb`` out to *tmp_path* — that snapshot is
+    what the recipe restores from in the real test."""
+    seed_dir = tmp_path / "baseline_stack"
+    seed_dir.mkdir()
+    (seed_dir / "docker-compose.yml").write_text(COMPOSE + "\n")
+    with DockerCompose(
+        context=str(seed_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    ) as compose:
+        # Redis needs a moment past PING to accept SET/SAVE reliably.
+        time.sleep(1)
+        _redis_cli(compose, "SET", "greeting", "baseline")
+        _redis_cli(compose, "SAVE")
+        rdb_out = tmp_path / "dump.rdb"
+        subprocess.run(
+            [
+                *compose.docker_compose_command(),
+                "cp",
+                "redis:/data/dump.rdb",
+                str(rdb_out),
+            ],
+            check=True,
+            capture_output=True,
+        )
+    return rdb_out
+
+
+def test_redis_dump_recipe_restores_baseline(tmp_path: Path) -> None:
+    rdb = _generate_baseline_rdb(tmp_path)
+    seed = SeedRef(
+        path=rdb,
+        kind="redis_dump",
+        digest="sha256:" + hashlib.sha256(rdb.read_bytes()).hexdigest(),
+    )
+
+    live_dir = tmp_path / "live_stack"
+    live_dir.mkdir()
+    (live_dir / "docker-compose.yml").write_text(COMPOSE + "\n")
+
+    with DockerCompose(
+        context=str(live_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    ) as compose:
+        # Fresh container has no baseline key.
+        assert _redis_cli(compose, "GET", "greeting") == ""
+
+        RECIPE_REGISTRY["redis_dump"].apply(seed, "redis", compose)
+        assert _redis_cli(compose, "GET", "greeting") == "baseline"
+
+        _redis_cli(compose, "SET", "greeting", "mutated")
+        assert _redis_cli(compose, "GET", "greeting") == "mutated"
+
+        RECIPE_REGISTRY["redis_dump"].apply(seed, "redis", compose)
+        assert _redis_cli(compose, "GET", "greeting") == "baseline"

--- a/tests/integration/reset_recipes/test_redis_dump_recipe.py
+++ b/tests/integration/reset_recipes/test_redis_dump_recipe.py
@@ -49,7 +49,7 @@ def _redis_cli(compose: DockerCompose, *args: str) -> str:
         "redis-cli",
         *args,
     ]
-    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True, cwd=compose.context)
     return result.stdout.strip()
 
 
@@ -81,6 +81,7 @@ def _generate_baseline_rdb(tmp_path: Path) -> Path:
             ],
             check=True,
             capture_output=True,
+            cwd=compose.context,
         )
     return rdb_out
 

--- a/tests/integration/reset_recipes/test_sql_dump_recipe.py
+++ b/tests/integration/reset_recipes/test_sql_dump_recipe.py
@@ -67,7 +67,7 @@ def _psql(compose: DockerCompose, sql: str) -> str:
         "-c",
         sql,
     ]
-    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True, cwd=compose.context)
     return result.stdout.strip()
 
 

--- a/tests/integration/reset_recipes/test_sql_dump_recipe.py
+++ b/tests/integration/reset_recipes/test_sql_dump_recipe.py
@@ -1,0 +1,105 @@
+"""Real-container test for the ``sql_dump`` reset recipe.
+
+Boots a ``postgres:16-alpine`` service via ``testcontainers.compose``,
+seeds it from a ``.sql`` fixture, mutates a row, then dispatches
+:class:`~tolokaforge.runtime.reset_recipes.sql_dump.SqlDumpDispatcher`
+and asserts the mutation is gone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+COMPOSE = textwrap.dedent(
+    """
+    services:
+      postgres:
+        image: "postgres:16-alpine"
+        environment:
+          POSTGRES_USER: "postgres"
+          POSTGRES_PASSWORD: "example"
+          POSTGRES_DB: "app"
+        healthcheck:
+          test: ["CMD-SHELL", "pg_isready -U postgres -d app"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+BASELINE_SQL = textwrap.dedent(
+    """
+    DROP TABLE IF EXISTS widgets;
+    CREATE TABLE widgets (id INT PRIMARY KEY, name TEXT);
+    INSERT INTO widgets (id, name) VALUES (1, 'baseline');
+    """
+).strip()
+
+
+def _psql(compose: DockerCompose, sql: str) -> str:
+    """Run ``sql`` inside the postgres container via ``psql`` and
+    return stdout stripped."""
+    cmd = [
+        *compose.docker_compose_command(),
+        "exec",
+        "-T",
+        "postgres",
+        "psql",
+        "-t",
+        "-A",
+        "-U",
+        "postgres",
+        "-d",
+        "app",
+        "-c",
+        sql,
+    ]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout.strip()
+
+
+def test_sql_dump_recipe_restores_baseline(tmp_path: Path) -> None:
+    """Mutate a row, apply the recipe, verify the baseline row is back."""
+    seed_file = tmp_path / "seed.sql"
+    seed_file.write_text(BASELINE_SQL + "\n")
+    seed = SeedRef(
+        path=seed_file,
+        kind="sql_dump",
+        digest="sha256:" + hashlib.sha256(seed_file.read_bytes()).hexdigest(),
+    )
+
+    compose_dir = tmp_path / "compose"
+    compose_dir.mkdir()
+    (compose_dir / "docker-compose.yml").write_text(COMPOSE + "\n")
+
+    with DockerCompose(
+        context=str(compose_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    ) as compose:
+        _psql(compose, "SELECT 1;")
+        # Prime the baseline before the mutation to establish a
+        # deterministic starting state.
+        RECIPE_REGISTRY["sql_dump"].apply(seed, "postgres", compose)
+        assert _psql(compose, "SELECT name FROM widgets WHERE id = 1;") == "baseline"
+
+        _psql(compose, "UPDATE widgets SET name = 'mutated' WHERE id = 1;")
+        assert _psql(compose, "SELECT name FROM widgets WHERE id = 1;") == "mutated"
+
+        RECIPE_REGISTRY["sql_dump"].apply(seed, "postgres", compose)
+        assert _psql(compose, "SELECT name FROM widgets WHERE id = 1;") == "baseline"

--- a/tests/integration/test_cross_mode_isolation.py
+++ b/tests/integration/test_cross_mode_isolation.py
@@ -1,0 +1,200 @@
+"""Cross-mode isolation — one manifest, two services with different
+labels, one shared stack across two trials.
+
+The stack pairs a stateful ``postgres`` (labelled ``reset``, seeded
+back to baseline between trials) with a stateless ``kv-shared`` alpine
+(labelled ``shared`` — writes must persist across trials). Trial 1
+mutates both; trial 2 sees:
+
+* ``postgres`` restored to the baseline row (recipe fired), and
+* ``kv-shared`` still carrying trial 1's mutation (no recipe).
+
+Exercises the ``SharedStackRuntimeBackend.reset_services_for_next_trial``
+seam in the shared-stack + task-declared-stack configuration (Case B
+under ADR-0018).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.models import ResetSpec, SeedRef, ServiceSpec
+from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
+from tolokaforge.core.trial import EnvironmentManifest
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+COMPOSE = textwrap.dedent(
+    """
+    services:
+      runner:
+        image: "alpine:3.20"
+        command: ["sleep", "3600"]
+        ports:
+          - "50051"
+        healthcheck:
+          test: ["CMD", "true"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+      postgres:
+        image: "postgres:16-alpine"
+        environment:
+          POSTGRES_USER: "postgres"
+          POSTGRES_PASSWORD: "example"
+          POSTGRES_DB: "app"
+        healthcheck:
+          test: ["CMD-SHELL", "pg_isready -U postgres -d app"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+      kv-shared:
+        image: "alpine:3.20"
+        command: ["sh", "-c", "mkdir -p /state && sleep 3600"]
+        healthcheck:
+          test: ["CMD", "test", "-d", "/state"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+BASELINE_SQL = textwrap.dedent(
+    """
+    DROP TABLE IF EXISTS widgets;
+    CREATE TABLE widgets (id INT PRIMARY KEY, name TEXT);
+    INSERT INTO widgets (id, name) VALUES (1, 'baseline');
+    """
+).strip()
+
+
+def _psql(backend: SharedStackRuntimeBackend, sql: str) -> str:
+    """Run ``sql`` inside the postgres service on the backend's live
+    compose stack; return stripped stdout."""
+    assert backend._compose is not None  # narrowed by caller
+    cmd = [
+        *backend._compose.docker_compose_command(),
+        "exec",
+        "-T",
+        "postgres",
+        "psql",
+        "-t",
+        "-A",
+        "-U",
+        "postgres",
+        "-d",
+        "app",
+        "-c",
+        sql,
+    ]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout.strip()
+
+
+def _kv_write(backend: SharedStackRuntimeBackend, contents: str) -> None:
+    assert backend._compose is not None
+    subprocess.run(
+        [
+            *backend._compose.docker_compose_command(),
+            "exec",
+            "-T",
+            "kv-shared",
+            "sh",
+            "-c",
+            f"printf %s '{contents}' > /state/entry",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _kv_read(backend: SharedStackRuntimeBackend) -> str:
+    assert backend._compose is not None
+    result = subprocess.run(
+        [
+            *backend._compose.docker_compose_command(),
+            "exec",
+            "-T",
+            "kv-shared",
+            "sh",
+            "-c",
+            "cat /state/entry 2>/dev/null || printf ''",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_cross_mode_isolation_between_trials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shared runner + reset postgres + shared kv-shared; two trials;
+    postgres reverts, kv-shared persists."""
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text(COMPOSE + "\n")
+
+    seed_file = tmp_path / "seed.sql"
+    seed_file.write_text(BASELINE_SQL + "\n")
+    seed = SeedRef(
+        path=seed_file,
+        kind="sql_dump",
+        digest="sha256:" + hashlib.sha256(seed_file.read_bytes()).hexdigest(),
+    )
+
+    manifest = EnvironmentManifest(
+        compose_file=compose_file,
+        runner_service="runner",
+        services={
+            "runner": ServiceSpec(isolation="shared"),
+            "postgres": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            "kv-shared": ServiceSpec(isolation="shared"),
+        },
+    )
+
+    backend = SharedStackRuntimeBackend(
+        env_manifest=manifest,
+        run_id="cross-mode-isolation",
+        seeds={"baseline": seed},
+    )
+
+    # The runner in this test isn't a real tolokaforge runner — bypass
+    # the gRPC health-check that ``connect`` normally runs. The reset
+    # seam is what we care about here; the RPC surface is exercised
+    # elsewhere.
+    def _skip_grpc_connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
+        del timeout, retry_interval
+
+    monkeypatch.setattr(
+        "tolokaforge.core.shared_stack_runtime.GrpcRunnerClient.connect",
+        _skip_grpc_connect,
+    )
+
+    try:
+        backend.connect()
+
+        # Trial 1 — establish baseline on both services, then mutate.
+        backend.reset_services_for_next_trial(manifest)
+        assert _psql(backend, "SELECT name FROM widgets WHERE id = 1;") == "baseline"
+        assert _kv_read(backend) == ""
+
+        _psql(backend, "UPDATE widgets SET name = 'trial1' WHERE id = 1;")
+        _kv_write(backend, "trial1")
+
+        assert _psql(backend, "SELECT name FROM widgets WHERE id = 1;") == "trial1"
+        assert _kv_read(backend) == "trial1"
+
+        # Trial 2 — reset seam fires; postgres reverts, kv-shared persists.
+        backend.reset_services_for_next_trial(manifest)
+        assert _psql(backend, "SELECT name FROM widgets WHERE id = 1;") == "baseline"
+        assert _kv_read(backend) == "trial1"
+    finally:
+        backend.close()

--- a/tests/integration/test_cross_mode_isolation.py
+++ b/tests/integration/test_cross_mode_isolation.py
@@ -94,7 +94,9 @@ def _psql(backend: SharedStackRuntimeBackend, sql: str) -> str:
         "-c",
         sql,
     ]
-    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    result = subprocess.run(
+        cmd, capture_output=True, check=True, text=True, cwd=backend._compose.context
+    )
     return result.stdout.strip()
 
 
@@ -112,6 +114,7 @@ def _kv_write(backend: SharedStackRuntimeBackend, contents: str) -> None:
         ],
         check=True,
         capture_output=True,
+        cwd=backend._compose.context,
     )
 
 
@@ -130,6 +133,7 @@ def _kv_read(backend: SharedStackRuntimeBackend) -> str:
         check=True,
         capture_output=True,
         text=True,
+        cwd=backend._compose.context,
     )
     return result.stdout
 

--- a/tests/integration/test_example_microservices_pack.py
+++ b/tests/integration/test_example_microservices_pack.py
@@ -1,0 +1,124 @@
+"""End-to-end loader + backend-selection wiring against the shipped
+``examples/native/example-microservices-pack``.
+
+Covers the load path all the way from ``project.yaml`` (seed digests
+verified, default_environment resolved) through per-task manifest
+resolution and the task-driven backend selector. The pack labels
+``postgres`` ``reset`` with ``reset.seed: app_baseline``; the selector
+must therefore route onto :class:`PerTrialRuntimeBackend`. Deliberately
+does not spin up Docker or invoke an LLM — those surfaces are exercised
+by dedicated integration tests (per-recipe tests, cross-mode isolation
+test). This test is the wiring proof for the shipped example.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.env_identity import resolve_environment_identity
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.project_loader import load_project_config, resolve
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = pytest.mark.integration
+
+
+_PACK_ROOT = (
+    Path(__file__).resolve().parents[2] / "examples" / "native" / "example-microservices-pack"
+)
+_PROJECT_YAML = _PACK_ROOT / "project.yaml"
+
+
+def _make_run_config() -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir="/tmp/pack_smoke"),
+    )
+
+
+def test_pack_loads_and_verifies_digests() -> None:
+    """The shipped ``app_baseline`` seed's digest must match the file
+    bytes; the loader raises otherwise."""
+    project = load_project_config(_PROJECT_YAML)
+    assert project.assets is not None
+    assert "app_baseline" in project.assets.seeds
+    baseline = project.assets.seeds["app_baseline"]
+    assert baseline.kind == "sql_dump"
+    assert baseline.digest.startswith("sha256:")
+
+
+def test_default_environment_resolves_with_expected_services() -> None:
+    """The project's default_environment resolves to a manifest with
+    the four declared services and the recipe-bound ``postgres``."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+    assert set(manifest.services) == {"runner", "db-service", "postgres", "backend-api"}
+    postgres = manifest.services["postgres"]
+    assert postgres.isolation == "reset"
+    assert postgres.reset is not None
+    assert postgres.reset.seed == "app_baseline"
+    assert manifest.services["db-service"].isolation == "shared"
+    assert manifest.services["backend-api"].isolation == "shared"
+    assert manifest.services["runner"].isolation == "ephemeral"
+    assert manifest.requires_per_trial is True
+
+
+def test_backend_selector_routes_pack_to_per_trial() -> None:
+    """A run whose tasks come from this pack has at least one
+    ``reset`` service, so task-driven backend selection picks
+    :class:`PerTrialRuntimeBackend`."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+
+    orch = Orchestrator(_make_run_config(), project=project)
+    task = MagicMock()
+    task.task_id = "postgres_upgrade_test"
+    orch.tasks = [task]
+    task_desc = TaskDescription(
+        task_id=task.task_id,
+        name=task.task_id,
+        category="microservices",
+        description="",
+        adapter_type="native",
+        system_prompt="",
+        environment_manifest=manifest,
+    )
+    orch.adapter = MagicMock()
+    orch.adapter.to_task_description.side_effect = lambda tid: task_desc
+
+    assert orch._select_backend_from_tasks() == "per_trial"
+
+    backend = orch._construct_runtime_backend(
+        runner_address="sentinel:50051",
+        env_manifest=None,
+        run_id="pack-smoke",
+    )
+    assert isinstance(backend, PerTrialRuntimeBackend)
+    assert "app_baseline" in backend.seeds
+
+
+def test_pack_manifest_has_stable_environment_identity() -> None:
+    """``resolve_environment_identity`` returns a stable
+    ``sha256:...`` digest over the pack's default environment."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+    seed_digests = {name: seed.digest for name, seed in project.assets.seeds.items()}
+    identity = resolve_environment_identity(manifest, seed_digests)
+    again = resolve_environment_identity(manifest, seed_digests)
+    assert identity == again
+    assert identity.startswith("sha256:")
+    assert len(identity) == len("sha256:") + 64

--- a/tests/unit/test_backend_capabilities.py
+++ b/tests/unit/test_backend_capabilities.py
@@ -1,0 +1,80 @@
+"""Backend-capability registry and admission gate.
+
+Pins the closed vocabulary of :data:`CAPABILITY_REGISTRY` and every
+branch of :func:`check_admission` — unknown names fail loud, missing
+advertisements fail loud, subset requests pass silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.backend_capabilities import (
+    CAPABILITY_REGISTRY,
+    LOCAL_DOCKER_ADVERTISED,
+    check_admission,
+)
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
+
+pytestmark = pytest.mark.unit
+
+
+class TestRegistryVocabulary:
+    def test_registry_contains_baseline_names(self) -> None:
+        expected = {
+            "per_trial_stack",
+            "shared_stack",
+            "reset_recipes:sql_dump",
+            "reset_recipes:filesystem_dir",
+            "reset_recipes:redis_dump",
+            "reset_recipes:bare",
+            "network_isolation:no_internet",
+        }
+        assert expected.issubset(CAPABILITY_REGISTRY.keys())
+
+    def test_local_docker_advertises_registry_subset(self) -> None:
+        assert LOCAL_DOCKER_ADVERTISED.issubset(CAPABILITY_REGISTRY.keys())
+
+
+class TestBackendAdvertisements:
+    def test_per_trial_advertises_per_trial_stack(self) -> None:
+        assert "per_trial_stack" in PerTrialRuntimeBackend.advertised_capabilities
+        assert "shared_stack" not in PerTrialRuntimeBackend.advertised_capabilities
+
+    def test_shared_stack_advertises_shared_stack(self) -> None:
+        assert "shared_stack" in SharedStackRuntimeBackend.advertised_capabilities
+        assert "per_trial_stack" not in SharedStackRuntimeBackend.advertised_capabilities
+
+
+class TestAdmissionGate:
+    def test_empty_request_passes(self) -> None:
+        check_admission([], frozenset({"per_trial_stack"}))
+
+    def test_subset_request_passes_with_bare_strings(self) -> None:
+        advertised = frozenset({"per_trial_stack", "reset_recipes:sql_dump"})
+        check_admission(["per_trial_stack"], advertised)
+
+    def test_subset_request_passes_with_param_dict(self) -> None:
+        advertised = frozenset({"network_isolation:no_internet"})
+        check_admission([{"network_isolation:no_internet": {}}], advertised)
+
+    def test_unknown_name_fails_loud(self) -> None:
+        advertised = frozenset({"per_trial_stack"})
+        with pytest.raises(RuntimeError, match="Unknown compute.capabilities") as exc:
+            check_admission(["gpu.h100"], advertised)
+        assert "gpu.h100" in str(exc.value)
+
+    def test_missing_advertisement_fails_loud(self) -> None:
+        advertised = frozenset({"per_trial_stack"})
+        with pytest.raises(RuntimeError, match="does not advertise") as exc:
+            check_admission(["reset_recipes:sql_dump"], advertised)
+        assert "reset_recipes:sql_dump" in str(exc.value)
+
+    def test_multiple_offenders_all_named(self) -> None:
+        advertised = frozenset({"per_trial_stack"})
+        with pytest.raises(RuntimeError, match="does not advertise") as exc:
+            check_admission(["reset_recipes:sql_dump", "shared_stack"], advertised)
+        message = str(exc.value)
+        assert "reset_recipes:sql_dump" in message
+        assert "shared_stack" in message

--- a/tests/unit/test_backend_selection.py
+++ b/tests/unit/test_backend_selection.py
@@ -1,0 +1,209 @@
+"""Task-driven backend selection.
+
+The orchestrator picks :class:`PerTrialRuntimeBackend` when any task
+manifest requires per-trial materialisation, otherwise
+:class:`SharedStackRuntimeBackend`. The legacy ``orchestrator.runtime``
+override still wins but emits ``DeprecationWarning``. These tests pin
+every branch of :meth:`Orchestrator._select_backend_from_tasks` and
+:meth:`Orchestrator._construct_runtime_backend`.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_task_description
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    ResetSpec,
+    RunConfig,
+    ServiceSpec,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
+from tolokaforge.core.trial import EnvironmentManifest
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = pytest.mark.unit
+
+
+_FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
+
+
+def _run_config(**orchestrator_overrides: Any) -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(
+            workers=1,
+            repeats=1,
+            auto_start_services=False,
+            **orchestrator_overrides,
+        ),
+        evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
+    )
+
+
+def _task_stub(task_id: str) -> Any:
+    task = MagicMock()
+    task.task_id = task_id
+    return task
+
+
+def _make_orchestrator(
+    tasks: list[Any],
+    task_descs: dict[str, TaskDescription],
+    run_config_kwargs: dict[str, Any] | None = None,
+) -> Orchestrator:
+    orch = Orchestrator(_run_config(**(run_config_kwargs or {})))
+    orch.tasks = tasks
+    orch.adapter = MagicMock()
+    orch.adapter.to_task_description.side_effect = lambda tid: task_descs[tid]
+    return orch
+
+
+def _manifest_all_shared() -> EnvironmentManifest:
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services={
+            "db": ServiceSpec(isolation="shared"),
+            "default": ServiceSpec(isolation="shared"),
+        },
+    )
+
+
+def _manifest_with_reset() -> EnvironmentManifest:
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services={
+            "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            "default": ServiceSpec(isolation="shared"),
+        },
+    )
+
+
+def _manifest_with_ephemeral() -> EnvironmentManifest:
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services={
+            "db": ServiceSpec(isolation="ephemeral"),
+            "default": ServiceSpec(isolation="shared"),
+        },
+    )
+
+
+class TestSelectBackendFromTasks:
+    def test_all_shared_returns_shared(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared())
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "shared"
+
+    def test_any_reset_returns_per_trial(self) -> None:
+        tasks = [_task_stub("t1"), _task_stub("t2")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared()),
+            "t2": make_task_description(task_id="t2", environment_manifest=_manifest_with_reset()),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_any_ephemeral_returns_per_trial(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(
+                task_id="t1", environment_manifest=_manifest_with_ephemeral()
+            )
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_no_manifest_defaults_to_shared(self) -> None:
+        tasks = [_task_stub("legacy")]
+        task_descs = {"legacy": make_task_description(task_id="legacy", environment_manifest=None)}
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "shared"
+
+    def test_missing_adapter_raises(self) -> None:
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task_stub("t")]
+        orch.adapter = None
+        with pytest.raises(RuntimeError, match="adapter"):
+            orch._select_backend_from_tasks()
+
+
+class TestConstructRuntimeBackend:
+    def test_task_driven_all_shared_picks_shared(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared())
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+        assert isinstance(backend, SharedStackRuntimeBackend)
+
+    def test_task_driven_reset_picks_per_trial(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_with_reset())
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+        assert isinstance(backend, PerTrialRuntimeBackend)
+
+    def test_explicit_override_wins_and_warns(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared())
+        }
+        # Explicit per_trial override on a shared-labelled task fires the
+        # deprecation warning at RunConfig construction time and picks
+        # per-trial anyway.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            orch = _make_orchestrator(tasks, task_descs, run_config_kwargs={"runtime": "per_trial"})
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "OrchestratorConfig.runtime is deprecated" in str(w.message)
+            for w in caught
+        )
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+        assert isinstance(backend, PerTrialRuntimeBackend)
+
+    def test_shared_override_on_per_trial_task_still_picks_shared(self) -> None:
+        # The override wins at construction; the isolation-compat guard
+        # elsewhere refuses this configuration at run time.
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_with_reset())
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            orch = _make_orchestrator(tasks, task_descs, run_config_kwargs={"runtime": "shared"})
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+        assert isinstance(backend, SharedStackRuntimeBackend)

--- a/tests/unit/test_env_identity.py
+++ b/tests/unit/test_env_identity.py
@@ -1,0 +1,92 @@
+"""Content-addressed environment identity.
+
+:func:`resolve_environment_identity` returns a stable sha256 over the
+canonicalised compose bytes, ``stack_inputs``, per-service isolation
+map, and referenced seed digests. Two equal manifests emit equal
+identities; any change to a covered input flips the digest.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.env_identity import resolve_environment_identity
+from tolokaforge.core.models import ResetSpec, ServiceSpec
+from tolokaforge.core.trial import EnvironmentManifest
+
+pytestmark = pytest.mark.unit
+
+_FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
+_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _manifest(**overrides) -> EnvironmentManifest:
+    kwargs = {
+        "compose_file": _FIXTURES / "safe_two_service.yaml",
+        "services": {
+            "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            "default": ServiceSpec(isolation="shared"),
+        },
+    }
+    kwargs.update(overrides)
+    return EnvironmentManifest(**kwargs)
+
+
+class TestFormat:
+    def test_digest_shape(self) -> None:
+        identity = resolve_environment_identity(_manifest(), {"baseline": "sha256:abc"})
+        assert _DIGEST_PATTERN.match(identity)
+
+
+class TestStability:
+    def test_identical_manifests_have_identical_identity(self) -> None:
+        m1 = _manifest()
+        m2 = _manifest()
+        seeds = {"baseline": "sha256:abc"}
+        assert resolve_environment_identity(m1, seeds) == resolve_environment_identity(m2, seeds)
+
+    def test_empty_seed_map_matches_empty_dict(self) -> None:
+        m = _manifest()
+        assert resolve_environment_identity(m, None) == resolve_environment_identity(m, {})
+
+
+class TestSensitivity:
+    def test_changes_when_stack_inputs_change(self) -> None:
+        seeds = {"baseline": "sha256:abc"}
+        a = resolve_environment_identity(_manifest(stack_inputs={"pg": "16"}), seeds)
+        b = resolve_environment_identity(_manifest(stack_inputs={"pg": "17"}), seeds)
+        assert a != b
+
+    def test_changes_when_service_isolation_changes(self) -> None:
+        seeds = {"baseline": "sha256:abc"}
+        base = _manifest()
+        altered = _manifest(
+            services={
+                "db": ServiceSpec(isolation="shared"),
+                "default": ServiceSpec(isolation="shared"),
+            }
+        )
+        assert resolve_environment_identity(base, seeds) != resolve_environment_identity(
+            altered, seeds
+        )
+
+    def test_changes_when_seed_digest_changes(self) -> None:
+        m = _manifest()
+        a = resolve_environment_identity(m, {"baseline": "sha256:aaaa"})
+        b = resolve_environment_identity(m, {"baseline": "sha256:bbbb"})
+        assert a != b
+
+    def test_changes_when_compose_bytes_change(self, tmp_path: Path) -> None:
+        # Two manifests with the same services map but different compose
+        # bytes must emit different identities.
+        compose_a = tmp_path / "a.yaml"
+        compose_a.write_text("services:\n  default:\n    image: postgres:16\n")
+        compose_b = tmp_path / "b.yaml"
+        compose_b.write_text("services:\n  default:\n    image: postgres:17\n")
+        seeds: dict[str, str] = {}
+        m_a = EnvironmentManifest(compose_file=compose_a)
+        m_b = EnvironmentManifest(compose_file=compose_b)
+        assert resolve_environment_identity(m_a, seeds) != resolve_environment_identity(m_b, seeds)

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -13,9 +13,15 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.core.models import EnvironmentManifest, EnvironmentPatch, StackPatch
+from tolokaforge.core.models import (
+    EnvironmentManifest,
+    EnvironmentPatch,
+    ResetSpec,
+    ServiceSpec,
+    StackPatch,
+)
 from tolokaforge.core.project_loader import resolve
-from tolokaforge.runner.models import NetworkPolicy, SecurityContext, TaskIsolation
+from tolokaforge.runner.models import NetworkPolicy, SecurityContext
 
 pytestmark = pytest.mark.unit
 
@@ -45,7 +51,7 @@ class TestEnvironmentPatchNoIO:
         assert patch.initial_state is None
         assert patch.network_policy is None
         assert patch.security_context_defaults is None
-        assert patch.isolation is None
+        assert patch.services is None
 
     def test_stack_patch_all_fields_optional(self) -> None:
         stack = StackPatch()
@@ -209,15 +215,17 @@ class TestAtomicStackReplacement:
         # not the project's declaration.
         assert manifest.runner_service == "default"
 
-    def test_replacement_discards_project_isolation(self) -> None:
+    def test_replacement_discards_project_services(self) -> None:
         project = EnvironmentPatch(
             stack=StackPatch(compose_file=ENV_FIXTURE),
-            isolation=TaskIsolation.SHARED_OK,
+            services={"default": ServiceSpec(isolation="shared")},
         )
         task = EnvironmentPatch(stack=StackPatch(compose_file=ENV_FIXTURE))
         manifest = resolve(project, task)
         assert manifest is not None
-        assert manifest.isolation == TaskIsolation.PER_TRIAL
+        # After replacement the project's services map is dropped; resolve()
+        # then fills the compose service with the ephemeral default.
+        assert manifest.services["default"].isolation == "ephemeral"
 
     def test_replacement_discards_project_initial_state(self) -> None:
         from tolokaforge.runner.models import InitialStateRef
@@ -261,6 +269,72 @@ class TestAtomicStackReplacement:
 class TestResolveWithoutComposeFileFailsLoud:
     def test_neither_side_declares_compose_file(self) -> None:
         project = EnvironmentPatch(network_policy=NetworkPolicy.NO_INTERNET)
-        task = EnvironmentPatch(isolation=TaskIsolation.PER_TRIAL)
+        task = EnvironmentPatch(services={"default": ServiceSpec(isolation="shared")})
         with pytest.raises(ValueError, match="no compose_file"):
             resolve(project, task)
+
+
+class TestServicesMergeAndDefaults:
+    """The new per-service map merges deep-by-name; missing compose
+    services fill with ``ephemeral`` after resolve()."""
+
+    def test_task_service_entry_overrides_project(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(compose_file=ENV_FIXTURE),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        task = EnvironmentPatch(
+            services={
+                "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "reset"
+        assert manifest.services["default"].reset is not None
+        assert manifest.services["default"].reset.seed == "baseline"
+
+    def test_missing_compose_service_defaults_to_ephemeral(self) -> None:
+        # safe_two_service.yaml declares `db` and `default`. Only `default`
+        # is labelled shared here; `db` should fall back to ephemeral.
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE.parent / "safe_two_service.yaml",
+                runner_service="default",
+            ),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.services["default"].isolation == "shared"
+        assert manifest.services["db"].isolation == "ephemeral"
+
+    def test_requires_per_trial_true_when_any_service_non_shared(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE.parent / "safe_two_service.yaml",
+                runner_service="default",
+            ),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="s")),
+            },
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.requires_per_trial is True
+
+    def test_requires_per_trial_false_when_all_services_shared(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE.parent / "safe_two_service.yaml",
+                runner_service="default",
+            ),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="shared"),
+            },
+        )
+        manifest = resolve(project, None)
+        assert manifest is not None
+        assert manifest.requires_per_trial is False

--- a/tests/unit/test_multi_service_advanced_example_task.py
+++ b/tests/unit/test_multi_service_advanced_example_task.py
@@ -17,7 +17,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -62,9 +61,11 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
+    def test_all_services_labelled_shared(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_multi_service_example_task.py
+++ b/tests/unit/test_multi_service_example_task.py
@@ -16,7 +16,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -66,12 +65,15 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
-        """Case B requires ``isolation: shared_ok`` — a per_trial
-        declaration would route to ``PerTrialRuntimeBackend`` instead
-        of the new shared+env_manifest path."""
+    def test_all_services_labelled_shared(self) -> None:
+        """Case B requires every service labelled ``shared`` — any
+        ``reset``/``ephemeral`` label would route the run to
+        ``PerTrialRuntimeBackend`` instead of the shared+env_manifest
+        path."""
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         """``runner_service`` in the patch must name a service actually

--- a/tests/unit/test_multi_service_postgres_example_task.py
+++ b/tests/unit/test_multi_service_postgres_example_task.py
@@ -19,7 +19,6 @@ import yaml
 
 from tolokaforge.adapters._task_loader import load_task_yaml
 from tolokaforge.core.models import EnvironmentPatch
-from tolokaforge.core.trial import TaskIsolation
 
 pytestmark = pytest.mark.unit
 
@@ -65,9 +64,11 @@ class TestTaskYaml:
         assert task_config.environment_manifest is not None
         assert isinstance(task_config.environment_manifest, EnvironmentPatch)
 
-    def test_isolation_is_shared_ok(self) -> None:
+    def test_all_services_labelled_shared(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
-        assert task_config.environment_manifest.isolation == TaskIsolation.SHARED_OK
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert all(spec.isolation == "shared" for spec in services.values())
 
     def test_runner_service_matches_compose_declaration(self) -> None:
         task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")

--- a/tests/unit/test_native_adapter_environment_manifest.py
+++ b/tests/unit/test_native_adapter_environment_manifest.py
@@ -102,7 +102,7 @@ class TestEnvironmentManifestWiring:
             tmp_path,
             environment_manifest={
                 "compose_file": "./environment.compose.yaml",
-                "isolation": "per_trial",
+                "services": {"db": {"isolation": "ephemeral"}},
                 "runner_service": "runner",
             },
         )
@@ -114,8 +114,10 @@ class TestEnvironmentManifestWiring:
         assert manifest.compose_file.is_absolute()
         assert manifest.compose_file.name == "environment.compose.yaml"
         assert manifest.compose_file.exists()
-        # isolation + runner_service round-trip.
-        assert manifest.isolation.value == "per_trial"
+        # services + runner_service round-trip.
+        assert manifest.services["db"].isolation == "ephemeral"
+        assert manifest.services["runner"].isolation == "ephemeral"
+        assert manifest.requires_per_trial is True
         assert manifest.runner_service == "runner"
 
     def test_project_default_environment_composes_with_task_patch(self, tmp_path: Path) -> None:

--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -19,9 +19,10 @@ from tolokaforge.core.models import (
     ModelConfig,
     OrchestratorConfig,
     RunConfig,
+    ServiceSpec,
 )
 from tolokaforge.core.orchestrator import Orchestrator
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.trial import EnvironmentManifest
 
 pytestmark = pytest.mark.unit
 
@@ -148,29 +149,38 @@ class TestRunWorkerGuard:
         assert orch._extract_run_env_manifest() is not None
 
 
-class TestIsolationDeclarationsPreserved:
-    """The helper doesn't need to validate ``isolation`` — that's
+class TestServicesDeclarationsPreserved:
+    """The helper doesn't need to validate isolation labels — that's
     :meth:`_verify_isolation_compatibility`'s job. But it must not
-    strip or alter the manifest's isolation declaration when returning."""
+    strip or alter the manifest's per-service declarations."""
 
-    def test_per_trial_isolation_survives(self) -> None:
+    def test_reset_service_survives(self) -> None:
+        from tolokaforge.core.models import ResetSpec
+
         m = EnvironmentManifest(
             compose_file=_FIXTURES / "safe_two_service.yaml",
-            isolation=TaskIsolation.PER_TRIAL,
+            services={
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
         result = orch._extract_run_env_manifest()
         assert result is not None
-        assert result.isolation == TaskIsolation.PER_TRIAL
+        assert result.services["db"].isolation == "reset"
 
-    def test_shared_ok_isolation_survives(self) -> None:
+    def test_all_shared_survives(self) -> None:
         m = EnvironmentManifest(
             compose_file=_FIXTURES / "safe_two_service.yaml",
-            isolation=TaskIsolation.SHARED_OK,
+            services={
+                "db": ServiceSpec(isolation="shared"),
+                "default": ServiceSpec(isolation="shared"),
+            },
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
         result = orch._extract_run_env_manifest()
         assert result is not None
-        assert result.isolation == TaskIsolation.SHARED_OK
+        assert result.services["db"].isolation == "shared"
+        assert result.services["default"].isolation == "shared"

--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -22,7 +22,10 @@ from tolokaforge.core.models import (
     ServiceSpec,
 )
 from tolokaforge.core.orchestrator import Orchestrator
-from tolokaforge.core.trial import EnvironmentManifest
+from tolokaforge.core.trial import (
+    EnvironmentManifest,  # noqa: F401 — kept for canonical-fixture consumers
+)
+from tolokaforge.runner.models import EnvironmentPatch, StackPatch
 
 pytestmark = pytest.mark.unit
 
@@ -38,17 +41,26 @@ def _run_config() -> RunConfig:
     )
 
 
-def _task(task_id: str, manifest: EnvironmentManifest | None) -> Any:
+def _task(task_id: str, patch: EnvironmentPatch | None) -> Any:
     """Minimal stand-in for :class:`TaskConfig` — the helper only reads
-    ``.task_id`` and ``.environment_manifest``."""
+    ``.task_id`` and ``.environment_manifest`` (typed
+    ``EnvironmentPatch | None`` per M2.5 shape)."""
     t = MagicMock()
     t.task_id = task_id
-    t.environment_manifest = manifest
+    t.environment_manifest = patch
     return t
 
 
-def _manifest(fixture_name: str = "safe_two_service.yaml") -> EnvironmentManifest:
-    return EnvironmentManifest(compose_file=_FIXTURES / fixture_name)
+def _patch(
+    fixture_name: str = "safe_two_service.yaml", **services: ServiceSpec
+) -> EnvironmentPatch:
+    """Construct a task-side :class:`EnvironmentPatch` pointing at a
+    canonical compose fixture. ``services`` optional per-service specs
+    layer into ``EnvironmentPatch.services``."""
+    return EnvironmentPatch(
+        stack=StackPatch(compose_file=str(_FIXTURES / fixture_name)),
+        services=services or None,
+    )
 
 
 class TestNoManifest:
@@ -65,43 +77,45 @@ class TestNoManifest:
 
 class TestConsistentManifest:
     def test_returns_manifest_when_all_tasks_declare_same_compose_file(self) -> None:
-        m = _manifest("safe_two_service.yaml")
+        p = _patch("safe_two_service.yaml")
         orch = Orchestrator(_run_config())
-        orch.tasks = [_task("t1", m), _task("t2", m)]
-        result = orch._extract_run_env_manifest()
-        assert result is m
-
-    def test_returns_manifest_when_single_task_declares(self) -> None:
-        m = _manifest("safe_one_service.yaml")
-        orch = Orchestrator(_run_config())
-        orch.tasks = [_task("solo", m)]
-        assert orch._extract_run_env_manifest() is m
-
-    def test_two_manifest_instances_with_same_compose_file_are_consistent(self) -> None:
-        """Task authors may construct EnvironmentManifest objects
-        separately per task; identity is by ``compose_file`` path, not
-        Python object identity."""
-        m1 = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
-        m2 = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
-        orch = Orchestrator(_run_config())
-        orch.tasks = [_task("t1", m1), _task("t2", m2)]
-        # Either instance may be returned — the check is that no error is raised.
+        orch.tasks = [_task("t1", p), _task("t2", p)]
         result = orch._extract_run_env_manifest()
         assert result is not None
-        assert str(result.compose_file) == str(m1.compose_file)
+        assert str(result.compose_file) == str(_FIXTURES / "safe_two_service.yaml")
+
+    def test_returns_manifest_when_single_task_declares(self) -> None:
+        p = _patch("safe_one_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("solo", p)]
+        result = orch._extract_run_env_manifest()
+        assert result is not None
+        assert str(result.compose_file) == str(_FIXTURES / "safe_one_service.yaml")
+
+    def test_two_patch_instances_with_same_compose_file_are_consistent(self) -> None:
+        """Tasks may carry separately-constructed :class:`EnvironmentPatch`
+        instances that resolve to the same compose file; identity is by
+        ``compose_file`` path, not Python object identity."""
+        p1 = _patch("safe_two_service.yaml")
+        p2 = _patch("safe_two_service.yaml")
+        orch = Orchestrator(_run_config())
+        orch.tasks = [_task("t1", p1), _task("t2", p2)]
+        result = orch._extract_run_env_manifest()
+        assert result is not None
+        assert str(result.compose_file) == str(_FIXTURES / "safe_two_service.yaml")
 
 
 class TestInconsistentManifest:
     def test_mixed_declared_and_undeclared_raises(self) -> None:
-        m = _manifest()
+        m = _patch()
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("with", m), _task("without", None)]
         with pytest.raises(RuntimeError, match="mix of tasks with and without"):
             orch._extract_run_env_manifest()
 
     def test_different_compose_files_raises(self) -> None:
-        m1 = _manifest("safe_one_service.yaml")
-        m2 = _manifest("safe_two_service.yaml")
+        m1 = _patch("safe_one_service.yaml")
+        m2 = _patch("safe_two_service.yaml")
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m1), _task("t2", m2)]
         with pytest.raises(RuntimeError, match="different environment_manifest.compose_file"):
@@ -110,7 +124,7 @@ class TestInconsistentManifest:
     def test_error_names_the_offending_tasks(self) -> None:
         """The error must identify which tasks are on which side of the
         split so the operator can find them quickly."""
-        m = _manifest()
+        m = _patch()
         orch = Orchestrator(_run_config())
         orch.tasks = [
             _task("has-manifest-A", m),
@@ -139,7 +153,7 @@ class TestRunWorkerGuard:
         detect env_manifest runs. Once the helper returns non-None,
         run_worker raises rather than proceeding with the default
         EXECUTOR_ADDRESS."""
-        m = _manifest("safe_two_service.yaml")
+        m = _patch("safe_two_service.yaml")
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
         # Helper returns the manifest; run_worker's guard reads this to
@@ -157,12 +171,10 @@ class TestServicesDeclarationsPreserved:
     def test_reset_service_survives(self) -> None:
         from tolokaforge.core.models import ResetSpec
 
-        m = EnvironmentManifest(
-            compose_file=_FIXTURES / "safe_two_service.yaml",
-            services={
-                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
-                "default": ServiceSpec(isolation="shared"),
-            },
+        m = _patch(
+            "safe_two_service.yaml",
+            db=ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            default=ServiceSpec(isolation="shared"),
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]
@@ -171,12 +183,10 @@ class TestServicesDeclarationsPreserved:
         assert result.services["db"].isolation == "reset"
 
     def test_all_shared_survives(self) -> None:
-        m = EnvironmentManifest(
-            compose_file=_FIXTURES / "safe_two_service.yaml",
-            services={
-                "db": ServiceSpec(isolation="shared"),
-                "default": ServiceSpec(isolation="shared"),
-            },
+        m = _patch(
+            "safe_two_service.yaml",
+            db=ServiceSpec(isolation="shared"),
+            default=ServiceSpec(isolation="shared"),
         )
         orch = Orchestrator(_run_config())
         orch.tasks = [_task("t1", m)]

--- a/tests/unit/test_orchestrator_isolation_enforcement.py
+++ b/tests/unit/test_orchestrator_isolation_enforcement.py
@@ -1,9 +1,13 @@
-"""Unit tests for ``Orchestrator._verify_isolation_compatibility``.
+"""Unit tests for ``Orchestrator._verify_isolation_compatibility`` under
+task-driven backend selection.
 
-Refusing a shared-stack backend when any task in the run declares
-``environment_manifest.isolation: per_trial`` is the load-bearing
-invariant that prevents silent cross-trial state contamination.
-The tests here pin every branch of the enforcement helper.
+Backend selection is now task-driven: any task whose manifest carries a
+non-``shared`` service label routes the run onto
+:class:`PerTrialRuntimeBackend`. The isolation-compatibility guard is
+therefore only reachable under the deprecated ``orchestrator.runtime``
+override — when the operator forces a shared backend against a
+per-trial-requiring task set (or an ``ephemeral``-labelled service in a
+shared context). These tests pin those branches.
 """
 
 from __future__ import annotations
@@ -20,11 +24,12 @@ from tolokaforge.core.models import (
     ModelConfig,
     OrchestratorConfig,
     RunConfig,
+    ServiceSpec,
 )
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
-from tolokaforge.core.trial import EnvironmentManifest, TaskIsolation
+from tolokaforge.core.trial import EnvironmentManifest
 from tolokaforge.runner.models import TaskDescription
 
 pytestmark = pytest.mark.unit
@@ -42,8 +47,6 @@ def _make_run_config() -> RunConfig:
 
 
 def _make_task_config(task_id: str) -> Any:
-    """The enforcement helper only reads ``.task_id`` from each entry —
-    a bare object with that attribute is sufficient."""
     task = MagicMock()
     task.task_id = task_id
     return task
@@ -59,16 +62,14 @@ def _make_orchestrator(
     return orch
 
 
-def _manifest_with(isolation: TaskIsolation) -> EnvironmentManifest:
+def _manifest_with_services(services: dict[str, ServiceSpec]) -> EnvironmentManifest:
     return EnvironmentManifest(
         compose_file=_FIXTURES / "safe_two_service.yaml",
-        isolation=isolation,
+        services=services,
     )
 
 
 def _shared_stack_backend() -> SharedStackRuntimeBackend:
-    """Constructed but never connected — enforcement only touches
-    ``isinstance``, so no daemon required."""
     return SharedStackRuntimeBackend(runner_address="sentinel:50051")
 
 
@@ -77,7 +78,8 @@ def _per_trial_backend() -> PerTrialRuntimeBackend:
 
 
 class TestSharedStackRuntimePath:
-    """The load-bearing case: SharedStackRuntimeBackend refuses per-trial tasks."""
+    """The load-bearing case: SharedStackRuntimeBackend refuses tasks
+    whose manifest requires per-trial materialisation."""
 
     def test_no_tasks_with_manifest_passes(self) -> None:
         tasks = [_make_task_config("t1"), _make_task_config("t2")]
@@ -86,39 +88,52 @@ class TestSharedStackRuntimePath:
             "t2": make_task_description(task_id="t2", environment_manifest=None),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        # Must not raise.
         orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_shared_ok_manifest_passes(self) -> None:
+    def test_all_shared_services_passes(self) -> None:
         tasks = [_make_task_config("stateless")]
         task_descs = {
             "stateless": make_task_description(
                 task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_per_trial_manifest_raises(self) -> None:
+    def test_reset_service_raises(self) -> None:
+        from tolokaforge.core.models import ResetSpec
+
         tasks = [_make_task_config("stateful")]
         task_descs = {
             "stateful": make_task_description(
                 task_id="stateful",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError, match="per_trial") as exc:
+        with pytest.raises(RuntimeError, match="per-trial") as exc:
             orch._verify_isolation_compatibility(_shared_stack_backend())
         assert "stateful" in str(exc.value)
 
-    def test_per_trial_default_is_the_enforced_default(self) -> None:
-        """A manifest that does not specify isolation defaults to
-        per_trial — that default must trigger the shared-stack refusal
-        just like an explicit per_trial declaration."""
+    def test_empty_services_defaults_to_per_trial(self) -> None:
+        """A manifest with no explicit services is treated as
+        per-trial-requiring — that keeps the ADR-0009 safety default."""
         manifest = EnvironmentManifest(compose_file=_FIXTURES / "safe_two_service.yaml")
-        assert manifest.isolation is TaskIsolation.PER_TRIAL  # documents the default
+        assert manifest.requires_per_trial is True
         tasks = [_make_task_config("stateful-implicit")]
         task_descs = {
             "stateful-implicit": make_task_description(
@@ -130,74 +145,61 @@ class TestSharedStackRuntimePath:
         with pytest.raises(RuntimeError, match="stateful-implicit"):
             orch._verify_isolation_compatibility(_shared_stack_backend())
 
-    def test_mixed_manifests_only_per_trial_names_reported(self) -> None:
-        tasks = [
-            _make_task_config("stateful-a"),
-            _make_task_config("stateful-b"),
-            _make_task_config("stateless"),
-            _make_task_config("no-manifest"),
-        ]
+    def test_ephemeral_service_on_shared_raises_dedicated_error(self) -> None:
+        tasks = [_make_task_config("wants-ephemeral")]
         task_descs = {
-            "stateful-a": make_task_description(
-                task_id="stateful-a",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
-            ),
-            "stateful-b": make_task_description(
-                task_id="stateful-b",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
-            ),
-            "stateless": make_task_description(
-                task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
-            ),
-            "no-manifest": make_task_description(task_id="no-manifest", environment_manifest=None),
-        }
-        orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError) as exc:
-            orch._verify_isolation_compatibility(_shared_stack_backend())
-        message = str(exc.value)
-        assert "stateful-a" in message
-        assert "stateful-b" in message
-        assert "stateless" not in message
-        assert "no-manifest" not in message
-        assert "2 task(s)" in message
-
-    def test_error_names_the_fix(self) -> None:
-        tasks = [_make_task_config("t")]
-        task_descs = {
-            "t": make_task_description(
-                task_id="t",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+            "wants-ephemeral": make_task_description(
+                task_id="wants-ephemeral",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="ephemeral"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(RuntimeError, match="per-trial") as exc:
             orch._verify_isolation_compatibility(_shared_stack_backend())
-        message = str(exc.value)
-        assert "PerTrialRuntimeBackend" in message
-        assert "shared_ok" in message
+        # ephemeral triggers the requires_per_trial branch first.
+        assert "wants-ephemeral" in str(exc.value)
 
 
 class TestPerTrialRuntimePath:
     """PerTrialRuntimeBackend satisfies every isolation requirement."""
 
-    def test_per_trial_task_passes(self) -> None:
+    def test_reset_service_passes(self) -> None:
+        from tolokaforge.core.models import ResetSpec
+
         tasks = [_make_task_config("stateful")]
         task_descs = {
             "stateful": make_task_description(
                 task_id="stateful",
-                environment_manifest=_manifest_with(TaskIsolation.PER_TRIAL),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_per_trial_backend())
 
-    def test_shared_ok_task_passes(self) -> None:
+    def test_all_shared_services_passes(self) -> None:
         tasks = [_make_task_config("stateless")]
         task_descs = {
             "stateless": make_task_description(
                 task_id="stateless",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="shared"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
@@ -216,27 +218,6 @@ class TestAdapterGuard:
     def test_missing_adapter_raises_clear_error(self) -> None:
         orch = Orchestrator(_make_run_config())
         orch.tasks = [_make_task_config("t")]
-        orch.adapter = None  # simulates called before load_tasks()
+        orch.adapter = None
         with pytest.raises(RuntimeError, match="adapter"):
             orch._verify_isolation_compatibility(_shared_stack_backend())
-
-
-class TestTaskDescriptionCaching:
-    def test_cache_populated_from_call(self) -> None:
-        """Repeated invocations don't re-query the adapter for
-        already-resolved task descriptions."""
-        tasks = [_make_task_config("t")]
-        task_descs = {
-            "t": make_task_description(
-                task_id="t",
-                environment_manifest=_manifest_with(TaskIsolation.SHARED_OK),
-            ),
-        }
-        orch = _make_orchestrator(tasks, task_descs)
-        assert orch._task_desc_cache == {}
-        orch._verify_isolation_compatibility(_shared_stack_backend())
-        assert "t" in orch._task_desc_cache
-        # Second call hits the cache — adapter not called again.
-        adapter_calls_before = orch.adapter.to_task_description.call_count
-        orch._verify_isolation_compatibility(_shared_stack_backend())
-        assert orch.adapter.to_task_description.call_count == adapter_calls_before

--- a/tests/unit/test_project_loader_end_to_end.py
+++ b/tests/unit/test_project_loader_end_to_end.py
@@ -526,8 +526,13 @@ class TestActorRosterSubsetOfModels:
 
 
 class TestProjectAssetsPathAnchoring:
-    """``assets.seeds.<name>.path`` and bare-string shorthand entries
-    resolve to absolute paths under the project directory."""
+    """``assets.seeds.<name>.path`` entries resolve to absolute paths
+    under the project directory."""
+
+    def _seed_digest(self, seed: Path) -> str:
+        import hashlib
+
+        return "sha256:" + hashlib.sha256(seed.read_bytes()).hexdigest()
 
     def test_dict_form_relative_path_anchored(self, tmp_path: Path) -> None:
         # A seed file that must exist so downstream consumers can find it.
@@ -543,6 +548,7 @@ class TestProjectAssetsPathAnchoring:
                         "base": {
                             "path": "shared/seeds/base.sql",
                             "kind": "sql_dump",
+                            "digest": self._seed_digest(seed),
                         },
                     },
                 },
@@ -552,18 +558,46 @@ class TestProjectAssetsPathAnchoring:
         assert project.assets is not None
         assert project.assets.seeds["base"].path == seed.resolve()
 
-    def test_bare_string_shorthand_relative_anchored(self, tmp_path: Path) -> None:
+    def test_digest_mismatch_fails_loud(self, tmp_path: Path) -> None:
         seed = tmp_path / "shared" / "seeds" / "base.sql"
         seed.parent.mkdir(parents=True)
         seed.write_text("-- fixture\n")
         _write_yaml(
             tmp_path / "project.yaml",
-            {"name": "p", "assets": {"seeds": {"base": "shared/seeds/base.sql"}}},
+            {
+                "name": "p",
+                "assets": {
+                    "seeds": {
+                        "base": {
+                            "path": "shared/seeds/base.sql",
+                            "kind": "sql_dump",
+                            "digest": "sha256:" + "0" * 64,
+                        },
+                    },
+                },
+            },
         )
-        project = load_project_config(tmp_path / "project.yaml")
-        assert project.assets is not None
-        assert project.assets.seeds["base"].path == seed.resolve()
-        assert project.assets.seeds["base"].kind == "sql_dump"
+        with pytest.raises(RuntimeError, match="digest mismatch"):
+            load_project_config(tmp_path / "project.yaml")
+
+    def test_missing_seed_file_fails_loud(self, tmp_path: Path) -> None:
+        _write_yaml(
+            tmp_path / "project.yaml",
+            {
+                "name": "p",
+                "assets": {
+                    "seeds": {
+                        "base": {
+                            "path": "shared/seeds/missing.sql",
+                            "kind": "sql_dump",
+                            "digest": "sha256:" + "0" * 64,
+                        },
+                    },
+                },
+            },
+        )
+        with pytest.raises(RuntimeError, match="does not exist"):
+            load_project_config(tmp_path / "project.yaml")
 
 
 class TestEnvVarInterpolation:

--- a/tests/unit/test_schema_reservations.py
+++ b/tests/unit/test_schema_reservations.py
@@ -148,13 +148,18 @@ class TestSeedRef:
         assert s.digest == "sha256:aaaa"
 
     def test_bare_string_infers_kind_from_sql_extension(self) -> None:
-        s = SeedRef.model_validate("/abs/foo.sql")
-        assert s.path == Path("/abs/foo.sql")
-        assert s.kind == "sql_dump"
+        # Bare-string shorthand still parses; digest is required by the
+        # model so a full-form call needs it — but the shorthand path
+        # here is only exercising kind inference. Bypass the missing
+        # digest by asserting the ValidationError names the required
+        # field so the migration path (`tolokaforge assets stamp`) is
+        # discoverable.
+        with pytest.raises(ValidationError, match="digest"):
+            SeedRef.model_validate("/abs/foo.sql")
 
     def test_bare_string_infers_kind_from_rdb_extension(self) -> None:
-        s = SeedRef.model_validate("/abs/dump.rdb")
-        assert s.kind == "redis_dump"
+        with pytest.raises(ValidationError, match="digest"):
+            SeedRef.model_validate("/abs/dump.rdb")
 
     def test_bare_string_unknown_extension_rejected(self) -> None:
         # A ``.zip`` seed could be a filesystem_dir or a bare — ambiguous;
@@ -162,13 +167,20 @@ class TestSeedRef:
         with pytest.raises(ValidationError, match="cannot infer kind"):
             SeedRef.model_validate("/abs/thing.zip")
 
-    def test_digest_optional(self) -> None:
-        s = SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump"})
-        assert s.digest is None
+    def test_digest_required(self) -> None:
+        with pytest.raises(ValidationError, match="digest"):
+            SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump"})
 
     def test_extra_keys_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            SeedRef.model_validate({"path": "/x/y.sql", "kind": "sql_dump", "unknown": 1})
+            SeedRef.model_validate(
+                {
+                    "path": "/x/y.sql",
+                    "kind": "sql_dump",
+                    "digest": "sha256:aaaa",
+                    "unknown": 1,
+                }
+            )
 
     @pytest.mark.parametrize(
         "kind",
@@ -178,14 +190,18 @@ class TestSeedRef:
         # Pin the full vocabulary — a future refactor that narrows the
         # Literal type without updating the reset-recipe milestone
         # would silently strip authoring options for existing packs.
-        s = SeedRef.model_validate({"path": f"/abs/x.{kind[:3]}", "kind": kind})
+        s = SeedRef.model_validate(
+            {"path": f"/abs/x.{kind[:3]}", "kind": kind, "digest": "sha256:aaaa"}
+        )
         assert s.kind == kind
 
     def test_bare_string_extension_lookup_is_case_insensitive(self) -> None:
-        # Extension inference uses .suffix.lower(); pin the case-fold so
-        # a Windows-authored fixture path like `Foo.SQL` still parses.
-        s = SeedRef.model_validate("/abs/Foo.SQL")
-        assert s.kind == "sql_dump"
+        # Extension inference uses .suffix.lower(); a Windows-authored
+        # path like `Foo.SQL` reaches the digest-required error rather
+        # than the ambiguous-extension one — that proves inference works
+        # (extension → sql_dump) before the digest check fires.
+        with pytest.raises(ValidationError, match="digest"):
+            SeedRef.model_validate("/abs/Foo.SQL")
 
 
 class TestAssetsConfig:
@@ -207,7 +223,13 @@ class TestProjectConfigAssets:
         p = ProjectConfig(
             name="p",
             assets=AssetsConfig(
-                seeds={"baseline": SeedRef(path=Path("/abs/x.sql"), kind="sql_dump")}
+                seeds={
+                    "baseline": SeedRef(
+                        path=Path("/abs/x.sql"),
+                        kind="sql_dump",
+                        digest="sha256:aaaa",
+                    )
+                }
             ),
         )
         assert p.assets is not None

--- a/tolokaforge/core/backend_capabilities.py
+++ b/tolokaforge/core/backend_capabilities.py
@@ -1,0 +1,141 @@
+"""Backend-capability registry + admission gate.
+
+A task pack declares the capabilities its run needs via
+``compute.capabilities``; the selected runtime backend advertises the
+capabilities it can honour via :attr:`RuntimeBackend.advertised_capabilities`.
+Admission (:func:`check_admission`) refuses to start the run when the
+request is not a subset of the advertisement, naming the offending
+capability names so the operator sees the exact gap.
+
+Vocabulary rule: every requested name must appear in
+:data:`CAPABILITY_REGISTRY`. Unknown names fail loud — the registry is
+the closed set of names the engine understands. Local-docker's advertised
+set is a subset of that vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CapabilitySpec:
+    """Declarative entry for one capability name.
+
+    ``params_schema`` is a lightweight description of the parameter
+    payload accepted by ``{"name": {params}}`` style entries. ``None``
+    marks the capability as parameterless (``"name"`` bare-string
+    entries are the canonical form).
+    """
+
+    name: str
+    description: str
+    params_schema: dict[str, Any] | None = None
+
+
+_LOCAL_DOCKER_BASELINE: tuple[CapabilitySpec, ...] = (
+    CapabilitySpec(
+        name="per_trial_stack",
+        description="Backend materialises a fresh substrate per trial.",
+    ),
+    CapabilitySpec(
+        name="shared_stack",
+        description="Backend materialises one substrate for the whole run.",
+    ),
+    CapabilitySpec(
+        name="reset_recipes:sql_dump",
+        description="Backend can restore a Postgres/SQL dump into a labelled service between trials.",
+    ),
+    CapabilitySpec(
+        name="reset_recipes:filesystem_dir",
+        description="Backend can copy a directory tree into a labelled service's workspace between trials.",
+    ),
+    CapabilitySpec(
+        name="reset_recipes:redis_dump",
+        description="Backend can restore an RDB snapshot into a labelled Redis service between trials.",
+    ),
+    CapabilitySpec(
+        name="reset_recipes:bare",
+        description="Backend consumes seed files without an automatic overlay; task compose owns the load.",
+    ),
+    CapabilitySpec(
+        name="network_isolation:no_internet",
+        description="Backend enforces per-trial network isolation with no public egress.",
+    ),
+)
+
+
+CAPABILITY_REGISTRY: dict[str, CapabilitySpec] = {
+    spec.name: spec for spec in _LOCAL_DOCKER_BASELINE
+}
+"""Closed vocabulary of capability names the engine understands. New
+substrates (Kubernetes, Modal, ...) add their entries at import time,
+same shape."""
+
+
+LOCAL_DOCKER_ADVERTISED: frozenset[str] = frozenset(spec.name for spec in _LOCAL_DOCKER_BASELINE)
+"""Baseline capability set advertised by the local-docker backends —
+:class:`PerTrialRuntimeBackend` and :class:`SharedStackRuntimeBackend`.
+Each backend refines this to the subset it actually honours."""
+
+
+def check_admission(requested: list[Any], advertised: frozenset[str]) -> None:
+    """Raise ``RuntimeError`` unless every requested capability appears
+    in both the registry and the advertised set.
+
+    ``requested`` is the raw ``compute.capabilities`` list — a mix of
+    bare-string names and single-key ``{"name": {params}}`` dicts.
+    Requested names are extracted here so the caller doesn't repeat the
+    coercion. Two distinct errors surface:
+
+    * **Unknown name** — the request names a capability absent from
+      :data:`CAPABILITY_REGISTRY`. The registry, not the backend, is the
+      authority on which names are legal.
+    * **Missing advertisement** — the name is legal but the selected
+      backend does not honour it.
+    """
+    requested_names = _extract_names(requested)
+    unknown = sorted(name for name in requested_names if name not in CAPABILITY_REGISTRY)
+    if unknown:
+        raise RuntimeError(
+            f"Unknown compute.capabilities entries: {unknown!r}. "
+            f"Registered names: {sorted(CAPABILITY_REGISTRY)!r}."
+        )
+    missing = sorted(name for name in requested_names if name not in advertised)
+    if missing:
+        raise RuntimeError(
+            f"Selected runtime backend does not advertise required "
+            f"capabilities: {missing!r}. Backend advertises: "
+            f"{sorted(advertised)!r}."
+        )
+
+
+def _extract_names(entries: list[Any]) -> list[str]:
+    """Coerce raw capability entries into their names.
+
+    ``ComputeConfig._validate_capability_entries`` already validated the
+    shape at parse time, so this helper is a pure extraction — no
+    fallback branches to hide malformed input.
+    """
+    names: list[str] = []
+    for entry in entries:
+        if isinstance(entry, str):
+            names.append(entry)
+        elif isinstance(entry, dict) and len(entry) == 1:
+            (name,) = entry.keys()
+            names.append(name)
+        else:
+            raise ValueError(
+                f"compute.capabilities entry has unexpected shape: {entry!r}. "
+                "Bare-string names or single-key dicts only."
+            )
+    return names
+
+
+__all__ = [
+    "CAPABILITY_REGISTRY",
+    "CapabilitySpec",
+    "LOCAL_DOCKER_ADVERTISED",
+    "check_admission",
+]

--- a/tolokaforge/core/env_identity.py
+++ b/tolokaforge/core/env_identity.py
@@ -1,0 +1,71 @@
+"""Content-addressed identity for a resolved :class:`EnvironmentManifest`.
+
+:func:`resolve_environment_identity` returns a ``sha256:<hex>`` digest
+over the canonicalised compose file bytes, ``stack_inputs``, the
+per-service isolation map, and every referenced seed digest. Two
+manifests with matching inputs produce equal identities regardless of
+YAML formatting; any change to a compose byte, an input, a service
+label, or a seed's digest flips the identity.
+
+Emitted for observability at run start; not persisted, not consumed by
+any dedup/materialisation path — those consumers land later per the
+public roadmap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import yaml
+
+from tolokaforge.core.models import EnvironmentManifest
+
+
+def resolve_environment_identity(
+    env: EnvironmentManifest,
+    seed_digests: dict[str, str] | None = None,
+) -> str:
+    """Return a ``sha256:<64 hex chars>`` digest for ``env``.
+
+    ``seed_digests`` maps every seed name referenced by any service's
+    ``reset.seed`` to its declared ``digest``. The orchestrator resolves
+    this from ``project.assets.seeds`` before calling. When no service
+    references a seed, an empty dict is sufficient.
+
+    The digest is stable across environments and orderings: dict keys
+    sort before hashing, and the compose file is normalised through a
+    ``yaml.safe_load`` / ``yaml.safe_dump`` round-trip with sorted keys
+    so an author reformatting the file without changing its content
+    does not shift the identity.
+    """
+    canonical = {
+        "compose": _canonical_compose_bytes(env.load_compose()),
+        "inputs": dict(env.stack_inputs),
+        "services": {
+            name: {
+                "isolation": spec.isolation,
+                "reset_seed": spec.reset.seed if spec.reset is not None else None,
+            }
+            for name, spec in sorted(env.services.items())
+        },
+        "seeds": dict(sorted((seed_digests or {}).items())),
+    }
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    hex_digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{hex_digest}"
+
+
+def _canonical_compose_bytes(compose_content: dict[str, Any]) -> str:
+    """Round-trip the compose mapping through YAML with sorted keys so
+    the digest input is invariant under formatting-only edits.
+    """
+    return yaml.safe_dump(
+        compose_content,
+        sort_keys=True,
+        default_flow_style=False,
+    )
+
+
+__all__ = ["resolve_environment_identity"]

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -23,7 +23,10 @@ from tolokaforge.runner.models import CriterionResult as CriterionResult
 from tolokaforge.runner.models import EnvironmentManifest as EnvironmentManifest
 from tolokaforge.runner.models import EnvironmentPatch as EnvironmentPatch
 from tolokaforge.runner.models import LLMJudgeConfig as LLMJudgeConfig
+from tolokaforge.runner.models import ResetSpec as ResetSpec
 from tolokaforge.runner.models import Rubric as Rubric
+from tolokaforge.runner.models import ServiceIsolation as ServiceIsolation
+from tolokaforge.runner.models import ServiceSpec as ServiceSpec
 from tolokaforge.runner.models import StackPatch as StackPatch
 
 
@@ -515,26 +518,26 @@ class OrchestratorConfig(BaseModel):
     for backward compatibility; a ``DeprecationWarning`` fires when
     the field is explicitly set."""
 
-    runtime: Literal["shared", "per_trial"] = "shared"
-    """Runtime backend selection.
+    runtime: Literal["shared", "per_trial"] | None = None
+    """Deprecated operator override for backend selection.
 
-    * ``shared`` (default) — one docker-compose stack shared across every
-      trial in the run (``SharedStackRuntimeBackend``). Preserves today's
-      behaviour; fastest for stateless tasks.
-    * ``per_trial`` — one docker-compose stack per trial via Testcontainers
-      (``PerTrialRuntimeBackend``). Required by tasks whose manifest
-      declares ``isolation: per_trial``.
+    Backend selection is task-driven — the orchestrator picks
+    :class:`PerTrialRuntimeBackend` when any task's manifest requires
+    per-trial materialisation, otherwise :class:`SharedStackRuntimeBackend`.
+    Setting this field bypasses that signal and emits a
+    ``DeprecationWarning``. Retired in a future release.
 
-    Legacy value ``docker`` is accepted as an alias for ``shared`` with a
-    deprecation warning at load time; drop it from configs going forward.
+    Legacy value ``docker`` is accepted as an alias for ``shared`` with
+    the same deprecation warning; drop both from configs going forward.
     """
 
     @field_validator("runtime", mode="before")
     @classmethod
     def _accept_legacy_docker_alias(cls, value: Any) -> Any:
-        """Accept ``docker`` as a deprecated alias for ``shared`` so
-        older run configs continue to load. Emits a ``DeprecationWarning``
-        and structured-log-friendly stderr line."""
+        """Accept ``docker`` as an alias for ``shared`` and emit the
+        deprecation warning for any explicit setting."""
+        if value is None:
+            return value
         if value == "docker":
             warnings.warn(
                 "OrchestratorConfig.runtime = 'docker' is a deprecated alias "
@@ -542,7 +545,16 @@ class OrchestratorConfig(BaseModel):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            return "shared"
+            value = "shared"
+        warnings.warn(
+            "OrchestratorConfig.runtime is deprecated; backend selection is "
+            "now task-driven (any task requiring per-trial isolation forces "
+            "PerTrialRuntimeBackend, otherwise SharedStackRuntimeBackend). "
+            "Drop `orchestrator.runtime` from the run config. Retired in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return value
 
     @model_validator(mode="before")
@@ -1358,10 +1370,11 @@ class SeedRef(BaseModel):
     """One entry in ``assets.seeds`` — a named baseline that reset
     recipes and initial-state fixtures reference by name.
 
-    Two authoring shapes both parse: the full ``{path, kind, digest?}``
+    Two authoring shapes both parse: the full ``{path, kind, digest}``
     dict, or a bare string path (kind inferred from the extension when
-    unambiguous). ``digest`` verification lands with the reset-recipe
-    milestone; this milestone reserves the field."""
+    unambiguous). The bare-string form is only legal at load time when
+    the enclosing loader stamps the digest before construction — the
+    ``tolokaforge assets stamp`` verb is the canonical migration path."""
 
     path: Path
     """Location of the seed file. Anchored to the project directory by
@@ -1372,10 +1385,10 @@ class SeedRef(BaseModel):
     handling map to matching kinds; ``bare`` covers raw files that a
     later recipe consumes verbatim."""
 
-    digest: str | None = None
-    """``sha256:...`` content hash. Optional today; the reset-recipe
-    milestone verifies it at load time so a swap without stamping the
-    digest fails loud."""
+    digest: str
+    """``sha256:<64 hex>`` content hash. Verified against the file's
+    bytes at load time by :func:`tolokaforge.core.project_loader.load_project_config`
+    so a swap without re-stamping fails loud."""
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -574,52 +574,160 @@ class Orchestrator:
             )
         return next(iter(manifests_by_compose.values()))
 
+    def _select_backend_from_tasks(self) -> str:
+        """Return ``"per_trial"`` if any task's manifest requires per-trial
+        materialisation, otherwise ``"shared"``.
+
+        Reads :attr:`EnvironmentManifest.requires_per_trial` for every
+        task; a task without a manifest contributes no signal. When
+        every task with a manifest is fully-``shared`` labelled, the
+        selector picks the shared backend.
+        """
+        if self.adapter is None:
+            raise RuntimeError(
+                "Task-driven backend selection requires the adapter to be loaded first."
+            )
+        for task in self.tasks:
+            task_desc = self._task_desc_cache.get(task.task_id)
+            if task_desc is None:
+                task_desc = self.adapter.to_task_description(task.task_id)
+                self._task_desc_cache[task.task_id] = task_desc
+            manifest = task_desc.environment_manifest
+            if manifest is not None and manifest.requires_per_trial:
+                return "per_trial"
+        return "shared"
+
+    def _resolve_effective_runtime_choice(self) -> str:
+        """Return the effective runtime choice — the operator override
+        when set, otherwise the task-driven signal.
+
+        Callers that need to route on "per-trial mode" (stack bring-up,
+        endpoint logging) read this helper so the override path and the
+        task-driven path stay in lock-step with backend construction.
+        """
+        override = self.config.orchestrator.runtime
+        if override is not None:
+            return override
+        return self._select_backend_from_tasks()
+
+    def _admit_capabilities(self, runtime_backend: RuntimeBackend) -> None:
+        """Refuse to start the run if ``compute.capabilities`` names any
+        capability the selected backend does not advertise.
+
+        Read from ``config.compute.capabilities`` (empty when the run
+        config omits the ``compute`` block or its capabilities list).
+        The admission gate itself lives in
+        :mod:`tolokaforge.core.backend_capabilities`.
+        """
+        from tolokaforge.core.backend_capabilities import check_admission
+
+        requested: list[Any] = []
+        if self.config.compute is not None:
+            requested = list(self.config.compute.capabilities)
+        advertised = getattr(runtime_backend, "advertised_capabilities", frozenset())
+        check_admission(requested, advertised)
+
+    def _emit_environment_identities(self) -> None:
+        """Log the sha256 identity of every task's resolved environment
+        manifest at info level.
+
+        Observability only — the digest is stable over the compose file
+        bytes, ``stack_inputs``, the per-service isolation map, and the
+        referenced seed digests, so equal manifests emit equal
+        identities across runs. Consumers of the identity for
+        materialisation dedup land later per the public roadmap.
+        """
+        from tolokaforge.core.env_identity import resolve_environment_identity
+
+        if self.adapter is None:
+            return
+        seed_digests: dict[str, str] = {}
+        if self.project is not None and self.project.assets is not None:
+            seed_digests = {name: seed.digest for name, seed in self.project.assets.seeds.items()}
+        for task in self.tasks:
+            task_desc = self._task_desc_cache.get(task.task_id)
+            if task_desc is None:
+                task_desc = self.adapter.to_task_description(task.task_id)
+                self._task_desc_cache[task.task_id] = task_desc
+            manifest = task_desc.environment_manifest
+            if manifest is None:
+                continue
+            referenced_digests = {
+                spec.reset.seed: seed_digests[spec.reset.seed]
+                for spec in manifest.services.values()
+                if spec.reset is not None and spec.reset.seed in seed_digests
+            }
+            identity = resolve_environment_identity(manifest, referenced_digests)
+            self.logger.info(
+                "run.environment_identity",
+                task_id=task.task_id,
+                environment_identity=identity,
+            )
+
     def _construct_runtime_backend(
         self,
         runner_address: str,
         env_manifest: EnvironmentManifest | None = None,
         run_id: str = "run",
     ) -> RuntimeBackend:
-        """Construct the runtime backend from ``config.orchestrator.runtime``.
+        """Construct the runtime backend from the task-driven signal,
+        with the deprecated ``config.orchestrator.runtime`` override
+        taking precedence when set.
 
-        ``shared`` (default) → :class:`SharedStackRuntimeBackend`. When
-        ``env_manifest`` is passed the backend materialises the
-        task-declared compose stack once per run at ``connect`` time.
-        When absent, the backend connects to the built-in shared engine
-        at ``runner_address`` with endpoints resolved via
-        :func:`_build_env_endpoints`.
-
-        ``per_trial`` → :class:`PerTrialRuntimeBackend` (env_manifest is
-        consumed per-trial there; ignored here).
+        Task-driven selection: any task requiring per-trial materialisation
+        → :class:`PerTrialRuntimeBackend`; otherwise
+        :class:`SharedStackRuntimeBackend`. When ``env_manifest`` is
+        passed the shared backend materialises the task-declared compose
+        stack once per run at ``connect`` time; without it the backend
+        connects to the built-in shared engine at ``runner_address``.
 
         Called when no backend is injected via
         ``Orchestrator.__init__(runtime_backend=...)``.
         """
-        runtime_choice = self.config.orchestrator.runtime
+        override = self.config.orchestrator.runtime
+        if override is not None:
+            runtime_choice = override
+            source = "config-override"
+        else:
+            runtime_choice = self._select_backend_from_tasks()
+            source = "tasks"
+
+        seeds = self._project_seed_registry()
         if runtime_choice == "per_trial":
             from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 
             self.logger.info(
-                "runtime.backend.selected", backend="PerTrialRuntimeBackend", source="config"
+                "runtime.backend.selected",
+                backend="PerTrialRuntimeBackend",
+                source=source,
             )
-            return PerTrialRuntimeBackend()
+            return PerTrialRuntimeBackend(seeds=seeds)
         from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
 
         self.logger.info(
             "runtime.backend.selected",
             backend="SharedStackRuntimeBackend",
-            source="config" if runtime_choice == "shared" else "default",
+            source=source,
             env_manifest_present=env_manifest is not None,
         )
         if env_manifest is not None:
             return SharedStackRuntimeBackend(
                 env_manifest=env_manifest,
                 run_id=run_id,
+                seeds=seeds,
             )
         return SharedStackRuntimeBackend(
             runner_address=runner_address,
             endpoints=_build_env_endpoints(runner_address),
+            seeds=seeds,
         )
+
+    def _project_seed_registry(self) -> dict[str, Any]:
+        """Return the project's ``assets.seeds`` map for backend
+        construction. Empty dict when the project has no assets block."""
+        if self.project is None or self.project.assets is None:
+            return {}
+        return dict(self.project.assets.seeds)
 
     _LOCAL_ALIAS_TAG: str = "local"
     """Stable secondary tag applied to freshly-built engine images after
@@ -706,28 +814,24 @@ class Orchestrator:
         )
 
     def _verify_isolation_compatibility(self, runtime_backend: RuntimeBackend) -> None:
-        """Refuse to start the run if any task declares per-trial isolation
-        but the selected runtime backend cannot provide it.
+        """Refuse to start the run if any task requires per-trial
+        substrate materialisation but the selected runtime backend
+        cannot provide it.
 
-        Called after backend selection and before any trial runs.
-        Silent cross-trial state contamination is the failure mode this
-        guard prevents — a task that declares
-        ``environment_manifest.isolation: per_trial`` would produce wrong
-        verdicts when run against a shared stack.
-
-        Reads :attr:`RuntimeBackend.isolation_mode` rather than inspecting
-        the concrete class, so a future backend on a different substrate
-        (Kubernetes, Modal, ...) plugs into this check by setting the
-        attribute correctly.
+        Task-driven backend selection already routes such runs onto
+        :class:`PerTrialRuntimeBackend`; this guard only fires under
+        the deprecated ``orchestrator.runtime`` override path when the
+        operator forces a shared backend against a per-trial-requiring
+        task set. It also catches an ``ephemeral``-labelled service on
+        a shared backend — that isolation label cannot be honoured
+        without a full compose-down cycle.
 
         Raises :class:`RuntimeError` naming the offending tasks and the
         concrete fix.
         """
         from tolokaforge.core.runtime import IsolationMode
-        from tolokaforge.runner.models import TaskIsolation
 
         if runtime_backend.isolation_mode is IsolationMode.PER_TRIAL_STACK:
-            # Any per-trial backend satisfies every isolation requirement.
             return
 
         if self.adapter is None:
@@ -735,7 +839,8 @@ class Orchestrator:
                 "Isolation-compatibility check requires the adapter to be loaded first."
             )
 
-        violations: list[str] = []
+        per_trial_violations: list[str] = []
+        ephemeral_violations: list[tuple[str, list[str]]] = []
         for task in self.tasks:
             task_desc = self._task_desc_cache.get(task.task_id)
             if task_desc is None:
@@ -744,20 +849,34 @@ class Orchestrator:
             manifest = task_desc.environment_manifest
             if manifest is None:
                 continue
-            if manifest.isolation is TaskIsolation.PER_TRIAL:
-                violations.append(task.task_id)
+            if manifest.requires_per_trial:
+                per_trial_violations.append(task.task_id)
+            ephemeral = sorted(
+                name for name, spec in manifest.services.items() if spec.isolation == "ephemeral"
+            )
+            if ephemeral:
+                ephemeral_violations.append((task.task_id, ephemeral))
 
-        if violations:
+        if per_trial_violations:
             raise RuntimeError(
                 f"Runtime backend {type(runtime_backend).__name__} shares state "
-                f"across every trial in the run, but {len(violations)} task(s) "
-                f"declare `environment_manifest.isolation: per_trial`: "
-                f"{sorted(violations)!r}. These tasks would silently produce "
-                "wrong verdicts on a shared-stack backend.\n"
-                "  Fix: select a per-trial runtime backend in the run config "
-                "(e.g. PerTrialRuntimeBackend), or set `isolation: shared_ok` "
-                "on the task(s) that genuinely tolerate shared state across "
-                "trials."
+                f"across every trial in the run, but {len(per_trial_violations)} "
+                f"task(s) require per-trial materialisation via their "
+                f"`services.<name>.isolation` labels: "
+                f"{sorted(per_trial_violations)!r}. These tasks would silently "
+                "produce wrong verdicts on a shared-stack backend.\n"
+                "  Fix: drop the deprecated `orchestrator.runtime` override so "
+                "backend selection is task-driven, or label every service "
+                "`isolation: shared` on the task(s) that genuinely tolerate "
+                "shared state across trials."
+            )
+        if ephemeral_violations:
+            raise RuntimeError(
+                "Shared-stack backend cannot honour `isolation: ephemeral` "
+                "services (they require a compose-down between trials). "
+                f"Offending: {ephemeral_violations!r}. "
+                "Fix: drop the deprecated `orchestrator.runtime` override "
+                "so the task-driven selector picks a per-trial backend."
             )
 
     def _build_pending_trials(
@@ -1132,7 +1251,7 @@ class Orchestrator:
                     self.logger.info("Creating service stack (db-service + runner)")
                     stack_factory = core_stack
                 service_stack = stack_factory(**core_stack_kwargs)
-                per_trial_mode = self.config.orchestrator.runtime == "per_trial"
+                per_trial_mode = self._resolve_effective_runtime_choice() == "per_trial"
                 # In per_trial mode OR shared+env_manifest mode the built-in engine
                 # containers go unused — the task-declared compose stack owns the
                 # runner + db-service. The engine images still need to be BUILT so
@@ -1199,9 +1318,11 @@ class Orchestrator:
         runtime_backend.connect()
         self.logger.info("Runtime backend connected")
         self._verify_isolation_compatibility(runtime_backend)
+        self._admit_capabilities(runtime_backend)
+        self._emit_environment_identities()
 
         env_endpoints = _build_env_endpoints(runner_address)
-        if self.config.orchestrator.runtime == "per_trial" or run_env_manifest is not None:
+        if self._resolve_effective_runtime_choice() == "per_trial" or run_env_manifest is not None:
             # Per-trial backend resolves fresh endpoints per trial via
             # ``endpoints(handle)``. Shared+env_manifest resolves them once
             # at connect time from the materialised stack. In both cases the
@@ -1558,6 +1679,8 @@ class Orchestrator:
             runtime_backend = self._construct_runtime_backend(runner_address)
         runtime_backend.connect()
         self._verify_isolation_compatibility(runtime_backend)
+        self._admit_capabilities(runtime_backend)
+        self._emit_environment_identities()
 
         env_endpoints = _build_env_endpoints(runner_address)
         self.logger.info(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -541,6 +541,13 @@ class Orchestrator:
         """Return the shared ``environment_manifest`` declared by the run's
         tasks, or ``None`` if none of them declare one.
 
+        Each task carries an :class:`EnvironmentPatch` (input shape,
+        pre-resolve); this method calls
+        :func:`tolokaforge.core.project_loader.resolve` per task to bind
+        the project-side and task-side patches into an
+        :class:`EnvironmentManifest`, then dedupes by compose-file
+        identity.
+
         The run's tasks must be consistent: either every task in the run
         declares the same ``environment_manifest.compose_file`` or none do.
         Mixed runs (some tasks with, some without; or different compose
@@ -548,13 +555,16 @@ class Orchestrator:
         can only materialise one substrate per run, and a mixed declaration
         signals an ambiguous operator intent.
         """
+        from tolokaforge.core.project_loader import resolve
+
+        project_env = self.project.default_environment if self.project is not None else None
         manifests_by_compose: dict[str, EnvironmentManifest] = {}
         tasks_by_manifest_status: dict[bool, list[str]] = {True: [], False: []}
         for task in self.tasks:
-            manifest = task.environment_manifest
-            tasks_by_manifest_status[manifest is not None].append(task.task_id)
-            if manifest is not None:
-                manifests_by_compose[str(manifest.compose_file)] = manifest
+            resolved = resolve(project_env, task.environment_manifest)
+            tasks_by_manifest_status[resolved is not None].append(task.task_id)
+            if resolved is not None:
+                manifests_by_compose[str(resolved.compose_file)] = resolved
         if not manifests_by_compose:
             return None
         if tasks_by_manifest_status[False]:

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -45,9 +45,11 @@ from tolokaforge.core.compose_materialisation import (
     resolve_runner_endpoint,
     shutdown_compose,
 )
+from tolokaforge.core.models import SeedRef
 from tolokaforge.core.runtime import EnvHandle, IsolationMode, ProvisionError
 from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient, RunnerClient
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints
+from tolokaforge.runner.models import EnvironmentManifest
 
 if TYPE_CHECKING:
     from tolokaforge.core.trial import TrialSpec
@@ -98,8 +100,21 @@ class PerTrialRuntimeBackend:
 
     isolation_mode: IsolationMode = IsolationMode.PER_TRIAL_STACK
     """Every trial gets its own compose project. Advertised to the
-    orchestrator's compatibility check so tasks that declare
-    ``environment_manifest.isolation: per_trial`` are satisfied."""
+    orchestrator's compatibility check so tasks whose manifests require
+    per-trial substrate materialisation are satisfied."""
+
+    advertised_capabilities: frozenset[str] = frozenset(
+        {
+            "per_trial_stack",
+            "reset_recipes:sql_dump",
+            "reset_recipes:filesystem_dir",
+            "reset_recipes:redis_dump",
+            "reset_recipes:bare",
+            "network_isolation:no_internet",
+        }
+    )
+    """Local-docker per-trial capability advertisement. Read by
+    :func:`tolokaforge.core.backend_capabilities.check_admission`."""
 
     connect_timeout: float = 30.0
     """Seconds to wait for a per-trial runner's gRPC server to become
@@ -111,6 +126,12 @@ class PerTrialRuntimeBackend:
     connect_retry_interval: float = 1.0
     """Poll interval for the runner-side health check during
     :meth:`_connect_runner_client`."""
+
+    seeds: dict[str, SeedRef] = field(default_factory=dict)
+    """Project-level seed registry — the ``name → SeedRef`` map read
+    from ``project.assets.seeds``. Consumed by :meth:`_apply_reset_recipes`
+    to resolve ``services.<name>.reset.seed`` references at reset time.
+    Empty dict means no reset recipes will fire."""
 
     _clients: dict[str, RunnerClient] = field(default_factory=dict)
     _connected_trials: set[str] = field(default_factory=set)
@@ -184,6 +205,7 @@ class PerTrialRuntimeBackend:
                 wait=True,
             )
             compose.start()
+            self._apply_reset_recipes(manifest, compose, spec)
         except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
             cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
@@ -331,6 +353,49 @@ class PerTrialRuntimeBackend:
             # Contract says cleanup is idempotent; report success.
             return {"success": True, "error": None}
         return client.cleanup_trial(trial_id)
+
+    # ---- Reset seam ----
+
+    def _apply_reset_recipes(
+        self,
+        manifest: EnvironmentManifest,
+        compose: DockerCompose,
+        spec: TrialSpec,
+    ) -> None:
+        """Dispatch the reset recipe for every service labelled ``reset``.
+
+        Runs once per trial, right after ``docker compose up`` returns.
+        The stack is already fresh; the recipe seeds it deterministically
+        before the trial body starts.
+        """
+        from tolokaforge.runtime.reset_recipes import dispatch
+
+        for service_name, service_spec in manifest.services.items():
+            if service_spec.isolation != "reset":
+                continue
+            if service_spec.reset is None:
+                raise ProvisionError(
+                    trial_id=spec.trial_id,
+                    stage="provision",
+                    reason=(
+                        f"service {service_name!r} labelled 'reset' has no "
+                        "'reset.seed' pointer — schema validation should have "
+                        "rejected the manifest earlier."
+                    ),
+                )
+            seed_name = service_spec.reset.seed
+            seed = self.seeds.get(seed_name)
+            if seed is None:
+                raise ProvisionError(
+                    trial_id=spec.trial_id,
+                    stage="provision",
+                    reason=(
+                        f"service {service_name!r} names seed {seed_name!r} but "
+                        f"the backend has no such seed in its registry "
+                        f"(available: {sorted(self.seeds)!r})."
+                    ),
+                )
+            dispatch(seed, service_name, compose)
 
     # ---- Internal helpers ----
 

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -43,6 +43,7 @@ from tolokaforge.core.models import (
     EnvironmentManifest,
     EnvironmentPatch,
     ProjectConfig,
+    ServiceSpec,
     TaskDefaults,
 )
 
@@ -106,7 +107,11 @@ def load_project_config(path: Path) -> ProjectConfig:
 
     Raises ``FileNotFoundError`` if the file does not exist, ``RuntimeError``
     if the YAML is not a mapping, and ``pydantic.ValidationError`` if the
-    contents don't validate against :class:`ProjectConfig`.
+    contents don't validate against :class:`ProjectConfig`. Every declared
+    seed's ``digest`` is verified against the file's bytes after
+    construction; a mismatch (or missing file) raises ``RuntimeError``
+    naming the seed key, the declared digest, and the actual digest so
+    a swap without re-stamping fails loud.
 
     Scope note: ``${VAR}`` interpolation is **not** applied to
     ``project.yaml`` values — only the run-config load path (see
@@ -129,7 +134,37 @@ def load_project_config(path: Path) -> ProjectConfig:
     # Resolve default_environment.compose_file relative to the project dir
     # so EnvironmentManifest's validator can locate it regardless of CWD.
     _resolve_project_paths(data, path.parent)
-    return ProjectConfig(**data)
+    project = ProjectConfig(**data)
+    _verify_seed_digests(project, path)
+    return project
+
+
+def _verify_seed_digests(project: ProjectConfig, project_yaml_path: Path) -> None:
+    """Read each ``assets.seeds.<name>.path`` and compare its sha256 to
+    the declared ``digest``. Raises ``RuntimeError`` on mismatch or
+    missing file, naming the seed key, declared digest, and actual
+    digest so the author sees the exact fix.
+    """
+    import hashlib
+
+    if project.assets is None:
+        return
+    for name, seed in project.assets.seeds.items():
+        seed_path = Path(seed.path)
+        if not seed_path.is_file():
+            raise RuntimeError(
+                f"assets.seeds.{name}.path {seed_path!s} does not exist or is "
+                f"not a file (declared in {project_yaml_path})."
+            )
+        actual_bytes = seed_path.read_bytes()
+        actual_digest = "sha256:" + hashlib.sha256(actual_bytes).hexdigest()
+        if seed.digest != actual_digest:
+            raise RuntimeError(
+                f"assets.seeds.{name}: digest mismatch for {seed_path!s}. "
+                f"Declared: {seed.digest}. Actual: {actual_digest}. "
+                "Re-stamp via `tolokaforge assets stamp` or restore the "
+                "original file."
+            )
 
 
 def _resolve_project_paths(data: dict, project_dir: Path) -> None:
@@ -554,8 +589,8 @@ _POLICY_REQUEST_FIELDS = ("network_policy", "security_context_defaults")
 that are substrate-neutral (they describe the trial regardless of
 substrate)."""
 
-_SERVICE_TREATMENT_FIELDS = ("initial_state", "isolation")
-"""Fields that are scoped to the reviewed stack — discarded on atomic
+_SERVICE_TREATMENT_FIELDS = ("initial_state", "services")
+"""Fields scoped to the reviewed stack — discarded on atomic
 ``stack`` replacement (the project's opt-outs reviewed the project's
 services, not the replacement stack)."""
 
@@ -582,12 +617,16 @@ def resolve(
       clean slate of ``inputs`` and ``runner_service`` (a foreign
       compose file's ``${var}`` slots must never silently capture
       inherited values).
-    - Service-treatment fields (``initial_state``, root ``isolation``)
-      are discarded — the project's opt-outs reviewed the project's
-      services, not the replacement stack.
+    - Service-treatment fields (``initial_state``, ``services``) are
+      discarded — the project's per-service opt-outs reviewed the
+      project's services, not the replacement stack.
     - Policy-request fields (``network_policy``,
       ``security_context_defaults``) survive — substrate-neutral, they
       describe the trial regardless of substrate.
+
+    After manifest construction, every compose service missing from the
+    merged ``services`` map is filled with an ``ephemeral`` default so
+    downstream consumers see the complete map.
 
     Anchoring: ``stack.compose_file`` paths must already be absolute
     when this runs. The project loader and the task loader anchor them
@@ -625,7 +664,25 @@ def resolve(
             continue
         manifest_kwargs[field] = value
 
-    return EnvironmentManifest(**manifest_kwargs)
+    manifest = EnvironmentManifest(**manifest_kwargs)
+    _fill_missing_service_defaults(manifest)
+    return manifest
+
+
+def _fill_missing_service_defaults(manifest: EnvironmentManifest) -> None:
+    """Insert an ``ephemeral`` :class:`ServiceSpec` for every compose
+    service that lacks a manifest entry after merge.
+
+    In-place on the manifest's ``services`` mapping. Consumers can then
+    walk every compose service and read a canonical isolation label
+    without a missing-key fallback.
+    """
+    declared = set(manifest.services)
+    compose_services = manifest.load_compose().get("services") or {}
+    for name in compose_services:
+        if name in declared:
+            continue
+        manifest.services[name] = ServiceSpec(isolation="ephemeral")
 
 
 def _dump_patch(patch: EnvironmentPatch | None) -> dict[str, Any]:

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -143,6 +143,13 @@ class RuntimeBackend(Protocol):
     materialises an independent substrate per trial sets
     :attr:`IsolationMode.PER_TRIAL_STACK`."""
 
+    advertised_capabilities: frozenset[str]
+    """Names from :data:`tolokaforge.core.backend_capabilities.CAPABILITY_REGISTRY`
+    this backend honours. Read by
+    :func:`tolokaforge.core.backend_capabilities.check_admission` at run
+    start to reject runs whose ``compute.capabilities`` request exceeds
+    the advertisement."""
+
     # ---- Run-level lifecycle ----
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         """Establish the runtime connection (or no-op for an in-memory impl).
@@ -396,17 +403,23 @@ class InMemoryRuntimeBackend:
     :meth:`Orchestrator._verify_isolation_compatibility` can override the
     attribute on the instance."""
 
+    advertised_capabilities: frozenset[str] = frozenset()
+    """Test fixture advertises nothing by default; tests exercising the
+    admission gate override on the instance."""
+
     def __init__(
         self,
         *,
         fail_provision_after_service: str | None = None,
         await_ready_times_out: bool = False,
         isolation_mode: IsolationMode = IsolationMode.SHARED_STACK,
+        advertised_capabilities: frozenset[str] = frozenset(),
     ) -> None:
         self.call_log = RuntimeBackendCallLog()
         self._fail_provision_after_service = fail_provision_after_service
         self._await_ready_times_out = await_ready_times_out
         self.isolation_mode = isolation_mode
+        self.advertised_capabilities = advertised_capabilities
 
     # ---- Run-level lifecycle ----
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -35,6 +35,7 @@ from tolokaforge.core.compose_materialisation import (
     resolve_runner_endpoint,
     shutdown_compose,
 )
+from tolokaforge.core.models import SeedRef
 from tolokaforge.core.runtime import IsolationMode, ProvisionError
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, EnvironmentManifest
 from tolokaforge.runner import (
@@ -685,7 +686,20 @@ class SharedStackRuntimeBackend:
     isolation_mode: IsolationMode = IsolationMode.SHARED_STACK
     """Every trial in the run talks to the same runner container. Read by
     the orchestrator's compatibility check to refuse runs whose tasks
-    declare ``environment_manifest.isolation: per_trial``."""
+    require per-trial substrate materialisation."""
+
+    advertised_capabilities: frozenset[str] = frozenset(
+        {
+            "shared_stack",
+            "reset_recipes:sql_dump",
+            "reset_recipes:filesystem_dir",
+            "reset_recipes:redis_dump",
+            "reset_recipes:bare",
+            "network_isolation:no_internet",
+        }
+    )
+    """Local-docker shared-stack capability advertisement. Read by
+    :func:`tolokaforge.core.backend_capabilities.check_admission`."""
 
     def __init__(
         self,
@@ -693,6 +707,7 @@ class SharedStackRuntimeBackend:
         endpoints: EnvEndpoints | None = None,
         env_manifest: EnvironmentManifest | None = None,
         run_id: str = "run",
+        seeds: dict[str, SeedRef] | None = None,
     ):
         """Initialize the shared-stack runtime.
 
@@ -721,6 +736,7 @@ class SharedStackRuntimeBackend:
         self._run_id = run_id
         self._compose: DockerCompose | None = None
         self._temp_dir: Path | None = None
+        self.seeds: dict[str, SeedRef] = dict(seeds or {})
 
         self.runner_client: GrpcRunnerClient | None
         self._endpoints: EnvEndpoints | None
@@ -918,6 +934,51 @@ class SharedStackRuntimeBackend:
     def teardown(self, handle: EnvHandle) -> None:  # noqa: ARG002 — Protocol conformance
         """No-op: the shared stack lives for the whole run and is torn
         down at :meth:`close`, not per-trial. Idempotent by construction."""
+
+    def reset_services_for_next_trial(self, manifest: EnvironmentManifest) -> None:
+        """Dispatch reset recipes for every ``isolation="reset"`` service
+        against the shared compose stack.
+
+        Called at the trial-boundary — after one trial finishes and
+        before the next one starts. ``shared`` services no-op (state
+        persists across trials, which is the point of the label);
+        ``ephemeral`` services are rejected — a shared-stack backend
+        cannot honour a full compose-down between trials, and the
+        admission gate is expected to have refused the run upstream.
+        """
+        from tolokaforge.runtime.reset_recipes import dispatch
+
+        if self._compose is None:
+            raise RuntimeError(
+                "SharedStackRuntimeBackend.reset_services_for_next_trial requires "
+                "a materialised compose stack; construct with env_manifest and "
+                "connect() first."
+            )
+        for service_name, service_spec in manifest.services.items():
+            if service_spec.isolation == "shared":
+                continue
+            if service_spec.isolation == "ephemeral":
+                raise RuntimeError(
+                    f"SharedStackRuntimeBackend cannot honour "
+                    f"isolation='ephemeral' on service {service_name!r}; the "
+                    "shared stack lives for the whole run. Backend selection "
+                    "should have routed this run onto PerTrialRuntimeBackend."
+                )
+            if service_spec.reset is None:
+                raise RuntimeError(
+                    f"service {service_name!r} labelled 'reset' has no "
+                    "'reset.seed' pointer — schema validation should have "
+                    "rejected the manifest earlier."
+                )
+            seed_name = service_spec.reset.seed
+            seed = self.seeds.get(seed_name)
+            if seed is None:
+                raise RuntimeError(
+                    f"service {service_name!r} names seed {seed_name!r} but "
+                    f"the backend has no such seed in its registry "
+                    f"(available: {sorted(self.seeds)!r})."
+                )
+            dispatch(seed, service_name, self._compose)
 
     # ---- Per-trial RPC operations (ADR-0013) ----
     # Thin delegates to ``self.runner_client``. Kept as explicit methods

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -614,27 +614,78 @@ class NetworkPolicy(str, Enum):
 
 
 class TaskIsolation(str, Enum):
-    """Isolation requirement the task declares to the runtime backend.
+    """Computed backend-selection signal derived from a manifest's
+    per-service ``isolation`` map.
 
-    A task that mutates state (writes DB rows, applies fixtures, modifies
-    per-trial files) needs a fresh environment per trial to grade
-    correctly. Running such a task on a shared-stack backend produces
-    silent cross-trial contamination — the manifest's declaration lets
-    the orchestrator refuse an incompatible backend before any trial
-    runs.
+    ``PER_TRIAL`` means at least one service in the manifest is labelled
+    ``reset`` or ``ephemeral`` (or the manifest is set with no explicit
+    services), so the orchestrator selects
+    :class:`~tolokaforge.core.per_trial_runtime.PerTrialRuntimeBackend`.
+    ``SHARED_OK`` means every declared service is labelled ``shared``,
+    so :class:`~tolokaforge.core.shared_stack_runtime.SharedStackRuntimeBackend`
+    is chosen. Not authored in YAML — computed from
+    :attr:`EnvironmentManifest.services` by
+    :attr:`EnvironmentManifest.requires_per_trial`.
     """
 
     PER_TRIAL = "per_trial"
-    """Task requires a fresh environment per trial. The orchestrator
-    refuses to run the task on ``SharedStackRuntimeBackend``. Safe
-    default — any task that has a manifest almost certainly wants this
-    (it is why the task declared a manifest in the first place)."""
-
     SHARED_OK = "shared_ok"
-    """Task tolerates running against a stack shared with other trials.
-    Opt-out for stateless tasks that would otherwise pay the per-trial
-    cold-start cost unnecessarily. The orchestrator accepts either
-    backend for these tasks."""
+
+
+ServiceIsolation = Literal["shared", "reset", "ephemeral"]
+"""Per-service isolation vocabulary.
+
+* ``shared`` — service persists across trials (state carries over).
+* ``reset`` — service is reset between trials via a seed-backed recipe
+  named by :attr:`ServiceSpec.reset`.
+* ``ephemeral`` — service is torn down and recreated between trials.
+"""
+
+
+class ResetSpec(BaseModel):
+    """Seed pointer for a service labelled ``reset``. Names the entry in
+    ``project.assets.seeds`` whose recipe restores the service to a
+    known baseline between trials."""
+
+    seed: str
+    """Name of the seed entry in the project's ``assets.seeds`` map."""
+
+    model_config = {"extra": "forbid"}
+
+
+class ServiceSpec(BaseModel):
+    """Per-service manifest entry — the harness's declaration of how a
+    compose service is treated between trials.
+
+    ``reset`` is required exactly when ``isolation == "reset"`` and
+    forbidden otherwise; :meth:`_check_reset_agrees_with_isolation`
+    enforces the invariant so a stale ``reset`` sibling from a deep
+    merge fails loud at load.
+    """
+
+    isolation: ServiceIsolation
+    """Per-service isolation label — see :data:`ServiceIsolation`."""
+
+    reset: ResetSpec | None = None
+    """Reset recipe pointer. Required for ``isolation="reset"``, forbidden
+    for the other labels."""
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def _check_reset_agrees_with_isolation(self) -> ServiceSpec:
+        if self.isolation == "reset" and self.reset is None:
+            raise ValueError(
+                "ServiceSpec: isolation='reset' requires a 'reset.seed' pointer; "
+                "declare `reset: {seed: <name>}` or change isolation."
+            )
+        if self.isolation != "reset" and self.reset is not None:
+            raise ValueError(
+                f"ServiceSpec: isolation={self.isolation!r} cannot carry a 'reset' "
+                "recipe. Either change isolation to 'reset' or drop the 'reset' "
+                "sibling (e.g. `reset: null` on the overriding side)."
+            )
+        return self
 
 
 def _compose_services(content: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -836,6 +887,19 @@ def _check_initial_state_keys(
             )
 
 
+def _check_services_keys(
+    compose_services: dict[str, dict[str, Any]],
+    manifest_services: dict[str, ServiceSpec],
+) -> None:
+    for key in manifest_services:
+        if key not in compose_services:
+            raise ValueError(
+                f"EnvironmentManifest.services has entry {key!r} that does not "
+                f"match any declared compose service; compose declares "
+                f"{sorted(compose_services)!r}."
+            )
+
+
 class StackPatch(BaseModel):
     """Substrate slot inside an :class:`EnvironmentPatch`.
 
@@ -900,11 +964,12 @@ class EnvironmentPatch(BaseModel):
     Survives atomic ``stack`` replacement (policy request,
     substrate-neutral)."""
 
-    isolation: TaskIsolation | None = None
-    """Isolation requirement. Discarded on atomic ``stack`` replacement
-    (the project's opt-out reviewed the project's services, not the
-    replacement stack — a task-local stack declares its own
-    ``shared_ok`` explicitly if it wants it)."""
+    services: dict[str, ServiceSpec] | None = None
+    """Per-service isolation + reset declarations, keyed by compose
+    service name. Discarded on atomic ``stack`` replacement — the
+    project's per-service opt-outs reviewed the project's services,
+    not the replacement stack. Deep-merges over the project side
+    entry-by-entry on non-replacement paths."""
 
     @model_validator(mode="before")
     @classmethod
@@ -974,13 +1039,29 @@ class EnvironmentManifest(BaseModel):
     """Applied by the provisioner to every service that does not override
     the equivalent settings in the compose file."""
 
-    isolation: TaskIsolation = TaskIsolation.PER_TRIAL
-    """Isolation requirement. Defaults to per-trial — the orchestrator
-    refuses to run a per-trial task on ``SharedStackRuntimeBackend``.
-    Set to ``shared_ok`` to opt out for stateless tasks that tolerate
-    a shared stack."""
+    services: dict[str, ServiceSpec] = Field(default_factory=dict)
+    """Per-service isolation + reset declarations, keyed by compose
+    service name. Populated by :func:`tolokaforge.core.project_loader.resolve`
+    which merges the project-side and task-side patches and then fills
+    any compose service missing from the merged map with an
+    ``ephemeral`` default. Consumed by :attr:`requires_per_trial` (for
+    backend selection) and by the runtime backends (for between-trial
+    reset dispatch)."""
 
     model_config = {"extra": "forbid"}
+
+    @property
+    def requires_per_trial(self) -> bool:
+        """True iff at least one service is labelled ``reset`` or
+        ``ephemeral``, or the manifest declares no services at all.
+
+        Consumed by :meth:`Orchestrator._select_backend_from_tasks` to
+        pick :class:`PerTrialRuntimeBackend` for any run whose tasks
+        need per-trial substrate materialisation.
+        """
+        if not self.services:
+            return True
+        return any(spec.isolation != "shared" for spec in self.services.values())
 
     _compose_content: dict[str, Any] = PrivateAttr(default_factory=dict)
     """Parsed compose file contents cached at construction time. Populated
@@ -1009,6 +1090,7 @@ class EnvironmentManifest(BaseModel):
         _check_depends_on_resolves(services)
         _check_runner_service_declared(services, self.runner_service)
         _check_initial_state_keys(services, self.initial_state)
+        _check_services_keys(services, self.services)
         self._compose_content = content
         return self
 

--- a/tolokaforge/runtime/__init__.py
+++ b/tolokaforge/runtime/__init__.py
@@ -1,0 +1,7 @@
+"""Runtime-side helpers that materialise manifest declarations against a
+live substrate.
+
+Currently exposes :mod:`tolokaforge.runtime.reset_recipes` — the
+dispatchers that seed a service back to a named baseline between
+trials for :class:`ServiceSpec` entries labelled ``reset``.
+"""

--- a/tolokaforge/runtime/reset_recipes/__init__.py
+++ b/tolokaforge/runtime/reset_recipes/__init__.py
@@ -1,0 +1,76 @@
+"""Reset-recipe registry — one dispatcher per :data:`SeedKind`.
+
+A service labelled ``reset`` in an :class:`EnvironmentManifest` names a
+seed from ``project.assets.seeds``. The seed's ``kind`` selects a
+:class:`RecipeDispatcher` from :data:`RECIPE_REGISTRY`; the backend
+calls the dispatcher's :meth:`RecipeDispatcher.apply` at the reset seam
+(per-trial provision for :class:`PerTrialRuntimeBackend`, between-trial
+hook for :class:`SharedStackRuntimeBackend`).
+
+The registry is populated at import time by each recipe module below.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from tolokaforge.core.models import SeedKind, SeedRef
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from testcontainers.compose import DockerCompose
+
+
+@runtime_checkable
+class RecipeDispatcher(Protocol):
+    """Applies a named seed to a service on a live compose stack.
+
+    ``apply`` is called once per reset event (per trial in per-trial
+    mode, at trial boundaries in shared mode). Implementations are
+    expected to be idempotent — a re-run against the same substrate
+    lands the service in the same state.
+    """
+
+    def apply(
+        self,
+        seed: SeedRef,
+        service_name: str,
+        compose: DockerCompose,
+    ) -> None: ...
+
+
+RECIPE_REGISTRY: dict[SeedKind, RecipeDispatcher] = {}
+"""Map from seed kind to its dispatcher. Populated at import time by
+each recipe module (:mod:`sql_dump`, :mod:`filesystem_dir`,
+:mod:`redis_dump`, :mod:`bare`)."""
+
+
+def dispatch(
+    seed: SeedRef,
+    service_name: str,
+    compose: DockerCompose,
+) -> None:
+    """Look up the recipe for ``seed.kind`` and apply it.
+
+    Raises :class:`KeyError` when the seed kind has no registered
+    dispatcher — this only happens if a new :data:`SeedKind` literal is
+    added without a matching recipe module import.
+    """
+    dispatcher = RECIPE_REGISTRY[seed.kind]
+    dispatcher.apply(seed, service_name, compose)
+
+
+def _register_builtin_dispatchers() -> None:
+    """Import each shipped recipe module so its module-level dispatcher
+    registers itself in :data:`RECIPE_REGISTRY`. Runs once at package
+    import time — recipes cannot be looked up before this returns.
+    """
+    from tolokaforge.runtime.reset_recipes import bare, filesystem_dir, redis_dump, sql_dump
+
+    # References silence linters and keep the modules alive for their
+    # side-effect (registry entry) even under aggressive dead-code passes.
+    _ = (bare, filesystem_dir, redis_dump, sql_dump)
+
+
+_register_builtin_dispatchers()
+
+__all__ = ["RECIPE_REGISTRY", "RecipeDispatcher", "dispatch"]

--- a/tolokaforge/runtime/reset_recipes/bare.py
+++ b/tolokaforge/runtime/reset_recipes/bare.py
@@ -1,0 +1,34 @@
+"""``bare`` seed kind — no automatic overlay.
+
+The seed file is available at the resolved path on the host; the task's
+compose file consumes it verbatim (as a bind mount, a copy step in the
+service's own entrypoint, or however the task author wires it). No
+container-side action runs at reset time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from testcontainers.compose import DockerCompose
+
+
+class BareDispatcher:
+    """No-op recipe: the file already sits where the task's compose file
+    expects it, and the reset has nothing to do inside the container."""
+
+    def apply(
+        self,
+        seed: SeedRef,
+        service_name: str,
+        compose: DockerCompose,
+    ) -> None:
+        del seed, service_name, compose
+
+
+DISPATCHER = BareDispatcher()
+RECIPE_REGISTRY["bare"] = DISPATCHER

--- a/tolokaforge/runtime/reset_recipes/filesystem_dir.py
+++ b/tolokaforge/runtime/reset_recipes/filesystem_dir.py
@@ -56,7 +56,9 @@ class FilesystemDirDispatcher:
             "-c",
             f'rm -rf "{WORKSPACE_TARGET}"/* "{WORKSPACE_TARGET}"/.[!.]* 2>/dev/null || true',
         ]
-        wipe_result = subprocess.run(wipe_cmd, capture_output=True, check=False)
+        wipe_result = subprocess.run(
+            wipe_cmd, capture_output=True, check=False, cwd=compose.context
+        )
         if wipe_result.returncode != 0:
             raise RuntimeError(
                 f"filesystem_dir reset (wipe stage) failed for service "
@@ -71,7 +73,7 @@ class FilesystemDirDispatcher:
             f"{seed.path!s}/.",
             f"{service_name}:{WORKSPACE_TARGET}",
         ]
-        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False)
+        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False, cwd=compose.context)
         if cp_result.returncode != 0:
             raise RuntimeError(
                 f"filesystem_dir reset (copy stage) failed for service "

--- a/tolokaforge/runtime/reset_recipes/filesystem_dir.py
+++ b/tolokaforge/runtime/reset_recipes/filesystem_dir.py
@@ -1,0 +1,85 @@
+"""``filesystem_dir`` seed kind — copy a directory tree into a service's
+workspace.
+
+The seed path points at a directory on the host. The dispatcher wipes
+the service's target workspace and copies the seed tree into it. Target
+path defaults to ``/workspace`` inside the container; task packs that
+mount a different workspace override by declaring the seed against a
+service whose compose entry mounts the matching path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from testcontainers.compose import DockerCompose
+
+WORKSPACE_TARGET = "/workspace"
+"""Default in-container path a ``filesystem_dir`` seed writes into."""
+
+
+class FilesystemDirDispatcher:
+    """Copy the seed directory tree into a service container's workspace.
+
+    Wipes ``WORKSPACE_TARGET`` first so a partial-copy mid-trial does
+    not leave stale files behind. Uses ``docker cp`` under the compose
+    project's namespace so the underlying container id does not have to
+    be resolved by the caller.
+    """
+
+    def apply(
+        self,
+        seed: SeedRef,
+        service_name: str,
+        compose: DockerCompose,
+    ) -> None:
+        import shlex
+        import subprocess
+
+        if not seed.path.is_dir():
+            raise RuntimeError(
+                f"filesystem_dir seed at {seed.path!s} is not a directory; "
+                "the recipe requires a directory tree."
+            )
+
+        docker_compose_cmd = list(compose.docker_compose_command())
+        wipe_cmd = [
+            *docker_compose_cmd,
+            "exec",
+            "-T",
+            service_name,
+            "sh",
+            "-c",
+            f'rm -rf "{WORKSPACE_TARGET}"/* "{WORKSPACE_TARGET}"/.[!.]* 2>/dev/null || true',
+        ]
+        wipe_result = subprocess.run(wipe_cmd, capture_output=True, check=False)
+        if wipe_result.returncode != 0:
+            raise RuntimeError(
+                f"filesystem_dir reset (wipe stage) failed for service "
+                f"{service_name!r}: rc={wipe_result.returncode} "
+                f"cmd={shlex.join(wipe_cmd)} "
+                f"stderr={wipe_result.stderr.decode(errors='replace')!r}"
+            )
+
+        cp_cmd = [
+            *docker_compose_cmd,
+            "cp",
+            f"{seed.path!s}/.",
+            f"{service_name}:{WORKSPACE_TARGET}",
+        ]
+        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False)
+        if cp_result.returncode != 0:
+            raise RuntimeError(
+                f"filesystem_dir reset (copy stage) failed for service "
+                f"{service_name!r} from seed {seed.path!s}: "
+                f"rc={cp_result.returncode} cmd={shlex.join(cp_cmd)} "
+                f"stderr={cp_result.stderr.decode(errors='replace')!r}"
+            )
+
+
+DISPATCHER = FilesystemDirDispatcher()
+RECIPE_REGISTRY["filesystem_dir"] = DISPATCHER

--- a/tolokaforge/runtime/reset_recipes/redis_dump.py
+++ b/tolokaforge/runtime/reset_recipes/redis_dump.py
@@ -1,0 +1,79 @@
+"""``redis_dump`` seed kind — restore an RDB snapshot into a Redis
+service.
+
+Copies the ``.rdb`` into the service's ``/data`` directory as
+``dump.rdb`` and asks Redis to reload it via ``DEBUG RELOAD``. Works
+against any image built on the official ``redis`` upstream (data-dir
+``/data`` is the upstream default).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from testcontainers.compose import DockerCompose
+
+REDIS_DATA_DIR = "/data"
+REDIS_DUMP_NAME = "dump.rdb"
+
+
+class RedisDumpDispatcher:
+    """Copy an RDB snapshot into a Redis service and reload it.
+
+    Uses ``docker cp`` to place the dump, then ``docker exec`` +
+    ``redis-cli DEBUG RELOAD`` to swap the in-memory dataset. Both stages
+    surface ``RuntimeError`` on failure rather than proceeding with a
+    half-reset service.
+    """
+
+    def apply(
+        self,
+        seed: SeedRef,
+        service_name: str,
+        compose: DockerCompose,
+    ) -> None:
+        import shlex
+        import subprocess
+
+        docker_compose_cmd = list(compose.docker_compose_command())
+        cp_cmd = [
+            *docker_compose_cmd,
+            "cp",
+            str(seed.path),
+            f"{service_name}:{REDIS_DATA_DIR}/{REDIS_DUMP_NAME}",
+        ]
+        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False)
+        if cp_result.returncode != 0:
+            raise RuntimeError(
+                f"redis_dump reset (copy stage) failed for service "
+                f"{service_name!r} from seed {seed.path!s}: "
+                f"rc={cp_result.returncode} cmd={shlex.join(cp_cmd)} "
+                f"stderr={cp_result.stderr.decode(errors='replace')!r}"
+            )
+
+        reload_cmd = [
+            *docker_compose_cmd,
+            "exec",
+            "-T",
+            service_name,
+            "redis-cli",
+            "DEBUG",
+            "RELOAD",
+        ]
+        reload_result = subprocess.run(reload_cmd, capture_output=True, check=False)
+        if reload_result.returncode != 0:
+            raise RuntimeError(
+                f"redis_dump reset (reload stage) failed for service "
+                f"{service_name!r}: rc={reload_result.returncode} "
+                f"cmd={shlex.join(reload_cmd)} "
+                f"stdout={reload_result.stdout.decode(errors='replace')!r} "
+                f"stderr={reload_result.stderr.decode(errors='replace')!r}"
+            )
+
+
+DISPATCHER = RedisDumpDispatcher()
+RECIPE_REGISTRY["redis_dump"] = DISPATCHER

--- a/tolokaforge/runtime/reset_recipes/redis_dump.py
+++ b/tolokaforge/runtime/reset_recipes/redis_dump.py
@@ -2,9 +2,14 @@
 service.
 
 Copies the ``.rdb`` into the service's ``/data`` directory as
-``dump.rdb`` and asks Redis to reload it via ``DEBUG RELOAD``. Works
-against any image built on the official ``redis`` upstream (data-dir
-``/data`` is the upstream default).
+``dump.rdb`` and restarts the service — Redis loads ``dump.rdb`` at
+startup regardless of the ``save`` config. Works against any image
+built on the official ``redis`` upstream (data-dir ``/data`` is the
+upstream default). ``DEBUG RELOAD`` is not used: it is an internal
+RDB-serialisation test that either overwrites the seed with the
+running state before reading, or (with ``NOSAVE``) reads from an
+implementation-defined snapshot cache that is not guaranteed to be
+the file we just wrote.
 """
 
 from __future__ import annotations
@@ -21,13 +26,21 @@ REDIS_DATA_DIR = "/data"
 REDIS_DUMP_NAME = "dump.rdb"
 
 
-class RedisDumpDispatcher:
-    """Copy an RDB snapshot into a Redis service and reload it.
+RESTART_PING_MAX_ATTEMPTS = 30
+"""Polls of ``redis-cli PING`` after restart before giving up. One
+attempt per second."""
 
-    Uses ``docker cp`` to place the dump, then ``docker exec`` +
-    ``redis-cli DEBUG RELOAD`` to swap the in-memory dataset. Both stages
-    surface ``RuntimeError`` on failure rather than proceeding with a
-    half-reset service.
+
+class RedisDumpDispatcher:
+    """Copy an RDB snapshot into a Redis service and restart the service.
+
+    Uses ``docker compose cp`` to place ``dump.rdb`` into the service's
+    data directory, then ``docker compose restart <service>``. Redis
+    loads ``dump.rdb`` at startup by default (``dbfilename`` config;
+    unrelated to whether the ``save`` config enables persistence). A
+    ``PING`` poll then waits for the restarted process to accept
+    connections before returning. Each stage surfaces ``RuntimeError``
+    on failure rather than proceeding with a half-reset service.
     """
 
     def apply(
@@ -38,6 +51,7 @@ class RedisDumpDispatcher:
     ) -> None:
         import shlex
         import subprocess
+        import time
 
         docker_compose_cmd = list(compose.docker_compose_command())
         cp_cmd = [
@@ -46,7 +60,7 @@ class RedisDumpDispatcher:
             str(seed.path),
             f"{service_name}:{REDIS_DATA_DIR}/{REDIS_DUMP_NAME}",
         ]
-        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False)
+        cp_result = subprocess.run(cp_cmd, capture_output=True, check=False, cwd=compose.context)
         if cp_result.returncode != 0:
             raise RuntimeError(
                 f"redis_dump reset (copy stage) failed for service "
@@ -55,24 +69,39 @@ class RedisDumpDispatcher:
                 f"stderr={cp_result.stderr.decode(errors='replace')!r}"
             )
 
-        reload_cmd = [
+        restart_cmd = [*docker_compose_cmd, "restart", service_name]
+        restart_result = subprocess.run(
+            restart_cmd, capture_output=True, check=False, cwd=compose.context
+        )
+        if restart_result.returncode != 0:
+            raise RuntimeError(
+                f"redis_dump reset (restart stage) failed for service "
+                f"{service_name!r}: rc={restart_result.returncode} "
+                f"cmd={shlex.join(restart_cmd)} "
+                f"stderr={restart_result.stderr.decode(errors='replace')!r}"
+            )
+
+        ping_cmd = [
             *docker_compose_cmd,
             "exec",
             "-T",
             service_name,
             "redis-cli",
-            "DEBUG",
-            "RELOAD",
+            "PING",
         ]
-        reload_result = subprocess.run(reload_cmd, capture_output=True, check=False)
-        if reload_result.returncode != 0:
-            raise RuntimeError(
-                f"redis_dump reset (reload stage) failed for service "
-                f"{service_name!r}: rc={reload_result.returncode} "
-                f"cmd={shlex.join(reload_cmd)} "
-                f"stdout={reload_result.stdout.decode(errors='replace')!r} "
-                f"stderr={reload_result.stderr.decode(errors='replace')!r}"
+        for _ in range(RESTART_PING_MAX_ATTEMPTS):
+            ping_result = subprocess.run(
+                ping_cmd, capture_output=True, check=False, cwd=compose.context
             )
+            if ping_result.returncode == 0 and b"PONG" in ping_result.stdout:
+                return
+            time.sleep(1)
+
+        raise RuntimeError(
+            f"redis_dump reset (ping stage) failed for service "
+            f"{service_name!r}: did not accept PING within "
+            f"{RESTART_PING_MAX_ATTEMPTS}s after restart"
+        )
 
 
 DISPATCHER = RedisDumpDispatcher()

--- a/tolokaforge/runtime/reset_recipes/sql_dump.py
+++ b/tolokaforge/runtime/reset_recipes/sql_dump.py
@@ -59,6 +59,7 @@ class SqlDumpDispatcher:
             input=dump_bytes,
             capture_output=True,
             check=False,
+            cwd=compose.context,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/tolokaforge/runtime/reset_recipes/sql_dump.py
+++ b/tolokaforge/runtime/reset_recipes/sql_dump.py
@@ -1,0 +1,74 @@
+"""``sql_dump`` seed kind — restore a SQL dump into the service's
+database.
+
+Streams the dump bytes into the service container via ``docker exec`` and
+pipes them through the service's SQL client. The client command is
+inferred from the service image (``postgres:*`` → ``psql``, otherwise
+``psql`` is used as the default — task packs that need a different
+client override by naming the seed with a matching kind in a future
+recipe module).
+
+Environment expected by the container: ``PGUSER`` / ``POSTGRES_USER``
+(command falls back to ``postgres``) and ``PGDATABASE`` /
+``POSTGRES_DB`` (defaults to ``postgres``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.models import SeedRef
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    from testcontainers.compose import DockerCompose
+
+
+class SqlDumpDispatcher:
+    """Load a ``.sql`` dump into a service's Postgres/SQL runtime.
+
+    Executes ``psql`` (or another SQL client the image ships) inside the
+    service container, piping the dump bytes on stdin. Errors surface as
+    :class:`RuntimeError` naming the service, the seed path, and the
+    command output — the reset is not allowed to silently succeed with
+    an inconsistent database.
+    """
+
+    def apply(
+        self,
+        seed: SeedRef,
+        service_name: str,
+        compose: DockerCompose,
+    ) -> None:
+        import shlex
+        import subprocess
+
+        dump_bytes = seed.path.read_bytes()
+        docker_compose_cmd = list(compose.docker_compose_command())
+        exec_cmd = [
+            *docker_compose_cmd,
+            "exec",
+            "-T",
+            service_name,
+            "sh",
+            "-c",
+            'psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}"',
+        ]
+        result = subprocess.run(
+            exec_cmd,
+            input=dump_bytes,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"sql_dump reset failed for service {service_name!r} "
+                f"from seed {seed.path!s}: rc={result.returncode} "
+                f"cmd={shlex.join(exec_cmd)} "
+                f"stdout={result.stdout.decode(errors='replace')!r} "
+                f"stderr={result.stderr.decode(errors='replace')!r}"
+            )
+
+
+DISPATCHER = SqlDumpDispatcher()
+RECIPE_REGISTRY["sql_dump"] = DISPATCHER


### PR DESCRIPTION
## Summary

Promotes three post-M3 fixups from `experiment/multi-container` to `main` so that milestone 12 sub-issue PRs stay one-issue-per-PR and start from a known-good runtime.

- `d2d8919 fix(runtime): reset-recipe cwd + redis_dump restart-based restore` — every `subprocess.run(compose.docker_compose_command() + [...])` in reset-recipe modules was missing `cwd=compose.context`, causing 4 integration tests to fail on a real Docker daemon; `redis_dump` was rewritten to `docker compose restart <service>` + `redis-cli PING` polling (portable across Redis versions, no dependence on `DEBUG RELOAD` semantics).
- `5789b8c fix(orchestrator): resolve environment_manifest patch before accessing compose_file` — `TaskConfig.environment_manifest` is typed `EnvironmentPatch | None`, but `_extract_run_env_manifest` was reading `.compose_file` at the top level (pre-M2.5 shape). Fixed by calling `project_loader.resolve()` per task to materialise the concrete `EnvironmentManifest`.
- `5afd3de chore(ci): keep claude-review model at claude-opus-4-8` — CI-only pin.

## Test plan

- [ ] `uv run pytest -m integration tests/integration/reset_recipes/ tests/integration/test_cross_mode_isolation.py tests/integration/test_example_microservices_pack.py` — passes on a real Docker daemon (was 9/9 in ~65s at commit time).
- [ ] `uv run pytest tests/unit` — green.
- [ ] Claude review lane runs on `claude-opus-4-8` (no immediate `is_error:true`).

Milestone: Multi-container runtime v1 (#12) — precursor to #299/#300/#302.