### PR TITLE
fix(loader): reject explicit stack:null and stack.compose_file:null at load time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Fix
 
 - **config**: `orchestrator.max_turns` now defaults to unset (`None`), making the run-level turn cap opt-in. A task's `max_turns` is no longer silently clamped to 50; the effective budget is `min(task, run cap)` only when the operator sets a cap, and the engine default (50 turns) applies when neither the run nor the task declares a value (#265).
+- **loader**: `stack: null` and `stack: {compose_file: null}` in a task's `environment_manifest` (and in a project's `default_environment`) are now rejected at load time with a `RuntimeError` naming the offending file and field, enforcing the documented full-override rule — a task cannot unset the environment (or its substrate pointer) out from under a project that declares one. Omit the key to inherit (#235).
 
 ## v0.9.0 (2026-07-17)
 

--- a/tests/unit/test_project_loader.py
+++ b/tests/unit/test_project_loader.py
@@ -191,6 +191,20 @@ class TestLoadProjectConfig:
         assert project.default_environment.stack.compose_file.is_absolute()
         assert project.default_environment.stack.compose_file == rel_compose.resolve()
 
+    def test_null_default_environment_stack_raises(self, tmp_path: Path) -> None:
+        path = self._write_project(tmp_path, {"default_environment": {"stack": None}})
+        with pytest.raises(RuntimeError, match="default_environment.stack' must not be null"):
+            load_project_config(path)
+
+    def test_null_default_environment_stack_compose_file_raises(self, tmp_path: Path) -> None:
+        path = self._write_project(
+            tmp_path, {"default_environment": {"stack": {"compose_file": None}}}
+        )
+        with pytest.raises(
+            RuntimeError, match="default_environment.stack.compose_file' must not be null"
+        ):
+            load_project_config(path)
+
     def test_missing_file_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             load_project_config(tmp_path / "nope.yaml")

--- a/tests/unit/test_task_loader.py
+++ b/tests/unit/test_task_loader.py
@@ -445,6 +445,60 @@ class TestLoadTaskYaml:
         assert task.environment_manifest.stack.compose_file.is_absolute()
         assert task.environment_manifest.stack.compose_file == rel_compose.resolve()
 
+    def _write_task_with_stack(self, tmp_path: Path, stack: object) -> Path:
+        task_path = tmp_path / "task.yaml"
+        _write_yaml(
+            task_path,
+            {
+                "task_id": "x",
+                "name": "x",
+                "category": "x",
+                "description": "x",
+                "initial_state": {},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {"mode": "scripted", "scripted_flow": []},
+                "grading": "g.yaml",
+                "environment_manifest": {"stack": stack},
+            },
+        )
+        return task_path
+
+    def test_null_stack_raises(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, None)
+        with pytest.raises(RuntimeError, match="stack' must not be null"):
+            load_task_yaml(task_path)
+
+    def test_null_stack_compose_file_raises(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, {"compose_file": None})
+        with pytest.raises(RuntimeError, match="stack.compose_file' must not be null"):
+            load_task_yaml(task_path)
+
+    def test_empty_stack_loads(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, {})
+        task, _ = load_task_yaml(task_path)
+        assert task.environment_manifest is not None
+
+    def test_stack_inputs_only_loads(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, {"inputs": {"x": "1"}})
+        task, _ = load_task_yaml(task_path)
+        assert task.environment_manifest is not None
+        assert task.environment_manifest.stack is not None
+        assert task.environment_manifest.stack.inputs == {"x": "1"}
+
+    def test_stack_real_compose_file_loads(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, {"compose_file": "env.compose.yaml"})
+        task, _ = load_task_yaml(task_path)
+        assert task.environment_manifest is not None
+        assert task.environment_manifest.stack is not None
+        assert task.environment_manifest.stack.compose_file is not None
+
+    def test_non_string_stack_compose_file_still_raises_type_error(self, tmp_path: Path) -> None:
+        task_path = self._write_task_with_stack(tmp_path, {"compose_file": 3})
+        with pytest.raises(
+            RuntimeError, match="stack.compose_file' must be a string \\(got int\\)"
+        ):
+            load_task_yaml(task_path)
+
     def test_dangling_domain_ref_raises(self, tmp_path: Path) -> None:
         task_path = tmp_path / "testcases" / "c" / "task.yaml"
         task_path.parent.mkdir(parents=True)

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -204,9 +204,23 @@ def _resolve_environment_manifest_paths(task_data: dict, task_root: Path, task_p
             f"(got {type(manifest).__name__})"
         )
 
+    if "stack" in manifest and manifest["stack"] is None:
+        raise RuntimeError(
+            f"Task file {task_path}: 'environment_manifest.stack' must not be null — "
+            "a task cannot unset the environment out from under a project that declares "
+            "one. Omit the key to inherit the project's stack, or declare a stack."
+        )
+
     stack = manifest.get("stack")
     if isinstance(stack, dict) and "compose_file" in stack:
         compose_file = stack["compose_file"]
+        if compose_file is None:
+            raise RuntimeError(
+                f"Task file {task_path}: "
+                f"'environment_manifest.stack.compose_file' must not be null — "
+                "a task cannot unset the substrate pointer; there is no engine-default "
+                "compose file to fall through to. Omit the key to inherit."
+            )
         if not isinstance(compose_file, str):
             raise RuntimeError(
                 f"Task file {task_path}: "

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -133,6 +133,7 @@ def load_project_config(path: Path) -> ProjectConfig:
         raise RuntimeError(
             f"project.yaml at {path} is not a YAML mapping (got {type(data).__name__})"
         )
+    _reject_null_stack(data, path)
     # Resolve default_environment.compose_file relative to the project dir
     # so EnvironmentManifest's validator can locate it regardless of CWD.
     _resolve_project_paths(data, path.parent)
@@ -166,6 +167,30 @@ def _verify_seed_digests(project: ProjectConfig, project_yaml_path: Path) -> Non
                 "Re-stamp via `tolokaforge assets stamp` or restore the "
                 "original file."
             )
+
+
+def _reject_null_stack(data: dict, path: Path) -> None:
+    """Fail loud when ``default_environment.stack`` (or its
+    ``compose_file``) is present but explicitly null. A project omits the
+    key to declare no environment default; explicit-null is nonsense and
+    would otherwise be silently dropped by Pydantic's optional handling.
+    Pre-Pydantic so the message carries the ``project.yaml`` path.
+    """
+    env = data.get("default_environment")
+    if not isinstance(env, dict):
+        return
+    if "stack" in env and env["stack"] is None:
+        raise RuntimeError(
+            f"project.yaml at {path}: 'default_environment.stack' must not be null — "
+            "omit the key to declare no environment default, or declare a stack."
+        )
+    stack = env.get("stack")
+    if isinstance(stack, dict) and "compose_file" in stack and stack["compose_file"] is None:
+        raise RuntimeError(
+            f"project.yaml at {path}: 'default_environment.stack.compose_file' must not "
+            "be null — there is no engine-default compose file to fall through to. "
+            "Omit the key to declare no substrate pointer, or declare one."
+        )
 
 
 def _resolve_project_paths(data: dict, project_dir: Path) -> None:


### PR DESCRIPTION
## Summary

- Enforce the `docs/PROJECTS.md:798-801` rule that a task's `stack: null` and `stack: {compose_file: null}` are load errors. Same for a project's `default_environment.stack{,.compose_file}`. Reality now matches the doc.
- `stack: null` was silently dropped by Pydantic's optional handling, letting the project's value pass through — the opposite of the documented full-override behaviour. `stack.compose_file: null` was surfacing as a misleading "must be a string (got NoneType)" type error rather than a purpose-built unset message.
- New errors are `RuntimeError` from the pre-Pydantic loader helpers, naming the offending file and field.

## Design choices

- **Rejection at the loader parse-boundary, not on `EnvironmentPatch` / `StackPatch`**: at the model level `EnvironmentPatch(stack=None)` is the *legitimate* default/inherit state — banning it would break the default and inherit semantics. The unset-vs-null distinction is only decidable at YAML parse time, and only the loader carries the file path that the issue's error-message requirement demands (patches perform no filesystem I/O at construction time). This is a deliberate deviation from the issue body's "reject in the model" phrasing, argued in the plan's Risks and endorsed by the critic after checking every load site for bypass holes. Follows AGENTS.md "validate at boundaries, trust internal code" — direct model construction with explicit-null is internal-programmer error, not a user boundary.
- **Dedicated null message before the type check**: on the task side the new null branch fires *before* the pre-existing `isinstance(compose_file, str)` check, so a deliberate unset attempt reads as "cannot unset the substrate pointer" rather than a type-mismatch message. The type-error branch survives for non-`None` non-`str` values (locked by a regression-guard test).
- **Symmetric project-side fix folded in**: `default_environment: {stack: null}` in `project.yaml` was silently accepted today via the same root cause. Splitting it into a separate ticket would have left the task and project surfaces inconsistent; a reviewer would rightly flag that. In-neighbourhood scope expansion.
- **`_reject_null_stack` as a new sibling helper on the project side**: `_anchor_stack_compose_file` only receives `anchor_dir` (= `path.parent`), not the full `project.yaml` path the error message needs. Threading `path` into it would blur its single-responsibility (path anchoring). The pre-Pydantic sibling keeps both concerns clean.

## Concepts introduced

None new to the vocabulary. Reinforces the **parse-boundary** principle: shape invariants that need file-context error messages live in the pre-Pydantic loader helpers alongside `_resolve_environment_manifest_paths` and `_verify_seed_digests`, not on the Pydantic patch models. This is now the canonical home for null-as-unset rejections and any future rules of the same class.

## Plan

### Goal

A task (or project) that explicitly writes `stack: null` or `stack: {compose_file: null}` fails at load time with a `RuntimeError` that names the offending **file** and **field** and paraphrases the doc rule. Omitting the key (inherit) stays valid; setting to a real value stays valid.

### Non-goals

- Any wider strictness pass — `extra="forbid"` etc. is the M4 strict-schema keystone (#213). Note `extra="forbid"` would NOT catch this (`null` is a valid Pydantic value for `Optional[...]`).
- Model-level `mode="before"` / `model_fields_set` rejection (defended deviation; see Design choices).
- Rejecting other malformed `stack` shapes (`stack: "foo"`, `stack: 3`); those already error at Pydantic construction.

### Stage 1 — Reject explicit-null `stack` / `stack.compose_file` at the load parse-boundary

**Task side** — `_resolve_environment_manifest_paths` (`_task_loader.py`):
- `"stack" in manifest and manifest["stack"] is None` → `RuntimeError(f"Task file {task_path}: 'environment_manifest.stack' must not be null — a task cannot unset the environment out from under a project that declares one. Omit the key to inherit the project's stack, or declare a stack.")`
- `stack` dict with `compose_file` present and `None` → dedicated null message *before* the existing `isinstance(..., str)` check.

**Project side** — new `_reject_null_stack(data, path)` helper called from `load_project_config` before `_resolve_project_paths` / `ProjectConfig(**data)`:
- Symmetric rejection for `default_environment.stack{,.compose_file}` with `project.yaml at {path}` context.

**Exception type**: `RuntimeError` in both homes, matching the existing fail-loud precedent. No new exception class. `EnvironmentPatch` / `StackPatch` in `runner/models.py` are untouched.

**Behaviour to lock (tier: unit).** Extends `tests/unit/test_task_loader.py` (6 tests: 2 negative, 3 positive, 1 regression-guard on the surviving type-check branch) and `tests/unit/test_project_loader.py` (2 negative — positive path covered by pre-existing `test_resolves_default_environment_stack_compose_relative_path`). All drive the real loaders via `tmp_path + _write_yaml`, no mocks.

**Compatibility**: `task.yaml` and `project.yaml` are public YAML compat surfaces. Grep of `examples/**` and `tasks/**` confirms zero packs use either rejected shape today — migration burden nil. `docs/PROJECTS.md:798-801` already states the rule as current fact; this makes reality match. CHANGELOG entry landed under Unreleased/Fix.

**Doc updates**:
- `docs/PROJECTS.md:798-801` — verify only, no rewrite (rule already current-fact).
- `CHANGELOG.md` — Unreleased/Fix entry naming both surfaces.
- `rg 'stack.*null|compose_file.*null'` sweep of `docs/` + `README.md` — only the doc anchor + CHANGELOG entry surfaced.

## Discovered issues

- **Fix in this PR**: project-side symmetric gap (`default_environment: {stack: null}`) folded into Stage 1 to keep task- and project-side parse-boundaries consistent.
- **Filed**: none.

## Test plan

- `uv run pytest -m unit -k "task_loader or project_loader"` — 111 pass (incl. 8 new).
- `uv run pytest -m unit` — 2537 pass, 1 skip, no regression in `test_task_loader.py`, `test_project_loader.py`, `test_project_config.py`, `test_environment_resolve.py`, `test_native_adapter_environment_manifest.py`, or example-pack task tests.
- `uv run pytest -m canonical` — 448 pass, no snapshot drift.
- Post-merge: any task/project YAML that today writes `stack: null` or `stack.compose_file: null` (there are none in-tree) will now fail loudly at load with a file-naming error.

Closes #235