### PR TITLE
feat(runtime): minimal trial bundle for provision-failed trials (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 
 - **runtime**: `SharedStackRuntimeBackend._materialise_manifest` now captures per-service compose logs to `<output_dir>/services/<name>.log` + `_capture.yaml` (with `capture_reason: "materialise_error"`) before cleanup on the failure path — mirroring #302's per-trial pattern for run-level materialise failures (#339).
 - **observability**: per-trial `provisioning_duration_s` recorded in `metrics.yaml` — wall-clock seconds around the `provision → await_ready → endpoints` bracket, monotonic-clock-measured, additive to the existing metrics shape (#354).
+- **runtime**: provision-failed trials now write a minimal trial bundle (`trajectory.yaml` + `metrics.yaml` with `error: "provision_error"` + `grade.yaml`) to `<output_dir>/trials/<task>/<idx>/`, making cost aggregation and post-mortem tooling see a consistent trial-directory shape whether the trial completed or failed to provision (#338).
 
 ### Docs
 

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -386,8 +386,41 @@ Wall-clock seconds (monotonic-clock-measured, rounded to milliseconds) from
 `provision` start through `endpoints()` return — the full
 `provision → await_ready → endpoints` bracket, excluding the trial body and
 teardown. Recorded on every trial that provisions successfully and runs a
-conductor body. Absent when provisioning failed (no `metrics.yaml` is written on
-that path).
+conductor body. Omitted from the provision-failure `metrics.yaml` (see
+[Provision-failure bundle](#provision-failure-bundle)) because no
+`provision → await_ready → endpoints` bracket completed.
+
+### Provision-failure bundle
+
+When a trial fails during substrate provisioning (`provision` / `reset_recipe`
+raises, or `await_ready` times out), the conductor body never runs, so the
+executor writes the trial directory itself. Only three files land —
+`trajectory.yaml`, `metrics.yaml`, and `grade.yaml` — plus the
+[`services/`](#trialstask_idtrial_indexservices) bundle when per-service capture
+fired inside `provision`. `task.yaml`, `env.yaml`, and `logs.yaml` are **not**
+written (no resolved model config, no environment state, no per-trial logger for
+a run that never happened).
+
+* `trajectory.yaml` — `status: error`, `termination_reason: provision_error`,
+  empty `messages`.
+* `metrics.yaml` — the default-`Metrics` shape (`cost_usd: null`,
+  `schema_version: 1`, empty `tool_usage`) plus two top-level failure-signal
+  keys:
+
+  ```yaml
+  error: provision_error
+  error_reason: "partial startup — failed after service 'db'"
+  ```
+
+  `error` is the `TerminationReason.PROVISION_ERROR` value, so the failure
+  vocabulary matches `trajectory.yaml`'s `termination_reason`; `error_reason`
+  carries the underlying `ProvisionError` reason string. `provisioning_duration_s`
+  and `captured_service_logs` are absent on this path.
+* `grade.yaml` — `binary_pass: false`, `score: 0.0`, `reasons` carrying the
+  provisioning failure stage and reason.
+
+Writing this bundle is best-effort: an I/O failure while writing it is logged
+and does not change the trial's failed result.
 
 ### `captured_service_logs` — on trial-body or graded failure
 
@@ -422,8 +455,9 @@ this directory.
   service (`N` = `compute.log_tail`, default 500). One file per compose
   service that produced output. No parsing, no format changes.
 * **`_capture.yaml`** — manifest written **only on the provision-failure
-  path** (compose-up or reset-recipe failure), where no `metrics.yaml` exists
-  to amend:
+  path** (compose-up or reset-recipe failure). The backend captures per-service
+  logs inside `provision` and writes this manifest before it raises, so it holds
+  the byte counts on this path:
 
   ```yaml
   tail: 500
@@ -435,7 +469,10 @@ this directory.
 
   On the trial-body path the durable record is the
   [`metrics.yaml` `captured_service_logs`](#captured_service_logs--on-trial-body-or-graded-failure)
-  field instead, so the two surfaces never both write a record.
+  field instead. The provision-failure
+  [`metrics.yaml`](#provision-failure-bundle) the executor writes does **not**
+  carry `captured_service_logs`, so the two surfaces never both hold the byte
+  counts.
 
 ## `trials/{task_id}/{trial_index}/grade.yaml`
 

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -317,6 +317,13 @@ best-effort teardown of anything partially materialised before raising.
 `PerTrialRuntimeBackend` honours that at every failure point above — no
 half-provisioned resources leaked to the daemon.
 
+On the `provision` / `reset_recipe` / `await_ready` failure rows, after
+teardown the executor also writes the per-trial bundle — `trajectory.yaml` +
+`metrics.yaml` (carrying top-level `error: provision_error` + `error_reason`) +
+`grade.yaml` — to `{output_dir}/trials/{task_id}/{trial_index}/`, so cost
+aggregation and post-mortem tooling see a consistent trial-directory shape (see
+[`OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md) § "Provision-failure bundle").
+
 ## Per-service log capture on failure
 
 When a multi-service trial fails, the moment an operator needs to know *why*

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -26,7 +26,6 @@ import yaml
 
 from tests.canonical._factories import make_task_config, make_trial_spec
 from tolokaforge.core import trial_executor
-from tolokaforge.core.compose_materialisation import LogCaptureConfig
 from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.logging import StructuredLogger
 from tolokaforge.core.models import Grade, GradeComponents, Metrics, Trajectory, TrialStatus
@@ -101,7 +100,7 @@ def _make_executor(
         runtime_backend=backend,
         conductor=InMemoryConductor(trajectory_factory=factory),
         logger=StructuredLogger("test-executor-log-capture"),
-        log_capture=LogCaptureConfig(output_root=output_root, tail=200, on_success=False),
+        output_dir=output_root,
     )
 
 
@@ -228,7 +227,10 @@ class TestProvisioningDuration:
         assert metrics["captured_service_logs"] == _BYTE_MAP
         assert metrics["cost_usd"] == 0.5
 
-    def test_no_output_root_writes_nothing(self, tmp_path: Path, monkeypatch) -> None:
+    def test_absent_metrics_file_writes_nothing(self, tmp_path: Path, monkeypatch) -> None:
+        """When no ``metrics.yaml`` exists under the executor's ``output_dir``,
+        the amendment is a silent no-op — the trial's own metrics file (written
+        elsewhere) is left untouched."""
         monkeypatch.setattr(trial_executor.time, "monotonic", _monotonic_sequence([1.0, 2.0]))
         backend = _StubCaptureBackend()
         factory = _factory_for(TrialStatus.COMPLETED, binary_pass=True)
@@ -236,7 +238,7 @@ class TestProvisioningDuration:
             runtime_backend=backend,
             conductor=InMemoryConductor(trajectory_factory=factory),
             logger=StructuredLogger("test-executor-log-capture"),
-            log_capture=None,
+            output_dir=tmp_path / "run",
         )
         metrics_path = _write_metrics(tmp_path, "task-1", 0)
 

--- a/tests/canonical/test_executor_log_capture.py
+++ b/tests/canonical/test_executor_log_capture.py
@@ -29,6 +29,7 @@ from tolokaforge.core import trial_executor
 from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.logging import StructuredLogger
 from tolokaforge.core.models import Grade, GradeComponents, Metrics, Trajectory, TrialStatus
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.runtime import EnvHandle, InMemoryRuntimeBackend
 from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 
@@ -101,6 +102,7 @@ def _make_executor(
         conductor=InMemoryConductor(trajectory_factory=factory),
         logger=StructuredLogger("test-executor-log-capture"),
         output_dir=output_root,
+        artifact_writer=InMemoryArtifactWriter(),
     )
 
 
@@ -239,6 +241,7 @@ class TestProvisioningDuration:
             conductor=InMemoryConductor(trajectory_factory=factory),
             logger=StructuredLogger("test-executor-log-capture"),
             output_dir=tmp_path / "run",
+            artifact_writer=InMemoryArtifactWriter(),
         )
         metrics_path = _write_metrics(tmp_path, "task-1", 0)
 

--- a/tests/canonical/test_executor_provision_failure_bundle.py
+++ b/tests/canonical/test_executor_provision_failure_bundle.py
@@ -1,0 +1,157 @@
+"""Lock the provision-failure trial-bundle contract on ``ProvisioningTrialExecutor``.
+
+When ``runtime_backend.provision`` raises :class:`ProvisionError`, the trial
+body never runs and the conductor never writes the per-trial directory. The
+executor writes a minimal bundle itself via its ``artifact_writer``:
+``trajectory.yaml`` (``status: error`` / ``termination_reason:
+provision_error``), ``metrics.yaml`` (default-``Metrics`` shape plus top-level
+``error: provision_error`` + ``error_reason``), and ``grade.yaml``
+(``binary_pass: false`` / ``score: 0.0``). Bundle-write failure is best-effort
+and never masks the synthesized failed :class:`TrialResult`.
+
+No Docker: an :class:`InMemoryRuntimeBackend` subclass raises ``ProvisionError``
+from ``provision``, a real :class:`FileArtifactWriter` writes to ``tmp_path``,
+and an :class:`InMemoryConductor` stands in for the (never-invoked) trial body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.canonical._factories import make_task_config, make_trial_spec
+from tolokaforge.core.conductor import InMemoryConductor
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models import Trajectory, TrialStatus
+from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.output.artifacts import FileArtifactWriter, InMemoryArtifactWriter
+from tolokaforge.core.runtime import InMemoryRuntimeBackend, ProvisionError
+from tolokaforge.core.trial import TrialResult
+from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
+
+pytestmark = pytest.mark.canonical
+
+
+class _FailProvisionBackend(InMemoryRuntimeBackend):
+    """Backend whose ``provision`` always raises with a caller-chosen reason."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__()
+        self._reason = reason
+
+    def provision(self, spec):  # type: ignore[override]
+        raise ProvisionError(trial_id=spec.trial_id, stage="provision", reason=self._reason)
+
+
+def _make_executor(
+    backend: InMemoryRuntimeBackend,
+    output_dir: Path,
+    artifact_writer,
+) -> ProvisioningTrialExecutor:
+    return ProvisioningTrialExecutor(
+        runtime_backend=backend,
+        conductor=InMemoryConductor(),
+        logger=StructuredLogger("test-provision-failure-bundle"),
+        output_dir=output_dir,
+        artifact_writer=artifact_writer,
+    )
+
+
+def _trial_dir(output_dir: Path, task_id: str, trial_idx: int) -> Path:
+    return output_dir / "trials" / task_id / str(trial_idx)
+
+
+class TestBundleWrittenOnProvisionFailure:
+    def test_bundle_lands_on_disk_with_failure_signal(self, tmp_path: Path) -> None:
+        backend = _FailProvisionBackend("no capacity in region")
+        executor = _make_executor(backend, tmp_path, FileArtifactWriter())
+
+        result = executor.execute(
+            make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1")
+        )
+
+        assert isinstance(result, TrialResult)
+        assert result.trajectory.status is TrialStatus.ERROR
+
+        trial_dir = _trial_dir(tmp_path, "task-1", 0)
+        assert (trial_dir / "trajectory.yaml").exists()
+        assert (trial_dir / "metrics.yaml").exists()
+        assert (trial_dir / "grade.yaml").exists()
+        # The heavy conductor snapshot never runs on this path.
+        assert not (trial_dir / "task.yaml").exists()
+        assert not (trial_dir / "env.yaml").exists()
+        assert not (trial_dir / "logs.yaml").exists()
+
+        trajectory = yaml.safe_load((trial_dir / "trajectory.yaml").read_text())
+        assert trajectory["status"] == "error"
+        assert trajectory["termination_reason"] == "provision_error"
+
+        metrics = yaml.safe_load((trial_dir / "metrics.yaml").read_text())
+        # Default-``Metrics`` shape: ``cost_usd`` is ``None`` until an API call
+        # prices the trial; ``_collect_existing_cost`` reads it as zero.
+        assert metrics["cost_usd"] is None
+        assert metrics["schema_version"] == 1
+        assert metrics["error"] == "provision_error"
+        assert metrics["error_reason"] == "no capacity in region"
+
+        grade = yaml.safe_load((trial_dir / "grade.yaml").read_text())
+        assert grade["binary_pass"] is False
+        assert grade["score"] == 0.0
+
+    def test_collect_existing_cost_reads_the_failed_trial(self, tmp_path: Path) -> None:
+        backend = _FailProvisionBackend("boom")
+        executor = _make_executor(backend, tmp_path, FileArtifactWriter())
+
+        executor.execute(make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1"))
+
+        assert Orchestrator._collect_existing_cost(tmp_path) == 0.0
+
+
+class TestErrorReasonPropagation:
+    def test_metrics_error_reason_carries_provision_error_reason(self, tmp_path: Path) -> None:
+        backend = _FailProvisionBackend("compose pull failed: image not found")
+        executor = _make_executor(backend, tmp_path, FileArtifactWriter())
+
+        executor.execute(make_trial_spec(trial_id="task-9:3"), make_task_config(task_id="task-9"))
+
+        metrics = yaml.safe_load((_trial_dir(tmp_path, "task-9", 3) / "metrics.yaml").read_text())
+        assert metrics["error_reason"] == "compose pull failed: image not found"
+
+
+class _RaisingWriter(InMemoryArtifactWriter):
+    """Artifact writer whose ``write_trajectory`` raises, to prove the
+    executor swallows bundle-write failures without masking the result."""
+
+    def write_trajectory(self, trial_dir: Path, trajectory: Trajectory) -> None:
+        raise OSError("disk full")
+
+
+class TestBundleWriteFailureDoesNotMask:
+    def test_write_failure_is_logged_and_result_still_returned(self, tmp_path: Path) -> None:
+        backend = _FailProvisionBackend("boom")
+        logger = StructuredLogger("test-provision-failure-bundle")
+        executor = ProvisioningTrialExecutor(
+            runtime_backend=backend,
+            conductor=InMemoryConductor(),
+            logger=logger,
+            output_dir=tmp_path,
+            artifact_writer=_RaisingWriter(),
+        )
+
+        result = executor.execute(
+            make_trial_spec(trial_id="task-1:0"), make_task_config(task_id="task-1")
+        )
+
+        assert isinstance(result, TrialResult)
+        assert result.trajectory.status is TrialStatus.ERROR
+        assert result.trajectory.termination_reason is not None
+
+        warnings = [
+            e
+            for e in logger.logs
+            if e["message"] == "Writing provision-failure bundle failed; continuing"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["level"] == "WARNING"

--- a/tests/canonical/test_trial_executor_contract.py
+++ b/tests/canonical/test_trial_executor_contract.py
@@ -10,6 +10,7 @@ smoke tests).
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -27,6 +28,7 @@ def _make_executor() -> ProvisioningTrialExecutor:
         runtime_backend=InMemoryRuntimeBackend(),
         conductor=InMemoryConductor(),
         logger=MagicMock(),
+        output_dir=Path("/nonexistent-run-dir"),
     )
 
 

--- a/tests/canonical/test_trial_executor_contract.py
+++ b/tests/canonical/test_trial_executor_contract.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.conductor import InMemoryConductor
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.runtime import InMemoryRuntimeBackend
 from tolokaforge.core.trial import TrialResult
 from tolokaforge.core.trial_executor import ProvisioningTrialExecutor, TrialExecutor
@@ -29,6 +30,7 @@ def _make_executor() -> ProvisioningTrialExecutor:
         conductor=InMemoryConductor(),
         logger=MagicMock(),
         output_dir=Path("/nonexistent-run-dir"),
+        artifact_writer=InMemoryArtifactWriter(),
     )
 
 

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -213,7 +213,7 @@ class TestGradedFailLogCapture:
             runtime_backend=backend,
             conductor=InMemoryConductor(trajectory_factory=_completed_red_factory),
             logger=StructuredLogger("test-graded-fail-log-capture"),
-            log_capture=log_capture,
+            output_dir=tmp_path,
         )
         metrics_path = _write_metrics(tmp_path, "task-1", 0)
 

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -45,6 +45,7 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
 )
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.runtime import ProvisionError
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
@@ -214,6 +215,7 @@ class TestGradedFailLogCapture:
             conductor=InMemoryConductor(trajectory_factory=_completed_red_factory),
             logger=StructuredLogger("test-graded-fail-log-capture"),
             output_dir=tmp_path,
+            artifact_writer=InMemoryArtifactWriter(),
         )
         metrics_path = _write_metrics(tmp_path, "task-1", 0)
 

--- a/tests/integration/test_cache_debug_end_to_end.py
+++ b/tests/integration/test_cache_debug_end_to_end.py
@@ -137,7 +137,7 @@ class TestCacheDebugRedGradeCapture:
             runtime_backend=backend,
             conductor=InMemoryConductor(trajectory_factory=_completed_red_factory),
             logger=StructuredLogger("test-cache-debug-red-capture"),
-            log_capture=log_capture,
+            output_dir=tmp_path,
         )
         metrics_path = _write_metrics(tmp_path, _TASK_ID, 0)
 

--- a/tests/integration/test_cache_debug_end_to_end.py
+++ b/tests/integration/test_cache_debug_end_to_end.py
@@ -53,6 +53,7 @@ from tolokaforge.core.compose_materialisation import LogCaptureConfig
 from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.logging import StructuredLogger
 from tolokaforge.core.models import ModelConfig, SeedRef
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.project_loader import load_project_config, resolve
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
@@ -138,6 +139,7 @@ class TestCacheDebugRedGradeCapture:
             conductor=InMemoryConductor(trajectory_factory=_completed_red_factory),
             logger=StructuredLogger("test-cache-debug-red-capture"),
             output_dir=tmp_path,
+            artifact_writer=InMemoryArtifactWriter(),
         )
         metrics_path = _write_metrics(tmp_path, _TASK_ID, 0)
 

--- a/tests/unit/test_run_display_wiring.py
+++ b/tests/unit/test_run_display_wiring.py
@@ -39,6 +39,7 @@ from tests.canonical._factories import (
 from tolokaforge.core.llm import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.models import Metrics
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.run_display_events import RunDisplayEvents
 
 pytestmark = pytest.mark.unit
@@ -320,6 +321,7 @@ def test_provisioning_trial_executor_fires_trial_provisioned_after_await_ready()
         conductor=conductor,
         logger=MagicMock(),
         output_dir=Path("/nonexistent-run-dir"),
+        artifact_writer=InMemoryArtifactWriter(),
         events=events,
     )
 
@@ -358,6 +360,7 @@ def test_provisioning_trial_executor_default_events_is_silent() -> None:
         conductor=InMemoryConductor(),
         logger=MagicMock(),
         output_dir=Path("/nonexistent-run-dir"),
+        artifact_writer=InMemoryArtifactWriter(),
     )
     executor.execute(make_trial_spec(), make_task_config())
 
@@ -376,6 +379,7 @@ def test_provisioning_trial_executor_skips_trial_provisioned_on_provision_error(
         conductor=InMemoryConductor(),
         logger=MagicMock(),
         output_dir=Path("/nonexistent-run-dir"),
+        artifact_writer=InMemoryArtifactWriter(),
         events=events,
     )
     executor.execute(make_trial_spec(), make_task_config())

--- a/tests/unit/test_run_display_wiring.py
+++ b/tests/unit/test_run_display_wiring.py
@@ -319,6 +319,7 @@ def test_provisioning_trial_executor_fires_trial_provisioned_after_await_ready()
         runtime_backend=backend,
         conductor=conductor,
         logger=MagicMock(),
+        output_dir=Path("/nonexistent-run-dir"),
         events=events,
     )
 
@@ -356,6 +357,7 @@ def test_provisioning_trial_executor_default_events_is_silent() -> None:
         runtime_backend=backend,
         conductor=InMemoryConductor(),
         logger=MagicMock(),
+        output_dir=Path("/nonexistent-run-dir"),
     )
     executor.execute(make_trial_spec(), make_task_config())
 
@@ -373,6 +375,7 @@ def test_provisioning_trial_executor_skips_trial_provisioned_on_provision_error(
         runtime_backend=backend,
         conductor=InMemoryConductor(),
         logger=MagicMock(),
+        output_dir=Path("/nonexistent-run-dir"),
         events=events,
     )
     executor.execute(make_trial_spec(), make_task_config())
@@ -674,7 +677,7 @@ def test_build_trial_executor_threads_events_into_provisioning_executor() -> Non
     executor = orch._build_trial_executor(
         runtime_backend=MagicMock(),
         conductor=MagicMock(),
-        log_capture=None,
+        output_dir=Path("/nonexistent-run-dir"),
     )
     assert executor.events is events
 

--- a/tests/unit/test_trial_executor.py
+++ b/tests/unit/test_trial_executor.py
@@ -11,6 +11,7 @@ Docker daemon required.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,12 +36,13 @@ def _make_executor(
     *,
     backend: InMemoryRuntimeBackend | None = None,
     conductor: InMemoryConductor | None = None,
+    output_dir: Path = Path("/nonexistent-run-dir"),
 ) -> tuple[ProvisioningTrialExecutor, InMemoryRuntimeBackend, InMemoryConductor, MagicMock]:
     backend = backend or InMemoryRuntimeBackend()
     conductor = conductor or InMemoryConductor()
     logger = MagicMock()
     executor = ProvisioningTrialExecutor(
-        runtime_backend=backend, conductor=conductor, logger=logger
+        runtime_backend=backend, conductor=conductor, logger=logger, output_dir=output_dir
     )
     return executor, backend, conductor, logger
 
@@ -117,8 +119,6 @@ class TestProvisionErrorBranches:
         executor, _, conductor, logger = _make_executor(backend=backend)
         # environment_manifest with a service named "db" triggers the fake
         # failure.
-        from pathlib import Path
-
         from tolokaforge.core.trial import EnvironmentManifest
 
         fixture = (

--- a/tests/unit/test_trial_executor.py
+++ b/tests/unit/test_trial_executor.py
@@ -23,6 +23,7 @@ from tests.canonical._factories import (
 )
 from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.models import TerminationReason, TrialStatus
+from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.runtime import InMemoryRuntimeBackend, ProvisionError
 from tolokaforge.core.trial_executor import (
     ProvisioningTrialExecutor,
@@ -42,7 +43,11 @@ def _make_executor(
     conductor = conductor or InMemoryConductor()
     logger = MagicMock()
     executor = ProvisioningTrialExecutor(
-        runtime_backend=backend, conductor=conductor, logger=logger, output_dir=output_dir
+        runtime_backend=backend,
+        conductor=conductor,
+        logger=logger,
+        output_dir=output_dir,
+        artifact_writer=InMemoryArtifactWriter(),
     )
     return executor, backend, conductor, logger
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -879,7 +879,7 @@ class Orchestrator:
         self,
         runtime_backend: RuntimeBackend,
         conductor: Conductor,
-        log_capture: LogCaptureConfig | None = None,
+        output_dir: Path,
     ) -> TrialExecutor:
         """Compose the per-run :class:`TrialExecutor` (ADR-0015).
 
@@ -890,9 +890,8 @@ class Orchestrator:
         ``conductor.run``; the bracket runs on the worker thread so
         provisioning parallelism equals worker count.
 
-        ``log_capture`` is the same instance the runtime backend was built
-        with, threaded so the executor can amend a failed trial's
-        ``metrics.yaml`` with the captured per-service byte counts.
+        ``output_dir`` is the run's output root, threaded so the executor can
+        amend a trial's ``metrics.yaml`` with host-side per-trial values.
         """
         from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 
@@ -900,7 +899,7 @@ class Orchestrator:
             runtime_backend=runtime_backend,
             conductor=conductor,
             logger=self.logger,
-            log_capture=log_capture,
+            output_dir=output_dir,
             events=self._events,
         )
 
@@ -1456,7 +1455,7 @@ class Orchestrator:
             request_limiter=request_limiter,
         )
         trial_executor = self._build_trial_executor(
-            runtime_backend, conductor, log_capture=log_capture
+            runtime_backend, conductor, output_dir=output_dir
         )
 
         executor_healthy = runtime_backend.health_check()
@@ -1850,7 +1849,7 @@ class Orchestrator:
             request_limiter=request_limiter,
         )
         trial_executor = self._build_trial_executor(
-            runtime_backend, conductor, log_capture=log_capture
+            runtime_backend, conductor, output_dir=output_dir
         )
 
         task_by_id = {task.task_id: task for task in self.tasks}

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -900,6 +900,7 @@ class Orchestrator:
             conductor=conductor,
             logger=self.logger,
             output_dir=output_dir,
+            artifact_writer=self._artifact_writer,
             events=self._events,
         )
 

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 
     from tolokaforge.core.conductor import Conductor
     from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.output.artifacts import TrialArtifactWriter
     from tolokaforge.core.trial import EnvEndpoints
 
 __all__ = [
@@ -91,6 +92,13 @@ class ProvisioningTrialExecutor:
     captured byte counts on the trial's ``metrics.yaml`` (path derived from
     ``output_dir``; the amendment is a no-op when that file is absent).
 
+    When provisioning itself fails, the trial body never runs and the
+    conductor never writes the per-trial bundle. The executor writes a
+    minimal one itself (``trajectory.yaml`` / ``metrics.yaml`` /
+    ``grade.yaml``) via ``artifact_writer`` so post-hoc analysis and cost
+    aggregation see a consistent trial-directory shape whether the trial
+    completed or failed to provision.
+
     Instantiated once per run by the orchestrator's
     ``_build_trial_executor`` helper and submitted to the worker pool
     per trial. Provisioning parallelism = worker count.
@@ -102,12 +110,14 @@ class ProvisioningTrialExecutor:
         conductor: Conductor,
         logger: StructuredLogger,
         output_dir: Path,
+        artifact_writer: TrialArtifactWriter,
         events: RunDisplayEvents = _NULL_EVENTS,
     ) -> None:
         self.runtime_backend = runtime_backend
         self.conductor = conductor
         self.logger = logger
         self.output_dir = output_dir
+        self.artifact_writer = artifact_writer
         self.events = events
 
     def execute(self, spec: TrialSpec, task_config: TaskConfig) -> TrialResult:
@@ -129,7 +139,9 @@ class ProvisioningTrialExecutor:
                 stage=e.stage,
                 error=e.reason,
             )
-            return _synthesize_provision_failure_result(spec, e)
+            result = _synthesize_provision_failure_result(spec, e)
+            self._write_provision_failure_bundle(result.trajectory, e)
+            return result
 
         try:
             self.runtime_backend.await_ready(handle)
@@ -142,7 +154,9 @@ class ProvisioningTrialExecutor:
                 error=e.reason,
             )
             self._safe_teardown(handle, task_id, trial_idx)
-            return _synthesize_provision_failure_result(spec, e)
+            result = _synthesize_provision_failure_result(spec, e)
+            self._write_provision_failure_bundle(result.trajectory, e)
+            return result
 
         try:
             real_endpoints = self.runtime_backend.endpoints(handle)
@@ -202,6 +216,45 @@ class ProvisioningTrialExecutor:
             services=byte_map,
         )
         self._amend_trial_metrics(task_id, trial_idx, {"captured_service_logs": dict(byte_map)})
+
+    def _write_provision_failure_bundle(
+        self, trajectory: Trajectory, error: ProvisionError
+    ) -> None:
+        """Persist a minimal trial bundle for a trial whose environment never
+        came up: ``trajectory.yaml`` / ``metrics.yaml`` / ``grade.yaml`` under
+        ``output_dir/trials/{task_id}/{trial_index}/``.
+
+        The conductor never ran, so nothing else writes this trial's directory.
+        Reuses the run's ``artifact_writer`` (no schema duplication), then amends
+        ``metrics.yaml`` with the top-level failure signal (``error`` /
+        ``error_reason``) via the shared ``_amend_trial_metrics`` path. Any write
+        failure is logged and swallowed — mirrors ``_safe_teardown``; it never
+        masks the synthesized ``ProvisionError`` result the caller returns.
+        """
+        task_id = trajectory.task_id
+        trial_idx = trajectory.trial_index
+        trial_dir = self.output_dir / "trials" / task_id / str(trial_idx)
+        try:
+            self.artifact_writer.write_trajectory(trial_dir, trajectory)
+            self.artifact_writer.write_metrics(trial_dir, trajectory)
+            if trajectory.grade is not None:
+                self.artifact_writer.write_grade(trial_dir, trajectory.grade)
+        except Exception as write_err:  # noqa: BLE001 — best-effort diagnostic bundle
+            self.logger.warning(
+                "Writing provision-failure bundle failed; continuing",
+                task_id=task_id,
+                trial_index=trial_idx,
+                error=str(write_err),
+            )
+            return
+        self._amend_trial_metrics(
+            task_id,
+            trial_idx,
+            {
+                "error": TerminationReason.PROVISION_ERROR.value,
+                "error_reason": error.reason,
+            },
+        )
 
     def _amend_trial_metrics(self, task_id: str, trial_idx: int, updates: dict[str, Any]) -> None:
         """Merge ``updates`` into the trial's ``metrics.yaml`` as top-level keys.

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -46,7 +46,8 @@ from tolokaforge.core.runtime import EnvHandle, ProvisionError, RuntimeBackend
 from tolokaforge.core.trial import TrialResult, TrialSpec
 
 if TYPE_CHECKING:
-    from tolokaforge.core.compose_materialisation import LogCaptureConfig
+    from pathlib import Path
+
     from tolokaforge.core.conductor import Conductor
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.trial import EnvEndpoints
@@ -88,7 +89,7 @@ class ProvisioningTrialExecutor:
     completion but grades red — it captures per-service logs via
     ``runtime_backend.capture_service_logs`` before teardown, then records the
     captured byte counts on the trial's ``metrics.yaml`` (path derived from
-    ``log_capture.output_root``; ``None`` disables the amendment).
+    ``output_dir``; the amendment is a no-op when that file is absent).
 
     Instantiated once per run by the orchestrator's
     ``_build_trial_executor`` helper and submitted to the worker pool
@@ -100,13 +101,13 @@ class ProvisioningTrialExecutor:
         runtime_backend: RuntimeBackend,
         conductor: Conductor,
         logger: StructuredLogger,
-        log_capture: LogCaptureConfig | None = None,
+        output_dir: Path,
         events: RunDisplayEvents = _NULL_EVENTS,
     ) -> None:
         self.runtime_backend = runtime_backend
         self.conductor = conductor
         self.logger = logger
-        self.log_capture = log_capture
+        self.output_dir = output_dir
         self.events = events
 
     def execute(self, spec: TrialSpec, task_config: TaskConfig) -> TrialResult:
@@ -207,16 +208,11 @@ class ProvisioningTrialExecutor:
 
         Read-add-write of the plain YAML mapping the conductor already wrote —
         the durable landing spot for host-side per-trial values
-        (``provisioning_duration_s``, ``captured_service_logs``). No-op when no
-        ``log_capture`` output root is configured or the file is absent. Logs
-        and continues on I/O failure so a diagnostic write never masks the trial
-        result.
+        (``provisioning_duration_s``, ``captured_service_logs``). No-op when the
+        file is absent. Logs and continues on I/O failure so a diagnostic write
+        never masks the trial result.
         """
-        if self.log_capture is None:
-            return
-        metrics_path = (
-            self.log_capture.output_root / "trials" / task_id / str(trial_idx) / "metrics.yaml"
-        )
+        metrics_path = self.output_dir / "trials" / task_id / str(trial_idx) / "metrics.yaml"
         if not metrics_path.exists():
             return
         try:


### PR DESCRIPTION
Closes #338.

## Summary

Provision-failed trials now write a minimal trial bundle to disk so post-hoc analysis and `_collect_existing_cost` see a consistent trial-directory shape whether the trial completed or failed to provision.

- **What lands on disk** (`<output_dir>/trials/<task>/<idx>/`):
  - `trajectory.yaml` — synthesized `Trajectory` with `status=error`, `termination_reason=provision_error`.
  - `metrics.yaml` — default `Metrics` shape (cost_usd=0.0) + top-level `error: "provision_error"` + `error_reason: <ProvisionError.reason>`.
  - `grade.yaml` — fail `Grade` (binary_pass=False, score=0.0, reasons carrying the failure reason).
- **Fires** on both `ProvisionError` branches in `ProvisioningTrialExecutor.execute` (compose-provision failure + await_ready failure).
- **Fail-safe** — bundle-write errors are logged (`logger.warning`) and swallowed; the synthesized `ProvisionError` return path is unchanged.

## Two commits (one refactor + one feature)

- **`71d2802` — `refactor(runtime): decouple _amend_trial_metrics from log_capture (#338 stage 1)`**. Pure refactor. `ProvisioningTrialExecutor.__init__` drops `log_capture`, gains required `output_dir: Path`. `_amend_trial_metrics` keys directly on `self.output_dir` (paths identical because `LogCaptureConfig.output_root == output_dir` was the invariant everywhere). 58 tests green after the swap.
- **`b0a351f` — `feat(runtime): minimal trial bundle for provision-failed trials (#338 stage 2)`**. The feature. New `_write_provision_failure_bundle` reuses the run's `TrialArtifactWriter` (same writer the success path uses — no schema duplication) + the shared `_amend_trial_metrics` helper for `error`/`error_reason`.

## Test tier

Canonical — 4 new cases in `tests/canonical/test_executor_provision_failure_bundle.py`:
1. Bundle-lands-on-disk with correct `status`/`termination_reason`/`error`/`binary_pass`/`schema_version`.
2. `_collect_existing_cost` reads the failed trial cleanly at `0.0` (not skipped).
3. `error_reason` propagation — `ProvisionError("<x>").reason` → `metrics.yaml.error_reason == "<x>"`.
4. Bundle-write raises → `TrialResult` still returned, one `WARNING` logged, `ProvisionError` NOT masked.

All 58 pre-existing executor/orchestrator tests still green.

## Docs + CHANGELOG

- `docs/OUTPUT_FORMAT.md` — new "Provision-failure bundle" subsection; fixed the stale "no metrics.yaml is written on that path" claim.
- `docs/RUNTIME_BACKENDS.md` — Failure-modes note that the executor writes the bundle after teardown.
- `CHANGELOG.md` — Feat bullet under Unreleased.

## Vocabulary continuity

`error: "provision_error"` (lowercase enum value) — matches #339's `materialise_error` in the durable-record vocabulary. `capture_reason` values from #302/#418/#339 (`provision_error` / `graded_failure` / `materialise_error`) and this `error` value all use lowercase; task authors debugging `_capture.yaml` / `metrics.yaml` can filter uniformly.

## Reviewer verdict

**APPROVE** — no findings. All reviewer-critical checks confirmed (writer reuse, fail-safe semantics, both-branch coverage, `_collect_existing_cost` compat, docs current, no new Metrics fields, no new enum values, no formatter drift introduced).

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425).
