### PR TITLE
test(canonical): entry-point adapter-convert smoke via scratch-venv demo adapter

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,7 +5,7 @@
 | Category | Directory | Marker | Speed | External Deps |
 |----------|-----------|--------|-------|---------------|
 | Unit | `tests/unit/` | `@pytest.mark.unit` | < 1s each | None |
-| Canonical | `tests/canonical/` | `@pytest.mark.canonical` | < 5s each | None (golden snapshots) |
+| Canonical | `tests/canonical/` | `@pytest.mark.canonical` | < 5s each, except the packaging/entry-point smoke tests that build a wheel and install it into a scratch venv (~10–25s) | Golden snapshots; the packaging/entry-point smoke tests also require the `uv` CLI (they skip loud without it) |
 | Integration | `tests/integration/` | `@pytest.mark.integration` | 5–60s each | Docker, API keys |
 
 ## Commands

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The test suite is organized into **3 categories**: unit, canonical, and integrat
 | Category | Directory | Speed | External deps | Marker |
 |----------|-----------|-------|---------------|--------|
 | Unit | `tests/unit/` | Fast (< 1s each) | None | `@pytest.mark.unit` |
-| Canonical | `tests/canonical/` | Fast (< 5s each) | None (uses golden snapshots) | `@pytest.mark.canonical` |
+| Canonical | `tests/canonical/` | Fast (< 5s each), except the packaging/entry-point smoke tests that build a wheel and install it into a scratch venv (~10–25s) | Golden snapshots; the packaging/entry-point smoke tests also require the `uv` CLI (they skip loud without it) | `@pytest.mark.canonical` |
 | Integration | `tests/integration/` | Slow (5-60s each) | Docker, API keys | `@pytest.mark.integration` |
 
 Current baseline: see [BASELINE.md](BASELINE.md) for up-to-date numbers.
@@ -48,8 +48,11 @@ tests/
 ├── unit/                    # Pure-logic tests, no I/O
 │   ├── grading/             # Grading subsystem tests
 │   └── adapters/            # Adapter unit tests
-├── canonical/               # Golden snapshot tests
-│   ├── conftest.py          # --update-canon flag, canon_snapshot fixture
+├── canonical/               # Golden snapshot + packaging/discovery smoke tests
+│   ├── conftest.py          # --update-canon flag, canon_snapshot + built_wheel session fixtures
+│   ├── test_adapter_convert_packaging.py    # wheel-inspection packaging smoke
+│   ├── test_adapter_convert_entry_point.py  # entry-point discovery smoke (scratch-venv install)
+│   ├── fixtures/            # tolokaforge-adapter-demo: demo conversion adapter installed into a scratch venv
 │   └── snapshots/           # Committed golden JSON files
 ├── integration/             # Docker/API integration tests
 │   └── docker/              # Docker foundation layer tests

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -1,11 +1,14 @@
 """Canonization infrastructure: --update-canon flag and canon_snapshot fixture."""
 
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def pytest_addoption(parser):
@@ -61,3 +64,32 @@ def shop_orders_02_task_dir(canonical_task_dir):
 def terminal_bench_tasks_dir(test_data_dir):
     """Get path to terminal_bench_tasks test data directory."""
     return test_data_dir / "terminal_bench_tasks"
+
+
+@pytest.fixture(scope="session")
+def built_wheel(tmp_path_factory) -> Path:
+    """Build the tolokaforge wheel once per session and return its path.
+
+    Skips loud if the ``uv`` CLI is unavailable; hard-fails with captured
+    build output if the build itself fails (fail-fast, no fallback).
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("uv CLI not available")
+
+    out_dir = tmp_path_factory.mktemp("built_wheel")
+    build_result = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert build_result.returncode == 0, (
+        f"uv build failed (rc={build_result.returncode}):\n"
+        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
+    )
+
+    wheels = sorted(out_dir.glob("tolokaforge-*.whl"))
+    assert wheels, f"No tolokaforge wheel produced under {out_dir}"
+    return wheels[-1]

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/pyproject.toml
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tolokaforge-adapter-demo"
+version = "0.1.0"
+description = "Demo conversion adapter — canonical-test fixture, never shipped in the tolokaforge wheel"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = ["tolokaforge"]
+
+[project.entry-points."tolokaforge.adapters"]
+demo = "tolokaforge_adapter_demo.adapter:DemoConversionAdapter"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tolokaforge_adapter_demo"]

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/__init__.py
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/__init__.py
@@ -1,0 +1,23 @@
+"""Demo conversion adapter — a canonical-test fixture package.
+
+Installed into a throwaway scratch venv alongside the built ``tolokaforge``
+wheel so the entry-point discovery smoke test exercises the production
+``importlib.metadata`` adapter-load path against a genuinely separate
+distribution. Never a uv workspace member and never packaged into the
+``tolokaforge`` wheel.
+"""
+
+__all__ = ["DemoConversionAdapter"]
+
+
+def __getattr__(name: str):
+    if name == "DemoConversionAdapter":
+        from tolokaforge_adapter_demo.adapter import DemoConversionAdapter
+
+        return DemoConversionAdapter
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__ + list(globals().keys()))

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/adapter.py
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/adapter.py
@@ -1,0 +1,57 @@
+"""A minimal conversion adapter for the entry-point discovery smoke test.
+
+``DemoConversionAdapter`` subclasses the concrete :class:`NativeAdapter` (so
+every :class:`BaseAdapter` abstract method is already satisfied) and overrides
+only the conversion surface. It reads simple JSON source files — each a mapping
+with at least a ``name`` key — matched by the configured ``tasks_glob``, and
+emits one native task bundle per file plus a single shared-resources marker.
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import json
+from pathlib import Path
+from typing import Any
+
+from tolokaforge.adapters.base import NativeTaskBundle
+from tolokaforge.adapters.native import NativeAdapter
+
+
+class DemoConversionAdapter(NativeAdapter):
+    """Convert JSON source files to native task bundles."""
+
+    def __init__(self, params: dict[str, Any]):
+        super().__init__(params)
+        self._sources: dict[str, Path] | None = None
+
+    def _discover_sources(self) -> dict[str, Path]:
+        if self._sources is None:
+            self._sources = {
+                Path(match).stem: Path(match)
+                for match in glob_module.glob(self.tasks_glob, recursive=True)
+            }
+        return self._sources
+
+    def get_task_ids(self) -> list[str]:
+        return sorted(self._discover_sources().keys())
+
+    def convert_to_native(self, task_id: str) -> NativeTaskBundle:
+        source = self._discover_sources()[task_id]
+        data = json.loads(source.read_text(encoding="utf-8"))
+        name = data["name"]
+        return NativeTaskBundle(
+            task_config={
+                "name": name,
+                "description": f"Demo task converted from {source.name}",
+                "category": "tool_use",
+            },
+            grading_config={"combine": {"method": "weighted", "pass_threshold": 1.0}},
+            fixtures={"tools": [{"name": "noop"}]},
+            metadata={"source_adapter": "demo", "source_file": source.name},
+        )
+
+    def write_shared_resources(self, output_dir: Path, bundle: NativeTaskBundle) -> None:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "_shared_marker").write_text("ok", encoding="utf-8")

--- a/tests/canonical/test_adapter_convert_entry_point.py
+++ b/tests/canonical/test_adapter_convert_entry_point.py
@@ -1,0 +1,115 @@
+"""Entry-point discovery smoke for ``tolokaforge adapter convert``.
+
+Installs the built ``tolokaforge`` wheel plus a separately-built demo adapter
+(registered through a ``tolokaforge.adapters`` entry point) into an isolated
+scratch venv, then drives ``tolokaforge adapter convert --validate`` through
+that venv's own console script.
+
+This is the only test that exercises the production adapter-discovery path —
+``importlib.metadata.entry_points(group="tolokaforge.adapters")`` + ``ep.load()``
+— against a genuinely separate distribution, the same mechanism external
+adapters use. It is the class of packaging regression GH #37 was.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+_FIXTURE_PKG = Path(__file__).parent / "fixtures" / "tolokaforge-adapter-demo"
+
+
+def _run(cmd: list[str], *, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"command failed (rc={result.returncode}): {' '.join(cmd)}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv CLI not available")
+def test_entry_point_adapter_convert_smoke(built_wheel: Path, tmp_path: Path) -> None:
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    task_ids = ["alpha", "beta"]
+    for task_id in task_ids:
+        (sources / f"{task_id}.json").write_text(
+            json.dumps({"name": f"Demo {task_id}"}), encoding="utf-8"
+        )
+
+    venv_dir = tmp_path / "venv"
+    _run(["uv", "venv", str(venv_dir)])
+    _run(["uv", "pip", "install", "--python", str(venv_dir), str(built_wheel)])
+    _run(["uv", "pip", "install", "--python", str(venv_dir), "--no-deps", str(_FIXTURE_PKG)])
+
+    tolokaforge_bin = venv_dir / "bin" / "tolokaforge"
+    python_bin = venv_dir / "bin" / "python"
+    out_dir = tmp_path / "out"
+
+    # COLUMNS=200 stops rich from soft-wrapping the validation summary line in a
+    # non-tty, so the ", 0 invalid" anchor stays on one line.
+    result = subprocess.run(
+        [
+            str(tolokaforge_bin),
+            "adapter",
+            "convert",
+            "--name",
+            "demo",
+            "--tasks-glob",
+            str(sources / "*.json"),
+            "--output",
+            str(out_dir),
+            "--validate",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={**os.environ, "COLUMNS": "200"},
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"convert failed (rc={result.returncode}):\n{combined}"
+
+    # Sole validation signal: #487 makes the exit code 0 and writes bundles
+    # regardless of validation, so neither exit-0 nor the on-disk files below
+    # corroborate this. The leading comma anchors the count to exactly 0.
+    assert ", 0 invalid" in combined, f"validation did not report clean:\n{combined}"
+
+    for task_id in task_ids:
+        assert (out_dir / task_id / "task.yaml").exists()
+        assert (out_dir / task_id / "grading.yaml").exists()
+        assert (out_dir / task_id / "fixtures" / "tools.json").exists()
+
+    assert (out_dir / "_shared_marker").exists()
+
+    from tolokaforge.adapters import available_adapters
+
+    assert "demo" not in available_adapters(), (
+        "demo adapter leaked into the repo venv — the fixture package must never "
+        "be a uv workspace member or enter the tolokaforge wheel"
+    )
+
+    discovery = _run(
+        [
+            str(python_bin),
+            "-c",
+            "from tolokaforge.adapters import available_adapters; print(available_adapters())",
+        ],
+        timeout=60,
+    )
+    discovered = discovery.stdout
+    assert "demo" in discovered, f"demo not discovered by scratch venv: {discovered}"

--- a/tests/canonical/test_adapter_convert_packaging.py
+++ b/tests/canonical/test_adapter_convert_packaging.py
@@ -35,8 +35,7 @@ def _uv_available() -> bool:
     return shutil.which("uv") is not None
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
-def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
+def test_bundle_writer_ships_in_the_built_wheel(built_wheel: Path) -> None:
     """``tolokaforge.adapters.bundle_writer`` must be present in the wheel
     hatchling produces.
 
@@ -45,24 +44,7 @@ def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
     test — the source tree still has the file. The only way to catch it
     is to build the wheel and look inside.
     """
-    build_result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert build_result.returncode == 0, (
-        f"uv build failed (rc={build_result.returncode}):\n"
-        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
-    )
-
-    wheels = sorted(tmp_path.glob("tolokaforge-*.whl"))
-    assert wheels, f"No tolokaforge wheel produced under {tmp_path}"
-    wheel = wheels[-1]
-
-    with zipfile.ZipFile(wheel) as zf:
+    with zipfile.ZipFile(built_wheel) as zf:
         members = set(zf.namelist())
 
     required = {
@@ -75,7 +57,7 @@ def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
     }
     missing = required - members
     assert not missing, (
-        f"Wheel {wheel.name} is missing modules that adapter convert depends on: "
+        f"Wheel {built_wheel.name} is missing modules that adapter convert depends on: "
         f"{sorted(missing)}. Members starting with 'tolokaforge/adapters/': "
         f"{sorted(m for m in members if m.startswith('tolokaforge/adapters/'))}"
     )
@@ -123,8 +105,7 @@ def test_bundle_writer_module_imports_cleanly() -> None:
     assert "tolokaforge.adapters.bundle_writer" in sys.modules
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
-def test_python_version_pin_ships_in_the_built_wheel(tmp_path: Path) -> None:
+def test_python_version_pin_ships_in_the_built_wheel(built_wheel: Path) -> None:
     """``tolokaforge/_python_version.txt`` must be present in the wheel.
 
     ``tolokaforge.docker.builder._pinned_python_version`` reads this
@@ -138,24 +119,7 @@ def test_python_version_pin_ships_in_the_built_wheel(tmp_path: Path) -> None:
     ``pyproject.toml``. This test pins that the copy actually happens
     and the value in the wheel matches the repo-root single source.
     """
-    build_result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert build_result.returncode == 0, (
-        f"uv build failed (rc={build_result.returncode}):\n"
-        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
-    )
-
-    wheels = sorted(tmp_path.glob("tolokaforge-*.whl"))
-    assert wheels, f"No tolokaforge wheel produced under {tmp_path}"
-    wheel = wheels[-1]
-
-    with zipfile.ZipFile(wheel) as zf:
+    with zipfile.ZipFile(built_wheel) as zf:
         members = set(zf.namelist())
         assert "tolokaforge/_python_version.txt" in members, (
             "Wheel is missing tolokaforge/_python_version.txt — "


### PR DESCRIPTION
## Summary
- New `canonical`-tier test `tests/canonical/test_adapter_convert_entry_point.py` installs the built `tolokaforge` wheel + a separately-built demo adapter (registered via `[project.entry-points."tolokaforge.adapters"]`) into an isolated scratch venv and drives `tolokaforge adapter convert --validate` through that venv's own console script — the only test exercising the production `importlib.metadata` discovery path against a genuinely separate distribution. Would have caught GH #37.
- New in-tree fixture package `tests/canonical/fixtures/tolokaforge-adapter-demo/` mirrors the shipped external-adapter template; explicitly not a workspace member and not in the tolokaforge wheel (isolation invariant regression-locked in-process by `assert "demo" not in available_adapters()`).
- Session-scoped `built_wheel` fixture in `tests/canonical/conftest.py` shares the `uv build --wheel` build across the two existing wheel-inspection tests and the new smoke test (one build per session instead of three).

## Design choices
- **Approach A (in-tree fixture package under `tests/`) not B (demo adapter in tolokaforge's own `pyproject.toml`)**: because B would ship a testing-only adapter in the public wheel and would already be discoverable in the repo `.venv`, defeating the whole "install a separate package and discover it" premise of #49. A installs a genuinely separate distribution into a throwaway venv — the real external-adapter story.
- **`", 0 invalid"` is the sole signal that validation reported clean**: because #487 makes `adapter convert --validate` exit 0 and write bundles regardless of validation, neither the exit-0 check nor the on-disk-file checks corroborate validation. The subprocess runs with `env={**os.environ, "COLUMNS": "200"}` so rich cannot soft-wrap the validation summary line, and the leading comma anchors the count to exactly zero.
- **`DemoConversionAdapter(NativeAdapter)`, not `(BaseAdapter)`**: subclassing the concrete `NativeAdapter` satisfies the abstract methods the demo doesn't need without duplicating boilerplate — matches the proven in-repo `_StubConversionAdapter` pattern in `tests/unit/test_adapter_convert_cli.py`. The CLI convert path only invokes `get_task_ids` / `convert_to_native` / `write_shared_resources`, which the demo overrides; the inherited native-only methods are never exercised.
- **Isolation invariant enforced in-process, not as a manual gate**: `from tolokaforge.adapters import available_adapters; assert "demo" not in available_adapters()` runs inside the repo-venv test process, so a future workspace-member leak fails the test loudly. Cheap, durable regression lock.

## Concepts introduced
None. The change is a test-infrastructure smoke, an in-tree fixture package used only by that smoke, and doc reconciliation of stale claims. No new production abstraction, contract, or vocabulary — the entry-point-plugin adapter mechanism it exercises has been in place since #37/#48.

## Plan

# Plan: CI smoke test for `tolokaforge adapter convert` via a real entry-point adapter

Issue: #49
Branch: feat/issue-49-adapter-convert-smoke (targets `feat/release-hygiene`)

## Context

Issue #49 is partially shipped on `main`. `tests/canonical/test_adapter_convert_packaging.py` already inspects the built wheel and runs `adapter convert --help` as a subprocess; `tests/unit/test_adapter_convert_cli.py` exercises conversion in-process with a monkeypatched `get_adapter`. The one code path with **no** end-to-end coverage is the production one: adapter discovery through `importlib.metadata.entry_points(group="tolokaforge.adapters")` + `ep.load()` in `tolokaforge/adapters/__init__.py:50`, driven by the installed `tolokaforge` console script against a **separately-installed** adapter package. That is the discovery mechanism external adapters actually use (see the shipped `external_adapters/tolokaforge-adapter-terminal-bench`), and the class of packaging regression that GH #37 was.

I reproduced the whole target flow with a throwaway fixture package in a scratch venv: `uv build --wheel` → `uv venv` → install wheel + install a demo-adapter package with a `[project.entry-points."tolokaforge.adapters"]` block → `tolokaforge adapter convert --name demo --validate`. It works: `available_adapters()` returns `['demo', 'native']`, the native bundle is written, and `write_shared_resources` fires. **Two findings shaped the design** (see Discovered issues): (1) `--validate` only reports "valid" if the converted `task_config` carries the `TaskConfig`-required `description` field, and (2) `--validate` prints "N invalid" but the command still exits 0, so the test must assert on the validation report text, not the exit code.

## Goal

A `canonical`-tier test that installs the built `tolokaforge` wheel **and** a real entry-point-registered demo adapter into an isolated scratch venv, then runs `tolokaforge adapter convert --name demo … --validate` through that venv's own console script and asserts: entry-point discovery loaded the demo adapter, the native bundle (`task.yaml` / `grading.yaml` / `fixtures/*`) is written per task, the validation pass reports zero invalid, and `write_shared_resources` produced its marker. The wheel is built once per test session and shared with the two existing wheel-inspection tests.

## Non-goals

- Fixing the `--validate` exit-code bug (filed as #487 — out of scope; the test works around it by asserting on the report text).
- Re-testing anything already covered by `test_adapter_convert_packaging.py` or `test_adapter_convert_cli.py`.
- Shipping any demo/testing adapter in the public `tolokaforge` wheel.
- Adding a dedicated CI workflow — the `canonical` marker already runs in the CI smoke lane.

## Stages

### Stage 1 — Session-scoped `built_wheel` fixture; existing wheel tests consume it
Session-scoped `built_wheel(tmp_path_factory) -> Path` in `tests/canonical/conftest.py` runs `uv build --wheel` once from the repo root and returns the wheel path. Refactored `test_bundle_writer_ships_in_the_built_wheel` and `test_python_version_pin_ships_in_the_built_wheel` to consume it. Real `uv build`, hard-assert on failure, loud `pytest.skip` if `uv` is unavailable. Verified: 5 canonical tests pass in 9.38s, single shared build confirmed.

### Stage 2 — Demo adapter fixture package + entry-point discovery smoke test
Fixture package `tests/canonical/fixtures/tolokaforge-adapter-demo/` (hatchling, `requires-python=">=3.10"`, entry point `demo = "tolokaforge_adapter_demo.adapter:DemoConversionAdapter"`, `dependencies=["tolokaforge"]`). `DemoConversionAdapter(NativeAdapter)` globs JSON sources, emits a `NativeTaskBundle` with the required `description` field, writes a `_shared_marker`. New canonical test `tests/canonical/test_adapter_convert_entry_point.py` takes the `built_wheel` fixture, builds a scratch `uv venv`, installs the wheel then the fixture (`--no-deps`), and runs `<venv>/bin/tolokaforge adapter convert --name demo --validate` as a real subprocess with `COLUMNS=200`. Asserts exit 0, `", 0 invalid"` in output, per-task on-disk bundles, `_shared_marker` present, scratch venv discovers `demo`, and repo venv does NOT discover `demo`. `tests/README.md` + `tests/AGENTS.md` reconciled: the stale "Canonical … Fast (< 5s each) … External deps: None" claim now reflects reality (~10-25s for the packaging/entry-point smoke lane; `uv` dependency called out). Verified: 6 canonical tests pass in 22.63s; `uv build` from repo root does not include `demo`.

## Discovered issues
- **Filed: #487** — `tolokaforge adapter convert --validate` reports invalid tasks but exits 0. Fail-fast violation; `_validate_converted` result never reaches the exit code. Out of scope for #49; the new smoke test asserts on the report text as the documented workaround.

## Discovered issues
- Filed: #487
- Fixed in this PR: None

## Test plan
- Local: `uv run pytest -m canonical tests/canonical/test_adapter_convert_entry_point.py -v` — the new smoke passes (~22s dominated by scratch-venv install).
- Local: `uv run pytest -m canonical tests/canonical/test_adapter_convert_packaging.py tests/canonical/test_adapter_convert_entry_point.py -v` — the whole canonical adapter-convert lane passes (~23s, session `built_wheel` shared).
- Local: `uv build --wheel` from repo root produces a wheel that does NOT contain any `tolokaforge_adapter_demo` module.
- Local: `uv sync` from repo root still resolves cleanly; the fixture's nested `pyproject.toml` under `tests/` is not picked up as a workspace member.
- CI: the `canonical` marker already runs in the smoke lane — no workflow changes needed.

Closes #49
