### PR TITLE
fix(adapter): fail conversion on invalid output

### DIFF
--- a/tests/unit/test_adapter_convert_cli.py
+++ b/tests/unit/test_adapter_convert_cli.py
@@ -90,6 +90,28 @@ def test_convert_writes_native_bundles(runner, tmp_path, monkeypatch):
     assert (out / "_shared_marker").exists()
 
 
+def test_convert_validate_exits_nonzero_for_invalid_output(runner, tmp_path, monkeypatch):
+    monkeypatch.setattr(adapters_pkg, "get_adapter", lambda name, params: _StubConversionAdapter())
+
+    result = runner.invoke(
+        cli,
+        [
+            "adapter",
+            "convert",
+            "--name",
+            "stub",
+            "--tasks-glob",
+            "x/**",
+            "--output",
+            str(tmp_path / "out"),
+            "--validate",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Validation: 0 valid, 2 invalid" in result.output
+
+
 def test_convert_works_without_shared_resources(runner, tmp_path, monkeypatch):
     stub = _NoSharedAdapter()
     monkeypatch.setattr(adapters_pkg, "get_adapter", lambda name, params: stub)

--- a/tolokaforge/cli/adapter_commands.py
+++ b/tolokaforge/cli/adapter_commands.py
@@ -118,16 +118,18 @@ def convert(
 
                 traceback.print_exc()
 
+    validation_errors = 0
+
     # Optional validation pass
     if do_validate and converted > 0:
-        _validate_converted(output_path, task_ids, verbose)
+        validation_errors = _validate_converted(output_path, task_ids, verbose)
 
     console.print(f"\nConverted {converted} tasks ({errors} errors)")
-    if errors > 0:
+    if errors > 0 or validation_errors > 0:
         raise SystemExit(1)
 
 
-def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -> None:
+def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -> int:
     """Validate converted output by loading via NativeAdapter."""
     from tolokaforge.adapters._task_loader import load_task_yaml
 
@@ -149,3 +151,4 @@ def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -
             console.print(f"  ✗ invalid: {task_id}: {exc}", style="red")
 
     console.print(f"  Validation: {valid} valid, {invalid} invalid")
+    return invalid


### PR DESCRIPTION
Closes #487.

`adapter convert --validate` now includes schema validation failures in its exit status instead of reporting invalid bundles and exiting 0. Added CLI regression coverage for invalid converted output.

Tested with `pytest tests/unit/test_adapter_convert_cli.py` plus Ruff check and format.
