### PR TITLE
docs: add multi-container breadcrumbs to top-level docs (#371)

### DIFF
--- a/docs/BENCHMARK_BACKEND_DESIGNS.md
+++ b/docs/BENCHMARK_BACKEND_DESIGNS.md
@@ -2,6 +2,11 @@
 
 This document captures backend/runtime design sketches per benchmark type.
 
+When a benchmark needs services beyond the engine's built-ins (a real
+database, a custom API, a bespoke topology) — the Case B/C path — a task
+can declare its own docker-compose stack via an `environment_manifest`.
+See the [multi-container tasks guide](guides/multi_container_tasks.md).
+
 ## Coding
 
 1. Runtime: sandboxed filesystem + shell tools.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,6 +55,10 @@ The engine auto-starts required services on `tolokaforge run`; you do
 not need to launch them manually. This step just pre-builds the images
 so the first run isn't slowed down by a cold docker build.
 
+For tasks that need extra services beyond the built-ins (a real
+database, a custom HTTP API), a task can ship its own docker-compose
+stack — see the [multi-container tasks guide](guides/multi_container_tasks.md).
+
 ## Set Up Tasks
 
 Task packs live outside the engine tree. Place your tasks in `tasks/` or use the `task_packs` configuration to point at any directory (see [Task Packs](TASK_PACKS.md)). See `examples/` for the expected layout.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -445,3 +445,4 @@ tools:
 - [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) - Adapter architecture for task loading
 - [CUSTOM_CHECKS.md](CUSTOM_CHECKS.md) - Custom Python validation
 - [SECURITY.md](SECURITY.md) - Security model
+- [Multi-container tasks guide](guides/multi_container_tasks.md) - Declaring an `environment_manifest` so a task ships its own docker-compose stack

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -58,6 +58,12 @@ uv run tolokaforge docker down --volumes      # Stop and cleanup
 uv run tolokaforge docker status
 ```
 
+When a task declares its own `environment_manifest`, the runner runs
+alongside those task-declared services for the duration of each trial,
+provisioning them per the manifest's isolation rules. See
+[architecture/RUNTIME_BACKENDS.md](architecture/RUNTIME_BACKENDS.md) for
+the backend lifecycle.
+
 ## Local Queue Run (SQLite)
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,6 +29,12 @@ This architecture provides:
 
 See `tolokaforge/docker/stacks/` for the predefined service stack definitions.
 
+When a task declares its own `environment_manifest`, its services inherit
+the same isolation posture: `network_policy` defaults to `no_internet`
+(task services get no public egress while the runner keeps its LLM-API
+access), and each service is torn down and re-provisioned per trial unless
+marked `shared`. See [architecture/PROJECTS.md](architecture/PROJECTS.md).
+
 ## Tool-Level Security
 
 ### Tool Allowlisting

--- a/docs/TASK_PACKS.md
+++ b/docs/TASK_PACKS.md
@@ -71,6 +71,11 @@ Minimum task directory contract:
    - `rag/`
    - task-local fixtures/files referenced by tools
 
+A task can also declare an `environment_manifest` to ship its own
+docker-compose stack (a real database, a custom API), with per-service
+isolation (`services.<name>.isolation: shared | reset | ephemeral`). See
+the [multi-container tasks guide](guides/multi_container_tasks.md).
+
 Recommended scorer patterns:
 
 1. Deterministic checks (`state_checks`, tool expectations) for objective outcomes.


### PR DESCRIPTION
Closes #371.

## Summary

- Add one-paragraph or one-line multi-container breadcrumbs to six top-level docs (\`GETTING_STARTED\`, \`RUNNER\`, \`TASK_PACKS\`, \`REFERENCE\`, \`SECURITY\`, \`BENCHMARK_BACKEND_DESIGNS\`) so a reader landing on any of them finds the path to the multi-container documentation.
- Cross-links target \`docs/guides/multi_container_tasks.md\`, \`docs/architecture/RUNTIME_BACKENDS.md\`, and \`docs/architecture/PROJECTS.md\` as appropriate to each file's angle. Vocabulary matches the primary docs.
- Primary docs unchanged.

Milestone: Project layer runnability (#16). Sub-issue 6 of umbrella #375.