### PR TITLE
feat(loop): intervention pump — InjectMessage handling (M1 sub-5a)

### DIFF
--- a/tests/unit/session/test_intervention_pump.py
+++ b/tests/unit/session/test_intervention_pump.py
@@ -1,0 +1,272 @@
+"""Unit tests for :class:`SessionInterventionHandler` — M1 sub-5a.
+
+Covers the intervention pump's InjectMessage handling, rejection of
+not-yet-supported kinds, ack-outcome updates on the durable session trace,
+and end-to-end integration with :class:`ToolCallingLoop`.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.llm.client import GenerationResult
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.logging import init_trial_logger
+from tolokaforge.core.loop import LoopConfig, ToolCallingLoop
+from tolokaforge.core.models import Message, MessageRole
+from tolokaforge.session import (
+    ApproveTool,
+    EditState,
+    InjectMessage,
+    InProcessTrialSession,
+    Kill,
+    ParticipantRole,
+    Pause,
+    RejectTool,
+    Resume,
+    SessionInterventionHandler,
+)
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _submit_inject(session: InProcessTrialSession, content: str = "try /v2/auth") -> InjectMessage:
+    handle = session.attach(f"p_{content}", ParticipantRole.PARTICIPANT)
+    intervention = InjectMessage(
+        trial_id=session.trial_id,
+        attach_to_seq=0,
+        participant_id=handle.participant_id,
+        timestamp=_NOW,
+        content=content,
+    )
+    session.interventions().submit(handle, intervention)
+    return intervention
+
+
+class TestInjectMessageApplication:
+    def test_pump_appends_user_message_from_inject(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        _submit_inject(session, "please try again")
+        handler = SessionInterventionHandler(session)
+
+        messages: list[Message] = []
+        handler.drain_and_apply(messages)
+
+        assert len(messages) == 1
+        assert messages[0].role == MessageRole.USER
+        assert messages[0].content == "please try again"
+
+    def test_pump_updates_ack_outcome_to_accepted(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        intervention = _submit_inject(session)
+        handler = SessionInterventionHandler(session)
+
+        # Before drain: ack is "queued" (returned by submit)
+        snap_before = session.snapshot()
+        assert snap_before["interventions"][0]["ack_outcome"] == "queued"
+
+        handler.drain_and_apply([])
+
+        # After drain: ack is "accepted"
+        snap_after = session.snapshot()
+        assert snap_after["interventions"][0]["ack_outcome"] == "accepted"
+        assert snap_after["interventions"][0]["ack_reason"] is None
+        # Sanity: same intervention record, not a duplicate
+        assert len(snap_after["interventions"]) == 1
+        assert intervention.content == "try /v2/auth"  # object still intact
+
+    def test_pump_applies_multiple_injects_in_order(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        for text in ["first", "second", "third"]:
+            _submit_inject(session, text)
+        handler = SessionInterventionHandler(session)
+
+        messages: list[Message] = []
+        handler.drain_and_apply(messages)
+
+        assert [m.content for m in messages] == ["first", "second", "third"]
+
+    def test_second_drain_is_noop_after_processing(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        _submit_inject(session)
+        handler = SessionInterventionHandler(session)
+
+        handler.drain_and_apply([])
+        # Now the queue is empty; second call must not re-apply
+        messages: list[Message] = []
+        handler.drain_and_apply(messages)
+        assert messages == []
+
+
+class TestNotYetSupportedKindsRejected:
+    def _session_with(self, intervention_factory) -> tuple[InProcessTrialSession, object]:
+        session = InProcessTrialSession(trial_id="t:0")
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        intervention = intervention_factory(handle.participant_id)
+        session.interventions().submit(handle, intervention)
+        return session, intervention
+
+    @pytest.mark.parametrize(
+        "factory,expected_reason_substring",
+        [
+            (
+                lambda pid: Kill(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id=pid,
+                    timestamp=_NOW,
+                    reason="stop please",
+                ),
+                "Kill",
+            ),
+            (
+                lambda pid: Pause(
+                    trial_id="t:0", attach_to_seq=0, participant_id=pid, timestamp=_NOW
+                ),
+                "Pause",
+            ),
+            (
+                lambda pid: Resume(
+                    trial_id="t:0", attach_to_seq=0, participant_id=pid, timestamp=_NOW
+                ),
+                "Resume",
+            ),
+            (
+                lambda pid: ApproveTool(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id=pid,
+                    timestamp=_NOW,
+                    call_id="c1",
+                ),
+                "ApproveTool",
+            ),
+            (
+                lambda pid: RejectTool(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id=pid,
+                    timestamp=_NOW,
+                    call_id="c1",
+                ),
+                "RejectTool",
+            ),
+            (
+                lambda pid: EditState(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id=pid,
+                    timestamp=_NOW,
+                    state_key="k",
+                    new_value=1,
+                ),
+                "EditState",
+            ),
+        ],
+    )
+    def test_unsupported_kind_rejected_with_reason(self, factory, expected_reason_substring):
+        session, intervention = self._session_with(factory)
+        handler = SessionInterventionHandler(session)
+        messages: list[Message] = []
+
+        handler.drain_and_apply(messages)
+
+        # No messages appended for unsupported kinds
+        assert messages == []
+        # Trace records the rejection with a documented reason
+        snap = session.snapshot()
+        assert snap["interventions"][0]["ack_outcome"] == "rejected"
+        assert expected_reason_substring in snap["interventions"][0]["ack_reason"]
+
+
+class TestLoopIntegration:
+    """Drive :class:`ToolCallingLoop` with the pump attached; verify that an
+    InjectMessage submitted between turns actually reaches the next agent
+    generate() call.
+    """
+
+    def test_injected_message_appears_in_agent_context_next_turn(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        # Simulate an external participant queuing an intervention before turn 1
+        _submit_inject(session, "try /v2/auth instead")
+
+        handler = SessionInterventionHandler(session)
+
+        # First generation triggers no more interventions; second-turn
+        # terminates the loop. We assert the second generate call sees the
+        # injected user message in its messages arg.
+        seen_messages_per_call: list[list[Message]] = []
+
+        def fake_generate(system, messages, tools, tool_choice="auto"):
+            seen_messages_per_call.append(list(messages))
+            return GenerationResult(text="ok", tool_calls=[], usage=Usage())
+
+        llm_client = MagicMock()
+        llm_client.generate.side_effect = fake_generate
+
+        loop = ToolCallingLoop(
+            llm_client=llm_client,
+            tool_executor=MagicMock(),
+            tool_schemas=[],
+            config=LoopConfig(max_turns=1, episode_timeout_s=60),
+            metrics=MagicMock(),
+            should_terminate=lambda result, turn, messages: None,
+            logger=init_trial_logger("t:0", verbose=False, strict=False),
+            intervention_handler=handler,
+        )
+        loop.run(system_prompt="sys", messages=[], start_time=time.time())
+
+        # The pump ran before turn 0's generate; the message list at generate
+        # time contains the injected user message.
+        assert len(seen_messages_per_call) == 1
+        contents = [m.content for m in seen_messages_per_call[0] if m.role == MessageRole.USER]
+        assert "try /v2/auth instead" in contents
+
+
+class TestNullPumpIsNoOp:
+    """The default :data:`_NULL_INTERVENTION_HANDLER` must be a byte-identical
+    no-op — sealed batch mode incurs zero behavior change from sub-5a.
+    """
+
+    def test_default_intervention_handler_is_no_op(self):
+        from tolokaforge.core.loop import _NULL_INTERVENTION_HANDLER
+
+        messages: list[Message] = []
+        _NULL_INTERVENTION_HANDLER.drain_and_apply(messages)
+        assert messages == []
+
+
+class TestOutcomeUpdateSemantics:
+    def test_record_intervention_outcome_matches_by_object_identity(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        inj = _submit_inject(session, "first")
+        session.record_intervention_outcome(inj, "accepted", "test-reason")
+
+        snap = session.snapshot()
+        assert snap["interventions"][0]["ack_outcome"] == "accepted"
+        assert snap["interventions"][0]["ack_reason"] == "test-reason"
+
+    def test_record_intervention_outcome_is_noop_for_unknown_intervention(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        _submit_inject(session, "in-history")
+
+        # An intervention object that was never submitted through this session
+        unknown = InjectMessage(
+            trial_id="t:0",
+            attach_to_seq=0,
+            participant_id="ghost",
+            timestamp=_NOW,
+            content="not-in-history",
+        )
+        # Should not raise; simply no-op
+        session.record_intervention_outcome(unknown, "accepted", None)
+
+        snap = session.snapshot()
+        assert len(snap["interventions"]) == 1
+        assert snap["interventions"][0]["ack_outcome"] == "queued"

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -37,7 +37,7 @@ from tolokaforge.core.llm.presets import (
     resolve_effective_preset,
     resolve_policy_names,
 )
-from tolokaforge.core.loop import LoopObserver
+from tolokaforge.core.loop import InterventionHandler, LoopObserver
 from tolokaforge.core.models import (
     Grade,
     GradeComponents,
@@ -110,6 +110,22 @@ class ConductorContext:
     a :class:`~tolokaforge.session.SessionLoopObserver`. Other observers
     (e.g. a metrics tap, a debug hook, a rule-based safety monitor) plug
     in the same way without further changes to the conductor.
+    """
+    intervention_handler_provider: Callable[[str], InterventionHandler | None] | None = None
+    """Optional per-trial :class:`InterventionHandler` factory — the inbound
+    counterpart to :attr:`observer_provider`.
+
+    Called with ``spec.trial_id`` at the top of each trial to produce an
+    optional handler that drains + applies interventions at every turn
+    boundary. ``None`` (or a provider returning ``None``) keeps the trial
+    sealed on the inbound side too — no pump call at pause points.
+
+    Generic like ``observer_provider``. Session-based intervention
+    application (the Open Agent Loop pump) is one specific caller-side
+    wiring: pass a provider that returns a
+    :class:`~tolokaforge.session.SessionInterventionHandler`. Alternate
+    handlers (rule-based safety enforcer, batch-scripted operator, etc.)
+    plug in the same way without conductor changes.
     """
 
 
@@ -306,6 +322,7 @@ class InProcessConductor:
         output_dir: Path,
         request_limiter: GlobalRateLimiter | None = None,
         observer_provider: Callable[[str], LoopObserver | None] | None = None,
+        intervention_handler_provider: Callable[[str], InterventionHandler | None] | None = None,
     ) -> None:
         self.adapter = adapter
         self._artifact_writer = artifact_writer
@@ -319,6 +336,18 @@ class InProcessConductor:
         self.output_dir = output_dir
         self.request_limiter = request_limiter
         self.observer_provider = observer_provider
+        self.intervention_handler_provider = intervention_handler_provider
+
+    def _maybe_build_intervention_handler(self, trial_id: str) -> InterventionHandler | None:
+        """Consult the ``intervention_handler_provider`` for this trial's pump.
+
+        Symmetric to :meth:`_maybe_build_loop_observer`. Returns ``None`` when
+        no provider is set or the provider returns ``None`` for this trial —
+        the sealed default.
+        """
+        if self.intervention_handler_provider is None:
+            return None
+        return self.intervention_handler_provider(trial_id)
 
     def _maybe_build_loop_observer(self, trial_id: str) -> LoopObserver | None:
         """Consult the ``observer_provider`` for this trial's loop observer.
@@ -607,6 +636,7 @@ class InProcessConductor:
             episode_timeout_s = run_episode_s
 
         loop_observer = self._maybe_build_loop_observer(spec.trial_id)
+        intervention_handler = self._maybe_build_intervention_handler(spec.trial_id)
 
         runner = TrialRunner(
             task_id=task.task_id,
@@ -624,6 +654,7 @@ class InProcessConductor:
             verbose=self.verbose,
             strict=self.strict,
             loop_observer=loop_observer,
+            intervention_handler=intervention_handler,
         )
 
         # Use initial_user_message if provided (e.g., tool-use style tasks).

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -210,6 +210,41 @@ class _NullLoopObserver:
 _NULL_LOOP_OBSERVER: LoopObserver = _NullLoopObserver()
 
 
+class InterventionHandler(Protocol):
+    """Inbound seam — drains queued interventions at pause points and applies
+    them to the running loop.
+
+    Symmetric to :class:`LoopObserver` (outbound). Called by
+    :class:`ToolCallingLoop` before each turn; the handler owns dispatch on
+    intervention *kind* so the loop stays decoupled from session-specific
+    intervention types. Handlers mutate ``messages`` in place (e.g. append
+    a user-role :class:`Message` for an ``InjectMessage``) and record ack
+    outcomes back to whatever store the caller wired in.
+
+    Default is :data:`_NULL_INTERVENTION_HANDLER` — sealed batch mode
+    incurs one no-op call per turn.
+    """
+
+    def drain_and_apply(self, messages: list[Message]) -> None:
+        """Drain pending interventions and apply them to the running trial.
+
+        Called at the top of each turn, before the LLM generate call. The
+        handler must return quickly (drain from a queue, apply to messages,
+        record outcomes) — the loop's producer thread is blocked while this
+        runs.
+        """
+
+
+class _NullInterventionHandler:
+    """No-op :class:`InterventionHandler` — the default when no pump is wired."""
+
+    def drain_and_apply(self, messages: list[Message]) -> None:
+        return None
+
+
+_NULL_INTERVENTION_HANDLER: InterventionHandler = _NullInterventionHandler()
+
+
 ErrorClassifier = Callable[[Exception], TerminationDecision]
 
 
@@ -285,6 +320,7 @@ class ToolCallingLoop:
     )
     classify_error: ErrorClassifier = classify_loop_error
     observer: LoopObserver = _NULL_LOOP_OBSERVER
+    intervention_handler: InterventionHandler = _NULL_INTERVENTION_HANDLER
 
     # Captured from the first generation's effective system prompt.
     _captured_effective_prompt: str | None = field(default=None, init=False)
@@ -301,6 +337,7 @@ class ToolCallingLoop:
         termination_reason: TerminationReason | None = None
 
         for turn in range(self.config.max_turns):
+            self.intervention_handler.drain_and_apply(messages)
             self.observer.on_turn_start(turn)
             timeout_decision = self._check_episode_timeout(start_time)
             if timeout_decision is not None:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -65,6 +65,7 @@ from tolokaforge.core.trial_executor import TrialExecutor
 from tolokaforge.runner.models import AdapterType, TaskDescription
 from tolokaforge.session import (
     InProcessTrialSession,
+    SessionInterventionHandler,
     SessionLoopObserver,
     SessionRegistry,
 )
@@ -442,6 +443,7 @@ class Orchestrator:
             output_dir=output_dir,
             request_limiter=request_limiter,
             observer_provider=self._build_observer_provider(),
+            intervention_handler_provider=self._build_intervention_handler_provider(),
         )
         if self._conductor_factory is not None:
             return self._conductor_factory(ctx)
@@ -516,6 +518,26 @@ class Orchestrator:
         def _provider(trial_id: str) -> SessionLoopObserver | None:
             session: InProcessTrialSession = registry.get_or_create(trial_id)
             return SessionLoopObserver(session)
+
+        return _provider
+
+    def _build_intervention_handler_provider(
+        self,
+    ) -> Callable[[str], SessionInterventionHandler | None] | None:
+        """Return a per-trial intervention-handler factory for the current run,
+        or ``None`` in sealed mode.
+
+        Symmetric to :meth:`_build_observer_provider`. Same registry — the
+        observer and the handler bind to the same session per trial, so
+        events and interventions round-trip through one bus.
+        """
+        registry = self._session_registry
+        if registry is None:
+            return None
+
+        def _provider(trial_id: str) -> SessionInterventionHandler | None:
+            session: InProcessTrialSession = registry.get_or_create(trial_id)
+            return SessionInterventionHandler(session)
 
         return _provider
 

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -7,6 +7,7 @@ from typing import Any
 from tolokaforge.core.llm import GenerationResult, LLMClient, UserSimulator
 from tolokaforge.core.logging import StructuredLogger, init_trial_logger
 from tolokaforge.core.loop import (
+    InterventionHandler,
     LoopConfig,
     LoopObserver,
     MetricsSink,
@@ -53,6 +54,7 @@ class TrialRunner:
         verbose: bool = False,
         strict: bool = False,
         loop_observer: LoopObserver | None = None,
+        intervention_handler: InterventionHandler | None = None,
     ):
         self.task_id = task_id
         self.trial_index = trial_index
@@ -69,6 +71,7 @@ class TrialRunner:
         self.verbose = verbose
         self.strict = strict
         self.loop_observer = loop_observer
+        self.intervention_handler = intervention_handler
 
         self.messages: list[Message] = []
         self.metrics = Metrics()
@@ -205,6 +208,8 @@ class TrialRunner:
             }
             if self.loop_observer is not None:
                 loop_kwargs["observer"] = self.loop_observer
+            if self.intervention_handler is not None:
+                loop_kwargs["intervention_handler"] = self.intervention_handler
             outcome = ToolCallingLoop(**loop_kwargs).run(
                 system_prompt, self.messages, self.start_time
             )

--- a/tolokaforge/session/__init__.py
+++ b/tolokaforge/session/__init__.py
@@ -36,6 +36,7 @@ from tolokaforge.session.events import (
     TurnStarted,
 )
 from tolokaforge.session.in_process import InProcessTrialSession, QueuedIntervention
+from tolokaforge.session.intervention_pump import SessionInterventionHandler
 from tolokaforge.session.interventions import (
     ApproveTool,
     EditState,
@@ -76,6 +77,7 @@ __all__ = [
     "RejectTool",
     "Resume",
     "ResumeAcknowledged",
+    "SessionInterventionHandler",
     "SessionLoopObserver",
     "SessionRegistry",
     "TerminalReached",

--- a/tolokaforge/session/in_process.py
+++ b/tolokaforge/session/in_process.py
@@ -67,7 +67,7 @@ class QueuedIntervention:
     submitted_at: datetime
 
 
-@dataclass(frozen=True)
+@dataclass
 class _InterventionRecord:
     """Durable trace-side record of one submitted intervention.
 
@@ -75,7 +75,10 @@ class _InterventionRecord:
     volatile producer queue and gets drained by the pause pump) — this
     record persists for the trial's lifetime and lands in the
     ``open_agent_loop`` trajectory-trace section. Includes the ack outcome
-    that ``submit`` returned so the trace tells the full story.
+    that ``submit`` returned; the intervention pump updates
+    ``ack_outcome`` and ``ack_reason`` in-place via
+    :meth:`InProcessTrialSession.record_intervention_outcome` once it
+    processes the intervention (``queued`` → ``accepted`` / ``rejected``).
     """
 
     trial_id: str
@@ -305,6 +308,27 @@ class InProcessTrialSession:
             except queue.Empty:
                 break
         return drained
+
+    def record_intervention_outcome(
+        self,
+        intervention: TrialIntervention,
+        outcome: str,
+        reason: str | None = None,
+    ) -> None:
+        """Update the durable trace record for ``intervention`` with the
+        outcome the pump decided.
+
+        Matches records by object identity (the pump processes the same
+        ``TrialIntervention`` instance that was submitted, so ``is`` is
+        the correct comparison). No-op when the intervention isn't found —
+        the trace-side write path must never mask a live-trial result.
+        """
+        with self._lock:
+            for record in self._intervention_history:
+                if record.intervention is intervention:
+                    record.ack_outcome = outcome
+                    record.ack_reason = reason
+                    return
 
     def close(self) -> None:
         """Force-close the session even without a :class:`TerminalReached`.

--- a/tolokaforge/session/intervention_pump.py
+++ b/tolokaforge/session/intervention_pump.py
@@ -1,0 +1,91 @@
+"""``SessionInterventionHandler`` — bridge from :class:`ToolCallingLoop`'s
+intervention pump into :class:`InProcessTrialSession`.
+
+Inbound counterpart to :class:`SessionLoopObserver`. Called at every turn
+boundary; drains interventions queued by attached participants, applies
+each one to the loop's transcript (``InjectMessage`` today), and updates
+the durable trace with the accept/reject verdict.
+
+Sub-5a scope: **InjectMessage only.** Every other kind is recorded with
+``outcome="rejected"`` and a reason noting the M1 sub-issue that will land
+its handling. This keeps the schema surface honest — the trace tells the
+full story of what was proposed and what actually happened.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from tolokaforge.core.models import Message, MessageRole
+from tolokaforge.session.in_process import InProcessTrialSession
+from tolokaforge.session.interventions import (
+    ApproveTool,
+    EditState,
+    InjectMessage,
+    Kill,
+    Pause,
+    RejectTool,
+    Resume,
+    TrialIntervention,
+)
+
+__all__ = ["SessionInterventionHandler"]
+
+
+_NOT_YET_SUPPORTED_REASONS: dict[type[TrialIntervention], str] = {
+    Kill: "Kill intervention not yet applied by the pump (M1 sub-5b).",
+    Pause: "Pause intervention not yet applied by the pump (M1 sub-5b).",
+    Resume: "Resume intervention not yet applied by the pump (M1 sub-5b).",
+    ApproveTool: (
+        "ApproveTool intervention applies at the tool-call seam, "
+        "not the turn-boundary pause point (M1 sub-5b)."
+    ),
+    RejectTool: (
+        "RejectTool intervention applies at the tool-call seam, "
+        "not the turn-boundary pause point (M1 sub-5b)."
+    ),
+    EditState: (
+        "EditState requires runner-side mediation; deferred until "
+        "the runner exposes the edit surface."
+    ),
+}
+
+
+class SessionInterventionHandler:
+    """Drains + applies interventions from an :class:`InProcessTrialSession`.
+
+    Instantiated per trial by the orchestrator when open mode is on.
+    Structurally satisfies the loop's :class:`InterventionHandler` Protocol.
+    """
+
+    def __init__(self, session: InProcessTrialSession) -> None:
+        self._session = session
+
+    def drain_and_apply(self, messages: list[Message]) -> None:
+        """Drain the session's pending interventions and apply supported kinds
+        to ``messages``. Records the outcome of each on the session's
+        durable trace history.
+        """
+        pending = self._session.drain_pending_interventions()
+        for queued in pending:
+            intervention = queued.intervention
+            if isinstance(intervention, InjectMessage):
+                messages.append(
+                    Message(
+                        role=MessageRole.USER,
+                        content=intervention.content,
+                        ts=datetime.now(UTC),
+                    )
+                )
+                self._session.record_intervention_outcome(
+                    intervention, outcome="accepted", reason=None
+                )
+                continue
+
+            reason = _NOT_YET_SUPPORTED_REASONS.get(
+                type(intervention),
+                f"Intervention kind {intervention.kind!r} not handled by the M1 pump.",
+            )
+            self._session.record_intervention_outcome(
+                intervention, outcome="rejected", reason=reason
+            )


### PR DESCRIPTION
Part of #408 (M1 umbrella). **Last M1 sub-PR — closes the loop end-to-end for InjectMessage.**

## Summary

Interventions submitted by attached participants now actually reach the running trial. An LLM copilot's or human intervener's `InjectMessage` appears as a user-role message in the next agent turn's context. This is the inbound counterpart to the outbound `LoopObserver` seam from sub-2.

**Sealed batch mode unchanged.** Default handler is `_NULL_INTERVENTION_HANDLER` — sealed trials incur one no-op call per turn, and the full canonical suite (426) is green byte-identical.

## What ships

### Loop seam
- **`InterventionHandler`** Protocol in `tolokaforge.core.loop` with a single `drain_and_apply(messages)` method. The handler owns intervention-kind dispatch so the loop stays decoupled from session-specific types.
- `_NULL_INTERVENTION_HANDLER` is the sealed-default no-op.
- **`ToolCallingLoop.intervention_handler`** — optional field, called at the top of each turn iteration (before the LLM generate call). Handler mutates the `messages` list in place.

### Session bridge
- **`SessionInterventionHandler`** in `tolokaforge/session/intervention_pump.py` — drains pending queued interventions, applies `InjectMessage` as a user-role `Message`, rejects other kinds with a per-kind reason. Every outcome (`accepted` / `rejected`) updates the durable trace record.
- **`InProcessTrialSession.record_intervention_outcome(intervention, outcome, reason)`** — matches by object identity, mutates the `_InterventionRecord` in-place. No-op for unknown interventions.
- `_InterventionRecord` un-frozen so ack fields can be updated.

### Wiring (parallel to observer_provider)
- `TrialRunner` accepts `intervention_handler` kwarg → threads to `ToolCallingLoop`.
- `InProcessConductor` accepts `intervention_handler_provider` kwarg + `_maybe_build_intervention_handler` helper.
- `ConductorContext` gets `intervention_handler_provider` field.
- `Orchestrator._build_intervention_handler_provider` closes over the same `SessionRegistry` as the observer provider; observer and handler bind to the same session per trial.

### End-to-end flow in open mode

```
Participant.submit(InjectMessage)
   → InProcessTrialSession queues + records ack_outcome=queued
Orchestrator's next trial run
   → InProcessConductor builds SessionInterventionHandler(session)
   → TrialRunner passes handler to ToolCallingLoop
   → Loop.run() before each turn:
      SessionInterventionHandler.drain_and_apply(messages)
         → drain_pending_interventions()
         → for InjectMessage: append user Message + record_intervention_outcome(accepted)
         → for others: record_intervention_outcome(rejected, reason)
   → Next generate() call sees the injected user message in context
   → open_agent_loop.yaml at trial completion records the whole story
      (event stream + intervention log with accept/reject outcomes)
```

## Not-yet-supported kinds

Every non-InjectMessage intervention lands in the trace as `rejected` with a per-kind reason pointing at the follow-up sub-issue:

- `Kill` / `Pause` / `Resume` → deferred to sub-5b (needs role-priority conflict resolution + a pause state machine).
- `ApproveTool` / `RejectTool` → deferred to sub-5b (they apply at the tool-call seam, not the turn-boundary pause point).
- `EditState` → deferred until the runner exposes an edit-state surface (M1 sub-5b or a later M-issue).

## Tests (14 new)

- **InjectMessage application** (4 tests): pump appends user message from InjectMessage; updates ack_outcome from `queued` → `accepted`; multiple injects applied in submit order; second drain is no-op after processing.
- **Not-yet-supported kinds** (6 parametrized tests): Kill / Pause / Resume / ApproveTool / RejectTool / EditState each rejected with kind-specific reason recorded in the trace.
- **Loop integration** (1 test): drives `ToolCallingLoop` with pump attached and asserts the injected message reaches the next `generate()` call's `messages` arg.
- **Null pump** (1 test): default handler is no-op (regression guard).
- **Outcome update semantics** (2 tests): `record_intervention_outcome` matches by object identity; unknown intervention is a no-op (no raise).

## Test plan

- [x] `uv run pytest tests/ -m canonical` → **426 passed** (no regressions — sealed default unchanged)
- [x] `uv run pytest tests/unit -m unit -k "session or loop or conductor or runner or orchestrator"` → **457 passed** (+14 new)
- [x] `uv run ruff check ...` → clean

## What this closes for M1

With sub-5a merged, **M1 is functionally complete** for the common case (LLM copilot / human intervener injecting messages into a running trial). The gate is:

1. **Configurable** — `open_agent_loop.enabled: true` in the run config (sub-4a).
2. **Live-observable** — participants see every turn boundary + tool call in `seq` order (sub-1, sub-2, sub-3, sub-4a).
3. **Persistent** — every event + intervention lands in `open_agent_loop.yaml` alongside `trajectory.yaml` (sub-4b).
4. **Actionable** — InjectMessage interventions reach the next agent turn (sub-5a, this PR).

## Follow-ups (sub-5b, non-blocking)

- Kill / Pause / Resume with role-priority conflict resolution (`admin > participant > observer`, later-wins within a tier).
- Tool-approval interventions applying at a new tool-call seam mid-turn.
- EditState once the runner exposes an edit surface.