### PR TITLE
chore(docs,tests): document Codespaces flow + canonical devcontainer structure guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync
 ```
 
+### GitHub Codespaces
+
+Open the repo in a Codespace (**Code → Codespaces → Create codespace**) for a
+ready-to-run environment. The container image ships a pinned `uv`, `git-lfs`,
+Node, the `gh` CLI, and Playwright's OS dependencies. On create and attach it
+runs `uv sync`, installs Playwright's Chromium, pulls Git LFS objects, and
+installs the pre-commit hooks. To run evaluations, supply a provider key as a
+[Codespaces secret](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces)
+or in `.env` — `tolokaforge run` reads it from the environment.
+
 See [Python Package Guide](docs/PYTHON_PACKAGE.md) for all extras and programmatic API usage.
 
 ## Quick Start

--- a/tests/canonical/test_devcontainer_structure.py
+++ b/tests/canonical/test_devcontainer_structure.py
@@ -1,0 +1,120 @@
+"""Guards the structural invariants a Codespace/dev-container boot depends on.
+
+The dev-container boots by running three lifecycle hooks declared in
+``.devcontainer/devcontainer.json``; those hooks in turn invoke the reused
+``scripts/setup/*`` scripts. A hook script that is renamed, loses its execute
+bit, or drops the ``scripts/setup`` invocation would break a fresh Codespace
+boot silently — no other test exercises this wiring. This guard turns each such
+regression into a CI failure. Runs under the ``canonical`` marker so it rides
+the existing smoke job without dedicated workflow wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVCONTAINER_DIR = _REPO_ROOT / ".devcontainer"
+_DEVCONTAINER_JSON = _DEVCONTAINER_DIR / "devcontainer.json"
+_README = _REPO_ROOT / "README.md"
+
+_LIFECYCLE_HOOKS = ("initializeCommand", "postCreateCommand", "postAttachCommand")
+
+# devcontainer.json is JSONC: only `//` line comments, no `//` inside string
+# values. A minimal line-comment strip makes it parseable by json.loads.
+_LINE_COMMENT_RE = re.compile(r"(^|\s)//[^\n]*")
+_CODESPACES_HEADING_RE = re.compile(r"^#{1,6}\s.*codespace", re.IGNORECASE | re.MULTILINE)
+
+
+def _load_devcontainer() -> dict:
+    assert _DEVCONTAINER_JSON.exists(), (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} is missing — "
+        "the dev-container definition must exist"
+    )
+    raw = _DEVCONTAINER_JSON.read_text()
+    stripped = _LINE_COMMENT_RE.sub(lambda m: m.group(1), raw)
+    config = json.loads(stripped)
+    assert config, (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} parsed to an empty document — "
+        "expected a populated dev-container config object"
+    )
+    return config
+
+
+def test_devcontainer_json_parses() -> None:
+    config = _load_devcontainer()
+    assert isinstance(config, dict), (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} must be a JSON object, "
+        f"got {type(config).__name__}"
+    )
+
+
+def test_lifecycle_hooks_resolve_to_executable_scripts() -> None:
+    config = _load_devcontainer()
+    violations: list[str] = []
+    for hook in _LIFECYCLE_HOOKS:
+        command = config.get(hook)
+        if not command:
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: lifecycle hook "
+                f"`{hook}` is missing — a Codespace boot requires it"
+            )
+            continue
+        script_rel = command.split()[0]
+        script = _REPO_ROOT / script_rel
+        if not script.exists():
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: hook `{hook}` points at "
+                f"`{script_rel}`, which does not exist under the repo root"
+            )
+        elif not os.access(script, os.X_OK):
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: hook `{hook}` script "
+                f"`{script_rel}` is not executable — run `chmod +x {script_rel}`"
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_reused_setup_scripts_exist_and_are_wired() -> None:
+    violations: list[str] = []
+    for script_rel in ("scripts/setup/create_python_venv.sh", "scripts/setup/init_git_lfs.sh"):
+        script = _REPO_ROOT / script_rel
+        if not script.exists():
+            violations.append(f"{script_rel} is missing — the dev-container hooks depend on it")
+        elif not os.access(script, os.X_OK):
+            violations.append(f"{script_rel} is not executable — run `chmod +x {script_rel}`")
+
+    wiring = (
+        (".devcontainer/post_attach_container.sh", "create_python_venv.sh"),
+        (".devcontainer/post_setup_container.sh", "init_git_lfs.sh"),
+    )
+    for hook_rel, expected_call in wiring:
+        hook = _REPO_ROOT / hook_rel
+        if not hook.exists():
+            violations.append(f"{hook_rel} is missing — the dev-container hook must exist")
+            continue
+        active = "\n".join(
+            line for line in hook.read_text().splitlines() if not line.lstrip().startswith("#")
+        )
+        if expected_call not in active:
+            violations.append(
+                f"{hook_rel} no longer invokes `{expected_call}` — the dev-container "
+                "boot would skip that setup step silently"
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_readme_documents_codespaces() -> None:
+    assert _README.exists(), f"{_README.relative_to(_REPO_ROOT)} is missing"
+    assert _CODESPACES_HEADING_RE.search(_README.read_text()), (
+        f"{_README.relative_to(_REPO_ROOT)} has no Codespaces heading — expected a markdown "
+        "heading matching `^#{1,6}\\s.*codespace` documenting the dev-container flow"
+    )


### PR DESCRIPTION
## Summary
- `README.md` gains a `### GitHub Codespaces` subsection under `## Installation` documenting the Codespaces boot flow (image ships pinned `uv`, `git-lfs`, Node, `gh`, Playwright OS deps; create/attach runs `uv sync`, installs Chromium, pulls Git LFS, installs pre-commit hooks; `tolokaforge run` needs a provider key via Codespaces secret or `.env`).
- New `canonical`-tier guard `tests/canonical/test_devcontainer_structure.py` locks the boot-critical structural invariants: `devcontainer.json` parses (JSONC); the three lifecycle hooks (`initializeCommand`, `postCreateCommand`, `postAttachCommand`) resolve to executable scripts; the reused `scripts/setup/create_python_venv.sh` and `init_git_lfs.sh` exist AND are still wired into the correct hooks (comment-out-safe substring check on non-comment lines); README carries a Codespaces heading.

## Design choices
- **Scope narrowed from "add a devcontainer" to "verify + document + lock invariants".** `.devcontainer/*` already shipped earlier in Milestone 3 — complete, correctly wired to `scripts/setup/*`, and reusing the existing setup scripts as the issue asked. Nothing to add there. The remaining work is documentation + a structural guard against silent regressions.
- **No `AGENTS.md` edit.** The issue named a "stale `.devcontainer/Dockerfile` reference in AGENTS.md"; verification shows both refs (lines 92 and 408) point at the existing, accurate path. The premise predates the devcontainer landing. Editing AGENTS.md would also collide with #480's adjacent Python-version invariant line.
- **Guard test uses `canonical` tier, not `unit`.** Static repo-invariant guards like this (mirroring `tests/canonical/test_python_version_single_source.py` landed in this milestone) run in the CI smoke lane without dedicated wiring. Not unit (nothing in isolation to test), not integration (no services, no keys).
- **Wiring assertion scans non-comment lines only.** A plain substring search would false-pass on `# create_python_venv.sh disabled`, the single most common disable pattern. Filtering `#`-prefixed lines closes that hole, so the assertion's docstring claim (silent-break detection) is honest rather than aspirational.
- **JSONC parser is deliberately local and naive** (`(^|\s)//[^\n]*` strip). Safe for the current file (line comments only, no `//` in string values). Documented in code so a future JSONC block-comment or URL-in-string forces a revisit.

## Concepts introduced
None. The devcontainer, setup scripts, and lifecycle hook mechanism all pre-date this PR. The guard test surfaces existing invariants for CI enforcement; the README subsection surfaces existing container capabilities for humans.

## Plan

# Plan: Codespaces devcontainer — verification + README documentation + structural guard

Issue: #25 (internal tracking TECHDEL-299)
Branch: chore/issue-25-codespaces-devcontainer

## Context (verified against `feat/release-hygiene`)

- `.devcontainer/{devcontainer.json, Dockerfile, pre_init_container.sh, post_setup_container.sh, post_attach_container.sh, setup_user.sh, setup_terminal.sh, .zshrc}` all exist. The three lifecycle hooks declared in `devcontainer.json` resolve to executable files.
- The devcontainer already reuses `scripts/setup/*` as the issue wanted: `post_attach_container.sh` runs `create_python_venv.sh` (uv sync + Playwright deps + Chromium); `post_setup_container.sh` runs `uv run pre-commit install` and `init_git_lfs.sh`.
- `uv` is pinned to 0.9.5 in the Dockerfile and reads `.python-version` (single-sourced by #480).
- `uv sync` from the current tree is green — the local proxy for a fresh Codespace's boot-time sync.
- **AGENTS.md's `.devcontainer/Dockerfile` reference is NOT stale.** Lines 92 and 408 both point at the existing, accurate path. The issue's "fix the stale reference" premise predates the devcontainer landing. No AGENTS.md edit in scope.
- **README has zero mention of Codespaces / devcontainer.** This is the real documentation gap.
- No structural guard locks the devcontainer wiring — a future rename or `chmod -x` would break Codespaces boot silently, with no failing test.

## Stage 1 — Document the Codespaces flow + lock devcontainer structure

- `README.md` gains a `### GitHub Codespaces` subsection under `## Installation`, as current fact — open in a Codespace; image ships pinned `uv`, `git-lfs`, Node, `gh`, Playwright OS deps; create/attach runs `uv sync`, installs Chromium, pulls Git LFS, installs pre-commit hooks; `tolokaforge run` needs a provider key.
- New `tests/canonical/test_devcontainer_structure.py` (marker `canonical`, `_REPO_ROOT = Path(__file__).resolve().parents[2]`), 4 assertions:
  1. `.devcontainer/devcontainer.json` parses after stripping `//` line comments.
  2. `initializeCommand`, `postCreateCommand`, `postAttachCommand` declared; first-token path resolves under repo root, exists, and is executable.
  3. `scripts/setup/create_python_venv.sh` and `init_git_lfs.sh` exist and are executable. Additionally, `post_attach_container.sh` (non-comment lines) contains `create_python_venv.sh` AND `post_setup_container.sh` (non-comment lines) contains `init_git_lfs.sh` — closes the wiring silent-break for both live changes and comment-outs.
  4. `README.md` contains a Codespaces heading (regex `^#{1,6}\s.*codespace` case-insensitive, multiline).

## Non-goals
- Editing `.devcontainer/*` behaviour — complete and correct.
- Editing `AGENTS.md` — references already accurate; #480 owns the adjacent Python-version line.
- Adding a Codespaces prebuild config — optional per issue wording; surfaced not filed.

## Discovered issues
- Filed: None. No wiring defect and no stale reference found — nothing to fix or track.
- Fixed in this PR: None.

## Test plan
- Local: `uv run pytest -m canonical tests/canonical/test_devcontainer_structure.py -v` — 4 tests pass.
- Local guard-bites (verified by the implementer):
  - Rename `init_git_lfs.sh` invocation in `post_setup_container.sh` → guard fails with actionable message.
  - Comment-out (`# create_python_venv.sh disabled`) → guard fails (comment-line filter bites).
- Local: `rg -ni 'codespace' README.md` → matches the new heading.
- Local: full `-m canonical` suite → no regressions (456 canonical tests pass).
- **Manual acceptance criterion CI cannot cover:** open a fresh Codespace off this branch; confirm it boots, `uv run pytest -m unit` passes, and `tolokaforge run` works with a provider key set as a Codespaces secret.

Closes #25
