### PR TITLE
fix(config): make OrchestratorConfig.max_turns default opt-in (None)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fix
+
+- **config**: `orchestrator.max_turns` now defaults to unset (`None`), making the run-level turn cap opt-in. A task's `max_turns` is no longer silently clamped to 50; the effective budget is `min(task, run cap)` only when the operator sets a cap, and the engine default (50 turns) applies when neither the run nor the task declares a value (#265).
+
 ## v0.9.0 (2026-07-17)
 
 ### Feat

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -45,7 +45,7 @@ orchestrator:
   max_attempt_retries: 1      # optional retries for transient infra failures
   queue_backend: "sqlite"     # "sqlite" (default) or "postgres"
   queue_postgres_dsn: null    # required when queue_backend="postgres"
-  max_turns: 50
+  # max_turns: 60             # optional run-level cap; omit for none
   continue_prompt: "Please proceed to the next step."
   timeouts:
     turn_s: 60

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -500,8 +500,10 @@ copies as **caps or removes them**:
   the task-resolved `max_turns` stands alone. When set, the
   effective turn budget = `min(task-resolved max_turns,
   orchestrator.max_turns)` — a task can never raise itself above
-  the run's cap. Most projects should leave it unset; set it
-  only as an operator guard (e.g. a tight CI profile).
+  the run's cap. When neither the run nor the task declares a
+  value, the engine default (50 turns) applies. Most projects
+  should leave it unset; set it only as an operator guard (e.g. a
+  tight CI profile).
 - `orchestrator.timeouts` caps the task-resolved timeouts the
   same way, and is optional the same way. M2 unifies the two
   timeout shapes onto the task-side field names

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -37,7 +37,7 @@ orchestrator:
   max_attempt_retries: 1            # Retry transient infra failures
   queue_backend: "sqlite"           # or "postgres" for distributed workers
   queue_postgres_dsn: null          # required when queue_backend="postgres"
-  max_turns: 50
+  # max_turns: 60                    # optional run-level cap; omit for none
 
   timeouts:
     turn_s: 60                      # Per-turn timeout

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -66,7 +66,7 @@ Multiple timeout layers prevent runaway execution:
 | Per-tool timeout | 30s | `ToolPolicy.timeout_s` |
 | Per-turn timeout | 60s | `orchestrator.timeouts.turn_s` |
 | Episode timeout | 1200s | `orchestrator.timeouts.episode_s` |
-| Max turns | 50 | `orchestrator.max_turns` |
+| Max turns | 50 (engine default) | `orchestrator.max_turns` (optional cap) |
 | Request throttle | 1.0/s | `orchestrator.max_requests_per_second` |
 
 ### Budget Cap

--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -14,12 +14,19 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.conductor import (
+    DEFAULT_MAX_TURNS,
     ConductorCallLog,
     InMemoryConductor,
     InProcessConductor,
     _default_success_trajectory,
+    resolve_max_turns,
 )
-from tolokaforge.core.models import ModelConfig, ResetSpec, ServiceSpec
+from tolokaforge.core.models import (
+    ModelConfig,
+    OrchestratorConfig,
+    ResetSpec,
+    ServiceSpec,
+)
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 from tolokaforge.runner.models import TaskDescription
 
@@ -290,3 +297,26 @@ class TestCaptureFinalStateEnvironmentBlock:
         self._conductor()._capture_final_state(spec, self._setup(), trajectory)
 
         assert "environment" not in trajectory.final_env_state
+
+
+class TestResolveMaxTurns:
+    def test_orchestrator_default_is_unset(self) -> None:
+        assert OrchestratorConfig().max_turns is None
+
+    def test_default_config_leaves_task_value_uncapped(self) -> None:
+        assert resolve_max_turns(100, OrchestratorConfig().max_turns) == 100
+
+    def test_both_unset_falls_back_to_engine_default(self) -> None:
+        assert resolve_max_turns(None, None) == DEFAULT_MAX_TURNS == 50
+
+    def test_run_cap_clamps_higher_task_value(self) -> None:
+        assert resolve_max_turns(100, 30) == 30
+
+    def test_task_value_stands_when_run_cap_unset(self) -> None:
+        assert resolve_max_turns(30, None) == 30
+
+    def test_run_cap_stands_when_task_value_unset(self) -> None:
+        assert resolve_max_turns(None, 30) == 30
+
+    def test_tighter_of_two_set_values_wins(self) -> None:
+        assert resolve_max_turns(100, 200) == 100

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -65,13 +65,37 @@ if TYPE_CHECKING:
     from tolokaforge.core.logging import StructuredLogger
 
 __all__ = [
+    "DEFAULT_MAX_TURNS",
     "Conductor",
     "ConductorCallLog",
     "ConductorContext",
     "ConductorFactory",
     "InMemoryConductor",
     "InProcessConductor",
+    "resolve_max_turns",
 ]
+
+#: Engine default per-trial turn budget, applied when neither the run-level
+#: cap (``OrchestratorConfig.max_turns``) nor the task declares a value.
+DEFAULT_MAX_TURNS = 50
+
+
+def resolve_max_turns(task_max_turns: int | None, run_cap: int | None) -> int:
+    """Coalesce the task-declared budget and the optional run-level cap into a
+    concrete per-trial turn budget.
+
+    The run cap is an optional operator-side clamp; the task value is
+    authoritative for the task's own semantics. When both are set the effective
+    budget is the tighter of the two. When neither is set the engine default
+    (:data:`DEFAULT_MAX_TURNS`) applies.
+    """
+    if task_max_turns is None and run_cap is None:
+        return DEFAULT_MAX_TURNS
+    if task_max_turns is None:
+        return run_cap
+    if run_cap is None:
+        return task_max_turns
+    return min(task_max_turns, run_cap)
 
 
 # ---------------------------------------------------------------------------
@@ -543,18 +567,7 @@ class InProcessConductor:
 
         system_prompt = self._build_system_prompt(task, setup.tool_schemas, setup.task_dir)
 
-        # Effective max_turns = min(task-resolved, run-level cap). The
-        # run-level cap is optional and acts as an operator-side clamp;
-        # the task's declared value is authoritative for the semantics
-        # of the task itself.
-        task_max_turns = task.max_turns
-        run_cap = self.config.orchestrator.max_turns
-        if task_max_turns is None:
-            max_turns = run_cap
-        elif run_cap is None:
-            max_turns = task_max_turns
-        else:
-            max_turns = min(task_max_turns, run_cap)
+        max_turns = resolve_max_turns(task.max_turns, self.config.orchestrator.max_turns)
 
         # Scale turn budget for complex multi-app mobile tasks only when task max_turns
         # is not explicitly pinned.

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -494,12 +494,12 @@ class OrchestratorConfig(BaseModel):
     Field-name migration to ``TimeoutDefaults`` (``trial_seconds`` /
     ``tool_call_seconds``) lands with the cleanup milestone."""
 
-    max_turns: int = 50
-    """Run-level cap on per-trial ``max_turns``. Effective value at
-    runtime = ``min(TaskConfig.max_turns, this)``. Unset behaviour is
-    preserved by the default (50) acting as the cap when the task
-    declares nothing higher — but authors should treat this as an
-    optional clamp rather than the authoritative value."""
+    max_turns: int | None = None
+    """Optional run-level cap on per-trial ``max_turns``. When set, the
+    effective budget is ``min(TaskConfig.max_turns, this)`` — an
+    operator-side clamp over the task-authoritative value. When unset,
+    the task-declared value stands alone. When neither the run nor the
+    task declares a value, the engine default (50 turns) applies."""
 
     auto_start_services: bool = True  # Auto-start Docker services via EngineStack
 


### PR DESCRIPTION
## Summary

- Flip `OrchestratorConfig.max_turns` default from `50` → `None` so the run-level turn cap is opt-in, not always-on. A task authoring `max_turns: 100` is no longer silently clamped to 50.
- Preserve today's runtime turn budget when nobody declares a value: `DEFAULT_MAX_TURNS = 50` engine constant applies when both the run and the task are unset.
- Extract the inline three-way min-rule at `InProcessConductor._run_agent_loop` into a pure, unit-testable `resolve_max_turns(task_max_turns, run_cap) -> int` that returns a concrete int in every branch — `None` can no longer reach `max(max_turns, 90)` in the mobile-scaling block or `range(...)` in the loop.

## Design choices

- **Default flips to `None`, not to a numeric value**: the issue's premise is that the *presence* of a run-level default inverts the design intent of the dual-home resolver (#241). Any numeric default reintroduces the always-on-cap bug. `None` is the only value that means "operator hasn't opted in".
- **Engine default `50` lives at the resolver, not the field**: the field's meaning is "operator cap"; the runtime's meaning is "budget when nobody declared one". Keeping them separate — a `DEFAULT_MAX_TURNS` constant next to the resolver, following the `DEFAULT_JUDGE_MAX_TURNS = 14` precedent (`grading/judge.py:83`) — keeps `None` from ever leaking into runner-side arithmetic.
- **Resolver extracted, not inlined**: the behaviour-lock has to catch a revert of `models.py:497` back to `50`. A pure function driven by `OrchestratorConfig()` as the default source (rather than by a literal `None`) transitively pins the field default in unit tests.
- **`timeouts` sibling bug not bundled**: same shape (always-on cap) but wider blast radius — four `episode_s * 2` lease-math sites in `orchestrator.py` collide with the scheduled M5 name migration. Filed as #489 for coordinated handling with M5. Rebuts the issue body's "same for `timeouts`" line with evidence.

## Concepts introduced

`DEFAULT_MAX_TURNS` — a module-level engine constant colocated with the resolver, used when both operator and task decline to declare a turn budget. Sibling in spirit to `DEFAULT_JUDGE_MAX_TURNS`. `resolve_max_turns()` is the first extracted resolver in the dual-home family (task/run min-rule); expect more to follow when the timeouts fix (#489) and future dual-home fields land, likely converging on a small `_resolution.py` module. This PR does not yet make that split — one function, one call site.

## Plan

### Goal

Flip `OrchestratorConfig.max_turns` to default `None` so the run cap is opt-in, while preserving today's runtime budget when nobody declares a value. Contract:

- `orchestrator.max_turns` unset (`None`) ⇒ no run-level cap; the task-resolved `max_turns` stands alone.
- Both run and task set ⇒ `min(run, task)` (unchanged).
- Both unset ⇒ the engine default turn budget (`50`) applies — the value that is the effective budget today when a task declares nothing. The runtime never receives `None`.

### Non-goals

- **`orchestrator.timeouts` default flip** — same bug class, but materially wider blast radius and a scheduled name migration make it a separate change. Filed as #489.
- Field-name migration `turn_s`/`episode_s` → `trial_seconds`/`tool_call_seconds` (scheduled for M5).
- `stuck_heuristics` / `continue_prompt` deprecation.
- Adding a `ge=1` validator to `max_turns` (default flip only, no schema change).

### Stage 1 — Flip `max_turns` default with an engine-default fallback

**Contract:**
- `tolokaforge/core/models.py:497` — `max_turns: int = 50` becomes `max_turns: int | None = None`. Docstring rewritten to describe the optional-cap semantics as current state (no "previously 50, now None" narrative).
- A single named engine-default constant `DEFAULT_MAX_TURNS = 50` (module constant, following the `DEFAULT_JUDGE_MAX_TURNS = 14` precedent).
- The min-rule + engine-default coalesce is extracted from the inline block into a pure `resolve_max_turns(task_max_turns: int | None, run_cap: int | None) -> int`:
  - both `None` → `DEFAULT_MAX_TURNS`
  - task `None`, run set → `run_cap`
  - run `None`, task set → `task_max_turns`
  - both set → `min(task_max_turns, run_cap)`
- `_run_agent_loop` calls the resolver **before** the mobile-scaling block so `max(max_turns, 90)` / `max(max_turns, 75)` always operate on an `int`.
- `TrialRunner` and `LoopConfig` signatures stay `max_turns: int` — they never receive `None`.

**Behaviour to lock (tier: unit):** the lock **must transitively pin the field default** (`models.py:497`), not just the resolver. A resolver-only test passing `None` literally stays green if a future edit reverts the default to `50`.

- **Default-config lock (mandatory):**
  - `OrchestratorConfig().max_turns is None`
  - `resolve_max_turns(100, OrchestratorConfig().max_turns) == 100` (the issue's acceptance item)
- **Resolver-branch coverage (literals):**
  - `resolve_max_turns(None, None) == 50`
  - `resolve_max_turns(100, 30) == 30`
  - `resolve_max_turns(30, None) == 30`, `resolve_max_turns(None, 30) == 30`, `resolve_max_turns(100, 200) == 100`

**Compatibility:** `OrchestratorConfig.max_turns` is a public run-config field. Behaviour change (implicit 50-cap removed) is the intended fix; the field widens `int → int | None` (still accepts every prior valid input). Migration = CHANGELOG entry + doc sweep.

**Doc updates (all in the same commit):**
- `docs/PROJECTS.md`, `docs/CONFIG.md`, `docs/REFERENCE.md`, `docs/SECURITY.md`, `CHANGELOG.md`.
- `docs/REFERENCE.md:213` and `docs/API.md:26` (`max_turns: int = 50,` in `TrialRunner` signature) intentionally left as-is — the runner-level default stays 50.

## Discovered issues

- **Filed:** #489 — `orchestrator.timeouts` sibling bug (assigned to milestone 9). Same always-on-cap inversion; deliberately out of scope for this PR because a naive flip breaks four `episode_s * 2` lease-math sites in `orchestrator.py` and collides with the scheduled M5 name migration. Recommended to bundle with M5.
- Pre-existing repo-wide black/ruff-format drift (47 files, none touched by this PR) surfaced during `format_check`. Flagged for main; not in this PR's scope. Aligns with the known formatting drift documented in AGENTS.md gotchas.

## Test plan

- `uv run pytest tests/unit/test_conductor.py::TestResolveMaxTurns` — 7 new tests, all green.
- `uv run pytest -m unit` — 2529 pass, 1 skip, no regression in `test_conductor` / `test_config_validator` / `test_tool_calling_loop` / `test_runner_logic`.
- `uv run pytest -m canonical` — 448 pass, no snapshot drift (no snapshot embeds the `OrchestratorConfig` default).
- Runtime probe: default=`None`; task=100/run=default → 100; both-unset → 50; 5-app mobile task with neither set → `max(50, 90) = 90` (no TypeError).
- Post-merge: any run config that omits `orchestrator.max_turns` continues to run 50-turn trials; any run config that sets it explicitly still clamps per `min(run, task)`.

Closes #265