### PR TITLE
feat(observability): per-trial provisioning_duration_s in metrics.yaml (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Feat
+
+- **observability**: per-trial `provisioning_duration_s` recorded in `metrics.yaml` — wall-clock seconds around the `provision → await_ready → endpoints` bracket, monotonic-clock-measured, additive to the existing metrics shape (#354).
+
 ### Docs
 
 - **guide**: task-pack image-layering guide covering the 3-tier base/environment/instance pattern from SWE-bench, with Dockerfile snippets and compose-file references (#146).

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -376,6 +376,19 @@ table):
 | `cache_read_input_tokens` | Anthropic | Tokens re-used from the ephemeral cache this call |
 | `provider_raw` | — | Best-effort dump of the *last* call's raw usage block |
 
+### `provisioning_duration_s` — wall-clock provisioning latency
+
+```yaml
+provisioning_duration_s: 5.5
+```
+
+Wall-clock seconds (monotonic-clock-measured, rounded to milliseconds) from
+`provision` start through `endpoints()` return — the full
+`provision → await_ready → endpoints` bracket, excluding the trial body and
+teardown. Recorded on every trial that provisions successfully and runs a
+conductor body. Absent when provisioning failed (no `metrics.yaml` is written on
+that path).
+
 ### `captured_service_logs` — on trial-body or graded failure
 
 When a trial is diagnostics-worthy — its body fails (`trajectory.status` is

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -359,6 +359,12 @@ this and captures on success too.
   (the hook writes only the `.log` files). See
   [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md:1) § `captured_service_logs`.
 
+On every trial that provisions successfully, the executor also amends the
+trial's `metrics.yaml` with a top-level `provisioning_duration_s` — the
+monotonic-clock wall-clock of the `provision → await_ready → endpoints` bracket,
+measured before `provision()` and stopped at `endpoints()` return. See
+[`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md:1) § `provisioning_duration_s`.
+
 Both surfaces are best-effort: capture runs *because* a failure was already
 decided, so a per-service fetch error is logged at debug and that service is
 omitted — capture never raises and never masks the original error.

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -17,6 +17,7 @@ per-service ``.log`` capture is locked by the Docker integration test.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -24,6 +25,7 @@ import pytest
 import yaml
 
 from tests.canonical._factories import make_task_config, make_trial_spec
+from tolokaforge.core import trial_executor
 from tolokaforge.core.compose_materialisation import LogCaptureConfig
 from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.logging import StructuredLogger
@@ -34,6 +36,11 @@ from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 pytestmark = pytest.mark.canonical
 
 _BYTE_MAP = {"db": 128, "runner": 64}
+
+
+def _monotonic_sequence(ticks: list[float]) -> Callable[[], float]:
+    it = iter(ticks)
+    return lambda: next(it)
 
 
 class _StubCaptureBackend(InMemoryRuntimeBackend):
@@ -186,3 +193,54 @@ class TestUngradedCompletedIsNotCapture:
 
         metrics = yaml.safe_load(metrics_path.read_text())
         assert "captured_service_logs" not in metrics
+
+
+class TestProvisioningDuration:
+    def test_records_on_passing_trial(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(trial_executor.time, "monotonic", _monotonic_sequence([10.0, 11.5]))
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.COMPLETED, binary_pass=True)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert metrics["provisioning_duration_s"] == 1.5
+        assert isinstance(metrics["provisioning_duration_s"], float)
+        # Pre-existing keys survive; a passing trial is not capture-worthy.
+        assert metrics["cost_usd"] == 0.5
+        assert "captured_service_logs" not in metrics
+
+    def test_coexists_with_captured_service_logs_on_red_trial(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(trial_executor.time, "monotonic", _monotonic_sequence([100.0, 105.5]))
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.ERROR, binary_pass=False)
+        executor = _make_executor(backend, factory, tmp_path)
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert metrics["provisioning_duration_s"] == 5.5
+        assert metrics["captured_service_logs"] == _BYTE_MAP
+        assert metrics["cost_usd"] == 0.5
+
+    def test_no_output_root_writes_nothing(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(trial_executor.time, "monotonic", _monotonic_sequence([1.0, 2.0]))
+        backend = _StubCaptureBackend()
+        factory = _factory_for(TrialStatus.COMPLETED, binary_pass=True)
+        executor = ProvisioningTrialExecutor(
+            runtime_backend=backend,
+            conductor=InMemoryConductor(trajectory_factory=factory),
+            logger=StructuredLogger("test-executor-log-capture"),
+            log_capture=None,
+        )
+        metrics_path = _write_metrics(tmp_path, "task-1", 0)
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        metrics = yaml.safe_load(metrics_path.read_text())
+        assert "provisioning_duration_s" not in metrics

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -23,8 +23,9 @@ without touching the orchestrator.
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import yaml
 
@@ -116,6 +117,7 @@ class ProvisioningTrialExecutor:
             task_id=task_id,
             trial_index=trial_idx,
         )
+        provision_start = time.monotonic()
         try:
             handle = self.runtime_backend.provision(spec)
         except ProvisionError as e:
@@ -143,6 +145,7 @@ class ProvisioningTrialExecutor:
 
         try:
             real_endpoints = self.runtime_backend.endpoints(handle)
+            provisioning_duration_s = time.monotonic() - provision_start
             containers = self.runtime_backend.get_infrastructure_snapshot(handle)
             self.events.trial_provisioned(
                 trial_id=spec.trial_id,
@@ -157,6 +160,11 @@ class ProvisioningTrialExecutor:
                 runner_url=real_endpoints.runner_url,
             )
             result = self.conductor.run(final_spec, task_config)
+            self._amend_trial_metrics(
+                task_id,
+                trial_idx,
+                {"provisioning_duration_s": round(provisioning_duration_s, 3)},
+            )
             self._capture_service_logs(handle, result, task_id, trial_idx)
             return result
         finally:
@@ -192,18 +200,17 @@ class ProvisioningTrialExecutor:
             trial_index=trial_idx,
             services=byte_map,
         )
-        self._amend_metrics_with_captured_logs(task_id, trial_idx, byte_map)
+        self._amend_trial_metrics(task_id, trial_idx, {"captured_service_logs": dict(byte_map)})
 
-    def _amend_metrics_with_captured_logs(
-        self, task_id: str, trial_idx: int, byte_map: dict[str, int]
-    ) -> None:
-        """Add a top-level ``captured_service_logs`` mapping to the trial's
-        ``metrics.yaml`` — the durable record for the trial-body path.
+    def _amend_trial_metrics(self, task_id: str, trial_idx: int, updates: dict[str, Any]) -> None:
+        """Merge ``updates`` into the trial's ``metrics.yaml`` as top-level keys.
 
-        Read-add-write of the plain YAML mapping the conductor already wrote.
-        No-op when no ``log_capture`` output root is configured or the file is
-        absent. Logs and continues on I/O failure so a diagnostic write never
-        masks the trial result.
+        Read-add-write of the plain YAML mapping the conductor already wrote —
+        the durable landing spot for host-side per-trial values
+        (``provisioning_duration_s``, ``captured_service_logs``). No-op when no
+        ``log_capture`` output root is configured or the file is absent. Logs
+        and continues on I/O failure so a diagnostic write never masks the trial
+        result.
         """
         if self.log_capture is None:
             return
@@ -215,12 +222,12 @@ class ProvisioningTrialExecutor:
         try:
             with metrics_path.open() as f:
                 metrics = yaml.safe_load(f) or {}
-            metrics["captured_service_logs"] = dict(byte_map)
+            metrics.update(updates)
             with metrics_path.open("w") as f:
                 yaml.safe_dump(metrics, f, sort_keys=False)
         except Exception as amend_err:  # noqa: BLE001 — best-effort diagnostic amendment
             self.logger.warning(
-                "Amending metrics.yaml with captured_service_logs failed; continuing",
+                "Amending metrics.yaml failed; continuing",
                 task_id=task_id,
                 trial_index=trial_idx,
                 error=str(amend_err),


### PR DESCRIPTION
Closes #354.

## Summary

- **New per-trial metric.** `metrics.yaml` gains a top-level `provisioning_duration_s: <float>` field recording wall-clock seconds across the `provision → await_ready → endpoints` bracket (deliberately excludes trial body + teardown). `time.monotonic()`-measured; recorded on every successfully-run trial.
- **DRY refactor.** Both `provisioning_duration_s` (new) and `captured_service_logs` (from #418) now route through a single `_amend_trial_metrics(task_id, trial_idx, updates)` helper in `tolokaforge/core/trial_executor.py`. The old `_amend_metrics_with_captured_logs` is deleted (no shim). Regression guard: `test_coexists_with_captured_service_logs_on_red_trial` asserts a red trial gets both keys.
- **Additive to `metrics.yaml`.** No schema break — new top-level field alongside existing keys. Both readers (`orchestrator.py:404`, `cli/main.py:599`) use `yaml.safe_load` + `.get()`; the `Metrics` pydantic model (which has `extra="forbid"`) is not round-tripped from disk.

## Test tier

Canonical only (marker `canonical` in `tests/canonical/test_executor_log_capture.py::TestProvisioningDuration`, 3 cases):
1. Passing trial records `provisioning_duration_s` (monkeypatched `time.monotonic()` → deterministic delta).
2. Red trial gets BOTH `provisioning_duration_s` AND `captured_service_logs` (DRY-refactor regression guard).
3. `log_capture=None` → no writes, no raise.

All 8 tests in the file (5 existing + 3 new) pass.

## Docs + CHANGELOG

- `docs/OUTPUT_FORMAT.md` — new `### provisioning_duration_s` subsection in the `metrics.yaml` field reference.
- `docs/RUNTIME_BACKENDS.md` — pointer in the trial-body amendment ("Two capture surfaces") section.
- `CHANGELOG.md` under `## Unreleased` → `### Feat`.

## Reviewer verdict

**APPROVE WITH NITS** — 1 optional nit (a future `monotonic()` call on the same code path would trip the exact-count-based test mock with `StopIteration`; defensible as-is since `execute()` calls it exactly twice today). No blockers. Refactor complete, boundaries match the plan, coverage honest.

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425).
