### PR TITLE
chore(release-hygiene): canonical guards for adapter-convert, python-version, devcontainer (M3)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     ca-certificates \
     gnupg \
+    # Host tooling only — the project interpreter is uv-managed from .python-version.
     python3 \
     python3-pip \
     python3-dev \

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -138,7 +138,7 @@ jobs:
           version: "0.9.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv python install 3.12
+      - run: uv python install "$(cat .python-version)"
       - run: uv sync --dev --locked
 
       - name: Parse candidate model from PR title

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -68,7 +68,7 @@ jobs:
           version: "0.9.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv python install 3.12
+      - run: uv python install "$(cat .python-version)"
       - run: uv sync --dev --locked
 
       - name: Poll the channel and resolve requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,8 @@ Recommended MCP servers for AI agents working on this project:
 - `ruff` for linting and formatting
 - `pytest` for testing
 
+The runtime Python version is single-sourced in `.python-version`; changing it propagates to dev, CI, the devcontainer (via uv), and all runtime Docker images. A canonical guard (`tests/canonical/test_python_version_single_source.py`) fails CI if a workflow or runtime Dockerfile hardcodes a version instead.
+
 **Don't suppress warnings** — update code to use actual functionality instead.
 
 ### Protected Directories

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv sync
 ```
 
+### GitHub Codespaces
+
+Open the repo in a Codespace (**Code → Codespaces → Create codespace**) for a
+ready-to-run environment. The container image ships a pinned `uv`, `git-lfs`,
+Node, the `gh` CLI, and Playwright's OS dependencies. On create and attach it
+runs `uv sync`, installs Playwright's Chromium, pulls Git LFS objects, and
+installs the pre-commit hooks. To run evaluations, supply a provider key as a
+[Codespaces secret](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces)
+or in `.env` — `tolokaforge run` reads it from the environment.
+
 See [Python Package Guide](docs/PYTHON_PACKAGE.md) for all extras and programmatic API usage.
 
 ## Quick Start

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,7 +5,7 @@
 | Category | Directory | Marker | Speed | External Deps |
 |----------|-----------|--------|-------|---------------|
 | Unit | `tests/unit/` | `@pytest.mark.unit` | < 1s each | None |
-| Canonical | `tests/canonical/` | `@pytest.mark.canonical` | < 5s each | None (golden snapshots) |
+| Canonical | `tests/canonical/` | `@pytest.mark.canonical` | < 5s each, except the packaging/entry-point smoke tests that build a wheel and install it into a scratch venv (~10–25s) | Golden snapshots; the packaging/entry-point smoke tests also require the `uv` CLI (they skip loud without it) |
 | Integration | `tests/integration/` | `@pytest.mark.integration` | 5–60s each | Docker, API keys |
 
 ## Commands

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The test suite is organized into **3 categories**: unit, canonical, and integrat
 | Category | Directory | Speed | External deps | Marker |
 |----------|-----------|-------|---------------|--------|
 | Unit | `tests/unit/` | Fast (< 1s each) | None | `@pytest.mark.unit` |
-| Canonical | `tests/canonical/` | Fast (< 5s each) | None (uses golden snapshots) | `@pytest.mark.canonical` |
+| Canonical | `tests/canonical/` | Fast (< 5s each), except the packaging/entry-point smoke tests that build a wheel and install it into a scratch venv (~10–25s) | Golden snapshots; the packaging/entry-point smoke tests also require the `uv` CLI (they skip loud without it) | `@pytest.mark.canonical` |
 | Integration | `tests/integration/` | Slow (5-60s each) | Docker, API keys | `@pytest.mark.integration` |
 
 Current baseline: see [BASELINE.md](BASELINE.md) for up-to-date numbers.
@@ -48,8 +48,11 @@ tests/
 ├── unit/                    # Pure-logic tests, no I/O
 │   ├── grading/             # Grading subsystem tests
 │   └── adapters/            # Adapter unit tests
-├── canonical/               # Golden snapshot tests
-│   ├── conftest.py          # --update-canon flag, canon_snapshot fixture
+├── canonical/               # Golden snapshot + packaging/discovery smoke tests
+│   ├── conftest.py          # --update-canon flag, canon_snapshot + built_wheel session fixtures
+│   ├── test_adapter_convert_packaging.py    # wheel-inspection packaging smoke
+│   ├── test_adapter_convert_entry_point.py  # entry-point discovery smoke (scratch-venv install)
+│   ├── fixtures/            # tolokaforge-adapter-demo: demo conversion adapter installed into a scratch venv
 │   └── snapshots/           # Committed golden JSON files
 ├── integration/             # Docker/API integration tests
 │   └── docker/              # Docker foundation layer tests

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -1,11 +1,14 @@
 """Canonization infrastructure: --update-canon flag and canon_snapshot fixture."""
 
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def pytest_addoption(parser):
@@ -61,3 +64,32 @@ def shop_orders_02_task_dir(canonical_task_dir):
 def terminal_bench_tasks_dir(test_data_dir):
     """Get path to terminal_bench_tasks test data directory."""
     return test_data_dir / "terminal_bench_tasks"
+
+
+@pytest.fixture(scope="session")
+def built_wheel(tmp_path_factory) -> Path:
+    """Build the tolokaforge wheel once per session and return its path.
+
+    Skips loud if the ``uv`` CLI is unavailable; hard-fails with captured
+    build output if the build itself fails (fail-fast, no fallback).
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("uv CLI not available")
+
+    out_dir = tmp_path_factory.mktemp("built_wheel")
+    build_result = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert build_result.returncode == 0, (
+        f"uv build failed (rc={build_result.returncode}):\n"
+        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
+    )
+
+    wheels = sorted(out_dir.glob("tolokaforge-*.whl"))
+    assert wheels, f"No tolokaforge wheel produced under {out_dir}"
+    return wheels[-1]

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/pyproject.toml
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tolokaforge-adapter-demo"
+version = "0.1.0"
+description = "Demo conversion adapter — canonical-test fixture, never shipped in the tolokaforge wheel"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = ["tolokaforge"]
+
+[project.entry-points."tolokaforge.adapters"]
+demo = "tolokaforge_adapter_demo.adapter:DemoConversionAdapter"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tolokaforge_adapter_demo"]

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/__init__.py
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/__init__.py
@@ -1,0 +1,23 @@
+"""Demo conversion adapter — a canonical-test fixture package.
+
+Installed into a throwaway scratch venv alongside the built ``tolokaforge``
+wheel so the entry-point discovery smoke test exercises the production
+``importlib.metadata`` adapter-load path against a genuinely separate
+distribution. Never a uv workspace member and never packaged into the
+``tolokaforge`` wheel.
+"""
+
+__all__ = ["DemoConversionAdapter"]
+
+
+def __getattr__(name: str):
+    if name == "DemoConversionAdapter":
+        from tolokaforge_adapter_demo.adapter import DemoConversionAdapter
+
+        return DemoConversionAdapter
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__ + list(globals().keys()))

--- a/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/adapter.py
+++ b/tests/canonical/fixtures/tolokaforge-adapter-demo/src/tolokaforge_adapter_demo/adapter.py
@@ -1,0 +1,57 @@
+"""A minimal conversion adapter for the entry-point discovery smoke test.
+
+``DemoConversionAdapter`` subclasses the concrete :class:`NativeAdapter` (so
+every :class:`BaseAdapter` abstract method is already satisfied) and overrides
+only the conversion surface. It reads simple JSON source files — each a mapping
+with at least a ``name`` key — matched by the configured ``tasks_glob``, and
+emits one native task bundle per file plus a single shared-resources marker.
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import json
+from pathlib import Path
+from typing import Any
+
+from tolokaforge.adapters.base import NativeTaskBundle
+from tolokaforge.adapters.native import NativeAdapter
+
+
+class DemoConversionAdapter(NativeAdapter):
+    """Convert JSON source files to native task bundles."""
+
+    def __init__(self, params: dict[str, Any]):
+        super().__init__(params)
+        self._sources: dict[str, Path] | None = None
+
+    def _discover_sources(self) -> dict[str, Path]:
+        if self._sources is None:
+            self._sources = {
+                Path(match).stem: Path(match)
+                for match in glob_module.glob(self.tasks_glob, recursive=True)
+            }
+        return self._sources
+
+    def get_task_ids(self) -> list[str]:
+        return sorted(self._discover_sources().keys())
+
+    def convert_to_native(self, task_id: str) -> NativeTaskBundle:
+        source = self._discover_sources()[task_id]
+        data = json.loads(source.read_text(encoding="utf-8"))
+        name = data["name"]
+        return NativeTaskBundle(
+            task_config={
+                "name": name,
+                "description": f"Demo task converted from {source.name}",
+                "category": "tool_use",
+            },
+            grading_config={"combine": {"method": "weighted", "pass_threshold": 1.0}},
+            fixtures={"tools": [{"name": "noop"}]},
+            metadata={"source_adapter": "demo", "source_file": source.name},
+        )
+
+    def write_shared_resources(self, output_dir: Path, bundle: NativeTaskBundle) -> None:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "_shared_marker").write_text("ok", encoding="utf-8")

--- a/tests/canonical/test_adapter_convert_entry_point.py
+++ b/tests/canonical/test_adapter_convert_entry_point.py
@@ -1,0 +1,115 @@
+"""Entry-point discovery smoke for ``tolokaforge adapter convert``.
+
+Installs the built ``tolokaforge`` wheel plus a separately-built demo adapter
+(registered through a ``tolokaforge.adapters`` entry point) into an isolated
+scratch venv, then drives ``tolokaforge adapter convert --validate`` through
+that venv's own console script.
+
+This is the only test that exercises the production adapter-discovery path —
+``importlib.metadata.entry_points(group="tolokaforge.adapters")`` + ``ep.load()``
+— against a genuinely separate distribution, the same mechanism external
+adapters use. It is the class of packaging regression GH #37 was.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+_FIXTURE_PKG = Path(__file__).parent / "fixtures" / "tolokaforge-adapter-demo"
+
+
+def _run(cmd: list[str], *, timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"command failed (rc={result.returncode}): {' '.join(cmd)}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv CLI not available")
+def test_entry_point_adapter_convert_smoke(built_wheel: Path, tmp_path: Path) -> None:
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    task_ids = ["alpha", "beta"]
+    for task_id in task_ids:
+        (sources / f"{task_id}.json").write_text(
+            json.dumps({"name": f"Demo {task_id}"}), encoding="utf-8"
+        )
+
+    venv_dir = tmp_path / "venv"
+    _run(["uv", "venv", str(venv_dir)])
+    _run(["uv", "pip", "install", "--python", str(venv_dir), str(built_wheel)])
+    _run(["uv", "pip", "install", "--python", str(venv_dir), "--no-deps", str(_FIXTURE_PKG)])
+
+    tolokaforge_bin = venv_dir / "bin" / "tolokaforge"
+    python_bin = venv_dir / "bin" / "python"
+    out_dir = tmp_path / "out"
+
+    # COLUMNS=200 stops rich from soft-wrapping the validation summary line in a
+    # non-tty, so the ", 0 invalid" anchor stays on one line.
+    result = subprocess.run(
+        [
+            str(tolokaforge_bin),
+            "adapter",
+            "convert",
+            "--name",
+            "demo",
+            "--tasks-glob",
+            str(sources / "*.json"),
+            "--output",
+            str(out_dir),
+            "--validate",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={**os.environ, "COLUMNS": "200"},
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"convert failed (rc={result.returncode}):\n{combined}"
+
+    # Sole validation signal: #487 makes the exit code 0 and writes bundles
+    # regardless of validation, so neither exit-0 nor the on-disk files below
+    # corroborate this. The leading comma anchors the count to exactly 0.
+    assert ", 0 invalid" in combined, f"validation did not report clean:\n{combined}"
+
+    for task_id in task_ids:
+        assert (out_dir / task_id / "task.yaml").exists()
+        assert (out_dir / task_id / "grading.yaml").exists()
+        assert (out_dir / task_id / "fixtures" / "tools.json").exists()
+
+    assert (out_dir / "_shared_marker").exists()
+
+    from tolokaforge.adapters import available_adapters
+
+    assert "demo" not in available_adapters(), (
+        "demo adapter leaked into the repo venv — the fixture package must never "
+        "be a uv workspace member or enter the tolokaforge wheel"
+    )
+
+    discovery = _run(
+        [
+            str(python_bin),
+            "-c",
+            "from tolokaforge.adapters import available_adapters; print(available_adapters())",
+        ],
+        timeout=60,
+    )
+    discovered = discovery.stdout
+    assert "demo" in discovered, f"demo not discovered by scratch venv: {discovered}"

--- a/tests/canonical/test_adapter_convert_packaging.py
+++ b/tests/canonical/test_adapter_convert_packaging.py
@@ -35,8 +35,7 @@ def _uv_available() -> bool:
     return shutil.which("uv") is not None
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
-def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
+def test_bundle_writer_ships_in_the_built_wheel(built_wheel: Path) -> None:
     """``tolokaforge.adapters.bundle_writer`` must be present in the wheel
     hatchling produces.
 
@@ -45,24 +44,7 @@ def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
     test — the source tree still has the file. The only way to catch it
     is to build the wheel and look inside.
     """
-    build_result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert build_result.returncode == 0, (
-        f"uv build failed (rc={build_result.returncode}):\n"
-        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
-    )
-
-    wheels = sorted(tmp_path.glob("tolokaforge-*.whl"))
-    assert wheels, f"No tolokaforge wheel produced under {tmp_path}"
-    wheel = wheels[-1]
-
-    with zipfile.ZipFile(wheel) as zf:
+    with zipfile.ZipFile(built_wheel) as zf:
         members = set(zf.namelist())
 
     required = {
@@ -75,7 +57,7 @@ def test_bundle_writer_ships_in_the_built_wheel(tmp_path: Path) -> None:
     }
     missing = required - members
     assert not missing, (
-        f"Wheel {wheel.name} is missing modules that adapter convert depends on: "
+        f"Wheel {built_wheel.name} is missing modules that adapter convert depends on: "
         f"{sorted(missing)}. Members starting with 'tolokaforge/adapters/': "
         f"{sorted(m for m in members if m.startswith('tolokaforge/adapters/'))}"
     )
@@ -123,8 +105,7 @@ def test_bundle_writer_module_imports_cleanly() -> None:
     assert "tolokaforge.adapters.bundle_writer" in sys.modules
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv CLI not available")
-def test_python_version_pin_ships_in_the_built_wheel(tmp_path: Path) -> None:
+def test_python_version_pin_ships_in_the_built_wheel(built_wheel: Path) -> None:
     """``tolokaforge/_python_version.txt`` must be present in the wheel.
 
     ``tolokaforge.docker.builder._pinned_python_version`` reads this
@@ -138,24 +119,7 @@ def test_python_version_pin_ships_in_the_built_wheel(tmp_path: Path) -> None:
     ``pyproject.toml``. This test pins that the copy actually happens
     and the value in the wheel matches the repo-root single source.
     """
-    build_result = subprocess.run(
-        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=180,
-        check=False,
-    )
-    assert build_result.returncode == 0, (
-        f"uv build failed (rc={build_result.returncode}):\n"
-        f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
-    )
-
-    wheels = sorted(tmp_path.glob("tolokaforge-*.whl"))
-    assert wheels, f"No tolokaforge wheel produced under {tmp_path}"
-    wheel = wheels[-1]
-
-    with zipfile.ZipFile(wheel) as zf:
+    with zipfile.ZipFile(built_wheel) as zf:
         members = set(zf.namelist())
         assert "tolokaforge/_python_version.txt" in members, (
             "Wheel is missing tolokaforge/_python_version.txt — "

--- a/tests/canonical/test_devcontainer_structure.py
+++ b/tests/canonical/test_devcontainer_structure.py
@@ -1,0 +1,120 @@
+"""Guards the structural invariants a Codespace/dev-container boot depends on.
+
+The dev-container boots by running three lifecycle hooks declared in
+``.devcontainer/devcontainer.json``; those hooks in turn invoke the reused
+``scripts/setup/*`` scripts. A hook script that is renamed, loses its execute
+bit, or drops the ``scripts/setup`` invocation would break a fresh Codespace
+boot silently — no other test exercises this wiring. This guard turns each such
+regression into a CI failure. Runs under the ``canonical`` marker so it rides
+the existing smoke job without dedicated workflow wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVCONTAINER_DIR = _REPO_ROOT / ".devcontainer"
+_DEVCONTAINER_JSON = _DEVCONTAINER_DIR / "devcontainer.json"
+_README = _REPO_ROOT / "README.md"
+
+_LIFECYCLE_HOOKS = ("initializeCommand", "postCreateCommand", "postAttachCommand")
+
+# devcontainer.json is JSONC: only `//` line comments, no `//` inside string
+# values. A minimal line-comment strip makes it parseable by json.loads.
+_LINE_COMMENT_RE = re.compile(r"(^|\s)//[^\n]*")
+_CODESPACES_HEADING_RE = re.compile(r"^#{1,6}\s.*codespace", re.IGNORECASE | re.MULTILINE)
+
+
+def _load_devcontainer() -> dict:
+    assert _DEVCONTAINER_JSON.exists(), (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} is missing — "
+        "the dev-container definition must exist"
+    )
+    raw = _DEVCONTAINER_JSON.read_text()
+    stripped = _LINE_COMMENT_RE.sub(lambda m: m.group(1), raw)
+    config = json.loads(stripped)
+    assert config, (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} parsed to an empty document — "
+        "expected a populated dev-container config object"
+    )
+    return config
+
+
+def test_devcontainer_json_parses() -> None:
+    config = _load_devcontainer()
+    assert isinstance(config, dict), (
+        f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)} must be a JSON object, "
+        f"got {type(config).__name__}"
+    )
+
+
+def test_lifecycle_hooks_resolve_to_executable_scripts() -> None:
+    config = _load_devcontainer()
+    violations: list[str] = []
+    for hook in _LIFECYCLE_HOOKS:
+        command = config.get(hook)
+        if not command:
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: lifecycle hook "
+                f"`{hook}` is missing — a Codespace boot requires it"
+            )
+            continue
+        script_rel = command.split()[0]
+        script = _REPO_ROOT / script_rel
+        if not script.exists():
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: hook `{hook}` points at "
+                f"`{script_rel}`, which does not exist under the repo root"
+            )
+        elif not os.access(script, os.X_OK):
+            violations.append(
+                f"{_DEVCONTAINER_JSON.relative_to(_REPO_ROOT)}: hook `{hook}` script "
+                f"`{script_rel}` is not executable — run `chmod +x {script_rel}`"
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_reused_setup_scripts_exist_and_are_wired() -> None:
+    violations: list[str] = []
+    for script_rel in ("scripts/setup/create_python_venv.sh", "scripts/setup/init_git_lfs.sh"):
+        script = _REPO_ROOT / script_rel
+        if not script.exists():
+            violations.append(f"{script_rel} is missing — the dev-container hooks depend on it")
+        elif not os.access(script, os.X_OK):
+            violations.append(f"{script_rel} is not executable — run `chmod +x {script_rel}`")
+
+    wiring = (
+        (".devcontainer/post_attach_container.sh", "create_python_venv.sh"),
+        (".devcontainer/post_setup_container.sh", "init_git_lfs.sh"),
+    )
+    for hook_rel, expected_call in wiring:
+        hook = _REPO_ROOT / hook_rel
+        if not hook.exists():
+            violations.append(f"{hook_rel} is missing — the dev-container hook must exist")
+            continue
+        active = "\n".join(
+            line for line in hook.read_text().splitlines() if not line.lstrip().startswith("#")
+        )
+        if expected_call not in active:
+            violations.append(
+                f"{hook_rel} no longer invokes `{expected_call}` — the dev-container "
+                "boot would skip that setup step silently"
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_readme_documents_codespaces() -> None:
+    assert _README.exists(), f"{_README.relative_to(_REPO_ROOT)} is missing"
+    assert _CODESPACES_HEADING_RE.search(_README.read_text()), (
+        f"{_README.relative_to(_REPO_ROOT)} has no Codespaces heading — expected a markdown "
+        "heading matching `^#{1,6}\\s.*codespace` documenting the dev-container flow"
+    )

--- a/tests/canonical/test_python_version_single_source.py
+++ b/tests/canonical/test_python_version_single_source.py
@@ -1,0 +1,122 @@
+"""Guards that the runtime Python version stays single-sourced in ``.python-version``.
+
+A regression that re-hardcodes a version — in a workflow's ``uv python install``
+line, an ``actions/setup-python`` pin, or a runtime Dockerfile ``FROM`` — must fail
+CI rather than silently drift from the pin. Runs under the ``canonical`` marker so it
+participates in the existing CI smoke job without dedicated workflow wiring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.canonical
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_DOCKERFILE_DIR = _REPO_ROOT / "tolokaforge" / "docker" / "dockerfiles"
+_PINNED_VERSION = (_REPO_ROOT / ".python-version").read_text().strip()
+
+_EXPECTED_INSTALL_ARG = '"$(cat .python-version)"'
+
+_INSTALL_RE = re.compile(r"uv python install\s+(.*?)\s*$")
+_TRAILING_COMMENT_RE = re.compile(r"\s+#.*$")
+_ARG_LINE_RE = re.compile(r"^ARG PYTHON_VERSION(?:=(\S+))?\s*$", re.MULTILINE)
+_FROM_LINE_RE = re.compile(r"^FROM python:\$\{PYTHON_VERSION\}", re.MULTILINE)
+
+
+def _workflow_files() -> list[Path]:
+    files = sorted((*_WORKFLOW_DIR.glob("*.yml"), *_WORKFLOW_DIR.glob("*.yaml")))
+    assert files, f"no workflow files found under {_WORKFLOW_DIR} — the guard would pass vacuously"
+    return files
+
+
+def _iter_steps(doc: object):
+    if not isinstance(doc, dict):
+        return
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                yield step
+
+
+def test_workflow_uv_python_install_reads_the_pin() -> None:
+    violations: list[str] = []
+    for path in _workflow_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            match = _INSTALL_RE.search(line)
+            if match is None:
+                continue
+            arg = _TRAILING_COMMENT_RE.sub("", match.group(1)).strip()
+            if arg != _EXPECTED_INSTALL_ARG:
+                rel = path.relative_to(_REPO_ROOT)
+                violations.append(
+                    f"{rel}:{lineno}: `uv python install {arg}` hardcodes the version — "
+                    f"expected `uv python install {_EXPECTED_INSTALL_ARG}`"
+                )
+    message = "Workflows must install the pinned Python via .python-version:\n" + "\n".join(
+        violations
+    )
+    assert not violations, message
+
+
+def test_workflow_setup_python_uses_version_file() -> None:
+    violations: list[str] = []
+    for path in _workflow_files():
+        doc = yaml.safe_load(path.read_text())
+        rel = path.relative_to(_REPO_ROOT)
+        for step in _iter_steps(doc):
+            uses = step.get("uses", "")
+            if not isinstance(uses, str) or not uses.startswith("actions/setup-python"):
+                continue
+            with_block = step.get("with") or {}
+            if "python-version" in with_block:
+                violations.append(
+                    f"{rel}: `actions/setup-python` pins `python-version` — "
+                    "use `python-version-file: .python-version` instead"
+                )
+            elif with_block.get("python-version-file") != ".python-version":
+                violations.append(
+                    f"{rel}: `actions/setup-python` must set `python-version-file: .python-version`"
+                )
+    assert not violations, "\n".join(violations)
+
+
+def test_runtime_dockerfiles_single_source_python() -> None:
+    dockerfiles = sorted(_DOCKERFILE_DIR.glob("*.Dockerfile"))
+    assert dockerfiles, f"no runtime Dockerfiles found under {_DOCKERFILE_DIR}"
+
+    violations: list[str] = []
+    for path in dockerfiles:
+        text = path.read_text()
+        rel = path.relative_to(_REPO_ROOT)
+        arg_match = _ARG_LINE_RE.search(text)
+        if arg_match is None:
+            violations.append(
+                f"{rel}: missing `ARG PYTHON_VERSION` — runtime image must accept the pin"
+            )
+            continue
+        if _FROM_LINE_RE.search(text) is None:
+            violations.append(
+                f"{rel}: missing `FROM python:${{PYTHON_VERSION}}` — image must build from the ARG, not a literal"
+            )
+        default = arg_match.group(1)
+        if default is not None and default.strip() != _PINNED_VERSION:
+            violations.append(
+                f"{rel}: `ARG PYTHON_VERSION={default}` default diverges from "
+                f".python-version ({_PINNED_VERSION}) — a plain `docker build` would use the stale default"
+            )
+    assert not violations, "\n".join(violations)


### PR DESCRIPTION

- Milestone: https://github.com/Toloka/tolokaforge/milestone/3
- Umbrella: milestone description itself (no dedicated umbrella issue)
- Integration branch: `feat/release-hygiene`
- Base at start: `origin/main` @ ed0efde ("chore(release): bump version to 0.9.0")
- Base at consolidation: `origin/main` @ bf72991 ("chore(release): bump version to 0.9.1") — rebased forward once during the milestone; no in-milestone conflicts.

## Merge log

- #49 → PR #490 → `2f4e78f` (post-rebase) — CI smoke test for `tolokaforge adapter convert` via entry-point discovery landed (canonical tier). Session `built_wheel` fixture added; demo fixture package under `tests/canonical/fixtures/`; `tests/README.md` + `tests/AGENTS.md` reconciled. Follow-ups filed: #487.
- #480 → PR #495 → `67ed353` (post-rebase) — Runtime Python version single-sourced from `.python-version` end-to-end. Two workflow holdouts fixed; new canonical guard `tests/canonical/test_python_version_single_source.py` enforces the invariant; `.devcontainer/Dockerfile` clarifying comment; `AGENTS.md` states the invariant. Follow-ups filed: #492.
- #25 → PR #498 → `c6dcb88` (post-rebase) — Codespaces flow documented in `README.md`; new canonical guard `tests/canonical/test_devcontainer_structure.py` locks the boot-critical structural invariants. No AGENTS.md edit (references were already accurate — issue premise stale).

## TL;DR

Release hygiene without new typed contracts: three canonical guard tests + doc reconciliation lock what was previously drifting. `tolokaforge adapter convert` now has real end-to-end coverage through the production `importlib.metadata` discovery path (would have caught GH #37); the runtime Python version is truly single-sourced from `.python-version` with a guard that catches future regressions in workflows and Dockerfile ARG defaults; and the shipped `.devcontainer/` for GitHub Codespaces is documented in the README with a structural guard against silent boot-wiring breaks. No compatibility surfaces changed. Closes #49, #480, #25.

## Impact on existing tasks — read this first

**None** in terms of runtime behaviour or contracts. This milestone is release-safety plumbing:

- No task-pack format, task contract, run-config schema, CLI, or published Python API changed.
- No new production abstraction, protocol, or vocabulary.
- `.python-version` value is unchanged (`3.12`); no image rebuilds, no dev-env changes.
- CI wall-clock increases by ~25s on the `canonical` lane (one scratch-venv install for the new adapter-convert smoke). Other lanes unchanged.
- Every new test lives at the `canonical` tier and rides the existing smoke lane — no new workflow files.

Safety guards added:

1. `tests/canonical/test_adapter_convert_entry_point.py` fails CI if a future change ships a wheel that omits any adapter-convert module, breaks entry-point discovery, or breaks `--validate`'s ability to report zero-invalid.
2. `tests/canonical/test_python_version_single_source.py` fails CI if any workflow's `uv python install` hardcodes a version, or if any runtime Dockerfile's `ARG PYTHON_VERSION` default diverges from `.python-version`.
3. `tests/canonical/test_devcontainer_structure.py` fails CI if any devcontainer lifecycle hook script goes missing, loses its exec bit, drops its `scripts/setup/*` invocation (comment-out-safe), or if the README loses its Codespaces heading.

Follow-ups filed (not blockers): #487 (`adapter convert --validate` exit code should reflect invalid count) and #492 (`docs/PERFORMANCE.md` pins a stale Python; needs benchmark re-run).

## Design walkthrough

```mermaid
flowchart LR
  subgraph SOT["Single sources of truth"]
    PYV[".python-version<br/>(3.12)"]
    DCJ["devcontainer.json<br/>+ hook scripts"]
    ADPT["adapters/__init__.py<br/>entry-point group"]
  end

  subgraph GUARDS["Canonical guards added (Milestone 3)"]
    G1["test_adapter_convert_entry_point<br/>real wheel + scratch venv"]
    G2["test_python_version_single_source<br/>workflows + Dockerfile ARG"]
    G3["test_devcontainer_structure<br/>hooks + wiring + README"]
  end

  subgraph CI["CI canonical lane"]
    LANE["pytest -m canonical"]
  end

  ADPT --> G1
  PYV --> G2
  DCJ --> G3

  G1 --> LANE
  G2 --> LANE
  G3 --> LANE

  LANE -->|red on regression| DEV[Developer fixes<br/>before merge]
```

## Key design choices

| Decision | Rationale |
|----------|-----------|
| End-to-end `adapter convert` smoke uses an in-tree fixture package installed into a scratch venv (Approach A), not a demo entry-point in `tolokaforge`'s own `pyproject.toml` (Approach B). | B would ship a testing-only adapter in the public wheel and would already be discoverable in the repo `.venv` — defeating the "install a separate package and discover it" premise. A exercises the real external-adapter story. |
| `", 0 invalid"` (with the leading `", "` anchor) is the sole signal that `adapter convert --validate` reported clean; `COLUMNS=200` suppresses rich soft-wrap. | Because #487 makes `--validate` exit 0 and write bundles regardless of validation, neither the exit-0 check nor on-disk-file checks corroborate validation. The text check is the only lock. |
| Session-scoped `built_wheel` fixture in `tests/canonical/conftest.py` shares one `uv build --wheel` across every wheel-inspection test. | Three wheel-inspection tests would otherwise each incur ~1s of wheel build; the session fixture is a straight de-dup. |
| Isolation invariant `assert "demo" not in available_adapters()` runs in-process inside the new test, not as a manual gate. | A future workspace-member leak would silently make the fixture discoverable in the repo venv; the in-process assert regression-locks it cheaply and durably. |
| Python-version single source enforced with a canonical guard, not just consolidated by refactor. | Consolidation without a guard degrades — a future dev adds `uv python install 3.13` in a new workflow and no CI catches it. The three-assertion guard is the enforcement interface. |
| Workflow guard covers both `.yml` and `.yaml` extensions. | GitHub Actions accepts both; the repo is `.yml`-only today, but a future `.yaml` file would be an invisible escape hatch defeating the guard's purpose. |
| Dockerfile ARG default must equal `.python-version`, not just be present. | Without this check, `docker build` with no `--build-arg` silently uses the stale ARG default after a pin bump — the exact "version lives in N places" failure the issue is about. Guarding the default makes "single source" literally true, not just "true through builder.py". |
| Devcontainer wiring guard scans non-comment lines only when checking that hooks still invoke `scripts/setup/*`. | The docstring claims the assertion turns a dropped invocation into a CI failure. A plain substring search over the whole file text false-passes on `# create_python_venv.sh disabled` — the exact silent break the assertion was added to close. Filtering `#`-prefixed lines makes the claim honest. |
| Non-empty guards on every glob-based canonical assertion. | A guard that iterates zero items and passes green is worse than no guard — it silently disables the invariant it was written to protect. Every `_workflow_files()` / `dockerfiles` / hook-set iteration asserts non-empty before scanning. |
| For issue #25, no `AGENTS.md` edit despite the issue naming a "stale reference". | Verification found both `.devcontainer/Dockerfile` refs on lines 92 and 408 are accurate on-branch; the issue's premise predates the devcontainer landing. Editing AGENTS.md would collide with #480's adjacent Python-version invariant line. |

## Industry precedents

- **Entry-point-based adapter discovery** — this milestone's #49 test locks the same pattern `setuptools`/`hatchling`/`poetry` use for plugin discovery in the Python packaging ecosystem (`importlib.metadata.entry_points(group=...)`). The design borrowed the "install a real separate distribution into a throwaway venv" approach from how pytest itself tests plugin discovery; it deliberately rejected the "register a demo entry-point in the main package's `pyproject.toml`" pattern that some projects use for tests, because it pollutes the public wheel.
- **Single-sourced runtime language version with a CI guard** — mirrors the `.node-version` / `.python-version` / `.tool-versions` conventions that many polyglot repos maintain, plus the `uv python install "$(cat .python-version)"` pattern already in use across most tolokaforge workflows. The novel step is the guard test that fails CI if the invariant regresses — inspired by shell-lint-style CI checks that prevent future drift rather than just fixing the current instance.
- **Canonical-tier static repo-invariant guards** — this milestone establishes a small pattern: guards that read repo files and assert structural invariants (single-source pins, executable hook wiring, packaging inclusion, entry-point discovery) live under `tests/canonical/` and ride the existing CI smoke lane. Each guard is deliberately small, actionable-on-failure, and non-vacuous. Similar in spirit to `.pre-commit-config.yaml` hooks but expressible as pytest assertions so they participate in local `pytest -m canonical` and CI without a separate runner.

## Suggested review order

1. **#490 (`2f4e78f`)** — start here. The most substantive change: the demo adapter fixture package + real subprocess-based smoke that exercises the production `importlib.metadata` path. Reading this first also makes the canonical-guard pattern legible.
2. **#495 (`67ed353`)** — the tightest change: two workflow one-liners + a canonical guard whose three assertions each close a specific drift path. Best studied as three little decisions in a row (yaml extension, matcher normalization, ARG default equality).
3. **#498 (`c6dcb88`)** — the last per-issue PR is the shortest: README subsection + a four-assertion guard on the already-shipped devcontainer. Notable for the finding that the issue's core premise was already resolved and no AGENTS.md edit was in scope after all.

Each PR is squashed into one commit on the integration branch, so the linear log matches the review order.

## Verification

- **CI per PR** — every per-issue PR passed `test-smoke` and `lint` (the two content lanes) with `test-full` / `test-gate` skipping on non-default-branch. `hygiene-review` failed on all three PRs due to a pre-existing infrastructure issue (Claude Code Action returns `is_error:true` in ~300ms with $0 cost — tracked separately as #398 / #425 and present on recent merged PRs on `main`); not a merge blocker under milestone-mode failure protocol.
- **Post-merge validation on `feat/release-hygiene`** — each newly-landed canonical test file run on the integration branch after merge: #49 (1 test, 21.89s), #480 (3 tests, 0.07s), #25 (4 tests, 0.02s). All green.
- **Rebase-on-main verification** — `feat/release-hygiene` rebased once, cleanly, over one intervening `chore(release): bump version to 0.9.1` commit; no conflicts.
- **Guard-bites proofs performed by the stage implementers, recorded in PR bodies**: reverting a workflow to `uv python install 3.12` fails the #480 guard with actionable diagnostic; commenting out `init_git_lfs.sh` in `post_setup_container.sh` fails the #25 wiring assertion; the #49 test would fail if any adapter-convert module were dropped from the wheel or if entry-point discovery broke.
- **Manual acceptance criterion CI cannot cover (from #25)**: a fresh Codespace boot off this branch, running `uv run pytest -m unit` and `tolokaforge run` with a provider key set as a Codespaces secret. Human-in-the-loop; not gating.

## What's next

- **#487** — `tolokaforge adapter convert --validate` should propagate invalid count to exit code. Filed as `bug`, out of milestone scope; the smoke test asserts on the report text as documented workaround.
- **#492** — `docs/PERFORMANCE.md` pins Python 3.11.7 while `.python-version` is 3.12; needs a benchmark re-run to update honestly. Filed as P3.
- **Optional (surfaced, not filed)** — no Codespaces prebuild config exists. A prebuild dramatically speeds first boot; not filed since the issue's own wording scoped this as optional. Can be added later if the team wants faster Codespaces cold-start.
