### PR TITLE
feat(env-identity): resolved manifest identity in env.yaml (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 
+- **env-identity**: Project-layer / multi-container trials now record resolved environment identity (services, pinned images, network policy, redacted DSNs, mounts) in `env.yaml`; previously these sections were empty (#419)
 - **grading**: a project's `task_defaults.grading_defaults.combine` now deep-merges under each task's own `grading.yaml.combine` (task fields win, `weights` merge key-by-key); a task that omits `combine` inherits the project block instead of an arbitrary `{state_checks: 1.0}` / `pass_threshold: 1.0` fallback, and `get_grading_config` no longer raises on tasks that ship no `combine` block (#376)
 - **runtime**: `SharedStackRuntimeBackend` no longer advertises `reset_recipes:*` capabilities — a shared stack cannot honour them (reset tasks route to `PerTrialRuntimeBackend`, which still advertises them). A shared-selected run that requested a `reset_recipes:*` capability was admitting a capability it could not deliver; it is now refused at run start with the standard admission error (#310)
 

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -252,10 +252,63 @@ user:
 db: {...}          # Full database state
 filesystem: {...}  # File system state
 mock_web_url: "..."
+agent_visible_dir: /work
+environment:       # present only for manifest-driven trials (see below)
+  network_policy: no_internet
+  runner_service: runner
+  services:
+    app-db:
+      image: postgres:16
+      pinned: true
+      isolation: reset
+      reset_seed: baseline
+      dsns: []
+      mounts:
+        - /docker-entrypoint-initdb.d/init.sql:ro
+    app-service:
+      image: tolokaforge-runner:0.5.0
+      pinned: true
+      isolation: shared
+      reset_seed: null
+      dsns:
+        - postgresql://app:***@app-db:5432/mfg
+      mounts:
+        - /srv/app/main.py:ro
 ```
 
 Free-form snapshot of the environment state at trial end. Adapters /
 tasks control the shape; no schema version attached.
+
+### `environment` — resolved environment identity
+
+Manifest-driven trials (a task carrying an `environment_manifest`, i.e.
+Project-layer / multi-container substrates) record the resolved
+environment identity under `environment`. The block is a pure function of
+the trial's `EnvironmentManifest`, so it is available for post-mortems
+even after a per-trial stack is torn down. Trials without a manifest
+(run.yaml-only / JSON-DB tasks) omit the key entirely.
+
+Top-level keys:
+
+| Key | Meaning |
+|---|---|
+| `network_policy` | Run-level network posture (`no_internet` / `limited_internet` / `full_internet`) |
+| `runner_service` | Compose service the runner executes inside |
+| `services` | Per-service identity, keyed by compose service name |
+
+Each `services.<name>` entry:
+
+| Field | Meaning |
+|---|---|
+| `image` | Resolved image reference after `${VAR}` / `${VAR:-default}` substitution from `stack_inputs` |
+| `pinned` | `true` when the resolved image carries a digest or a non-floating tag |
+| `isolation` | `shared` / `reset` / `ephemeral`; services absent from the manifest default to `ephemeral` |
+| `reset_seed` | Seed name for a `reset` service, else `null` |
+| `dsns` | Connection strings from the service's compose `environment`, each with any embedded password replaced by `***` |
+| `mounts` | Container-side mount targets (`<target>:<mode>`); host source paths are omitted |
+
+DSN passwords are redacted and host mount sources are never recorded, so
+the block is safe to share and stable across hosts.
 
 ## `trials/{task_id}/{trial_index}/metrics.yaml`
 

--- a/docs/multi_container_tasks.md
+++ b/docs/multi_container_tasks.md
@@ -267,6 +267,18 @@ time. Full field reference in
 [`docs/GRADING.md`](GRADING.md) § Substrate Grading; the
 `multi_service_lot_ops` pack below is the worked example.
 
+## Recorded environment identity
+
+Each trial's `env.yaml` records the resolved environment identity under an
+`environment` block: the network policy, the runner service, and per-service
+image (pinned or floating), isolation, reset seed, redacted DSNs, and
+container mount targets. Because it is a pure function of the resolved
+manifest, the identity survives per-trial stack teardown and gives a
+post-mortem the exact substrate a trial ran against — which image, which
+DSN, which mounts — without leaking secrets or host paths. See
+[`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md) § `env.yaml` for the field
+reference.
+
 ## Further reading
 
 - [`examples/native/multi_service_postgres_reset/README.md`](../examples/native/multi_service_postgres_reset/README.md)

--- a/tests/canonical/fixtures/environment_manifest/identity_multi_service.yaml
+++ b/tests/canonical/fixtures/environment_manifest/identity_multi_service.yaml
@@ -1,0 +1,19 @@
+services:
+  runner:
+    image: tolokaforge-runner:0.5.0
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+  app-service:
+    image: tolokaforge-runner:0.5.0
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/mfg"
+    volumes:
+      - ./app/main.py:/srv/app/main.py:ro
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "mfg"
+      POSTGRES_USER: "app"
+      POSTGRES_PASSWORD: "app_pw"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro

--- a/tests/canonical/snapshots/env_identity/multi_service.json
+++ b/tests/canonical/snapshots/env_identity/multi_service.json
@@ -1,0 +1,38 @@
+{
+  "network_policy": "no_internet",
+  "runner_service": "runner",
+  "services": {
+    "app-db": {
+      "dsns": [],
+      "image": "postgres:16",
+      "isolation": "reset",
+      "mounts": [
+        "/docker-entrypoint-initdb.d/init.sql:ro"
+      ],
+      "pinned": true,
+      "reset_seed": "baseline"
+    },
+    "app-service": {
+      "dsns": [
+        "postgresql://app:***@app-db:5432/mfg"
+      ],
+      "image": "tolokaforge-runner:0.5.0",
+      "isolation": "shared",
+      "mounts": [
+        "/srv/app/main.py:ro"
+      ],
+      "pinned": true,
+      "reset_seed": null
+    },
+    "runner": {
+      "dsns": [
+        "http://db-service:8000"
+      ],
+      "image": "tolokaforge-runner:0.5.0",
+      "isolation": "shared",
+      "mounts": [],
+      "pinned": true,
+      "reset_seed": null
+    }
+  }
+}

--- a/tests/canonical/test_env_identity_snapshot.py
+++ b/tests/canonical/test_env_identity_snapshot.py
@@ -1,0 +1,68 @@
+"""Golden snapshot of the resolved ``environment`` block written into
+``env.yaml`` for a manifest-driven (Project-layer / multi-container) trial.
+
+The conductor records ``describe_environment_identity(manifest).model_dump()``
+under ``final_env_state["environment"]``. This snapshot pins that serialised
+shape against a fixture stack mirroring ``multi_service_lot_ops``: pinned
+images, a DSN carrying an embedded password, a plaintext-secret env, ``ro``
+bind mounts, and a reset-seed service. The snapshot is the recurrence guard
+that DSN passwords are redacted, host mount sources are dropped, and every
+required identity piece (images, network policy, DSNs, mounts) is present.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.env_identity import describe_environment_identity
+from tolokaforge.core.models import ResetSpec, ServiceSpec
+from tolokaforge.core.trial import EnvironmentManifest
+
+pytestmark = pytest.mark.canonical
+
+FIXTURE = (
+    Path(__file__).parent / "fixtures" / "environment_manifest" / "identity_multi_service.yaml"
+)
+
+
+def _manifest() -> EnvironmentManifest:
+    return EnvironmentManifest(
+        compose_file=FIXTURE,
+        runner_service="runner",
+        services={
+            "runner": ServiceSpec(isolation="shared"),
+            "app-service": ServiceSpec(isolation="shared"),
+            "app-db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+        },
+    )
+
+
+def test_environment_block_snapshot(canon_snapshot) -> None:
+    """Snapshot the exact ``environment`` mapping the conductor writes."""
+    block = describe_environment_identity(_manifest()).model_dump(mode="json")
+    canon_snapshot("env_identity").assert_match(block, "multi_service.json")
+
+
+def test_required_identity_pieces_present() -> None:
+    block = describe_environment_identity(_manifest()).model_dump(mode="json")
+
+    assert block["network_policy"] == "no_internet"
+    assert block["runner_service"] == "runner"
+
+    app_db = block["services"]["app-db"]
+    assert app_db["image"] == "postgres:16"
+    assert app_db["pinned"] is True
+    assert app_db["isolation"] == "reset"
+    assert app_db["reset_seed"] == "baseline"
+
+    app_service = block["services"]["app-service"]
+    assert app_service["dsns"] == ["postgresql://app:***@app-db:5432/mfg"]
+    assert app_service["mounts"] == ["/srv/app/main.py:ro"]
+
+
+def test_embedded_secret_never_serialised() -> None:
+    block = describe_environment_identity(_manifest()).model_dump(mode="json")
+    assert "app_pw" not in json.dumps(block)

--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -7,6 +7,7 @@ in ``tests/canonical/test_conductor_contract.py``.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -15,9 +16,10 @@ import pytest
 from tolokaforge.core.conductor import (
     ConductorCallLog,
     InMemoryConductor,
+    InProcessConductor,
     _default_success_trajectory,
 )
-from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.models import ModelConfig, ResetSpec, ServiceSpec
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 from tolokaforge.runner.models import TaskDescription
 
@@ -215,3 +217,76 @@ class TestTrialSpecWireExclusion:
 
         assert '"task_id":"t1"' in wire_json
         assert '"adapter_type":"native"' in wire_json
+
+
+class TestCaptureFinalStateEnvironmentBlock:
+    """``_capture_final_state`` records the resolved environment identity under
+    ``final_env_state["environment"]`` only when the trial's task carries an
+    ``environment_manifest``. Manifest-less trials keep the JSON-DB-only shape —
+    the additive/back-compat guarantee the descriptor rests on.
+    """
+
+    def _conductor(self) -> InProcessConductor:
+        conductor = InProcessConductor(
+            adapter=MagicMock(),
+            artifact_writer=MagicMock(),
+            config=MagicMock(),
+            logger=MagicMock(),
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            trial_grader=MagicMock(),
+            output_dir=Path("/tmp"),
+        )
+        conductor.runtime_backend.get_state.return_value = {"success": False}
+        return conductor
+
+    def _setup(self) -> MagicMock:
+        setup = MagicMock()
+        setup.trial_id = "t1:0"
+        setup.env_state.get_final_state.return_value = {}
+        setup.env_state.agent_visible_dir = Path("/tmp/agent")
+        setup.adapter_env.data = None
+        return setup
+
+    def _manifest(self) -> EnvironmentManifest:
+        fixture = (
+            Path(__file__).parent.parent
+            / "canonical"
+            / "fixtures"
+            / "environment_manifest"
+            / "identity_multi_service.yaml"
+        )
+        return EnvironmentManifest(
+            compose_file=fixture,
+            runner_service="runner",
+            services={
+                "runner": ServiceSpec(isolation="shared"),
+                "app-service": ServiceSpec(isolation="shared"),
+                "app-db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+
+    def test_manifest_bearing_trial_gains_environment_block(self) -> None:
+        spec = _make_spec()
+        spec = spec.model_copy(
+            update={"task": spec.task.model_copy(update={"environment_manifest": self._manifest()})}
+        )
+        trajectory = _default_success_trajectory("t1", 0)
+
+        self._conductor()._capture_final_state(spec, self._setup(), trajectory)
+
+        environment = trajectory.final_env_state["environment"]
+        assert set(environment["services"]) == {"runner", "app-service", "app-db"}
+        assert environment["services"]["app-service"]["dsns"] == [
+            "postgresql://app:***@app-db:5432/mfg"
+        ]
+        assert "app_pw" not in json.dumps(trajectory.final_env_state)
+
+    def test_manifest_less_trial_omits_environment_block(self) -> None:
+        spec = _make_spec()
+        assert spec.task.environment_manifest is None
+        trajectory = _default_success_trajectory("t1", 0)
+
+        self._conductor()._capture_final_state(spec, self._setup(), trajectory)
+
+        assert "environment" not in trajectory.final_env_state

--- a/tests/unit/test_env_identity_descriptor.py
+++ b/tests/unit/test_env_identity_descriptor.py
@@ -114,6 +114,44 @@ class TestDsnRedaction:
         assert identity.services["app-db"].dsns == []
 
 
+_QUERY_PW_COMPOSE = """\
+services:
+  runner:
+    image: tolokaforge-runner:0.5.0
+  app-service:
+    image: postgres:16
+    environment:
+      QUERY_DSN: "postgresql://app@app-db:5432/mfg?password=app_pw&sslmode=require"
+      BOTH_DSN: "postgresql://app:app_pw@app-db:5432/mfg?sslpassword=app_pw"
+      CLEAN_DSN: "postgresql://app@app-db:5432/mfg?sslmode=require"
+"""
+
+
+def _query_pw_manifest(tmp_path: Path) -> EnvironmentManifest:
+    compose_file = tmp_path / "environment.compose.yaml"
+    compose_file.write_text(_QUERY_PW_COMPOSE)
+    return EnvironmentManifest(
+        compose_file=compose_file,
+        runner_service="runner",
+        services={"runner": ServiceSpec(isolation="shared")},
+    )
+
+
+class TestDsnQueryPasswordRedaction:
+    def test_query_string_password_redacted_others_preserved(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_query_pw_manifest(tmp_path))
+        dsns = identity.services["app-service"].dsns
+        assert dsns == [
+            "postgresql://app:***@app-db:5432/mfg?sslpassword=***",
+            "postgresql://app@app-db:5432/mfg?password=***&sslmode=require",
+            "postgresql://app@app-db:5432/mfg?sslmode=require",
+        ]
+
+    def test_query_string_secret_never_appears(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_query_pw_manifest(tmp_path))
+        assert "app_pw" not in identity.model_dump_json()
+
+
 class TestMounts:
     def test_target_and_mode_recorded_host_source_excluded(self, tmp_path: Path) -> None:
         identity = describe_environment_identity(_manifest(tmp_path))

--- a/tests/unit/test_env_identity_descriptor.py
+++ b/tests/unit/test_env_identity_descriptor.py
@@ -1,0 +1,135 @@
+"""Resolved environment-identity descriptor.
+
+:func:`describe_environment_identity` turns a resolved
+:class:`EnvironmentManifest` into a human-readable
+:class:`EnvironmentIdentity`: per-service resolved images (pinned or
+floating), isolation, reset seeds, redacted connection strings, and
+container mount targets, plus the run-level network policy and
+runner-service pointer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.env_identity import describe_environment_identity
+from tolokaforge.core.models import ResetSpec, ServiceSpec
+from tolokaforge.core.trial import EnvironmentManifest, NetworkPolicy
+
+pytestmark = pytest.mark.unit
+
+_COMPOSE = """\
+services:
+  runner:
+    image: tolokaforge-runner:0.5.0
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+  app-service:
+    image: ${APP_IMAGE:-postgres:16}
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/mfg"
+    volumes:
+      - ./app/main.py:/srv/app/main.py:ro
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "mfg"
+      POSTGRES_USER: "app"
+      POSTGRES_PASSWORD: "app_pw"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+"""
+
+
+def _manifest(tmp_path: Path, **overrides) -> EnvironmentManifest:
+    compose_file = tmp_path / "environment.compose.yaml"
+    compose_file.write_text(_COMPOSE)
+    kwargs = {
+        "compose_file": compose_file,
+        "runner_service": "runner",
+        "services": {
+            "runner": ServiceSpec(isolation="shared"),
+            "app-service": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+        },
+    }
+    kwargs.update(overrides)
+    return EnvironmentManifest(**kwargs)
+
+
+class TestImages:
+    def test_literal_pinned_tag(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        app_db = identity.services["app-db"]
+        assert app_db.image == "postgres:16"
+        assert app_db.pinned is True
+
+    def test_resolved_floating_tag_is_not_pinned(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(
+            _manifest(tmp_path, stack_inputs={"APP_IMAGE": "postgres:latest"})
+        )
+        app_service = identity.services["app-service"]
+        assert app_service.image == "postgres:latest"
+        assert app_service.pinned is False
+
+    def test_var_image_resolves_from_stack_inputs(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(
+            _manifest(tmp_path, stack_inputs={"APP_IMAGE": "registry.example/app:2.0"})
+        )
+        app_service = identity.services["app-service"]
+        assert app_service.image == "registry.example/app:2.0"
+        assert app_service.pinned is True
+
+    def test_var_image_falls_back_to_default(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        app_service = identity.services["app-service"]
+        assert app_service.image == "postgres:16"
+        assert app_service.pinned is True
+
+
+class TestNetworkPolicy:
+    def test_defaults_to_no_internet(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        assert identity.network_policy == "no_internet"
+
+    def test_reflects_set_value(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(
+            _manifest(tmp_path, network_policy=NetworkPolicy.FULL_INTERNET)
+        )
+        assert identity.network_policy == "full_internet"
+
+
+class TestDsnRedaction:
+    def test_password_redacted_components_preserved(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        assert identity.services["app-service"].dsns == ["postgresql://app:***@app-db:5432/mfg"]
+
+    def test_secret_never_appears(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        assert "app_pw" not in identity.model_dump_json()
+
+    def test_plaintext_secret_env_is_not_a_dsn(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        assert identity.services["app-db"].dsns == []
+
+
+class TestMounts:
+    def test_target_and_mode_recorded_host_source_excluded(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        mounts = identity.services["app-service"].mounts
+        assert mounts == ["/srv/app/main.py:ro"]
+        assert "./app/main.py" not in identity.model_dump_json()
+
+
+class TestIsolation:
+    def test_service_absent_from_manifest_defaults_to_ephemeral(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        assert identity.services["app-db"].isolation == "ephemeral"
+        assert identity.services["app-db"].reset_seed is None
+
+    def test_reset_seed_recorded(self, tmp_path: Path) -> None:
+        identity = describe_environment_identity(_manifest(tmp_path))
+        app_service = identity.services["app-service"]
+        assert app_service.isolation == "reset"
+        assert app_service.reset_seed == "baseline"

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from tolokaforge.adapters import BaseAdapter
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.docker_adapter import DockerRunnerAdapter
+from tolokaforge.core.env_identity import describe_environment_identity
 from tolokaforge.core.env_state import EnvironmentState
 from tolokaforge.core.llm import LLMClient, UserSimulator, build_capabilities
 from tolokaforge.core.llm.presets import (
@@ -321,7 +322,7 @@ class InProcessConductor:
         """
         setup = self._setup_trial(spec, task_config)
         trajectory, runner, system_prompt = self._run_agent_loop(spec, task_config, setup)
-        self._capture_final_state(setup, trajectory)
+        self._capture_final_state(spec, setup, trajectory)
         self._grade(spec, task_config, setup, trajectory, runner, system_prompt)
         self._write_artifacts(spec, task_config, setup, trajectory, runner)
         return TrialResult.from_trajectory(
@@ -599,6 +600,7 @@ class InProcessConductor:
 
     def _capture_final_state(
         self,
+        spec: TrialSpec,
         setup: _TrialSetup,
         trajectory: Trajectory,
     ) -> None:
@@ -610,6 +612,12 @@ class InProcessConductor:
         ``adapter_env.data`` (from :meth:`BaseAdapter.create_environment`)
         is a snapshot from before the trial ran; it is used as a fallback
         only when the Runner-side read fails.
+
+        When the trial's task carries an ``environment_manifest`` (a
+        Project-layer / multi-container substrate), the resolved
+        environment identity is recorded under the ``environment`` key so a
+        post-mortem can read which services, images, DSNs, and mounts backed
+        the trial. Manifest-less trials keep the JSON-DB-only shape.
         """
         runner_state: dict[str, Any] | None = None
         try:
@@ -648,6 +656,13 @@ class InProcessConductor:
         final_state = setup.env_state.get_final_state()
         # Pass agent_visible_dir so the agentic judge can read files from disk.
         final_state["agent_visible_dir"] = str(setup.env_state.agent_visible_dir)
+
+        manifest = spec.task.environment_manifest
+        if manifest is not None:
+            final_state["environment"] = describe_environment_identity(manifest).model_dump(
+                mode="json"
+            )
+
         trajectory.final_env_state = final_state
 
     def _grade(

--- a/tolokaforge/core/env_identity.py
+++ b/tolokaforge/core/env_identity.py
@@ -21,7 +21,7 @@ import hashlib
 import json
 import re
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import yaml
 from pydantic import BaseModel, Field
@@ -201,16 +201,35 @@ def _looks_like_dsn(value: str) -> bool:
     return bool(parsed.scheme and parsed.netloc)
 
 
+_PASSWORD_QUERY_KEYS = frozenset({"password", "sslpassword", "pgpassword"})
+
+
 def _redact_dsn(value: str) -> str:
-    """Replace an embedded netloc password with ``***``, preserving every
-    other component. A value without a password is returned unchanged."""
+    """Replace an embedded password with ``***`` wherever it lives — the
+    netloc userinfo password and any password-bearing query parameter
+    (``password``, ``sslpassword``, ``pgpassword``, matched case-insensitively).
+    Every other component is preserved; a value carrying no password anywhere
+    is returned unchanged."""
     parsed = urlsplit(value)
-    if parsed.password is None:
+    redacted_query = _redact_query_passwords(parsed.query)
+    if parsed.password is None and redacted_query == parsed.query:
         return value
-    userinfo, _, hostport = parsed.netloc.rpartition("@")
-    user = userinfo.partition(":")[0]
-    redacted_netloc = f"{user}:***@{hostport}"
-    return urlunsplit((parsed.scheme, redacted_netloc, parsed.path, parsed.query, parsed.fragment))
+    netloc = parsed.netloc
+    if parsed.password is not None:
+        userinfo, _, hostport = netloc.rpartition("@")
+        user = userinfo.partition(":")[0]
+        netloc = f"{user}:***@{hostport}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, redacted_query, parsed.fragment))
+
+
+def _redact_query_passwords(query: str) -> str:
+    if not query:
+        return query
+    pairs = parse_qsl(query, keep_blank_values=True)
+    redacted = [
+        (key, "***" if key.lower() in _PASSWORD_QUERY_KEYS else value) for key, value in pairs
+    ]
+    return urlencode(redacted, safe="*")
 
 
 def _service_mounts(body: dict[str, Any]) -> list[str]:

--- a/tolokaforge/core/env_identity.py
+++ b/tolokaforge/core/env_identity.py
@@ -1,26 +1,33 @@
-"""Content-addressed identity for a resolved :class:`EnvironmentManifest`.
+"""Identity views over a resolved :class:`EnvironmentManifest`.
 
 :func:`resolve_environment_identity` returns a ``sha256:<hex>`` digest
 over the canonicalised compose file bytes, ``stack_inputs``, the
 per-service isolation map, and every referenced seed digest. Two
 manifests with matching inputs produce equal identities regardless of
 YAML formatting; any change to a compose byte, an input, a service
-label, or a seed's digest flips the identity.
+label, or a seed's digest flips the identity. Emitted for observability
+at run start; not persisted.
 
-Emitted for observability at run start; not persisted, not consumed by
-any dedup/materialisation path — those consumers land later per the
-public roadmap.
+:func:`describe_environment_identity` returns a human-readable
+:class:`EnvironmentIdentity` descriptor — per-service resolved images,
+isolation, reset seeds, redacted connection strings, and container mount
+targets, plus the run-level network policy and runner-service pointer. A
+pure function of the manifest, safe to serialise into a trial artifact.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import re
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import yaml
+from pydantic import BaseModel, Field
 
 from tolokaforge.core.models import EnvironmentManifest
+from tolokaforge.runner.models import _FLOATING_IMAGE_TAGS, _image_tag_or_digest
 
 
 def resolve_environment_identity(
@@ -68,4 +75,176 @@ def _canonical_compose_bytes(compose_content: dict[str, Any]) -> str:
     )
 
 
-__all__ = ["resolve_environment_identity"]
+class ServiceIdentity(BaseModel):
+    """Resolved identity of a single compose service."""
+
+    image: str | None = None
+    pinned: bool = False
+    isolation: str
+    reset_seed: str | None = None
+    dsns: list[str] = Field(default_factory=list)
+    mounts: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "forbid"}
+
+
+class EnvironmentIdentity(BaseModel):
+    """Resolved identity of a whole manifest-driven environment."""
+
+    network_policy: str
+    runner_service: str
+    services: dict[str, ServiceIdentity]
+
+    model_config = {"extra": "forbid"}
+
+
+_IMAGE_VAR_RE = re.compile(r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}")
+
+
+def describe_environment_identity(manifest: EnvironmentManifest) -> EnvironmentIdentity:
+    """Return the resolved :class:`EnvironmentIdentity` for ``manifest``.
+
+    A pure function of the manifest's compose content, ``stack_inputs``,
+    per-service isolation map, network policy, and runner-service pointer.
+    Compose services absent from ``manifest.services`` default to
+    ``ephemeral`` isolation, mirroring the resolver's fill rule.
+    """
+    compose_services = manifest.load_compose()["services"]
+    services = {
+        name: _describe_service(name, body, manifest)
+        for name, body in sorted(compose_services.items())
+    }
+    return EnvironmentIdentity(
+        network_policy=manifest.network_policy.value,
+        runner_service=manifest.runner_service,
+        services=services,
+    )
+
+
+def _describe_service(
+    name: str, body: dict[str, Any], manifest: EnvironmentManifest
+) -> ServiceIdentity:
+    spec = manifest.services.get(name)
+    image = _resolve_image(body.get("image"), manifest.stack_inputs)
+    return ServiceIdentity(
+        image=image,
+        pinned=_is_pinned(image),
+        isolation=spec.isolation if spec is not None else "ephemeral",
+        reset_seed=spec.reset.seed if spec is not None and spec.reset is not None else None,
+        dsns=_service_dsns(body),
+        mounts=_service_mounts(body),
+    )
+
+
+def _resolve_image(image: Any, stack_inputs: dict[str, str]) -> str | None:
+    """Substitute ``${VAR}`` / ``${VAR:-default}`` slots from ``stack_inputs``.
+
+    A ``${VAR}`` with no default that is absent from ``stack_inputs`` cannot
+    be resolved — raise rather than emit a half-substituted reference.
+    """
+    if image is None:
+        return None
+
+    def _repl(match: re.Match[str]) -> str:
+        var = match.group("name")
+        if var in stack_inputs:
+            return stack_inputs[var]
+        default = match.group("default")
+        if default is not None:
+            return default
+        raise ValueError(
+            f"environment identity: image reference {image!r} uses ${{{var}}} which is "
+            "absent from stack_inputs and has no default."
+        )
+
+    return _IMAGE_VAR_RE.sub(_repl, image)
+
+
+def _is_pinned(image: str | None) -> bool:
+    """True when ``image`` carries a digest or a non-floating tag."""
+    if not image:
+        return False
+    tag, digest = _image_tag_or_digest(image)
+    if digest is not None:
+        return True
+    if tag is None:
+        return False
+    return tag.lower() not in _FLOATING_IMAGE_TAGS
+
+
+def _service_dsns(body: dict[str, Any]) -> list[str]:
+    """Redacted connection strings from the service's compose ``environment``.
+
+    Only URI-shaped values (scheme + netloc) are recorded; each has any
+    embedded password replaced with ``***``. Non-URI env values (e.g. a bare
+    ``POSTGRES_PASSWORD``) are excluded entirely.
+    """
+    dsns = [_redact_dsn(value) for value in _environment_values(body) if _looks_like_dsn(value)]
+    return sorted(dsns)
+
+
+def _environment_values(body: dict[str, Any]) -> list[str]:
+    env = body.get("environment")
+    if env is None:
+        return []
+    if isinstance(env, dict):
+        return [str(value) for value in env.values()]
+    if isinstance(env, list):
+        return [item.split("=", 1)[1] for item in env if isinstance(item, str) and "=" in item]
+    raise ValueError(
+        f"compose `environment:` must be a mapping or a list; got {type(env).__name__}"
+    )
+
+
+def _looks_like_dsn(value: str) -> bool:
+    parsed = urlsplit(value)
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def _redact_dsn(value: str) -> str:
+    """Replace an embedded netloc password with ``***``, preserving every
+    other component. A value without a password is returned unchanged."""
+    parsed = urlsplit(value)
+    if parsed.password is None:
+        return value
+    userinfo, _, hostport = parsed.netloc.rpartition("@")
+    user = userinfo.partition(":")[0]
+    redacted_netloc = f"{user}:***@{hostport}"
+    return urlunsplit((parsed.scheme, redacted_netloc, parsed.path, parsed.query, parsed.fragment))
+
+
+def _service_mounts(body: dict[str, Any]) -> list[str]:
+    """Container-side mount targets (``"<target>:<mode>"``, mode omitted when
+    absent). Host source paths are excluded."""
+    volumes = body.get("volumes")
+    if not volumes:
+        return []
+    mounts = [_mount_descriptor(entry) for entry in volumes]
+    return [mount for mount in mounts if mount is not None]
+
+
+def _mount_descriptor(entry: Any) -> str | None:
+    if isinstance(entry, str):
+        parts = entry.split(":")
+        if len(parts) == 1:
+            target, mode = parts[0], None
+        elif len(parts) == 2:
+            target, mode = parts[1], None
+        else:
+            target, mode = parts[1], parts[2]
+    elif isinstance(entry, dict):
+        target = entry.get("target")
+        if not isinstance(target, str):
+            return None
+        mode = "ro" if entry.get("read_only") else None
+    else:
+        return None
+    return f"{target}:{mode}" if mode else target
+
+
+__all__ = [
+    "EnvironmentIdentity",
+    "ServiceIdentity",
+    "describe_environment_identity",
+    "resolve_environment_identity",
+]


### PR DESCRIPTION
Closes #419.

## Summary

- **New descriptor `describe_environment_identity(manifest) -> EnvironmentIdentity`** — a pure function of the resolved `EnvironmentManifest` producing a serialisable identity block: run-level `network_policy` + `runner_service` and a per-service map with resolved image (after `${VAR}` substitution from `stack_inputs`), `pinned` flag, `isolation`, `reset_seed`, DSNs (secrets redacted), and container mount targets. Pydantic `extra="forbid"` at the serialisation boundary.
- **Wired into `env.yaml`** — `InProcessConductor._capture_final_state` adds a top-level `environment:` block for manifest-driven trials only; manifest-less trials keep their existing shape exactly. Additive on a documented free-form surface.
- **DSN redaction is load-bearing.** `_redact_dsn` scrubs both netloc userinfo passwords (`postgresql://app:app_pw@…`) AND password-bearing query params (`?password=…&sslpassword=…&pgpassword=…`, case-insensitive) — a real libpq/JDBC pattern the reviewer caught before merge. Non-DSN env vars (bare `POSTGRES_PASSWORD`) are excluded entirely. Host mount source paths are excluded — container targets only.

## Design walkthrough

```
EnvironmentManifest (resolved)
        │
        ▼
describe_environment_identity(manifest)  ← pure function
        │
        ▼
EnvironmentIdentity (Pydantic extra="forbid")
        │  .model_dump(mode="json")
        ▼
trajectory.final_env_state["environment"]      ← manifest-driven trials only
        │
        ▼
<trial_dir>/env.yaml                            ← additive top-level key
```

## Test tiers

- **Unit** — `tests/unit/test_env_identity_descriptor.py` (14 cases): pinned/floating image detection via `${VAR}` substitution (`postgres:16` pinned; `postgres:latest` via VAR not pinned), default vs set `network_policy`, netloc password redaction preserving user/host/db/port, mount container target + mode with host source omitted, `${VAR}`/`${VAR:-default}` substitution from `stack_inputs`, compose-only service defaulting to `ephemeral` isolation, reset seed capture, `TestDsnQueryPasswordRedaction` locking query-only + netloc+query + clean cases (`app_pw` never in serialised output).
- **Unit** — `tests/unit/test_conductor.py::TestCaptureFinalStateEnvironmentBlock` (2 cases, added on reviewer request): manifest-bearing spec → `final_env_state["environment"]["services"]` populated + `app_pw` absent; `environment_manifest=None` → key omitted. Drives `_capture_final_state` directly.
- **Canonical** — `tests/canonical/test_env_identity_snapshot.py` (3 cases): golden snapshot of the serialised block for a `multi_service_lot_ops`-shaped fixture (pinned image + DSN with embedded secret + plaintext password env + reset seed + `ro` mounts); presence-of-required-pieces check; `app_pw`-never-serialised check. Snapshot regenerated via `update_canonical_snapshots`, not hand-edited.

## Docs + changelog

- `docs/OUTPUT_FORMAT.md` `env.yaml` section rewritten to include the resolved `environment` block as current state (top-level keys, per-service field table, redaction rules, manifest-only presence).
- `docs/multi_container_tasks.md` — new "Recorded environment identity" subsection cross-linking `OUTPUT_FORMAT.md`.
- `CHANGELOG.md` Unreleased → `### Fix` entry.

## Follow-ups filed during this PR

- #434 — `docs/ADAPTERS.md` attributes post-trial state sync to `orchestrator._run_trial()`; logic now lives in `conductor._capture_final_state`. Doc-freshness drift.
- #435 — `env_identity` imports underscore-private helpers from `runner.models`; promote to shared public surface. (Reviewer nit; deliberately deferred from this PR.)

## Reviewer verdict

**APPROVE** on re-review of `fa3ecb2` — two Majors closed with proper behaviour-locking tests, no new violations, snapshot integrity preserved. Original REQUEST CHANGES caught (a) untested conductor wiring (fixed by conductor-tier test) and (b) query-string DSN passwords not redacted (fixed by `parse_qsl`/`urlencode` scrub with case-insensitive password-key matching).

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425). Not caused by this change.

## Test plan (post-merge)

- [ ] Canonical + unit tiers stay green on the M18 integration branch.
- [ ] Any future trial dir under `results/multi_service_*/trials/*/0/env.yaml` should carry the resolved `environment` block (visual confirmation during #401/#402/#403 work).
