### PR TITLE
feat(session): Kill intervention + role-priority conflict resolution (M1 sub-5b PR A)

### DIFF
--- a/tests/unit/session/test_intervention_pump.py
+++ b/tests/unit/session/test_intervention_pump.py
@@ -17,7 +17,7 @@ from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import init_trial_logger
 from tolokaforge.core.loop import LoopConfig, ToolCallingLoop
-from tolokaforge.core.models import Message, MessageRole
+from tolokaforge.core.models import Message, MessageRole, TerminationReason, TrialStatus
 from tolokaforge.session import (
     ApproveTool,
     EditState,
@@ -116,16 +116,6 @@ class TestNotYetSupportedKindsRejected:
         "factory,expected_reason_substring",
         [
             (
-                lambda pid: Kill(
-                    trial_id="t:0",
-                    attach_to_seq=0,
-                    participant_id=pid,
-                    timestamp=_NOW,
-                    reason="stop please",
-                ),
-                "Kill",
-            ),
-            (
                 lambda pid: Pause(
                     trial_id="t:0", attach_to_seq=0, participant_id=pid, timestamp=_NOW
                 ),
@@ -185,6 +175,143 @@ class TestNotYetSupportedKindsRejected:
         assert expected_reason_substring in snap["interventions"][0]["ack_reason"]
 
 
+class TestKillHandling:
+    """Kill terminates the loop cleanly with USER_STOP and the participant's
+    reason. Non-kill drained interventions at the same pause point are marked
+    ``superseded``.
+    """
+
+    def _submit_kill(
+        self,
+        session: InProcessTrialSession,
+        participant_id: str = "p_kill",
+        role: ParticipantRole = ParticipantRole.PARTICIPANT,
+        reason: str = "give up",
+    ):
+        handle = session.attach(participant_id, role)
+        intervention = Kill(
+            trial_id=session.trial_id,
+            attach_to_seq=0,
+            participant_id=handle.participant_id,
+            timestamp=_NOW,
+            reason=reason,
+        )
+        session.interventions().submit(handle, intervention)
+        return handle, intervention
+
+    def test_kill_returns_termination_decision_with_user_stop(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        _, kill = self._submit_kill(session, reason="stop please")
+        handler = SessionInterventionHandler(session)
+
+        decision = handler.drain_and_apply([])
+
+        assert decision is not None
+        assert decision.reason == TerminationReason.USER_STOP
+        assert decision.status == TrialStatus.FAILED
+        assert "stop please" in decision.system_message
+        assert kill.participant_id in decision.system_message
+
+    def test_kill_recorded_as_accepted_in_trace(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        self._submit_kill(session)
+        handler = SessionInterventionHandler(session)
+
+        handler.drain_and_apply([])
+
+        snap = session.snapshot()
+        assert snap["interventions"][0]["ack_outcome"] == "accepted"
+
+    def test_kill_supersedes_concurrent_inject(self):
+        """A Kill and an Inject drained at the same pause point: Kill wins,
+        Inject is superseded, ``messages`` is unchanged.
+        """
+        session = InProcessTrialSession(trial_id="t:0")
+        _submit_inject(session, "please try again")
+        self._submit_kill(session, reason="never mind")
+        handler = SessionInterventionHandler(session)
+
+        messages: list[Message] = []
+        decision = handler.drain_and_apply(messages)
+
+        assert decision is not None
+        assert messages == []  # Inject NOT applied
+
+        outcomes = {
+            rec["intervention"]["kind"]: rec["ack_outcome"]
+            for rec in session.snapshot()["interventions"]
+        }
+        assert outcomes["inject_message"] == "superseded"
+        assert outcomes["kill"] == "accepted"
+
+
+class TestRolePriority:
+    """Two Kill interventions from different roles at the same pause point:
+    admin > participant. Within a tier, later submission wins.
+    """
+
+    def _submit_kill_from(
+        self,
+        session: InProcessTrialSession,
+        participant_id: str,
+        role: ParticipantRole,
+        reason: str,
+    ) -> Kill:
+        handle = session.attach(participant_id, role)
+        intervention = Kill(
+            trial_id=session.trial_id,
+            attach_to_seq=0,
+            participant_id=participant_id,
+            timestamp=_NOW,
+            reason=reason,
+        )
+        session.interventions().submit(handle, intervention)
+        return intervention
+
+    def test_admin_kill_beats_participant_kill(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        # Participant kill submitted FIRST, admin kill submitted SECOND —
+        # admin still wins on role priority (not submit order).
+        self._submit_kill_from(session, "p_user", ParticipantRole.PARTICIPANT, "user says stop")
+        self._submit_kill_from(session, "p_admin", ParticipantRole.ADMIN, "admin says stop")
+
+        handler = SessionInterventionHandler(session)
+        decision = handler.drain_and_apply([])
+
+        assert decision is not None
+        assert "admin says stop" in decision.system_message
+        assert "p_admin" in decision.system_message
+
+    def test_later_submitted_wins_within_same_tier(self):
+        """Two participant-role kills: later submission wins (stable sort +
+        reversed index in the priority tuple).
+        """
+        session = InProcessTrialSession(trial_id="t:0")
+        self._submit_kill_from(session, "p_first", ParticipantRole.PARTICIPANT, "first reason")
+        self._submit_kill_from(session, "p_second", ParticipantRole.PARTICIPANT, "second reason")
+
+        handler = SessionInterventionHandler(session)
+        decision = handler.drain_and_apply([])
+
+        assert decision is not None
+        assert "second reason" in decision.system_message
+        assert "p_second" in decision.system_message
+
+    def test_losing_kill_marked_superseded_with_reference_to_winner(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        self._submit_kill_from(session, "p_user", ParticipantRole.PARTICIPANT, "user reason")
+        self._submit_kill_from(session, "p_admin", ParticipantRole.ADMIN, "admin reason")
+
+        handler = SessionInterventionHandler(session)
+        handler.drain_and_apply([])
+
+        snap = session.snapshot()
+        outcomes_by_pid = {rec["participant_id"]: rec for rec in snap["interventions"]}
+        assert outcomes_by_pid["p_admin"]["ack_outcome"] == "accepted"
+        assert outcomes_by_pid["p_user"]["ack_outcome"] == "superseded"
+        assert "p_admin" in outcomes_by_pid["p_user"]["ack_reason"]
+
+
 class TestLoopIntegration:
     """Drive :class:`ToolCallingLoop` with the pump attached; verify that an
     InjectMessage submitted between turns actually reaches the next agent
@@ -227,6 +354,54 @@ class TestLoopIntegration:
         assert len(seen_messages_per_call) == 1
         contents = [m.content for m in seen_messages_per_call[0] if m.role == MessageRole.USER]
         assert "try /v2/auth instead" in contents
+
+
+class TestLoopIntegrationKill:
+    """Kill submitted between turns actually terminates the running loop."""
+
+    def test_kill_terminates_loop_with_user_stop(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        # Queue a Kill before turn 0's generate runs
+        handle = session.attach("p_kill", ParticipantRole.PARTICIPANT)
+        session.interventions().submit(
+            handle,
+            Kill(
+                trial_id="t:0",
+                attach_to_seq=0,
+                participant_id="p_kill",
+                timestamp=_NOW,
+                reason="operator abort",
+            ),
+        )
+        handler = SessionInterventionHandler(session)
+
+        # If Kill were ignored, this side_effect would run and the loop
+        # would call generate 10 times (max_turns). If Kill works, the loop
+        # terminates before the first generate and the mock is never called.
+        llm_client = MagicMock()
+        llm_client.generate.side_effect = lambda *a, **kw: GenerationResult(
+            text="never runs", tool_calls=[], usage=Usage()
+        )
+
+        loop = ToolCallingLoop(
+            llm_client=llm_client,
+            tool_executor=MagicMock(),
+            tool_schemas=[],
+            config=LoopConfig(max_turns=10, episode_timeout_s=60),
+            metrics=MagicMock(),
+            should_terminate=lambda result, turn, messages: None,
+            logger=init_trial_logger("t:0", verbose=False, strict=False),
+            intervention_handler=handler,
+        )
+        messages: list[Message] = []
+        outcome = loop.run(system_prompt="sys", messages=messages, start_time=time.time())
+
+        assert outcome.termination_reason == TerminationReason.USER_STOP
+        assert outcome.status == TrialStatus.FAILED
+        llm_client.generate.assert_not_called()
+        # A system message recording the kill lands on the transcript
+        system_contents = [m.content for m in messages if m.role == MessageRole.SYSTEM]
+        assert any("operator abort" in c for c in system_contents)
 
 
 class TestNullPumpIsNoOp:

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -225,20 +225,27 @@ class InterventionHandler(Protocol):
     incurs one no-op call per turn.
     """
 
-    def drain_and_apply(self, messages: list[Message]) -> None:
+    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
         """Drain pending interventions and apply them to the running trial.
 
         Called at the top of each turn, before the LLM generate call. The
         handler must return quickly (drain from a queue, apply to messages,
         record outcomes) — the loop's producer thread is blocked while this
         runs.
+
+        Returns a :class:`TerminationDecision` when a drained intervention
+        (typically ``Kill``) should terminate the loop cleanly. Returning
+        ``None`` means "no terminal intervention; continue with the next turn".
+        The returned decision's ``system_message`` is appended to the transcript
+        by the loop and its ``reason`` becomes the trajectory's
+        ``termination_reason``.
         """
 
 
 class _NullInterventionHandler:
     """No-op :class:`InterventionHandler` — the default when no pump is wired."""
 
-    def drain_and_apply(self, messages: list[Message]) -> None:
+    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
         return None
 
 
@@ -337,7 +344,12 @@ class ToolCallingLoop:
         termination_reason: TerminationReason | None = None
 
         for turn in range(self.config.max_turns):
-            self.intervention_handler.drain_and_apply(messages)
+            kill_decision = self.intervention_handler.drain_and_apply(messages)
+            if kill_decision is not None:
+                messages.append(self._system_message(kill_decision.system_message))
+                status = kill_decision.status or status
+                termination_reason = kill_decision.reason
+                break
             self.observer.on_turn_start(turn)
             timeout_decision = self._check_episode_timeout(start_time)
             if timeout_decision is not None:

--- a/tolokaforge/session/intervention_pump.py
+++ b/tolokaforge/session/intervention_pump.py
@@ -3,21 +3,36 @@ intervention pump into :class:`InProcessTrialSession`.
 
 Inbound counterpart to :class:`SessionLoopObserver`. Called at every turn
 boundary; drains interventions queued by attached participants, applies
-each one to the loop's transcript (``InjectMessage`` today), and updates
-the durable trace with the accept/reject verdict.
+each one to the loop's transcript or returns a :class:`TerminationDecision`
+that terminates the loop, and updates the durable trace with the accept
+/ reject verdict.
 
-Sub-5a scope: **InjectMessage only.** Every other kind is recorded with
-``outcome="rejected"`` and a reason noting the M1 sub-issue that will land
-its handling. This keeps the schema surface honest — the trace tells the
-full story of what was proposed and what actually happened.
+Scope today (M1 sub-5a + PR A of sub-5b):
+
+* ``InjectMessage`` — applied as a user-role :class:`Message` on the
+  transcript, ``ack_outcome="accepted"``.
+* ``Kill`` — returns a :class:`TerminationDecision` with
+  :data:`TerminationReason.USER_STOP` and the submitting participant's
+  ``reason`` verbatim in the ``system_message``. ``ack_outcome="accepted"``.
+* **Role priority** (``admin`` > ``participant`` > ``observer``,
+  later-wins within a tier) applies when multiple ``Kill`` interventions
+  arrive at the same pause point; the losers are marked
+  ``ack_outcome="superseded"`` in the trace. Non-terminal interventions
+  drained alongside a winning Kill are also marked ``superseded`` —
+  a killed trial does not accept any further message injections.
+
+Deferred kinds (PR B of sub-5b — Pause / Resume / ApproveTool /
+RejectTool / EditState) still land in the trace as ``rejected`` with a
+per-kind reason.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from tolokaforge.core.models import Message, MessageRole
-from tolokaforge.session.in_process import InProcessTrialSession
+from tolokaforge.core.loop import TerminationDecision
+from tolokaforge.core.models import Message, MessageRole, TerminationReason, TrialStatus
+from tolokaforge.session.in_process import InProcessTrialSession, QueuedIntervention
 from tolokaforge.session.interventions import (
     ApproveTool,
     EditState,
@@ -28,27 +43,36 @@ from tolokaforge.session.interventions import (
     Resume,
     TrialIntervention,
 )
+from tolokaforge.session.protocols import ParticipantRole
 
 __all__ = ["SessionInterventionHandler"]
 
 
 _NOT_YET_SUPPORTED_REASONS: dict[type[TrialIntervention], str] = {
-    Kill: "Kill intervention not yet applied by the pump (M1 sub-5b).",
-    Pause: "Pause intervention not yet applied by the pump (M1 sub-5b).",
-    Resume: "Resume intervention not yet applied by the pump (M1 sub-5b).",
+    Pause: "Pause intervention not yet applied by the pump (M1 sub-5b PR B).",
+    Resume: "Resume intervention not yet applied by the pump (M1 sub-5b PR B).",
     ApproveTool: (
         "ApproveTool intervention applies at the tool-call seam, "
-        "not the turn-boundary pause point (M1 sub-5b)."
+        "not the turn-boundary pause point (M1 sub-5b PR B)."
     ),
     RejectTool: (
         "RejectTool intervention applies at the tool-call seam, "
-        "not the turn-boundary pause point (M1 sub-5b)."
+        "not the turn-boundary pause point (M1 sub-5b PR B)."
     ),
     EditState: (
         "EditState requires runner-side mediation; deferred until "
         "the runner exposes the edit surface."
     ),
 }
+
+_ROLE_PRIORITY: dict[ParticipantRole, int] = {
+    ParticipantRole.ADMIN: 0,
+    ParticipantRole.PARTICIPANT: 1,
+    ParticipantRole.OBSERVER: 2,
+}
+"""Lower is higher priority. Admin beats participant beats observer;
+within a tier, later submission beats earlier (list order preserved
+after stable-sort)."""
 
 
 class SessionInterventionHandler:
@@ -61,31 +85,107 @@ class SessionInterventionHandler:
     def __init__(self, session: InProcessTrialSession) -> None:
         self._session = session
 
-    def drain_and_apply(self, messages: list[Message]) -> None:
-        """Drain the session's pending interventions and apply supported kinds
-        to ``messages``. Records the outcome of each on the session's
-        durable trace history.
+    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
+        """Drain the session's pending interventions and apply supported kinds.
+
+        Kill wins over everything at the same pause point — if any Kill was
+        submitted, it terminates the trial and every other drained
+        intervention (including InjectMessages) is marked ``superseded``.
+        Otherwise, InjectMessages append to ``messages`` in submit order and
+        unsupported kinds land in the trace as ``rejected`` with a per-kind
+        reason.
+
+        Returns a :class:`TerminationDecision` on Kill, ``None`` otherwise.
         """
         pending = self._session.drain_pending_interventions()
-        for queued in pending:
-            intervention = queued.intervention
-            if isinstance(intervention, InjectMessage):
-                messages.append(
-                    Message(
-                        role=MessageRole.USER,
-                        content=intervention.content,
-                        ts=datetime.now(UTC),
-                    )
-                )
-                self._session.record_intervention_outcome(
-                    intervention, outcome="accepted", reason=None
-                )
-                continue
+        if not pending:
+            return None
 
-            reason = _NOT_YET_SUPPORTED_REASONS.get(
-                type(intervention),
-                f"Intervention kind {intervention.kind!r} not handled by the M1 pump.",
+        kills = [queued for queued in pending if isinstance(queued.intervention, Kill)]
+        if kills:
+            winning_kill = self._select_kill_winner(kills)
+            # Every non-winning drained intervention (including all
+            # non-Kill kinds) is superseded — a killed trial does not
+            # accept further pump-side effects.
+            for queued in pending:
+                if queued is winning_kill:
+                    continue
+                self._record_superseded(queued, winning_kill)
+            return self._apply_kill(winning_kill)
+
+        # No terminal intervention — apply the rest in submit order.
+        for queued in pending:
+            self._apply_non_terminal(queued, messages)
+        return None
+
+    # ------------------------------------------------------------------
+    # Kill handling
+    # ------------------------------------------------------------------
+
+    def _select_kill_winner(self, kills: list[QueuedIntervention]) -> QueuedIntervention:
+        """Pick the highest-priority Kill; within a tier, later submission wins.
+
+        Python's ``sorted`` is stable, so preserving submit-order within a
+        priority tier is automatic after sorting by role. Reversing then
+        taking the first entry yields the last-submitted of the top-priority
+        tier.
+        """
+        # Sort by role ascending (admin=0 first), then by submit order
+        # (index in the drained list — original order is submit order).
+        indexed = list(enumerate(kills))
+        indexed.sort(
+            key=lambda pair: (
+                _ROLE_PRIORITY.get(pair[1].handle.role, len(_ROLE_PRIORITY)),
+                -pair[0],  # later index (= later submission) beats earlier within a tier
             )
-            self._session.record_intervention_outcome(
-                intervention, outcome="rejected", reason=reason
+        )
+        return indexed[0][1]
+
+    def _apply_kill(self, queued: QueuedIntervention) -> TerminationDecision:
+        assert isinstance(queued.intervention, Kill)
+        self._session.record_intervention_outcome(
+            queued.intervention, outcome="accepted", reason=None
+        )
+        return TerminationDecision(
+            reason=TerminationReason.USER_STOP,
+            system_message=(
+                f"Trial killed by participant {queued.intervention.participant_id!r}: "
+                f"{queued.intervention.reason}"
+            ),
+            status=TrialStatus.FAILED,
+        )
+
+    def _record_superseded(
+        self, queued: QueuedIntervention, winning_kill: QueuedIntervention
+    ) -> None:
+        self._session.record_intervention_outcome(
+            queued.intervention,
+            outcome="superseded",
+            reason=(
+                f"Superseded by Kill from participant "
+                f"{winning_kill.intervention.participant_id!r} at the same pause point."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Non-terminal intervention application
+    # ------------------------------------------------------------------
+
+    def _apply_non_terminal(self, queued: QueuedIntervention, messages: list[Message]) -> None:
+        intervention = queued.intervention
+        if isinstance(intervention, InjectMessage):
+            messages.append(
+                Message(
+                    role=MessageRole.USER,
+                    content=intervention.content,
+                    ts=datetime.now(UTC),
+                )
             )
+            self._session.record_intervention_outcome(intervention, outcome="accepted", reason=None)
+            return
+
+        reason = _NOT_YET_SUPPORTED_REASONS.get(
+            type(intervention),
+            f"Intervention kind {intervention.kind!r} not handled by the M1 pump.",
+        )
+        self._session.record_intervention_outcome(intervention, outcome="rejected", reason=reason)


### PR DESCRIPTION
Part of #408 (M1 umbrella), #441 (sub-5b tracker).

First of two sub-5b PRs. Adds Kill handling + role-priority conflict resolution to the intervention pump. PR B (Pause/Resume + tool-approval mid-turn seam) follows.

## Summary

An LLM copilot or human operator can now Kill a stuck trial. When multiple Kill interventions arrive at the same pause point from different participants, role priority (``admin > participant > observer``, later-wins within a tier) picks the winner; the losers are marked ``ack_outcome=\"superseded\"`` in the trace.

## What ships

### Loop-side (small contract widening)
- ``InterventionHandler.drain_and_apply`` return type widened from ``None`` to ``TerminationDecision | None``. **Backward-compatible**: the null handler still returns ``None``; existing pass-through paths unchanged.
- ``ToolCallingLoop.run`` respects the returned decision — appends the system message to the transcript, promotes the trial status, records the termination reason, breaks out of the loop.

### Pump-side (Kill + role priority)
- ``SessionInterventionHandler.drain_and_apply``:
  - If any Kill was drained, select the winner via role priority, mark every other drained intervention (including InjectMessages) as ``superseded``, return a ``TerminationDecision(reason=USER_STOP, status=FAILED, system_message=\"Trial killed by <pid>: <reason>\")``.
  - Otherwise apply InjectMessages in submit order (unchanged from sub-5a) and reject the other kinds with per-kind reasons.
- ``_ROLE_PRIORITY`` map + stable-sort with ``(role_priority, -submit_index)`` key ensures deterministic winner selection.

### Reason for shipping Kill first
Most-often-wanted intervention outside InjectMessage. If a copilot detects a broken trial pattern (repeated tool errors, stuck loop signature), you want to stop it — otherwise the trial burns budget until ``max_turns`` or ``episode_timeout``.

## Tests (7 new)

- ``TestKillHandling`` (3) — Kill returns USER_STOP decision, is recorded as accepted, supersedes concurrent Inject.
- ``TestRolePriority`` (3) — admin beats participant regardless of submit order, later submission wins within tier, losing Kill's trace record references winner.
- ``TestLoopIntegrationKill`` (1) — ``ToolCallingLoop`` with pump attached terminates before ``generate()`` is even called; system message lands on transcript; ``llm_client.generate`` never invoked (loop breaks before turn 0).

## Test plan

- [x] ``uv run pytest tests/ -m canonical`` → **429 passed** (no regressions)
- [x] ``uv run pytest tests/unit -m unit -k \"loop or session or conductor or runner or orchestrator\"`` → **480 passed** (+7 new)
- [x] ``uv run ruff check ...`` → clean

## Follow-ups (PR B of sub-5b, next up)

- ``Pause`` / ``Resume`` with polling-loop state machine + episode-timeout guard.
- ``ApproveTool`` / ``RejectTool`` at a new pause point *inside* ``_execute_tool_calls`` (mid-turn seam). Requires a second ``InterventionHandler`` Protocol method — ``intercept_tool_call(call_id, tool_name, arguments) -> ToolCallDecision | None`` — and a per-call ``ToolCallDecision`` value.