### PR TITLE
feat(session): Pause/Resume + tool-approval + timeout-during-pause (M1 sub-5b PR B)

### DIFF
--- a/tests/unit/session/test_intervention_pump.py
+++ b/tests/unit/session/test_intervention_pump.py
@@ -7,6 +7,7 @@ and end-to-end integration with :class:`ToolCallingLoop`.
 
 from __future__ import annotations
 
+import threading
 import time
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
@@ -16,8 +17,8 @@ import pytest
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import init_trial_logger
-from tolokaforge.core.loop import LoopConfig, ToolCallingLoop
-from tolokaforge.core.models import Message, MessageRole, TerminationReason, TrialStatus
+from tolokaforge.core.loop import LoopConfig, TerminationDecision, ToolCallingLoop
+from tolokaforge.core.models import Message, MessageRole, TerminationReason, ToolCall, TrialStatus
 from tolokaforge.session import (
     ApproveTool,
     EditState,
@@ -34,6 +35,10 @@ from tolokaforge.session import (
 pytestmark = pytest.mark.unit
 
 _NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def _tool_call_with_id(id_: str, name: str, args: dict):
+    return ToolCall(id=id_, name=name, arguments=args)
 
 
 def _submit_inject(session: InProcessTrialSession, content: str = "try /v2/auth") -> InjectMessage:
@@ -115,38 +120,6 @@ class TestNotYetSupportedKindsRejected:
     @pytest.mark.parametrize(
         "factory,expected_reason_substring",
         [
-            (
-                lambda pid: Pause(
-                    trial_id="t:0", attach_to_seq=0, participant_id=pid, timestamp=_NOW
-                ),
-                "Pause",
-            ),
-            (
-                lambda pid: Resume(
-                    trial_id="t:0", attach_to_seq=0, participant_id=pid, timestamp=_NOW
-                ),
-                "Resume",
-            ),
-            (
-                lambda pid: ApproveTool(
-                    trial_id="t:0",
-                    attach_to_seq=0,
-                    participant_id=pid,
-                    timestamp=_NOW,
-                    call_id="c1",
-                ),
-                "ApproveTool",
-            ),
-            (
-                lambda pid: RejectTool(
-                    trial_id="t:0",
-                    attach_to_seq=0,
-                    participant_id=pid,
-                    timestamp=_NOW,
-                    call_id="c1",
-                ),
-                "RejectTool",
-            ),
             (
                 lambda pid: EditState(
                     trial_id="t:0",
@@ -402,6 +375,269 @@ class TestLoopIntegrationKill:
         # A system message recording the kill lands on the transcript
         system_contents = [m.content for m in messages if m.role == MessageRole.SYSTEM]
         assert any("operator abort" in c for c in system_contents)
+
+
+class TestPauseResumeFlow:
+    """Pause enters a poll loop; Resume exits it. Both emit acknowledgement
+    events on the session so attached participants can see the state
+    transitions in real time.
+    """
+
+    def _submit(self, session, intervention, participant_id="p1", role=None):
+        if role is None:
+            role = ParticipantRole.PARTICIPANT
+        # Reuse an already-attached handle when it exists (matched by pid)
+        if participant_id in session.attached_participant_ids:
+            # get_or_create shim via drain_pending_interventions history
+            for slot_pid in session.attached_participant_ids:
+                if slot_pid == participant_id:
+                    from tolokaforge.session.protocols import ParticipantHandle
+
+                    handle = ParticipantHandle(
+                        participant_id=participant_id,
+                        role=role,
+                        trial_id=session.trial_id,
+                    )
+                    break
+        else:
+            handle = session.attach(participant_id, role)
+        session.interventions().submit(handle, intervention)
+
+    def test_pause_then_resume_returns_none_and_emits_ack_events(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        handle = session.attach("p_pauser", ParticipantRole.PARTICIPANT)
+        session.interventions().submit(
+            handle,
+            Pause(
+                trial_id="t:0",
+                attach_to_seq=0,
+                participant_id="p_pauser",
+                timestamp=_NOW,
+            ),
+        )
+
+        # Fire Resume from a background thread after a short delay so the
+        # pause loop exits.
+        def resume_after_delay():
+            time.sleep(0.3)
+            resume_handle = session.attach("p_resumer", ParticipantRole.PARTICIPANT)
+            session.interventions().submit(
+                resume_handle,
+                Resume(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id="p_resumer",
+                    timestamp=_NOW,
+                ),
+            )
+
+        threading.Thread(target=resume_after_delay, daemon=True).start()
+
+        result = handler.drain_and_apply([])
+        assert result is None  # Resume path returns None to continue the loop
+
+        # Trace records both Pause and Resume as accepted; PauseAcknowledged
+        # and ResumeAcknowledged events landed in event history.
+        snap = session.snapshot()
+        outcomes_by_kind = {
+            rec["intervention"]["kind"]: rec["ack_outcome"] for rec in snap["interventions"]
+        }
+        assert outcomes_by_kind["pause"] == "accepted"
+        assert outcomes_by_kind["resume"] == "accepted"
+
+        event_kinds = [e["kind"] for e in snap["events"]]
+        assert "pause_acknowledged" in event_kinds
+        assert "resume_acknowledged" in event_kinds
+
+    def test_kill_during_pause_supersedes_and_terminates(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        pause_handle = session.attach("p_pauser", ParticipantRole.PARTICIPANT)
+        session.interventions().submit(
+            pause_handle,
+            Pause(
+                trial_id="t:0",
+                attach_to_seq=0,
+                participant_id="p_pauser",
+                timestamp=_NOW,
+            ),
+        )
+
+        def kill_after_delay():
+            time.sleep(0.3)
+            kill_handle = session.attach("p_killer", ParticipantRole.PARTICIPANT)
+            session.interventions().submit(
+                kill_handle,
+                Kill(
+                    trial_id="t:0",
+                    attach_to_seq=0,
+                    participant_id="p_killer",
+                    timestamp=_NOW,
+                    reason="cancel the trial",
+                ),
+            )
+
+        threading.Thread(target=kill_after_delay, daemon=True).start()
+
+        result = handler.drain_and_apply([])
+        assert result is not None
+        assert result.reason == TerminationReason.USER_STOP
+        assert "cancel the trial" in result.system_message
+
+        # ResumeAcknowledged still emitted (the pause did end, just not via Resume)
+        event_kinds = [e["kind"] for e in session.snapshot()["events"]]
+        assert "pause_acknowledged" in event_kinds
+        assert "resume_acknowledged" in event_kinds
+
+    def test_pause_returns_timeout_decision_when_check_timeout_fires(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        handle = session.attach("p_pauser", ParticipantRole.PARTICIPANT)
+        session.interventions().submit(
+            handle,
+            Pause(
+                trial_id="t:0",
+                attach_to_seq=0,
+                participant_id="p_pauser",
+                timestamp=_NOW,
+            ),
+        )
+
+        timeout_decision = TerminationDecision(
+            reason=TerminationReason.TIMEOUT,
+            system_message="Episode timeout hit while paused.",
+            status=TrialStatus.TIMEOUT,
+        )
+        # First call to check_timeout returns None; second returns the
+        # timeout decision. The pump loops on _PAUSE_POLL_INTERVAL_S = 0.1 s,
+        # so we expect ~0.2 s total.
+        call_count = {"n": 0}
+
+        def check_timeout():
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                return timeout_decision
+            return None
+
+        result = handler.drain_and_apply([], check_timeout=check_timeout)
+        assert result is timeout_decision
+
+
+class TestToolApproval:
+    """ApproveTool / RejectTool interventions consulted via intercept_tool_call
+    at the tool-call seam.
+    """
+
+    def test_no_pending_decision_returns_none(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+        # No ApproveTool / RejectTool ever submitted
+        assert handler.intercept_tool_call("c1", "lookup", {}) is None
+
+    def test_reject_tool_returned_and_recorded_accepted(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        reject = RejectTool(
+            trial_id="t:0",
+            attach_to_seq=0,
+            participant_id="p1",
+            timestamp=_NOW,
+            call_id="c1",
+            reason="unsafe payload",
+        )
+        session.interventions().submit(handle, reject)
+
+        # Drain at turn boundary to queue the decision
+        handler.drain_and_apply([])
+        # Now the tool-call seam sees the decision
+        decision = handler.intercept_tool_call("c1", "lookup", {"q": "x"})
+
+        assert decision is not None
+        assert decision.action == "reject"
+        assert decision.reason == "unsafe payload"
+
+        # Ack outcome recorded on tool-call-seam consumption
+        snap = session.snapshot()
+        assert snap["interventions"][0]["ack_outcome"] == "accepted"
+
+    def test_approve_tool_returned_and_recorded(self):
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        handle = session.attach("p1", ParticipantRole.PARTICIPANT)
+        approve = ApproveTool(
+            trial_id="t:0",
+            attach_to_seq=0,
+            participant_id="p1",
+            timestamp=_NOW,
+            call_id="c1",
+            reason="ok",
+        )
+        session.interventions().submit(handle, approve)
+
+        handler.drain_and_apply([])
+        decision = handler.intercept_tool_call("c1", "lookup", {})
+
+        assert decision is not None
+        assert decision.action == "approve"
+
+    def test_reject_tool_short_circuits_executor_in_loop(self):
+        """End-to-end: RejectTool submitted before the tool fires; the loop
+        sees the reject at the tool-call seam and synthesizes a tool-error
+        message without invoking the executor.
+        """
+        session = InProcessTrialSession(trial_id="t:0")
+        handler = SessionInterventionHandler(session)
+
+        # Pre-submit a RejectTool matching call_id "c_A"
+        handle = session.attach("p_gate", ParticipantRole.PARTICIPANT)
+        session.interventions().submit(
+            handle,
+            RejectTool(
+                trial_id="t:0",
+                attach_to_seq=0,
+                participant_id="p_gate",
+                timestamp=_NOW,
+                call_id="c_A",
+                reason="policy violation",
+            ),
+        )
+
+        tool_call = _tool_call_with_id(id_="c_A", name="lookup", args={"q": "x"})
+        llm_client = MagicMock()
+        # First generate emits the tool call; second stops.
+        llm_client.generate.side_effect = [
+            GenerationResult(text="calling tool", tool_calls=[tool_call], usage=Usage()),
+            GenerationResult(text="done after reject", tool_calls=[], usage=Usage()),
+        ]
+
+        tool_executor = MagicMock()
+        # If the executor is invoked, the test fails: RejectTool should
+        # short-circuit it.
+        tool_executor.execute.side_effect = AssertionError("executor should not be called")
+
+        loop = ToolCallingLoop(
+            llm_client=llm_client,
+            tool_executor=tool_executor,
+            tool_schemas=[],
+            config=LoopConfig(max_turns=2, episode_timeout_s=60),
+            metrics=MagicMock(),
+            should_terminate=lambda result, turn, messages: None,
+            logger=init_trial_logger("t:0", verbose=False, strict=False),
+            intervention_handler=handler,
+        )
+        messages: list[Message] = []
+        loop.run(system_prompt="sys", messages=messages, start_time=time.time())
+
+        tool_executor.execute.assert_not_called()
+        tool_role_msgs = [m for m in messages if m.role == MessageRole.TOOL]
+        assert any("policy violation" in m.content for m in tool_role_msgs)
 
 
 class TestNullPumpIsNoOp:

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -36,7 +36,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from tolokaforge.core.llm.client import GenerationResult, LLMApiTimeoutError
 from tolokaforge.core.logging import StructuredLogger
@@ -210,42 +210,90 @@ class _NullLoopObserver:
 _NULL_LOOP_OBSERVER: LoopObserver = _NullLoopObserver()
 
 
+@dataclass(frozen=True)
+class ToolCallDecision:
+    """Verdict returned by :meth:`InterventionHandler.intercept_tool_call`.
+
+    ``action="approve"`` lets the tool call dispatch normally.
+    ``action="reject"`` skips the executor and synthesizes a tool-result
+    message carrying ``reason`` as the tool's error output — the agent
+    sees the rejection as a normal tool error and can react in its next
+    turn.
+    """
+
+    action: Literal["approve", "reject"]
+    reason: str | None = None
+
+
 class InterventionHandler(Protocol):
     """Inbound seam — drains queued interventions at pause points and applies
     them to the running loop.
 
     Symmetric to :class:`LoopObserver` (outbound). Called by
-    :class:`ToolCallingLoop` before each turn; the handler owns dispatch on
-    intervention *kind* so the loop stays decoupled from session-specific
-    intervention types. Handlers mutate ``messages`` in place (e.g. append
-    a user-role :class:`Message` for an ``InjectMessage``) and record ack
-    outcomes back to whatever store the caller wired in.
+    :class:`ToolCallingLoop` at two pause points:
+
+    * :meth:`drain_and_apply` — at the top of each turn iteration, before
+      the LLM generate call. Handles transcript mutations (``InjectMessage``),
+      terminal interventions (``Kill``), and pause / resume flow.
+    * :meth:`intercept_tool_call` — inside ``_execute_tool_calls``, before
+      each tool is dispatched. Handles per-call approve / reject.
+
+    Handlers own dispatch on intervention *kind* so the loop stays
+    decoupled from session-specific intervention types.
 
     Default is :data:`_NULL_INTERVENTION_HANDLER` — sealed batch mode
-    incurs one no-op call per turn.
+    incurs one no-op call per turn plus one no-op call per tool call.
     """
 
-    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
+    def drain_and_apply(
+        self,
+        messages: list[Message],
+        check_timeout: Callable[[], TerminationDecision | None] = lambda: None,
+    ) -> TerminationDecision | None:
         """Drain pending interventions and apply them to the running trial.
 
         Called at the top of each turn, before the LLM generate call. The
-        handler must return quickly (drain from a queue, apply to messages,
-        record outcomes) — the loop's producer thread is blocked while this
-        runs.
+        handler must return quickly under normal conditions (drain from a
+        queue, apply to messages, record outcomes). The exception is
+        ``Pause``: when a Pause intervention is drained, the handler enters
+        a poll loop until Resume arrives, an admin Kill supersedes, or
+        ``check_timeout`` returns a :class:`TerminationDecision` (episode
+        timeout hit while paused). The ``check_timeout`` callback lets the
+        pump respect wall-clock limits without owning the timer.
 
         Returns a :class:`TerminationDecision` when a drained intervention
-        (typically ``Kill``) should terminate the loop cleanly. Returning
-        ``None`` means "no terminal intervention; continue with the next turn".
-        The returned decision's ``system_message`` is appended to the transcript
-        by the loop and its ``reason`` becomes the trajectory's
-        ``termination_reason``.
+        should terminate the loop cleanly (``Kill``, or a timeout that hit
+        while paused). Returning ``None`` means "no terminal intervention;
+        continue with the next turn".
+        """
+
+    def intercept_tool_call(
+        self, call_id: str, tool_name: str, arguments: dict[str, Any]
+    ) -> ToolCallDecision | None:
+        """Consult the handler before dispatching a tool call.
+
+        Called inside ``_execute_tool_calls`` between the ``on_tool_call``
+        observer event and ``tool_executor.execute``. Returning ``None``
+        means "no intervention for this call; approve implicitly by
+        default." A :class:`ToolCallDecision` explicitly approves or
+        rejects — on reject, the loop synthesizes a tool-result message
+        with the decision's ``reason`` as the tool's error output.
         """
 
 
 class _NullInterventionHandler:
     """No-op :class:`InterventionHandler` — the default when no pump is wired."""
 
-    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
+    def drain_and_apply(
+        self,
+        messages: list[Message],
+        check_timeout: Callable[[], TerminationDecision | None] = lambda: None,
+    ) -> TerminationDecision | None:
+        return None
+
+    def intercept_tool_call(
+        self, call_id: str, tool_name: str, arguments: dict[str, Any]
+    ) -> ToolCallDecision | None:
         return None
 
 
@@ -344,7 +392,10 @@ class ToolCallingLoop:
         termination_reason: TerminationReason | None = None
 
         for turn in range(self.config.max_turns):
-            kill_decision = self.intervention_handler.drain_and_apply(messages)
+            kill_decision = self.intervention_handler.drain_and_apply(
+                messages,
+                check_timeout=lambda: self._check_episode_timeout(start_time),
+            )
             if kill_decision is not None:
                 messages.append(self._system_message(kill_decision.system_message))
                 status = kill_decision.status or status
@@ -459,9 +510,41 @@ class ToolCallingLoop:
     def _execute_tool_calls(self, result: GenerationResult, messages: list[Message]) -> None:
         for tc in result.tool_calls:
             self._maybe_recover_arguments(tc, result.text)
-            self.observer.on_tool_call(
-                call_id=tc.id, tool_name=tc.name, arguments=dict(tc.arguments or {})
+            arguments_dict = dict(tc.arguments or {})
+            self.observer.on_tool_call(call_id=tc.id, tool_name=tc.name, arguments=arguments_dict)
+
+            # Tool-approval seam: participants can reject this specific call
+            # via a RejectTool intervention. RejectTool short-circuits the
+            # executor and synthesizes a tool-result carrying the reason as
+            # the tool's error output — the agent sees a normal tool error
+            # and can react in its next turn.
+            decision = self.intervention_handler.intercept_tool_call(
+                call_id=tc.id, tool_name=tc.name, arguments=arguments_dict
             )
+            if decision is not None and decision.action == "reject":
+                tool_output = (
+                    f"Tool call rejected by operator: {decision.reason}"
+                    if decision.reason
+                    else "Tool call rejected by operator."
+                )
+                self.observer.on_tool_result(
+                    call_id=tc.id,
+                    tool_name=tc.name,
+                    duration_ms=0,
+                    output=tool_output,
+                    success=False,
+                )
+                messages.append(
+                    Message(
+                        role=MessageRole.TOOL,
+                        content=tool_output,
+                        content_blocks=None,
+                        tool_call_id=tc.id,
+                        ts=_now(),
+                    )
+                )
+                continue
+
             tool_start = time.time()
             tool_result = self.tool_executor.execute(tc.name, tc.arguments)
             tool_duration = time.time() - tool_start

--- a/tolokaforge/session/intervention_pump.py
+++ b/tolokaforge/session/intervention_pump.py
@@ -2,36 +2,42 @@
 intervention pump into :class:`InProcessTrialSession`.
 
 Inbound counterpart to :class:`SessionLoopObserver`. Called at every turn
-boundary; drains interventions queued by attached participants, applies
-each one to the loop's transcript or returns a :class:`TerminationDecision`
-that terminates the loop, and updates the durable trace with the accept
-/ reject verdict.
+boundary (via :meth:`drain_and_apply`) and before every tool dispatch
+(via :meth:`intercept_tool_call`); drains interventions queued by
+attached participants, applies each one to the loop's transcript or
+returns a decision the loop respects.
 
-Scope today (M1 sub-5a + PR A of sub-5b):
+Scope today (M1 sub-5a + sub-5b PR A + sub-5b PR B):
 
-* ``InjectMessage`` — applied as a user-role :class:`Message` on the
-  transcript, ``ack_outcome="accepted"``.
+* ``InjectMessage`` — applied as a user-role :class:`Message`,
+  ``ack_outcome="accepted"``.
 * ``Kill`` — returns a :class:`TerminationDecision` with
-  :data:`TerminationReason.USER_STOP` and the submitting participant's
-  ``reason`` verbatim in the ``system_message``. ``ack_outcome="accepted"``.
-* **Role priority** (``admin`` > ``participant`` > ``observer``,
-  later-wins within a tier) applies when multiple ``Kill`` interventions
-  arrive at the same pause point; the losers are marked
-  ``ack_outcome="superseded"`` in the trace. Non-terminal interventions
-  drained alongside a winning Kill are also marked ``superseded`` —
-  a killed trial does not accept any further message injections.
+  :data:`TerminationReason.USER_STOP`; ``ack_outcome="accepted"``.
+* ``Pause`` / ``Resume`` — Pause enters a poll loop; Resume exits it.
+  Emits ``PauseAcknowledged`` / ``ResumeAcknowledged`` events on the
+  session so attached participants see the state transitions. If the
+  loop's episode timeout hits while paused, the pump returns a timeout
+  decision so the loop terminates cleanly.
+* ``ApproveTool`` / ``RejectTool`` — consulted per tool call via
+  :meth:`intercept_tool_call`. RejectTool short-circuits the executor
+  and the loop synthesizes a tool-error result.
+* ``EditState`` — still deferred; recorded as ``rejected`` (runner-side
+  mediation not implemented).
 
-Deferred kinds (PR B of sub-5b — Pause / Resume / ApproveTool /
-RejectTool / EditState) still land in the trace as ``rejected`` with a
-per-kind reason.
+**Role priority** (``admin`` > ``participant`` > ``observer``,
+later-wins within a tier) applies to Kill selection among concurrent
+Kills at the same pause point. Losing Kills are marked
+``ack_outcome="superseded"``.
 """
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime
 
-from tolokaforge.core.loop import TerminationDecision
+from tolokaforge.core.loop import TerminationDecision, ToolCallDecision
 from tolokaforge.core.models import Message, MessageRole, TerminationReason, TrialStatus
+from tolokaforge.session.events import PauseAcknowledged, ResumeAcknowledged
 from tolokaforge.session.in_process import InProcessTrialSession, QueuedIntervention
 from tolokaforge.session.interventions import (
     ApproveTool,
@@ -49,16 +55,6 @@ __all__ = ["SessionInterventionHandler"]
 
 
 _NOT_YET_SUPPORTED_REASONS: dict[type[TrialIntervention], str] = {
-    Pause: "Pause intervention not yet applied by the pump (M1 sub-5b PR B).",
-    Resume: "Resume intervention not yet applied by the pump (M1 sub-5b PR B).",
-    ApproveTool: (
-        "ApproveTool intervention applies at the tool-call seam, "
-        "not the turn-boundary pause point (M1 sub-5b PR B)."
-    ),
-    RejectTool: (
-        "RejectTool intervention applies at the tool-call seam, "
-        "not the turn-boundary pause point (M1 sub-5b PR B)."
-    ),
     EditState: (
         "EditState requires runner-side mediation; deferred until "
         "the runner exposes the edit surface."
@@ -71,32 +67,58 @@ _ROLE_PRIORITY: dict[ParticipantRole, int] = {
     ParticipantRole.OBSERVER: 2,
 }
 """Lower is higher priority. Admin beats participant beats observer;
-within a tier, later submission beats earlier (list order preserved
-after stable-sort)."""
+within a tier, later submission beats earlier (stable-sort preserves
+list order for equal keys)."""
+
+_PAUSE_POLL_INTERVAL_S = 0.1
+"""How often the pause loop re-drains and re-checks episode timeout.
+Small enough that a Resume shows up promptly; large enough that a
+5-second pause doesn't spin at 5000 Hz."""
 
 
 class SessionInterventionHandler:
     """Drains + applies interventions from an :class:`InProcessTrialSession`.
 
-    Instantiated per trial by the orchestrator when open mode is on.
-    Structurally satisfies the loop's :class:`InterventionHandler` Protocol.
+    Instantiated per trial by the orchestrator (via
+    :class:`OpenAgentLoopManager`) when open mode is on. Structurally
+    satisfies the loop's :class:`InterventionHandler` Protocol.
+
+    Holds a pending set of pre-approved tool-call decisions keyed by
+    ``call_id`` — populated when a matching ``ApproveTool`` / ``RejectTool``
+    is drained at the turn-boundary pause point. Consulted (and drained
+    from) inside :meth:`intercept_tool_call`. This lets participants
+    submit tool decisions ahead of when the tool actually fires.
     """
 
     def __init__(self, session: InProcessTrialSession) -> None:
         self._session = session
+        # call_id → (ToolCallDecision, backing intervention). Filled
+        # opportunistically when ApproveTool / RejectTool is drained at
+        # the turn-boundary pump point; consumed inside intercept_tool_call.
+        self._pending_tool_decisions: dict[str, tuple[ToolCallDecision, TrialIntervention]] = {}
 
-    def drain_and_apply(self, messages: list[Message]) -> TerminationDecision | None:
-        """Drain the session's pending interventions and apply supported kinds.
+    # ------------------------------------------------------------------
+    # InterventionHandler Protocol — drain_and_apply
+    # ------------------------------------------------------------------
 
-        Kill wins over everything at the same pause point — if any Kill was
-        submitted, it terminates the trial and every other drained
-        intervention (including InjectMessages) is marked ``superseded``.
-        Otherwise, InjectMessages append to ``messages`` in submit order and
-        unsupported kinds land in the trace as ``rejected`` with a per-kind
-        reason.
+    def drain_and_apply(
+        self,
+        messages: list[Message],
+        check_timeout=lambda: None,
+    ) -> TerminationDecision | None:
+        """Drain pending interventions, apply supported kinds.
 
-        Returns a :class:`TerminationDecision` on Kill, ``None`` otherwise.
+        Kill wins over everything at the same pause point. Pause enters
+        the poll loop and only returns when Resume arrives, Kill supersedes,
+        or ``check_timeout`` returns a timeout decision.
         """
+        return self._drain_and_apply_once(messages, check_timeout)
+
+    def _drain_and_apply_once(
+        self,
+        messages: list[Message],
+        check_timeout,
+    ) -> TerminationDecision | None:
         pending = self._session.drain_pending_interventions()
         if not pending:
             return None
@@ -104,39 +126,72 @@ class SessionInterventionHandler:
         kills = [queued for queued in pending if isinstance(queued.intervention, Kill)]
         if kills:
             winning_kill = self._select_kill_winner(kills)
-            # Every non-winning drained intervention (including all
-            # non-Kill kinds) is superseded — a killed trial does not
-            # accept further pump-side effects.
             for queued in pending:
                 if queued is winning_kill:
                     continue
-                self._record_superseded(queued, winning_kill)
+                self._record_superseded_by_kill(queued, winning_kill)
             return self._apply_kill(winning_kill)
 
-        # No terminal intervention — apply the rest in submit order.
+        # No Kill — check for Pause. Pause enters poll loop.
+        pauses = [queued for queued in pending if isinstance(queued.intervention, Pause)]
+        if pauses:
+            # Apply any non-terminal, non-Pause interventions first so the
+            # trial's transcript reflects everything queued alongside Pause.
+            for queued in pending:
+                if isinstance(queued.intervention, Pause):
+                    continue
+                self._apply_non_terminal(queued, messages)
+            # Then enter the pause loop with the first-in-order Pause.
+            first_pause = pauses[0]
+            for extra_pause in pauses[1:]:
+                self._record_superseded(
+                    extra_pause,
+                    reason=(
+                        f"Superseded by earlier Pause at the same pause point "
+                        f"(participant {first_pause.intervention.participant_id!r})."
+                    ),
+                )
+            return self._enter_pause_loop(first_pause, messages, check_timeout)
+
+        # No terminal or pause intervention — apply the rest in submit order.
         for queued in pending:
             self._apply_non_terminal(queued, messages)
         return None
+
+    # ------------------------------------------------------------------
+    # InterventionHandler Protocol — intercept_tool_call
+    # ------------------------------------------------------------------
+
+    def intercept_tool_call(
+        self,
+        call_id: str,
+        tool_name: str,
+        arguments: dict,
+    ) -> ToolCallDecision | None:
+        """Consult pending Approve/Reject for ``call_id``.
+
+        If a matching ``ApproveTool`` or ``RejectTool`` was drained at a
+        prior pause point, apply it and record ``ack_outcome="accepted"``.
+        Otherwise return ``None`` — default approve (executor runs).
+        """
+        del tool_name, arguments  # not used today; part of the Protocol contract
+        entry = self._pending_tool_decisions.pop(call_id, None)
+        if entry is None:
+            return None
+        decision, intervention = entry
+        self._session.record_intervention_outcome(intervention, outcome="accepted", reason=None)
+        return decision
 
     # ------------------------------------------------------------------
     # Kill handling
     # ------------------------------------------------------------------
 
     def _select_kill_winner(self, kills: list[QueuedIntervention]) -> QueuedIntervention:
-        """Pick the highest-priority Kill; within a tier, later submission wins.
-
-        Python's ``sorted`` is stable, so preserving submit-order within a
-        priority tier is automatic after sorting by role. Reversing then
-        taking the first entry yields the last-submitted of the top-priority
-        tier.
-        """
-        # Sort by role ascending (admin=0 first), then by submit order
-        # (index in the drained list — original order is submit order).
         indexed = list(enumerate(kills))
         indexed.sort(
             key=lambda pair: (
                 _ROLE_PRIORITY.get(pair[1].handle.role, len(_ROLE_PRIORITY)),
-                -pair[0],  # later index (= later submission) beats earlier within a tier
+                -pair[0],
             )
         )
         return indexed[0][1]
@@ -155,7 +210,7 @@ class SessionInterventionHandler:
             status=TrialStatus.FAILED,
         )
 
-    def _record_superseded(
+    def _record_superseded_by_kill(
         self, queued: QueuedIntervention, winning_kill: QueuedIntervention
     ) -> None:
         self._session.record_intervention_outcome(
@@ -165,6 +220,113 @@ class SessionInterventionHandler:
                 f"Superseded by Kill from participant "
                 f"{winning_kill.intervention.participant_id!r} at the same pause point."
             ),
+        )
+
+    def _record_superseded(self, queued: QueuedIntervention, reason: str) -> None:
+        self._session.record_intervention_outcome(
+            queued.intervention, outcome="superseded", reason=reason
+        )
+
+    # ------------------------------------------------------------------
+    # Pause / Resume state machine
+    # ------------------------------------------------------------------
+
+    def _enter_pause_loop(
+        self,
+        pause_queued: QueuedIntervention,
+        messages: list[Message],
+        check_timeout,
+    ) -> TerminationDecision | None:
+        """Block the loop's producer thread until Resume, Kill, or timeout.
+
+        Publishes ``PauseAcknowledged`` on entry and ``ResumeAcknowledged``
+        on normal exit. On Kill mid-pause, publishes ResumeAcknowledged
+        (the pause ended, just not on the participant's terms) then returns
+        the Kill's termination decision. On timeout, terminates with the
+        timeout decision.
+        """
+        pause_intervention = pause_queued.intervention
+        self._session.record_intervention_outcome(
+            pause_intervention, outcome="accepted", reason=None
+        )
+        self._session.publish(
+            PauseAcknowledged(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                triggered_by_participant=pause_intervention.participant_id,
+            )
+        )
+
+        while True:
+            time.sleep(_PAUSE_POLL_INTERVAL_S)
+
+            timeout_decision = check_timeout()
+            if timeout_decision is not None:
+                self._publish_resume_ack(pause_intervention.participant_id)
+                return timeout_decision
+
+            pending = self._session.drain_pending_interventions()
+            if not pending:
+                continue
+
+            # Kill wins even inside a pause.
+            kills = [q for q in pending if isinstance(q.intervention, Kill)]
+            if kills:
+                winning_kill = self._select_kill_winner(kills)
+                for q in pending:
+                    if q is winning_kill:
+                        continue
+                    self._record_superseded_by_kill(q, winning_kill)
+                self._publish_resume_ack(pause_intervention.participant_id)
+                return self._apply_kill(winning_kill)
+
+            resumes = [q for q in pending if isinstance(q.intervention, Resume)]
+            if resumes:
+                # First Resume wins; extras (unlikely) marked superseded.
+                first_resume = resumes[0]
+                self._session.record_intervention_outcome(
+                    first_resume.intervention, outcome="accepted", reason=None
+                )
+                for extra in resumes[1:]:
+                    self._record_superseded(
+                        extra,
+                        reason="Superseded by an earlier Resume at the same wake-up.",
+                    )
+                # Apply any non-Resume, non-Kill interventions that came in
+                # alongside the Resume (e.g. an Inject the operator queued
+                # to fire on wake-up).
+                for q in pending:
+                    if isinstance(q.intervention, (Resume, Kill)):
+                        continue
+                    self._apply_non_terminal(q, messages)
+                self._publish_resume_ack(first_resume.intervention.participant_id)
+                return None
+
+            # No Kill, no Resume — buffer everything else as superseded
+            # (a paused trial shouldn't accept mutations until Resume
+            # brings it back).
+            for q in pending:
+                if isinstance(q.intervention, Pause):
+                    self._record_superseded(q, reason="Already paused; extra Pause ignored.")
+                else:
+                    self._record_superseded(
+                        q,
+                        reason=(
+                            f"Trial is paused (by participant "
+                            f"{pause_intervention.participant_id!r}); "
+                            "intervention buffered as superseded."
+                        ),
+                    )
+
+    def _publish_resume_ack(self, triggered_by: str) -> None:
+        self._session.publish(
+            ResumeAcknowledged(
+                trial_id=self._session.trial_id,
+                seq=self._session.next_seq(),
+                timestamp=_now(),
+                triggered_by_participant=triggered_by,
+            )
         )
 
     # ------------------------------------------------------------------
@@ -178,10 +340,34 @@ class SessionInterventionHandler:
                 Message(
                     role=MessageRole.USER,
                     content=intervention.content,
-                    ts=datetime.now(UTC),
+                    ts=_now(),
                 )
             )
             self._session.record_intervention_outcome(intervention, outcome="accepted", reason=None)
+            return
+
+        if isinstance(intervention, ApproveTool):
+            self._pending_tool_decisions[intervention.call_id] = (
+                ToolCallDecision(action="approve", reason=intervention.reason),
+                intervention,
+            )
+            # Outcome recorded when intercept_tool_call fires; queued for now
+            return
+
+        if isinstance(intervention, RejectTool):
+            self._pending_tool_decisions[intervention.call_id] = (
+                ToolCallDecision(action="reject", reason=intervention.reason),
+                intervention,
+            )
+            return
+
+        if isinstance(intervention, Resume):
+            # A Resume outside a pause loop is a no-op — nothing to resume from.
+            self._session.record_intervention_outcome(
+                intervention,
+                outcome="rejected",
+                reason="Resume received while trial is not paused; no state to change.",
+            )
             return
 
         reason = _NOT_YET_SUPPORTED_REASONS.get(
@@ -189,3 +375,7 @@ class SessionInterventionHandler:
             f"Intervention kind {intervention.kind!r} not handled by the M1 pump.",
         )
         self._session.record_intervention_outcome(intervention, outcome="rejected", reason=reason)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)


### PR DESCRIPTION
Part of #408 (M1 umbrella). **Closes most of #441** (sub-5b tracker); EditState remains deferred (needs runner-side edit surface).

Second of two sub-5b PRs. PR A (#455, merged) added Kill + role priority. This PR adds the remaining M1 intervention kinds.

## Summary

Copilots and human operators can now:

- **Pause** a trial mid-flight for inspection. Pause enters a poll loop; the loop remains alive but doesn't advance turns until Resume arrives (or Kill supersedes, or episode timeout hits).
- **Resume** a paused trial. Any interventions queued alongside the Resume (e.g. an Inject the operator wanted to fire on wake-up) apply before the loop continues.
- **Approve** or **RejectTool** individual tool calls before they execute. RejectTool short-circuits ``tool_executor.execute`` and synthesizes a tool-error message carrying the reject reason — the agent sees a normal tool-error result and reacts in its next turn.

Both operations emit typed events on the session (``PauseAcknowledged`` / ``ResumeAcknowledged``) so attached participants see state transitions in real time.

## What ships

### Loop-side (contract widening)

- New ``ToolCallDecision`` dataclass (``approve`` | ``reject`` with optional reason).
- ``InterventionHandler`` Protocol gains ``intercept_tool_call(call_id, tool_name, arguments) -> ToolCallDecision | None`` — consulted between the ``on_tool_call`` observer emit and ``tool_executor.execute``.
- ``drain_and_apply`` signature gains ``check_timeout`` callable — the pump respects episode-timeout while paused without owning the timer.
- ``_execute_tool_calls`` calls the handler before each dispatch; on reject, synthesizes a tool-error message with ``ack_outcome=\"success=False\"`` and skips the executor.

### Pump-side (SessionInterventionHandler)

- **Pause / Resume state machine.** Pause enters a poll loop (``_PAUSE_POLL_INTERVAL_S = 0.1 s``). Emits ``PauseAcknowledged`` event; on exit (Resume / Kill / timeout) emits ``ResumeAcknowledged``. Non-Pause interventions drained alongside Pause are applied first; the pause loop blocks on the next drain cycle.
- **Kill during pause** supersedes and terminates. Participant-side sees ``ResumeAcknowledged`` so they know the state ended (just not on their terms), plus the trajectory records the Kill.
- **Timeout during pause** — the ``check_timeout`` callback returns the loop's timeout decision; pump propagates it as its own return value.
- **ApproveTool / RejectTool** drained at turn boundary → parked in an internal ``call_id`` → ``ToolCallDecision`` dict. Consumed by ``intercept_tool_call`` when the tool actually fires. Ack outcome recorded on consumption (``accepted`` — the decision was applied).
- **Resume outside a pause loop** is a no-op (rejected in trace).
- **EditState** remains rejected (runner-side mediation not implemented).

## Tests (7 new, 23 total in the pump suite)

- ``TestPauseResumeFlow`` (3) — Pause then Resume from another thread returns ``None`` + emits both ack events; Kill mid-pause supersedes and terminates; timeout via ``check_timeout`` callback returns the timeout decision.
- ``TestToolApproval`` (4) — no pending decision returns ``None``; RejectTool queued at turn boundary is returned by ``intercept_tool_call`` + recorded ``accepted``; ApproveTool same; **end-to-end loop test proves RejectTool short-circuits the executor** (``tool_executor.execute`` never called; a synthetic tool-error carrying the reject reason lands on the transcript).

## Test plan

- [x] ``uv run pytest tests/ -m canonical`` → **429 passed** (no regressions)
- [x] ``uv run pytest tests/unit -m unit -k \"loop or session or conductor or runner or orchestrator\"`` → **483 passed** (+7 new)
- [x] ``uv run ruff check ...`` → clean

## What remains after this

- **EditState** — the last unimplemented intervention kind. Blocked on the runner exposing a mediated edit-state surface. Separate follow-up.
- **Live-attach from a remote process** — M4 (``tolokaforge session attach`` CLI + socket transport). Issue #442.