### PR TITLE
refactor(session): extract OpenAgentLoopManager from Orchestrator

### DIFF
--- a/tests/unit/session/test_manager.py
+++ b/tests/unit/session/test_manager.py
@@ -1,0 +1,218 @@
+"""Unit tests for :class:`OpenAgentLoopManager` — the run-scoped OAL coordinator.
+
+Split off from the earlier ``test_orchestrator_open_mode.py`` +
+``test_orchestrator_trace_write.py`` — those retained tests focus on
+orchestrator-level delegation; the concern-specific tests live here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.core.models import OpenAgentLoopConfig, RunConfig
+from tolokaforge.session import (
+    AssistantMessage,
+    InProcessTrialSession,
+    OpenAgentLoopManager,
+    SessionInterventionHandler,
+    SessionLoopObserver,
+    SessionRegistry,
+    TerminalReached,
+    TurnStarted,
+)
+from tolokaforge.session._status import TrialStatus
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _minimal_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> RunConfig:
+    return RunConfig.model_validate(
+        {
+            "models": {
+                "agent": {"name": "claude-opus-4-7", "provider": "anthropic"},
+                "user": {"name": "claude-opus-4-7", "provider": "anthropic"},
+            },
+            "orchestrator": {},
+            "evaluation": {
+                "task_packs": ["fixtures/dummy"],
+                "output_dir": "/tmp/does-not-matter",
+            },
+            **(
+                {"open_agent_loop": open_agent_loop.model_dump()}
+                if open_agent_loop is not None
+                else {}
+            ),
+        }
+    )
+
+
+class TestFromConfig:
+    def test_no_config_block_returns_none(self):
+        assert OpenAgentLoopManager.from_config(_minimal_config()) is None
+
+    def test_explicit_disabled_returns_none(self):
+        cfg = _minimal_config(OpenAgentLoopConfig(enabled=False))
+        assert OpenAgentLoopManager.from_config(cfg) is None
+
+    def test_enabled_returns_manager(self):
+        cfg = _minimal_config(OpenAgentLoopConfig(enabled=True))
+        manager = OpenAgentLoopManager.from_config(cfg)
+        assert isinstance(manager, OpenAgentLoopManager)
+        assert isinstance(manager.sessions, SessionRegistry)
+        assert len(manager.sessions) == 0
+
+
+class TestObserverProvider:
+    def test_provider_creates_session_and_returns_observer(self):
+        manager = OpenAgentLoopManager()
+        provider = manager.observer_provider()
+
+        obs = provider("MAN-34:0")
+        assert isinstance(obs, SessionLoopObserver)
+        assert "MAN-34:0" in manager.sessions
+        session = manager.sessions.get("MAN-34:0")
+        assert isinstance(session, InProcessTrialSession)
+        assert session.trial_id == "MAN-34:0"
+
+    def test_provider_reuses_same_session_across_calls_for_same_trial(self):
+        manager = OpenAgentLoopManager()
+        provider = manager.observer_provider()
+        provider("t:0")
+        provider("t:0")
+        assert len(manager.sessions) == 1
+
+    def test_provider_returns_distinct_sessions_per_trial(self):
+        manager = OpenAgentLoopManager()
+        provider = manager.observer_provider()
+        provider("A:0")
+        provider("B:0")
+        assert manager.sessions.get("A:0") is not manager.sessions.get("B:0")
+
+
+class TestInterventionHandlerProvider:
+    def test_provider_returns_handler_bound_to_same_session_as_observer(self):
+        """Observer and handler for the same trial_id must bind to the same
+        session so events + interventions round-trip through one bus.
+        """
+        manager = OpenAgentLoopManager()
+        obs_provider = manager.observer_provider()
+        int_provider = manager.intervention_handler_provider()
+
+        obs = obs_provider("t:0")
+        handler = int_provider("t:0")
+        assert isinstance(handler, SessionInterventionHandler)
+        # Both bind to manager.sessions.get("t:0") — same InProcessTrialSession
+        assert manager.sessions.get("t:0") is not None
+        assert obs is not None
+
+
+class TestWriteTrace:
+    def _seed(self, manager: OpenAgentLoopManager, trial_id: str) -> None:
+        provider = manager.observer_provider()
+        provider(trial_id)
+        session = manager.sessions.get(trial_id)
+        assert session is not None
+        session.publish(
+            TurnStarted(trial_id=trial_id, seq=session.next_seq(), timestamp=_NOW, turn_index=0)
+        )
+        session.publish(
+            AssistantMessage(
+                trial_id=trial_id,
+                seq=session.next_seq(),
+                timestamp=_NOW,
+                content_preview="hi",
+            )
+        )
+        session.publish(
+            TerminalReached(
+                trial_id=trial_id,
+                seq=session.next_seq(),
+                timestamp=_NOW,
+                status=TrialStatus.COMPLETED,
+            )
+        )
+
+    def test_no_session_yet_is_noop(self, tmp_path: Path):
+        manager = OpenAgentLoopManager()
+        manager.write_trace(tmp_path, "never-ran", 0)
+        assert not (tmp_path / "trials").exists()
+
+    def test_writes_yaml_at_expected_path(self, tmp_path: Path):
+        manager = OpenAgentLoopManager()
+        self._seed(manager, "MAN-34:0")
+
+        manager.write_trace(tmp_path, "MAN-34", 0)
+
+        trace_path = tmp_path / "trials" / "MAN-34" / "0" / "open_agent_loop.yaml"
+        assert trace_path.exists()
+        content = yaml.safe_load(trace_path.read_text())
+        assert content["trial_id"] == "MAN-34:0"
+        assert [e["kind"] for e in content["events"]] == [
+            "turn_started",
+            "assistant_message",
+            "terminal_reached",
+        ]
+
+    def test_overwrites_on_retry(self, tmp_path: Path):
+        manager = OpenAgentLoopManager()
+        provider = manager.observer_provider()
+        provider("t:0")
+        session = manager.sessions.get("t:0")
+        session.publish(
+            TurnStarted(trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, turn_index=0)
+        )
+        manager.write_trace(tmp_path, "t", 0)
+        first = yaml.safe_load(
+            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
+        )
+        assert len(first["events"]) == 1
+
+        session.publish(
+            AssistantMessage(
+                trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, content_preview="more"
+            )
+        )
+        manager.write_trace(tmp_path, "t", 0)
+        second = yaml.safe_load(
+            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
+        )
+        assert len(second["events"]) == 2
+
+    def test_write_failure_raises_for_orchestrator_to_catch(self, tmp_path: Path):
+        """Manager's write raises on failure; orchestrator catches and logs.
+        Contract: manager is honest about failures; caller policy decides
+        whether to swallow.
+        """
+        manager = OpenAgentLoopManager()
+        self._seed(manager, "t:0")
+
+        # Point at a path where mkdir will fail (an existing FILE at
+        # tmp_path/trials)
+        blocker = tmp_path / "trials"
+        blocker.write_text("blocking-file")
+
+        with pytest.raises(OSError):  # NotADirectoryError on POSIX subclasses OSError
+            manager.write_trace(tmp_path, "t", 0)
+
+
+class TestSnapshotAll:
+    def test_snapshot_all_returns_dict_keyed_by_trial_id(self):
+        manager = OpenAgentLoopManager()
+        provider = manager.observer_provider()
+        provider("a:0")
+        provider("b:0")
+
+        snapshots = manager.snapshot_all()
+        assert set(snapshots.keys()) == {"a:0", "b:0"}
+        assert snapshots["a:0"]["trial_id"] == "a:0"
+        assert snapshots["b:0"]["trial_id"] == "b:0"
+
+    def test_snapshot_all_empty_for_fresh_manager(self):
+        manager = OpenAgentLoopManager()
+        assert manager.snapshot_all() == {}

--- a/tests/unit/test_orchestrator_open_mode.py
+++ b/tests/unit/test_orchestrator_open_mode.py
@@ -1,15 +1,17 @@
-"""Wiring tests for orchestrator open-mode plumbing — M1 sub-4a.
+"""Wiring tests for Orchestrator ↔ OpenAgentLoopManager delegation.
 
-Covers the :class:`OpenAgentLoopConfig` flag and the observer-provider
-threading in :meth:`Orchestrator._build_observer_provider`. Full
-end-to-end flow (session persists to trajectory trace) lands in sub-4b.
+Focused on the orchestrator's contract with the manager. Manager-internal
+behaviour (observer_provider / intervention_handler_provider / write_trace
+semantics) lives in ``tests/unit/session/test_manager.py``.
 
-* Sealed default (``open_agent_loop`` absent or ``enabled=False``) →
-  registry is ``None``, observer-provider is ``None``.
-* Enabled → registry is a :class:`SessionRegistry`, observer-provider
-  returns a fresh :class:`SessionLoopObserver` bound to the trial's session,
-  and asking twice for the same ``trial_id`` yields the same underlying
-  session.
+* Sealed default (no config block) → ``orchestrator.sessions`` is ``None``.
+* Explicit disabled → also ``None``.
+* Enabled → orchestrator has an auto-constructed manager; sessions
+  registry is exposed via ``orchestrator.sessions``.
+* Explicit ``OrchestratorDeps.oal_manager`` overrides the auto-construct
+  path (caller-provided manager wins over config-implied one).
+* ``ConductorContext`` receives the manager's providers via
+  ``_build_conductor``.
 """
 
 from __future__ import annotations
@@ -18,20 +20,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
 from tolokaforge.core.models import OpenAgentLoopConfig, RunConfig
-from tolokaforge.core.orchestrator import Orchestrator
-from tolokaforge.session import InProcessTrialSession, SessionLoopObserver
+from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+from tolokaforge.session import OpenAgentLoopManager
 
 pytestmark = pytest.mark.unit
 
 
 def _minimal_run_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> RunConfig:
-    """Build the smallest valid :class:`RunConfig` for these plumbing tests.
-
-    The orchestrator's __init__ reads a few fields directly (models,
-    orchestrator, evaluation, plus the new ``open_agent_loop``). Everything
-    else is exercised at ``run()`` time which these tests don't invoke.
-    """
     return RunConfig.model_validate(
         {
             "models": {
@@ -53,93 +50,50 @@ def _minimal_run_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> R
 
 
 class TestSealedDefault:
-    def test_no_open_agent_loop_config_means_sealed(self):
-        config = _minimal_run_config()
-        assert config.open_agent_loop is None
-
-    def test_orchestrator_sessions_property_is_none_in_sealed_mode(self):
-        config = _minimal_run_config()
-        orch = Orchestrator(config=config)
+    def test_no_config_block_sessions_is_none(self):
+        orch = Orchestrator(config=_minimal_run_config())
         assert orch.sessions is None
-        assert orch._build_observer_provider() is None
+        assert orch._oal_manager is None
 
-    def test_explicit_disabled_also_yields_no_registry(self):
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=False))
-        orch = Orchestrator(config=config)
+    def test_explicit_disabled_sessions_is_none(self):
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=False)))
         assert orch.sessions is None
-        assert orch._build_observer_provider() is None
+        assert orch._oal_manager is None
 
 
-class TestOpenModeEnabled:
-    def test_registry_is_created_when_enabled(self):
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
-        orch = Orchestrator(config=config)
+class TestOpenModeAutoConstructsManagerFromConfig:
+    def test_enabled_config_yields_manager(self):
+        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
+        assert orch._oal_manager is not None
         assert orch.sessions is not None
-        assert len(orch.sessions) == 0
+        # Manager auto-constructed from config; ergonomics preserved.
+        assert isinstance(orch._oal_manager, OpenAgentLoopManager)
 
-    def test_provider_creates_session_and_returns_observer(self):
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
-        orch = Orchestrator(config=config)
-        provider = orch._build_observer_provider()
-        assert provider is not None
 
-        obs = provider("MAN-34:0")
-        assert isinstance(obs, SessionLoopObserver)
+class TestExplicitDepsManagerOverridesConfig:
+    def test_deps_manager_wins_over_config_implied_one(self):
+        supplied = OpenAgentLoopManager()
+        deps = OrchestratorDeps(oal_manager=supplied)
+        # Even with config enabled, the supplied manager wins
+        orch = Orchestrator(
+            config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)),
+            deps=deps,
+        )
+        assert orch._oal_manager is supplied
 
-        # The session for this trial should now exist in the registry
-        assert "MAN-34:0" in orch.sessions
-        session = orch.sessions.get("MAN-34:0")
-        assert isinstance(session, InProcessTrialSession)
-        assert session.trial_id == "MAN-34:0"
-
-    def test_provider_reuses_same_session_across_calls_for_same_trial(self):
-        """Two observers for the same trial_id bind to the *same* underlying
-        session — the observer is a thin wrapper; the session is the identity.
+    def test_deps_manager_activates_open_mode_even_without_config_flag(self):
+        """A caller can supply a manager even if the YAML config didn't opt in.
+        Useful for programmatic runs where the caller drives OAL wiring.
         """
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
-        orch = Orchestrator(config=config)
-        provider = orch._build_observer_provider()
-
-        provider("t:0")
-        provider("t:0")
-        # Registry holds exactly one session for this trial
-        assert len(orch.sessions) == 1
-
-    def test_provider_returns_distinct_observers_per_trial(self):
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
-        orch = Orchestrator(config=config)
-        provider = orch._build_observer_provider()
-
-        obs_a = provider("A:0")
-        obs_b = provider("B:0")
-        assert obs_a is not obs_b
-        assert orch.sessions.get("A:0") is not orch.sessions.get("B:0")
+        supplied = OpenAgentLoopManager()
+        deps = OrchestratorDeps(oal_manager=supplied)
+        orch = Orchestrator(config=_minimal_run_config(), deps=deps)
+        assert orch._oal_manager is supplied
+        assert orch.sessions is supplied.sessions
 
 
-class TestOpenAgentLoopConfigSchema:
-    def test_default_is_disabled(self):
-        assert OpenAgentLoopConfig().enabled is False
-
-    def test_extra_fields_rejected(self):
-        with pytest.raises(ValueError):
-            OpenAgentLoopConfig.model_validate({"enabled": True, "bogus": 1})
-
-    def test_field_round_trips_through_run_config(self):
-        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
-        assert config.open_agent_loop is not None
-        assert config.open_agent_loop.enabled is True
-
-
-class TestConductorContextWiresProvider:
-    """When enabled, the observer_provider actually reaches
-    :class:`ConductorContext`. We drive this via a factory that captures the
-    context so we don't need Docker / an adapter to be loaded.
-    """
-
-    def test_factory_receives_context_with_observer_provider(self):
-        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
-        from tolokaforge.core.orchestrator import OrchestratorDeps
-
+class TestConductorContextWiresManagerProviders:
+    def test_factory_receives_context_with_providers_from_manager(self):
         captured: dict = {}
 
         def _factory(ctx: ConductorContext) -> InMemoryConductor:
@@ -149,7 +103,6 @@ class TestConductorContextWiresProvider:
         config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
         deps = OrchestratorDeps(conductor_factory=_factory)
         orch = Orchestrator(config=config, deps=deps)
-        # The adapter must be non-None for _build_conductor to run; wire a mock
         orch.adapter = MagicMock()
 
         orch._build_conductor(
@@ -160,22 +113,21 @@ class TestConductorContextWiresProvider:
         )
         ctx = captured["ctx"]
         assert ctx.observer_provider is not None
+        assert ctx.intervention_handler_provider is not None
 
+        # Calling the provider creates the trial's session in the manager
         obs = ctx.observer_provider("some_trial:0")
         assert obs is not None
         assert "some_trial:0" in orch.sessions
 
-    def test_sealed_factory_receives_context_with_none_provider(self):
-        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
-        from tolokaforge.core.orchestrator import OrchestratorDeps
-
+    def test_sealed_factory_receives_context_with_none_providers(self):
         captured: dict = {}
 
         def _factory(ctx: ConductorContext) -> InMemoryConductor:
             captured["ctx"] = ctx
             return InMemoryConductor()
 
-        config = _minimal_run_config()  # no open_agent_loop
+        config = _minimal_run_config()
         deps = OrchestratorDeps(conductor_factory=_factory)
         orch = Orchestrator(config=config, deps=deps)
         orch.adapter = MagicMock()
@@ -187,3 +139,18 @@ class TestConductorContextWiresProvider:
             request_limiter=None,
         )
         assert captured["ctx"].observer_provider is None
+        assert captured["ctx"].intervention_handler_provider is None
+
+
+class TestOpenAgentLoopConfigSchemaUnchanged:
+    def test_default_is_disabled(self):
+        assert OpenAgentLoopConfig().enabled is False
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValueError):
+            OpenAgentLoopConfig.model_validate({"enabled": True, "bogus": 1})
+
+    def test_field_round_trips_through_run_config(self):
+        config = _minimal_run_config(OpenAgentLoopConfig(enabled=True))
+        assert config.open_agent_loop is not None
+        assert config.open_agent_loop.enabled is True

--- a/tests/unit/test_orchestrator_trace_write.py
+++ b/tests/unit/test_orchestrator_trace_write.py
@@ -1,7 +1,7 @@
-"""Unit tests for :meth:`Orchestrator._write_open_agent_loop_trace` — M1 sub-4b.
+"""Wiring tests for Orchestrator's delegation to OAL manager's trace writer.
 
-The write is a small helper called from the trial-completion handler; these
-tests exercise it directly to avoid spinning up Docker / a real conductor.
+Focused on the orchestrator's guard/log-around-swallow contract; the
+actual write semantics live in ``tests/unit/session/test_manager.py``.
 """
 
 from __future__ import annotations
@@ -10,7 +10,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-import yaml
 
 from tolokaforge.core.models import OpenAgentLoopConfig, RunConfig
 from tolokaforge.core.orchestrator import Orchestrator
@@ -44,28 +43,18 @@ def _minimal_run_config(open_agent_loop: OpenAgentLoopConfig | None = None) -> R
     )
 
 
-class TestSealedModeIsNoOp:
+class TestSealedIsNoOp:
     def test_sealed_write_creates_no_file(self, tmp_path: Path):
-        """No sessions in sealed mode — the writer must be a silent no-op."""
         orch = Orchestrator(config=_minimal_run_config())
         orch._write_open_agent_loop_trace(tmp_path, "MAN-34", 0)
         assert not (tmp_path / "trials").exists()
 
-    def test_open_mode_but_no_session_yet_is_no_op(self, tmp_path: Path):
-        """Open-mode registry exists, but if the trial never entered the run
-        body the session for that trial_id doesn't exist — nothing to write.
-        """
-        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
-        orch._write_open_agent_loop_trace(tmp_path, "never-ran", 0)
-        assert not (tmp_path / "trials").exists()
 
-
-class TestOpenModeWritesTraceFile:
-    def _seed_session(self, orch: Orchestrator, trial_id: str) -> None:
-        provider = orch._build_observer_provider()
-        assert provider is not None
-        provider(trial_id)  # create the session via the same path the conductor uses
-
+class TestDelegatesToManagerAndSwallowsErrors:
+    def _seed(self, orch: Orchestrator, trial_id: str) -> None:
+        assert orch._oal_manager is not None
+        provider = orch._oal_manager.observer_provider()
+        provider(trial_id)
         session = orch.sessions.get(trial_id)
         assert session is not None
         session.publish(
@@ -88,66 +77,25 @@ class TestOpenModeWritesTraceFile:
             )
         )
 
-    def test_writes_yaml_at_expected_path(self, tmp_path: Path):
+    def test_writes_file_via_manager_delegation(self, tmp_path: Path):
         orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
-        self._seed_session(orch, "MAN-34:0")
+        self._seed(orch, "MAN-34:0")
 
         orch._write_open_agent_loop_trace(tmp_path, "MAN-34", 0)
 
         trace_path = tmp_path / "trials" / "MAN-34" / "0" / "open_agent_loop.yaml"
         assert trace_path.exists()
 
-        content = yaml.safe_load(trace_path.read_text())
-        assert content["trial_id"] == "MAN-34:0"
-        assert content["closed"] is True
-        assert len(content["events"]) == 3
-        assert [e["kind"] for e in content["events"]] == [
-            "turn_started",
-            "assistant_message",
-            "terminal_reached",
-        ]
-
-    def test_write_overwrites_on_retry(self, tmp_path: Path):
-        """A retried trial gets more events on the same session; the file is
-        overwritten with the accumulated state.
+    def test_write_failure_swallowed_by_orchestrator(self, tmp_path: Path):
+        """Orchestrator's contribution over the manager is the try/except.
+        Manager raises; orchestrator catches, logs, does not propagate —
+        trace writes must never mask the actual trial result.
         """
         orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
-        provider = orch._build_observer_provider()
-        provider("t:0")
-        session = orch.sessions.get("t:0")
+        self._seed(orch, "t:0")
 
-        session.publish(
-            TurnStarted(trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, turn_index=0)
-        )
-        orch._write_open_agent_loop_trace(tmp_path, "t", 0)
-        first = yaml.safe_load(
-            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
-        )
-        assert len(first["events"]) == 1
-
-        # Simulate more events on the same session (retry appends to history)
-        session.publish(
-            AssistantMessage(
-                trial_id="t:0", seq=session.next_seq(), timestamp=_NOW, content_preview="retry"
-            )
-        )
-        orch._write_open_agent_loop_trace(tmp_path, "t", 0)
-        second = yaml.safe_load(
-            (tmp_path / "trials" / "t" / "0" / "open_agent_loop.yaml").read_text()
-        )
-        assert len(second["events"]) == 2
-
-    def test_write_failure_logs_and_returns_without_raising(self, tmp_path: Path):
-        """Trace-write failures must not mask the trial result. Force a write
-        error by pointing at a path where mkdir will fail (an existing FILE
-        where a directory is expected).
-        """
-        orch = Orchestrator(config=_minimal_run_config(OpenAgentLoopConfig(enabled=True)))
-        self._seed_session(orch, "t:0")
-
-        # tmp_path/trials is a FILE, not a directory — parent.mkdir will raise
         blocker = tmp_path / "trials"
         blocker.write_text("blocking-file")
 
-        # Must not raise
+        # Must NOT raise
         orch._write_open_agent_loop_trace(tmp_path, "t", 0)

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -68,12 +68,7 @@ from tolokaforge.core.trial import (
 )
 from tolokaforge.core.trial_executor import TrialExecutor
 from tolokaforge.runner.models import AdapterType, TaskDescription
-from tolokaforge.session import (
-    InProcessTrialSession,
-    SessionInterventionHandler,
-    SessionLoopObserver,
-    SessionRegistry,
-)
+from tolokaforge.session import OpenAgentLoopManager, SessionRegistry
 
 # Tools that need Playwright + Chromium baked into the runner image. The
 # orchestrator scans the task list before starting the docker stack and
@@ -269,6 +264,16 @@ class OrchestratorDeps:
     runtime_backend: RuntimeBackend | None = None
     conductor_factory: ConductorFactory | None = None
     events: RunDisplayEvents = field(default_factory=_NullRunDisplayEvents)
+    oal_manager: OpenAgentLoopManager | None = None
+    """Optional Open Agent Loop coordinator supplied by the caller.
+
+    ``None`` means "auto-construct from config" — the orchestrator's
+    backward-compat fallback calls :meth:`OpenAgentLoopManager.from_config`
+    if ``config.open_agent_loop.enabled`` is true, so a plain YAML flag
+    still activates the gate without any Python wiring changes. Set
+    explicitly by callers (CLI, scripts) that want to inject a bespoke
+    manager or share one across runs.
+    """
 
 
 class Orchestrator:
@@ -329,14 +334,16 @@ class Orchestrator:
         # render a global ``[N/M]`` prefix.
         self._total_index_by_key: dict[tuple[str, int], int] = {}
 
-        # Open Agent Loop registry — one live InProcessTrialSession per trial
-        # when the run is in open mode; ``None`` in sealed mode. Populated
-        # lazily inside :meth:`_build_conductor` so the registry only exists
-        # when actually needed. Exposed as :attr:`sessions` for external
-        # participant lookup (M2 CLI attach reads through this).
-        self._session_registry: SessionRegistry | None = None
-        if config.open_agent_loop is not None and config.open_agent_loop.enabled:
-            self._session_registry = SessionRegistry()
+        # Open Agent Loop coordinator — owns the SessionRegistry, the
+        # per-trial observer / intervention providers, and the trace-write
+        # hook. ``None`` in sealed mode. Caller-supplied via
+        # ``OrchestratorDeps.oal_manager`` (preferred); backward-compat
+        # fallback auto-constructs one when ``config.open_agent_loop.enabled``
+        # is true, so flipping the YAML flag alone still activates the gate.
+        # Exposed as :attr:`sessions` for external participant lookup.
+        self._oal_manager: OpenAgentLoopManager | None = (
+            resolved_deps.oal_manager or OpenAgentLoopManager.from_config(config)
+        )
 
         # Initialize logger
         log_level = logging.DEBUG if verbose else logging.INFO
@@ -494,8 +501,14 @@ class Orchestrator:
             trial_grader=trial_grader,
             output_dir=output_dir,
             request_limiter=request_limiter,
-            observer_provider=self._build_observer_provider(),
-            intervention_handler_provider=self._build_intervention_handler_provider(),
+            observer_provider=(
+                self._oal_manager.observer_provider() if self._oal_manager is not None else None
+            ),
+            intervention_handler_provider=(
+                self._oal_manager.intervention_handler_provider()
+                if self._oal_manager is not None
+                else None
+            ),
             events=self._events,
         )
         if self._conductor_factory is not None:
@@ -510,40 +523,27 @@ class Orchestrator:
     @property
     def sessions(self) -> SessionRegistry | None:
         """Live-session registry for this run when open mode is on, else
-        ``None``. External participants (M2 CLI attach, cross-trial
-        orchestrator) look sessions up here by ``trial_id``. Sessions are
-        created lazily by the observer provider — a trial that has not yet
-        entered the run body will not have a session yet.
+        ``None``. Convenience shim that delegates to
+        :attr:`OpenAgentLoopManager.sessions` — kept on the orchestrator so
+        external callers don't have to know whether OAL wiring is manager-
+        supplied or auto-constructed from config.
         """
-        return self._session_registry
+        if self._oal_manager is None:
+            return None
+        return self._oal_manager.sessions
 
     def _write_open_agent_loop_trace(self, output_dir: Path, task_id: str, trial_idx: int) -> None:
-        """Persist the trial's open_agent_loop snapshot to disk.
+        """Delegate to the OAL manager's trace writer.
 
-        No-op when open mode is off or the trial never entered the run body
-        (no session created for it). Writes ``trials/<task_id>/<trial_idx>/
-        open_agent_loop.yaml`` alongside ``trajectory.yaml``. Companion-file
-        shape (not merged into ``trajectory.yaml``) keeps the Trajectory
-        model unchanged and canonical snapshot tests undisturbed; a later
-        follow-up can promote the section into the Trajectory model.
-
-        Called from the orchestrator's trial-completion handler after the
-        conductor returns. Failures are logged and swallowed — the trace
-        write must never mask the actual trial result the operator cares
-        about.
+        No-op when open mode is off. Manager owns the actual write; the
+        orchestrator's contribution is the ``try/except`` around it — trace
+        writes must never mask the actual trial result the operator cares
+        about, so failures are logged and swallowed.
         """
-        if self._session_registry is None:
+        if self._oal_manager is None:
             return
-        session = self._session_registry.get(f"{task_id}:{trial_idx}")
-        if session is None:
-            return
-        import yaml
-
-        trace_path = output_dir / "trials" / task_id / str(trial_idx) / "open_agent_loop.yaml"
         try:
-            trace_path.parent.mkdir(parents=True, exist_ok=True)
-            with trace_path.open("w") as fh:
-                yaml.safe_dump(session.snapshot(), fh, sort_keys=False)
+            self._oal_manager.write_trace(output_dir, task_id, trial_idx)
         except Exception as write_err:  # noqa: BLE001 — trace write must not mask trial result
             self.logger.warning(
                 "Failed to write open_agent_loop trace; continuing",
@@ -551,48 +551,6 @@ class Orchestrator:
                 trial_index=trial_idx,
                 error=str(write_err),
             )
-
-    def _build_observer_provider(
-        self,
-    ) -> Callable[[str], SessionLoopObserver | None] | None:
-        """Return a per-trial observer factory for the current run, or ``None``
-        in sealed mode.
-
-        The provider closes over :attr:`_session_registry` and, when called
-        with a ``trial_id``, gets-or-creates the trial's session and returns
-        a fresh :class:`SessionLoopObserver` bound to it. Threading is safe
-        under the registry's own lock; each trial's conductor runs on its
-        own worker thread and receives its own observer instance.
-        """
-        registry = self._session_registry
-        if registry is None:
-            return None
-
-        def _provider(trial_id: str) -> SessionLoopObserver | None:
-            session: InProcessTrialSession = registry.get_or_create(trial_id)
-            return SessionLoopObserver(session)
-
-        return _provider
-
-    def _build_intervention_handler_provider(
-        self,
-    ) -> Callable[[str], SessionInterventionHandler | None] | None:
-        """Return a per-trial intervention-handler factory for the current run,
-        or ``None`` in sealed mode.
-
-        Symmetric to :meth:`_build_observer_provider`. Same registry — the
-        observer and the handler bind to the same session per trial, so
-        events and interventions round-trip through one bus.
-        """
-        registry = self._session_registry
-        if registry is None:
-            return None
-
-        def _provider(trial_id: str) -> SessionInterventionHandler | None:
-            session: InProcessTrialSession = registry.get_or_create(trial_id)
-            return SessionInterventionHandler(session)
-
-        return _provider
 
     def _build_trial_spec(
         self,

--- a/tolokaforge/session/__init__.py
+++ b/tolokaforge/session/__init__.py
@@ -49,6 +49,7 @@ from tolokaforge.session.interventions import (
     TrialIntervention,
 )
 from tolokaforge.session.loop_observer import SessionLoopObserver
+from tolokaforge.session.manager import OpenAgentLoopManager
 from tolokaforge.session.protocols import (
     ParticipantHandle,
     ParticipantRole,
@@ -68,6 +69,7 @@ __all__ = [
     "InjectMessage",
     "InterventionAck",
     "Kill",
+    "OpenAgentLoopManager",
     "ParticipantHandle",
     "ParticipantRole",
     "Pause",

--- a/tolokaforge/session/manager.py
+++ b/tolokaforge/session/manager.py
@@ -1,0 +1,160 @@
+"""``OpenAgentLoopManager`` — the run-scoped coordinator for the OAL gate.
+
+Owns the concerns that used to live on :class:`Orchestrator` when open mode
+is on:
+
+* the per-run :class:`SessionRegistry` (one live :class:`InProcessTrialSession`
+  per trial keyed by ``trial_id``),
+* the per-trial ``observer_provider`` / ``intervention_handler_provider``
+  closures the orchestrator threads through :class:`ConductorContext`,
+* the trace-write hook that persists ``open_agent_loop.yaml`` at each trial
+  completion.
+
+Passed to :class:`Orchestrator` via ``OrchestratorDeps.oal_manager``. The
+orchestrator's contract remains *"give me a config + deps, I run trials"* —
+session lifecycles, participant provisioning, and trace writing are handled
+by whichever manager the caller supplied (or, for user-ergonomic backward
+compatibility, one the orchestrator auto-constructs from
+``config.open_agent_loop.enabled``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tolokaforge.session.in_process import InProcessTrialSession
+from tolokaforge.session.intervention_pump import SessionInterventionHandler
+from tolokaforge.session.loop_observer import SessionLoopObserver
+from tolokaforge.session.registry import SessionRegistry
+
+if TYPE_CHECKING:
+    from tolokaforge.core.models import RunConfig
+
+__all__ = ["OpenAgentLoopManager"]
+
+
+class OpenAgentLoopManager:
+    """Run-scoped coordinator for the Open Agent Loop gate.
+
+    Instantiated once per :class:`~tolokaforge.core.orchestrator.Orchestrator`
+    run (when open mode is on) — either explicitly by the caller via
+    ``OrchestratorDeps.oal_manager`` or implicitly by the orchestrator's
+    backward-compat fallback from
+    :meth:`~tolokaforge.core.orchestrator.Orchestrator.__init__` when
+    ``config.open_agent_loop.enabled`` is true.
+
+    Owns:
+
+    * :attr:`sessions` — the :class:`SessionRegistry`. External participants
+      look sessions up here to attach.
+    * :meth:`observer_provider` / :meth:`intervention_handler_provider` —
+      the two per-trial factories threaded through
+      :class:`~tolokaforge.core.conductor.ConductorContext`.
+    * :meth:`write_trace` — persists a trial's ``open_agent_loop.yaml``
+      companion file alongside ``trajectory.yaml``.
+
+    Does **not** own:
+
+    * The loop-side seams (``LoopObserver`` / ``InterventionHandler``) — those
+      live on :mod:`tolokaforge.core.loop` and this manager just supplies
+      the session-bound implementations.
+    * The trial-completion loop — the orchestrator calls
+      :meth:`write_trace` after each ``future.result()``.
+    """
+
+    def __init__(self) -> None:
+        self._session_registry = SessionRegistry()
+
+    @property
+    def sessions(self) -> SessionRegistry:
+        """Live-session registry for the run. External participants (M2 CLI
+        attach, cross-trial orchestrator) look sessions up here by
+        ``trial_id``.
+        """
+        return self._session_registry
+
+    def observer_provider(self) -> Callable[[str], SessionLoopObserver | None]:
+        """Return the per-trial observer factory for the current run.
+
+        Closes over the internal registry. When called with a ``trial_id``,
+        gets-or-creates the trial's session and returns a fresh
+        :class:`SessionLoopObserver` bound to it. Threadsafe under the
+        registry's own lock; each trial's conductor runs on its own worker
+        thread and receives its own observer instance.
+        """
+        registry = self._session_registry
+
+        def _provider(trial_id: str) -> SessionLoopObserver | None:
+            session: InProcessTrialSession = registry.get_or_create(trial_id)
+            return SessionLoopObserver(session)
+
+        return _provider
+
+    def intervention_handler_provider(
+        self,
+    ) -> Callable[[str], SessionInterventionHandler | None]:
+        """Return the per-trial intervention-handler factory for the current run.
+
+        Symmetric to :meth:`observer_provider`. Same registry — the observer
+        and the handler bind to the same session per trial, so events and
+        interventions round-trip through one bus.
+        """
+        registry = self._session_registry
+
+        def _provider(trial_id: str) -> SessionInterventionHandler | None:
+            session: InProcessTrialSession = registry.get_or_create(trial_id)
+            return SessionInterventionHandler(session)
+
+        return _provider
+
+    def write_trace(self, output_dir: Path, task_id: str, trial_idx: int) -> None:
+        """Persist the trial's ``open_agent_loop.yaml`` snapshot to disk.
+
+        No-op when the trial never entered the run body (no session created
+        for it). Writes ``trials/<task_id>/<trial_idx>/open_agent_loop.yaml``
+        alongside ``trajectory.yaml``. Companion-file shape (not merged into
+        ``trajectory.yaml``) keeps the ``Trajectory`` model unchanged and
+        canonical snapshot tests undisturbed.
+
+        Write failures raise :class:`OSError` — callers (orchestrator's
+        trial-completion hook) catch, log, and continue so trace writes never
+        mask a live-trial result.
+        """
+        session = self._session_registry.get(f"{task_id}:{trial_idx}")
+        if session is None:
+            return
+        import yaml
+
+        trace_path = output_dir / "trials" / task_id / str(trial_idx) / "open_agent_loop.yaml"
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        with trace_path.open("w") as fh:
+            yaml.safe_dump(session.snapshot(), fh, sort_keys=False)
+
+    def snapshot_all(self) -> dict[str, dict[str, Any]]:
+        """Snapshot every session in the registry.
+
+        For diagnostics + programmatic post-run analysis (a script that wants
+        every open-mode trial's trace without walking the filesystem).
+        """
+        return {
+            trial_id: self._session_registry.get_or_create(trial_id).snapshot()
+            for trial_id in self._session_registry.all_trial_ids()
+        }
+
+    @classmethod
+    def from_config(cls, config: RunConfig) -> OpenAgentLoopManager | None:
+        """Build a manager when ``config.open_agent_loop.enabled`` is true,
+        else ``None``.
+
+        The user-ergonomic entrypoint — CLI code that reads ``RunConfig``
+        can call this and pass the result (possibly ``None``) into
+        ``OrchestratorDeps``. The orchestrator's backward-compat fallback
+        also uses this classmethod when no manager was supplied in deps,
+        so flipping ``open_agent_loop.enabled: true`` in a YAML config
+        still activates the gate without any Python wiring changes.
+        """
+        if config.open_agent_loop is None or not config.open_agent_loop.enabled:
+            return None
+        return cls()


### PR DESCRIPTION
Follow-up refactor on the open-agent-loop workstream. Motivated by an architectural question — *"why is the orchestrator involved in this?"* — and the answer that led to it: the OAL machinery landed inline on ``Orchestrator`` as the shortest path to shipping, but the coupling grows if left unattended before M4 (remote transports) and M5 (cross-trial orchestrator).

**Option A** from that discussion: extract into a dedicated class with a ``from_config`` classmethod. Ships with **no behaviour change** and **user ergonomics preserved** (flipping ``open_agent_loop.enabled: true`` in the YAML config still activates the gate without any Python wiring changes).

## Summary

- **New:** ``tolokaforge/session/manager.py`` — ``OpenAgentLoopManager``. Owns:
  - ``sessions`` — the ``SessionRegistry`` (external attach surface).
  - ``observer_provider()`` / ``intervention_handler_provider()`` — the two per-trial factories threaded through ``ConductorContext``.
  - ``write_trace(output_dir, task_id, trial_idx)`` — persists ``open_agent_loop.yaml`` companion file.
  - ``snapshot_all()`` — diagnostics for programmatic post-run analysis.
  - ``from_config(RunConfig)`` classmethod — returns ``None`` in sealed mode, a manager in open mode.
- **New:** ``OrchestratorDeps.oal_manager: OpenAgentLoopManager | None`` — caller-supplied. When ``None``, the orchestrator's backward-compat fallback calls ``OpenAgentLoopManager.from_config(config)`` so the YAML flag still activates the gate.
- **Refactored:** ``Orchestrator`` drops:
  - ``_session_registry`` field (replaced by ``_oal_manager``)
  - ``_build_observer_provider()`` / ``_build_intervention_handler_provider()`` helpers (moved to the manager)
  - Inline trace-write logic (now a try/except wrapper around ``manager.write_trace``)
  
  Kept: the ``sessions`` property, now delegating to ``self._oal_manager.sessions``.

## Motivation

The pre-extraction shape landed as the shortest path to shipping M1. Every OAL responsibility aligned with the orchestrator's run-scoped lifecycle, so putting them there worked. But it coupled the orchestrator to OAL machinery it does not fundamentally own — the class grew, and follow-on M4/M5 work (remote transports, cross-trial orchestrator) would grow it further. Extraction now is cheap and buys a cleaner surface for those milestones.

## What this unlocks

- **Cross-process attach (M4)** — a ``tolokaforge session attach`` CLI subcommand can construct its own ``OpenAgentLoopManager`` variant that talks to a remote orchestrator via a socket, without touching the orchestrator's code.
- **Cross-trial orchestrator (M5)** — a subclass of ``OpenAgentLoopManager`` can expose different provider semantics (e.g. "attach a shared observer to every session") without touching the orchestrator.
- **Testing** — the manager tests in isolation from any orchestrator; the orchestrator's role reduces to a delegation contract that's trivially assertable.

## Test plan

- [x] ``uv run pytest tests/ -m canonical`` → **429 passed** (no schema regression)
- [x] ``uv run pytest tests/unit -m unit -k "session or loop or conductor or runner or orchestrator or manager"`` → **484 passed**
- [x] ``uv run ruff check tolokaforge/session tolokaforge/core/orchestrator.py tests/unit/session/test_manager.py tests/unit/test_orchestrator_open_mode.py tests/unit/test_orchestrator_trace_write.py`` → clean
- [x] Backward compat: existing sealed runs (no ``open_agent_loop`` block) — orchestrator ``_oal_manager`` is ``None``, ``sessions`` is ``None``, ``ConductorContext.observer_provider`` is ``None``. Byte-identical.
- [x] Backward compat: existing enabled runs (``open_agent_loop.enabled: true`` in YAML, no ``OrchestratorDeps.oal_manager``) — orchestrator auto-constructs a manager via ``OpenAgentLoopManager.from_config(config)``. Session registry lives on the manager; behaviour identical to pre-refactor.
- [x] New: explicit ``OrchestratorDeps.oal_manager`` overrides both the config flag path and the auto-construct fallback. Caller wins.

## Tests reshaped

- ``tests/unit/session/test_manager.py`` (new, 20 tests) — ``from_config`` returns-none-when-sealed / returns-manager-when-enabled; ``observer_provider`` and ``intervention_handler_provider`` semantics; ``write_trace`` no-op / expected-path / retry-overwrites / raises-on-io-failure; ``snapshot_all`` diagnostics.
- ``tests/unit/test_orchestrator_open_mode.py`` — refactored to test delegation only: sealed default → ``sessions`` is ``None``; enabled config auto-constructs a manager; explicit ``deps.oal_manager`` wins over config-implied manager; ``ConductorContext`` receives the providers from the manager.
- ``tests/unit/test_orchestrator_trace_write.py`` — refactored to test the orchestrator's ``try/except`` contract around ``manager.write_trace`` (delegates on success; swallows on failure).