### PR TITLE
feat(examples): runnable reset-recipe pack + end-to-end integration test (#299)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -214,6 +214,7 @@ The orchestrator process and the Docker stack live on the same host. There is no
 |---|---|
 | **Secrets handling** | [AGENTS.md § Secrets — single abstraction](../../AGENTS.md#secrets--single-abstraction) · `tolokaforge/secrets` |
 | **Determinism & state hashing** | [`docs/GRADING.md`](../GRADING.md) · [`docs/GOLDEN_TRIALS.md`](../GOLDEN_TRIALS.md) |
+| **Per-trial isolation & reset recipes** | [`RUNTIME_BACKENDS.md`](RUNTIME_BACKENDS.md) · [`RESET_RECIPES.md`](RESET_RECIPES.md) |
 | **Per-provider capability handling** | [`docs/LLM_LAYER.md`](../LLM_LAYER.md) · [AGENTS.md § Known Gotchas](../../AGENTS.md#known-gotchas) |
 | **Tool isolation & sandboxing** | [`docs/SECURITY.md`](../SECURITY.md) · [`docs/BROWSER_TOOLS.md`](../BROWSER_TOOLS.md) |
 | **Telemetry & metrics** | [`docs/LOGGING.md`](../LOGGING.md) · [`docs/ANALYTICS.md`](../ANALYTICS.md) |

--- a/docs/architecture/RESET_RECIPES.md
+++ b/docs/architecture/RESET_RECIPES.md
@@ -1,0 +1,97 @@
+# Reset recipes — seeding a service to a named baseline
+
+A **reset recipe** restores a service to a known baseline at the start of
+every trial. A project registers named seed files under `assets.seeds`,
+labels a service `isolation: "reset"`, and points it at a seed by name;
+the per-trial runtime backend applies that seed right after the service's
+container comes up, so the trial body always starts from the same state.
+
+Companion reading: [`RUNTIME_BACKENDS.md`](RUNTIME_BACKENDS.md) (the
+`RuntimeBackend` seam and per-trial provisioning),
+[`PROJECTS.md`](PROJECTS.md) (the Project schema that owns `assets.seeds`
+and `default_environment`).
+
+## Seed kinds
+
+A seed's `kind` selects how its bytes are applied. Four kinds ship
+(`SeedKind` in [`tolokaforge/core/models.py`](../../tolokaforge/core/models.py)):
+
+| Kind | Applied by | Typical file |
+|---|---|---|
+| `sql_dump` | `psql` / SQL client executes the dump against the service | `.sql` |
+| `filesystem_dir` | Contents copied into the service's workspace | directory |
+| `redis_dump` | RDB snapshot loaded into the Redis service | `.rdb` |
+| `bare` | Raw file handed to the service verbatim, no interpretation | any |
+
+`sql_dump` and `redis_dump` are inferred from the `.sql` / `.rdb`
+extension when a seed is declared as a bare path string; every other case
+requires the full `{path, kind, digest}` form.
+
+## Declaring a reset recipe
+
+Three pieces in the project spec wire a recipe (see
+[`PROJECTS.md`](PROJECTS.md) for the full schema):
+
+1. **Register the seed** under `assets.seeds`. Each entry carries a
+   `path`, a `kind`, and a `sha256:` `digest`. The loader
+   (`load_project_config`) verifies the digest against the file bytes and
+   fails loud on a mismatch, so a seed swap without re-stamping is caught
+   at load time. `tolokaforge assets stamp` fills the digest.
+2. **Label the service** `isolation: "reset"` under
+   `default_environment.services.<svc>` (or a task's `environment_manifest`).
+3. **Bind the seed** with `reset: { seed: <name> }` on that same service.
+
+```yaml
+assets:
+  seeds:
+    postgres_baseline:
+      path: "./assets/postgres_baseline.sql"
+      kind: "sql_dump"
+      digest: "sha256:..."
+
+default_environment:
+  services:
+    app-db:
+      isolation: "reset"
+      reset: { seed: "postgres_baseline" }
+```
+
+A `reset` service makes `EnvironmentManifest.requires_per_trial` true, so
+backend selection routes the run onto `PerTrialRuntimeBackend` (see
+[`RUNTIME_BACKENDS.md`](RUNTIME_BACKENDS.md)). Services left unlabelled
+default to `ephemeral` (fresh per trial); the `reset`/`ephemeral` mix
+still forces per-trial selection.
+
+## The provision seam
+
+`PerTrialRuntimeBackend.provision` brings up a fresh compose stack per
+trial and calls `_apply_reset_recipes`
+([`tolokaforge/core/per_trial_runtime.py`](../../tolokaforge/core/per_trial_runtime.py))
+immediately after `docker compose up` returns. For every service labelled
+`reset`, it resolves `reset.seed` against the backend's seed registry
+(populated from `project.assets.seeds`) and calls
+`tolokaforge.runtime.reset_recipes.dispatch(seed, service_name, compose)`,
+which routes to the handler for the seed's `kind`. A `reset` service with
+no `reset.seed`, or a seed name absent from the registry, raises
+`ProvisionError` — the recipe never silently no-ops.
+
+Because provision runs once per trial, `repeats: K` applies the seed `K`
+times, each onto a freshly-started container.
+
+Failure-mode behaviour (partial application, retries, per-service log
+capture on a failed seed) is out of scope for this document and tracked
+in #300.
+
+## Reference example
+
+[`examples/native/multi_service_postgres_reset`](../../examples/native/multi_service_postgres_reset)
+is the runnable end-to-end example. Its compose `init.sql` seeds a widget
+row `name = 'factory_default'`; the `postgres_baseline` seed
+(`sql_dump`) overwrites it to `name = 'baseline'` at every provision. The
+task's agent reads the row back over a PostgREST API and writes it to a
+submission file, and deterministic `state_checks` grading asserts the file
+reads `baseline`. Had the recipe not fired, the row would still read
+`factory_default` and grading would fail — so a green run proves the
+`sql_dump` dispatch ran. `tests/integration/test_reset_recipe_end_to_end.py`
+drives the pack via `tolokaforge run` at `repeats: 2` and asserts both
+trials observe `baseline`.

--- a/docs/plans/2026-07-14-issue-299-reset-recipe-pack.md
+++ b/docs/plans/2026-07-14-issue-299-reset-recipe-pack.md
@@ -1,0 +1,269 @@
+# Plan: reset-recipe pack via `tolokaforge run`
+
+Issue: #299 (Multi-container runtime v1, keystone of umbrella #304; #300/#302 depend on this)
+Branch: feat/reset-recipe-pack
+
+## Context
+
+M3 (#298, promoted via #307) shipped the seed-backed reset recipes
+(`sql_dump`, `filesystem_dir`, `redis_dump`, `bare`) and per-recipe
+real-container integration tests, but **no task pack exercises the reset
+code path via `tolokaforge run` end-to-end.** Discovery confirmed the
+exact wiring:
+
+- A service labelled `isolation: "reset"` makes
+  `EnvironmentManifest.requires_per_trial` true
+  ([`tolokaforge/runner/models.py:1053`](../../tolokaforge/runner/models.py)),
+  so backend selection routes the run onto **`PerTrialRuntimeBackend`**
+  ([`orchestrator.py:587`](../../tolokaforge/core/orchestrator.py)).
+- `PerTrialRuntimeBackend.provision` brings up a **fresh compose stack
+  per trial** and calls `_apply_reset_recipes` right after `compose up`
+  ([`per_trial_runtime.py:208,359`](../../tolokaforge/core/per_trial_runtime.py)),
+  which resolves `services.<svc>.reset.seed` against the project's
+  `assets.seeds` registry and dispatches the seed's recipe.
+- `trial_executor.py:102` calls `provision(spec)` once per trial, and
+  `repeats: K` produces K trials
+  ([`orchestrator.py:906`](../../tolokaforge/core/orchestrator.py)), so
+  `repeats: 2` ⇒ 2 provisions ⇒ 2 seed applications.
+- `tolokaforge run` loads the enclosing `project.yaml` (walking up from
+  `--config`) and passes it to the orchestrator
+  ([`cli/main.py:224,291`](../../tolokaforge/cli/main.py) via
+  `load_effective_run_config`), so `assets.seeds` reaches the backend.
+
+The existing `examples/native/multi_service_postgres` pack uses
+`isolation: "shared"` everywhere + `repeats: 1`, so the reset seam never
+fires from the CLI. The existing `examples/native/example-microservices-pack`
+*declares* `postgres` `reset` but is **not runnable** — it uses a
+fictional image (`myrepo/example-backend:v1.4.0`) and expensive
+judge-graded tasks; its test
+([`tests/integration/test_example_microservices_pack.py`](../../tests/integration/test_example_microservices_pack.py))
+is a load/wiring proof only (no Docker, no LLM).
+
+## Goal
+
+Ship a **runnable** pack, `examples/native/multi_service_postgres_reset/`,
+that declares `isolation: "reset"` on a real postgres service bound to a
+named seed, and prove — with a deterministic grade and a subprocess
+`tolokaforge run` integration test at `repeats: 2` — that the reset
+recipe fires end-to-end through the CLI.
+
+**The deterministic proof.** Per-trial mode gives every trial a *fresh*
+container, so a cross-trial mutation is gone regardless of any recipe —
+that alone proves nothing about the recipe. So the pack makes the seed
+*load-bearing and observable*: the compose's `init.sql` seeds the row
+with `name = 'factory_default'`; the reset seed
+(`postgres_baseline.sql`, kind `sql_dump`) overwrites it to
+`name = 'baseline'` at provision. The agent reads the row over the REST
+API and writes the value to a file; grading asserts the file reads
+`baseline`. If `_apply_reset_recipes` → `sql_dump` dispatch → `psql`
+had **not** run, the row would still read `factory_default` and grading
+would fail. `repeats: 2` exercises the recipe twice.
+
+## Non-goals
+
+- **No new seed kinds** beyond the four M3 shipped.
+- **No reset-recipe internals** changes (dispatchers validated at
+  integration scope already).
+- **No orchestrator behaviour changes** — the wired per-trial seam is
+  exercised as-is. The unreachable shared-stack reset seam is a
+  Discovered issue, not fixed here.
+- **No shared-stack "reset in place between trials"** — that path
+  (`SharedStackRuntimeBackend.reset_services_for_next_trial`) is
+  unreachable via the CLI (see Discovered issues) and out of scope.
+
+## Stages
+
+### Stage 1: Ship the runnable reset pack + wiring test
+
+- **Contract — new files under `examples/native/multi_service_postgres_reset/`:**
+  - `project.yaml` (a Project spec; `find_project_yaml` discovers it by
+    walking up from the run config):
+    - `assets.seeds.postgres_baseline: {path: ./assets/postgres_baseline.sql, kind: sql_dump, digest: sha256:<stamped>}`.
+    - `default_environment.stack: {compose_file: ./shared/environment.compose.yaml, runner_service: runner}`.
+    - `default_environment.services.app-db: {isolation: "reset", reset: {seed: postgres_baseline}}`.
+      Other compose services (`runner`, `db-service`, `app-service`) are
+      left unlabelled → default `ephemeral` (per-trial), matching the
+      fresh-per-trial reality; do **not** label them `shared` (a
+      `shared` label under a per-trial backend is a semantic wart — see
+      the existing microservices pack). The `reset`/`ephemeral` mix
+      still makes `requires_per_trial` true, forcing per-trial selection.
+    - `task_defaults` (adapter `native`, small `max_turns`, `actors.user`),
+      `run_defaults` (compute/storage/observability; `orchestrator`).
+  - `run_config.yaml` at pack root (root file, not a legacy `run_config/`
+    dir — sits next to `project.yaml` so discovery resolves it):
+    - `models.agent` + `models.user` (cheap model, e.g.
+      `openrouter` `anthropic/claude-haiku-4-5`).
+    - `orchestrator.repeats: 2`, `workers: 1`, a small `max_turns`.
+    - `evaluation.projects: [examples/native/multi_service_postgres_reset/dataset]`
+      (canonical field — **not** `task_packs`, to avoid a new
+      `DeprecationWarning`), `tasks_glob: tasks/reset_probe/task.yaml`,
+      `output_dir: results/multi_service_postgres_reset_example`.
+  - `assets/postgres_baseline.sql` — the reset seed. Data-only, no DDL,
+    idempotent: `INSERT INTO api.widgets (id, name) VALUES (1, 'baseline') ON CONFLICT (id) DO UPDATE SET name = 'baseline';`
+    (data-only keeps PostgREST's schema cache valid — see Risks).
+  - `shared/environment.compose.yaml` — mirror the runnable
+    `multi_service_postgres` compose: `runner` (`tolokaforge-runner:local`),
+    `db-service` (`tolokaforge-db-service:local`), `app-service`
+    (`postgrest/postgrest:v12.2.0`, `PGRST_DB_SCHEMAS=api`), `app-db`
+    (`postgres:16`, bind-mounts `./app-db/init.sql`). Real images only.
+  - `shared/app-db/init.sql` — `CREATE SCHEMA api;` roles
+    (`web_anon` NOLOGIN, granted to `authenticator`), `CREATE TABLE
+    api.widgets (id int PRIMARY KEY, name text NOT NULL);`, `GRANT
+    SELECT ON api.widgets TO web_anon;`, and `INSERT ... (1,
+    'factory_default')`. Must sit under the compose file's directory so
+    `copy_compose_context` includes it in the per-trial materialisation.
+  - `dataset/tasks/reset_probe/task.yaml` — declares **no**
+    `environment_manifest` (inherits the project `default_environment`
+    whole, incl. `app-db: reset`; declaring a task-level
+    `stack.compose_file` would atomically replace the stack and drop the
+    project's `services`). `initial_user_message` is **goal-oriented, not
+    a walkthrough** (AGENTS.md Task Design Quality Bar item 2; this ships
+    under `examples/native/` so users copy it): describe the objective and
+    the environment, and let the agent choose its tools, query, and output
+    filename — e.g. "A support REST API at `http://app-service:3000`
+    serves a `widgets` resource (fields: `id`, `name`); the on-call needs
+    the current `name` of widget 1 on record — read it and write it to a
+    file under `submissions/`." Do **not** dictate the exact URL/query,
+    the `python3 -c urllib` technique, or the exact filename. Determinism
+    is preserved by grading's `submissions/*` glob (below), not by
+    scripting the prompt. A brief `policies.guidance` note that the runner
+    reaches `app-service` by service name (bash allowlist permits python,
+    not curl/wget) is fine — that is environment fact, not a walkthrough.
+    `tools.agent.enabled: [bash, write_file]`. User simulator cooperative
+    (`###STOP###`).
+  - `dataset/tasks/reset_probe/grading.yaml` — **deterministic, no
+    `llm_judge`**: `state_checks.jsonpaths` on
+    `/env/fs/agent-visible/submissions/*` `contains_ci: "baseline"`;
+    `transcript_rules.required_actions` for `bash` + `write_file`.
+  - `README.md` — what the pack demonstrates and how the `factory_default`
+    → `baseline` overwrite proves the recipe fired.
+- **Behaviour to lock (canonical):** a wiring test
+  `tests/canonical/test_reset_recipe_pack_wiring.py` (no Docker, no keys —
+  pure load/resolve/select, correct tier per AGENTS.md). Asserts:
+  `load_project_config` verifies the `postgres_baseline` digest;
+  `resolve(default_environment, None)` yields a manifest with
+  `services["app-db"].isolation == "reset"` and
+  `reset.seed == "postgres_baseline"` and `requires_per_trial is True`;
+  `Orchestrator._select_backend_from_tasks() == "per_trial"` and the
+  constructed `PerTrialRuntimeBackend.seeds` contains `postgres_baseline`.
+  (Mirror `test_example_microservices_pack.py`, but marked `canonical`.)
+- **Compatibility:** internal only — new example files + a new test. No
+  compatibility surface touched (uses only the already-shipped Project
+  schema, `assets.seeds`, `ServiceIsolation`, and the `evaluation.projects`
+  canonical field).
+- **Deliverable:** the pack exists, seed digest is stamped, the canonical
+  wiring test passes.
+- **Validation:**
+  - `uv run tolokaforge assets stamp examples/native/multi_service_postgres_reset/project.yaml` (fills the digest).
+  - `uv run pytest -m canonical tests/canonical/test_reset_recipe_pack_wiring.py -v`.
+  - `uv run tolokaforge validate --tasks "examples/native/multi_service_postgres_reset/dataset/tasks/**/task.yaml"`.
+  - `uv run ruff check` / `ruff format --check` on the new test.
+  - Reviewer checks: seed is data-only (no DDL); task declares no
+    `environment_manifest`; grading has no `llm_judge`;
+    `evaluation.projects` (not `task_packs`); real images only.
+- **Doc updates:** `examples/native/multi_service_postgres_reset/README.md`
+  (new).
+
+### Stage 2: End-to-end integration test + RESET_RECIPES.md
+
+- **Contract — `tests/integration/test_reset_recipe_end_to_end.py`:**
+  Marked `pytest.mark.integration` + `pytest.mark.docker` +
+  `pytest.mark.requires_api`. Use the **existing shared auto-skips**, not
+  a bespoke key check: `@pytest.mark.requires_api` skips when no
+  `ANTHROPIC`/`OPENAI`/`OPENROUTER` key is set (conftest.py:45-53; marker
+  registered pyproject.toml:216), and the established Docker-availability
+  skip (`@pytest.mark.docker` / the `skip_if_no_docker_runner` fixture)
+  covers a missing daemon. (No secret-rule risk — the static-grep test
+  scans only `tolokaforge/`, not `tests/`.) Runs
+  `tolokaforge run --config examples/native/multi_service_postgres_reset/run_config.yaml`
+  via `subprocess` (env loaded the same way `scripts/with_env.sh` does)
+  with `repeats: 2`. Asserts:
+  - exit code 0;
+  - `results/<output_dir>/trials/reset_probe/0/grade.yaml` **and**
+    `.../1/grade.yaml` both exist with `binary_pass: true` (the
+    `state_checks` component reflects `baseline` observed) — per the
+    output layout in
+    [`docs/OUTPUT_FORMAT.md`](../OUTPUT_FORMAT.md) §
+    `trials/{task_id}/{trial_index}/grade.yaml`;
+  - (optional) the run log recorded
+    `runtime.backend.selected backend=PerTrialRuntimeBackend`.
+- **Behaviour to lock (integration):** the reset recipe fires
+  end-to-end via the CLI across two trials; both trials observe the
+  seeded `baseline` (i.e. `_apply_reset_recipes` → `sql_dump` dispatch →
+  `psql` applied `postgres_baseline.sql` on top of the compose's
+  `factory_default`). This is the gap the M3 boundary flagged.
+- **Compatibility:** internal only — new test + new doc.
+- **Deliverable:** the integration test passes on a real Docker daemon
+  with an LLM key; the ship-condition `tolokaforge run` command exits 0.
+- **Validation:**
+  - `scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres_reset/run_config.yaml` — exits 0, trial 2 grade reads baseline.
+  - `scripts/with_env.sh uv run pytest -m integration tests/integration/test_reset_recipe_end_to_end.py -v` — passes.
+  - No new `DeprecationWarning` beyond the M3 baseline (uses
+    `evaluation.projects`, not `task_packs`).
+- **Doc updates:**
+  - `docs/architecture/RESET_RECIPES.md` (new) — concise **current-state**
+    description of the wired reset path: the four seed kinds; how a pack
+    declares `assets.seeds` + `services.<svc>.isolation: "reset"` +
+    `reset.seed`; the per-trial provision seam (`_apply_reset_recipes`);
+    and `multi_service_postgres_reset` as the reference example. Written
+    as if the current state is the only state (no migration history).
+    Note that #300 will extend it with failure modes.
+  - `docs/architecture/README.md` — add the new doc to the index.
+
+## Discovered issues
+
+- **Fix in this PR (cheap, in the neighbourhood):**
+  - `tests/integration/test_example_microservices_pack.py` is marked
+    `integration` but needs neither Docker nor an LLM key (pure
+    load/resolve/select) — it should be `canonical`. Correcting it while
+    adding the sibling `canonical` wiring test keeps the tier discipline
+    consistent. (Confirm with main; skip if it risks scope creep.)
+- **File as issues (GitHub MCP was unavailable in this session — main
+  should file these):**
+  1. **Shared-stack reset seam is unreachable via `tolokaforge run`.**
+     `SharedStackRuntimeBackend.reset_services_for_next_trial`
+     ([`shared_stack_runtime.py:938`](../../tolokaforge/core/shared_stack_runtime.py))
+     has **no run-loop caller** — only
+     `tests/integration/test_cross_mode_isolation.py` invokes it
+     directly. Backend selection routes *every* `reset` service to
+     `PerTrialRuntimeBackend` (`requires_per_trial` is true for `reset`),
+     and forcing the shared backend with a `reset` service is rejected by
+     the isolation-compat gate (`orchestrator.py:826-885`). So the
+     shared-stack "reset a service in place between trials" behaviour is
+     unreachable from the CLI. Either it is intended for a future
+     shared-stack-with-in-place-reset mode (then document it as
+     speculative) or it is dead code. This is the real gap behind #299's
+     "mutate trial 1 / trial 2 reads baseline" framing. Relates to
+     #300 (failure modes) and #303 (startup stress).
+  2. **`docs/architecture/ROADMAP.md` 0.11.0 row still reads "Planned"**
+     despite M2/M3 having shipped (#298, #307). Doc staleness (AGENTS.md
+     Core Rule 8). Recommend folding into the milestone-close task (#7)
+     rather than this PR, to keep #299 tightly scoped.
+
+## Risks / open questions
+
+- **The issue's cross-trial mutation framing is reinterpreted.**
+  Per-trial fresh containers make a trial-1 mutation vanish in trial 2
+  regardless of any recipe, and the shared-reset-in-place seam is
+  unreachable (Discovered issue #1). The honest, deterministic proof is
+  the `factory_default` → `baseline` overwrite within each trial.
+  **Needs user sign-off** that this faithfully satisfies #299's intent
+  (exercise the reset code path via `tolokaforge run`).
+- **PostgREST schema cache.** PostgREST introspects the schema at
+  startup. Keeping the schema/table in `init.sql` (present before
+  PostgREST connects) and the reset seed **data-only** (no DDL) avoids a
+  stale-cache miss on `GET /widgets`. The implementer must verify the row
+  is readable over REST after the seed applies.
+- **LLM cost / flakiness in the integration test.** The agent must be a
+  real LLM (the `mock` provider emits no tool calls). Mitigated by a
+  dead-simple single-GET-plus-write task, a cheap model, a small
+  `max_turns`, and deterministic state-check grading (no judge). Cost is
+  ~cents × 2 trials. Consider a scripted user simulator to halve the LLM
+  cost; keep the agent real.
+- **Task discovery.** `evaluation.projects` is set explicitly (pointing
+  at `dataset`) rather than relying on the unproven
+  empty-projects-→-enclosing-project default; `tasks_glob` selects the
+  single task.
+- **Compose context copy.** `init.sql` must live under the compose file's
+  directory (`shared/app-db/init.sql`) so `copy_compose_context`
+  materialises it per trial.

--- a/docs/plans/2026-07-14-issue-299-reset-recipe-pack.md
+++ b/docs/plans/2026-07-14-issue-299-reset-recipe-pack.md
@@ -88,7 +88,11 @@ would fail. `repeats: 2` exercises the recipe twice.
       the existing microservices pack). The `reset`/`ephemeral` mix
       still makes `requires_per_trial` true, forcing per-trial selection.
     - `task_defaults` (adapter `native`, small `max_turns`, `actors.user`),
-      `run_defaults` (compute/storage/observability; `orchestrator`).
+      `run_defaults` (compute + `orchestrator` only; storage/observability
+      are **intentionally omitted** — see plan note below on the loader
+      discriminator-strip bug — and the effective RunConfig picks up the
+      identical local-storage / sqlite-queue defaults from `RunConfig`
+      itself).
   - `run_config.yaml` at pack root (root file, not a legacy `run_config/`
     dir — sits next to `project.yaml` so discovery resolves it):
     - `models.agent` + `models.user` (cheap model, e.g.
@@ -217,7 +221,23 @@ would fail. `repeats: 2` exercises the recipe twice.
     `integration` but needs neither Docker nor an LLM key (pure
     load/resolve/select) — it should be `canonical`. Correcting it while
     adding the sibling `canonical` wiring test keeps the tier discipline
-    consistent. (Confirm with main; skip if it risks scope creep.)
+    consistent. **Main decision (2026-07-14): skip this in-PR to keep #299
+    tightly scoped; file as a separate follow-up if needed.**
+
+- **Loader discriminator-strip bug (surfaced during Stage 1 implementation).**
+  `resolve_effective_run_config_data` in
+  [`tolokaforge/core/project_loader.py`](../../tolokaforge/core/project_loader.py)
+  dumps `run_defaults` with `exclude_defaults=True`, which strips the
+  `type: "local"` discriminator tag from `storage.artifacts` / `storage.logs`,
+  making the merged `RunConfig` unloadable with
+  `union_tag_not_found`. Any pack declaring `run_defaults.storage` trips
+  this — the shipped `examples/native/example-microservices-pack/run_configs/dev.yaml`
+  reproduces it, only masked because that pack isn't runnable. Filed as a
+  separate GitHub issue (see below); NOT fixed in this PR (touches the
+  loader/models, out of #299 scope). This is why Stage 1 ships
+  `run_defaults` with only `compute` + `orchestrator` — the pack must be
+  runnable end-to-end for Stage 2's proof, and declaring
+  `run_defaults.storage` currently makes it unloadable.
 - **File as issues (GitHub MCP was unavailable in this session — main
   should file these):**
   1. **Shared-stack reset seam is unreachable via `tolokaforge run`.**

--- a/examples/native/multi_service_postgres_reset/README.md
+++ b/examples/native/multi_service_postgres_reset/README.md
@@ -1,0 +1,92 @@
+# Multi-service `postgres` reset example
+
+A **runnable** example that exercises the seed-backed reset recipe path
+end-to-end through `tolokaforge run`. A real postgres service is labelled
+`isolation: reset` and bound to a named SQL seed; the per-trial backend
+applies that seed to a fresh stack at the start of every trial.
+
+```
+agent → PostgREST (HTTP API) → postgres:16 (real database, reset per trial)
+```
+
+## What this example demonstrates
+
+- **A service reset to a named seed per trial.** `app-db` is labelled
+  `isolation: reset` with `reset.seed: postgres_baseline` in
+  `project.yaml`. The seed (`assets/postgres_baseline.sql`, kind
+  `sql_dump`) is registered under `assets.seeds` and applied by the
+  per-trial backend right after the compose stack comes up.
+- **The reset is load-bearing and observable.** The compose stack's
+  `shared/app-db/init.sql` seeds widget 1 with `name = 'factory_default'`.
+  The reset seed overwrites it to `name = 'baseline'`. The agent reads the
+  widget back over the REST API and writes the value to a file under
+  `submissions/`; grading asserts the file reads `baseline`. **If the
+  recipe had not fired, the row would still read `factory_default` and
+  grading would fail** — that gap is the whole proof.
+- **`repeats: 2` fires the recipe twice.** Each trial gets a fresh stack
+  and a fresh seed application.
+
+## Why per-trial (not shared)
+
+`app-db` is `reset` and the other three compose services default to
+`ephemeral` (fresh per trial). That mix makes the manifest's
+`requires_per_trial` true, so backend selection routes the run onto the
+per-trial backend — the only backend that applies reset recipes.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_postgres_reset/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres_reset/run_config.yaml
+```
+
+First run is slower than the JSON examples — postgres has to initialise
+and seed, and PostgREST has to introspect the schema. Compose volumes are
+removed at teardown, so every trial starts from a clean `factory_default`
+before the reset seed applies.
+
+## Layout
+
+```
+examples/native/multi_service_postgres_reset/
+├── project.yaml                       # Project spec: assets.seeds + default_environment (app-db: reset)
+├── run_config.yaml                    # haiku agent + user, repeats: 2
+├── README.md                          # this file
+├── assets/
+│   └── postgres_baseline.sql          # the reset seed (data-only, overwrites the row with `baseline`)
+├── shared/
+│   ├── environment.compose.yaml       # 4-service compose (runner + db-service + app-service + app-db)
+│   └── app-db/
+│       └── init.sql                   # factory schema + `factory_default` row (docker-entrypoint-initdb.d)
+└── dataset/tasks/reset_probe/
+    ├── task.yaml                       # inherits the project default_environment whole; no environment_manifest
+    └── grading.yaml                    # deterministic state check on the written submission
+```
+
+## Design notes
+
+- **The seed is data-only (no DDL).** The schema, roles, and table are
+  created once by `init.sql` before PostgREST connects, so PostgREST's
+  start-up schema cache stays valid. The seed only overwrites a row, which
+  keeps `GET /widgets` readable immediately after the reset.
+- **The task declares no `environment_manifest`.** It inherits the
+  project's `default_environment` whole (including `app-db: reset`). A
+  task-level `stack.compose_file` would atomically replace the stack and
+  drop the project's `services` map.
+- **Deterministic grading, no judge.** The pass/fail signal is a state
+  check that the submission contains `baseline`; correctness does not
+  depend on an LLM grader.
+- **Pinned real images.** `postgrest/postgrest:v12.2.0` and `postgres:16`;
+  the engine images are referenced as `tolokaforge-runner:local` /
+  `tolokaforge-db-service:local`.
+
+## Related
+
+- [`../multi_service_postgres/README.md`](../multi_service_postgres/README.md) —
+  the shared-runtime three-tier postgres example this pack's compose stack
+  mirrors.

--- a/examples/native/multi_service_postgres_reset/assets/postgres_baseline.sql
+++ b/examples/native/multi_service_postgres_reset/assets/postgres_baseline.sql
@@ -1,0 +1,16 @@
+-- postgres_baseline seed — the named baseline `app-db` resets to at the
+-- start of every trial (see project.yaml: assets.seeds.postgres_baseline
+-- and default_environment.services.app-db.reset).
+--
+-- Data-only and idempotent by design. The schema, role grants, and table
+-- are created once by shared/app-db/init.sql before PostgREST connects;
+-- keeping this seed free of DDL leaves PostgREST's start-up schema cache
+-- valid, so `GET /widgets` stays readable after the reset applies.
+--
+-- Applied by the sql_dump recipe as `psql -U ${POSTGRES_USER} -d
+-- ${POSTGRES_DB}` inside the app-db container — i.e. as the `authenticator`
+-- owner role. It overwrites init.sql's `factory_default` row with
+-- `baseline`; the agent reading `baseline` back over the REST API is the
+-- observable proof that the recipe fired.
+INSERT INTO api.widgets (id, name) VALUES (1, 'baseline')
+  ON CONFLICT (id) DO UPDATE SET name = 'baseline';

--- a/examples/native/multi_service_postgres_reset/dataset/tasks/reset_probe/grading.yaml
+++ b/examples/native/multi_service_postgres_reset/dataset/tasks/reset_probe/grading.yaml
@@ -1,0 +1,24 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.7
+    transcript_rules: 0.3
+  pass_threshold: 0.5
+state_checks:
+  jsonpaths:
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "baseline"
+      description: "Submission records the seeded widget name — proof the reset recipe overwrote init.sql's factory_default with baseline"
+transcript_rules:
+  max_turns: 8
+  required_actions:
+    - action_id: "query_api"
+      requestor: assistant
+      name: bash
+      arguments: {}
+      compare_args: []
+    - action_id: "write_submission"
+      requestor: assistant
+      name: write_file
+      arguments: {}
+      compare_args: []

--- a/examples/native/multi_service_postgres_reset/dataset/tasks/reset_probe/task.yaml
+++ b/examples/native/multi_service_postgres_reset/dataset/tasks/reset_probe/task.yaml
@@ -1,0 +1,25 @@
+task_id: "reset_probe"
+name: "Widget Baseline Lookup"
+category: "reset_probe"
+description: "Read a single widget's current name from a PostgREST API backed by a real postgres database whose baseline is restored by a reset recipe, and record it to a submission file."
+initial_user_message: |
+  A support REST API at http://app-service:3000 serves a `widgets` resource
+  (fields: `id`, `name`). The on-call needs the current `name` of widget 1
+  on record — read it from the API and write it to a file under
+  `submissions/`. Let me know once it's recorded.
+adapter_type: "native"
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["bash", "write_file"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are the on-call engineer waiting for the widget's name to be recorded. Answer brief clarifying questions if asked and end with ###STOP### once the value is written to a submission file."
+policies:
+  guidance:
+    - "Reach the REST API from `bash` with `python3 -c 'import urllib.request; ...'` — the runner container joins the same docker network as `app-service` and resolves it by service name. (The bash allowlist permits python but not curl/wget.)"
+grading: "grading.yaml"

--- a/examples/native/multi_service_postgres_reset/project.yaml
+++ b/examples/native/multi_service_postgres_reset/project.yaml
@@ -1,0 +1,69 @@
+# Project spec for the reset-recipe example.
+#
+# Demonstrates the wired reset code path end-to-end via `tolokaforge run`:
+# `app-db` is labelled `isolation: reset` and bound to the named seed
+# `postgres_baseline`. At the start of every trial the per-trial backend
+# brings up a fresh compose stack and applies the seed, overwriting the
+# `factory_default` row init.sql seeded with `baseline`. See README.md.
+#
+# See docs/architecture/PROJECTS.md for the full Project model.
+
+name: "multi-service-postgres-reset"
+version: 1
+description: >
+  Single-task project proving the seed-backed reset recipe fires through
+  the CLI. A real postgres service (app-db) is reset to the
+  `postgres_baseline` SQL seed per trial; the agent reads the seeded value
+  back over a PostgREST API and grading asserts it observed `baseline`.
+
+tasks:
+  discovery:
+    glob: "tasks/**/task.yaml"
+
+# ── Shared assets ───────────────────────────────────────────────
+# Named baselines the reset recipe references by name.
+assets:
+  seeds:
+    postgres_baseline:
+      path: "./assets/postgres_baseline.sql"
+      kind: "sql_dump"
+      digest: "sha256:6ef10f37326ab35c4fa4c20efbe902a7ce961be7c8916db2bef89dd5fb655580"
+
+# ── Default environment ─────────────────────────────────────────
+# Every task inherits this unless it declares its own
+# `environment_manifest`. The reset_probe task declares none, so it
+# inherits this stack whole (including `app-db: reset`).
+default_environment:
+  stack:
+    compose_file: "./shared/environment.compose.yaml"
+    runner_service: "runner"
+  services:
+    # `app-db` is reset to the named seed at the start of every trial.
+    # The other three compose services carry no entry → they default to
+    # `ephemeral` (fresh per trial), matching the per-trial reality. The
+    # reset/ephemeral mix makes `requires_per_trial` true, forcing
+    # per-trial backend selection.
+    app-db:
+      isolation: "reset"
+      reset: { seed: "postgres_baseline" }
+
+# ── Task defaults — base for every task ─────────────────────────
+task_defaults:
+  adapter_type: "native"
+  max_turns: 8
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"
+
+# ── Run defaults — base for every run config ────────────────────
+# Storage and observability use the RunConfig defaults (local artifacts
+# + logs, sqlite queue); only compute and orchestrator knobs are set as
+# project-wide bases here.
+run_defaults:
+  compute:
+    provider: "local-docker"
+    workers: 1
+  orchestrator:
+    auto_start_services: true
+    shuffle_trials: false

--- a/examples/native/multi_service_postgres_reset/run_config.yaml
+++ b/examples/native/multi_service_postgres_reset/run_config.yaml
@@ -1,0 +1,32 @@
+# Reset-recipe example — run config.
+#
+# Sits next to project.yaml so discovery resolves the enclosing project
+# (and its `assets.seeds` + `default_environment`). Exercises the reset
+# code path via `tolokaforge run`: `repeats: 2` provisions the stack
+# twice, so the `postgres_baseline` seed is applied on each of the two
+# trials.
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env.
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 2048
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+
+orchestrator:
+  repeats: 2
+  max_turns: 8
+
+evaluation:
+  projects:
+    - "examples/native/multi_service_postgres_reset/dataset"
+  tasks_glob: "tasks/reset_probe/task.yaml"
+  output_dir: "results/multi_service_postgres_reset_example"

--- a/examples/native/multi_service_postgres_reset/shared/app-db/init.sql
+++ b/examples/native/multi_service_postgres_reset/shared/app-db/init.sql
@@ -1,0 +1,34 @@
+-- Factory schema + data for the `multi_service_postgres_reset` example.
+--
+-- Loaded by postgres:16's docker-entrypoint-initdb.d at container start
+-- (once, before any client connects). Defines everything PostgREST
+-- introspects at start-up, so the schema cache is populated before the
+-- first request:
+--   * `api` schema         — everything PostgREST exposes over HTTP.
+--   * `web_anon` role      — the role PostgREST assumes for unauthenticated
+--                            requests. NOLOGIN — only reachable via the
+--                            authenticator's SET ROLE.
+--   * `authenticator` role — the LOGIN role in POSTGRES_USER; PostgREST
+--                            connects as this and switches to `web_anon`
+--                            per request.
+--
+-- The `factory_default` row below is the value present until the reset
+-- recipe overwrites it. If the recipe never fired, `GET /widgets` would
+-- return `factory_default` and grading (which asserts `baseline`) would
+-- fail — that gap is the whole point of the example.
+
+CREATE SCHEMA api;
+
+CREATE ROLE web_anon NOLOGIN;
+GRANT web_anon TO authenticator;
+
+GRANT USAGE ON SCHEMA api TO web_anon;
+
+CREATE TABLE api.widgets (
+  id   INT  PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+GRANT SELECT ON api.widgets TO web_anon;
+
+INSERT INTO api.widgets (id, name) VALUES (1, 'factory_default');

--- a/examples/native/multi_service_postgres_reset/shared/environment.compose.yaml
+++ b/examples/native/multi_service_postgres_reset/shared/environment.compose.yaml
@@ -1,0 +1,84 @@
+# Compose stack for the `multi_service_postgres_reset` example.
+#
+# Four services on the same docker-compose network:
+#   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
+#   - `db-service`  — tolokaforge-db-service (in-memory sqlite), the engine's
+#                     state / grading backend.
+#   - `app-service` — PostgREST auto-generating REST endpoints from the `api`
+#                     schema in `app-db`. Reachable from the runner container as
+#                     `http://app-service:3000/`.
+#   - `app-db`      — real postgres:16 backing the task's application. Schema
+#                     and the `factory_default` row are seeded at start via
+#                     `./app-db/init.sql`; the reset recipe overwrites that row
+#                     with `baseline` per trial.
+#
+# `app-db` is the only service the manifest labels `reset` (project.yaml);
+# the rest default to ephemeral (fresh per trial). Real images only.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_started
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 8s
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  app-service:
+    image: postgrest/postgrest:v12.2.0
+    environment:
+      PGRST_DB_URI: "postgres://authenticator:auth_pass@app-db:5432/appdb"
+      PGRST_DB_ANON_ROLE: "web_anon"
+      PGRST_DB_SCHEMAS: "api"
+      PGRST_SERVER_PORT: "3000"
+      PGRST_OPENAPI_SERVER_PROXY_URI: "http://app-service:3000"
+    ports:
+      - "3000"
+    depends_on:
+      app-db:
+        condition: service_healthy
+
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "appdb"
+      POSTGRES_USER: "authenticator"
+      POSTGRES_PASSWORD: "auth_pass"
+    ports:
+      - "5432"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U authenticator -d appdb"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s

--- a/tests/canonical/test_reset_recipe_pack_wiring.py
+++ b/tests/canonical/test_reset_recipe_pack_wiring.py
@@ -1,0 +1,106 @@
+"""Load + resolve + backend-selection wiring for the shipped
+``examples/native/multi_service_postgres_reset`` pack.
+
+Proves the reset seam is wired from disk to backend construction: the
+project loads and verifies the ``postgres_baseline`` seed digest, the
+default environment resolves to a manifest that labels ``app-db``
+``reset``, and the task-driven selector routes the run onto
+:class:`PerTrialRuntimeBackend` with the seed in its registry. No Docker
+and no LLM key — this is the pure load/resolve/select contract; the
+end-to-end recipe firing is covered by the sibling integration test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.project_loader import load_project_config, resolve
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = pytest.mark.canonical
+
+
+_PACK_ROOT = (
+    Path(__file__).resolve().parents[2] / "examples" / "native" / "multi_service_postgres_reset"
+)
+_PROJECT_YAML = _PACK_ROOT / "project.yaml"
+
+
+def _make_run_config() -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openrouter", name="anthropic/claude-haiku-4-5")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=2, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir="/tmp/reset_pack_smoke"),
+    )
+
+
+def test_pack_loads_and_verifies_seed_digest() -> None:
+    """``load_project_config`` verifies the ``postgres_baseline`` seed's
+    digest against the file bytes; a stale digest would raise here."""
+    project = load_project_config(_PROJECT_YAML)
+    assert project.assets is not None
+    assert "postgres_baseline" in project.assets.seeds
+    seed = project.assets.seeds["postgres_baseline"]
+    assert seed.kind == "sql_dump"
+    assert seed.digest.startswith("sha256:")
+
+
+def test_default_environment_resolves_app_db_reset() -> None:
+    """The default environment resolves to a manifest that labels
+    ``app-db`` ``reset`` (bound to ``postgres_baseline``) and therefore
+    requires per-trial materialisation."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+    app_db = manifest.services["app-db"]
+    assert app_db.isolation == "reset"
+    assert app_db.reset is not None
+    assert app_db.reset.seed == "postgres_baseline"
+    assert manifest.requires_per_trial is True
+
+
+def test_backend_selector_routes_pack_to_per_trial() -> None:
+    """A run whose task inherits this project's default environment has a
+    ``reset`` service, so backend selection picks
+    :class:`PerTrialRuntimeBackend` with ``postgres_baseline`` in its
+    seed registry."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+
+    orch = Orchestrator(_make_run_config(), project=project)
+    task = MagicMock()
+    task.task_id = "reset_probe"
+    orch.tasks = [task]
+    task_desc = TaskDescription(
+        task_id=task.task_id,
+        name=task.task_id,
+        category="reset_probe",
+        description="",
+        adapter_type="native",
+        system_prompt="",
+        environment_manifest=manifest,
+    )
+    orch.adapter = MagicMock()
+    orch.adapter.to_task_description.side_effect = lambda tid: task_desc
+
+    assert orch._select_backend_from_tasks() == "per_trial"
+
+    backend = orch._construct_runtime_backend(
+        runner_address="sentinel:50051",
+        env_manifest=None,
+        run_id="reset-pack-smoke",
+    )
+    assert isinstance(backend, PerTrialRuntimeBackend)
+    assert "postgres_baseline" in backend.seeds

--- a/tests/integration/test_reset_recipe_end_to_end.py
+++ b/tests/integration/test_reset_recipe_end_to_end.py
@@ -1,0 +1,115 @@
+"""End-to-end proof that a seed-backed reset recipe fires through
+``tolokaforge run``.
+
+Drives the shipped ``examples/native/multi_service_postgres_reset`` pack
+as a real subprocess at ``repeats: 2``. The pack labels ``app-db``
+``isolation: reset`` bound to the ``postgres_baseline`` seed: the
+compose's ``init.sql`` seeds the widget row ``factory_default``, and the
+reset recipe (``sql_dump``) overwrites it to ``baseline`` at every
+provision. The agent reads the row back over the PostgREST API and writes
+it to a submission file; grading's ``state_checks`` glob asserts the file
+reads ``baseline``. Both trials passing proves ``_apply_reset_recipes`` →
+``sql_dump`` dispatch → ``psql`` applied the seed on top of the compose
+default, once per trial.
+
+**Gated.** Requires a real Docker daemon (the per-trial backend brings up
+a fresh compose stack) and a real LLM provider key (the agent must emit
+real tool calls; the ``mock`` provider emits none). ``requires_api``
+auto-skips without a key (see ``tests/conftest.py``); the ``docker`` skip
+below covers a missing daemon.
+
+**Cost.** Two trials of one single-GET-plus-write task (max 8 turns) on
+``anthropic/claude-haiku-4-5`` via OpenRouter. Cents.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.requires_api,
+    pytest.mark.llm,
+    pytest.mark.slow,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK = "examples/native/multi_service_postgres_reset"
+_RUN_CONFIG = f"{_PACK}/run_config.yaml"
+
+
+def _output_basename() -> str:
+    """The configured ``output_dir`` basename the orchestrator suffixes
+    with a run timestamp (``<basename>_<YYYYmmdd_HHMMSS>``)."""
+    cfg = yaml.safe_load((_REPO_ROOT / _RUN_CONFIG).read_text())
+    return Path(cfg["evaluation"]["output_dir"]).name
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial backend needs it)",
+)
+def test_reset_recipe_fires_end_to_end_across_two_trials() -> None:
+    """Both trials observe the seeded ``baseline`` — the reset recipe
+    fired via the CLI on each provision."""
+    basename = _output_basename()
+    results_root = _REPO_ROOT / "results"
+    before = set(results_root.glob(f"{basename}_*")) if results_root.exists() else set()
+
+    proc = subprocess.run(
+        ["uv", "run", "tolokaforge", "run", "--config", _RUN_CONFIG],
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"tolokaforge run failed (rc={proc.returncode}):\n"
+        f"stdout:\n{proc.stdout[-4000:]}\n"
+        f"stderr:\n{proc.stderr[-4000:]}"
+    )
+
+    combined = proc.stdout + proc.stderr
+    assert "runtime.backend.selected" in combined and "PerTrialRuntimeBackend" in combined, (
+        "run did not route onto PerTrialRuntimeBackend — the reset seam never fired.\n"
+        f"stderr tail:\n{proc.stderr[-2000:]}"
+    )
+
+    after = set(results_root.glob(f"{basename}_*"))
+    created = after - before
+    assert len(created) == 1, (
+        f"expected exactly one new run dir under {results_root} matching "
+        f"{basename}_*; got {sorted(created)}"
+    )
+    run_dir = created.pop()
+
+    try:
+        for trial_index in (0, 1):
+            grade_path = run_dir / "trials" / "reset_probe" / str(trial_index) / "grade.yaml"
+            assert grade_path.exists(), (
+                f"missing grade.yaml for trial {trial_index} at {grade_path}.\n"
+                f"run dir contents: {sorted(p.name for p in run_dir.rglob('*'))[:50]}"
+            )
+            grade = yaml.safe_load(grade_path.read_text())
+            assert grade["binary_pass"] is True, (
+                f"trial {trial_index} did not pass — the recipe likely did not seed "
+                f"'baseline' (row would still read init.sql's 'factory_default').\n"
+                f"grade: {grade}"
+            )
+            assert grade["components"]["state_checks"] == 1.0, (
+                f"trial {trial_index} state_checks != 1.0; the submission did not "
+                f"contain the seeded 'baseline' value.\ngrade: {grade}"
+            )
+    finally:
+        shutil.rmtree(run_dir, ignore_errors=True)


### PR DESCRIPTION
Closes #299.

## Summary

- Ship `examples/native/multi_service_postgres_reset/` — a runnable pack with `postgres` labelled `isolation: reset` bound to a named SQL seed. The per-trial backend applies the seed on top of `init.sql`'s `factory_default` on each provision; an agent reads the row back over PostgREST and deterministic grading asserts `baseline` — proof the recipe fired.
- Lock the load/resolve/select wiring with a canonical test (no Docker, no keys) and the reset code path end-to-end with a subprocess `tolokaforge run` integration test at `repeats: 2` (Docker + LLM key, both auto-skipped when absent).
- Ship `docs/architecture/RESET_RECIPES.md` describing the current reset path (four seed kinds, `assets.seeds` + `isolation: reset` + `reset.seed`, the `_apply_reset_recipes` per-trial provision seam) and index it in the architecture README.

## Plan

See `docs/plans/2026-07-14-issue-299-reset-recipe-pack.md`. Plan-critic approved on round 2 after fixes to a walkthrough-scripted prompt and skip-marker discipline.

**Premise correction.** The issue's original \"mutate DB in trial 1, trial 2 reads baseline\" framing does not prove anything about the recipe — `isolation: reset` routes to `PerTrialRuntimeBackend` (fresh container per trial), so any cross-trial mutation vanishes regardless of the recipe. Plan reinterprets: `init.sql` seeds `factory_default`, the reset seed overwrites to `baseline`, observing `baseline` is a positive control that `_apply_reset_recipes` → `sql_dump` dispatch ran. `repeats: 2` fires the recipe twice.

## Discovered issues

- Filed: #310 (unreachable shared-stack reset seam), #311 (ROADMAP 0.11.0 staleness), #312 (loader discriminator-strip bug — surfaced during Stage 1; workaround: omit `storage`/`observability` from `run_defaults`, which this pack does).
- Fixed in this PR: none opportunistic (the plan floated a test tier retag for `test_example_microservices_pack.py`; skipped in-PR to keep #299 tightly scoped).

## Test plan

- [x] `uv run pytest -m canonical tests/canonical/test_reset_recipe_pack_wiring.py -v` — 3 passed.
- [x] `scripts/with_env.sh uv run pytest -m integration tests/integration/test_reset_recipe_end_to_end.py -v` — 1 passed in 53.34s on real Docker + OpenRouter key. Both trials `binary_pass: true`.
- [x] `scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres_reset/run_config.yaml` — exits 0.
- [x] No new `DeprecationWarning` (uses `evaluation.projects`, not `task_packs`; no `orchestrator.workers`).
- [x] Reviewer (branch-code-reviewer) — APPROVE, clean across all categories.

Milestone: Multi-container runtime v1 (#12). Unblocks #300 and #302.