### PR TITLE
feat(automation): calibrate candidate parallelism before observe (429 staircase)

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -210,6 +210,37 @@ jobs:
         run: |
           uv run automation ensure-pricing --name "$TF_NAME" || true
 
+      - name: Calibrate candidate parallelism (429 staircase; can only LOWER the defaults)
+        # New / low-capacity models often rate-limit under the default 10-wide probe pools,
+        # which contaminates the observe (429/instability -> infra-dirty -> needs-human).
+        # A cheap staircase (waves of concurrent 1-token completions at 2/4/6/8/10) finds the
+        # highest clean concurrency; the recommendation caps at the configured values (it can
+        # only lower parallelism, never raise it) and floors at 2. Advisory + fail-open: no
+        # recommendation (tool error, missing key, OBSERVE_CALIBRATE=false) keeps the defaults.
+        id: calibrate
+        if: vars.OBSERVE_CALIBRATE != 'false'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+          TF_NAME: ${{ steps.parse.outputs.name }}
+        run: |
+          set -uo pipefail
+          OUT="$(uv run automation calibrate-parallelism --name "$TF_NAME" \
+                 --ceiling "$CAP_PARALLEL" --floor 2 2>/dev/null || true)"
+          printf '%s\n' "$OUT"
+          REC="$(printf '%s' "$OUT" | jq -r '.recommended // empty' 2>/dev/null || true)"
+          if [ -n "$REC" ]; then
+            W=$(( REC < WORKERS ? REC : WORKERS ))
+            R=$(( REC < RESOLVE_CAP_PARALLEL ? REC : RESOLVE_CAP_PARALLEL ))
+            {
+              echo "cap_parallel=$REC"
+              echo "workers=$W"
+              echo "resolve_cap_parallel=$R"
+            } >> "$GITHUB_OUTPUT"
+            echo "calibrated: cap_parallel=$REC workers=$W resolve_cap_parallel=$R (defaults $CAP_PARALLEL/$WORKERS/$RESOLVE_CAP_PARALLEL)"
+          else
+            echo "::warning::parallelism calibration produced no recommendation - keeping defaults ($CAP_PARALLEL/$WORKERS/$RESOLVE_CAP_PARALLEL)"
+          fi
+
       # ---------------------------------------------------------------- OBSERVE
       - name: Capability integration probes (report-only, CAPABILITY_K repeats)
         # All capabilities run against the candidate (ephemeral all-required cert injected via
@@ -221,6 +252,8 @@ jobs:
           TF_CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
           OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+          # Calibrated pool width (empty/skipped calibration -> the configured default).
+          CAP_PARALLEL: ${{ steps.calibrate.outputs.cap_parallel || env.CAP_PARALLEL }}
         run: |
           # Flat (node x rep) pool: collect the candidate's capability nodes once, then run
           # each node x rep as its own single-node pytest at CAP_PARALLEL width - so nodes AND
@@ -239,6 +272,7 @@ jobs:
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
           TF_RUN_VARIANTS: "1"
           OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+          CAP_PARALLEL: ${{ steps.calibrate.outputs.cap_parallel || env.CAP_PARALLEL }}
         run: |
           # Same flat (node x rep) pool as the capability step. The variant cases are the
           # slowest for a reasoning model (heavy thinking on the shape-sensitive shapes), so
@@ -254,6 +288,9 @@ jobs:
         env:
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
+          # Calibrated orchestrator width (the candidate is the binding constraint; the
+          # user-sim runs on a high-capacity slug). Empty/skipped -> the configured default.
+          WORKERS: ${{ steps.calibrate.outputs.workers || env.WORKERS }}
         run: |
           set -euo pipefail
           cat > observation/candidate_run.yaml <<YAML
@@ -469,6 +506,8 @@ jobs:
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          # The reprobe drives the same candidate, so it shares the calibrated limit.
+          RESOLVE_CAP_PARALLEL: ${{ steps.calibrate.outputs.resolve_cap_parallel || env.RESOLVE_CAP_PARALLEL }}
         run: |
           set -uo pipefail
           mkdir -p observation/resolve

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -103,6 +103,7 @@ Both the AGENT and the CANDIDATE run on the OpenRouter budget (`ARENA_AUTOMATION
 | `OBSERVE_WIRE_K` | 10 | observe wire-probe repeats |
 | `OBSERVE_WORKERS` | 10 | wire-probe orchestrator workers (trial-level) |
 | `OBSERVE_CAP_PARALLEL` | 10 | capability + variant flat (node x rep) pool width (raised from 4; the old per-rep pool was serial-within-rep and cost a slow reasoning model hours) |
+| `OBSERVE_CALIBRATE` | (unset = on) | set `false` to skip the pre-observe parallelism calibration. When on, a cheap 429 staircase (`automation calibrate-parallelism`: waves of concurrent 1-token completions at 2/4/6/8/10) measures the highest concurrency the candidate serves cleanly and LOWERS `CAP_PARALLEL` / `WORKERS` / `RESOLVE_CAP_PARALLEL` to it for this run (never raises them; floor 2). New / low-capacity models otherwise 429 or destabilize under the default 10-wide pools and land in needs-human for infra reasons. Advisory + fail-open: a failed probe keeps the defaults. Note: a heavily throttled model calibrates down to 2, which makes the observe proportionally slower - that is the trade for a clean observation. |
 | `RESOLVE_MAX_ITER` | 8 | resolve fix-loop iterations (the agent can also escalate early, see below) |
 | `RESOLVE_MAX_TURNS` | 80 | per-iteration agent turn budget (headroom for code-CREATE; exhausting it degrades to needs-human, never hard-fails) |
 | `RESOLVE_AGENT_MODEL` | claude-opus-4-8 | resolve agent model alias (shared by the Claude Code CLI and the gateway; keep it a full model id, not a CLI shorthand like `opus`) |

--- a/tools/automation/src/automation/calibrate.py
+++ b/tools/automation/src/automation/calibrate.py
@@ -1,0 +1,143 @@
+"""Calibrate how much request parallelism the candidate model tolerates (429 staircase).
+
+New / low-capacity OpenRouter models often rate-limit (or destabilize) under the observe
+stage's default 10-wide probe pool, which contaminates the observation and lands the PR in
+needs-human for infra reasons. This probe measures the candidate BEFORE the heavy stages:
+fire ``waves`` waves of ``level`` concurrent minimal completions at increasing concurrency
+levels; a level is CLEAN when it produced zero HTTP 429 and at most one transient non-429
+error. The recommendation is the highest clean level.
+
+Safety property: the recommendation is capped by the configured ceiling (today's default),
+so calibration can only LOWER parallelism for a weak model, never raise it above the
+configured value; the floor keeps a totally-throttled model from going below a workable
+minimum. The workflow treats a missing/failed calibration as fail-open (defaults stay).
+
+Deterministic orchestration (``staircase``) is separated from the network call
+(``_request_once``) so the logic is unit-testable with a fake requester.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import urllib.error
+import urllib.request
+
+import typer
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+DEFAULT_LEVELS = "2,4,6,8,10"
+DEFAULT_WAVES = 2
+
+
+def classify(status: int | None) -> str:
+    """One outcome bucket per request: ok / rate_limited / error (incl. no-status = transport)."""
+    if status == 429:
+        return "rate_limited"
+    if status is not None and 200 <= status < 300:
+        return "ok"
+    return "error"
+
+
+def level_clean(counts: dict[str, int]) -> bool:
+    """A level passes with ZERO 429s and at most one transient non-429 error (a lone flake
+    must not halve the parallelism of the whole observe)."""
+    return counts.get("rate_limited", 0) == 0 and counts.get("error", 0) <= 1
+
+
+def choose(clean_levels: list[int], floor: int, ceiling: int) -> int:
+    """Highest clean level, clamped to [floor, ceiling]; no clean level at all -> floor."""
+    best = max(clean_levels) if clean_levels else floor
+    return max(floor, min(best, ceiling))
+
+
+def staircase(
+    request_fn,
+    levels: list[int],
+    waves: int,
+    floor: int,
+    ceiling: int,
+) -> dict:
+    """Probe increasing concurrency levels until one is dirty; recommend the last clean one.
+
+    ``request_fn`` is a zero-arg callable returning a classification bucket (see
+    :func:`classify`); each level fires ``waves`` waves of ``level`` concurrent calls.
+    Levels above the ceiling are not probed (their answer could not be used anyway).
+    """
+    results: list[dict] = []
+    clean: list[int] = []
+    for level in sorted(levels):
+        if level > ceiling:
+            break
+        counts = {"ok": 0, "rate_limited": 0, "error": 0}
+        for _ in range(waves):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=level) as pool:
+                for outcome in pool.map(lambda _i: request_fn(), range(level)):
+                    counts[outcome] = counts.get(outcome, 0) + 1
+        results.append({"level": level, **counts})
+        if not level_clean(counts):
+            break
+        clean.append(level)
+    return {
+        "recommended": choose(clean, floor, ceiling),
+        "levels": results,
+        "floor": floor,
+        "ceiling": ceiling,
+    }
+
+
+def _request_once(name: str, api_key: str, timeout: float) -> str:
+    """One minimal completion against the candidate (max_tokens=1); returns its bucket."""
+    payload = json.dumps(
+        {"model": name, "messages": [{"role": "user", "content": "ping"}], "max_tokens": 1}
+    ).encode()
+    req = urllib.request.Request(
+        OPENROUTER_URL,
+        data=payload,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return classify(resp.status)
+    except urllib.error.HTTPError as exc:
+        return classify(exc.code)
+    except Exception:
+        return classify(None)
+
+
+def cli(
+    name: str = typer.Option(..., "--name", help="candidate model slug (e.g. meta/muse-spark-1.1)"),
+    ceiling: int = typer.Option(
+        10, "--ceiling", help="configured parallelism (the cap; calibration only lowers)"
+    ),
+    floor: int = typer.Option(
+        2, "--floor", help="minimum recommendation even when fully throttled"
+    ),
+    levels: str = typer.Option(
+        DEFAULT_LEVELS, "--levels", help="comma-separated concurrency levels to probe"
+    ),
+    waves: int = typer.Option(
+        DEFAULT_WAVES, "--waves", help="waves of concurrent requests per level"
+    ),
+    timeout: float = typer.Option(45.0, "--timeout", help="per-request timeout seconds"),
+) -> None:
+    """Print a JSON parallelism recommendation for the candidate ({"recommended": N, ...}).
+
+    Always exits 0: calibration is advisory and must never fail the pipeline; a missing key
+    or an unusable probe yields {"recommended": null} and the workflow keeps its defaults.
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    if not api_key:
+        print(json.dumps({"recommended": None, "error": "OPENROUTER_API_KEY is not set"}))
+        raise typer.Exit(0)
+    try:
+        level_list = [int(x) for x in levels.split(",") if x.strip()]
+        result = staircase(
+            lambda: _request_once(name, api_key, timeout), level_list, waves, floor, ceiling
+        )
+    except Exception as exc:  # advisory step: degrade to "no recommendation", never fail
+        result = {"recommended": None, "error": str(exc)}
+    print(json.dumps(result))
+    raise typer.Exit(0)

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -10,6 +10,7 @@ import json
 import typer
 
 from automation import (
+    calibrate,
     cert,
     greencheck,
     model_resolver,
@@ -36,6 +37,9 @@ app.command("slack-poll")(poller.cli)
 
 # The needs-human "why it did not converge" report composer.
 app.command("resolve-report")(resolve_report.cli)
+
+# The candidate rate-limit staircase (parallelism recommendation for the observe/resolve pools).
+app.command("calibrate-parallelism")(calibrate.cli)
 
 
 @app.command("reconcile-cert")

--- a/tools/automation/tests/test_calibrate.py
+++ b/tools/automation/tests/test_calibrate.py
@@ -1,0 +1,86 @@
+"""Unit tests for the candidate parallelism calibration (429 staircase)."""
+
+from __future__ import annotations
+
+import automation.calibrate as cal
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestClassify:
+    def test_429_is_rate_limited(self):
+        assert cal.classify(429) == "rate_limited"
+
+    def test_2xx_is_ok(self):
+        assert cal.classify(200) == "ok"
+        assert cal.classify(201) == "ok"
+
+    def test_5xx_and_transport_are_error(self):
+        assert cal.classify(500) == "error"
+        assert cal.classify(None) == "error"
+
+
+class TestLevelClean:
+    def test_clean_when_no_429_and_no_errors(self):
+        assert cal.level_clean({"ok": 8, "rate_limited": 0, "error": 0})
+
+    def test_one_transient_error_is_tolerated(self):
+        assert cal.level_clean({"ok": 7, "rate_limited": 0, "error": 1})
+
+    def test_any_429_is_dirty(self):
+        assert not cal.level_clean({"ok": 7, "rate_limited": 1, "error": 0})
+
+    def test_two_errors_are_dirty(self):
+        assert not cal.level_clean({"ok": 6, "rate_limited": 0, "error": 2})
+
+
+class TestChoose:
+    def test_highest_clean_level_wins(self):
+        assert cal.choose([2, 4, 6], floor=2, ceiling=10) == 6
+
+    def test_ceiling_caps_the_recommendation(self):
+        assert cal.choose([2, 4, 6, 8], floor=2, ceiling=6) == 6
+
+    def test_no_clean_level_falls_to_floor(self):
+        assert cal.choose([], floor=2, ceiling=10) == 2
+
+
+class TestStaircase:
+    def test_all_clean_recommends_highest_probed_level(self):
+        result = cal.staircase(lambda: "ok", [2, 4, 6], waves=1, floor=2, ceiling=10)
+        assert result["recommended"] == 6
+        assert [r["level"] for r in result["levels"]] == [2, 4, 6]
+
+    def test_stops_at_first_dirty_level(self):
+        # Clean through level 4, then every request 429s.
+        calls = {"n": 0}
+
+        def fn():
+            calls["n"] += 1
+            return "ok" if calls["n"] <= 2 + 4 else "rate_limited"
+
+        result = cal.staircase(fn, [2, 4, 6, 8], waves=1, floor=2, ceiling=10)
+        assert result["recommended"] == 4
+        # Level 8 was never probed (6 was dirty).
+        assert [r["level"] for r in result["levels"]] == [2, 4, 6]
+
+    def test_fully_throttled_model_gets_the_floor(self):
+        result = cal.staircase(lambda: "rate_limited", [2, 4], waves=1, floor=2, ceiling=10)
+        assert result["recommended"] == 2
+        assert len(result["levels"]) == 1  # stopped immediately
+
+    def test_levels_above_the_ceiling_are_not_probed(self):
+        result = cal.staircase(lambda: "ok", [2, 4, 16], waves=1, floor=2, ceiling=10)
+        assert [r["level"] for r in result["levels"]] == [2, 4]
+        assert result["recommended"] == 4
+
+    def test_waves_multiply_the_request_count(self):
+        calls = {"n": 0}
+
+        def fn():
+            calls["n"] += 1
+            return "ok"
+
+        cal.staircase(fn, [3], waves=2, floor=2, ceiling=10)
+        assert calls["n"] == 6  # 2 waves x 3 concurrent


### PR DESCRIPTION
New / low-capacity models often rate-limit under the observe stage's default 10-wide probe pools, contaminating the observation (429/instability) and landing the PR in needs-human for infra reasons. This adds a cheap pre-observe calibration step that measures the concurrency the candidate actually serves cleanly and lowers the pool widths for that run.

## What
- **`automation calibrate-parallelism`** (new subcommand): staircase of waves of concurrent 1-token completions at increasing levels (2/4/6/8/10). A level is clean with zero 429 and at most one transient error; recommendation = highest clean level. Pure orchestration separated from the network call; **15 unit tests**.
- **`integrate-model.yml`**: `Calibrate candidate parallelism` step after pricing; the capability / shape-variant / wire-probe / resolve-reprobe steps consume the calibrated widths via step env with fallback to the configured defaults.
- **docs**: `OBSERVE_CALIBRATE` config row.

## Safety properties
- Can only **LOWER** parallelism (ceiling = configured `CAP_PARALLEL`; workers/resolve widths min'd against their configured values) - never more aggressive than today.
- **Advisory + fail-open**: tool error / missing key / `OBSERVE_CALIBRATE=false` keeps the defaults.
- Floor 2: a fully throttled model still probes, just slowly (the trade for a clean observation).

## Cost
~60 one-token requests, ~1-2 min, negligible spend.

## Honest scoping
This addresses the 429/capacity contamination class. A max_turns-dominated dirty observe (like muse-spark-1.1's 163/200: the model loops without finishing) is a different failure mode and still correctly routes to needs-human at the gate.

Validation: 146 tool tests green, ruff + black clean, workflow YAML parses, CLI fail-open verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)