### PR TITLE
docs+test(runtime): Case A EngineStack is full_internet by construction (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this project are documented in this file.
 ### Docs
 
 - **guide**: task-pack image-layering guide covering the 3-tier base/environment/instance pattern from SWE-bench, with Dockerfile snippets and compose-file references (#146).
+- **security/runtime**: document the built-in (Case A) `EngineStack` as `full_internet` by construction — the built-in `runner-net` is non-internal and the runner retains egress for in-container LLM-as-judge grading; task-declared stacks remain the only path with an enforceable `network_policy`. Recorded in ADR-0018 + `RUNTIME_BACKENDS.md`, and locks the `Network.internal` foundation primitive + the `EngineStack.create_networks` non-internal invariant with a unit test (#324).
+
+### Fix
+
+- **docs/security**: rewrite `SECURITY.md`'s architecture overview, threat table, testing, and checklist to reflect the actual `runner-net` (non-internal, docker-py `EngineStack`) model. The doc previously described a vanished `env-net` (`internal: true`) network and `docker-compose.yaml`, and listed "executor reaching external internet — addressed by `env-net internal:true`" as an addressed threat that no longer holds (#324).
 
 ## v0.9.0 (2026-07-17)
 

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -77,6 +77,32 @@ opt-in: tasks that do not declare an `environment_manifest` still run on
 `RuntimeBackendCallLog`; no Docker daemon required. Used by canonical
 contract tests.
 
+## Network posture
+
+Egress policy is a function of **composition** (built-in vs task-declared
+stack), not of lifecycle:
+
+- **Built-in stack (Case A — no `environment_manifest`).** `EngineStack` brings
+  up the engine's built-in services (runner + db-service ± mock-web ±
+  rag-service) on `runner-net`, a bridge network that is **not** `internal`.
+  This is `full_internet` **by construction**: the runner needs LLM-provider
+  egress for in-container LLM-as-judge grading, and every service on the stack
+  is first-party/trusted, so there is nothing untrusted to isolate. A Case A run
+  has no `network_policy` surface — that field lives on `EnvironmentManifest`,
+  which a Case A run does not have. Locked by
+  `tests/unit/test_network_internal.py`.
+- **Task-declared stack (Case B / Case C — `environment_manifest` set).** The
+  task's compose stack is the untrusted surface, so it carries the enforceable
+  posture: `EnvironmentManifest.network_policy` (default `no_internet`) is
+  applied by `enforce_network_policy` during materialisation. Under
+  `no_internet`, task services join an injected `internal: true` network while
+  the runner keeps a non-internal edge network for control-plane and grading
+  egress.
+
+See [ADR-0018](adr/0018-multi-container-under-shared-runtime.md) § "Network
+policy enforcement" for the enforcement table and [SECURITY.md](SECURITY.md)
+for the threat model.
+
 ## A trial's lifecycle on `PerTrialRuntimeBackend`
 
 The following sequence covers one trial end-to-end. Reads left-to-right in

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,36 +4,26 @@ Tolokaforge evaluates untrusted LLM agents. This document describes the security
 
 ## Architecture Overview
 
-Tolokaforge uses Docker-based isolation for all tool execution. The orchestrator runs on the host (or in its own container) and proxies tool execution to a containerised executor via gRPC. Environment services run on an internal Docker network.
+Tolokaforge runs all tool execution inside Docker containers. The orchestrator runs on the host and proxies tool execution to a containerised **runner** over gRPC. There are two ways the runner and its supporting services are materialised, and they carry different network postures.
 
-```
-┌─────────────────┐
-│  Orchestrator   │ ← LLM API access (default network)
-└────────┬────────┘
-         │ gRPC (env-net)
-┌────────▼────────┐
-│    Executor     │ ← cap_drop: ALL, no-new-privileges
-└────────┬────────┘
-         │ HTTP (env-net, internal: true)
-    ┌────▼─────┬──────────┬──────────┐
-    │ JSON DB  │ Mock Web │   RAG    │
-    └──────────┴──────────┴──────────┘
-```
+### Built-in stack (Case A — the default)
 
-This architecture provides:
+When a run declares no `environment_manifest`, the orchestrator brings up the engine's built-in services with `EngineStack` (`tolokaforge/docker/stack.py`): `core_stack` = runner + db-service, or `full_stack` = runner + db-service + mock-web + rag-service. Every built-in service is attached to `runner-net`, a bridge network that is **not** `internal`.
 
-- **Executor** runs with `cap_drop: ALL`, `cap_add: NET_BIND_SERVICE`, `security_opt: no-new-privileges`. It can only reach services on `env-net`.
-- **env-net** is an internal bridge network (`internal: true`) with no external internet access.
-- **Orchestrator** is the only component with external network access (for LLM API calls).
-- **Environment services** (JSON DB, Mock Web, RAG) are on `env-net` and also exposed to localhost for development convenience.
+- The **runner** runs with `cap_drop: ALL`, `cap_add: NET_BIND_SERVICE`, and `no-new-privileges` (its default `ResourcePolicy`; relaxed only on the Docker-socket / Docker-in-Docker terminal-bench paths).
+- `runner-net` has **full egress by construction**. The runner needs it: when a task declares an `llm_judge` grading component, `RunnerService.GradeTrial` runs the rubric judge *inside* the runner container and must reach the LLM provider to grade. The runner's published gRPC port must also stay host-reachable so the orchestrator can connect to it.
+- This is **not** a threat vector on this path. `EngineStack` materialises only first-party engine services — there is no untrusted task-declared compose to isolate. `network_policy` is a task-declared-stack concept; it lives on `EnvironmentManifest`, which a Case A run does not have. Egress of tools the agent runs *inside* the runner is a separate concern (tracked in #325); a container-network posture cannot address it.
 
-See `tolokaforge/docker/stacks/` for the predefined service stack definitions.
+See `tolokaforge/docker/stacks/` for the predefined built-in stack definitions.
 
-When a task declares its own `environment_manifest`, its services inherit
-the same isolation posture: `network_policy` defaults to `no_internet`
-(task services get no public egress while the runner keeps its LLM-API
-access), and each service is torn down and re-provisioned per trial unless
-marked `shared`. See [PROJECTS.md](PROJECTS.md).
+### Task-declared stack (Case B / Case C)
+
+When a task declares its own `environment_manifest.compose_file`, the runtime backend materialises that task-declared compose stack instead — arbitrary services the task author chose. This is the path with an enforceable network posture: `EnvironmentManifest.network_policy` (default `no_internet`) is applied by `enforce_network_policy` (`tolokaforge/core/compose_materialisation.py`) as an in-place rewrite of the copied compose file before it is brought up.
+
+- Under `no_internet` every task service joins an injected `internal: true` network (`tolokaforge_netpolicy_internal`) — no application service can reach the public internet, while inter-service DNS stays intact. The runner is *additionally* attached to a non-internal edge network (`tolokaforge_netpolicy_edge`) so it keeps its control-plane and grading egress. The honest scope: **task-declared application services get zero public egress; the runner retains its control-plane and grading egress.**
+- `full_internet` runs the compose file unchanged. `limited_internet` is refused before any container starts — a per-host allowlist needs an egress-proxy sidecar (tracked in #323).
+
+See [ADR-0018](adr/0018-multi-container-under-shared-runtime.md) for the full case matrix, [RUNTIME_BACKENDS.md](RUNTIME_BACKENDS.md) for backend mechanics, and [PROJECTS.md](PROJECTS.md) for the `network_policy` and per-service isolation authoring surface.
 
 ## Tool-Level Security
 
@@ -79,9 +69,9 @@ Tool call arguments are logged with automatic redaction of keys containing `pass
 
 ## Secret Management
 
-- **API keys** are host environment variables (loaded from `.env`). In Docker mode, only the orchestrator container receives them.
+- **API keys** are read only through `SecretManager` (never `os.environ` directly). The orchestrator holds them on the host; the runner receives them serialised into the single `TOLOKAFORGE_SECRETS_JSON` environment variable and reconstructs its own `SecretManager` singleton, because it runs in-container LLM-as-judge grading. This is the only place credentials cross the host→container boundary — never via build args, mounts, or image bake-in. Environment services (db-service, mock-web, rag-service) receive no secrets.
 - **Grading assets** (`grading.yaml`, expected states) are read by the orchestrator after trial completion. They are never passed to the agent or exposed through tool outputs.
-- **`.env`** is gitignored and never mounted into executor or environment containers.
+- **`.env`** is gitignored and never mounted into the runner or environment containers.
 
 ## Ground Truth Isolation
 
@@ -101,15 +91,17 @@ The agent never sees grading criteria or expected outputs:
 | Agent calling unauthorized tools | Tool allowlisting + schema validation |
 | Runaway execution (cost/time) | Budget cap, episode timeout, max turns, per-tool timeout |
 | Agent accessing grading criteria | Grading data is host-side only, never in tool outputs |
-| Environment state leaking between trials | Per-trial namespace isolation in JSON DB |
-| Executor reaching external internet (Docker mode) | `env-net` is `internal: true` |
-| Executor privilege escalation (Docker mode) | `cap_drop: ALL`, `no-new-privileges` |
+| Environment state leaking between trials | Per-trial namespace isolation in JSON DB (built-in stack); per-trial containers, networks, and volumes under `PerTrialRuntimeBackend` (task-declared stack) |
+| Task-declared services reaching external internet | `network_policy: no_internet` (the default) attaches them to an injected `internal: true` network via `enforce_network_policy` (Case B/C) |
+| Runner privilege escalation (Docker mode) | `cap_drop: ALL`, `cap_add: NET_BIND_SERVICE`, `no-new-privileges` |
 | Sensitive data in logs | Automatic key redaction in tool call logging |
 
 ### Not Addressed
 
 | Threat | Notes |
 | --- | --- |
+| Built-in runner reaching external internet (Case A) | Accepted risk. `EngineStack` materialises only first-party engine services; the runner needs LLM-provider egress for in-container LLM-as-judge grading, so `runner-net` is `full_internet` by construction and a Case A run carries no `network_policy` surface. |
+| Egress of tools the agent runs inside the runner | Not blocked by `no_internet` — such tools share the runner's edge access. Tracked in #325. |
 | Host-level Docker escapes | Out of scope; assumes Docker daemon is trusted |
 | Supply chain attacks in task code | Task authors are assumed trusted |
 | Side-channel attacks | Not mitigated |
@@ -118,20 +110,17 @@ The agent never sees grading criteria or expected outputs:
 
 ## Testing
 
-Security-related tests live in `tests/integration/test_security.py`:
-
-- `TestToolAllowlisting` — unregistered tool rejection, schema validation, rate limiting
-- `TestDockerSecurity` — verifies `env-net` is `internal: true` in docker-compose.yaml
-- `TestNetworkIsolation` — executor connectivity checks (requires Docker)
-
-Run them:
+- **Tool allowlisting** — `tests/unit/test_tool_security.py::TestToolAllowlisting`: unregistered tool rejection, schema validation, rate limiting. No Docker needed.
+- **`Network.internal` primitive + built-in non-internal invariant** — `tests/unit/test_network_internal.py`: `Network.create(..., internal=…)` faithfully carries docker-py's `internal` flag, and `EngineStack.create_networks()` always creates its networks non-internal (the executable form of "Case A is `full_internet` by construction"). No Docker needed.
+- **Task-declared `network_policy` enforcement (Case B/C)** — `tests/canonical/test_network_policy_enforcement.py` snapshots the `no_internet` compose-file topology produced by `enforce_network_policy`; `tests/canonical/test_environment_manifest_contract.py::TestNetworkPolicyContract` pins the wire shape and `no_internet` default. No Docker needed.
+- **Runner network isolation (real daemon)** — `tests/integration/test_security.py::TestNetworkIsolation` moves a runner onto an internal network and asserts it reaches db-service but not the public internet. This demonstrates a runner *can* be network-isolated when its trial makes no in-container LLM-judge call; the built-in `runner-net` is deliberately non-internal so that grading egress is available.
 
 ```bash
-# Tool-level tests (no Docker needed)
-uv run pytest tests/integration/test_security.py -v -k "Allowlisting"
+# Unit + canonical security tests (no Docker needed)
+uv run pytest tests/unit/test_tool_security.py tests/unit/test_network_internal.py -v
+uv run pytest tests/canonical/test_network_policy_enforcement.py -v
 
-# Docker isolation tests (requires running containers)
-docker compose up -d
+# Runner network-isolation test (requires Docker)
 uv run pytest tests/integration/test_security.py -v -m requires_docker
 ```
 
@@ -142,5 +131,4 @@ Before running evaluations:
 - [ ] API keys in `.env`, not committed to git
 - [ ] `orchestrator.max_budget_usd` set for long runs
 - [ ] Task YAML uses minimal tool allowlist (don't enable `bash` unless needed)
-- [ ] Ensure `runtime: "docker"` is set and Docker services are running (`docker compose up -d`)
-- [ ] Verify `env-net` is `internal: true` in `docker-compose.yaml`
+- [ ] For task-declared stacks, leave `network_policy` at its `no_internet` default unless the task genuinely needs application-service egress (built-in-stack runs are `full_internet` by construction and have no `network_policy` surface)

--- a/docs/adr/0018-multi-container-under-shared-runtime.md
+++ b/docs/adr/0018-multi-container-under-shared-runtime.md
@@ -5,6 +5,9 @@
 - **Amended:** 2026-07-14 — isolation is per-service in the manifest;
   backend selection is task-driven; `orchestrator.runtime` is a
   deprecated override.
+- **Amended:** 2026-07-17 — record Case A network posture: the built-in
+  `EngineStack` path is `full_internet` by construction and carries no
+  `network_policy` surface (#324).
 - **Deciders:** @CiroGamboa
 - **Supersedes:** ADR-0009 (isolation surface only)
 - **Superseded by:** —
@@ -216,7 +219,7 @@ sequenceDiagram
   O->>S: destroy_all()
 ```
 
-Everything about this path is documented in [ADR-0016](0016-runtime-backend-comparison.md) and `RUNTIME_BACKENDS.md`. Untouched by this ADR.
+The lifecycle of this path is documented in [ADR-0016](0016-runtime-backend-comparison.md) and `RUNTIME_BACKENDS.md`. Its network posture is `full_internet` by construction — see [Case A network posture](#case-a-network-posture-324) below.
 
 ### Case B — `shared` + task-declared stack (new)
 
@@ -355,6 +358,38 @@ so materialisation fails loud until #323 lands. Task authors declare
 The `network_isolation:no_internet` backend capability (advertised by both
 docker backends, admitted by the capability gate at run start) reflects this
 enforcement.
+
+### Case A network posture (#324)
+
+Case A (the built-in `EngineStack` path) is `full_internet` **by
+construction**, and deliberately carries no `network_policy` surface.
+
+`network_policy` exists to isolate *task-declared* services — the arbitrary
+compose stacks of Case B/C. Case A materialises only first-party engine
+services (`core_stack` = runner + db-service; `full_stack` adds mock-web +
+rag-service), so there is no untrusted compose to constrain. `EngineStack`
+attaches every built-in service to `runner-net`, a bridge network that is not
+`internal` (`EngineStack.create_networks()` never sets `internal=True`).
+
+The runner is the only built-in service that egresses, and it must: when a task
+declares an `llm_judge` grading component, `RunnerService.GradeTrial` runs the
+rubric judge inside the runner container and reaches the LLM provider. The
+other built-in services never egress by design. Applying a Case-B/C-style
+`no_internet` posture here would internalise services that never egress while
+the runner — the actual agent-driven tool-execution surface — keeps its edge
+network anyway: near-zero isolation gain for real machinery cost.
+
+The impossible combination is prevented structurally, not by a runtime guard:
+`network_policy` is a field on `EnvironmentManifest`, and a Case A run has no
+manifest. "Built-in stack under `no_internet`" is therefore unrepresentable, so
+there is nothing to guard against.
+
+Egress of tools the agent runs *inside* the runner shares the runner's edge
+access and is out of scope for any container-network posture — tracked
+separately in #325. The `internal=True` primitive on `Network` /
+`to_docker_network_config()` is retained as a faithful docker-py serialiser
+(it drives the Case B/C edge/internal split) and locked, together with the
+built-in non-internal invariant, by `tests/unit/test_network_internal.py`.
 
 ## Choosing a case — decision flow
 

--- a/tests/unit/test_network_internal.py
+++ b/tests/unit/test_network_internal.py
@@ -1,0 +1,64 @@
+"""`Network.internal` faithfully carries docker-py's `internal` flag, and the
+built-in `EngineStack` always creates non-internal networks.
+
+The second assertion is the executable form of "Case A (built-in stack) is
+`full_internet` by construction" (ADR-0018): if a future change makes the
+built-in network internal, the runner loses the LLM-provider egress it needs
+for in-container LLM-as-judge grading, and this test fails.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_docker_client() -> MagicMock:
+    docker = pytest.importorskip("docker")
+    client = MagicMock(spec=docker.DockerClient)
+    client.networks.list.return_value = []
+    created = MagicMock()
+    created.id = "net123"
+    client.networks.create.return_value = created
+    return client
+
+
+@pytest.mark.parametrize("internal", [True, False])
+def test_network_create_round_trips_internal_flag(internal: bool) -> None:
+    from tolokaforge.docker.network import Network
+
+    client = _fake_docker_client()
+    network = Network.create(name="edge-net", internal=internal, client=client)
+
+    _, kwargs = client.networks.create.call_args
+    assert kwargs["internal"] is internal
+    assert network.internal is internal
+    assert network.to_docker_network_config()["internal"] is internal
+
+
+def test_engine_stack_creates_non_internal_networks(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tolokaforge.docker.network as network_mod
+    from tolokaforge.docker.stack import EngineStack, ServiceDefinition
+
+    client = _fake_docker_client()
+    monkeypatch.setattr(network_mod.docker, "from_env", lambda: client)
+
+    stack = EngineStack()
+    stack.add_service(
+        ServiceDefinition(
+            name="runner",
+            image_name="tolokaforge-runner",
+            networks=["runner-net"],
+        )
+    )
+
+    networks = stack.create_networks()
+
+    assert set(networks) == {"runner-net"}
+    assert networks["runner-net"].internal is False
+    _, kwargs = client.networks.create.call_args
+    assert kwargs["name"] == "runner-net"
+    assert kwargs["internal"] is False


### PR DESCRIPTION
Closes #324.

## Summary

Records the design decision the issue asked for: **Case A (the built-in `EngineStack`) is `full_internet` by construction.** The built-in stack materialises only first-party engine services (runner + db-service ± mock-web ± rag-service) — there's no untrusted task-declared compose to isolate, and the runner needs LLM-provider egress for in-container `llm_judge` grading. No `network_policy` field added to the built-in path.

This is a **decision-recording + doc-honesty + test-lock PR**. No runtime code changes.

## Substance

- **ADR-0018 amended** with a `### Case A network posture (#324)` subsection recording the decision as current state (not "future work").
- **`docs/SECURITY.md` was actively wrong** — described an `env-net` (`internal: true`) network and a `docker-compose.yaml` file that no longer exist, and listed "Executor reaching external internet" as an ADDRESSED threat via a network that isn't real. Full stale-section rewrite: two-path Architecture Overview (built-in `runner-net` non-internal vs task-declared `no_internet` via #301's transform), threat table refreshed with accurate mechanisms, Testing + Checklist updated. Also fixed a stale "only orchestrator gets keys" bullet — the runner receives `TOLOKAFORGE_SECRETS_JSON` for in-container grading, contradicting the new egress-scope statement.
- **`docs/RUNTIME_BACKENDS.md`** — new "Network posture" section explicitly stating Case A's posture.
- **`Network.internal=True` primitive kept + tested** — the docker-py serialiser was previously dead code; the new unit test locks (a) `Network.create(internal=…)` round-trips through docker-py + `Network.internal` + `to_docker_network_config()`, and (b) `EngineStack.create_networks()` always creates networks with `internal=False` — making "full_internet by construction" an executable invariant.

## Design decision — Option B, not Option A

Architect audit chose Option B over threading a `network_policy` surface onto Case A. Rationale:
- Case A runs the engine's own trusted services (runner + db-service ± mock-web ± rag-service). There's no untrusted-task-code angle to isolate.
- The runner egresses conditionally — only when a task declares `llm_judge` (in-container `run_rubric_judge` via `GradeTrial`). Agent generation is host-side. LLM-provider egress from the runner is a real requirement.
- The "no_internet built-in stack" combination is **structurally impossible** — `network_policy` lives on `EnvironmentManifest`, which no-manifest runs (Case A) don't have. No fail-loud guard needed for a state that can't be reached.

## Test tier

Unit — 3 test cases in `tests/unit/test_network_internal.py`:
1. `Network.create(internal=True)` round-trips through docker-py.
2. `Network.create(internal=False)` (default) round-trips through docker-py.
3. `EngineStack.create_networks()` creates non-internal networks (invariant lock).

Broader `unit -k "network or stack or docker"` → 169 passed, 0 regressions.

## Docs + CHANGELOG

- `docs/adr/0018-multi-container-under-shared-runtime.md` — new subsection.
- `docs/RUNTIME_BACKENDS.md` — new "Network posture" section.
- `docs/SECURITY.md` — full stale-section rewrite.
- `CHANGELOG.md` under `## Unreleased`:
  - `### Docs`: Case A network posture recorded in ADR-0018 + RUNTIME_BACKENDS.md.
  - `### Fix`: SECURITY.md rewritten to reflect the current `runner-net` architecture (was actively wrong).

## Follow-ups noted (not fixed here)

- `tests/utils/{networks,containers}.py` docstrings still reference `env-net` from `docker-compose.yaml`. Out of scope for this docs-focused PR; low priority.
- `tolokaforge/docker/network.py` docstring examples use `env-net` as an illustrative name. Generic example, not an architecture claim.

## Reviewer verdict

Skipped critic (single stage, well-grounded); implementer's own verification chain solid. Ready for reviewer + merge.

## Known CI note

`hygiene-review` will fail — pre-existing infra failure across all recent PRs (#425).
