### PR TITLE
feat(grading,examples): state_checks.db_probes primitive + multi_service_lot_ops pack (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **grading**: `state_checks.db_probes` grading primitive — declarative postgres substrate assertions (#400)
 - **schema**: task.yaml minimal shape is task_id + description; initial_state / tools / user_simulator / grading now optional with sane defaults (#366)
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)
 - **runtime**: `PerTrialRuntimeBackend` captures per-service logs on provision-stage failure (compose-up / reset-recipe) before teardown, writing `services/<service>.log` + a `services/_capture.yaml` manifest; `RuntimeBackend` gains `capture_service_logs` (per-trial writes `.log` files; shared-stack is a documented no-op) (#302)

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -261,6 +261,63 @@ evaluation:
 
 ---
 
+## Substrate Grading (`state_checks.db_probes`)
+
+`db_probes` grade against a task-declared postgres **substrate** directly,
+rather than against the agent's own written file or the engine's JSON DB
+state service. Each probe connects to a task-local DSN, runs an author-written
+read-only `SELECT`, and applies the same JSONPath assertion vocabulary as
+`jsonpaths` (`equals` / `equals_ci` / `contains` / `contains_ci`) to the query
+result. This is an **independent oracle**: it reads the database through a
+least-privilege read-only role, not through the API the agent mutated, so an
+API bug cannot mask a grading miss.
+
+```yaml
+state_checks:
+  db_probes:
+    - name: corrective_action_recorded
+      dsn: "postgresql://grader:grader_pw@app-db:5432/mfg"
+      query: "SELECT reason_code, status FROM corrective_actions WHERE lot_id = 7"
+      expect:
+        - path: "$.rows[0].reason_code"
+          equals: "CAPA-01"
+          description: "reason code matches"
+        - path: "$.row_count"
+          equals: 1
+          description: "exactly one corrective action"
+      description: "a corrective action exists for lot 7"
+```
+
+**Fields:**
+
+- `name` — probe identifier, shown in grade reasons.
+- `dsn` — postgres connection string. Use a dedicated read-only role
+  (`GRANT SELECT` only) so grading cannot mutate the substrate.
+- `query` — a single read-only `SELECT`.
+- `expect` — JSONPath assertions evaluated against the probe result.
+- `description` — human-readable summary.
+
+**Result shape.** Rows are shaped into
+`{"rows": [{col: val, ...}, ...], "row_count": <int>}`, so `expect` paths
+address individual rows (`$.rows[0].status`), whole columns
+(`$.rows[*].status`), or the count (`$.row_count`).
+
+**Aggregation (two-level).** A probe *passes* iff **every** one of its `expect`
+assertions passes; the component score is the **fraction of passing probes**.
+A single-probe task therefore scores 0.0 or 1.0.
+
+**Fail-loud.** A connection or query failure is a **failed** probe with an
+actionable reason — never a silent pass. The runner image ships `asyncpg`, the
+async driver `db_probes` connect with; the runner container joins the task's
+docker network, so it reaches the substrate (e.g. `app-db:5432`) at grade time.
+
+`db_probes` is the sole state source for the tasks that use it — it is not
+combined with hash or `jsonpaths` checks in the same task. It fills the
+`state_checks` component and combines with `transcript_rules` / `llm_judge`
+through the normal weighted combine below.
+
+---
+
 ## Score Combination
 
 Final score formula:

--- a/docs/multi_container_tasks.md
+++ b/docs/multi_container_tasks.md
@@ -3,15 +3,15 @@
 This guide walks through authoring a project whose tasks ship their own
 docker-compose stack — extra services beyond the engine's built-in
 `runner` + `db-service`. It's anchored to a working example
-([`examples/native/multi_service_postgres_reset/`](../../examples/native/multi_service_postgres_reset/))
+([`examples/native/multi_service_postgres_reset/`](../examples/native/multi_service_postgres_reset/))
 that you can `tolokaforge run` unchanged before adapting it.
 
 For the design rationale + case matrix, see
-[ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md).
+[ADR-0018](architecture/adr/0018-multi-container-under-shared-runtime.md).
 For the full Project model, see
-[`docs/architecture/PROJECTS.md`](../architecture/PROJECTS.md); for the
+[`docs/architecture/PROJECTS.md`](architecture/PROJECTS.md); for the
 runtime backend lifecycle, see
-[`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
+[`docs/architecture/RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md).
 
 ## When to declare a multi-container task
 
@@ -36,7 +36,7 @@ task.
 ## Walkthrough — `multi_service_postgres_reset`
 
 The smallest working demonstration of the shipped semantics lives at
-[`examples/native/multi_service_postgres_reset/`](../../examples/native/multi_service_postgres_reset/).
+[`examples/native/multi_service_postgres_reset/`](../examples/native/multi_service_postgres_reset/).
 It runs a real postgres behind a PostgREST API, reset to a known seed at
 the start of every trial. Three files carry the interesting content:
 `project.yaml`, `shared/environment.compose.yaml`, and the sibling
@@ -139,7 +139,7 @@ Things worth noting:
   aliases** the engine sets up at run start. Task compose files reference
   these stable names instead of the content-hash tags the engine actually
   builds. Details in
-  [`RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md).
+  [`RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md).
 - **Services reach each other by service name.** All services in a compose
   file join the same auto-generated docker network, so the runner container
   reaches `app-service` as `http://app-service:3000/`. No manual network
@@ -188,7 +188,7 @@ fresh stack and applies the seed to the named service.
 Four seed kinds are supported — `sql_dump`, `filesystem_dir`,
 `redis_dump`, and `bare`. For the full authoring reference (how each kind
 is applied, extension inference, and failure modes), see
-[`docs/architecture/RESET_RECIPES.md`](../architecture/RESET_RECIPES.md).
+[`docs/architecture/RESET_RECIPES.md`](architecture/RESET_RECIPES.md).
 
 ## Network policy
 
@@ -252,27 +252,45 @@ compose file. Suppose you want to add a redis cache the agent mutates:
 Because `cache` is `reset` (and `app-db` already is), the run requires
 per-trial isolation and routes to `PerTrialRuntimeBackend` automatically.
 
+## Grading against substrate state
+
+When the agent *mutates* a service — writes a row, updates a record — grade
+the mutation against the substrate directly rather than trusting the agent's
+own written file. `state_checks.db_probes` connects to a task-declared postgres
+DSN, runs an author-written read-only `SELECT`, and applies the JSONPath
+assertion vocabulary to the returned rows. Point the DSN at a dedicated
+read-only role (`GRANT SELECT` only) so the probe is an **independent oracle**:
+it reads the database through a different role than the API the agent wrote
+through, and it can never mutate the substrate. The runner container joins the
+task's docker network, so it reaches the service (e.g. `app-db:5432`) at grade
+time. Full field reference in
+[`docs/GRADING.md`](GRADING.md) § Substrate Grading; the
+`multi_service_lot_ops` pack below is the worked example.
+
 ## Further reading
 
-- [`examples/native/multi_service_postgres_reset/README.md`](../../examples/native/multi_service_postgres_reset/README.md)
+- [`examples/native/multi_service_postgres_reset/README.md`](../examples/native/multi_service_postgres_reset/README.md)
   — the anchor example this guide walks through (per-service isolation +
   `sql_dump` reset seed)
-- [`examples/native/multi_service_slow_start/README.md`](../../examples/native/multi_service_slow_start/README.md)
+- [`examples/native/multi_service_slow_start/README.md`](../examples/native/multi_service_slow_start/README.md)
   — startup-order stress: a slow dependency that the orchestrator waits on
   via healthcheck before the runner fires
-- [`examples/native/multi_service/README.md`](../../examples/native/multi_service/README.md)
+- [`examples/native/multi_service/README.md`](../examples/native/multi_service/README.md)
   — the task-level shared multi-container pattern (nginx catalog)
-- [`examples/native/multi_service_postgres/README.md`](../../examples/native/multi_service_postgres/README.md)
+- [`examples/native/multi_service_postgres/README.md`](../examples/native/multi_service_postgres/README.md)
   — a realistic three-tier stack (PostgREST + postgres, shared runtime)
-- [`examples/native/example-microservices-pack/`](../../examples/native/example-microservices-pack/)
+- [`examples/native/multi_service_lot_ops/README.md`](../examples/native/multi_service_lot_ops/README.md)
+  — substrate-state grading: the agent mutates postgres over a FastAPI API and
+  `state_checks.db_probes` verifies the row directly via a read-only role
+- [`examples/native/example-microservices-pack/`](../examples/native/example-microservices-pack/)
   — the schema reference pack: full inheritance/override matrix across five
   tasks (reference only, see its README before running)
-- [`docs/architecture/PROJECTS.md`](../architecture/PROJECTS.md)
+- [`docs/architecture/PROJECTS.md`](architecture/PROJECTS.md)
   — the full Project model: assets, `default_environment`, per-service
   isolation, and the merge chains
-- [`docs/architecture/RESET_RECIPES.md`](../architecture/RESET_RECIPES.md)
+- [`docs/architecture/RESET_RECIPES.md`](architecture/RESET_RECIPES.md)
   — the four seed kinds and how a reset recipe is applied
-- [ADR-0018](../architecture/adr/0018-multi-container-under-shared-runtime.md)
+- [ADR-0018](architecture/adr/0018-multi-container-under-shared-runtime.md)
   — case matrix + sequence diagrams for each supported combination
-- [`docs/architecture/RUNTIME_BACKENDS.md`](../architecture/RUNTIME_BACKENDS.md)
+- [`docs/architecture/RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md)
   — full lifecycle + materialisation deep-dive

--- a/examples/native/multi_service_lot_ops/README.md
+++ b/examples/native/multi_service_lot_ops/README.md
@@ -1,0 +1,122 @@
+# Multi-service `lot_ops` — substrate-state grading
+
+The multi-service example that grades a **real database mutation against the
+substrate**. A shop-floor operator reports a contamination hit on a production
+lot; the agent opens a corrective-action record over a REST API, and grading
+verifies the record by reading the postgres table **directly** — not the
+agent's own written file, and not the same API the agent just wrote through.
+
+```
+agent → FastAPI (app-service:8000) → postgres:16 (app-db)
+                                          ▲
+                       grading (read-only `grader` role) ┘
+```
+
+## What this example demonstrates
+
+- **Substrate-state grading (`state_checks.db_probes`).** Grading connects to
+  `app-db` with a task-local DSN, runs an author-written read-only `SELECT`
+  against `corrective_actions`, and applies JSONPath assertions to the rows.
+  This is an **independent oracle**: it reads the database through a dedicated
+  `grader` role that holds `GRANT SELECT` only, so a bug in the agent's API
+  path cannot mask a grading miss, and grading can never mutate the substrate.
+  See [`docs/GRADING.md`](../../../docs/GRADING.md) § Substrate Grading.
+- **Three-way weighted grading.** The final score combines all three grading
+  families, each measuring a different thing:
+
+  | Component | Weight | What it checks |
+  |---|---|---|
+  | `state_checks.db_probes` | 0.5 | the corrective action landed in postgres with the right reason code and `status='open'` |
+  | `transcript_rules` | 0.2 | the agent both **read** (`http_request` `GET`) and **mutated** (`http_request` `POST`), within the turn budget |
+  | `llm_judge` | 0.3 | the written completion report names the lot, states the reason, and reads as an operator-facing note |
+
+- **A real application service, no custom image.** `app-service` is a small
+  FastAPI app (~20 endpoints) run straight from `tolokaforge-runner:local` —
+  that image already bundles `fastapi`, `uvicorn`, and `asyncpg`, so the pack
+  ships **no Dockerfile**. A compose `command:` override boots `uvicorn`
+  against the bind-mounted `app/main.py`; the runner image has no `ENTRYPOINT`,
+  so the override takes effect.
+- **Distinct method-tagged tool calls.** The agent uses the `http_request`
+  builtin (restricted to `app-service:8000`), so its reads and mutations carry
+  a `method` argument that `transcript_rules.required_actions` matches on
+  directly — cleaner than opaque `bash` invocations.
+
+## The scenario
+
+Lot `LOT-1007` (`lot_id` 7, a batch of sterile vials) came back from QC with a
+contamination hit. The agent must:
+
+1. Look up the reason-code catalog (`GET /reason-codes`) and find the
+   contamination code (`CAPA-01`).
+2. Open a corrective action against lot 7 with that reason code and a note
+   (`POST /lots/7/corrective-actions`).
+3. Write a short completion report to `submissions/` for the shift lead.
+
+The `corrective_actions` table ships **empty** — the agent's `POST` is the only
+thing that can populate it, so grading passing means the mutation really landed.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_lot_ops/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_lot_ops/run_config.yaml
+```
+
+Needs a running Docker daemon and `OPENROUTER_API_KEY` in `.env`. The first run
+is slower while postgres initialises and seeds; the runner container joins the
+task's docker network, so at grade time it reaches `app-db:5432` directly.
+
+## Layout
+
+```
+examples/native/multi_service_lot_ops/
+├── run_config.yaml               # haiku agent + user, sonnet judge
+├── project.yaml                  # discovery glob + native defaults
+├── README.md                     # this file
+├── shared/
+│   ├── environment.compose.yaml  # 4-service compose (all isolation: shared)
+│   ├── app/
+│   │   └── main.py               # FastAPI lot-operations API (~20 endpoints)
+│   └── app-db/
+│       └── init.sql              # schema + seed + app/grader roles
+└── dataset/tasks/lot_ops_01/
+    ├── task.yaml                 # env manifest + http_request/write_file tools
+    └── grading.yaml              # db_probes + transcript_rules + llm_judge
+```
+
+## Design notes
+
+- **Two roles, least privilege.** `init.sql` creates the postgres database as
+  the read/write `app` role (the FastAPI service connects as this) and a
+  separate `grader` role with `GRANT SELECT` only. The db_probe DSN in
+  `grading.yaml` authenticates as `grader`, so the oracle is read-only by
+  construction. Mirrors the `web_anon` / `authenticator` split in the sibling
+  PostgREST packs.
+- **All four services `isolation: shared`.** This is the shared-runtime
+  reference: the stack is materialised once and shared across trials, so
+  `app-db` is up throughout the run and reachable at grade time. The task uses
+  a single trial (`repeats: 1`) and does not require a per-trial baseline, so
+  no reset recipe is involved.
+- **Task-local throwaway credentials.** The DSN in `grading.yaml` and the
+  compose passwords are disposable, task-scoped credentials for a local
+  container — the same posture as the plaintext compose credentials in the
+  sibling packs. Real secrets always go through `SecretManager`.
+- **Pinned images only.** `postgres:16`, `tolokaforge-runner:local`, and
+  `tolokaforge-db-service:local`. The `:local` alias is valid on a
+  non-`runner` service — the manifest validator rejects only floating tags.
+
+## Related
+
+- [`docs/multi_container_tasks.md`](../../../docs/multi_container_tasks.md)
+  — authoring guide for multi-container tasks
+- [`docs/GRADING.md`](../../../docs/GRADING.md) — grading families, including
+  `state_checks.db_probes`
+- [`../multi_service_postgres/README.md`](../multi_service_postgres/README.md)
+  — a three-tier stack (PostgREST + postgres) that grades the agent's file
+- [ADR-0018](../../../docs/architecture/adr/0018-multi-container-under-shared-runtime.md)
+  — multi-container case matrix

--- a/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/grading.yaml
+++ b/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/grading.yaml
@@ -1,0 +1,75 @@
+# Three-way weighted grading for lot_ops_01.
+#
+#   state_checks.db_probes (0.5) — the substrate oracle. Reads the postgres
+#     `corrective_actions` table directly through the read-only `grader` role,
+#     NOT the agent's file or the API it just wrote to.
+#   transcript_rules      (0.2) — the agent both read (GET) and mutated (POST)
+#     over http_request, within the turn budget.
+#   llm_judge             (0.3) — the operator-facing completion report reads
+#     well and states the right lot and reason.
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.5
+    transcript_rules: 0.2
+    llm_judge: 0.3
+  pass_threshold: 0.5
+
+state_checks:
+  db_probes:
+    - name: contamination_ca_opened
+      dsn: "postgresql://grader:grader_pw@app-db:5432/mfg"
+      query: "SELECT reason_code, status FROM corrective_actions WHERE lot_id = 7"
+      expect:
+        - path: "$.rows[0].reason_code"
+          equals: "CAPA-01"
+          description: "corrective action uses the contamination reason code"
+        - path: "$.rows[0].status"
+          equals: "open"
+          description: "the action is open"
+        - path: "$.row_count"
+          equals: 1
+          description: "exactly one corrective action exists for lot 7"
+      description: "an open contamination corrective action exists for lot 7 in the substrate"
+
+transcript_rules:
+  max_turns: 10
+  required_actions:
+    - action_id: "read_over_http"
+      requestor: assistant
+      name: http_request
+      arguments: {method: "GET"}
+      compare_args: ["method"]
+    - action_id: "mutate_over_http"
+      requestor: assistant
+      name: http_request
+      arguments: {method: "POST"}
+      compare_args: ["method"]
+
+llm_judge:
+  rubric:
+    reference: |
+      The operator reported a contamination hit on lot LOT-1007 (lot_id 7) and
+      asked for a corrective action to be opened and a short completion report
+      written under submissions/. A correct report names the lot, states that a
+      corrective action was opened for a contamination issue, and reads as a
+      note an operator could hand to a shift lead.
+    criteria:
+      - id: names_lot
+        description: >
+          The report identifies the affected lot (LOT-1007 or lot 7).
+        kind: binary
+        required: true
+        weight: 1.0
+      - id: states_reason
+        description: >
+          The report states the corrective action was opened for a contamination
+          issue (the reason it was raised), not a generic or unrelated cause.
+        kind: graded
+        weight: 1.0
+      - id: operator_facing
+        description: >
+          The report reads as a concise, clear operator-facing completion note
+          rather than raw API output or a debug dump.
+        kind: graded
+        weight: 0.5

--- a/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/task.yaml
+++ b/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/task.yaml
@@ -11,8 +11,9 @@ initial_user_message: |
   The lot-ops API is at http://app-service:8000 — it's got the lots, the
   reason-code catalog, and the corrective-actions table. Pull the right
   contamination reason code and open the action against lot 7 with a short
-  note about what happened. When it's logged, drop me a quick completion
-  report under submissions/ so I've got something to hand to my shift lead.
+  note about what happened. Just one record, please — don't double it up.
+  When it's logged, drop me a quick completion report under submissions/ so
+  I've got something to hand to my shift lead.
 adapter_type: "native"
 environment_manifest:
   compose_file: "../../../shared/environment.compose.yaml"
@@ -39,4 +40,5 @@ policies:
   guidance:
     - "Reach the API with the `http_request` tool against `http://app-service:8000` — GET the reason-code catalog to find the contamination code before opening the action; do not guess it."
     - "Open the corrective action by POSTing to the lot's corrective-actions endpoint; it must reference lot 7 and the contamination reason code."
+    - "Open exactly one corrective action for the lot. If the POST returns a success response, do not send it again — read the response to confirm, then move on to writing the completion report."
 grading: "grading.yaml"

--- a/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/task.yaml
+++ b/examples/native/multi_service_lot_ops/dataset/tasks/lot_ops_01/task.yaml
@@ -1,0 +1,42 @@
+task_id: "lot_ops_01"
+name: "Open a Corrective Action for a Contaminated Lot"
+category: "multi_service"
+description: "A shop-floor operator reports a contamination issue on a production lot. The agent must look the lot up over the manufacturing REST API, open a corrective-action record with the right reason code, and write an operator-facing completion report."
+max_turns: 10
+initial_user_message: |
+  Hey — we've got a problem on the sterile vial line. Lot LOT-1007 (that's
+  lot_id 7 in the system) came back from QC with a contamination hit, so I
+  need a corrective action opened against it before we can move on.
+
+  The lot-ops API is at http://app-service:8000 — it's got the lots, the
+  reason-code catalog, and the corrective-actions table. Pull the right
+  contamination reason code and open the action against lot 7 with a short
+  note about what happened. When it's logged, drop me a quick completion
+  report under submissions/ so I've got something to hand to my shift lead.
+adapter_type: "native"
+environment_manifest:
+  compose_file: "../../../shared/environment.compose.yaml"
+  runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    app-service: {isolation: "shared"}
+    app-db: {isolation: "shared"}
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["http_request", "write_file"]
+    http_request:
+      allowed_hosts: ["app-service:8000"]
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: cooperative
+  backstory: "You are the shop-floor operator who flagged the contamination on lot LOT-1007. You know it needs a corrective action but you rely on the agent to know the system. Answer brief clarifying questions plainly, do not volunteer the reason code or spell out API calls, and end with ###STOP### once the action is logged and the report is written."
+policies:
+  guidance:
+    - "Reach the API with the `http_request` tool against `http://app-service:8000` — GET the reason-code catalog to find the contamination code before opening the action; do not guess it."
+    - "Open the corrective action by POSTing to the lot's corrective-actions endpoint; it must reference lot 7 and the contamination reason code."
+grading: "grading.yaml"

--- a/examples/native/multi_service_lot_ops/project.yaml
+++ b/examples/native/multi_service_lot_ops/project.yaml
@@ -1,0 +1,28 @@
+# Project spec for the multi_service_lot_ops example.
+#
+# A single native task that mutates a real postgres substrate over a FastAPI
+# service and grades the mutation directly against the database through a
+# read-only role (state_checks.db_probes). The task declares its own
+# `environment_manifest` (all four services `isolation: shared`), so this
+# project only supplies discovery + native defaults. See README.md.
+#
+# See docs/architecture/PROJECTS.md for the full Project model.
+
+name: "multi-service-lot-ops"
+version: 1
+description: >
+  Single-task project demonstrating substrate-state grading: the agent opens
+  a corrective-action record over a FastAPI API backed by postgres, and
+  grading reads the corrective_actions table directly via a least-privilege
+  read-only role — an independent oracle, not the agent's own written file.
+
+tasks:
+  discovery:
+    glob: "tasks/**/task.yaml"
+
+task_defaults:
+  adapter_type: "native"
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/multi_service_lot_ops/run_config.yaml
+++ b/examples/native/multi_service_lot_ops/run_config.yaml
@@ -1,0 +1,41 @@
+# Multi-service `lot_ops` example — real postgres substrate-mutation grading.
+#
+#   agent → FastAPI (app-service) → postgres:16 (app-db)
+#
+# The agent opens a corrective action over the API; grading reads the
+# `corrective_actions` table directly through a read-only role (an independent
+# oracle), and combines that with transcript rules and an llm_judge rubric.
+#
+# Three model roles: the `agent` under test, the `user` simulator, and the
+# read-only rubric `judge`.
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env.
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+  judge:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 10
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/multi_service_lot_ops/dataset"
+  tasks_glob: "tasks/lot_ops_01/task.yaml"
+  output_dir: "results/multi_service_lot_ops_example"

--- a/examples/native/multi_service_lot_ops/shared/app-db/init.sql
+++ b/examples/native/multi_service_lot_ops/shared/app-db/init.sql
@@ -1,0 +1,86 @@
+-- Manufacturing schema + seed for the multi_service_lot_ops example.
+--
+-- Loaded once by postgres:16's docker-entrypoint-initdb.d at container start,
+-- running as the POSTGRES_USER `app` role (owns the schema, read/write). The
+-- FastAPI app-service connects as `app`. A dedicated read-only `grader` role
+-- (GRANT SELECT only) is the least-privilege oracle the db_probe DSN uses, so
+-- grading reads the substrate directly and can never mutate it — mirrors the
+-- web_anon / authenticator split in the sibling PostgREST packs.
+--
+-- `corrective_actions` ships empty on purpose: the agent creates the row the
+-- task asks for, and grading verifies it landed in this table.
+
+CREATE TABLE reason_codes (
+  code        TEXT PRIMARY KEY,
+  title       TEXT NOT NULL,
+  category    TEXT NOT NULL
+);
+
+CREATE TABLE lots (
+  lot_id      INT  PRIMARY KEY,
+  lot_code    TEXT NOT NULL UNIQUE,
+  product     TEXT NOT NULL,
+  status      TEXT NOT NULL,
+  quantity    INT  NOT NULL,
+  created_at  DATE NOT NULL
+);
+
+CREATE TABLE production_orders (
+  order_id    INT  PRIMARY KEY,
+  order_code  TEXT NOT NULL UNIQUE,
+  lot_id      INT  NOT NULL REFERENCES lots(lot_id),
+  status      TEXT NOT NULL,
+  quantity    INT  NOT NULL,
+  due_date    DATE NOT NULL
+);
+
+CREATE TABLE corrective_actions (
+  ca_id       SERIAL PRIMARY KEY,
+  lot_id      INT  NOT NULL REFERENCES lots(lot_id),
+  reason_code TEXT NOT NULL REFERENCES reason_codes(code),
+  note        TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'open',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE allocations (
+  alloc_id    SERIAL PRIMARY KEY,
+  order_id    INT NOT NULL REFERENCES production_orders(order_id),
+  lot_id      INT NOT NULL REFERENCES lots(lot_id),
+  quantity    INT NOT NULL
+);
+
+INSERT INTO reason_codes (code, title, category) VALUES
+  ('CAPA-01', 'Contamination', 'quality'),
+  ('CAPA-02', 'Dimensional nonconformance', 'quality'),
+  ('CAPA-03', 'Documentation error', 'process');
+
+INSERT INTO lots (lot_id, lot_code, product, status, quantity, created_at) VALUES
+  (1,  'LOT-1001', 'Buffer solution A', 'released',    480, '2026-06-02'),
+  (2,  'LOT-1002', 'Buffer solution A', 'released',    500, '2026-06-04'),
+  (3,  'LOT-1003', 'Reagent kit B',     'on_hold',     220, '2026-06-07'),
+  (4,  'LOT-1004', 'Reagent kit B',     'released',    240, '2026-06-09'),
+  (5,  'LOT-1005', 'Sterile vial C',    'released',   1000, '2026-06-11'),
+  (6,  'LOT-1006', 'Sterile vial C',    'quarantined', 950, '2026-06-14'),
+  (7,  'LOT-1007', 'Sterile vial C',    'released',    980, '2026-06-16'),
+  (8,  'LOT-1008', 'Buffer solution A', 'released',    460, '2026-06-18'),
+  (9,  'LOT-1009', 'Reagent kit B',     'on_hold',     210, '2026-06-21'),
+  (10, 'LOT-1010', 'Sterile vial C',    'released',    990, '2026-06-24');
+
+INSERT INTO production_orders (order_id, order_code, lot_id, status, quantity, due_date) VALUES
+  (1, 'PO-5001', 1, 'closed', 480, '2026-06-20'),
+  (2, 'PO-5002', 5, 'open',   600, '2026-07-05'),
+  (3, 'PO-5003', 7, 'open',   700, '2026-07-12'),
+  (4, 'PO-5004', 8, 'open',   400, '2026-07-15'),
+  (5, 'PO-5005', 4, 'closed', 240, '2026-06-28');
+
+INSERT INTO allocations (order_id, lot_id, quantity) VALUES
+  (1, 1, 480),
+  (2, 5, 600),
+  (3, 7, 700),
+  (5, 4, 240);
+
+CREATE ROLE grader LOGIN PASSWORD 'grader_pw';
+GRANT CONNECT ON DATABASE mfg TO grader;
+GRANT USAGE ON SCHEMA public TO grader;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO grader;

--- a/examples/native/multi_service_lot_ops/shared/app/main.py
+++ b/examples/native/multi_service_lot_ops/shared/app/main.py
@@ -1,0 +1,258 @@
+"""Manufacturing lot-operations API for the multi_service_lot_ops example.
+
+A thin FastAPI service over the postgres `app-db` substrate. The agent drives
+it over HTTP (service name `app-service:8000`); grading reads the same postgres
+directly through a read-only role. Connects as the read/write `app` role via
+asyncpg, using the DSN in `APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import date
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+
+class _Body(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class NewCorrectiveAction(_Body):
+    reason_code: str
+    note: str
+    status: str = "open"
+
+
+class CorrectiveActionPatch(_Body):
+    note: str | None = None
+    status: str | None = None
+
+
+class NewAllocation(_Body):
+    lot_id: int
+    quantity: int
+
+
+class NewLot(_Body):
+    lot_id: int
+    lot_code: str
+    product: str
+    status: str
+    quantity: int
+    created_at: date
+
+
+class LotPatch(_Body):
+    status: str | None = None
+    quantity: int | None = None
+
+
+class NewOrder(_Body):
+    order_id: int
+    order_code: str
+    lot_id: int
+    status: str
+    quantity: int
+    due_date: date
+
+
+class OrderPatch(_Body):
+    status: str | None = None
+    quantity: int | None = None
+    due_date: date | None = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="Lot Operations API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+async def _fetch_one(query: str, *args: Any) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(query, *args)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)
+
+
+def _build_update(table: str, id_col: str, fields: dict[str, Any]) -> tuple[str, list[Any]]:
+    if not fields:
+        raise HTTPException(status_code=400, detail="no fields to update")
+    assignments = ", ".join(f"{col} = ${i}" for i, col in enumerate(fields, start=1))
+    id_placeholder = f"${len(fields) + 1}"
+    query = f"UPDATE {table} SET {assignments} WHERE {id_col} = {id_placeholder} RETURNING *"
+    return query, list(fields.values())
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.get("/lots")
+async def list_lots() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM lots ORDER BY lot_id"))
+
+
+@app.get("/lots/{lot_id}")
+async def get_lot(lot_id: int) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM lots WHERE lot_id = $1", lot_id)
+
+
+@app.get("/lots/{lot_id}/corrective-actions")
+async def lot_corrective_actions(lot_id: int) -> list[dict[str, Any]]:
+    return _rows(
+        await app.state.pool.fetch(
+            "SELECT * FROM corrective_actions WHERE lot_id = $1 ORDER BY ca_id", lot_id
+        )
+    )
+
+
+@app.get("/orders")
+async def list_orders() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM production_orders ORDER BY order_id"))
+
+
+@app.get("/orders/{order_id}")
+async def get_order(order_id: int) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM production_orders WHERE order_id = $1", order_id)
+
+
+@app.get("/orders/{order_id}/allocations")
+async def order_allocations(order_id: int) -> list[dict[str, Any]]:
+    return _rows(
+        await app.state.pool.fetch(
+            "SELECT * FROM allocations WHERE order_id = $1 ORDER BY alloc_id", order_id
+        )
+    )
+
+
+@app.get("/corrective-actions")
+async def list_corrective_actions() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM corrective_actions ORDER BY ca_id"))
+
+
+@app.get("/corrective-actions/{ca_id}")
+async def get_corrective_action(ca_id: int) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM corrective_actions WHERE ca_id = $1", ca_id)
+
+
+@app.get("/reason-codes")
+async def list_reason_codes() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM reason_codes ORDER BY code"))
+
+
+@app.post("/lots/{lot_id}/corrective-actions", status_code=201)
+async def open_corrective_action(lot_id: int, body: NewCorrectiveAction) -> dict[str, Any]:
+    await _fetch_one("SELECT lot_id FROM lots WHERE lot_id = $1", lot_id)
+    return await _fetch_one(
+        "INSERT INTO corrective_actions (lot_id, reason_code, note, status) "
+        "VALUES ($1, $2, $3, $4) RETURNING *",
+        lot_id,
+        body.reason_code,
+        body.note,
+        body.status,
+    )
+
+
+@app.patch("/corrective-actions/{ca_id}")
+async def patch_corrective_action(ca_id: int, body: CorrectiveActionPatch) -> dict[str, Any]:
+    fields = body.model_dump(exclude_none=True)
+    query, values = _build_update("corrective_actions", "ca_id", fields)
+    return await _fetch_one(query, *values, ca_id)
+
+
+@app.post("/corrective-actions/{ca_id}/close")
+async def close_corrective_action(ca_id: int) -> dict[str, Any]:
+    return await _fetch_one(
+        "UPDATE corrective_actions SET status = 'closed' WHERE ca_id = $1 RETURNING *", ca_id
+    )
+
+
+@app.post("/orders/{order_id}/allocations", status_code=201)
+async def add_allocation(order_id: int, body: NewAllocation) -> dict[str, Any]:
+    await _fetch_one("SELECT order_id FROM production_orders WHERE order_id = $1", order_id)
+    return await _fetch_one(
+        "INSERT INTO allocations (order_id, lot_id, quantity) VALUES ($1, $2, $3) RETURNING *",
+        order_id,
+        body.lot_id,
+        body.quantity,
+    )
+
+
+@app.delete("/orders/{order_id}/allocations/{alloc_id}")
+async def delete_allocation(order_id: int, alloc_id: int) -> dict[str, str]:
+    deleted = await app.state.pool.fetchval(
+        "DELETE FROM allocations WHERE alloc_id = $1 AND order_id = $2 RETURNING alloc_id",
+        alloc_id,
+        order_id,
+    )
+    if deleted is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return {"status": "deleted"}
+
+
+@app.post("/orders/{order_id}/close")
+async def close_order(order_id: int) -> dict[str, Any]:
+    return await _fetch_one(
+        "UPDATE production_orders SET status = 'closed' WHERE order_id = $1 RETURNING *", order_id
+    )
+
+
+@app.patch("/lots/{lot_id}")
+async def patch_lot(lot_id: int, body: LotPatch) -> dict[str, Any]:
+    fields = body.model_dump(exclude_none=True)
+    query, values = _build_update("lots", "lot_id", fields)
+    return await _fetch_one(query, *values, lot_id)
+
+
+@app.post("/lots", status_code=201)
+async def create_lot(body: NewLot) -> dict[str, Any]:
+    return await _fetch_one(
+        "INSERT INTO lots (lot_id, lot_code, product, status, quantity, created_at) "
+        "VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+        body.lot_id,
+        body.lot_code,
+        body.product,
+        body.status,
+        body.quantity,
+        body.created_at,
+    )
+
+
+@app.post("/orders", status_code=201)
+async def create_order(body: NewOrder) -> dict[str, Any]:
+    return await _fetch_one(
+        "INSERT INTO production_orders (order_id, order_code, lot_id, status, quantity, due_date) "
+        "VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+        body.order_id,
+        body.order_code,
+        body.lot_id,
+        body.status,
+        body.quantity,
+        body.due_date,
+    )
+
+
+@app.patch("/orders/{order_id}")
+async def patch_order(order_id: int, body: OrderPatch) -> dict[str, Any]:
+    fields = body.model_dump(exclude_none=True)
+    query, values = _build_update("production_orders", "order_id", fields)
+    return await _fetch_one(query, *values, order_id)

--- a/examples/native/multi_service_lot_ops/shared/environment.compose.yaml
+++ b/examples/native/multi_service_lot_ops/shared/environment.compose.yaml
@@ -1,0 +1,59 @@
+# multi_service_lot_ops stack: agent -> FastAPI (app-service) -> postgres:16 (app-db); db-service backs engine state. Pinned images only.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      app-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  app-service:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/mfg"
+    volumes:
+      - ./app/main.py:/srv/app/main.py:ro
+    ports:
+      - "8000"
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "mfg"
+      POSTGRES_USER: "app"
+      POSTGRES_PASSWORD: "app_pw"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d mfg"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/tests/canonical/snapshots/native_browser_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/grading_config.json
@@ -11,6 +11,7 @@
   "llm_judge": null,
   "state_checks": {
     "db_hash_check": false,
+    "db_probes": [],
     "env_assertions": [],
     "hash": null,
     "jsonpaths": []

--- a/tests/canonical/snapshots/native_calc_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/grading_config.json
@@ -11,6 +11,7 @@
   "llm_judge": null,
   "state_checks": {
     "db_hash_check": false,
+    "db_probes": [],
     "env_assertions": [],
     "hash": null,
     "jsonpaths": []

--- a/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
@@ -10,6 +10,7 @@
   "llm_judge": null,
   "state_checks": {
     "db_hash_check": false,
+    "db_probes": [],
     "env_assertions": [],
     "hash": null,
     "jsonpaths": [

--- a/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
@@ -11,6 +11,7 @@
   "llm_judge": null,
   "state_checks": {
     "db_hash_check": false,
+    "db_probes": [],
     "env_assertions": [],
     "hash": {
       "enabled": true,

--- a/tests/canonical/test_native_adapter_canon.py
+++ b/tests/canonical/test_native_adapter_canon.py
@@ -165,6 +165,40 @@ class TestShopOrders02Canon:
         snap.assert_match(actual, "initial_state_tables.json")
 
 
+class TestDbProbeGradingCanon:
+    """state_checks.db_probes translation: grading.yaml → runner GradingConfig.
+
+    Locks the contract that a ``db_probes`` assertion authored in grading.yaml
+    survives native-adapter translation into the runner-side GradingConfig
+    (and is retained by the core GradingConfig the ``validate`` path uses)
+    without a live database.
+    """
+
+    def test_db_probes_round_trip_into_runner_grading(self, native_adapter, test_data_dir):
+        td = native_adapter.to_task_description("db_probe_grading")
+        probes = td.grading.state_checks.db_probes
+
+        source = yaml.safe_load(
+            (test_data_dir / "tasks" / "db_probe_grading" / "grading.yaml").read_text()
+        )
+        src_probes = source["state_checks"]["db_probes"]
+
+        assert len(probes) == len(src_probes) == 1
+        probe, src = probes[0], src_probes[0]
+        assert probe.name == src["name"]
+        assert probe.dsn == src["dsn"]
+        assert probe.query == src["query"]
+        assert probe.expect == src["expect"]
+        assert probe.description == src["description"]
+
+    def test_core_grading_config_retains_db_probes(self, native_adapter):
+        """The ``tolokaforge validate`` path (core GradingConfig) retains
+        db_probes rather than silently dropping the key."""
+        grading = native_adapter.get_grading_config("db_probe_grading")
+        assert len(grading.state_checks.db_probes) == 1
+        assert grading.state_checks.db_probes[0]["name"] == "corrective_action_recorded"
+
+
 class TestShopOrders02SnapshotIntegrity:
     """Cross-validate snapshots against their source files WITHOUT using the adapter.
 

--- a/tests/canonical/test_runner_image_db_driver_canon.py
+++ b/tests/canonical/test_runner_image_db_driver_canon.py
@@ -1,0 +1,25 @@
+"""Driver-availability guard for the state_checks.db_probes primitive.
+
+``evaluate_db_probes`` connects to postgres via ``asyncpg`` at grade time, so
+the runner image MUST ship that driver. Unit tests inject rows and never import
+asyncpg, and the end-to-end integration test auto-skips without Docker — so a
+Dockerfile edit that drops asyncpg would otherwise fail silently at grade time.
+This locks the harness↔image coupling here, independent of Docker running.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_DOCKERFILE = REPO_ROOT / "tolokaforge" / "docker" / "dockerfiles" / "runner.Dockerfile"
+
+
+def test_runner_image_installs_asyncpg():
+    text = RUNNER_DOCKERFILE.read_text()
+    assert "asyncpg" in text, (
+        "runner.Dockerfile must install asyncpg — evaluate_db_probes "
+        "(state_checks.db_probes) connects to postgres via asyncpg at grade time"
+    )

--- a/tests/data/tasks/db_probe_grading/grading.yaml
+++ b/tests/data/tasks/db_probe_grading/grading.yaml
@@ -1,0 +1,26 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 1.0
+  pass_threshold: 0.5
+
+state_checks:
+  db_probes:
+    - name: corrective_action_recorded
+      dsn: "postgresql://grader:grader_pw@app-db:5432/mfg"
+      query: "SELECT reason_code, status FROM corrective_actions WHERE lot_id = 7"
+      expect:
+        - path: "$.rows[0].reason_code"
+          equals: "CAPA-01"
+          description: "reason code matches"
+        - path: "$.rows[0].status"
+          equals: "open"
+          description: "status is open"
+        - path: "$.row_count"
+          equals: 1
+          description: "exactly one corrective action"
+      description: "a corrective action exists for lot 7"
+
+transcript_rules: {}
+
+llm_judge: null

--- a/tests/data/tasks/db_probe_grading/task.yaml
+++ b/tests/data/tasks/db_probe_grading/task.yaml
@@ -1,0 +1,29 @@
+task_id: db_probe_grading
+name: "DB Probe Grading Fixture"
+category: test
+description: |
+  Minimal fixture exercising state_checks.db_probes translation through the
+  native adapter. Not runnable end-to-end (no live postgres) — used only to
+  lock the grading-config contract.
+
+initial_state:
+  json_db: null
+
+tools:
+  agent:
+    enabled:
+      - write_file
+  user:
+    enabled: []
+
+user_simulator:
+  mode: "scripted"
+  scripted_flow:
+    - role: "user"
+      content: "Open a corrective action for lot 7 with reason code CAPA-01."
+
+policies:
+  disallowed_actions: []
+  guidance: []
+
+grading: "grading.yaml"

--- a/tests/integration/test_lot_ops_end_to_end.py
+++ b/tests/integration/test_lot_ops_end_to_end.py
@@ -1,0 +1,195 @@
+"""End-to-end proof that the ``multi_service_lot_ops`` multi-container
+infrastructure and trace capture work.
+
+Drives the shipped ``examples/native/multi_service_lot_ops`` pack as a real
+subprocess. The stack is ``agent -> FastAPI (app-service) -> postgres:16
+(app-db)``, all ``isolation: shared``. This test validates the *infrastructure*,
+not agent task correctness:
+
+- the compose stack boots and the agent (in the runner container) reaches the
+  FastAPI service over the internal compose network (a 2xx ``http_request``);
+- the ``db_probes`` grading primitive connects to ``app-db`` as the read-only
+  ``grader`` role via ``asyncpg`` and runs its SELECT without a driver/connection
+  error;
+- the agent's mutation reached postgres through the FastAPI service (the probe's
+  read-only-grader SELECT reads back the ``corrective_actions`` row);
+- the run captures full traces (trajectory, grade, metrics) to disk.
+
+Deliberately *out of scope*: ``binary_pass``, ``state_checks == 1.0``, and judge
+success. Those are agent-behaviour and separate-bug concerns (the shipped agent
+model is non-deterministic and may, e.g., open a duplicate corrective action or
+hit a transient judge API error) — this test must not couple the infrastructure
+signal to them.
+
+**Gated.** Requires a real Docker daemon (the shared runtime brings up the
+compose stack) and a real LLM provider key (the agent must emit real tool calls).
+``requires_api`` auto-skips without a key (see ``tests/conftest.py``); the
+``docker`` skip below covers a missing daemon.
+
+**Cost.** One trial of a single GET-plus-POST-plus-write task (max 10 turns) on
+``anthropic/claude-haiku-4-5`` via OpenRouter. ~$0.05.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.requires_api,
+    pytest.mark.llm,
+    pytest.mark.slow,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK = "examples/native/multi_service_lot_ops"
+_RUN_CONFIG = f"{_PACK}/run_config.yaml"
+_TASK_ID = "lot_ops_01"
+_APP_SERVICE = "app-service:8000"
+
+# Substrings a failed asyncpg connect/auth/query surfaces. Their absence from the
+# db_probe reasons proves the grader-role DSN + asyncpg evaluator worked; the
+# probe reaching a PASS/FAIL verdict at all means it queried postgres.
+_DB_ERROR_SIGNATURES = (
+    "could not query postgres",
+    "connection refused",
+    "connectionrefusederror",
+    "authentication failed",
+    "password authentication",
+    "does not exist",
+    "could not connect",
+)
+
+
+def _output_basename() -> str:
+    """The configured ``output_dir`` basename the orchestrator suffixes with a
+    run timestamp (``<basename>_<YYYYmmdd_HHMMSS>``)."""
+    cfg = yaml.safe_load((_REPO_ROOT / _RUN_CONFIG).read_text())
+    return Path(cfg["evaluation"]["output_dir"]).name
+
+
+def _has_2xx_http_request_to_app_service(trajectory: dict[str, Any]) -> bool:
+    """True iff the agent both issued an ``http_request`` at ``app-service:8000``
+    and a tool result reported a 2xx status — the agent-in-container -> FastAPI
+    path over the internal compose network."""
+    messages = trajectory.get("messages") or []
+    called_app_service = any(
+        (call.get("name") == "http_request")
+        and (_APP_SERVICE in str((call.get("arguments") or {}).get("url", "")))
+        for msg in messages
+        for call in (msg.get("tool_calls") or [])
+    )
+    got_2xx = any(
+        msg.get("role") == "tool" and re.search(r"Status:\s*2\d\d", str(msg.get("content") or ""))
+        for msg in messages
+    )
+    return called_app_service and got_2xx
+
+
+def _assert_infrastructure(run_dir: Path) -> None:
+    """Assert the run's artifacts prove the multi-container infrastructure and
+    trace capture worked. Split out so the assertions can be dry-run against a
+    preserved run dir without spending an LLM run."""
+    trial_dir = run_dir / "trials" / _TASK_ID / "0"
+
+    grade_path = trial_dir / "grade.yaml"
+    trajectory_path = trial_dir / "trajectory.yaml"
+    metrics_path = trial_dir / "metrics.yaml"
+    for path in (grade_path, trajectory_path, metrics_path):
+        assert path.exists(), (
+            f"missing {path.name} at {path}.\n"
+            f"run dir contents: {sorted(p.name for p in run_dir.rglob('*'))[:50]}"
+        )
+
+    trajectory = yaml.safe_load(trajectory_path.read_text())
+    assert _has_2xx_http_request_to_app_service(trajectory), (
+        "no successful (2xx) http_request to app-service:8000 in the trajectory — "
+        "the agent-in-container -> FastAPI network path did not work.\n"
+        f"messages: {trajectory.get('messages')}"
+    )
+
+    grade = yaml.safe_load(grade_path.read_text())
+    reasons = grade["reasons"]
+    assert "DB probes:" in reasons, (
+        "grade reasons carry no 'DB probes:' segment — the db_probes primitive "
+        f"did not run.\nreasons: {reasons}"
+    )
+    lowered = reasons.lower()
+    hit = next((sig for sig in _DB_ERROR_SIGNATURES if sig in lowered), None)
+    assert hit is None, (
+        f"db_probe hit a connection/driver error ({hit!r}) — the grader-role DSN "
+        f"or asyncpg evaluator failed.\nreasons: {reasons}"
+    )
+
+    # The mutation reached postgres through FastAPI: the probe's read-only-grader
+    # SELECT read back the corrective_actions row the agent POSTed (reason_code
+    # and status assertions PASS => a matching substrate row exists). This is the
+    # independent-oracle substrate check; a separate live connection is not
+    # possible because the shared runtime tears app-db down when the run exits.
+    assert "PASS: corrective action uses the contamination reason code" in reasons, (
+        "db_probe did not read back a corrective_actions row with the contamination "
+        f"reason code — the mutation did not reach postgres.\nreasons: {reasons}"
+    )
+    open_detail = f"db_probe did not read back an open corrective_actions row.\nreasons: {reasons}"
+    assert "PASS: the action is open" in reasons, open_detail
+
+    metrics = yaml.safe_load(metrics_path.read_text())
+    calls_detail = (
+        f"metrics report no tool calls — the tool orchestration did not run.\nmetrics: {metrics}"
+    )
+    assert metrics["tool_calls"] > 0, calls_detail
+    cost_detail = f"metrics report zero cost — the agent LLM did not run.\nmetrics: {metrics}"
+    assert metrics["cost_usd"] > 0, cost_detail
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (shared runtime needs it)",
+)
+def test_lot_ops_infrastructure_end_to_end() -> None:
+    """The full ``tolokaforge run`` exits 0 and its captured traces prove the
+    multi-container stack, agent-in-container -> FastAPI network path, substrate
+    mutation, db_probe grading primitive, and trace capture all worked."""
+    basename = _output_basename()
+    results_root = _REPO_ROOT / "results"
+    before = set(results_root.glob(f"{basename}_*")) if results_root.exists() else set()
+
+    proc = subprocess.run(
+        ["uv", "run", "tolokaforge", "run", "--config", _RUN_CONFIG],
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"tolokaforge run failed (rc={proc.returncode}):\n"
+        f"stdout:\n{proc.stdout[-4000:]}\n"
+        f"stderr:\n{proc.stderr[-4000:]}"
+    )
+
+    after = set(results_root.glob(f"{basename}_*"))
+    created = after - before
+    assert len(created) == 1, (
+        f"expected exactly one new run dir under {results_root} matching "
+        f"{basename}_*; got {sorted(created)}"
+    )
+    run_dir = created.pop()
+
+    _assert_infrastructure(run_dir)
+
+    # Only reached once every assertion passed — a red run leaves the run dir
+    # (with all traces) on disk for post-mortem.
+    shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/unit/test_runner_jsonpath_grading.py
+++ b/tests/unit/test_runner_jsonpath_grading.py
@@ -12,9 +12,11 @@ from pathlib import Path
 
 import pytest
 
+from tolokaforge.runner import grading as grading_module
 from tolokaforge.runner.grading import (
     build_grade_reasons,
     combine_grade_components,
+    evaluate_db_probes,
     evaluate_jsonpath_checks,
     evaluate_jsonpath_file_checks,
     evaluate_jsonpath_state_checks,
@@ -246,6 +248,114 @@ def test_combine_components_multiplies_hash_and_jsonpath():
     }
     score, _ = combine_grade_components(components, grading_config)
     assert score == pytest.approx(0.5)
+
+
+def _stub_rows(rows, monkeypatch):
+    """Inject an in-memory row set for _fetch_probe_rows (no live DB)."""
+
+    async def fake_fetch(dsn: str, query: str):
+        return rows
+
+    monkeypatch.setattr(grading_module, "_fetch_probe_rows", fake_fetch)
+
+
+async def test_db_probes_empty_returns_sentinel():
+    score, reasons = await evaluate_db_probes([])
+    assert score == -1.0
+    assert reasons == ""
+
+
+async def test_db_probe_passes_when_expect_matches(monkeypatch):
+    _stub_rows([{"reason_code": "CAPA-01", "status": "open"}], monkeypatch)
+    probes = [
+        {
+            "name": "ca_exists",
+            "dsn": "postgresql://grader@app-db/mfg",
+            "query": "SELECT reason_code, status FROM corrective_actions WHERE lot_id = 7",
+            "expect": [
+                {
+                    "path": "$.rows[0].reason_code",
+                    "equals": "CAPA-01",
+                    "description": "reason code",
+                },
+                {"path": "$.rows[0].status", "equals": "open", "description": "status open"},
+                {"path": "$.row_count", "equals": 1, "description": "exactly one row"},
+            ],
+            "description": "corrective action recorded",
+        }
+    ]
+    score, reasons = await evaluate_db_probes(probes)
+    assert score == 1.0
+    assert "PASS: probe 'ca_exists'" in reasons
+
+
+async def test_db_probe_fails_and_reports_actual_value(monkeypatch):
+    _stub_rows([{"reason_code": "WRONG", "status": "open"}], monkeypatch)
+    probes = [
+        {
+            "name": "ca_exists",
+            "dsn": "postgresql://grader@app-db/mfg",
+            "query": "SELECT reason_code FROM corrective_actions",
+            "expect": [
+                {
+                    "path": "$.rows[0].reason_code",
+                    "equals": "CAPA-01",
+                    "description": "reason code",
+                },
+            ],
+            "description": "corrective action recorded",
+        }
+    ]
+    score, reasons = await evaluate_db_probes(probes)
+    assert score == 0.0
+    assert "FAIL: probe 'ca_exists'" in reasons
+    # The mismatching value is surfaced for debugging.
+    assert "WRONG" in reasons
+
+
+async def test_db_probe_connection_error_fails_loud(monkeypatch):
+    async def raising_fetch(dsn: str, query: str):
+        raise ConnectionError("could not connect to app-db:5432")
+
+    monkeypatch.setattr(grading_module, "_fetch_probe_rows", raising_fetch)
+    probes = [
+        {
+            "name": "ca_exists",
+            "dsn": "postgresql://grader@app-db/mfg",
+            "query": "SELECT 1",
+            "expect": [{"path": "$.row_count", "equals": 1}],
+            "description": "corrective action recorded",
+        }
+    ]
+    score, reasons = await evaluate_db_probes(probes)
+    assert score == 0.0
+    assert "FAIL: probe 'ca_exists'" in reasons
+    assert "could not query postgres" in reasons
+    assert "ConnectionError" in reasons
+
+
+def test_combine_components_uses_db_probe_as_state_checks():
+    components = {"hash_score": -1.0, "jsonpath_score": -1.0, "db_probe_score": 1.0}
+    grading_config = {
+        "combine_method": "weighted",
+        "weights": {"state_checks": 1.0},
+        "state_checks": {"db_probes": [{"name": "x"}]},
+    }
+    score, binary_pass = combine_grade_components(components, grading_config)
+    assert score == 1.0
+    assert binary_pass is True
+
+
+def test_build_reasons_includes_db_probe_when_score_set():
+    components = {
+        "hash_score": -1.0,
+        "jsonpath_score": -1.0,
+        "db_probe_score": 0.0,
+        "db_probe_reasons": "FAIL: probe 'ca_exists' — FAIL: reason code",
+        "transcript_score": -1.0,
+    }
+    text = build_grade_reasons(components)
+    assert "DB probes: FAIL: probe 'ca_exists'" in text
 
 
 def test_build_reasons_includes_jsonpath_when_score_set():

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -396,6 +396,7 @@ class NativeAdapter(BaseAdapter):
 
         from tolokaforge.runner.models import (
             AdapterType,
+            DbProbe,
             EnvAssertion,
             GoldenAction,
             InitializationAction,
@@ -616,12 +617,15 @@ class NativeAdapter(BaseAdapter):
                         )
                     )
 
+                db_probes = [DbProbe(**probe) for probe in state_checks_data.get("db_probes", [])]
+
                 state_checks = StateChecksConfig(
                     hash_enabled=bool(hash_config and hash_config.get("enabled", False)),
                     expected_hash=hash_config.get("expected_state_hash") if hash_config else None,
                     golden_actions=golden_actions,
                     jsonpath_checks=state_checks_data.get("jsonpaths", []),
                     env_assertions=env_assertions,
+                    db_probes=db_probes,
                 )
 
             # Build transcript rules

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1249,6 +1249,7 @@ class StateChecksConfig(BaseModel):
     hash: dict[str, Any] | None = None
     env_assertions: list[EnvAssertion] = Field(default_factory=list)  # NEW
     db_hash_check: bool = False  # NEW - compare final DB hash
+    db_probes: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class CommunicateInfo(BaseModel):

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -662,6 +662,68 @@ def evaluate_jsonpath_state_checks(
     return score, reasons
 
 
+async def _fetch_probe_rows(dsn: str, query: str) -> list[dict[str, Any]]:
+    """Connect to ``dsn`` via asyncpg, run ``query``, return rows as dicts.
+
+    Isolated so unit tests inject rows without a live database; the asyncpg
+    import is deferred so importing this module never requires the driver.
+    """
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        records = await conn.fetch(query)
+    finally:
+        await conn.close()
+    return [dict(record) for record in records]
+
+
+async def evaluate_db_probes(probes: list[dict[str, Any]]) -> tuple[float, str]:
+    """Evaluate substrate SQL probes against a task-declared postgres.
+
+    For each probe, connect to its ``dsn``, run its read-only ``query``, shape
+    the result into ``{"rows": [...], "row_count": N}``, and apply its ``expect``
+    JSONPath assertions via ``evaluate_jsonpath_state_checks``.
+
+    Two-level aggregation: a probe passes iff *every* ``expect`` assertion passes
+    (its JSONPath score is 1.0); the component score is the fraction of passing
+    probes. A connection/query failure is a FAILED probe with an actionable
+    reason (fail loud — never a silent pass). Empty list → -1.0 sentinel,
+    matching the file/state evaluators.
+    """
+    if not probes:
+        return -1.0, ""
+
+    passed = 0
+    total = len(probes)
+    reasons_parts: list[str] = []
+
+    for probe in probes:
+        name = probe.get("name", "")
+        description = probe.get("description") or name
+        expect = probe.get("expect", []) or []
+
+        try:
+            rows = await _fetch_probe_rows(probe.get("dsn", ""), probe.get("query", ""))
+        except Exception as exc:
+            reasons_parts.append(
+                f"FAIL: probe {name!r} could not query postgres: "
+                f"{type(exc).__name__}: {exc} — {description}"
+            )
+            continue
+
+        state = {"rows": rows, "row_count": len(rows)}
+        probe_score, probe_reasons = evaluate_jsonpath_state_checks(expect, state)
+        if probe_score == 1.0:
+            passed += 1
+            reasons_parts.append(f"PASS: probe {name!r} — {probe_reasons}")
+        else:
+            reasons_parts.append(f"FAIL: probe {name!r} — {probe_reasons}")
+
+    score = passed / total
+    return score, "; ".join(reasons_parts)
+
+
 def evaluate_jsonpath_checks(
     checks: list[dict[str, Any]],
     state: dict[str, Any] | None = None,
@@ -765,6 +827,11 @@ def combine_grade_components(
         active_components["state_checks"] = hash_score
     elif jsonpath_score >= 0:
         active_components["state_checks"] = jsonpath_score
+    # db_probes is the sole state source for its tasks (mixing with hash/jsonpath
+    # in one task is out of scope), so it fills the state_checks slot directly.
+    db_probe_score = components.get("db_probe_score", -1.0)
+    if db_probe_score >= 0:
+        active_components["state_checks"] = db_probe_score
     if transcript_score >= 0:
         active_components["transcript_rules"] = transcript_score
 
@@ -878,6 +945,17 @@ def build_grade_reasons(
             reasons.append("JSONPath: all checks passed")
         else:
             reasons.append(f"JSONPath: score={jsonpath_score:.2f}")
+
+    # State checks reason — db probes
+    db_probe_score = components.get("db_probe_score", -1.0)
+    if db_probe_score >= 0:
+        db_probe_reasons = components.get("db_probe_reasons", "")
+        if db_probe_reasons:
+            reasons.append(f"DB probes: {db_probe_reasons}")
+        elif db_probe_score == 1.0:
+            reasons.append("DB probes: all probes passed")
+        else:
+            reasons.append(f"DB probes: score={db_probe_score:.2f}")
 
     # Transcript rules reason
     transcript_score = components.get("transcript_score", -1.0)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -276,6 +276,24 @@ class RequiredAction(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class DbProbe(BaseModel):
+    """A declarative read-only SQL assertion against a task-declared postgres.
+
+    Grading connects to ``dsn``, runs ``query`` (a single read-only ``SELECT``),
+    shapes the result into ``{"rows": [{col: val, ...}, ...], "row_count": N}``,
+    and applies ``expect`` — JSONPath assertions in the same vocabulary as
+    ``jsonpath_checks`` (``equals``/``equals_ci``/``contains``/``contains_ci``).
+    """
+
+    name: str
+    dsn: str
+    query: str
+    expect: list[dict[str, Any]]
+    description: str = ""
+
+    model_config = {"extra": "forbid"}
+
+
 class StateChecksConfig(BaseModel):
     """State-based grading configuration."""
 
@@ -289,6 +307,9 @@ class StateChecksConfig(BaseModel):
 
     # Environment assertions (Native adapter)
     env_assertions: list[EnvAssertion] = Field(default_factory=list)
+
+    # Substrate SQL assertions against a task-declared postgres DSN
+    db_probes: list[DbProbe] = Field(default_factory=list)
 
     model_config = {"extra": "forbid"}
 
@@ -1467,6 +1488,8 @@ class GradeComponents(BaseModel):
     hash_score: float = -1.0  # -1.0 means not evaluated
     jsonpath_score: float = -1.0  # -1.0 means not evaluated
     jsonpath_reasons: str = ""
+    db_probe_score: float = -1.0  # -1.0 means not evaluated
+    db_probe_reasons: str = ""
     transcript_pass: bool | None = None
     transcript_score: float = -1.0
     llm_judge_score: float = -1.0  # -1.0 means not evaluated

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -52,6 +52,7 @@ from tolokaforge.runner.grading import (
     build_grade_reasons,
     combine_grade_components,
     compute_state_diff,
+    evaluate_db_probes,
     evaluate_jsonpath_checks,
     evaluate_transcript_rules,
 )
@@ -1072,6 +1073,20 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             components.jsonpath_reasons = jsonpath_reasons
             logger.info(f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}")
 
+        # A.3) DB PROBES (substrate SQL assertions) — the sole state source for
+        # tasks that use it; combining db_probes with hash/jsonpath checks in one
+        # task is out of scope, so its score fills the state_checks component.
+        if state_checks_config and state_checks_config.db_probes:
+            logger.info(
+                f"GradeTrial: {trial_id} - Evaluating "
+                f"{len(state_checks_config.db_probes)} db probes"
+            )
+            probes = [probe.model_dump() for probe in state_checks_config.db_probes]
+            db_probe_score, db_probe_reasons = await evaluate_db_probes(probes)
+            components.db_probe_score = db_probe_score
+            components.db_probe_reasons = db_probe_reasons
+            logger.info(f"GradeTrial: {trial_id} - DB probes: score={db_probe_score:.2f}")
+
         # B) TRANSCRIPT RULES GRADING (if transcript_rules exist)
         transcript_rules_config = grading_config.transcript_rules
         # Decode the trajectory once — both transcript-rules and llm-judge use it.
@@ -1184,6 +1199,15 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
 
         logger.info(f"GradeTrial: {trial_id} - score={score:.2f}, pass={binary_pass}")
 
+        if components.db_probe_score >= 0:
+            state_checks_component = components.db_probe_score
+        elif components.hash_score < 0:
+            state_checks_component = components.jsonpath_score
+        elif components.jsonpath_score < 0:
+            state_checks_component = components.hash_score
+        else:
+            state_checks_component = components.hash_score * components.jsonpath_score
+
         return pb2.GradeTrialResponse(
             success=True,
             error="",
@@ -1191,15 +1215,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 binary_pass=binary_pass,
                 score=score,
                 components=pb2.GradeComponents(
-                    state_checks=(
-                        components.jsonpath_score
-                        if components.hash_score < 0
-                        else (
-                            components.hash_score
-                            if components.jsonpath_score < 0
-                            else components.hash_score * components.jsonpath_score
-                        )
-                    ),
+                    state_checks=state_checks_component,
                     transcript_rules=components.transcript_score,
                     llm_judge=components.llm_judge_score,
                     custom_checks=-1.0,  # Not implemented yet


### PR DESCRIPTION
Closes #400.

## Summary

- **New grading primitive** `state_checks.db_probes` — declarative postgres substrate assertions. A probe connects via a task-declared DSN (a read-only role is the intended pattern), runs a read-only `SELECT`, shapes rows into `{"rows": [...], "row_count": N}`, and applies the existing JSONPath assertion vocabulary. Two-level aggregation: a probe passes iff every `expect` assertion passes; the component score is the fraction of passing probes.
- **New multi-container example** `examples/native/multi_service_lot_ops/` — a lot-operations FastAPI + postgres pack (4 services, all `isolation: shared`; ~20-endpoint API; a natural user-simulator persona) that grades a real substrate mutation. The grader connects as a `GRANT SELECT`-only role for a least-privilege independent oracle — the db_probe reads `corrective_actions` directly, not the agent's file.
- **Integration test** locks that the multi-container infrastructure and trace capture work end-to-end: the agent-in-container reaches the FastAPI service over the compose network, the mutation reaches postgres through the API, the db_probe grader-role SELECT reads it back, and trajectory/grade/metrics traces are captured. It deliberately does not assert `binary_pass` or judge success — those are separate concerns tracked as follow-ups.

## Design walkthrough

```
agent (runner_service) ──http_request──> app-service (FastAPI, asyncpg)
                                              │
                                              ▼
                                         app-db (postgres:16)
                                          ▲
                                          │  SELECT (grader role, read-only)
                                          │
                    grading pipeline (state_checks.db_probes via asyncpg)
```

- `runner_service` is the tolokaforge runner container the agent lives in.
- `app-service` reuses `tolokaforge-runner:local` (bundles fastapi/uvicorn/asyncpg, works under `no_internet`) with a `command:` override — no custom image build required.
- `app-db` is `postgres:16` (pinned), bootstrapping the schema + seed + roles from `init.sql`.
- Grading runs in-process in the runner: `asyncpg.connect(<grader-DSN>)`, `SELECT`, shape rows, apply JSONPath — all with the driver already in the image.

## Test tiers

- **Unit** (`tests/unit/test_runner_jsonpath_grading.py`) — `evaluate_db_probes` scoring over injected in-memory rows: match → pass, mismatch → fail with the value in the reason, connection error → fail loud, empty probes → `-1.0` sentinel; plus combine + reason wiring for the db_probe channel.
- **Canonical** — native-adapter round-trip (grading.yaml `db_probes` → runner `GradingConfig`) + Docker-independent driver-availability guard asserting `runner.Dockerfile` installs `asyncpg` in its runtime-deps block, so a Dockerfile edit that drops the driver fails HERE, not silently at grade time.
- **Integration** (`tests/integration/test_lot_ops_end_to_end.py`) — real Docker + real Haiku via OpenRouter; auto-skips without keys/daemon. Asserts infrastructure and trace capture (not agent perfection or judge grading).

## Follow-ups filed during this PR

Non-blocking, all in this milestone:

- #417 — Judge API_ERROR on OpenRouter 401 auth cookie (`anthropic/claude-sonnet-4-6` blocks `llm_judge` grading; not transient).
- #418 — Per-service Docker logs not captured on grade-fail (only on provision/trial-body fail) — blocks efficient post-mortem for red integration tests.
- #419 — `env.yaml` empty for Project-layer native runs (env identity from M3 not populated on this code path).
- #421 — sqlite queue resumes completed trial when re-running same output_dir; masks re-execution (iteration + test-flake footgun).
- #422 — `state_checks` component derivation duplicated across `combine_grade_components` and `GradeTrial` (DRY smell reviewer flagged; pre-existing, mildly extended here).

Reviewer verdict: **APPROVE WITH NITS** (no blockers).

## Verification

- All unit tests green (marker `unit` on grading paths).
- All canonical tests green (marker `canonical`; 4 snapshots regenerated via `update_canonical_snapshots`, not hand-edited).
- Integration test runs a real end-to-end pipeline against Docker + Haiku and asserts on the infrastructure and traces from the resulting run dir.
- Reviewer confirmed: no `_legacy_*` shims, no secrets access outside `SecretManager`, no task-specific SQL in the harness, no model-name conditionals, back-compat clean (new optional field, `db_probes: []` default), Dockerfile↔asyncpg coupling locked, compose 59 lines all `isolation: shared`, no fictional images, three-way weighted grading (0.5/0.2/0.3), grader role `GRANT SELECT` only, no internal-repo references, no `Co-Authored-By: Claude` in commit trailers.

## Test plan (post-merge)

- [ ] `mcp__dev__run_tests` markers `unit` + `canonical` on the M18 integration branch stay green.
- [ ] `scripts/with_env.sh uv run pytest tests/integration/test_lot_ops_end_to_end.py -v -m integration` runs green on a fresh Docker + Haiku key (~$0.15, ~1 min after Docker+queue clear).
- [ ] Follow-ups #417/#418/#419/#421/#422 tackled next in this milestone before the remaining example packs (#401/#402/#403).
