### PR TITLE
feat(examples): swap example-microservices-pack backend-api to postgrest (real image)

### DIFF
--- a/examples/native/example-microservices-pack/README.md
+++ b/examples/native/example-microservices-pack/README.md
@@ -11,9 +11,13 @@ inheritance and override patterns. Read alongside
 > **Status.** Reference project for the Project schema — full
 > inheritance/override matrix across 5 tasks. See
 > [`docs/architecture/PROJECTS.md`](../../../docs/architecture/PROJECTS.md).
-> Note: the `backend-api` image (`myrepo/example-backend:v1.4.0`) is a
-> placeholder; the pack currently loads and resolves, but end-to-end
-> `tolokaforge run` needs a real backend image (separate follow-up).
+> `backend-api` runs [PostgREST](https://postgrest.org), which
+> auto-generates a REST API from the postgres schema — the pack ships
+> no application code. The compose stack materialises and serves the
+> seeded schema; the loader and per-task manifest resolution work
+> end-to-end. Running individual tasks via `tolokaforge run` needs
+> task-schema relaxation (#366) to land first, since these tasks use
+> the minimal `task_id` + `description` shape PROJECTS.md documents.
 
 ## Layout
 

--- a/examples/native/example-microservices-pack/project.yaml
+++ b/examples/native/example-microservices-pack/project.yaml
@@ -31,7 +31,7 @@ assets:
     app_baseline:
       path: "./shared/seeds/app_baseline.sql"
       kind: "sql_dump"             # bound to a service by the reset recipe below
-      digest: "sha256:ea8649942763d29c3b5ae79f3af98e3df5dfa607173c58bd98c03e95431bf729"
+      digest: "sha256:ed1e9ab5ccf4f940d9860885b3b79458acecc562eb0b3e56b811d03c876504bd"
 
 # ── Default environment ─────────────────────────────────────────
 # Every task inherits this unless it declares its own

--- a/examples/native/example-microservices-pack/shared/environment.compose.yaml
+++ b/examples/native/example-microservices-pack/shared/environment.compose.yaml
@@ -19,7 +19,7 @@ services:
       db-service:
         condition: service_healthy
       backend-api:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test:
         - CMD
@@ -57,6 +57,11 @@ services:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "example"
       POSTGRES_DB: "app"
+    volumes:
+      # Seed the schema at first-init so backend-api (PostgREST)
+      # introspects a populated database on startup. The reset recipe
+      # re-applies the same seed at each trial boundary (idempotent).
+      - "./seeds/app_baseline.sql:/docker-entrypoint-initdb.d/app_baseline.sql:ro"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d app"]
       interval: 2s
@@ -65,17 +70,22 @@ services:
       start_period: 5s
 
   backend-api:
-    image: "myrepo/example-backend:v1.4.0"     # pinned; never `latest`
+    # PostgREST auto-generates a REST API from the postgres schema, so
+    # this project ships no application code — the seed defines the
+    # tables and PostgREST exposes them. Listens on 8080 (PGRST_SERVER_PORT)
+    # so the service is reachable at `backend-api:8080` on the shared
+    # network. No healthcheck: the image ships no HTTP client, so
+    # dependents wait on `service_started` (same pattern as the other
+    # postgres examples).
+    image: "postgrest/postgrest:v12.2.0"
     environment:
-      DATABASE_URL: "postgresql://postgres:example@postgres/app"
+      PGRST_DB_URI: "postgres://postgres:example@postgres:5432/app"
+      PGRST_DB_ANON_ROLE: "postgres"
+      PGRST_DB_SCHEMAS: "public"
+      PGRST_SERVER_PORT: "8080"
+      PGRST_OPENAPI_SERVER_PROXY_URI: "http://backend-api:8080"
     ports:
       - "8080"
     depends_on:
       postgres:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://localhost:8080/health"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
-      start_period: 5s

--- a/examples/native/example-microservices-pack/shared/seeds/app_baseline.sql
+++ b/examples/native/example-microservices-pack/shared/seeds/app_baseline.sql
@@ -6,6 +6,11 @@
 -- orders domain. Kept intentionally tiny; tasks that need volume
 -- (db_query_tuning) generate additional load in-trial.
 
+-- Idempotent: the reset recipe re-applies this seed at every trial
+-- boundary, so start from a clean slate on each application.
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS customers CASCADE;
+
 CREATE TABLE customers (
     id         SERIAL PRIMARY KEY,
     tenant     TEXT        NOT NULL,


### PR DESCRIPTION
## Summary

- Swap the pack's fictional `backend-api` image (`myrepo/example-backend:v1.4.0`) for `postgrest/postgrest:v12.2.0` — the same pin the other multi_service packs use. PostgREST auto-generates a REST API from the seeded postgres schema, so no application code and no new build.
- Bind-mount the seed into postgres `docker-entrypoint-initdb.d` so PostgREST introspects a populated schema at startup; the seed is now idempotent (`DROP TABLE IF EXISTS ... CASCADE` prelude) so the reset recipe can safely re-apply it between trials.
- Recompute the `app_baseline` seed digest.
- Rewrite the pack README status note.

## Plan

Part B of the milestone-12-close audit — precondition unblocked by #365 (loader discriminator-strip fix).

## Discovered issues

- Filed: **#366** — task-schema relaxation blocks the pack from running end-to-end. Every task in the pack uses the minimal `task_id` + `description` shape PROJECTS.md documents, but `TaskConfig` still requires `initial_state` / `user_simulator` / `grading`, so `tolokaforge run` refuses to load any task from this pack. Independent of the image swap — the compose stack materialises correctly with this PR.
- The pack has three additional aspirational graders (`api_endpoint_add`, `long_debugging_session`, `postgres_upgrade_test`) that no stock image can satisfy — code injection, injected bugs, `postgres:17` under `no_internet`+`pull=False`. Documented in the audit; NOT filed as an issue yet (they need a redesign of the tasks, not a runtime fix).

## Test plan

- [x] `mcp__dev__validate_tasks examples/native/example-microservices-pack/tasks/**/task.yaml` — all 5 tasks still parse.
- [x] `uv run pytest tests/integration/test_example_microservices_pack.py -v` — 4/4 pass (loader + wiring + digest verification of the updated seed).
- [x] Compose-level smoke — the swapped stack materialises, postgres init imports the seed, PostgREST introspects a populated schema and serves `GET /orders` (4 rows) + `GET /customers` (3 rows).
- [ ] End-to-end `tolokaforge run` — blocked on #366 (task-schema relaxation); not applicable to this PR.