### PR TITLE
fix(loader): preserve storage discriminator tag under run_defaults merge (#312)

### DIFF
--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -259,3 +259,40 @@ class TestResolveEffectiveRunConfig:
         run_config = {"orchestrator": {"workers": 4}}
         merged = resolve_effective_run_config_data(project, run_config)
         assert merged is not run_config
+
+    def test_preserves_storage_discriminator_when_type_matches_default(self) -> None:
+        # Regression: dumping run_defaults with exclude_defaults=True dropped
+        # the `type: "local"` discriminator on storage.artifacts/logs (matches
+        # LocalStorageConfig.type default), then RunConfig(**merged) failed
+        # to reconstruct the discriminated union with union_tag_not_found.
+        # The example-microservices-pack is the shipped repro.
+        from tolokaforge.core.models import RunConfig
+
+        project = ProjectConfig(
+            name="p",
+            run_defaults=RunDefaults.model_validate(
+                {
+                    "compute": {"workers": 1},
+                    "storage": {
+                        "artifacts": {"type": "local", "path": "./results"},
+                        "logs": {"type": "local", "path": "./results/logs"},
+                    },
+                }
+            ),
+        )
+        run_config = {
+            "models": {"agent": {"provider": "openrouter", "name": "moonshotai/kimi-k2.6"}},
+            "orchestrator": {"repeats": 1, "max_turns": 4},
+            "evaluation": {
+                "projects": ["examples/native/tool_use/dataset"],
+                "tasks_glob": "**/task.yaml",
+                "output_dir": "results/regression",
+            },
+        }
+        merged = resolve_effective_run_config_data(project, run_config)
+        # Discriminator tag survives the dump.
+        assert merged["storage"]["artifacts"]["type"] == "local"
+        assert merged["storage"]["logs"]["type"] == "local"
+        # And the merged dict reconstructs into a RunConfig without
+        # union_tag_not_found on the discriminated storage backends.
+        RunConfig(**merged)

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -327,11 +327,16 @@ def resolve_effective_run_config_data(
     """
     if project is None or project.run_defaults is None:
         return dict(run_config_data)
-    # ``exclude_defaults`` drops fields whose value equals the schema
-    # default (None for optionals, {} / [] for containers). Every
-    # dropped key therefore adds no information — merging them in
-    # would just repeat the schema default at merge time.
-    base = project.run_defaults.model_dump(exclude_defaults=True)
+    # ``exclude_unset`` drops fields the author never touched, keeping the
+    # ones they explicitly wrote — including fields whose value equals the
+    # schema default. ``exclude_defaults`` would drop those too, and that
+    # silently strips the ``type`` discriminator from
+    # ``storage.artifacts`` / ``storage.logs`` (``type: "local"`` matches
+    # the ``LocalStorageConfig.type`` default), which then makes
+    # ``RunConfig(**merged)`` fail to reconstruct the discriminated union
+    # with ``union_tag_not_found``. Any run_config's own fields still win
+    # on conflict via ``deep_merge`` below.
+    base = project.run_defaults.model_dump(exclude_unset=True)
     return deep_merge(base, run_config_data)
 
 


### PR DESCRIPTION
Closes #312.

## Summary

- `resolve_effective_run_config_data` dumped `project.run_defaults` with `exclude_defaults=True`, which dropped the `type` discriminator on `storage.artifacts` / `storage.logs` whenever it equalled the `LocalStorageConfig.type` default. The merged dict then failed to reconstruct the `StorageBackend` discriminated union with `union_tag_not_found`, so any project declaring `run_defaults.storage` via a Project-schema `run_configs/*.yaml` crashed at load time.
- One-line fix: switch to `exclude_unset=True`. Drops fields the author never touched while keeping fields they explicitly wrote — including discriminator tags whose value matches the schema default. `deep_merge` still lets the run_config's own fields win on conflict.
- Canonical regression test locks the exact repro (explicit `storage.artifacts/logs { type: local, path: ... }` on `run_defaults` survives the dump and reconstructs into a full `RunConfig`).

## Plan

Discovered during #299 Stage 1 (filed as #312) and again during the milestone-12-close pack audit — the fictional-image swap on `example-microservices-pack` is blocked on this because that pack is the only one that goes through the Project-schema `run_configs/*.yaml` loader path with an explicit `storage:` block.

## Test plan

- [x] `uv run pytest -m unit tests/unit/test_project_loader.py -v` — 25/25 pass including the new regression test.
- [x] `uv run pytest -m unit tests/unit/test_project_loader_end_to_end.py -v` — 37/37 pass.
- [x] Pre-commit ruff + black clean.