### PR TITLE
feat(examples): multi_service_helpdesk_workflow flagship pack (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **examples**: multi_service_helpdesk_workflow flagship pack — four FastAPI services + in-container postgres-FTS policy search, adversarial three-path resolution graded on policy correctness, explicit ephemeral substrate, and the first documented LLM user-simulator persona pattern (#401)
 - **runtime**: per-service log capture now also fires on a completed-but-red grade (`status: completed`, `binary_pass: false`), not only execution failures — writes `services/<service>.log` + amends `metrics.yaml.captured_service_logs` before teardown (#418)
 - **grading**: `state_checks.db_probes` grading primitive — declarative postgres substrate assertions (#400)
 - **schema**: task.yaml minimal shape is task_id + description; initial_state / tools / user_simulator / grading now optional with sane defaults (#366)

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -316,6 +316,14 @@ combined with hash or `jsonpaths` checks in the same task. It fills the
 `state_checks` component and combines with `transcript_rules` / `llm_judge`
 through the normal weighted combine below.
 
+A probe can encode **policy correctness**, not just existence: assert the
+specific value a policy selects (`resolution_path == "reschedule"`) rather than
+that any well-formed row was written, so an agent that takes a plausible-but-wrong
+path grades down even though its row parses. The
+[`multi_service_helpdesk_workflow`](../examples/native/multi_service_helpdesk_workflow/)
+pack is the adversarial example — three resolution paths look defensible; the
+probe passes only for the one the after-hours policy permits.
+
 ---
 
 ## Score Combination

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -177,6 +177,36 @@ user_simulator:
 
 Scripted mode (`mode: "scripted"`) is available for simple deterministic flows but produces less realistic conversations.
 
+### Specialised personas
+
+For adversarial, multi-step tasks where the agent must *extract* the deciding
+facts through conversation, sharpen the `backstory` into a specialised persona.
+A specialised persona is a `backstory` with five components:
+
+- **Named persona.** Give the user a name, role, and organisation ("You are Ana
+  Reyes, operations coordinator at Northwind Biologics"). Concreteness keeps the
+  simulator in character across a long exchange.
+- **Facts the user knows.** State plainly what this person is aware of — the
+  problem they are chasing, the constraints they live under — so the simulator
+  answers consistently.
+- **Reveal-on-ask rules.** List the deciding facts the user will confirm *only
+  when asked*, each with an explicit "do NOT volunteer this unprompted". This
+  forces the agent to investigate rather than be handed the answer.
+- **Never name the solution.** Bar the user from naming the resolution, quoting
+  policy, or otherwise doing the agent's reasoning ("Never name a resolution path
+  or quote policy; that is the agent's job").
+- **Natural opening.** Instruct the user to open in their own words with the
+  problem, not a list of fields — this is what makes the first turn realistic.
+- **`###STOP###` exit.** Give a precise exit condition ("Say `###STOP###` once
+  the agent confirms a resolution is recorded"), not a generic "when done".
+
+The worked example is
+[`examples/native/multi_service_helpdesk_workflow`](../examples/native/multi_service_helpdesk_workflow/):
+its coordinator persona knows the shipment is delayed and after-hours, confirms
+the site has no cold storage or specialist only when asked, and never names the
+policy-correct resolution — so the agent must reconcile four services plus a
+policy corpus to derive it.
+
 ## Browser vs Mobile Tool
 
 Use `browser` for full web browsing tasks (URL navigation, search). Use `mobile` for phone app tasks (no URL bar, mobile viewport).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -181,7 +181,7 @@ Scripted mode (`mode: "scripted"`) is available for simple deterministic flows b
 
 For adversarial, multi-step tasks where the agent must *extract* the deciding
 facts through conversation, sharpen the `backstory` into a specialised persona.
-A specialised persona is a `backstory` with five components:
+A specialised persona is a `backstory` with six components:
 
 - **Named persona.** Give the user a name, role, and organisation ("You are Ana
   Reyes, operations coordinator at Northwind Biologics"). Concreteness keeps the

--- a/docs/multi_container_tasks.md
+++ b/docs/multi_container_tasks.md
@@ -172,6 +172,13 @@ down and re-provisions between trials, and the only one that applies reset
 recipes). If every service is `shared`, the run uses the shared-stack
 backend, which materialises the stack once and shares it across all trials.
 
+Declaring a substrate service `ephemeral` explicitly is the named form of the
+unlabelled default: it routes the whole run to the per-trial backend and gives
+each trial a clean substrate, which is the correct posture for a mutation task
+graded on the state it leaves behind. The
+[`multi_service_helpdesk_workflow`](../examples/native/multi_service_helpdesk_workflow/)
+pack declares its postgres `app-db` `ephemeral` for exactly this reason.
+
 Rule of thumb: leave a service unlabelled (defaults to `ephemeral`) unless
 you have a reason not to. Declare `shared` only after verifying the service
 carries no cross-trial state that could leak into grading; declare `reset`
@@ -294,6 +301,11 @@ reference.
 - [`examples/native/multi_service_lot_ops/README.md`](../examples/native/multi_service_lot_ops/README.md)
   — substrate-state grading: the agent mutates postgres over a FastAPI API and
   `state_checks.db_probes` verifies the row directly via a read-only role
+- [`examples/native/multi_service_helpdesk_workflow/README.md`](../examples/native/multi_service_helpdesk_workflow/README.md)
+  — flagship cross-service pack: four FastAPI services + in-container
+  postgres-FTS policy search, an adversarial three-path resolution graded on
+  policy correctness, an explicit `ephemeral` substrate, and the specialised
+  user-simulator persona pattern
 - [`examples/native/example-microservices-pack/`](../examples/native/example-microservices-pack/)
   — the schema reference pack: full inheritance/override matrix across five
   tasks (reference only, see its README before running)

--- a/examples/native/multi_service_helpdesk_workflow/README.md
+++ b/examples/native/multi_service_helpdesk_workflow/README.md
@@ -1,0 +1,179 @@
+# Multi-service `helpdesk_workflow` — cross-service reasoning + policy correctness
+
+The flagship multi-service example. A temperature-sensitive shipment is running
+late and will arrive after the receiving dock closes. The agent must reconcile
+data across **four** business services plus an in-container **policy corpus**,
+work out the *one* resolution the after-hours policy actually permits, record it
+as a CRM case, and annotate the delivery. Grading reads the postgres substrate
+**directly** through a read-only role and checks **policy correctness** — the
+value the policy selects, not merely that a well-formed row exists.
+
+```
+                 ┌── delivery-tracker:8000 ─┐
+                 ├── product-catalog:8000  ─┤
+agent  ──http──▶ ├── client-locations:8000 ─┤──▶ postgres:16 (app-db)
+                 ├── crm:8000              ─┤          ▲
+                 └── policy-search:8000 ───┘          │
+                                    grading (read-only `grader` role) ┘
+```
+
+## What this example demonstrates
+
+- **Cross-service reasoning graded on policy correctness.** Three resolution
+  paths are superficially plausible; policy applied to the site's capabilities
+  narrows to exactly one. An agent that picks a different path writes a
+  well-formed CRM row and still grades down, because `state_checks.db_probes`
+  asserts the *policy-correct value* (`reschedule`), not just row existence.
+
+  | path | superficially attractive because… | ruled out by… |
+  |---|---|---|
+  | `temp_controlled_hold` | product is temp-sensitive → "just refrigerate it" | site `has_temp_storage = false` |
+  | `specialist_handoff` | sounds premium / customer-friendly | site `has_specialist = false` |
+  | `reschedule` | — | **the surviving, policy-correct path** |
+
+  The `NORTHWIND` site ships with `has_temp_storage = false` and
+  `has_specialist = false`, so both alternatives are excluded by policy applied
+  to data — reasoning the agent must actually perform, not a keyword lookup.
+
+- **In-container full-text policy search.** `policy-search` exposes the
+  `policy_docs` corpus (a generated `tsvector` column + GIN index) via postgres
+  `websearch_to_tsquery`. The decisive paragraph states that a temperature-
+  sensitive after-hours shipment must be rescheduled when the site has neither
+  cold storage nor a specialist; decoy paragraphs describe the other two paths
+  in isolation so a keyword-only reader can be misled.
+
+- **A discriminating three-way weighted combine.** The final score combines all
+  three grading families, and the `state_checks` component alone is decisive:
+
+  | Component | Weight | What it checks |
+  |---|---|---|
+  | `state_checks.db_probes` | 0.60 | the CRM case **and** the delivery annotation both carry `reschedule` for the right customer |
+  | `transcript_rules` | 0.15 | the agent searched policy, created the case, and annotated the delivery over `http_request`, within 18 turns |
+  | `llm_judge` | 0.25 | the CRM summary names the customer + delivery and justifies the reschedule from policy |
+
+  Because `state_checks` carries 0.60 against a `0.6` pass threshold, a
+  wrong-path run cannot pass even with full `transcript_rules` + `llm_judge`
+  credit — and a correct run still passes if the `llm_judge` errors and is
+  dropped from the combine (`state_checks` 0.60 + `transcript_rules` 0.15 =
+  0.75 of the surviving weight clears the threshold).
+
+- **Five application services, no custom image.** Each service is a small
+  FastAPI app run straight from `tolokaforge-runner:local` — that image already
+  bundles `fastapi`, `uvicorn`, and `asyncpg`, so the pack ships **no
+  Dockerfile**. A compose `command:` override boots `uvicorn` against each
+  bind-mounted `main.py`.
+
+## The scenario
+
+Shipment `DLV-4021` (`delivery_id 4021`) for customer `NORTHWIND` is a
+temperature-sensitive reagent kit (`RGT-COLD-12`). It was delayed; the new ETA
+(20:00) lands after the site's staffed window closes (17:00). The agent must:
+
+1. Read the delivery (`GET /deliveries/4021`), its product, and the Northwind
+   site to establish that the shipment is temp-sensitive, arrives after hours,
+   and the site has neither cold storage nor a specialist.
+2. Search the policy corpus (`POST /search`) to find the after-hours rule.
+3. Derive the only permitted path (`reschedule`), record it as a CRM case
+   (`POST /cases`), and annotate the delivery (`PATCH /deliveries/4021`).
+
+`crm_cases` ships **empty**, so the agent's `POST` is the only thing that can
+populate it — grading passing means the mutation really landed with the
+policy-correct value.
+
+### Why policy search is `POST /search`
+
+The query rides in the JSON body of a fixed-URL `POST /search`, not a
+`GET /search?q=…` query string. `transcript_rules.required_actions` matches a
+tool call by **exact** URL + method equality (no substring, regex, or ordering),
+so a per-query `GET` URL could not be asserted; a fixed `POST` URL can. The
+`search_policy` required action matches on `{url, method}` alone.
+
+## The user-simulator persona pattern
+
+This pack ships the reusable **specialised-persona** shape for the LLM user
+simulator: a named character with a concrete backstory, the facts they know,
+reveal-on-ask rules, a "never name the solution" rule, a natural opening, and a
+`###STOP###` exit. The point is a user who is *cooperative but not a cheat
+sheet* — they confirm the site has no cold storage or specialist **only when
+asked**, and never name a resolution path or quote policy. That forces the agent
+to do the reconciling. See `dataset/tasks/helpdesk_01/task.yaml` →
+`user_simulator.backstory`, and `docs/TASKS.md` § User Simulator.
+
+## Isolation: the explicit ephemeral substrate
+
+The postgres `app-db` is declared **`isolation: ephemeral`** explicitly; the
+five stateless services are `shared`. Because at least one service is
+non-`shared`, the whole run routes to the **per-trial backend**, which
+materialises the entire compose stack fresh per trial — so each trial gets a
+clean, freshly seeded postgres (reference data reseeded by `init.sql`,
+`crm_cases` empty). This is the explicit form of the per-trial default and the
+correct substrate posture for a mutation task: it keeps trials independent if
+`repeats` is raised. With `repeats: 1` it is a single materialisation. The
+stateless API services are labelled `shared` to document that they hold no
+cross-trial state the task depends on.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/multi_service_helpdesk_workflow/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_helpdesk_workflow/run_config.yaml
+```
+
+Needs a running Docker daemon and `OPENROUTER_API_KEY` in `.env`. The first run
+is slower while postgres initialises and seeds; the runner container joins the
+task's docker network, so the agent reaches each service by name (e.g.
+`policy-search:8000`) and grading reaches `app-db:5432` directly.
+
+## Layout
+
+```
+examples/native/multi_service_helpdesk_workflow/
+├── run_config.yaml               # haiku agent + user, sonnet judge, per_trial runtime
+├── project.yaml                  # discovery glob + native defaults
+├── README.md                     # this file
+├── shared/
+│   ├── environment.compose.yaml  # 8-service compose (app-db ephemeral, rest shared)
+│   ├── delivery-tracker/main.py  # FastAPI: read + PATCH the delivery
+│   ├── product-catalog/main.py   # FastAPI: product temp-sensitivity + hold limits
+│   ├── client-locations/main.py  # FastAPI: site staffed window + capabilities
+│   ├── crm/main.py               # FastAPI: create + read cases
+│   ├── policy-search/main.py     # FastAPI: postgres-FTS policy search (POST /search)
+│   └── app-db/
+│       └── init.sql              # schema + seed + policy corpus + app/grader roles
+└── dataset/tasks/helpdesk_01/
+    ├── task.yaml                 # env manifest + http_request/write_file tools + persona
+    └── grading.yaml              # db_probes + transcript_rules + llm_judge
+```
+
+## Design notes
+
+- **Two roles, least privilege.** `init.sql` creates the database as the
+  read/write `app` role (every FastAPI service connects as this) and a separate
+  `grader` role with `GRANT SELECT` only. The db_probe DSN authenticates as
+  `grader`, so the oracle is read-only by construction and can never mutate the
+  substrate.
+- **`db_probes` encode policy correctness.** The probes assert
+  `resolution_path = reschedule` — the value policy selects — in both
+  `crm_cases` and `deliveries`, not just that a row exists. See
+  [`docs/GRADING.md`](../../../docs/GRADING.md) § Substrate Grading.
+- **Task-local throwaway credentials.** The DSN in `grading.yaml` and the
+  compose passwords are disposable, task-scoped credentials for a local
+  container. Real secrets always go through `SecretManager`.
+- **Pinned images only.** `postgres:16`, `tolokaforge-runner:local`,
+  `tolokaforge-db-service:local`.
+
+## Related
+
+- [`docs/multi_container_tasks.md`](../../../docs/multi_container_tasks.md)
+  — authoring guide for multi-container tasks
+- [`docs/GRADING.md`](../../../docs/GRADING.md) — grading families, including
+  `state_checks.db_probes`
+- [`docs/TASKS.md`](../../../docs/TASKS.md) — task authoring, including the
+  user-simulator persona pattern
+- [`../multi_service_lot_ops/README.md`](../multi_service_lot_ops/README.md)
+  — the single-service substrate-grading sibling this pack extends

--- a/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/grading.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/grading.yaml
@@ -1,0 +1,49 @@
+# Three-way weighted grading for helpdesk_01.
+#
+#   state_checks.db_probes (0.6) — the substrate oracle. Reads postgres directly
+#     through the read-only `grader` role and encodes *policy correctness*: the
+#     CRM case and the delivery annotation must both carry `reschedule`, the one
+#     path the after-hours policy permits for a site with neither cold storage
+#     nor a specialist. This component alone is discriminating, so a wrong-path
+#     run fails even if the llm_judge errors and is dropped from the combine.
+#   transcript_rules      (0.15) — the agent searched policy, created the case,
+#     and annotated the delivery over http_request, within the turn budget.
+#   llm_judge             (0.25) — the CRM summary names the customer + delivery
+#     and justifies the reschedule from the site's lack of cold storage/specialist.
+combine:
+  method: weighted
+  weights: { state_checks: 0.6, transcript_rules: 0.15, llm_judge: 0.25 }
+  pass_threshold: 0.6
+state_checks:
+  db_probes:
+    - name: crm_case_policy_correct
+      dsn: "postgresql://grader:grader_pw@app-db:5432/helpdesk"
+      query: "SELECT customer_id, resolution_path FROM crm_cases WHERE delivery_id = 4021"
+      expect:
+        - { path: "$.rows[0].resolution_path", equals: "reschedule", description: "CRM case records the policy-correct path" }
+        - { path: "$.rows[0].customer_id", equals: "NORTHWIND", description: "correct customer linkage" }
+        - { path: "$.row_count", equals: 1, description: "exactly one CRM case for the delivery" }
+    - name: delivery_annotated
+      dsn: "postgresql://grader:grader_pw@app-db:5432/helpdesk"
+      query: "SELECT resolution_path FROM deliveries WHERE delivery_id = 4021"
+      expect:
+        - { path: "$.rows[0].resolution_path", equals: "reschedule", description: "delivery annotated with the handoff decision" }
+transcript_rules:
+  max_turns: 18
+  required_actions:
+    - { action_id: search_policy,  requestor: assistant, name: http_request, arguments: { url: "http://policy-search:8000/search", method: "POST" },  compare_args: [url, method] }
+    - { action_id: create_case,    requestor: assistant, name: http_request, arguments: { url: "http://crm:8000/cases", method: "POST" },              compare_args: [url, method] }
+    - { action_id: annotate_deliv, requestor: assistant, name: http_request, arguments: { url: "http://delivery-tracker:8000/deliveries/4021", method: "PATCH" }, compare_args: [url, method] }
+llm_judge:
+  rubric:
+    reference: |
+      The correct resolution is reschedule: the shipment is temperature-sensitive
+      and arrives after the site's staffed window, and the site has neither on-site
+      temperature-controlled storage nor a certified specialist, so policy forbids a
+      temp-controlled hold and a specialist handoff. A good CRM summary names the
+      customer and delivery, states the reschedule decision, and justifies it from the
+      site's lack of cold storage/specialist per policy.
+    criteria:
+      - { id: names_customer_delivery, description: "Names the customer (Northwind) and delivery (DLV-4021 / 4021).", kind: binary, required: true, weight: 1.0 }
+      - { id: policy_reasoning, description: "Justifies the chosen path from the site's lack of on-site cold storage and specialist per the after-hours policy.", kind: graded, weight: 1.0 }
+      - { id: tone_completeness, description: "Reads as a complete, professional, customer-facing case note, not a raw API dump.", kind: graded, weight: 0.5 }

--- a/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml
@@ -1,0 +1,69 @@
+task_id: "helpdesk_01"
+name: "Resolve an After-Hours Cold-Chain Delivery"
+category: "multi_service"
+description: "A temperature-sensitive shipment will arrive after the receiving dock's staffed window closes. The agent must reconcile data across four business services plus an in-container policy corpus, derive the one policy-valid resolution, record it as a CRM case, and annotate the delivery."
+max_turns: 18
+initial_user_message: |
+  Hi — I'm chasing shipment DLV-4021 for us at Northwind. It's a
+  temperature-sensitive reagent kit and it got delayed, so now it's landing
+  around 20:00, which is after our receiving dock shuts for the day. I really
+  need to make sure the right thing happens with it so the reagent stays good
+  and someone qualified actually receives it.
+
+  Can you work out the correct way to handle this and get it recorded? The
+  systems you'll need are the delivery tracker at http://delivery-tracker:8000,
+  the product catalog at http://product-catalog:8000, our site info at
+  http://client-locations:8000, the policy search at http://policy-search:8000,
+  and the CRM at http://crm:8000. I don't know our after-hours policy myself —
+  I'm counting on you to figure out what we're actually allowed to do.
+adapter_type: "native"
+environment_manifest:
+  compose_file: "../../../shared/environment.compose.yaml"
+  runner_service: "runner"
+  services:
+    runner: {isolation: "shared"}
+    db-service: {isolation: "shared"}
+    delivery-tracker: {isolation: "shared"}
+    product-catalog: {isolation: "shared"}
+    client-locations: {isolation: "shared"}
+    crm: {isolation: "shared"}
+    policy-search: {isolation: "shared"}
+    app-db: {isolation: "ephemeral"}
+initial_state:
+  filesystem: {}
+tools:
+  agent:
+    enabled: ["http_request", "write_file"]
+    http_request:
+      allowed_hosts:
+        - "delivery-tracker:8000"
+        - "product-catalog:8000"
+        - "client-locations:8000"
+        - "crm:8000"
+        - "policy-search:8000"
+  user:
+    enabled: []
+user_simulator:
+  mode: llm
+  persona: "logistics coordinator"
+  backstory: |
+    You are Ana Reyes, operations coordinator at Northwind Biologics. You are
+    chasing a delayed temperature-sensitive shipment (DLV-4021) that will now
+    arrive around 20:00 — after your receiving dock closes at 17:00. You care
+    that the reagent stays viable and that someone qualified receives it. You do
+    NOT know the company's after-hours cold-chain policy and you rely on the
+    agent to work out the right resolution.
+    Rules:
+    - Open naturally, in your own words, with the problem — not a list of fields.
+    - Answer clarifying questions plainly and truthfully from what you know.
+    - If asked, confirm your site has no on-site cold storage and no receiving
+      specialist on the late shift — but do NOT volunteer this unprompted.
+    - Never name a resolution path or quote policy; that is the agent's job.
+    - Say ###STOP### once the agent confirms a resolution is recorded.
+policies:
+  guidance:
+    - "Reach each service by its base URL with the `http_request` tool: the delivery tracker, product catalog, and site info are read with GET; inspect DLV-4021 (delivery_id 4021), its product, and the Northwind site."
+    - "Search the policy corpus by POSTing your query to `http://policy-search:8000/search` with a JSON body `{\"q\": \"...\"}` — do not guess the after-hours rule, read it."
+    - "Derive the resolution path from the policy applied to the site's capabilities; do not assume it. Only one path is permitted for this site."
+    - "Record the outcome as a CRM case (`POST http://crm:8000/cases`) naming the customer, delivery, chosen path, and a short justification, then annotate the delivery (`PATCH http://delivery-tracker:8000/deliveries/4021`) with the same resolution path."
+grading: "grading.yaml"

--- a/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml
@@ -64,6 +64,7 @@ policies:
   guidance:
     - "Reach each service by its base URL with the `http_request` tool: the delivery tracker, product catalog, and site info are read with GET; inspect DLV-4021 (delivery_id 4021), its product, and the Northwind site."
     - "Search the policy corpus by POSTing your query to `http://policy-search:8000/search` with a JSON body `{\"q\": \"...\"}` — do not guess the after-hours rule, read it."
-    - "Derive the resolution path from the policy applied to the site's capabilities; do not assume it. Only one path is permitted for this site."
-    - "Record the outcome as a CRM case (`POST http://crm:8000/cases`) naming the customer, delivery, chosen path, and a short justification, then annotate the delivery (`PATCH http://delivery-tracker:8000/deliveries/4021`) with the same resolution path."
+    - "Derive the resolution path from the policy applied to the site's capabilities; do not assume it. Only one path is permitted for this site. The `resolution_path` value must be one of the short slugs `reschedule`, `temp_controlled_hold`, or `specialist_handoff`."
+    - "Record the outcome as a CRM case by POSTing to `http://crm:8000/cases` with a JSON body `{\"delivery_id\": 4021, \"customer_id\": \"NORTHWIND\", \"resolution_path\": \"<the chosen slug>\", \"summary\": \"<one sentence naming the customer, the delivery, the chosen path, and why per policy>\"}` — use the integer `delivery_id` 4021, not the string label."
+    - "Then annotate the delivery with `PATCH http://delivery-tracker:8000/deliveries/4021` and a JSON body `{\"resolution_path\": \"<the same slug>\", \"resolution_note\": \"<one-sentence justification>\"}`."
 grading: "grading.yaml"

--- a/examples/native/multi_service_helpdesk_workflow/project.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/project.yaml
@@ -1,0 +1,27 @@
+# Project spec for the multi_service_helpdesk_workflow example.
+#
+# A single native task that reconciles data across four FastAPI business
+# services plus an in-container postgres-FTS policy corpus over one postgres
+# substrate, and grades the resulting mutation directly against the database
+# through a read-only role (state_checks.db_probes) for *policy correctness*.
+# The task declares its own `environment_manifest` (postgres `app-db` is
+# `isolation: ephemeral`, the stateless services `shared`), so this project
+# only supplies discovery + native defaults. See README.md.
+#
+# See docs/architecture/PROJECTS.md for the full Project model.
+
+name: "multi-service-helpdesk-workflow"
+version: 1
+description: >
+  Single-task flagship project demonstrating cross-service reasoning and
+  policy-correctness grading: the agent reconciles four services plus a policy
+  corpus to derive the one permitted resolution, records it as a CRM case, and
+  grading reads the substrate directly via a least-privilege read-only role —
+  an independent oracle that checks the policy-correct value, not mere existence.
+
+tasks:
+  discovery:
+    glob: "tasks/**/task.yaml"
+
+task_defaults:
+  adapter_type: "native"

--- a/examples/native/multi_service_helpdesk_workflow/run_config.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/run_config.yaml
@@ -1,0 +1,48 @@
+# Multi-service `helpdesk_workflow` example — flagship cross-service reasoning.
+#
+#   agent → 5 FastAPI services (delivery-tracker, product-catalog,
+#           client-locations, crm, policy-search) → postgres:16 (app-db)
+#
+# The agent reconciles data across four business services plus an in-container
+# postgres-FTS policy corpus, derives the one policy-valid resolution
+# (`reschedule`), records it as a CRM case, and annotates the delivery. Grading
+# reads the substrate directly through a read-only role and checks *policy
+# correctness*, combined with transcript rules and an llm_judge rubric.
+#
+# Three model roles: the `agent` under test, the `user` simulator, and the
+# read-only rubric `judge`.
+#
+# `runtime: per_trial` because the postgres substrate is declared
+# `isolation: ephemeral`, which routes the whole run to the per-trial backend
+# so each trial gets a freshly seeded database (`crm_cases` empty).
+#
+# Requirements:
+#   - Docker daemon running.
+#   - OPENROUTER_API_KEY in .env.
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+  judge:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 18
+  runtime: per_trial
+  queue_backend: sqlite
+
+evaluation:
+  task_packs:
+    - "examples/native/multi_service_helpdesk_workflow/dataset"
+  tasks_glob: "tasks/helpdesk_01/task.yaml"
+  output_dir: "results/multi_service_helpdesk_workflow_example"

--- a/examples/native/multi_service_helpdesk_workflow/shared/app-db/init.sql
+++ b/examples/native/multi_service_helpdesk_workflow/shared/app-db/init.sql
@@ -1,0 +1,104 @@
+-- Helpdesk-workflow schema + seed for the multi_service_helpdesk_workflow example.
+--
+-- Loaded once by postgres:16's docker-entrypoint-initdb.d at container start,
+-- running as the POSTGRES_USER `app` role (owns the schema, read/write). The
+-- five FastAPI services connect as `app`. A dedicated read-only `grader` role
+-- (GRANT SELECT only) is the least-privilege oracle the db_probe DSN uses, so
+-- grading reads the substrate directly and can never mutate it.
+--
+-- `crm_cases` ships empty on purpose: the agent creates the case the task asks
+-- for, and grading verifies it landed with the policy-correct resolution path.
+
+CREATE TABLE deliveries (
+  delivery_id     INT  PRIMARY KEY,
+  customer_id     TEXT NOT NULL,
+  product_sku     TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  original_eta    TIMESTAMPTZ NOT NULL,
+  new_eta         TIMESTAMPTZ NOT NULL,
+  temp_controlled BOOLEAN NOT NULL,
+  resolution_path TEXT,
+  resolution_note TEXT
+);
+
+CREATE TABLE products (
+  sku                 TEXT PRIMARY KEY,
+  name                TEXT NOT NULL,
+  temp_sensitive      BOOLEAN NOT NULL,
+  storage_requirement TEXT NOT NULL,
+  max_hold_hours      INT  NOT NULL
+);
+
+CREATE TABLE sites (
+  customer_id      TEXT PRIMARY KEY,
+  site_name        TEXT NOT NULL,
+  timezone         TEXT NOT NULL,
+  staffed_until    TIME NOT NULL,
+  has_temp_storage BOOLEAN NOT NULL,
+  has_specialist   BOOLEAN NOT NULL
+);
+
+CREATE TABLE policy_docs (
+  policy_id TEXT PRIMARY KEY,
+  title     TEXT NOT NULL,
+  body      TEXT NOT NULL,
+  ts        TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', title || ' ' || body)) STORED
+);
+
+CREATE INDEX policy_docs_ts_idx ON policy_docs USING GIN (ts);
+
+CREATE TABLE crm_cases (
+  case_id         SERIAL PRIMARY KEY,
+  delivery_id     INT  NOT NULL,
+  customer_id     TEXT NOT NULL,
+  resolution_path TEXT NOT NULL,
+  summary         TEXT NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO products (sku, name, temp_sensitive, storage_requirement, max_hold_hours) VALUES
+  ('RGT-COLD-12', 'Cold-chain reagent kit',   TRUE,  '2-8C refrigerated', 6),
+  ('RGT-STD-04',  'Standard assay reagent',   FALSE, 'ambient',           72),
+  ('CNS-DRY-30',  'Dry consumables pack',     FALSE, 'ambient',           240),
+  ('VAC-FRZ-09',  'Frozen vaccine lot',       TRUE,  'frozen -20C',       4);
+
+INSERT INTO sites (customer_id, site_name, timezone, staffed_until, has_temp_storage, has_specialist) VALUES
+  ('NORTHWIND', 'Northwind Biologics receiving dock', 'America/New_York', '17:00', FALSE, FALSE),
+  ('CONTOSO',   'Contoso Labs cold room',             'America/Chicago',  '18:00', TRUE,  FALSE),
+  ('FABRIKAM',  'Fabrikam Bio night-shift dock',      'America/Denver',   '22:00', FALSE, TRUE),
+  ('WINGTIP',   'Wingtip Diagnostics main dock',      'America/New_York', '17:00', TRUE,  TRUE);
+
+INSERT INTO deliveries
+  (delivery_id, customer_id, product_sku, status, original_eta, new_eta, temp_controlled, resolution_path, resolution_note)
+VALUES
+  (4021, 'NORTHWIND', 'RGT-COLD-12', 'delayed',    '2026-07-16 14:00-04', '2026-07-16 20:00-04', TRUE,  NULL, NULL),
+  (4022, 'CONTOSO',   'RGT-STD-04',  'in_transit', '2026-07-16 11:00-05', '2026-07-16 15:00-05', FALSE, NULL, NULL),
+  (4023, 'FABRIKAM',  'VAC-FRZ-09',  'delayed',    '2026-07-16 16:00-06', '2026-07-16 21:00-06', TRUE,  NULL, NULL),
+  (4024, 'WINGTIP',   'CNS-DRY-30',  'in_transit', '2026-07-16 09:00-04', '2026-07-16 13:00-04', FALSE, NULL, NULL);
+
+INSERT INTO policy_docs (policy_id, title, body) VALUES
+  ('POL-AH-01', 'After-hours receiving of temperature-sensitive shipments',
+   'A temperature-sensitive shipment arriving outside a site''s staffed window may only be held on site when the site has certified temperature-controlled storage; where the receiving site has neither on-site temperature-controlled storage nor a certified receiving specialist, the shipment must be rescheduled to the next staffed window — a specialist handoff is not permitted without a certified specialist on site.'),
+  ('POL-HOLD-02', 'On-site temperature-controlled hold',
+   'When a receiving site is equipped with certified temperature-controlled storage, a delayed temperature-sensitive shipment may be held on site until the next staffed window, provided the product''s maximum hold time is not exceeded.'),
+  ('POL-SPEC-03', 'Certified specialist handoff',
+   'A late shipment may be handed off to a certified receiving specialist for after-hours acceptance when the site keeps a specialist on the late shift; the specialist assumes chain-of-custody until the dock reopens.'),
+  ('POL-RESC-04', 'Rescheduling to the next staffed window',
+   'Rescheduling returns a shipment to the carrier for redelivery at the start of the next staffed window. It is the default resolution when no compliant on-site handling option is available.'),
+  ('POL-AMB-05', 'Ambient shipments after hours',
+   'Shipments that are not temperature-sensitive may be left in the secure ambient holding area after hours and do not require a specialist or cold storage.'),
+  ('POL-COLD-06', 'Cold-chain hold time limits',
+   'Refrigerated reagents must return to 2-8C storage within their maximum hold hours; frozen products have shorter tolerances. Exceeding the hold time voids the shipment regardless of the resolution chosen.'),
+  ('POL-CUST-07', 'Chain-of-custody documentation',
+   'Every after-hours resolution must be recorded as a case with the customer, delivery, and the chosen resolution path so the receiving team has an auditable trail.'),
+  ('POL-ESC-08', 'Escalation for perishable loss risk',
+   'If no compliant resolution can keep a perishable shipment viable, escalate to the customer''s account manager before the product expires.'),
+  ('POL-CARR-09', 'Carrier redelivery windows',
+   'Carriers guarantee redelivery at the next staffed window when a reschedule is requested before the shipment reaches the dock.'),
+  ('POL-STAFF-10', 'Staffed window definition',
+   'A site''s staffed window is the interval during which qualified receiving personnel are on the dock; deliveries landing after this window are treated as after-hours arrivals.');
+
+CREATE ROLE grader LOGIN PASSWORD 'grader_pw';
+GRANT CONNECT ON DATABASE helpdesk TO grader;
+GRANT USAGE ON SCHEMA public TO grader;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO grader;

--- a/examples/native/multi_service_helpdesk_workflow/shared/client-locations/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/client-locations/main.py
@@ -1,0 +1,57 @@
+"""Client-locations API for the multi_service_helpdesk_workflow example.
+
+A thin FastAPI service over the postgres `app-db` substrate. The agent drives
+it over HTTP (service name `client-locations:8000`) to learn a receiving
+site's staffed window and its on-site capabilities (cold storage, specialist).
+Connects as the read/write `app` role via asyncpg, using the DSN in
+`APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="Client Locations API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+async def _fetch_one(query: str, *args: Any) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(query, *args)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.get("/sites")
+async def list_sites() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM sites ORDER BY customer_id"))
+
+
+@app.get("/sites/{customer_id}")
+async def get_site(customer_id: str) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM sites WHERE customer_id = $1", customer_id)

--- a/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
@@ -16,11 +16,10 @@ from typing import Any
 
 import asyncpg
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 
 class NewCase(BaseModel):
-    model_config = ConfigDict(extra="forbid")
     delivery_id: int
     customer_id: str
     resolution_path: str

--- a/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 
 class NewCase(BaseModel):
+    # No extra="forbid": stray agent-added fields are dropped, not 422'd — keeps a guidance-following agent's POST valid.
     delivery_id: int
     customer_id: str
     resolution_path: str

--- a/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/crm/main.py
@@ -1,0 +1,78 @@
+"""CRM API for the multi_service_helpdesk_workflow example.
+
+A thin FastAPI service over the postgres `app-db` substrate. The agent drives
+it over HTTP (service name `crm:8000`) to record the resolution as a case.
+Grading reads the `crm_cases` table directly through a read-only role, so the
+`POST /cases` write is the only thing that can populate it. Connects as the
+read/write `app` role via asyncpg, using the DSN in `APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+
+class NewCase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    delivery_id: int
+    customer_id: str
+    resolution_path: str
+    summary: str
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="CRM API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+async def _fetch_one(query: str, *args: Any) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(query, *args)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.get("/cases")
+async def list_cases() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM crm_cases ORDER BY case_id"))
+
+
+@app.get("/cases/{case_id}")
+async def get_case(case_id: int) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM crm_cases WHERE case_id = $1", case_id)
+
+
+@app.post("/cases", status_code=201)
+async def create_case(body: NewCase) -> dict[str, Any]:
+    return await _fetch_one(
+        "INSERT INTO crm_cases (delivery_id, customer_id, resolution_path, summary) "
+        "VALUES ($1, $2, $3, $4) RETURNING *",
+        body.delivery_id,
+        body.customer_id,
+        body.resolution_path,
+        body.summary,
+    )

--- a/examples/native/multi_service_helpdesk_workflow/shared/delivery-tracker/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/delivery-tracker/main.py
@@ -1,0 +1,74 @@
+"""Delivery-tracker API for the multi_service_helpdesk_workflow example.
+
+A thin FastAPI service over the postgres `app-db` substrate. The agent drives
+it over HTTP (service name `delivery-tracker:8000`) to read a delivery and
+annotate it with the chosen resolution. Connects as the read/write `app` role
+via asyncpg, using the DSN in `APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+
+class DeliveryPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    resolution_path: str
+    resolution_note: str | None = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="Delivery Tracker API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+async def _fetch_one(query: str, *args: Any) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(query, *args)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.get("/deliveries")
+async def list_deliveries() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM deliveries ORDER BY delivery_id"))
+
+
+@app.get("/deliveries/{delivery_id}")
+async def get_delivery(delivery_id: int) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM deliveries WHERE delivery_id = $1", delivery_id)
+
+
+@app.patch("/deliveries/{delivery_id}")
+async def patch_delivery(delivery_id: int, body: DeliveryPatch) -> dict[str, Any]:
+    return await _fetch_one(
+        "UPDATE deliveries SET resolution_path = $1, resolution_note = $2 "
+        "WHERE delivery_id = $3 RETURNING *",
+        body.resolution_path,
+        body.resolution_note,
+        delivery_id,
+    )

--- a/examples/native/multi_service_helpdesk_workflow/shared/environment.compose.yaml
+++ b/examples/native/multi_service_helpdesk_workflow/shared/environment.compose.yaml
@@ -1,0 +1,123 @@
+# multi_service_helpdesk_workflow stack: agent -> 5 FastAPI services -> postgres:16 (app-db); db-service backs engine state. Pinned images only.
+services:
+  runner:
+    image: tolokaforge-runner:local
+    environment:
+      DB_SERVICE_URL: "http://db-service:8000"
+    ports:
+      - "50051"
+    depends_on:
+      db-service:
+        condition: service_healthy
+      delivery-tracker:
+        condition: service_healthy
+      product-catalog:
+        condition: service_healthy
+      client-locations:
+        condition: service_healthy
+      crm:
+        condition: service_healthy
+      policy-search:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import grpc; grpc.channel_ready_future(grpc.insecure_channel('localhost:50051')).result(timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  db-service:
+    image: tolokaforge-db-service:local
+    ports:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  delivery-tracker:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/helpdesk"
+    volumes:
+      - ./delivery-tracker/main.py:/srv/app/main.py:ro
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  product-catalog:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/helpdesk"
+    volumes:
+      - ./product-catalog/main.py:/srv/app/main.py:ro
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  client-locations:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/helpdesk"
+    volumes:
+      - ./client-locations/main.py:/srv/app/main.py:ro
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  crm:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/helpdesk"
+    volumes:
+      - ./crm/main.py:/srv/app/main.py:ro
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  policy-search:
+    image: tolokaforge-runner:local
+    command: ["python", "-m", "uvicorn", "main:app", "--app-dir", "/srv/app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      APP_DB_DSN: "postgresql://app:app_pw@app-db:5432/helpdesk"
+    volumes:
+      - ./policy-search/main.py:/srv/app/main.py:ro
+    depends_on:
+      app-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2)"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+  app-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "helpdesk"
+      POSTGRES_USER: "app"
+      POSTGRES_PASSWORD: "app_pw"
+    volumes:
+      - ./app-db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d helpdesk"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/examples/native/multi_service_helpdesk_workflow/shared/policy-search/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/policy-search/main.py
@@ -1,0 +1,76 @@
+"""Policy-search API for the multi_service_helpdesk_workflow example.
+
+A thin FastAPI service over the postgres `app-db` substrate that exposes the
+policy corpus via postgres full-text search. The agent drives it over HTTP
+(service name `policy-search:8000`).
+
+Search is a `POST /search` with the query in the JSON body (not a `GET` query
+string) so the request URL is fixed and the grader's `required_actions` rule
+can match it by exact URL + method. Connects as the read/write `app` role via
+asyncpg, using the DSN in `APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict
+
+
+class SearchQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    q: str
+    top_k: int = 5
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="Policy Search API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.post("/search")
+async def search(body: SearchQuery) -> list[dict[str, Any]]:
+    return _rows(
+        await app.state.pool.fetch(
+            "SELECT policy_id, title, body, "
+            "ts_rank(ts, websearch_to_tsquery('english', $1)) AS rank "
+            "FROM policy_docs "
+            "WHERE ts @@ websearch_to_tsquery('english', $1) "
+            "ORDER BY rank DESC, policy_id "
+            "LIMIT $2",
+            body.q,
+            body.top_k,
+        )
+    )
+
+
+@app.get("/policies/{policy_id}")
+async def get_policy(policy_id: str) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(
+        "SELECT policy_id, title, body FROM policy_docs WHERE policy_id = $1", policy_id
+    )
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)

--- a/examples/native/multi_service_helpdesk_workflow/shared/product-catalog/main.py
+++ b/examples/native/multi_service_helpdesk_workflow/shared/product-catalog/main.py
@@ -1,0 +1,56 @@
+"""Product-catalog API for the multi_service_helpdesk_workflow example.
+
+A thin FastAPI service over the postgres `app-db` substrate. The agent drives
+it over HTTP (service name `product-catalog:8000`) to learn whether a product
+is temperature-sensitive and its hold limits. Connects as the read/write `app`
+role via asyncpg, using the DSN in `APP_DB_DSN`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    app.state.pool = await asyncpg.create_pool(os.environ["APP_DB_DSN"])
+    try:
+        yield
+    finally:
+        await app.state.pool.close()
+
+
+app = FastAPI(title="Product Catalog API", lifespan=lifespan)
+
+
+def _rows(records: list[asyncpg.Record]) -> list[dict[str, Any]]:
+    return [dict(r) for r in records]
+
+
+async def _fetch_one(query: str, *args: Any) -> dict[str, Any]:
+    record = await app.state.pool.fetchrow(query, *args)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return dict(record)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    await app.state.pool.fetchval("SELECT 1")
+    return {"status": "ok"}
+
+
+@app.get("/products")
+async def list_products() -> list[dict[str, Any]]:
+    return _rows(await app.state.pool.fetch("SELECT * FROM products ORDER BY sku"))
+
+
+@app.get("/products/{sku}")
+async def get_product(sku: str) -> dict[str, Any]:
+    return await _fetch_one("SELECT * FROM products WHERE sku = $1", sku)

--- a/tests/integration/test_helpdesk_workflow_end_to_end.py
+++ b/tests/integration/test_helpdesk_workflow_end_to_end.py
@@ -1,0 +1,254 @@
+"""End-to-end proof that the ``multi_service_helpdesk_workflow`` multi-container
+infrastructure and trace capture work.
+
+Drives the shipped ``examples/native/multi_service_helpdesk_workflow`` pack as a
+real subprocess. The stack is ``agent -> 5 FastAPI services (delivery-tracker,
+product-catalog, client-locations, crm, policy-search) -> postgres:16
+(app-db)``, with ``app-db`` declared ``isolation: ephemeral`` (which routes the
+whole run to the per-trial backend). This test validates the *infrastructure*,
+not agent task correctness:
+
+- the compose stack boots and the agent (in the runner container) reaches the
+  FastAPI services over the internal compose network — 2xx ``http_request`` s to
+  at least three distinct app hostnames, including ``policy-search:8000`` and
+  ``crm:8000`` (the cross-service internal-network path; three-of-five is the
+  infra bar, not agent thoroughness);
+- the agent's CRM mutation reached postgres through FastAPI — a 2xx ``POST`` to
+  ``http://crm:8000/cases`` (the agent -> crm -> postgres write path);
+- the ``db_probes`` grading primitive connects to ``app-db`` as the read-only
+  ``grader`` role via ``asyncpg`` and runs its SELECT without a driver/connection
+  error (the grade reasons carry a ``DB probes:`` segment and none of the asyncpg
+  connection/auth/query error signatures);
+- the run captures full traces (trajectory, grade, metrics) to disk.
+
+Deliberately *out of scope*: ``resolution_path == reschedule``, ``binary_pass``,
+``state_checks == 1.0``, and judge success. Those are agent-correctness and
+separate-bug concerns — the task is adversarial by design (the agent must reason
+across policy + site capabilities to pick the one valid path and may not), and
+the Sonnet-4-6 judge has a known OpenRouter 401 (tracked separately). This test
+must not couple the infrastructure signal to any of them.
+
+**Gated.** Requires a real Docker daemon (the per-trial runtime brings up the
+compose stack) and a real LLM provider key (the agent must emit real tool calls).
+``requires_api`` auto-skips without a key (see ``tests/conftest.py``); the
+``docker`` skip below covers a missing daemon.
+
+**Cost.** One trial of an 18-turn cross-service task on
+``anthropic/claude-haiku-4-5`` via OpenRouter. ~$0.30-1.00.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.requires_api,
+    pytest.mark.llm,
+    pytest.mark.slow,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK = "examples/native/multi_service_helpdesk_workflow"
+_RUN_CONFIG = f"{_PACK}/run_config.yaml"
+_TASK_ID = "helpdesk_01"
+
+# The five FastAPI app services the agent reaches over the internal compose
+# network. The infra bar is 2xx to >= 3 distinct ones, including these two.
+_APP_HOSTNAMES = (
+    "delivery-tracker:8000",
+    "product-catalog:8000",
+    "client-locations:8000",
+    "crm:8000",
+    "policy-search:8000",
+)
+_REQUIRED_HOSTNAMES = ("policy-search:8000", "crm:8000")
+_MIN_DISTINCT_HOSTNAMES = 3
+_CRM_CREATE_URL = "http://crm:8000/cases"
+
+# Substrings a failed asyncpg connect/auth/query surfaces. Their absence from the
+# db_probe reasons proves the grader-role DSN + asyncpg evaluator worked; the
+# probe reaching a PASS/FAIL verdict at all means it queried postgres.
+_DB_ERROR_SIGNATURES = (
+    "could not query postgres",
+    "connection refused",
+    "connectionrefusederror",
+    "authentication failed",
+    "password authentication",
+    "does not exist",
+    "could not connect",
+)
+
+
+def _output_basename() -> str:
+    """The configured ``output_dir`` basename the orchestrator suffixes with a
+    run timestamp (``<basename>_<YYYYmmdd_HHMMSS>``)."""
+    cfg = yaml.safe_load((_REPO_ROOT / _RUN_CONFIG).read_text())
+    return Path(cfg["evaluation"]["output_dir"]).name
+
+
+def _status_by_tool_call_id(messages: list[dict[str, Any]]) -> dict[str, int]:
+    """Map each ``tool_call_id`` to the HTTP status parsed from its tool-result
+    message content (``http_request`` output begins ``Status: <code>``). Lets a
+    2xx be tied back to the specific ``http_request`` that produced it."""
+    statuses: dict[str, int] = {}
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        tool_call_id = msg.get("tool_call_id")
+        if not tool_call_id:
+            continue
+        match = re.search(r"Status:\s*(\d{3})", str(msg.get("content") or ""))
+        if match:
+            statuses[tool_call_id] = int(match.group(1))
+    return statuses
+
+
+def _app_hostnames_with_2xx(trajectory: dict[str, Any]) -> set[str]:
+    """The set of app hostnames the agent hit with a 2xx ``http_request`` —
+    each ``http_request`` tool call correlated to its result status by
+    ``tool_call_id``. Proves the agent-in-container -> FastAPI network path per
+    distinct service."""
+    messages = trajectory.get("messages") or []
+    statuses = _status_by_tool_call_id(messages)
+    reached: set[str] = set()
+    for msg in messages:
+        for call in msg.get("tool_calls") or []:
+            if call.get("name") != "http_request":
+                continue
+            status = statuses.get(call.get("id"))
+            if status is None or not (200 <= status < 300):
+                continue
+            url = str((call.get("arguments") or {}).get("url", ""))
+            reached.update(host for host in _APP_HOSTNAMES if host in url)
+    return reached
+
+
+def _has_2xx_post_to(trajectory: dict[str, Any], url_fragment: str) -> bool:
+    """True iff the agent issued a ``POST`` ``http_request`` whose URL contains
+    *url_fragment* and whose result reported a 2xx status."""
+    messages = trajectory.get("messages") or []
+    statuses = _status_by_tool_call_id(messages)
+    for msg in messages:
+        for call in msg.get("tool_calls") or []:
+            if call.get("name") != "http_request":
+                continue
+            args = call.get("arguments") or {}
+            if str(args.get("method", "")).upper() != "POST":
+                continue
+            if url_fragment not in str(args.get("url", "")):
+                continue
+            status = statuses.get(call.get("id"))
+            if status is not None and 200 <= status < 300:
+                return True
+    return False
+
+
+def _assert_infrastructure(run_dir: Path) -> None:
+    """Assert the run's artifacts prove the multi-container infrastructure and
+    trace capture worked. Split out so the assertions can be dry-run against a
+    preserved run dir without spending an LLM run."""
+    trial_dir = run_dir / "trials" / _TASK_ID / "0"
+
+    grade_path = trial_dir / "grade.yaml"
+    trajectory_path = trial_dir / "trajectory.yaml"
+    metrics_path = trial_dir / "metrics.yaml"
+    for path in (grade_path, trajectory_path, metrics_path):
+        assert path.exists(), (
+            f"missing {path.name} at {path}.\n"
+            f"run dir contents: {sorted(p.name for p in run_dir.rglob('*'))[:50]}"
+        )
+
+    trajectory = yaml.safe_load(trajectory_path.read_text())
+    reached = _app_hostnames_with_2xx(trajectory)
+    assert len(reached) >= _MIN_DISTINCT_HOSTNAMES, (
+        f"agent reached fewer than {_MIN_DISTINCT_HOSTNAMES} distinct app hostnames "
+        f"with a 2xx http_request — the multi-service internal-network path did not "
+        f"work.\nreached: {sorted(reached)}\nmessages: {trajectory.get('messages')}"
+    )
+    missing = [host for host in _REQUIRED_HOSTNAMES if host not in reached]
+    assert not missing, (
+        f"agent did not reach {missing} with a 2xx http_request — the cross-service "
+        f"path to those services did not work.\nreached: {sorted(reached)}"
+    )
+
+    assert _has_2xx_post_to(trajectory, _CRM_CREATE_URL), (
+        f"no successful (2xx) POST to {_CRM_CREATE_URL} in the trajectory — the "
+        f"agent -> crm -> postgres write path did not work.\n"
+        f"messages: {trajectory.get('messages')}"
+    )
+
+    grade = yaml.safe_load(grade_path.read_text())
+    reasons = grade["reasons"]
+    assert "DB probes:" in reasons, (
+        "grade reasons carry no 'DB probes:' segment — the db_probes primitive "
+        f"did not run.\nreasons: {reasons}"
+    )
+    lowered = reasons.lower()
+    hit = next((sig for sig in _DB_ERROR_SIGNATURES if sig in lowered), None)
+    assert hit is None, (
+        f"db_probe hit a connection/driver error ({hit!r}) — the grader-role DSN "
+        f"or asyncpg evaluator failed.\nreasons: {reasons}"
+    )
+
+    metrics = yaml.safe_load(metrics_path.read_text())
+    calls_detail = (
+        f"metrics report no tool calls — the tool orchestration did not run.\nmetrics: {metrics}"
+    )
+    assert metrics["tool_calls"] > 0, calls_detail
+    cost_detail = f"metrics report zero cost — the agent LLM did not run.\nmetrics: {metrics}"
+    assert metrics["cost_usd"] > 0, cost_detail
+
+
+@pytest.mark.skipif(
+    not is_docker_daemon_available(),
+    reason="Docker daemon not available (per-trial runtime needs it)",
+)
+def test_helpdesk_workflow_infrastructure_end_to_end() -> None:
+    """The full ``tolokaforge run`` exits 0 and its captured traces prove the
+    multi-container stack, agent-in-container -> multi-FastAPI network path
+    (>= 3 distinct services incl. policy-search + crm), the CRM write path to
+    postgres, the db_probe grading primitive, and trace capture all worked."""
+    basename = _output_basename()
+    results_root = _REPO_ROOT / "results"
+    before = set(results_root.glob(f"{basename}_*")) if results_root.exists() else set()
+
+    proc = subprocess.run(
+        ["uv", "run", "tolokaforge", "run", "--config", _RUN_CONFIG],
+        cwd=str(_REPO_ROOT),
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"tolokaforge run failed (rc={proc.returncode}):\n"
+        f"stdout:\n{proc.stdout[-4000:]}\n"
+        f"stderr:\n{proc.stderr[-4000:]}"
+    )
+
+    after = set(results_root.glob(f"{basename}_*"))
+    created = after - before
+    assert len(created) == 1, (
+        f"expected exactly one new run dir under {results_root} matching "
+        f"{basename}_*; got {sorted(created)}"
+    )
+    run_dir = created.pop()
+
+    _assert_infrastructure(run_dir)
+
+    # Only reached once every assertion passed — a red run leaves the run dir
+    # (with all traces, incl. per-service Docker logs) on disk for post-mortem.
+    shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/unit/test_helpdesk_workflow_example_task.py
+++ b/tests/unit/test_helpdesk_workflow_example_task.py
@@ -1,0 +1,248 @@
+"""Static-shape + adversarial-seed tests for the ``helpdesk_01`` task pack.
+
+The task pack under ``examples/native/multi_service_helpdesk_workflow/`` is the
+flagship cross-service-reasoning workload: the agent reconciles four FastAPI
+business services plus an in-container postgres-FTS policy corpus over one
+postgres substrate, derives the one policy-valid resolution (``reschedule``),
+and grading checks that value directly against the substrate. Real docker
+execution lives in the integration suite; here we pin, without docker, the
+pack's static shape, the grading wiring, and — the load-bearing check — the
+seed invariant that makes the grader's ``reschedule`` assertion non-decorative.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.models import EnvironmentPatch, GradingConfig
+
+pytestmark = pytest.mark.unit
+
+
+_PACK_DIR = (
+    Path(__file__).parent.parent.parent / "examples" / "native" / "multi_service_helpdesk_workflow"
+)
+_SHARED = _PACK_DIR / "shared"
+_TASK_DIR = _PACK_DIR / "dataset" / "tasks" / "helpdesk_01"
+_COMPOSE = _SHARED / "environment.compose.yaml"
+_INIT_SQL = _SHARED / "app-db" / "init.sql"
+
+_APP_SERVICES = {
+    "delivery-tracker",
+    "product-catalog",
+    "client-locations",
+    "crm",
+    "policy-search",
+}
+_ALL_SERVICES = _APP_SERVICES | {"runner", "db-service", "app-db"}
+_APP_HOSTS = {f"{svc}:8000" for svc in _APP_SERVICES}
+_FLOATING_TAGS = {"latest", "edge", "stable", "main", "master"}
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(_COMPOSE.read_text())
+
+
+def _load_grading() -> GradingConfig:
+    return GradingConfig.model_validate(yaml.safe_load((_TASK_DIR / "grading.yaml").read_text()))
+
+
+class TestPackLayoutOnDisk:
+    def test_all_pack_files_exist(self) -> None:
+        expected = [
+            _PACK_DIR / "project.yaml",
+            _PACK_DIR / "run_config.yaml",
+            _PACK_DIR / "README.md",
+            _COMPOSE,
+            _INIT_SQL,
+            _TASK_DIR / "task.yaml",
+            _TASK_DIR / "grading.yaml",
+        ]
+        expected += [_SHARED / svc / "main.py" for svc in _APP_SERVICES]
+        missing = [str(p) for p in expected if not p.is_file()]
+        assert not missing, f"missing pack files: {missing}"
+
+
+class TestComposeShape:
+    def test_declares_exactly_eight_named_services(self) -> None:
+        compose = _load_compose()
+        assert set(compose["services"].keys()) == _ALL_SERVICES
+
+    def test_images_pinned(self) -> None:
+        compose = _load_compose()
+        expected_image = {
+            "runner": "tolokaforge-runner:local",
+            "db-service": "tolokaforge-db-service:local",
+            "app-db": "postgres:16",
+            **dict.fromkeys(_APP_SERVICES, "tolokaforge-runner:local"),
+        }
+        for svc, image in expected_image.items():
+            assert compose["services"][svc]["image"] == image
+            tag = image.split(":", 1)[1]
+            assert tag not in _FLOATING_TAGS
+
+    def test_app_services_bind_mount_own_main_read_only(self) -> None:
+        compose = _load_compose()
+        for svc in _APP_SERVICES:
+            mounts = compose["services"][svc]["volumes"]
+            has_ro_mount = any(
+                m.startswith(f"./{svc}/main.py:") and m.endswith(":ro") for m in mounts
+            )
+            assert has_ro_mount, f"{svc}: no read-only bind mount of its own main.py in {mounts!r}"
+
+    def test_app_services_depend_on_healthy_db(self) -> None:
+        compose = _load_compose()
+        for svc in _APP_SERVICES:
+            depends = compose["services"][svc]["depends_on"]
+            assert depends["app-db"]["condition"] == "service_healthy"
+
+    def test_runner_depends_on_all_apps_and_db_service(self) -> None:
+        compose = _load_compose()
+        depends = set(compose["services"]["runner"]["depends_on"].keys())
+        assert depends == _APP_SERVICES | {"db-service"}
+
+    def test_compose_under_line_budget(self) -> None:
+        line_count = len(_COMPOSE.read_text().splitlines())
+        assert line_count < 150, f"compose file is {line_count} lines (budget < 150)"
+
+
+class TestTaskManifest:
+    def test_loads_via_task_loader(self) -> None:
+        task_config, task_root = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert task_config.task_id == "helpdesk_01"
+        assert task_root == _TASK_DIR
+
+    def test_declares_environment_manifest(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        assert isinstance(task_config.environment_manifest, EnvironmentPatch)
+
+    def test_app_db_ephemeral_others_shared(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        services = task_config.environment_manifest.services
+        assert services is not None
+        assert services["app-db"].isolation == "ephemeral"
+        assert all(
+            spec.isolation == "shared" for name, spec in services.items() if name != "app-db"
+        )
+
+    def test_allowed_hosts_list_all_five_app_services(self) -> None:
+        task_config, _ = load_task_yaml(_TASK_DIR / "task.yaml")
+        allowed = set(task_config.tools.agent["http_request"]["allowed_hosts"])
+        assert allowed == _APP_HOSTS
+
+
+class TestInitSql:
+    def _sql(self) -> str:
+        return _INIT_SQL.read_text()
+
+    def test_creates_read_only_grader_role(self) -> None:
+        sql = self._sql()
+        assert "CREATE ROLE grader" in sql
+        assert "GRANT SELECT ON ALL TABLES IN SCHEMA public TO grader" in sql
+        for verb in ("GRANT INSERT", "GRANT UPDATE", "GRANT DELETE", "GRANT ALL"):
+            assert verb not in sql, f"grader role must be read-only; found {verb!r}"
+
+    def test_crm_cases_ships_empty(self) -> None:
+        sql = self._sql()
+        assert "CREATE TABLE crm_cases" in sql
+        assert "INSERT INTO crm_cases" not in sql
+
+
+def _parse_sites(sql: str) -> dict[str, dict[str, bool]]:
+    """Extract the ``sites`` INSERT rows into a
+    ``{customer_id: {has_temp_storage, has_specialist}}`` dict. Regex-based —
+    we pin the seed shape without asking postgres to run it."""
+    m = re.search(r"INSERT INTO sites\s*\([^)]+\)\s*VALUES\s*(.+?);", sql, re.DOTALL)
+    assert m is not None, "sites INSERT not found in init.sql"
+    row_re = re.compile(
+        r"\(\s*'([^']+)'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,"
+        r"\s*(TRUE|FALSE)\s*,\s*(TRUE|FALSE)\s*\)"
+    )
+    return {
+        cid: {"has_temp_storage": temp == "TRUE", "has_specialist": spec == "TRUE"}
+        for cid, temp, spec in row_re.findall(m.group(1))
+    }
+
+
+def _defensible_path(has_temp_storage: bool, has_specialist: bool) -> str:
+    """The resolution path the after-hours policy permits for a temperature-
+    sensitive shipment arriving after the staffed window, given a site's
+    capabilities: on-site cold storage → hold, else a certified specialist →
+    handoff, else the shipment must be rescheduled."""
+    if has_temp_storage:
+        return "temp_controlled_hold"
+    if has_specialist:
+        return "specialist_handoff"
+    return "reschedule"
+
+
+class TestAdversarialSeedInvariant:
+    """The load-bearing check (mirrors
+    ``test_multi_service_postgres_example_task.py::test_filters_actually_matter``):
+    the seed must be arranged so both alternative paths are excluded *only* by
+    the data, making the grader's ``reschedule`` assertion non-decorative."""
+
+    def _grading_target(self) -> str:
+        grading = _load_grading()
+        crm_probe = next(
+            p for p in grading.state_checks.db_probes if p["name"] == "crm_case_policy_correct"
+        )
+        expect = next(e for e in crm_probe["expect"] if e["path"] == "$.rows[0].resolution_path")
+        return expect["equals"]
+
+    def test_northwind_capabilities_force_reschedule(self) -> None:
+        sites = _parse_sites(_INIT_SQL.read_text())
+        northwind = sites["NORTHWIND"]
+        assert northwind["has_temp_storage"] is False
+        assert northwind["has_specialist"] is False
+        assert self._grading_target() == "reschedule"
+        assert _defensible_path(False, False) == "reschedule"
+
+    def test_either_capability_would_change_the_path(self) -> None:
+        assert _defensible_path(True, False) != "reschedule"
+        assert _defensible_path(False, True) != "reschedule"
+
+
+class TestGradingWiring:
+    def test_parses_to_grading_config(self) -> None:
+        grading = _load_grading()
+        assert grading.state_checks is not None
+        assert grading.transcript_rules is not None
+        assert grading.llm_judge is not None
+
+    def test_db_probes_present_with_exact_shape(self) -> None:
+        grading = _load_grading()
+        probes = {p["name"]: p for p in grading.state_checks.db_probes}
+        assert set(probes) == {"crm_case_policy_correct", "delivery_annotated"}
+        for probe in probes.values():
+            assert probe["dsn"] == "postgresql://grader:grader_pw@app-db:5432/helpdesk"
+        deliv_expect = probes["delivery_annotated"]["expect"][0]
+        assert deliv_expect["path"] == "$.rows[0].resolution_path"
+        assert deliv_expect["equals"] == "reschedule"
+
+    def test_required_actions_present_with_exact_urls(self) -> None:
+        grading = _load_grading()
+        actions = {a.action_id: a for a in grading.transcript_rules.required_actions}
+        assert set(actions) == {"search_policy", "create_case", "annotate_deliv"}
+        expected = {
+            "search_policy": ("http://policy-search:8000/search", "POST"),
+            "create_case": ("http://crm:8000/cases", "POST"),
+            "annotate_deliv": ("http://delivery-tracker:8000/deliveries/4021", "PATCH"),
+        }
+        for action_id, (url, method) in expected.items():
+            action = actions[action_id]
+            assert action.arguments["url"] == url
+            assert action.arguments["method"] == method
+            assert set(action.compare_args) == {"url", "method"}
+
+    def test_weights_sum_and_threshold(self) -> None:
+        grading = _load_grading()
+        weights = grading.combine.weights
+        assert weights == {"state_checks": 0.6, "transcript_rules": 0.15, "llm_judge": 0.25}
+        assert abs(sum(weights.values()) - 1.0) < 1e-9
+        assert grading.combine.pass_threshold == 0.6


### PR DESCRIPTION
Closes #401.

## Summary

- **Flagship multi-container example** — `examples/native/multi_service_helpdesk_workflow/` — five FastAPI services (delivery-tracker, product-catalog, client-locations, crm, policy-search with in-container postgres FTS) over one postgres substrate. The agent must reconcile customer + product + site + policy data to pick one of three plausible resolution paths (`reschedule` / `temp_controlled_hold` / `specialist_handoff`); site capabilities + policy narrow to `reschedule`, so a wrong path grades down even with a well-formed CRM row.
- **First pack with an explicit `ephemeral` substrate declaration** — `app-db` is `ephemeral`, other services `shared`. Routes the whole run to the per-trial backend so each trial gets a clean postgres.
- **First documented LLM user-simulator persona pattern** — "Ana Reyes, operations coordinator" with backstory + reveal-on-ask rules + `###STOP###` exit. `docs/TASKS.md` § User Simulator now formalises the pattern as "Specialised personas".
- **Grading is a three-way weighted combine** (state_checks 0.6 / transcript_rules 0.15 / llm_judge 0.25, threshold 0.6) engineered so the wrong path fails even if the judge drops out — `state_checks` alone gates `resolution_path == "reschedule"` via db_probes.

## Design walkthrough

```
agent (runner) ──http_request──> 5 FastAPI services (bind-mounted main.py per service)
                                        │
                                        ▼
                                  app-db (postgres:16, ephemeral per trial)
                                        ▲
                                        │  read-only grader-role SELECT
                                        │
                        state_checks.db_probes (independent oracle)
```

- All apps run on `tolokaforge-runner:local` with a `command:` uvicorn override — no custom Docker image build required (the runner image bundles fastapi + uvicorn + asyncpg).
- `policy-search` uses postgres `tsvector` + GIN index on a small policy corpus (10 paragraphs, including decoys). `POST /search` (query in body) so the required-action URL is exact-matchable by `transcript_rules.required_actions`.
- Grader connects as `GRANT SELECT`-only role; the db_probe cannot mutate the substrate.

## Test tiers

- **Unit** (`tests/unit/test_helpdesk_workflow_example_task.py`, 19 cases) — static shape (8 services, images pinned, `app-db: ephemeral` + others `shared`, `http_request.allowed_hosts` lists all five app services, `init.sql` creates the `grader` role and ships `crm_cases` empty, compose < 150 lines) + adversarial-seed invariant (NORTHWIND `has_temp_storage=false, has_specialist=false` → `reschedule`; flipping either capability yields a different defensible path — the grader's assertion is non-decorative) + grading wiring (`db_probes` DSN and JSONPath expects, three `required_actions` fixed URLs, weights sum + threshold).
- **Integration** (`tests/integration/test_helpdesk_workflow_end_to_end.py`) — real Docker + one Haiku run; correlates `tool_call_id` to each `http_request` result's `Status: <code>`. Asserts ≥3 distinct app hostnames reached with 2xx (must include `policy-search:8000` + `crm:8000`), a 2xx POST to `http://crm:8000/cases`, `grade.reasons` contains `DB probes:` with no asyncpg error signatures, non-zero `tool_calls` + `cost_usd`. Does **not** assert `binary_pass`, `state_checks == 1.0`, `resolution_path == reschedule`, or judge success — those are agent-correctness and separate-bug concerns.

Live run outcome: **passed** (2:17, ~$0.14 Haiku).

## Docs

- `docs/TASKS.md` § User Simulator — new "Specialised personas" subsection formalising the pattern.
- `docs/multi_container_tasks.md` — "Choosing isolation" note about explicit `ephemeral` + Further Reading entry.
- `docs/GRADING.md` § Substrate Grading — one sentence noting `db_probes` can encode policy correctness (assert the value a policy selects, not just existence).
- Pack `README.md` — scenario, topology, three-path adversarial table, isolation story, persona pattern, run + validate commands.
- `CHANGELOG.md` Unreleased → Feat entry.

## Follow-ups filed during this PR

- **#438** — `transcript_rules.required_actions` supports only presence + exact-arg-equality (no ordering, substring, regex). Drove the `POST /search` fixed-URL design.
- **#444** — `http_request` tool discards HTTP error body on non-2xx; agents can't self-correct from 4xx. Surfaced by the pre-tuning e2e run where Haiku POSTed a malformed body twice and saw no 422 detail. Worked around here by sharpening `policies.guidance` to name the CRM body shape exactly; the underlying fix is harness-side.

Non-blocking pre-existing item (worth noting, not filed):
- `EnvironmentPatch` flat `compose_file`/`runner_service` deprecation warning fires on load; all three `multi_service_*` packs share the flat form. Candidate for a repo-wide migration to the nested `stack:` form in a future issue.

## Reviewer verdict

**APPROVE WITH NITS** — infrastructure, grading discrimination, and adversarial invariant all correct and well-tested. Two nits landed as `586c9a7`: persona component-count typo fixed, `NewCase` `extra="forbid"` omission guarded with a refactor-warning comment.

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all PRs in this repo (#425). Not caused by this change.

## Test plan (post-merge)

- [ ] Canonical + unit tiers stay green on the M18 integration branch.
- [ ] The pack becomes the working example the docs `docs/TASKS.md § Specialised personas` cross-link points at.
