### PR TITLE
docs(adr): ADR-0016 + isolated_trials.md updated to per-service isolation vocabulary (#370)

### DIFF
--- a/docs/architecture/adr/0009-environment-manifest.md
+++ b/docs/architecture/adr/0009-environment-manifest.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-07-02
 - **Deciders:** @CiroGamboa
 - **Supersedes:** —
-- **Superseded by:** —
+- **Superseded by:** ADR-0018 (isolation surface only — 2026-07-14 amendment)
 
 ## Context and Problem Statement
 

--- a/docs/architecture/adr/0016-runtime-backend-comparison.md
+++ b/docs/architecture/adr/0016-runtime-backend-comparison.md
@@ -88,7 +88,7 @@ Tasks that declare many services or slow-starting services (large postgres seeds
 
 Cross-referencing `RUNTIME_BACKENDS.md`'s "Failure modes" section, the mode-specific soft failures are:
 
-- **`shared` only — cross-trial state contamination.** Two trials writing to the same DB can see each other's writes. Deterministic-grading tasks (whose grader reads the DB) can produce wrong verdicts if the code that writes to the DB doesn't scope by `trial_id`. Detection is task-author responsibility — the runtime doesn't know what a task's grader expects. Guardrail: the task's `environment_manifest.isolation` declaration; `SharedStackRuntimeBackend` refuses to run tasks that declare `isolation: per_trial`.
+- **`shared` only — cross-trial state contamination.** Two trials writing to the same DB can see each other's writes. Deterministic-grading tasks (whose grader reads the DB) can produce wrong verdicts if the code that writes to the DB doesn't scope by `trial_id`. Detection is task-author responsibility — the runtime doesn't know what a task's grader expects. Guardrail: per-service `services.<name>.isolation` labels drive backend selection. `SharedStackRuntimeBackend` runs a task only when every service is labelled `isolation: shared` — the task author's acknowledgment of the shared-state responsibility. A task declaring any service `isolation: reset` or `ephemeral` is auto-routed to `PerTrialRuntimeBackend` by task-driven selection. The deprecated `orchestrator.runtime` override is the only way to force a shared backend against a per-trial-requiring task set, and `_verify_isolation_compatibility` refuses that at startup.
 - **`per_trial` only — daemon-throughput ceiling.** Running many workers on one host multiplies compose-up cost by worker count. On daemons with low concurrent-project limits or slow image cache, workers can starve at the docker-daemon boundary. Guardrail: bound worker count against observed daemon throughput; ADR-0010 requires provisioners to fail loud on `ProvisionError` and attribute the failure deterministically so throughput ceilings surface in the aggregate report rather than looking like task failures.
 
 Hard failures (image build error, network bring-up error, grader RPC error, runner crash) are shared between modes and covered in `RUNTIME_BACKENDS.md`.
@@ -97,11 +97,11 @@ Hard failures (image build error, network bring-up error, grader RPC error, runn
 
 A concrete flow, per task:
 
-1. **Does the task declare `environment_manifest.isolation: per_trial`?** → run on `PerTrialRuntimeBackend`. The declaration says the task's grader cannot tolerate shared state; the shared backend refuses to run it (isolation-enforcement guard).
-2. **Does the task declare `environment_manifest.isolation: shared_ok`?** → `SharedStackRuntimeBackend` is safe and faster. `PerTrialRuntimeBackend` also works and provides stronger isolation than needed; pick based on throughput and cost preference.
-3. **Does the task not declare an `environment_manifest`?** → `SharedStackRuntimeBackend` only. `PerTrialRuntimeBackend.provision()` requires a manifest and fails loud without one. Migration to per-trial isolation requires the task-pack side to author a manifest.
-4. **Genuinely stateless workload where cost dominates?** → `shared`, with the caveat that the author is responsible for the "no cross-trial contamination" invariant.
-5. **Cross-trial isolation matters more than cost?** → `per_trial`, budget the ~10 s and ~9% cost premium per trial visible in the A/B numbers above.
+1. **Does the task declare any service `isolation: reset` or `ephemeral`?** → the run lands on `PerTrialRuntimeBackend`, selected automatically. The declaration says the task's grader cannot tolerate shared state; task-driven selection routes it there without operator action.
+2. **Does the task declare every service `isolation: shared`?** → the run lands on `SharedStackRuntimeBackend`, which is safe and faster. `PerTrialRuntimeBackend` also provides stronger isolation than needed; the deprecated `orchestrator.runtime` override is the only way to force it.
+3. **Does the task not declare an `environment_manifest`?** → no `services:` map means nothing requires per-trial materialisation, so task-driven selection lands the run on `SharedStackRuntimeBackend`. `PerTrialRuntimeBackend.provision()` requires a manifest and fails loud without one, so a task that needs per-trial isolation must first author a manifest with per-service labels.
+4. **Genuinely stateless workload where cost dominates?** → label every service `isolation: shared`; the run lands on `SharedStackRuntimeBackend` (substrate materialised once per run), and the author owns the "no cross-trial contamination" invariant the label asserts.
+5. **Cross-trial isolation matters more than cost?** → label the relevant services `isolation: reset` or `ephemeral`; the run lands on `PerTrialRuntimeBackend`. Budget the ~10 s and ~9% cost premium per trial visible in the A/B numbers above.
 
 ## Observability parity
 
@@ -126,7 +126,7 @@ Logging, metrics, and artifact writes do **not** vary by mode:
 
 ### Follow-ups
 
-- **Task-pack migration to per-trial.** Migration of the existing task packs that declare `isolation: per_trial` semantics (or need it in principle) into `environment_manifest`-shaped tasks is separate task-pack work. This ADR does not gate that migration.
+- **Task-pack migration to per-trial.** Migration of the existing task packs that need per-trial isolation into `environment_manifest`-shaped tasks with `isolation: reset` / `ephemeral` service labels is separate task-pack work. This ADR does not gate that migration.
 - **Runner image publication.** `RUNTIME_BACKENDS.md` "Follow-up work" already tracks publishing engine images to a public registry so task compose files can reference published tags directly (`:local` stays as the local-dev alias). Independent of this ADR.
 - **Per-trial concurrency benchmarks.** The resource profile table gives order-of-magnitude framing; a proper benchmark harness would produce numbers on a range of task shapes and daemon configurations. Filed as a follow-up.
 - **Cost-premium characterisation.** The small-sample runs cited above don't distinguish LLM-routing noise from any putative substrate-driven $-cost premium. Open questions: does the trial clock consume LLM tokens during compose-up (e.g. via user-simulator warm-up or agent context establishment)? Does openrouter route consistently at temperature=0 across mode-differentiated runs? A ≥20-trial-per-arm run with token-level accounting would settle both. Filed as a follow-up.

--- a/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/architecture/adr/0018-multi-container-under-shared-runtime.md
@@ -6,7 +6,7 @@
   backend selection is task-driven; `orchestrator.runtime` is a
   deprecated override.
 - **Deciders:** @CiroGamboa
-- **Supersedes:** —
+- **Supersedes:** ADR-0009 (isolation surface only)
 - **Superseded by:** —
 
 ## TL;DR

--- a/docs/guides/isolated_trials.md
+++ b/docs/guides/isolated_trials.md
@@ -88,7 +88,9 @@ cannot tolerate shared state declares its requirement in
 environment_manifest:
   compose_file: "./environment.compose.yaml"
   runner_service: "runner"
-  isolation: "per_trial"
+  services:
+    db:
+      isolation: ephemeral
 ```
 
 This is a **hard requirement**: if the run's backend can't satisfy it,
@@ -97,13 +99,13 @@ the orchestrator refuses to start. You'll see a startup-time
 
 ```
 Runtime backend SharedStackRuntimeBackend shares state across every
-trial in the run, but 2 task(s) declare
-`environment_manifest.isolation: per_trial`: ['support_triage_01',
-'orders_customers_join_01']. These tasks would silently produce wrong
+trial in the run, but 2 task(s) require per-trial materialisation via
+their `services.<name>.isolation` labels: ['orders_customers_join_01',
+'support_triage_01']. These tasks would silently produce wrong
 verdicts on a shared-stack backend.
-  Fix: select a per-trial runtime backend in the run config (e.g.
-  PerTrialRuntimeBackend), or set `isolation: shared_ok` on the task(s)
-  that genuinely tolerate shared state across trials.
+  Fix: drop the deprecated `orchestrator.runtime` override so backend
+  selection is task-driven, or label every service `isolation: shared`
+  on the task(s) that genuinely tolerate shared state across trials.
 ```
 
 The refusal is deliberate — silent cross-trial contamination is a
@@ -196,5 +198,5 @@ for the full case analysis.
 - [ADR-0016](../architecture/adr/0016-runtime-backend-comparison.md)
   — shared vs per-trial tradeoff analysis.
 - [`docs/TASKS.md`](../TASKS.md#multi-container-environments-environment_manifest)
-  — reference schema for `environment_manifest.isolation` and the other
+  — reference schema for `services.<name>.isolation` and the other
   manifest fields.

--- a/docs/plans/2026-07-15-issue-370-adr-0016-vocabulary.md
+++ b/docs/plans/2026-07-15-issue-370-adr-0016-vocabulary.md
@@ -1,0 +1,165 @@
+# Plan: ADR-0016 isolation vocabulary → per-service model
+
+Issue: #370
+Branch: docs/issue-370-adr-0016-vocabulary
+
+## Context
+
+`docs/architecture/adr/0016-runtime-backend-comparison.md` still describes isolation
+using the pre-amendment whole-manifest `environment_manifest.isolation: per_trial | shared_ok`
+field. That field was superseded by the ADR-0018 amendment (2026-07-14): isolation is now
+declared **per compose service** as `services.<name>.isolation: shared | reset | ephemeral`,
+and backend selection is **task-driven** (any `reset`/`ephemeral` service routes the run to
+`PerTrialRuntimeBackend`; `orchestrator.runtime` survives only as a deprecated override).
+`RUNTIME_BACKENDS.md` § "Isolation enforcement" (updated in #360) already speaks the current
+vocabulary; ADR-0016 must match it.
+
+The issue frames this as a single guardrail-paragraph fix in ADR-0016 (~line 91). Discovery
+found the superseded field vocabulary lives in **three files**: ADR-0016 (multiple sites),
+the user-facing guide `docs/guides/isolated_trials.md` (including an active instruction telling
+operators to write a value that no longer exists), and ADR-0009 (the manifest ADR whose
+isolation field ADR-0018 superseded). Leaving any of those live violates AGENTS.md Rule 8.
+
+## Goal
+
+The engine's current-state docs read as if per-service isolation + task-driven backend
+selection is the only model that ever existed. Every occurrence of the whole-manifest
+`environment_manifest.isolation` field (and its `per_trial` / `shared_ok` values) in the two
+current-state docs (ADR-0016, `isolated_trials.md`) is replaced with per-service
+`services.<name>.isolation: shared | reset | ephemeral` vocabulary and the task-driven
+selection framing, mirroring `RUNTIME_BACKENDS.md` § "Isolation enforcement". ADR-0009 —
+a historical record — gets a scoped `Superseded by` header pointer to ADR-0018 for the
+isolation surface, its body left intact. The lifecycle-axis `shared` / `per_trial` naming
+(backend/mode names + the `--runtime` CLI flag / `orchestrator.runtime` deprecated override —
+all still current) is left untouched everywhere.
+
+## Non-goals
+
+- No change to ADR-0016's grading-equivalence section, the A/B table / numbers on
+  `coding_public_example_01`, the resource-profile table, observability parity, or
+  consequences — those are results/mechanics and stay verbatim.
+- No rewrite of ADR-0009's body. Per ADR-0018 (lines ~79–81) only ADR-0009's *isolation
+  surface* moved; the compose-as-source-of-truth contract and `EnvironmentManifest` outer
+  contract are still current. ADR-0009 is a historical record — it gets a header pointer, not
+  a body edit.
+- No edit to ADR-0018's amendment section — it is the current-state authority and legitimately
+  names the superseded field to record the amendment.
+- No rename of the ADR-0016 title or the lifecycle-axis `shared` / `per_trial` mode names, and
+  no change to `--runtime per_trial` / `runtime: per_trial` CLI-flag and config examples in
+  `isolated_trials.md` — those are Axis-1 / deprecated-override syntax that survive.
+- No code, test, or schema-source edits.
+
+## Stages
+
+### Stage 1: Rewrite isolation-field vocabulary to per-service across ADR-0016 + isolated_trials.md; header-pointer ADR-0009
+
+- **Contract:** Documentation-only. No code, config, CLI, or schema surface. Target vocabulary
+  everywhere is exactly what `RUNTIME_BACKENDS.md` §"Isolation enforcement" (lines ~271–296)
+  and the ADR-0018 amendment (lines ~22–46) use: `shared | reset | ephemeral`,
+  `services.<name>.isolation`, unlabelled-defaults-to-`ephemeral`, task-driven selection, any
+  `reset`/`ephemeral` service → `PerTrialRuntimeBackend`, all-`shared` (or no `services:` map)
+  → `SharedStackRuntimeBackend`, `orchestrator.runtime` deprecated override, guard
+  `_verify_isolation_compatibility` firing only on the override path.
+
+  **File 1 — `docs/architecture/adr/0016-runtime-backend-comparison.md` (7 sites):**
+  1. **~line 91 — "Failure-mode differences", `shared`-only bullet.** Old guardrail:
+     `environment_manifest.isolation` declaration; shared backend refuses `isolation: per_trial`.
+     New: the shared backend runs a task only when every service is `isolation: shared` (the
+     task author's acknowledgment of the shared-state responsibility); a task declaring any
+     `reset`/`ephemeral` service is auto-routed to `PerTrialRuntimeBackend` by task-driven
+     selection; the deprecated `orchestrator.runtime` override is the only way to force a shared
+     backend against a per-trial-requiring task set, and `_verify_isolation_compatibility`
+     refuses that at startup.
+  2. **~line 100 — decision-rubric step 1.** `environment_manifest.isolation: per_trial` →
+     "declares any service `isolation: reset` or `ephemeral`" → `PerTrialRuntimeBackend`
+     (selected automatically).
+  3. **~line 101 — decision-rubric step 2.** `environment_manifest.isolation: shared_ok` →
+     "declares every service `isolation: shared`" → `SharedStackRuntimeBackend`.
+  4. **~line 102 — decision-rubric step 3.** "task does not declare an `environment_manifest`"
+     stays factually correct (no manifest → built-in stack → shared); reword only as needed so
+     the rubric reads as one task-driven flow.
+  5. **~line 103 — decision-rubric step 4 (🟡).** Reframe "Genuinely stateless workload …
+     → `shared`" as the *outcome of the declaration*: every service labelled `isolation: shared`
+     → run lands on `SharedStackRuntimeBackend` (once per run); author owns the
+     no-cross-trial-contamination invariant.
+  6. **~line 104 — decision-rubric step 5 (🟡).** Reframe "Cross-trial isolation matters more
+     than cost … → `per_trial`" as: any service labelled `reset`/`ephemeral` → run lands on
+     `PerTrialRuntimeBackend`; budget the ~10 s / ~9% premium from the A/B numbers above. After
+     steps 4–5 are reframed the whole rubric is task-driven and internally consistent — no
+     mixed operator-picks-a-mode vs task-driven framing.
+  7. **~line 129 — "Follow-ups", "Task-pack migration to per-trial" bullet.** `task packs that
+     declare `isolation: per_trial` semantics` → per-service `isolation: reset` / `ephemeral`
+     phrasing.
+
+  **File 2 — `docs/guides/isolated_trials.md` (4 sites):**
+  8. **~line 91 — manifest example `isolation: "per_trial"`.** Rewrite to a per-service
+     example: `services.<name>.isolation: reset` (or `ephemeral`) under the manifest's
+     `services:` map.
+  9. **~line 101 — quoted `environment_manifest.isolation: per_trial` RuntimeError.** Replace
+     with the error string the current override guard emits. The implementer reads the actual
+     message from `_verify_isolation_compatibility` in `tolokaforge/core/orchestrator.py` and
+     quotes it verbatim — do **not** invent a plausible-looking error.
+  10. **~line 105 — active operator instruction "set `isolation: shared_ok` on the task(s)".**
+     This is the worst site (tells operators to write a value that no longer exists). Rewrite to
+     the current remedy: label the relevant services `isolation: shared` (or drop the deprecated
+     `orchestrator.runtime` override), consistent with whatever the current error message advises.
+  11. **~line 199 — reference-schema mention `environment_manifest.isolation`.** Update to
+     `services.<name>.isolation` per-service form.
+  Lifecycle/CLI sites in this guide (`--runtime per_trial`, `runtime: per_trial`, and prose
+  using `per_trial` as the isolation *mode* name — lines ~24, ~70, ~80, ~131, ~178, ~180) stay:
+  those are valid mode/CLI vocabulary. If the surrounding guide prose reads incoherently after
+  the four field-vocab swaps, note it for the reviewer rather than widening silently.
+
+  **File 3 — `docs/architecture/adr/0009-environment-manifest.md` (header only):**
+  12. Change the `- **Superseded by:** —` header line to a scoped pointer:
+     `- **Superseded by:** ADR-0018 (isolation surface only — 2026-07-14 amendment)`.
+     The body (`TaskIsolation`, `shared_ok`/`per_trial` field values, lines ~95–113) is a
+     historical record and stays byte-identical.
+
+- **Behaviour to lock:** No runtime behaviour — docs only. Verification is a **file-scoped**
+  grep guard, not a test tier:
+  - `rg 'shared_ok' docs/architecture/adr/0016-runtime-backend-comparison.md docs/guides/isolated_trials.md` → no matches.
+  - `rg 'environment_manifest\.isolation\b' docs/architecture/adr/0016-runtime-backend-comparison.md docs/guides/isolated_trials.md` → no matches.
+  - `rg 'services\.<name>\.isolation|isolation: (shared|reset|ephemeral)'` over the same two files → matches present at the rewritten sites.
+  - ADR-0009 is **excluded** from the `shared_ok` guard (its body legitimately retains the
+    superseded vocabulary as history); the only ADR-0009 change is the header line.
+- **Compatibility:** Internal only. ADRs and guides are not compatibility surfaces — no
+  CHANGELOG entry, no migration note (the migration is ADR-0018's amendment, already
+  documented). All prose is current-state per AGENTS.md Rule 8: no "previously X, now Y".
+- **Deliverable:** ADR-0016 (7 sites rewritten, rest byte-identical), `isolated_trials.md`
+  (4 sites rewritten, lifecycle/CLI examples intact), ADR-0009 (one header line changed, body
+  intact).
+- **Validation:**
+  - The three `rg` guards above.
+  - Reviewer diff-check: only the named sites changed; ADR-0016's grading-equivalence, A/B
+    numbers, resource-profile, observability, and consequences sections untouched; ADR-0016
+    title and lifecycle mode names untouched; ADR-0009 body untouched; ADR-0018 untouched.
+  - Reviewer confirms the `isolated_trials.md` line-101 error string matches the string
+    `_verify_isolation_compatibility` actually emits today.
+- **Doc updates:** These three docs *are* the deliverable. Confirm no other current-state doc
+  carries the superseded field: `rg 'shared_ok|environment_manifest\.isolation\b' docs/` after
+  the edit returns matches only inside ADR-0009's body and ADR-0018's amendment section (both
+  legitimate historical/authoritative mentions) — nowhere else.
+
+## Discovered issues
+
+- **Fix in this PR:** The issue scoped one ADR-0016 paragraph (~line 91); the superseded field
+  vocabulary is actually across three files — ADR-0016 (7 sites incl. the whole decision
+  rubric), `docs/guides/isolated_trials.md` (4 sites, incl. a live "set `isolation: shared_ok`"
+  operator instruction), and ADR-0009 (header pointer). All folded into Stage 1: fixing only
+  line 91 would leave `shared_ok` live elsewhere — the exact Rule-8 violation #370 targets.
+- **Filed as issues:** None.
+
+## Risks / open questions
+
+- **`isolated_trials.md` line-101 error string.** The guide quotes a RuntimeError. The current
+  override guard (`_verify_isolation_compatibility`) emits a different message than the
+  pre-amendment enforcement did; the implementer must quote the *current* string verbatim from
+  `tolokaforge/core/orchestrator.py`, not paraphrase. Flagged so the reviewer checks it.
+- **Guide coherence beyond the 4 sites.** `isolated_trials.md` is framed around per-trial
+  isolation as an operator choice. The four field-vocab swaps keep it Rule-8-clean, but if the
+  reviewer finds the surrounding prose now reads as mixed operator-choice vs task-driven, a
+  broader guide refresh is a candidate follow-up — out of scope for this vocab fix unless the
+  approval gate widens it.
+- No behaviour to reproduce: pure docs vocab change, so no dev-MCP repro or test was run in
+  discovery (nothing observable to run).


### PR DESCRIPTION
Closes #370.

## Summary

- Rewrite \`docs/architecture/adr/0016-runtime-backend-comparison.md\` around per-service \`services.<name>.isolation: shared | reset | ephemeral\` + task-driven backend selection, matching the ADR-0018 amendment and \`RUNTIME_BACKENDS.md\` § "Isolation enforcement". 7 sites: failure-mode guardrail + decision-rubric steps 1-5 + task-pack-migration follow-up.
- Update \`docs/guides/isolated_trials.md\` — 4 sites — manifest example uses the per-service \`services:\` map; the quoted RuntimeError is now byte-for-byte the current string from \`_verify_isolation_compatibility\` (\`orchestrator.py:897-908\`); reference-schema mention swapped. Lifecycle/CLI \`--runtime per_trial\` and mode-name prose are untouched (they name backends/modes, not the manifest field).
- Add a \`Superseded by: ADR-0018 (isolation surface only — 2026-07-14 amendment)\` pointer to \`docs/architecture/adr/0009-environment-manifest.md\` header (body byte-identical); add the reciprocal \`Supersedes: ADR-0009 (isolation surface only)\` to ADR-0018's header (review nit fold-in).

## Plan

See \`docs/plans/2026-07-15-issue-370-adr-0016-vocabulary.md\`. Plan-critic APPROVE WITH NOTES on round 2 after the round-1 REVISE (widened scope to catch \`isolated_trials.md\` + fixed rubric steps 4-5 for internal coherence).

## Discovered issues

- Filed: **#380** — \`isolated_trials.md\` §"How to opt in" framing is orphaned by task-driven selection. Reviewer confirmed the diff made the contradiction more visible (new error text says "drop the deprecated \`orchestrator.runtime\` override" but the prose above still calls those overrides the primary opt-in surfaces). Assigned to milestone #16.
- Fixed in this PR: rubric steps 4-5 vocabulary coherence + ADR-0018 supersession reciprocity nit.

## Test plan

- [x] \`rg 'shared_ok' docs/architecture/adr/0016-*.md docs/guides/isolated_trials.md\` — zero hits.
- [x] \`rg 'environment_manifest\.isolation\b' docs/architecture/adr/0016-*.md docs/guides/isolated_trials.md\` — zero hits.
- [x] Quoted RuntimeError in \`isolated_trials.md\` matches \`orchestrator.py:897-908\` verbatim (including sorted() task-id ordering).
- [x] ADR-0009 body byte-identical (1+/1- diff = header only).
- [x] Reviewer APPROVE WITH NITS (both nits folded in).

Milestone: Project layer runnability (#16). Sub-issue 4 of umbrella #375.