### PR TITLE
chore(schema): TaskConfig minimal shape is task_id + description (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **schema**: task.yaml minimal shape is task_id + description; initial_state / tools / user_simulator / grading now optional with sane defaults (#366)
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
 - **runtime**: `PerTrialRuntimeBackend` captures per-service logs on provision-stage failure (compose-up / reset-recipe) before teardown, writing `services/<service>.log` + a `services/_capture.yaml` manifest; `RuntimeBackend` gains `capture_service_logs` (per-trial writes `.log` files; shared-stack is a documented no-op) (#302)
 - **runtime**: on a trial-body failure (`ERROR` / `TIMEOUT`) the trial executor captures per-service logs before teardown, emits a `trial.service_logs_captured` summary line, and amends the trial's `metrics.yaml` with a `captured_service_logs` byte-count map (#302)

--- a/docs/NATIVE_ADAPTER.md
+++ b/docs/NATIVE_ADAPTER.md
@@ -51,7 +51,7 @@ tool registry.
 ```
 tasks/<category>/<task_id>/
 ├── task.yaml                    # required — task config
-├── grading.yaml                 # required — grading config
+├── grading.yaml                 # optional — grading config; auto-picked up when present
 ├── system_prompt.md             # optional — agent system prompt / wiki
 ├── initial_state.json           # optional — seed data for JSON DB
 ├── mcp_server.py                # required if agent uses tools

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -60,6 +60,25 @@ user_simulator:
 grading: "grading.yaml"
 ```
 
+### Minimal task
+
+The only required fields are `task_id` and `description`. Everything above is
+optional and defaults to a sane value:
+
+| Field | Default when omitted |
+| --- | --- |
+| `initial_state` | empty state (no JSON DB, filesystem, mock-web, or RAG) |
+| `tools` | no tools enabled for agent or user |
+| `user_simulator` | cooperative LLM user (`mode: llm`, `persona: cooperative`) |
+| `grading` | a `grading.yaml` sitting next to `task.yaml` is picked up automatically; if there is none, the task has no grading configured |
+
+So a task that inherits everything from its Project needs only:
+
+```yaml
+task_id: "api_endpoint_add"
+description: "Add a POST /orders endpoint backed by the orders table."
+```
+
 ## Initial State
 
 - `json_db`: JSON file loaded into the JSON DB service. Use this for any task state that needs to be verified by grading.

--- a/docs/plans/2026-07-15-issue-366-task-schema-relaxation.md
+++ b/docs/plans/2026-07-15-issue-366-task-schema-relaxation.md
@@ -1,0 +1,218 @@
+# Plan: task-schema relaxation — minimal `task.yaml` is `task_id` + `description`
+
+Issue: #366
+Branch: chore/task-schema-relaxation
+
+## Context
+
+Every task in `examples/native/example-microservices-pack/tasks/*/task.yaml`
+uses the minimal Project-schema shape documented in
+`docs/architecture/PROJECTS.md` ("A task that declares only `task_id` and
+`description` inherits *everything* from the Project") — just `task_id` +
+`description` (+ an optional `environment_manifest` override). But
+`TaskConfig` still requires four fields from every task, so `tolokaforge run`
+refuses to load any of the pack's tasks:
+
+```
+TaskConfig
+  initial_state    Field required
+  tools            Field required
+  user_simulator   Field required
+  grading          Field required
+```
+
+(The issue named three; `tools` is the fourth. Reproduced via
+`TaskConfig(task_id="x", description="y")`.) `#240` shipped the *reservations*
+half of the relaxation (actor/seed/capability name-squatting) plus a
+placeholder test that still passes all four fields; this issue completes the
+required→optional change and adds sibling-`grading.yaml` auto-pickup.
+
+## Goal
+
+`TaskConfig` accepts the minimal shape `task_id` + `description`. The four
+currently-required fields become optional with the sane defaults the
+PROJECTS.md contract names:
+
+- `initial_state` → empty state (`InitialStateConfig()`)
+- `tools` → no tools (`ToolsConfig()`)
+- `user_simulator` → cooperative LLM user (`UserSimulatorConfig()` — already
+  `mode="llm"`, `persona="cooperative"`, `backstory=None`)
+- `grading` → `None`, with the loader auto-picking up a sibling `grading.yaml`
+  when one exists next to `task.yaml`
+
+All five microservices-pack tasks then load through `NativeAdapter` and
+produce a valid `TaskDescription` (verified: with the four defaults injected,
+all five validate and the defaults are the only blockers).
+
+## Non-goals
+
+- **Grading-combine correctness.** `project.task_defaults.grading_defaults`
+  is dead config (never merged into any task's grading) — filed as **#376**.
+  The pack tasks will load and run after this PR but grade with default
+  combine weights, not the project's declared `weights: {llm_judge: 1.0}`.
+  Out of scope here; do not wire `grading_defaults` in this PR.
+- **A "no-grade" grading path.** `Grade.binary_pass` is a required `bool`; a
+  task with no grading anywhere (no `grading:` field and no sibling
+  `grading.yaml`) is a valid *authoring* state but its run-time grade
+  semantics are unchanged by this PR — `to_task_description` already
+  synthesises an empty grading config, and the two in-process grading
+  accessors fail loud (see Stage 1). No new no-grade behaviour is built.
+- **Removing the now-redundant `if task.<field> and …` guards** scattered in
+  `native.py`/`conductor.py`. With model-instance defaults they are always
+  truthy and harmless; removing them is churn. Leave them.
+- **terminal_bench tasks.** They use the upstream terminal-bench schema
+  (`instruction:`, `max_agent_timeout_sec`, …) via a separate adapter, not
+  `TaskConfig`. Unaffected.
+
+## Stages
+
+### Stage 1: Relax `TaskConfig` — four fields optional with safe defaults
+
+- **Contract** (`tolokaforge/core/models.py`, `class TaskConfig`):
+  - `initial_state: InitialStateConfig = Field(default_factory=InitialStateConfig)`
+  - `tools: ToolsConfig = Field(default_factory=ToolsConfig)`
+  - `user_simulator: UserSimulatorConfig = Field(default_factory=UserSimulatorConfig)`
+  - `grading: str | None = None`
+  - No other `TaskConfig` field changes — `name`, `category`, `max_turns`,
+    `adapter_type`, `metadata`, `policies`, `adapter_settings`,
+    `system_prompt`, `stuck_heuristics`, `timeouts`, `environment_manifest`,
+    `actors` are already optional.
+  - Model-instance defaults (not `None`) are deliberate: the live trial path
+    (`conductor.py` `task.user_simulator.mode`, `task.tools.agent`; `native.py`
+    `create_environment` `task.initial_state.json_db`) dereferences these
+    unguarded, so a default instance keeps every consumer working with **zero
+    consumer changes**. The default `UserSimulatorConfig()` is exactly the
+    "cooperative user simulator" the issue asks for.
+  - **`grading` None-handling (fail-loud, not `TypeError`):** the two
+    in-process consumers that dereference `task.grading` unguarded —
+    `NativeAdapter.get_grading_config` and `NativeAdapter.compute_golden_hash`
+    (which calls it) — must raise a clear `ValueError`
+    ("task `<id>` has no grading configured …") when `task.grading is None`,
+    instead of `task_dir / None` raising a bare `TypeError`. `to_task_description`
+    is already fully guarded (`if task.grading:`) and needs no change.
+- **Behaviour to lock (unit):**
+  - `TaskConfig(task_id="x", description="y")` validates; `initial_state`,
+    `tools`, `user_simulator` are the empty model instances;
+    `user_simulator.mode == "llm"` and `persona == "cooperative"`;
+    `grading is None`.
+  - **Rewrite** the existing placeholder
+    `tests/unit/test_schema_reservations.py::TestTaskConfigMinimal::test_task_id_plus_description_is_enough`
+    so its body actually omits the four fields (today it passes all four,
+    contradicting its own name) and asserts the defaults above.
+  - `get_grading_config` on a task with `grading=None` raises `ValueError`
+    with a message naming the task, not `TypeError`.
+- **Compatibility:** `task.yaml` is a task-pack compatibility surface
+  (AGENTS.md Core Rule 5). required→optional is **additive** — verified every
+  shipped example pack still validates (`native_shared_domain` supplies
+  `tools` via its `_shared/domain.yaml` merge; other packs declare all four).
+  CHANGELOG entry under `## Unreleased` → `### Feat`:
+  `**schema**: task.yaml minimal shape is task_id + description; initial_state
+  / tools / user_simulator / grading now optional with sane defaults (#366)`.
+- **Deliverable:** `TaskConfig` accepts the minimal shape; unit tests green.
+- **Validation:** `run_tests` marker `unit` (path
+  `tests/unit/test_schema_reservations.py`); `run_python` reproducing
+  `TaskConfig(task_id="x", description="y")` now succeeds. Reviewer checks the
+  defaults are model instances (not `None`) and the fail-loud grading guard.
+- **Doc updates:** `docs/TASKS.md` § "task.yaml Essentials" — add a short
+  "Minimal task" note stating the minimal shape is `task_id` + `description`
+  and listing the four optional fields with their defaults (empty state, no
+  tools, cooperative LLM user, sibling `grading.yaml` auto-picked — see Stage
+  2). Rewrite so the minimal shape reads as the normal state, not a "now
+  relaxed" migration note.
+
+### Stage 2: Sibling `grading.yaml` auto-pickup in the task loader
+
+- **Contract** (`tolokaforge/adapters/_task_loader.py`, `load_task_yaml`):
+  after the domain/project/task deep-merge and before
+  `_resolve_environment_manifest_paths` / `TaskConfig(**task_data)`, when the
+  merged `task_data` has no `grading` key (or it is falsy) **and** a
+  `grading.yaml` file exists next to `task.yaml`
+  (`task_path.parent / "grading.yaml"`), set `task_data["grading"]` to that
+  file's **absolute** path. An explicit `grading:` in `task.yaml` (or from the
+  domain/project layers) always wins — auto-pickup only fills an unset field.
+  Absolute path is deliberate: it is layout-independent (flat and
+  shared-domain), survives `task_dir / task.grading` joins unchanged, and
+  needs no `_PATH_FIELD_REWRITERS` entry.
+- **Behaviour to lock (unit):**
+  - A `task.yaml` omitting `grading` with a sibling `grading.yaml` →
+    `TaskConfig.grading` resolves to that sibling and `get_grading_config`
+    loads it.
+  - The same `task.yaml` with **no** sibling `grading.yaml` → `grading is
+    None` (no crash, no fabricated path).
+  - An explicit `grading: <other>.yaml` in `task.yaml` is **not** overridden
+    by a present sibling `grading.yaml`.
+  - Add to `tests/unit/test_task_loader.py`.
+- **Compatibility:** internal loader behaviour; additive (packs that declared
+  `grading:` explicitly are unchanged). No compatibility-surface migration.
+- **Deliverable:** loader auto-picks a sibling `grading.yaml`; unit tests green.
+- **Validation:** `run_tests` marker `unit` (path
+  `tests/unit/test_task_loader.py`). Reviewer checks explicit-wins precedence
+  and the no-sibling → `None` case.
+- **Doc updates:** `docs/TASKS.md` — in the same "Minimal task" note from
+  Stage 1, state that a `grading.yaml` sitting next to `task.yaml` is used
+  automatically without a `grading:` line.
+
+### Stage 3: End-to-end acceptance — the microservices pack loads and builds
+
+- **Contract:** no production code — the acceptance proof. All five
+  `example-microservices-pack` tasks, loaded through the same path the
+  orchestrator uses (`NativeAdapter` with the pack's `project_task_defaults`,
+  as `Orchestrator` wires via `load_task_yaml(project_task_defaults=…)`),
+  each yield a valid `TaskConfig` and a `to_task_description()` that carries
+  the per-task `llm_judge` rubric (from the auto-picked sibling `grading.yaml`)
+  and the cooperative user simulator.
+- **Behaviour to lock (integration):** extend
+  `tests/integration/test_example_microservices_pack.py` (already the pack's
+  wiring proof — deliberately no Docker, no LLM):
+  - The adapter discovers all five tasks (`api_endpoint_add`,
+    `db_query_tuning`, `long_debugging_session`, `postgres_upgrade_test`,
+    `schema_isolation_migration`).
+  - Each `to_task_description(task_id)` succeeds and its `grading.llm_judge`
+    is populated (rubric criteria present).
+  - `user_simulator.mode == "llm"` on each (inherited default).
+  - `schema_isolation_migration` resolves its task-local stack (full
+    `stack.compose_file` override); the other four resolve the project
+    default. (The existing tests already cover env resolution at the
+    project level; this adds the per-task `to_task_description` proof.)
+  - Keep the marker `integration` and the no-Docker/no-LLM philosophy of the
+    existing file.
+- **Compatibility:** test-only.
+- **Deliverable:** the pack's five tasks provably load + build; the issue's
+  repro no longer fails.
+- **Validation:** `run_tests` marker `integration` (path
+  `tests/integration/test_example_microservices_pack.py`). No API keys /
+  Docker required for these assertions.
+- **Doc updates:** none (Stages 1–2 own the doc changes).
+
+## Discovered issues
+
+- **Filed as issues:**
+  - **#376** — `project.task_defaults.grading_defaults` is dead config (never
+    merged into a task's grading). The pack relies on it for combine weights;
+    without it the judge-only tasks grade against a non-existent
+    `state_checks` component. Distinct from #218. Out of scope for #366.
+- **Fix in this PR:**
+  - Rewrite the misleading placeholder
+    `test_schema_reservations.py::TestTaskConfigMinimal` (Stage 1) — its name
+    claims "task_id + description is enough" but its body passes all four
+    fields.
+- **Noted, not fixed (no churn):** the redundant `if task.<field> and …`
+  guards in `native.py`/`conductor.py` become always-true with the new
+  defaults; leaving them is cheaper and safer than a guard-removal sweep.
+
+## Risks / open questions
+
+- **The pack loads but does not yet grade to its declared policy** (#376).
+  Stage 3 asserts loading + `to_task_description` wiring only, not grade
+  correctness — matching the existing test file's no-LLM philosophy. If the
+  reviewer expects "runs end-to-end" to include a correct combined grade,
+  that is #376, not this PR.
+- **Model-instance defaults vs `None`:** chosen so the unguarded live
+  consumers keep working without a guard sweep. The trade-off is that a task
+  that "declares no user simulator" still gets a cooperative LLM user rather
+  than "no user" — which is the intended contract per PROJECTS.md, not a
+  workaround.
+- **`grading` absolute-path auto-pickup** assumes the sibling sits next to
+  `task.yaml` (true for flat and shared-domain case dirs). If a future layout
+  puts `grading.yaml` elsewhere, the auto-pickup simply doesn't fire and
+  `grading` stays `None` — no wrong-file risk.

--- a/tests/integration/test_example_microservices_pack.py
+++ b/tests/integration/test_example_microservices_pack.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.env_identity import resolve_environment_identity
 from tolokaforge.core.models import (
     EvaluationConfig,
@@ -38,12 +39,51 @@ _PACK_ROOT = (
 )
 _PROJECT_YAML = _PACK_ROOT / "project.yaml"
 
+_EXPECTED_TASK_IDS = {
+    "api_endpoint_add",
+    "db_query_tuning",
+    "long_debugging_session",
+    "postgres_upgrade_test",
+    "schema_isolation_migration",
+}
+
+# Per-task compose file the resolved manifest must anchor to. Four tasks
+# inherit the project's shared stack; ``schema_isolation_migration`` ships a
+# full ``stack.compose_file`` override that replaces it.
+_SHARED_COMPOSE = _PACK_ROOT / "shared" / "environment.compose.yaml"
+_EXPECTED_COMPOSE_FILE = {
+    "api_endpoint_add": _SHARED_COMPOSE,
+    "db_query_tuning": _SHARED_COMPOSE,
+    "long_debugging_session": _SHARED_COMPOSE,
+    "postgres_upgrade_test": _SHARED_COMPOSE,
+    "schema_isolation_migration": (
+        _PACK_ROOT / "tasks" / "schema_isolation_migration" / "environment.compose.yaml"
+    ),
+}
+
 
 def _make_run_config() -> RunConfig:
     return RunConfig(
         models={"agent": ModelConfig(provider="openai", name="gpt-4")},
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir="/tmp/pack_smoke"),
+    )
+
+
+def _make_pack_adapter() -> NativeAdapter:
+    """Build a ``NativeAdapter`` for the pack via the same wiring the
+    :class:`Orchestrator` uses: the project's discovery glob under the pack
+    root, with ``project.task_defaults`` and ``default_environment`` layered
+    in (see ``Orchestrator._create_adapter``)."""
+    project = load_project_config(_PROJECT_YAML)
+    defaults = project.task_defaults.model_dump(exclude_defaults=True)
+    return NativeAdapter(
+        {
+            "tasks_glob": project.tasks.discovery.glob,
+            "task_packs": [str(_PACK_ROOT)],
+            "project_task_defaults": defaults or None,
+            "project_default_environment": project.default_environment,
+        }
     )
 
 
@@ -122,3 +162,40 @@ def test_pack_manifest_has_stable_environment_identity() -> None:
     assert identity == again
     assert identity.startswith("sha256:")
     assert len(identity) == len("sha256:") + 64
+
+
+def test_adapter_discovers_all_five_pack_tasks() -> None:
+    """The native adapter, wired the orchestrator's way, discovers every
+    task in the pack — the minimal ``task_id`` + ``description`` shape loads
+    without the four formerly-required fields."""
+    adapter = _make_pack_adapter()
+    assert set(adapter.get_task_ids()) == _EXPECTED_TASK_IDS
+
+
+@pytest.mark.parametrize("task_id", sorted(_EXPECTED_TASK_IDS))
+def test_task_builds_description_with_judge_rubric_and_llm_user(task_id: str) -> None:
+    """Each minimal pack task builds a ``TaskDescription`` whose grading
+    carries the per-task ``llm_judge`` rubric (auto-picked from the sibling
+    ``grading.yaml``) and whose user simulator is the inherited cooperative
+    LLM default — the end-to-end proof that the schema relaxation and
+    sibling-grading pickup wire through ``NativeAdapter``."""
+    adapter = _make_pack_adapter()
+
+    task_desc = adapter.to_task_description(task_id)
+
+    assert task_desc.grading.llm_judge is not None
+    assert len(task_desc.grading.llm_judge.rubric.criteria) > 0
+    assert task_desc.user_simulator.mode == "llm"
+
+
+@pytest.mark.parametrize("task_id", sorted(_EXPECTED_TASK_IDS))
+def test_task_manifest_resolves_expected_stack(task_id: str) -> None:
+    """``schema_isolation_migration`` resolves its task-local
+    ``stack.compose_file`` override; the other four resolve the project's
+    shared stack. Both anchor to an absolute compose path on disk."""
+    adapter = _make_pack_adapter()
+
+    manifest = adapter.to_task_description(task_id).environment_manifest
+
+    assert manifest is not None
+    assert manifest.compose_file == _EXPECTED_COMPOSE_FILE[task_id].resolve()

--- a/tests/unit/test_schema_reservations.py
+++ b/tests/unit/test_schema_reservations.py
@@ -241,17 +241,18 @@ class TestProjectConfigAssets:
 
 class TestTaskConfigMinimal:
     def test_task_id_plus_description_is_enough(self) -> None:
-        t = TaskConfig(
-            task_id="x",
-            description="y",
-            initial_state=InitialStateConfig(),
-            tools=ToolsConfig(),
-            user_simulator=UserSimulatorConfig(),
-            grading="grading.yaml",
-        )
+        t = TaskConfig(task_id="x", description="y")
         assert t.task_id == "x"
         assert t.name is None
         assert t.category is None
+        # The four relaxed fields default to model instances (not None) so the
+        # unguarded live consumers in conductor.py / native.py keep working.
+        assert isinstance(t.initial_state, InitialStateConfig)
+        assert isinstance(t.tools, ToolsConfig)
+        assert isinstance(t.user_simulator, UserSimulatorConfig)
+        assert t.user_simulator.mode == "llm"
+        assert t.user_simulator.persona == "cooperative"
+        assert t.grading is None
 
     def test_name_still_set_when_provided(self) -> None:
         t = TaskConfig(
@@ -266,6 +267,23 @@ class TestTaskConfigMinimal:
         )
         assert t.name == "Nice Name"
         assert t.category == "cat"
+
+
+class TestGradingNoneGuard:
+    def test_get_grading_config_fails_loud_when_grading_none(self, tmp_path: Path) -> None:
+        # A minimal task with no `grading:` and no sibling grading.yaml loads
+        # with grading=None; get_grading_config must fail loud naming the task
+        # rather than let `task_dir / None` raise a bare TypeError.
+        from tolokaforge.adapters.native import NativeAdapter
+
+        task_dir = tmp_path / "tasks" / "minimal"
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.yaml").write_text("task_id: minimal\ndescription: does nothing\n")
+
+        adapter = NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+        assert adapter.get_task("minimal").grading is None
+        with pytest.raises(ValueError, match="minimal"):
+            adapter.get_grading_config("minimal")
 
 
 # ── SecurityContext type widening ───────────────────────────────

--- a/tests/unit/test_schema_reservations.py
+++ b/tests/unit/test_schema_reservations.py
@@ -245,8 +245,10 @@ class TestTaskConfigMinimal:
         assert t.task_id == "x"
         assert t.name is None
         assert t.category is None
-        # The four relaxed fields default to model instances (not None) so the
-        # unguarded live consumers in conductor.py / native.py keep working.
+        # Three of the four relaxed fields default to model instances (not
+        # None) so the unguarded live consumers in conductor.py / native.py
+        # keep working; grading defaults to None (path field, guarded fail-
+        # loud where dereferenced).
         assert isinstance(t.initial_state, InitialStateConfig)
         assert isinstance(t.tools, ToolsConfig)
         assert isinstance(t.user_simulator, UserSimulatorConfig)

--- a/tests/unit/test_task_loader.py
+++ b/tests/unit/test_task_loader.py
@@ -22,6 +22,7 @@ from tolokaforge.adapters._task_loader import (
     deep_merge,
     load_task_yaml,
 )
+from tolokaforge.adapters.native import NativeAdapter
 
 pytestmark = pytest.mark.unit
 
@@ -495,6 +496,61 @@ def test_inline_json_db_dict_survives_load(tmp_path: Path) -> None:
     )
     task, _ = load_task_yaml(case_dir / "task.yaml")
     assert task.initial_state.json_db == {"items": [{"id": 1}]}
+
+
+class TestSiblingGradingAutoPickup:
+    """A ``grading.yaml`` next to ``task.yaml`` is auto-picked when the merged
+    config sets no ``grading``. Explicit ``grading:`` always wins; a missing
+    sibling leaves ``grading`` unset rather than fabricating a path."""
+
+    @staticmethod
+    def _write_minimal_task(task_dir: Path, **extra: object) -> Path:
+        task_dir.mkdir(parents=True, exist_ok=True)
+        data: dict = {"task_id": "min", "description": "minimal task"}
+        data.update(extra)
+        _write_yaml(task_dir / "task.yaml", data)
+        return task_dir / "task.yaml"
+
+    @staticmethod
+    def _write_grading(path: Path) -> None:
+        _write_yaml(
+            path,
+            {
+                "combine": {
+                    "method": "weighted",
+                    "weights": {"state_checks": 1.0},
+                    "pass_threshold": 1.0,
+                }
+            },
+        )
+
+    def test_sibling_grading_auto_picked_and_loads(self, tmp_path: Path) -> None:
+        task_dir = tmp_path / "flat_task"
+        task_path = self._write_minimal_task(task_dir)
+        self._write_grading(task_dir / "grading.yaml")
+
+        task, task_root = load_task_yaml(task_path)
+
+        expected = (task_dir / "grading.yaml").resolve()
+        assert task.grading == str(expected)
+        assert Path(task.grading).is_absolute()
+
+        adapter = NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(tmp_path)})
+        grading = adapter.get_grading_config("min")
+        assert grading.combine.weights == {"state_checks": 1.0}
+
+    def test_no_sibling_leaves_grading_none(self, tmp_path: Path) -> None:
+        task_path = self._write_minimal_task(tmp_path / "flat_task")
+        task, _ = load_task_yaml(task_path)
+        assert task.grading is None
+
+    def test_explicit_grading_not_overridden_by_sibling(self, tmp_path: Path) -> None:
+        task_dir = tmp_path / "flat_task"
+        task_path = self._write_minimal_task(task_dir, grading="other.yaml")
+        self._write_grading(task_dir / "grading.yaml")
+
+        task, _ = load_task_yaml(task_path)
+        assert task.grading == "other.yaml"
 
 
 def test_load_task_yaml_real_example(tmp_path: Path) -> None:

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -163,6 +163,15 @@ def load_task_yaml(
         base = deep_merge(base, project_task_defaults)
     task_data = deep_merge(base, task_data)
 
+    # Auto-pick a sibling ``grading.yaml`` when no layer set ``grading``. An
+    # explicit ``grading:`` from any layer always wins. The absolute path is
+    # layout-independent and survives ``task_dir / task.grading`` joins
+    # downstream unchanged, so it needs no ``_PATH_FIELD_REWRITERS`` entry.
+    if not task_data.get("grading"):
+        sibling_grading = task_path.parent / "grading.yaml"
+        if sibling_grading.exists():
+            task_data["grading"] = str(sibling_grading.resolve())
+
     # Resolve environment_manifest.compose_file to an absolute path
     # against the task root so ``EnvironmentManifest``'s file-existence
     # validator can locate the file regardless of the CWD at load time.

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -315,6 +315,12 @@ class NativeAdapter(BaseAdapter):
         task = self.get_task(task_id)
         task_dir = self.get_task_dir(task_id)
 
+        if task.grading is None:
+            raise ValueError(
+                f"task {task_id!r} has no grading configured "
+                "(no `grading:` field and no sibling grading.yaml)"
+            )
+
         grading_path = task_dir / task.grading
         if grading_path.exists():
             with open(grading_path) as f:

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1171,9 +1171,9 @@ class TaskConfig(BaseModel):
     adapter_type: str = "native"  # Adapter runtime type (native, tlk_mcp_core, tau, …)
     max_turns: int | None = None  # Optional per-task turn cap override
     initial_user_message: str | None = None  # If provided, sent directly as first user message
-    initial_state: InitialStateConfig
-    tools: ToolsConfig
-    user_simulator: UserSimulatorConfig
+    initial_state: InitialStateConfig = Field(default_factory=InitialStateConfig)
+    tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    user_simulator: UserSimulatorConfig = Field(default_factory=UserSimulatorConfig)
     actors: dict[str, ActorSpec] | None = None
     """Task-level actor overrides. Reserved at the parse layer; runtime
     binding lands with the canonical rename. Reserved actor names
@@ -1183,7 +1183,7 @@ class TaskConfig(BaseModel):
     policies: dict[str, Any] = Field(
         default_factory=dict
     )  # Can contain guidance list or agent_system_prompt string
-    grading: str  # Path to grading.yaml
+    grading: str | None = None  # Path to grading.yaml; sibling grading.yaml auto-picked when unset
     system_prompt: str | None = None  # Path to system prompt file (e.g., wiki.md)
     adapter_settings: dict[str, Any] | None = None  # Opaque dict parsed by each adapter type
 


### PR DESCRIPTION
Closes #366.

## Summary

- Relax \`TaskConfig\` so the minimal \`task.yaml\` shape is \`task_id\` + \`description\` per the PROJECTS.md contract. Four fields go from required to optional: \`initial_state\` / \`tools\` / \`user_simulator\` default to empty model instances (\`UserSimulatorConfig()\` is already the cooperative LLM user); \`grading\` becomes \`str | None\`.
- Model-instance defaults (not \`None\`) are deliberate — the live trial path has ~15 unguarded derefs across \`conductor.py\` and \`native.py\` that would break under \`None\`. Model instances keep every consumer working with zero consumer changes.
- \`NativeAdapter.get_grading_config\` gains a fail-loud guard when \`task.grading is None\`, raising \`ValueError\` naming the task instead of the bare \`TypeError\` \`task_dir / None\` would otherwise produce. \`to_task_description\` is already guarded and unchanged.
- Task loader auto-picks a sibling \`grading.yaml\` sitting next to \`task.yaml\` when no explicit \`grading:\` is set — this is what makes \`examples/native/example-microservices-pack\` load without \`task.yaml\` explicitly referencing \`grading.yaml\` in every task.

## Plan

See \`docs/plans/2026-07-15-issue-366-task-schema-relaxation.md\`. Plan-critic APPROVE WITH NOTES on round 1 (one cosmetic 🟡 on declared-vs-auto-picked path parity — deliberately unfixed, harmless, documented in-plan). Branch reviewer APPROVE WITH NITS; the one code nit is fixed (\`2c0c187\`).

## Discovered issues

- Filed: **#376** — \`project.task_defaults.grading_defaults\` is dead config (never merged into a task's grading). The pack's tasks will now load and run after this PR, but their combined grade uses default weights instead of the project's declared \`weights: {llm_judge: 1.0}\`. #376 is now part of milestone #16 and will land as its own PR before the milestone consolidation.
- Fixed in this PR: rewrote the placeholder \`TestTaskConfigMinimal::test_task_id_plus_description_is_enough\` whose body previously passed all four fields, contradicting its own name.

## Test plan

- [x] \`uv run pytest -m unit tests/unit/test_schema_reservations.py -v\` — 36 passed (including rewritten placeholder + new \`TestGradingNoneGuard\`).
- [x] \`uv run pytest -m unit tests/unit/test_task_loader.py -v\` — 30 passed (including new \`TestSiblingGradingAutoPickup\` — 3 cases).
- [x] \`uv run pytest -m integration tests/integration/test_example_microservices_pack.py -v\` — 15 passed (4 pre-existing + 11 new; all 5 pack tasks discover, build \`to_task_description\` with \`llm_judge.rubric.criteria\` populated, resolve expected stacks).
- [x] Broader unit sweep (\`-k "task_config or TaskConfig or native_adapter or task_loader or task_packs or grading"\`) → 362 passed, 1 skipped, no regressions.
- [x] Branch reviewer — APPROVE WITH NITS; the one code nit is fixed inline.

Milestone: Project layer runnability (#16). Sub-issue 1 of 6 of umbrella #375.