### PR TITLE
feat(runtime): per-service log capture on trial failure (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Feat
 
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
+- **runtime**: `PerTrialRuntimeBackend` captures per-service logs on provision-stage failure (compose-up / reset-recipe) before teardown, writing `services/<service>.log` + a `services/_capture.yaml` manifest; `RuntimeBackend` gains `capture_service_logs` (per-trial writes `.log` files; shared-stack is a documented no-op) (#302)
 
 ## v0.8.4 (2026-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
+
 ## v0.8.4 (2026-07-15)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
 - **runtime**: `PerTrialRuntimeBackend` captures per-service logs on provision-stage failure (compose-up / reset-recipe) before teardown, writing `services/<service>.log` + a `services/_capture.yaml` manifest; `RuntimeBackend` gains `capture_service_logs` (per-trial writes `.log` files; shared-stack is a documented no-op) (#302)
+- **runtime**: on a trial-body failure (`ERROR` / `TIMEOUT`) the trial executor captures per-service logs before teardown, emits a `trial.service_logs_captured` summary line, and amends the trial's `metrics.yaml` with a `captured_service_logs` byte-count map (#302)
 
 ## v0.8.4 (2026-07-15)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -77,6 +77,8 @@ Notes:
 - `max_budget_usd` pauses scheduling new trials when cumulative spend reaches the budget.
 - `max_requests_per_second` applies a global limiter across worker threads.
 - `max_attempt_retries` retries transient failures (`rate_limit`, `api_error`, `timeout`) before marking a trial failed.
+- `compute.log_tail` (default `500`, must be `>= 1`) bounds the `docker compose logs --tail` line count captured per service when a multi-service trial fails on the per-trial backend.
+- `compute.capture_logs_on_success` (default `false`) is a debug escape hatch: when `true`, per-service logs are captured for successful trials too, not only failures.
 - `queue_backend: postgres` enables distributed queue/state using Postgres; set `queue_postgres_dsn`.
 - If `evaluation.task_packs` is empty, `tasks_glob` is resolved relative to the working directory.
 - If `evaluation.task_packs` is set, relative `tasks_glob` patterns are resolved under each task-pack root and merged.

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -25,7 +25,10 @@ bumped and this document is updated in the same commit.
             ├── judge_trajectory.yaml       ← rubric-judge transcript (only when an LLM judge ran)
             ├── logs.yaml
             ├── prompts.yaml                ← agent + user-sim system prompts
-            └── tools_schemas.yaml          ← post-policy tool list
+            ├── tools_schemas.yaml          ← post-policy tool list
+            └── services/                   ← per-service compose logs (only on trial failure)
+                ├── {service}.log
+                └── _capture.yaml           ← manifest (provision-failure path only)
 ```
 
 * `{output_dir}` = the orchestrator's run output root. The naming
@@ -319,6 +322,53 @@ table):
 | `cache_creation_input_tokens` | Anthropic | Tokens written to the ephemeral cache this call |
 | `cache_read_input_tokens` | Anthropic | Tokens re-used from the ephemeral cache this call |
 | `provider_raw` | — | Best-effort dump of the *last* call's raw usage block |
+
+### `captured_service_logs` — only on trial-body failure
+
+When a trial body fails (`trajectory.status` is `error` or `timeout`) on the
+per-trial runtime backend, the executor captures each compose service's
+`docker compose logs` output to
+[`services/{service}.log`](#trialstask_idtrial_indexservices) **before**
+teardown and records the byte counts as a top-level mapping on this file:
+
+```yaml
+captured_service_logs:
+  db: 4096
+  runner: 512
+```
+
+The key is present only when at least one service produced output. Capture on
+a successful trial is off by default; enable it with
+`compute.capture_logs_on_success: true` (see [`docs/CONFIG.md`](CONFIG.md:1)).
+Graded failures (`status: completed`, `binary_pass: false`) do **not** trigger
+capture — that keeps the output-dir footprint bounded.
+
+## `trials/{task_id}/{trial_index}/services/`
+
+Per-service compose logs, written **only on trial failure** and only on the
+per-trial runtime backend (see
+[`docs/architecture/RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md:1)
+§ "Per-service log capture on failure"). The shared-stack backend never writes
+this directory.
+
+* **`{service}.log`** — raw `docker compose logs --tail=N` bytes for one
+  service (`N` = `compute.log_tail`, default 500). One file per compose
+  service that produced output. No parsing, no format changes.
+* **`_capture.yaml`** — manifest written **only on the provision-failure
+  path** (compose-up or reset-recipe failure), where no `metrics.yaml` exists
+  to amend:
+
+  ```yaml
+  tail: 500
+  capture_reason: provision_error
+  services:
+    db:
+      bytes: 4096
+  ```
+
+  On the trial-body-failure path the durable record is the
+  [`metrics.yaml` `captured_service_logs`](#captured_service_logs--only-on-trial-body-failure)
+  field instead, so the two surfaces never both write a record.
 
 ## `trials/{task_id}/{trial_index}/grade.yaml`
 

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -336,12 +336,16 @@ captures on success too.
   (the conductor never ran), so the durable record is a `services/_capture.yaml`
   manifest written alongside the `.log` files:
   `{"tail": int, "capture_reason": "provision_error", "services": {"<name>": {"bytes": int}}}`.
-- **Trial-body-failure path** — `capture_service_logs(handle, *, failed)` is the
-  Protocol hook that writes the per-service `.log` files for a still-live trial
-  stack (the `service_names` snapshot taken at provision time), returning a
-  `{service: bytes_written}` map. It writes only the `.log` files; the durable
-  record on this path is a `captured_service_logs` amendment on the trial's
-  existing `metrics.yaml`.
+- **Trial-body-failure path** — the [`TrialExecutor`](#per-trial-substrate-bracket-trialexecutor)
+  drives this surface: after `conductor.run` returns and before teardown it
+  calls `capture_service_logs(handle, *, failed)`, the Protocol hook that writes
+  the per-service `.log` files for a still-live trial stack (the `service_names`
+  snapshot taken at provision time) and returns a `{service: bytes_written}`
+  map. On a non-empty map the executor emits the `trial.service_logs_captured`
+  summary log line and amends the trial's existing `metrics.yaml` with a
+  top-level `captured_service_logs` mapping — the durable record on this path
+  (the hook writes only the `.log` files). See
+  [`docs/OUTPUT_FORMAT.md`](../OUTPUT_FORMAT.md:1) § `captured_service_logs`.
 
 Both surfaces are best-effort: capture runs *because* a failure was already
 decided, so a per-service fetch error is logged at debug and that service is

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -13,15 +13,15 @@ wrapper over an external artifact).
 ## The seam
 
 `RuntimeBackend` is the orchestrator's execution surface. A single Protocol,
-nine methods, three concerns:
+ten methods, three concerns:
 
 | Group | Methods | Called when |
 |---|---|---|
 | Run-level lifecycle | `connect`, `close`, `health_check` | Once per orchestrator run |
-| Per-trial provisioning (ADR-0010) | `provision`, `await_ready`, `endpoints`, `teardown` | Around every trial body |
+| Per-trial provisioning (ADR-0010) | `provision`, `await_ready`, `endpoints`, `teardown`, `capture_service_logs` | Around every trial body |
 | Per-trial RPC (ADR-0013) | `register_trial`, `execute_tool`, `grade_trial`, `get_state`, `reset_trial`, `cleanup_trial` | Inside the trial body |
 
-Every implementation ships all nine. The orchestrator holds one backend
+Every implementation ships all ten. The orchestrator holds one backend
 instance for the whole run; the conductor calls it per-trial.
 
 ```mermaid
@@ -291,7 +291,8 @@ Enforcement lives at the orchestrator layer, not on `SharedStackRuntimeBackend.p
 | Where | What is raised | What is cleaned up before the raise |
 |---|---|---|
 | `provision` — no manifest | `ProvisionError(stage="provision")` | Nothing to clean |
-| `provision` — compose start fails | `ProvisionError(stage="provision")` wrapping the compose error | Per-trial temp dir removed |
+| `provision` — compose start fails | `ProvisionError(stage="provision")` wrapping the compose error | Per-service logs captured before teardown (see below); per-trial temp dir removed |
+| `provision` — reset recipe fails | `ProvisionError(stage="reset_recipe")` | Per-service logs captured before teardown (see below); compose stack torn down + temp dir removed |
 | `provision` — runner-client construction (host/port unresolvable) | `ProvisionError(stage="provision")` | Compose stack torn down + temp dir removed |
 | `provision` — endpoint resolution (missing `db-service`) | Not a failure — `EnvEndpoints.db_url` stays `None`; the runner reads `DB_SERVICE_URL` from its container env | — |
 | `await_ready` | Never raises today (`--wait` gates during provision); reserved for future backends | — |
@@ -306,6 +307,58 @@ The provisioning contract (ADR-0010) requires provisioners to make a
 best-effort teardown of anything partially materialised before raising.
 `PerTrialRuntimeBackend` honours that at every failure point above — no
 half-provisioned resources leaked to the daemon.
+
+## Per-service log capture on failure
+
+When a multi-service trial fails, the moment an operator needs to know *why*
+postgres / PostgREST went sideways is exactly the moment the containers are
+about to be torn down. `PerTrialRuntimeBackend` captures each declared
+service's `docker compose logs` output — one `<service>.log` per service —
+into the trial bundle **before** the stack comes down, under:
+
+```
+<output_dir>/trials/<task_id>/<trial_index>/services/<service>.log
+```
+
+**What counts as failure.** Capture fires on a `ProvisionError` (the
+provision-stage path) or an execution failure (`trajectory.status` in
+`{ERROR, TIMEOUT}`, the trial-body path). A `COMPLETED` trial that merely
+failed grading (`binary_pass=False`) is **not** a capture trigger — that
+would capture on most trials of a hard benchmark and blow the output-dir size
+budget. The `compute.capture_logs_on_success` debug flag overrides this and
+captures on success too.
+
+**Two capture surfaces.**
+
+- **Provision-failure path** — `provision()` captures before
+  `cleanup_partial_materialisation` in both failure branches (compose
+  `up --wait` failure and reset-recipe failure). No `metrics.yaml` exists yet
+  (the conductor never ran), so the durable record is a `services/_capture.yaml`
+  manifest written alongside the `.log` files:
+  `{"tail": int, "capture_reason": "provision_error", "services": {"<name>": {"bytes": int}}}`.
+- **Trial-body-failure path** — `capture_service_logs(handle, *, failed)` is the
+  Protocol hook that writes the per-service `.log` files for a still-live trial
+  stack (the `service_names` snapshot taken at provision time), returning a
+  `{service: bytes_written}` map. It writes only the `.log` files; the durable
+  record on this path is a `captured_service_logs` amendment on the trial's
+  existing `metrics.yaml`.
+
+Both surfaces are best-effort: capture runs *because* a failure was already
+decided, so a per-service fetch error is logged at debug and that service is
+omitted — capture never raises and never masks the original error.
+
+**`--tail` mechanism.** Testcontainers' `DockerCompose.get_logs` has no tail
+bound, so the helper drives the compose CLI directly
+(`docker compose … logs --no-color --no-log-prefix --tail=<N> <service>`),
+deriving the base command from the `DockerCompose` instance and running the
+subprocess with `cwd=<context>` so Compose resolves the per-trial project from
+the context-dir basename. `compute.log_tail` (default 500) sets `N`.
+
+**Shared-stack no-op.** `SharedStackRuntimeBackend.capture_service_logs` returns
+`{}` unconditionally. Its stack is run-wide, not trial-scoped, and its per-trial
+`teardown` is a no-op — there is no per-trial stack to read, and capturing the
+same run-wide containers on every trial would be meaningless. Run-level capture
+on a shared-stack materialise failure is a separate, future surface.
 
 ## `SharedStackRuntimeBackend` vs `PerTrialRuntimeBackend` side-by-side
 
@@ -351,7 +404,7 @@ The manifest is **substrate-neutral by design**: `EnvironmentManifest` points at
 
 Concretely, when the next substrate lands (e.g. Kubernetes):
 
-- Write a new class that satisfies the nine-method `RuntimeBackend` Protocol.
+- Write a new class that satisfies the ten-method `RuntimeBackend` Protocol.
 - Inside `provision`, translate `manifest.load_compose()` into that substrate's shape (a k8s backend would use `kompose` or a small owned translator to render Pod / Service specs, then `kubectl apply`; a Modal / E2B backend would render into its SDK's spec type).
 - Advertise the backend's isolation posture by setting the class-level `isolation_mode: IsolationMode` attribute — `SHARED_STACK` if trials share one materialisation, `PER_TRIAL_STACK` if each trial gets its own. The orchestrator's isolation-compatibility check reads this attribute, not the class name, so a `KubernetesPerTrialRuntimeBackend` (or whatever it's called) slots into the enforcement path with zero orchestrator changes.
 - Wire the backend into config: extend the `orchestrator.runtime` selector so operators can pick between the shipped backends.

--- a/docs/plans/2026-07-15-issue-302-per-service-log-capture.md
+++ b/docs/plans/2026-07-15-issue-302-per-service-log-capture.md
@@ -1,0 +1,295 @@
+# Plan: per-service log capture on trial failure
+
+Issue: #302 (umbrella #304, Multi-container runtime v1, sub-issue 4/5)
+Branch: feat/per-service-log-capture
+
+## Context
+
+When a multi-service trial fails, per-service Docker logs are never captured to
+the trial output dir. The two failure surfaces both throw the logs away:
+
+- **Provision-stage failures** — `PerTrialRuntimeBackend.provision` (compose
+  `up --wait` healthcheck failure) and its reset-recipe path both call
+  `cleanup_partial_materialisation` (`docker compose down -v`) *inside*
+  `provision()` before the typed `ProvisionError` is re-raised
+  (`tolokaforge/core/per_trial_runtime.py:216`, `:234`). By the time
+  `ProvisioningTrialExecutor` sees the error, the containers are gone.
+- **Trial-body failures** — `Conductor.run` returns a failed `TrialResult`;
+  `ProvisioningTrialExecutor.execute` tears the stack down in its `finally`
+  (`tolokaforge/core/trial_executor.py:136`) with no capture in between.
+
+So the exact moment an operator needs to know *why postgres/PostgREST went
+sideways*, the evidence is already deleted. This is the observability gap for
+multi-container workloads. `compute.log_tail` does not exist yet — this plan
+adds it.
+
+## Goal
+
+On **trial failure** on the per-trial backend, for every service the task's
+compose stack declares, write `docker compose logs`-style output to
+`<output_dir>/trials/<task_id>/<trial_index>/services/<service>.log`, captured
+**before** the stack is torn down. Emit a structured summary line naming the
+captured services and their byte counts, and record the captured services + byte counts on a durable surface: a
+`captured_service_logs` field on the trial's `metrics.yaml` where that file
+exists (the trial-body path), and a `services/_capture.yaml` manifest on the
+provision-failure path (where `metrics.yaml` is never written). On success, capture
+nothing unless a debug flag is set. Raw `docker compose logs` text is the v1
+format — no parsing, no structured per-service metrics.
+
+Failure, for capture purposes, means **execution failure**
+(`trajectory.status in {ERROR, TIMEOUT}`) or a `ProvisionError` — *not* a clean
+run that merely failed grading. A `COMPLETED` trial with `binary_pass=False` is
+not a capture trigger (that would capture on most trials of a hard benchmark and
+blow the output-dir size budget the issue explicitly wants bounded).
+
+## Non-goals
+
+- No structured per-service metrics (CPU / memory / restart counts).
+- No log-format changes — raw `docker compose logs --tail=N` output only.
+- No UI, no per-service dashboard — files on disk plus one structured log line.
+- No capture on the **shared-stack** backend: its stack is run-wide (not
+  trial-scoped) and its per-trial `teardown` is a no-op, so per-trial capture is
+  meaningless. `SharedStackRuntimeBackend.capture_service_logs` is a documented
+  no-op. The run-level materialise-failure gap is filed as #339.
+- `metrics.yaml` gains a `captured_service_logs` field on the trial-body path
+  (ship condition #3), but no run-level `aggregate.json` roll-up (filed as
+  #337); no full trial bundle for provision-failed trials (filed as #338).
+
+## Stages
+
+### Stage 1: capture primitive + config knobs
+
+- **Contract:**
+  - `ComputeConfig` (`tolokaforge/core/models.py`) gains two fields:
+    - `log_tail: int = Field(default=500, ge=1)` — tail line count passed to
+      `docker compose logs --tail`.
+    - `capture_logs_on_success: bool = False` — debug escape hatch; when `True`,
+      capture runs for successful trials too.
+    `ComputeConfig` (`models.py:672`) declares no `model_config` and inherits
+    Pydantic's default `extra="ignore"` — unknown compute keys are silently
+    ignored today, not rejected. Both new fields are additive and defaulted, so
+    existing configs load unchanged either way; this plan does **not** tighten
+    `extra` (out of scope).
+  - New frozen value object `LogCaptureConfig` in
+    `tolokaforge/core/compose_materialisation.py`
+    (`@dataclass(frozen=True)`, internal in-process value — per the type-system
+    table): `output_root: Path`, `tail: int`, `on_success: bool`.
+  - New helper in the same module:
+    `capture_compose_service_logs(compose: DockerCompose | None,
+    service_names: Iterable[str], dest_dir: Path, tail: int) -> dict[str, int]`.
+    - Writes `dest_dir/<service>.log` for each name; returns
+      `{service_name: bytes_written}` (only services that produced output).
+    - Honours `--tail=N` by invoking the compose CLI with a tail bound
+      (testcontainers `DockerCompose.get_logs(*services)` has **no** tail
+      parameter — verified against `testcontainers>=4.14.2`). Build the command
+      from `compose.compose_command_property` (the base
+      `docker compose -f <file>` list, `compose.py:254`) and append
+      `logs --no-color --no-log-prefix --tail=<N> <service>`. The subprocess
+      **must run with `cwd=str(compose.context)`** — `compose_command_property`
+      carries no `-p/--project-name`, so Docker Compose derives the project from
+      the context-dir basename (the per-trial temp dir whose name encodes the
+      trial id); a wrong cwd silently targets no project and returns empty logs.
+    - **Never raises** (fail-fast rule applies to the trial body, not to
+      best-effort diagnostics captured *because* something already failed): a
+      per-service fetch error is `logger.debug`-logged and that service is
+      omitted from the returned map. `compose is None` → returns `{}` (nothing
+      materialised to read).
+    - Creates `dest_dir` (parents=True) only when there is at least one service
+      to attempt.
+- **Behaviour to lock:**
+  - unit (`tests/unit/test_compose_log_capture.py`): against a fake object
+    exposing `compose_command_property` + `context`, assert one `.log` file per
+    service with the expected bytes in the returned map; assert a raising
+    service is omitted and no exception propagates; assert `compose=None` → `{}`
+    and no dir created. The fake pins the **command shape** (verb order, `--tail`
+    value); it cannot verify the live `cwd=compose.context` project-resolution
+    invariant — that is locked by the Stage 2 integration test.
+  - canonical (extend the `ComputeConfig` schema test): `log_tail` defaults to
+    500, rejects `0`/negative (`ge=1`), `capture_logs_on_success` defaults
+    `False`.
+- **Compatibility:** `ComputeConfig` is a run-config schema surface. Additive,
+  both fields defaulted — existing configs load unchanged. Migration note:
+  CHANGELOG entry + `docs/CONFIG.md` compute section documents the two fields.
+- **Deliverable:** the config fields and the capture helper exist and are
+  tested; no backend wires them yet.
+- **Validation:** `run_tests` markers `unit` + `canonical`; `lint_check`.
+- **Doc updates:** `docs/CONFIG.md` (compute block — add `log_tail`,
+  `capture_logs_on_success` with defaults/semantics); `CHANGELOG.md`.
+
+### Stage 2: per-trial capture — provision-failure path + backend Protocol method
+
+- **Contract:**
+  - `RuntimeBackend` Protocol (`tolokaforge/core/runtime.py`) gains one method:
+    `capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]`.
+    Semantics: when the backend has a live per-trial stack for `handle` and
+    (`failed` or the backend's `on_success` policy), write per-service logs to
+    the handle-derived trial `services/` dir and return the byte map; otherwise
+    return `{}`. Never raises. This is an internal Protocol (not a published
+    API) — all three implementations update in this stage, no shim.
+  - `PerTrialRuntimeBackend`:
+    - New field `log_capture: LogCaptureConfig | None = None` (None = disabled,
+      e.g. tests / when construction supplies no output root).
+    - `_LocalEnvHandle` gains `service_names: tuple[str, ...]` (snapshot of the
+      compose stack's declared services at provision time).
+    - `provision()` failure paths (the two `except` blocks at
+      `per_trial_runtime.py:216` and `:234`) call the shared helper to capture
+      **before** `cleanup_partial_materialisation`, deriving `dest_dir` from
+      `log_capture.output_root` + `spec.trial_id` and the manifest's service
+      names (`manifest.load_compose()["services"]`). No-op when
+      `log_capture is None` or `compose is None`. On this path `metrics.yaml`
+      does not exist (the conductor never ran), so the durable record is a
+      `services/_capture.yaml` manifest written alongside the `.log` files
+      (shape in Stage 3; the writer lives in the shared module).
+    - `capture_service_logs(handle, *, failed)`: no-op `{}` when
+      `log_capture is None`; else gate on `failed or log_capture.on_success`;
+      else capture `handle.service_names` from `handle.compose` into the derived
+      trial `services/` dir; return the byte map. The durable record here is the
+      `metrics.yaml` amendment written by the executor (Stage 3), which owns the
+      failure decision — this method only writes the `.log` files and returns
+      the map.
+  - `SharedStackRuntimeBackend.capture_service_logs`: documented no-op returning
+    `{}` (rationale in the docstring + RUNTIME_BACKENDS.md; run-level gap is
+    #339).
+  - `InMemoryRuntimeBackend.capture_service_logs`: records the call
+    (`RuntimeBackendCallLog` gains `capture_service_logs_calls:
+    list[tuple[str, bool]]`) and returns `{}`.
+  - Orchestrator wiring: `run()` / `run_worker()` build **one**
+    `LogCaptureConfig` from `output_dir` + `compute.log_tail` +
+    `compute.capture_logs_on_success` (`output_dir` is in scope at both sites —
+    `orchestrator.py:1121` and `:1614`) and pass the same instance to
+    `_construct_runtime_backend` (→ `PerTrialRuntimeBackend(seeds=...,
+    log_capture=...)`) and to `_build_trial_executor` (Stage 3, for the
+    `metrics.yaml` amendment). Both helpers gain a `log_capture:
+    LogCaptureConfig | None` parameter. Built-in shared mode passes `None`.
+- **Behaviour to lock:**
+  - integration (`tests/integration/docker/test_per_trial_log_capture_integration.py`,
+    real Docker, no LLM keys — provisioning fails before the agent loop):
+    construct a `PerTrialRuntimeBackend` with a `LogCaptureConfig` pointed at a
+    `tmp_path`, provision a manifest whose extra service fails its healthcheck
+    (or a reset-recipe pointed at a missing seed) → assert `ProvisionError`
+    **and** `tmp_path/trials/<task>/<idx>/services/<service>.log` exists with
+    size > 0 for the declared services, and `_capture.yaml` byte counts match
+    the file sizes. Mirrors the harness in
+    `tests/integration/docker/test_per_trial_runtime_backend_integration.py`.
+  - canonical (extend `tests/canonical/test_runtime_backend_contract.py`, which
+    already owns the `runtime_checkable` isinstance parity check across all three
+    backends at lines 51–62 — add cases there, do **not** add a parallel file):
+    `InMemoryRuntimeBackend.capture_service_logs(handle, failed=True/False)`
+    records the call; `SharedStackRuntimeBackend.capture_service_logs` returns
+    `{}`; the existing conformance check still passes with the new method on the
+    Protocol.
+- **Compatibility:** internal only — `RuntimeBackend` is an in-repo Protocol,
+  not a compatibility surface. All implementations land in this stage.
+- **Deliverable:** provision-stage failures write per-service logs on the
+  per-trial backend end-to-end; the Protocol method exists on every backend.
+- **Validation:** `run_tests` markers `canonical` (+ `integration` with Docker);
+  `lint_check`.
+- **Doc updates:** `docs/architecture/RUNTIME_BACKENDS.md` — new "Per-service
+  log capture on failure" section describing the two capture surfaces, the
+  failure definition, the shared-stack no-op rationale, and the `compute`
+  knobs; update the "Failure modes" table rows for `provision` /
+  `reset_recipe` to note logs are captured before teardown. `CHANGELOG.md`.
+
+### Stage 3: executor drives trial-body-failure capture + summary line + `services/` bundle
+
+- **Contract:**
+  - `ProvisioningTrialExecutor.execute` (`tolokaforge/core/trial_executor.py`):
+    after `conductor.run` returns and **before** the `finally` teardown, compute
+    `failed = result.trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT)`
+    and call `self.runtime_backend.capture_service_logs(handle, failed=failed)`.
+    When the returned map is non-empty: (1) emit
+    `self.logger.info("trial.service_logs_captured", task_id=..., trial_index=...,
+    services={name: bytes})` — the required aggregate summary line; and (2)
+    amend the trial's `metrics.yaml` with a top-level
+    `captured_service_logs: {"<service>": <bytes>}` mapping. This literally meets
+    ship condition #3 on the surface the issue names ("per-trial `metrics.yaml`
+    mentions the captured logs") — `metrics.yaml` is already written by the
+    conductor by the time the executor runs on the trial-body path. Capture
+    failures never change control flow (the method itself never raises); the
+    `metrics.yaml` amendment is a read-add-write of a plain YAML mapping (the
+    same file `_collect_existing_cost` reads at `orchestrator.py:350`) and is a
+    no-op if the file is unexpectedly absent.
+  - `services/_capture.yaml` manifest (provision-failure path only, where no
+    `metrics.yaml` exists — #338): written by the shared module, shape
+    `{"tail": int, "capture_reason": "provision_error", "services":
+    {"<name>": {"bytes": int}}}`. It is the durable record for that surface;
+    the trial-body path uses the `metrics.yaml` amendment instead, so the two
+    surfaces never both write.
+  - The executor owns the `metrics.yaml` amendment and derives the trial dir
+    from the backend's `LogCaptureConfig.output_root` + `handle.trial_id`
+    (threaded into the executor via `_build_trial_executor`, which reads the
+    same `LogCaptureConfig` the backend was constructed with). The per-service
+    `.log` files and their destination remain backend-owned via
+    `capture_service_logs`.
+- **Behaviour to lock:**
+  - canonical (`tests/canonical/test_executor_log_capture.py`): inject an
+    `InMemoryRuntimeBackend` (with `capture_service_logs` stubbed to return a
+    non-empty map and to write nothing) and a fake `Conductor` returning an
+    `ERROR` trajectory, with a pre-written `metrics.yaml` in the trial dir →
+    assert `capture_service_logs(handle, failed=True)` recorded, a
+    `trial.service_logs_captured` line emitted (via an in-memory
+    `StructuredLogger`), and the `metrics.yaml` now carries
+    `captured_service_logs`; a `COMPLETED` (`binary_pass=False`) trajectory →
+    `capture_service_logs(handle, failed=False)` recorded, **no** summary line
+    and **no** `metrics.yaml` amendment when the map is empty. Locks both the
+    "graded-fail is not a capture trigger" contract and the ship-condition-#3
+    `metrics.yaml` surface, without Docker.
+  - integration (extend the Stage 2 file): after a *successful* provision, call
+    `capture_service_logs(handle, failed=False)` with
+    `capture_logs_on_success=False` → assert **no** `services/*.log`; with
+    `capture_logs_on_success=True` → assert `services/*.log` present. (The
+    `metrics.yaml` amendment is locked at the canonical tier above; the
+    integration tier locks the real-Docker per-service `.log` capture.)
+- **Compatibility:** `services/<service>.log` + `services/_capture.yaml` are new
+  entries in the trial output bundle — an additive `docs/OUTPUT_FORMAT.md`
+  surface. Documented, not versioned (additive files don't break readers).
+- **Deliverable:** trial-body failures capture per-service logs, emit the
+  summary log line, and amend `metrics.yaml` with `captured_service_logs`;
+  provision failures record `_capture.yaml`; success skips capture by default.
+- **Validation:** `run_tests` markers `canonical` (+ `integration`);
+  `lint_check`; `format_check`.
+- **Doc updates:** `docs/OUTPUT_FORMAT.md` — add `services/<service>.log` +
+  `services/_capture.yaml` to the `trials/{task_id}/{trial_index}/` tree, and
+  document the `captured_service_logs` field in the `metrics.yaml` section,
+  each with a note on which failure surface produces it;
+  `docs/architecture/RUNTIME_BACKENDS.md` cross-link the trial-body path.
+  `CHANGELOG.md`.
+
+## Discovered issues
+
+- **Fix in this PR:** none — the neighbourhood is clean; the capture helper's
+  broad-but-logged exception handling matches the existing
+  `compose_materialisation.py` best-effort teardown idiom (not a fail-fast
+  violation, since capture only runs *after* a failure is already decided).
+- **Filed as issues:**
+  - #337 — surface captured service logs in the run-level `aggregate.json`
+    report (per-trial `metrics.yaml.captured_service_logs` and
+    `services/_capture.yaml` ship in this PR; the run-level roll-up is deferred).
+  - #338 — provision-failed trials get no full trial bundle (`Conductor.run`
+    never runs for them; only the synthesized trajectory is aggregated).
+  - #339 — capture shared-stack compose logs on run-level materialise failure
+    (`_materialise_manifest`'s `connect()`-time `docker compose up` failure).
+
+## Risks / open questions
+
+- **`--tail` mechanism.** testcontainers' `DockerCompose.get_logs` has no tail
+  parameter, so the helper drives the compose CLI directly with `--tail=N`. The
+  implementer must derive the correct base command (compose file + context dir)
+  from the `DockerCompose` instance rather than hardcoding `docker compose`;
+  Stage 1's unit test uses a fake to pin the command shape.
+- **Failure definition.** Capturing only on `status in {ERROR, TIMEOUT}` (plus
+  `ProvisionError`) — not on `binary_pass=False` — is the load-bearing scoping
+  decision that keeps the output-dir bounded. If reviewers want graded-fail
+  capture too, that is a policy flip on one predicate, but it changes the
+  disk-footprint contract and should be a conscious call.
+- **Reset-recipe stage.** The `reset_recipe` `except` in `provision()` catches
+  broadly (typed `ProvisionError` *and* programming errors) before re-raising;
+  the capture call sits before `cleanup_partial_materialisation` in that block
+  too, so both stages are covered. The capture must not itself mask the
+  original error — it is a separate best-effort statement before the re-raise.
+- **Service-name source.** Capture covers every service in the compose stack
+  (`manifest.load_compose()["services"]` at provision; `handle.service_names`
+  snapshot for the trial-body path), which is a superset-safe reading of "every
+  service declared in `EnvironmentManifest.services`" (that map may be empty
+  when a task declares no per-service isolation but still runs multiple compose
+  services).

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -1,0 +1,144 @@
+"""Lock the trial-body log-capture contract on ``ProvisioningTrialExecutor``.
+
+After ``conductor.run`` returns and before teardown, the executor calls
+``runtime_backend.capture_service_logs(handle, failed=...)`` where ``failed``
+is true only for an execution failure (``ERROR`` / ``TIMEOUT``) — a clean run
+that merely failed grading is not a capture trigger. When the backend returns
+a non-empty byte map the executor emits the ``trial.service_logs_captured``
+summary line and amends the trial's ``metrics.yaml`` with a top-level
+``captured_service_logs`` mapping.
+
+No Docker: an :class:`InMemoryRuntimeBackend` subclass returns a stub byte map
+(gated on the ``failed`` flag, writing no ``.log`` files) and an
+:class:`InMemoryConductor` drives the trajectory status. The real per-service
+``.log`` capture is locked by the Docker integration test.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.canonical._factories import make_task_config, make_trial_spec
+from tolokaforge.core.compose_materialisation import LogCaptureConfig
+from tolokaforge.core.conductor import InMemoryConductor
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models import Grade, GradeComponents, Metrics, Trajectory, TrialStatus
+from tolokaforge.core.runtime import EnvHandle, InMemoryRuntimeBackend
+from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
+
+pytestmark = pytest.mark.canonical
+
+_BYTE_MAP = {"db": 128, "runner": 64}
+
+
+class _StubCaptureBackend(InMemoryRuntimeBackend):
+    """In-memory backend whose ``capture_service_logs`` returns a stub byte
+    map, gated exactly like the real backend (``failed`` or on-success), and
+    writes no ``.log`` files. Still records the ``(trial_id, failed)`` call."""
+
+    def __init__(self, *, on_success: bool = False) -> None:
+        super().__init__()
+        self._on_success = on_success
+
+    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
+        self.call_log.capture_service_logs_calls.append((handle.trial_id, failed))
+        if failed or self._on_success:
+            return dict(_BYTE_MAP)
+        return {}
+
+
+def _factory_for(status: TrialStatus, *, binary_pass: bool) -> object:
+    def _factory(task_id: str, trial_idx: int) -> Trajectory:
+        now = datetime.now(UTC)
+        return Trajectory(
+            task_id=task_id,
+            trial_index=trial_idx,
+            start_ts=now,
+            end_ts=now,
+            status=status,
+            messages=[],
+            metrics=Metrics(),
+            grade=Grade(
+                binary_pass=binary_pass,
+                score=1.0 if binary_pass else 0.0,
+                components=GradeComponents(),
+                reasons="synthetic",
+            ),
+        )
+
+    return _factory
+
+
+def _write_metrics(output_root: Path, task_id: str, trial_idx: int) -> Path:
+    metrics_path = output_root / "trials" / task_id / str(trial_idx) / "metrics.yaml"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(yaml.safe_dump({"cost_usd": 0.5}, sort_keys=False))
+    return metrics_path
+
+
+def _make_executor(
+    backend: InMemoryRuntimeBackend, factory, output_root: Path
+) -> ProvisioningTrialExecutor:
+    return ProvisioningTrialExecutor(
+        runtime_backend=backend,
+        conductor=InMemoryConductor(trajectory_factory=factory),
+        logger=StructuredLogger("test-executor-log-capture"),
+        log_capture=LogCaptureConfig(output_root=output_root, tail=200, on_success=False),
+    )
+
+
+def _summary_lines(logger: StructuredLogger) -> list[dict]:
+    return [e for e in logger.logs if e["message"] == "trial.service_logs_captured"]
+
+
+class TestErrorTrialCapture:
+    def test_error_trajectory_captures_and_amends_metrics(self, tmp_path: Path) -> None:
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.ERROR, binary_pass=False)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        assert backend.call_log.capture_service_logs_calls == [("task-1:0", True)]
+
+        summary = _summary_lines(executor.logger)
+        assert len(summary) == 1
+        assert summary[0]["context"]["services"] == _BYTE_MAP
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert metrics["captured_service_logs"] == _BYTE_MAP
+        # Pre-existing keys survive the read-add-write amendment.
+        assert metrics["cost_usd"] == 0.5
+
+    def test_timeout_trajectory_is_also_a_failure(self, tmp_path: Path) -> None:
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.TIMEOUT, binary_pass=False)
+        executor = _make_executor(backend, factory, tmp_path)
+        _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        assert backend.call_log.capture_service_logs_calls == [("task-1:0", True)]
+        assert len(_summary_lines(executor.logger)) == 1
+
+
+class TestGradedFailIsNotCapture:
+    def test_completed_binary_fail_does_not_capture(self, tmp_path: Path) -> None:
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.COMPLETED, binary_pass=False)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        # Capture is still consulted, but with failed=False the map is empty.
+        assert backend.call_log.capture_service_logs_calls == [("task-1:0", False)]
+        assert _summary_lines(executor.logger) == []
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert "captured_service_logs" not in metrics

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -241,13 +241,18 @@ def _make_one_service_manifest() -> EnvironmentManifest:
 class TestProvisioningProtocolConformance:
     def test_shared_stack_runtime_backend_has_provisioning_methods(self) -> None:
         backend = SharedStackRuntimeBackend(runner_address="sentinel:50051")
-        for method in ("provision", "await_ready", "endpoints", "teardown"):
+        for method in ("provision", "await_ready", "endpoints", "teardown", "capture_service_logs"):
             assert callable(getattr(backend, method))
 
     def test_in_memory_backend_has_provisioning_methods(self) -> None:
         backend = InMemoryRuntimeBackend()
-        for method in ("provision", "await_ready", "endpoints", "teardown"):
+        for method in ("provision", "await_ready", "endpoints", "teardown", "capture_service_logs"):
             assert callable(getattr(backend, method))
+
+    def test_per_trial_backend_has_capture_service_logs(self) -> None:
+        from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+
+        assert callable(PerTrialRuntimeBackend().capture_service_logs)
 
 
 class TestEnvHandleShape:
@@ -423,3 +428,27 @@ class TestInMemoryProvisioningCallLog:
         backend = InMemoryRuntimeBackend(fail_provision_after_service="db")
         with pytest.raises(ProvisionError):
             backend.provision(_make_trial_spec(manifest=_make_two_service_manifest()))
+
+
+class TestCaptureServiceLogsContract:
+    """``capture_service_logs`` is a Protocol method on every backend. The
+    in-memory fixture records the ``(trial_id, failed)`` pair for tests to
+    assert against; the shared-stack backend is a documented no-op. Real
+    per-service ``.log`` capture on the per-trial backend is locked by the
+    Docker integration test."""
+
+    def test_in_memory_records_call_and_returns_empty(self) -> None:
+        backend = InMemoryRuntimeBackend()
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        assert backend.capture_service_logs(handle, failed=True) == {}
+        assert backend.capture_service_logs(handle, failed=False) == {}
+        assert backend.call_log.capture_service_logs_calls == [
+            ("task-1:0", True),
+            ("task-1:0", False),
+        ]
+
+    def test_shared_stack_is_no_op(self) -> None:
+        backend = SharedStackRuntimeBackend(runner_address="localhost:50051")
+        handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
+        assert backend.capture_service_logs(handle, failed=True) == {}
+        assert backend.capture_service_logs(handle, failed=False) == {}

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -43,14 +43,15 @@ _FIXTURE = (
 )
 
 
-def _make_trial_spec(trial_id: str) -> TrialSpec:
+def _make_trial_spec(trial_id: str, *, manifest: EnvironmentManifest | None = None) -> TrialSpec:
     # 'db' is labelled reset with a seed the backend registry will not carry,
     # so provision brings the healthy stack up and then fails in the
     # reset_recipe stage — the branch that captures logs before teardown.
-    manifest = EnvironmentManifest(
-        compose_file=_FIXTURE,
-        services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="absent-seed"))},
-    )
+    if manifest is None:
+        manifest = EnvironmentManifest(
+            compose_file=_FIXTURE,
+            services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="absent-seed"))},
+        )
     return TrialSpec(
         trial_id=trial_id,
         run_id="log-capture-integration",
@@ -101,3 +102,44 @@ class TestProvisionFailureLogCapture:
         # Recorded byte counts match the files actually written.
         for service, entry in manifest["services"].items():
             assert entry["bytes"] == (services_dir / f"{service}.log").stat().st_size
+
+
+@pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
+class TestSuccessPathCapture:
+    """After a *successful* provision, ``capture_service_logs(handle,
+    failed=False)`` writes per-service ``.log`` files only when the on-success
+    debug policy is set — the default keeps the output dir bounded."""
+
+    @staticmethod
+    def _success_spec(trial_id: str) -> TrialSpec:
+        # No reset service: the healthy stack comes up and provision succeeds.
+        return _make_trial_spec(trial_id, manifest=EnvironmentManifest(compose_file=_FIXTURE))
+
+    def test_on_success_false_captures_nothing(self, tmp_path: Path) -> None:
+        backend = PerTrialRuntimeBackend(
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
+        )
+        handle = backend.provision(self._success_spec("task-1:0"))
+        try:
+            assert backend.capture_service_logs(handle, failed=False) == {}
+        finally:
+            backend.teardown(handle)
+
+        assert not (tmp_path / "trials" / "task-1" / "0" / "services").exists()
+
+    def test_on_success_true_captures_logs(self, tmp_path: Path) -> None:
+        backend = PerTrialRuntimeBackend(
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=True)
+        )
+        handle = backend.provision(self._success_spec("task-1:0"))
+        try:
+            captured = backend.capture_service_logs(handle, failed=False)
+        finally:
+            backend.teardown(handle)
+
+        services_dir = tmp_path / "trials" / "task-1" / "0" / "services"
+        assert services_dir.is_dir()
+        for service in captured:
+            log_file = services_dir / f"{service}.log"
+            assert log_file.is_file()
+            assert log_file.stat().st_size > 0

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -1,0 +1,103 @@
+"""Integration test for per-service log capture on a provision failure.
+
+Real docker-daemon coverage for :class:`PerTrialRuntimeBackend`'s
+provision-stage capture path. Brings up the public two-service fixture
+(``postgres:16`` + ``nginx:alpine``), then forces a ``reset_recipe``
+failure (a service labelled ``reset`` whose seed is absent from the
+backend registry). The stack is healthy at that point, so every declared
+service has real logs to capture *before* teardown.
+
+Asserts the provision failure surfaces as :class:`ProvisionError` and that
+per-service ``.log`` files plus the ``_capture.yaml`` manifest land in the
+trial ``services/`` dir with byte counts that match the files on disk.
+
+No LLM keys required — the failure happens before the agent loop. Mirrors
+the harness in ``test_per_trial_runtime_backend_integration.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.canonical._factories import make_task_description
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.core.compose_materialisation import LogCaptureConfig
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
+from tolokaforge.runner.models import ResetSpec, ServiceSpec
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+_FIXTURE = (
+    Path(__file__).parent.parent.parent
+    / "canonical"
+    / "fixtures"
+    / "environment_manifest"
+    / "lifecycle_public.yaml"
+)
+
+
+def _make_trial_spec(trial_id: str) -> TrialSpec:
+    # 'db' is labelled reset with a seed the backend registry will not carry,
+    # so provision brings the healthy stack up and then fails in the
+    # reset_recipe stage — the branch that captures logs before teardown.
+    manifest = EnvironmentManifest(
+        compose_file=_FIXTURE,
+        services={"db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="absent-seed"))},
+    )
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="log-capture-integration",
+        task=make_task_description(
+            task_id="task-1",
+            name="probe",
+            category="general",
+            description="per-service log capture integration test",
+            environment_manifest=manifest,
+        ),
+        agent_model_config=ModelConfig(name="claude-sonnet-4-6", provider="anthropic"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://placeholder:5432",
+            runner_url="http://placeholder:50051",
+        ),
+    )
+
+
+@pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
+class TestProvisionFailureLogCapture:
+    def test_reset_recipe_failure_captures_service_logs_before_teardown(
+        self, tmp_path: Path
+    ) -> None:
+        backend = PerTrialRuntimeBackend(
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
+        )
+        spec = _make_trial_spec(trial_id="task-1:0")
+
+        with pytest.raises(ProvisionError) as exc:
+            backend.provision(spec)
+        assert exc.value.stage == "reset_recipe"
+
+        services_dir = tmp_path / "trials" / "task-1" / "0" / "services"
+        assert services_dir.is_dir()
+
+        # Both declared services were healthy, so both produced logs.
+        for service in ("db", "default"):
+            log_file = services_dir / f"{service}.log"
+            assert log_file.is_file(), f"missing {service}.log"
+            assert log_file.stat().st_size > 0, f"empty {service}.log"
+
+        manifest_path = services_dir / "_capture.yaml"
+        assert manifest_path.is_file()
+        manifest = yaml.safe_load(manifest_path.read_text())
+        assert manifest["tail"] == 200
+        assert manifest["capture_reason"] == "provision_error"
+
+        # Recorded byte counts match the files actually written.
+        for service, entry in manifest["services"].items():
+            assert entry["bytes"] == (services_dir / f"{service}.log").stat().st_size

--- a/tests/unit/test_compose_log_capture.py
+++ b/tests/unit/test_compose_log_capture.py
@@ -1,0 +1,123 @@
+"""Unit tests for the per-service compose-log capture primitive."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.compose_materialisation import capture_compose_service_logs
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCompose:
+    """Pins the command shape capture_compose_service_logs must build.
+
+    Exposes the same ``compose_command_property`` base list and ``context``
+    attribute the real testcontainers ``DockerCompose`` carries. Records the
+    argv of every ``docker compose logs`` invocation and returns canned bytes
+    per service; a service listed in ``raising`` raises instead.
+    """
+
+    def __init__(self, context: Path, outputs: dict[str, bytes], raising: set[str] | None = None):
+        self.compose_command_property = ["docker", "compose", "-f", "compose.yaml"]
+        self.context = context
+        self._outputs = outputs
+        self._raising = raising or set()
+        self.calls: list[list[str]] = []
+
+    def run(self, command: list[str], *, cwd: str, capture_output: bool, check: bool):
+        self.calls.append(command)
+        service = command[-1]
+        if service in self._raising:
+            raise subprocess.CalledProcessError(1, command)
+        return subprocess.CompletedProcess(command, 0, stdout=self._outputs.get(service, b""))
+
+
+def test_writes_one_log_file_per_service(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dest = tmp_path / "services"
+    fake = _FakeCompose(
+        context=tmp_path / "ctx",
+        outputs={"db": b"db log line\n", "api": b"api boot\napi ready\n"},
+    )
+    monkeypatch.setattr(subprocess, "run", fake.run)
+
+    result = capture_compose_service_logs(fake, ["db", "api"], dest, tail=250)
+
+    assert result == {"db": len(b"db log line\n"), "api": len(b"api boot\napi ready\n")}
+    assert (dest / "db.log").read_bytes() == b"db log line\n"
+    assert (dest / "api.log").read_bytes() == b"api boot\napi ready\n"
+
+
+def test_command_shape_and_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = tmp_path / "ctx"
+    fake = _FakeCompose(context=ctx, outputs={"db": b"x"})
+    monkeypatch.setattr(subprocess, "run", fake.run)
+
+    capture_compose_service_logs(fake, ["db"], tmp_path / "services", tail=99)
+
+    assert fake.calls == [
+        [
+            "docker",
+            "compose",
+            "-f",
+            "compose.yaml",
+            "logs",
+            "--no-color",
+            "--no-log-prefix",
+            "--tail",
+            "99",
+            "db",
+        ]
+    ]
+
+
+def test_raising_service_is_omitted_without_propagating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dest = tmp_path / "services"
+    fake = _FakeCompose(
+        context=tmp_path / "ctx",
+        outputs={"db": b"db log\n"},
+        raising={"api"},
+    )
+    monkeypatch.setattr(subprocess, "run", fake.run)
+
+    result = capture_compose_service_logs(fake, ["db", "api"], dest, tail=100)
+
+    assert result == {"db": len(b"db log\n")}
+    assert (dest / "db.log").exists()
+    assert not (dest / "api.log").exists()
+
+
+def test_empty_output_service_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dest = tmp_path / "services"
+    fake = _FakeCompose(context=tmp_path / "ctx", outputs={"db": b"", "api": b"api\n"})
+    monkeypatch.setattr(subprocess, "run", fake.run)
+
+    result = capture_compose_service_logs(fake, ["db", "api"], dest, tail=100)
+
+    assert result == {"api": len(b"api\n")}
+    assert not (dest / "db.log").exists()
+
+
+def test_none_compose_returns_empty_and_creates_no_dir(tmp_path: Path) -> None:
+    dest = tmp_path / "services"
+
+    result = capture_compose_service_logs(None, ["db"], dest, tail=100)
+
+    assert result == {}
+    assert not dest.exists()
+
+
+def test_empty_service_names_creates_no_dir(tmp_path: Path) -> None:
+    ctx = tmp_path / "ctx"
+    dest = tmp_path / "services"
+    fake = _FakeCompose(context=ctx, outputs={})
+
+    result = capture_compose_service_logs(fake, [], dest, tail=100)
+
+    assert result == {}
+    assert not dest.exists()

--- a/tests/unit/test_run_defaults_schema.py
+++ b/tests/unit/test_run_defaults_schema.py
@@ -35,6 +35,8 @@ class TestComputeConfig:
         assert c.max_budget_usd is None
         assert c.max_requests_per_second is None
         assert c.max_attempt_retries == 0
+        assert c.log_tail == 500
+        assert c.capture_logs_on_success is False
         assert c.local_docker is None
 
     def test_rejects_unknown_provider(self) -> None:
@@ -58,6 +60,17 @@ class TestComputeConfig:
         with pytest.raises(ValidationError):
             ComputeConfig(max_attempt_retries=-1)
         ComputeConfig(max_attempt_retries=0)  # zero is allowed
+
+    def test_log_tail_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            ComputeConfig(log_tail=0)
+        with pytest.raises(ValidationError):
+            ComputeConfig(log_tail=-1)
+        assert ComputeConfig(log_tail=1).log_tail == 1
+
+    def test_capture_logs_on_success_defaults_false(self) -> None:
+        assert ComputeConfig().capture_logs_on_success is False
+        assert ComputeConfig(capture_logs_on_success=True).capture_logs_on_success is True
 
     def test_provider_sub_block_binds(self) -> None:
         c = ComputeConfig(local_docker=LocalDockerComputeConfig())

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -25,7 +25,7 @@ import logging
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -456,3 +456,36 @@ def _fetch_service_logs(
         logger.debug("compose_materialisation: logs fetch for service %r failed: %s", service, exc)
         return None
     return result.stdout
+
+
+def trial_services_dir(output_root: Path, trial_id: str) -> Path:
+    """Return the per-trial ``services/`` capture dir for ``trial_id``.
+
+    ``trial_id`` is the canonical ``"{task_id}:{trial_index}"`` id; the tail
+    ``:index`` becomes the trial subdir, matching the conductor's
+    ``output_root/trials/<task_id>/<index>/`` bundle layout.
+    """
+    task_id, trial_index = trial_id.rsplit(":", 1)
+    return output_root / "trials" / task_id / trial_index / "services"
+
+
+def write_capture_manifest(
+    dest_dir: Path,
+    tail: int,
+    captured: Mapping[str, int],
+    capture_reason: str = "provision_error",
+) -> None:
+    """Write ``dest_dir/_capture.yaml`` recording captured per-service byte counts.
+
+    The durable record for the provision-failure path, where no ``metrics.yaml``
+    exists to amend. Shape:
+    ``{"tail": int, "capture_reason": str, "services": {"<name>": {"bytes": int}}}``.
+    ``dest_dir`` must already exist (the ``.log`` writer creates it).
+    """
+    manifest = {
+        "tail": tail,
+        "capture_reason": capture_reason,
+        "services": {name: {"bytes": count} for name, count in captured.items()},
+    }
+    with (dest_dir / "_capture.yaml").open("w") as f:
+        yaml.safe_dump(manifest, f, sort_keys=False)

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 import copy
 import logging
 import shutil
+import subprocess
 import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -371,3 +374,85 @@ def cleanup_partial_materialisation(compose: DockerCompose | None, temp_dir: Pat
     if compose is not None:
         shutdown_compose(compose)
     shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Per-service log capture on failure
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LogCaptureConfig:
+    """Per-run policy for capturing per-service compose logs on trial failure.
+
+    ``output_root`` is the run's ``output_dir``; capture writes under
+    ``output_root/trials/<task>/<idx>/services/``. ``tail`` is the
+    ``docker compose logs --tail`` bound. ``on_success`` is the debug escape
+    hatch that captures logs for successful trials too.
+    """
+
+    output_root: Path
+    tail: int
+    on_success: bool
+
+
+def capture_compose_service_logs(
+    compose: DockerCompose | None,
+    service_names: Iterable[str],
+    dest_dir: Path,
+    tail: int,
+) -> dict[str, int]:
+    """Write ``docker compose logs`` output per service to ``dest_dir``.
+
+    Returns ``{service_name: bytes_written}`` for the services that produced
+    output. Best-effort diagnostics captured *because* a trial already failed:
+    a per-service fetch error is ``logger.debug``-logged and that service is
+    omitted from the map — this function never raises.
+
+    The compose CLI is driven directly (testcontainers' ``get_logs`` has no
+    tail bound): the base command comes from ``compose.compose_command_property``
+    (``docker compose -f <file>``), and the subprocess runs with
+    ``cwd=str(compose.context)`` so Docker Compose derives the project name from
+    the context-dir basename — the same basename the per-trial temp dir encodes.
+    A wrong cwd silently targets no project and returns empty logs.
+
+    ``compose is None`` (nothing materialised) or an empty ``service_names``
+    returns ``{}`` without creating ``dest_dir``. ``dest_dir`` is created
+    (parents included) only when there is at least one service to attempt.
+    """
+    if compose is None:
+        return {}
+    names = list(service_names)
+    if not names:
+        return {}
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    base_command = list(compose.compose_command_property)
+    context = str(compose.context)
+    captured: dict[str, int] = {}
+    for name in names:
+        output = _fetch_service_logs(base_command, context, name, tail)
+        if not output:
+            continue
+        (dest_dir / f"{name}.log").write_bytes(output)
+        captured[name] = len(output)
+    return captured
+
+
+def _fetch_service_logs(
+    base_command: list[str], context: str, service: str, tail: int
+) -> bytes | None:
+    """Run ``docker compose logs`` for one service, returning its raw bytes.
+
+    ``None`` on any subprocess failure (logged at debug) — the caller omits the
+    service. Empty output is returned as-is and the caller skips it.
+    """
+    command = [*base_command, "logs", "--no-color", "--no-log-prefix", "--tail", str(tail), service]
+    try:
+        result = subprocess.run(command, cwd=context, capture_output=True, check=True)
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 — best-effort diagnostics; subprocess raises varied types
+        logger.debug("compose_materialisation: logs fetch for service %r failed: %s", service, exc)
+        return None
+    return result.stdout

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -683,6 +683,8 @@ class ComputeConfig(BaseModel):
     max_budget_usd: float | None = Field(default=None, ge=0.0)
     max_requests_per_second: float | None = Field(default=None, gt=0.0)
     max_attempt_retries: int = Field(default=0, ge=0)
+    log_tail: int = Field(default=500, ge=1)
+    capture_logs_on_success: bool = False
     local_docker: LocalDockerComputeConfig | None = None
 
     capabilities: list[Any] = Field(default_factory=list)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -822,7 +822,10 @@ class Orchestrator:
                 continue
 
     def _build_trial_executor(
-        self, runtime_backend: RuntimeBackend, conductor: Conductor
+        self,
+        runtime_backend: RuntimeBackend,
+        conductor: Conductor,
+        log_capture: LogCaptureConfig | None = None,
     ) -> TrialExecutor:
         """Compose the per-run :class:`TrialExecutor` (ADR-0015).
 
@@ -832,6 +835,10 @@ class Orchestrator:
         ``trial_executor.execute`` to the worker pool in place of
         ``conductor.run``; the bracket runs on the worker thread so
         provisioning parallelism equals worker count.
+
+        ``log_capture`` is the same instance the runtime backend was built
+        with, threaded so the executor can amend a failed trial's
+        ``metrics.yaml`` with the captured per-service byte counts.
         """
         from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 
@@ -839,6 +846,7 @@ class Orchestrator:
             runtime_backend=runtime_backend,
             conductor=conductor,
             logger=self.logger,
+            log_capture=log_capture,
         )
 
     def _verify_isolation_compatibility(self, runtime_backend: RuntimeBackend) -> None:
@@ -1376,7 +1384,9 @@ class Orchestrator:
             output_dir=output_dir,
             request_limiter=request_limiter,
         )
-        trial_executor = self._build_trial_executor(runtime_backend, conductor)
+        trial_executor = self._build_trial_executor(
+            runtime_backend, conductor, log_capture=log_capture
+        )
 
         executor_healthy = runtime_backend.health_check()
         self.logger.info("Docker runtime health check", executor_healthy=executor_healthy)
@@ -1729,7 +1739,9 @@ class Orchestrator:
             output_dir=output_dir,
             request_limiter=request_limiter,
         )
-        trial_executor = self._build_trial_executor(runtime_backend, conductor)
+        trial_executor = self._build_trial_executor(
+            runtime_backend, conductor, log_capture=log_capture
+        )
 
         task_by_id = {task.task_id: task for task in self.tasks}
         run_queue = create_run_queue(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_adapter
+from tolokaforge.core.compose_materialisation import LogCaptureConfig
 from tolokaforge.core.conductor import (
     Conductor,
     ConductorContext,
@@ -38,6 +39,7 @@ from tolokaforge.core.metrics import (
     calculate_task_metrics,
 )
 from tolokaforge.core.models import (
+    ComputeConfig,
     ModelConfig,
     ProjectConfig,
     RunConfig,
@@ -674,11 +676,27 @@ class Orchestrator:
                 environment_identity=identity,
             )
 
+    def _build_log_capture(self, output_dir: Path) -> LogCaptureConfig:
+        """Build the run's per-service log-capture policy from ``compute``.
+
+        Reads ``compute.log_tail`` + ``compute.capture_logs_on_success``
+        (their schema defaults apply when no ``compute`` block is declared),
+        anchoring capture under ``output_dir``. One instance is shared by the
+        runtime backend and the trial executor so both write to the same tree.
+        """
+        compute = self.config.compute or ComputeConfig()
+        return LogCaptureConfig(
+            output_root=output_dir,
+            tail=compute.log_tail,
+            on_success=compute.capture_logs_on_success,
+        )
+
     def _construct_runtime_backend(
         self,
         runner_address: str,
         env_manifest: EnvironmentManifest | None = None,
         run_id: str = "run",
+        log_capture: LogCaptureConfig | None = None,
     ) -> RuntimeBackend:
         """Construct the runtime backend from the task-driven signal,
         with the deprecated ``config.orchestrator.runtime`` override
@@ -711,7 +729,7 @@ class Orchestrator:
                 backend="PerTrialRuntimeBackend",
                 source=source,
             )
-            return PerTrialRuntimeBackend(seeds=seeds)
+            return PerTrialRuntimeBackend(seeds=seeds, log_capture=log_capture)
         from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
 
         self.logger.info(
@@ -1316,6 +1334,7 @@ class Orchestrator:
         if runner_address is None:
             runner_address = os.environ.get("EXECUTOR_ADDRESS", "executor:50051")
 
+        log_capture = self._build_log_capture(output_dir)
         runtime_backend: RuntimeBackend
         if self._injected_runtime_backend is not None:
             runtime_backend = self._injected_runtime_backend
@@ -1324,6 +1343,7 @@ class Orchestrator:
                 runner_address,
                 env_manifest=run_env_manifest,
                 run_id=run_id,
+                log_capture=log_capture,
             )
         runtime_backend.connect()
         self.logger.info("Runtime backend connected")
@@ -1682,11 +1702,14 @@ class Orchestrator:
                 "runs, or drop the manifest and use the built-in shared stack."
             )
 
+        log_capture = self._build_log_capture(output_dir)
         runtime_backend: RuntimeBackend
         if self._injected_runtime_backend is not None:
             runtime_backend = self._injected_runtime_backend
         else:
-            runtime_backend = self._construct_runtime_backend(runner_address)
+            runtime_backend = self._construct_runtime_backend(
+                runner_address, log_capture=log_capture
+            )
         runtime_backend.connect()
         self._verify_isolation_compatibility(runtime_backend)
         self._admit_capabilities(runtime_backend)

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -38,14 +38,18 @@ from testcontainers.compose import DockerCompose
 
 from tolokaforge.core.compose_materialisation import (
     RUNNER_PORT_DEFAULT,
+    LogCaptureConfig,
     apply_network_policy_to_compose_file,
+    capture_compose_service_logs,
     cleanup_partial_materialisation,
     copy_compose_context,
     make_project_temp_dir,
     resolve_env_endpoints,
     resolve_runner_endpoint,
     shutdown_compose,
+    trial_services_dir,
     verify_network_policy_supported,
+    write_capture_manifest,
 )
 from tolokaforge.core.models import SeedRef
 from tolokaforge.core.runtime import EnvHandle, IsolationMode, ProvisionError
@@ -80,6 +84,11 @@ class _LocalEnvHandle:
     runner_port: int
     temp_dir: Path
     endpoints: EnvEndpoints
+    service_names: tuple[str, ...]
+    """Compose stack's declared service names, snapshot at provision time.
+    Read by :meth:`PerTrialRuntimeBackend.capture_service_logs` so the
+    trial-body-failure path captures every service without re-parsing the
+    (already torn-down) manifest."""
 
 
 @dataclass
@@ -134,6 +143,12 @@ class PerTrialRuntimeBackend:
     from ``project.assets.seeds``. Consumed by :meth:`_apply_reset_recipes`
     to resolve ``services.<name>.reset.seed`` references at reset time.
     Empty dict means no reset recipes will fire."""
+
+    log_capture: LogCaptureConfig | None = None
+    """Per-service log-capture policy. ``None`` disables capture (tests, or
+    construction with no run output root). When set, provision-stage failures
+    and :meth:`capture_service_logs` write ``docker compose logs`` output under
+    ``log_capture.output_root/trials/<task>/<idx>/services/`` before teardown."""
 
     _clients: dict[str, RunnerClient] = field(default_factory=dict)
     _connected_trials: set[str] = field(default_factory=set)
@@ -196,6 +211,7 @@ class PerTrialRuntimeBackend:
             )
 
         verify_network_policy_supported(manifest.network_policy)
+        service_names = tuple(manifest.load_compose()["services"])
         temp_dir = make_project_temp_dir(spec.trial_id)
         compose: DockerCompose | None = None
         try:
@@ -214,6 +230,7 @@ class PerTrialRuntimeBackend:
             )
             compose.start()
         except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
+            self._capture_provision_failure_logs(spec.trial_id, service_names, compose)
             cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
                 trial_id=spec.trial_id,
@@ -232,6 +249,7 @@ class PerTrialRuntimeBackend:
         try:
             self._apply_reset_recipes(manifest, compose, spec)
         except Exception:
+            self._capture_provision_failure_logs(spec.trial_id, service_names, compose)
             cleanup_partial_materialisation(compose, temp_dir)
             raise
 
@@ -268,6 +286,7 @@ class PerTrialRuntimeBackend:
             runner_port=runner_port,
             temp_dir=temp_dir,
             endpoints=endpoints,
+            service_names=service_names,
         )
 
     def await_ready(self, handle: EnvHandle) -> None:
@@ -307,6 +326,27 @@ class PerTrialRuntimeBackend:
                 )
         shutdown_compose(handle.compose)
         shutil.rmtree(handle.temp_dir, ignore_errors=True)
+
+    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
+        """Capture per-service logs for the trial-body-failure path.
+
+        No-op ``{}`` when capture is disabled, the gate (``failed`` or the
+        on-success policy) is not met, or ``handle`` is foreign. Otherwise
+        writes ``docker compose logs`` output for the handle's snapshot
+        services into the trial ``services/`` dir and returns the byte map.
+        Writes only the ``.log`` files — the durable ``metrics.yaml``
+        amendment on this path is the executor's responsibility. Never raises.
+        """
+        if self.log_capture is None:
+            return {}
+        if not (failed or self.log_capture.on_success):
+            return {}
+        if not isinstance(handle, _LocalEnvHandle):
+            return {}
+        dest_dir = trial_services_dir(self.log_capture.output_root, handle.trial_id)
+        return capture_compose_service_logs(
+            handle.compose, handle.service_names, dest_dir, self.log_capture.tail
+        )
 
     # ---- Per-trial RPC operations (ADR-0013) ----
 
@@ -429,6 +469,29 @@ class PerTrialRuntimeBackend:
                 ) from exc
 
     # ---- Internal helpers ----
+
+    def _capture_provision_failure_logs(
+        self,
+        trial_id: str,
+        service_names: tuple[str, ...],
+        compose: DockerCompose | None,
+    ) -> None:
+        """Best-effort per-service log capture on a provision-stage failure,
+        before the partial stack is torn down.
+
+        No-op when capture is disabled or nothing materialised (``compose is
+        None``). Writes the ``.log`` files plus a ``services/_capture.yaml``
+        durable record — the provision path never reaches
+        ``conductor.run``, so no ``metrics.yaml`` exists to amend. Never
+        raises (the underlying helpers swallow their own errors)."""
+        if self.log_capture is None:
+            return
+        dest_dir = trial_services_dir(self.log_capture.output_root, trial_id)
+        captured = capture_compose_service_logs(
+            compose, service_names, dest_dir, self.log_capture.tail
+        )
+        if captured:
+            write_capture_manifest(dest_dir, self.log_capture.tail, captured)
 
     def _client_for(self, trial_id: str) -> RunnerClient:
         client = self._clients.get(trial_id)

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -322,6 +322,20 @@ class RuntimeBackend(Protocol):
         """
         ...
 
+    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
+        """Capture per-service logs for ``handle``'s stack; return a
+        ``{service_name: bytes_written}`` map.
+
+        Writes ``docker compose logs`` output to the handle's trial
+        ``services/`` dir when the backend has a live per-trial stack and
+        (``failed`` or the backend's on-success policy), then returns the
+        byte map for the services that produced output; returns ``{}``
+        otherwise. Never raises — best-effort diagnostics captured *because*
+        a failure is already decided. Backends without a trial-scoped stack
+        (the shared-stack backend) are documented no-ops returning ``{}``.
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # InMemoryRuntimeBackend — non-gRPC, test fixture
@@ -344,6 +358,7 @@ class RuntimeBackendCallLog:
     await_ready_calls: list[str] = field(default_factory=list)
     endpoints_calls: list[str] = field(default_factory=list)
     torn_down_trials: list[str] = field(default_factory=list)
+    capture_service_logs_calls: list[tuple[str, bool]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -476,6 +491,10 @@ class InMemoryRuntimeBackend:
 
     def teardown(self, handle: EnvHandle) -> None:
         self.call_log.torn_down_trials.append(handle.trial_id)
+
+    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
+        self.call_log.capture_service_logs_calls.append((handle.trial_id, failed))
+        return {}
 
     # ---- Per-trial RPC operations (ADR-0013) ----
     # The in-memory backend has no runner service to talk to; every RPC

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -943,6 +943,19 @@ class SharedStackRuntimeBackend:
         """No-op: the shared stack lives for the whole run and is torn
         down at :meth:`close`, not per-trial. Idempotent by construction."""
 
+    def capture_service_logs(  # noqa: ARG002 — Protocol conformance
+        self, handle: EnvHandle, *, failed: bool
+    ) -> dict[str, int]:
+        """Documented no-op returning ``{}``.
+
+        The shared stack is run-wide, not trial-scoped, and per-trial
+        :meth:`teardown` is a no-op — so per-trial log capture has no
+        stack to read and would capture the same run-wide containers on
+        every trial. Run-level capture on a shared-stack materialise
+        failure is a separate surface (see
+        ``docs/architecture/RUNTIME_BACKENDS.md``)."""
+        return {}
+
     def reset_services_for_next_trial(self, manifest: EnvironmentManifest) -> None:
         """Dispatch reset recipes for every ``isolation="reset"`` service
         against the shared compose stack.

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+import yaml
+
 from tolokaforge.core.models import (
     Grade,
     GradeComponents,
@@ -39,6 +41,7 @@ from tolokaforge.core.runtime import EnvHandle, ProvisionError, RuntimeBackend
 from tolokaforge.core.trial import TrialResult, TrialSpec
 
 if TYPE_CHECKING:
+    from tolokaforge.core.compose_materialisation import LogCaptureConfig
     from tolokaforge.core.conductor import Conductor
     from tolokaforge.core.logging import StructuredLogger
 
@@ -75,6 +78,11 @@ class ProvisioningTrialExecutor:
     ``conductor`` for the trial body, and ``logger`` for per-branch
     structured observability at the substrate seam.
 
+    On a failed trial body it captures per-service logs via
+    ``runtime_backend.capture_service_logs`` before teardown, then records the
+    captured byte counts on the trial's ``metrics.yaml`` (path derived from
+    ``log_capture.output_root``; ``None`` disables the amendment).
+
     Instantiated once per run by the orchestrator's
     ``_build_trial_executor`` helper and submitted to the worker pool
     per trial. Provisioning parallelism = worker count.
@@ -85,10 +93,12 @@ class ProvisioningTrialExecutor:
         runtime_backend: RuntimeBackend,
         conductor: Conductor,
         logger: StructuredLogger,
+        log_capture: LogCaptureConfig | None = None,
     ) -> None:
         self.runtime_backend = runtime_backend
         self.conductor = conductor
         self.logger = logger
+        self.log_capture = log_capture
 
     def execute(self, spec: TrialSpec, task_config: TaskConfig) -> TrialResult:
         task_id, trial_idx = _split_trial_id(spec.trial_id)
@@ -132,9 +142,68 @@ class ProvisioningTrialExecutor:
                 trial_index=trial_idx,
                 runner_url=real_endpoints.runner_url,
             )
-            return self.conductor.run(final_spec, task_config)
+            result = self.conductor.run(final_spec, task_config)
+            self._capture_service_logs(handle, result, task_id, trial_idx)
+            return result
         finally:
             self._safe_teardown(handle, task_id, trial_idx)
+
+    def _capture_service_logs(
+        self, handle: EnvHandle, result: TrialResult, task_id: str, trial_idx: int
+    ) -> None:
+        """Capture per-service logs for a failed trial body, before teardown.
+
+        Failure here means execution failure (``ERROR`` / ``TIMEOUT``), not a
+        clean run that merely failed grading — the backend gates the actual
+        write on this ``failed`` flag plus its on-success policy. When the
+        backend returns a non-empty byte map, emit the aggregate summary line
+        and amend the trial's ``metrics.yaml`` with ``captured_service_logs``.
+        Best-effort diagnostics captured *because* a failure is already
+        decided: never changes control flow.
+        """
+        failed = result.trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT)
+        byte_map = self.runtime_backend.capture_service_logs(handle, failed=failed)
+        if not byte_map:
+            return
+        self.logger.info(
+            "trial.service_logs_captured",
+            task_id=task_id,
+            trial_index=trial_idx,
+            services=byte_map,
+        )
+        self._amend_metrics_with_captured_logs(task_id, trial_idx, byte_map)
+
+    def _amend_metrics_with_captured_logs(
+        self, task_id: str, trial_idx: int, byte_map: dict[str, int]
+    ) -> None:
+        """Add a top-level ``captured_service_logs`` mapping to the trial's
+        ``metrics.yaml`` — the durable record for the trial-body path.
+
+        Read-add-write of the plain YAML mapping the conductor already wrote.
+        No-op when no ``log_capture`` output root is configured or the file is
+        absent. Logs and continues on I/O failure so a diagnostic write never
+        masks the trial result.
+        """
+        if self.log_capture is None:
+            return
+        metrics_path = (
+            self.log_capture.output_root / "trials" / task_id / str(trial_idx) / "metrics.yaml"
+        )
+        if not metrics_path.exists():
+            return
+        try:
+            with metrics_path.open() as f:
+                metrics = yaml.safe_load(f) or {}
+            metrics["captured_service_logs"] = dict(byte_map)
+            with metrics_path.open("w") as f:
+                yaml.safe_dump(metrics, f, sort_keys=False)
+        except Exception as amend_err:  # noqa: BLE001 — best-effort diagnostic amendment
+            self.logger.warning(
+                "Amending metrics.yaml with captured_service_logs failed; continuing",
+                task_id=task_id,
+                trial_index=trial_idx,
+                error=str(amend_err),
+            )
 
     def _safe_teardown(self, handle: EnvHandle, task_id: str, trial_idx: int) -> None:
         """Best-effort teardown that logs failures instead of swallowing them.


### PR DESCRIPTION
Closes #302.

## Summary

- On trial failure, capture `docker compose logs --tail=N` per service to `<output_dir>/trials/<task_id>/<trial_index>/services/<service>.log` BEFORE stack teardown. Covers both failure surfaces: provision-stage (`PerTrialRuntimeBackend.provision`'s two `except` blocks) and trial-body (`ProvisioningTrialExecutor.execute` after `conductor.run` returns).
- Executor emits a `trial.service_logs_captured` structured log line and amends the trial's `metrics.yaml` with `captured_service_logs: {name: bytes}` (surfaces on the trial-body path); provision-fail path writes `services/_capture.yaml` (no `metrics.yaml` exists there yet). Successful trials skip capture unless `compute.capture_logs_on_success` is set.
- New config knobs: `compute.log_tail` (default 500) + `compute.capture_logs_on_success` (default False). New `RuntimeBackend.capture_service_logs` Protocol method (per-trial does the work; shared + in-memory are documented no-ops).

## Plan

See `docs/plans/2026-07-15-issue-302-per-service-log-capture.md`.

## Discovered issues

- Filed: #337 (surface captured logs in the run-level `aggregate.json` roll-up), #338 (provision-failed trials get no full trial bundle), #339 (shared-stack run-level materialise-failure capture).
- Fixed in this PR: none — the neighbourhood was clean.

## Test plan

- [x] Unit — `capture_compose_service_logs` helper (command shape, cwd requirement, per-service error omission, `compose=None` handling); `ComputeConfig` field defaults + `ge=1`.
- [x] Canonical — `RuntimeBackend` conformance (all 3 backends implement); executor drives capture on ERROR/TIMEOUT + amends metrics.yaml; graded-fail (COMPLETED + `binary_pass=False`) does NOT trigger capture.
- [x] Integration (real Docker, no LLM keys) — provision-fail path writes `.log` files + `_capture.yaml`; success path with `capture_logs_on_success=False` → no `services/` dir; with `=True` → `.log` files present.