### PR TITLE
docs(guides): reframe isolated_trials.md around task-driven isolation selection (#380)

### DIFF
--- a/docs/guides/isolated_trials.md
+++ b/docs/guides/isolated_trials.md
@@ -1,9 +1,10 @@
 # Isolated trials
 
 This guide explains what per-trial isolation buys you, when to use it,
-and how to opt in. It covers the CLI, the run config, and the task-level
-declaration, plus a worked example you can run against an unchanged
-example task pack.
+and how it is decided. It covers the per-service declaration in the task
+manifest that drives backend selection, the deprecated CLI/config
+overrides, and a worked example you can run against an unchanged example
+task pack.
 
 For the underlying protocol and materialisation lifecycle see
 [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
@@ -32,7 +33,8 @@ without polluting any other trial's grading.
 
 ## When to use it
 
-Choose `per_trial` when **any** of the following is true:
+Label a task's services `reset`/`ephemeral` — so the run materialises a
+fresh stack per trial — when **any** of the following is true:
 
 - The task's grading depends on state the trial itself created (a row
   the agent wrote, a file it edited, a message it posted).
@@ -43,7 +45,8 @@ Choose `per_trial` when **any** of the following is true:
 - You measure `pass@k` and need every retry to be genuinely
   independent.
 
-Choose `shared` when **all** of the following are true:
+Leave a task's services `shared` — so the run stays on the shared stack
+— when **all** of the following are true:
 
 - Grading only inspects the agent's output (a written file, a returned
   string).
@@ -52,37 +55,25 @@ Choose `shared` when **all** of the following are true:
 - The trials do not race on any shared state that could cause
   non-determinism.
 
-Default is `shared` because the cold-start cost is real: every trial in
+The shared stack is where the task-driven selector lands when no service
+requires isolation, because the cold-start cost is real: every trial in
 a per-trial run pays the cost of `docker compose up` again. On a task
 whose stack takes 30s to reach healthy, a 100-trial run costs an extra
 ~50 minutes of wall clock in materialisation alone. See [Cost](#cost)
 below.
 
-## How to opt in
+## How isolation is decided
 
-Three surfaces, in ascending order of precedence:
+Isolation is decided by the *task*, not opted into by the operator.
+Every compose service in a task's manifest carries an isolation label
+via `services.<name>.isolation` — `shared`, `reset`, or `ephemeral` (a
+service with no manifest entry defaults to `ephemeral`). Backend
+selection is task-driven and automatic: any `reset`/`ephemeral` service
+on any task in the run routes the whole run onto per-trial
+materialisation, and a run whose services are all `shared` (or whose
+tasks carry no manifest at all) stays on the shared stack.
 
-**1. Config file (per-run default).** Set `orchestrator.runtime` in the
-run config YAML:
-
-```yaml
-orchestrator:
-  runtime: per_trial          # or "shared"
-```
-
-**2. CLI flag (override for this invocation).** `--runtime` overrides
-whatever is in the config, so you can flip an existing config without
-editing it:
-
-```bash
-uv run tolokaforge run \
-  --config examples/native/coding/run_config.yaml \
-  --runtime per_trial
-```
-
-**3. Task-level declaration (mandatory requirement).** A task that
-cannot tolerate shared state declares its requirement in
-`task.yaml`:
+A task declares its per-service labels in `task.yaml`:
 
 ```yaml
 environment_manifest:
@@ -93,9 +84,39 @@ environment_manifest:
       isolation: ephemeral
 ```
 
-This is a **hard requirement**: if the run's backend can't satisfy it,
-the orchestrator refuses to start. You'll see a startup-time
-`RuntimeError` naming the offending task(s):
+That declaration is the whole mechanism. There is nothing to switch on
+at run time — the orchestrator reads every task's manifest, and if any
+service needs a fresh substrate it selects the per-trial backend that
+satisfies it. The normal path never refuses to start; it auto-selects
+the satisfying backend.
+
+### Deprecated overrides
+
+Two surfaces force a backend regardless of the task-driven signal, each
+emitting a `DeprecationWarning`. They exist for edge cases —
+backwards-compatibility, forcing a shared stack while profile-testing,
+or forcing per-trial on a manifest-less pack to observe isolation
+behaviour (exactly what the worked example below does).
+
+**Config file.** Set `orchestrator.runtime` in the run config YAML:
+
+```yaml
+orchestrator:
+  runtime: per_trial          # or "shared"
+```
+
+**CLI flag.** `--runtime` overrides whatever is in the config:
+
+```bash
+uv run tolokaforge run \
+  --config examples/native/coding/run_config.yaml \
+  --runtime per_trial
+```
+
+Forcing a *shared* backend against a task set that requires per-trial
+materialisation is the one path that refuses to start. The orchestrator
+rejects the conflict at startup with a `RuntimeError` naming the
+offending task(s):
 
 ```
 Runtime backend SharedStackRuntimeBackend shares state across every
@@ -110,14 +131,18 @@ verdicts on a shared-stack backend.
 
 The refusal is deliberate — silent cross-trial contamination is a
 failure mode where the grader believes it, so making it a startup error
-rather than a subtle grading bug is the safer default.
+rather than a subtle grading bug is the safer default. Drop the override
+and the task-driven selector picks the satisfying backend on its own.
 
 ## Worked example
 
-`--runtime per_trial` works on any task pack, with or without a
-task-declared manifest. When the task has no manifest, the engine's
-built-in stack (`runner` + `db-service`) is what gets materialised per
-trial.
+This example forces the backend with the deprecated `--runtime`
+override (see [Deprecated overrides](#deprecated-overrides)) precisely
+to observe isolation behaviour on a manifest-less pack — it is not the
+normal selection path. `--runtime per_trial` works on any task pack,
+with or without a task-declared manifest. When the task has no manifest,
+the engine's built-in stack (`runner` + `db-service`) is what gets
+materialised per trial.
 
 Take the smallest existing example (`examples/native/coding`, no
 manifest) and run it under each backend:
@@ -171,8 +196,10 @@ does, budget for the wall-clock cost.
 
 ## Interaction with multi-container tasks
 
-Isolation and multi-container are orthogonal — you choose them
-independently. All four combinations exist:
+Isolation and multi-container are orthogonal properties of the task, not
+operator choices: isolation follows the task's per-service labels, and
+multi-container follows whether the task declares extra services. All
+four combinations exist:
 
 | Task | Runtime | Behaviour |
 | --- | --- | --- |

--- a/docs/plans/2026-07-15-issue-380-isolated-trials-framing.md
+++ b/docs/plans/2026-07-15-issue-380-isolated-trials-framing.md
@@ -1,0 +1,196 @@
+# Plan: isolated_trials.md — reframe opt-in as task-driven selection
+
+Issue: #380
+Branch: docs/issue-380-isolated-trials-framing (commit scope `docs(guides):`)
+
+## Context
+
+`docs/guides/isolated_trials.md` §"How to opt in" (lines 61–98) frames
+per-trial isolation as an operator opt-in via "three surfaces, in ascending
+order of precedence": `orchestrator.runtime` config, `--runtime` CLI, and a
+task-level declaration described as a "hard requirement" where "the
+orchestrator refuses to start". This contradicts current behaviour. Backend
+selection is task-driven: `Orchestrator._select_backend_from_tasks`
+(`tolokaforge/core/orchestrator.py:589`) reads
+`EnvironmentManifest.requires_per_trial` for every task and auto-routes any
+run with a `reset`/`ephemeral` service onto `PerTrialRuntimeBackend`. The
+orchestrator does **not** refuse to start on that path — it selects the
+satisfying backend. `_verify_isolation_compatibility`
+(`orchestrator.py:852`) early-returns when the selected backend is
+`PER_TRIAL_STACK` (line 870–871); its `RuntimeError` fires **only** under the
+deprecated `orchestrator.runtime` override path, when an operator forces a
+shared backend against a per-trial-requiring task set (or asks for an
+`ephemeral` service on a shared backend). The vocabulary in this file is
+already current (per #370); this is a framing fix, not a vocabulary fix.
+
+## Goal
+
+§"How to opt in" reads as current state: per-service
+`services.<name>.isolation` in the task manifest is the **only** selection
+mechanism on the normal path; backend selection is task-driven and automatic;
+`orchestrator.runtime` / `--runtime` are **deprecated overrides** for edge
+cases; and "refuses to start" language is scoped to the override-conflict path
+only. The rewrite must not contradict the intro, "When to use it", or "Worked
+example" sections — those get a light touch for coherence where their current
+verbs imply an operator picks a backend.
+
+## Non-goals
+
+- No vocabulary changes (`shared`/`reset`/`ephemeral` already correct per #370).
+- No code changes. `_select_backend_from_tasks` /
+  `_verify_isolation_compatibility` are the authority; the doc conforms to
+  them, not vice-versa.
+- No changes to `RUNTIME_BACKENDS.md` or ADR-0018 — they already carry the
+  task-driven framing (RUNTIME_BACKENDS.md §"Isolation enforcement";
+  ADR-0018 §"Amendment"). This plan aligns the guide *to* them.
+- No new examples, no restructuring of the "Cost" / "Interaction with
+  multi-container tasks" / "Further reading" sections.
+
+## Stages
+
+### Stage 1: Reframe isolation selection as task-driven
+
+- **Contract:** Documentation prose only. No API, CLI, config-schema, or
+  wire-format change. The `docs/guides/isolated_trials.md` "How isolation is
+  decided" section (renamed from "How to opt in") is the observable surface.
+  Concrete edits:
+  1. **Rename** `## How to opt in` (line 61) → `## How isolation is decided`.
+     No inbound anchor links to `#how-to-opt-in` exist anywhere in the repo
+     (verified by grep), so the rename is safe.
+  2. **Delete** the "Three surfaces, in ascending order of precedence:"
+     framing (line 63) and the numbered surface list (config → CLI →
+     task-level).
+  3. **New lead:** isolation is decided by the *task*, not opted into by the
+     operator. Every compose service carries `services.<name>.isolation`
+     (`shared` / `reset` / `ephemeral`; a service with no manifest entry
+     defaults to `ephemeral`). Backend selection is task-driven — any
+     `reset`/`ephemeral` service on any task in the run routes the whole run
+     onto per-trial materialisation automatically; a run whose services are
+     all `shared` (or tasks with no manifest at all) stays on the shared
+     stack. Present the existing `task.yaml` block (current lines 87–94) as
+     THE mechanism.
+  4. **Demote overrides:** a subsection ("Deprecated overrides") documenting
+     `orchestrator.runtime` (config) and `--runtime` (CLI) as overrides that
+     force a backend regardless of the task-driven signal, emitting a
+     `DeprecationWarning`. Keep the existing config-YAML and CLI examples
+     (current lines 68–81) but framed as overrides for edge cases:
+     backwards-compatibility, forcing a shared stack while profile-testing,
+     or forcing per-trial on a manifest-less pack to observe isolation
+     behaviour (which is exactly what the Worked example does).
+  5. **Scope the refusal:** the "hard requirement / orchestrator refuses to
+     start" language (current lines 96–113) applies **only** to the
+     override-conflict path — an operator forcing `shared` against a
+     per-trial-requiring task set. State plainly that the normal
+     (task-driven) path never refuses: it auto-selects the satisfying
+     backend. Keep the quoted `RuntimeError` block **verbatim** — it must
+     stay byte-identical to the message in
+     `_verify_isolation_compatibility` (`orchestrator.py:897–908`) — but
+     re-caption it as the override-conflict error, not the
+     task-declaration consequence.
+  6. **Intro (lines 3–6):** reframe "how to opt in. It covers the CLI, the
+     run config, and the task-level declaration" → language describing how
+     isolation is decided: the per-service declaration that drives backend
+     selection, the deprecated CLI/config overrides, and a worked example.
+  7. **"When to use it" (lines 33–59) — light touch:** the current
+     "Choose `per_trial` when…" / "Choose `shared` when…" verbs read as an
+     operator picking a backend, which would contradict the rewritten
+     section. Change the framing verbs so the decision maps onto the
+     per-service label the *task author* declares (needs fresh state →
+     declare `reset`/`ephemeral`; tolerates shared state → declare
+     `shared`). Preserve every decision bullet unchanged. The "Default is
+     `shared`…" cost paragraph (55–59) stays, reframed so "default" means
+     "the task-driven selector lands on the shared stack when no service
+     requires isolation" rather than an operator default.
+  8. **"Worked example" (lines 116–151) — one clause:** the example uses
+     `--runtime per_trial` on a manifest-less pack. Add a short framing
+     reference tying that usage back to the "Deprecated overrides"
+     subsection (forcing per-trial to observe behaviour), so it doesn't
+     re-read as the primary opt-in path. No command changes.
+  9. **"Interaction with multi-container tasks" (line 174) — one clause:**
+     "Isolation and multi-container are orthogonal — **you choose them
+     independently**" is the same operator-picks framing and would ship
+     contradicting the rewritten section. Reframe the "you choose them
+     independently" clause so the operator is not the one choosing
+     isolation (isolation follows the task's per-service labels;
+     multi-container follows whether the task declares extra services —
+     the two are independent *properties of the task*, not operator
+     choices). Preserve the 2×2 table (lines 177–182) and every cell
+     intact — the table documents legitimate manifest × backend
+     combinations, including override-reachable ones.
+
+- **Behaviour to lock:** No behaviour changes, so no new automated test. The
+  one invariant is textual fidelity: the `RuntimeError` block quoted in the
+  guide must stay faithful to `_verify_isolation_compatibility`
+  (`orchestrator.py:897–908`) — the same wording and the same distinctive
+  fragments, with the message's f-string placeholders
+  (`{type(...).__name__}`, `{sorted(...)!r}`) rendered as an illustrative
+  example and hard-wrapped for the guide. The two are not byte-identical (the
+  source is an unformatted f-string with substitution points; the doc block
+  is rendered + wrapped) and the criterion does not demand it. Validation is a
+  manual comparison of the wording plus an `rg` fragment check (below), not a
+  new test tier. Adding a unit/canonical test here would only restate the
+  implementation — forbidden.
+
+- **Compatibility:** Documentation of a compatibility surface (the CLI
+  `--runtime` flag and `orchestrator.runtime` config field both still exist
+  and are unchanged). No migration needed — the flag/field behaviour is
+  unchanged; only the guide's framing of them changes. No CHANGELOG entry
+  required (no user-facing behaviour change). Current-state prose per
+  AGENTS.md Rule 8 — the rewrite reads as if task-driven selection is the only
+  state; **no** "previously an opt-in, now task-driven" migration language.
+
+- **Deliverable:** `docs/guides/isolated_trials.md` with §"How isolation is
+  decided" (renamed), the overrides demoted to a deprecated-override note, the
+  refusal scoped to the override-conflict path, and the intro / "When to use
+  it" / "Worked example" sections coherent with the rewrite.
+
+- **Validation:** the implementer runs:
+  - `rg -n "opt.in|ascending order of precedence|three surfaces" docs/guides/isolated_trials.md`
+    → expect zero hits.
+  - `rg -n "how-to-opt-in|How to opt in" docs/ README.md` → expect zero hits
+    (no dangling anchors).
+  - Compare the quoted `RuntimeError` block against `orchestrator.py:897–908`
+    → wording + fragments faithful (placeholders rendered as an example,
+    wrapped for the guide); not byte-identical.
+  - Re-read the intro, "When to use it", "Worked example", and "Interaction
+    with multi-container tasks" (line 174) sections → no residual "choose a
+    backend / opt-in surface / you choose them independently" framing that
+    contradicts the rewrite. The 2×2 table (177–182) stays intact.
+  The reviewer checks: framing matches RUNTIME_BACKENDS.md §"Isolation
+  enforcement" and ADR-0018 §"Amendment"; no migration-history prose; the
+  refusal is scoped correctly; the override note names it deprecated.
+
+- **Doc updates:** `docs/guides/isolated_trials.md` (this is the doc). No
+  other doc references the renamed section, so no cross-file edits.
+
+## Discovered issues
+
+- **Fix in this PR:** the light-touch reframes to the intro, "When to use
+  it", "Worked example", and "Interaction with multi-container tasks"
+  (line 174) sections (Stage 1 items 6–9). They are in the same file and
+  would otherwise contradict the rewritten section — fixing them here is
+  cheaper than a follow-up and required for internal coherence.
+- **Filed as issues:** #387 (filed by main) — the CLI `--runtime` help text
+  (`cli/main.py:188–194`) and the `_print_runtime_banner` output still present
+  `--runtime` as a normal selector with no deprecation note, so `--help` will
+  read as non-deprecated while this guide calls it deprecated. That is a code
+  surface, out of scope for this docs-only PR, and is tracked in #387. (This
+  is why the plan does not claim the guide is the *only* stale surface —
+  RUNTIME_BACKENDS.md and ADR-0018 already carry the correct task-driven
+  framing, but the CLI help/banner does not.)
+
+## Risks / open questions
+
+- **Verbatim error block drift.** The guide quotes the
+  `_verify_isolation_compatibility` `RuntimeError` verbatim. If that message
+  is later edited without updating the guide, the two drift. This risk
+  pre-exists this PR (the block is already quoted); the plan does not worsen
+  it. Not worth a doctest given no docs-test harness exists in the repo
+  (verified: no markdown lint / link checker in Makefile or CI workflows).
+- **"When to use it" scope.** The teammate scoped the issue to lines 61–98,
+  but the "Choose per_trial / Choose shared" verbs in "When to use it" would
+  contradict the rewrite if left. The plan touches them lightly (verbs +
+  linkage to the per-service label only, bullets preserved). If the reviewer
+  prefers to leave that section untouched, the fallback is to keep its
+  wording and add a single bridging sentence pointing to "How isolation is
+  decided" — but the light-touch reframe is the cleaner result.


### PR DESCRIPTION
Closes #380.

## Summary

- Rewrite \`docs/guides/isolated_trials.md\` §"How to opt in" (renamed → §"How isolation is decided") so per-service \`services.<name>.isolation\` in the task manifest is the ONLY selection mechanism and backend selection is task-driven / automatic.
- Demote \`orchestrator.runtime\` config + \`--runtime\` CLI flag to a "Deprecated overrides" subsection. Kept documented; noted they emit \`DeprecationWarning\`.
- Scope the "orchestrator refuses to start" language to the override-conflict path (forcing \`--runtime shared\` against per-trial-requiring tasks). Quoted \`RuntimeError\` block preserved faithfully; only re-captioned.
- Light-touch coherence sweep on intro / §"When to use it" / §"Worked example" / the "you choose them independently" clause (line ~174) so operator-choice verbs don't contradict the rewrite. 2×2 table preserved byte-identical.

## Plan

See \`docs/plans/2026-07-15-issue-380-isolated-trials-framing.md\`. Plan-critic APPROVE WITH NOTES on round 2 after fixing (a) line-174 coherence contradiction, (b) byte-identical criterion (unsatisfiable for an f-string vs rendered block), (c) "guide is the only stale surface" overreach — filed CLI help follow-up as #387. Branch reviewer APPROVE.

## Discovered issues

- Filed: **#387** — CLI \`--runtime\` help text + \`_print_runtime_banner\` still present the flag as a normal selector without a deprecation note. After this PR the guide calls it deprecated while \`--help\` doesn't. Low-priority follow-up.

## Test plan

- [x] \`rg 'How to opt in|opt-in surfaces in ascending order|choose them independently|orchestrator refuses to start|three surfaces|ascending order of precedence' docs/guides/isolated_trials.md\` → zero hits.
- [x] \`rg 'services\\.<name>\\.isolation|task-driven|Deprecated overrides|DeprecationWarning' docs/guides/isolated_trials.md\` → matches present.
- [x] 2×2 table preserved byte-identical (no table rows in the diff).
- [x] RuntimeError block matches \`orchestrator.py:897-909\` verbatim (placeholders rendered as illustrative example).
- [x] Branch reviewer APPROVE (all 9 checks clean).

Milestone: Project layer runnability (#16). Sub-issue 8 (final) of umbrella #375.