### PR TITLE
docs: multi-container examples walkthrough for colleague onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project are documented in this file.
 - **grading**: a project's `task_defaults.grading_defaults.combine` now deep-merges under each task's own `grading.yaml.combine` (task fields win, `weights` merge key-by-key); a task that omits `combine` inherits the project block instead of an arbitrary `{state_checks: 1.0}` / `pass_threshold: 1.0` fallback, and `get_grading_config` no longer raises on tasks that ship no `combine` block (#376)
 - **runtime**: `SharedStackRuntimeBackend` no longer advertises `reset_recipes:*` capabilities — a shared stack cannot honour them (reset tasks route to `PerTrialRuntimeBackend`, which still advertises them). A shared-selected run that requested a `reset_recipes:*` capability was admitting a capability it could not deliver; it is now refused at run start with the standard admission error (#310)
 
+### Docs
+
+- **multi-container**: guided "Running the examples" walkthrough in `docs/multi_container_tasks.md` — pack catalog, the end-to-end run command + cost expectations per pack, and how to read the trial output (`grade.yaml` incl. the `DB probes:` reason, `env.yaml` environment identity, per-service logs); fixes the broken `guides/multi_container_tasks.md` cross-links across the docs tree
+
 ## v0.8.4 (2026-07-15)
 
 ### Feat

--- a/docs/BENCHMARK_BACKEND_DESIGNS.md
+++ b/docs/BENCHMARK_BACKEND_DESIGNS.md
@@ -5,7 +5,7 @@ This document captures backend/runtime design sketches per benchmark type.
 When a benchmark needs services beyond the engine's built-ins (a real
 database, a custom API, a bespoke topology) — the Case B/C path — a task
 can declare its own docker-compose stack via an `environment_manifest`.
-See the [multi-container tasks guide](guides/multi_container_tasks.md).
+See the [multi-container tasks guide](multi_container_tasks.md).
 
 ## Coding
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -57,7 +57,7 @@ so the first run isn't slowed down by a cold docker build.
 
 For tasks that need extra services beyond the built-ins (a real
 database, a custom HTTP API), a task can ship its own docker-compose
-stack — see the [multi-container tasks guide](guides/multi_container_tasks.md).
+stack — see the [multi-container tasks guide](multi_container_tasks.md).
 
 ## Set Up Tasks
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -445,4 +445,4 @@ tools:
 - [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) - Adapter architecture for task loading
 - [CUSTOM_CHECKS.md](CUSTOM_CHECKS.md) - Custom Python validation
 - [SECURITY.md](SECURITY.md) - Security model
-- [Multi-container tasks guide](guides/multi_container_tasks.md) - Declaring an `environment_manifest` so a task ships its own docker-compose stack
+- [Multi-container tasks guide](multi_container_tasks.md) - Declaring an `environment_manifest` so a task ships its own docker-compose stack

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -114,7 +114,7 @@ Field reference:
 | --- | --- | --- | --- |
 | `compose_file` | yes | — | Path to the docker-compose YAML. Relative paths resolve against `task.yaml`. This file is the sole source of truth for services, images, ports, volumes, healthchecks, and `depends_on`. |
 | `runner_service` | no | `"default"` | Which compose service is the tolokaforge runner. Must be a service declared in the compose file. |
-| `services.<name>.isolation` | no | `"ephemeral"` | Per-service posture: `"shared"` (long-lived across trials), `"reset"` (fresh container per trial + `reset.seed` recipe reapplied at each provision), `"ephemeral"` (fresh container per trial, no seed). Backend selection is task-driven — any `reset`/`ephemeral` service routes the run to `PerTrialRuntimeBackend` automatically. See the [multi-container guide](guides/multi_container_tasks.md#choosing-isolation) for how to pick. |
+| `services.<name>.isolation` | no | `"ephemeral"` | Per-service posture: `"shared"` (long-lived across trials), `"reset"` (fresh container per trial + `reset.seed` recipe reapplied at each provision), `"ephemeral"` (fresh container per trial, no seed). Backend selection is task-driven — any `reset`/`ephemeral` service routes the run to `PerTrialRuntimeBackend` automatically. See the [multi-container guide](multi_container_tasks.md#choosing-isolation) for how to pick. |
 | `services.<name>.reset.seed` | when `isolation: reset` | — | Name of the seed to apply on each provision. Must exist in the project's `assets.seeds` registry. See [`docs/architecture/RESET_RECIPES.md`](architecture/RESET_RECIPES.md) for the four seed kinds (`sql_dump` / `filesystem_dir` / `redis_dump` / `bare`). |
 | `network_policy` | no | `"no_internet"` | Public-egress posture for the task's application services. `no_internet` (default) attaches every task service to an `internal` docker network so no service can reach the public internet; `full_internet` runs the compose file unchanged. `limited_internet` is refused at materialisation (needs an egress-allowlist proxy — #323). See below. |
 
@@ -157,7 +157,7 @@ load:
 - `runner_service` must be declared in the compose file.
 
 For a full walkthrough anchored to a working example, see the
-[multi-container tasks guide](guides/multi_container_tasks.md). For the
+[multi-container tasks guide](multi_container_tasks.md). For the
 underlying case matrix (built-in vs task-declared × shared vs per-trial)
 see [ADR-0018](architecture/adr/0018-multi-container-under-shared-runtime.md).
 

--- a/docs/TASK_PACKS.md
+++ b/docs/TASK_PACKS.md
@@ -74,7 +74,7 @@ Minimum task directory contract:
 A task can also declare an `environment_manifest` to ship its own
 docker-compose stack (a real database, a custom API), with per-service
 isolation (`services.<name>.isolation: shared | reset | ephemeral`). See
-the [multi-container tasks guide](guides/multi_container_tasks.md).
+the [multi-container tasks guide](multi_container_tasks.md).
 
 Recommended scorer patterns:
 

--- a/docs/multi_container_tasks.md
+++ b/docs/multi_container_tasks.md
@@ -13,6 +13,117 @@ For the full Project model, see
 runtime backend lifecycle, see
 [`docs/architecture/RUNTIME_BACKENDS.md`](architecture/RUNTIME_BACKENDS.md).
 
+## Running the examples
+
+If you want to see the machinery work before authoring your own stack, the
+repo ships four multi-container packs that run end-to-end with one command
+each. They form a ladder — start at the top for the simplest shape, drop to
+the bottom for the flagship.
+
+| Pack | What makes it different |
+| --- | --- |
+| [`multi_service_postgres`](../examples/native/multi_service_postgres/README.md) | The primer. A single postgres behind a PostgREST API — the simplest real three-tier stack, no application code to author (PostgREST generates the REST endpoints from the schema). |
+| [`multi_service_postgres_reset`](../examples/native/multi_service_postgres_reset/README.md) | Adds the reset-recipe pattern: a `reset` postgres service re-seeded from a named `sql_dump` seed at the start of every trial. |
+| [`multi_service_lot_ops`](../examples/native/multi_service_lot_ops/README.md) | The first pack to grade the substrate. The agent mutates postgres over a FastAPI API; `state_checks.db_probes` verifies the row directly through a read-only `grader` role — an independent oracle, not the API the agent wrote through. |
+| [`multi_service_helpdesk_workflow`](../examples/native/multi_service_helpdesk_workflow/README.md) | The flagship. Five FastAPI services + an in-container postgres-FTS policy corpus. The agent must reconcile customer, product, site, and policy data to pick the one policy-valid resolution of three plausible paths; a wrong path grades down even with a well-formed CRM row. Declares its postgres substrate `ephemeral` explicitly and formalises the LLM user-simulator persona pattern. |
+
+### The command
+
+Every pack runs the same way — point `tolokaforge run` at its `run_config.yaml`:
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres/run_config.yaml
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_postgres_reset/run_config.yaml
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_lot_ops/run_config.yaml
+scripts/with_env.sh uv run tolokaforge run --config examples/native/multi_service_helpdesk_workflow/run_config.yaml
+```
+
+`scripts/with_env.sh` loads `.env` (so `OPENROUTER_API_KEY` reaches the run)
+before invoking the CLI. Prerequisites for every pack:
+
+- A running Docker daemon — `docker version` must return cleanly.
+- `OPENROUTER_API_KEY` in `.env`; every pack drives real models.
+
+Each run writes to the `output_dir` named in its `run_config.yaml` (under
+`results/`). To validate a pack's tasks without running them, use
+`uv run tolokaforge validate --tasks "<pack>/dataset/**/task.yaml"`.
+
+**Cost expectations** (a single trial each, honest ballpark — check each
+pack's `run_config.yaml` for the exact models):
+
+| Pack | Models | Rough cost |
+| --- | --- | --- |
+| `multi_service_postgres` | Sonnet agent + user, 15 turns | ~$1–3 |
+| `multi_service_postgres_reset` | Haiku agent + user, `repeats: 2` | ~$0.15–0.40 |
+| `multi_service_lot_ops` | Haiku agent + user, Sonnet judge | ~$0.30–1.00 |
+| `multi_service_helpdesk_workflow` | Haiku agent + user, Sonnet judge, 18 turns | ~$0.50–1.50 |
+
+### What to look at in the output
+
+Every trial lands under `<run_dir>/trials/<task_id>/<trial_index>/`. The
+files worth opening after a run:
+
+- **`grade.yaml`** — the verdict: `binary_pass`, `score`, the per-family
+  `components` breakdown, and a `reasons` string. For a pack that uses
+  `db_probes`, `reasons` carries a `DB probes: …` segment (`DB probes: all
+  probes passed`, or the failing assertion). When an LLM judge ran,
+  `criterion_results` gives the per-criterion rubric breakdown.
+- **`env.yaml`** — for a manifest-driven trial this carries an
+  `environment:` block recording the resolved substrate: `network_policy`,
+  `runner_service`, and a per-service `services:` map with each service's
+  resolved image (and whether it's `pinned`), `isolation`, `reset_seed`,
+  `dsns` (passwords redacted to `***`), and container-side `mounts` (host
+  source paths omitted). It is a pure function of the resolved manifest, so
+  it survives per-trial teardown and tells a post-mortem exactly which
+  image / DSN / mounts a trial ran against without leaking secrets.
+- **`services/<name>.log`** — raw `docker compose logs` for each service,
+  written on the per-trial backend when a trial is diagnostics-worthy: it
+  fails to provision, its body errors/times out, **or** it runs to
+  completion but grades red. One file per service that produced output; the
+  tail bound is `compute.log_tail` (default 500 lines). A passing trial does
+  not trigger capture. This makes post-mortem on a red integration run
+  trivial — the service that misbehaved is right there.
+- **`trajectory.yaml`** and **`metrics.yaml`** — the message transcript and
+  the per-trial usage / cost / tool-call telemetry. Both are documented in
+  [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md); `metrics.yaml` also amends a
+  `captured_service_logs` byte-count map when service logs are captured.
+
+### How the pieces fit
+
+A multi-container run composes five layers:
+
+1. **The task pack declares an `environment_manifest`** — a compose file
+   plus a per-service isolation map (`shared` / `reset` / `ephemeral`).
+   This is the sole source of truth for the topology.
+2. **The runtime backend materialises the stack.** Isolation drives the
+   choice automatically: any `reset`/`ephemeral` service routes the run to
+   the per-trial backend (fresh stack per trial, reset recipes applied);
+   an all-`shared` manifest uses the shared-stack backend (materialised
+   once). No flag selects this — the tasks do.
+3. **The agent runs inside the runner container** and reaches the other
+   services over the internal compose network by service name (e.g.
+   `http://policy-search:8000`). `network_policy` governs public egress.
+4. **Grading blends independent signals** — `state_checks.db_probes`
+   (an independent postgres oracle via a read-only role) with
+   `transcript_rules.required_actions` (did the agent take the right tool
+   actions) and an `llm_judge` rubric, combined by weight.
+5. **Traces land in the trial dir** — `grade.yaml`, `trajectory.yaml`,
+   `metrics.yaml`, `env.yaml`, and (on failure) per-service logs — the full
+   post-mortem surface for one trial.
+
+### Where to go next
+
+- [`docs/architecture/PROJECTS.md`](architecture/PROJECTS.md) — the Project
+  schema: `assets`, `default_environment`, per-service isolation, merge chains.
+- [`docs/GRADING.md`](GRADING.md) § Substrate Grading — the full
+  `state_checks.db_probes` field reference and aggregation rules.
+- [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md) — every trial artifact in detail.
+- [`docs/TASKS.md`](TASKS.md) § User Simulator — the specialised-persona
+  pattern the helpdesk pack uses for its LLM user simulator.
+
+The rest of this guide is the authoring reference: how to declare a stack,
+choose isolation, write reset recipes, and grade against substrate state.
+
 ## When to declare a multi-container task
 
 The engine already ships built-in stacks — `core_stack` (runner +


### PR DESCRIPTION
## Summary

Extends `docs/multi_container_tasks.md` with a "Running the examples" section (~917 words, 5-7 min read) covering the four multi-container packs the milestone has shipped:

- `multi_service_postgres` — primer (postgres + PostgREST).
- `multi_service_postgres_reset` — adds the `sql_dump` reset recipe pattern.
- `multi_service_lot_ops` — first pack to use `state_checks.db_probes` (substrate grading via a read-only grader role).
- `multi_service_helpdesk_workflow` — flagship (5-service reasoning, in-container FTS policy search, adversarial three-path grading, explicit ephemeral substrate, LLM user-simulator persona).

The new section covers:

1. **Pack catalog** — one-line differentiator per pack + link to each `README.md`.
2. **Run commands** — canonical `scripts/with_env.sh uv run tolokaforge run --config <pack>/run_config.yaml` invocation, prerequisites (Docker + `OPENROUTER_API_KEY`), per-pack cost expectations (Haiku ~$0.15-1.00, Sonnet ~$1-3).
3. **Trial-dir tour** — how to read `grade.yaml` (calling out the `DB probes:` reason segment), `env.yaml` (the `environment:` block from #419), `services/<name>.log` (the grade-fail capture from #418), `trajectory.yaml`, `metrics.yaml`.
4. **How the pieces fit** — a 5-layer paragraph explaining task-pack → runtime backend → agent → grading → traces.
5. **Where to go next** — cross-links to `PROJECTS.md`, `GRADING.md`, `OUTPUT_FORMAT.md`, `TASKS.md`.

## Also fixed in the same commit

Five broken `guides/multi_container_tasks.md` cross-links (the guide lives at `docs/multi_container_tasks.md`; there is no `guides/` directory) — across `docs/TASKS.md`, `docs/GETTING_STARTED.md`, `docs/REFERENCE.md`, `docs/BENCHMARK_BACKEND_DESIGNS.md`, `docs/TASK_PACKS.md`. Zero remaining `guides/multi_container_tasks.md` references repo-wide.

## Test plan

- [ ] Read the section end-to-end; every command copy-pastes and runs.
- [ ] Every pack referenced actually exists on the integration branch.
- [ ] All cross-links resolve.

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425). Not caused by this change.
