### PR TITLE
fix(loader,tests): pack-load regression + promote pack tests to canonical + parallel-safe integration lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
     - name: Run integration tests
       if: (github.event_name == 'schedule' || github.event_name == 'push') && steps.docker-build-full.outcome == 'success'
       run: |
-        uv run pytest tests/integration/ -v --tb=short
+        uv run pytest tests/integration/ -v --tb=short -n auto
 
     - name: Generate coverage XML for Codecov
       if: github.event_name == 'schedule'
@@ -321,7 +321,7 @@ jobs:
     - name: Run integration tests
       if: steps.docker-build.outcome == 'success'
       run: |
-        uv run pytest tests/integration/ -v --tb=short
+        uv run pytest tests/integration/ -v --tb=short -n auto
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,14 +123,16 @@ uv run pytest tests/ -v -m unit
 # Canonical tests — snapshot/contract tests, no external services
 uv run pytest tests/ -v -m canonical
 
-# Integration tests — require API keys and/or services
-scripts/with_env.sh uv run pytest tests/ -v -m integration
+# Integration tests — require API keys and/or services; run in parallel
+scripts/with_env.sh uv run pytest tests/ -v -m integration -n auto
 
 # Validate task definitions (tasks/ must be cloned locally or use a custom TASKS_GLOB)
 uv run tolokaforge validate --tasks "tasks/**/task.yaml"
 ```
 
 **`scripts/with_env.sh` convention:** Use `scripts/with_env.sh uv run ...` when you need `.env` variables (API keys, service URLs). Use plain `uv run ...` for tasks that don't need environment variables (unit tests, linting).
+
+**Parallel integration tests:** `-n auto` (pytest-xdist) spreads the integration lane across worker processes. `tests/integration/conftest.py` gives each worker a unique `COMPOSE_PROJECT_NAME`, so concurrent Docker Compose stacks never share a project namespace or collide on container/network names. A test that boots two mutually-isolated stacks at once must set its own per-stack `COMPOSE_PROJECT_NAME`.
 
 ### Local Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ uv run tolokaforge validate --tasks "tasks/**/task.yaml"
 
 **`scripts/with_env.sh` convention:** Use `scripts/with_env.sh uv run ...` when you need `.env` variables (API keys, service URLs). Use plain `uv run ...` for tasks that don't need environment variables (unit tests, linting).
 
-**Parallel integration tests:** `-n auto` (pytest-xdist) spreads the integration lane across worker processes. `tests/integration/conftest.py` gives each worker a unique `COMPOSE_PROJECT_NAME`, so concurrent Docker Compose stacks never share a project namespace or collide on container/network names. A test that boots two mutually-isolated stacks at once must set its own per-stack `COMPOSE_PROJECT_NAME`.
+**Parallel integration tests:** `-n auto` (pytest-xdist) spreads the integration lane across worker processes. `tests/integration/reset_recipes/conftest.py` gives each worker a unique `COMPOSE_PROJECT_NAME` for the reset-recipe suite, whose stacks all share the `compose` basename and would otherwise collide across workers. The rest of the integration suite derives per-test project names from slug-encoded `make_project_temp_dir` basenames, so it stays disjoint without the env pin.
 
 ### Local Services
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 
 ### Fix
 
+- **loader**: project `task_defaults` again loads the shipped `example-microservices-pack`. Only `TaskConfig`-shaped keys of `task_defaults` are merged into each task dict before its `extra="forbid"` validation; project-scoped-only keys (`grading_defaults`, `continue_prompt`) are excluded from that merge and reach the engine through their own seams. Without this, the pack could not build a single `TaskDescription` — every task failed with `unknown key 'grading_defaults' in task.yaml`. The excluded set is derived from the schema (`TaskDefaults.model_fields - TaskConfig.model_fields`), so future project-only defaults are handled automatically (#277, regression from #213).
 - **config**: `orchestrator.max_turns` now defaults to unset (`None`), making the run-level turn cap opt-in. A task's `max_turns` is no longer silently clamped to 50; the effective budget is `min(task, run cap)` only when the operator sets a cap, and the engine default (50 turns) applies when neither the run nor the task declares a value (#265).
 - **loader**: `stack: null` and `stack: {compose_file: null}` in a task's `environment_manifest` (and in a project's `default_environment`) are now rejected at load time with a `RuntimeError` naming the offending file and field, enforcing the documented full-override rule — a task cannot unset the environment (or its substrate pointer) out from under a project that declares one. Omit the key to inherit (#235).
 

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -1104,7 +1104,8 @@ field and vice versa.
 | Identity (`name`, `version`, `description`) | project.yaml | — |
 | `tasks.discovery` | project.yaml | — |
 | `default_environment` | project.yaml | task.yaml's `environment_manifest` |
-| `task_defaults.*` (adapter, prompt, tools, actors, policies, grading_defaults, timeouts, stuck_heuristics, continue_prompt) | `project.task_defaults` | `task.yaml` |
+| `task_defaults.*` — task-scoped (adapter, prompt, tools, actors, policies, timeouts, stuck_heuristics, max_turns, adapter_settings, metadata, system_prompt) | `project.task_defaults` | `task.yaml` |
+| `task_defaults` — project-scoped only (grading_defaults, continue_prompt) | `project.task_defaults` | — (no per-task delta; `grading_defaults` reaches the engine via `NativeAdapter.get_grading_config`, `continue_prompt` via turn logic) |
 | `compute` (provider, workers, budget, rate limits, retries) | `project.run_defaults.compute` | `run_configs/<name>.yaml` |
 | `storage` (artifacts, logs, queue) | `project.run_defaults.storage` | `run_configs/<name>.yaml` |
 | `observability` (tracing, metrics, logging) | `project.run_defaults.observability` | `run_configs/<name>.yaml` |

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -1104,7 +1104,7 @@ field and vice versa.
 | Identity (`name`, `version`, `description`) | project.yaml | — |
 | `tasks.discovery` | project.yaml | — |
 | `default_environment` | project.yaml | task.yaml's `environment_manifest` |
-| `task_defaults.*` — task-scoped (adapter, prompt, tools, actors, policies, timeouts, stuck_heuristics, max_turns, adapter_settings, metadata, system_prompt) | `project.task_defaults` | `task.yaml` |
+| `task_defaults.*` — task-scoped (adapter, tools, actors, policies, timeouts, stuck_heuristics, max_turns, adapter_settings, metadata, system_prompt) | `project.task_defaults` | `task.yaml` |
 | `task_defaults` — project-scoped only (grading_defaults, continue_prompt) | `project.task_defaults` | — (no per-task delta; `grading_defaults` reaches the engine via `NativeAdapter.get_grading_config`, `continue_prompt` via turn logic) |
 | `compute` (provider, workers, budget, rate limits, retries) | `project.run_defaults.compute` | `run_configs/<name>.yaml` |
 | `storage` (artifacts, logs, queue) | `project.run_defaults.storage` | `run_configs/<name>.yaml` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,7 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
     "pytest-docker>=2.0.0",
+    "pytest-xdist>=3.5.0",
     "psutil>=5.9.0",
     "black==26.3.1",
     "ruff==0.14.4",

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,15 +30,17 @@ uv run pytest tests/ -v -m canonical
 uv run pytest tests/canonical/ --update-canon -v
 ```
 
-Integration tests need `.env` variables (API keys, service URLs) — use `scripts/with_env.sh`:
+Integration tests need `.env` variables (API keys, service URLs) — use `scripts/with_env.sh`. They run in parallel with `-n auto` (pytest-xdist):
 
 ```bash
 # Integration tests (needs Docker + API keys in .env)
-scripts/with_env.sh uv run pytest tests/ -v -m integration
+scripts/with_env.sh uv run pytest tests/ -v -m integration -n auto
 
 # Full suite
 scripts/with_env.sh uv run pytest tests/ -v
 ```
+
+Under `-n auto`, `tests/integration/conftest.py` assigns each xdist worker a unique `COMPOSE_PROJECT_NAME`, so concurrent Docker Compose stacks stay in disjoint project namespaces and never collide on container/network names. A single test that boots two mutually-isolated stacks at once must set its own per-stack `COMPOSE_PROJECT_NAME`.
 
 ## Directory Structure
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ scripts/with_env.sh uv run pytest tests/ -v -m integration -n auto
 scripts/with_env.sh uv run pytest tests/ -v
 ```
 
-Under `-n auto`, `tests/integration/conftest.py` assigns each xdist worker a unique `COMPOSE_PROJECT_NAME`, so concurrent Docker Compose stacks stay in disjoint project namespaces and never collide on container/network names. A single test that boots two mutually-isolated stacks at once must set its own per-stack `COMPOSE_PROJECT_NAME`.
+Under `-n auto`, `tests/integration/reset_recipes/conftest.py` assigns each xdist worker a unique `COMPOSE_PROJECT_NAME` for the reset-recipe suite, whose stacks all share the `compose` basename and would otherwise collide across workers. The rest of the integration suite derives per-test project names from slug-encoded `make_project_temp_dir` basenames, so it stays in disjoint namespaces without the env pin.
 
 ## Directory Structure
 

--- a/tests/canonical/test_example_microservices_pack.py
+++ b/tests/canonical/test_example_microservices_pack.py
@@ -31,7 +31,7 @@ from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.project_loader import load_project_config, resolve
 from tolokaforge.runner.models import TaskDescription
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.canonical
 
 
 _PACK_ROOT = (

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,42 @@
+"""Integration-tier pytest configuration.
+
+``testcontainers`` passes no ``--project-name`` and runs Docker Compose with
+``cwd`` set to the context dir, so Compose derives the project name from that
+dir's basename. Integration tests that build their stack under
+``tmp_path / "compose"`` therefore all resolve to project name ``compose`` —
+harmless sequentially, but under ``pytest -n auto`` two such stacks on
+different workers share one project namespace and collide on container /
+network names. Pinning ``COMPOSE_PROJECT_NAME`` per worker keeps every
+worker's stacks disjoint in one place, without editing each call site.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def apply_compose_project_isolation() -> str:
+    """Set and return this worker's ``COMPOSE_PROJECT_NAME``.
+
+    Reads xdist's ``PYTEST_XDIST_WORKER`` (e.g. ``gw0``); absent it (no
+    xdist) falls back to one stable name.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    name = f"tolokaforge-it-{worker}"
+    os.environ["COMPOSE_PROJECT_NAME"] = name
+    return name
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolate_compose_project_per_worker() -> None:
+    """Pin one ``COMPOSE_PROJECT_NAME`` per xdist worker so concurrent stacks
+    on different workers never share a Compose project namespace.
+
+    Per-worker uniqueness suffices because a worker runs its tests
+    sequentially. Assumes no single test boots two mutually-isolated Compose
+    stacks concurrently — those would share this per-worker name and collide,
+    and must set their own per-stack ``COMPOSE_PROJECT_NAME``.
+    """
+    apply_compose_project_isolation()

--- a/tests/integration/reset_recipes/conftest.py
+++ b/tests/integration/reset_recipes/conftest.py
@@ -1,13 +1,17 @@
-"""Integration-tier pytest configuration.
+"""Pytest configuration for the reset-recipe integration suite.
 
 ``testcontainers`` passes no ``--project-name`` and runs Docker Compose with
 ``cwd`` set to the context dir, so Compose derives the project name from that
-dir's basename. Integration tests that build their stack under
-``tmp_path / "compose"`` therefore all resolve to project name ``compose`` —
+dir's basename. Every reset-recipe test builds its stack under
+``tmp_path / "compose"``, so they all resolve to project name ``compose`` —
 harmless sequentially, but under ``pytest -n auto`` two such stacks on
 different workers share one project namespace and collide on container /
 network names. Pinning ``COMPOSE_PROJECT_NAME`` per worker keeps every
 worker's stacks disjoint in one place, without editing each call site.
+
+Scoped to this suite: other integration tests derive per-test project names
+from slug-encoded ``make_project_temp_dir`` basenames and must not have that
+overridden by a per-worker env var.
 """
 
 from __future__ import annotations
@@ -31,12 +35,11 @@ def apply_compose_project_isolation() -> str:
 
 @pytest.fixture(scope="session", autouse=True)
 def isolate_compose_project_per_worker() -> None:
-    """Pin one ``COMPOSE_PROJECT_NAME`` per xdist worker so concurrent stacks
-    on different workers never share a Compose project namespace.
+    """Pin one ``COMPOSE_PROJECT_NAME`` per xdist worker so concurrent
+    reset-recipe stacks on different workers never share a Compose project
+    namespace.
 
     Per-worker uniqueness suffices because a worker runs its tests
-    sequentially. Assumes no single test boots two mutually-isolated Compose
-    stacks concurrently — those would share this per-worker name and collide,
-    and must set their own per-stack ``COMPOSE_PROJECT_NAME``.
+    sequentially and each reset-recipe test boots a single stack.
     """
     apply_compose_project_isolation()

--- a/tests/integration/reset_recipes/conftest.py
+++ b/tests/integration/reset_recipes/conftest.py
@@ -33,13 +33,14 @@ def apply_compose_project_isolation() -> str:
     return name
 
 
-@pytest.fixture(scope="session", autouse=True)
-def isolate_compose_project_per_worker() -> None:
-    """Pin one ``COMPOSE_PROJECT_NAME`` per xdist worker so concurrent
-    reset-recipe stacks on different workers never share a Compose project
-    namespace.
-
-    Per-worker uniqueness suffices because a worker runs its tests
-    sequentially and each reset-recipe test boots a single stack.
+@pytest.fixture(autouse=True)
+def isolate_compose_project_per_worker(monkeypatch) -> None:
+    """Pin one ``COMPOSE_PROJECT_NAME`` per xdist worker for the duration
+    of a reset-recipe test only. Function-scoped monkeypatch restores the
+    prior env after each test so downstream tests on the same worker
+    (notably ``test_per_trial_isolation_across_concurrent_instances``, which
+    boots two mutually-isolated stacks) still get their own basename-derived
+    project names.
     """
-    apply_compose_project_isolation()
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    monkeypatch.setenv("COMPOSE_PROJECT_NAME", f"tolokaforge-it-{worker}")

--- a/tests/unit/test_compose_project_isolation.py
+++ b/tests/unit/test_compose_project_isolation.py
@@ -1,0 +1,32 @@
+"""Locks the per-worker ``COMPOSE_PROJECT_NAME`` isolation that keeps
+parallel (``pytest -n auto``) Docker integration stacks from colliding.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.integration.conftest import apply_compose_project_isolation
+
+pytestmark = pytest.mark.unit
+
+
+def test_distinct_workers_get_distinct_names(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    gw0 = apply_compose_project_isolation()
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    gw1 = apply_compose_project_isolation()
+    assert gw0 != gw1
+
+
+def test_sets_the_env_var_docker_compose_reads(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw2")
+    returned = apply_compose_project_isolation()
+    assert os.environ["COMPOSE_PROJECT_NAME"] == returned == "tolokaforge-it-gw2"
+
+
+def test_no_xdist_maps_to_one_stable_name(monkeypatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    assert apply_compose_project_isolation() == "tolokaforge-it-main"

--- a/tests/unit/test_compose_project_isolation.py
+++ b/tests/unit/test_compose_project_isolation.py
@@ -1,5 +1,5 @@
 """Locks the per-worker ``COMPOSE_PROJECT_NAME`` isolation that keeps
-parallel (``pytest -n auto``) Docker integration stacks from colliding.
+parallel (``pytest -n auto``) reset-recipe Docker stacks from colliding.
 """
 
 from __future__ import annotations
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from tests.integration.conftest import apply_compose_project_isolation
+from tests.integration.reset_recipes.conftest import apply_compose_project_isolation
 
 pytestmark = pytest.mark.unit
 

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -54,8 +54,16 @@ from typing import Any
 import yaml
 
 from tolokaforge.core.deprecations import canonicalize_actor_config
-from tolokaforge.core.models import TaskConfig
+from tolokaforge.core.models import TaskConfig, TaskDefaults
 from tolokaforge.core.project_loader import construct_config, deep_merge
+
+# Keys that live on ``project.task_defaults`` but are not ``TaskConfig`` fields.
+# They reach the engine through their own seams (``grading_defaults`` via
+# ``NativeAdapter.get_grading_config``, ``continue_prompt`` via turn logic), so
+# merging them into a task dict would fail its ``extra="forbid"`` validation.
+_PROJECT_SCOPED_DEFAULT_KEYS = frozenset(TaskDefaults.model_fields) - frozenset(
+    TaskConfig.model_fields
+)
 
 
 def validate_grading_yaml(grading_path: Path) -> None:
@@ -113,12 +121,14 @@ def load_task_yaml(
     Args:
         task_path: Absolute or relative path to ``task.yaml``.
         project_task_defaults: Optional ``project.task_defaults`` dict from
-            the enclosing project. When supplied, it is layered above the
-            adapter's Domain merge and below the task's own fields.
-            Precedence, low to high: adapter Domain bundle → project
-            defaults → task.yaml. Task fields win on conflict; project
-            defaults win over the Domain bundle where they overlap and
-            the task doesn't set the field.
+            the enclosing project. Only its ``TaskConfig``-shaped keys are
+            layered into the task dict — above the adapter's Domain merge and
+            below the task's own fields. Project-scoped-only keys
+            (``grading_defaults``, ``continue_prompt``) are excluded here and
+            reach the engine through their own seams. Precedence, low to high:
+            adapter Domain bundle → project defaults → task.yaml. Task fields
+            win on conflict; project defaults win over the Domain bundle where
+            they overlap and the task doesn't set the field.
 
     Returns:
         ``(task_config, effective_task_dir)``. ``effective_task_dir`` is the
@@ -172,7 +182,12 @@ def load_task_yaml(
     # is delta-wins, so the second argument overrides the first on conflict.
     base = domain_data
     if project_task_defaults:
-        base = deep_merge(base, project_task_defaults)
+        task_shaped_defaults = {
+            key: value
+            for key, value in project_task_defaults.items()
+            if key not in _PROJECT_SCOPED_DEFAULT_KEYS
+        }
+        base = deep_merge(base, task_shaped_defaults)
     task_data = deep_merge(base, task_data)
 
     # Auto-pick a sibling ``grading.yaml`` when no layer set ``grading``. An

--- a/uv.lock
+++ b/uv.lock
@@ -895,6 +895,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -3093,6 +3102,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4006,6 +4028,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-docker" },
+    { name = "pytest-xdist" },
     { name = "rank-bm25" },
     { name = "ruff" },
     { name = "tolokaforge-adapter-terminal-bench" },
@@ -4079,6 +4102,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-docker", specifier = ">=2.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
     { name = "ruff", specifier = "==0.14.4" },
     { name = "tolokaforge-adapter-terminal-bench", editable = "external_adapters/tolokaforge-adapter-terminal-bench" },


### PR DESCRIPTION
## Summary

- **Fix a shipped-pack load regression** introduced by #213 / #529: the M4 `extra="forbid"` on `TaskConfig` combined with the whole-dict `project_task_defaults` merge in the task loader caused every task in the flagship `example-microservices-pack` to fail load with `RuntimeError: unknown key 'grading_defaults' in task.yaml`. Narrow the merged defaults to `TaskConfig`-owned keys (derived, not hardcoded). `tolokaforge run` on the shipped pack works again.
- **Promote the pack wiring-proof tests from `integration` → `canonical`** so the required PR gate (`test-smoke`) catches this class of regression on the introducing PR. The regression stayed hidden precisely because `integration` runs only on push/nightly/gate-label, never on a feature-branch PR — exactly the gap #277 was chartered to close.
- **Add `pytest-xdist` and make the reset-recipe Docker suite parallel-safe** by pinning `COMPOSE_PROJECT_NAME` per worker via a function-scoped autouse `monkeypatch` fixture. CI integration lanes get `-n auto`.

## Design choices

- **Filter derived from schema shapes, not a hardcoded list**: `_PROJECT_SCOPED_DEFAULT_KEYS = frozenset(TaskDefaults.model_fields) - frozenset(TaskConfig.model_fields)`. Today that resolves to `{grading_defaults, continue_prompt}`; a future `TaskDefaults`-only field is handled automatically without another PR. Module-level (import-time evaluation, one computation per process).
- **Loader filters only the `project_task_defaults` layer, not `task_data`**: a genuinely-unknown key authored in a `task.yaml` still raises the friendly `construct_config` error. The bug wasn't "the schema is too strict" — the bug was the merge feeding it project-scoped keys as if they were task keys. Fix is at the merge boundary, not at the schema.
- **Adapter's stored `_project_task_defaults` is NOT filtered**: the grading path reads from it (`NativeAdapter.get_grading_config` at `native.py:346`). The loader mutates a local shallow copy; the adapter's copy keeps `grading_defaults` for its own consumption. Grading inheritance intact.
- **Physical `git mv` of the pack test file, not just a `pytestmark` change**: CI selects integration by directory (`pytest tests/integration/`), not by `-m integration`. The required gate `test-smoke` runs `pytest tests/unit/ tests/canonical/` by directory. A canonical-marked file that still sits under `tests/integration/` would keep running in the wrong lane and NOT run in the gate — the exact opposite of the goal.
- **Conftest scope-narrowed to `tests/integration/reset_recipes/` + function-scoped `monkeypatch`**: session-scoped env mutations leak across a worker's queue. Sibling docker tests (`test_per_trial_isolation_across_concurrent_instances` in particular) rely on `make_project_temp_dir`'s cwd-basename precedence for per-trial isolation; a pinned `COMPOSE_PROJECT_NAME` would collapse two concurrent stacks together. Function-scope + `monkeypatch.setenv` bounds the pin to a single reset-recipe test and auto-restores after — parallel-safety inside reset-recipes preserved, docker suite unaffected.
- **`pytest-xdist` in `[dependency-groups].dev` (PEP 735)**, not `[project.optional-dependencies]` — per AGENTS.md uv workspace rule.

## Concepts introduced

**Split of `TaskDefaults` field ownership at the loader merge boundary.** The `TaskDefaults` model is the *shape* of `project.task_defaults`. Some of its fields (`adapter`, `prompt`, `tools`, `actors`, `policies`, `timeouts`, `stuck_heuristics`, `max_turns`, `adapter_settings`, `metadata`, `system_prompt`) are also `TaskConfig` fields — those have a `task.yaml` delta path (the loader merges them into each task dict; the task can override). The remaining fields (`grading_defaults`, `continue_prompt`) are *project-scoped only* — they have no `task.yaml` delta and reach the engine through their own seams (`NativeAdapter.get_grading_config` and turn logic). The `docs/PROJECTS.md:1107` field-ownership table now reflects this split explicitly.

The reset-recipe conftest introduces a **narrow per-worker `COMPOSE_PROJECT_NAME` isolation pattern** — applies to a suite whose tests all share the same cwd basename (`compose`), scoped to function lifetime via `monkeypatch` so it doesn't leak into sibling suites that rely on the default basename-precedence for their own isolation.

## Plan

### Goal

(1) The flagship `example-microservices-pack` loads end-to-end again — all 5 tasks build `TaskDescription` with grading inheritance intact. (2) The pack's wiring-proof tests run in the required PR gate so a similar regression is caught on the introducing PR. (3) The integration suite can run under `pytest -n auto` safely — concurrent Docker stacks in the reset-recipe suite never collide on compose project name.

### Non-goals

Proposals #3/#4/#5 from the issue (session-scoped postgres, pre-pull conftest, `pull=False`); a specific wall-clock number (the "under 40s" target in the issue is stale — the suite grew from 9 to 1413 tests); refactoring reset-recipe tests to skip Docker (they need real containers).

### Stage 1 — Stop project-scoped defaults leaking into the strict task schema

- `_task_loader.py`: module-level `_PROJECT_SCOPED_DEFAULT_KEYS = frozenset(TaskDefaults.model_fields) - frozenset(TaskConfig.model_fields)`. At the merge site, filter `project_task_defaults` to keys not in that set before `deep_merge`. `task_data` unfiltered — unknown authored keys still error via `construct_config`.
- Adapter's stored `_project_task_defaults` unchanged (grading path preserved).
- CHANGELOG entry under **Fixed** naming the pack-load regression and referencing #213.
- Behaviour-lock: all 21 tests in `test_example_microservices_pack.py` pass (still `integration`-marked at S1; move at S2).

### Stage 2 — Relocate the pack wiring-proof tests into the required gate

- `git mv tests/integration/test_example_microservices_pack.py → tests/canonical/`; `pytestmark integration → canonical`.
- File is Docker-free + LLM-free (module docstring asserts this) → meets canonical-tier contract.
- Repo-root anchor `Path(__file__).resolve().parents[2]` unchanged (both `tests/<tier>/file.py` are two levels deep).
- After the move, runs on every PR via `test-smoke`.

### Stage 3 — Add `pytest-xdist` and make the reset-recipe Docker suite parallel-safe

- `pytest-xdist>=3.5.0` added to `pyproject.toml` `[dependency-groups].dev`. `uv sync` relocks (`pytest-xdist==3.8.0` + `execnet==2.1.2`).
- `tests/integration/reset_recipes/conftest.py` — function-scoped autouse fixture taking `monkeypatch`, pins `COMPOSE_PROJECT_NAME` to `tolokaforge-it-<worker>` for the duration of a reset-recipe test only. Auto-restored after each test so sibling docker tests keep their `make_project_temp_dir`-derived cwd-basename precedence.
- `apply_compose_project_isolation()` helper split out so the behaviour is unit-testable at `tests/unit/test_compose_project_isolation.py`.
- `.github/workflows/ci.yml` — `-n auto` on `Run integration tests` in both `test-full` and `test-gate`.
- AGENTS.md §Testing + `tests/README.md` describe the narrower scope accurately.

**Reviewer-driven refinements landed in this PR:**
- `docs/PROJECTS.md:1107` field-ownership row split into two (TaskConfig-owned delta vs project-scoped-only) — the reality since #213 shipped. (Was a hygiene M1 in review R1.)
- The reset-recipe conftest was first `git mv`'d from `tests/integration/conftest.py` to the narrower `tests/integration/reset_recipes/` location, then its fixture converted from session-scope-fire-and-forget to function-scope-monkeypatch. Two review rounds — the first narrowing the directory scope, the second bounding the env-var lifetime.

## Discovered issues

**Fix in this PR (Stage 1):** the `grading_defaults`/`continue_prompt` merge leak — a production regression from #213/#529 that breaks loading of the shipped `example-microservices-pack`. Fixed here because it is the direct blocker to Stage 2 (cannot promote red tests into the required gate) and #277 is the final milestone-9 issue.

**Filed:** none. Two `test_per_trial_runtime_backend_integration.py` failures were seen locally during discovery — likely a missing-built-image dev-env artifact, not filed without confirmation. Not caused by this PR.

**Follow-up nits (not blocking):** hygiene reviewer suggested extracting `apply_compose_project_isolation()` to `tests/support/compose_isolation.py` (or similar) so the unit test doesn't do a sibling-tier import from a conftest. Optional polish.

## Test plan

- `uv run pytest tests/canonical/test_example_microservices_pack.py` → 21 pass (in the required PR gate now).
- `uv run pytest -m unit` — full unit suite green including the new `test_compose_project_isolation.py` (3 tests).
- `uv run pytest tests/integration/reset_recipes/ -n 2` — 8 pass, 47.5s, no container/network collisions (verified locally with Docker up).
- `uv run pytest --collect-only tests/integration/docker/test_per_trial_runtime_backend_integration.py` — collects cleanly under the new conftest.
- CI: `-n auto` applied on both `test-full` and `test-gate` "Run integration tests" steps. If runners over-subscribe the Docker daemon, drop to `-n 2` / `-n 4` — the safety property (per-worker isolation) is what's locked, not a specific worker count.

**CI note:** the `hygiene-review` workflow lane has a known infrastructure failure on this repo right now; merging past it is standard (matches the last several PRs).

Closes #277