### PR TITLE
fix(tools): advertise PATCH requests

### DIFF
--- a/tests/unit/test_tool_builtins.py
+++ b/tests/unit/test_tool_builtins.py
@@ -298,6 +298,7 @@ class TestHTTPRequestTool:
         assert func["name"] == "http_request"
         params = func["parameters"]
         assert "method" in params["properties"]
+        assert "PATCH" in params["properties"]["method"]["enum"]
         assert "url" in params["properties"]
         assert "headers" in params["properties"]
         assert "json" in params["properties"]

--- a/tolokaforge/tools/builtin/http_request.py
+++ b/tolokaforge/tools/builtin/http_request.py
@@ -40,7 +40,7 @@ class HTTPRequestTool(Tool):
                     "properties": {
                         "method": {
                             "type": "string",
-                            "enum": ["GET", "POST", "PUT", "DELETE"],
+                            "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
                             "description": "HTTP method",
                         },
                         "url": {


### PR DESCRIPTION
Fixes #452.

Adds `PATCH` to the advertised HTTP request methods, matching the runtime's existing forwarding behavior. The schema regression test fails on `main` and passes with this change; all 19 `HTTPRequestTool` unit tests pass.
