### PR TITLE
chore(ci,tests): single-source runtime Python version + canonical guard

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     ca-certificates \
     gnupg \
+    # Host tooling only — the project interpreter is uv-managed from .python-version.
     python3 \
     python3-pip \
     python3-dev \

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -138,7 +138,7 @@ jobs:
           version: "0.9.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv python install 3.12
+      - run: uv python install "$(cat .python-version)"
       - run: uv sync --dev --locked
 
       - name: Parse candidate model from PR title

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -68,7 +68,7 @@ jobs:
           version: "0.9.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv python install 3.12
+      - run: uv python install "$(cat .python-version)"
       - run: uv sync --dev --locked
 
       - name: Poll the channel and resolve requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,8 @@ Recommended MCP servers for AI agents working on this project:
 - `ruff` for linting and formatting
 - `pytest` for testing
 
+The runtime Python version is single-sourced in `.python-version`; changing it propagates to dev, CI, the devcontainer (via uv), and all runtime Docker images. A canonical guard (`tests/canonical/test_python_version_single_source.py`) fails CI if a workflow or runtime Dockerfile hardcodes a version instead.
+
 **Don't suppress warnings** — update code to use actual functionality instead.
 
 ### Protected Directories

--- a/tests/canonical/test_python_version_single_source.py
+++ b/tests/canonical/test_python_version_single_source.py
@@ -1,0 +1,122 @@
+"""Guards that the runtime Python version stays single-sourced in ``.python-version``.
+
+A regression that re-hardcodes a version — in a workflow's ``uv python install``
+line, an ``actions/setup-python`` pin, or a runtime Dockerfile ``FROM`` — must fail
+CI rather than silently drift from the pin. Runs under the ``canonical`` marker so it
+participates in the existing CI smoke job without dedicated workflow wiring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.canonical
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_DOCKERFILE_DIR = _REPO_ROOT / "tolokaforge" / "docker" / "dockerfiles"
+_PINNED_VERSION = (_REPO_ROOT / ".python-version").read_text().strip()
+
+_EXPECTED_INSTALL_ARG = '"$(cat .python-version)"'
+
+_INSTALL_RE = re.compile(r"uv python install\s+(.*?)\s*$")
+_TRAILING_COMMENT_RE = re.compile(r"\s+#.*$")
+_ARG_LINE_RE = re.compile(r"^ARG PYTHON_VERSION(?:=(\S+))?\s*$", re.MULTILINE)
+_FROM_LINE_RE = re.compile(r"^FROM python:\$\{PYTHON_VERSION\}", re.MULTILINE)
+
+
+def _workflow_files() -> list[Path]:
+    files = sorted((*_WORKFLOW_DIR.glob("*.yml"), *_WORKFLOW_DIR.glob("*.yaml")))
+    assert files, f"no workflow files found under {_WORKFLOW_DIR} — the guard would pass vacuously"
+    return files
+
+
+def _iter_steps(doc: object):
+    if not isinstance(doc, dict):
+        return
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                yield step
+
+
+def test_workflow_uv_python_install_reads_the_pin() -> None:
+    violations: list[str] = []
+    for path in _workflow_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            match = _INSTALL_RE.search(line)
+            if match is None:
+                continue
+            arg = _TRAILING_COMMENT_RE.sub("", match.group(1)).strip()
+            if arg != _EXPECTED_INSTALL_ARG:
+                rel = path.relative_to(_REPO_ROOT)
+                violations.append(
+                    f"{rel}:{lineno}: `uv python install {arg}` hardcodes the version — "
+                    f"expected `uv python install {_EXPECTED_INSTALL_ARG}`"
+                )
+    message = "Workflows must install the pinned Python via .python-version:\n" + "\n".join(
+        violations
+    )
+    assert not violations, message
+
+
+def test_workflow_setup_python_uses_version_file() -> None:
+    violations: list[str] = []
+    for path in _workflow_files():
+        doc = yaml.safe_load(path.read_text())
+        rel = path.relative_to(_REPO_ROOT)
+        for step in _iter_steps(doc):
+            uses = step.get("uses", "")
+            if not isinstance(uses, str) or not uses.startswith("actions/setup-python"):
+                continue
+            with_block = step.get("with") or {}
+            if "python-version" in with_block:
+                violations.append(
+                    f"{rel}: `actions/setup-python` pins `python-version` — "
+                    "use `python-version-file: .python-version` instead"
+                )
+            elif with_block.get("python-version-file") != ".python-version":
+                violations.append(
+                    f"{rel}: `actions/setup-python` must set `python-version-file: .python-version`"
+                )
+    assert not violations, "\n".join(violations)
+
+
+def test_runtime_dockerfiles_single_source_python() -> None:
+    dockerfiles = sorted(_DOCKERFILE_DIR.glob("*.Dockerfile"))
+    assert dockerfiles, f"no runtime Dockerfiles found under {_DOCKERFILE_DIR}"
+
+    violations: list[str] = []
+    for path in dockerfiles:
+        text = path.read_text()
+        rel = path.relative_to(_REPO_ROOT)
+        arg_match = _ARG_LINE_RE.search(text)
+        if arg_match is None:
+            violations.append(
+                f"{rel}: missing `ARG PYTHON_VERSION` — runtime image must accept the pin"
+            )
+            continue
+        if _FROM_LINE_RE.search(text) is None:
+            violations.append(
+                f"{rel}: missing `FROM python:${{PYTHON_VERSION}}` — image must build from the ARG, not a literal"
+            )
+        default = arg_match.group(1)
+        if default is not None and default.strip() != _PINNED_VERSION:
+            violations.append(
+                f"{rel}: `ARG PYTHON_VERSION={default}` default diverges from "
+                f".python-version ({_PINNED_VERSION}) — a plain `docker build` would use the stale default"
+            )
+    assert not violations, "\n".join(violations)


### PR DESCRIPTION
## Summary
- Both `.github/workflows/slack-integrate.yml` and `.github/workflows/integrate-model.yml` now install the runtime Python via `"$(cat .python-version)"` instead of hardcoding `3.12`. Every workflow's `uv python install` step now reads `.python-version`.
- New `canonical`-tier guard `tests/canonical/test_python_version_single_source.py` enforces the single source with three assertions: (a) every `uv python install <arg>` in every workflow (both `.yml` and `.yaml`) reads `.python-version`; (b) any future `actions/setup-python` step must use `python-version-file: .python-version`; (c) every runtime Dockerfile under `tolokaforge/docker/dockerfiles/` uses `ARG PYTHON_VERSION` + `FROM python:${PYTHON_VERSION}`, and if the ARG carries a default it must equal `.python-version`.
- One-line WHY comment in `.devcontainer/Dockerfile` clarifies that the apt `python3` is host tooling only — the project interpreter is uv-managed from `.python-version`.
- One-line note in `AGENTS.md` states the single-source invariant.

## Design choices
- **Guard test enforces the invariant, not a mechanical text-substitution refactor.** The point of `.python-version` isn't just consolidation; it's that a *future* regression fails CI. The three assertions are the enforcement interface.
- **Assertion 3 checks that if `ARG PYTHON_VERSION` carries a default, that default equals `.python-version`.** Without this check, a direct `docker build …/runner.Dockerfile` with no `--build-arg` silently uses the stale ARG default after a `.python-version` bump — exactly the "version lives in N places / images drift" failure this issue is about. Closing that path makes the single-source claim literally true, not just "true through `builder.py`".
- **Workflow assertions cover both `*.yml` and `*.yaml`.** GitHub Actions accepts both extensions; the repo is `.yml`-only today, but a future dev writing `foo.yaml` with `uv python install 3.13` would otherwise sail past CI, defeating the guard's whole purpose.
- **Non-empty guard in the workflow helper prevents vacuous pass** if `.github/workflows` is ever renamed/moved — the guard fails loudly instead of silently disabling itself. Symmetric with the existing Dockerfile non-empty assertion.
- **Devcontainer divergence documented, not "aligned".** The apt `python3` on `ubuntu:jammy` is 3.10; the project's actual interpreter is uv-managed from `.python-version` (3.12). The apt install exists for host tooling. A one-line WHY comment prevents a future reader from pointlessly bumping the apt python.

## Concepts introduced
None. The change surfaces an existing invariant (`.python-version` is the single runtime pin — already true through `builder.py`) with an enforcement test, and closes two remaining drift paths (two workflows + Dockerfile ARG defaults). No new production abstraction, contract, or vocabulary.

## Plan

# Plan: Single-source the Python version and align runtime images

Issue: #480
Branch: chore/issue-480-python-version-single-source

## Context (verified against `feat/release-hygiene` before planning)

- All four runtime Dockerfiles (`tolokaforge/docker/dockerfiles/{runner,db_service,mock_web,rag}.Dockerfile`) already use `ARG PYTHON_VERSION=3.12` + `FROM python:${PYTHON_VERSION}-slim`. `tolokaforge/docker/builder.py::_pinned_python_version()` reads `.python-version` and passes it as the ARG.
- Six workflows already read `.python-version`. Only two hardcoded `uv python install 3.12`: `slack-integrate.yml:71` and `integrate-model.yml:141`.
- Orphan Dockerfiles the issue asked to clean up (`executor/json_db/agent/orchestrator`) **no longer exist** — line item moot.
- No workflow uses `actions/setup-python` — the setup-python-with-hardcoded-version alternative is not applicable.
- Devcontainer already honours `.python-version` via uv-managed Python; the apt `python3` (3.10 on jammy) is unrelated host tooling. Clarifying comment only, not a code change.
- `docs/PERFORMANCE.md` pins `Python | 3.11.7` — historical benchmark record, out of scope; filed as #492.

## Stage 1 — Single-source the runtime Python version end-to-end

- Edit `slack-integrate.yml:71` and `integrate-model.yml:141` to `uv python install "$(cat .python-version)"` (terse style preserved).
- New `tests/canonical/test_python_version_single_source.py`:
  - Assertion 1 — every `uv python install <arg>` in every `.github/workflows/*.{yml,yaml}` has `<arg>` equal to `"$(cat .python-version)"` after stripping trailing `#…` and surrounding whitespace; match the full quoted token, not a first-token split.
  - Assertion 2 — no `actions/setup-python` step pins a literal `python-version:`; must use `python-version-file: .python-version`. (Zero usages today; future-proofing.)
  - Assertion 3 — every `tolokaforge/docker/dockerfiles/*.Dockerfile` has `ARG PYTHON_VERSION` + `FROM python:${PYTHON_VERSION}`; **and if `ARG PYTHON_VERSION` has a default, it must equal `.python-version`**.
  - Non-empty helper guard prevents vacuous pass if `.github/workflows` disappears.
- One-line WHY comment in `.devcontainer/Dockerfile` at the apt `python3` install.
- One-line invariant note in `AGENTS.md` under Python Conventions → Style and Tooling.

## Discovered issues
- Filed: #492 (docs/PERFORMANCE.md pins Python 3.11.7; historical benchmark, out of scope)
- Fixed in this PR: None

## Test plan
- Local: `uv run pytest -m canonical tests/canonical/test_python_version_single_source.py -v` — 3 tests pass (~0.11s).
- Local guard-bites check: `sed -i '' 's|uv python install "$(cat .python-version)"|uv python install 3.13|' .github/workflows/slack-integrate.yml` → re-run the guard → confirms it fails with file:line:arg. (Verified by the implementer; do not re-run and commit the revert.)
- Local: `rg -n 'uv python install' .github/workflows/` — every hit reads `.python-version`; `rg 'uv python install 3\.' .github/` — no matches.
- Local: `uv build --wheel` from repo root still succeeds.
- CI: canonical lane runs the new guard.

## Non-goals
- Changing `requires-python = ">=3.10"` or ruff/black `target-version = py310` (intentional OSS support floor).
- Re-touching `test_python_version_pin_ships_in_the_built_wheel` or the `built_wheel` fixture (owned by #49, landed as `fbaafec`).
- Refreshing `docs/PERFORMANCE.md` (out of scope; #492).
- Any upgrade of the pinned version itself (stays `3.12`).

Closes #480
