### PR TITLE
test(runtime): reset-recipe failure-mode coverage + truthful stage attribution (#300)

### DIFF
--- a/docs/architecture/RESET_RECIPES.md
+++ b/docs/architecture/RESET_RECIPES.md
@@ -78,9 +78,41 @@ no `reset.seed`, or a seed name absent from the registry, raises
 Because provision runs once per trial, `repeats: K` applies the seed `K`
 times, each onto a freshly-started container.
 
-Failure-mode behaviour (partial application, retries, per-service log
-capture on a failed seed) is out of scope for this document and tracked
-in #300.
+## Failure modes
+
+Every recipe is fail-loud: a dispatcher that cannot restore its baseline
+raises `RuntimeError` naming the service and carrying the failing command's
+diagnostic output. What triggers that raise differs by kind:
+
+| Kind | Failure trigger | Surfaced as |
+|---|---|---|
+| `sql_dump` | `psql` exits non-zero (e.g. a syntax error in the dump; `ON_ERROR_STOP=1`) | `RuntimeError` with the service name, seed path, `rc`, and `psql` stderr |
+| `filesystem_dir` | Seed path is not a directory (guard, before any container call); or copy/wipe exits non-zero | `RuntimeError` naming the path |
+| `redis_dump` | Corrupt RDB → Redis crash-loops on restart → `PING` never returns `PONG` | ping-stage `RuntimeError` naming the service |
+| `bare` | — | Cannot fail from the caller's side: no container action is taken |
+
+At the provision seam, `_apply_reset_recipes` catches that `RuntimeError`
+and re-raises it as `ProvisionError(stage="reset_recipe")` whose reason
+names the service, the seed, the kind, and the recipe's own error text. The
+same stage also covers the pre-dispatch guards — a `reset` service with no
+`reset.seed`, or a seed name absent from the registry. Before the
+`ProvisionError` propagates, the stack is torn down
+(`docker compose down --volumes`), so a failed seed leaves no leaked
+containers or networks.
+
+The trial is then marked failed with
+`termination_reason=PROVISION_ERROR`: the conductor never runs, the trial
+is **non-retryable** (the failure is deterministic), and it counts toward
+the run's `failed_attempts`.
+
+A task author sees this in `grade.yaml` as `binary_pass: false` with a
+`reasons` string of the form:
+
+```
+Provisioning failed at reset_recipe: reset recipe for service 'app-db' (seed 'postgres_baseline', kind 'sql_dump') failed: <recipe error text>
+```
+
+carrying the recipe's own diagnostic output at the end.
 
 ## Reference example
 

--- a/docs/plans/2026-07-15-issue-300-reset-recipe-failure-modes.md
+++ b/docs/plans/2026-07-15-issue-300-reset-recipe-failure-modes.md
@@ -1,0 +1,268 @@
+# Plan: reset-recipe failure-mode coverage + RESET_RECIPES.md failure section
+
+Issue: #300 (Multi-container runtime v1, sub-issue 2/5; depends on #299 which shipped `docs/architecture/RESET_RECIPES.md` and the runnable `multi_service_postgres_reset` pack)
+Branch: test/reset-recipe-failure-modes
+
+## Context
+
+M3 gave each reset recipe a fail-loud contract — every dispatcher raises
+`RuntimeError` naming the service and carrying the failing command's
+output ([`sql_dump.py:64`](../../tolokaforge/runtime/reset_recipes/sql_dump.py),
+[`filesystem_dir.py:43`](../../tolokaforge/runtime/reset_recipes/filesystem_dir.py),
+[`redis_dump.py:100`](../../tolokaforge/runtime/reset_recipes/redis_dump.py)).
+Discovery traced the full propagation path for a recipe failure and it is
+sound but **untested end-to-end** and **mislabelled**:
+
+- `PerTrialRuntimeBackend.provision` runs `_apply_reset_recipes` inside the
+  *same* `try` that wraps `compose.start()`
+  ([`per_trial_runtime.py:198-215`](../../tolokaforge/core/per_trial_runtime.py)).
+  A recipe `RuntimeError` is caught, `cleanup_partial_materialisation`
+  runs (`docker compose down --volumes` → containers **and** the project
+  network removed), then a `ProvisionError` is re-raised — but with
+  `stage="provision"` and reason **`"docker compose up failed: …"`**. For a
+  reset-recipe failure the compose stack came up fine; the label is a
+  factual lie that would misdirect failure attribution to the compose file
+  instead of the seed.
+- `ProvisioningTrialExecutor.execute` catches that `ProvisionError` and
+  synthesises a failed `TrialResult` (`TrialStatus.ERROR`,
+  `TerminationReason.PROVISION_ERROR`, `binary_pass=False`, the reason in
+  `Grade.reasons`), and **never runs the conductor**
+  ([`trial_executor.py:101-111`](../../tolokaforge/core/trial_executor.py)).
+  `PROVISION_ERROR` is classified non-retryable
+  ([`orchestrator.py:373`](../../tolokaforge/core/orchestrator.py)) and the
+  failed trial is counted by `summarize_failure_attributions`
+  (`total_failed_attempts`, [`failure_attribution.py:180`](../../tolokaforge/core/failure_attribution.py)).
+
+**Existing coverage already proves the executor's control flow** (trial
+marked failed, conductor not run, reason carried) via
+`tests/unit/test_trial_executor.py::TestProvisionErrorBranches` using
+`InMemoryRuntimeBackend`, and `provision_failure` attribution via
+`tests/unit/test_failure_attribution.py::test_provision_error_classification`.
+What is missing: (1) that each recipe actually **raises** on the failure
+inputs the issue names; (2) that a real `provision` against a live stack
+tears the stack down cleanly on a recipe failure (**no orphan containers /
+networks**); (3) a **truthful** failure reason distinguishing a reset-recipe
+failure from a compose-up failure.
+
+**Note on the issue body's "hardening in `shared_stack_runtime.py`":** that
+pointer is misdirected. Reset recipes reachable via `tolokaforge run` route
+exclusively through `PerTrialRuntimeBackend` (a `reset` service makes
+`requires_per_trial` true → per-trial backend selection). The shared-stack
+reset seam has no run-loop caller and is already tracked as an unreachable-seam
+issue (#310). All hardening in this plan targets `per_trial_runtime.py`.
+
+## Goal
+
+Lock the reset-recipe failure contract with tests at the right tier, and
+give a reset-recipe failure a **clear, correctly-attributed** reason:
+
+1. Each recipe raises `RuntimeError` on the failure input the issue names,
+   carrying the service name + diagnostic output (recipe tier).
+2. A real `provision` against a live stack, when the recipe fails, raises a
+   `ProvisionError(stage="reset_recipe")` whose reason names the service and
+   carries the recipe error, and leaves **no orphan containers or networks**.
+3. `docs/architecture/RESET_RECIPES.md` gains a current-state "Failure modes"
+   section describing what a task author observes.
+
+## Non-goals
+
+- **No change to recipe happy-path semantics** (issue boundary).
+- **No retry logic** — a recipe failure is a hard trial failure; the
+  existing non-retryable `PROVISION_ERROR` classification stays as-is.
+- **No new full `tolokaforge run` subprocess test.** Forcing a recipe to
+  fail needs no LLM (the agent never runs); the provision seam is the
+  correct, cheaper level to exercise. The green-path CLI run is already
+  covered by `tests/integration/test_reset_recipe_end_to_end.py` (#299).
+- **No shared-stack work** — its reset seam is unreachable via the CLI (#310).
+- **No new seed kinds.**
+
+## Stages
+
+### Stage 1: Truthful reset-recipe failure attribution (`per_trial_runtime.py`)
+
+- **Contract:**
+  - `ProvisionStage` (in [`tolokaforge/core/runtime.py:88`](../../tolokaforge/core/runtime.py))
+    gains a third member: `Literal["provision", "await_ready", "reset_recipe"]`.
+  - `PerTrialRuntimeBackend.provision` splits the single materialisation
+    `try` into two: `compose.start()` failures keep
+    `ProvisionError(stage="provision", reason="docker compose up failed: …")`;
+    `_apply_reset_recipes` failures surface as
+    `ProvisionError(stage="reset_recipe", reason=…)`. Both paths still call
+    `cleanup_partial_materialisation` before raising (unchanged teardown).
+  - `_apply_reset_recipes` owns the `reset_recipe` stage for **all** its
+    failure exits: its existing guards (a `reset` service with no
+    `reset.seed`; a seed name absent from the registry) move from
+    `stage="provision"` to `stage="reset_recipe"`, and the `dispatch(...)`
+    call is wrapped so a recipe `RuntimeError` re-raises as
+    `ProvisionError(stage="reset_recipe", reason=f"reset recipe for service {name!r} (seed {seed_name!r}, kind {seed.kind!r}) failed: {exc}")`.
+    The reason therefore names the service, the seed, the kind, and the
+    recipe's own diagnostic text.
+- **Behaviour to lock (canonical):** extend
+  `tests/canonical/test_per_trial_runtime_backend.py` (uses `_FakeCompose`,
+  no Docker):
+  - a `reset`-labelled manifest whose service names a seed **absent** from
+    `backend.seeds` → `provision` raises `ProvisionError`, `stage == "reset_recipe"`,
+    reason names the missing seed, and no client is cached.
+  - a `reset`-labelled service with `reset=None` → `ProvisionError(stage="reset_recipe")`.
+  - regression guard: a `compose.start()` failure still yields
+    `stage == "provision"` (the existing
+    `test_compose_start_failure_raises_provision_error` already asserts this —
+    confirm it still passes unchanged).
+- **Behaviour to lock (unit):** `tests/unit/test_failure_attribution.py`
+  already classifies a `PROVISION_ERROR` trajectory as `provision_failure`;
+  add one assertion that such an attribution is counted by
+  `summarize_failure_attributions` (`total_failed_attempts == 1`). Extend the
+  existing test module; do **not** add a new file.
+- **Compatibility:** internal only. `ProvisionError` is an in-process
+  exception; `stage` flows into log fields and the `Grade.reasons` string
+  (diagnostic surfaces), not into any persisted schema, gRPC message, or
+  published API. Extending the `ProvisionStage` Literal and adding a stage
+  value is an internal refactor — no migration note.
+- **Deliverable:** a reset-recipe failure produces
+  `ProvisionError(stage="reset_recipe")` with a reason that does not claim
+  "docker compose up failed"; canonical + unit locks pass with no Docker.
+- **Validation:**
+  - `uv run pytest -m canonical tests/canonical/test_per_trial_runtime_backend.py -v`
+  - `uv run pytest -m unit tests/unit/test_failure_attribution.py tests/unit/test_trial_executor.py -v`
+  - `rg 'stage="provision"|stage == "provision"' tests/ tolokaforge/` — confirm
+    no assertion depended on the reset path using `stage="provision"` (the
+    two canonical hits are compose-start / missing-manifest, both unchanged).
+  - `uv run ruff check` / `ruff format --check` on touched files.
+  - Reviewer checks: no `_legacy_*`/shim; `stage="provision"` retained for
+    genuine compose-up failures; reason string no longer mislabels a recipe
+    failure.
+- **Doc updates:** none (docs land in Stage 3, describing the final state).
+
+### Stage 2: Per-recipe failure-mode + clean-teardown integration tests
+
+- **Contract — new `tests/integration/reset_recipes/test_failure_modes.py`**
+  (mirrors the existing per-recipe happy-path files: inline `COMPOSE`,
+  `SeedRef` built in-test, `pytestmark = [pytest.mark.integration, pytest.mark.docker]`;
+  **no** `requires_api` — no LLM is involved). One class per case:
+  - **`TestSqlDumpFailure`** — seed is a `.sql` with a syntax error; boot
+    `postgres:16-alpine`, call `RECIPE_REGISTRY["sql_dump"].apply(seed, "postgres", compose)`,
+    assert it raises `RuntimeError` whose message names the service
+    (`'postgres'`), the seed path, a non-zero `rc`, and the `psql` stderr
+    (the `ON_ERROR_STOP=1` non-zero exit propagates).
+  - **`TestFilesystemDirFailure`** — `seed.path` points at a **file, not a
+    directory**; assert `apply(...)` raises `RuntimeError` from the
+    `is_dir()` guard naming the path, and (against a live `alpine` stack, as
+    in `test_bare_recipe.py`) that no container mutation occurred. The guard
+    precedes any Docker call, so this case is fast.
+  - **`TestRedisDumpFailure`** — `dump.rdb` is **corrupt** (non-empty garbage
+    bytes; an *empty* file is a valid empty DB and would not fail). Boot
+    `redis:7-alpine`, `apply(...)`: copy + `restart` succeed, but Redis
+    crash-loops on the bad RDB so `PING` never returns `PONG` → the
+    ping-stage `RuntimeError` fires. To avoid the full 30 s production poll,
+    monkeypatch `redis_dump.RESTART_PING_MAX_ATTEMPTS` down (e.g. to 3) for
+    this test — patching a module constant, not faking behaviour; assert the
+    raised message names the service and the ping-stage failure.
+  - **`bare`** — N/A (documented no-op; covered as such by
+    `test_bare_recipe.py`). Add a one-line comment in the module saying why
+    `bare` has no failure case, not a skipped test.
+  - **`TestProvisionTearsDownCleanlyOnRecipeFailure`** — the clean-teardown
+    proof through the real backend. Build a **minimal inline** compose (one
+    `postgres:16-alpine` service) + an `EnvironmentManifest` labelling that
+    service `isolation: "reset"` → a broken sql seed, and a
+    `PerTrialRuntimeBackend(seeds={...})`. Snapshot `docker ps -aq` and
+    `docker network ls -q` before; call `backend.provision(spec)`; assert it
+    raises `ProvisionError` with `stage == "reset_recipe"` and a reason
+    naming the service + recipe text; then assert the after-set of
+    containers **and** networks is a subset of the before-set (no new
+    survivors) — i.e. `cleanup_partial_materialisation` removed the stack.
+    (No runner/db-service needed: `_apply_reset_recipes` raises before runner
+    endpoint resolution, so a single postgres service suffices and no
+    project images must be pre-built.)
+- **Behaviour to lock (integration):** each recipe raises on its named
+  failure input carrying service + diagnostic; a real recipe failure inside
+  `provision` yields `stage="reset_recipe"` and a Docker-clean teardown.
+- **Compatibility:** internal only — new test file, no production change.
+- **Deliverable:** all failure-mode tests pass on a real Docker daemon;
+  `docker ps -a` / `docker network ls` show no survivors after the
+  teardown test.
+- **Validation:**
+  - `scripts/with_env.sh uv run pytest -m "integration and docker" tests/integration/reset_recipes/test_failure_modes.py -v`
+  - Manual `docker ps -a` / `docker network ls` after the run — clean.
+  - `uv run ruff check` / `ruff format --check` on the new file.
+  - Reviewer checks: correct markers (no `requires_api`); the teardown test
+    asserts subset semantics on both containers and networks; redis uses
+    corrupt (not empty) bytes; `bare` documented, not skipped.
+- **Doc updates:** none (Stage 3).
+
+### Stage 3: RESET_RECIPES.md — "Failure modes" section
+
+- **Contract — `docs/architecture/RESET_RECIPES.md`:**
+  - **Replace** the forward-pointer note (current lines ~81-83, "Failure-mode
+    behaviour … out of scope … tracked in #300") with a real
+    **"Failure modes"** section. Written current-state (AGENTS.md Rule 8):
+    no "previously out of scope / now added", no `#300` pointer — the section
+    reads as the only state.
+  - Content:
+    - Per-recipe failure surface: `sql_dump` — `psql` non-zero (e.g. bad SQL)
+      → `RuntimeError`; `filesystem_dir` — seed path not a directory → guard
+      `RuntimeError` (plus copy/wipe non-zero); `redis_dump` — corrupt RDB →
+      restart crash-loop → ping-stage `RuntimeError`; `bare` — cannot fail
+      from the caller's side (no container action).
+    - The provision-seam response: the recipe `RuntimeError` becomes a
+      `ProvisionError(stage="reset_recipe")`; the stack is torn down
+      (`docker compose down --volumes` — no leaked containers or networks);
+      the trial is marked failed with `termination_reason=PROVISION_ERROR`,
+      is **non-retryable** (deterministic), and counts toward the run's
+      `failed_attempts`.
+    - What a task author sees: `grade.yaml` `binary_pass: false` with
+      `reasons` = "Provisioning failed at reset_recipe: reset recipe for
+      service … failed: …" carrying the recipe's own error text.
+- **Compatibility:** documentation only. `RESET_RECIPES.md` is a
+  source-of-truth architecture doc — this is an additive current-state
+  section, no migration history.
+- **Deliverable:** the doc's failure section matches the tested behaviour;
+  the `#300` forward-pointer is gone.
+- **Validation:**
+  - `rg -n '#300|out of scope|will extend' docs/architecture/RESET_RECIPES.md`
+    → no stale forward-pointer remains.
+  - Reviewer reads the section against Stage 1/2 behaviour for accuracy;
+    confirms current-state voice (no migration narration).
+  - `docs/architecture/README.md` already links `RESET_RECIPES.md`
+    (cross-cutting concepts row) — no index change needed.
+- **Doc updates:** `docs/architecture/RESET_RECIPES.md`.
+
+## Discovered issues
+
+- **Fix in this PR (cheap, in the neighbourhood):** the misleading
+  `"docker compose up failed: …"` reason on a reset-recipe failure — fixed by
+  Stage 1's `stage="reset_recipe"` split. This is the "small orchestrator
+  hardening" the issue body anticipated, re-targeted from
+  `shared_stack_runtime.py` to `per_trial_runtime.py` per grounding.
+- **Filed as issues:** None. The shared-stack reset seam unreachability is
+  already tracked as #310; the redis 30 s ping-poll on a crash-looped
+  container is by-design (surfaces the failure) and is handled in-test by
+  patching the constant — not worth a follow-up.
+
+## Risks / open questions
+
+- **Stage 1 is a production change in a `test(...)`-titled issue.** It is
+  small, internal-only, and severable: if a pure test+doc PR is preferred,
+  drop Stage 1 and have Stage 2's teardown test assert the current
+  `stage="provision"` / "docker compose up failed" reason instead.
+  **Recommendation: keep Stage 1** — the mislabel directly undercuts the
+  ship condition's "clear reason", and `_synthesize_provision_failure_result`
+  is explicitly built to let analytics distinguish substrate-failure kinds.
+  Flagging for user/critic sign-off.
+- **`redis_dump` failure timing.** Corrupt RDB → crash-loop → the recipe
+  waits `RESTART_PING_MAX_ATTEMPTS` seconds before raising. Mitigated by
+  monkeypatching the constant down in the test; without that the test would
+  add ~30 s.
+- **`filesystem_dir` guard is Docker-independent.** The not-a-directory case
+  short-circuits before any Docker call, so it technically needs no daemon;
+  it lives in the integration module for cohesion with the other recipe
+  cases and is asserted against a live stack to also prove no container
+  mutation. Acceptable; noted so the reviewer isn't surprised the assertion
+  would pass without Docker.
+- **Shared CI box container/network snapshot.** The teardown test asserts the
+  after-set is a **subset** of the before-set — that catches any leak (a new
+  survivor would fail `after ⊆ before`) while tolerating unrelated
+  pre-existing containers/networks. Integration tests run serially in CI
+  (`.github/workflows/ci.yml` — no `-n`/xdist), so there's no concurrent-start
+  vector. The strongest form would filter by the trial's
+  `com.docker.compose.project` label, but the auto-generated project name is
+  not exposed on a failed provision; global-diff is the pragmatic choice.

--- a/tests/canonical/test_per_trial_runtime_backend.py
+++ b/tests/canonical/test_per_trial_runtime_backend.py
@@ -23,6 +23,7 @@ from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend, _LocalEnvHandle
 from tolokaforge.core.runtime import EnvHandle, ProvisionError, RuntimeBackend
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
+from tolokaforge.runner.models import ResetSpec, ServiceSpec
 
 pytestmark = pytest.mark.canonical
 
@@ -215,8 +216,14 @@ def patched_backend(monkeypatch: pytest.MonkeyPatch) -> PerTrialRuntimeBackend:
 def _make_trial_spec(
     trial_id: str = "task-1:0",
     compose_file: Path | None = None,
+    services: dict[str, ServiceSpec] | None = None,
 ) -> TrialSpec:
-    manifest = EnvironmentManifest(compose_file=compose_file) if compose_file is not None else None
+    if compose_file is None:
+        manifest = None
+    elif services is None:
+        manifest = EnvironmentManifest(compose_file=compose_file)
+    else:
+        manifest = EnvironmentManifest(compose_file=compose_file, services=services)
     return TrialSpec(
         trial_id=trial_id,
         run_id="run_contract_test",
@@ -410,6 +417,50 @@ class TestProvision:
         assert isinstance(h_a, _LocalEnvHandle)
         assert isinstance(h_b, _LocalEnvHandle)
         assert h_a.temp_dir != h_b.temp_dir
+
+
+# ---------------------------------------------------------------------------
+# Reset-recipe failure attribution — the reset seam owns ``stage="reset_recipe"``
+# ---------------------------------------------------------------------------
+
+
+class TestResetRecipeFailureAttribution:
+    """A reset-recipe failure is distinct from a compose-up failure. The
+    compose stack came up fine, so ``provision`` must attribute the failure
+    to ``stage="reset_recipe"`` (never ``"provision"``) and never leave a
+    client cached."""
+
+    def test_missing_seed_raises_reset_recipe_stage(
+        self, patched_backend: PerTrialRuntimeBackend
+    ) -> None:
+        spec = _make_trial_spec(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline"))},
+        )
+        # backend.seeds is empty — the named seed is absent from the registry.
+        with pytest.raises(ProvisionError) as exc:
+            patched_backend.provision(spec)
+        assert exc.value.stage == "reset_recipe"
+        assert "baseline" in exc.value.reason
+        assert "compose up failed" not in exc.value.reason
+        assert spec.trial_id not in patched_backend._clients
+
+    def test_reset_service_without_seed_pointer_raises_reset_recipe_stage(
+        self, patched_backend: PerTrialRuntimeBackend
+    ) -> None:
+        # The ServiceSpec invariant forbids isolation='reset' with reset=None,
+        # so reaching the backend's defensive guard means clearing the pointer
+        # after construction (schema validation would reject it upstream).
+        spec = _make_trial_spec(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline"))},
+        )
+        assert spec.task.environment_manifest is not None
+        spec.task.environment_manifest.services["db"].reset = None
+        with pytest.raises(ProvisionError) as exc:
+            patched_backend.provision(spec)
+        assert exc.value.stage == "reset_recipe"
+        assert spec.trial_id not in patched_backend._clients
 
 
 # ---------------------------------------------------------------------------

--- a/tests/canonical/test_per_trial_runtime_backend.py
+++ b/tests/canonical/test_per_trial_runtime_backend.py
@@ -462,6 +462,42 @@ class TestResetRecipeFailureAttribution:
         assert exc.value.stage == "reset_recipe"
         assert spec.trial_id not in patched_backend._clients
 
+    def test_non_provision_error_from_reset_seam_still_tears_down(
+        self,
+        patched_backend: PerTrialRuntimeBackend,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A non-ProvisionError out of the reset seam (e.g. an unregistered
+        # SeedKind surfacing as KeyError from dispatch) must still tear the
+        # partial stack down, then propagate fail-fast. Locks the broad
+        # ``except`` in provision — a re-narrowing to ProvisionError leaks.
+        spec = _make_trial_spec(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline"))},
+        )
+
+        def _raise_key_error(*_args: Any, **_kwargs: Any) -> None:
+            raise KeyError("no such kind")
+
+        monkeypatch.setattr(patched_backend, "_apply_reset_recipes", _raise_key_error)
+
+        cleanup_calls: list[tuple[Any, Any]] = []
+        real_cleanup = per_trial_runtime_module.cleanup_partial_materialisation
+
+        def _recording_cleanup(compose: Any, temp_dir: Any) -> None:
+            cleanup_calls.append((compose, temp_dir))
+            real_cleanup(compose, temp_dir)
+
+        monkeypatch.setattr(
+            per_trial_runtime_module, "cleanup_partial_materialisation", _recording_cleanup
+        )
+
+        with pytest.raises(KeyError, match="no such kind"):
+            patched_backend.provision(spec)
+
+        assert len(cleanup_calls) == 1
+        assert spec.trial_id not in patched_backend._clients
+
 
 # ---------------------------------------------------------------------------
 # await_ready — no-op contract

--- a/tests/integration/reset_recipes/test_failure_modes.py
+++ b/tests/integration/reset_recipes/test_failure_modes.py
@@ -1,0 +1,236 @@
+"""Real-container failure-mode tests for the reset recipes.
+
+Each recipe has a fail-loud contract: on its named failure input it
+raises :class:`RuntimeError` naming the service and carrying the failing
+command's diagnostic output. These tests boot a real stack per recipe and
+assert that contract against genuine Docker behaviour (bad SQL, a
+non-directory seed, a corrupt RDB), then prove that a recipe failure
+inside :meth:`PerTrialRuntimeBackend.provision` surfaces as
+``ProvisionError(stage="reset_recipe")`` and tears the stack down with no
+leaked containers or networks.
+
+``bare`` has no failure case: it performs no container-side action (see
+``test_bare_recipe.py``), so there is nothing for a caller to break.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+from tests.canonical._factories import make_task_description
+from tolokaforge.core.models import ModelConfig, SeedRef
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
+from tolokaforge.runner.models import ResetSpec, ServiceSpec
+from tolokaforge.runtime.reset_recipes import RECIPE_REGISTRY, redis_dump
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+POSTGRES_COMPOSE = textwrap.dedent(
+    """
+    services:
+      postgres:
+        image: "postgres:16-alpine"
+        environment:
+          POSTGRES_USER: "postgres"
+          POSTGRES_PASSWORD: "example"
+          POSTGRES_DB: "app"
+        healthcheck:
+          test: ["CMD-SHELL", "pg_isready -U postgres -d app"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+REDIS_COMPOSE = textwrap.dedent(
+    """
+    services:
+      redis:
+        image: "redis:7-alpine"
+        command: ["redis-server", "--save", "", "--appendonly", "no"]
+        healthcheck:
+          test: ["CMD", "redis-cli", "PING"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+ALPINE_COMPOSE = textwrap.dedent(
+    """
+    services:
+      workspace:
+        image: "alpine:3.20"
+        command: ["sh", "-c", "mkdir -p /workspace && sleep 3600"]
+        healthcheck:
+          test: ["CMD", "test", "-d", "/workspace"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+    """
+).strip()
+
+
+BROKEN_SQL = "CREATE TABLE widgets (id INT PRIMARY KEY;\nTHIS IS NOT VALID SQL;\n"
+
+
+def _digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _write_compose(tmp_path: Path, compose_text: str) -> Path:
+    compose_dir = tmp_path / "compose"
+    compose_dir.mkdir()
+    (compose_dir / "docker-compose.yml").write_text(compose_text + "\n")
+    return compose_dir
+
+
+def _boot(compose_dir: Path) -> DockerCompose:
+    return DockerCompose(
+        context=str(compose_dir),
+        compose_file_name="docker-compose.yml",
+        pull=True,
+        build=False,
+        wait=True,
+    )
+
+
+class TestSqlDumpFailure:
+    def test_bad_sql_raises_runtime_error_with_service_and_stderr(self, tmp_path: Path) -> None:
+        seed_file = tmp_path / "broken.sql"
+        seed_file.write_text(BROKEN_SQL)
+        seed = SeedRef(path=seed_file, kind="sql_dump", digest=_digest(seed_file.read_bytes()))
+
+        with _boot(_write_compose(tmp_path, POSTGRES_COMPOSE)) as compose:
+            with pytest.raises(RuntimeError) as exc:
+                RECIPE_REGISTRY["sql_dump"].apply(seed, "postgres", compose)
+
+        message = str(exc.value)
+        assert "'postgres'" in message
+        assert str(seed_file) in message
+        assert "rc=0" not in message
+        assert "syntax error" in message
+
+
+class TestFilesystemDirFailure:
+    def test_non_directory_seed_raises_before_any_container_action(self, tmp_path: Path) -> None:
+        seed_file = tmp_path / "not_a_dir.txt"
+        seed_file.write_text("this is a file, not a directory tree")
+        seed = SeedRef(
+            path=seed_file, kind="filesystem_dir", digest=_digest(seed_file.read_bytes())
+        )
+
+        with _boot(_write_compose(tmp_path, ALPINE_COMPOSE)) as compose:
+            # The is_dir() guard precedes any Docker call; a live stack is
+            # here only to prove no container mutation is attempted.
+            with patch.object(subprocess, "run") as run_mock:
+                with pytest.raises(RuntimeError) as exc:
+                    RECIPE_REGISTRY["filesystem_dir"].apply(seed, "workspace", compose)
+            assert run_mock.call_count == 0
+
+        message = str(exc.value)
+        assert str(seed_file) in message
+        assert "not a directory" in message
+
+
+class TestRedisDumpFailure:
+    def test_corrupt_rdb_crash_loops_and_fails_ping_stage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Non-empty garbage: Redis rejects the RDB signature at startup and
+        # exits, so the restarted process never accepts PING. (An *empty*
+        # file is a valid empty DB and would load cleanly.)
+        rdb = tmp_path / "dump.rdb"
+        rdb.write_bytes(b"not-a-valid-redis-rdb-file\x00\xff\x01\x02")
+        seed = SeedRef(path=rdb, kind="redis_dump", digest=_digest(rdb.read_bytes()))
+
+        # Patch the module constant (not behaviour) so the crash-loop is
+        # detected in a few seconds instead of the 30 s production poll.
+        monkeypatch.setattr(redis_dump, "RESTART_PING_MAX_ATTEMPTS", 3)
+
+        with _boot(_write_compose(tmp_path, REDIS_COMPOSE)) as compose:
+            with pytest.raises(RuntimeError) as exc:
+                RECIPE_REGISTRY["redis_dump"].apply(seed, "redis", compose)
+
+        message = str(exc.value)
+        assert "'redis'" in message
+        assert "ping stage" in message
+
+
+class TestProvisionTearsDownCleanlyOnRecipeFailure:
+    """A real recipe failure inside ``provision`` must attribute to
+    ``stage="reset_recipe"`` and leave no orphan containers or networks —
+    ``cleanup_partial_materialisation`` brings the whole stack down."""
+
+    def test_broken_seed_yields_reset_recipe_stage_and_clean_teardown(self, tmp_path: Path) -> None:
+        compose_file = _write_compose(tmp_path, POSTGRES_COMPOSE) / "docker-compose.yml"
+        seed_file = tmp_path / "broken.sql"
+        seed_file.write_text(BROKEN_SQL)
+
+        manifest = EnvironmentManifest(
+            compose_file=compose_file,
+            runner_service="postgres",
+            services={"postgres": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline"))},
+        )
+        backend = PerTrialRuntimeBackend(
+            seeds={
+                "baseline": SeedRef(
+                    path=seed_file, kind="sql_dump", digest=_digest(seed_file.read_bytes())
+                )
+            }
+        )
+        spec = TrialSpec(
+            trial_id="reset-failure:0",
+            run_id="reset-recipe-failure-teardown",
+            task=make_task_description(
+                task_id="task-1",
+                name="probe",
+                category="general",
+                description="reset-recipe failure teardown test",
+                environment_manifest=manifest,
+            ),
+            agent_model_config=ModelConfig(name="claude-sonnet-4-6", provider="anthropic"),
+            env_endpoints=EnvEndpoints(
+                db_url="http://placeholder:5432",
+                runner_url="http://placeholder:50051",
+            ),
+        )
+
+        before_containers = _docker_container_ids()
+        before_networks = _docker_network_ids()
+
+        with pytest.raises(ProvisionError) as exc:
+            backend.provision(spec)
+
+        assert exc.value.stage == "reset_recipe"
+        assert "'postgres'" in exc.value.reason
+        assert "reset recipe" in exc.value.reason
+
+        # No new container or network survived the failed provision.
+        assert _docker_container_ids() <= before_containers
+        assert _docker_network_ids() <= before_networks
+        assert spec.trial_id not in backend._clients
+
+
+def _docker_container_ids() -> set[str]:
+    result = subprocess.run(["docker", "ps", "-aq"], capture_output=True, check=True, text=True)
+    return set(result.stdout.split())
+
+
+def _docker_network_ids() -> set[str]:
+    result = subprocess.run(
+        ["docker", "network", "ls", "-q"], capture_output=True, check=True, text=True
+    )
+    return set(result.stdout.split())

--- a/tests/unit/test_failure_attribution.py
+++ b/tests/unit/test_failure_attribution.py
@@ -62,6 +62,12 @@ def test_provision_error_classification():
     assert attribution["deterministic"] is True
     assert any(e["kind"] == "termination_reason" for e in attribution["evidence"])
 
+    # A provision failure (which a reset-recipe failure surfaces as) counts
+    # toward the run's failed attempts in the summary rollup.
+    summary = summarize_failure_attributions([attribution])
+    assert summary["total_failed_attempts"] == 1
+    assert summary["by_failure_class"]["provision_failure"] == 1
+
 
 def test_tool_argument_classification():
     traj = _base_trajectory()

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -205,7 +205,6 @@ class PerTrialRuntimeBackend:
                 wait=True,
             )
             compose.start()
-            self._apply_reset_recipes(manifest, compose, spec)
         except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
             cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
@@ -213,6 +212,16 @@ class PerTrialRuntimeBackend:
                 stage="provision",
                 reason=f"docker compose up failed: {exc}",
             ) from exc
+
+        # Reset recipes run against the started stack; a recipe failure is
+        # distinct from a compose-up failure (the stack came up fine), so
+        # _apply_reset_recipes owns the reset_recipe stage. Teardown is the
+        # same either way — the partially materialised stack must come down.
+        try:
+            self._apply_reset_recipes(manifest, compose, spec)
+        except ProvisionError:
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise
 
         runner_service = manifest.runner_service
         runner_port = RUNNER_PORT_DEFAULT
@@ -376,7 +385,7 @@ class PerTrialRuntimeBackend:
             if service_spec.reset is None:
                 raise ProvisionError(
                     trial_id=spec.trial_id,
-                    stage="provision",
+                    stage="reset_recipe",
                     reason=(
                         f"service {service_name!r} labelled 'reset' has no "
                         "'reset.seed' pointer — schema validation should have "
@@ -388,14 +397,24 @@ class PerTrialRuntimeBackend:
             if seed is None:
                 raise ProvisionError(
                     trial_id=spec.trial_id,
-                    stage="provision",
+                    stage="reset_recipe",
                     reason=(
                         f"service {service_name!r} names seed {seed_name!r} but "
                         f"the backend has no such seed in its registry "
                         f"(available: {sorted(self.seeds)!r})."
                     ),
                 )
-            dispatch(seed, service_name, compose)
+            try:
+                dispatch(seed, service_name, compose)
+            except RuntimeError as exc:
+                raise ProvisionError(
+                    trial_id=spec.trial_id,
+                    stage="reset_recipe",
+                    reason=(
+                        f"reset recipe for service {service_name!r} "
+                        f"(seed {seed_name!r}, kind {seed.kind!r}) failed: {exc}"
+                    ),
+                ) from exc
 
     # ---- Internal helpers ----
 

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -217,9 +217,13 @@ class PerTrialRuntimeBackend:
         # distinct from a compose-up failure (the stack came up fine), so
         # _apply_reset_recipes owns the reset_recipe stage. Teardown is the
         # same either way — the partially materialised stack must come down.
+        # The catch is broad on purpose: a typed ProvisionError and a
+        # programming error (e.g. an unregistered SeedKind surfacing as
+        # KeyError from dispatch) both require the stack torn down. The
+        # non-ProvisionError re-raise still propagates fail-fast.
         try:
             self._apply_reset_recipes(manifest, compose, spec)
-        except ProvisionError:
+        except Exception:
             cleanup_partial_materialisation(compose, temp_dir)
             raise
 

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -85,7 +85,7 @@ class EnvHandle(Protocol):
 # ---------------------------------------------------------------------------
 
 
-ProvisionStage = Literal["provision", "await_ready"]
+ProvisionStage = Literal["provision", "await_ready", "reset_recipe"]
 
 
 class ProvisionError(Exception):


### PR DESCRIPTION
Closes #300.

## Summary

- **Truthful failure attribution** (`per_trial_runtime.py`): a reset-recipe failure now surfaces as `ProvisionError(stage=\"reset_recipe\")` with reason `\"reset recipe for service '…' (seed '…', kind '…') failed: …\"` — previously it was mislabelled `stage=\"provision\"` / `\"docker compose up failed: …\"` even though compose came up fine, misdirecting failure attribution to the compose file.
- **Per-recipe failure-mode integration tests** — one class per active recipe (`sql_dump` bad SQL / `filesystem_dir` non-dir guard / `redis_dump` corrupt RDB). Plus a clean-teardown proof that a real `PerTrialRuntimeBackend.provision` failure leaves no orphan containers or networks.
- **`docs/architecture/RESET_RECIPES.md` \"Failure modes\" section** replacing the previous \"#300\" forward-pointer — describes per-recipe failure surfaces, the `ProvisionError(stage=\"reset_recipe\")` translation, teardown behaviour, non-retryable classification, and the exact `grade.yaml.reasons` string a task author sees.
- **Reset-seam teardown regression closed** (branch reviewer catch): the reset-seam guard now `except Exception:` (was narrowed to `except ProvisionError` in Stage 1), so a programming-error class exception like `KeyError` from `dispatch` on an unregistered `SeedKind` also runs `cleanup_partial_materialisation` before re-raising. Locked by a canonical regression test.

## Plan

See \`docs/plans/2026-07-15-issue-300-reset-recipe-failure-modes.md\`. Plan-critic APPROVE WITH NOTES on round 1 (one 🟡 rationale reword applied inline).

**Premise correction:** the issue body pointed at \`shared_stack_runtime.py\` for hardening — that path is unreachable via \`tolokaforge run\` (already tracked as #310). All hardening in this PR targets \`per_trial_runtime.py\`.

## Discovered issues

- None filed new (shared-stack unreachability already #310; redis 30s ping-poll on crash-loop is by-design + handled in-test by monkeypatching `RESTART_PING_MAX_ATTEMPTS`).

## Test plan

- [x] `uv run pytest -m canonical tests/canonical/test_per_trial_runtime_backend.py -v` — 36 passed (includes new failure-attribution + regression tests).
- [x] `uv run pytest -m unit tests/unit/test_failure_attribution.py tests/unit/test_trial_executor.py -v` — 17 passed.
- [x] `scripts/with_env.sh uv run pytest -m \"integration and docker\" tests/integration/reset_recipes/test_failure_modes.py -v` — 4 passed on real Docker (~30s); \`docker ps -a\` / \`network ls\` clean afterwards.
- [x] Branch reviewer — round 1 flagged one 🟠 (reset-seam teardown regression on non-\`ProvisionError\`); fixed as one-line widen + canonical regression test; round 2 APPROVE.

Milestone: Multi-container runtime v1 (#12). Sub-issue 2/5 of umbrella #304.