### PR TITLE
docs(multi-container): align guides + top-level docs with per-service isolation vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,16 @@ materialises that stack instead. Real databases, real APIs, custom
 services, whatever the compose file names.
 
 ```yaml
-# task.yaml
-environment_manifest:
-  compose_file: "./environment.compose.yaml"
-  runner_service: "runner"
-  isolation: "shared_ok"        # or "per_trial"
+# project.yaml
+default_environment:
+  stack:
+    compose_file: "./environment.compose.yaml"
+    runner_service: "runner"
+  services:
+    app-db:                     # per-service isolation: shared | reset | ephemeral
+      isolation: "reset"
+      reset: { seed: "postgres_baseline" }
+  network_policy: "no_internet"
 ```
 
 The [`multi_service`](examples/native/multi_service/) example is the

--- a/docs/architecture/PROJECTS.md
+++ b/docs/architecture/PROJECTS.md
@@ -5,15 +5,10 @@ in TolokaForge: what a project owns, how tasks inherit from it, how
 per-invocation settings compose on top, and how every config file
 that a project ships fits into the layered model.
 
-> **Status: PROPOSAL — part of the Project-layer refactoring.**
-> This is the *target* design (#189, delivered via milestones
-> #211–#214); it intentionally describes behaviour that does not
-> exist yet. The schema models shipped in #215; the loader, merge
-> chains, strict validation, and isolation vocabulary have not.
-> [Delta from current implementation](#delta-from-current-implementation)
-> lists exactly what this design adds, what it changes, and which
-> ADRs it amends. Examples are written against the *proposed*
-> schema and are not runnable against the current CLI.
+> **Status: Shipped.** M2 (loader, base+delta merging) shipped in
+> v0.8.3; M3 (per-service isolation, seed-backed reset recipes, backend
+> capabilities, environment identity) shipped in v0.8.4. This document
+> reflects the current implementation.
 
 Companion reading:
 [`RUNTIME_BACKENDS.md`](RUNTIME_BACKENDS.md) (compute substrates,
@@ -50,104 +45,25 @@ extends),
 
 ## Delta from current implementation
 
-What exists today vs. what this proposal adds. Keep this section
-current as milestones land; delete it when the last one does.
+The Project layer landed across two milestones. M2 delivered the loader
+and both base+delta merge chains, the environment-schema restructuring
+(`EnvironmentPatch` as the type of both `default_environment` and task
+`environment_manifest`, with the `stack` sub-object and post-merge
+`resolve()`), strict unknown-key rejection, `evaluation.projects`,
+dual-home knob resolution, task-schema relaxation to `task_id` +
+`description`, and `${VAR}` run-config interpolation. M3 delivered
+per-service isolation (`services.<name>.isolation`:
+`shared` / `reset` / `ephemeral`), seed-backed reset recipes,
+task-driven backend selection, backend-capability admission, the
+shared-assets registry, the grading provider registry, and
+`resolve_environment_identity`. See the CHANGELOG for the per-release
+detail.
 
-**Exists today (v0.8.x):**
-
-- Schema models `ProjectConfig`, `TaskDefaults`, `RunDefaults` and
-  the compute/storage/observability blocks (#215) — schema only;
-  nothing loads or merges them yet.
-- Single-file run configs: `tolokaforge run --config <file>` parses
-  the named file directly into `RunConfig` (`models`,
-  `orchestrator`, `evaluation` all required). No `run_defaults`
-  merging happens yet.
-- `evaluation.task_packs` — the current name for what this document
-  calls `evaluation.projects`.
-
-**This proposal adds (owning milestone in parentheses):**
-
-- The loader and both base+delta merge chains (M2, #211).
-- Per-service isolation declarations
-  (`default_environment.services.<name>.isolation`:
-  `shared` / `reset` / `ephemeral`), seed-backed reset recipes,
-  task-driven backend selection, backend-capability admission,
-  and `resolve_environment_identity` for observability (M3,
-  #212, shipped — amends ADR-0018's whole-stack model). Compose
-  labels are **not** an input: no label mechanism exists and none
-  is added — the manifest is the only home for per-service
-  semantics.
-- Strict unknown-key rejection with closest-match hints (M4,
-  #213). Today unknown keys are **silently ignored** (Pydantic
-  default) on all Project-layer models.
-- `evaluation.projects` as the rename of `evaluation.task_packs`
-  (legacy alias retired in M5, #214).
-- The environment-schema restructuring (M2; a clean break —
-  nothing loads these files yet, so no aliases):
-  `EnvironmentPatch` (all-optional, no construction-time I/O) as
-  the type of both `default_environment` and task
-  `environment_manifest`, with today's eagerly-validating
-  `EnvironmentManifest` becoming the output of a post-merge
-  `resolve()` — see
-  [Patches and the resolved environment document](#patches-and-the-resolved-environment-document);
-  the `stack` sub-object grouping `compose_file` / `inputs` /
-  `runner_service` with atomic replacement (`inputs` is new —
-  today's schema would reject it); `SecurityContext`
-  `run_as_user`/`run_as_group` widened to `int | str`.
-- Shape reservations, name-squatted now to avoid migrations
-  later: typed seed-registry entries (`{path, kind}`, bare-string
-  shorthand); `agent`/`judge` reserved as illegal actor names +
-  the roster ⊆ `models` load-time cross-check;
-  `actors.<name>.tools` and `actors.<name>.service`;
-  backend-capability entries as `string | {name: params}` with a
-  registry-owned vocabulary. `network_policy` deliberately stays
-  a closed enum; parameterisation is finalised before the first
-  major release.
-- The [shared-assets registry](#shared-assets--seeds-and-other-project-level-files)
-  with `initial_state.seed` / `overlay` and registry-level
-  digests (schema addition; M3, #212 — activated together with
-  seed-backed reset recipes). The [`actors` map](#actor-composition)
-  (root-level `user_simulator` becomes a legacy alias for
-  `actors.user`; the field lands in M4, the alias retires in
-  M5). The [grading provider registry](#grading-model--what-the-harness-owns)
-  (M3, #212) and
-  [services/backend scaffolding](#services-and-backends--scaffolding) (M3, #212).
-- Dual-home knob resolution (see
-  [Knobs that exist in both chains](#knobs-that-exist-in-both-chains)):
-  `orchestrator.max_turns`/`orchestrator.timeouts` are redefined
-  as run-level caps; `orchestrator.stuck_heuristics` is
-  deprecated (M2 repoints the conductor); `continue_prompt` is
-  wired or dropped in M2. On the run side, `compute.*` becomes
-  the only home for `workers` / `max_budget_usd` /
-  `max_requests_per_second` / `max_attempt_retries` and
-  `storage.queue` for the queue backend; the `OrchestratorConfig`
-  duplicates become read-time aliases retired in M5 (#214).
-- Task-schema relaxation: today's `TaskConfig` requires `name`,
-  `category`, `initial_state`, `tools`, `user_simulator`, and
-  `grading`; the minimal task in this design is `task_id` +
-  `description`. M2 relaxes the required set; `name` and
-  `category` are dropped (identity is `task_id`; the domain
-  association lives at project level).
-- `${VAR}` interpolation in run-config string values,
-  substituted from the process environment at load time;
-  unresolved variables fail loud.
-- Env-var layer restricted to infrastructure fields: the CLI's
-  current `USER_MODEL`/`JUDGE_MODEL` env-var overrides are
-  retired in M5 — model choices belong in version-controlled run
-  configs.
-- New CLI surface (M2): a `--workers` flag and the
-  `tolokaforge assets stamp` verb (final name settled in M2).
-  Seed references gain an optional `target: <service>` binding
-  for `sql_dump` seeds not consumed by a recipe.
-
-**ADR alignment:**
-
-- The isolation default stays `per_trial`, per ADR-0009 —
-  unlabelled services default to `ephemeral`. (An earlier draft
-  proposed `shared_ok` by default; that is withdrawn: safe by
-  default, relaxation is an explicit reviewable label.)
-- The per-service vocabulary amends ADR-0018 — see the ADR's
-  "Amendment" section.
+Two ADR-alignment facts carry into the current design: the isolation
+default stays `per_trial` per ADR-0009 (unlabelled services default to
+`ephemeral`), and the per-service isolation vocabulary amends ADR-0018 —
+see the ADR's "Amendment" section. Compose files carry no isolation
+semantics; the manifest is the only home for per-service treatment.
 
 ## Naming — "Project" vs "task pack"
 

--- a/docs/guides/multi_container_tasks.md
+++ b/docs/guides/multi_container_tasks.md
@@ -1,24 +1,26 @@
 # Multi-container tasks
 
-This guide walks through authoring a task that ships its own docker-compose
-stack — extra services beyond the engine's built-in `runner` + `db-service`.
-It's anchored to a working example
-([`examples/native/multi_service/`](../../examples/native/multi_service/))
+This guide walks through authoring a project whose tasks ship their own
+docker-compose stack — extra services beyond the engine's built-in
+`runner` + `db-service`. It's anchored to a working example
+([`examples/native/multi_service_postgres_reset/`](../../examples/native/multi_service_postgres_reset/))
 that you can `tolokaforge run` unchanged before adapting it.
 
 For the design rationale + case matrix, see
 [ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md).
-For the runtime backend lifecycle, see
+For the full Project model, see
+[`docs/architecture/PROJECTS.md`](../architecture/PROJECTS.md); for the
+runtime backend lifecycle, see
 [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
 
 ## When to declare a multi-container task
 
 The engine already ships built-in stacks — `core_stack` (runner +
 db-service) and `full_stack` (adds mock-web + rag-service). If your task
-only needs those services, don't declare a manifest; just point at the
+only needs those services, don't declare a stack; just point at the
 right run config and the engine wires the built-ins for you.
 
-You want a task-declared manifest when the task genuinely needs *something
+You want a task-declared stack when the task genuinely needs *something
 else running alongside* the runner:
 
 - A real database the agent should query (postgres, mysql, redis, ...).
@@ -27,50 +29,78 @@ else running alongside* the runner:
 - A queue, cache, or worker the agent has to interact with.
 - Any topology the engine defaults don't cover.
 
-The manifest hands the engine a `docker-compose.yaml` you write, and the
-engine materialises **exactly** those services — no more, no fewer — for
-the task.
+You hand the engine a `docker-compose.yaml` you write, and the engine
+materialises **exactly** those services — no more, no fewer — for the
+task.
 
-## Walkthrough — `multi_service_example_01`
+## Walkthrough — `multi_service_postgres_reset`
 
-The smallest working demonstration lives at
-[`examples/native/multi_service/`](../../examples/native/multi_service/).
-Three files carry the interesting content: `task.yaml`,
-`environment.compose.yaml`, and the sibling `README.md` that describes the
-scenario.
+The smallest working demonstration of the shipped semantics lives at
+[`examples/native/multi_service_postgres_reset/`](../../examples/native/multi_service_postgres_reset/).
+It runs a real postgres behind a PostgREST API, reset to a known seed at
+the start of every trial. Three files carry the interesting content:
+`project.yaml`, `shared/environment.compose.yaml`, and the sibling
+`README.md` that describes the scenario.
 
-### The task-YAML declaration
+### The project-YAML declaration
 
-The task declares its manifest via `environment_manifest`:
+The stack and its per-service treatment are declared on the project under
+`default_environment`. Every task inherits this unless it declares its own
+`environment_manifest`.
 
 ```yaml
-# examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/task.yaml
-environment_manifest:
-  compose_file: "./environment.compose.yaml"
-  isolation: "shared_ok"
-  runner_service: "runner"
+# examples/native/multi_service_postgres_reset/project.yaml
+assets:
+  seeds:
+    postgres_baseline:
+      path: ./assets/postgres_baseline.sql
+      kind: sql_dump
+      digest: sha256:...
+
+default_environment:
+  stack:
+    compose_file: ./shared/environment.compose.yaml
+    runner_service: runner
+  services:
+    app-db:
+      isolation: reset
+      reset:
+        seed: postgres_baseline
+    # the other compose services carry no entry → they default to
+    # `ephemeral` (fresh per trial); no entry needed.
+  network_policy: no_internet
 ```
 
-Three fields matter:
+The pieces that matter:
 
-- **`compose_file`** — path to the docker-compose YAML, relative to
-  `task.yaml`. This file is the sole source of truth for images, ports,
-  volumes, health probes, and inter-service dependencies. The engine reads
-  it verbatim.
-- **`runner_service`** — which service in the compose file is the
+- **`stack.compose_file`** — path to the docker-compose YAML, relative to
+  the file that declares it. This file is the sole source of truth for
+  images, ports, volumes, health probes, and inter-service dependencies.
+  The engine reads it verbatim.
+- **`stack.runner_service`** — which service in the compose file is the
   tolokaforge runner. The engine talks gRPC to this service to dispatch
   tool calls and grade the trial.
-- **`isolation`** — whether the task tolerates state sharing across
-  trials (`shared_ok`) or requires a fresh substrate per trial
-  (`per_trial`). Default is `per_trial`. See [choosing isolation](#choosing-isolation)
+- **`services.<name>.isolation`** — the per-service isolation treatment.
+  The compose file carries **zero** isolation semantics; the `services`
+  map is the single authority. See [choosing isolation](#choosing-isolation)
   below.
+- **`services.<name>.reset.seed`** — for a `reset` service, the named seed
+  from `assets.seeds` applied at every provision. See
+  [reset recipes](#reset-recipes) below.
+- **`network_policy`** — the egress posture for task services. See
+  [network policy](#network-policy) below.
+
+A task can declare its own `environment_manifest` with the same shape; it
+deep-merges on top of `default_environment` per service. A task that
+supplies its own `stack.compose_file` replaces the stack atomically and
+drops the project's `services` entries with it.
 
 ### The compose file
 
 The compose file lists the services the engine should bring up:
 
 ```yaml
-# examples/native/multi_service/dataset/tasks/multi_service/multi_service_example_01/environment.compose.yaml
+# examples/native/multi_service_postgres_reset/shared/environment.compose.yaml
 services:
   runner:
     image: tolokaforge-runner:local
@@ -91,16 +121,19 @@ services:
       - "8000"
     healthcheck: ...
 
+  app-db:
+    image: postgres:16
+    healthcheck: ...
+
   app-service:
-    image: nginx:1.27-alpine
-    ports:
-      - "80"
-    volumes:
-      - ./fixtures/products.json:/usr/share/nginx/html/products.json:ro
+    image: postgrest/postgrest:v12.2.0
+    depends_on:
+      app-db:
+        condition: service_healthy
     healthcheck: ...
 ```
 
-Three things worth noting:
+Things worth noting:
 
 - **`tolokaforge-runner:local` and `tolokaforge-db-service:local` are
   aliases** the engine sets up at run start. Task compose files reference
@@ -109,56 +142,76 @@ Three things worth noting:
   [`RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
 - **Services reach each other by service name.** All services in a compose
   file join the same auto-generated docker network, so the runner container
-  reaches `app-service` as `http://app-service/products.json`. No manual
-  network wiring needed.
-- **Pinned image tags are enforced.** The manifest validator rejects
-  floating tags like `nginx:latest` — pin to a specific version
-  (`nginx:1.27-alpine` above) so runs stay reproducible.
+  reaches `app-service` as `http://app-service:3000/`. No manual network
+  wiring needed.
+- **Pinned image tags are enforced.** The validator rejects floating tags
+  like `postgres:latest` — pin to a specific version (`postgres:16` above)
+  so runs stay reproducible.
 
-The engine validates a few more safety invariants when it loads the
-manifest: no `network_mode: host`, no `privileged: true`, no `cap_add`,
-`depends_on` must resolve, `runner_service` must be declared in the compose
-file. Violations fail at task-load time with a clear error, not at trial
-start.
+The engine validates a few more safety invariants when it loads the stack:
+no `network_mode: host`, no `privileged: true`, no `cap_add`, `depends_on`
+must resolve, `runner_service` must be declared in the compose file.
+Violations fail at load time with a clear error, not at trial start.
 
 ## Choosing isolation
 
-Two runtime backends decide *when* a stack materialises. Two isolation
-values on the task decide *what the backend must satisfy*. The four
-combinations aren't all supported:
+Isolation is declared **per service**, under
+`services.<name>.isolation`. There are three values:
 
-| Task `isolation` | `--runtime shared` | `--runtime per_trial` |
+| `isolation` | Between trials | Use when |
 | --- | --- | --- |
-| `shared_ok` | ✅ Stack materialises once per run, all trials share it. Fastest. | ✅ Fresh stack per trial. Slower but stricter. |
-| `per_trial` | ❌ Orchestrator refuses at startup — cross-trial contamination would break grading. | ✅ Fresh stack per trial. Required. |
+| `shared` | The container persists; all trials share it. | The service is long-lived and stateless, or its state is meant to accumulate across trials. Fastest. |
+| `reset` | A fresh container per trial, with a named seed applied at each provision. | The agent mutates the service (DB writes, side-effects) and each trial must start from a known baseline. |
+| `ephemeral` | A fresh container per trial, no seed. | The agent mutates the service and a clean substrate — not a specific seed — is enough. This is the **default** for any service without an entry. |
 
-Rule of thumb:
+Backend selection is **automatic** and driven by the tasks, not by a flag.
+The orchestrator reads each task's resolved environment: if **any** service
+is `reset` or `ephemeral`, the manifest requires per-trial isolation and
+the run routes to `PerTrialRuntimeBackend` (the only backend that tears
+down and re-provisions between trials, and the only one that applies reset
+recipes). If every service is `shared`, the run uses the shared-stack
+backend, which materialises the stack once and shares it across all trials.
 
-- If the task's grading only inspects the agent's output (files it wrote,
-  a message it sent), and the services in the stack are read-only or
-  reset-idempotent — declare `shared_ok`.
-- If any trial mutates the environment in a way a later trial could observe
-  (DB writes, filesystem edits, side-effects in a service) — declare
-  `per_trial`. The orchestrator will enforce this by refusing an
-  incompatible backend, so a grading bug from cross-trial contamination is
-  a startup-time error, not a silent failure.
+Rule of thumb: leave a service unlabelled (defaults to `ephemeral`) unless
+you have a reason not to. Declare `shared` only after verifying the service
+carries no cross-trial state that could leak into grading; declare `reset`
+when a trial needs a specific known baseline it can mutate freely.
 
-Default is `per_trial` — the safer choice. Opt into `shared_ok` only after
-verifying grading is stateless.
+## Reset recipes
+
+A `reset` service binds to a named seed via
+`services.<name>.reset.seed: <name-from-assets.seeds>`. The seed itself is
+declared once under `project.assets.seeds` with a `path`, a `kind`, and a
+`digest`. At the start of every trial the per-trial backend brings up a
+fresh stack and applies the seed to the named service.
+
+Four seed kinds are supported — `sql_dump`, `filesystem_dir`,
+`redis_dump`, and `bare`. For the full authoring reference (how each kind
+is applied, extension inference, and failure modes), see
+[`docs/architecture/RESET_RECIPES.md`](../architecture/RESET_RECIPES.md).
+
+## Network policy
+
+`network_policy` sets the egress posture for task services. The default is
+`no_internet`: task services have no public egress, while the runner keeps
+an edge network so LLM-judge grading can still reach model providers.
+
+`full_internet` is the explicit opt-in for a task that legitimately needs
+egress (fetching a remote resource, calling a third-party API under test).
+`limited_internet` fails loud today — the egress-proxy sidecar it needs is
+not yet shipped — so declaring it is a load-time error, not a silent
+degrade.
 
 ## Adding another service
 
-Take the working `multi_service` example and extend its compose file.
-Suppose you want to add a redis cache:
+Take the working `multi_service_postgres_reset` example and extend its
+compose file. Suppose you want to add a redis cache the agent mutates:
 
-1. Copy the example into your task pack:
-   ```
-   cp -r examples/native/multi_service my_pack/tasks/my_new_task
-   ```
-2. Add a `cache` service to `environment.compose.yaml`:
+1. Copy the example into your project.
+2. Add a `cache` service to `shared/environment.compose.yaml`:
    ```yaml
    services:
-     # ... existing runner, db-service, app-service ...
+     # ... existing runner, db-service, app-db, app-service ...
      cache:
        image: redis:7.4-alpine     # pinned tag — floating tags rejected
        ports:
@@ -169,39 +222,57 @@ Suppose you want to add a redis cache:
          retries: 30
          start_period: 2s
    ```
-3. If the runner needs to reach it, add a `depends_on` and (optionally)
-   an env var:
+3. Give it an isolation treatment in `project.yaml`. Leave it out to get
+   the `ephemeral` default, or reset it to a seed:
+   ```yaml
+   default_environment:
+     services:
+       cache:
+         isolation: reset
+         reset:
+           seed: cache_baseline   # declare under assets.seeds, kind: redis_dump
+   ```
+4. If the runner needs to reach it, add a `depends_on` and (optionally) an
+   env var in the compose file:
    ```yaml
    services:
      runner:
        environment:
-         DB_SERVICE_URL: "http://db-service:8000"
          REDIS_URL: "redis://cache:6379"
        depends_on:
          cache:
            condition: service_healthy
    ```
-4. Validate and run:
+5. Validate and run:
    ```bash
-   uv run tolokaforge validate --tasks "my_pack/**/task.yaml"
-   uv run tolokaforge run --config my_pack/run_config.yaml
+   uv run tolokaforge validate --tasks "my_project/**/task.yaml"
+   scripts/with_env.sh uv run tolokaforge run --config my_project/run_config.yaml
    ```
 
-The engine will materialise `runner`, `db-service`, `app-service`, and
-`cache` for the run (or per trial, depending on the runtime you selected).
+Because `cache` is `reset` (and `app-db` already is), the run requires
+per-trial isolation and routes to `PerTrialRuntimeBackend` automatically.
 
 ## Further reading
 
+- [`examples/native/multi_service_postgres_reset/README.md`](../../examples/native/multi_service_postgres_reset/README.md)
+  — the anchor example this guide walks through (per-service isolation +
+  `sql_dump` reset seed)
+- [`examples/native/multi_service_slow_start/README.md`](../../examples/native/multi_service_slow_start/README.md)
+  — startup-order stress: a slow dependency that the orchestrator waits on
+  via healthcheck before the runner fires
 - [`examples/native/multi_service/README.md`](../../examples/native/multi_service/README.md)
-  — the anchor example this guide walks through
-- [`examples/native/multi_service_advanced/README.md`](../../examples/native/multi_service_advanced/README.md)
-  — multi-endpoint aggregation across two task-specific HTTP APIs
+  — the task-level shared multi-container pattern (nginx catalog)
 - [`examples/native/multi_service_postgres/README.md`](../../examples/native/multi_service_postgres/README.md)
-  — a realistic three-tier stack (PostgREST + postgres, no application
-  code in the task pack)
+  — a realistic three-tier stack (PostgREST + postgres, shared runtime)
+- [`examples/native/example-microservices-pack/`](../../examples/native/example-microservices-pack/)
+  — the schema reference pack: full inheritance/override matrix across five
+  tasks (reference only, see its README before running)
+- [`docs/architecture/PROJECTS.md`](../architecture/PROJECTS.md)
+  — the full Project model: assets, `default_environment`, per-service
+  isolation, and the merge chains
+- [`docs/architecture/RESET_RECIPES.md`](../architecture/RESET_RECIPES.md)
+  — the four seed kinds and how a reset recipe is applied
 - [ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md)
   — case matrix + sequence diagrams for each supported combination
 - [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md)
   — full lifecycle + materialisation deep-dive
-- [`docs/TASKS.md`](../TASKS.md#multi-container-environments-environment_manifest)
-  — reference schema for every `environment_manifest` field

--- a/examples/native/example-microservices-pack/README.md
+++ b/examples/native/example-microservices-pack/README.md
@@ -8,22 +8,12 @@ per-item deltas live in `tasks/<name>/task.yaml` and
 inheritance and override patterns. Read alongside
 [`docs/architecture/PROJECTS.md`](../../../docs/architecture/PROJECTS.md).
 
-> **Status.** This project is authored against the **proposed**
-> Project schema (PROJECTS.md § "Delta from current
-> implementation") and is the reference example the milestones
-> implement against.
->
-> The Project-layer rollout lands in stages: **M2 (#211)** wires
-> the `project.yaml` loader and base+delta merging; **M2.5
-> (#220)** adds the environment-patch / `stack` sub-object /
-> `actors` reservation / dual-home resolution that this pack
-> already uses; **M3 (#212)** delivers the manifest `services`
-> map, seed-backed reset recipes, and the backend-capabilities
-> registry. Until M2.5 lands, `tolokaforge run` will silently
-> ignore fields such as `assets.seeds`, `default_environment.stack`,
-> `default_environment.services`, and `task_defaults.actors`
-> (they're not in today's shipped schema); strict validation
-> that rejects them arrives with **M4 (#213)**.
+> **Status.** Reference project for the Project schema — full
+> inheritance/override matrix across 5 tasks. See
+> [`docs/architecture/PROJECTS.md`](../../../docs/architecture/PROJECTS.md).
+> Note: the `backend-api` image (`myrepo/example-backend:v1.4.0`) is a
+> placeholder; the pack currently loads and resolves, but end-to-end
+> `tolokaforge run` needs a real backend image (separate follow-up).
 
 ## Layout
 


### PR DESCRIPTION
## Summary

- M3 (v0.8.4) amended ADR-0018 to per-service `services.<name>.isolation: shared | reset | ephemeral`, superseding the whole-manifest `isolation: shared_ok | per_trial` field. The guide + top-level docs still described the pre-amendment shape, so anyone following them today wrote a manifest the loader rejects.
- Fixes the four MUST doc-drift items identified during the milestone-12 close audit.

## Plan

Audit source: two Explore surveys of the docs + examples state post-milestone-12. The four MUST fixes are the ones a reader hits as contradictions while trying to run the multi-container packs.

## Files changed

- `docs/guides/multi_container_tasks.md` — rewritten around per-service isolation; new anchor example (`multi_service_postgres_reset`); short sections on reset recipes and network_policy; refreshed further-reading list.
- `README.md` — replaced the `environment_manifest` snippet with the per-service `services:` map shape.
- `docs/architecture/PROJECTS.md` — flipped the `Status: PROPOSAL` banner to `Status: Shipped` (M2 v0.8.3 / M3 v0.8.4); trimmed the Delta section to a paragraph pointing at CHANGELOG.
- `examples/native/example-microservices-pack/README.md` — replaced the "Until M2.5 lands..." banner with a current-state note pointing at `PROJECTS.md`; called out the placeholder `backend-api` image as a separate follow-up.

## Test plan

- [x] `rg 'shared_ok|isolation: "per_trial"' docs/guides/multi_container_tasks.md README.md` → 0 hits.
- [x] `rg 'PROPOSAL|Until M2.5|silently ignore' docs/architecture/PROJECTS.md examples/native/example-microservices-pack/README.md` → 0 hits.
- [x] `mcp__dev__lint_check` clean.
- [x] `git diff --stat` — only the 4 named files touched.

## Follow-ups (not in this PR)

- Part A SHOULD items — README examples table, Documentation table adds for `PROJECTS.md`/`RESET_RECIPES.md`, `RUNTIME_BACKENDS.md § Isolation enforcement` vocab, `TASKS.md` vocab + `network_policy` note.
- Part B — `example-microservices-pack` fictional-image swap.
- Testing scenarios 1–7 (delivered as a copy-paste recipe in the approved plan file).