### PR TITLE
test(runtime): cross-service startup-order stress test (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
 - **runtime**: `PerTrialRuntimeBackend` captures per-service logs on provision-stage failure (compose-up / reset-recipe) before teardown, writing `services/<service>.log` + a `services/_capture.yaml` manifest; `RuntimeBackend` gains `capture_service_logs` (per-trial writes `.log` files; shared-stack is a documented no-op) (#302)
 - **runtime**: on a trial-body failure (`ERROR` / `TIMEOUT`) the trial executor captures per-service logs before teardown, emits a `trial.service_logs_captured` summary line, and amends the trial's `metrics.yaml` with a `captured_service_logs` byte-count map (#302)
+- **examples**: `multi_service_slow_start` pack + `test_startup_order_stress.py` stress-cover the `depends_on` + healthcheck + `--wait` start-order chain against a `pg_sleep`-driven ≥20 s slow dependency, proving the per-trial backend blocks on the full chain before the trial's first RPC (#303)
 
 ## v0.8.4 (2026-07-15)
 

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -168,6 +168,12 @@ Nine steps, in order. Failure at any step raises `ProvisionError(stage="provisio
 8. **Cache the client** — `self._clients[spec.trial_id] = client`. This is the map every per-trial RPC method reads from.
 9. **Return `_LocalEnvHandle`** carrying the trial_id (public), the compose stack, the runner service name + port, the temp dir, and the endpoints snapshot. All except `trial_id` are backend-private; callers treat the handle as an opaque token.
 
+### Slow-dependency start order
+
+Step 5's `--wait` is the whole start-order contract: it blocks until every service's compose `healthcheck:` reports healthy, and each service's `depends_on: {condition: service_healthy}` gates the start sequence. So `PerTrialRuntimeBackend` blocks on the full dependency chain before the trial's first RPC — a service never starts against a dependency that is not yet accepting connections.
+
+The `examples/native/multi_service_slow_start` pack stress-covers this against a deliberately slow dependency. Its `app-db` runs a trailing `SELECT pg_sleep(25)` in a `docker-entrypoint-initdb.d` init script (which postgres executes on a socket-only temp server, so TCP :5432 is genuinely refused for the window) and a TCP-probing healthcheck (`pg_isready -h`) with `start_period` sized above the sleep. `app-service` (PostgREST) declares `depends_on: {app-db: {condition: service_healthy}}`, so `--wait` holds it — and the trial's first tool call — until postgres is TCP-reachable. A passing grade proves the chain held: had it not, PostgREST would start against a refused connection and the first runner → app-service → postgres call would fail. `tests/integration/test_startup_order_stress.py` asserts the provision takes ≥20 s and the grade passes.
+
 ## Endpoint resolution
 
 `endpoints(handle)` is a **pure read** — it returns `handle.endpoints`, resolved once at provision time. This is a deliberate departure from an earlier design where `endpoints()` re-queried the compose stack every call: a method named `endpoints` mutating state on missing-service was surprising.

--- a/docs/plans/2026-07-15-issue-303-startup-order-stress.md
+++ b/docs/plans/2026-07-15-issue-303-startup-order-stress.md
@@ -1,0 +1,276 @@
+# Plan: cross-service startup-order stress test
+
+Issue: #303 (umbrella #304, Multi-container runtime v1, sub-issue 5/5 — last before milestone close)
+Branch: test/startup-order-stress
+
+## Context
+
+`PerTrialRuntimeBackend.provision` brings each trial's compose stack up with
+`docker compose up -d --wait` (`per_trial_runtime.py:224-231`, `wait=True`).
+`--wait` blocks until every service's compose `healthcheck:` reports healthy,
+and `depends_on: {condition: service_healthy}` gates the start order. The
+existing `multi_service_postgres` / `_reset` packs work because postgres +
+PostgREST start fast (a few seconds), so the `depends_on` + healthcheck chain
+is never exercised under a genuinely slow dependency. The unproven race: if the
+chain did *not* hold, `app-service` (PostgREST) would start before `app-db`
+(postgres) is accepting TCP connections, and the agent's first tool call
+(runner → PostgREST → postgres) would hit `ConnectionRefusedError` / a 500.
+
+This is a **pure test issue**: no orchestrator or backend change. It proves the
+*existing* `--wait` + healthcheck + `depends_on` behaviour holds when a
+dependency is deliberately slow to become ready.
+
+**How the slow start is produced (the load-bearing design decision).** The
+postgres official entrypoint runs `docker-entrypoint-initdb.d/*.sql` on a
+*socket-only* temporary server (`listen_addresses=''`) and only starts the real
+**TCP** listener after every init script returns. So an init script that blocks
+holds the container in a state where **TCP :5432 is genuinely refused** — the
+honest failure surface the race would hit. The stress pack drives that window
+deterministically with a trailing `SELECT pg_sleep(<N>)` in `init.sql`
+(`N≈25`), and forces the app-db healthcheck to probe **TCP** so it correctly
+reports "starting" for the whole window (see Stage 1 contract). A small but
+real dataset (`generate_series`) is seeded ahead of the sleep so the DB the
+agent queries is genuine.
+
+Three slow-start options were weighed (issue body): (a) a large data import,
+(b) an artificial init sleep, (c) a healthcheck that lies "starting" for N s.
+**(a) is non-deterministic** — import CPU time varies by hardware, so a `≥20 s`
+floor is flaky on fast CI and slow elsewhere. **(c) is dishonest** — postgres
+would actually be ready, so a broken chain would *not* surface a connection
+error; the test would prove nothing about the race. **(b) is the honest,
+deterministic choice**: a `pg_sleep` in the init phase makes postgres genuinely
+TCP-unreachable for a hardware-independent, wall-clock-bounded window, so the
+`depends_on` chain is under real pressure and the `≥20 s` floor is stable. The
+plan uses (b) with a real (if small) seeded dataset for realism.
+
+**Correction to the issue's file sketch.** The issue lists
+`assets/large_seed.sql`. A *reset asset* runs **after** `up --wait` returns
+(`_apply_reset_recipes`, post-healthcheck), so it would not delay the chain
+`--wait` gates and would stress nothing. The slow seed must be a
+**docker-entrypoint-initdb.d init script** (under the compose context, so
+`copy_compose_context` materialises it). The pack therefore has **no**
+`assets/` / `assets.seeds` and **no** reset labelling — it is `multi_service_postgres`
+with a slow init, not a reset pack.
+
+## Goal
+
+Ship a runnable pack `examples/native/multi_service_slow_start/` whose `app-db`
+takes ≥20 s to become healthy, and prove — with tests at the right tiers — that:
+
+1. the pack loads, resolves to a per-trial manifest, and routes to
+   `PerTrialRuntimeBackend` (canonical, no Docker/keys);
+2. a real trial through the CLI provisions in ≥20 s (slow start fired), emits
+   **no** tool-call error, and completes with a valid passing grade (integration,
+   real Docker + LLM key).
+
+## Non-goals
+
+- **No new startup mechanism** — uses Docker's existing `depends_on` +
+  `healthcheck` + `--wait` only.
+- **No orchestrator / backend change** — `provision()`'s `--wait` behaviour is
+  exercised as-is. (The absence of a machine-readable provisioning-duration
+  metric is filed as #354, not fixed here.)
+- **No reset recipe** — this pack is about start *order*, not between-trial
+  reset; `app-db` carries no `isolation: reset` and no seed asset.
+- **No new `SeedKind` / no `assets.seeds`.**
+- **No change to existing packs** — `multi_service_postgres` / `_reset` are
+  untouched; the stress pack is additive.
+
+## Stages
+
+### Stage 1: Ship the slow-start pack + canonical wiring test
+
+- **Contract — new files under `examples/native/multi_service_slow_start/`,
+  mirroring `multi_service_postgres_reset` minus the reset asset/labels:**
+  - `project.yaml` — Project spec (discovered by `find_project_yaml` walking up
+    from the run config):
+    - `tasks.discovery.glob: "tasks/**/task.yaml"`.
+    - `default_environment.stack: {compose_file: ./shared/environment.compose.yaml, runner_service: runner}`.
+    - **No** `default_environment.services` block. The loader fills every compose
+      service with the `ephemeral` default, so `EnvironmentManifest.requires_per_trial`
+      is `True` (`runner/models.py:1062-1064`: true when any service ≠ `shared`),
+      routing the run to `PerTrialRuntimeBackend` without any `orchestrator.runtime`
+      override and without the `shared`-label wart the #299 plan warned against.
+    - **No** `assets:` block.
+    - `task_defaults` (adapter `native`, small `max_turns: 8`, cooperative
+      `actors.user`) and `run_defaults` (`compute` + `orchestrator` only —
+      storage/observability omitted, same loader-discriminator constraint the
+      #299 plan documented).
+  - `run_config.yaml` at pack root (next to `project.yaml`):
+    - `models.agent` + `models.user` = a cheap model (`openrouter`
+      `anthropic/claude-haiku-4-5`), mirroring the reset pack.
+    - `orchestrator.repeats: 1`, `workers: 1`, `max_turns: 8`. **`repeats: 1`**
+      so the single trial produces exactly one `"Provisioning trial env"` /
+      `"Trial env provisioned"` log pair — unambiguous for the Stage 2 latency
+      parse.
+    - `evaluation.projects: [examples/native/multi_service_slow_start/dataset]`
+      (canonical field, **not** `task_packs`), `tasks_glob: tasks/startup_probe/task.yaml`,
+      `output_dir: results/multi_service_slow_start_example`.
+  - `shared/environment.compose.yaml` — the four-service stack copied from the
+    reset pack (`runner` `tolokaforge-runner:local`, `db-service`
+    `tolokaforge-db-service:local`, `app-service` `postgrest/postgrest:v12.2.0`,
+    `app-db` `postgres:16`), real images only, with **two changes on `app-db`**:
+    - **Healthcheck probes TCP, not the socket.** The reset pack's
+      `pg_isready -U authenticator -d appdb` uses the unix socket, which the
+      temp init server *does* answer — it would flap healthy mid-init and defeat
+      the slow start. Use `pg_isready -h 127.0.0.1 -U authenticator -d appdb`
+      (or `-h app-db`) so the check fails while only the socket-only temp server
+      is up, and passes only once the real TCP listener starts (i.e. after
+      `init.sql` incl. `pg_sleep` returns).
+    - **`start_period` sized above the slow-start window** so failing TCP probes
+      during init keep the container `starting` (not `unhealthy`, which would
+      fail `--wait`): `start_period: 45s`, `interval: 2s`, `timeout: 3s`,
+      `retries: 15` for a `pg_sleep(25)`.
+    `app-service.depends_on.app-db.condition: service_healthy` and the `runner`
+    `depends_on` block are unchanged from the reset pack — that chain is exactly
+    what is under test.
+  - `shared/app-db/init.sql` — schema + roles + grants (identical shape to the
+    reset pack: `api` schema, `web_anon`/`authenticator` roles, `api.widgets`
+    table, `GRANT SELECT`), then a **small real dataset** via
+    `INSERT ... SELECT ... FROM generate_series(...)` (a few thousand rows) plus
+    the distinctive probe row (`id=1, name='slow_start_ok'`), then a trailing
+    **`SELECT pg_sleep(25);`** as the last statement. Because init scripts run on
+    the socket-only temp server, this whole file executes before the real TCP
+    server starts — the schema/data are fully present by the time PostgREST
+    (gated on `app-db` healthy) connects, so no stale-schema-cache miss.
+  - `dataset/tasks/startup_probe/task.yaml` — declares **no**
+    `environment_manifest` (inherits the project `default_environment` whole).
+    Goal-oriented `initial_user_message` (AGENTS.md Task Design Quality Bar #2,
+    not a walkthrough): read widget 1's `name` from
+    `http://app-service:3000` and write it under `submissions/`. `tools.agent.enabled:
+    [bash, write_file]`; cooperative user simulator ending `###STOP###`; the
+    same `policies.guidance` note the reset pack uses (reach the API from `bash`
+    via `python3 -c urllib`, service-name DNS, no curl/wget).
+  - `dataset/tasks/startup_probe/grading.yaml` — deterministic, **no `llm_judge`**:
+    `state_checks.jsonpaths` on `/env/fs/agent-visible/submissions/*`
+    `contains_ci: "slow_start_ok"` (the agent could only have read this after the
+    chain came up cleanly — proof of no premature-connection failure);
+    `transcript_rules.required_actions` for `bash` + `write_file`.
+  - `README.md` — what the pack demonstrates: the `pg_sleep`-driven slow start,
+    the TCP healthcheck, and how a passing grade proves the `depends_on` chain
+    held. Written as current-state prose (no migration history).
+- **Behaviour to lock (canonical):** `tests/canonical/test_slow_start_pack_wiring.py`
+  (no Docker, no keys — pure load/resolve/select), mirroring
+  `tests/canonical/test_reset_recipe_pack_wiring.py`. Asserts:
+  - `load_project_config(project.yaml)` loads and has **no** `assets.seeds`
+    (`project.assets is None` or `.seeds == {}`);
+  - `resolve(project.default_environment, None)` yields a manifest whose
+    services are all `ephemeral` (no `shared`, no `reset`) and
+    `requires_per_trial is True`;
+  - `Orchestrator._select_backend_from_tasks() == "per_trial"` and
+    `_construct_runtime_backend(...)` returns a `PerTrialRuntimeBackend`.
+- **Compatibility:** internal only — new example files + a new canonical test.
+  No compatibility surface touched (uses the already-shipped Project schema,
+  `default_environment`, and `evaluation.projects`).
+- **Deliverable:** the pack exists; the canonical wiring test passes.
+- **Validation:**
+  - `uv run pytest -m canonical tests/canonical/test_slow_start_pack_wiring.py -v`.
+  - `uv run tolokaforge validate --tasks "examples/native/multi_service_slow_start/dataset/tasks/**/task.yaml"`.
+  - `uv run ruff check` / `ruff format --check` on the new test.
+  - Reviewer checks: no `assets.seeds`; no service labelled `shared`; app-db
+    healthcheck uses `-h` (TCP); `start_period` > `pg_sleep`; grading has no
+    `llm_judge`; `evaluation.projects` (not `task_packs`); real images only.
+- **Doc updates:** `examples/native/multi_service_slow_start/README.md` (new).
+
+### Stage 2: End-to-end slow-start stress integration test + RUNTIME_BACKENDS.md
+
+- **Contract — `tests/integration/test_startup_order_stress.py`:** marked
+  `integration` + `docker` + `requires_api` + `llm` + `slow`, mirroring
+  `tests/integration/test_reset_recipe_end_to_end.py` (shared auto-skips:
+  `requires_api` skips with no LLM key per `conftest.py`; `is_docker_daemon_available()`
+  skip covers a missing daemon). Runs
+  `uv run tolokaforge run --config examples/native/multi_service_slow_start/run_config.yaml`
+  via `subprocess` (env `os.environ.copy()`), one trial, capturing stdout+stderr.
+  Asserts all three ship conditions:
+  1. **Slow start fired (latency ≥ 20 s).** Parse the single trial's
+     `"Provisioning trial env"` and `"Trial env provisioned"` console log lines
+     (emitted by `ProvisioningTrialExecutor.execute`, `trial_executor.py:106,139`)
+     from the captured output; each carries the `StructuredLogger` console
+     prefix `%Y-%m-%d %H:%M:%S` (`logging.py:52-53`). Assert the wall-clock delta
+     ≥ 20 s. `repeats: 1` guarantees exactly one such pair, so the parse is
+     unambiguous. (Image build happens *before* the first `"Provisioning trial
+     env"`, so the delta is provision-only — build time does not inflate it.)
+  2. **No tool-call error during the trial.** Assert exit code 0 **and**
+     `grade.yaml.components.state_checks == 1.0` — the agent read
+     `slow_start_ok` back over PostgREST, which is only possible if the first
+     runner → app-service → postgres call succeeded (no `ConnectionRefusedError` /
+     500). A premature-connection failure would leave the submission empty and
+     `state_checks` at 0.
+  3. **Valid grade.** Assert the single `trials/startup_probe/0/grade.yaml`
+     exists with `binary_pass: true` (per `docs/OUTPUT_FORMAT.md` §
+     `trials/{task_id}/{trial_index}/grade.yaml`).
+  Also assert `"runtime.backend.selected"` + `"PerTrialRuntimeBackend"` appear
+  in the output (route confirmation), as the reset e2e does. Reuse the reset
+  e2e's `output_dir` discovery + cleanup pattern (`before`/`after` glob on the
+  timestamped run dir, `shutil.rmtree` in `finally`).
+- **Behaviour to lock (integration):** the `depends_on` + healthcheck + `--wait`
+  chain holds under a ≥20 s slow dependency — the trial provisions slowly, the
+  first tool call succeeds, and grading passes. This is the exact race the issue
+  flags, exercised end-to-end via the CLI.
+- **Compatibility:** internal only — new test + doc section.
+- **Deliverable:** the integration test passes on a real Docker daemon with an
+  LLM key; the ship-condition `tolokaforge run` command exits 0 with a slow
+  provision and a passing grade.
+- **Validation:**
+  - `scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_slow_start/run_config.yaml` — exits 0; provision visibly ≥20 s; grade reads `slow_start_ok`.
+  - `scripts/with_env.sh uv run pytest -m integration tests/integration/test_startup_order_stress.py -v`.
+  - No new `DeprecationWarning` beyond baseline (uses `evaluation.projects`).
+- **Doc updates:** `docs/architecture/RUNTIME_BACKENDS.md` — a brief subsection
+  (under "Deep-dive — `provision()`" or "Per-trial isolation") noting that the
+  `--wait` + `depends_on: service_healthy` chain is stress-covered against a
+  deliberately slow dependency by `multi_service_slow_start`, and that
+  `PerTrialRuntimeBackend` blocks on the full chain before the trial's first RPC.
+  Current-state prose only. `CHANGELOG.md` entry.
+
+## Discovered issues
+
+- **Fix in this PR:** none — the pack is additive and the neighbourhood is clean.
+- **Filed as issues:**
+  - **#354** — record per-trial provisioning duration as a first-class metric.
+    There is no machine-readable provisioning-latency signal today
+    (`TrialResult`/`metrics.yaml` carry none; the executor's two log lines have
+    no `duration_s`), so Stage 2 parses console `asctime` (second granularity).
+    A `provisioning_duration_s` field would make latency assertions robust and
+    feeds the perf-optimisation umbrella (RUNTIME_BACKENDS § Follow-up work).
+    Out of scope for this pure-test issue.
+- **Documented in-plan (not a separate issue):** the issue's `assets/large_seed.sql`
+  sketch is corrected to a `docker-entrypoint-initdb.d` init script (see Context)
+  — a reset asset runs post-`--wait` and would stress nothing.
+
+## Risks / open questions
+
+- **Latency-parse brittleness.** The ≥20 s assertion diffs two console
+  timestamps at `%H:%M:%S` (second) granularity. Robust enough for a 20 s floor
+  and unambiguous at `repeats: 1`, but format-coupled to `logging.py`'s console
+  formatter. The clean fix is #354 (a `duration_s` field); until then the parse
+  targets the stable event *messages* (`"Provisioning trial env"` /
+  `"Trial env provisioned"`), not their positional format. If a reviewer prefers
+  zero log-parsing, the fallback is a direct-`provision()` integration test in
+  `tests/integration/docker/` timing the call with `time.monotonic()` — but that
+  needs the `tolokaforge-runner:local` / `db-service:local` images pre-built
+  (the subprocess path builds them itself), so it trades one fragility for a
+  heavier fixture. Recommendation: ship the subprocess parse; revisit under #354.
+- **Healthcheck must probe TCP.** The single most common way to get this pack
+  wrong is to keep the reset pack's socket-based `pg_isready` — the temp init
+  server answers the socket, the check flaps healthy mid-`pg_sleep`, and the
+  slow start never fires (latency assertion fails, or app-service races postgres
+  anyway). The `-h 127.0.0.1` TCP probe + `start_period > pg_sleep` is the
+  load-bearing contract; Stage 1's reviewer check and Stage 2's ≥20 s assertion
+  both catch a regression here.
+- **`pg_sleep` honesty.** `pg_sleep(25)` is a deterministic stand-in for
+  genuine cold-start / large-import / index-build latency. It stresses the exact
+  same chain (postgres genuinely TCP-unreachable for the window) while keeping
+  the `≥20 s` floor hardware-independent. A data-volume-only delay was rejected
+  as non-deterministic (see Context). The seeded `generate_series` dataset keeps
+  the DB a real one the agent queries.
+- **CI cost / flakiness.** One trial, one cheap model, ~8 turns, deterministic
+  state-check grading (no judge). Cost ≈ cents. The dominant wall-clock cost is
+  the 25 s slow start itself plus first-run image build; the `slow` marker and
+  the reset e2e's 1800 s subprocess timeout cover it.
+- **`start_period` vs Docker version.** The contract relies on modern Docker
+  semantics where failing healthchecks *during* `start_period` keep a container
+  `starting` (not `unhealthy`) and `--wait` keeps waiting. `start_period: 45s`
+  for `pg_sleep(25)` leaves generous margin; if a very old daemon counted
+  start-period failures toward `retries`, `--wait` could fail — acceptable
+  because CI/dev run current Docker, and a `ProvisionError` would fail loudly,
+  not silently pass.

--- a/examples/native/multi_service_slow_start/README.md
+++ b/examples/native/multi_service_slow_start/README.md
@@ -1,0 +1,124 @@
+# Multi-service slow-start example
+
+A **runnable** example that stress-covers Docker's start-order chain —
+compose `depends_on: {condition: service_healthy}` + service
+`healthcheck:` + `up --wait` — against a dependency that is deliberately
+slow to become ready.
+
+```
+agent → PostgREST (HTTP API) → postgres:16 (real database, slow to accept TCP)
+```
+
+## What this example demonstrates
+
+- **A genuinely slow dependency.** `app-db`'s
+  `shared/app-db/init.sql` seeds the schema and a small real dataset and
+  then runs `SELECT pg_sleep(25)` as its last statement. postgres runs
+  init scripts on a temporary **socket-only** server and opens the real
+  **TCP** listener only after the last script returns, so TCP :5432 is
+  genuinely refused for ~25 s. This is the honest failure surface the
+  startup-order race would hit — not a healthcheck that merely lies
+  "starting" while postgres is actually ready.
+- **The chain must hold the start order.** `app-service` (PostgREST)
+  declares `depends_on: app-db {condition: service_healthy}`, and the
+  per-trial backend brings the stack up with `up --wait`. If the chain
+  did *not* hold, PostgREST would start before `app-db` accepts
+  connections and the agent's first API call (runner → app-service →
+  postgres) would hit a refused connection / 500.
+- **A passing grade is the proof.** The agent reads widget 1's
+  `name` (`slow_start_ok`) back over the REST API and writes it to a file
+  under `submissions/`; grading asserts the file contains `slow_start_ok`.
+  The agent can only have read that value if the chain gated the start
+  order and the first call succeeded. A premature-connection failure
+  would leave the submission empty and fail the state check.
+
+## The load-bearing healthcheck
+
+`app-db`'s healthcheck probes **TCP**, not the unix socket:
+
+```yaml
+test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U authenticator -d appdb"]
+interval: 2s
+timeout: 3s
+retries: 15
+start_period: 45s
+```
+
+- **`-h 127.0.0.1` (TCP), not the socket.** The temporary init server
+  answers the unix socket during init. A socket-based `pg_isready` would
+  flap healthy mid-`pg_sleep`, `--wait` would return early, and the slow
+  start would never fire. The TCP probe fails while only the socket-only
+  server is up and passes only once the real listener opens.
+- **`start_period: 45s` sits above the ~25 s window.** Failing probes
+  *during* `start_period` keep the container `starting` rather than
+  `unhealthy` (which would fail `--wait`), so the stack waits out the
+  slow start instead of erroring.
+
+## Why per-trial (not shared)
+
+`project.yaml` declares **no** `default_environment.services` block, so
+the loader fills every compose service with the `ephemeral` default. That
+makes the manifest's `requires_per_trial` true, so backend selection
+routes the run onto the per-trial backend — the backend whose
+`provision()` blocks on the full `depends_on` + healthcheck chain before
+the trial's first RPC.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_slow_start/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_slow_start/run_config.yaml
+```
+
+Provisioning takes ≥25 s: the stack blocks on `app-db` becoming healthy,
+which cannot happen until the `pg_sleep` in `init.sql` returns and the TCP
+listener opens. Compose volumes are removed at teardown, so the slow init
+runs fresh on every trial.
+
+## Layout
+
+```
+examples/native/multi_service_slow_start/
+├── project.yaml                       # Project spec: default_environment only (no services block, no assets)
+├── run_config.yaml                    # haiku agent + user, repeats: 1
+├── README.md                          # this file
+├── shared/
+│   ├── environment.compose.yaml       # 4-service compose; app-db TCP healthcheck + wide start_period
+│   └── app-db/
+│       └── init.sql                   # schema + seeded data + trailing pg_sleep(25) (docker-entrypoint-initdb.d)
+└── dataset/tasks/startup_probe/
+    ├── task.yaml                       # inherits the project default_environment whole; no environment_manifest
+    └── grading.yaml                    # deterministic state check on the written submission
+```
+
+## Design notes
+
+- **No reset recipe, no seed asset.** This pack is about start *order*,
+  not between-trial reset. `app-db` carries no `isolation: reset` and the
+  project declares no `assets.seeds`. A reset asset runs *after*
+  `up --wait` returns, so it would not delay the chain under test.
+- **`pg_sleep` over a large import.** A `pg_sleep(25)` makes postgres
+  genuinely TCP-unreachable for a hardware-independent, wall-clock-bounded
+  window, so the ≥20 s slow-start floor is stable across machines. A
+  data-volume-only delay would vary by hardware and flake. The seeded
+  `generate_series` dataset keeps the queried DB a real one.
+- **The task declares no `environment_manifest`.** It inherits the
+  project's `default_environment` whole. A task-level `stack.compose_file`
+  would atomically replace the stack and drop the project's services map.
+- **Deterministic grading, no judge.** The pass/fail signal is a state
+  check that the submission contains `slow_start_ok`; correctness does not
+  depend on an LLM grader.
+- **Pinned real images.** `postgrest/postgrest:v12.2.0` and `postgres:16`;
+  the engine images are referenced as `tolokaforge-runner:local` /
+  `tolokaforge-db-service:local`.
+
+## Related
+
+- [`../multi_service_postgres_reset/README.md`](../multi_service_postgres_reset/README.md) —
+  the reset-recipe example this pack's compose stack mirrors (minus the
+  reset asset and labels).

--- a/examples/native/multi_service_slow_start/dataset/tasks/startup_probe/grading.yaml
+++ b/examples/native/multi_service_slow_start/dataset/tasks/startup_probe/grading.yaml
@@ -1,0 +1,24 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.7
+    transcript_rules: 0.3
+  pass_threshold: 0.5
+state_checks:
+  jsonpaths:
+    - path_glob: "/env/fs/agent-visible/submissions/*"
+      contains_ci: "slow_start_ok"
+      description: "Submission records the seeded widget name — proof the agent read it over PostgREST, which is only possible if the depends_on + healthcheck chain held the start order and the first API call did not hit a refused connection"
+transcript_rules:
+  max_turns: 8
+  required_actions:
+    - action_id: "query_api"
+      requestor: assistant
+      name: bash
+      arguments: {}
+      compare_args: []
+    - action_id: "write_submission"
+      requestor: assistant
+      name: write_file
+      arguments: {}
+      compare_args: []

--- a/examples/native/multi_service_slow_start/dataset/tasks/startup_probe/task.yaml
+++ b/examples/native/multi_service_slow_start/dataset/tasks/startup_probe/task.yaml
@@ -1,0 +1,25 @@
+task_id: "startup_probe"
+name: "Widget Lookup Behind a Slow Database"
+category: "startup_probe"
+description: "Read a single widget's name from a PostgREST API backed by a real postgres database that is deliberately slow to accept connections at start, and record it to a submission file."
+initial_user_message: |
+  A support REST API at http://app-service:3000 serves a `widgets` resource
+  (fields: `id`, `name`). The on-call needs the current `name` of widget 1
+  on record — read it from the API and write it to a file under
+  `submissions/`. Let me know once it's recorded.
+adapter_type: "native"
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["bash", "write_file"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are the on-call engineer waiting for the widget's name to be recorded. Answer brief clarifying questions if asked and end with ###STOP### once the value is written to a submission file."
+policies:
+  guidance:
+    - "Reach the REST API from `bash` with `python3 -c 'import urllib.request; ...'` — the runner container joins the same docker network as `app-service` and resolves it by service name. (The bash allowlist permits python but not curl/wget.)"
+grading: "grading.yaml"

--- a/examples/native/multi_service_slow_start/project.yaml
+++ b/examples/native/multi_service_slow_start/project.yaml
@@ -1,0 +1,56 @@
+# Project spec for the cross-service startup-order stress example.
+#
+# Stress-covers Docker's `depends_on: {condition: service_healthy}` +
+# compose `healthcheck:` + `up --wait` chain against a deliberately slow
+# dependency. `app-db` is genuinely TCP-unreachable for ~25 s while its
+# init script runs, so `app-service` (PostgREST) must not start — and the
+# agent's first API call must not fire — until the chain reports healthy.
+# See README.md.
+#
+# See docs/architecture/PROJECTS.md for the full Project model.
+
+name: "multi-service-slow-start"
+version: 1
+description: >
+  Single-task project proving the compose depends_on + healthcheck +
+  `up --wait` chain holds when a dependency is deliberately slow to become
+  ready. A real postgres service (app-db) blocks TCP for ~25 s during
+  init; the agent reads a seeded value back over PostgREST and grading
+  asserts it observed it, which is only possible if the chain gated the
+  start order correctly.
+
+tasks:
+  discovery:
+    glob: "tasks/**/task.yaml"
+
+# ── Default environment ─────────────────────────────────────────
+# Every task inherits this unless it declares its own
+# `environment_manifest`. No `services` block: the loader fills every
+# compose service with the `ephemeral` default, so the manifest's
+# `requires_per_trial` is true and backend selection routes the run onto
+# the per-trial backend without any `orchestrator.runtime` override.
+default_environment:
+  stack:
+    compose_file: "./shared/environment.compose.yaml"
+    runner_service: "runner"
+
+# ── Task defaults — base for every task ─────────────────────────
+task_defaults:
+  adapter_type: "native"
+  max_turns: 8
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"
+
+# ── Run defaults — base for every run config ────────────────────
+# Storage and observability use the RunConfig defaults (local artifacts
+# + logs, sqlite queue); only compute and orchestrator knobs are set as
+# project-wide bases here.
+run_defaults:
+  compute:
+    provider: "local-docker"
+    workers: 1
+  orchestrator:
+    auto_start_services: true
+    shuffle_trials: false

--- a/examples/native/multi_service_slow_start/run_config.yaml
+++ b/examples/native/multi_service_slow_start/run_config.yaml
@@ -1,0 +1,32 @@
+# Cross-service startup-order stress example — run config.
+#
+# Sits next to project.yaml so discovery resolves the enclosing project
+# (and its `default_environment`). `repeats: 1` provisions the stack once,
+# so the single trial produces exactly one provision log pair — an
+# unambiguous target for the slow-start latency assertion.
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env.
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 2048
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+
+orchestrator:
+  repeats: 1
+  workers: 1
+  max_turns: 8
+
+evaluation:
+  projects:
+    - "examples/native/multi_service_slow_start/dataset"
+  tasks_glob: "tasks/startup_probe/task.yaml"
+  output_dir: "results/multi_service_slow_start_example"

--- a/examples/native/multi_service_slow_start/shared/app-db/init.sql
+++ b/examples/native/multi_service_slow_start/shared/app-db/init.sql
@@ -1,0 +1,52 @@
+-- Schema + data + slow-start driver for the `multi_service_slow_start`
+-- example.
+--
+-- Loaded by postgres:16's docker-entrypoint-initdb.d at container start.
+-- postgres runs every init script on a temporary socket-only server
+-- (listen_addresses='') and only opens the real TCP listener after the
+-- last script returns. The trailing `SELECT pg_sleep(25)` therefore holds
+-- the container in a state where TCP :5432 is genuinely refused for ~25 s
+-- — the honest failure surface the startup-order race would hit.
+--
+-- Everything PostgREST introspects is defined before the sleep, so the
+-- schema and data are fully present by the time PostgREST (gated on
+-- app-db healthy) connects:
+--   * `api` schema         — everything PostgREST exposes over HTTP.
+--   * `web_anon` role      — the role PostgREST assumes for unauthenticated
+--                            requests. NOLOGIN — only reachable via the
+--                            authenticator's SET ROLE.
+--   * `authenticator` role — the LOGIN role in POSTGRES_USER; PostgREST
+--                            connects as this and switches to `web_anon`
+--                            per request.
+--
+-- Widget 1's `name = 'slow_start_ok'` is the distinctive probe value the
+-- agent reads back over the REST API. The agent can only observe it if the
+-- depends_on + healthcheck chain gated the start order — i.e. app-service
+-- did not race ahead of postgres and the first API call did not hit a
+-- refused connection. That gap is the whole point of the example.
+
+CREATE SCHEMA api;
+
+CREATE ROLE web_anon NOLOGIN;
+GRANT web_anon TO authenticator;
+
+GRANT USAGE ON SCHEMA api TO web_anon;
+
+CREATE TABLE api.widgets (
+  id   INT  PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+GRANT SELECT ON api.widgets TO web_anon;
+
+-- A small but real dataset so the queried DB is genuine, not a stub.
+INSERT INTO api.widgets (id, name)
+SELECT g, 'widget_' || g
+FROM generate_series(2, 5000) AS g;
+
+-- The distinctive probe row the task reads back.
+INSERT INTO api.widgets (id, name) VALUES (1, 'slow_start_ok');
+
+-- LAST: hold the socket-only init server for the slow-start window so the
+-- real TCP listener stays down until schema + data are fully present.
+SELECT pg_sleep(25);

--- a/examples/native/multi_service_slow_start/shared/environment.compose.yaml
+++ b/examples/native/multi_service_slow_start/shared/environment.compose.yaml
@@ -1,0 +1,95 @@
+# Compose stack for the `multi_service_slow_start` example.
+#
+# Four services on the same docker-compose network:
+#   - `runner`      — tolokaforge-runner, the gRPC server the conductor talks to.
+#   - `db-service`  — tolokaforge-db-service (in-memory sqlite), the engine's
+#                     state / grading backend.
+#   - `app-service` — PostgREST auto-generating REST endpoints from the `api`
+#                     schema in `app-db`. Reachable from the runner container as
+#                     `http://app-service:3000/`.
+#   - `app-db`      — real postgres:16 backing the task's application. Its
+#                     `./app-db/init.sql` seeds the schema + data and then blocks
+#                     on `SELECT pg_sleep(25)`, so the real TCP listener does not
+#                     start for ~25 s (postgres runs init scripts on a temporary
+#                     socket-only server before opening TCP).
+#
+# The chain `app-service.depends_on.app-db (service_healthy)` +
+# `runner.depends_on.app-service (service_started)` + `up --wait` is exactly
+# what is under test: it must hold PostgREST — and the runner's first RPC —
+# back until `app-db` reports healthy on TCP. Real images only.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_started
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 8s
+
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+
+  app-service:
+    image: postgrest/postgrest:v12.2.0
+    environment:
+      PGRST_DB_URI: "postgres://authenticator:auth_pass@app-db:5432/appdb"
+      PGRST_DB_ANON_ROLE: "web_anon"
+      PGRST_DB_SCHEMAS: "api"
+      PGRST_SERVER_PORT: "3000"
+      PGRST_OPENAPI_SERVER_PROXY_URI: "http://app-service:3000"
+    ports:
+      - "3000"
+    depends_on:
+      app-db:
+        condition: service_healthy
+
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "appdb"
+      POSTGRES_USER: "authenticator"
+      POSTGRES_PASSWORD: "auth_pass"
+    ports:
+      - "5432"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    # TCP probe (`-h`), NOT the unix socket: the temporary init server
+    # answers the socket during init and would flap healthy mid-`pg_sleep`,
+    # defeating the slow start. The `-h 127.0.0.1` check fails while only
+    # the socket-only server is up and passes only once the real TCP
+    # listener opens (i.e. after init.sql incl. pg_sleep returns).
+    # `start_period` sits above the ~25 s slow-start window so failing
+    # probes during init keep the container `starting` (not `unhealthy`,
+    # which would fail `up --wait`).
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U authenticator -d appdb"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 45s

--- a/tests/canonical/test_slow_start_pack_wiring.py
+++ b/tests/canonical/test_slow_start_pack_wiring.py
@@ -1,0 +1,103 @@
+"""Load + resolve + backend-selection wiring for the shipped
+``examples/native/multi_service_slow_start`` pack.
+
+Proves the pack routes from disk to backend construction on the
+no-services-block seam: the project loads with no ``assets.seeds`` and no
+per-service isolation, so the default environment resolves to a manifest
+whose every service is ``ephemeral`` (making ``requires_per_trial`` true),
+and the task-driven selector routes the run onto
+:class:`PerTrialRuntimeBackend`. No Docker and no LLM key — this is the
+pure load/resolve/select contract; the end-to-end slow start firing is
+covered by the sibling integration test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.project_loader import load_project_config, resolve
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = pytest.mark.canonical
+
+
+_PACK_ROOT = (
+    Path(__file__).resolve().parents[2] / "examples" / "native" / "multi_service_slow_start"
+)
+_PROJECT_YAML = _PACK_ROOT / "project.yaml"
+
+
+def _make_run_config() -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openrouter", name="anthropic/claude-haiku-4-5")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir="/tmp/slow_start_pack_smoke"),
+    )
+
+
+def test_pack_loads_without_seed_assets() -> None:
+    """The pack is additive over the reset pack minus the reset asset: it
+    declares no seeds, so ``project.assets`` is absent or carries an empty
+    seed map. A stray ``assets.seeds`` would mean the pack accidentally
+    became a reset pack."""
+    project = load_project_config(_PROJECT_YAML)
+    assert project.assets is None or project.assets.seeds == {}
+
+
+def test_default_environment_resolves_all_ephemeral() -> None:
+    """With no ``default_environment.services`` block the loader fills
+    every compose service with the ``ephemeral`` default — none is
+    ``shared`` or ``reset`` — so the manifest requires per-trial
+    materialisation."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+    assert manifest.services
+    assert all(spec.isolation == "ephemeral" for spec in manifest.services.values())
+    assert all(spec.reset is None for spec in manifest.services.values())
+    assert manifest.requires_per_trial is True
+
+
+def test_backend_selector_routes_pack_to_per_trial() -> None:
+    """A run whose task inherits this project's all-ephemeral default
+    environment requires per-trial substrate, so backend selection picks
+    :class:`PerTrialRuntimeBackend`."""
+    project = load_project_config(_PROJECT_YAML)
+    manifest = resolve(project.default_environment, None)
+    assert manifest is not None
+
+    orch = Orchestrator(_make_run_config(), project=project)
+    task = MagicMock()
+    task.task_id = "startup_probe"
+    orch.tasks = [task]
+    task_desc = TaskDescription(
+        task_id=task.task_id,
+        name=task.task_id,
+        category="startup_probe",
+        description="",
+        adapter_type="native",
+        system_prompt="",
+        environment_manifest=manifest,
+    )
+    orch.adapter = MagicMock()
+    orch.adapter.to_task_description.side_effect = lambda tid: task_desc
+
+    assert orch._select_backend_from_tasks() == "per_trial"
+
+    backend = orch._construct_runtime_backend(
+        runner_address="sentinel:50051",
+        env_manifest=None,
+        run_id="slow-start-pack-smoke",
+    )
+    assert isinstance(backend, PerTrialRuntimeBackend)

--- a/tests/integration/test_startup_order_stress.py
+++ b/tests/integration/test_startup_order_stress.py
@@ -1,0 +1,187 @@
+"""End-to-end proof that the ``depends_on`` + healthcheck + ``--wait``
+start-order chain holds under a deliberately slow dependency.
+
+Drives the shipped ``examples/native/multi_service_slow_start`` pack as a
+real subprocess at ``repeats: 1``. The pack's ``app-db`` runs a trailing
+``SELECT pg_sleep(25)`` in its ``docker-entrypoint-initdb.d`` init script,
+so postgres is genuinely TCP-unreachable for ~25 s, and its healthcheck
+probes TCP (``pg_isready -h``) so the container reports ``starting`` for
+the whole window. ``PerTrialRuntimeBackend.provision`` runs ``docker
+compose up -d --wait``, which blocks until every service (incl. the slow
+``app-db``) is healthy before the trial's first RPC. The agent then reads
+widget 1's ``slow_start_ok`` name over PostgREST and writes it to a
+submission file; deterministic ``state_checks`` grading asserts the file
+contains it.
+
+A passing grade is proof the chain held: if ``depends_on:
+service_healthy`` did not gate the order, ``app-service`` (PostgREST) would
+start before postgres accepted TCP, and the agent's first tool call would
+hit a refused connection, leaving the submission empty and ``state_checks``
+at 0.
+
+**Gated.** Requires a real Docker daemon (the per-trial backend brings up a
+fresh compose stack) and a real LLM provider key (the agent must emit real
+tool calls; the ``mock`` provider emits none). ``requires_api`` auto-skips
+without a key (see ``tests/conftest.py``); the ``docker`` skip below covers
+a missing daemon.
+
+**Cost.** One trial of a single-GET-plus-write task (max 8 turns) on
+``anthropic/claude-haiku-4-5`` via OpenRouter. Cents. Dominant wall-clock
+cost is the ~25 s slow start plus first-run image build.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.requires_api,
+    pytest.mark.llm,
+    pytest.mark.slow,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK = "examples/native/multi_service_slow_start"
+_RUN_CONFIG = f"{_PACK}/run_config.yaml"
+
+_MIN_PROVISION_SECONDS = 20.0
+
+# StructuredLogger's console formatter prefixes every record with an
+# `asctime` at this granularity (`tolokaforge/core/logging.py`).
+_CONSOLE_TS = "%Y-%m-%d %H:%M:%S"
+_PROVISION_START = "Provisioning trial env"
+_PROVISION_DONE = "Trial env provisioned"
+
+# A refused/failed first connection would surface as one of these in the
+# captured output or trajectory. Grading already proves the chain held, so
+# any of these appearing alongside a passing grade means the agent recovered
+# from an error the start-order chain should have prevented — flag it.
+_TOOL_CALL_ERROR_MARKERS = (
+    "ConnectionRefused",
+    "ProvisionError",
+    "connection refused",
+    "could not connect",
+)
+
+
+def _output_basename() -> str:
+    """The configured ``output_dir`` basename the orchestrator suffixes
+    with a run timestamp (``<basename>_<YYYYmmdd_HHMMSS>``)."""
+    cfg = yaml.safe_load((_REPO_ROOT / _RUN_CONFIG).read_text())
+    return Path(cfg["evaluation"]["output_dir"]).name
+
+
+def _console_timestamp(combined: str, message: str) -> datetime:
+    """Wall-clock timestamp of the single console record whose message is
+    ``message``. ``repeats: 1`` guarantees exactly one match."""
+    matches = [
+        datetime.strptime(line[:19], _CONSOLE_TS)
+        for line in combined.splitlines()
+        if message in line and re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ", line)
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one console record containing {message!r} at repeats=1; "
+        f"got {len(matches)}"
+    )
+    return matches[0]
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial backend needs it)",
+)
+def test_slow_start_chain_holds_end_to_end() -> None:
+    """The trial provisions in ≥20 s (slow start fired), the first tool
+    call succeeds, and grading passes — the start-order chain held."""
+    basename = _output_basename()
+    results_root = _REPO_ROOT / "results"
+    before = set(results_root.glob(f"{basename}_*")) if results_root.exists() else set()
+
+    proc = subprocess.run(
+        ["uv", "run", "tolokaforge", "run", "--config", _RUN_CONFIG],
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, (
+        f"tolokaforge run failed (rc={proc.returncode}):\n"
+        f"stdout:\n{proc.stdout[-4000:]}\n"
+        f"stderr:\n{proc.stderr[-4000:]}"
+    )
+
+    assert "runtime.backend.selected" in combined and "PerTrialRuntimeBackend" in combined, (
+        "run did not route onto PerTrialRuntimeBackend — the slow-start chain never fired.\n"
+        f"stderr tail:\n{proc.stderr[-2000:]}"
+    )
+
+    provision_seconds = (
+        _console_timestamp(combined, _PROVISION_DONE)
+        - _console_timestamp(combined, _PROVISION_START)
+    ).total_seconds()
+    assert provision_seconds >= _MIN_PROVISION_SECONDS, (
+        f"provision took {provision_seconds:.0f}s (< {_MIN_PROVISION_SECONDS:.0f}s floor) — "
+        "the slow start did not fire; the app-db healthcheck likely flapped healthy on the "
+        "socket-only init server instead of probing TCP.\n"
+        f"stdout tail:\n{proc.stdout[-2000:]}"
+    )
+
+    after = set(results_root.glob(f"{basename}_*"))
+    created = after - before
+    assert len(created) == 1, (
+        f"expected exactly one new run dir under {results_root} matching "
+        f"{basename}_*; got {sorted(created)}"
+    )
+    run_dir = created.pop()
+
+    try:
+        grade_path = run_dir / "trials" / "startup_probe" / "0" / "grade.yaml"
+        assert grade_path.exists(), (
+            f"missing grade.yaml at {grade_path}.\n"
+            f"run dir contents: {sorted(p.name for p in run_dir.rglob('*'))[:50]}"
+        )
+        grade = yaml.safe_load(grade_path.read_text())
+        assert grade["binary_pass"] is True, (
+            "trial did not pass — the agent likely could not read 'slow_start_ok' over "
+            "PostgREST, which means the start-order chain did not hold.\n"
+            f"grade: {grade}"
+        )
+        assert grade["components"]["state_checks"] == 1.0, (
+            "state_checks != 1.0 — the submission did not contain the seeded "
+            "'slow_start_ok'; the first runner → app-service → postgres call failed.\n"
+            f"grade: {grade}"
+        )
+
+        haystacks = [combined]
+        haystacks += [p.read_text() for p in run_dir.rglob("trajectory.yaml")]
+        found = sorted(
+            {
+                marker
+                for marker in _TOOL_CALL_ERROR_MARKERS
+                for hay in haystacks
+                if marker.lower() in hay.lower()
+            }
+        )
+        assert not found, (
+            "grade passed but tool-call error markers appeared in the output/trajectory "
+            f"({found}) — the agent recovered from a connection error the start-order chain "
+            "should have prevented; the slow start may be racing.\n"
+            f"stdout tail:\n{proc.stdout[-2000:]}"
+        )
+    finally:
+        shutil.rmtree(run_dir, ignore_errors=True)


### PR DESCRIPTION
Closes #303.

## Summary

- Ship `examples/native/multi_service_slow_start/` — a runnable pack whose `app-db` deliberately takes ≥20 s to become healthy via `pg_sleep(25)` in a `docker-entrypoint-initdb.d` init script (NOT a reset asset; reset recipes run *after* `up --wait` and would stress nothing).
- Prove the existing `--wait` + `depends_on: service_healthy` + healthcheck chain holds under a slow dependency: the trial provisions in ≥20 s, the first tool call succeeds, grading passes.
- Load-bearing detail: `app-db` healthcheck probes TCP (`pg_isready -h 127.0.0.1`), not the unix socket. The postgres official image runs init scripts on a socket-only temp server, so a socket-based check would flap healthy mid-init and defeat the test.

## Plan

See `docs/plans/2026-07-15-issue-303-startup-order-stress.md`.

## Discovered issues

- Filed: **#354** — record per-trial provisioning duration as a first-class metric. No machine-readable provisioning-latency signal exists today, so the integration test parses the executor's two console log lines' asctime delta. A `provisioning_duration_s` field would make latency assertions robust.
- Fixed in this PR: none.

## Test plan

- [x] Canonical wiring test — pack loads, resolves to all-ephemeral per-trial manifest, routes to `PerTrialRuntimeBackend` (no Docker, no keys). 3/3 pass.
- [x] Integration test — `tolokaforge run` on the pack: provision latency ≥20 s, no tool-call errors (grade proxy + belt-and-suspenders scan for `ConnectionRefused`/`ProvisionError`/`connection refused`/`could not connect`), valid passing grade. 1 pass in 2m30s on real Docker + OpenRouter key.
- [x] Branch reviewer — APPROVE, clean across all 14 verified claims.