### PR TITLE
feat(runtime): per-service log capture on completed-but-red grades (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **runtime**: per-service log capture now also fires on a completed-but-red grade (`status: completed`, `binary_pass: false`), not only execution failures — writes `services/<service>.log` + amends `metrics.yaml.captured_service_logs` before teardown (#418)
 - **grading**: `state_checks.db_probes` grading primitive — declarative postgres substrate assertions (#400)
 - **schema**: task.yaml minimal shape is task_id + description; initial_state / tools / user_simulator / grading now optional with sane defaults (#366)
 - **runtime**: `compute.log_tail` + `compute.capture_logs_on_success` config knobs and a per-service compose-log capture primitive for trial-failure diagnostics (#302)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -77,7 +77,7 @@ Notes:
 - `max_budget_usd` pauses scheduling new trials when cumulative spend reaches the budget.
 - `max_requests_per_second` applies a global limiter across worker threads.
 - `max_attempt_retries` retries transient failures (`rate_limit`, `api_error`, `timeout`) before marking a trial failed.
-- `compute.log_tail` (default `500`, must be `>= 1`) bounds the `docker compose logs --tail` line count captured per service when a multi-service trial fails on the per-trial backend.
+- `compute.log_tail` (default `500`, must be `>= 1`) bounds the `docker compose logs --tail` line count captured per service when a multi-service trial fails or grades red on the per-trial backend.
 - `compute.capture_logs_on_success` (default `false`) is a debug escape hatch: when `true`, per-service logs are captured for successful trials too, not only failures.
 - `queue_backend: postgres` enables distributed queue/state using Postgres; set `queue_postgres_dsn`.
 - If `evaluation.task_packs` is empty, `tasks_glob` is resolved relative to the working directory.

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -26,7 +26,7 @@ bumped and this document is updated in the same commit.
             ├── logs.yaml
             ├── prompts.yaml                ← agent + user-sim system prompts
             ├── tools_schemas.yaml          ← post-policy tool list
-            └── services/                   ← per-service compose logs (only on trial failure)
+            └── services/                   ← per-service compose logs (on trial-body or graded failure)
                 ├── {service}.log
                 └── _capture.yaml           ← manifest (provision-failure path only)
 ```
@@ -323,9 +323,11 @@ table):
 | `cache_read_input_tokens` | Anthropic | Tokens re-used from the ephemeral cache this call |
 | `provider_raw` | — | Best-effort dump of the *last* call's raw usage block |
 
-### `captured_service_logs` — only on trial-body failure
+### `captured_service_logs` — on trial-body or graded failure
 
-When a trial body fails (`trajectory.status` is `error` or `timeout`) on the
+When a trial is diagnostics-worthy — its body fails (`trajectory.status` is
+`error` or `timeout`) **or** it runs to completion but grades red
+(`trajectory.status` is `completed` with `grade.binary_pass: false`) — on the
 per-trial runtime backend, the executor captures each compose service's
 `docker compose logs` output to
 [`services/{service}.log`](#trialstask_idtrial_indexservices) **before**
@@ -337,16 +339,15 @@ captured_service_logs:
   runner: 512
 ```
 
-The key is present only when at least one service produced output. Capture on
-a successful trial is off by default; enable it with
+The key is present only when at least one service produced output. A
+`completed` trial that passes, or one with no grade, does not trigger capture.
+Capture on a successful trial is off by default; enable it with
 `compute.capture_logs_on_success: true` (see [`docs/CONFIG.md`](CONFIG.md:1)).
-Graded failures (`status: completed`, `binary_pass: false`) do **not** trigger
-capture — that keeps the output-dir footprint bounded.
 
 ## `trials/{task_id}/{trial_index}/services/`
 
-Per-service compose logs, written **only on trial failure** and only on the
-per-trial runtime backend (see
+Per-service compose logs, written on a trial-body or graded failure and only on
+the per-trial runtime backend (see
 [`docs/architecture/RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md:1)
 § "Per-service log capture on failure"). The shared-stack backend never writes
 this directory.
@@ -366,8 +367,8 @@ this directory.
       bytes: 4096
   ```
 
-  On the trial-body-failure path the durable record is the
-  [`metrics.yaml` `captured_service_logs`](#captured_service_logs--only-on-trial-body-failure)
+  On the trial-body path the durable record is the
+  [`metrics.yaml` `captured_service_logs`](#captured_service_logs--on-trial-body-or-graded-failure)
   field instead, so the two surfaces never both write a record.
 
 ## `trials/{task_id}/{trial_index}/grade.yaml`

--- a/docs/architecture/RUNTIME_BACKENDS.md
+++ b/docs/architecture/RUNTIME_BACKENDS.md
@@ -329,13 +329,14 @@ into the trial bundle **before** the stack comes down, under:
 <output_dir>/trials/<task_id>/<trial_index>/services/<service>.log
 ```
 
-**What counts as failure.** Capture fires on a `ProvisionError` (the
-provision-stage path) or an execution failure (`trajectory.status` in
-`{ERROR, TIMEOUT}`, the trial-body path). A `COMPLETED` trial that merely
-failed grading (`binary_pass=False`) is **not** a capture trigger — that
-would capture on most trials of a hard benchmark and blow the output-dir size
-budget. The `compute.capture_logs_on_success` debug flag overrides this and
-captures on success too.
+**What counts as diagnostics-worthy.** Capture fires on a `ProvisionError`
+(the provision-stage path), an execution failure (`trajectory.status` in
+`{ERROR, TIMEOUT}`), or a completed-but-red grade (`trajectory.status`
+`COMPLETED` with `grade.binary_pass=False`) — the last is the case where a task
+author needs postgres / PostgREST output to diagnose why the agent's mutations
+did not land. A `COMPLETED` trial that passes, or one with no grade, does not
+trigger capture. The `compute.capture_logs_on_success` debug flag overrides
+this and captures on success too.
 
 **Two capture surfaces.**
 
@@ -345,12 +346,14 @@ captures on success too.
   (the conductor never ran), so the durable record is a `services/_capture.yaml`
   manifest written alongside the `.log` files:
   `{"tail": int, "capture_reason": "provision_error", "services": {"<name>": {"bytes": int}}}`.
-- **Trial-body-failure path** — the [`TrialExecutor`](#per-trial-substrate-bracket-trialexecutor)
+- **Trial-body path** — the [`TrialExecutor`](#per-trial-substrate-bracket-trialexecutor)
   drives this surface: after `conductor.run` returns and before teardown it
-  calls `capture_service_logs(handle, *, failed)`, the Protocol hook that writes
-  the per-service `.log` files for a still-live trial stack (the `service_names`
-  snapshot taken at provision time) and returns a `{service: bytes_written}`
-  map. On a non-empty map the executor emits the `trial.service_logs_captured`
+  computes whether the outcome is diagnostics-worthy (execution failure or a
+  completed-but-red grade) and calls `capture_service_logs(handle, *,
+  capture_worthy)`, the Protocol hook that writes the per-service `.log` files
+  for a still-live trial stack (the `service_names` snapshot taken at provision
+  time) and returns a `{service: bytes_written}` map. On a non-empty map the
+  executor emits the `trial.service_logs_captured`
   summary log line and amends the trial's existing `metrics.yaml` with a
   top-level `captured_service_logs` mapping — the durable record on this path
   (the hook writes only the `.log` files). See

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -1,17 +1,18 @@
 """Lock the trial-body log-capture contract on ``ProvisioningTrialExecutor``.
 
 After ``conductor.run`` returns and before teardown, the executor calls
-``runtime_backend.capture_service_logs(handle, failed=...)`` where ``failed``
-is true only for an execution failure (``ERROR`` / ``TIMEOUT``) — a clean run
-that merely failed grading is not a capture trigger. When the backend returns
-a non-empty byte map the executor emits the ``trial.service_logs_captured``
+``runtime_backend.capture_service_logs(handle, capture_worthy=...)`` where
+``capture_worthy`` is true for an execution failure (``ERROR`` / ``TIMEOUT``)
+or a completed-but-red grade (``COMPLETED`` with ``binary_pass is False``). A
+completed trial that passes is not capture-worthy. When the backend returns a
+non-empty byte map the executor emits the ``trial.service_logs_captured``
 summary line and amends the trial's ``metrics.yaml`` with a top-level
 ``captured_service_logs`` mapping.
 
 No Docker: an :class:`InMemoryRuntimeBackend` subclass returns a stub byte map
-(gated on the ``failed`` flag, writing no ``.log`` files) and an
-:class:`InMemoryConductor` drives the trajectory status. The real per-service
-``.log`` capture is locked by the Docker integration test.
+(gated on the ``capture_worthy`` flag, writing no ``.log`` files) and an
+:class:`InMemoryConductor` drives the trajectory status and grade. The real
+per-service ``.log`` capture is locked by the Docker integration test.
 """
 
 from __future__ import annotations
@@ -37,16 +38,17 @@ _BYTE_MAP = {"db": 128, "runner": 64}
 
 class _StubCaptureBackend(InMemoryRuntimeBackend):
     """In-memory backend whose ``capture_service_logs`` returns a stub byte
-    map, gated exactly like the real backend (``failed`` or on-success), and
-    writes no ``.log`` files. Still records the ``(trial_id, failed)`` call."""
+    map, gated exactly like the real backend (``capture_worthy`` or
+    on-success), and writes no ``.log`` files. Still records the
+    ``(trial_id, capture_worthy)`` call."""
 
     def __init__(self, *, on_success: bool = False) -> None:
         super().__init__()
         self._on_success = on_success
 
-    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
-        self.call_log.capture_service_logs_calls.append((handle.trial_id, failed))
-        if failed or self._on_success:
+    def capture_service_logs(self, handle: EnvHandle, *, capture_worthy: bool) -> dict[str, int]:
+        self.call_log.capture_service_logs_calls.append((handle.trial_id, capture_worthy))
+        if capture_worthy or self._on_success:
             return dict(_BYTE_MAP)
         return {}
 
@@ -127,8 +129,8 @@ class TestErrorTrialCapture:
         assert len(_summary_lines(executor.logger)) == 1
 
 
-class TestGradedFailIsNotCapture:
-    def test_completed_binary_fail_does_not_capture(self, tmp_path: Path) -> None:
+class TestGradedFailIsCapture:
+    def test_completed_binary_fail_captures_and_amends_metrics(self, tmp_path: Path) -> None:
         backend = _StubCaptureBackend()
         factory = _factory_for(TrialStatus.COMPLETED, binary_pass=False)
         executor = _make_executor(backend, factory, tmp_path)
@@ -136,7 +138,29 @@ class TestGradedFailIsNotCapture:
 
         executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
 
-        # Capture is still consulted, but with failed=False the map is empty.
+        # A completed-but-red grade is capture-worthy.
+        assert backend.call_log.capture_service_logs_calls == [("task-1:0", True)]
+
+        summary = _summary_lines(executor.logger)
+        assert len(summary) == 1
+        assert summary[0]["context"]["services"] == _BYTE_MAP
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert metrics["captured_service_logs"] == _BYTE_MAP
+        # Pre-existing keys survive the read-add-write amendment.
+        assert metrics["cost_usd"] == 0.5
+
+
+class TestPassingTrialIsNotCapture:
+    def test_completed_binary_pass_does_not_capture(self, tmp_path: Path) -> None:
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.COMPLETED, binary_pass=True)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        # Capture is still consulted, but with capture_worthy=False the map is empty.
         assert backend.call_log.capture_service_logs_calls == [("task-1:0", False)]
         assert _summary_lines(executor.logger) == []
 

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -53,9 +53,19 @@ class _StubCaptureBackend(InMemoryRuntimeBackend):
         return {}
 
 
-def _factory_for(status: TrialStatus, *, binary_pass: bool) -> object:
+def _factory_for(status: TrialStatus, *, binary_pass: bool | None) -> object:
     def _factory(task_id: str, trial_idx: int) -> Trajectory:
         now = datetime.now(UTC)
+        grade = (
+            None
+            if binary_pass is None
+            else Grade(
+                binary_pass=binary_pass,
+                score=1.0 if binary_pass else 0.0,
+                components=GradeComponents(),
+                reasons="synthetic",
+            )
+        )
         return Trajectory(
             task_id=task_id,
             trial_index=trial_idx,
@@ -64,12 +74,7 @@ def _factory_for(status: TrialStatus, *, binary_pass: bool) -> object:
             status=status,
             messages=[],
             metrics=Metrics(),
-            grade=Grade(
-                binary_pass=binary_pass,
-                score=1.0 if binary_pass else 0.0,
-                components=GradeComponents(),
-                reasons="synthetic",
-            ),
+            grade=grade,
         )
 
     return _factory
@@ -138,7 +143,6 @@ class TestGradedFailIsCapture:
 
         executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
 
-        # A completed-but-red grade is capture-worthy.
         assert backend.call_log.capture_service_logs_calls == [("task-1:0", True)]
 
         summary = _summary_lines(executor.logger)
@@ -161,6 +165,22 @@ class TestPassingTrialIsNotCapture:
         executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
 
         # Capture is still consulted, but with capture_worthy=False the map is empty.
+        assert backend.call_log.capture_service_logs_calls == [("task-1:0", False)]
+        assert _summary_lines(executor.logger) == []
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert "captured_service_logs" not in metrics
+
+
+class TestUngradedCompletedIsNotCapture:
+    def test_completed_without_grade_does_not_capture(self, tmp_path: Path) -> None:
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.COMPLETED, binary_pass=None)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
         assert backend.call_log.capture_service_logs_calls == [("task-1:0", False)]
         assert _summary_lines(executor.logger) == []
 

--- a/tests/canonical/test_runtime_backend_contract.py
+++ b/tests/canonical/test_runtime_backend_contract.py
@@ -432,16 +432,16 @@ class TestInMemoryProvisioningCallLog:
 
 class TestCaptureServiceLogsContract:
     """``capture_service_logs`` is a Protocol method on every backend. The
-    in-memory fixture records the ``(trial_id, failed)`` pair for tests to
-    assert against; the shared-stack backend is a documented no-op. Real
+    in-memory fixture records the ``(trial_id, capture_worthy)`` pair for tests
+    to assert against; the shared-stack backend is a documented no-op. Real
     per-service ``.log`` capture on the per-trial backend is locked by the
     Docker integration test."""
 
     def test_in_memory_records_call_and_returns_empty(self) -> None:
         backend = InMemoryRuntimeBackend()
         handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
-        assert backend.capture_service_logs(handle, failed=True) == {}
-        assert backend.capture_service_logs(handle, failed=False) == {}
+        assert backend.capture_service_logs(handle, capture_worthy=True) == {}
+        assert backend.capture_service_logs(handle, capture_worthy=False) == {}
         assert backend.call_log.capture_service_logs_calls == [
             ("task-1:0", True),
             ("task-1:0", False),
@@ -450,5 +450,5 @@ class TestCaptureServiceLogsContract:
     def test_shared_stack_is_no_op(self) -> None:
         backend = SharedStackRuntimeBackend(runner_address="localhost:50051")
         handle = backend.provision(_make_trial_spec(trial_id="task-1:0"))
-        assert backend.capture_service_logs(handle, failed=True) == {}
-        assert backend.capture_service_logs(handle, failed=False) == {}
+        assert backend.capture_service_logs(handle, capture_worthy=True) == {}
+        assert backend.capture_service_logs(handle, capture_worthy=False) == {}

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -107,8 +107,8 @@ class TestProvisionFailureLogCapture:
 @pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
 class TestSuccessPathCapture:
     """After a *successful* provision, ``capture_service_logs(handle,
-    failed=False)`` writes per-service ``.log`` files only when the on-success
-    debug policy is set — the default keeps the output dir bounded."""
+    capture_worthy=False)`` writes per-service ``.log`` files only when the
+    on-success debug policy is set — the default keeps the output dir bounded."""
 
     @staticmethod
     def _success_spec(trial_id: str) -> TrialSpec:
@@ -121,7 +121,7 @@ class TestSuccessPathCapture:
         )
         handle = backend.provision(self._success_spec("task-1:0"))
         try:
-            assert backend.capture_service_logs(handle, failed=False) == {}
+            assert backend.capture_service_logs(handle, capture_worthy=False) == {}
         finally:
             backend.teardown(handle)
 
@@ -133,7 +133,7 @@ class TestSuccessPathCapture:
         )
         handle = backend.provision(self._success_spec("task-1:0"))
         try:
-            captured = backend.capture_service_logs(handle, failed=False)
+            captured = backend.capture_service_logs(handle, capture_worthy=False)
         finally:
             backend.teardown(handle)
 

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -1,34 +1,54 @@
-"""Integration test for per-service log capture on a provision failure.
+"""Integration tests for per-service log capture on a real Docker stack.
 
-Real docker-daemon coverage for :class:`PerTrialRuntimeBackend`'s
-provision-stage capture path. Brings up the public two-service fixture
-(``postgres:16`` + ``nginx:alpine``), then forces a ``reset_recipe``
-failure (a service labelled ``reset`` whose seed is absent from the
-backend registry). The stack is healthy at that point, so every declared
-service has real logs to capture *before* teardown.
+Real docker-daemon coverage for :class:`PerTrialRuntimeBackend`'s two
+capture paths, both driven over the public two-service fixture
+(``postgres:16`` + ``nginx:alpine``):
 
-Asserts the provision failure surfaces as :class:`ProvisionError` and that
-per-service ``.log`` files plus the ``_capture.yaml`` manifest land in the
-trial ``services/`` dir with byte counts that match the files on disk.
+* **Provision-stage capture** — a forced ``reset_recipe`` failure (a
+  service labelled ``reset`` whose seed is absent from the backend
+  registry). The stack is healthy at that point, so every declared service
+  has real logs to capture *before* teardown; asserts the failure surfaces
+  as :class:`ProvisionError` and that per-service ``.log`` files plus the
+  ``_capture.yaml`` manifest land in the trial ``services/`` dir.
+* **Executor trial-body graded-fail capture** — a successful provision
+  followed by a completed-but-red trial (``status COMPLETED``,
+  ``grade.binary_pass False``) driven through
+  :meth:`ProvisioningTrialExecutor.execute` with an
+  :class:`InMemoryConductor`. The executor computes the trial
+  capture-worthy and the real backend writes per-service ``.log`` files
+  before teardown; asserts the files land on disk and the amended
+  ``metrics.yaml.captured_service_logs`` byte counts match them.
 
-No LLM keys required — the failure happens before the agent loop. Mirrors
-the harness in ``test_per_trial_runtime_backend_integration.py``.
+Only the trial outcome is set deterministically — the Docker stack, the
+compose-logs subprocess, and the capture are all real. No LLM keys are
+required (the in-memory conductor runs no agent loop).
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 import yaml
 
-from tests.canonical._factories import make_task_description
+from tests.canonical._factories import make_task_config, make_task_description
 from tests.utils.docker_helpers import is_docker_daemon_available
 from tolokaforge.core.compose_materialisation import LogCaptureConfig
-from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.conductor import InMemoryConductor
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    Metrics,
+    ModelConfig,
+    Trajectory,
+    TrialStatus,
+)
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.runtime import ProvisionError
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
+from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 from tolokaforge.runner.models import ResetSpec, ServiceSpec
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
@@ -143,3 +163,81 @@ class TestSuccessPathCapture:
             log_file = services_dir / f"{service}.log"
             assert log_file.is_file()
             assert log_file.stat().st_size > 0
+
+
+def _completed_red_factory(task_id: str, trial_idx: int) -> Trajectory:
+    """Trajectory factory for a completed-but-red trial (the grade-fail trigger)."""
+    now = datetime.now(UTC)
+    return Trajectory(
+        task_id=task_id,
+        trial_index=trial_idx,
+        start_ts=now,
+        end_ts=now,
+        status=TrialStatus.COMPLETED,
+        messages=[],
+        metrics=Metrics(),
+        grade=Grade(
+            binary_pass=False,
+            score=0.0,
+            components=GradeComponents(),
+            reasons="synthetic-red",
+        ),
+    )
+
+
+def _write_metrics(output_root: Path, task_id: str, trial_idx: int) -> Path:
+    metrics_path = output_root / "trials" / task_id / str(trial_idx) / "metrics.yaml"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(yaml.safe_dump({"cost_usd": 0.5}, sort_keys=False))
+    return metrics_path
+
+
+@pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
+class TestGradedFailLogCapture:
+    """A completed-but-red trial on the per-trial backend captures each
+    declared service's logs to ``services/<name>.log`` and amends the trial's
+    ``metrics.yaml`` before teardown. The stack, the compose-logs subprocess,
+    and the capture are all real — only the trial outcome is deterministic."""
+
+    def test_completed_but_red_grade_captures_service_logs_before_teardown(
+        self, tmp_path: Path
+    ) -> None:
+        log_capture = LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
+        backend = PerTrialRuntimeBackend(log_capture=log_capture)
+        # No reset service: the healthy stack comes up and provision succeeds,
+        # so the completed-but-red grade is the sole capture trigger.
+        spec = _make_trial_spec(
+            trial_id="task-1:0", manifest=EnvironmentManifest(compose_file=_FIXTURE)
+        )
+        executor = ProvisioningTrialExecutor(
+            runtime_backend=backend,
+            conductor=InMemoryConductor(trajectory_factory=_completed_red_factory),
+            logger=StructuredLogger("test-graded-fail-log-capture"),
+            log_capture=log_capture,
+        )
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        # execute() owns provision + teardown (teardown in its own finally).
+        result = executor.execute(spec, make_task_config(task_id="task-1"))
+        assert result.trajectory.status == TrialStatus.COMPLETED
+        assert result.trajectory.grade is not None
+        assert result.trajectory.grade.binary_pass is False
+
+        services_dir = tmp_path / "trials" / "task-1" / "0" / "services"
+        assert services_dir.is_dir()
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        captured = metrics["captured_service_logs"]
+        assert set(captured) == {"db", "default"}
+
+        # Both declared services were healthy, so both produced non-empty logs,
+        # and the amended byte counts match the files actually written.
+        for service in ("db", "default"):
+            log_file = services_dir / f"{service}.log"
+            assert log_file.is_file(), f"missing {service}.log"
+            size = log_file.stat().st_size
+            assert size > 0, f"empty {service}.log"
+            assert captured[service] == size
+
+        # Pre-existing metrics keys survive the read-add-write amendment.
+        assert metrics["cost_usd"] == 0.5

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -327,11 +327,11 @@ class PerTrialRuntimeBackend:
         shutdown_compose(handle.compose)
         shutil.rmtree(handle.temp_dir, ignore_errors=True)
 
-    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
-        """Capture per-service logs for the trial-body-failure path.
+    def capture_service_logs(self, handle: EnvHandle, *, capture_worthy: bool) -> dict[str, int]:
+        """Capture per-service logs for the trial-body diagnostics path.
 
-        No-op ``{}`` when capture is disabled, the gate (``failed`` or the
-        on-success policy) is not met, or ``handle`` is foreign. Otherwise
+        No-op ``{}`` when capture is disabled, the gate (``capture_worthy`` or
+        the on-success policy) is not met, or ``handle`` is foreign. Otherwise
         writes ``docker compose logs`` output for the handle's snapshot
         services into the trial ``services/`` dir and returns the byte map.
         Writes only the ``.log`` files — the durable ``metrics.yaml``
@@ -339,7 +339,7 @@ class PerTrialRuntimeBackend:
         """
         if self.log_capture is None:
             return {}
-        if not (failed or self.log_capture.on_success):
+        if not (capture_worthy or self.log_capture.on_success):
             return {}
         if not isinstance(handle, _LocalEnvHandle):
             return {}

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -322,17 +322,20 @@ class RuntimeBackend(Protocol):
         """
         ...
 
-    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
+    def capture_service_logs(self, handle: EnvHandle, *, capture_worthy: bool) -> dict[str, int]:
         """Capture per-service logs for ``handle``'s stack; return a
         ``{service_name: bytes_written}`` map.
 
         Writes ``docker compose logs`` output to the handle's trial
         ``services/`` dir when the backend has a live per-trial stack and
-        (``failed`` or the backend's on-success policy), then returns the
-        byte map for the services that produced output; returns ``{}``
-        otherwise. Never raises — best-effort diagnostics captured *because*
-        a failure is already decided. Backends without a trial-scoped stack
-        (the shared-stack backend) are documented no-ops returning ``{}``.
+        (``capture_worthy`` or the backend's on-success policy), then returns
+        the byte map for the services that produced output; returns ``{}``
+        otherwise. ``capture_worthy`` is the executor's verdict that this
+        trial's outcome warrants diagnostics (execution failure or a
+        completed-but-red grade). Never raises — best-effort diagnostics
+        captured *because* the outcome is already decided. Backends without a
+        trial-scoped stack (the shared-stack backend) are documented no-ops
+        returning ``{}``.
         """
         ...
 
@@ -492,8 +495,8 @@ class InMemoryRuntimeBackend:
     def teardown(self, handle: EnvHandle) -> None:
         self.call_log.torn_down_trials.append(handle.trial_id)
 
-    def capture_service_logs(self, handle: EnvHandle, *, failed: bool) -> dict[str, int]:
-        self.call_log.capture_service_logs_calls.append((handle.trial_id, failed))
+    def capture_service_logs(self, handle: EnvHandle, *, capture_worthy: bool) -> dict[str, int]:
+        self.call_log.capture_service_logs_calls.append((handle.trial_id, capture_worthy))
         return {}
 
     # ---- Per-trial RPC operations (ADR-0013) ----

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -937,7 +937,7 @@ class SharedStackRuntimeBackend:
         down at :meth:`close`, not per-trial. Idempotent by construction."""
 
     def capture_service_logs(  # noqa: ARG002 — Protocol conformance
-        self, handle: EnvHandle, *, failed: bool
+        self, handle: EnvHandle, *, capture_worthy: bool
     ) -> dict[str, int]:
         """Documented no-op returning ``{}``.
 

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -78,7 +78,8 @@ class ProvisioningTrialExecutor:
     ``conductor`` for the trial body, and ``logger`` for per-branch
     structured observability at the substrate seam.
 
-    On a failed trial body it captures per-service logs via
+    On a diagnostics-worthy trial — one that fails execution or runs to
+    completion but grades red — it captures per-service logs via
     ``runtime_backend.capture_service_logs`` before teardown, then records the
     captured byte counts on the trial's ``metrics.yaml`` (path derived from
     ``log_capture.output_root``; ``None`` disables the amendment).
@@ -151,18 +152,25 @@ class ProvisioningTrialExecutor:
     def _capture_service_logs(
         self, handle: EnvHandle, result: TrialResult, task_id: str, trial_idx: int
     ) -> None:
-        """Capture per-service logs for a failed trial body, before teardown.
+        """Capture per-service logs for a diagnostics-worthy trial, before teardown.
 
-        Failure here means execution failure (``ERROR`` / ``TIMEOUT``), not a
-        clean run that merely failed grading — the backend gates the actual
-        write on this ``failed`` flag plus its on-success policy. When the
-        backend returns a non-empty byte map, emit the aggregate summary line
-        and amend the trial's ``metrics.yaml`` with ``captured_service_logs``.
-        Best-effort diagnostics captured *because* a failure is already
-        decided: never changes control flow.
+        A trial is capture-worthy when it either fails execution
+        (``ERROR`` / ``TIMEOUT``) or runs to completion but grades red
+        (``COMPLETED`` with ``grade.binary_pass is False``) — the case where a
+        task author needs service output to diagnose why the agent's mutations
+        did not land. A completed trial that passes, or one with no grade, is
+        not capture-worthy. The backend gates the actual write on this verdict
+        plus its on-success policy. When the backend returns a non-empty byte
+        map, emit the aggregate summary line and amend the trial's
+        ``metrics.yaml`` with ``captured_service_logs``. Best-effort
+        diagnostics captured *because* the outcome is already decided: never
+        changes control flow.
         """
-        failed = result.trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT)
-        byte_map = self.runtime_backend.capture_service_logs(handle, failed=failed)
+        trajectory = result.trajectory
+        capture_worthy = trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT) or (
+            trajectory.grade is not None and trajectory.grade.binary_pass is False
+        )
+        byte_map = self.runtime_backend.capture_service_logs(handle, capture_worthy=capture_worthy)
         if not byte_map:
             return
         self.logger.info(


### PR DESCRIPTION
Closes #418.

## Summary

- Broaden the trial-body per-service log-capture trigger so a trial that runs to completion but grades red (`status: completed`, `binary_pass: false`) captures each declared service's compose logs to `<trial_dir>/services/<name>.log` and amends `metrics.yaml.captured_service_logs` before teardown — the case where a task author needs postgres/uvicorn output to diagnose why the agent's mutations didn't land.
- Rename the `RuntimeBackend.capture_service_logs` gate flag `failed` → `capture_worthy` across the Protocol + all three implementations, so a `COMPLETED` trial passed to the backend is no longer mislabelled "failed". Internal Protocol — not a compatibility surface, no shim.
- Integration test on real Docker + real `PerTrialRuntimeBackend` locks the new trigger: two declared services produce non-empty `.log` files on disk and the amended metrics byte counts match.

## Trigger predicate (in `ProvisioningTrialExecutor._capture_service_logs`)

```python
capture_worthy = (
    result.trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT)
    or (result.trajectory.grade is not None and result.trajectory.grade.binary_pass is False)
)
```

Boundaries locked by canonical tests: `ERROR` + `TIMEOUT` → capture (unchanged), `COMPLETED + binary_pass=False` → capture (new), `COMPLETED + binary_pass=True` → no capture (locks pass-path), `COMPLETED + grade=None` → no capture (anomalous, safe default; guards against `None.binary_pass`).

## What is NOT changed

- Provision-failure trigger — unchanged (`services/_capture.yaml` remains provision-only).
- Trial-body-failure trigger for `ERROR`/`TIMEOUT` — unchanged.
- `on_success` debug override — unchanged.
- Shared-stack backend `capture_service_logs` — remains the documented `{}` no-op.
- Task-pack format, run-config schema, CLI, published Python API — unaffected. `metrics.yaml.captured_service_logs` key + shape unchanged (additive trigger for an existing field).

## Test tiers

- **Canonical** (`tests/canonical/test_executor_log_capture.py`): `TestErrorTrialCapture`, `TestGradedFailIsCapture`, `TestPassingTrialIsNotCapture`, `TestUngradedCompletedIsNotCapture` — all four outcome boundaries locked with the in-memory backend factory. → 5 passed.
- **Canonical** (`tests/canonical/test_runtime_backend_contract.py`): `capture_worthy=` keyword renamed at all Protocol call sites.
- **Integration** (`tests/integration/docker/test_per_trial_log_capture_integration.py::TestGradedFailLogCapture`): real Docker daemon + real `PerTrialRuntimeBackend` + real compose-logs subprocess + `InMemoryConductor` returning `COMPLETED`+`binary_pass=False`. Auto-skips without daemon; no LLM keys. → 1 passed live, 4 in the file total.

## Docs + changelog

- `docs/architecture/RUNTIME_BACKENDS.md` § "Per-service log capture on failure" rewritten — trigger set is now `ProvisionError` OR execution failure (`ERROR`/`TIMEOUT`) OR completed-but-red grade.
- `docs/OUTPUT_FORMAT.md` — `captured_service_logs` heading + anchor + back-references + services-tree note updated to cover trial-body AND graded failure.
- `docs/CONFIG.md` — trigger phrasing updated.
- `CHANGELOG.md` Unreleased → Feat entry added.

## Reviewer verdict

**APPROVE** — 1 Major (untested `COMPLETED + grade=None` boundary) fixed in the corrective commit; all findings closed on re-review. See `1e6b2ee`.

## Known CI note

`hygiene-review` lane will fail — pre-existing infra failure across all recent PRs (tracked as #425). Not caused by this change.

## Test plan (post-merge)

- [ ] Canonical + integration tiers stay green on the M18 integration branch.
- [ ] Next M18 e2e work benefits: red trials now leave `services/*.log` for post-mortem, unblocking iteration on the remaining example packs (#401, #402, #403).
