### PR TITLE
feat(session): persist open_agent_loop.yaml companion file per trial (M1 sub-4b)

### DIFF
--- a/tests/unit/session/test_snapshot.py
+++ b/tests/unit/session/test_snapshot.py
@@ -1,0 +1,176 @@
+"""Unit tests for :meth:`InProcessTrialSession.snapshot` — M1 sub-4b.
+
+Covers the durable event/intervention history the ``open_agent_loop``
+trajectory-trace section persists to disk.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from tolokaforge.session import (
+    AssistantMessage,
+    InjectMessage,
+    InProcessTrialSession,
+    ParticipantRole,
+    TerminalReached,
+    ToolCallEmitted,
+    TurnStarted,
+)
+from tolokaforge.session._status import TrialStatus
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_session_with_activity() -> InProcessTrialSession:
+    session = InProcessTrialSession(trial_id="MAN-34:0")
+    session.publish(
+        TurnStarted(trial_id="MAN-34:0", seq=session.next_seq(), timestamp=_NOW, turn_index=0)
+    )
+    session.publish(
+        AssistantMessage(
+            trial_id="MAN-34:0",
+            seq=session.next_seq(),
+            timestamp=_NOW,
+            content_preview="hi",
+        )
+    )
+    session.publish(
+        ToolCallEmitted(
+            trial_id="MAN-34:0",
+            seq=session.next_seq(),
+            timestamp=_NOW,
+            call_id="c1",
+            tool_name="lookup",
+            arguments_preview='{"q":"x"}',
+        )
+    )
+    session.publish(
+        TerminalReached(
+            trial_id="MAN-34:0",
+            seq=session.next_seq(),
+            timestamp=_NOW,
+            status=TrialStatus.COMPLETED,
+        )
+    )
+    return session
+
+
+class TestEventHistory:
+    def test_snapshot_records_every_published_event_even_without_participants(self):
+        """The trace must be faithful even when no participant is attached —
+        events go into per-participant queues *and* the durable history.
+        """
+        session = _make_session_with_activity()
+        snap = session.snapshot()
+
+        assert snap["trial_id"] == "MAN-34:0"
+        assert snap["closed"] is True
+        assert len(snap["events"]) == 4
+        assert snap["events"][0]["kind"] == "turn_started"
+        assert snap["events"][-1]["kind"] == "terminal_reached"
+
+    def test_snapshot_events_preserve_seq_order(self):
+        session = _make_session_with_activity()
+        snap = session.snapshot()
+        seqs = [e["seq"] for e in snap["events"]]
+        assert seqs == sorted(seqs)
+        assert seqs[0] == 0
+
+    def test_snapshot_events_pass_through_pydantic_json_serialization(self):
+        session = _make_session_with_activity()
+        snap = session.snapshot()
+        # timestamp is ISO-formatted (mode="json"), status is a string
+        term = snap["events"][-1]
+        assert isinstance(term["timestamp"], str)
+        assert term["status"] == "completed"
+
+
+class TestInterventionHistory:
+    def _session_with_intervention(self) -> tuple[InProcessTrialSession, InjectMessage]:
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        intervention = InjectMessage(
+            trial_id="t:0",
+            attach_to_seq=0,
+            participant_id="p1",
+            timestamp=_NOW,
+            content="try /v2/auth",
+        )
+        session.interventions().submit(handle, intervention)
+        return session, intervention
+
+    def test_snapshot_records_submitted_interventions(self):
+        session, intervention = self._session_with_intervention()
+        snap = session.snapshot()
+        assert len(snap["interventions"]) == 1
+        rec = snap["interventions"][0]
+        assert rec["intervention"]["kind"] == "inject_message"
+        assert rec["intervention"]["content"] == "try /v2/auth"
+
+    def test_snapshot_records_ack_outcome(self):
+        session, _ = self._session_with_intervention()
+        snap = session.snapshot()
+        rec = snap["interventions"][0]
+        # In-process transport returns "queued" synchronously
+        assert rec["ack_outcome"] == "queued"
+
+    def test_snapshot_intervention_survives_queue_drain(self):
+        """The pause-pump-side queue drain must not empty the durable trace
+        history — that's the whole point of separating _intervention_history
+        from _intervention_queue.
+        """
+        session, _ = self._session_with_intervention()
+        drained = session.drain_pending_interventions()
+        assert len(drained) == 1
+        # History persists after drain
+        snap = session.snapshot()
+        assert len(snap["interventions"]) == 1
+
+    def test_snapshot_records_multiple_interventions_in_order(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        for i, content in enumerate(["a", "b", "c"]):
+            session.interventions().submit(
+                handle,
+                InjectMessage(
+                    trial_id="t:0",
+                    attach_to_seq=i,
+                    participant_id="p1",
+                    timestamp=_NOW,
+                    content=content,
+                ),
+            )
+        snap = session.snapshot()
+        assert [rec["intervention"]["content"] for rec in snap["interventions"]] == ["a", "b", "c"]
+
+
+class TestSnapshotSerialisability:
+    def test_snapshot_is_yaml_serialisable(self):
+        """The snapshot must land on disk cleanly. Verify with an in-memory
+        yaml.safe_dump round-trip.
+        """
+        import yaml
+
+        session = _make_session_with_activity()
+        snap = session.snapshot()
+        dumped = yaml.safe_dump(snap, sort_keys=False)
+        parsed = yaml.safe_load(dumped)
+
+        assert parsed["trial_id"] == "MAN-34:0"
+        assert len(parsed["events"]) == 4
+        assert parsed["events"][0]["kind"] == "turn_started"
+
+    def test_empty_session_snapshot_is_stable(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        snap = session.snapshot()
+        assert snap == {
+            "trial_id": "t:0",
+            "closed": False,
+            "events": [],
+            "interventions": [],
+        }

--- a/tests/unit/test_orchestrator_trace_write.py
+++ b/tests/unit/test_orchestrator_trace_write.py
@@ -1,0 +1,153 @@
+"""Unit tests for :meth:`Orchestrator._write_open_agent_loop_trace` — M1 sub-4b.
+
+The write is a small helper called from the trial-completion handler; these
+tests exercise it directly to avoid spinning up Docker / a real conductor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.models import OpenAgentLoopConfig, RunConfig
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.session import AssistantMessage, TurnStarted
+from tolokaforge.session._status import TrialStatus
+from tolokaforge.session.events import TerminalReached
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _minimal_run_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> RunConfig:
+    return RunConfig.model_validate(
+        {
+            "models": {
+                "agent": {"name": "claude-opus-4-7", "provider": "anthropic"},
+                "user": {"name": "claude-opus-4-7", "provider": "anthropic"},
+            },
+            "orchestrator": {},
+            "evaluation": {
+                "task_packs": ["fixtures/dummy"],
+                "output_dir": "/tmp/does-not-matter",
+            },
+            **(
+                {"open_agent_loop": open_agent_loop.model_dump()}
+                if open_agent_loop is not None
+                else {}
+            ),
+        }
+    )
+
+
+class TestSealedModeIsNoOp:
+    def test_sealed_write_creates_no_file(self, tmp_path: Path):
+        """No sessions in sealed mode — the writer must be a silent no-op."""
+        orch = Orchestrator(config=_minimal_run_config())
+        orch._write_open_agent_loop_trace(tmp_path, "MAN-34", 0)
+        assert not (tmp_path / "trials").exists()
+
+    def test_open_mode_but_no_session_yet_is_no_op(self, tmp_path: Path):
+        """Open-mode registry exists, but if the trial never entered the run
+        body the session for that trial_id doesn't exist — nothing to write.
+        """
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
+        orch._write_open_agent_loop_trace(tmp_path, "never-ran", 0)
+        assert not (tmp_path / "trials").exists()
+
+
+class TestOpenModeWritesTraceFile:
+    def _seed_session(self, orch: Orchestrator, trial_id: str) -> None:
+        provider = orch._build_observer_provider()
+        assert provider is not None
+        provider(trial_id)  # create the session via the same path the conductor uses
+
+        session = orch.sessions.get(trial_id)
+        assert session is not None
+        session.publish(
+            TurnStarted(trial_id=trial_id, seq=session.next_seq(), timestamp=_NOW, turn_index=0)
+        )
+        session.publish(
+            AssistantMessage(
+                trial_id=trial_id,
+                seq=session.next_seq(),
+                timestamp=_NOW,
+                content_preview="hi",
+            )
+        )
+        session.publish(
+            TerminalReached(
+                trial_id=trial_id,
+                seq=session.next_seq(),
+                timestamp=_NOW,
+                status=TrialStatus.COMPLETED,
+            )
+        )
+
+    def test_writes_yaml_at_expected_path(self, tmp_path: Path):
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
+        self._seed_session(orch, "MAN-34:0")
+
+        orch._write_open_agent_loop_trace(tmp_path, "MAN-34", 0)
+
+        trace_path = tmp_path / "trials" / "MAN-34" / "0" / "open_agent_loop.yaml"
+        assert trace_path.exists()
+
+        content = yaml.safe_load(trace_path.read_text())
+        assert content["trial_id"] == "MAN-34:0"
+        assert content["closed"] is True
+        assert len(content["events"]) == 3
+        assert [e["kind"] for e in content["events"]] == [
+            "turn_started",
+            "assistant_message",
+            "terminal_reached",
+        ]
+
+    def test_write_overwrites_on_retry(self, tmp_path: Path):
+        """A retried trial gets more events on the same session; the file is
+        overwritten with the accumulated state.
+        """
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
+        provider = orch._build_observer_provider()
+        provider("t:0")
+        session = orch.sessions.get("t:0")
+
+        session.publish(
+            TurnStarted(trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, turn_index=0)
+        )
+        orch._write_open_agent_loop_trace(tmp_path, "t", 0)
+        first = yaml.safe_load(
+            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
+        )
+        assert len(first["events"]) == 1
+
+        # Simulate more events on the same session (retry appends to history)
+        session.publish(
+            AssistantMessage(
+                trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, content_preview="retry"
+            )
+        )
+        orch._write_open_agent_loop_trace(tmp_path, "t", 0)
+        second = yaml.safe_load(
+            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
+        )
+        assert len(second["events"]) == 2
+
+    def test_write_failure_logs_and_returns_without_raising(self, tmp_path: Path):
+        """Trace-write failures must not mask the trial result. Force a write
+        error by pointing at a path where mkdir will fail (an existing FILE
+        where a directory is expected).
+        """
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
+        self._seed_session(orch, "t:0")
+
+        # tmp_path/trials is a FILE, not a directory — parent.mkdir will raise
+        blocker = tmp_path / "trials"
+        blocker.write_text("blocking-file")
+
+        # Must not raise
+        orch._write_open_agent_loop_trace(tmp_path, "t", 0)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -462,6 +462,41 @@ class Orchestrator:
         """
         return self._session_registry
 
+    def _write_open_agent_loop_trace(self, output_dir: Path, task_id: str, trial_idx: int) -> None:
+        """Persist the trial's open_agent_loop snapshot to disk.
+
+        No-op when open mode is off or the trial never entered the run body
+        (no session created for it). Writes ``trials/<task_id>/<trial_idx>/
+        open_agent_loop.yaml`` alongside ``trajectory.yaml``. Companion-file
+        shape (not merged into ``trajectory.yaml``) keeps the Trajectory
+        model unchanged and canonical snapshot tests undisturbed; a later
+        follow-up can promote the section into the Trajectory model.
+
+        Called from the orchestrator's trial-completion handler after the
+        conductor returns. Failures are logged and swallowed — the trace
+        write must never mask the actual trial result the operator cares
+        about.
+        """
+        if self._session_registry is None:
+            return
+        session = self._session_registry.get(f"{task_id}:{trial_idx}")
+        if session is None:
+            return
+        import yaml
+
+        trace_path = output_dir / "trials" / task_id / str(trial_idx) / "open_agent_loop.yaml"
+        try:
+            trace_path.parent.mkdir(parents=True, exist_ok=True)
+            with trace_path.open("w") as fh:
+                yaml.safe_dump(session.snapshot(), fh, sort_keys=False)
+        except Exception as write_err:  # noqa: BLE001 — trace write must not mask trial result
+            self.logger.warning(
+                "Failed to write open_agent_loop trace; continuing",
+                task_id=task_id,
+                trial_index=trial_idx,
+                error=str(write_err),
+            )
+
     def _build_observer_provider(
         self,
     ) -> Callable[[str], SessionLoopObserver | None] | None:
@@ -1546,6 +1581,13 @@ class Orchestrator:
                         self.results.append(trajectory)
                         trial_cost = trajectory.metrics.cost_usd or 0.0
                         total_cost_usd += trial_cost
+
+                        # Persist the open_agent_loop trace on every attempt
+                        # completion — no-op when open mode is off or the trial
+                        # never entered the run body. On retry the file is
+                        # overwritten with the accumulated session history
+                        # across attempts (session is keyed by trial_id).
+                        self._write_open_agent_loop_trace(output_dir, task_id, trial_idx)
 
                         # Retry transient infra failures based on queue retry policy.
                         if self._is_retryable_trajectory(trajectory):

--- a/tolokaforge/session/in_process.py
+++ b/tolokaforge/session/in_process.py
@@ -67,6 +67,25 @@ class QueuedIntervention:
     submitted_at: datetime
 
 
+@dataclass(frozen=True)
+class _InterventionRecord:
+    """Durable trace-side record of one submitted intervention.
+
+    Kept separate from :class:`QueuedIntervention` (which lives on the
+    volatile producer queue and gets drained by the pause pump) — this
+    record persists for the trial's lifetime and lands in the
+    ``open_agent_loop`` trajectory-trace section. Includes the ack outcome
+    that ``submit`` returned so the trace tells the full story.
+    """
+
+    trial_id: str
+    participant_id: str
+    intervention: TrialIntervention
+    ack_outcome: str
+    ack_reason: str | None
+    submitted_at: datetime
+
+
 @dataclass
 class _ParticipantSlot:
     """Per-participant queue + handle. One slot per attached participant."""
@@ -97,6 +116,14 @@ class InProcessTrialSession:
         self._lock = threading.RLock()
         self._seq_counter = 0
         self._closed = False
+        # History captured for the durable open_agent_loop trace. Every
+        # published event lands here in seq order regardless of whether any
+        # participant is attached; every intervention submitted through
+        # :meth:`submit` is recorded with the ack outcome so the trace
+        # replays deterministically once written to disk (see
+        # :meth:`snapshot`). Bounded implicitly by the trial's turn budget.
+        self._event_history: list[TrialEvent] = []
+        self._intervention_history: list[_InterventionRecord] = []
 
     # ------------------------------------------------------------------
     # TrialSession Protocol
@@ -190,20 +217,33 @@ class InProcessTrialSession:
         # Confirm the handle is still attached; a detached participant
         # cannot submit further interventions.
         self._require_slot(handle)
+        submitted_at = datetime.now(UTC)
         self._intervention_queue.put(
             QueuedIntervention(
                 handle=handle,
                 intervention=intervention,
-                submitted_at=datetime.now(UTC),
+                submitted_at=submitted_at,
             )
         )
-        return InterventionAck(
+        ack = InterventionAck(
             intervention_kind=intervention.kind,
             trial_id=self._trial_id,
             participant_id=handle.participant_id,
             outcome="queued",
             reason=None,
         )
+        with self._lock:
+            self._intervention_history.append(
+                _InterventionRecord(
+                    trial_id=self._trial_id,
+                    participant_id=handle.participant_id,
+                    intervention=intervention,
+                    ack_outcome=ack.outcome,
+                    ack_reason=ack.reason,
+                    submitted_at=submitted_at,
+                )
+            )
+        return ack
 
     # ------------------------------------------------------------------
     # Producer-side API (concrete class, not on the Protocol)
@@ -229,12 +269,18 @@ class InProcessTrialSession:
         Publishing after close is a programmer error and raises
         ``RuntimeError`` — the sealed conductor would never do this;
         catching this early avoids silent event loss.
+
+        Records the event on the durable history buffer regardless of
+        whether any participant is attached, so the ``open_agent_loop``
+        trajectory-trace snapshot is faithful even for unattached open-mode
+        trials.
         """
         with self._lock:
             if self._closed:
                 raise RuntimeError(
                     f"Cannot publish {event.kind!r} to a closed session (trial_id={self._trial_id!r})."
                 )
+            self._event_history.append(event)
             for slot in self._participants.values():
                 slot.event_queue.put(event)
             if isinstance(event, TerminalReached):
@@ -277,6 +323,38 @@ class InProcessTrialSession:
     @property
     def is_closed(self) -> bool:
         return self._closed
+
+    def snapshot(self) -> dict[str, Any]:
+        """Serialisable snapshot of everything published + submitted for this
+        trial, in the shape the ``open_agent_loop`` trajectory-trace section
+        persists to disk.
+
+        Returns a plain ``dict`` (not a Pydantic model) so callers can drop
+        it straight into a YAML dump without wrestling with model shapes.
+        Every event and intervention round-trips through Pydantic v2's
+        ``model_dump(mode="json")`` so datetime / enum / discriminator
+        handling matches the wire format the session module already uses
+        elsewhere.
+        """
+        with self._lock:
+            events = [event.model_dump(mode="json") for event in self._event_history]
+            interventions = [
+                {
+                    "trial_id": record.trial_id,
+                    "participant_id": record.participant_id,
+                    "submitted_at": record.submitted_at.isoformat(),
+                    "ack_outcome": record.ack_outcome,
+                    "ack_reason": record.ack_reason,
+                    "intervention": record.intervention.model_dump(mode="json"),
+                }
+                for record in self._intervention_history
+            ]
+        return {
+            "trial_id": self._trial_id,
+            "closed": self._closed,
+            "events": events,
+            "interventions": interventions,
+        }
 
     @property
     def attached_participant_ids(self) -> list[str]:


### PR DESCRIPTION
Part of #408 (M1 umbrella).

## Summary

Fifth M1 sub-PR. Open-mode trials now leave a replayable trace on disk. Each attempted trial with an active session gets a `trials/<task_id>/<trial_idx>/open_agent_loop.yaml` companion file written by the orchestrator on trial completion.

**Chose companion file over Trajectory schema extension** (Option B from the earlier planning): keeps the `Trajectory` model unchanged, canonical snapshot tests undisturbed, zero blast radius on existing consumers. A follow-up can promote the section into the `Trajectory` model once the shape is settled.

## What ships

### Session history + snapshot
- **`InProcessTrialSession`** retains an in-memory history of every event published (via `publish()`) and every intervention submitted (via `submit()`) in a new `_InterventionRecord` that carries the ack outcome.
- History is populated **even when no participant is attached** — the trace is faithful regardless of who's listening.
- **`InProcessTrialSession.snapshot() -> dict`** returns a YAML-serialisable structure `{trial_id, closed, events[], interventions[]}` that round-trips discriminated unions cleanly (uses `model_dump(mode="json")`).

### Trace persistence
- **`Orchestrator._write_open_agent_loop_trace(output_dir, task_id, trial_idx)`** — no-ops in sealed mode or when a session for the `trial_id` doesn't exist; otherwise writes the snapshot. Write failures are logged and swallowed — diagnostic trace writes must never mask the actual trial result.
- Trial-completion handler in `Orchestrator.run()` calls the writer after each attempt result lands, so retries overwrite the file with the accumulated session history (session is keyed by `trial_id`; retries append to the same history).

### Path
```
trials/<task_id>/<trial_idx>/open_agent_loop.yaml
```
Alongside the existing `trajectory.yaml`, `grade.yaml`, `metrics.yaml`, etc.

### File shape
```yaml
trial_id: MAN-34:0
closed: true
events:
  - kind: turn_started
    trial_id: MAN-34:0
    seq: 0
    timestamp: '2026-07-16T12:00:00+00:00'
    turn_index: 0
  - kind: assistant_message
    ...
interventions:
  - trial_id: MAN-34:0
    participant_id: llm_intervener
    submitted_at: '...'
    ack_outcome: queued
    ack_reason: null
    intervention:
      kind: inject_message
      content: try /v2/auth
      ...
```

## Tests (14 new)

- **`tests/unit/session/test_snapshot.py`** (9 tests) — event history captured even without participants, seq order preserved, pydantic JSON serialisation passes through cleanly, intervention history survives the `drain_pending_interventions` queue drain, YAML round-trip, empty session shape stable, multi-intervention ordering.

- **`tests/unit/test_orchestrator_trace_write.py`** (5 tests) — sealed mode is a silent no-op, open-mode-but-no-session is a silent no-op, writes YAML at the expected path with expected contents, overwrites on retry, write failure (existing file blocking `mkdir`) is logged and does not raise.

## Test plan

- [x] `uv run pytest tests/ -m canonical` → **426 passed** (no regressions in schema snapshots — `Trajectory` model untouched)
- [x] `uv run pytest tests/unit -m unit -k "session or loop or conductor or runner or orchestrator"` → **443 passed**
- [x] `uv run ruff check ...` → clean

## What this closes for M1

With sub-4b merged, open mode is **end-to-end**:

1. Operator sets `open_agent_loop.enabled: true` in the run config (sub-4a).
2. Orchestrator creates a `SessionRegistry` and wires an observer provider (sub-4a).
3. Each trial's `ToolCallingLoop` reports natural seams via the `LoopObserver` bridge (sub-2, sub-3).
4. Events are published live to attached participants via `InProcessTrialSession` (sub-1) **and** captured in the session's history buffer (sub-4b).
5. Interventions submitted through `submit()` queue for the pause pump (still to land in sub-5) **and** are captured with their ack outcome in the trace.
6. On trial completion, the orchestrator writes the snapshot to `open_agent_loop.yaml` (sub-4b). Trace is deterministic replayable via `RecordedTrialSession.from_events(...)` fed from the file.

## Follow-ups (last piece of M1)

- **M1 sub-5** — intervention pump: pause-point polling of `drain_pending_interventions` inside `ToolCallingLoop` (via another observer-style seam), role-priority conflict resolution (`admin > participant > observer`, later-wins within a tier), and updating the intervention history's `ack_outcome` from `queued` to `accepted` / `superseded` / `rejected`. This is the piece that makes interventions actually affect the running trial rather than being silently queued.