### PR TITLE
docs(multi-container): breadcrumbs + vocab sweep on RUNTIME_BACKENDS.md and TASKS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ examples/             # Reference task layouts with runnable run_config.yaml
 ├── native/           # default `native` adapter
 │   ├── browser_task/
 │   ├── coding/
-│   ├── multi_service/          # task-declared compose (nginx catalog)
-│   ├── multi_service_advanced/ # multi-endpoint join
-│   ├── multi_service_postgres/ # PostgREST + postgres three-tier
+│   ├── multi_service/                # task-declared compose (nginx catalog)
+│   ├── multi_service_advanced/       # multi-endpoint join
+│   ├── multi_service_postgres/       # PostgREST + postgres three-tier
+│   ├── multi_service_postgres_reset/ # project layer + per-trial postgres reset
+│   ├── multi_service_slow_start/     # startup-order stress (slow-start postgres)
+│   ├── example-microservices-pack/   # reference project for the Project schema
 │   ├── native_shared_domain/
 │   └── tool_use/
 └── terminal_bench/   # `terminal_bench` adapter (Docker compose)
@@ -177,6 +180,8 @@ examples/             # Reference task layouts with runnable run_config.yaml
 | Browser/mobile tools | [docs/BROWSER_TOOLS.md](docs/BROWSER_TOOLS.md) |
 | Runner & distributed execution | [docs/RUNNER.md](docs/RUNNER.md) |
 | Runtime backends (shared vs per-trial) | [docs/architecture/RUNTIME_BACKENDS.md](docs/architecture/RUNTIME_BACKENDS.md) |
+| Projects — top-level abstraction | [docs/architecture/PROJECTS.md](docs/architecture/PROJECTS.md) |
+| Reset recipes (seed-backed per-trial reset) | [docs/architecture/RESET_RECIPES.md](docs/architecture/RESET_RECIPES.md) |
 | Isolated trials guide | [docs/guides/isolated_trials.md](docs/guides/isolated_trials.md) |
 | Multi-container task guide | [docs/guides/multi_container_tasks.md](docs/guides/multi_container_tasks.md) |
 | Adapter architecture | [docs/ADAPTER_ARCHITECTURE.md](docs/ADAPTER_ARCHITECTURE.md) |
@@ -210,6 +215,9 @@ additional services (see [multi_container_tasks.md](docs/guides/multi_container_
 | [`examples/native/multi_service/`](examples/native/multi_service/) | Smallest multi-service task — runner + db-service + nginx product catalog |
 | [`examples/native/multi_service_advanced/`](examples/native/multi_service_advanced/) | Multi-endpoint aggregation across two task-specific HTTP APIs |
 | [`examples/native/multi_service_postgres/`](examples/native/multi_service_postgres/) | Realistic three-tier stack — PostgREST + postgres, no application code in the task pack |
+| [`examples/native/multi_service_postgres_reset/`](examples/native/multi_service_postgres_reset/) | Project layer — per-trial postgres reset via a named `sql_dump` seed |
+| [`examples/native/multi_service_slow_start/`](examples/native/multi_service_slow_start/) | Cross-service startup-order stress — slow-start postgres + `depends_on: service_healthy` |
+| [`examples/native/example-microservices-pack/`](examples/native/example-microservices-pack/) | Reference project for the full Project schema (see [`docs/architecture/PROJECTS.md`](docs/architecture/PROJECTS.md)) |
 
 ## Testing
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -75,13 +75,18 @@ docker-compose stack — extra services beyond the engine's built-in
 stack (extended to include mock-web / rag-service if the task uses their
 tools).
 
-The manifest points at a compose file that lives next to `task.yaml`:
+The manifest points at a compose file that lives next to `task.yaml`, plus a per-service `services:` map that declares each service's isolation posture:
 
 ```yaml
 environment_manifest:
   compose_file: "./environment.compose.yaml"
   runner_service: "runner"
-  isolation: "shared_ok"          # or "per_trial" (default)
+  services:
+    app-db:
+      isolation: "reset"
+      reset:
+        seed: "postgres_baseline"   # name from project-level assets.seeds
+    # any service not listed here defaults to `ephemeral`
 ```
 
 Field reference:
@@ -90,7 +95,8 @@ Field reference:
 | --- | --- | --- | --- |
 | `compose_file` | yes | — | Path to the docker-compose YAML. Relative paths resolve against `task.yaml`. This file is the sole source of truth for services, images, ports, volumes, healthchecks, and `depends_on`. |
 | `runner_service` | no | `"default"` | Which compose service is the tolokaforge runner. Must be a service declared in the compose file. |
-| `isolation` | no | `"per_trial"` | `"per_trial"` (fresh stack per trial) or `"shared_ok"` (all trials share the run's stack). See [multi-container guide](guides/multi_container_tasks.md#choosing-isolation) for how to pick. |
+| `services.<name>.isolation` | no | `"ephemeral"` | Per-service posture: `"shared"` (long-lived across trials), `"reset"` (fresh container per trial + `reset.seed` recipe reapplied at each provision), `"ephemeral"` (fresh container per trial, no seed). Backend selection is task-driven — any `reset`/`ephemeral` service routes the run to `PerTrialRuntimeBackend` automatically. See the [multi-container guide](guides/multi_container_tasks.md#choosing-isolation) for how to pick. |
+| `services.<name>.reset.seed` | when `isolation: reset` | — | Name of the seed to apply on each provision. Must exist in the project's `assets.seeds` registry. See [`docs/architecture/RESET_RECIPES.md`](architecture/RESET_RECIPES.md) for the four seed kinds (`sql_dump` / `filesystem_dir` / `redis_dump` / `bare`). |
 | `network_policy` | no | `"no_internet"` | Public-egress posture for the task's application services. `no_internet` (default) attaches every task service to an `internal` docker network so no service can reach the public internet; `full_internet` runs the compose file unchanged. `limited_internet` is refused at materialisation (needs an egress-allowlist proxy — #323). See below. |
 
 `network_policy` enforcement (docker backends):

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -52,7 +52,7 @@ Selection is a run-level choice with two knobs and a safety enforcement:
 
 - **Config**: `orchestrator.runtime: shared | per_trial` in the run config YAML. Default `shared`.
 - **CLI override**: `tolokaforge run --runtime {shared,per_trial}` overrides the config for a single invocation. The banner printed at run start names the backend and the source (`cli-flag` vs `config` vs `default`) so operators can see what actually got chosen.
-- **Task-side enforcement**: every task's `environment_manifest.isolation` declares its requirement (`per_trial` default, `shared_ok` opt-out). The orchestrator refuses to start the run if any task requires `per_trial` and the selected backend is `SharedStackRuntimeBackend` — silent cross-trial state contamination is what this guard prevents. See "Isolation enforcement" below.
+- **Task-side enforcement**: every task's `environment_manifest.services.<name>.isolation` declares its per-service posture (`shared` / `reset` / `ephemeral`; unlabelled services default to `ephemeral`). Backend selection is task-driven: any `reset` or `ephemeral` service routes the run to `PerTrialRuntimeBackend` automatically. An explicit `orchestrator.runtime` override is refused at startup if it contradicts per-service semantics — silent cross-trial state contamination is what this guard prevents. See "Isolation enforcement" below.
 
 Legacy `orchestrator.runtime: docker` is accepted as a deprecated alias for `shared` with a `DeprecationWarning` at config load.
 
@@ -270,27 +270,30 @@ A second `teardown(handle)` call finds nothing in the cache, exits quickly. Fore
 
 ## Isolation enforcement
 
-Every `EnvironmentManifest` declares a `TaskIsolation` (default `per_trial`, opt-out `shared_ok`). The orchestrator reads this immediately after backend selection and refuses the run if the combination is unsafe.
+Isolation is declared **per service** on the resolved `EnvironmentManifest` via `services.<name>.isolation`. Three values (per ADR-0018 amendment):
+
+- **`shared`** — the service is long-lived across trials; all trials in the run see the same container instance.
+- **`reset`** — a fresh container per trial, plus the recipe named by `reset.seed` runs at each provision to reapply the seed state.
+- **`ephemeral`** — a fresh container per trial, no seed applied. This is the default for any service declared in the compose file without an explicit `isolation` entry.
+
+Backend selection is **task-driven**, not operator-driven: if any service on any task in the run has `isolation: reset` or `ephemeral`, the orchestrator routes to `PerTrialRuntimeBackend` automatically. A run with every service labelled `shared` (or a task with no `services:` map at all — the pre-Project-layer shape) stays on `SharedStackRuntimeBackend`. An explicit `orchestrator.runtime` override in the run config wins, but is refused at startup if it violates a task's declared per-service semantics (silent cross-trial state contamination is what this guard prevents).
 
 ```mermaid
 flowchart TD
-    Start[Orchestrator.run] --> Backend[Construct RuntimeBackend<br/>per config / CLI override]
-    Backend --> Check{{"For each task in the run:<br/>manifest.isolation ?"}}
-    Check -->|None or shared_ok| OK[Compatible]
-    Check -->|per_trial + PerTrialRuntimeBackend| OK
-    Check -->|per_trial + SharedStackRuntimeBackend| Refuse["Refuse run<br/>RuntimeError names offending tasks<br/>+ two concrete fixes"]
-    OK --> Trials[Run trials]
+    Start[Orchestrator.run] --> Select{{"For each task:<br/>any service `reset` / `ephemeral` ?"}}
+    Select -->|No — all `shared`| Shared[SharedStackRuntimeBackend]
+    Select -->|Yes| PerTrial[PerTrialRuntimeBackend]
+    Override[Explicit orchestrator.runtime override] -.->|Compatible?| Shared
+    Override -.->|Compatible?| PerTrial
+    Override -.->|Incompatible| Refuse["Refuse run<br/>RuntimeError names offending tasks<br/>+ concrete fix"]
+    Shared --> Trials[Run trials]
+    PerTrial --> Trials
     Refuse --> Stop[Zero trials executed]
 ```
 
-Fail-loud fix message names both remedies:
-
-- Switch the runtime: pass `--runtime per_trial` or set `orchestrator.runtime: per_trial` in the config.
-- Opt the task out: set `environment_manifest.isolation: shared_ok` (only appropriate for genuinely stateless tasks).
-
-Enforcement lives at the orchestrator layer, not on `SharedStackRuntimeBackend.provision()`. Refusing the run BEFORE any trial starts (rather than trial-by-trial) means the operator sees the whole failure at once instead of watching trials time out or produce garbage verdicts.
-
 `PerTrialRuntimeBackend` accepts every task — per-trial isolation is a superset of shared-stack semantics for correctness purposes. Cost of per-trial provisioning for genuinely stateless tasks is a separate concern (the loud-defaults banner surfaces the cost/benefit trade so operators can pick the right backend for their workload).
+
+See [`RESET_RECIPES.md`](RESET_RECIPES.md) for the four seed kinds (`sql_dump`, `filesystem_dir`, `redis_dump`, `bare`) that `isolation: reset` binds to via `services.<name>.reset.seed`.
 
 ## Failure modes
 


### PR DESCRIPTION
## Summary

- Follows #356. Remaining Part A SHOULD doc-drift items from the milestone-12 close audit.
- README surfaces the four newer example packs (`multi_service_postgres_reset`, `multi_service_slow_start`, `example-microservices-pack`) in both the Project Structure diagram and the Multi-container examples table; Documentation table gains rows for `PROJECTS.md` and `RESET_RECIPES.md`.
- `RUNTIME_BACKENDS.md § Isolation enforcement` rewritten around per-service `services.<name>.isolation: shared | reset | ephemeral` + task-driven backend selection (matches ADR-0018 amendment + what M3 shipped).
- `TASKS.md` multi-container reference table replaces the whole-manifest `isolation` field with `services.<name>.isolation` + `services.<name>.reset.seed`.

## Plan

Audit source: same two Explore surveys as #356. These are the discoverability + vocab-drift items that #356 explicitly deferred.

## Files changed

- `README.md` — examples table + Project Structure diagram + Documentation table.
- `docs/architecture/RUNTIME_BACKENDS.md` — § Isolation enforcement rewritten around per-service model; task-side-enforcement bullet updated.
- `docs/TASKS.md` — multi-container snippet + field table now match the shipped per-service schema.

## Test plan

- [x] `rg 'shared_ok|"per_trial"|TaskIsolation' README.md docs/architecture/RUNTIME_BACKENDS.md docs/TASKS.md` → 0 hits.
- [x] `git diff --stat` — only the 3 named files changed.

## Follow-ups (not in this PR)

- Part B — `example-microservices-pack` fictional-image swap.
- Part A NICE — ADR-0013 status flip, ADR-0016 vocab, ROADMAP rows, breadcrumbs from `GETTING_STARTED.md` / `RUNNER.md` / `TASK_PACKS.md` / `REFERENCE.md` / `SECURITY.md` / `BENCHMARK_BACKEND_DESIGNS.md`.