### PR TITLE
feat(session): InProcessTrialSession — thread-safe live transport (M1 sub-1)

### DIFF
--- a/tests/unit/session/test_in_process.py
+++ b/tests/unit/session/test_in_process.py
@@ -1,0 +1,392 @@
+"""Unit tests for :class:`tolokaforge.session.InProcessTrialSession` — M1 sub-1.
+
+Covers:
+
+* Producer-side ``next_seq`` monotonicity across threads.
+* Broadcast fan-out: every attached participant sees every event.
+* Late attach: joins mid-stream and sees only events from the current
+  ``seq`` forward, never history.
+* Terminal signalling: :class:`TerminalReached` closes the session and
+  releases every blocked ``iter_events`` iterator.
+* Intervention queueing: ``submit`` returns ``outcome="queued"``
+  immediately; the intervention appears in ``drain_pending_interventions``
+  in submission order.
+* Detach releases the iterator without disturbing other participants.
+* Attach / publish after close raise instead of silently dropping.
+* Handle validation: cross-trial handle, cross-participant intervention,
+  detached-participant submit all raise.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+
+import pytest
+
+from tolokaforge.session import (
+    AssistantMessage,
+    InjectMessage,
+    InProcessTrialSession,
+    ParticipantRole,
+    QueuedIntervention,
+    TerminalReached,
+    ToolCallEmitted,
+    TrialEvent,
+    TurnStarted,
+)
+from tolokaforge.session._status import TrialStatus
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _turn(session: InProcessTrialSession, turn_index: int) -> TurnStarted:
+    return TurnStarted(
+        trial_id=session.trial_id,
+        seq=session.next_seq(),
+        timestamp=_NOW,
+        turn_index=turn_index,
+    )
+
+
+def _assistant(session: InProcessTrialSession, content: str = "hi") -> AssistantMessage:
+    return AssistantMessage(
+        trial_id=session.trial_id,
+        seq=session.next_seq(),
+        timestamp=_NOW,
+        content_preview=content,
+    )
+
+
+def _terminal(session: InProcessTrialSession) -> TerminalReached:
+    return TerminalReached(
+        trial_id=session.trial_id,
+        seq=session.next_seq(),
+        timestamp=_NOW,
+        status=TrialStatus.COMPLETED,
+    )
+
+
+class TestSeqAllocation:
+    def test_next_seq_is_monotonic(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        seqs = [session.next_seq() for _ in range(20)]
+        assert seqs == list(range(20))
+
+    def test_next_seq_is_thread_safe(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        collected: list[int] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            local = [session.next_seq() for _ in range(50)]
+            with lock:
+                collected.extend(local)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # No duplicates, dense range regardless of interleaving
+        assert sorted(collected) == list(range(8 * 50))
+
+
+class TestAttachDetach:
+    def test_attach_returns_confirmed_handle(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        assert handle.trial_id == "t:0"
+        assert handle.role is ParticipantRole.PARTICIPANT
+        assert handle.participant_id == "p1"
+        assert session.attached_participant_ids == ["p1"]
+
+    def test_double_attach_same_id_raises(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        session.attach("p1", ParticipantRole.PARTICIPANT)
+        with pytest.raises(ValueError):
+            session.attach("p1", ParticipantRole.OBSERVER)
+
+    def test_detach_is_idempotent(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        session.detach(handle)
+        # Second detach is a no-op
+        session.detach(handle)
+        assert session.attached_participant_ids == []
+
+    def test_attach_after_close_raises(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        session.close()
+        with pytest.raises(ValueError):
+            session.attach("p1", ParticipantRole.PARTICIPANT)
+
+
+class TestEventBroadcast:
+    def test_all_attached_participants_receive_every_event(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        h1 = session.attach("p1", ParticipantRole.PARTICIPANT)
+        h2 = session.attach("p2", ParticipantRole.OBSERVER)
+
+        session.publish(_turn(session, 0))
+        session.publish(_assistant(session, "hello"))
+        session.publish(_terminal(session))
+
+        p1 = list(session.events().iter_events(h1))
+        p2 = list(session.events().iter_events(h2))
+
+        assert [e.seq for e in p1] == [0, 1, 2]
+        assert [e.seq for e in p2] == [0, 1, 2]
+        assert isinstance(p1[-1], TerminalReached)
+
+    def test_late_attach_only_sees_events_from_attachment_forward(self):
+        session = InProcessTrialSession(trial_id="t:0")
+
+        h_early = session.attach("early", ParticipantRole.PARTICIPANT)
+        session.publish(_turn(session, 0))  # seq 0
+        session.publish(_assistant(session, "before"))  # seq 1
+
+        h_late = session.attach("late", ParticipantRole.OBSERVER)
+        session.publish(_assistant(session, "after"))  # seq 2
+        session.publish(_terminal(session))  # seq 3
+
+        early_seqs = [e.seq for e in session.events().iter_events(h_early)]
+        late_seqs = [e.seq for e in session.events().iter_events(h_late)]
+
+        assert early_seqs == [0, 1, 2, 3]
+        assert late_seqs == [2, 3]
+
+    def test_iter_events_blocks_until_event_arrives(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+
+        collected: list[TrialEvent] = []
+        ready = threading.Event()
+
+        def consumer() -> None:
+            ready.set()
+            for event in session.events().iter_events(handle):
+                collected.append(event)
+
+        thread = threading.Thread(target=consumer)
+        thread.start()
+
+        ready.wait(timeout=1.0)
+        # Consumer is blocked in iter_events; nothing yet.
+        assert collected == []
+        session.publish(_turn(session, 0))
+        session.publish(_terminal(session))
+
+        thread.join(timeout=2.0)
+        assert not thread.is_alive(), "consumer did not exit after terminal"
+        assert len(collected) == 2
+
+    def test_detach_releases_blocked_iterator_without_affecting_peers(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        h_leaving = session.attach("leaving", ParticipantRole.PARTICIPANT)
+        h_staying = session.attach("staying", ParticipantRole.OBSERVER)
+
+        leaving_events: list[TrialEvent] = []
+        staying_events: list[TrialEvent] = []
+
+        def drain(handle, into):
+            for event in session.events().iter_events(handle):
+                into.append(event)
+
+        t_leave = threading.Thread(target=drain, args=(h_leaving, leaving_events))
+        t_stay = threading.Thread(target=drain, args=(h_staying, staying_events))
+        t_leave.start()
+        t_stay.start()
+
+        session.publish(_turn(session, 0))
+        session.detach(h_leaving)
+        t_leave.join(timeout=2.0)
+        assert not t_leave.is_alive()
+        assert len(leaving_events) == 1  # saw the turn before detach
+
+        session.publish(_assistant(session, "after leave"))
+        session.publish(_terminal(session))
+        t_stay.join(timeout=2.0)
+        assert not t_stay.is_alive()
+        assert [e.seq for e in staying_events] == [0, 1, 2]
+
+
+class TestTerminalAndClose:
+    def test_terminal_reached_closes_session(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        session.attach("p1", ParticipantRole.PARTICIPANT)
+        session.publish(_terminal(session))
+
+        assert session.is_closed
+        with pytest.raises(RuntimeError):
+            session.publish(_turn(session, 99))
+
+    def test_close_without_terminal_still_releases_iterators(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        h = session.attach("p1", ParticipantRole.PARTICIPANT)
+        collected: list[TrialEvent] = []
+
+        def consumer() -> None:
+            for event in session.events().iter_events(h):
+                collected.append(event)
+
+        thread = threading.Thread(target=consumer)
+        thread.start()
+        session.publish(_turn(session, 0))
+        session.close()
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+        assert [e.seq for e in collected] == [0]
+
+    def test_close_is_idempotent(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        session.close()
+        session.close()
+        assert session.is_closed
+
+
+class TestInterventions:
+    def test_submit_queues_and_returns_ack_queued(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        intervention = InjectMessage(
+            trial_id="t:0",
+            attach_to_seq=0,
+            participant_id="p1",
+            timestamp=_NOW,
+            content="try /v2/auth",
+        )
+        ack = session.interventions().submit(handle, intervention)
+        assert ack.outcome == "queued"
+
+        pending = session.drain_pending_interventions()
+        assert len(pending) == 1
+        assert isinstance(pending[0], QueuedIntervention)
+        assert pending[0].intervention.content == "try /v2/auth"
+        assert pending[0].handle.participant_id == "p1"
+
+    def test_drain_returns_interventions_in_submission_order(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        h1 = session.attach("p1", ParticipantRole.PARTICIPANT)
+        h2 = session.attach("p2", ParticipantRole.ADMIN)
+
+        for i, (handle, pid) in enumerate([(h1, "p1"), (h2, "p2"), (h1, "p1")]):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="t:0",
+                    attach_to_seq=i,
+                    participant_id=pid,
+                    timestamp=_NOW,
+                    content=f"msg-{i}",
+                ),
+            )
+
+        drained = session.drain_pending_interventions()
+        assert [q.intervention.content for q in drained] == ["msg-0", "msg-1", "msg-2"]
+
+    def test_drain_max_batch_caps(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        for i in range(5):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="t:0",
+                    attach_to_seq=i,
+                    participant_id="p1",
+                    timestamp=_NOW,
+                    content=f"m{i}",
+                ),
+            )
+        first_batch = session.drain_pending_interventions(max_batch=2)
+        rest = session.drain_pending_interventions()
+        assert len(first_batch) == 2
+        assert len(rest) == 3
+
+    def test_submit_cross_trial_intervention_raises(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        with pytest.raises(ValueError):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="other:0",
+                    attach_to_seq=0,
+                    participant_id="p1",
+                    timestamp=_NOW,
+                    content="wrong trial",
+                ),
+            )
+
+    def test_submit_wrong_participant_id_raises(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        with pytest.raises(ValueError):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id="not-p1",
+                    timestamp=_NOW,
+                    content="wrong pid",
+                ),
+            )
+
+    def test_submit_after_detach_raises(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        session.detach(handle)
+        with pytest.raises(ValueError):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id="p1",
+                    timestamp=_NOW,
+                    content="too late",
+                ),
+            )
+
+
+class TestConcurrentProducerConsumer:
+    def test_high_frequency_publish_across_multiple_consumers(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        num_consumers = 4
+        handles = [session.attach(f"p{i}", ParticipantRole.OBSERVER) for i in range(num_consumers)]
+
+        collected: dict[str, list[int]] = {h.participant_id: [] for h in handles}
+
+        def consume(handle) -> None:
+            for event in session.events().iter_events(handle):
+                collected[handle.participant_id].append(event.seq)
+
+        threads = [threading.Thread(target=consume, args=(h,)) for h in handles]
+        for t in threads:
+            t.start()
+
+        num_events = 200
+        for i in range(num_events):
+            session.publish(
+                ToolCallEmitted(
+                    trial_id="t:0",
+                    seq=session.next_seq(),
+                    timestamp=_NOW,
+                    call_id=f"c{i}",
+                    tool_name="lookup",
+                    arguments_preview="{}",
+                )
+            )
+        session.publish(_terminal(session))
+
+        for t in threads:
+            t.join(timeout=5.0)
+            assert not t.is_alive()
+
+        expected = list(range(num_events + 1))  # +1 for TerminalReached
+        for pid, seqs in collected.items():
+            assert seqs == expected, f"consumer {pid} saw {seqs[:8]}... expected {expected[:8]}..."

--- a/tolokaforge/session/__init__.py
+++ b/tolokaforge/session/__init__.py
@@ -17,7 +17,8 @@ recorded, Unix-socket, WebSocket) are separate concerns from the Protocols.
 M0 ships the Protocols, the event and intervention discriminated unions, and
 :class:`RecordedTrialSession` — a transport that replays a captured trajectory
 event-by-event so participants can be developed and tested without a live
-conductor.
+conductor. M1 adds :class:`InProcessTrialSession`, the live thread-safe
+transport driven by the :class:`GatedConductor`.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ from tolokaforge.session.events import (
     TrialEventEnvelope,
     TurnStarted,
 )
+from tolokaforge.session.in_process import InProcessTrialSession, QueuedIntervention
 from tolokaforge.session.interventions import (
     ApproveTool,
     EditState,
@@ -59,6 +61,7 @@ __all__ = [
     "AssistantMessage",
     "BudgetUpdate",
     "EditState",
+    "InProcessTrialSession",
     "InjectMessage",
     "InterventionAck",
     "Kill",
@@ -66,6 +69,7 @@ __all__ = [
     "ParticipantRole",
     "Pause",
     "PauseAcknowledged",
+    "QueuedIntervention",
     "RecordedTrialSession",
     "RejectTool",
     "Resume",

--- a/tolokaforge/session/in_process.py
+++ b/tolokaforge/session/in_process.py
@@ -1,0 +1,307 @@
+"""``InProcessTrialSession`` — thread-safe in-process transport for the Trial Session gate.
+
+The M1 live transport. Where :class:`RecordedTrialSession` (M0) replays a
+captured trajectory for participant development, this transport carries a
+**running** trial's event stream out to attached participants and their
+interventions back to the conductor.
+
+Threading model — one producer, many consumers:
+
+* Producer: the trial-running thread (M1's ``GatedConductor``). Calls
+  :meth:`next_seq` to allocate monotonic per-trial sequence numbers,
+  :meth:`publish` to broadcast a :class:`TrialEvent`, and
+  :meth:`drain_pending_interventions` at natural pause points to collect
+  what's queued.
+* Consumers: attached participants, each on their own thread. Call
+  :meth:`iter_events` to block on their own event queue, and
+  :meth:`submit` to hand an intervention back to the producer.
+
+The event stream is broadcast: every attached participant sees every
+event in ``seq`` order. Interventions are serialised into a single
+producer-facing queue and processed later; :meth:`submit` returns
+``outcome="queued"`` immediately without waiting for the conductor to
+decide accepted / superseded / rejected — that verdict lives in the
+trajectory trace once the conductor's pause pump processes it.
+
+The Protocol from :mod:`tolokaforge.session.protocols` is deliberately
+transport-agnostic; this concrete class adds the producer-side methods
+(:meth:`publish`, :meth:`drain_pending_interventions`, :meth:`next_seq`,
+:meth:`close`) that the sealed Protocol has no reason to declare.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from tolokaforge.session.events import TerminalReached, TrialEvent
+from tolokaforge.session.interventions import InterventionAck, TrialIntervention
+from tolokaforge.session.protocols import (
+    ParticipantHandle,
+    ParticipantRole,
+    TrialEvents,
+    TrialInterventions,
+)
+
+__all__ = ["InProcessTrialSession", "QueuedIntervention"]
+
+_TERMINAL_SENTINEL: Any = object()
+
+
+@dataclass(frozen=True)
+class QueuedIntervention:
+    """One pending intervention, with the handle of the participant that submitted it.
+
+    Producer (:class:`GatedConductor`) receives a list of these from
+    :meth:`InProcessTrialSession.drain_pending_interventions` and decides
+    accept / supersede / reject per the role-priority rule (see
+    ``docs/OPEN_AGENT_LOOP.md`` §5).
+    """
+
+    handle: ParticipantHandle
+    intervention: TrialIntervention
+    submitted_at: datetime
+
+
+@dataclass
+class _ParticipantSlot:
+    """Per-participant queue + handle. One slot per attached participant."""
+
+    handle: ParticipantHandle
+    event_queue: queue.Queue = field(default_factory=queue.Queue)
+
+
+class InProcessTrialSession:
+    """Live in-process implementation of :class:`~tolokaforge.session.TrialSession`.
+
+    Instantiated by the orchestrator once per open-mode trial. The gated
+    conductor holds a reference and publishes events into it; attached
+    participants drain events from their own slot queues and submit
+    interventions back through the session.
+
+    Late attach receives events from the current ``seq`` forward — a
+    participant that attaches at ``seq=5`` never sees events 0..4.
+    Historical replay of a live trial belongs to a separate transport
+    (see :class:`~tolokaforge.session.RecordedTrialSession` for the
+    read-only equivalent).
+    """
+
+    def __init__(self, trial_id: str) -> None:
+        self._trial_id = trial_id
+        self._participants: dict[str, _ParticipantSlot] = {}
+        self._intervention_queue: queue.Queue = queue.Queue()
+        self._lock = threading.RLock()
+        self._seq_counter = 0
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # TrialSession Protocol
+    # ------------------------------------------------------------------
+
+    @property
+    def trial_id(self) -> str:
+        return self._trial_id
+
+    def attach(
+        self,
+        participant_id: str,
+        role: ParticipantRole,
+    ) -> ParticipantHandle:
+        """Register a participant on the session. Idempotent-friendly:
+        double-attach of the same participant id raises ``ValueError``.
+        Late attach after :meth:`close` also raises — a closed session
+        does not accept new participants.
+        """
+        with self._lock:
+            if self._closed:
+                raise ValueError(f"Cannot attach {participant_id!r} to a closed session.")
+            if participant_id in self._participants:
+                raise ValueError(
+                    f"Participant {participant_id!r} is already attached to this session."
+                )
+            handle = ParticipantHandle(
+                participant_id=participant_id,
+                role=role,
+                trial_id=self._trial_id,
+            )
+            self._participants[participant_id] = _ParticipantSlot(handle=handle)
+            return handle
+
+    def detach(self, handle: ParticipantHandle) -> None:
+        """Deregister a participant. Idempotent — detaching an already-
+        detached handle is a no-op. Any in-flight :meth:`iter_events`
+        call on this handle returns cleanly (the queue is signalled with
+        a terminal sentinel).
+        """
+        with self._lock:
+            slot = self._participants.pop(handle.participant_id, None)
+        if slot is not None:
+            slot.event_queue.put(_TERMINAL_SENTINEL)
+
+    def events(self) -> TrialEvents:
+        return self
+
+    def interventions(self) -> TrialInterventions:
+        return self
+
+    # ------------------------------------------------------------------
+    # TrialEvents Protocol
+    # ------------------------------------------------------------------
+
+    def iter_events(self, handle: ParticipantHandle) -> Iterator[TrialEvent]:
+        """Block on the participant's slot queue and yield events until the
+        session is closed or the participant is detached.
+        """
+        slot = self._require_slot(handle)
+        while True:
+            event = slot.event_queue.get()
+            if event is _TERMINAL_SENTINEL:
+                return
+            yield event
+
+    # ------------------------------------------------------------------
+    # TrialInterventions Protocol
+    # ------------------------------------------------------------------
+
+    def submit(
+        self,
+        handle: ParticipantHandle,
+        intervention: TrialIntervention,
+    ) -> InterventionAck:
+        """Enqueue the intervention for the conductor to process at its
+        next pause point. Returns ``outcome="queued"`` synchronously —
+        the accept / supersede / reject verdict is decided later and
+        recorded in the trajectory trace, not returned here.
+        """
+        if intervention.trial_id != self._trial_id:
+            raise ValueError(
+                f"Intervention trial_id={intervention.trial_id!r} does not match "
+                f"session trial_id={self._trial_id!r}"
+            )
+        if intervention.participant_id != handle.participant_id:
+            raise ValueError(
+                f"Intervention participant_id={intervention.participant_id!r} does not match "
+                f"handle participant_id={handle.participant_id!r}"
+            )
+        # Confirm the handle is still attached; a detached participant
+        # cannot submit further interventions.
+        self._require_slot(handle)
+        self._intervention_queue.put(
+            QueuedIntervention(
+                handle=handle,
+                intervention=intervention,
+                submitted_at=datetime.now(UTC),
+            )
+        )
+        return InterventionAck(
+            intervention_kind=intervention.kind,
+            trial_id=self._trial_id,
+            participant_id=handle.participant_id,
+            outcome="queued",
+            reason=None,
+        )
+
+    # ------------------------------------------------------------------
+    # Producer-side API (concrete class, not on the Protocol)
+    # ------------------------------------------------------------------
+
+    def next_seq(self) -> int:
+        """Allocate the next monotonic ``seq`` for a fresh event. Called
+        by the producer just before constructing a :class:`TrialEvent`.
+        """
+        with self._lock:
+            seq = self._seq_counter
+            self._seq_counter += 1
+            return seq
+
+    def publish(self, event: TrialEvent) -> None:
+        """Broadcast an event to every attached participant.
+
+        If the event is a :class:`TerminalReached`, the session
+        auto-closes after fanning the event out: every slot receives a
+        terminal sentinel and subsequent :meth:`attach` / :meth:`publish`
+        calls raise.
+
+        Publishing after close is a programmer error and raises
+        ``RuntimeError`` — the sealed conductor would never do this;
+        catching this early avoids silent event loss.
+        """
+        with self._lock:
+            if self._closed:
+                raise RuntimeError(
+                    f"Cannot publish {event.kind!r} to a closed session (trial_id={self._trial_id!r})."
+                )
+            for slot in self._participants.values():
+                slot.event_queue.put(event)
+            if isinstance(event, TerminalReached):
+                self._closed = True
+                for slot in self._participants.values():
+                    slot.event_queue.put(_TERMINAL_SENTINEL)
+
+    def drain_pending_interventions(self, max_batch: int | None = None) -> list[QueuedIntervention]:
+        """Non-blocking pull of all interventions submitted since the last drain.
+
+        Called by the conductor's pause pump at natural seams (before
+        each turn, before a tool call dispatch, on ``Pause``). Returns
+        interventions in submission order. ``max_batch`` caps the pull;
+        ``None`` means "everything currently queued".
+        """
+        drained: list[QueuedIntervention] = []
+        while True:
+            if max_batch is not None and len(drained) >= max_batch:
+                break
+            try:
+                drained.append(self._intervention_queue.get_nowait())
+            except queue.Empty:
+                break
+        return drained
+
+    def close(self) -> None:
+        """Force-close the session even without a :class:`TerminalReached`.
+
+        Provided for error paths — a conductor that crashes or times
+        out without publishing a proper terminal event must call this to
+        release any blocked :meth:`iter_events` iterators. Idempotent.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            for slot in self._participants.values():
+                slot.event_queue.put(_TERMINAL_SENTINEL)
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    @property
+    def attached_participant_ids(self) -> list[str]:
+        """Snapshot of currently attached participant ids. For diagnostics
+        and tests; the underlying set can change between the read and any
+        subsequent call.
+        """
+        with self._lock:
+            return list(self._participants.keys())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_slot(self, handle: ParticipantHandle) -> _ParticipantSlot:
+        with self._lock:
+            slot = self._participants.get(handle.participant_id)
+        if slot is None:
+            raise ValueError(
+                f"Participant {handle.participant_id!r} is not attached to this session "
+                f"(trial_id={self._trial_id!r})."
+            )
+        if slot.handle.trial_id != handle.trial_id:
+            raise ValueError(
+                f"Handle trial_id={handle.trial_id!r} does not match session "
+                f"trial_id={self._trial_id!r}."
+            )
+        return slot


### PR DESCRIPTION
Part of #408 (M1 umbrella).

## Summary

First M1 sub-PR. Introduces `tolokaforge.session.InProcessTrialSession` — the live thread-safe transport that will back the future `GatedConductor`. Broadcasts events to attached participants and queues their interventions back to the conductor. No conductor changes yet; this piece is testable in isolation and independent of M1's later PRs.

## What ships

- `tolokaforge/session/in_process.py` — `InProcessTrialSession` and `QueuedIntervention`. Per-participant `queue.Queue` for event fan-out, single shared queue for interventions back to the producer, sentinel-based terminal signaling, thread-safe `next_seq` allocator.
- `tolokaforge/session/__init__.py` — new re-exports.
- `tests/unit/session/test_in_process.py` — **20 unit tests** covering:
  - `next_seq` monotonicity under concurrent producers (8 threads × 50 allocations, no duplicates).
  - Broadcast fan-out — every attached participant sees every event.
  - **Late attach** — joins at `seq=k` and never sees events `< k`.
  - Blocking `iter_events` — consumer blocks until an event arrives.
  - Detach releases the blocked iterator without disturbing peers.
  - `TerminalReached` auto-closes the session; explicit `close()` covers crash/timeout paths.
  - Attach / publish after close raise instead of silently dropping.
  - Intervention queueing with cross-trial, cross-participant, and post-detach guards.
  - `drain_pending_interventions(max_batch=k)` caps batch size.
  - **Concurrent soak**: 200 events × 4 consumer threads, every consumer sees every event in `seq` order.

## Design decisions

- **Broadcast events, serialised interventions.** Every attached participant gets its own `queue.Queue` for events (independent consumption rates); interventions land in a single conductor-facing queue processed in submission order at pause points. Matches `docs/OPEN_AGENT_LOOP.md` §5.
- **`submit()` returns `outcome="queued"` synchronously.** The accept / supersede / reject verdict happens later at the conductor's pause pump and is recorded in the trajectory trace, not in the ack. Live participants don't block waiting for a decision.
- **Late attach forfeits history.** A participant that attaches at `seq=5` never sees events 0..4. Historical replay of a live trial belongs to a separate transport (M4 for remote, or `RecordedTrialSession` for post-hoc).
- **Terminal sentinel releases blocked iterators.** Both `TerminalReached` and explicit `close()` fan a sentinel out to every slot's queue so `iter_events` returns cleanly on all consumers.
- **Producer-side methods live on the concrete class.** `next_seq`, `publish`, `drain_pending_interventions`, `close` are not on the `TrialSession` Protocol — the sealed Protocol has no reason to declare them.

## Test plan

- [x] `uv run pytest tests/unit/session/ -m unit` → **37 passed** (17 M0 + 20 new).
- [x] `uv run ruff check tolokaforge/session tests/unit/session` → clean.
- [x] Import surface: `tolokaforge.session` still does not pull `tolokaforge.runner` / grpcio / docker.

## Follow-ups (next M1 sub-PRs on `experiment/m1-*` branches → `feat/open-agent-loop`)

- `GatedConductor` — wraps an inner sealed conductor, publishes events at natural seams, polls `drain_pending_interventions` at pause points (before each turn, before a tool call dispatch, on `Pause`). Applies role-priority conflict resolution.
- Run-config open-mode flag + orchestrator wiring; sealed default preserved.
- `open_agent_loop` section in the trajectory trace — records every event and every intervention with outcome.
- `RunDisplayEvents` → `TrialEvents` bridge — the existing terminal-dx display seam becomes a thin `TrialEvents` consumer.