### PR TITLE
fix(adapter): fail validation conversions

### DIFF
--- a/tests/unit/test_adapter_convert_cli.py
+++ b/tests/unit/test_adapter_convert_cli.py
@@ -40,7 +40,11 @@ class _StubConversionAdapter(NativeAdapter):
 
     def convert_to_native(self, task_id: str) -> NativeTaskBundle:
         return NativeTaskBundle(
-            task_config={"name": f"Task {task_id}", "category": "tool_use"},
+            task_config={
+                "name": f"Task {task_id}",
+                "category": "tool_use",
+                "description": "A valid converted task.",
+            },
             grading_config={"combine": {"method": "weighted", "pass_threshold": 1.0}},
             fixtures={"tools": [{"name": "noop"}]},
             metadata={"source_adapter": "stub"},
@@ -59,6 +63,16 @@ class _NoSharedAdapter(_StubConversionAdapter):
     """Conversion adapter that does NOT emit shared resources (default no-op)."""
 
     write_shared_resources = BaseAdapter.write_shared_resources
+
+
+class _InvalidConversionAdapter(_StubConversionAdapter):
+    """Conversion adapter that produces one invalid native task bundle."""
+
+    def convert_to_native(self, task_id: str) -> NativeTaskBundle:
+        bundle = super().convert_to_native(task_id)
+        if task_id == "t2":
+            bundle.task_config.pop("description")
+        return bundle
 
 
 @pytest.fixture
@@ -88,6 +102,30 @@ def test_convert_writes_native_bundles(runner, tmp_path, monkeypatch):
     # shared-resources hook runs exactly once (with the first bundle)
     assert len(stub.shared_calls) == 1
     assert (out / "_shared_marker").exists()
+
+
+def test_convert_with_invalid_validation_output_exits_nonzero(runner, tmp_path, monkeypatch):
+    stub = _InvalidConversionAdapter()
+    monkeypatch.setattr(adapters_pkg, "get_adapter", lambda name, params: stub)
+
+    out = tmp_path / "out"
+    result = runner.invoke(
+        cli,
+        [
+            "adapter",
+            "convert",
+            "--name",
+            "stub",
+            "--tasks-glob",
+            "x/**",
+            "--output",
+            str(out),
+            "--validate",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Validation: 1 valid, 1 invalid" in result.output
 
 
 def test_convert_works_without_shared_resources(runner, tmp_path, monkeypatch):

--- a/tolokaforge/cli/adapter_commands.py
+++ b/tolokaforge/cli/adapter_commands.py
@@ -119,15 +119,16 @@ def convert(
                 traceback.print_exc()
 
     # Optional validation pass
+    validation_errors = 0
     if do_validate and converted > 0:
-        _validate_converted(output_path, task_ids, verbose)
+        validation_errors = _validate_converted(output_path, task_ids, verbose)
 
     console.print(f"\nConverted {converted} tasks ({errors} errors)")
-    if errors > 0:
+    if errors + validation_errors > 0:
         raise SystemExit(1)
 
 
-def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -> None:
+def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -> int:
     """Validate converted output by loading via NativeAdapter."""
     from tolokaforge.adapters._task_loader import load_task_yaml
 
@@ -149,3 +150,4 @@ def _validate_converted(output_path: Path, task_ids: list[str], verbose: bool) -
             console.print(f"  ✗ invalid: {task_id}: {exc}", style="red")
 
     console.print(f"  Validation: {valid} valid, {invalid} invalid")
+    return invalid


### PR DESCRIPTION
# fix(adapter): fail validation conversions

## Summary

`tolokaforge adapter convert --validate` reported invalid converted tasks but still exited successfully. The command now treats validation failures as command failures while preserving the existing exit behavior when `--validate` is omitted.

Fixes #487

## Changes

- Return the invalid-task count from the converted-output validation pass.
- Exit nonzero when conversion or requested validation finds errors.
- Cover a real malformed converted bundle through the CLI unit test.

## Testing

Ran in the required sandbox:

- `python -m pip install 'uv==0.9.5' && uv run pytest tests/unit/test_adapter_convert_cli.py -v` — 3 passed.
- `python -m pip install 'uv==0.9.5' && uv run ruff check tolokaforge/cli/adapter_commands.py tests/unit/test_adapter_convert_cli.py && uv run ruff format --check tolokaforge/cli/adapter_commands.py tests/unit/test_adapter_convert_cli.py` — passed; 2 files already formatted.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
