### PR TITLE
feat(runtime): enforce network_policy in docker provisioner + tests (#301)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -91,14 +91,29 @@ Field reference:
 | `compose_file` | yes | — | Path to the docker-compose YAML. Relative paths resolve against `task.yaml`. This file is the sole source of truth for services, images, ports, volumes, healthchecks, and `depends_on`. |
 | `runner_service` | no | `"default"` | Which compose service is the tolokaforge runner. Must be a service declared in the compose file. |
 | `isolation` | no | `"per_trial"` | `"per_trial"` (fresh stack per trial) or `"shared_ok"` (all trials share the run's stack). See [multi-container guide](guides/multi_container_tasks.md#choosing-isolation) for how to pick. |
+| `network_policy` | no | `"no_internet"` | Public-egress posture for the task's application services. `no_internet` (default) attaches every task service to an `internal` docker network so no service can reach the public internet; `full_internet` runs the compose file unchanged. `limited_internet` is refused at materialisation (needs an egress-allowlist proxy — #323). See below. |
+
+`network_policy` enforcement (docker backends):
+
+- `no_internet` (default) — every task service joins an injected `internal:
+  true` network, so no application service reaches the public internet;
+  inter-service DNS still works. The `runner_service` additionally joins a
+  non-internal edge network so its published gRPC port stays host-reachable
+  and it retains egress for in-container LLM-as-judge grading. The contract
+  is scoped to application services — egress of tools the agent executes
+  *inside* the runner is not blocked (#325).
+- `full_internet` — the compose file runs verbatim; every service keeps
+  whatever egress its networks allow.
+- `limited_internet` — refused before any container starts (raises
+  `NetworkPolicyError`). A per-host allowlist needs an egress-proxy sidecar,
+  tracked in #323; refusing is the only honest option since docker's
+  `internal` flag is binary. Declare `no_internet` or `full_internet`
+  explicitly.
 
 Fields declared on the model but **not yet enforced by the provisioner** —
 declaring them is accepted for forward-compatibility but has no runtime
 effect today:
 
-- `network_policy` — reserved. Default `no_internet` is documented but not
-  yet enforced. Compose-file `network_mode: host` is still rejected by the
-  manifest validator regardless.
 - `security_context_defaults` — reserved. No provisioner consumer yet.
 - `initial_state` (on the manifest itself, not the task-level
   `initial_state`) — reserved for per-service fixture copy operations. Use

--- a/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
+++ b/docs/architecture/adr/0010-runtime-backend-provisioning-contract.md
@@ -148,9 +148,9 @@ A `RuntimeBackend` implementation is contractually obligated to honour every dec
 
 | Declared where | Provisioner obligation |
 |---|---|
-| `EnvironmentManifest.network_policy` = `no_internet` | No egress to the public internet; no reachability across per-trial projects. Enforce via substrate-native network isolation. |
-| `EnvironmentManifest.network_policy` = `limited_internet` | Egress permitted for the provisioner-defined allowlist; no cross-trial reachability. |
-| `EnvironmentManifest.network_policy` = `full_internet` | Unrestricted egress; still no cross-trial reachability. |
+| `EnvironmentManifest.network_policy` = `no_internet` | No public egress for the task's application services; no reachability across per-trial projects. The docker backends enforce it by attaching every task service to an injected `internal: true` network and additionally attaching `runner_service` to a non-internal edge network (so its published port stays host-reachable and it keeps judge egress). Scoped to application services — runner-executed tool egress is not blocked (#325). |
+| `EnvironmentManifest.network_policy` = `limited_internet` | Egress permitted for the provisioner-defined allowlist; no cross-trial reachability. The docker backends refuse this at materialisation (`NetworkPolicyError`) — a per-host allowlist needs an egress-proxy sidecar (#323). |
+| `EnvironmentManifest.network_policy` = `full_internet` | Unrestricted egress; still no cross-trial reachability. The docker backends run the compose file unchanged. |
 | `EnvironmentManifest.security_context_defaults` | Every declared field applied to each compose service that does not set the equivalent explicitly (`run_as_user`, `read_only_root_filesystem`, `no_new_privileges`, capability drops / adds). Fail `ProvisionError` if the substrate cannot enforce a declared field. |
 | `EnvironmentManifest.initial_state` | Fixture applied per its `kind` (`sql` / `copy` / `script`) to the named compose service before `await_ready` returns. |
 | Compose service `deploy.resources` / `mem_limit` / `cpus` | Container-level CPU / memory caps enforced as declared. |

--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -311,6 +311,51 @@ Key differences from Case B:
 
 Shipped in v0.7.0 (`PerTrialRuntimeBackend` + `--runtime` CLI).
 
+## Network policy enforcement
+
+`EnvironmentManifest.network_policy` parameterises how the docker backends
+materialise a task-declared stack (Case B and Case C). It is a closed enum
+with three values; the default is `no_internet`.
+
+Both backends materialise the same way: `copy_compose_context` copies the
+task's compose file into an isolated project directory, the copy is rewritten
+in place by `enforce_network_policy` (`compose_materialisation.py`), then
+`DockerCompose` brings the rewritten file up.
+
+| Value | Enforcement |
+|---|---|
+| `no_internet` (default) | Every task service is attached to an injected `internal: true` network (`tolokaforge_netpolicy_internal`), and any network the task already declared is forced `internal: true`. No application service can reach the public internet; inter-service DNS is intact because every service shares the internal network. The `runner_service` is *additionally* attached to a non-internal edge network (`tolokaforge_netpolicy_edge`). |
+| `full_internet` | The compose file is run unchanged; the transform is identity. |
+| `limited_internet` | Refused before any container starts. `verify_network_policy_supported` raises `NetworkPolicyError` ahead of the compose-up. |
+
+The injected network names are prefixed by compose with the per-run /
+per-trial project name, so they are unique on the daemon and cannot collide
+with a task-declared network of the same base name.
+
+**Why the runner keeps egress under `no_internet`.** The engine runner runs
+LLM-as-judge grading in-container and must reach the LLM provider to grade;
+its published gRPC port must also stay host-reachable so the backend can
+resolve and connect to it. The edge-network attachment gives the runner both.
+The honest `no_internet` contract is therefore scoped: **task-declared
+application services have zero public egress; the runner retains its
+control-plane and grading egress.**
+
+**Scope boundary.** `no_internet` blocks egress at the container-network
+level, so it does not block egress of tools the agent executes *inside* the
+runner (those share the runner's edge access). Blocking runner-executed tool
+egress is tracked separately in #325.
+
+**`limited_internet` is refused, not approximated.** Docker's `internal` flag
+is binary — a network either has egress or it does not. A real per-host
+allowlist needs an egress-proxy sidecar, tracked in #323. Silently granting
+full or no internet would under- or over-enforce a declared security posture,
+so materialisation fails loud until #323 lands. Task authors declare
+`no_internet` or `full_internet` explicitly.
+
+The `network_isolation:no_internet` backend capability (advertised by both
+docker backends, admitted by the capability gate at run start) reflects this
+enforcement.
+
 ## Choosing a case — decision flow
 
 ```mermaid

--- a/docs/plans/2026-07-15-issue-301-network-policy-enforcement.md
+++ b/docs/plans/2026-07-15-issue-301-network-policy-enforcement.md
@@ -1,0 +1,297 @@
+# Plan: network_policy enforcement + tests (Multi-container 3/5)
+
+Issue: #301 (umbrella #304)
+Branch: feat/network-policy-enforcement
+
+## Context
+
+**Audit result — enforcement is entirely absent for task-declared stacks; the capability advertisement is false.**
+
+`network_policy` is declared on `EnvironmentPatch` / `EnvironmentManifest`
+(`tolokaforge/runner/models.py:958`, `:1035`), validated as a closed enum
+(`no_internet` | `limited_internet` | `full_internet`, default `no_internet`),
+and resolved onto the manifest by `tolokaforge/core/project_loader.py`. From
+there it is **read nowhere**. `rg network_policy` returns only the model
+definitions, the resolver, docs, and one example pack — **zero** hits in the
+docker-provisioner path (`compose_materialisation.py`, `shared_stack_runtime.py`,
+`per_trial_runtime.py`, `tolokaforge/docker/`).
+
+Both backends nonetheless **advertise** `network_isolation:no_internet` as an
+honoured capability (`shared_stack_runtime.py:698`, `per_trial_runtime.py:113`;
+registered at `backend_capabilities.py:63` with the description "Backend
+enforces per-trial network isolation with no public egress"). The admission gate
+(`check_admission`) will happily admit a run that requires it — giving operators
+false confidence. `docs/TASKS.md:99` is at least honest: "`network_policy` —
+reserved. Default `no_internet` is documented but not enforced."
+
+The materialisation path in both backends is identical:
+`copy_compose_context(manifest.compose_file, temp_dir)` →
+`DockerCompose(context=temp_dir, compose_file_name=…, …)` → `compose.start()`
+(`shared_stack_runtime.py:835-843`, `per_trial_runtime.py:199-207`). The task's
+compose file is run **verbatim**; whatever networks it declares (or the compose
+default bridge) are used, all egress-capable.
+
+The `internal=True` flag on `tolokaforge/docker/network.py`'s `Network.create`
+exists but is dead code — the only production caller (`docker/stack.py:411`, the
+Case A `EngineStack`) creates its networks **without** it, and the testcontainers
+`DockerCompose` path never touches `Network` at all.
+
+**Reproduced by running (2026-07-15, real Docker 24.0.5).** A two-service compose
+(`alpine` + `nginx`, default network) reaches the open internet today:
+`ping 8.8.8.8` → `EGRESS_OK`, `wget http://1.1.1.1` → `EGRESS_OK`. This is the
+leak: a task pack declaring `no_internet` is silently granted full internet.
+
+**Enforcement mechanism validated by running.** Marking the compose default
+network `internal: true` blocks egress (`EGRESS_BLOCKED`) and preserves
+inter-service traffic — **but drops the host-published port** (`docker compose
+port` → NONE), which the backend depends on to resolve and reach the runner's
+gRPC endpoint. A naive "mark the default network internal" therefore breaks
+Case B/C materialisation entirely.
+
+The working topology (validated by running) is a **two-network split**: every
+service joins an `internal: true` network (no egress, inter-service DNS intact),
+and the runner service *additionally* joins a non-internal "edge" network.
+Result: `host->runner HTTP 200` (backend resolves + reaches the runner),
+`INTERSVC_OK` (runner → app-service by DNS), `APP_EGRESS_BLOCKED` (application
+services cannot egress), `RUNNER_EGRESS_OK` (runner keeps egress).
+
+The runner keeping egress is **required by design, not a leak**: the runner runs
+LLM-as-judge in-container (`tolokaforge/runner/service.py:1321`, keys exported at
+`runner/__main__.py:91`) and must reach the LLM provider to grade. So the honest
+`no_internet` contract is: *task-declared application services have zero public
+egress; the engine runner retains its control-plane + grading egress.*
+
+## Goal
+
+Make `manifest.network_policy` actually parameterise the docker provisioner for
+task-declared stacks (Cases B and C), turning the existing
+`network_isolation:no_internet` capability advertisement truthful:
+
+- **`no_internet`** — every task service on an `internal: true` network (no
+  public egress); runner additionally on a non-internal edge network so its
+  published gRPC port stays host-reachable and it retains judge egress.
+- **`full_internet`** — compose run unchanged (current behaviour).
+- **`limited_internet`** — **fail loud** at materialisation. Docker's `internal`
+  flag is binary; a real allowlist needs an egress-proxy sidecar (filed as
+  #323). Refusing to run is the only honest option — silently granting full or
+  no internet would under/over-enforce a declared security posture.
+
+## Non-goals
+
+- `limited_internet` allowlist enforcement (egress proxy) — #323.
+- Network posture for the built-in Case A `EngineStack` — #324.
+- Blocking egress of agent tools that execute inside the runner — #325.
+- Any new `network_policy` enum value (boundary: does not extend the set).
+- Kubernetes / non-docker substrates.
+
+## Stages
+
+### Stage 1: Enforcement transform + backend wiring
+
+- **Contract:** New pure transform in `tolokaforge/core/compose_materialisation.py`:
+
+  ```python
+  def enforce_network_policy(
+      compose_doc: dict[str, Any],
+      policy: NetworkPolicy,
+      runner_service: str,
+  ) -> dict[str, Any]:
+      """Return a compose doc rewritten to enforce `policy`."""
+  ```
+
+  Semantics (interface, not implementation):
+  - `full_internet` → returns the doc unchanged.
+  - `no_internet` → the returned doc guarantees: (1) **every** service is
+    attached to a network with `internal: true` (any network the task already
+    declared is also forced `internal: true` — no task service may egress);
+    (2) `runner_service` is *additionally* attached to a non-internal edge
+    network. Use distinctive injected network names (e.g.
+    `tolokaforge_netpolicy_internal` / `tolokaforge_netpolicy_edge`) to avoid
+    collision with task-declared networks; compose prefixes them with the
+    per-run/per-trial project name, so they are unique on the daemon.
+  - `limited_internet` → the transform is **not** the enforcement point for this
+    value (see the pre-check below). As belt-and-suspenders it must still refuse
+    `limited_internet` — raise the same `NetworkPolicyError` — so a caller that
+    reaches the transform with `LIMITED_INTERNET` (a wiring bug) fails loud
+    rather than silently returning an unmodified, egress-capable doc.
+  - `runner_service` is guaranteed present in `services` by
+    `EnvironmentManifest` validation — trust it, no defensive branch.
+
+  **Fail-loud pre-check (the enforcement point for `limited_internet`).** Add a
+  new module-level helper that reads *only* `manifest.network_policy` (no compose
+  I/O) and raises `NetworkPolicyError` for `LIMITED_INTERNET`, naming #323 and the
+  two enforced values:
+
+  ```python
+  # tolokaforge/core/compose_materialisation.py
+  class NetworkPolicyError(ValueError): ...
+
+  def verify_network_policy_supported(policy: NetworkPolicy) -> None:
+      """Raise NetworkPolicyError if `policy` has no docker enforcement yet.
+      limited_internet needs the #323 egress-proxy; refuse rather than
+      silently grant full/no internet."""
+  ```
+
+  **Wiring (both backends).** `copy_compose_context` sits *inside* the compose-up
+  `try` in both backends (`shared_stack_runtime.py:834-835`,
+  `per_trial_runtime.py:198-199`), so a transform that reads the copied file can
+  only run inside that `try` and its raise would be swallowed by the
+  `except Exception` (shared `:844`, per-trial `:208`) and re-wrapped as a
+  misleading `ProvisionError("docker compose up failed…")`. Resolve this by
+  splitting enforcement across the try boundary:
+  - **Before** the `try` (immediately before `temp_dir = make_project_temp_dir(...)`):
+    call `verify_network_policy_supported(manifest.network_policy)`. It needs no
+    compose read, so `limited_internet` fails with its own clear
+    `NetworkPolicyError` *before any docker work or temp-dir creation*.
+  - **Inside** the `try`, right after `copy_compose_context`: read the copied
+    compose file, apply `enforce_network_policy`, write it back, then construct
+    `DockerCompose(...)`. For `no_internet` / `full_internet` this rewrite cannot
+    raise `NetworkPolicyError` (the pre-check already excluded the only refusing
+    value); a genuine I/O error here correctly surfaces as `ProvisionError`,
+    matching today's copy-failure semantics (option (a): no change to
+    copy-context error semantics).
+
+  A small file-level wrapper (read → `enforce_network_policy` → write) may live
+  beside the pure transform; the pure transform is the unit-testable core.
+
+- **Behaviour to lock:**
+  - `unit` — `enforce_network_policy` on a minimal compose doc: `no_internet`
+    yields internal-marked networks on every service + edge on runner;
+    `full_internet` is identity; `limited_internet` raises `NetworkPolicyError`
+    (belt-and-suspenders). Include a doc that **already declares its own
+    `networks:`** — assert those are forced `internal: true` and the runner
+    still gains the edge network.
+  - `unit` — `verify_network_policy_supported`: raises `NetworkPolicyError` for
+    `LIMITED_INTERNET`, returns cleanly for `NO_INTERNET` and `FULL_INTERNET`.
+  - `canonical` — snapshot the transformed compose doc for the
+    `multi_service_example_01` compose under `no_internet` (pins the exact
+    injected topology so a future refactor cannot silently change the wire shape).
+
+- **Compatibility:** Internal only — `enforce_network_policy` is a new internal
+  seam; no task-pack, config, CLI, or public-API surface changes. The
+  `network_policy` field, its enum, and the manifest wire shape are unchanged.
+  Note in the PR body that enforcing the *default* `no_internet` changes the
+  observable network posture of every existing task-declared stack (previously
+  unenforced) — this realises the already-documented default, not a contract break.
+
+- **Deliverable:** `manifest.network_policy` parameterises both backends; the
+  `network_isolation:no_internet` advertisement is now truthful.
+
+- **Validation:** `mcp__dev__run_tests` markers `unit` + `canonical`;
+  `mcp__dev__lint_check`. Reviewer checks the transform is a pure function; the
+  `verify_network_policy_supported` pre-check is hoisted **before** the
+  compose-up `try` in both backends (so the `limited_internet`
+  `NetworkPolicyError` escapes the `except` and is not re-wrapped as
+  `ProvisionError`); the doc-rewrite sits inside the `try` right after
+  `copy_compose_context`; and no model-name / policy-string branching leaks
+  outside this transform.
+
+- **Doc updates:** None in this stage (docs land in Stage 3 as one coherent rewrite).
+
+### Stage 2: Integration proof — real egress enforcement
+
+- **Contract:** New `tests/integration/network_policy/` (mirrors
+  `tests/integration/reset_recipes/`), marker `integration`. Reuse the existing
+  Case B/C harness pattern (`test_example_microservices_pack.py`,
+  `tests/integration/reset_recipes/*`): materialise a task-declared stack via
+  the real backend and assert observable network behaviour. The fixture stack
+  needs a service the test can exec a curl/wget from (an `alpine`/`curl` service
+  is sufficient; no LLM keys required).
+
+- **Behaviour to lock (`integration`):**
+  - `test_no_internet.py` — a `no_internet` stack: an application service's
+    `curl`/`wget` to a public host (raw IP `http://1.1.1.1` and a DNS name) fails
+    with a connection/network-unreachable error (or times out cleanly); the
+    runner's published gRPC port is still resolvable and reachable from the host;
+    inter-service DNS still works.
+  - `test_full_internet.py` — the same stack under `full_internet`: the public
+    request succeeds (guards against over-enforcement regression).
+  - `test_limited_internet.py` — materialising a `limited_internet` stack raises
+    `NetworkPolicyError` (surfaced before any container starts).
+
+- **Compatibility:** Internal (tests only).
+
+- **Deliverable:** The ship condition is met and pinned: `no_internet` curl
+  fails, `full_internet` curl succeeds, `limited_internet` refuses to run.
+
+- **Validation:** `scripts/with_env.sh uv run pytest tests/integration/network_policy -v`
+  (or dev MCP `run_tests` marker `integration`). **Regression sweep (required):**
+  re-run the existing task-declared-stack integration tests under the new
+  default-`no_internet` behaviour —
+  `tests/integration/test_example_microservices_pack.py`,
+  `tests/integration/reset_recipes/`,
+  `tests/integration/test_reset_recipe_end_to_end.py`,
+  `tests/integration/test_cross_mode_isolation.py`,
+  `tests/integration/docker/test_per_trial_runtime_backend_integration.py`.
+  Audit shows these reach non-runner services via in-network DNS (not host
+  ports) and need no egress, so they should pass unchanged; confirm by running.
+
+- **Doc updates:** `tests/README.md` if the network_policy suite needs a marker
+  or fixture note (only if it introduces a pattern not already covered).
+
+### Stage 3: Docs + capability truthfulness
+
+- **Contract:** Documentation reflects the enforced contract as the only state.
+
+- **Behaviour to lock:** none (docs). A `canonical` guard already asserts the
+  wire enum (`test_environment_manifest_contract.py:467`); leave it.
+
+- **Compatibility:** Docs are a source-of-truth surface (AGENTS.md Core Rule 8) —
+  rewrite to current state, delete legacy "not enforced" mentions.
+
+- **Deliverable + doc updates:**
+  - `docs/architecture/adr/0018-multi-container-under-shared-runtime.md` — add a
+    "Network policy enforcement" section: the internal+edge two-network topology,
+    the three policy values, why the runner keeps egress (judge), and the scoped
+    contract (application services, not runner-executed tools — cross-ref #325).
+  - `docs/TASKS.md:99` — rewrite the `network_policy` line so it reads as an
+    enforced field (no_internet / full_internet enforced, limited_internet
+    refused pending #323); delete "documented but not enforced".
+  - `docs/architecture/adr/0010-runtime-backend-provisioning-contract.md:151-153`
+    — reconcile the "Enforce via substrate-native network isolation" rows with
+    the shipped mechanism (name the internal-network + edge split); the
+    `limited_internet` row points at #323.
+  - `rg network_policy docs/` and reconcile any remaining "reserved / not
+    enforced" phrasing (esp. `docs/architecture/PROJECTS.md`); the "policy
+    request" vocabulary framing stays accurate and should be left intact.
+  - `tolokaforge/core/backend_capabilities.py:64` — verify the
+    `network_isolation:no_internet` description still reads true now that
+    enforcement is real (adjust wording if it over-claims per-trial specificity).
+
+- **Validation:** `mcp__dev__run_tests` marker `canonical` (manifest contract
+  still green); manual doc read.
+
+## Discovered issues
+
+- **Fix in this PR:** The false `network_isolation:no_internet` capability
+  advertisement — made truthful by Stage 1 (no separate issue; it *is* the fix).
+- **Filed as issues:**
+  - #323 — `limited_internet` egress-allowlist enforcement (proxy sidecar).
+    This PR fails loud on `limited_internet` until #323 lands.
+  - #324 — built-in Case A `EngineStack` ignores network posture; `internal=True`
+    on `Network.create` is otherwise-dead code.
+  - #325 — runner-executed tool egress is not blocked under `no_internet`
+    (design-note; runner egress is required for judge, so the contract is scoped
+    to application services).
+
+## Risks / open questions
+
+- **Default `no_internet` now bites every task-declared stack.** Previously
+  unenforced; now every Case B/C run without an explicit `full_internet` gets
+  egress-blocked application services. Audit indicates existing examples/tests
+  are self-contained (no egress, no non-runner host-port dependence), but Stage 2's
+  regression sweep is the gate — if any example legitimately needs egress it must
+  declare `network_policy: full_internet` explicitly.
+- **`db-service` loses its host-published port under `no_internet`** (internal-only).
+  The resolve path already tolerates `db_url=None` (`shared_stack_runtime.py:867`;
+  the runner reaches db-service by in-network DNS via `DB_SERVICE_URL`), so this is
+  expected, not a regression — confirmed by the audit that no test resolves the
+  db host port.
+- **CI does not run integration tests by default** (need Docker + the gated job).
+  Stage 2's proof runs in the integration lane; the fast unit/canonical gate
+  covers the transform. Reviewer should confirm the integration job is exercised
+  before merge.
+- **Injected network-name collision** with a task that already declares a network
+  of the same name — mitigated by distinctive names; the transform should treat a
+  pre-existing same-named network as its own (idempotent) rather than error, but
+  this is an implementation detail for the implementer to settle with a unit test.

--- a/tests/canonical/snapshots/network_policy_enforcement/multi_service_example_01_no_internet.json
+++ b/tests/canonical/snapshots/network_policy_enforcement/multi_service_example_01_no_internet.json
@@ -1,0 +1,89 @@
+{
+  "networks": {
+    "tolokaforge_netpolicy_edge": {},
+    "tolokaforge_netpolicy_internal": {
+      "internal": true
+    }
+  },
+  "services": {
+    "app-service": {
+      "healthcheck": {
+        "interval": "2s",
+        "retries": 30,
+        "start_period": "3s",
+        "test": [
+          "CMD",
+          "wget",
+          "-q",
+          "-O-",
+          "http://localhost/products.json"
+        ],
+        "timeout": "3s"
+      },
+      "image": "nginx:1.27-alpine",
+      "networks": [
+        "tolokaforge_netpolicy_internal"
+      ],
+      "ports": [
+        "80"
+      ],
+      "volumes": [
+        "./fixtures/products.json:/usr/share/nginx/html/products.json:ro"
+      ]
+    },
+    "db-service": {
+      "healthcheck": {
+        "interval": "2s",
+        "retries": 30,
+        "start_period": "3s",
+        "test": [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+        ],
+        "timeout": "3s"
+      },
+      "image": "tolokaforge-db-service:local",
+      "networks": [
+        "tolokaforge_netpolicy_internal"
+      ],
+      "ports": [
+        "8000"
+      ]
+    },
+    "runner": {
+      "depends_on": {
+        "app-service": {
+          "condition": "service_healthy"
+        },
+        "db-service": {
+          "condition": "service_healthy"
+        }
+      },
+      "environment": {
+        "DB_SERVICE_URL": "http://db-service:8000"
+      },
+      "healthcheck": {
+        "interval": "2s",
+        "retries": 30,
+        "start_period": "5s",
+        "test": [
+          "CMD",
+          "python",
+          "-c",
+          "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+        ],
+        "timeout": "3s"
+      },
+      "image": "tolokaforge-runner:local",
+      "networks": [
+        "tolokaforge_netpolicy_internal",
+        "tolokaforge_netpolicy_edge"
+      ],
+      "ports": [
+        "50051"
+      ]
+    }
+  }
+}

--- a/tests/canonical/test_network_policy_enforcement.py
+++ b/tests/canonical/test_network_policy_enforcement.py
@@ -1,0 +1,42 @@
+"""Pin the exact injected topology of the ``no_internet`` network-policy
+transform against the ``multi_service_example_01`` compose file.
+
+The snapshot fixes the wire shape of :func:`enforce_network_policy` so a
+future refactor cannot silently change which networks are injected, which
+services join them, or the ``internal: true`` markings that block egress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.compose_materialisation import enforce_network_policy
+from tolokaforge.core.trial import NetworkPolicy
+
+pytestmark = pytest.mark.canonical
+
+
+EXAMPLE_COMPOSE = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "native"
+    / "multi_service"
+    / "dataset"
+    / "tasks"
+    / "multi_service"
+    / "multi_service_example_01"
+    / "environment.compose.yaml"
+)
+
+
+def test_no_internet_topology_snapshot(canon_snapshot) -> None:
+    assert EXAMPLE_COMPOSE.is_file(), f"missing example compose: {EXAMPLE_COMPOSE}"
+    doc = yaml.safe_load(EXAMPLE_COMPOSE.read_text())
+
+    transformed = enforce_network_policy(doc, NetworkPolicy.NO_INTERNET, "runner")
+
+    snapshot = canon_snapshot("network_policy_enforcement")
+    snapshot.assert_match(transformed, "multi_service_example_01_no_internet.json")

--- a/tests/integration/network_policy/__init__.py
+++ b/tests/integration/network_policy/__init__.py
@@ -1,0 +1,16 @@
+"""Integration proof that ``manifest.network_policy`` enforces real egress.
+
+Each module materialises a minimal two-service stack (an ``nginx`` runner
+plus a ``curl`` application service) through the real
+:class:`~tolokaforge.core.per_trial_runtime.PerTrialRuntimeBackend` and
+asserts observable network behaviour against a live Docker daemon:
+
+* ``test_no_internet`` — application egress (raw IP and DNS) is blocked
+  while inter-service DNS and the host-published runner port stay reachable.
+* ``test_full_internet`` — application egress succeeds (over-enforcement
+  guard).
+* ``test_limited_internet`` — materialisation refuses before any container
+  starts.
+
+Marked ``integration`` + ``docker`` — requires a real Docker daemon.
+"""

--- a/tests/integration/network_policy/_harness.py
+++ b/tests/integration/network_policy/_harness.py
@@ -1,0 +1,126 @@
+"""Shared harness for the network_policy integration suite.
+
+Materialises a minimal two-service stack through the real
+:class:`~tolokaforge.core.per_trial_runtime.PerTrialRuntimeBackend`, so
+``manifest.network_policy`` is enforced by the shipped provisioning path
+(``apply_network_policy_to_compose_file`` inside ``provision``) rather than
+a test-only shim. The stack is:
+
+* ``runner`` — ``nginx:alpine`` serving ``runner-ok`` on the runner gRPC
+  port (:data:`RUNNER_PORT_DEFAULT`), published to the host and health-gated
+  so ``docker compose up --wait`` blocks until it responds.
+* ``app`` — ``curlimages/curl`` kept alive with ``sleep``; the service the
+  test execs outbound ``curl`` from.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+from testcontainers.compose import DockerCompose
+
+from tests.canonical._factories import make_task_description
+from tolokaforge.core.compose_materialisation import RUNNER_PORT_DEFAULT
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, NetworkPolicy, TrialSpec
+
+RUNNER_SERVICE = "runner"
+APP_SERVICE = "app"
+
+PUBLIC_IP_URL = "http://1.1.1.1"
+"""Raw-IP public target — probes egress without touching DNS."""
+
+PUBLIC_DNS_URL = "http://example.com"
+"""DNS-name public target — probes egress including name resolution."""
+
+INTER_SERVICE_URL = f"http://{RUNNER_SERVICE}:{RUNNER_PORT_DEFAULT}/"
+RUNNER_OK_BODY = "runner-ok"
+
+
+_COMPOSE_TEMPLATE = f"""
+    services:
+      {RUNNER_SERVICE}:
+        image: "nginx:alpine"
+        command:
+          - sh
+          - -c
+          - |
+            printf 'server {{ listen {RUNNER_PORT_DEFAULT}; location / {{ return 200 "{RUNNER_OK_BODY}\\n"; }} }}' > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'
+        ports:
+          - "{RUNNER_PORT_DEFAULT}"
+        healthcheck:
+          test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:{RUNNER_PORT_DEFAULT}/"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+      {APP_SERVICE}:
+        image: "curlimages/curl:8.10.1"
+        entrypoint: ["sleep", "3600"]
+    """
+
+COMPOSE = textwrap.dedent(_COMPOSE_TEMPLATE).strip()
+
+
+def write_manifest(compose_dir: Path, policy: NetworkPolicy) -> EnvironmentManifest:
+    """Write :data:`COMPOSE` into ``compose_dir`` and return a manifest that
+    binds it under ``policy``. The manifest validators parse the compose file
+    at construction, so the file is written first."""
+    compose_dir.mkdir(parents=True, exist_ok=True)
+    compose_file = compose_dir / "docker-compose.yml"
+    compose_file.write_text(COMPOSE + "\n")
+    return EnvironmentManifest(
+        compose_file=compose_file,
+        runner_service=RUNNER_SERVICE,
+        network_policy=policy,
+    )
+
+
+def make_spec(manifest: EnvironmentManifest, trial_id: str) -> TrialSpec:
+    """Build a :class:`TrialSpec` carrying ``manifest``. The endpoints and
+    model config are placeholders — provisioning never connects the runner
+    client (connect is lazy) and no LLM is invoked."""
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="netpolicy-integration",
+        task=make_task_description(
+            task_id="netpolicy-probe",
+            name="netpolicy-probe",
+            category="general",
+            description="network_policy egress-enforcement probe",
+            environment_manifest=manifest,
+        ),
+        agent_model_config=ModelConfig(provider="openai", name="gpt-4"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://placeholder:8000",
+            runner_url="http://placeholder:50051",
+        ),
+    )
+
+
+def run_curl(
+    compose: DockerCompose, url: str, *, max_time: int = 10
+) -> subprocess.CompletedProcess:
+    """Exec ``curl <url>`` inside the ``app`` service and return the completed
+    process (never raises on non-zero exit). A blocked egress surfaces as a
+    non-zero return code (curl 6 = DNS failure, 7 = connection refused,
+    28 = timeout); a reachable target returns 0 with the body on stdout."""
+    cmd = [
+        *compose.docker_compose_command(),
+        "exec",
+        "-T",
+        APP_SERVICE,
+        "curl",
+        "--max-time",
+        str(max_time),
+        "-sS",
+        url,
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=compose.context, check=False)
+
+
+def docker_container_ids() -> set[str]:
+    """All container ids on the daemon (running or stopped)."""
+    result = subprocess.run(["docker", "ps", "-aq"], capture_output=True, check=True, text=True)
+    return set(result.stdout.split())

--- a/tests/integration/network_policy/test_full_internet.py
+++ b/tests/integration/network_policy/test_full_internet.py
@@ -1,0 +1,36 @@
+"""``full_internet`` leaves application egress intact.
+
+The over-enforcement guard: the same stack that is egress-blocked under
+``no_internet`` must reach the public internet when the task declares
+``full_internet`` (the transform is identity for this policy).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.network_policy import _harness
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.trial import NetworkPolicy
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial backend needs it)",
+)
+def test_full_internet_allows_public_egress(tmp_path) -> None:
+    manifest = _harness.write_manifest(tmp_path / "stack", NetworkPolicy.FULL_INTERNET)
+    backend = PerTrialRuntimeBackend()
+    handle = backend.provision(_harness.make_spec(manifest, "netpolicy-full-internet:0"))
+
+    try:
+        public = _harness.run_curl(handle.compose, _harness.PUBLIC_DNS_URL, max_time=15)
+        assert public.returncode == 0, (
+            f"public egress to {_harness.PUBLIC_DNS_URL} must succeed under full_internet; "
+            f"curl exited {public.returncode} (stderr: {public.stderr!r})"
+        )
+    finally:
+        backend.teardown(handle)

--- a/tests/integration/network_policy/test_limited_internet.py
+++ b/tests/integration/network_policy/test_limited_internet.py
@@ -1,0 +1,38 @@
+"""``limited_internet`` refuses to materialise.
+
+Docker's ``internal`` flag is binary — a real allowlist needs an
+egress-proxy sidecar (#323). Until then the backend must fail loud *before*
+any container starts, rather than silently granting full or no internet.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.network_policy import _harness
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.core.compose_materialisation import NetworkPolicyError
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.trial import NetworkPolicy
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial backend needs it)",
+)
+def test_limited_internet_refuses_before_any_container_starts(tmp_path) -> None:
+    manifest = _harness.write_manifest(tmp_path / "stack", NetworkPolicy.LIMITED_INTERNET)
+    backend = PerTrialRuntimeBackend()
+    spec = _harness.make_spec(manifest, "netpolicy-limited-internet:0")
+
+    before = _harness.docker_container_ids()
+    with pytest.raises(NetworkPolicyError) as exc:
+        backend.provision(spec)
+
+    message = str(exc.value)
+    assert "limited_internet" in message
+    assert "#323" in message
+    no_containers = "limited_internet must be refused before any container is created"
+    assert _harness.docker_container_ids() <= before, no_containers

--- a/tests/integration/network_policy/test_no_internet.py
+++ b/tests/integration/network_policy/test_no_internet.py
@@ -1,0 +1,59 @@
+"""``no_internet`` blocks application egress while preserving the runner's
+host-published port and inter-service DNS.
+
+Materialises the two-service stack through the real backend under the
+default ``no_internet`` policy and asserts the honest contract: the ``app``
+service cannot reach the public internet (raw IP *or* DNS name), yet the
+runner's published port stays host-reachable and services still resolve each
+other by name.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.integration.network_policy import _harness
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.trial import NetworkPolicy
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial backend needs it)",
+)
+def test_no_internet_blocks_egress_but_keeps_runner_reachable(tmp_path) -> None:
+    manifest = _harness.write_manifest(tmp_path / "stack", NetworkPolicy.NO_INTERNET)
+    backend = PerTrialRuntimeBackend()
+    handle = backend.provision(_harness.make_spec(manifest, "netpolicy-no-internet:0"))
+
+    try:
+        raw_ip = _harness.run_curl(handle.compose, _harness.PUBLIC_IP_URL)
+        assert raw_ip.returncode != 0, (
+            f"raw-IP egress to {_harness.PUBLIC_IP_URL} should be blocked under no_internet; "
+            f"curl exited 0 (stdout: {raw_ip.stdout!r})"
+        )
+
+        dns = _harness.run_curl(handle.compose, _harness.PUBLIC_DNS_URL)
+        assert dns.returncode != 0, (
+            f"DNS-name egress to {_harness.PUBLIC_DNS_URL} should be blocked under no_internet; "
+            f"curl exited 0 (stdout: {dns.stdout!r})"
+        )
+
+        inter = _harness.run_curl(handle.compose, _harness.INTER_SERVICE_URL)
+        assert inter.returncode == 0, (
+            "inter-service DNS + connectivity must survive no_internet; "
+            f"curl to {_harness.INTER_SERVICE_URL} exited {inter.returncode} "
+            f"(stderr: {inter.stderr!r})"
+        )
+        assert _harness.RUNNER_OK_BODY in inter.stdout
+
+        runner_url = backend.endpoints(handle).runner_url
+        response = httpx.get(runner_url, timeout=10)
+        assert response.status_code == 200, f"runner {runner_url} not host-reachable"
+        assert _harness.RUNNER_OK_BODY in response.text
+    finally:
+        backend.teardown(handle)

--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -20,9 +20,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.compose_materialisation import (
+    NETPOLICY_EDGE_NETWORK,
+    NETPOLICY_INTERNAL_NETWORK,
     RUNNER_PORT_DEFAULT,
+    NetworkPolicyError,
+    apply_network_policy_to_compose_file,
     cleanup_partial_materialisation,
     copy_compose_context,
+    enforce_network_policy,
     first_published_port,
     make_project_temp_dir,
     resolve_env_endpoints,
@@ -30,7 +35,9 @@ from tolokaforge.core.compose_materialisation import (
     resolve_rag_url,
     resolve_runner_endpoint,
     shutdown_compose,
+    verify_network_policy_supported,
 )
+from tolokaforge.core.trial import NetworkPolicy
 
 pytestmark = pytest.mark.unit
 
@@ -293,3 +300,122 @@ class TestCleanupPartialMaterialisation:
         """Teardown is idempotent — a temp dir already removed
         (or never created) doesn't cause a failure."""
         cleanup_partial_materialisation(None, tmp_path / "does-not-exist")
+
+
+def _minimal_compose() -> dict:
+    """Two services, no task-declared networks (join the compose default)."""
+    return {
+        "services": {
+            "runner": {"image": "tolokaforge-runner:local", "ports": ["50051"]},
+            "app-service": {"image": "nginx:1.27-alpine", "ports": ["80"]},
+        }
+    }
+
+
+class TestVerifyNetworkPolicySupported:
+    def test_limited_internet_raises(self) -> None:
+        with pytest.raises(NetworkPolicyError, match="limited_internet"):
+            verify_network_policy_supported(NetworkPolicy.LIMITED_INTERNET)
+
+    def test_error_names_323_and_alternatives(self) -> None:
+        with pytest.raises(NetworkPolicyError) as excinfo:
+            verify_network_policy_supported(NetworkPolicy.LIMITED_INTERNET)
+        message = str(excinfo.value)
+        assert "#323" in message
+        assert "no_internet" in message
+        assert "full_internet" in message
+
+    @pytest.mark.parametrize("policy", [NetworkPolicy.NO_INTERNET, NetworkPolicy.FULL_INTERNET])
+    def test_enforceable_policies_return_cleanly(self, policy: NetworkPolicy) -> None:
+        assert verify_network_policy_supported(policy) is None
+
+
+class TestEnforceNetworkPolicy:
+    def test_full_internet_is_identity(self) -> None:
+        doc = _minimal_compose()
+        result = enforce_network_policy(doc, NetworkPolicy.FULL_INTERNET, "runner")
+        assert result is doc
+
+    def test_limited_internet_raises_belt_and_suspenders(self) -> None:
+        with pytest.raises(NetworkPolicyError):
+            enforce_network_policy(_minimal_compose(), NetworkPolicy.LIMITED_INTERNET, "runner")
+
+    def test_no_internet_does_not_mutate_input(self) -> None:
+        doc = _minimal_compose()
+        enforce_network_policy(doc, NetworkPolicy.NO_INTERNET, "runner")
+        assert "networks" not in doc
+        assert "networks" not in doc["services"]["runner"]
+
+    def test_no_internet_injects_internal_and_edge_networks(self) -> None:
+        result = enforce_network_policy(_minimal_compose(), NetworkPolicy.NO_INTERNET, "runner")
+        assert result["networks"][NETPOLICY_INTERNAL_NETWORK] == {"internal": True}
+        assert result["networks"][NETPOLICY_EDGE_NETWORK] == {}
+
+    def test_no_internet_attaches_every_service_to_internal(self) -> None:
+        result = enforce_network_policy(_minimal_compose(), NetworkPolicy.NO_INTERNET, "runner")
+        for service in result["services"].values():
+            assert NETPOLICY_INTERNAL_NETWORK in service["networks"]
+
+    def test_no_internet_runner_additionally_on_edge(self) -> None:
+        result = enforce_network_policy(_minimal_compose(), NetworkPolicy.NO_INTERNET, "runner")
+        assert NETPOLICY_EDGE_NETWORK in result["services"]["runner"]["networks"]
+        assert NETPOLICY_EDGE_NETWORK not in result["services"]["app-service"]["networks"]
+
+    def test_no_internet_forces_task_declared_networks_internal(self) -> None:
+        """A doc that declares its own networks: those are forced
+        internal:true, and the runner still gains the edge network."""
+        doc = {
+            "services": {
+                "runner": {"image": "r:local", "networks": ["backplane"]},
+                "app-service": {"image": "nginx:1.27-alpine", "networks": ["backplane"]},
+            },
+            "networks": {"backplane": {"driver": "bridge"}},
+        }
+        result = enforce_network_policy(doc, NetworkPolicy.NO_INTERNET, "runner")
+
+        assert result["networks"]["backplane"]["internal"] is True
+        assert result["networks"]["backplane"]["driver"] == "bridge"
+        for service in result["services"].values():
+            assert "backplane" in service["networks"]
+            assert NETPOLICY_INTERNAL_NETWORK in service["networks"]
+        assert NETPOLICY_EDGE_NETWORK in result["services"]["runner"]["networks"]
+
+    def test_no_internet_preserves_mapping_form_networks(self) -> None:
+        """A service using the mapping form (aliases / static IPs) keeps
+        that shape and its per-network config when the internal net is
+        merged in."""
+        doc = {
+            "services": {
+                "runner": {
+                    "image": "r:local",
+                    "networks": {"backplane": {"aliases": ["r"]}},
+                },
+            },
+            "networks": {"backplane": {}},
+        }
+        result = enforce_network_policy(doc, NetworkPolicy.NO_INTERNET, "runner")
+        nets = result["services"]["runner"]["networks"]
+        assert isinstance(nets, dict)
+        assert nets["backplane"] == {"aliases": ["r"]}
+        assert NETPOLICY_INTERNAL_NETWORK in nets
+        assert NETPOLICY_EDGE_NETWORK in nets
+
+
+class TestApplyNetworkPolicyToComposeFile:
+    def test_full_internet_leaves_file_byte_identical(self, tmp_path: Path) -> None:
+        compose = tmp_path / "compose.yaml"
+        original = "services:\n  runner:\n    image: r:local  # keep this comment\n"
+        compose.write_text(original)
+        apply_network_policy_to_compose_file(compose, NetworkPolicy.FULL_INTERNET, "runner")
+        assert compose.read_text() == original
+
+    def test_no_internet_rewrites_file_with_injected_networks(self, tmp_path: Path) -> None:
+        import yaml
+
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  runner:\n    image: r:local\n")
+        apply_network_policy_to_compose_file(compose, NetworkPolicy.NO_INTERNET, "runner")
+
+        doc = yaml.safe_load(compose.read_text())
+        assert doc["networks"][NETPOLICY_INTERNAL_NETWORK] == {"internal": True}
+        assert NETPOLICY_EDGE_NETWORK in doc["services"]["runner"]["networks"]

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -116,6 +116,10 @@ class TestConnectMaterialises:
                 lambda src, dst: None,
             ),
             patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch(
                 "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
                 return_value=("localhost", 60051),
             ),
@@ -150,6 +154,10 @@ class TestConnectMaterialises:
             patch(
                 "tolokaforge.core.shared_stack_runtime.copy_compose_context",
                 lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
             ),
             patch(
                 "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
@@ -187,6 +195,10 @@ class TestConnectMaterialises:
                 lambda src, dst: None,
             ),
             patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch(
                 "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
                 return_value=("localhost", 60051),
             ),
@@ -215,6 +227,10 @@ class TestConnectMaterialises:
             patch(
                 "tolokaforge.core.shared_stack_runtime.copy_compose_context",
                 lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
             ),
             patch(
                 "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"

--- a/tolokaforge/core/backend_capabilities.py
+++ b/tolokaforge/core/backend_capabilities.py
@@ -61,7 +61,7 @@ _LOCAL_DOCKER_BASELINE: tuple[CapabilitySpec, ...] = (
     ),
     CapabilitySpec(
         name="network_isolation:no_internet",
-        description="Backend enforces per-trial network isolation with no public egress.",
+        description="Backend attaches task application services to an internal network with no public egress; the runner keeps egress for grading.",
     ),
 )
 

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -20,15 +20,17 @@ handles). The backends layer those on top.
 
 from __future__ import annotations
 
+import copy
 import logging
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
 
+import yaml
 from testcontainers.compose import DockerCompose
 
-from tolokaforge.core.trial import EnvEndpoints
+from tolokaforge.core.trial import EnvEndpoints, NetworkPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +58,124 @@ core stack exposes and the port task compose files publish for the
 RAG_SERVICE_CANDIDATES = ("rag", "rag-service")
 """Compose service names checked when resolving the RAG endpoint.
 First match wins; ``None`` returned if no match is exposed."""
+
+
+# ---------------------------------------------------------------------------
+# Network-policy enforcement
+# ---------------------------------------------------------------------------
+
+
+NETPOLICY_INTERNAL_NETWORK = "tolokaforge_netpolicy_internal"
+"""Injected ``internal: true`` network every task service joins under
+``no_internet``. No public egress; inter-service DNS stays intact because
+every service shares it. Compose prefixes it with the per-run/per-trial
+project name, so the fully-qualified network is unique on the daemon and
+cannot collide with a task-declared network of the same base name."""
+
+NETPOLICY_EDGE_NETWORK = "tolokaforge_netpolicy_edge"
+"""Injected non-internal network the runner service *additionally* joins
+under ``no_internet``, so its published gRPC port stays host-reachable and
+it retains egress for in-container LLM-as-judge grading."""
+
+
+class NetworkPolicyError(ValueError):
+    """A declared ``network_policy`` has no docker enforcement available."""
+
+
+def verify_network_policy_supported(policy: NetworkPolicy) -> None:
+    """Raise :class:`NetworkPolicyError` if ``policy`` cannot be enforced by
+    the docker provisioner. ``limited_internet`` needs an egress-allowlist
+    proxy sidecar (#323); refusing to run is the only honest option —
+    silently granting full or no internet would under/over-enforce a
+    declared security posture. ``no_internet`` and ``full_internet`` return
+    cleanly. Reads only ``policy`` — no compose I/O — so callers can hoist it
+    before any temp-dir creation or docker work."""
+    if policy is NetworkPolicy.LIMITED_INTERNET:
+        raise NetworkPolicyError(
+            "network_policy 'limited_internet' is not enforceable yet: it needs an "
+            "egress-allowlist proxy sidecar (#323). Declare 'no_internet' or "
+            "'full_internet' explicitly."
+        )
+
+
+def enforce_network_policy(
+    compose_doc: dict[str, Any],
+    policy: NetworkPolicy,
+    runner_service: str,
+) -> dict[str, Any]:
+    """Return a compose doc rewritten to enforce ``policy``.
+
+    ``full_internet`` returns ``compose_doc`` unchanged (same object).
+    ``no_internet`` returns a deep copy in which (1) every service joins the
+    injected :data:`NETPOLICY_INTERNAL_NETWORK` (``internal: true`` — no
+    egress), any network the task already declared is forced ``internal:
+    true`` too, and (2) ``runner_service`` additionally joins the non-internal
+    :data:`NETPOLICY_EDGE_NETWORK`. ``limited_internet`` raises
+    :class:`NetworkPolicyError` (belt-and-suspenders — the enforcement point
+    is :func:`verify_network_policy_supported`; reaching here with it is a
+    wiring bug and must fail loud rather than return an egress-capable doc).
+
+    ``runner_service`` is guaranteed present in ``services`` by
+    :class:`EnvironmentManifest` validation.
+    """
+    if policy is NetworkPolicy.FULL_INTERNET:
+        return compose_doc
+    if policy is NetworkPolicy.LIMITED_INTERNET:
+        raise NetworkPolicyError(
+            "enforce_network_policy reached with 'limited_internet'; this value has no "
+            "docker enforcement (#323) and must be refused by verify_network_policy_supported "
+            "before any compose rewrite."
+        )
+
+    doc = copy.deepcopy(compose_doc)
+    networks: dict[str, Any] = doc.setdefault("networks", {})
+    for name, config in networks.items():
+        merged = dict(config) if isinstance(config, dict) else {}
+        merged["internal"] = True
+        networks[name] = merged
+    networks[NETPOLICY_INTERNAL_NETWORK] = {"internal": True}
+    networks[NETPOLICY_EDGE_NETWORK] = {}
+
+    services: dict[str, Any] = doc["services"]
+    for service_name, service in services.items():
+        attachments = [NETPOLICY_INTERNAL_NETWORK]
+        if service_name == runner_service:
+            attachments.append(NETPOLICY_EDGE_NETWORK)
+        service["networks"] = _merge_service_networks(service.get("networks"), attachments)
+    return doc
+
+
+def _merge_service_networks(existing: Any, additions: list[str]) -> Any:
+    """Add each name in ``additions`` to a service-level ``networks:`` value,
+    preserving its declared shape (list or mapping) and any per-network config
+    (aliases, static IPs). Absent ``existing`` yields a plain list. Idempotent:
+    a name already present is left untouched."""
+    if isinstance(existing, dict):
+        merged = dict(existing)
+        for name in additions:
+            if name not in merged:
+                merged[name] = None
+        return merged
+    current = list(existing) if isinstance(existing, list) else []
+    for name in additions:
+        if name not in current:
+            current.append(name)
+    return current
+
+
+def apply_network_policy_to_compose_file(
+    compose_file: Path, policy: NetworkPolicy, runner_service: str
+) -> None:
+    """Read ``compose_file``, apply :func:`enforce_network_policy`, and write
+    the result back in place. ``full_internet`` leaves the file byte-identical
+    (the transform is identity), so its comments and formatting survive."""
+    with compose_file.open() as f:
+        doc = yaml.safe_load(f)
+    transformed = enforce_network_policy(doc, policy, runner_service)
+    if transformed is doc:
+        return
+    with compose_file.open("w") as f:
+        yaml.safe_dump(transformed, f, sort_keys=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -38,12 +38,14 @@ from testcontainers.compose import DockerCompose
 
 from tolokaforge.core.compose_materialisation import (
     RUNNER_PORT_DEFAULT,
+    apply_network_policy_to_compose_file,
     cleanup_partial_materialisation,
     copy_compose_context,
     make_project_temp_dir,
     resolve_env_endpoints,
     resolve_runner_endpoint,
     shutdown_compose,
+    verify_network_policy_supported,
 )
 from tolokaforge.core.models import SeedRef
 from tolokaforge.core.runtime import EnvHandle, IsolationMode, ProvisionError
@@ -193,10 +195,16 @@ class PerTrialRuntimeBackend:
                 ),
             )
 
+        verify_network_policy_supported(manifest.network_policy)
         temp_dir = make_project_temp_dir(spec.trial_id)
         compose: DockerCompose | None = None
         try:
             copy_compose_context(manifest.compose_file, temp_dir)
+            apply_network_policy_to_compose_file(
+                temp_dir / manifest.compose_file.name,
+                manifest.network_policy,
+                manifest.runner_service,
+            )
             compose = DockerCompose(
                 context=str(temp_dir),
                 compose_file_name=manifest.compose_file.name,

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -28,12 +28,14 @@ from testcontainers.compose import DockerCompose
 
 from tolokaforge.core.compose_materialisation import (
     RUNNER_PORT_DEFAULT,
+    apply_network_policy_to_compose_file,
     cleanup_partial_materialisation,
     copy_compose_context,
     make_project_temp_dir,
     resolve_env_endpoints,
     resolve_runner_endpoint,
     shutdown_compose,
+    verify_network_policy_supported,
 )
 from tolokaforge.core.models import SeedRef
 from tolokaforge.core.runtime import IsolationMode, ProvisionError
@@ -829,10 +831,16 @@ class SharedStackRuntimeBackend:
         assert self._env_manifest is not None  # narrowed by caller
         manifest = self._env_manifest
 
+        verify_network_policy_supported(manifest.network_policy)
         temp_dir = make_project_temp_dir(self._run_id)
         compose: DockerCompose | None = None
         try:
             copy_compose_context(manifest.compose_file, temp_dir)
+            apply_network_policy_to_compose_file(
+                temp_dir / manifest.compose_file.name,
+                manifest.network_policy,
+                manifest.runner_service,
+            )
             compose = DockerCompose(
                 context=str(temp_dir),
                 compose_file_name=manifest.compose_file.name,


### PR DESCRIPTION
Closes #301.

## Summary

- Wire `manifest.network_policy` into both docker backends (`shared_stack_runtime.py`, `per_trial_runtime.py`) — previously declared but read nowhere, so the `network_isolation:no_internet` capability was falsely advertised.
- `no_internet` isolates task services on an injected `internal:true` network while the runner keeps a separate edge network (published gRPC port + judge egress). `full_internet` is a passthrough. `limited_internet` fails loud (needs the #323 egress proxy).
- 3 real-Docker integration tests + a regression sweep on existing task-declared-stack integration tests.

## Plan

See `docs/plans/2026-07-15-issue-301-network-policy-enforcement.md`.

## Discovered issues

- Filed: #323 (limited_internet proxy sidecar), #324 (Case A `EngineStack` ignores network posture), #325 (runner-tool egress not blocked under no_internet), #335 (pre-existing `test_per_trial_runtime_backend_integration.py` db_url fixture bug — fails on main too, not this PR).
- Fixed in this PR: false `network_isolation:no_internet` capability advertisement.

## Test plan

- [x] Unit + canonical locks on the transform and pre-check.
- [x] Integration: `no_internet` blocks raw-IP + DNS egress from app services; runner published port + inter-service DNS stay reachable; `full_internet` allows egress; `limited_internet` refuses before any container starts.
- [x] Regression sweep on existing task-declared-stack integration tests — pass under the new default `no_internet`.

## Behaviour change

Realises the already-documented default `no_internet`. Public examples/tests are self-contained and pass unchanged. Any pack that legitimately needs egress must declare `network_policy: full_internet` explicitly.