### PR TITLE
feat(runtime): capture shared-stack compose logs on materialise failure (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **runtime**: `SharedStackRuntimeBackend._materialise_manifest` now captures per-service compose logs to `<output_dir>/services/<name>.log` + `_capture.yaml` (with `capture_reason: "materialise_error"`) before cleanup on the failure path — mirroring #302's per-trial pattern for run-level materialise failures (#339).
 - **observability**: per-trial `provisioning_duration_s` recorded in `metrics.yaml` — wall-clock seconds around the `provision → await_ready → endpoints` bracket, monotonic-clock-measured, additive to the existing metrics shape (#354).
 
 ### Docs

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -338,7 +338,8 @@ did not land. A `COMPLETED` trial that passes, or one with no grade, does not
 trigger capture. The `compute.capture_logs_on_success` debug flag overrides
 this and captures on success too.
 
-**Two capture surfaces.**
+**Capture surfaces.** Two are per-trial (`PerTrialRuntimeBackend`); the third is
+run-level (`SharedStackRuntimeBackend`).
 
 - **Provision-failure path** — `provision()` captures before
   `cleanup_partial_materialisation` in both failure branches (compose
@@ -358,6 +359,16 @@ this and captures on success too.
   top-level `captured_service_logs` mapping — the durable record on this path
   (the hook writes only the `.log` files). See
   [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md:1) § `captured_service_logs`.
+- **Shared-stack materialise-failure path** — `SharedStackRuntimeBackend`
+  materialises the task-declared compose stack once at `connect` time for the
+  whole run. If it fails (compose `up --wait` failure or the declared runner
+  service never exposing its port), the run-wide per-service logs are captured
+  before `cleanup_partial_materialisation` to a **run-level** location,
+  `<output_dir>/services/<name>.log`, with a `services/_capture.yaml` durable
+  record carrying `capture_reason: "materialise_error"` (distinguishing it from
+  the per-trial `"provision_error"`). The run then aborts with the same
+  `ProvisionError`; a run with no `log_capture` configured writes no
+  `services/` dir.
 
 On every trial that provisions successfully, the executor also amends the
 trial's `metrics.yaml` with a top-level `provisioning_duration_s` — the
@@ -365,9 +376,12 @@ monotonic-clock wall-clock of the `provision → await_ready → endpoints` brac
 measured before `provision()` and stopped at `endpoints()` return. See
 [`docs/OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md:1) § `provisioning_duration_s`.
 
-Both surfaces are best-effort: capture runs *because* a failure was already
+Every surface is best-effort: capture runs *because* a failure was already
 decided, so a per-service fetch error is logged at debug and that service is
-omitted — capture never raises and never masks the original error.
+omitted — capture never raises and never masks the original error. On the
+shared-stack run-level surface the whole capture is additionally wrapped in a
+fail-safe boundary so a compose-parse or manifest-write error cannot mask the
+`ProvisionError`.
 
 **`--tail` mechanism.** Testcontainers' `DockerCompose.get_logs` has no tail
 bound, so the helper drives the compose CLI directly
@@ -376,11 +390,16 @@ deriving the base command from the `DockerCompose` instance and running the
 subprocess with `cwd=<context>` so Compose resolves the per-trial project from
 the context-dir basename. `compute.log_tail` (default 500) sets `N`.
 
-**Shared-stack no-op.** `SharedStackRuntimeBackend.capture_service_logs` returns
-`{}` unconditionally. Its stack is run-wide, not trial-scoped, and its per-trial
-`teardown` is a no-op — there is no per-trial stack to read, and capturing the
-same run-wide containers on every trial would be meaningless. Run-level capture
-on a shared-stack materialise failure is a separate, future surface.
+**Shared-stack surfaces.** `SharedStackRuntimeBackend.capture_service_logs`
+(the per-trial hook) returns `{}` unconditionally: its stack is run-wide, not
+trial-scoped, and its per-trial `teardown` is a no-op — there is no per-trial
+stack to read, and capturing the same run-wide containers on every trial would
+be meaningless. Capture on the shared stack happens once, at run scope, on the
+materialise-failure path (see the run-level surface above): if the task-declared
+compose stack fails to come up at `connect` time, the run-wide per-service logs
+are written to `<output_dir>/services/<name>.log` plus a
+`services/_capture.yaml` (`capture_reason: "materialise_error"`) before the
+partial stack is torn down.
 
 ## `SharedStackRuntimeBackend` vs `PerTrialRuntimeBackend` side-by-side
 

--- a/tests/unit/test_shared_stack_runtime_env_manifest.py
+++ b/tests/unit/test_shared_stack_runtime_env_manifest.py
@@ -20,7 +20,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
+from tolokaforge.core.compose_materialisation import LogCaptureConfig
 from tolokaforge.core.runtime import ProvisionError
 from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest
@@ -238,6 +240,172 @@ class TestConnectMaterialises:
             pytest.raises(ProvisionError, match="docker compose up failed"),
         ):
             backend.connect()
+        mock_cleanup.assert_called_once()
+
+    def test_capture_writes_run_level_bundle_on_compose_start_failure(self, tmp_path: Path) -> None:
+        """On the compose-start failure branch the run-level ``services/``
+        bundle (per-service ``.log`` files + ``_capture.yaml`` with
+        ``capture_reason: "materialise_error"``) is written before cleanup,
+        and the original ``ProvisionError`` still propagates.
+
+        Only the docker subprocess boundary (``_fetch_service_logs``) is
+        stubbed — the real capture/manifest/file-writing code runs."""
+        manifest = _make_manifest(tmp_path)
+        log_capture = LogCaptureConfig(output_root=tmp_path, tail=100, on_success=False)
+        backend = SharedStackRuntimeBackend(
+            env_manifest=manifest, run_id="run-x", log_capture=log_capture
+        )
+
+        fake_compose = MagicMock()
+        fake_compose.start.side_effect = RuntimeError("daemon socket refused")
+        fake_compose.compose_command_property = ["docker", "compose", "-f", "x.yaml"]
+        fake_compose.context = str(tmp_path)
+
+        def fake_fetch(base_command, context, service, tail):  # noqa: ANN001, ANN202
+            return f"log-bytes-for-{service}".encode()
+
+        def assert_captured_first(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            assert (tmp_path / "services" / "runner.log").exists()
+
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation",
+                side_effect=assert_captured_first,
+            ),
+            patch(
+                "tolokaforge.core.compose_materialisation._fetch_service_logs",
+                side_effect=fake_fetch,
+            ),
+            pytest.raises(ProvisionError, match="docker compose up failed"),
+        ):
+            backend.connect()
+
+        services_dir = tmp_path / "services"
+        assert (services_dir / "runner.log").read_bytes() == b"log-bytes-for-runner"
+        assert (services_dir / "db-service.log").read_bytes() == b"log-bytes-for-db-service"
+        recorded = yaml.safe_load((services_dir / "_capture.yaml").read_text())
+        assert recorded["capture_reason"] == "materialise_error"
+        assert recorded["services"] == {
+            "runner": {"bytes": len(b"log-bytes-for-runner")},
+            "db-service": {"bytes": len(b"log-bytes-for-db-service")},
+        }
+
+    def test_capture_error_does_not_mask_provision_error(self, tmp_path: Path) -> None:
+        """A capture-time error is swallowed and logged — the original
+        ``ProvisionError`` is what propagates, never the capture error."""
+        manifest = _make_manifest(tmp_path)
+        log_capture = LogCaptureConfig(output_root=tmp_path, tail=100, on_success=False)
+        backend = SharedStackRuntimeBackend(
+            env_manifest=manifest, run_id="run-x", log_capture=log_capture
+        )
+
+        fake_compose = MagicMock()
+        fake_compose.start.side_effect = RuntimeError("daemon socket refused")
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch("tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.capture_compose_service_logs",
+                side_effect=RuntimeError("capture boom"),
+            ),
+            pytest.raises(ProvisionError, match="docker compose up failed"),
+        ):
+            backend.connect()
+
+    def test_no_capture_when_log_capture_none(self, tmp_path: Path) -> None:
+        """With no ``log_capture`` configured, capture is a silent no-op:
+        cleanup still runs, the ``ProvisionError`` still raises, and no
+        run-level ``services/`` dir is created."""
+        manifest = _make_manifest(tmp_path)
+        backend = SharedStackRuntimeBackend(env_manifest=manifest, run_id="run-x")
+
+        fake_compose = MagicMock()
+        fake_compose.start.side_effect = RuntimeError("daemon socket refused")
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation"
+            ) as mock_cleanup,
+            pytest.raises(ProvisionError, match="docker compose up failed"),
+        ):
+            backend.connect()
+        mock_cleanup.assert_called_once()
+        assert not (tmp_path / "services").exists()
+
+    def test_capture_fires_on_missing_runner_endpoint_branch(self, tmp_path: Path) -> None:
+        """The missing-runner-endpoint branch captures the run-level bundle
+        before cleanup, same as the compose-start branch."""
+        manifest = _make_manifest(tmp_path)
+        log_capture = LogCaptureConfig(output_root=tmp_path, tail=100, on_success=False)
+        backend = SharedStackRuntimeBackend(
+            env_manifest=manifest, run_id="run-x", log_capture=log_capture
+        )
+
+        fake_compose = MagicMock()
+        fake_compose.compose_command_property = ["docker", "compose", "-f", "x.yaml"]
+        fake_compose.context = str(tmp_path)
+
+        def fake_fetch(base_command, context, service, tail):  # noqa: ANN001, ANN202
+            return f"log-bytes-for-{service}".encode()
+
+        def assert_captured_first(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            assert (tmp_path / "services" / "runner.log").exists()
+
+        with (
+            patch("tolokaforge.core.shared_stack_runtime.DockerCompose", return_value=fake_compose),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.copy_compose_context",
+                lambda src, dst: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.apply_network_policy_to_compose_file",
+                lambda *a, **k: None,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.resolve_runner_endpoint",
+                return_value=None,
+            ),
+            patch(
+                "tolokaforge.core.compose_materialisation._fetch_service_logs",
+                side_effect=fake_fetch,
+            ),
+            patch(
+                "tolokaforge.core.shared_stack_runtime.cleanup_partial_materialisation",
+                side_effect=assert_captured_first,
+            ) as mock_cleanup,
+            pytest.raises(ProvisionError, match="runner_service"),
+        ):
+            backend.connect()
+
+        services_dir = tmp_path / "services"
+        assert (services_dir / "runner.log").read_bytes() == b"log-bytes-for-runner"
+        recorded = yaml.safe_load((services_dir / "_capture.yaml").read_text())
+        assert recorded["capture_reason"] == "materialise_error"
         mock_cleanup.assert_called_once()
 
 

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -491,6 +491,15 @@ def trial_services_dir(output_root: Path, trial_id: str) -> Path:
     return output_root / "trials" / task_id / trial_index / "services"
 
 
+def run_services_dir(output_root: Path) -> Path:
+    """Return the run-level ``services/`` capture dir under ``output_root``.
+
+    The run-scoped counterpart to :func:`trial_services_dir`: where a
+    shared-stack materialise failure writes the run-wide stack's per-service
+    logs, one level up from the per-trial bundles."""
+    return output_root / "services"
+
+
 def write_capture_manifest(
     dest_dir: Path,
     tail: int,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -796,6 +796,7 @@ class Orchestrator:
                 env_manifest=env_manifest,
                 run_id=run_id,
                 seeds=seeds,
+                log_capture=log_capture,
             )
         return SharedStackRuntimeBackend(
             runner_address=runner_address,

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -28,15 +28,19 @@ from testcontainers.compose import DockerCompose
 
 from tolokaforge.core.compose_materialisation import (
     RUNNER_PORT_DEFAULT,
+    LogCaptureConfig,
     apply_network_policy_to_compose_file,
+    capture_compose_service_logs,
     cleanup_partial_materialisation,
     compose_container_to_snapshot,
     copy_compose_context,
     make_project_temp_dir,
     resolve_env_endpoints,
     resolve_runner_endpoint,
+    run_services_dir,
     shutdown_compose,
     verify_network_policy_supported,
+    write_capture_manifest,
 )
 from tolokaforge.core.models import SeedRef
 from tolokaforge.core.run_display_events import ContainerSnapshot
@@ -704,6 +708,7 @@ class SharedStackRuntimeBackend:
         env_manifest: EnvironmentManifest | None = None,
         run_id: str = "run",
         seeds: dict[str, SeedRef] | None = None,
+        log_capture: LogCaptureConfig | None = None,
     ):
         """Initialize the shared-stack runtime.
 
@@ -733,6 +738,7 @@ class SharedStackRuntimeBackend:
         self._compose: DockerCompose | None = None
         self._temp_dir: Path | None = None
         self.seeds: dict[str, SeedRef] = dict(seeds or {})
+        self.log_capture = log_capture
 
         self.runner_client: GrpcRunnerClient | None
         self._endpoints: EnvEndpoints | None
@@ -844,6 +850,7 @@ class SharedStackRuntimeBackend:
             )
             compose.start()
         except Exception as exc:  # noqa: BLE001 — surface as typed ProvisionError
+            self._capture_materialise_failure_logs(compose)
             cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
                 trial_id=self._run_id,
@@ -855,6 +862,7 @@ class SharedStackRuntimeBackend:
             compose, manifest.runner_service, RUNNER_PORT_DEFAULT
         )
         if runner_endpoint is None:
+            self._capture_materialise_failure_logs(compose)
             cleanup_partial_materialisation(compose, temp_dir)
             raise ProvisionError(
                 trial_id=self._run_id,
@@ -878,6 +886,41 @@ class SharedStackRuntimeBackend:
         self._temp_dir = temp_dir
         self._endpoints = endpoints
         self.runner_client = GrpcRunnerClient(runner_address=f"{runner_host}:{runner_host_port}")
+
+    def _capture_materialise_failure_logs(self, compose: DockerCompose | None) -> None:
+        """Best-effort run-level capture of the shared stack's per-service
+        compose logs on a materialise failure, before the partial stack is
+        torn down.
+
+        No-op when ``self.log_capture is None``. Writes the ``.log`` files
+        plus a ``services/_capture.yaml`` record
+        (``capture_reason: "materialise_error"``) under
+        ``<output_root>/services/`` — the run-level counterpart to
+        :class:`PerTrialRuntimeBackend`'s per-trial provision capture.
+
+        Wrapped in a fail-safe boundary: any capture error (compose parse,
+        manifest write) is logged and swallowed so it never masks the
+        :class:`ProvisionError` the caller is about to raise."""
+        if self.log_capture is None:
+            return
+        try:
+            assert self._env_manifest is not None  # narrowed by caller
+            service_names = tuple(self._env_manifest.load_compose()["services"])
+            dest_dir = run_services_dir(self.log_capture.output_root)
+            captured = capture_compose_service_logs(
+                compose, service_names, dest_dir, self.log_capture.tail
+            )
+            if captured:
+                write_capture_manifest(
+                    dest_dir,
+                    self.log_capture.tail,
+                    captured,
+                    capture_reason="materialise_error",
+                )
+        except Exception:  # noqa: BLE001 — fail-safe: must never mask the ProvisionError
+            logger.exception(
+                "SharedStackRuntimeBackend: run-level materialise-failure log capture failed"
+            )
 
     def health_check(self) -> bool:
         """Check health of Runner service"""


### PR DESCRIPTION
Closes #339.

## Summary

Shared-stack materialise-failure was a real observability blind spot: when `SharedStackRuntimeBackend._materialise_manifest` failed (compose healthcheck fail OR missing-runner-endpoint), the run aborted before any trial with the stack torn down and zero logs captured. This PR closes that gap — a third capture surface alongside #302's provision-fail and #418's grade-fail per-trial surfaces.

- **Where the logs land:** `<output_dir>/services/<name>.log` (run-level; mirrors the per-trial `<trial_dir>/services/*` layout) + `_capture.yaml` with `capture_reason: "materialise_error"`.
- **When it fires:** both failure branches in `_materialise_manifest` — compose-start failure AND missing-runner-endpoint. Capture runs BEFORE `cleanup_partial_materialisation`.
- **Fail-safe:** capture errors never mask the original `ProvisionError` — `logger.exception` + swallow.
- **`log_capture is None` → silent no-op.** Runs with no capture configured are unaffected.

## Files changed

- `tolokaforge/core/compose_materialisation.py` — new `run_services_dir(output_root)` helper (mirrors `trial_services_dir`).
- `tolokaforge/core/shared_stack_runtime.py` — `log_capture` param on `__init__`; new `_capture_materialise_failure_logs(compose)` method; called before cleanup in both failure branches.
- `tolokaforge/core/orchestrator.py` — one-line forward of `log_capture` into the env_manifest backend construction.
- `tests/unit/test_shared_stack_runtime_env_manifest.py` — 4 new cases in `TestConnectMaterialises`.
- `docs/RUNTIME_BACKENDS.md` — rewrote "Shared-stack no-op" paragraph, added third capture surface to the enumeration, deleted "future surface" language.
- `CHANGELOG.md` — Feat bullet under Unreleased.

## Test tier

Unit — 4 new cases:
1. Compose-start failure → capture-then-cleanup, `_capture.yaml` has `capture_reason: "materialise_error"`, `ProvisionError` raised.
2. Capture error swallowed, original `ProvisionError` still surfaces.
3. `log_capture=None` → no `services/` dir, cleanup still runs, `ProvisionError` still raises.
4. Missing-runner-endpoint branch → same capture bundle.

All 17 tests in the file pass (existing 13 + 4 new). No integration coverage needed — only `_fetch_service_logs` is stubbed (the honest docker boundary), the real capture/manifest/file-write code exercises against a temp dir.

## Reviewer verdict

**APPROVE WITH NITS** — one non-gating nit about unjustified `# noqa: ANN00X` in test fakes (existing precedent in the sibling test file; skipping since it's optional). Reviewer confirmed helper reuse, ordering-lock mechanism, fail-safe semantics, both-branch coverage, `capture_reason` distinction from per-trial, orchestrator forward correctness, and doc currency.

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425).
