### PR TITLE
feat(loop): LoopObserver seam + SessionLoopObserver bridge (M1 sub-2)

### DIFF
--- a/tests/unit/session/test_loop_observer.py
+++ b/tests/unit/session/test_loop_observer.py
@@ -1,0 +1,244 @@
+"""Unit tests for :class:`SessionLoopObserver` — bridges the ToolCallingLoop
+observer seam into an :class:`InProcessTrialSession`.
+
+Covers translation semantics for each observer callback plus a small
+end-to-end run of :class:`ToolCallingLoop` with the bridge attached to
+confirm the loop's seams fire in the expected order.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.llm.client import GenerationResult
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.logging import init_trial_logger
+from tolokaforge.core.loop import LoopConfig, ToolCallingLoop
+from tolokaforge.core.models import (
+    TerminationReason,
+    ToolCall,
+    TrialStatus,
+)
+from tolokaforge.session import (
+    AssistantMessage,
+    InProcessTrialSession,
+    ParticipantRole,
+    SessionLoopObserver,
+    TerminalReached,
+    ToolCallEmitted,
+    ToolResultObserved,
+    TurnStarted,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestSessionLoopObserverTranslations:
+    """Direct-call tests: invoke each observer method and verify the
+    resulting event on the session queue matches the expected shape.
+    """
+
+    def _observer(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.OBSERVER)
+        return session, handle, SessionLoopObserver(session)
+
+    def test_on_turn_start_publishes_turn_started(self):
+        session, handle, obs = self._observer()
+        obs.on_turn_start(turn_index=0)
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert len(events) == 1
+        assert isinstance(events[0], TurnStarted)
+        assert events[0].turn_index == 0
+        assert events[0].seq == 0
+
+    def test_on_assistant_message_publishes_assistant_event(self):
+        session, handle, obs = self._observer()
+        obs.on_assistant_message(content="Hello world", has_reasoning=True)
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert isinstance(events[0], AssistantMessage)
+        assert events[0].content_preview == "Hello world"
+        assert events[0].has_reasoning is True
+
+    def test_on_tool_call_publishes_tool_call_event_with_argument_preview(self):
+        session, handle, obs = self._observer()
+        obs.on_tool_call(call_id="c1", tool_name="lookup", arguments={"q": "org1"})
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert isinstance(events[0], ToolCallEmitted)
+        assert events[0].call_id == "c1"
+        assert events[0].tool_name == "lookup"
+        assert "org1" in events[0].arguments_preview
+
+    def test_on_tool_result_publishes_tool_result_event(self):
+        session, handle, obs = self._observer()
+        obs.on_tool_result(
+            call_id="c1", tool_name="lookup", duration_ms=142, output="found", success=True
+        )
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert isinstance(events[0], ToolResultObserved)
+        assert events[0].duration_ms == 142
+        assert events[0].truncated_preview == "found"
+
+    def test_on_terminal_translates_core_enums_into_session_enums(self):
+        session, handle, obs = self._observer()
+        obs.on_terminal(
+            status=TrialStatus.COMPLETED, termination_reason=TerminationReason.MAX_TURNS
+        )
+        events = list(session.events().iter_events(handle))
+        assert isinstance(events[0], TerminalReached)
+        # Session's enum has same string values as core, but is a distinct class
+        assert events[0].status.value == "completed"
+        assert events[0].termination_reason is not None
+        assert events[0].termination_reason.value == "max_turns"
+        assert session.is_closed  # TerminalReached auto-closes the session
+
+    def test_on_terminal_handles_none_reason(self):
+        session, handle, obs = self._observer()
+        obs.on_terminal(status=TrialStatus.COMPLETED, termination_reason=None)
+        events = list(session.events().iter_events(handle))
+        assert events[0].termination_reason is None
+
+    def test_seq_is_monotonic_across_observer_calls(self):
+        session, handle, obs = self._observer()
+        obs.on_turn_start(turn_index=0)
+        obs.on_assistant_message(content="hi", has_reasoning=False)
+        obs.on_tool_call(call_id="c1", tool_name="f", arguments={})
+        obs.on_tool_result(call_id="c1", tool_name="f", duration_ms=10, output="ok", success=True)
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert [e.seq for e in events] == [0, 1, 2, 3]
+
+    def test_argument_preview_is_truncated(self):
+        session, handle, obs = self._observer()
+        big = {"blob": "x" * 500}
+        obs.on_tool_call(call_id="c1", tool_name="f", arguments=big)
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert len(events[0].arguments_preview) <= 240
+
+    def test_argument_preview_handles_unserialisable_values(self):
+        """Non-JSON-serialisable arguments must not crash — the bridge falls
+        back to ``repr`` under a broad exception guard.
+        """
+        session, handle, obs = self._observer()
+        obs.on_tool_call(call_id="c1", tool_name="f", arguments={"obj": object()})
+        session.close()
+        events = list(session.events().iter_events(handle))
+        assert isinstance(events[0], ToolCallEmitted)
+
+
+class TestToolCallingLoopEndToEndWithObserver:
+    """Drive :class:`ToolCallingLoop` with the bridge attached; verify the
+    natural seams fire in the right order for a small synthetic run.
+    """
+
+    def _make_result(
+        self, text: str = "reply", tool_calls: list[ToolCall] | None = None
+    ) -> GenerationResult:
+        return GenerationResult(text=text, tool_calls=tool_calls or [], usage=Usage())
+
+    def test_observer_receives_ordered_turn_and_terminal_events(self):
+        """A one-turn run with no tool calls emits turn_start, assistant,
+        then terminal (via max_turns==1). Order and count are the whole
+        point of the test.
+        """
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.OBSERVER)
+        observer = SessionLoopObserver(session)
+
+        llm_client = MagicMock()
+        llm_client.generate.return_value = self._make_result("hi from agent")
+
+        tool_executor = MagicMock()
+        metrics = MagicMock()
+
+        loop = ToolCallingLoop(
+            llm_client=llm_client,
+            tool_executor=tool_executor,
+            tool_schemas=[],
+            config=LoopConfig(max_turns=1, episode_timeout_s=60),
+            metrics=metrics,
+            should_terminate=lambda result, turn, messages: None,
+            logger=init_trial_logger("t:0", verbose=False, strict=False),
+            observer=observer,
+        )
+        loop.run(system_prompt="sys", messages=[], start_time=time.time())
+
+        events = list(session.events().iter_events(handle))
+        kinds = [e.kind for e in events]
+        # turn_start → assistant_message → terminal_reached
+        assert kinds == ["turn_started", "assistant_message", "terminal_reached"]
+        assert isinstance(events[-1], TerminalReached)
+
+    def test_observer_receives_tool_call_and_result_events(self):
+        """A run with one tool call emits tool_call and tool_result events."""
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.OBSERVER)
+        observer = SessionLoopObserver(session)
+
+        tc = ToolCall(id="c_a", name="lookup", arguments={"q": "x"})
+        # First generation carries a tool call; second generation stops with no tool call.
+        llm_client = MagicMock()
+        llm_client.generate.side_effect = [
+            self._make_result(text="calling", tool_calls=[tc]),
+            self._make_result(text="done", tool_calls=[]),
+        ]
+
+        tool_result = MagicMock()
+        tool_result.success = True
+        tool_result.output = "found: x"
+        tool_result.content_blocks = None
+        tool_result.error = None
+
+        tool_executor = MagicMock()
+        tool_executor.execute.return_value = tool_result
+
+        loop = ToolCallingLoop(
+            llm_client=llm_client,
+            tool_executor=tool_executor,
+            tool_schemas=[],
+            config=LoopConfig(max_turns=2, episode_timeout_s=60),
+            metrics=MagicMock(),
+            should_terminate=lambda result, turn, messages: None,
+            logger=init_trial_logger("t:0", verbose=False, strict=False),
+            observer=observer,
+        )
+        loop.run(system_prompt="sys", messages=[], start_time=time.time())
+
+        events = list(session.events().iter_events(handle))
+        kinds = [e.kind for e in events]
+        assert "tool_call_emitted" in kinds
+        assert "tool_result_observed" in kinds
+
+        tool_call_event = next(e for e in events if isinstance(e, ToolCallEmitted))
+        tool_result_event = next(e for e in events if isinstance(e, ToolResultObserved))
+        assert tool_call_event.call_id == "c_a"
+        assert tool_call_event.tool_name == "lookup"
+        assert tool_result_event.call_id == "c_a"
+        assert tool_result_event.tool_name == "lookup"
+        assert "found" in tool_result_event.truncated_preview
+
+
+class TestDefaultNoOpObserver:
+    """The loop's default observer is a no-op; existing behavior is preserved
+    when no bridge is attached. Covered indirectly by every pre-existing
+    ToolCallingLoop test that passes; this explicit test locks it in.
+    """
+
+    def test_default_observer_is_no_op(self):
+        # If the default observer ever regresses (e.g. someone binds it to a
+        # global sink), this import assertion + attribute check fails loudly.
+        from tolokaforge.core.loop import _NULL_LOOP_OBSERVER
+
+        _NULL_LOOP_OBSERVER.on_turn_start(0)
+        _NULL_LOOP_OBSERVER.on_assistant_message("x", False)
+        _NULL_LOOP_OBSERVER.on_tool_call("c", "t", {})
+        _NULL_LOOP_OBSERVER.on_tool_result("c", "t", 0, "o", True)
+        _NULL_LOOP_OBSERVER.on_terminal(TrialStatus.COMPLETED, None)

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -149,6 +149,67 @@ class MetricsSink(Protocol):
     def record_tool_call(self) -> None: ...
 
 
+class LoopObserver(Protocol):
+    """Passive observer of the loop's natural seams.
+
+    An optional seam that lets an external consumer — today the Open Agent
+    Loop's ``SessionLoopObserver`` — receive turn-boundary and tool-call
+    signals without touching the loop's control flow. All methods are
+    called synchronously from the loop's producer thread; implementations
+    must return quickly (queue-put or similar) to avoid blocking the trial.
+
+    Every method has a default no-op via :data:`_NULL_LOOP_OBSERVER`, so
+    the loop's sealed batch mode incurs no overhead when no observer is
+    attached.
+    """
+
+    def on_turn_start(self, turn_index: int) -> None:
+        """Called at the top of each turn iteration, before the LLM call."""
+
+    def on_assistant_message(self, content: str, has_reasoning: bool) -> None:
+        """Called immediately after the assistant's message is appended to the
+        transcript, before termination or tool-execution branches run."""
+
+    def on_tool_call(self, call_id: str, tool_name: str, arguments: dict[str, Any]) -> None:
+        """Called before each tool call is dispatched to the executor."""
+
+    def on_tool_result(
+        self, call_id: str, tool_name: str, duration_ms: int, output: str, success: bool
+    ) -> None:
+        """Called after each tool call returns, with duration and outcome."""
+
+    def on_terminal(
+        self, status: TrialStatus, termination_reason: TerminationReason | None
+    ) -> None:
+        """Called exactly once at the end of :meth:`ToolCallingLoop.run`."""
+
+
+class _NullLoopObserver:
+    """No-op :class:`LoopObserver` — the default when no observer is attached."""
+
+    def on_turn_start(self, turn_index: int) -> None:
+        return None
+
+    def on_assistant_message(self, content: str, has_reasoning: bool) -> None:
+        return None
+
+    def on_tool_call(self, call_id: str, tool_name: str, arguments: dict[str, Any]) -> None:
+        return None
+
+    def on_tool_result(
+        self, call_id: str, tool_name: str, duration_ms: int, output: str, success: bool
+    ) -> None:
+        return None
+
+    def on_terminal(
+        self, status: TrialStatus, termination_reason: TerminationReason | None
+    ) -> None:
+        return None
+
+
+_NULL_LOOP_OBSERVER: LoopObserver = _NullLoopObserver()
+
+
 ErrorClassifier = Callable[[Exception], TerminationDecision]
 
 
@@ -223,6 +284,7 @@ class ToolCallingLoop:
         None
     )
     classify_error: ErrorClassifier = classify_loop_error
+    observer: LoopObserver = _NULL_LOOP_OBSERVER
 
     # Captured from the first generation's effective system prompt.
     _captured_effective_prompt: str | None = field(default=None, init=False)
@@ -239,6 +301,7 @@ class ToolCallingLoop:
         termination_reason: TerminationReason | None = None
 
         for turn in range(self.config.max_turns):
+            self.observer.on_turn_start(turn)
             timeout_decision = self._check_episode_timeout(start_time)
             if timeout_decision is not None:
                 status = timeout_decision.status or status
@@ -274,6 +337,7 @@ class ToolCallingLoop:
                 )
             )
 
+        self.observer.on_terminal(status, termination_reason)
         return LoopOutcome(
             status=status,
             termination_reason=termination_reason,
@@ -294,6 +358,12 @@ class ToolCallingLoop:
         self.metrics.record_generation(result)
         self._log_generation(turn, result)
         messages.append(self._assistant_message(result))
+        self.observer.on_assistant_message(
+            content=result.text or "",
+            has_reasoning=bool(
+                getattr(result, "reasoning", None) or getattr(result, "thinking_blocks", None)
+            ),
+        )
 
         decision = self.should_terminate(result, turn, messages)
         if decision is not None:
@@ -340,6 +410,9 @@ class ToolCallingLoop:
     def _execute_tool_calls(self, result: GenerationResult, messages: list[Message]) -> None:
         for tc in result.tool_calls:
             self._maybe_recover_arguments(tc, result.text)
+            self.observer.on_tool_call(
+                call_id=tc.id, tool_name=tc.name, arguments=dict(tc.arguments or {})
+            )
             tool_start = time.time()
             tool_result = self.tool_executor.execute(tc.name, tc.arguments)
             tool_duration = time.time() - tool_start
@@ -352,12 +425,20 @@ class ToolCallingLoop:
             else:
                 self.logger.warning("Tool execution failed", tool=tc.name, error=tool_result.error)
 
+            tool_output = (
+                tool_result.output if tool_result.success else f"Error: {tool_result.error}"
+            )
+            self.observer.on_tool_result(
+                call_id=tc.id,
+                tool_name=tc.name,
+                duration_ms=int(tool_duration * 1000),
+                output=tool_output,
+                success=tool_result.success,
+            )
             messages.append(
                 Message(
                     role=MessageRole.TOOL,
-                    content=(
-                        tool_result.output if tool_result.success else f"Error: {tool_result.error}"
-                    ),
+                    content=tool_output,
                     content_blocks=(tool_result.content_blocks if tool_result.success else None),
                     tool_call_id=tc.id,
                     ts=_now(),

--- a/tolokaforge/session/__init__.py
+++ b/tolokaforge/session/__init__.py
@@ -47,6 +47,7 @@ from tolokaforge.session.interventions import (
     Resume,
     TrialIntervention,
 )
+from tolokaforge.session.loop_observer import SessionLoopObserver
 from tolokaforge.session.protocols import (
     ParticipantHandle,
     ParticipantRole,
@@ -74,6 +75,7 @@ __all__ = [
     "RejectTool",
     "Resume",
     "ResumeAcknowledged",
+    "SessionLoopObserver",
     "TerminalReached",
     "ToolCallEmitted",
     "ToolResultObserved",

--- a/tolokaforge/session/loop_observer.py
+++ b/tolokaforge/session/loop_observer.py
@@ -1,0 +1,153 @@
+"""``SessionLoopObserver`` — bridge from :class:`ToolCallingLoop` to :class:`TrialSession`.
+
+The ``LoopObserver`` seam in :mod:`tolokaforge.core.loop` is deliberately
+loop-shaped (turn start, assistant message, tool call, tool result,
+terminal). This bridge translates each callback into the corresponding
+:class:`~tolokaforge.session.TrialEvent` variant and publishes it onto an
+:class:`~tolokaforge.session.InProcessTrialSession`, so a live trial's
+event stream reaches attached participants in ``seq`` order.
+
+The observer never blocks the producer — publishes are non-blocking queue
+puts (see :class:`InProcessTrialSession.publish`).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from tolokaforge.core.models import TerminationReason
+from tolokaforge.core.models import TrialStatus as _CoreTrialStatus
+from tolokaforge.session._status import (
+    TerminationReason as SessionTerminationReason,
+)
+from tolokaforge.session._status import (
+    TrialStatus as SessionTrialStatus,
+)
+from tolokaforge.session.events import (
+    AssistantMessage,
+    TerminalReached,
+    ToolCallEmitted,
+    ToolResultObserved,
+    TurnStarted,
+)
+from tolokaforge.session.in_process import InProcessTrialSession
+
+__all__ = ["SessionLoopObserver"]
+
+_PREVIEW_LEN = 240
+
+
+class SessionLoopObserver:
+    """Bridge a :class:`ToolCallingLoop`'s seams into
+    :class:`InProcessTrialSession` events.
+
+    Instantiated per trial by the code that assembles the loop (M1 sub-3
+    wires this into :class:`~tolokaforge.core.runner.TrialRunner`). Holds
+    a reference to the session and stamps each event with a fresh ``seq``
+    at publish time.
+    """
+
+    def __init__(self, session: InProcessTrialSession) -> None:
+        self._session = session
+
+    # ------------------------------------------------------------------
+    # LoopObserver Protocol (satisfied structurally; no explicit inherit)
+    # ------------------------------------------------------------------
+
+    def on_turn_start(self, turn_index: int) -> None:
+        self._session.publish(
+            TurnStarted(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                turn_index=turn_index,
+            )
+        )
+
+    def on_assistant_message(self, content: str, has_reasoning: bool) -> None:
+        self._session.publish(
+            AssistantMessage(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                content_preview=_preview(content),
+                has_reasoning=has_reasoning,
+            )
+        )
+
+    def on_tool_call(self, call_id: str, tool_name: str, arguments: dict[str, Any]) -> None:
+        self._session.publish(
+            ToolCallEmitted(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                call_id=call_id,
+                tool_name=tool_name,
+                arguments_preview=_preview(_stringify_arguments(arguments)),
+            )
+        )
+
+    def on_tool_result(
+        self, call_id: str, tool_name: str, duration_ms: int, output: str, success: bool
+    ) -> None:
+        # ``success`` is not part of the event payload today — it's carried
+        # implicitly by the transcript. Kept as a parameter so the observer
+        # protocol can grow into a richer event variant without a signature
+        # change here (M4/M5).
+        del success
+        self._session.publish(
+            ToolResultObserved(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                call_id=call_id,
+                tool_name=tool_name,
+                duration_ms=duration_ms,
+                truncated_preview=_preview(output),
+            )
+        )
+
+    def on_terminal(
+        self, status: _CoreTrialStatus, termination_reason: TerminationReason | None
+    ) -> None:
+        self._session.publish(
+            TerminalReached(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                status=_translate_status(status),
+                termination_reason=_translate_reason(termination_reason),
+            )
+        )
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _preview(text: str) -> str:
+    if len(text) <= _PREVIEW_LEN:
+        return text
+    return text[: _PREVIEW_LEN - 1] + "…"
+
+
+def _stringify_arguments(arguments: dict[str, Any]) -> str:
+    if not arguments:
+        return "{}"
+    import json
+
+    try:
+        return json.dumps(arguments, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return repr(arguments)
+
+
+def _translate_status(status: _CoreTrialStatus) -> SessionTrialStatus:
+    return SessionTrialStatus(status.value)
+
+
+def _translate_reason(reason: TerminationReason | None) -> SessionTerminationReason | None:
+    if reason is None:
+        return None
+    return SessionTerminationReason(reason.value)


### PR DESCRIPTION
Part of #408 (M1 umbrella).

## Summary

Second M1 sub-PR. Adds an optional passive observer seam to `ToolCallingLoop` so external consumers can watch the trial's turn boundaries without touching the loop's control flow. The first real observer — `SessionLoopObserver` — bridges loop callbacks into an `InProcessTrialSession` as the corresponding `TrialEvent` variants, so a live trial's event stream reaches attached participants in `seq` order.

**No behavior change in sealed batch mode.** The observer defaults to a no-op (`_NULL_LOOP_OBSERVER`); pre-existing loop tests pass byte-identical and the full canonical suite (426 tests) is green.

## What ships

- **`tolokaforge/core/loop.py`** — `LoopObserver` Protocol + `_NullLoopObserver` default + emit calls at five natural seams:
  - **turn start** — top of the `for turn in range(...)` iteration (before LLM call)
  - **assistant message** — after the assistant message is appended to the transcript
  - **tool call** — before each tool is dispatched to the executor
  - **tool result** — after each tool returns (with duration + success outcome)
  - **terminal** — exactly once at the end of `run()`

- **`tolokaforge/session/loop_observer.py`** — `SessionLoopObserver` bridging each callback to `InProcessTrialSession.publish` as a typed `TrialEvent`. Arguments are JSON-serialised with a 240-char preview cap; unserialisable values fall back to `repr` under a broad exception guard. Enum translation between `tolokaforge.core.models` and `tolokaforge.session._status` preserves the session module's runner-import decoupling.

- **`tolokaforge/session/__init__.py`** — new `SessionLoopObserver` re-export.

- **`tests/unit/session/test_loop_observer.py`** — 13 new tests:
  - Each observer translation (`on_turn_start`, `on_assistant_message`, `on_tool_call`, `on_tool_result`, `on_terminal`) → correct event variant with correct fields.
  - `seq` monotonic across mixed observer calls.
  - Argument-preview truncation and non-JSON fallback.
  - Terminal enum translation (both with a reason and with `None`).
  - `ToolCallingLoop` end-to-end run with the bridge attached — turn/assistant/terminal ordering, tool-call + tool-result event emission.
  - `_NULL_LOOP_OBSERVER` no-op default's non-regression.

## Design decisions

- **Observer as an optional seam, not a required Protocol.** The Protocol has default no-op methods, and `ToolCallingLoop.observer` defaults to `_NULL_LOOP_OBSERVER`. Existing callers pass nothing; sealed-mode overhead is one method call per seam.
- **Structural typing.** `SessionLoopObserver` does not explicitly inherit `LoopObserver` — it satisfies the Protocol structurally so it can live in `tolokaforge/session/` without importing loop internals besides the enum bridge.
- **Enum bridge over shared type.** The session module keeps its own mirrored `TrialStatus` / `TerminationReason` enums (per M0's `_status.py` decision) so importing `tolokaforge.session` does not pull `tolokaforge.runner` / grpcio / docker. `SessionLoopObserver` translates at the boundary.
- **`success` on `on_tool_result` is not on the event payload yet.** Kept as a parameter for future event enrichment (M4/M5) without forcing a Protocol change on the loop side.

## Test plan

- [x] `uv run pytest tests/unit/session/ -m unit` → **49 passed**
- [x] `uv run pytest tests/unit -m unit -k loop` → **26 passed** (no regressions in pre-existing loop tests)
- [x] `uv run pytest tests/ -m canonical` → **426 passed** (no regressions in canonical snapshots)
- [x] `uv run ruff check tolokaforge/session tolokaforge/core/loop.py tests/unit/session` → clean

## Follow-ups (M1 sub-3)

Wiring `SessionLoopObserver` into the trial-execution path — extend `TrialRunner.__init__` with an optional `session: InProcessTrialSession | None = None`, construct the observer + bind it to the loop when the session is present, and add the same optional pass-through to `InProcessConductor` (via `ConductorContext`). Sealed default preserved.

Intervention application (the inbound half) is a separate follow-up sub-PR — it needs a pause-pump inside `ToolCallingLoop` that polls `drain_pending_interventions` at the seams and applies each per the role-priority rule.