### PR TITLE
feat(orchestrator): open_agent_loop config + observer_provider wiring (M1 sub-4a)

### DIFF
--- a/tests/unit/session/test_registry.py
+++ b/tests/unit/session/test_registry.py
@@ -1,0 +1,99 @@
+"""Unit tests for :class:`tolokaforge.session.SessionRegistry` — M1 sub-4a.
+
+Idempotent lookup, concurrent creation, missing-vs-present semantics,
+and diagnostics accessors.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from tolokaforge.session import InProcessTrialSession, SessionRegistry
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetOrCreate:
+    def test_first_call_creates_a_session(self):
+        reg = SessionRegistry()
+        session = reg.get_or_create("t:0")
+        assert isinstance(session, InProcessTrialSession)
+        assert session.trial_id == "t:0"
+
+    def test_second_call_returns_same_instance(self):
+        reg = SessionRegistry()
+        s1 = reg.get_or_create("t:0")
+        s2 = reg.get_or_create("t:0")
+        assert s1 is s2
+
+    def test_different_trial_ids_get_different_sessions(self):
+        reg = SessionRegistry()
+        s1 = reg.get_or_create("t:0")
+        s2 = reg.get_or_create("t:1")
+        assert s1 is not s2
+        assert s1.trial_id == "t:0"
+        assert s2.trial_id == "t:1"
+
+    def test_concurrent_create_returns_same_instance_per_trial_id(self):
+        reg = SessionRegistry()
+        results: dict[int, InProcessTrialSession] = {}
+        barrier = threading.Barrier(8)
+
+        def worker(idx: int) -> None:
+            barrier.wait()
+            results[idx] = reg.get_or_create("shared")
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        first = results[0]
+        assert all(s is first for s in results.values())
+        assert len(reg) == 1
+
+
+class TestGet:
+    def test_missing_returns_none(self):
+        reg = SessionRegistry()
+        assert reg.get("nope") is None
+
+    def test_get_does_not_create(self):
+        reg = SessionRegistry()
+        assert reg.get("t:0") is None
+        assert len(reg) == 0
+
+    def test_get_returns_existing(self):
+        reg = SessionRegistry()
+        created = reg.get_or_create("t:0")
+        assert reg.get("t:0") is created
+
+
+class TestDiagnostics:
+    def test_all_trial_ids_snapshot(self):
+        reg = SessionRegistry()
+        reg.get_or_create("a:0")
+        reg.get_or_create("b:0")
+        reg.get_or_create("c:0")
+        assert sorted(reg.all_trial_ids()) == ["a:0", "b:0", "c:0"]
+
+    def test_len_reflects_created_sessions(self):
+        reg = SessionRegistry()
+        assert len(reg) == 0
+        reg.get_or_create("a:0")
+        assert len(reg) == 1
+        reg.get_or_create("a:0")  # idempotent
+        assert len(reg) == 1
+        reg.get_or_create("b:0")
+        assert len(reg) == 2
+
+    def test_contains_only_matches_present_string_trial_ids(self):
+        reg = SessionRegistry()
+        reg.get_or_create("t:0")
+        assert "t:0" in reg
+        assert "t:99" not in reg
+        assert 42 not in reg  # non-string is False, not TypeError
+        assert None not in reg

--- a/tests/unit/test_orchestrator_open_mode.py
+++ b/tests/unit/test_orchestrator_open_mode.py
@@ -1,0 +1,189 @@
+"""Wiring tests for orchestrator open-mode plumbing — M1 sub-4a.
+
+Covers the :class:`OpenAgentLoopConfig` flag and the observer-provider
+threading in :meth:`Orchestrator._build_observer_provider`. Full
+end-to-end flow (session persists to trajectory trace) lands in sub-4b.
+
+* Sealed default (``open_agent_loop`` absent or ``enabled=False``) →
+  registry is ``None``, observer-provider is ``None``.
+* Enabled → registry is a :class:`SessionRegistry`, observer-provider
+  returns a fresh :class:`SessionLoopObserver` bound to the trial's session,
+  and asking twice for the same ``trial_id`` yields the same underlying
+  session.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.models import OpenAgentLoopConfig, RunConfig
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.session import InProcessTrialSession, SessionLoopObserver
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal_run_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> RunConfig:
+    """Build the smallest valid :class:`RunConfig` for these plumbing tests.
+
+    The orchestrator's __init__ reads a few fields directly (models,
+    orchestrator, evaluation, plus the new ``open_agent_loop``). Everything
+    else is exercised at ``run()`` time which these tests don't invoke.
+    """
+    return RunConfig.model_validate(
+        {
+            "models": {
+                "agent": {"name": "claude-opus-4-7", "provider": "anthropic"},
+                "user": {"name": "claude-opus-4-7", "provider": "anthropic"},
+            },
+            "orchestrator": {},
+            "evaluation": {
+                "task_packs": ["fixtures/dummy"],
+                "output_dir": "/tmp/does-not-matter",
+            },
+            **(
+                {"open_agent_loop": open_agent_loop.model_dump()}
+                if open_agent_loop is not None
+                else {}
+            ),
+        }
+    )
+
+
+class TestSealedDefault:
+    def test_no_open_agent_loop_config_means_sealed(self):
+        config = _minimal_run_config()
+        assert config.open_agent_loop is None
+
+    def test_orchestrator_sessions_property_is_none_in_sealed_mode(self):
+        config = _minimal_run_config()
+        orch = Orchestrator(config=config)
+        assert orch.sessions is None
+        assert orch._build_observer_provider() is None
+
+    def test_explicit_disabled_also_yields_no_registry(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=False))
+        orch = Orchestrator(config=config)
+        assert orch.sessions is None
+        assert orch._build_observer_provider() is None
+
+
+class TestOpenModeEnabled:
+    def test_registry_is_created_when_enabled(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        orch = Orchestrator(config=config)
+        assert orch.sessions is not None
+        assert len(orch.sessions) == 0
+
+    def test_provider_creates_session_and_returns_observer(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        orch = Orchestrator(config=config)
+        provider = orch._build_observer_provider()
+        assert provider is not None
+
+        obs = provider("MAN-34:0")
+        assert isinstance(obs, SessionLoopObserver)
+
+        # The session for this trial should now exist in the registry
+        assert "MAN-34:0" in orch.sessions
+        session = orch.sessions.get("MAN-34:0")
+        assert isinstance(session, InProcessTrialSession)
+        assert session.trial_id == "MAN-34:0"
+
+    def test_provider_reuses_same_session_across_calls_for_same_trial(self):
+        """Two observers for the same trial_id bind to the *same* underlying
+        session — the observer is a thin wrapper; the session is the identity.
+        """
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        orch = Orchestrator(config=config)
+        provider = orch._build_observer_provider()
+
+        provider("t:0")
+        provider("t:0")
+        # Registry holds exactly one session for this trial
+        assert len(orch.sessions) == 1
+
+    def test_provider_returns_distinct_observers_per_trial(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        orch = Orchestrator(config=config)
+        provider = orch._build_observer_provider()
+
+        obs_a = provider("A:0")
+        obs_b = provider("B:0")
+        assert obs_a is not obs_b
+        assert orch.sessions.get("A:0") is not orch.sessions.get("B:0")
+
+
+class TestOpenAgentLoopConfigSchema:
+    def test_default_is_disabled(self):
+        assert OpenAgentLoopConfig().enabled is False
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValueError):
+            OpenAgentLoopConfig.model_validate({"enabled": True, "bogus": 1})
+
+    def test_field_round_trips_through_run_config(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        assert config.open_agent_loop is not None
+        assert config.open_agent_loop.enabled is True
+
+
+class TestConductorContextWiresProvider:
+    """When enabled, the observer_provider actually reaches
+    :class:`ConductorContext`. We drive this via a factory that captures the
+    context so we don't need Docker / an adapter to be loaded.
+    """
+
+    def test_factory_receives_context_with_observer_provider(self):
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import OrchestratorDeps
+
+        captured: dict = {}
+
+        def _factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
+            return InMemoryConductor()
+
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        deps = OrchestratorDeps(conductor_factory=_factory)
+        orch = Orchestrator(config=config, deps=deps)
+        # The adapter must be non-None for _build_conductor to run; wire a mock
+        orch.adapter = MagicMock()
+
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            output_dir=MagicMock(),
+            request_limiter=None,
+        )
+        ctx = captured["ctx"]
+        assert ctx.observer_provider is not None
+
+        obs = ctx.observer_provider("some_trial:0")
+        assert obs is not None
+        assert "some_trial:0" in orch.sessions
+
+    def test_sealed_factory_receives_context_with_none_provider(self):
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import OrchestratorDeps
+
+        captured: dict = {}
+
+        def _factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
+            return InMemoryConductor()
+
+        config = _minimal_run_config()  # no open_agent_loop
+        deps = OrchestratorDeps(conductor_factory=_factory)
+        orch = Orchestrator(config=config, deps=deps)
+        orch.adapter = MagicMock()
+
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            output_dir=MagicMock(),
+            request_limiter=None,
+        )
+        assert captured["ctx"].observer_provider is None

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -852,6 +852,29 @@ class ObservabilityConfig(BaseModel):
     logging: LoggingConfig | None = None
 
 
+class OpenAgentLoopConfig(BaseModel):
+    """Per-run knobs for the Open Agent Loop gate.
+
+    When ``enabled`` is true, every trial in the run gets a live
+    :class:`tolokaforge.session.InProcessTrialSession` and the orchestrator
+    fills :attr:`ConductorContext.observer_provider` with a factory that
+    returns a :class:`SessionLoopObserver` bound to that trial's session.
+    Sealed batch behaviour is the unchanged default (``enabled=False``);
+    setting the flag does not affect any trial that does not attach a
+    participant — events are published but simply discarded by the bounded
+    per-participant queues when no one is listening.
+
+    Future fields will land here for M1 sub-5 (pause / intervention policy)
+    and M4 (transport selection). Kept intentionally minimal today so the
+    schema addition is additive.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = False
+    """Turn open mode on. Default sealed."""
+
+
 _DUAL_HOME_COMPUTE_ALIASES: tuple[tuple[str, str], ...] = (
     ("workers", "workers"),
     ("max_budget_usd", "max_budget_usd"),
@@ -881,6 +904,10 @@ class RunConfig(BaseModel):
     compute: ComputeConfig | None = None
     storage: StorageConfig | None = None
     observability: ObservabilityConfig | None = None
+    open_agent_loop: OpenAgentLoopConfig | None = None
+    """Open Agent Loop gate configuration. ``None`` (default) keeps every
+    trial sealed; setting ``open_agent_loop.enabled = True`` puts the run
+    in open mode. See :class:`OpenAgentLoopConfig`."""
 
     @property
     def effective_workers(self) -> int:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -63,6 +63,11 @@ from tolokaforge.core.trial import (
 )
 from tolokaforge.core.trial_executor import TrialExecutor
 from tolokaforge.runner.models import AdapterType, TaskDescription
+from tolokaforge.session import (
+    InProcessTrialSession,
+    SessionLoopObserver,
+    SessionRegistry,
+)
 
 # Tools that need Playwright + Chromium baked into the runner image. The
 # orchestrator scans the task list before starting the docker stack and
@@ -271,6 +276,15 @@ class Orchestrator:
         # task is wasted work. Populated lazily by ``_build_trial_spec``.
         self._task_desc_cache: dict[str, TaskDescription] = {}
 
+        # Open Agent Loop registry — one live InProcessTrialSession per trial
+        # when the run is in open mode; ``None`` in sealed mode. Populated
+        # lazily inside :meth:`_build_conductor` so the registry only exists
+        # when actually needed. Exposed as :attr:`sessions` for external
+        # participant lookup (M2 CLI attach reads through this).
+        self._session_registry: SessionRegistry | None = None
+        if config.open_agent_loop is not None and config.open_agent_loop.enabled:
+            self._session_registry = SessionRegistry()
+
         # Initialize logger
         log_level = logging.DEBUG if verbose else logging.INFO
         self.logger = get_logger("orchestrator", level=log_level, strict=strict)
@@ -427,6 +441,7 @@ class Orchestrator:
             trial_grader=trial_grader,
             output_dir=output_dir,
             request_limiter=request_limiter,
+            observer_provider=self._build_observer_provider(),
         )
         if self._conductor_factory is not None:
             return self._conductor_factory(ctx)
@@ -436,6 +451,38 @@ class Orchestrator:
         # field on the context surfaces as a loud unexpected-kwarg
         # error here instead of a silent omission.
         return InProcessConductor(**vars(ctx))
+
+    @property
+    def sessions(self) -> SessionRegistry | None:
+        """Live-session registry for this run when open mode is on, else
+        ``None``. External participants (M2 CLI attach, cross-trial
+        orchestrator) look sessions up here by ``trial_id``. Sessions are
+        created lazily by the observer provider — a trial that has not yet
+        entered the run body will not have a session yet.
+        """
+        return self._session_registry
+
+    def _build_observer_provider(
+        self,
+    ) -> Callable[[str], SessionLoopObserver | None] | None:
+        """Return a per-trial observer factory for the current run, or ``None``
+        in sealed mode.
+
+        The provider closes over :attr:`_session_registry` and, when called
+        with a ``trial_id``, gets-or-creates the trial's session and returns
+        a fresh :class:`SessionLoopObserver` bound to it. Threading is safe
+        under the registry's own lock; each trial's conductor runs on its
+        own worker thread and receives its own observer instance.
+        """
+        registry = self._session_registry
+        if registry is None:
+            return None
+
+        def _provider(trial_id: str) -> SessionLoopObserver | None:
+            session: InProcessTrialSession = registry.get_or_create(trial_id)
+            return SessionLoopObserver(session)
+
+        return _provider
 
     def _build_trial_spec(
         self,

--- a/tolokaforge/session/__init__.py
+++ b/tolokaforge/session/__init__.py
@@ -56,6 +56,7 @@ from tolokaforge.session.protocols import (
     TrialSession,
 )
 from tolokaforge.session.recorded import RecordedTrialSession
+from tolokaforge.session.registry import SessionRegistry
 
 __all__ = [
     "ApproveTool",
@@ -76,6 +77,7 @@ __all__ = [
     "Resume",
     "ResumeAcknowledged",
     "SessionLoopObserver",
+    "SessionRegistry",
     "TerminalReached",
     "ToolCallEmitted",
     "ToolResultObserved",

--- a/tolokaforge/session/registry.py
+++ b/tolokaforge/session/registry.py
@@ -1,0 +1,76 @@
+"""``SessionRegistry`` — per-run store of live :class:`InProcessTrialSession`
+handles keyed by ``trial_id``.
+
+Held by the orchestrator when a run is in open mode. Every trial that
+enters the run body claims (or creates on first access) its session
+through :meth:`get_or_create`; external participants — a CLI attach
+subcommand, a web UI, a cross-trial orchestrator — look sessions up by
+``trial_id`` through :meth:`get` to attach.
+
+Thread-safe under the same threading model as
+:class:`InProcessTrialSession`: many worker threads may call
+:meth:`get_or_create` concurrently; each ``trial_id`` maps to exactly
+one session for the lifetime of the run.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from tolokaforge.session.in_process import InProcessTrialSession
+
+__all__ = ["SessionRegistry"]
+
+
+class SessionRegistry:
+    """Thread-safe map of ``trial_id`` → :class:`InProcessTrialSession`.
+
+    A single registry lives on the orchestrator for the duration of a
+    run. Sessions are created lazily on first ``get_or_create`` — the
+    orchestrator does not know its full trial list up front (retries and
+    resumes may add new ``trial_id``s at any time).
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, InProcessTrialSession] = {}
+        self._lock = threading.RLock()
+
+    def get_or_create(self, trial_id: str) -> InProcessTrialSession:
+        """Return the session for ``trial_id``, creating one on first access.
+
+        Idempotent — repeated calls with the same ``trial_id`` return the
+        same instance for the registry's lifetime.
+        """
+        with self._lock:
+            session = self._sessions.get(trial_id)
+            if session is None:
+                session = InProcessTrialSession(trial_id=trial_id)
+                self._sessions[trial_id] = session
+            return session
+
+    def get(self, trial_id: str) -> InProcessTrialSession | None:
+        """Return the session for ``trial_id`` if one has been created, else
+        ``None``. External participants use this to find the session they
+        want to attach to without accidentally creating a fresh empty one.
+        """
+        with self._lock:
+            return self._sessions.get(trial_id)
+
+    def all_trial_ids(self) -> list[str]:
+        """Snapshot of every ``trial_id`` currently registered.
+
+        For diagnostics and CLI listing. The underlying set may change
+        between the read and any subsequent operation.
+        """
+        with self._lock:
+            return list(self._sessions.keys())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._sessions)
+
+    def __contains__(self, trial_id: object) -> bool:
+        if not isinstance(trial_id, str):
+            return False
+        with self._lock:
+            return trial_id in self._sessions


### PR DESCRIPTION
Part of #408 (M1 umbrella).

## Summary

Fourth M1 sub-PR. Adds the run-level `open_agent_loop` config flag and the orchestrator plumbing that fills `ConductorContext.observer_provider` with a per-trial `SessionLoopObserver` factory when the flag is on. Sealed batch mode is the unchanged default.

**Live events now flow end-to-end when open mode is enabled.** A trial running under this orchestrator with `open_agent_loop.enabled: true` will have its loop seams published as `TrialEvent`s onto a live `InProcessTrialSession` — external participants that attach to the session (via `orchestrator.sessions.get(trial_id)`) see them in `seq` order.

Persistence into the trajectory trace on disk (`open_agent_loop:` section of `trajectory.yaml`) lands in sub-4b.

## What ships

### Config schema
- `OpenAgentLoopConfig` in `tolokaforge/core/models.py` — Pydantic v2 with `extra="forbid"`. Single field today (`enabled: bool = False`); shape designed to grow into pause-policy / transport knobs in M1 sub-5 and M4 without breaking the schema.
- `RunConfig.open_agent_loop: OpenAgentLoopConfig | None = None` — additive optional field; no dual-home lift needed since the block is new and has no legacy counterpart.

### Session registry
- `tolokaforge.session.SessionRegistry` — thread-safe map of `trial_id → InProcessTrialSession`. `get_or_create` is idempotent and safe under concurrent workers (RLock); `get` / `__contains__` / `all_trial_ids` / `__len__` for external lookup + diagnostics without side effects.

### Orchestrator wiring
- `Orchestrator._session_registry` constructed lazily when `config.open_agent_loop.enabled` is True.
- `Orchestrator.sessions` property surfaces the registry for external participants — M2 CLI attach reads through this.
- `Orchestrator._build_observer_provider()` returns a closure that `get_or_create`s the session per `trial_id` and wraps it in a `SessionLoopObserver`.
- `_build_conductor` threads the provider into `ConductorContext.observer_provider`.

## Tests (22 new)

- **`tests/unit/session/test_registry.py`** (12 tests) — `get_or_create` idempotency, distinct sessions per `trial_id`, **concurrent creation across 8 threads converges to one session** (RLock invariant), `get` is side-effect-free, `contains` / `len` / `all_trial_ids` diagnostics.

- **`tests/unit/test_orchestrator_open_mode.py`** (10 tests) — sealed default (config absent or `enabled=False`) yields `sessions=None` and `observer_provider=None`; enabled yields `SessionRegistry` + a working provider that creates one session per `trial_id` and returns `SessionLoopObserver`s; provider is wired through `ConductorContext` via `_build_conductor` (verified via factory-capture) for both open and sealed modes; `extra=forbid` on `OpenAgentLoopConfig`; `open_agent_loop` round-trips through `RunConfig`.

## Test plan

- [x] `uv run pytest tests/ -m canonical` → **426 passed** (no regressions in schema snapshots — `RunConfig` addition is backward-compatible)
- [x] `uv run pytest tests/unit -m unit -k \"conductor or runner or loop or session or orchestrator\"` → **429 passed**
- [x] `uv run ruff check tolokaforge/core/orchestrator.py tolokaforge/session/registry.py tests/unit/session/test_registry.py tests/unit/test_orchestrator_open_mode.py` → clean

## Follow-ups

- **M1 sub-4b** — persist the event stream + intervention log to `trajectory.yaml` as an `open_agent_loop:` section so open-mode trials are replayable off disk.
- **M1 sub-5** — intervention pump: pause-point polling of `drain_pending_interventions` inside `ToolCallingLoop` + role-priority conflict resolution.
- **M2 completion** — CLI attach subcommand reads through `Orchestrator.sessions` (or an equivalent per-run session-directory contract) to find the target session and attach a participant.