### PR TITLE
docs(examples): open_agent_loop copilot-attach example (M2 completion)

### DIFF
--- a/examples/open_agent_loop/README.md
+++ b/examples/open_agent_loop/README.md
@@ -1,0 +1,33 @@
+# Open Agent Loop — copilot attach example
+
+Runs the bundled `tool_use` tasks under **open mode** and attaches an LLM copilot participant in the same process. Demonstrates the full flow:
+
+1. Trials run through the normal `Orchestrator` + `InProcessConductor` path.
+2. `open_agent_loop.enabled: true` in the run config activates the gate — each trial gets a live `InProcessTrialSession`.
+3. A background thread runs the `LLMIntervener` copilot against each session — it observes turn boundaries, tool calls, and assistant messages as they happen, and drafts intervention suggestions.
+4. Every trial ends with `trials/<task_id>/<idx>/open_agent_loop.yaml` next to the usual `trajectory.yaml` — the durable, replayable trace of every event and every intervention with its ack outcome.
+
+## What it does not do
+
+- **No cross-process attach.** Sessions live inside the `Orchestrator` process. Cross-process attach — a separate `tolokaforge session attach` CLI — needs a socket transport and lands in a later milestone. The Python API (`orchestrator.sessions`) is the attach surface today.
+- **No mid-run intervention that reaches the agent** — beyond `InjectMessage`. `Kill` / `Pause` / `Resume` / tool-approval interventions land in the trace as `rejected` with a per-kind reason (M1 sub-5b follow-up).
+
+## Running
+
+Requires `ANTHROPIC_API_KEY` (or the equivalent for whichever provider you route through) in `.env` for both the agent-under-test and the copilot's drafter. Optional: install `anthropic` for the LLM drafter path; otherwise the copilot uses its deterministic heuristic drafter (still exercises the whole pipeline, just with heuristic-quality suggestions).
+
+```bash
+uv sync
+# The intervener package is a workspace member; --package installs it into the venv
+# so the example's `from intervener.participants import LLMIntervener` resolves.
+scripts/with_env.sh uv run --package intervener python examples/open_agent_loop/run_with_copilot.py
+```
+
+Output lands under `results/open_agent_loop_example/`. Inspect `trials/<task_id>/<idx>/open_agent_loop.yaml` for the event + intervention trace.
+
+## Anatomy
+
+- `run_config.yaml` — same shape as `examples/native/tool_use/run_config.yaml` but with an `open_agent_loop:` block turning the gate on.
+- `run_with_copilot.py` — driver that (a) builds the `Orchestrator`, (b) spawns an `LLMIntervener` on a background thread per expected trial, (c) runs the orchestrator, (d) waits for the copilots to drain, (e) prints a summary of every intervention that was proposed and its ack outcome.
+
+The task pack itself is the bundled `examples/native/tool_use/dataset` — no new tasks introduced; this example is purely about the gate wiring.

--- a/examples/open_agent_loop/run_config.yaml
+++ b/examples/open_agent_loop/run_config.yaml
@@ -1,0 +1,34 @@
+# Open Agent Loop example — runs the bundled tool_use tasks under open mode
+# so a copilot participant can attach live via the Python API. See README.md
+# in this directory for the full flow.
+#
+#   scripts/with_env.sh uv run python examples/open_agent_loop/run_with_copilot.py
+#
+# The `open_agent_loop.enabled: true` block below is the only field that
+# differs from examples/native/tool_use/run_config.yaml — sealed batch runs
+# ignore it entirely.
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 8
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/tool_use/dataset"
+  tasks_glob: "**/task.yaml"
+  output_dir: "results/open_agent_loop_example"
+
+open_agent_loop:
+  enabled: true

--- a/examples/open_agent_loop/run_with_copilot.py
+++ b/examples/open_agent_loop/run_with_copilot.py
@@ -1,0 +1,170 @@
+"""Open Agent Loop example — run tool-use trials with a live LLM copilot attached.
+
+Wires the pieces the `feat/open-agent-loop` workstream shipped:
+
+* Configures a run with ``open_agent_loop.enabled: true`` — see
+  ``examples/open_agent_loop/run_config.yaml``.
+* Pre-creates each trial's :class:`InProcessTrialSession` via
+  ``orchestrator.sessions.get_or_create`` so a copilot can attach before
+  the trial actually starts.
+* Spawns an :class:`LLMIntervener` on a background thread per expected
+  trial — it iterates events as the trial runs and proposes interventions
+  (drafter uses ``ANTHROPIC_API_KEY`` if available; otherwise the built-in
+  deterministic heuristic).
+* Runs the orchestrator on the main thread (blocks until every trial
+  finishes and every session is closed).
+* Waits for the copilots to drain, prints a summary of every intervention
+  it proposed and the ack outcome recorded in the trace.
+
+The intervener package lives at ``tools/intervener/`` — see its README for
+the participant contract. The gate itself is documented in
+``docs/OPEN_AGENT_LOOP.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# The intervener is a workspace peer; when this script is run via
+# ``uv run python`` from the repo root the workspace install makes it
+# importable directly.
+from intervener.participants import LLMIntervener
+
+from tolokaforge.core.models import RunConfig
+from tolokaforge.core.orchestrator import Orchestrator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / "examples" / "open_agent_loop" / "run_config.yaml"
+
+
+def _load_config(config_path: Path) -> RunConfig:
+    with config_path.open() as fh:
+        raw = yaml.safe_load(fh)
+    return RunConfig.model_validate(raw)
+
+
+def _discover_trial_ids(config: RunConfig) -> list[str]:
+    """Best-effort enumeration of the trial_ids this run will produce.
+
+    Walks the configured task packs, applies the tasks glob, and builds
+    ``"{task_id}:{trial_index}"`` for every ``trials`` combination the
+    orchestrator would spawn. Kept intentionally simple: any task the
+    config would run gets its session pre-created.
+    """
+    trial_ids: list[str] = []
+    tasks_glob = config.evaluation.tasks_glob
+    repeats = config.orchestrator.repeats
+    for task_pack in config.evaluation.task_packs:
+        task_root = REPO_ROOT / task_pack
+        for task_file in task_root.glob(tasks_glob):
+            with task_file.open() as fh:
+                task_raw = yaml.safe_load(fh)
+            task_id = task_raw.get("task_id") or task_file.parent.name
+            for trial_idx in range(repeats):
+                trial_ids.append(f"{task_id}:{trial_idx}")
+    return trial_ids
+
+
+def _spawn_copilot_thread(orchestrator: Orchestrator, trial_id: str) -> threading.Thread:
+    """Pre-create the session for ``trial_id`` and start a copilot on it.
+
+    Pre-creating the session before the orchestrator's observer provider
+    tries to is safe — :meth:`SessionRegistry.get_or_create` is idempotent
+    and threadsafe. The observer provider will hand back the same session,
+    and the LoopObserver will publish into it while the copilot's own
+    thread iterates events.
+    """
+    session = orchestrator.sessions.get_or_create(trial_id)
+    copilot = LLMIntervener(
+        participant_id=f"copilot:{trial_id}",
+        auto_inject=False,  # log suggestions in the trace, don't inject into the trial
+    )
+
+    thread = threading.Thread(
+        target=copilot.run,
+        args=(session,),
+        name=f"copilot-{trial_id}",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _print_summary(config: RunConfig, trial_ids: list[str]) -> None:
+    output_root = REPO_ROOT / config.evaluation.output_dir
+    print(f"\nOpen-agent-loop trace summaries (results in {output_root}):")
+    for trial_id in trial_ids:
+        task_id, idx_s = trial_id.rsplit(":", 1)
+        trace_path = output_root / "trials" / task_id / idx_s / "open_agent_loop.yaml"
+        if not trace_path.exists():
+            print(f"  {trial_id}: no trace (trial may not have run)")
+            continue
+        with trace_path.open() as fh:
+            trace = yaml.safe_load(fh)
+        events = trace.get("events") or []
+        interventions = trace.get("interventions") or []
+        outcomes = _tally_outcomes(interventions)
+        print(
+            f"  {trial_id}: {len(events)} events, "
+            f"{len(interventions)} interventions (outcomes: {outcomes})"
+        )
+
+
+def _tally_outcomes(interventions: list[dict[str, Any]]) -> dict[str, int]:
+    tally: dict[str, int] = {}
+    for rec in interventions:
+        outcome = rec.get("ack_outcome", "unknown")
+        tally[outcome] = tally.get(outcome, 0) + 1
+    return tally
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help=f"Run config YAML (default: {DEFAULT_CONFIG.relative_to(REPO_ROOT)})",
+    )
+    args = parser.parse_args(argv)
+
+    config = _load_config(args.config)
+    if config.open_agent_loop is None or not config.open_agent_loop.enabled:
+        print(
+            "This example expects `open_agent_loop.enabled: true` in the run "
+            "config. Falling back to sealed mode would run the trials but skip "
+            "the whole point of the demo.",
+            file=sys.stderr,
+        )
+        return 2
+
+    orchestrator = Orchestrator(config=config)
+    if orchestrator.sessions is None:
+        print("Session registry is None — open mode did not activate. Aborting.", file=sys.stderr)
+        return 3
+
+    trial_ids = _discover_trial_ids(config)
+    print(f"Attaching copilot to {len(trial_ids)} trial session(s): {trial_ids}")
+    copilot_threads = [_spawn_copilot_thread(orchestrator, tid) for tid in trial_ids]
+
+    print("Running orchestrator (this makes real LLM calls; costs real tokens)…")
+    orchestrator.run()
+
+    print("Waiting for copilot threads to drain…")
+    for thread in copilot_threads:
+        thread.join(timeout=30.0)
+        if thread.is_alive():
+            print(f"  {thread.name}: still running after 30s; abandoning", file=sys.stderr)
+
+    _print_summary(config, trial_ids)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #409 (M2 umbrella). Demonstrates the full open-mode flow end-to-end.

## Summary

An LLM copilot attaches to a live in-process trial session, observes turn boundaries and tool calls as they happen, and drafts intervention suggestions that land in the ``open_agent_loop.yaml`` trace.

The example is purely about the gate wiring — the underlying task pack is the bundled ``examples/native/tool_use/dataset``. No new tasks; no new participant code (the ``LLMIntervener`` scaffold from #412 already works against a live ``InProcessTrialSession`` because both live and recorded transports satisfy the same ``TrialSession`` Protocol).

## What ships

- **``examples/open_agent_loop/README.md``** — explains the flow, what it does not do (cross-process attach; Kill/Pause/Resume; those are M4 / M1 sub-5b), and how to run.
- **``examples/open_agent_loop/run_config.yaml``** — same shape as the ``tool_use`` example plus a single ``open_agent_loop.enabled: true`` block.
- **``examples/open_agent_loop/run_with_copilot.py``** — driver that:
  1. Discovers the ``trial_ids`` the run will produce (walks the configured task packs).
  2. Pre-creates each trial's session via ``orchestrator.sessions.get_or_create`` so a copilot can attach before the trial actually starts.
  3. Spawns an ``LLMIntervener`` on a background thread per trial (``auto_inject=False`` — logs suggestions in the trace, does not inject).
  4. Runs the orchestrator on the main thread.
  5. Waits for copilots to drain, prints a summary of every intervention and its ack outcome.

## Deferred (documented in the README)

- **Cross-process attach** (a separate ``tolokaforge session attach`` CLI) needs a socket transport and lands with the M4 remote-transport milestone. The Python API — ``orchestrator.sessions.get_or_create`` — is the attach surface today.
- **Kill / Pause / Resume / tool-approval interventions** — those land in M1 sub-5b (Pause / Resume state machine, mid-turn tool-approval seam, role-priority conflict resolution). Today they land in the trace as ``rejected`` with a per-kind reason.

## Test plan

- [x] ``uv run ruff check examples/open_agent_loop/``: clean
- [x] Config loads through ``RunConfig.model_validate``: ``open_agent_loop.enabled == True``
- [x] Intervener package imports cleanly via ``uv run --package intervener``
- [ ] Not run against real trials in this PR (needs LLM keys + real cost); will be exercised as part of the feat/open-agent-loop → main consolidation review.