### PR TITLE
integrate: z-ai/glm-5.2

### DIFF
--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1514,52 +1514,6 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # GLM-5.2 (Zhipu / Z.AI via OpenRouter). Same z-ai/glm-5 family + shared
-    # ``openrouter_dict_stringify_recovery`` preset as glm-5.1, so this cert
-    # MIRRORS the glm-5.1 sibling (17 required / 3 known_unsupported) as the
-    # integration starting point. NOT yet live-certified: verify against the
-    # live route, and demote any capability it refutes, when the model is
-    # first evaluated (same approach as the nemotron-3-ultra integration, #65).
-    MC(
-        model_id="openrouter__z-ai_glm-5.2",
-        provider="openrouter",
-        name="z-ai/glm-5.2",
-        env_key="OPENROUTER_API_KEY",
-        required=frozenset(
-            {
-                C.BASIC_COMPLETION,
-                C.SIMPLE_TOOL_CALL,
-                C.RECURSIVE_REF_TOOL_CALL,
-                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
-                C.ALLOF_MERGE_TOOL_CALL,
-                C.MULTI_TURN_TOOL_USE,
-                C.MULTI_TURN_ERROR_RECOVERY,
-                C.ENUM_SLASH_TOLERANCE,
-                C.RE2_PATTERN_TOLERANCE,
-                C.DICT_MAP_TOOL_CALL,
-                C.DISCRIMINATED_UNION_TOOL_CALL,
-                C.DECIMAL_FIELD_TOOL_CALL,
-                C.THINKING_EMITS_BLOCKS,
-                C.IMPLICIT_PROMPT_CACHING,
-                C.USAGE_METRICS_POPULATED,
-                C.COST_USD_POPULATED,
-                C.TOOL_NAME_DISCIPLINE,
-                C.LEXICAL_TOOL_INVENTION,
-                C.REQUIRED_FIELDS_COMPLETE,
-                C.PROGRESS_AFTER_SUCCESS,
-            }
-        ),
-        known_unsupported=frozenset(
-            {
-                # No Anthropic-style ephemeral cache markers on this route.
-                C.PROMPT_CACHING,
-                # Reasoning surfaces only as an unsigned summary via the openai
-                # codec (no signed blocks to replay; the codec replay is a no-op).
-                C.THINKING_REPLAY_ROUNDTRIP,
-                C.UNSIGNED_THINKING_REPLAY,
-            }
-        ),
-    ),
     # Mistral-Medium-3.5 (Mistral AI via OpenRouter). Clean tool-caller on
     # the default route — dict-map, discriminated-union, decimal all
     # round-trip natively, so no preset is needed. It is a NON-reasoning

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -1514,6 +1514,76 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # GLM-5.2 (Zhipu / Z.AI via OpenRouter). Successor to glm-5.1. Routes
+    # through its OWN preset ``openrouter_glm_5_2_dict_stringify`` (passthrough
+    # schema + dict_map_hints + json_coerce response + openai reasoning codec)
+    # — same composition as the shared ``openrouter_dict_stringify_recovery``
+    # sibling, but a dedicated entry because that preset's globs do not match
+    # glm-5.2. Auto-resolve integration 2026-07-15 (PR #362): the default route
+    # stringified the top-level object tool-args on all five fix-target probes
+    # (discriminated_union bare/explicit, heterogeneous_array nested_in_object,
+    # dict_map nested_in_object, discriminated_union nested_union); json_coerce
+    # decodes them and the final reprobe went 5/5 on every one. 18 required /
+    # 5 known_unsupported.
+    #
+    # The known_unsupported set is NOT copied from glm-5.1: it diverges in two
+    # ways confirmed on the observe baseline. RECURSIVE_REF_TOOL_CALL is a
+    # genuine structural collapse json_coerce cannot fix — deep_chain / wide_tree
+    # flatten to a single ``{"label": "A"}`` node (the model drops the tree, not
+    # a wire-shape issue), so it stays a ceiling (glm-5.1 held it required).
+    # THINKING_EMITS_BLOCKS is demoted to known_unsupported: the observe baseline
+    # showed "StructuredReasoning should be surfaced" failing 15/15, so the
+    # openai codec did not surface reasoning reliably on this route (glm-5.1
+    # held it required).
+    MC(
+        model_id="openrouter__z-ai_glm-5.2",
+        provider="openrouter",
+        name="z-ai/glm-5.2",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.DICT_MAP_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.RE2_PATTERN_TOLERANCE,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Genuine structural collapse: deep_chain / wide_tree recursive
+                # trees flatten to a single ``{"label": "A"}`` node on the
+                # observe baseline (the model drops the nested children, not a
+                # stringification json_coerce can recover). Ceiling.
+                C.RECURSIVE_REF_TOOL_CALL,
+                # No Anthropic-style ephemeral cache markers on this route
+                # (cache_policy: none on the preset). IMPLICIT_PROMPT_CACHING
+                # (auto-cache surface) IS required above.
+                C.PROMPT_CACHING,
+                # Observe baseline: "StructuredReasoning should be surfaced"
+                # failed 15/15 — the openai codec did not surface structured
+                # reasoning reliably on this route, so emit is not a reliable
+                # gate. Replay is a no-op on the openai codec (no signed blocks,
+                # empty encode_for_replay), same posture as the glm-5.1 sibling.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
     # Mistral-Medium-3.5 (Mistral AI via OpenRouter). Clean tool-caller on
     # the default route — dict-map, discriminated-union, decimal all
     # round-trip natively, so no preset is needed. It is a NON-reasoning

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -151,6 +151,27 @@ presets:
     prompt_policy: dict_map_hints
     reasoning_codec: openai
 
+  # z-ai/glm-5.2 (Zhipu / Z.AI via OpenRouter). Dedicated entry rather than
+  # joining ``openrouter_dict_stringify_recovery`` above (whose globs do NOT
+  # match glm-5.2). Same failure mechanism and composition, though: glm-5.2
+  # serialises TOP-LEVEL object / dict-valued tool-call arguments as
+  # JSON-encoded STRINGS instead of native dicts on the default route —
+  # ``{"item": "{\"kind\":...}"}`` / ``{"message": "{...}"}`` /
+  # ``{"order": "{...}"}`` / ``{"envelope": "{...}"}`` — the exact quirk
+  # ``JsonCoerceResponse`` (``json_coerce``) recovers on Qwen / mimo / kimi.
+  # ``passthrough`` schema keeps hints / schema / task-docs dict-shaped,
+  # ``dict_map_hints`` mitigates the shared ``Dict[str, T]`` blind spot, and
+  # the ``openai`` reasoning codec lands its reasoning_content summary in the
+  # trajectory logs. Live-certified 2026-07-15 (auto-resolve, PR #362).
+  openrouter_glm_5_2_dict_stringify:
+    match:
+      - "z-ai/glm-5.2"
+      - "*glm-5.2"
+    schema_sanitizer: passthrough
+    response_policy: json_coerce
+    prompt_policy: dict_map_hints
+    reasoning_codec: openai
+
   # DeepSeek V3.2-Exp experimental V3.2 reasoning route.
   # Unlike the V4 line (openrouter_dict_stringify_recovery, above) it
   # round-trips dict-map and discriminated-union tool calls cleanly on

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -142,8 +142,6 @@ presets:
       - "*kimi-k2*"
       - "deepseek/deepseek-v4*"
       - "*deepseek-v4*"
-      - "z-ai/glm-5*"
-      - "*glm-5*"
       - "tencent/hy3*"
       - "*hy3-preview*"
       - "nvidia/nemotron*"


### PR DESCRIPTION
## Integrate `z-ai/glm-5.2` (openrouter) via auto-resolve

**Candidate:** provider `openrouter`, model `z-ai/glm-5.2`
(`model_id=openrouter__z-ai_glm-5.2`).

**Engine ref:** this branch (`test/observe-glm-5.2-orgw`).

### Policy

New model-scoped preset `openrouter_glm_5_2_dict_stringify` in
`tolokaforge/core/data/model_presets.yaml`:

- `schema_sanitizer: passthrough`
- `response_policy: json_coerce`
- `prompt_policy: dict_map_hints`
- `reasoning_codec: openai`

glm-5.2 serialises top-level object / dict-valued tool-call arguments as
JSON-encoded strings on the default route; `json_coerce` decodes them back to
native dicts before validation (same mechanism handled for Qwen / mimo / kimi).
No new adapter class — the composition reuses shipped policies. A dedicated
entry, not a widening of the shared `openrouter_dict_stringify_recovery` glob.

Certificate added to `tests/integration/llm/registry.py`
(**18 required / 5 known_unsupported**); pricing confirmed present in
`tolokaforge/core/data/pricing.json`.

### Ceilings (`known_unsupported`)

`RECURSIVE_REF_TOOL_CALL` (structural collapse of recursive trees),
`PROMPT_CACHING` (no ephemeral cache markers on this route),
`THINKING_EMITS_BLOCKS` + `THINKING_REPLAY_ROUNDTRIP` +
`UNSIGNED_THINKING_REPLAY` (openai codec surfaces no reliable / replayable
structured reasoning).

### Provenance

Integrated automatically by the observe → resolve auto-resolve pipeline: the fix
loop converged and the final reprobe went 5/5 on every fix-target. **This is a
disposable test branch — do NOT merge.**
