### PR TITLE
feat(conductor): observer_provider seam wires LoopObserver through TrialRunner (M1 sub-3)

### DIFF
--- a/tests/unit/test_conductor_observer_wiring.py
+++ b/tests/unit/test_conductor_observer_wiring.py
@@ -1,0 +1,160 @@
+"""Wiring tests for :attr:`ConductorContext.observer_provider` /
+:attr:`InProcessConductor.observer_provider` — M1 sub-3.
+
+Covers the shape of the wiring and its no-op default. The end-to-end path
+where an observer sees real turn events lives in
+``tests/unit/session/test_loop_observer.py`` (M1 sub-2); here we only
+prove the plumbing threads through without regressing the sealed default.
+
+* Sealed default (``observer_provider=None``) → :attr:`TrialRunner.loop_observer`
+  is ``None``. Existing behavior byte-identical.
+* Custom provider returning ``None`` for this trial → also None. Provider is
+  called per-trial with the trial_id.
+* Custom provider returning an observer → :attr:`TrialRunner.loop_observer`
+  is that observer.
+* ``observer_provider`` field survives ``**vars(ctx)`` unpacking into
+  :class:`InProcessConductor` — the "1:1 kwarg parity" invariant the class
+  docstring names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.conductor import ConductorContext, InProcessConductor
+from tolokaforge.core.loop import LoopObserver
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingObserver:
+    """Trivial :class:`LoopObserver` that records every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def on_turn_start(self, turn_index: int) -> None:
+        self.calls.append(("turn_start", (turn_index,), {}))
+
+    def on_assistant_message(self, content: str, has_reasoning: bool) -> None:
+        self.calls.append(("assistant", (content, has_reasoning), {}))
+
+    def on_tool_call(self, call_id, tool_name, arguments) -> None:
+        self.calls.append(("tool_call", (call_id, tool_name), {}))
+
+    def on_tool_result(self, call_id, tool_name, duration_ms, output, success) -> None:
+        self.calls.append(("tool_result", (call_id, tool_name), {}))
+
+    def on_terminal(self, status, termination_reason) -> None:
+        self.calls.append(("terminal", (status,), {}))
+
+
+def _mock_ctx(**overrides) -> ConductorContext:
+    """Build a :class:`ConductorContext` with mocked dependencies for
+    plumbing tests. Nothing here reaches the trial body — we only exercise
+    the observer-provider seam.
+    """
+    defaults: dict = {
+        "adapter": MagicMock(),
+        "artifact_writer": MagicMock(),
+        "config": MagicMock(),
+        "logger": MagicMock(),
+        "verbose": False,
+        "strict": False,
+        "agent_client": MagicMock(),
+        "runtime_backend": MagicMock(),
+        "trial_grader": MagicMock(),
+        "output_dir": Path("/tmp/does-not-matter"),
+        "request_limiter": None,
+    }
+    defaults.update(overrides)
+    return ConductorContext(**defaults)
+
+
+class TestConductorContextObserverProviderField:
+    def test_default_is_none(self):
+        ctx = _mock_ctx()
+        assert ctx.observer_provider is None
+
+    def test_field_survives_vars_unpack_into_conductor(self):
+        """The ``**vars(ctx)`` unpack path the orchestrator uses must round-trip
+        the new field. Load-bearing per :class:`InProcessConductor`'s docstring.
+        """
+        observer = _RecordingObserver()
+
+        def provider(trial_id: str) -> LoopObserver | None:
+            return observer
+
+        ctx = _mock_ctx(observer_provider=provider)
+        conductor = InProcessConductor(**vars(ctx))
+        assert conductor.observer_provider is provider
+
+
+class TestMaybeBuildLoopObserver:
+    def test_no_provider_returns_none(self):
+        ctx = _mock_ctx()
+        conductor = InProcessConductor(**vars(ctx))
+        assert conductor._maybe_build_loop_observer("t:0") is None
+
+    def test_provider_returning_none_returns_none(self):
+        ctx = _mock_ctx(observer_provider=lambda trial_id: None)
+        conductor = InProcessConductor(**vars(ctx))
+        assert conductor._maybe_build_loop_observer("t:0") is None
+
+    def test_provider_receives_trial_id_and_returns_observer(self):
+        received: list[str] = []
+        observer = _RecordingObserver()
+
+        def provider(trial_id: str) -> LoopObserver | None:
+            received.append(trial_id)
+            return observer
+
+        ctx = _mock_ctx(observer_provider=provider)
+        conductor = InProcessConductor(**vars(ctx))
+        result = conductor._maybe_build_loop_observer("MAN-34:0")
+        assert result is observer
+        assert received == ["MAN-34:0"]
+
+    def test_provider_can_return_different_observer_per_trial(self):
+        """Two different trial_ids may map to different observers, matching
+        the "per-trial session" model on which the Open Agent Loop gate
+        depends.
+        """
+        obs_a = _RecordingObserver()
+        obs_b = _RecordingObserver()
+
+        def provider(trial_id: str) -> LoopObserver | None:
+            return obs_a if trial_id.startswith("A") else obs_b
+
+        ctx = _mock_ctx(observer_provider=provider)
+        conductor = InProcessConductor(**vars(ctx))
+        assert conductor._maybe_build_loop_observer("A:0") is obs_a
+        assert conductor._maybe_build_loop_observer("B:0") is obs_b
+
+
+class TestObserverProviderIsExtensionPoint:
+    """Extensibility check: the observer type is deliberately generic — a
+    non-session observer plugs in the same way a session-based one does.
+    Regression guard against future changes that would smuggle
+    session-specific coupling into the sealed conductor.
+    """
+
+    def test_conductor_accepts_any_loop_observer_no_session_import_required(self):
+        """The sealed conductor must not require importing
+        :mod:`tolokaforge.session` to use ``observer_provider``. A plain
+        :class:`LoopObserver` (not a :class:`SessionLoopObserver`) is
+        accepted end-to-end.
+        """
+        observer = _RecordingObserver()
+        ctx = _mock_ctx(observer_provider=lambda tid: observer)
+        conductor = InProcessConductor(**vars(ctx))
+
+        # Verify the provider round-trips without invoking anything that
+        # would pull tolokaforge.session; the observer we hand in doesn't
+        # know about session events at all.
+        got = conductor._maybe_build_loop_observer("t:0")
+        assert got is observer
+        assert not hasattr(got, "_session")  # not a SessionLoopObserver

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -37,6 +37,7 @@ from tolokaforge.core.llm.presets import (
     resolve_effective_preset,
     resolve_policy_names,
 )
+from tolokaforge.core.loop import LoopObserver
 from tolokaforge.core.models import (
     Grade,
     GradeComponents,
@@ -94,6 +95,22 @@ class ConductorContext:
     trial_grader: TrialGrader
     output_dir: Path
     request_limiter: GlobalRateLimiter | None
+    observer_provider: Callable[[str], LoopObserver | None] | None = None
+    """Optional per-trial :class:`LoopObserver` factory.
+
+    Called with ``spec.trial_id`` at the top of each trial to produce an
+    optional observer that receives loop seams (turn start / assistant
+    message / tool call / tool result / terminal). ``None`` (or a provider
+    returning ``None``) keeps the trial in **sealed** batch mode — no
+    observer attached, existing behaviour unchanged.
+
+    The observer type is deliberately generic — the sealed conductor knows
+    nothing about sessions. Session-based observation (the Open Agent Loop
+    gate) is one specific caller-side wiring: pass a provider that returns
+    a :class:`~tolokaforge.session.SessionLoopObserver`. Other observers
+    (e.g. a metrics tap, a debug hook, a rule-based safety monitor) plug
+    in the same way without further changes to the conductor.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +305,7 @@ class InProcessConductor:
         trial_grader: TrialGrader,
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None = None,
+        observer_provider: Callable[[str], LoopObserver | None] | None = None,
     ) -> None:
         self.adapter = adapter
         self._artifact_writer = artifact_writer
@@ -300,6 +318,21 @@ class InProcessConductor:
         self.trial_grader = trial_grader
         self.output_dir = output_dir
         self.request_limiter = request_limiter
+        self.observer_provider = observer_provider
+
+    def _maybe_build_loop_observer(self, trial_id: str) -> LoopObserver | None:
+        """Consult the ``observer_provider`` for this trial's loop observer.
+
+        Returns ``None`` when no provider is set or the provider returns
+        ``None`` for this trial — the sealed default.
+
+        Kept as a single indirection so callers cannot accidentally construct
+        an observer without the ``None`` guard, and so subclasses that want
+        a different provider-lookup strategy have one seam to override.
+        """
+        if self.observer_provider is None:
+            return None
+        return self.observer_provider(trial_id)
 
     def run(
         self,
@@ -573,6 +606,8 @@ class InProcessConductor:
             turn_timeout_s = run_turn_s
             episode_timeout_s = run_episode_s
 
+        loop_observer = self._maybe_build_loop_observer(spec.trial_id)
+
         runner = TrialRunner(
             task_id=task.task_id,
             trial_index=setup.trial_idx,
@@ -588,6 +623,7 @@ class InProcessConductor:
             request_limiter=self.request_limiter,
             verbose=self.verbose,
             strict=self.strict,
+            loop_observer=loop_observer,
         )
 
         # Use initial_user_message if provided (e.g., tool-use style tasks).

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -8,6 +8,7 @@ from tolokaforge.core.llm import GenerationResult, LLMClient, UserSimulator
 from tolokaforge.core.logging import StructuredLogger, init_trial_logger
 from tolokaforge.core.loop import (
     LoopConfig,
+    LoopObserver,
     MetricsSink,
     TerminationDecision,
     ToolCallingLoop,
@@ -51,6 +52,7 @@ class TrialRunner:
         request_limiter: GlobalRateLimiter | None = None,
         verbose: bool = False,
         strict: bool = False,
+        loop_observer: LoopObserver | None = None,
     ):
         self.task_id = task_id
         self.trial_index = trial_index
@@ -66,6 +68,7 @@ class TrialRunner:
         self.request_limiter = request_limiter
         self.verbose = verbose
         self.strict = strict
+        self.loop_observer = loop_observer
 
         self.messages: list[Message] = []
         self.metrics = Metrics()
@@ -185,21 +188,26 @@ class TrialRunner:
         try:
             self._seed_first_user_message(initial_user_message)
 
-            outcome = ToolCallingLoop(
-                llm_client=self.agent_client,
-                tool_executor=self.tool_executor,
-                tool_schemas=self.tool_schemas,
-                config=LoopConfig(
+            loop_kwargs: dict[str, Any] = {
+                "llm_client": self.agent_client,
+                "tool_executor": self.tool_executor,
+                "tool_schemas": self.tool_schemas,
+                "config": LoopConfig(
                     max_turns=self.max_turns,
                     episode_timeout_s=self.episode_timeout_s,
                 ),
-                metrics=_AgentMetricsSink(self.metrics),
-                should_terminate=self._agent_termination,
-                user_turn=self._agent_user_turn,
-                request_limiter=self.request_limiter,
-                normalize_tool_arguments=self._normalize_tool_arguments,
-                logger=self.logger,
-            ).run(system_prompt, self.messages, self.start_time)
+                "metrics": _AgentMetricsSink(self.metrics),
+                "should_terminate": self._agent_termination,
+                "user_turn": self._agent_user_turn,
+                "request_limiter": self.request_limiter,
+                "normalize_tool_arguments": self._normalize_tool_arguments,
+                "logger": self.logger,
+            }
+            if self.loop_observer is not None:
+                loop_kwargs["observer"] = self.loop_observer
+            outcome = ToolCallingLoop(**loop_kwargs).run(
+                system_prompt, self.messages, self.start_time
+            )
 
             status = outcome.status
             termination_reason = outcome.termination_reason


### PR DESCRIPTION
Part of #408 (M1 umbrella).

## Summary

Third M1 sub-PR. Threads the optional `LoopObserver` from sub-2 through the trial-execution path so any observer — session-based, metrics tap, debug hook, safety monitor — can attach to a live trial without further changes to the sealed conductor.

**No behavior change in sealed mode.** The observer defaults to `None`; every existing caller path is byte-identical. Verified by the full canonical suite (**426 passed**) plus 278 affected unit tests.

## Design pivot (calls out an earlier design issue)

Earlier drafts of `docs/OPEN_AGENT_LOOP.md` §6 proposed a separate **`GatedConductor`** class that would wrap `InProcessConductor`. Building it revealed that a **generic `LoopObserver` seam + optional `observer_provider` on `ConductorContext`** is both simpler and strictly more extensible:

- **No mutation of the sealed conductor's semantics.** The `observer_provider` is optional (`None` default). Existing sealed callers change nothing.
- **Genuinely extensible.** Any observer type plugs in identically: session observation (`SessionLoopObserver`) is one consumer, but a metrics tap, debug hook, safety monitor, or future observation strategy all use the same seam with **zero further changes to the conductor**.
- **The sealed conductor does not import `tolokaforge.session`.** Session observation lives entirely in the caller. Regression guard test in place.
- **Composable across conductor implementations.** Any future `Conductor` implementation can adopt the same `observer_provider` field or ignore it. It's a hint, not a Protocol requirement.
- **"Gated conductor" as a configuration, not a class.** To open the gate, pass an `observer_provider` returning `SessionLoopObserver(session)`. No separate wrapper class needed.

Design doc updated (`docs/OPEN_AGENT_LOOP.md` §6 rewritten; G3 in the decision table replaces the wrapper-class language with the observer-seam design).

## What ships

- **`TrialRunner`** — new optional `loop_observer: LoopObserver | None = None` parameter. When non-`None`, passed to the `ToolCallingLoop` it constructs.
- **`ConductorContext`** — new optional `observer_provider: Callable[[str], LoopObserver | None] | None = None` field. Per-trial factory keyed by `trial_id`.
- **`InProcessConductor`** — accepts the same `observer_provider` kwarg (kept in `**vars(ctx)` unpack parity). New `_maybe_build_loop_observer(trial_id)` helper — one seam for subclasses that want a different provider-lookup strategy. `_run_agent_loop` calls it and threads the result to `TrialRunner`.
- **`docs/OPEN_AGENT_LOOP.md`** — §6 rewritten around the observer seam; G3 decision entry updated.
- **`tests/unit/test_conductor_observer_wiring.py`** — 7 new tests:
  - `observer_provider` field default is `None`.
  - Field round-trips through `**vars(ctx)` unpack into `InProcessConductor` (the load-bearing kwarg-parity invariant).
  - `_maybe_build_loop_observer` returns `None` with no provider, `None` when provider returns `None`, and the actual observer otherwise.
  - Provider receives the correct `trial_id` argument.
  - Two different `trial_id`s can map to two different observers (per-trial session model).
  - **Extension-point regression guard**: a plain non-session `LoopObserver` plugs in without any `tolokaforge.session` import required by the sealed conductor.

## Test plan

- [x] `uv run pytest tests/ -m canonical` → **426 passed** (no regressions in canonical snapshots)
- [x] `uv run pytest tests/unit -m unit -k \"conductor or runner or loop or session\"` → **278 passed**
- [x] `uv run pytest tests/unit/test_conductor_observer_wiring.py -v` → **7 passed** (new)
- [x] `uv run ruff check tolokaforge/core/conductor.py tolokaforge/core/runner.py` → clean
- [x] Regression guard: `tolokaforge.core.conductor` does **not** import `tolokaforge.session`.

## Follow-ups

- **M1 sub-4** — orchestrator plumbing + open-mode run-config flag. When the flag is set, the orchestrator fills `ConductorContext.observer_provider` with a session-generating factory + threads the per-trial sessions into the trajectory-trace `open_agent_loop` section.
- **M1 sub-5** — intervention pump (the inbound half): another seam on `ToolCallingLoop` for pause-point polling of `drain_pending_interventions`, plus the role-priority conflict resolution described in §5.