### PR TITLE
fix(grading): merge project grading_defaults.combine into task grading (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 
+- **grading**: a project's `task_defaults.grading_defaults.combine` now deep-merges under each task's own `grading.yaml.combine` (task fields win, `weights` merge key-by-key); a task that omits `combine` inherits the project block instead of an arbitrary `{state_checks: 1.0}` / `pass_threshold: 1.0` fallback, and `get_grading_config` no longer raises on tasks that ship no `combine` block (#376)
 - **runtime**: `SharedStackRuntimeBackend` no longer advertises `reset_recipes:*` capabilities — a shared stack cannot honour them (reset tasks route to `PerTrialRuntimeBackend`, which still advertises them). A shared-selected run that requested a `reset_recipes:*` capability was admitting a capability it could not deliver; it is now refused at run start with the standard admission error (#310)
 
 ## v0.8.4 (2026-07-15)

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -293,6 +293,34 @@ combine:
   pass_threshold: 0.75
 ```
 
+### Inheriting `combine` from the project
+
+`combine` is optional per task. A task's effective `combine` is the project's
+`task_defaults.grading_defaults.combine` with the task's own `grading.yaml.combine`
+layered on top: task fields win, `weights` merge key-by-key (a task key overrides
+the project's; project-only keys survive), and any field neither layer sets falls
+through to the canonical defaults (`method: weighted`, `weights: {}`,
+`pass_threshold: 0.8`).
+
+A task that ships no `combine` block inherits the project block whole; a task that
+ships a partial block inherits every field it does not set. When the project
+declares no `grading_defaults`, a task without `combine` resolves to the canonical
+defaults.
+
+```yaml
+# project.yaml
+task_defaults:
+  grading_defaults:
+    combine:
+      weights: { llm_judge: 1.0 }
+      pass_threshold: 0.8
+
+# tasks/long_debugging_session/grading.yaml — overrides only pass_threshold
+combine:
+  pass_threshold: 0.7
+# effective: weights { llm_judge: 1.0 } (inherited), pass_threshold 0.7, method weighted
+```
+
 ---
 
 ## Grading for RL Training

--- a/docs/plans/2026-07-15-issue-376-grading-defaults-merge.md
+++ b/docs/plans/2026-07-15-issue-376-grading-defaults-merge.md
@@ -1,0 +1,197 @@
+# Plan: Wire project grading_defaults.combine into a task's resolved grading
+
+Issue: #376
+Branch: fix/grading-defaults-merge (landing on `feat/project-layer-runnability`)
+
+## Context
+
+`ProjectConfig.task_defaults.grading_defaults.combine` is dead config: no
+code path merges it into a task's effective grading. `PROJECTS.md`
+§ "Grading model" says a project's `grading_defaults.combine` deep-merges
+under each task's own `grading.yaml.combine`, and the `GradingDefaults`
+docstring already claims "A task's own `grading.yaml.combine` deep-merges
+on top" — but that merge was never implemented.
+
+Reproduced empirically against the shipped `example-microservices-pack`
+(five judge-only tasks; project declares `combine.weights: {llm_judge: 1.0}`,
+`pass_threshold: 0.8`). Building each task's `TaskDescription` today:
+
+- `api_endpoint_add` (ships no `combine` block) → `weights={'state_checks': 1.0}`,
+  `pass_threshold=1.0` — the arbitrary hardcoded fallback in
+  `NativeAdapter.to_task_description` (`native.py:659-660`). `state_checks`
+  is not even a component these tasks produce, so the trial grades on a
+  non-existent component.
+- `long_debugging_session` (ships `combine: {pass_threshold: 0.7}` only) →
+  `weights={'state_checks': 1.0}`, `pass_threshold=0.7`. The task's own
+  `pass_threshold` survives, but the project's `weights` never fills in.
+
+Second, latent, defect found while tracing: `NativeAdapter.get_grading_config`
+(`native.py:313`, called live by `conductor.py`) does
+`GradingConfig(**grading_data)` where core `GradingConfig.combine` is a
+**required** field. A judge-only task shipping no `combine` block raises a
+`ValidationError` there today. The four no-`combine` microservices tasks hit
+this. The same resolver that fixes the merge also fixes this crash.
+
+## Goal
+
+A task's effective grading `combine` is resolved as a deep-merge of three
+layers, later wins per field:
+
+1. Canonical `GradingCombineConfig` defaults (`method="weighted"`,
+   `weights={}`, `pass_threshold=0.8`).
+2. `project.task_defaults.grading_defaults.combine` (project base).
+3. The task's own `grading.yaml.combine` (task delta).
+
+`weights` is a map, so it merges key-by-key per the documented config
+algebra (`project_loader.deep_merge`); scalar fields (`method`,
+`pass_threshold`) take the highest layer that sets them. A task that ships
+no `combine` block inherits the project's whole block; a task that ships a
+partial block (e.g. `pass_threshold` only) inherits every field it does not
+set. Both `to_task_description` (runner-side `GradingConfig`) and
+`get_grading_config` (core-side `GradingConfig`) apply the same resolution.
+
+## Non-goals
+
+- Not touching the combine *execution* logic (`runner/grading.py`,
+  `core/grading/combine.py`) — only how the combine *config* is resolved.
+- Not fixing #218 (silently-unimplemented `combine_method` values) — the
+  resolver preserves whatever `method` the layers specify; unknown-method
+  fail-loud is #218's scope.
+- Not consolidating the three divergent default sources for `combine` (see
+  Discovered issues) beyond routing the adapter through the canonical one.
+- Not changing the `grading.yaml` file format, the `GradingDefaults` schema,
+  or the orchestrator → adapter plumbing (`project_task_defaults` already
+  carries `grading_defaults` to the adapter).
+
+## Stages
+
+### Stage 1: Pure combine resolver + unit tests
+
+- **Contract:** new function in `tolokaforge/core/project_loader.py`
+  (the module that owns `deep_merge` and the sibling `resolve_effective_*`
+  resolvers; already imports `tolokaforge.core.models`):
+
+  ```python
+  def resolve_effective_grading_combine(
+      project_combine: dict[str, Any] | None,
+      task_combine: dict[str, Any] | None,
+  ) -> GradingCombineConfig:
+      merged = deep_merge(project_combine or {}, task_combine or {})
+      return GradingCombineConfig(**merged)
+  ```
+
+  Semantics: `task_combine` wins over `project_combine` per field;
+  `weights` merges key-by-key (task key wins, project-only keys survive);
+  absent fields fall through to `GradingCombineConfig`'s own defaults.
+  Inputs are raw dicts (the shape both call sites already hold — the
+  project defaults arrive as a `model_dump` dict, the task combine as
+  parsed YAML), so the resolver needs no model on either input side.
+- **Behaviour to lock (unit, `tests/unit/test_project_loader.py`):**
+  - both `None` → `GradingCombineConfig()` (method `weighted`, weights `{}`,
+    pass_threshold `0.8`).
+  - project-only `{weights: {llm_judge: 1.0}}`, task `None` → weights
+    `{llm_judge: 1.0}`, pass_threshold `0.8` (canonical default fills in).
+  - task-only (no project) → task values verbatim; project layer is a no-op
+    (locks zero blast radius for packs without `grading_defaults`).
+  - partial task delta `{pass_threshold: 0.7}` over project
+    `{weights: {llm_judge: 1.0}}` → `{method: weighted, weights: {llm_judge: 1.0},
+    pass_threshold: 0.7}` (the `long_debugging_session` shape).
+  - scalar conflict: task `pass_threshold` wins over project `pass_threshold`.
+  - `weights` key-by-key: project `{a: 1.0}` + task `{b: 1.0}` →
+    `{a: 1.0, b: 1.0}`; project `{a: 1.0}` + task `{a: 0.5}` → `{a: 0.5}`.
+- **Compatibility:** internal only — new pure function, no caller yet.
+- **Deliverable:** `resolve_effective_grading_combine` importable from
+  `tolokaforge.core.project_loader`, unit tests green.
+- **Validation:** `dev run_tests -m unit -k grading_combine`.
+- **Doc updates:** none this stage (behaviour is not yet wired).
+
+### Stage 2: Wire the resolver into NativeAdapter + lock pack inheritance
+
+- **Contract:** `NativeAdapter` applies `resolve_effective_grading_combine`
+  at both grading-construction sites, sourcing the project layer from the
+  `grading_defaults.combine` sub-dict of `self._project_task_defaults`
+  (already passed in by `Orchestrator._create_adapter`; `None`/absent when
+  there is no project). No new constructor param, no signature change on
+  `to_task_description` / `get_grading_config`.
+  - `to_task_description`: replace the hardcoded fallback block
+    (`native.py:656-664`) — resolve the effective combine, then build the
+    runner `GradingConfig` from it (`combine_method=effective.method`,
+    `weights=effective.weights`, `pass_threshold=effective.pass_threshold`).
+    The `{"state_checks": 1.0}` / `1.0` literals are deleted.
+  - `get_grading_config`: construct the core `GradingConfig` with
+    `combine=` the resolved `GradingCombineConfig` (the rest of
+    `grading_data` unchanged). Fixes the required-field crash for
+    no-`combine` tasks and applies the same inheritance.
+- **Behaviour to lock (integration,
+  `tests/integration/test_example_microservices_pack.py` — reuses the
+  existing `_make_pack_adapter()` real-loader wiring, no Docker/LLM):**
+  - `api_endpoint_add.grading` → `combine_method="weighted"`,
+    `weights == {"llm_judge": 1.0}`, `pass_threshold == 0.8` (whole block
+    inherited).
+  - `long_debugging_session.grading` → `weights == {"llm_judge": 1.0}`
+    (inherited), `pass_threshold == 0.7` (task override), method `weighted`.
+  - `adapter.get_grading_config("api_endpoint_add")` returns without raising
+    and its `combine.weights == {"llm_judge": 1.0}` (regression lock on the
+    latent crash).
+- **Compatibility:** `grading.yaml` is a compatibility surface (AGENTS.md
+  Core Rule 5). This is additive for every task that ships a full `combine`
+  block (16 of 16 non-microservices example tasks specify both `weights`
+  and `pass_threshold`; their resolved combine is byte-identical). Behaviour
+  changes only for tasks that ship no/partial `combine`: they now inherit
+  the project block instead of the arbitrary `{state_checks:1.0}`/`1.0`
+  fallback — fixing a documented-but-unshipped contract. A task shipping no
+  `combine` under a project with no `grading_defaults` now resolves to the
+  canonical `weights={}` / `pass_threshold=0.8` instead of
+  `{state_checks:1.0}` / `1.0`; no shipped pack has this shape (verified via
+  `rg` over `examples/`). CHANGELOG "Fix" entry required.
+- **Deliverable:** the merge is live; both microservices assertions and the
+  crash-regression assertion pass; existing pack tests still pass.
+- **Validation:** `dev run_tests -m integration -k microservices_pack`;
+  `dev run_tests -m unit` (adapter/loader regressions);
+  `dev run_tests -m canonical -k native_adapter` (no snapshot drift).
+- **Doc updates:**
+  - `CHANGELOG.md` → "Unreleased" / "Fix": one line naming #376 —
+    project `grading_defaults.combine` now deep-merges under each task's
+    `grading.yaml.combine`.
+  - `docs/GRADING.md` → in the combine section, add that `combine` is
+    optional per task and inherits from `project.task_defaults.grading_defaults.combine`
+    when omitted or partial (task fields win). Rewrite so the inheritance
+    reads as the only behaviour — no "now merges" phrasing.
+
+## Discovered issues
+
+- **Fix in this PR:** `NativeAdapter.get_grading_config` raised
+  `ValidationError` on any task shipping no `combine` block (core
+  `GradingConfig.combine` is required), on the live `conductor.py` path.
+  Stage 2's resolver injection fixes it; the crash-regression assertion
+  locks it.
+- **Recommend filing (GitHub MCP not connected this session — main to
+  file against Toloka/tolokaforge):** `combine` has three divergent default
+  sources — core `GradingCombineConfig` (`weights={}`, `pass_threshold=0.8`),
+  runner `GradingConfig` (`weights={"state_checks":1.0}`, `pass_threshold=0.8`),
+  and (pre-fix) the `native.py` hardcode (`{"state_checks":1.0}`, `1.0`).
+  This PR routes the adapter through the canonical core model, but the runner
+  model's `default_factory=lambda: {"state_checks": 1.0}` still diverges for
+  any other construction path. Track a follow-up to unify on the canonical
+  default.
+
+## Risks / open questions
+
+- **`weights` merge semantics = key-by-key union, not wholesale replace.**
+  This follows `PROJECTS.md` § "Deep-merge, precisely" (maps merge key-by-key;
+  only lists replace) and the existing `deep_merge`. Consequence: a task
+  cannot *remove* a weight key the project set — it can only override or add.
+  Consistent with the rest of the config system, which also cannot express
+  map-key removal. Flagging for confirmation; wholesale-replace is the only
+  alternative and would diverge from the documented algebra.
+- **Empty `weights` with `method="weighted"`** yields `total_weight == 0`;
+  both combine implementations guard `if total_weight > 0`, so the score is
+  `0.0` (task fails) — no division-by-zero, no crash. Only reachable by a
+  no-`combine` task under a project with no `grading_defaults`, which no
+  shipped pack has.
+- **`exclude_defaults=True`** in `Orchestrator._create_adapter` strips a
+  project author's explicitly-written combine fields that equal a model
+  default (the microservices `pass_threshold: 0.8` is stripped before it
+  reaches the adapter). Benign here: the canonical `GradingCombineConfig`
+  default re-supplies the identical value, so the resolved result is correct.
+  Called out so a reviewer does not read it as a lost override.

--- a/tests/integration/test_example_microservices_pack.py
+++ b/tests/integration/test_example_microservices_pack.py
@@ -188,6 +188,46 @@ def test_task_builds_description_with_judge_rubric_and_llm_user(task_id: str) ->
     assert task_desc.user_simulator.mode == "llm"
 
 
+# ``pass_threshold`` inherited from the project default (0.8) unless the task
+# overrides it; ``long_debugging_session`` ships ``combine.pass_threshold: 0.7``.
+_EXPECTED_PASS_THRESHOLD = {
+    "api_endpoint_add": 0.8,
+    "db_query_tuning": 0.8,
+    "long_debugging_session": 0.7,
+    "postgres_upgrade_test": 0.8,
+    "schema_isolation_migration": 0.8,
+}
+
+
+@pytest.mark.parametrize("task_id", sorted(_EXPECTED_TASK_IDS))
+def test_task_combine_inherits_project_grading_defaults(task_id: str) -> None:
+    """Each task's resolved ``combine`` inherits the project's
+    ``grading_defaults.combine`` (``method="weighted"``,
+    ``weights={"llm_judge": 1.0}``) key-by-key; a task that ships its own
+    ``combine`` (``long_debugging_session``: ``pass_threshold: 0.7``)
+    overrides that field while still inheriting the project's ``weights``."""
+    adapter = _make_pack_adapter()
+
+    grading = adapter.to_task_description(task_id).grading
+
+    assert grading.combine_method == "weighted"
+    assert grading.weights == {"llm_judge": 1.0}
+    assert grading.pass_threshold == _EXPECTED_PASS_THRESHOLD[task_id]
+
+
+def test_get_grading_config_no_longer_crashes_on_no_combine_task() -> None:
+    """``get_grading_config`` on a task that ships no ``combine`` block
+    (``api_endpoint_add``) resolves the project default instead of raising
+    on core ``GradingConfig``'s required ``combine`` field."""
+    adapter = _make_pack_adapter()
+
+    grading = adapter.get_grading_config("api_endpoint_add")
+
+    assert grading.combine.method == "weighted"
+    assert grading.combine.weights == {"llm_judge": 1.0}
+    assert grading.combine.pass_threshold == 0.8
+
+
 @pytest.mark.parametrize("task_id", sorted(_EXPECTED_TASK_IDS))
 def test_task_manifest_resolves_expected_stack(task_id: str) -> None:
     """``schema_isolation_migration`` resolves its task-local

--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tolokaforge.core.models import ProjectConfig, RunDefaults, TaskDefaults
+from tolokaforge.core.models import (
+    GradingCombineConfig,
+    ProjectConfig,
+    RunDefaults,
+    TaskDefaults,
+)
 from tolokaforge.core.project_loader import (
     CANONICAL_RUN_CONFIGS_DIR,
     LEGACY_RUN_CONFIG_DIR,
@@ -17,6 +22,7 @@ from tolokaforge.core.project_loader import (
     detect_project_layout,
     find_project_yaml,
     load_project_config,
+    resolve_effective_grading_combine,
     resolve_effective_run_config_data,
     synthesize_default_project,
     warn_legacy_run_config_dir,
@@ -296,3 +302,56 @@ class TestResolveEffectiveRunConfig:
         # And the merged dict reconstructs into a RunConfig without
         # union_tag_not_found on the discriminated storage backends.
         RunConfig(**merged)
+
+
+# ── resolve_effective_grading_combine ──────────────────────────────────
+
+
+class TestResolveEffectiveGradingCombine:
+    def test_both_none_yields_canonical_defaults(self) -> None:
+        combine = resolve_effective_grading_combine(None, None)
+        assert combine == GradingCombineConfig()
+        assert combine.method == "weighted"
+        assert combine.weights == {}
+        assert combine.pass_threshold == 0.8
+
+    def test_project_only_fills_canonical_defaults(self) -> None:
+        combine = resolve_effective_grading_combine({"weights": {"llm_judge": 1.0}}, None)
+        assert combine.weights == {"llm_judge": 1.0}
+        assert combine.pass_threshold == 0.8
+        assert combine.method == "weighted"
+
+    def test_task_only_wins_project_is_noop(self) -> None:
+        combine = resolve_effective_grading_combine(
+            None, {"weights": {"state_checks": 0.5}, "pass_threshold": 0.6}
+        )
+        assert combine.weights == {"state_checks": 0.5}
+        assert combine.pass_threshold == 0.6
+
+    def test_partial_task_delta_inherits_project_weights(self) -> None:
+        # The ``long_debugging_session`` shape: task ships only
+        # ``pass_threshold`` and inherits the project's whole ``weights``.
+        combine = resolve_effective_grading_combine(
+            {"weights": {"llm_judge": 1.0}}, {"pass_threshold": 0.7}
+        )
+        assert combine.method == "weighted"
+        assert combine.weights == {"llm_judge": 1.0}
+        assert combine.pass_threshold == 0.7
+
+    def test_task_scalar_shadows_project_scalar(self) -> None:
+        combine = resolve_effective_grading_combine(
+            {"pass_threshold": 0.8}, {"pass_threshold": 0.7}
+        )
+        assert combine.pass_threshold == 0.7
+
+    def test_weights_merge_key_by_key(self) -> None:
+        combine = resolve_effective_grading_combine(
+            {"weights": {"llm_judge": 1.0}}, {"weights": {"state_checks": 0.5}}
+        )
+        assert combine.weights == {"llm_judge": 1.0, "state_checks": 0.5}
+
+    def test_weights_task_overrides_shared_key(self) -> None:
+        combine = resolve_effective_grading_combine(
+            {"weights": {"llm_judge": 1.0}}, {"weights": {"llm_judge": 0.5}}
+        )
+        assert combine.weights == {"llm_judge": 0.5}

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -13,6 +13,7 @@ from tolokaforge.adapters.base import AdapterEnvironment, BaseAdapter
 from tolokaforge.core.logging import get_logger
 from tolokaforge.core.models import EnvironmentPatch, GradingConfig, TaskConfig
 from tolokaforge.core.project_loader import resolve as resolve_environment
+from tolokaforge.core.project_loader import resolve_effective_grading_combine
 
 if TYPE_CHECKING:
     from tolokaforge.runner.models import TaskDescription
@@ -325,9 +326,19 @@ class NativeAdapter(BaseAdapter):
         if grading_path.exists():
             with open(grading_path) as f:
                 grading_data = yaml.safe_load(f)
-            return GradingConfig(**grading_data)
+            task_combine = grading_data.pop("combine", None)
+            combine = resolve_effective_grading_combine(
+                self._project_combine_defaults(), task_combine
+            )
+            return GradingConfig(**grading_data, combine=combine)
 
         raise ValueError(f"Grading config not found: {grading_path}")
+
+    def _project_combine_defaults(self) -> dict[str, Any] | None:
+        """The project's ``task_defaults.grading_defaults.combine`` sub-dict,
+        the base layer under each task's own ``grading.yaml.combine``.
+        ``None`` when the enclosing project sets no grading defaults."""
+        return self._project_task_defaults.get("grading_defaults", {}).get("combine")
 
     def reset_environment(self, env: AdapterEnvironment) -> None:
         """Reset environment to initial state by reloading data"""
@@ -653,11 +664,14 @@ class NativeAdapter(BaseAdapter):
             llm_judge_config = RunnerLLMJudgeConfig(**llm_judge_data)
 
         # Build combined grading config
-        combine_data = grading_data.get("combine", {}) if grading_data else {}
+        combine_data = grading_data.get("combine") if grading_data else None
+        effective_combine = resolve_effective_grading_combine(
+            self._project_combine_defaults(), combine_data
+        )
         grading_config = RunnerGradingConfig(
-            combine_method=combine_data.get("method", "weighted"),
-            weights=combine_data.get("weights", {"state_checks": 1.0}),
-            pass_threshold=combine_data.get("pass_threshold", 1.0),
+            combine_method=effective_combine.method,
+            weights=effective_combine.weights,
+            pass_threshold=effective_combine.pass_threshold,
             state_checks=state_checks,
             transcript_rules=transcript_rules,
             llm_judge=llm_judge_config,

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -42,6 +42,7 @@ import yaml
 from tolokaforge.core.models import (
     EnvironmentManifest,
     EnvironmentPatch,
+    GradingCombineConfig,
     ProjectConfig,
     ServiceSpec,
     TaskDefaults,
@@ -338,6 +339,27 @@ def resolve_effective_run_config_data(
     # on conflict via ``deep_merge`` below.
     base = project.run_defaults.model_dump(exclude_unset=True)
     return deep_merge(base, run_config_data)
+
+
+def resolve_effective_grading_combine(
+    project_combine: dict[str, Any] | None,
+    task_combine: dict[str, Any] | None,
+) -> GradingCombineConfig:
+    """Resolve a task's effective ``combine`` from the project defaults
+    layered under the task's own ``grading.yaml.combine``.
+
+    ``task_combine`` wins over ``project_combine`` field-by-field;
+    ``weights`` merges key-by-key (task key wins, project-only keys
+    survive) per the documented config algebra. Any field neither layer
+    sets falls through to :class:`GradingCombineConfig`'s own defaults
+    (``method="weighted"``, ``weights={}``, ``pass_threshold=0.8``).
+
+    Both inputs are raw dicts — the project defaults arrive as a
+    ``model_dump`` view and the task combine as parsed ``grading.yaml`` —
+    so neither side needs a model instance.
+    """
+    merged = deep_merge(project_combine or {}, task_combine or {})
+    return GradingCombineConfig(**merged)
 
 
 # ── High-level loader entry point ──────────────────────────────────────


### PR DESCRIPTION
Closes #376.

## Summary

- Wire \`project.task_defaults.grading_defaults.combine\` into each task's resolved grading via a pure \`resolve_effective_grading_combine(project_combine, task_combine)\` deep-merge helper. Task wins field-by-field; \`weights\` merges key-by-key. Canonical \`GradingCombineConfig\` defaults fill anything neither layer sets.
- \`NativeAdapter\` now routes both grading-construction sites (\`to_task_description\` + \`get_grading_config\`) through the resolver. The arbitrary \`{state_checks:1.0}, pass_threshold=1.0\` fallback in \`to_task_description\` is deleted.
- **Second defect fixed in the same PR** (same root cause): \`NativeAdapter.get_grading_config\` previously did \`GradingConfig(**grading_data)\`, which \`ValidationError\`-crashed on any task with no \`combine\` block. All 5 no-\`combine\` tasks in \`example-microservices-pack\` triggered this today. \`combine\` is now popped and passed explicitly as the resolved value.

## Plan

See \`docs/plans/2026-07-15-issue-376-grading-defaults-merge.md\`. Plan-critic APPROVE WITH NOTES on round 1 (two 🟡 filed as separate follow-ups: #384 divergent \`combine\` defaults across core/runner/native, #385 PROJECTS.md \`null\`-unset merge rule not implemented). Branch reviewer APPROVE.

## Discovered issues

- Filed: **#384** (divergent \`combine\` defaults across model layers — runner-side still has its own default even after this fix), **#385** (PROJECTS.md \`null\`-unset merge rule is not implemented in deep_merge). Both low-priority follow-ups; neither blocks this PR.
- Fixed in this PR: the \`get_grading_config\` no-\`combine\` crash (same root cause as the dead \`grading_defaults\` merge).

## Test plan

- [x] \`uv run pytest -m unit tests/unit/test_project_loader.py -k GradingCombine -v\` — 7 pass (Stage 1's merge semantics).
- [x] \`uv run pytest -m integration tests/integration/test_example_microservices_pack.py -v\` — 21 pass, including 5 parametrized cases for the new inheritance assertion (\`weights={llm_judge:1.0}\` for all 5; \`pass_threshold=0.7\` on \`long_debugging_session\` per task override, \`0.8\` elsewhere) and a crash-regression case on \`api_endpoint_add\`.
- [x] Full unit + canonical sweep — no regressions (2371 pass, 1 pre-existing skip).
- [x] Backward compat: 15 non-microservices example grading.yaml files all ship full explicit \`combine\` blocks; their resolved combine is byte-identical. Spot-checked \`startup_probe\` (\`pass_threshold=0.5\`, unchanged).

Milestone: Project layer runnability (#16). Sub-issue 7 of umbrella #375.