### PR TITLE
feat(skills): milestone integration-branch workflow with rich consolidation PR

### DIFF
--- a/.agents/skills/executing-development-tickets/SKILL.md
+++ b/.agents/skills/executing-development-tickets/SKILL.md
@@ -23,7 +23,7 @@ Main is responsible for: target confirmation, critique-loop mediation, plan appr
 ## Invocation
 
 ```
-/executing-development-tickets <issue-number>
+/executing-development-tickets <issue-number> [base_branch=<ref>]
 ```
 
 or natural language: "execute issue #237", "let's do #244".
@@ -31,8 +31,11 @@ or natural language: "execute issue #237", "let's do #244".
 Examples:
 - `/executing-development-tickets 237`
 - "Execute issue #245"
+- `/executing-development-tickets 245 base_branch=feat/terminal-dx` — target a milestone integration branch
 
 The skill expects the issue to live in `Toloka/tolokaforge`. If a different repo is needed, ask the user.
+
+**Base branch.** Optional context, defaults to `main`. Direct invocations should almost always use the default. `/implement-milestone` passes `base_branch=feat/<milestone-slug>` so per-issue branches stack on the milestone integration branch and per-issue PRs merge into it rather than `main`. When set, it replaces `main` in Step 6 (branch creation) and Step 10 (PR creation). Nothing else changes — the critic, implementer, and reviewer are agnostic to the base branch.
 
 ## Workflow
 
@@ -118,12 +121,12 @@ When the critique loop settles:
 
 ```bash
 git fetch origin
-git checkout main
-git pull origin main
+git checkout <base_branch>            # main by default; feat/<slug> under /implement-milestone
+git pull --ff-only origin <base_branch>
 git checkout -b <branch-from-plan>
 ```
 
-Confirm clean working tree first (`git status`). If dirty, ask the user before proceeding.
+Confirm clean working tree first (`git status`). If dirty, ask the user before proceeding. If `<base_branch>` doesn't exist on `origin`, stop and ask — a milestone integration branch that should exist but doesn't is a bookkeeping error, not something to paper over.
 
 ### Step 7 — Stage dispatch loop
 
@@ -158,9 +161,9 @@ Per-stage cycle cap: if a stage requires more than 2 corrective implementer laun
 When all stages are done, launch `branch-code-reviewer` via the Agent tool. Prompt:
 
 ```
-Review the current branch vs main against AGENTS.md and the code-review skill rules.
-Plan: <docs/plans/...>. Cover branch + staged + unstaged. Return findings in the
-standard format.
+Review the current branch vs <base_branch> against AGENTS.md and the code-review
+skill rules. Plan: <docs/plans/...>. Cover branch + staged + unstaged. Return
+findings in the standard format.
 ```
 
 ### Step 9 — Fix Blocker / Major findings
@@ -183,10 +186,18 @@ Nit / Minor findings: surface to the user as optional follow-ups; don't block th
 
 ### Step 10 — Open the PR
 
+Per-issue PR bodies are read by three audiences: the human reviewer, the next agent that plans work in this area, and the milestone consolidation PR (which draws its Decision / Rationale rows from every stacked PR). The template below gives each of them what they need without ballooning the body — every heading below is required; keep bullets tight.
+
 ```bash
-gh pr create --title "<concise title from plan>" --body "$(cat <<'EOF'
+gh pr create --base <base_branch> --title "<concise title from plan>" --body "$(cat <<'EOF'
 ## Summary
-<2–3 bullets from the plan's Goal>
+<2–3 bullets from the plan's Goal — what user-visible thing changes>
+
+## Design choices
+- **<Decision>**: <"X because Y" — one line each; 1–3 rows for a typical ticket, more only if the ticket genuinely introduced multiple decisions>
+
+## Concepts introduced
+<One short paragraph naming any new abstraction, contract, policy slot, or vocabulary the reader will encounter. If none, write "None — mechanical change."  This is the section the milestone consolidation PR cites when explaining the whole to a future reader or agent.>
 
 ## Plan
 See docs/plans/<file>
@@ -198,12 +209,14 @@ See docs/plans/<file>
 ## Test plan
 - <bullets — what to verify post-merge>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Closes #<issue>
 EOF
 )"
 ```
 
-The `claude-review.yml` workflow will run its own hygiene pass on the PR — treat its findings like reviewer findings (fix or rebut, don't ignore).
+Do not add an AI-attribution footer. The `claude-review.yml` workflow will run its own hygiene pass on the PR — treat its findings like reviewer findings (fix or rebut, don't ignore).
+
+Full worked template with placeholder examples lives at `.agents/skills/implement-milestone/pr-templates.md` — same source of truth used by the milestone consolidation PR.
 
 ### Step 11 — Hand-off
 
@@ -235,6 +248,7 @@ Surface to the user:
 | Implementer drifts from the plan | Justified → update the plan, show diff, continue. Unjustified → corrective implementer launch. Cap at 2 corrections per stage; then revise the plan with the architect. |
 | Reviewer keeps finding the same Blocker | Stop after 2 fix rounds and ask the user. Don't loop indefinitely. |
 | Working tree dirty when Step 6 starts | Ask the user before mutating — uncommitted work may be theirs. |
+| `base_branch` passed but not present on `origin` | Stop and ask. A milestone integration branch that should exist but doesn't is a bookkeeping error upstream in `/implement-milestone`, not something to paper over by silently falling back to `main`. |
 
 ## Anti-patterns
 

--- a/.agents/skills/implement-milestone/SKILL.md
+++ b/.agents/skills/implement-milestone/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: implement-milestone
 description: >
-  Drive a whole GitHub milestone end-to-end: sequence its issues, run the
-  executing-development-tickets pipeline per issue with a relaxed approval gate,
-  merge PRs on green CI, keep issues/umbrella/milestone current, validate every
-  merge, file prioritized follow-ups, escalate only critical forks.
+  Drive a whole GitHub milestone end-to-end on a dedicated integration branch:
+  sequence issues, run the executing-development-tickets pipeline per issue with
+  a relaxed approval gate, squash-merge PRs into the integration branch on green
+  CI, keep issues/umbrella/milestone current, validate every merge, file
+  prioritized follow-ups, and — once all issues are closed — prepare a single
+  consolidation PR from the integration branch to `main` with a rich design
+  writeup, then stop and hand off to the user for review and merge.
   Triggers on: "implement milestone N", "/implement-milestone <N|URL>",
   "execute milestone N", "finish the milestone", "run milestone #8".
 ---
 
 # Implementing a Milestone
 
-Main-process orchestrator one level above `/executing-development-tickets`. One milestone = many issues = many PRs, driven serially to merged without stopping between issues. **Main never implements issues inline** — every issue goes through the executing-development-tickets pipeline (architect → critic → stage implementers → reviewer); this skill owns the loop around it: sequencing, CI, merging, bookkeeping, post-merge validation, escalation.
+Main-process orchestrator one level above `/executing-development-tickets`. One milestone = many issues = many per-issue PRs stacked on a single **integration branch** `feat/<milestone-slug>`, driven serially to merged into that branch without stopping between issues. When every issue is closed, the skill opens **one consolidation PR** from `feat/<milestone-slug>` to `main` — with a design walkthrough, decision/rationale table, and a Mermaid diagram — and stops there for human review. **Main never implements issues inline** — every issue goes through the executing-development-tickets pipeline (architect → critic → stage implementers → reviewer); this skill owns the loop around it: sequencing, CI, merging into the integration branch, bookkeeping, post-merge validation, escalation, and the final consolidation PR.
 
 ## Invocation
 
@@ -27,92 +30,155 @@ Invoking this skill **is** the user's explicit grant to, without re-asking:
 
 - Run the `/executing-development-tickets` pipeline per issue, including all its subagents.
 - Create, update, label, re-scope, and close GitHub issues; file follow-up issues; assign issues to the milestone; comment on issues and the umbrella.
-- Create and switch branches; commit; push; rebase feature branches on `main`.
-- Open PRs and **merge them once CI is green** (`gh pr merge <N> --squash`).
+- Create the milestone **integration branch** `feat/<milestone-slug>` off `main`, push it, and force-push it during in-milestone rebases against `main` (no one else pushes to a milestone integration branch).
+- Create per-issue feature branches off the integration branch; commit; push; rebase feature branches on the integration branch.
+- Open per-issue PRs against the integration branch and **squash-merge them once CI is green** (`gh pr merge <N> --squash`).
 - Start, stop, and rebuild the local Docker stack (`make docker-up` / `docker-down` / `docker-build`) as needed for validation.
-- Close the milestone when every issue in it is closed.
+- Rebase the integration branch on `main` at the end of the milestone and **open** the consolidation PR from the integration branch to `main`.
+- Close the milestone when the user has merged the consolidation PR.
 
-**Never granted — always stop and ask:** releases and version tags (`release.yml` / `release-gate.yml` are human-triggered), publishing packages, anything touching provider accounts or API-key budgets beyond normal test runs, force-pushing or committing directly to `main`, deleting the milestone, and merging on red or unverified-flaky CI.
+**Never granted — always stop and ask:** releases and version tags (`release.yml` / `release-gate.yml` are human-triggered), publishing packages, anything touching provider accounts or API-key budgets beyond normal test runs, force-pushing or committing directly to `main`, deleting the milestone, merging on red or unverified-flaky CI, and — critically — **merging the consolidation PR into `main`**. The consolidation PR is prepared but never auto-merged; the human reviews and merges it.
 
 ## Step 1 — Intake
 
 1. Resolve the milestone: `gh api 'repos/Toloka/tolokaforge/milestones/<N>'` (the URL's trailing number is the milestone number). List its issues, open and closed: `gh api 'repos/Toloka/tolokaforge/issues?milestone=<N>&state=all&per_page=100'`.
 2. Read the **umbrella issue** in full — it is the SSOT for scope, sequencing constraints, and completion state. Read any design docs it links (`docs/*.md`, `docs/plans/*.md`). Read other issues only as needed for clarity.
 3. Build the execution queue. Ordering: hard dependencies first, then priority, then risk — pull the keystone / highest-uncertainty issue early so design problems surface while everything is still cheap to change.
-4. Post the queue to the user as a status message (ordering + anything that looks stale or mis-premised) and **proceed** — this is informational, not an approval gate. The user interrupts if they disagree.
+4. Derive `<milestone-slug>`: kebab-case of the milestone title, ≤ 30 chars, alnum + `-` only. Examples: milestone "Terminal DX" → `terminal-dx`; "Multi-container environments" → `multi-container`.
+5. Post the queue **and the chosen slug** to the user as a status message (ordering + anything that looks stale or mis-premised + the integration-branch name `feat/<slug>`) and **proceed** — this is informational, not an approval gate. The user interrupts if they disagree with the ordering or the slug.
 
-## Step 2 — Per-issue loop
+## Step 2 — Integration branch
+
+1. `git fetch origin`. Working tree must be clean; if dirty, ask before mutating.
+2. If `origin/feat/<slug>` **exists**:
+   - Adopt it: `git checkout feat/<slug> && git pull --ff-only origin feat/<slug>`.
+   - Compare it to `origin/main`: `git log --oneline origin/main..feat/<slug>` — the commits should look like prior per-issue merges of this milestone. If it looks like an unrelated branch, stop and ask.
+   - Look for `docs/plans/<date>-milestone-<N>-integration.md` — if present, adopt it as the running design journal. If missing, create it (Step 2.4) from the umbrella and existing squash-merge commit messages.
+3. If `origin/feat/<slug>` **does not exist**:
+   - `git checkout main && git pull origin main`.
+   - `git checkout -b feat/<slug>`.
+   - `git push -u origin feat/<slug>`.
+4. **Bootstrap the running design journal.** Create `docs/plans/<YYYY-MM-DD>-milestone-<N>-integration.md` with:
+   - `# Milestone <N>: <title>` header + link to the milestone + link to the umbrella issue.
+   - Empty stubs for the final-PR sections: `## TL;DR`, `## Impact on existing tasks`, `## Design walkthrough` (with a placeholder ```mermaid``` block), `## Key design choices` (empty Decision / Rationale table with header row), `## Industry precedents`, `## Suggested review order`, `## Verification`, `## What's next`.
+   - Commit this seed: `chore(milestone-<N>): bootstrap integration journal`, push to `feat/<slug>`. This is the ONLY commit main makes directly to the integration branch. All subsequent commits arrive via squash-merged per-issue PRs — with one exception: the final rebase against `main` in Step 4, which does not add commits, and the append-only journal updates below, which land as part of each per-issue PR's stage that touches `docs/plans/`.
+
+## Step 3 — Per-issue loop
 
 For each issue, serially (one branch / one PR in flight at a time — the working tree is shared and the per-issue pipeline is already multi-agent):
 
-1. **Sync:** `git checkout main && git pull origin main`. Working tree must be clean.
-2. **Run the executing-development-tickets pipeline** through PR creation, with the milestone-mode deltas below.
-3. **CI:** watch with `gh pr checks <PR#> --watch`. On failure, decide *branch-caused vs pre-existing*: check whether the same lane fails on `main` before grinding. Branch-caused → corrective `plan-stage-implementer` launch. Pre-existing → note it on the PR, file an issue if unfiled, and don't block on it if the branch's own lanes are green. (Known pre-existing formatting drift is documented in AGENTS.md gotchas #3/#4 — don't mistake it for branch damage.)
-4. **Merge when green:** confirm the PR body says `Closes #<issue>`, then `gh pr merge <PR#> --squash`. Verify the issue auto-closed; close it manually with a one-line evidence comment if not.
+1. **Sync:** `git checkout feat/<slug> && git pull --ff-only origin feat/<slug>`. Working tree must be clean.
+2. **Run the executing-development-tickets pipeline** with `base_branch=feat/<slug>` — per-issue branches branch off the integration branch and per-issue PRs target it. The pipeline drives through PR creation, with the milestone-mode deltas below.
+3. **CI:** watch with `gh pr checks <PR#> --watch`. On failure, decide *branch-caused vs pre-existing*: check whether the same lane fails on `feat/<slug>` before grinding — and, if that lane also fails on `main`, it's genuinely upstream. Branch-caused → corrective `plan-stage-implementer` launch. Pre-existing → note it on the PR, file an issue if unfiled, and don't block on it if the branch's own lanes are green. (Known pre-existing formatting drift is documented in AGENTS.md gotchas #3/#4 — don't mistake it for branch damage.)
+4. **Merge when green:** confirm the PR body says `Closes #<issue>`, then `gh pr merge <PR#> --squash` (target: the integration branch). Verify the issue auto-closed; close it manually with a one-line evidence comment if not.
 5. **Bookkeeping:** tick the umbrella checklist; comment on the umbrella: `#<issue> → PR #<pr> → <merge-sha> — <one-line outcome; follow-ups filed: #a, #b>`. This comment is load-bearing (see Durable state).
-6. **Post-merge validation** for anything runtime-affecting: `git checkout main && git pull`, then validate the shipped behaviour — dev MCP `run_tests` targeted at the affected markers/paths; for env-service changes `make docker-up` + `make docker-status`; for LLM-layer or model changes a targeted capability test, or a cheap `tolokaforge run` smoke against a bundled example (needs LLM keys in `.env`, costs real tokens — keep it minimal). A broken `main` is never acceptable: fix it before starting the next issue.
-7. Next issue.
+6. **Append to the design journal.** In `docs/plans/<date>-milestone-<N>-integration.md`, append: (a) a one-paragraph "what this issue delivered" note, (b) 1–3 rows for the Decision / Rationale table drawn from the per-issue PR's "Design choices" section, and (c) any new "Concepts introduced" one-liner. Commit as a follow-up on `feat/<slug>` directly — `chore(milestone-<N>): journal update for #<issue>` — and push. (This is the sanctioned exception to "no direct commits to the integration branch": the journal update is bookkeeping, not code, and never touches source or docs outside the plan file.)
+7. **Post-merge validation** for anything runtime-affecting: `git checkout feat/<slug> && git pull`, then validate the shipped behaviour — dev MCP `run_tests` targeted at the affected markers/paths; for env-service changes `make docker-up` + `make docker-status`; for LLM-layer or model changes a targeted capability test, or a cheap `tolokaforge run` smoke against a bundled example (needs LLM keys in `.env`, costs real tokens — keep it minimal). A broken integration branch is never acceptable: fix it before starting the next issue.
+8. Next issue.
 
 ### Milestone-mode deltas to executing-development-tickets
 
 Everything in that skill applies except:
 
+- **Base branch: pass `base_branch=feat/<slug>`.** The pipeline's Step 6 (branch creation) branches off it; Step 10 (PR creation) targets it via `gh pr create --base feat/<slug>`.
 - **Step 2 (confirm target): don't ask the user.** Validate the issue premise against the umbrella and the current behaviour instead. Ticket premises rot — when evidence contradicts one, update or close the issue with the evidence attached and move on. Escalate only if the correction materially changes milestone scope.
 - **Step 5 (plan approval): the critic loop is the gate.** Auto-approve when `plan-critic` returns `APPROVE` / `APPROVE WITH NOTES` and your own read of the plan is clean. Escalate to the user only for: critic↔architect deadlock; `DISCOVERY-BLOCKER` that evidence can't resolve; plans that break a compatibility surface (task contracts, config schemas, CLI, published API) or have irreversible data effects.
-- **Step 11 (hand-off): don't stop at the PR.** Drive CI → merge → bookkeeping → post-merge validation per the loop above.
+- **Step 11 (hand-off): don't stop at the per-issue PR.** Drive CI → merge into `feat/<slug>` → bookkeeping → journal update → post-merge validation per the loop above.
+
+## Step 4 — Prepare the consolidation PR
+
+Runs once the milestone has zero open issues (and every closed-as-completed issue has a `#<issue> →` line on the umbrella).
+
+1. **Rebase the integration branch on `main`.** `git checkout feat/<slug> && git fetch origin && git rebase origin/main`. Squash-merged per-issue commits stay individual on the integration branch — the rebase only shifts them onto the current `main` tip so the final PR presents as linear history. If the rebase conflicts, resolve inside `feat/<slug>` (never on `main`); push with `--force-with-lease` since only this skill writes to the integration branch. If conflicts are non-trivial, stop and ask.
+2. **Finalize the design journal.** Complete every stub in `docs/plans/<date>-milestone-<N>-integration.md`:
+   - **TL;DR** — one paragraph naming the compatibility impact (or lack thereof) and ending with the roll-up of every `Closes #<n>` in the milestone.
+   - **Impact on existing tasks — read this first** — reviewer-safety framing: near-term / today / longer-term commitments, safety guards, follow-up ticket links.
+   - **Design walkthrough** — required ```mermaid``` block. Pick the shape that fits (flowchart for architecture, sequence for interactions, state for lifecycles). The diagram is the picture of the change; do not omit it for architectural milestones.
+   - **Key design choices** — Decision / Rationale markdown table, one row per accepted decision, sourced from the appends made in Step 3.6.
+   - **Industry precedents** — when the milestone was informed by prior art, link each and state what was borrowed and what was deliberately rejected. Omit the section when N/A.
+   - **Suggested review order** — numbered list of the per-issue PRs (with squash SHAs), ordered to make the story readable start-to-finish.
+   - **Verification** — CI lane pass counts, post-merge validations that ran, and any lanes deliberately skipped with a reason.
+   - **What's next** — one or two sentences of forward links to follow-up issues or the next milestone.
+   - Commit as `chore(milestone-<N>): finalize integration journal` and push.
+3. **Draft the PR body.** The consolidation PR body **is** the design journal — copy the file contents verbatim into the PR body (skipping only the file's `# Milestone <N>:` header line, since `gh pr create --title` supplies the PR title). Match PR-121-style discipline: flat outline (`##` / `###` only), no emoji-heavy section names, no AI attribution footer.
+4. **Open the PR.**
+   ```bash
+   gh pr create \
+     --base main \
+     --head feat/<slug> \
+     --title "feat(<scope>): <milestone title>" \
+     --body-file docs/plans/<date>-milestone-<N>-integration.md
+   ```
+   The `<scope>` follows the repo's conventional-commits convention — the subsystem the milestone predominantly touches (e.g. `runtime`, `cli`, `core`).
+5. **Hand off and stop.** Post to the user: PR URL, one-line summary, follow-ups filed with priorities (implemented vs deferred), post-merge validations run, and the reminder that human review is the gate here. **Do not merge.** **Do not close the milestone yet** — that happens after the user merges the PR, on the user's cue.
+
+The full template with placeholders and worked-example headings lives in `pr-templates.md` next to this file.
 
 ## Follow-ups and discovered work
 
 File everything you discover (bugs, improvements, deferred edge cases) as issues per the `writing-development-tickets` conventions — type label always, priority stated in the body. Then triage:
 
 - **High-priority and in-scope** → assign to the milestone and insert into the queue (implement this session).
-- **Low-priority or out-of-scope** → file, cross-link from the source issue/PR, leave for later. Note it in the final report.
+- **Low-priority or out-of-scope** → file, cross-link from the source issue/PR, leave for later. Note it in the final report and in the design journal's `## What's next` section.
 
 Never let discovered work die in a PR comment or the conversation — if it isn't an issue, it didn't happen.
 
 ## Durable state — the session will outlive its context
 
-A milestone run is long; the conversation will be compacted. The durable record lives in GitHub, never in the conversation:
+A milestone run is long; the conversation will be compacted. The durable record lives in GitHub and on the integration branch, never in the conversation:
 
-- Umbrella comments are the run journal (step 2.5) — one per merged issue.
-- Issue state (open/closed/labels/milestone) is always current — stale bookkeeping is a bug, not cosmetics.
-- Plans live in `docs/plans/` on `main` once merged.
+- **Umbrella comments** are the run journal for merge events (Step 3.5) — one per merged issue.
+- **`docs/plans/<date>-milestone-<N>-integration.md`** on the integration branch is the running design journal (Step 2.4 and Step 3.6) — it accumulates as issues merge and *becomes* the consolidation PR body in Step 4.
+- **Issue state** (open/closed/labels/milestone) is always current — stale bookkeeping is a bug, not cosmetics.
+- **Plan files** for each issue live in `docs/plans/` on the integration branch once merged, and land on `main` when the consolidation PR merges.
 
-After compaction or an interrupted session, rebuild state from the milestone page + umbrella comments + `git log` — never from what you remember of the conversation.
+After compaction or an interrupted session, rebuild state from: the milestone page + umbrella comments + `git log feat/<slug>` + the running design journal + `gh pr list --base feat/<slug>` — never from what you remember of the conversation.
 
 ## Escalation — the only reasons to stop and ask
 
 1. A compatibility-surface break, security-sensitive change, or irreversible data operation where the plan forces a choice.
 2. A genuine design fork the umbrella and design docs are silent on, where the options materially diverge.
 3. `main` or CI infrastructure broken in a way you didn't cause and can't fix, blocking all progress.
-4. Milestone scope change: closing a major issue as wrong-premise, or discovered work large enough to rival an existing issue.
+4. The integration branch `feat/<slug>` conflicts irreconcilably with `main` mid-milestone (Step 4 rebase surfaces conflicts that touch more than mechanical import ordering).
+5. Milestone scope change: closing a major issue as wrong-premise, or discovered work large enough to rival an existing issue.
+6. Consolidation PR review conflict: the human reviewer surfaces a design fork the skill missed. Stop, ask — do not attempt to unwind squash-merged issues.
 
-Everything else has a sensible default: take it, record the decision in the issue/PR, keep moving.
+Everything else has a sensible default: take it, record the decision in the issue/PR and the design journal, keep moving.
 
 ## Completion
 
-1. Every milestone issue and in-scope follow-up is closed; the milestone shows 0 open → close the milestone.
-2. Final report to the user: table of issue → PR → merge commit; follow-ups filed with priorities (implemented vs deferred); premise corrections made; what was validated post-merge; and what remains for the user — typically release tagging and anything provider-account-related, which this skill never performs.
+Two phases:
+
+**Phase A — skill-owned.** Every milestone issue and in-scope follow-up is closed. The integration branch is rebased on `main`. The consolidation PR is open with the finalized design journal as its body. Report to the user: table of issue → PR → merge commit; follow-ups filed with priorities (implemented vs deferred); premise corrections made; post-merge validations run; the consolidation PR URL. **Stop.**
+
+**Phase B — human-owned.** The user reviews the consolidation PR and merges it (or requests changes). When the user confirms merge, close the milestone (`gh api -X PATCH 'repos/Toloka/tolokaforge/milestones/<N>' -f state=closed`). Anything else — release tags, provider accounts, package publishing — remains outside this skill's scope.
 
 ## Failure modes
 
 | Symptom | Resolution |
 |---|---|
-| CI lane fails on the branch and on `main` | Pre-existing — file/annotate an issue, don't grind the branch. Merge only if branch-attributable lanes are green. |
-| CI flake suspected | One re-run, max. Still red without a `main` repro → treat as branch-caused. |
-| Merge conflict | Rebase the feature branch on `main`, re-run targeted tests, push. |
+| CI lane fails on the per-issue branch and on `feat/<slug>` | Pre-existing on the integration branch — file/annotate an issue, don't grind the branch. Merge only if the per-issue PR's own lanes are green. |
+| CI lane fails on `feat/<slug>` and also on `main` | Genuinely upstream — file/annotate an issue against `main`; not a milestone blocker. |
+| CI flake suspected | One re-run, max. Still red without a `feat/<slug>` or `main` repro → treat as branch-caused. |
+| Merge conflict on a per-issue PR | Rebase the feature branch on `feat/<slug>`, re-run targeted tests, push. |
+| Integration branch conflicts with `main` mid-milestone | Rebase `feat/<slug>` on `main`, `git push --force-with-lease`, re-run targeted tests. Only this skill writes to `feat/<slug>`, so the force-push is safe. |
 | Docker stack broken after a merge | `make docker-down` + `make docker-build-core` + `make docker-up`; check `make docker-status`. Do not start the next issue on a broken stack. |
 | Integration tests skip-green for missing keys | Check which keys the lane needs (AGENTS.md lists them); a skipped test is not a passed test when the skipped behaviour is what the issue shipped. |
-| Issue already has an open PR | Yours (this session / a prior run): adopt and drive it to merge. Someone else's: escalate. |
+| Issue already has an open PR | Yours (this session / a prior run, targeting `feat/<slug>`): adopt and drive it to merge. Someone else's, or targeting `main`: escalate. |
 | Issue premise contradicted by evidence | Update or close it with the evidence, comment on the umbrella, continue. Escalate only on material scope change. |
-| Context compacted mid-issue | Rebuild from umbrella comments + `docs/plans/` + `git log` + `gh pr list`. |
+| Context compacted mid-issue | Rebuild from umbrella comments + `docs/plans/<date>-milestone-<N>-integration.md` on `feat/<slug>` + `git log feat/<slug>` + `gh pr list --base feat/<slug>`. |
+| `origin/feat/<slug>` exists but points to an unrelated branch | Ask the user before adopting or renaming — never overwrite unknown history. |
+| The design-journal file would leak internal names (private repo names, private adapter/lib names, internal ticket IDs) into the consolidation PR body | Blocker — strip those refs before opening the PR. Public repo hygiene applies. |
 
 ## Anti-patterns
 
-- **Don't implement issues inline in main.** Even a "one-liner" issue goes through the pipeline — inline fixes skip the critic, the reviewer, and the behaviour-locking test.
-- **Don't batch unrelated issues into one PR.** 1 issue = 1 PR. Bundle only true duplicates, recorded in both issues.
-- **Don't merge on red**, or on "probably flaky" without a `main` comparison.
+- **Don't implement issues inline on the integration branch.** Even a "one-liner" issue goes through the pipeline — inline fixes skip the critic, the reviewer, and the behaviour-locking test. The only direct commits allowed on `feat/<slug>` are the journal seed (Step 2.4), the per-issue journal appends (Step 3.6), and the journal finalization (Step 4.2).
+- **Don't batch unrelated issues into one per-issue PR.** 1 issue = 1 PR. Bundle only true duplicates, recorded in both issues.
+- **Don't merge on red**, or on "probably flaky" without a `feat/<slug>` or `main` comparison.
 - **Don't skip post-merge validation because CI is green.** CI lanes don't cover everything (integration lanes auto-skip without keys).
-- **Don't leave bookkeeping for the end.** Umbrella comments and issue state are updated per-issue, not in a final sweep — compaction can hit at any time.
+- **Don't leave bookkeeping for the end.** Umbrella comments, issue state, and the design journal are updated per-issue, not in a final sweep — compaction can hit at any time, and the journal *is* the future PR body.
+- **Don't merge the consolidation PR yourself.** Preparing it is the skill's job; merging it is the human's. This is the deliberate quality gate — the whole point of the integration-branch flow is that a human reviews one well-documented PR instead of N stacked minimal ones.
+- **Don't reconstruct the design journal after the fact.** Squash-commit messages are terse and lose the reasoning; the journal is written as you go so the consolidation PR body is honest, not archaeological.
 - **Don't re-ask for permissions this skill grants**, and don't assume ones it excludes.
 - **Don't parallelize issues.** Shared working tree; serial merges keep every rebase trivial.
+- **Don't leak internal names into public artefacts.** Consolidation PR bodies, per-issue PR bodies, and journal files land on `main` (a public repo) — no private repo names, no private adapter/lib names, no internal ticket IDs. Link from the internal side instead.

--- a/.agents/skills/implement-milestone/pr-templates.md
+++ b/.agents/skills/implement-milestone/pr-templates.md
@@ -1,0 +1,114 @@
+# PR body templates
+
+Two templates, one source of truth. The per-issue template drives Step 10 of `/executing-development-tickets`; the consolidation template drives Step 4 of `/implement-milestone`. Both are read by three audiences — the human reviewer, future agents planning follow-up work, and (for per-issue PRs) the milestone consolidation body that cites them.
+
+Discipline shared by both templates (modelled on [Toloka/tolokaforge#121](https://github.com/Toloka/tolokaforge/pull/121)):
+
+- Flat outline: `##` and `###` only, no deeper.
+- No emoji-heavy section names, no decorative headers.
+- No AI-attribution footer.
+- Every backticked type / field / preset / file path renders as code.
+- Diagrams use fenced ```mermaid``` blocks — GitHub renders them natively.
+- No internal names in the body: no private repo names, no private adapter or library names, no internal ticket IDs. Link from the internal side instead.
+
+---
+
+## 1. Per-issue PR body — for PRs merging into the integration branch
+
+```markdown
+## Summary
+- <what user-visible thing changes — bullet one>
+- <bullet two, one more if the change genuinely spans two surfaces>
+
+## Design choices
+- **<Decision>**: <"X because Y" — one line; the rationale a reader can't recover from the diff>
+- **<Decision>**: <...>
+
+## Concepts introduced
+<One short paragraph naming any new abstraction, contract, policy slot, or vocabulary the reader will encounter. Enough for a future agent scanning stacked PRs to say "ah, this is where FailureKind came from" without opening the diff. If the change is mechanical, write "None — mechanical change." and move on.>
+
+## Plan
+See docs/plans/<YYYY-MM-DD>-issue-<N>-<short-name>.md
+
+## Discovered issues
+- Filed: #<n>, #<m>
+- Fixed in this PR: <one-line each>
+
+## Test plan
+- <what to verify post-merge — one bullet per verification>
+
+Closes #<issue>
+```
+
+**Anti-patterns to avoid:**
+- Restating the diff. "Renamed X to Y" is what the diff shows; the PR body says *why*.
+- Decision entries that are actually implementation notes ("used a `dict` for O(1) lookup"). Design choices are the branches taken at forks the reader would otherwise wonder about — data model shape, error semantics, migration story, whether a contract is a Protocol or a Pydantic model.
+- Empty `Concepts introduced` for architectural changes. If the ticket introduced a new policy slot or a new task contract, name it — the milestone consolidation PR draws its `Key design choices` table from these sections and cannot cite what wasn't written down.
+
+---
+
+## 2. Consolidation PR body — for the single PR from `feat/<slug>` to `main`
+
+The consolidation PR body **is** the finalized running design journal (`docs/plans/<YYYY-MM-DD>-milestone-<N>-integration.md`). Copy the file contents verbatim, skipping only the file's own `# Milestone <N>: <title>` H1 — `gh pr create --title` supplies the PR title.
+
+```markdown
+## TL;DR
+<One paragraph. Start with the compatibility posture — "This milestone changes X and does NOT change Y" — because that is the reviewer's first anxiety. Name the shape of the change (new subsystem, new contract, refactor with no behaviour change, …). End with the roll-up of every issue: "Closes #<n1>, #<n2>, #<n3>, ...">
+
+## Impact on existing tasks — read this first
+- **Today (nothing changes):** <what continues to work exactly as before, and where the guard rails are>
+- **Near-term (opt-in):** <what users can adopt today if they want the new surface>
+- **Longer-term (planned):** <where this milestone points; forward links to follow-up issues>
+
+## Design walkthrough
+<Two or three paragraphs framing the shape of the change. Enough that a reader who never saw the milestone can hold the picture. The Mermaid block below is the picture — not decorative.>
+
+```mermaid
+flowchart LR
+    A[<node>] --> B[<node>]
+    B --> C[<node>]
+```
+<Choose the diagram shape by fit: flowchart for architecture, sequence for interactions across services, state for lifecycle changes. The diagram is required for architectural milestones; omit only for milestones that are purely additive with no structural change.>
+
+### <Subsystem or concept 1>
+<Sub-section paragraphs when a single concept needs its own walkthrough. Prefer annotated code / YAML / message blocks over prose when the schema *is* the picture.>
+
+### <Subsystem or concept 2>
+<...>
+
+## Key design choices
+
+| Decision | Rationale |
+|---|---|
+| <Choice> | <"X because Y — and here is what we deliberately rejected"> |
+| <Choice> | <one row per accepted decision, sourced from each per-issue PR's Design choices section> |
+
+## Industry precedents
+<Include only when the milestone was informed by prior art. For each precedent: a link, one sentence of what was borrowed, one sentence of what was deliberately rejected. Reversibility framing — "this choice can be revisited if X changes" — is welcome. Omit the section when N/A rather than filling it with hand-waves.>
+
+- **<Project or paper>** ([link]) — Borrowed: <one line>. Rejected: <one line>.
+- **<...>** — ...
+
+## Suggested review order
+The stacked PRs, in the order that makes them make sense:
+
+1. **#<PR>** (`<squash-sha>`) — <one-line reason this is first>
+2. **#<PR>** (`<squash-sha>`) — <one-line reason>
+3. ...
+
+## Verification
+- CI lanes: <lint / unit / canonical / integration pass counts, matrix legs>
+- Post-merge validations run: <targeted dev-MCP `run_tests`, docker stack health, capability tests>
+- Deliberately skipped: <lane> — <reason, e.g. "integration-openai; no OPENAI_API_KEY set in this session — smoke covered by the equivalent Gemini lane">
+
+## What's next
+<Two sentences of forward-looking scope. Follow-up issues filed during the milestone are linked here (`#<n>`, `#<m>`) with a one-line description each. If a follow-up milestone is already tracked, name it.>
+```
+
+**Anti-patterns to avoid:**
+- Reconstructing the body from squash commits at the end. Squash commit subjects are terse and lose the reasoning; the design journal is written as issues merge (see `/implement-milestone` Step 3.6) so the consolidation body is honest, not archaeological.
+- Skipping the Mermaid diagram for architectural milestones because "the reader can figure it out". The diagram compresses what the prose has to spell out — its absence is what makes long PR bodies feel undifferentiated.
+- Decorative `Industry precedents` sections with no rejected-precedents. If nothing was rejected, the section is a citation list, not design reasoning — better to omit and put links inline where relevant.
+- Dropping the `Impact on existing tasks — read this first` section for a "small" milestone. Reviewer anxiety about compat impact is inversely proportional to how much this section reassures them; err on the side of writing it, even briefly.
+- Leaving `Suggested review order` unstamped ("in numerical order"). The order that makes the story readable is often not the order of PR numbers.
+- Any AI-attribution footer. Repo policy: no Claude/AI attribution in commits or PR bodies.


### PR DESCRIPTION
## Summary
- `/implement-milestone` now runs each milestone on a dedicated integration branch `feat/<slug>` — per-issue PRs stack on it and squash-merge into it, and a single consolidation PR opens from `feat/<slug>` to `main` at the end with a design walkthrough.
- The consolidation PR is prepared, never auto-merged — the human reviewer is the gate, seeing one well-documented rollup instead of N stacked minimal PRs.
- Per-issue PRs gain `## Design choices` and `## Concepts introduced` sections so each stacked PR reads as standalone learning material and feeds the consolidation body's Decision / Rationale table.

## Design choices
- **Integration branch prefix `feat/<slug>`, not `dev/<slug>` or `experiment/<slug>`**: matches the pattern the repo already uses in practice (e.g. `feat/terminal-dx`, currently active as base for 8+ per-issue PRs). Codifying an emerging convention beats introducing a new prefix.
- **Consolidation PR body *is* a running design journal, not a retroactive writeup**: `docs/plans/<date>-milestone-<N>-integration.md` is bootstrapped on Step 2 and appended after every merged issue in Step 3.6. Squash-commit subjects lose reasoning; a journal written as issues merge makes the final PR honest instead of archaeological.
- **Skill *prepares* the consolidation PR but never merges it**: added to the "Never granted" list alongside releases and version tags. The whole point of the integration-branch flow is that a human reviews one rich PR — auto-merging it would defeat the design.
- **`base_branch` as optional context on `/executing-development-tickets`, defaulting to `main`**: direct invocations stay unchanged; only `/implement-milestone` passes `base_branch=feat/<slug>`. The critic, implementer, and reviewer are agnostic to the base branch — no agent-spec changes needed.
- **Template modelled on Toloka/tolokaforge#121, not free-form**: flat outline (`##` / `###` only), Decision/Rationale table as the densest reasoning surface, required Mermaid diagram for architectural milestones, `Impact on existing tasks — read this first` section framed for reviewer safety.

## Concepts introduced
Two new artefacts anchor the workflow. The **milestone integration branch** `feat/<slug>` is a long-lived base that per-issue PRs target and squash-merge into; only `/implement-milestone` writes to it, which makes end-of-milestone rebases against `main` safe under `--force-with-lease`. The **running design journal** at `docs/plans/<date>-milestone-<N>-integration.md` accumulates each merged issue's design rationale (one paragraph + 1–3 Decision rows + Concepts one-liner) and *becomes* the consolidation PR body verbatim in Step 4 — no separate writeup step, no reconstruction from squash commits.

## Plan
See `/Users/cirogam/.claude/plans/i-need-to-improve-ticklish-kay.md` (local plan file; not part of this diff — the repo's per-issue plan convention `docs/plans/<date>-issue-<N>-<slug>.md` doesn't apply to a workflow-change PR).

## Discovered issues
- Filed: none.
- Fixed in this PR: removed the `🤖 Generated with [Claude Code]` footer that used to be templated into every per-issue PR body — matches repo policy (no AI attribution in commits or PR bodies).

## Test plan
- Grep verification (already run in the working tree): no internal names (Jira keys, private repo names, private adapter/lib names) in any of the three files; no AI attribution; `base_branch` mentioned consistently across both skills; `feat/<slug>` and `feat/<milestone-slug>` placeholders consistent.
- Symlink sanity: `.claude/skills/implement-milestone/` still resolves to the modified `SKILL.md` and reaches the new `pr-templates.md`. Confirmed via `ls -la .claude/skills/implement-milestone/` post-edit.
- Rendering: the ```mermaid``` block in `pr-templates.md` is a syntactically valid flowchart placeholder — GitHub renders these natively in PR bodies. This PR body itself is a live smoke of the new per-issue template (Summary / Design choices / Concepts introduced / Plan / Discovered / Test plan / Closes) and renders cleanly.
- Not run: end-to-end `/implement-milestone` dry-run — the skill mutates GitHub state and can only be exercised on a real milestone. First real use will be the next milestone opened after this merges.
