### PR TITLE
feat(cli): structured log format with -v/-q/--log-format (#279)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ amzn_delivery/
 
 *.log
 !tasks/**/fixtures/*.log
+!tests/canonical/golden/**/*.log
 
 # TypeSense data
 .cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **logging**: structured console format `HH:MM:SS.mmm | LEVEL | k=v | message` with root `--verbose` / `--quiet` / `--log-format={pretty,plain,json}` flags; auto-select `pretty` on TTY / `plain` on pipe; ANSI palette matches `_display.THEME`. See [docs/CLI.md](docs/CLI.md) § Structured logging. (#279)
+
+### Breaking Changes
+
+1. **`StructuredLogger` console output moves from `sys.stdout` to `sys.stderr`.** Every tolokaforge log record — including the `orchestrator`, `runner`, `output_writer`, and adapter records that previously wrote to `stdout` via `StructuredLogger`'s private handler — now propagates through the root handler installed by `configure_root_logging`, which writes to `sys.stderr`. Downstream consumers piping tolokaforge's stdout to capture log lines should switch to `2>&1 | …` or to `--log-format=json` (still on stderr). Aligned with the `stdout=artifact` carveout coming in #280.
+2. **Console log line shape changed to `HH:MM:SS.mmm | LEVEL | k=v | message`.** The legacy `"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` format (seconds resolution, inline `(k=v, k=v)` in the message string) is gone. Machine consumers grepping the old shape need to update to the new column layout — the pipe-separated columns, ANSI palette, and JSON schema are pinned by canonical goldens under `tests/canonical/golden/logging/`. (#279)
+
 ## v0.8.3 (2026-07-13)
 
 ### Feat

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -75,3 +75,43 @@ Defaults: `refresh_per_second=4.0`, `transient=False`, `screen=False`, `vertical
 - **Persistent status region that repaints in place** (multi-line dashboard, live cost tracker): `make_live()`.
 
 Nested progress inside a Live region is supported by Rich — pass the same `console` (the default) and Rich cooperates automatically.
+
+## Structured logging
+
+Three flags on the top-level `tolokaforge` group control every log line the CLI emits. `configure_root_logging` runs from the group callback before any subcommand executes, installs a single `StructuredFormatter` handler on the root logger, and writes to `sys.stderr`.
+
+| Flag | Effect |
+|------|--------|
+| `--verbose` / `-v` | Root level → `DEBUG`. |
+| `--quiet` / `-q` | Root level → `WARNING`. |
+| `--log-format={pretty,plain,json}` | Line shape. Default: `pretty` when `stderr.isatty()`, `plain` otherwise. |
+
+`-v` and `-q` are mutually exclusive — passing both exits with `UsageError`. Auto-selection considers only `stderr`; `stdout` piping does not switch the mode.
+
+### Line shape
+
+Every line — `pretty` or `plain` — has the shape:
+
+```
+HH:MM:SS.mmm | LEVEL | k=v k=v | message
+```
+
+Scope pairs come from `LogRecord.__dict__` (typically populated via `logger.info(msg, extra={...})` or `StructuredLogger.info(msg, key=val)`). Keys are alphabetically sorted for deterministic output; values that contain whitespace or `|` render via `repr` (`k='hello world'`). Empty scope preserves the double-space middle (`... | INFO |  | message`) so column grep stays trivial.
+
+`pretty` wraps the whole line in an ANSI level colour matching `_display.THEME` — `INFO`=cyan, `WARNING`=yellow, `ERROR`=bold red, `DEBUG`=dim. `plain` emits no ANSI escapes. `json` emits one JSON object per line with keys `{"ts", "level", "logger", "message", "extra"}`; the schema is locked by `tests/canonical/golden/logging/json__*.log`.
+
+### Precedence with subcommand `--verbose`
+
+`run`, `prepare`, `worker`, and `adapter convert` each carry their own `--verbose` flag. It drives the per-trial `logs.yaml` level (via `Orchestrator(verbose=True)` → `StructuredLogger(level=DEBUG)`) and additionally bumps the root console handler to `DEBUG` unless the root `-q` flag is set. Root `-q` always wins on the console; subcommand `--verbose` still records `DEBUG` in `logs.yaml`.
+
+| Root | Subcommand `--verbose` | Console level | `logs.yaml` level |
+|------|------------------------|---------------|-------------------|
+| (none) | (none) | INFO | INFO |
+| `-v` | (none) | DEBUG | INFO |
+| `-q` | (none) | WARNING | INFO |
+| (none) | `--verbose` | DEBUG | DEBUG |
+| `-v` | `--verbose` | DEBUG | DEBUG |
+| `-q` | `--verbose` | WARNING | DEBUG |
+| `-v -q` | (any) | `UsageError` — exit 2 | — |
+
+See [`docs/LOGGING.md`](LOGGING.md) for the full API of `StructuredLogger`, `get_logger`, and `init_trial_logger`, and for the `logs.yaml` on-disk shape.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -99,80 +99,115 @@ logger.error("Failed to load MCP server", path="/path/to/mcp_server.py")
 
 ## CLI Flags
 
-### --verbose
-Enables DEBUG level logging:
+### Root flags — verbosity and line shape
+
+Three flags on the top-level `tolokaforge` group control every log record the CLI emits. They apply to every subcommand and are set before the subcommand runs.
+
+| Flag | Effect |
+|------|--------|
+| `--verbose` / `-v` | Console level → `DEBUG`. |
+| `--quiet` / `-q` | Console level → `WARNING`. |
+| `--log-format={pretty,plain,json}` | Line shape (see § Log stream). Default: `pretty` on a TTY, `plain` otherwise. |
+
+`-v` and `-q` are mutually exclusive; passing both exits with `UsageError`.
 
 ```bash
-# Normal mode (INFO and above)
-tolokaforge run --config config.yaml
+# Debug-level console output
+tolokaforge -v run --config config.yaml
 
-# Verbose mode (DEBUG and above)
-tolokaforge run --config config.yaml --verbose
+# Silence everything below WARNING
+tolokaforge -q run --config config.yaml
+
+# Machine-parseable JSON logs (one object per line, still on stderr)
+tolokaforge --log-format=json run --config config.yaml
 ```
 
-**Use cases:**
-- Debugging task execution
-- Understanding tool behavior
-- Analyzing performance
-- Troubleshooting MCP integration
+### Subcommand `--verbose` on `run` / `prepare` / `worker` / `convert`
 
-### --strict
-Raises RuntimeError on ERROR logs:
+The subcommand `--verbose` flag drives the per-trial `logs.yaml` level (via `Orchestrator(verbose=True)` → `StructuredLogger(level=DEBUG)`) and, when the root `-q` flag is *not* set, additionally bumps the root console handler to `DEBUG` so the terminal shows the same detail.
+
+**Composition rule:** root `-q` wins on the console. Passing `-q ... --verbose` silences the terminal to `WARNING` while `logs.yaml` still records at `DEBUG`.
+
+| Root | Subcommand `--verbose` | Console level | `logs.yaml` level |
+|------|------------------------|---------------|-------------------|
+| (none) | (none) | INFO | INFO |
+| `-v` | (none) | DEBUG | INFO |
+| `-q` | (none) | WARNING | INFO |
+| (none) | `--verbose` | DEBUG | DEBUG |
+| `-v` | `--verbose` | DEBUG | DEBUG |
+| `-q` | `--verbose` | WARNING | DEBUG |
+| `-v -q` | (any) | `UsageError` — exit 2 | — |
+
+### `--strict`
+
+Raises `RuntimeError` on any ERROR-level log so a bad trial aborts immediately.
 
 ```bash
-# Normal mode (logs errors, continues)
-tolokaforge run --config config.yaml
-
-# Strict mode (raises on errors)
+# Fail-fast: any ERROR raises
 tolokaforge run --config config.yaml --strict
 ```
 
-**Use cases:**
-- CI/CD pipelines (fail fast)
-- Development (catch errors immediately)
-- Debugging specific failures
-- Testing error handling
+Use in CI, when validating golden sets, or when debugging a single failing trial. Combine with root `-v` for maximum visibility on the failure.
 
-### Combined
+## Log stream
+
+Every tolokaforge log record — the stdlib `logging` records from `tolokaforge.docker.*`, `tolokaforge.adapters.*`, `tolokaforge.core.*`, and the `StructuredLogger` records surfaced by `orchestrator` / `runner` / `output_writer` — writes to `sys.stderr` through the single root handler installed by `configure_root_logging`. `sys.stdout` is reserved for the machine-parseable artifact path a later milestone introduces (issue #280).
+
+Pipe with `2>&1` when you want log lines in a text capture:
+
 ```bash
-tolokaforge run --config config.yaml --verbose --strict
+tolokaforge run --config config.yaml 2>&1 | tee run.log
 ```
 
-**Use cases:**
-- Maximum visibility + fail-fast behavior
-- Debugging complex issues
-- Validating golden sets
+For a machine consumer, prefer `--log-format=json` — each line is a single JSON object with the schema documented in § Log Output Structure below, still on stderr.
 
 ## Log Output Structure
 
 ### Console Output
+
+Every root-formatter line has the shape `HH:MM:SS.mmm | LEVEL | k=v k=v | message` with alphabetically sorted scope pairs and millisecond-resolution local time. The three modes selected by `--log-format` differ only in the wrapper:
+
+- **`pretty`** (default on a TTY) — the whole line is wrapped in an ANSI level colour: `INFO`=cyan, `WARNING`=yellow, `ERROR`=bold red, `DEBUG`=dim. Colours match `tolokaforge.cli._display.THEME`.
+- **`plain`** (default on a pipe) — identical layout, no ANSI escape codes. Safe for `grep -F`.
+- **`json`** — one JSON object per line, keys `{"ts", "level", "logger", "message", "extra"}`.
+
+Empty scope preserves the double-space middle so column grep stays trivial:
+
 ```
-2025-11-24 15:22:50 - trial-123:0 - INFO - Starting trial execution (task_id=task-123,  trial_index=0, max_turns=50)
-2025-11-24 15:22:51 - trial-123:0 - DEBUG - Agent response received (turn=0, prompt_tokens=8450, completion_tokens=215, reasoning_tokens=0, cache_read_input_tokens=7800)
-2025-11-24 15:22:52 - trial-123:0 - WARNING - Tool execution failed (tool=get_user, error=not found)
-2025-11-24 15:22:53 - trial-123:0 - INFO - Trial execution finished (status=completed, turns=5, latency_s=3.2)
+14:30:00.500 | INFO |  | trial started
+14:30:00.500 | INFO | judge=kimi-k2 run_id=abc sample=42 | trial started
+14:30:00.500 | WARNING | error='not found' tool=get_user | tool execution failed
 ```
 
-### JSON Output (logs.json)
-```json
-{
-  "trial_id": "task-123:0",
-  "total_logs": 45,
-  "logs": [
-    {
-      "timestamp": "2025-11-24T15:22:50.185275",
-      "level": "INFO",
-      "module": "task-123:0",
-      "message": "Starting trial execution",
-      "context": {
-        "task_id": "task-123",
-        "trial_index": 0,
-        "max_turns": 50
-      }
-    }
-  ]
-}
+Values that contain whitespace or `|` render via `repr` (`k='hello world'`, `k='pipe|here'`) so the delimiter stays unambiguous.
+
+### JSON output on the wire (`--log-format=json`)
+
 ```
+{"ts": "14:30:00.500", "level": "INFO", "logger": "tolokaforge.orch", "message": "trial started", "extra": {"judge": "kimi-k2", "run_id": "abc", "sample": 42}}
+```
+
+The `{ts, level, logger, message, extra}` shape is locked by canonical goldens (`tests/canonical/golden/logging/json__*.log`). A schema change requires a CHANGELOG entry and updated goldens in the same commit.
+
+### On-disk YAML output (`logs.yaml`)
+
+Every trial's `StructuredLogger` writes its collected records to `<trial_dir>/logs.yaml` via `save_to_file`:
+
+```yaml
+trial_id: task-123:0
+total_logs: 45
+logs:
+- timestamp: '2026-07-14T15:22:50.185275+00:00'
+  level: INFO
+  module: task-123:0
+  message: Starting trial execution
+  context:
+    task_id: task-123
+    trial_index: 0
+    max_turns: 50
+```
+
+Timestamps are UTC ISO-8601 with microsecond precision — a distinct shape from the console line's `HH:MM:SS.mmm`. The on-disk YAML keys `{timestamp, level, module, message, context}` are a separate contract from the JSON-on-the-wire keys `{ts, level, logger, message, extra}`; see [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md) § `logs.yaml`.
 
 ## Logger Registry
 

--- a/docs/plans/2026-07-14-issue-279-a3-structured-log-format.md
+++ b/docs/plans/2026-07-14-issue-279-a3-structured-log-format.md
@@ -1,0 +1,274 @@
+# Plan: A3 — Structured log format with `--verbose`/`--quiet`
+
+Issue: Toloka/tolokaforge#279 (milestone: Terminal DX, umbrella #297)
+Branch: `feat/issue-279-a3-structured-log-format` (branches off `feat/terminal-dx`, PR targets `feat/terminal-dx`)
+
+## Context
+
+The CLI's log output today is fragmentary. Three separate paths render logs, none share a format, all default to noisy INFO+context on the console:
+
+- **stdlib** `logging.getLogger(__name__)` (used by `tolokaforge/docker/*`, `tolokaforge/adapters/*`, `tolokaforge/core/*`) — records emitted via `logger.info(msg, extra={...})`. **The `extra` payload is attached to `LogRecord.__dict__` but the current formatter never renders it.** No process-wide handler configuration exists in the CLI entrypoint; records reach `logging.lastResort` or a per-caller `basicConfig`. Reproduced with `run_python`:
+
+  ```
+  2026-07-14 19:54:03 - tolokaforge.demo - INFO - Loaded          # extra={"judge": "kimi-k2"} silently dropped
+  ```
+
+- **`StructuredLogger`** (`tolokaforge/core/logging.py:16`) — used by `orchestrator`, `runner/core`, `output_writer`, adapters. Owns its own `StreamHandler(sys.stdout)` (`logging.py:48`) with the legacy format `"%(asctime)s - %(name)s - %(levelname)s - %(message)s"` and `datefmt="%Y-%m-%d %H:%M:%S"` (seconds resolution, no msec). Sets `propagate = False`, so it bypasses any root handler. Inlines context kwargs into the message string (`_log` → `f"{message} ({k=v, k=v})"`), producing:
+
+  ```
+  2026-07-14 19:54:03 - trial:0 - INFO - Processing trial (task_id=task-123, trial_index=0)
+  ```
+
+- **Ad-hoc `logging.basicConfig` sites** — `tolokaforge/cli/adapter_commands.py:46` (when `convert --verbose`), `tolokaforge/runner/__main__.py:55`, `tolokaforge/env/rag_service/app.py:35`, plus a duplicate `docker_logger` handler installed inside `Orchestrator.__init__` at `orchestrator.py:280-290`. Each pins the legacy format.
+
+There is no root-level flag surface for verbosity. Every subcommand (`run`, `prepare`, `worker`, `convert`) has its own `--verbose` flag (`main.py:158,328,385`, `adapter_commands.py:35`) whose semantics differ: on `run/prepare/worker` it flows into `Orchestrator(verbose=…)` → `StructuredLogger(level=DEBUG)`; on `convert` it fires a bare `logging.basicConfig(level=DEBUG)`.
+
+A1 (#276) shipped the shared `_display.console` (stderr, THEME, `soft_wrap=True`). The canonical grep-guard `tests/canonical/test_cli_display_invariants.py::test_no_ad_hoc_console_in_cli` forbids new `rich.Console(...)` constructions in `tolokaforge/cli/*` — A3 must reuse the shared surface for coloured output.
+
+## Goal
+
+One structured formatter, one root logging bootstrap, one authoritative root flag surface.
+
+- New `StructuredFormatter(logging.Formatter)` in `tolokaforge/core/logging.py` emits three shapes:
+  - **pretty** (default when `sys.stderr.isatty()`): `HH:MM:SS.mmm | LEVEL | k=v k=v | message`, with ANSI colours mapped from A1's `THEME` — `INFO=cyan`, `WARNING=yellow`, `ERROR=bold red`, `DEBUG=dim`. Message text stays uncoloured so downstream `grep` on the message survives.
+  - **plain** (default when `sys.stderr` is not a TTY): identical layout with no ANSI escape codes.
+  - **json** (opt-in): one JSON object per line — `{"ts": "HH:MM:SS.mmm", "level": "INFO", "logger": "tolokaforge.orchestrator", "message": "...", "extra": {...}}`. Every line parses with `json.loads`.
+- One public function `configure_root_logging(level, log_format, stream=sys.stderr) -> None` installs / replaces the root handler. Idempotent. Sets `logging.getLogger()` handler to a `StreamHandler(stream)` with `StructuredFormatter(mode=…)`.
+- New root CLI flags on the `cli` group:
+  - `--verbose / -v` → DEBUG.
+  - `--quiet / -q` → WARNING only.
+  - `--log-format={pretty,plain,json}` — `pretty` on TTY, `plain` on non-TTY, `json` opt-in.
+  - Precedence: rejecting `--verbose` and `--quiet` together with `click.UsageError`; otherwise `-q > default > -v`.
+- The group callback runs before every subcommand and calls `configure_root_logging(...)`.
+- `StructuredLogger` is rewired to route through root — its `.info(msg, key=val)` call becomes `self.logger.log(level, msg, extra={sanitized})` with `propagate = True`. The `.logs[]` list and `save_to_file()` YAML output stay bit-identical. The private handler / private formatter go away.
+- The `docker_logger` handler in `Orchestrator.__init__` (a duplicate legacy formatter) is deleted; the root handler covers `tolokaforge.docker.*` via propagation.
+- The `logging.basicConfig` in `adapter_commands.py:46` goes away — the root formatter already handles the subcommand's `--verbose`.
+
+Canonical golden files pin the exact rendered bytes per mode. A JSON-parseability test asserts `json.loads(line)` returns the expected shape.
+
+## Non-goals
+
+- **Runner container / RAG env service structured logging.** Both are separate processes (`runner/__main__.py`, `env/rag_service/app.py`) whose logging is set up before the CLI's group callback would ever run. Filed as #308 (runner) and #309 (rag service). Out of A3's process scope.
+- **Env-var overrides for log format** (`TOLOKAFORGE_LOG_FORMAT=…`). B2 (#282) owns the `--display` env-var protocol and can extend the same protocol to `--log-format` in a follow-up. A3 wires only the CLI flags.
+- **Deleting the subcommand `--verbose` flags** on `run/prepare/worker/convert`. They flow into `Orchestrator(verbose=…)` and set the *trial* log level, which is a distinct axis (per-trial `StructuredLogger.level` in `save_to_file` output). Kept as-is; deprecation is a separate hygiene follow-up.
+- **A4's `stdout=artifact` split (#280).** A3 writes exclusively to stderr — that's compatible with A4's future contract, but A3 does not itself carve out the stdout channel or touch the run-dir print path.
+- **B2's `--display` toggle (#282).** `--display=log` is a *display mode*; `--log-format={pretty,plain,json}` is a *line shape*. Orthogonal axes. B2 will consume A3's `configure_root_logging(…, log_format="plain")` when `--display=log` picks the log-only mode.
+- **Removing `StructuredLogger` in favour of stdlib.** Deferred; #279 preserves the class semantics per the issue's Notes.
+
+## Target formatter and configuration surface
+
+```python
+# tolokaforge/core/logging.py
+
+class LogFormat(str, Enum):
+    PRETTY = "pretty"
+    PLAIN = "plain"
+    JSON = "json"
+
+
+class StructuredFormatter(logging.Formatter):
+    """Renders LogRecord in one of three modes.
+
+    Layout (pretty & plain):
+
+        HH:MM:SS.mmm | LEVEL | k1=v1 k2=v2 | message
+
+    - Time is millisecond-resolution local time by default; ``clock`` may
+      inject a deterministic ``datetime`` factory for tests.
+    - Scope pairs are every ``LogRecord.__dict__`` key that is NOT one of
+      stdlib's built-in record attributes (computed once against a
+      canonical ``_LOG_RECORD_RESERVED`` set). Keys are alphabetically
+      sorted for deterministic golden files. Values render via ``repr``
+      when they contain whitespace or ``|``, else bare.
+    - When there are no scope pairs the middle segment is empty:
+      ``HH:MM:SS.mmm | LEVEL |  | message`` (double-space preserved so
+      column grep is trivial).
+
+    JSON mode emits one JSON object per line with keys:
+    ``{"ts", "level", "logger", "message", "extra"}``. ``extra`` is the
+    same scope-pair dict; missing extras render as ``{}``. Non-JSONable
+    values fall back to ``repr``.
+    """
+
+    def __init__(
+        self,
+        mode: LogFormat,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        use_colour: bool | None = None,  # None means: auto from mode (pretty=True, else False)
+    ) -> None: ...
+
+    def format(self, record: logging.LogRecord) -> str: ...
+
+
+def configure_root_logging(
+    *,
+    level: int = logging.INFO,
+    log_format: LogFormat | None = None,   # None = auto-select from stream.isatty()
+    stream: TextIO | None = None,          # default: sys.stderr
+) -> None:
+    """Install (or replace) the tolokaforge root log handler.
+
+    Idempotent: if a previous tolokaforge handler is installed (detected
+    via a sentinel attribute on the handler), it is removed before the
+    new one is added. Sets ``logging.root.level`` and returns nothing.
+    """
+```
+
+Rendering contract for scope pairs:
+
+- Reserved LogRecord attributes not rendered: `name, msg, args, levelname, levelno, pathname, filename, module, exc_info, exc_text, stack_info, lineno, funcName, created, msecs, relativeCreated, thread, threadName, processName, process, message, taskName, asctime` (canonical set — locked by a unit test that constructs a blank LogRecord and reads its `__dict__`).
+- Any `_`-prefixed keys are also skipped as a general defensive rule (private attributes and any accidental leakage of internal sentinels). Note: the `_FACTORY_SENTINEL` used by `tolokaforge/secrets/log_filter.py:133` is set on the *factory function object*, not on `LogRecord.__dict__`, so it never appears as a scope key — but the `_`-prefix rule covers any similar future case.
+- Ordering: alphabetical (stable, deterministic goldens).
+
+## Design decision: subcommand `--verbose` × root `-v/-q` composition
+
+Two axes carry the name `--verbose`: the root flag on `cli` (console log level) and the per-subcommand flag on `run/prepare/worker/convert` (per-trial `StructuredLogger.level` inside the orchestrator, which lands in `<trial>/logs.yaml`).
+
+**Decision: option (a) — symmetric.** Subcommand `--verbose` on `run/prepare/worker/convert` continues to bump the console log level to DEBUG, matching today's behaviour (`Orchestrator(verbose=True)` currently produces visible DEBUG on the console because `StructuredLogger` owns its own stdout handler at DEBUG). After the rewire in Stage 2, `StructuredLogger` propagates through root — so the subcommand flag must explicitly bump the root handler to keep console DEBUG visible.
+
+Rationale: users today read `tolokaforge run --verbose` as "give me DEBUG on the terminal". Silently dropping that behaviour (option b) would be a regression at the user-facing surface even if the flag continues to affect `logs.yaml`. Symmetric also aligns `run/prepare/worker` with `convert` (which already forces DEBUG on console when `--verbose` is set).
+
+**Precedence table** (locked by parametrized tests in Stage 2):
+
+| Root flag | Subcommand `--verbose` | Console level | `logs.yaml` level |
+|-----------|------------------------|---------------|-------------------|
+| (none)    | (none)                 | INFO          | INFO              |
+| `-v`      | (none)                 | DEBUG         | INFO              |
+| `-q`      | (none)                 | WARNING       | INFO              |
+| `-v` `-q` | any                    | exit 2 with `UsageError("--verbose and --quiet are mutually exclusive")` | — |
+| (none)    | `--verbose`            | DEBUG         | DEBUG             |
+| `-v`      | `--verbose`            | DEBUG         | DEBUG             |
+| `-q`      | `--verbose`            | WARNING (root `-q` wins on console) | DEBUG |
+
+The rule for the last row: root `-q` is *explicit* user intent to silence the console; subcommand `--verbose` still affects the orchestrator's per-trial logger (and therefore `logs.yaml`), but does not override the root's console-quiet decision. Implementation: subcommand handlers pass their `--verbose` value into `Orchestrator(verbose=…)` unconditionally, and additionally call `configure_root_logging(level=DEBUG)` only when the click context's root-level flag was not `-q`. A tiny helper on the click `ctx.obj` (`ctx.obj["root_quiet"] = True/False`) records the root's decision so subcommands can inspect it.
+
+## Stages
+
+Every stage lands as one commit, has its own tests that would fail without the stage, and updates the docs that describe *current state*.
+
+### Stage 1: `StructuredFormatter` + `configure_root_logging` (formatter only, not yet wired)
+
+- **Contract:** the two symbols above (`StructuredFormatter`, `configure_root_logging`, and the `LogFormat` enum) are added to `tolokaforge/core/logging.py`. No production caller is changed yet.
+- **Behaviour to lock (tier: `unit`):**
+  - `StructuredFormatter(mode=PLAIN, clock=fixed).format(record_bare)` returns exactly `"14:30:00.500 | INFO |  | started"` (double-space around empty scope segment).
+  - `StructuredFormatter(mode=PLAIN, clock=fixed).format(record_with_extra)` returns `"14:30:00.500 | INFO | judge=kimi-k2 run_id=abc sample=42 | trial started"` — keys alphabetically sorted.
+  - `StructuredFormatter(mode=JSON, clock=fixed).format(record_with_extra)` produces exactly one JSON object; `json.loads(line)` returns `{"ts": "14:30:00.500", "level": "INFO", "logger": "tolokaforge.orch", "message": "trial started", "extra": {"judge": "kimi-k2", "run_id": "abc", "sample": 42}}`.
+  - `StructuredFormatter(mode=PRETTY, clock=fixed).format(record_info)` starts with `"\x1b[36m14:30:00.500"` (cyan escape code for INFO), ends with the same message payload plus a reset (`"\x1b[0m"`).
+  - `configure_root_logging(level=DEBUG, log_format=None, stream=<pipe>)` — with a non-TTY stream — auto-selects `PLAIN`. Called twice, only one handler is present on `logging.root` (idempotence).
+  - **isatty auto-selection (both directions).** Two tests using in-memory fake streams (no `sys.stderr` monkeypatching):
+    - `configure_root_logging(log_format=None, stream=fake_tty)` where `fake_tty` is a `StringIO`-like object with `isatty=lambda: True` → the installed handler's formatter mode is `PRETTY`.
+    - `configure_root_logging(log_format=None, stream=fake_pipe)` where `fake_pipe.isatty` returns `False` → mode is `PLAIN`.
+  - Scope pairs are filtered against the canonical reserved-attribute set — a synthetic `LogRecord` with every reserved key set to a distinguishable value renders `k=v | message` with no reserved leakage.
+  - Values containing whitespace or `|` render via `repr` (`k='hello world'` / `k='pipe|here'`).
+  - `_`-prefixed extra keys are dropped (defensive rule): a record with `LogRecord.__dict__["_internal"] = "hidden"` renders with no `_internal=…` pair.
+- **Compatibility:** internal only — no CLI or public API changes yet. New symbols are additive.
+- **Deliverable:**
+  - `tolokaforge/core/logging.py` gains `LogFormat`, `StructuredFormatter`, `configure_root_logging`, and the reserved-attribute set as a module-level frozenset.
+  - `tests/unit/test_logging_formatter.py` (new file).
+- **Validation:** `dev.run_tests(marker="unit", pattern="test_logging_formatter")`; ruff clean.
+- **Doc updates:** none in this stage (docs get updated in Stage 3 when the flags land).
+
+### Stage 2: Root CLI flags + wiring + StructuredLogger rewire + legacy cleanups
+
+- **Contract:**
+  - `@cli.command()` group `cli` in `tolokaforge/cli/main.py` gains:
+    - `--verbose / -v` — flag, mutually exclusive with `--quiet`.
+    - `--quiet / -q` — flag.
+    - `--log-format` — `click.Choice(["pretty", "plain", "json"], case_sensitive=False)`, default `None` (auto).
+    - Precedence: both set → `click.UsageError("--verbose and --quiet are mutually exclusive")`. Otherwise level resolves to `WARNING` (`-q`) / `DEBUG` (`-v`) / `INFO` (neither).
+    - The group's callback (`cli()`) calls `configure_root_logging(level=…, log_format=…)` before any subcommand runs, and stores the resolved decision on `ctx.obj` (at minimum: `ctx.obj["root_quiet"] = bool`, `ctx.obj["root_verbose"] = bool`) so subcommands can honour it.
+    - `install_global_redactor()` continues to run — the redacting record factory sits *upstream* of the new formatter, so secret scrubbing keeps working.
+  - `StructuredLogger._log(...)` in `tolokaforge/core/logging.py` — its stdlib delegate call becomes `self.logger.log(log_level, message, extra=self._sanitize_extra(full_context))`; the appended `" ({k=v, ..})"` string is removed. `self.logger.propagate` is flipped to `True` and the private `StreamHandler` in `__init__` is deleted. `_sanitize_extra` renames any key that collides with a reserved LogRecord attribute (prefix `ctx_`) so `.extra=` never raises.
+  - Duplicate `docker_logger` handler installation in `tolokaforge/core/orchestrator.py:280-290` is deleted — the root handler receives its records via propagation. `docker_logger.setLevel(log_level)` stays (per-namespace threshold) but no handler / formatter attached.
+  - `logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)` at `tolokaforge/cli/adapter_commands.py:46` is deleted — the root formatter handles it.
+  - **Subcommand `--verbose` wiring (symmetric, option a — see "Design decision" section above).** On `run/prepare/worker/convert`, when `--verbose` is set: the handler passes `verbose=True` to `Orchestrator` (unchanged; drives per-trial `logs.yaml` level) AND — provided `ctx.obj["root_quiet"]` is `False` — calls `configure_root_logging(level=logging.DEBUG)` to bump the root handler so console DEBUG is visible. If root `-q` was set, the console call is skipped (root wins on console suppression); the orchestrator still gets `verbose=True`.
+- **Behaviour to lock (tier: `unit`):**
+  - **Composition matrix** (parametrized test — each row spies via a `logging.Handler` attached AFTER group callback returns, and inspects both the spy's captured records AND the trial-level `logs.yaml` where relevant):
+    - `["-v", "run", ...]` → spy sees a DEBUG record (root level = DEBUG).
+    - `["-q", "run", ...]` → spy does NOT see an INFO record; sees WARNING (root level = WARNING).
+    - `["-v", "-q", "run", ...]` → exit code 2, stderr contains `--verbose and --quiet are mutually exclusive`.
+    - `["-v", "run", "--verbose", ...]` → spy sees DEBUG record; `Orchestrator(verbose=True)` invoked (asserted via a mocked constructor or via a run-fixture that captures the ctor kwargs).
+    - `["-q", "run", "--verbose", ...]` → spy does NOT see any DEBUG or INFO record (root `-q` wins on console); AND `Orchestrator(verbose=True)` is still invoked (subcommand verbose still affects per-trial output).
+    - `["run", "--verbose", ...]` (no root flag) → spy sees DEBUG record (subcommand verbose bumps console to DEBUG when root neither -v nor -q); `Orchestrator(verbose=True)` invoked.
+    - Repeat the two subcommand-verbose bumping rows for `prepare --verbose`, `worker --verbose`, and `convert --verbose` so all four subcommands are locked symmetrically.
+  - `CliRunner().invoke(cli, ["--log-format", "json", "--help"])` — help exits cleanly (proves the option parses).
+  - `StructuredLogger("orch").info("hello", task_id="t1")` produces a stdlib `LogRecord` whose `__dict__["task_id"] == "t1"`. `StructuredLogger.logs[0]["context"]["task_id"] == "t1"` (in-memory list unchanged).
+  - After `configure_root_logging(log_format=PLAIN)`, calling `logging.getLogger("tolokaforge.demo").info("started", extra={"k": "v"})` emits exactly one line to stderr matching `r"^\d\d:\d\d:\d\d\.\d\d\d \| INFO \| k=v \| started$"`.
+  - **`tolokaforge.docker.*` records reach root exactly once** after the orchestrator no longer installs its own handler. Concrete assertion: with a single spy handler attached to `logging.root`, `docker_logger.info("pulled image")` produces `captured_lines.count("pulled image") == 1`. This locks *absence-of-double* — a future refactor that re-adds a docker-namespace handler would produce `count == 2` and fail this test.
+- **Compatibility:**
+  - **Root CLI flag surface** is a compatibility surface. Added flags are additive; `--verbose`/`--quiet` mutual exclusion is documented in `--help` and `docs/CLI.md` (Stage 3). No existing subcommand flag is removed.
+  - **`StructuredLogger` public API** unchanged: method signatures, `.logs` list, `save_to_file()` output, strict-mode raise semantics — all bit-identical. The change is internal (private handler removal + `extra=` routing). Migration note: none needed — no caller reads the private handler.
+  - **`StructuredLogger` on-console rendering** changes shape (from `"msg (k=v, k=v)"` to root-formatter's `"HH:MM:SS.mmm | INFO | k=v k=v | msg"`). Console output is not a compatibility surface (no test asserts on it today; no external contract). Documented in `docs/LOGGING.md` (Stage 3).
+  - **StructuredLogger console output moves from `sys.stdout` (current `tolokaforge/core/logging.py:48`) to `sys.stderr`** via the new root handler — aligned with A4's stdout carveout (#280). Downstream consumers that piped tolokaforge's stdout to capture log lines will now see them on stderr. Documented in `docs/LOGGING.md` and `CHANGELOG.md` (Stage 3); called out explicitly in the PR body so any external stdout-consumers can adjust.
+  - **Subcommand `--verbose` × root `-q` interaction** is a new documented behaviour (see "Design decision" section). Locked by the composition matrix test above.
+- **Deliverable:**
+  - `tolokaforge/cli/main.py` — group flags + `configure_root_logging(...)` call in `cli()` body; `ctx.obj["root_quiet"]` / `ctx.obj["root_verbose"]` stashed.
+  - `tolokaforge/cli/main.py` — `run`, `prepare`, `worker` subcommand handlers gain the honour-root-quiet subcommand-verbose bump: `if verbose and not ctx.obj["root_quiet"]: configure_root_logging(level=logging.DEBUG)`.
+  - `tolokaforge/cli/adapter_commands.py` — same subcommand-verbose bump on `convert`; the existing `logging.basicConfig` at line 46 is deleted.
+  - `tolokaforge/core/logging.py` — `StructuredLogger._log`, `_sanitize_extra`, `__init__` no longer install a handler, `propagate = True`.
+  - `tolokaforge/core/orchestrator.py:280-290` — deleted (kept the `setLevel` line if it survives review).
+  - `tests/unit/test_logging_cli_flags.py` (new) — parametrized composition matrix.
+  - `tests/unit/test_logging.py` — update `test_structured_logger_basic` if it starts asserting on the private handler (spot check; today's assertions are on `.logs[]` only, so no change expected).
+- **Validation:** `dev.run_tests(marker="unit", pattern="test_logging")`; smoke `uv run tolokaforge --help` and `uv run tolokaforge -v run --help` both exit 0 with expected flag lines.
+- **Doc updates:** none yet; docs land in Stage 3 with the golden file.
+
+### Stage 3: Canonical golden files + docs rewrite
+
+- **Contract:** golden files pin exact rendered bytes per mode and lock the JSON schema.
+- **Behaviour to lock (tier: `canonical`):**
+  - `tests/canonical/golden/logging/pretty__scoped.log` — one line, ANSI-included, with the exact text produced by `StructuredFormatter(PRETTY, clock=fixed_20260714_143000_500)` for a record with logger `tolokaforge.orch`, level `INFO`, message `trial started`, and `extra={"judge": "kimi-k2", "sample": 42, "run_id": "abc"}`.
+  - `tests/canonical/golden/logging/plain__scoped.log` — same record, plain mode.
+  - `tests/canonical/golden/logging/json__scoped.log` — one JSON line, same record.
+  - `pretty__bare.log`, `plain__bare.log`, `json__bare.log` — same records without any extras.
+  - `pretty__warning.log`, `pretty__error.log`, `pretty__debug.log` — the three other levels (locks the ANSI palette).
+  - `pretty__reserved_collision.log` — a record whose extras include a key that shadows a reserved LogRecord attribute (e.g. `extra={"module": "shadowed"}`) — locks the `_sanitize_extra` `ctx_module` rename.
+  - `tests/canonical/test_logging_golden.py` compares each generated line byte-for-byte against the golden. JSON files additionally round-trip through `json.loads` before diffing (so trailing-newline drift doesn't leak into the comparison).
+  - JSON parseability assertion: for every JSON golden, `json.loads(open(path).read().rstrip("\n"))` returns a dict with exactly the keys `{"ts", "level", "logger", "message", "extra"}` and expected values.
+- **Compatibility:**
+  - **JSON schema** is a compatibility surface — machine consumers will grep. The `{ts, level, logger, message, extra}` shape is locked here; a schema change in a future PR needs a CHANGELOG entry and doc update.
+  - **Pretty/plain layout** is a compatibility surface for grep patterns; column shape (`HH:MM:SS.mmm | LEVEL | k=v | message`) is locked by the golden files.
+- **Deliverable:**
+  - `tests/canonical/golden/logging/*.log` — 10 golden files (3 modes × {bare, scoped} + pretty {warning, error, debug, reserved_collision}).
+  - `tests/canonical/test_logging_golden.py` (new).
+  - `docs/CLI.md` — new section **"Log format & verbosity"** documenting the three root flags, precedence, auto-selection, and the exact `HH:MM:SS.mmm | LEVEL | k=v | message` line contract. Rewrite: this reads as if the new format is the only format that ever existed — no "previously" or "as of A3".
+  - `docs/LOGGING.md` — rewrite § **Console Output** (line 148 today) to show the new format; rewrite § **CLI Flags** (line 100) to document the root `-v/-q/--log-format` surface and describe the subcommand `--verbose` × root `-q` composition rule (root `-q` wins on console; subcommand `--verbose` still drives `logs.yaml`). Add a one-paragraph § **Log stream** noting that all tolokaforge log output goes to `sys.stderr` — including records that historically went to `sys.stdout` via `StructuredLogger`.
+  - `CHANGELOG.md` — two lines:
+    - "Structured log format (`HH:MM:SS.mmm | LEVEL | k=v | msg`) with root `--verbose`/`--quiet`/`--log-format`. See docs/CLI.md."
+    - "BREAKING (observable): `StructuredLogger` console output now goes to `sys.stderr` (previously `sys.stdout`). Downstream stdout-consumers should switch to `2>&1` or `--log-format=json` on stderr."
+- **Validation:** `dev.run_tests(marker="canonical", pattern="test_logging_golden")`; grep every doc for stale format strings (`rg "%(asctime)s"` in `docs/` should return zero hits after the rewrite).
+
+## Test strategy
+
+- **Fixed-clock injection.** `StructuredFormatter.__init__` accepts an optional `clock: Callable[[], datetime]` argument (default: `lambda: datetime.now()`). Tests instantiate with `clock=lambda: datetime(2026, 7, 14, 14, 30, 0, 500_000)` — millisecond precision baked into a stable ISO instant. Golden files are generated once against this clock.
+- **isatty auto-selection uses fake streams — no `sys.stderr` monkeypatching.** Both directions covered:
+  - Pretty: a lightweight stub with `write=…, flush=…, isatty=lambda: True` is passed as `stream=` — `configure_root_logging(log_format=None, stream=fake_tty)` selects `PRETTY`.
+  - Plain: same stub with `isatty=lambda: False` — selects `PLAIN`.
+  This avoids process-global `sys.stderr` monkeypatching flakiness and keeps the tests deterministic in parallel test runs.
+- **ANSI escape assertions.** Pretty-mode goldens include raw ANSI. `test_logging_formatter.py` asserts the level-prefix escape codes (`\x1b[36m` for INFO, `\x1b[33m` for WARN, `\x1b[1;31m` for ERROR, `\x1b[2m` for DEBUG) and the trailing `\x1b[0m`.
+- **Golden regeneration** guard: `dev.update_canonical_snapshots` is the escape hatch; the test invokes the formatter with the fixed clock, so regeneration is deterministic.
+- **Redaction interaction.** `test_logging_formatter_redaction.py` — install `SecretManager` with a fake secret, emit a record containing that secret, assert the formatted line has `***REDACTED***` and no leak. Locks the invariant that the record factory scrubs before the formatter renders.
+- **CliRunner assertions on level.** `test_logging_cli_flags.py` uses a spy handler attached after `configure_root_logging` returns, so it reads the fully installed handler chain rather than intercepting mid-configuration.
+- **Orchestrator constructor capture.** The composition-matrix rows that assert `Orchestrator(verbose=True)` was invoked use a `monkeypatch.setattr` on `Orchestrator.__init__` (or a light shim that records the `verbose` kwarg) rather than running a real orchestrator — cheap, deterministic, needs no LLM/docker.
+- **Docker-namespace absence-of-double.** The docker propagation test attaches exactly one spy `Handler` to `logging.root`, emits one record via `docker_logger.info("pulled image")`, and asserts `captured_lines.count("pulled image") == 1`. Locks that no docker-namespace handler is re-added silently in the future.
+
+## Discovered issues
+
+- **Fix in this PR (Stage 2):**
+  - Delete duplicate `docker_logger` handler installation in `tolokaforge/core/orchestrator.py:280-290`. Today it forces the legacy format on every `tolokaforge.docker.*` record and would double-render alongside the new root formatter.
+  - Delete `logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)` at `tolokaforge/cli/adapter_commands.py:46`. Root formatter subsumes it; the subcommand `--verbose` calls `configure_root_logging(level=DEBUG)` instead.
+- **Filed as issues:**
+  - **#308** — Runner container (`tolokaforge/runner/__main__.py:55`) bypasses `--log-format`; needs env-var propagation.
+  - **#309** — RAG env service (`tolokaforge/env/rag_service/app.py:35`) same class of drift.
+- **Deferred / not in scope:**
+  - Deleting `--verbose` on `run/prepare/worker/convert` — kept for back-compat (per-trial log-level knob). Future hygiene issue.
+  - Env-var equivalents for `--log-format` — B2 (#282) territory.
+
+## Risks / open questions
+
+- **Line-shape lock is a compatibility surface.** Once a machine consumer greps `HH:MM:SS.mmm | INFO | ...`, changing the delimiter (e.g. two-space vs single-pipe) breaks them. Locked by canonical goldens; changes need a CHANGELOG entry.
+- **JSON key stability.** `{ts, level, logger, message, extra}` chosen deliberately: `logger` (not `module`) matches the stdlib attribute; `extra` (not `context`) matches `logger.info(msg, extra=…)` idiom. Deviating from `StructuredLogger.save_to_file()`'s `{timestamp, level, module, message, context}` shape — that on-disk YAML is a separate contract (`docs/OUTPUT_FORMAT.md`) and stays unchanged. **Open question:** should the on-disk YAML shape converge on the same key names in a follow-up? Recommend yes (separate PR, semver-aware) — out of A3's scope.
+- **ANSI on Windows CMD.** Modern Windows Terminal handles ANSI, but classic `cmd.exe` does not. `sys.stderr.isatty()` returns True in both. Users on classic `cmd.exe` see raw escape codes — the escape hatch is `--log-format=plain`. Documented explicitly.
+- **Rich soft-wrapping vs pipe safety.** A1's `_display.console` is `soft_wrap=True`. The new handler writes to `sys.stderr` (the raw stream, not through Rich), so it is unaffected by soft-wrap policy. Consistent with the "structured, greppable" goal — Rich's wrapping would break `grep -F`.
+- **B2 collision.** B2's `--display={full,rich,plain,log,none}` is a display-mode selector; A3's `--log-format={pretty,plain,json}` is a line-shape selector. No name overlap; both may coexist. Document the composition rule in B2.
+- **Subcommand `--verbose` semantics.** Resolved (see "Design decision" section): option (a) symmetric — subcommand `--verbose` on `run/prepare/worker/convert` bumps both `Orchestrator(verbose=True)` (per-trial `logs.yaml` DEBUG) AND, when root `-q` is not set, the root handler to DEBUG so console output stays consistent with today's behaviour. Root `-q` wins on console suppression. Documented in `docs/LOGGING.md`; locked by the Stage 2 composition matrix test. Renaming one of the two flags to disambiguate the axes is a separate hygiene follow-up.

--- a/tests/canonical/golden/logging/json__bare.log
+++ b/tests/canonical/golden/logging/json__bare.log
@@ -1,0 +1,1 @@
+{"ts": "14:30:00.500", "level": "INFO", "logger": "tolokaforge.orch", "message": "trial started", "extra": {}}

--- a/tests/canonical/golden/logging/json__scoped.log
+++ b/tests/canonical/golden/logging/json__scoped.log
@@ -1,0 +1,1 @@
+{"ts": "14:30:00.500", "level": "INFO", "logger": "tolokaforge.orch", "message": "trial started", "extra": {"judge": "kimi-k2", "run_id": "abc", "sample": 42}}

--- a/tests/canonical/golden/logging/plain__bare.log
+++ b/tests/canonical/golden/logging/plain__bare.log
@@ -1,0 +1,1 @@
+14:30:00.500 | INFO |  | trial started

--- a/tests/canonical/golden/logging/plain__scoped.log
+++ b/tests/canonical/golden/logging/plain__scoped.log
@@ -1,0 +1,1 @@
+14:30:00.500 | INFO | judge=kimi-k2 run_id=abc sample=42 | trial started

--- a/tests/canonical/golden/logging/pretty__bare.log
+++ b/tests/canonical/golden/logging/pretty__bare.log
@@ -1,0 +1,1 @@
+[36m14:30:00.500 | INFO |  | trial started[0m

--- a/tests/canonical/golden/logging/pretty__debug.log
+++ b/tests/canonical/golden/logging/pretty__debug.log
@@ -1,0 +1,1 @@
+[2m14:30:00.500 | DEBUG |  | trial started[0m

--- a/tests/canonical/golden/logging/pretty__error.log
+++ b/tests/canonical/golden/logging/pretty__error.log
@@ -1,0 +1,1 @@
+[1;31m14:30:00.500 | ERROR |  | trial started[0m

--- a/tests/canonical/golden/logging/pretty__reserved_collision.log
+++ b/tests/canonical/golden/logging/pretty__reserved_collision.log
@@ -1,0 +1,1 @@
+[36m14:30:00.500 | INFO | ctx_module=shadowed | trial started[0m

--- a/tests/canonical/golden/logging/pretty__scoped.log
+++ b/tests/canonical/golden/logging/pretty__scoped.log
@@ -1,0 +1,1 @@
+[36m14:30:00.500 | INFO | judge=kimi-k2 run_id=abc sample=42 | trial started[0m

--- a/tests/canonical/golden/logging/pretty__warning.log
+++ b/tests/canonical/golden/logging/pretty__warning.log
@@ -1,0 +1,1 @@
+[33m14:30:00.500 | WARNING |  | trial started[0m

--- a/tests/canonical/test_logging_goldens.py
+++ b/tests/canonical/test_logging_goldens.py
@@ -1,0 +1,171 @@
+"""Byte-level canonical goldens for `StructuredFormatter`.
+
+Every ``.log`` golden under ``tests/canonical/golden/logging/`` locks the
+exact bytes a fixed-clock ``StructuredFormatter`` produces for a single
+``logging.LogRecord``. The suite covers the three modes
+(``pretty`` / ``plain`` / ``json``) with and without extras, the four
+level palette entries in ``pretty`` mode, and the ``ctx_``-prefix rename
+that ``StructuredLogger._sanitize_extra`` performs when an extra key
+collides with a reserved ``LogRecord`` attribute.
+
+**Golden regeneration.** Bytes are locked byte-for-byte. When the palette
+in ``tolokaforge.cli._display.THEME`` shifts or the layout changes, the
+goldens must be regenerated in the *same* commit as the code change:
+
+    uv run pytest tests/canonical/test_logging_goldens.py --update-canon
+
+Never edit the ``.log`` files by hand — text editors normalise ANSI escape
+codes and CR/LF, which drifts the bytes away from what the formatter emits.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.logging import (
+    LogFormat,
+    StructuredFormatter,
+    StructuredLogger,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+GOLDEN_DIR = Path(__file__).parent / "golden" / "logging"
+
+FIXED_INSTANT = datetime(2026, 7, 14, 14, 30, 0, 500_000)
+
+SCOPED_EXTRAS: dict[str, Any] = {"judge": "kimi-k2", "run_id": "abc", "sample": 42}
+
+
+def _fixed_clock() -> datetime:
+    return FIXED_INSTANT
+
+
+def _make_record(
+    *,
+    level: int,
+    extras: dict[str, Any] | None,
+) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="tolokaforge.orch",
+        level=level,
+        pathname="tolokaforge/core/orchestrator.py",
+        lineno=42,
+        msg="trial started",
+        args=None,
+        exc_info=None,
+    )
+    for key, value in (extras or {}).items():
+        record.__dict__[key] = value
+    return record
+
+
+def _formatter(mode: LogFormat) -> StructuredFormatter:
+    return StructuredFormatter(mode, clock=_fixed_clock)
+
+
+# ---------------------------------------------------------------------------
+# Case table — one row per golden file. `extras_factory` runs lazily so the
+# reserved-collision case can exercise `StructuredLogger._sanitize_extra`.
+# ---------------------------------------------------------------------------
+
+_CASES: tuple[tuple[str, LogFormat, int, Any], ...] = (
+    ("pretty__bare.log", LogFormat.PRETTY, logging.INFO, None),
+    ("pretty__scoped.log", LogFormat.PRETTY, logging.INFO, SCOPED_EXTRAS),
+    ("plain__bare.log", LogFormat.PLAIN, logging.INFO, None),
+    ("plain__scoped.log", LogFormat.PLAIN, logging.INFO, SCOPED_EXTRAS),
+    ("json__bare.log", LogFormat.JSON, logging.INFO, None),
+    ("json__scoped.log", LogFormat.JSON, logging.INFO, SCOPED_EXTRAS),
+    ("pretty__warning.log", LogFormat.PRETTY, logging.WARNING, None),
+    ("pretty__error.log", LogFormat.PRETTY, logging.ERROR, None),
+    ("pretty__debug.log", LogFormat.PRETTY, logging.DEBUG, None),
+    (
+        "pretty__reserved_collision.log",
+        LogFormat.PRETTY,
+        logging.INFO,
+        StructuredLogger._sanitize_extra({"module": "shadowed"}),
+    ),
+)
+
+
+def _render_case(mode: LogFormat, level: int, extras: dict[str, Any] | None) -> bytes:
+    record = _make_record(level=level, extras=extras)
+    return (_formatter(mode).format(record) + "\n").encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    ("golden_name", "mode", "level", "extras"),
+    _CASES,
+    ids=[c[0] for c in _CASES],
+)
+def test_golden_bytes_match(
+    request: pytest.FixtureRequest,
+    golden_name: str,
+    mode: LogFormat,
+    level: int,
+    extras: dict[str, Any] | None,
+) -> None:
+    """The formatter's output must match the golden's bytes byte-for-byte."""
+
+    actual = _render_case(mode, level, extras)
+    golden_path = GOLDEN_DIR / golden_name
+
+    if request.config.getoption("--update-canon"):
+        golden_path.parent.mkdir(parents=True, exist_ok=True)
+        golden_path.write_bytes(actual)
+        return
+
+    assert golden_path.exists(), (
+        f"Golden missing: {golden_path.relative_to(GOLDEN_DIR.parent.parent.parent)}. "
+        "Run `uv run pytest tests/canonical/test_logging_goldens.py --update-canon`."
+    )
+    expected = golden_path.read_bytes()
+    if actual != expected:
+        pytest.fail(
+            f"Golden byte drift for {golden_name}:\n"
+            f"  expected: {expected!r}\n"
+            f"  actual:   {actual!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# JSON-parseability: the on-wire schema is a compatibility surface.
+# ---------------------------------------------------------------------------
+
+_JSON_GOLDEN_EXPECTATIONS: dict[str, dict[str, Any]] = {
+    "json__bare.log": {
+        "ts": "14:30:00.500",
+        "level": "INFO",
+        "logger": "tolokaforge.orch",
+        "message": "trial started",
+        "extra": {},
+    },
+    "json__scoped.log": {
+        "ts": "14:30:00.500",
+        "level": "INFO",
+        "logger": "tolokaforge.orch",
+        "message": "trial started",
+        "extra": {"judge": "kimi-k2", "run_id": "abc", "sample": 42},
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "golden_name", sorted(_JSON_GOLDEN_EXPECTATIONS), ids=sorted(_JSON_GOLDEN_EXPECTATIONS)
+)
+def test_json_goldens_parse_to_schema(golden_name: str) -> None:
+    """Every JSON golden line must round-trip through ``json.loads`` and
+    match the ``{ts, level, logger, message, extra}`` schema exactly."""
+
+    golden_path = GOLDEN_DIR / golden_name
+    raw = golden_path.read_bytes().rstrip(b"\n").decode("utf-8")
+    payload = json.loads(raw)
+    assert payload == _JSON_GOLDEN_EXPECTATIONS[golden_name]
+    assert set(payload) == {"ts", "level", "logger", "message", "extra"}

--- a/tests/unit/test_logging_cli_flags.py
+++ b/tests/unit/test_logging_cli_flags.py
@@ -177,6 +177,43 @@ def test_root_quiet_alone_silences_info_records(runner: CliRunner, spy: _ListHan
     assert logging.WARNING in levels
 
 
+def test_root_quiet_silences_docker_namespace_even_when_child_level_is_info() -> None:
+    """Root ``-q`` must gate ``tolokaforge.docker.*`` INFO records at the handler.
+
+    ``Orchestrator.__init__`` sets ``logging.getLogger("tolokaforge.docker").setLevel(INFO)``
+    unconditionally, so the child logger admits INFO records at origin. Without a
+    handler-level cap, those records would propagate to the root's tolokaforge
+    handler (default level 0) and emit — contradicting the ``-q`` promise. The
+    handler-level cap in ``configure_root_logging`` is what makes ``-q`` authoritative.
+    """
+    import io
+
+    stream = io.StringIO()
+    configure_root_logging(level=logging.WARNING, log_format=LogFormat.PLAIN, stream=stream)
+
+    # Verify the fix is in place: the tolokaforge handler carries the level cap.
+    root_handler = next(
+        h
+        for h in logging.getLogger().handlers
+        if getattr(h, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, False)
+    )
+    assert root_handler.level == logging.WARNING
+
+    # Simulate Orchestrator.__init__'s setLevel(INFO) on the docker namespace.
+    docker_logger = logging.getLogger("tolokaforge.docker")
+    saved = docker_logger.level
+    try:
+        docker_logger.setLevel(logging.INFO)
+        docker_logger.info("pulled image")
+        docker_logger.warning("pull failed")
+    finally:
+        docker_logger.setLevel(saved)
+
+    output = stream.getvalue()
+    assert "pulled image" not in output, output
+    assert "pull failed" in output, output
+
+
 def test_root_verbose_and_quiet_together_is_usage_error(runner: CliRunner) -> None:
     result = runner.invoke(cli, ["-v", "-q", "run", "--help"])
 

--- a/tests/unit/test_logging_cli_flags.py
+++ b/tests/unit/test_logging_cli_flags.py
@@ -1,0 +1,512 @@
+"""Composition-matrix tests for root `--verbose`/`--quiet`/`--log-format`
+and subcommand `--verbose` on `run/prepare/worker/convert`.
+
+Each row of the precedence table in
+``docs/plans/2026-07-14-issue-279-a3-structured-log-format.md`` is locked
+here: root `-v` bumps the console to DEBUG, root `-q` silences to
+WARNING, `-v -q` is a `UsageError`, subcommand `--verbose` bumps the
+console when root did not pass `-q`, and root `-q` wins over subcommand
+`--verbose` on the console (while the orchestrator still receives
+``verbose=True`` so per-trial ``logs.yaml`` records DEBUG).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+import tolokaforge.cli.main as cli_main
+import tolokaforge.core.orchestrator as orchestrator_module
+from tolokaforge.cli.main import cli
+from tolokaforge.core.logging import (
+    _TOLOKAFORGE_ROOT_HANDLER_SENTINEL,
+    LogFormat,
+    configure_root_logging,
+)
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _ListHandler(logging.Handler):
+    """Captures every record emitted through the root logger."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture(autouse=True)
+def isolated_root_logging():
+    """Snapshot root handlers/level so each test starts clean."""
+
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    root.handlers = []
+    root.setLevel(logging.WARNING)
+    yield
+    # Remove any tolokaforge sentinel handlers installed during the test.
+    for handler in list(root.handlers):
+        if getattr(handler, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, False):
+            root.removeHandler(handler)
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture
+def spy() -> _ListHandler:
+    handler = _ListHandler()
+    logging.getLogger().addHandler(handler)
+    yield handler
+    logging.getLogger().removeHandler(handler)
+
+
+class _RecordingOrchestrator:
+    """Stand-in orchestrator that records constructor kwargs.
+
+    The composition-matrix asserts that ``verbose=True`` propagates into
+    ``Orchestrator`` for subcommand ``--verbose`` cases, without actually
+    running a trial. `load_tasks` returns nothing so the CLI takes the
+    empty-tasks early-return branch.
+    """
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.__class__.calls.append(kwargs)
+        self.tasks: list = []
+
+    def load_tasks(self) -> None:
+        return None
+
+    def run(self) -> None:
+        return None
+
+    def prepare_run(self, run_dir: Path, reset_queue: bool = False) -> dict:
+        return {
+            "queued_attempts": 0,
+            "queue_counts": {"pending": 0, "total": 0},
+            "queue_backend": "sqlite",
+        }
+
+    def run_worker(self, run_dir: Path, max_attempts: int | None = None) -> dict:
+        return {
+            "processed_attempts": 0,
+            "completed_attempts": 0,
+            "failed_attempts": 0,
+            "requeued_attempts": 0,
+            "total_cost_usd": 0.0,
+        }
+
+
+@pytest.fixture
+def stub_orchestrator(monkeypatch: pytest.MonkeyPatch) -> type[_RecordingOrchestrator]:
+    _RecordingOrchestrator.calls = []
+    monkeypatch.setattr(cli_main, "Orchestrator", _RecordingOrchestrator)
+    return _RecordingOrchestrator
+
+
+@pytest.fixture
+def valid_config(tmp_path: Path) -> Path:
+    """Minimal `run` config: loader parses it, RunConfig validates it."""
+
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {
+                    "output_dir": str(tmp_path / "out"),
+                    "tasks_glob": str(tmp_path / "tasks" / "*"),
+                },
+                "orchestrator": {"repeats": 1, "auto_start_services": False},
+                "compute": {"workers": 1},
+            }
+        )
+    )
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Root flag surface — level, mutual exclusion, log-format parse
+# ---------------------------------------------------------------------------
+
+
+def test_root_verbose_alone_sets_debug_on_console(runner: CliRunner, spy: _ListHandler) -> None:
+    result = runner.invoke(cli, ["-v", "run", "--help"])
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+    logging.getLogger("tolokaforge.probe").debug("probe")
+    assert any(r.levelno == logging.DEBUG for r in spy.records)
+
+
+def test_root_quiet_alone_silences_info_records(runner: CliRunner, spy: _ListHandler) -> None:
+    result = runner.invoke(cli, ["-q", "run", "--help"])
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.WARNING
+    logging.getLogger("tolokaforge.probe").info("dropped")
+    logging.getLogger("tolokaforge.probe").warning("kept")
+    levels = {r.levelno for r in spy.records}
+    assert logging.INFO not in levels
+    assert logging.WARNING in levels
+
+
+def test_root_verbose_and_quiet_together_is_usage_error(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["-v", "-q", "run", "--help"])
+
+    assert result.exit_code == 2
+    combined = (result.output or "") + (result.stderr or "")
+    assert "--verbose and --quiet are mutually exclusive" in combined
+
+
+def test_root_log_format_json_parses(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["--log-format", "json", "--help"])
+
+    assert result.exit_code == 0, result.stderr
+
+
+def test_root_log_format_choice_rejects_unknown(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["--log-format", "wombat", "run", "--help"])
+
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Subcommand --verbose × root -v/-q composition (symmetric option a)
+# ---------------------------------------------------------------------------
+
+
+def test_root_verbose_with_run_verbose_keeps_debug_and_bumps_orchestrator(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["-v", "run", "--config", str(valid_config), "--verbose"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+    assert stub_orchestrator.calls, "Orchestrator was never constructed"
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_root_quiet_with_run_verbose_silences_console_but_orchestrator_still_verbose(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["-q", "run", "--config", str(valid_config), "--verbose"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    # Root `-q` wins: subcommand `--verbose` does NOT bump the console.
+    assert logging.getLogger().level == logging.WARNING
+    logging.getLogger("tolokaforge.probe").debug("dropped-debug")
+    logging.getLogger("tolokaforge.probe").info("dropped-info")
+    levels = {r.levelno for r in spy.records}
+    assert logging.DEBUG not in levels
+    assert logging.INFO not in levels
+    # Orchestrator still receives verbose=True (per-trial logs.yaml @ DEBUG).
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_plain_run_verbose_bumps_console_to_debug(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["run", "--config", str(valid_config), "--verbose"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+    logging.getLogger("tolokaforge.probe").debug("probe")
+    assert any(r.levelno == logging.DEBUG for r in spy.records)
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_plain_run_without_verbose_stays_at_info(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        ["run", "--config", str(valid_config)],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.INFO
+    logging.getLogger("tolokaforge.probe").debug("dropped")
+    logging.getLogger("tolokaforge.probe").info("kept")
+    levels = {r.levelno for r in spy.records}
+    assert logging.DEBUG not in levels
+    assert logging.INFO in levels
+    assert stub_orchestrator.calls[0]["verbose"] is False
+
+
+# Subcommand-verbose bump parametrised over prepare / worker / convert.
+# `convert` uses tasks_glob, so we feed it a temporary empty glob and
+# assert only on the root level bump (the command itself exits before
+# doing any conversion work when the glob matches nothing).
+
+
+def test_prepare_verbose_bumps_console_to_debug(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "prepare",
+            "--config",
+            str(valid_config),
+            "--run-dir",
+            str(tmp_path / "run_dir"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_root_quiet_with_prepare_verbose_silences_console(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "-q",
+            "prepare",
+            "--config",
+            str(valid_config),
+            "--run-dir",
+            str(tmp_path / "run_dir"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.WARNING
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_worker_verbose_bumps_console_to_debug(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "worker",
+            "--config",
+            str(valid_config),
+            "--run-dir",
+            str(tmp_path / "run_dir"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_root_quiet_with_worker_verbose_silences_console(
+    runner: CliRunner,
+    spy: _ListHandler,
+    stub_orchestrator: type[_RecordingOrchestrator],
+    valid_config: Path,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "-q",
+            "worker",
+            "--config",
+            str(valid_config),
+            "--run-dir",
+            str(tmp_path / "run_dir"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.WARNING
+    assert stub_orchestrator.calls[0]["verbose"] is True
+
+
+def test_convert_verbose_bumps_console_to_debug(
+    runner: CliRunner,
+    spy: _ListHandler,
+    tmp_path: Path,
+) -> None:
+    # Empty output dir + glob that matches nothing → exit 0 with a "no tasks"
+    # message. `convert --verbose` fires the console bump before the empty
+    # short-circuit, so the root level is DEBUG after the run.
+    result = runner.invoke(
+        cli,
+        [
+            "adapter",
+            "convert",
+            "--name",
+            "native",
+            "--tasks-glob",
+            str(tmp_path / "no_such_tasks" / "*"),
+            "--output",
+            str(tmp_path / "out"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_root_quiet_with_convert_verbose_silences_console(
+    runner: CliRunner,
+    spy: _ListHandler,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(
+        cli,
+        [
+            "-q",
+            "adapter",
+            "convert",
+            "--name",
+            "native",
+            "--tasks-glob",
+            str(tmp_path / "no_such_tasks" / "*"),
+            "--output",
+            str(tmp_path / "out"),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert logging.getLogger().level == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# StructuredLogger routes through root; docker handler is gone
+# ---------------------------------------------------------------------------
+
+
+def test_structured_logger_extra_lands_in_logrecord_dict(
+    spy: _ListHandler,
+) -> None:
+    from tolokaforge.core.logging import StructuredLogger, clear_logger_registry
+
+    clear_logger_registry()
+    configure_root_logging(level=logging.INFO, log_format=LogFormat.PLAIN)
+    try:
+        logger = StructuredLogger("orch")
+        logger.info("hello", task_id="t1")
+
+        # In-memory list keeps the original key.
+        assert logger.logs[0]["context"]["task_id"] == "t1"
+        # And the stdlib record's `__dict__` carries the sanitised extra.
+        emitted = [r for r in spy.records if r.getMessage() == "hello"]
+        assert emitted, "record did not reach root"
+        assert emitted[0].__dict__["task_id"] == "t1"
+    finally:
+        clear_logger_registry()
+
+
+def test_structured_logger_reserved_key_collision_renamed_ctx_prefix(
+    spy: _ListHandler,
+) -> None:
+    from tolokaforge.core.logging import StructuredLogger, clear_logger_registry
+
+    clear_logger_registry()
+    configure_root_logging(level=logging.INFO, log_format=LogFormat.PLAIN)
+    try:
+        logger = StructuredLogger("orch")
+        logger.info("hello", module="shadowed")
+
+        emitted = [r for r in spy.records if r.getMessage() == "hello"]
+        assert emitted
+        # The reserved `module` slot stays as the stdlib default; our value
+        # is renamed to `ctx_module` so LogRecord.__init__ does not raise.
+        assert emitted[0].__dict__["ctx_module"] == "shadowed"
+        assert emitted[0].__dict__["module"] != "shadowed"
+    finally:
+        clear_logger_registry()
+
+
+def test_docker_namespace_records_reach_root_exactly_once(
+    spy: _ListHandler,
+    tmp_path: Path,
+) -> None:
+    """After orchestrator init, `tolokaforge.docker` no longer has its own
+    handler. A single spy on root sees each record exactly once — the
+    absence-of-double invariant that locks the removed handler."""
+
+    configure_root_logging(level=logging.INFO, log_format=LogFormat.PLAIN)
+
+    run_config = RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir=str(tmp_path / "out")),
+    )
+    orchestrator_module.Orchestrator(run_config)
+
+    # tolokaforge.docker has no handlers of its own — records propagate to root.
+    docker_logger = logging.getLogger("tolokaforge.docker")
+    assert docker_logger.handlers == []
+
+    spy.records.clear()
+    docker_logger.info("pulled image")
+
+    matches = [r for r in spy.records if r.getMessage() == "pulled image"]
+    assert len(matches) == 1

--- a/tests/unit/test_logging_formatter.py
+++ b/tests/unit/test_logging_formatter.py
@@ -363,6 +363,8 @@ def test_redaction_scrubs_secret_before_formatter_renders(isolated_root):
     not just each piece independently. A future refactor that swaps their
     order would leak the secret into the formatted line and fail here.
     """
+    from tolokaforge.secrets import log_filter as log_filter_module
+    from tolokaforge.secrets import manager as manager_module
     from tolokaforge.secrets.log_filter import (
         _FACTORY_SENTINEL,
         PLACEHOLDER,
@@ -372,9 +374,15 @@ def test_redaction_scrubs_secret_before_formatter_renders(isolated_root):
 
     secret = "supersecretvalue123"
     saved_factory = logging.getLogRecordFactory()
+    saved_manager = manager_module._default_manager
+    saved_cached_manager = log_filter_module._cached_manager
+    saved_cached_values = log_filter_module._cached_values
     try:
-        # Reset to a clean factory so install_global_redactor wraps only the default.
         logging.setLogRecordFactory(logging.LogRecord)
+        manager_module._default_manager = None
+        log_filter_module._cached_manager = None
+        log_filter_module._cached_values = frozenset()
+
         init_default_from(SecretManager.from_dict({"API_KEY": secret}))
         install_global_redactor()
         assert getattr(logging.getLogRecordFactory(), _FACTORY_SENTINEL, False)
@@ -388,3 +396,6 @@ def test_redaction_scrubs_secret_before_formatter_renders(isolated_root):
         assert PLACEHOLDER in output, output
     finally:
         logging.setLogRecordFactory(saved_factory)
+        manager_module._default_manager = saved_manager
+        log_filter_module._cached_manager = saved_cached_manager
+        log_filter_module._cached_values = saved_cached_values

--- a/tests/unit/test_logging_formatter.py
+++ b/tests/unit/test_logging_formatter.py
@@ -1,0 +1,356 @@
+"""Unit tests for `StructuredFormatter` and `configure_root_logging`."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.logging import (
+    _LOG_RECORD_RESERVED,
+    _TOLOKAFORGE_ROOT_HANDLER_SENTINEL,
+    LogFormat,
+    StructuredFormatter,
+    configure_root_logging,
+)
+
+pytestmark = pytest.mark.unit
+
+
+FIXED_INSTANT = datetime(2026, 7, 14, 14, 30, 0, 500_000)
+
+
+def _fixed_clock() -> datetime:
+    return FIXED_INSTANT
+
+
+class _FakeStream(io.StringIO):
+    """StringIO with a controllable `isatty()` result."""
+
+    def __init__(self, *, is_tty: bool) -> None:
+        super().__init__()
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:  # noqa: D401 — simple accessor
+        return self._is_tty
+
+
+def _make_record(
+    *,
+    level: int = logging.INFO,
+    name: str = "tolokaforge.orch",
+    message: str = "trial started",
+    extras: dict[str, Any] | None = None,
+) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="tolokaforge/core/orchestrator.py",
+        lineno=42,
+        msg=message,
+        args=None,
+        exc_info=None,
+    )
+    if extras:
+        for key, value in extras.items():
+            record.__dict__[key] = value
+    return record
+
+
+@pytest.fixture
+def isolated_root() -> None:
+    """Snapshot root handlers/level; restore after the test."""
+
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    root.handlers = []
+    yield
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+
+
+# ---------------------------------------------------------------------------
+# Plain / pretty / JSON rendering with fixed clock
+# ---------------------------------------------------------------------------
+
+
+def test_plain_bare_record_double_space_middle():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(message="started")
+
+    line = formatter.format(record)
+
+    assert line == "14:30:00.500 | INFO |  | started"
+
+
+def test_plain_scoped_record_sorted_keys():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(
+        extras={"run_id": "abc", "judge": "kimi-k2", "sample": 42},
+    )
+
+    line = formatter.format(record)
+
+    assert line == "14:30:00.500 | INFO | judge=kimi-k2 run_id=abc sample=42 | trial started"
+
+
+def test_json_scoped_record_parses_and_matches_schema():
+    formatter = StructuredFormatter(LogFormat.JSON, clock=_fixed_clock)
+    record = _make_record(
+        extras={"judge": "kimi-k2", "run_id": "abc", "sample": 42},
+    )
+
+    line = formatter.format(record)
+    payload = json.loads(line)
+
+    assert payload == {
+        "ts": "14:30:00.500",
+        "level": "INFO",
+        "logger": "tolokaforge.orch",
+        "message": "trial started",
+        "extra": {"judge": "kimi-k2", "run_id": "abc", "sample": 42},
+    }
+
+
+def test_json_bare_record_has_empty_extra_dict():
+    formatter = StructuredFormatter(LogFormat.JSON, clock=_fixed_clock)
+    record = _make_record(message="started")
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["extra"] == {}
+
+
+def test_pretty_info_wraps_line_with_cyan_and_reset():
+    formatter = StructuredFormatter(LogFormat.PRETTY, clock=_fixed_clock)
+    record = _make_record(message="started")
+
+    line = formatter.format(record)
+
+    assert line.startswith("\x1b[36m14:30:00.500")
+    assert line.endswith("started\x1b[0m")
+
+
+@pytest.mark.parametrize(
+    ("level", "level_name", "escape"),
+    [
+        (logging.DEBUG, "DEBUG", "\x1b[2m"),
+        (logging.INFO, "INFO", "\x1b[36m"),
+        (logging.WARNING, "WARNING", "\x1b[33m"),
+        (logging.ERROR, "ERROR", "\x1b[1;31m"),
+    ],
+)
+def test_pretty_level_palette(level: int, level_name: str, escape: str):
+    formatter = StructuredFormatter(LogFormat.PRETTY, clock=_fixed_clock)
+    record = _make_record(level=level, message="m")
+
+    line = formatter.format(record)
+
+    assert line.startswith(escape)
+    assert f"| {level_name} |" in line
+    assert line.endswith("\x1b[0m")
+
+
+def test_pretty_ansi_codes_match_display_theme():
+    """The hardcoded ANSI table must stay in lockstep with `_display.THEME`.
+
+    Rich renders a `THEME` style on a truecolor terminal as exactly the
+    bytes we emit — this guards against a THEME palette change silently
+    diverging from the formatter.
+    """
+    from rich.console import Console
+
+    from tolokaforge.cli._display import THEME
+    from tolokaforge.core.logging import _ANSI_RESET, _LEVEL_ANSI
+
+    console = Console(force_terminal=True, theme=THEME, color_system="truecolor")
+    for level_name, theme_style in (
+        ("DEBUG", "muted"),
+        ("INFO", "info"),
+        ("WARNING", "warn"),
+        ("ERROR", "error"),
+    ):
+        with console.capture() as cap:
+            console.print("x", style=theme_style, end="")
+        rendered = cap.get()
+        expected = f"{_LEVEL_ANSI[level_name]}x{_ANSI_RESET}"
+        assert rendered == expected, f"ANSI drift for {level_name!r}: THEME={rendered!r}"
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering rules
+# ---------------------------------------------------------------------------
+
+
+def test_reserved_set_covers_bare_logrecord_dict():
+    """The reserved set must include every attribute a blank `LogRecord`
+    populates plus the two `Formatter.format`-injected keys."""
+    bare = logging.LogRecord(
+        name="n",
+        level=logging.INFO,
+        pathname="p",
+        lineno=1,
+        msg="m",
+        args=None,
+        exc_info=None,
+    )
+    populated = set(bare.__dict__) | {"message", "asctime"}
+    missing = populated - _LOG_RECORD_RESERVED
+    assert not missing, f"reserved set missing keys populated by stdlib: {sorted(missing)}"
+
+
+def test_reserved_attributes_never_leak_into_scope_pairs():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(extras={"payload": "keep"})
+    # Overwrite every reserved key with a distinguishable value; the formatter
+    # must not render any of these as `k=v` pairs. `msg` and `args` are what
+    # `LogRecord.getMessage()` interpolates — keep the record valid by
+    # pinning `msg` to the marker string (still a reserved key we want to
+    # verify is filtered) and `args` to `None` (no interpolation).
+    marker = "LEAKED"
+    skip_render_keys = {"args"}
+    for key in _LOG_RECORD_RESERVED - skip_render_keys:
+        record.__dict__[key] = marker
+    record.__dict__["args"] = None
+
+    line = formatter.format(record)
+
+    # `levelname` and `msg` are reserved slots the formatter itself reads —
+    # overwriting them puts the marker in the level and message segments,
+    # which is fine. What matters: no reserved key leaks into the *scope*
+    # segment as a `k=v` pair.
+    scope_segment = line.split(" | ")[2]
+    assert marker not in scope_segment
+    assert scope_segment == "payload=keep"
+
+
+def test_underscore_prefixed_extras_are_dropped():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(extras={"_internal": "hidden", "shown": "yes"})
+
+    line = formatter.format(record)
+
+    assert "_internal" not in line
+    assert "shown=yes" in line
+
+
+def test_values_with_whitespace_or_pipe_render_via_repr():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(
+        extras={"spaced": "hello world", "piped": "pipe|here", "clean": "ok"},
+    )
+
+    line = formatter.format(record)
+
+    assert "spaced='hello world'" in line
+    assert "piped='pipe|here'" in line
+    assert "clean=ok" in line
+
+
+def test_scope_pairs_sorted_alphabetically():
+    formatter = StructuredFormatter(LogFormat.PLAIN, clock=_fixed_clock)
+    record = _make_record(extras={"zebra": 1, "alpha": 2, "mike": 3})
+
+    line = formatter.format(record)
+
+    scope_segment = line.split(" | ")[2]
+    assert scope_segment == "alpha=2 mike=3 zebra=1"
+
+
+def test_json_non_jsonable_value_falls_back_to_repr():
+    formatter = StructuredFormatter(LogFormat.JSON, clock=_fixed_clock)
+
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird!>"
+
+    record = _make_record(extras={"obj": Weird()})
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["extra"] == {"obj": "<weird!>"}
+
+
+# ---------------------------------------------------------------------------
+# configure_root_logging: idempotence and isatty auto-selection
+# ---------------------------------------------------------------------------
+
+
+def _tolokaforge_root_handlers() -> list[logging.Handler]:
+    return [
+        h
+        for h in logging.getLogger().handlers
+        if getattr(h, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, False)
+    ]
+
+
+def test_configure_root_logging_non_tty_stream_auto_selects_plain(isolated_root):
+    stream = _FakeStream(is_tty=False)
+
+    configure_root_logging(level=logging.DEBUG, log_format=None, stream=stream)
+
+    handlers = _tolokaforge_root_handlers()
+    assert len(handlers) == 1
+    assert isinstance(handlers[0].formatter, StructuredFormatter)
+    assert handlers[0].formatter.mode is LogFormat.PLAIN
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_configure_root_logging_tty_stream_auto_selects_pretty(isolated_root):
+    stream = _FakeStream(is_tty=True)
+
+    configure_root_logging(log_format=None, stream=stream)
+
+    handlers = _tolokaforge_root_handlers()
+    assert len(handlers) == 1
+    assert handlers[0].formatter.mode is LogFormat.PRETTY
+
+
+def test_configure_root_logging_is_idempotent(isolated_root):
+    stream = _FakeStream(is_tty=False)
+
+    configure_root_logging(stream=stream)
+    configure_root_logging(stream=stream)
+
+    assert len(_tolokaforge_root_handlers()) == 1
+
+
+def test_configure_root_logging_leaves_foreign_handlers_alone(isolated_root):
+    foreign = logging.StreamHandler(io.StringIO())
+    logging.getLogger().addHandler(foreign)
+
+    configure_root_logging(stream=_FakeStream(is_tty=False))
+    configure_root_logging(stream=_FakeStream(is_tty=False))
+
+    root_handlers = logging.getLogger().handlers
+    assert foreign in root_handlers
+    assert len(_tolokaforge_root_handlers()) == 1
+
+
+def test_configure_root_logging_explicit_format_overrides_auto(isolated_root):
+    stream = _FakeStream(is_tty=True)  # would auto-select PRETTY
+
+    configure_root_logging(log_format=LogFormat.JSON, stream=stream)
+
+    handlers = _tolokaforge_root_handlers()
+    assert handlers[0].formatter.mode is LogFormat.JSON
+
+
+def test_configure_root_logging_replaces_previous_formatter(isolated_root):
+    """Second call with a different format installs a fresh handler."""
+    stream = _FakeStream(is_tty=False)
+
+    configure_root_logging(log_format=LogFormat.PLAIN, stream=stream)
+    first = _tolokaforge_root_handlers()[0]
+
+    configure_root_logging(log_format=LogFormat.JSON, stream=stream)
+    handlers = _tolokaforge_root_handlers()
+
+    assert len(handlers) == 1
+    assert handlers[0] is not first
+    assert handlers[0].formatter.mode is LogFormat.JSON

--- a/tests/unit/test_logging_formatter.py
+++ b/tests/unit/test_logging_formatter.py
@@ -354,3 +354,37 @@ def test_configure_root_logging_replaces_previous_formatter(isolated_root):
     assert len(handlers) == 1
     assert handlers[0] is not first
     assert handlers[0].formatter.mode is LogFormat.JSON
+
+
+def test_redaction_scrubs_secret_before_formatter_renders(isolated_root):
+    """The record factory scrubs before StructuredFormatter renders.
+
+    Locks the composed pipeline (redactor factory → StructuredFormatter),
+    not just each piece independently. A future refactor that swaps their
+    order would leak the secret into the formatted line and fail here.
+    """
+    from tolokaforge.secrets.log_filter import (
+        _FACTORY_SENTINEL,
+        PLACEHOLDER,
+        install_global_redactor,
+    )
+    from tolokaforge.secrets.manager import SecretManager, init_default_from
+
+    secret = "supersecretvalue123"
+    saved_factory = logging.getLogRecordFactory()
+    try:
+        # Reset to a clean factory so install_global_redactor wraps only the default.
+        logging.setLogRecordFactory(logging.LogRecord)
+        init_default_from(SecretManager.from_dict({"API_KEY": secret}))
+        install_global_redactor()
+        assert getattr(logging.getLogRecordFactory(), _FACTORY_SENTINEL, False)
+
+        stream = _FakeStream(is_tty=False)
+        configure_root_logging(log_format=LogFormat.PLAIN, stream=stream)
+        logging.getLogger("t").warning("token %s in header", secret)
+
+        output = stream.getvalue()
+        assert secret not in output, output
+        assert PLACEHOLDER in output, output
+    finally:
+        logging.setLogRecordFactory(saved_factory)

--- a/tolokaforge/cli/adapter_commands.py
+++ b/tolokaforge/cli/adapter_commands.py
@@ -8,8 +8,6 @@ TolokaForge format.
 from __future__ import annotations
 
 import json
-import logging
-import sys
 from pathlib import Path
 
 import click
@@ -33,7 +31,9 @@ def adapter():
 @click.option("--adapter-params", default="{}", help="JSON string of extra adapter params")
 @click.option("--validate", "do_validate", is_flag=True, help="Validate converted output")
 @click.option("--verbose", is_flag=True, help="Enable debug output")
+@click.pass_context
 def convert(
+    ctx: click.Context,
     name: str,
     tasks_glob: str,
     output: str,
@@ -43,7 +43,9 @@ def convert(
 ) -> None:
     """Convert external tasks to native TolokaForge format."""
     if verbose:
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+        from tolokaforge.cli.main import _bump_console_debug_if_allowed
+
+        _bump_console_debug_if_allowed(ctx)
 
     from tolokaforge.adapters import get_adapter
     from tolokaforge.adapters.bundle_writer import write_bundle

--- a/tolokaforge/cli/main.py
+++ b/tolokaforge/cli/main.py
@@ -1,6 +1,7 @@
 """Main CLI entry point"""
 
 import json
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
@@ -16,6 +17,7 @@ from tolokaforge.core.llm.presets import (
     set_overlay_path,
     validate_overlay_file,
 )
+from tolokaforge.core.logging import LogFormat, configure_root_logging
 from tolokaforge.core.models import RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.project_loader import load_effective_run_config
@@ -77,9 +79,66 @@ def _print_runtime_banner(*, console: Console, runtime_choice: str, source: str)
 
 
 @click.group()
-def cli():
+@click.option(
+    "--verbose",
+    "-v",
+    "verbose",
+    is_flag=True,
+    help="Console log level DEBUG (mutually exclusive with --quiet).",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    "quiet",
+    is_flag=True,
+    help="Console log level WARNING (mutually exclusive with --verbose).",
+)
+@click.option(
+    "--log-format",
+    "log_format",
+    type=click.Choice([m.value for m in LogFormat], case_sensitive=False),
+    default=None,
+    help=(
+        "Line shape for log records on the console. Defaults to "
+        "'pretty' on a TTY, 'plain' otherwise. 'json' emits one JSON "
+        "object per line."
+    ),
+)
+@click.pass_context
+def cli(ctx: click.Context, verbose: bool, quiet: bool, log_format: str | None) -> None:
     """Universal LLM Tool-Use Benchmarking Harness (ULB-H)"""
-    pass
+    if verbose and quiet:
+        raise click.UsageError("--verbose and --quiet are mutually exclusive")
+
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    resolved_format = LogFormat(log_format.lower()) if log_format is not None else None
+    configure_root_logging(level=level, log_format=resolved_format)
+
+    ctx.ensure_object(dict)
+    ctx.obj["root_verbose"] = verbose
+    ctx.obj["root_quiet"] = quiet
+    ctx.obj["log_format"] = resolved_format
+
+
+def _bump_console_debug_if_allowed(ctx: click.Context) -> None:
+    """Raise the root handler to DEBUG for subcommand `--verbose`, unless
+    the root callback saw `-q`.
+
+    Root `-q` is an explicit request to silence the console; the subcommand
+    flag still drives the per-trial `logs.yaml` level via
+    `Orchestrator(verbose=True)`, but must not override the operator's
+    console-quiet decision.
+    """
+    root_obj = ctx.find_root().obj or {}
+    if root_obj.get("root_quiet"):
+        return
+    configure_root_logging(level=logging.DEBUG, log_format=root_obj.get("log_format"))
 
 
 # Register docker subcommand group (lazy import to avoid docker dep at registration)
@@ -201,7 +260,9 @@ def _activate_presets_overlay(
         "in the run config. Must be a positive integer. See docs/CONFIG.md."
     ),
 )
+@click.pass_context
 def run(
+    ctx: click.Context,
     config: str,
     resume: bool,
     verbose: bool,
@@ -213,6 +274,9 @@ def run(
     workers: int | None,
 ):
     """Run benchmark with specified configuration"""
+    if verbose:
+        _bump_console_debug_if_allowed(ctx)
+
     console.print(f"[bold blue]Loading configuration from {config}...[/bold blue]")
 
     # Load config with the enclosing project's run_defaults layered under
@@ -338,7 +402,9 @@ def run(
         "engine.presets_file."
     ),
 )
+@click.pass_context
 def prepare(
+    ctx: click.Context,
     config: str,
     run_dir: str,
     reset_queue: bool,
@@ -347,6 +413,9 @@ def prepare(
     presets_file: str | None,
 ):
     """Prepare a queue-backed run directory for distributed workers."""
+    if verbose:
+        _bump_console_debug_if_allowed(ctx)
+
     console.print(f"[bold blue]Preparing run from config {config}...[/bold blue]")
     config_data, project = load_effective_run_config(Path(config))
     run_config = RunConfig(**config_data)
@@ -395,7 +464,9 @@ def prepare(
         "falls back to engine.presets_file."
     ),
 )
+@click.pass_context
 def worker(
+    ctx: click.Context,
     config: str,
     run_dir: str,
     max_attempts: int | None,
@@ -404,6 +475,9 @@ def worker(
     presets_file: str | None,
 ):
     """Run a queue worker process (distributed execution mode)."""
+    if verbose:
+        _bump_console_debug_if_allowed(ctx)
+
     console.print(f"[bold blue]Loading worker config from {config}...[/bold blue]")
     config_data, project = load_effective_run_config(Path(config))
     run_config = RunConfig(**config_data)

--- a/tolokaforge/core/logging.py
+++ b/tolokaforge/core/logging.py
@@ -200,7 +200,7 @@ def configure_root_logging(
 
 
 class StructuredLogger:
-    """Thread-safe structured logger with JSON output and strict mode
+    """Thread-safe structured logger with in-memory list + YAML output.
 
     Attributes:
         name: Logger name (typically module or trial ID)
@@ -208,6 +208,11 @@ class StructuredLogger:
         log_file: Optional file path for log output
         strict: If True, raise RuntimeError on ERROR level
         logs: Collected structured log entries
+
+    Records are routed through the stdlib logger with `propagate=True` so
+    the root handler installed by `configure_root_logging` owns rendering.
+    The in-memory `logs` list and `save_to_file` YAML shape are separate
+    from the console rendering.
     """
 
     def __init__(
@@ -223,26 +228,26 @@ class StructuredLogger:
         self.strict = strict
         self.logs: list[dict[str, Any]] = []
 
-        # Create standard logger for console output
         self.logger = logging.getLogger(name)
         self.logger.setLevel(level)
-
-        # Remove existing handlers to avoid duplicates
         self.logger.handlers.clear()
+        self.logger.propagate = True
 
-        # Add console handler
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setLevel(level)
+    @staticmethod
+    def _sanitize_extra(context: dict[str, Any]) -> dict[str, Any]:
+        """Rename keys that would collide with `LogRecord` attributes.
 
-        # Format: timestamp - name - level - message
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-        )
-        console_handler.setFormatter(formatter)
-        self.logger.addHandler(console_handler)
-
-        # Prevent propagation to root logger
-        self.logger.propagate = False
+        `logging.Logger.log(..., extra=...)` copies each key straight onto
+        `LogRecord.__dict__`; a key like `module` or `name` would raise
+        `KeyError` at `LogRecord.__init__`. Prefix such collisions with
+        `ctx_` so the record survives — the `StructuredFormatter` reads the
+        renamed keys via the same scope-pair rule.
+        """
+        sanitized: dict[str, Any] = {}
+        for key, value in context.items():
+            safe_key = f"ctx_{key}" if key in _LOG_RECORD_RESERVED else key
+            sanitized[safe_key] = value
+        return sanitized
 
     def _log(self, level: str, message: str, context: dict[str, Any] | None = None, **kwargs):
         """Internal logging method
@@ -253,20 +258,16 @@ class StructuredLogger:
             context: Optional context dictionary
             **kwargs: Additional context as keyword arguments
         """
-        # Get numeric log level
         log_level = getattr(logging, level)
 
-        # Skip if below threshold (filter based on logger level)
         if log_level < self.level:
             return
 
         # Defensive handling for non-dict context (e.g., exception passed as positional arg)
         if context is not None and not isinstance(context, dict):
             context = {"context": str(context)}
-        # Merge context and kwargs
         full_context = {**(context or {}), **kwargs}
 
-        # Create structured log entry
         log_entry = {
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "level": level,
@@ -276,20 +277,11 @@ class StructuredLogger:
         }
         self.logs.append(log_entry)
 
-        # Format context for display
-        if full_context:
-            context_str = ", ".join(f"{k}={v}" for k, v in full_context.items())
-            display_message = f"{message} ({context_str})"
-        else:
-            display_message = message
+        self.logger.log(log_level, message, extra=self._sanitize_extra(full_context))
 
-        self.logger.log(log_level, display_message)
-
-        # Raise exception in strict mode for ERROR level
         if self.strict and level == "ERROR":
             error_msg = f"[STRICT MODE] {message}"
             if full_context:
-                # Format context in a way that matches test expectations
                 context_parts = [f"{k}={v}" for k, v in full_context.items()]
                 error_msg += f" ({', '.join(context_parts)})"
             raise RuntimeError(error_msg)

--- a/tolokaforge/core/logging.py
+++ b/tolokaforge/core/logging.py
@@ -2,15 +2,201 @@
 
 This module provides structured logging with YAML output, context support,
 and optional strict mode that raises errors on ERROR level.
+
+It also provides the process-wide log formatter (`StructuredFormatter`,
+`LogFormat`) and root-handler bootstrap (`configure_root_logging`) used
+by the CLI to render every `logging.getLogger(...)` record with a
+consistent `HH:MM:SS.mmm | LEVEL | k=v | message` shape on stderr.
 """
 
+from __future__ import annotations
+
+import json
 import logging
 import sys
+from collections.abc import Callable
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 import yaml
+
+
+class LogFormat(str, Enum):
+    """Line shape emitted by `StructuredFormatter`."""
+
+    PRETTY = "pretty"
+    PLAIN = "plain"
+    JSON = "json"
+
+
+_LOG_RECORD_RESERVED: frozenset[str] = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "taskName",
+        "thread",
+        "threadName",
+    }
+)
+
+_ANSI_RESET = "\x1b[0m"
+_LEVEL_ANSI: dict[str, str] = {
+    "DEBUG": "\x1b[2m",
+    "INFO": "\x1b[36m",
+    "WARNING": "\x1b[33m",
+    "ERROR": "\x1b[1;31m",
+    "CRITICAL": "\x1b[1;31m",
+}
+
+_TOLOKAFORGE_ROOT_HANDLER_SENTINEL = "_tolokaforge_root_handler"
+
+
+def _render_scalar(key: str, value: Any) -> str:
+    text = str(value)
+    if any(ch.isspace() for ch in text) or "|" in text:
+        return f"{key}={value!r}"
+    return f"{key}={text}"
+
+
+def _to_jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return repr(value)
+    return value
+
+
+class StructuredFormatter(logging.Formatter):
+    """Render a `LogRecord` in one of the three `LogFormat` modes.
+
+    Layout (pretty & plain):
+
+        HH:MM:SS.mmm | LEVEL | k1=v1 k2=v2 | message
+
+    - Timestamp is millisecond-resolution local time. `clock` may inject a
+      deterministic `datetime` factory for tests (default: `datetime.now`).
+    - Scope pairs are every `LogRecord.__dict__` key not in
+      `_LOG_RECORD_RESERVED` and not starting with `_`. Keys are sorted
+      alphabetically for deterministic goldens.
+    - Values render bare (`k=v`) unless `str(v)` contains whitespace or
+      `|`, in which case the value renders via `repr` (`k='hello world'`).
+    - Empty scope renders as an empty middle segment — the two spaces
+      between the surrounding `|` delimiters are preserved (`... | LEVEL
+      |  | message`).
+
+    JSON mode emits one JSON object per line with keys
+    `{"ts", "level", "logger", "message", "extra"}`. Non-JSONable
+    extra values fall back to `repr`.
+
+    Pretty mode wraps the entire line with the ANSI escape sequence for
+    the record's level (INFO=cyan, WARNING=yellow, ERROR=bold red,
+    DEBUG=dim) — matching the semantics of
+    `tolokaforge.cli._display.THEME`.
+    """
+
+    def __init__(
+        self,
+        mode: LogFormat,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__()
+        self.mode = mode
+        self._clock = clock or datetime.now
+
+    def format(self, record: logging.LogRecord) -> str:
+        timestamp = self._render_timestamp()
+        scope = self._scope_pairs(record)
+        message = record.getMessage()
+        if self.mode is LogFormat.JSON:
+            return self._render_json(timestamp, record, scope, message)
+        scope_segment = " ".join(_render_scalar(k, v) for k, v in scope.items())
+        line = f"{timestamp} | {record.levelname} | {scope_segment} | {message}"
+        if self.mode is LogFormat.PRETTY:
+            color = _LEVEL_ANSI.get(record.levelname)
+            if color is not None:
+                line = f"{color}{line}{_ANSI_RESET}"
+        return line
+
+    def _render_timestamp(self) -> str:
+        now = self._clock()
+        return f"{now:%H:%M:%S}.{now.microsecond // 1000:03d}"
+
+    @staticmethod
+    def _scope_pairs(record: logging.LogRecord) -> dict[str, Any]:
+        return {
+            key: record.__dict__[key]
+            for key in sorted(record.__dict__)
+            if key not in _LOG_RECORD_RESERVED and not key.startswith("_")
+        }
+
+    @staticmethod
+    def _render_json(
+        timestamp: str,
+        record: logging.LogRecord,
+        scope: dict[str, Any],
+        message: str,
+    ) -> str:
+        payload = {
+            "ts": timestamp,
+            "level": record.levelname,
+            "logger": record.name,
+            "message": message,
+            "extra": {k: _to_jsonable(v) for k, v in scope.items()},
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_root_logging(
+    *,
+    level: int = logging.INFO,
+    log_format: LogFormat | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Install (or replace) the tolokaforge root log handler.
+
+    Idempotent: a previously installed tolokaforge root handler (tagged
+    via the `_tolokaforge_root_handler` sentinel attribute) is removed
+    before the new one is added. Foreign handlers on `logging.root`
+    (e.g. pytest's `caplog`) are left untouched.
+
+    `log_format=None` auto-selects `PRETTY` if `stream.isatty()` returns
+    truthy, otherwise `PLAIN`. `stream=None` defaults to `sys.stderr`.
+    """
+    target_stream = stream if stream is not None else sys.stderr
+    if log_format is None:
+        log_format = LogFormat.PRETTY if target_stream.isatty() else LogFormat.PLAIN
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if getattr(handler, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, False):
+            root.removeHandler(handler)
+
+    handler = logging.StreamHandler(target_stream)
+    handler.setFormatter(StructuredFormatter(log_format))
+    setattr(handler, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, True)
+    root.addHandler(handler)
+    root.setLevel(level)
 
 
 class StructuredLogger:

--- a/tolokaforge/core/logging.py
+++ b/tolokaforge/core/logging.py
@@ -180,6 +180,12 @@ def configure_root_logging(
     before the new one is added. Foreign handlers on `logging.root`
     (e.g. pytest's `caplog`) are left untouched.
 
+    Both the root logger and the tolokaforge handler are set to `level`
+    — the handler level is authoritative so a child logger that raises
+    its own effective level (e.g. `Orchestrator.__init__` calling
+    `logging.getLogger("tolokaforge.docker").setLevel(INFO)`) still gets
+    filtered when root `-q` requests WARNING+ on console.
+
     `log_format=None` auto-selects `PRETTY` if `stream.isatty()` returns
     truthy, otherwise `PLAIN`. `stream=None` defaults to `sys.stderr`.
     """
@@ -194,6 +200,7 @@ def configure_root_logging(
 
     handler = logging.StreamHandler(target_stream)
     handler.setFormatter(StructuredFormatter(log_format))
+    handler.setLevel(level)
     setattr(handler, _TOLOKAFORGE_ROOT_HANDLER_SENTINEL, True)
     root.addHandler(handler)
     root.setLevel(level)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -273,21 +273,11 @@ class Orchestrator:
         log_level = logging.DEBUG if verbose else logging.INFO
         self.logger = get_logger("orchestrator", level=log_level, strict=strict)
 
-        # Configure standard Python logging for Docker modules so their
-        # progress messages (image building, container startup, health checks)
-        # are visible to the user.  These modules use logging.getLogger(__name__)
-        # which defaults to WARNING without explicit configuration.
-        docker_logger = logging.getLogger("tolokaforge.docker")
-        if not docker_logger.handlers:
-            handler = logging.StreamHandler()
-            handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-                    datefmt="%Y-%m-%d %H:%M:%S",
-                )
-            )
-            docker_logger.addHandler(handler)
-        docker_logger.setLevel(log_level)
+        # Docker submodules use `logging.getLogger(__name__)`; the root
+        # handler installed by `configure_root_logging` renders them via
+        # propagation. Set the namespace threshold so INFO-level progress
+        # messages emit even when root sits at WARNING.
+        logging.getLogger("tolokaforge.docker").setLevel(log_level)
 
     def _create_adapter(self) -> BaseAdapter:
         """Create adapter based on configuration"""


### PR DESCRIPTION
## Summary

Closes #279.

Milestone 11 A3. Replaces the ad-hoc log format with a structured, greppable shape (`HH:MM:SS.mmm | LEVEL | k=v k=v | message`) in three modes (`pretty` with ANSI, `plain`, `json`). Adds root CLI flags `-v/--verbose`, `-q/--quiet`, `--log-format={pretty,plain,json}` with auto-selection by `sys.stderr.isatty()`. Rewires `StructuredLogger` to propagate through the shared root handler.

- **Formatter (`tolokaforge/core/logging.py`)**: `StructuredFormatter` with pretty/plain/json modes. Reserved `LogRecord` attributes filtered from scope; `_`-prefixed extras dropped; whitespace/`|` values quoted via `repr`; non-JSONable JSON values fall back to `repr`. `configure_root_logging` is idempotent and caps the handler at the requested level.
- **Root flags**: `-v -q` mutually exclusive; symmetric option (a) on subcommand `--verbose` — `run/prepare/worker/convert --verbose` all bump console to DEBUG unless root `-q` overrides. On-disk `logs.yaml` still gets DEBUG via `Orchestrator(verbose=True)` when the subcommand flag is set, regardless of root `-q`.
- **StructuredLogger rewire**: private stdout `StreamHandler` deleted; `propagate=True`; `_sanitize_extra` renames reserved-attribute collisions with `ctx_` prefix. `.logs[]`, `save_to_file` YAML shape, `.strict`, and singleton behaviour preserved (existing `tests/unit/test_logging.py` still green).
- **Cleanups**: removed duplicate `docker_logger` handler in `orchestrator.py:280-290` and `logging.basicConfig(...)` in `adapter_commands.py:46`. Absence-of-double locked by `count == 1` assertion.
- **Canonical goldens**: 10 files under `tests/canonical/golden/logging/` locking exact bytes across pretty/plain/json × bare/scoped/warning/error/debug/reserved_collision. `.gitignore` un-ignores `!tests/canonical/golden/**/*.log`.
- **Docs**: `docs/CLI.md` `## Structured logging` section; `docs/LOGGING.md` § CLI Flags / § Log stream / § Console Output rewritten; corrected one legacy `logs.json` reference (8 more remain as pre-existing drift, out of scope).

## Behavior changes (BREAKING — noted in CHANGELOG)

1. **`StructuredLogger` console output moves from stdout to stderr** — aligned with A4's stdout carveout (coming in #280). Downstream stdout-consumers should switch to `2>&1 |`.
2. **Console log line shape changes** to `HH:MM:SS.mmm | LEVEL | k=v k=v | message`. Machine consumers grepping the old format need to update. Golden files lock the new shape.

## Follow-ups filed

- #308 — runner container's `logging.basicConfig` (out-of-process; deferred).
- #309 — RAG env service's `logging.basicConfig` (out-of-process; deferred).

## Commits (5)

- `dd56c59` docs(plans): add A3 plan
- `0b1e0bd` feat(logging): structured formatter with pretty/plain/json modes
- `6666f3f` feat(cli): --verbose/--quiet/--log-format root flags + StructuredLogger rewire
- `c961977` test(logging): canonical goldens + docs/CHANGELOG for structured logging
- `c55ac1c` fix(logging): cap root handler at requested level so -q silences docker INFO

## Test plan

- [x] `uv run pytest tests/unit/test_logging.py tests/unit/test_logging_formatter.py tests/unit/test_logging_cli_flags.py tests/canonical/test_logging_goldens.py` — 62 tests, all green.
- [x] Full unit sweep — 2360+ passed.
- [x] Full canonical sweep — 422 passed.
- [x] `-q run` no longer prints docker INFO (fixed via handler-level cap).
- [x] Redaction × formatter integration test — secret scrubbed before line is rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)