### PR TITLE
fix(grading): compare numerically-equal state values as equal

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -12,35 +12,52 @@ Scores are weighted and combined into a final score. See [REFERENCE.md](REFERENC
 
 ## Hash-Based Grading (Tau-Bench Compatible)
 
-Hash grading compares SHA256 of final state against a pre-computed golden hash.
+Hash grading canonicalizes the final state and the golden state, hashes both
+with SHA256, and passes iff the two hashes match. Grading is **engine-vs-engine**:
+the golden hash is (re)computed live by replaying the golden actions, not read
+from a stored literal (see the caveat below).
 
 ### Algorithm
 
+Scalars pass through `canonical_number()` so a pure numeric-representation
+difference is not graded as a state change. Two tiers:
+
+- **Numeric TYPES** (`int` / `float` / `Decimal`) always fold:
+  `72 == 72.0 == Decimal("72.00")`. Generic and safe (the type declares
+  number-ness). On by default.
+- **Numeric-looking STRINGS** (`"130.00" == "130.0"`) fold ONLY for values under
+  a record key listed in `state_checks.numeric_string_fields` (see below).
+  Per-field, because a string that merely looks numeric can carry meaning in its
+  exact form (versions `"1.10"` vs `"1.1"`, codes, zero-padded ids).
+
 ```python
 import hashlib
-from typing import Any, Dict, List, Set, Tuple, Union
+from tolokaforge.core.grading.state_checks import to_hashable, consistent_hash
 
-ToHashable = Union[str, int, float, Dict[str, "ToHashable"], List["ToHashable"], Set["ToHashable"]]
-Hashable = Union[str, int, float, Tuple["Hashable"], Tuple[Tuple[str, "Hashable"]]]
+# to_hashable(item, string_fields=None) sorts dict keys, canonicalizes numbers
+# via canonical_number, and is key-aware for the string tier: a value folds
+# numeric strings only when its immediate record key is in string_fields.
+# consistent_hash(value) = sha256(str(value)).
 
-def to_hashable(item: ToHashable) -> Hashable:
-    """Convert to hashable representation (tau-bench compatible)"""
-    if isinstance(item, dict):
-        return tuple((key, to_hashable(value)) for key, value in sorted(item.items()))
-    elif isinstance(item, list):
-        return tuple(to_hashable(element) for element in item)
-    elif isinstance(item, set):
-        return tuple(sorted(to_hashable(element) for element in item))
-    else:
-        return item
-
-def consistent_hash(value: Hashable) -> str:
-    """Compute SHA256 hash"""
-    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
-
-# Usage:
+# Usage (types-only folding, the default):
 # golden_hash = consistent_hash(to_hashable(final_state))
+# Usage (also fold numeric strings under the money field):
+# golden_hash = consistent_hash(to_hashable(final_state, frozenset(["custom_refund_amount"])))
 ```
+
+Guards (both tiers): `bool` never folds to `int`; leading-zero ids (`"00123"`)
+are never equated with `"123"`; genuinely different numbers stay different; a
+genuine string that begins with the reserved numeric-token prefix is escaped so
+it cannot masquerade as a number.
+
+> **Hash-algorithm change (recompute stored hashes).** `to_hashable` now applies
+> `canonical_number`, so it produces different digests than the pre-canonicalization
+> version for any numeric-bearing state. Because grading recomputes the golden
+> hash live (golden-action replay via `compute_tau_style_expected_hash`), this is
+> symmetric and safe. But any **externally pre-computed** `expected_state_hash`
+> stored from before this change is stale and will false-fail — recompute it.
+> (Scanned at time of writing: `0` task-pack grading configs store a hash literal,
+> so there is nothing to migrate in-tree.)
 
 ### Computing Golden Hashes
 
@@ -56,10 +73,33 @@ from tolokaforge.core.grading.state_checks import to_hashable, consistent_hash
 golden_hash = consistent_hash(to_hashable(env.dump()))
 ```
 
+### Folding numeric strings for a money / quantity field
+
+Some backends round-trip `Decimal` columns as strings, so the same amount can
+surface as `"130.00"` on one side and `"130.0"` on the other and false-fail a
+correct trial. Opt the specific field(s) into string folding — never globally:
+
+```yaml
+state_checks:
+  hash:
+    enabled: true
+    weight: 1.0
+  numeric_string_fields:      # per-field allow-list; matched by record key at any depth
+    - custom_refund_amount    # e.g. the d365 travel refund field
+```
+
+Only list fields that are genuinely numeric quantities. Do NOT list identifier
+or code fields (`payment_method_last4`, `id`, `organization_id`): folding those
+would treat `"0042"`-style values as numbers. This key is honored identically on
+both grading substrates (the core `GradingEngine`/`to_hashable` path and the
+runner gRPC/`compute_stable_hash` path).
+
 ### Best Practices
 
 - Filter non-deterministic fields (timestamps, UUIDs) before hashing
-- Document how golden hash was computed
+- Prefer golden-action replay over storing a hash literal; if you must store one,
+  recompute it whenever the hashing algorithm changes (see the callout above)
+- Fold numeric strings per-field (`numeric_string_fields`), never as a global switch
 - Combine with JSONPath assertions using `weight: 0.8` for flexibility
 
 ---

--- a/docs/GRADING_VERIFICATION.md
+++ b/docs/GRADING_VERIFICATION.md
@@ -27,39 +27,64 @@ The grading system uses SHA-256 hash comparison to determine if the agent achiev
 **Algorithm:**
 ```python
 # From tolokaforge/core/hash.py
-def compute_stable_hash(state: dict, unstable_fields: list[str] | None = None) -> str:
+def compute_stable_hash(
+    state: dict,
+    unstable_fields: list[str] | None = None,
+    *,
+    canonicalize_numbers: bool = True,          # fold numeric TYPES (72 == 72.0)
+    numeric_string_fields: list[str] | None = None,  # per-field: fold numeric STRINGS
+) -> str:
     # 1. Filter out unstable fields (timestamps, auto-generated IDs)
     if unstable_fields:
         state = filter_unstable_fields(state, unstable_fields)
-    
+
     # 2. Convert datetime objects to ISO format strings
     serializable_state = _convert_datetime_to_str(state)
-    
-    # 3. Serialize to JSON with canonical format
+
+    # 3. Canonicalize numbers (types always; strings only under listed fields)
+    if canonicalize_numbers:
+        serializable_state = _canonicalize_numbers(serializable_state, ...)
+
+    # 4. Serialize to JSON with canonical format, then SHA-256 hexdigest
     json_str = json.dumps(serializable_state, sort_keys=True, separators=(",", ":"), default=str)
-    
-    # 4. Compute SHA-256 hexdigest
     return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
 ```
 
 **Tau-bench compatible algorithm** (used by StateChecker):
 ```python
 # From tolokaforge/core/grading/state_checks.py
-def to_hashable(item):
-    """Convert to hashable representation (tau-bench compatible)"""
+def to_hashable(item, string_fields=None, *, _normalize_strings=False):
+    """Convert to hashable representation (tau-bench compatible).
+
+    Scalars pass through canonical_number(); numeric-looking strings fold only
+    under a record key in string_fields (key-aware, like _canonicalize_numbers).
+    """
     if isinstance(item, dict):
-        return tuple((key, to_hashable(value)) for key, value in sorted(item.items()))
+        return tuple(
+            (k, to_hashable(v, string_fields,
+                            _normalize_strings=(string_fields is not None and k in string_fields)))
+            for k, v in sorted(item.items())
+        )
     elif isinstance(item, list):
-        return tuple(to_hashable(element) for element in item)
+        return tuple(to_hashable(e, string_fields, _normalize_strings=_normalize_strings) for e in item)
     elif isinstance(item, set):
-        return tuple(sorted(to_hashable(element) for element in item))
+        return tuple(sorted(
+            (to_hashable(e, string_fields, _normalize_strings=_normalize_strings) for e in item),
+            key=lambda x: (type(x).__name__, str(x)),   # type-stable: mixed canonical scalars
+        ))
     else:
-        return item
+        return canonical_number(item, normalize_strings=_normalize_strings)
 
 def consistent_hash(value) -> str:
     """Compute SHA256 hash"""
     return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
 ```
+
+> Both hashers canonicalize numbers so a pure representation difference
+> (`"130.00"` vs `"130.0"`, `72` vs `72.0`) is not graded as a state change. The
+> string tier is opt-in per field via `state_checks.numeric_string_fields` — see
+> [GRADING.md](GRADING.md#hash-based-grading-tau-bench-compatible). Any hash
+> literal precomputed before this change must be recomputed.
 
 ### 2. Golden Set Comparison
 

--- a/tests/canonical/snapshots/native_browser_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/grading_config.json
@@ -14,7 +14,8 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
-    "jsonpaths": []
+    "jsonpaths": [],
+    "numeric_string_fields": []
   },
   "transcript_rules": {
     "communicate_info": [],

--- a/tests/canonical/snapshots/native_calc_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/grading_config.json
@@ -14,7 +14,8 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
-    "jsonpaths": []
+    "jsonpaths": [],
+    "numeric_string_fields": []
   },
   "transcript_rules": {
     "communicate_info": [],

--- a/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
@@ -19,7 +19,8 @@
         "equals": [],
         "path": "$.db.items"
       }
-    ]
+    ],
+    "numeric_string_fields": []
   },
   "transcript_rules": null
 }

--- a/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
@@ -79,7 +79,8 @@
         "equals": 13,
         "path": "$.db.products[1].stock"
       }
-    ]
+    ],
+    "numeric_string_fields": []
   },
   "transcript_rules": {
     "communicate_info": [

--- a/tests/data/projects/tau_retail_mini/output/trials/0f3b1ff7/0/task.yaml
+++ b/tests/data/projects/tau_retail_mini/output/trials/0f3b1ff7/0/task.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c396f2b706158fc1686dbd00c16147b6395f62228d95c4a50e1a2249e7a8995c
+oid sha256:9b5ff5e8f1fb625d59556a3d405b3eded9e5e20c5d5c91c8bb4e49f34fe08b4e
 size 744

--- a/tests/data/projects/tau_retail_mini/output/trials/test_001/0/task.yaml
+++ b/tests/data/projects/tau_retail_mini/output/trials/test_001/0/task.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa26cab9e8b14d6951ea4a812ed26e82330aeb4b6d0e0a1ad15bd77a2be5bf3b
+oid sha256:472f1a4c856758070d1929fd6a4a7ce8564350f3bb607328cc52885eac50a966
 size 703

--- a/tests/data/projects/tau_retail_mini/output/trials/test_002/0/task.yaml
+++ b/tests/data/projects/tau_retail_mini/output/trials/test_002/0/task.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d59849feb5dceb9d9a0fdb92220a5184a31d5b274b2b0c0f0aceaeb26a565c8
+oid sha256:7cb0d873cc0af6e48309095c860c9ad0cc024ae4dfc1460ec3a34b749524b9c8
 size 739

--- a/tests/unit/grading/test_grading_correctness.py
+++ b/tests/unit/grading/test_grading_correctness.py
@@ -914,6 +914,32 @@ class TestNumericCanonicalization:
             "123", normalize_strings=True
         )
 
+    def test_to_hashable_folds_strings_only_for_listed_field(self):
+        """The core path (to_hashable) honors numeric_string_fields with the same
+        per-field selectivity as the runner path (compute_stable_hash): a listed
+        money field folds while an unlisted sibling version string is preserved.
+        """
+        a = {"cases": [{"refund": "130.00", "version": "1.10"}]}
+        b = {"cases": [{"refund": "130.0", "version": "1.1"}]}
+
+        # No field set: numeric-looking strings never fold.
+        assert consistent_hash(to_hashable(a)) != consistent_hash(to_hashable(b))
+        # Only "refund" listed: the "version" 1.10 vs 1.1 difference is preserved,
+        # so the two states stay distinct.
+        assert consistent_hash(to_hashable(a, frozenset(["refund"]))) != consistent_hash(
+            to_hashable(b, frozenset(["refund"]))
+        )
+        # Both listed: everything numeric folds and the states match.
+        assert consistent_hash(to_hashable(a, frozenset(["refund", "version"]))) == consistent_hash(
+            to_hashable(b, frozenset(["refund", "version"]))
+        )
+        # Money-only formatting difference under the listed field folds.
+        c = {"cases": [{"refund": "130.00", "version": "1.1"}]}
+        d = {"cases": [{"refund": "130.0", "version": "1.1"}]}
+        assert consistent_hash(to_hashable(c, frozenset(["refund"]))) == consistent_hash(
+            to_hashable(d, frozenset(["refund"]))
+        )
+
     def test_bool_not_collapsed_to_int(self):
         """bool stays distinct from its int twin (True == 1 in Python)."""
         assert consistent_hash(to_hashable(True)) != consistent_hash(to_hashable(1))

--- a/tests/unit/grading/test_grading_correctness.py
+++ b/tests/unit/grading/test_grading_correctness.py
@@ -871,3 +871,53 @@ class TestStableHashComputation:
 
         assert hash1 == hash2
         assert len(hash1) == 64
+
+
+class TestNumericCanonicalization:
+    """Numerically-equal state values must not be graded as a state change.
+
+    Regression: the DB round-trips ``Decimal`` columns through strings, so the
+    same amount surfaces as ``"130.00"`` on one side and ``"130.0"`` (or an
+    ``int``) on the other. The naive hash / diff treated that pure formatting
+    difference as a mismatch and false-failed correct trials (observed on the
+    OTS ``custom_refund_amount`` / payroll ``amount`` fields).
+    """
+
+    def test_decimal_format_hashes_equal(self):
+        """to_hashable/consistent_hash collapse trailing-zero decimal formats."""
+        assert consistent_hash(to_hashable("130.00")) == consistent_hash(to_hashable("130.0"))
+        assert consistent_hash(to_hashable("72.00")) == consistent_hash(to_hashable(72))
+        assert consistent_hash(to_hashable("0.0")) == consistent_hash(to_hashable("0.00"))
+        assert consistent_hash(to_hashable("-5.50")) == consistent_hash(to_hashable("-5.5"))
+
+    def test_state_hash_matches_across_decimal_format(self):
+        """A whole state differing only by decimal format hashes identically."""
+        golden = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.00"}]}
+        trial = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.0"}]}
+        assert consistent_hash(to_hashable(trial)) == consistent_hash(to_hashable(golden))
+
+    def test_genuine_numeric_difference_still_differs(self):
+        """A real value difference (790.00 vs 0.0) must remain a mismatch."""
+        assert consistent_hash(to_hashable("790.00")) != consistent_hash(to_hashable("0.0"))
+
+    def test_leading_zero_identifier_not_collapsed(self):
+        """Leading-zero id-like strings must not be numerically equated."""
+        assert consistent_hash(to_hashable("00123")) != consistent_hash(to_hashable("123"))
+
+    def test_bool_not_collapsed_to_int(self):
+        """bool stays distinct from its int twin (True == 1 in Python)."""
+        assert consistent_hash(to_hashable(True)) != consistent_hash(to_hashable(1))
+
+    def test_compute_state_diff_ignores_decimal_format(self):
+        """compute_state_diff reports no change when only decimal format differs."""
+        golden = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.00"}]}
+        trial = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.0"}]}
+        diff = compute_state_diff(trial, golden)
+        assert diff.summary == "States match", f"expected match, got: {diff.summary}"
+
+    def test_compute_state_diff_flags_genuine_amount_difference(self):
+        """A real refund difference is still reported as a mismatch."""
+        golden = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "790.00"}]}
+        trial = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "0.0"}]}
+        diff = compute_state_diff(trial, golden)
+        assert diff.summary != "States match"

--- a/tests/unit/grading/test_grading_correctness.py
+++ b/tests/unit/grading/test_grading_correctness.py
@@ -883,35 +883,49 @@ class TestNumericCanonicalization:
     OTS ``custom_refund_amount`` / payroll ``amount`` fields).
     """
 
-    def test_decimal_format_hashes_equal(self):
-        """to_hashable/consistent_hash collapse trailing-zero decimal formats."""
-        assert consistent_hash(to_hashable("130.00")) == consistent_hash(to_hashable("130.0"))
-        assert consistent_hash(to_hashable("72.00")) == consistent_hash(to_hashable(72))
-        assert consistent_hash(to_hashable("0.0")) == consistent_hash(to_hashable("0.00"))
-        assert consistent_hash(to_hashable("-5.50")) == consistent_hash(to_hashable("-5.5"))
+    def test_numeric_types_hash_equal_by_default(self):
+        """to_hashable/consistent_hash collapse numeric TYPES (int/float/Decimal)."""
+        from decimal import Decimal
 
-    def test_state_hash_matches_across_decimal_format(self):
-        """A whole state differing only by decimal format hashes identically."""
-        golden = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.00"}]}
-        trial = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.0"}]}
-        assert consistent_hash(to_hashable(trial)) == consistent_hash(to_hashable(golden))
+        assert consistent_hash(to_hashable(72)) == consistent_hash(to_hashable(72.0))
+        assert consistent_hash(to_hashable(72)) == consistent_hash(to_hashable(Decimal("72.00")))
 
-    def test_genuine_numeric_difference_still_differs(self):
-        """A real value difference (790.00 vs 0.0) must remain a mismatch."""
-        assert consistent_hash(to_hashable("790.00")) != consistent_hash(to_hashable("0.0"))
+    def test_numeric_strings_do_not_fold_by_default(self):
+        """Numeric-looking STRINGS stay distinct without the per-task flag."""
+        assert consistent_hash(to_hashable("130.00")) != consistent_hash(to_hashable("130.0"))
+        assert consistent_hash(to_hashable("72.00")) != consistent_hash(to_hashable(72))
 
-    def test_leading_zero_identifier_not_collapsed(self):
-        """Leading-zero id-like strings must not be numerically equated."""
-        assert consistent_hash(to_hashable("00123")) != consistent_hash(to_hashable("123"))
+    def test_numeric_strings_fold_with_flag(self):
+        """canonical_number(normalize_strings=True) folds decimal string formats."""
+        from tolokaforge.core.hash import canonical_number
+
+        assert canonical_number("130.00", normalize_strings=True) == canonical_number(
+            "130.0", normalize_strings=True
+        )
+        assert canonical_number("72.00", normalize_strings=True) == canonical_number(72)
+        assert canonical_number("790.00", normalize_strings=True) != canonical_number(
+            "0.0", normalize_strings=True
+        )
+        assert canonical_number("00123", normalize_strings=True) != canonical_number(
+            "123", normalize_strings=True
+        )
 
     def test_bool_not_collapsed_to_int(self):
         """bool stays distinct from its int twin (True == 1 in Python)."""
         assert consistent_hash(to_hashable(True)) != consistent_hash(to_hashable(1))
 
-    def test_compute_state_diff_ignores_decimal_format(self):
-        """compute_state_diff reports no change when only decimal format differs."""
+    def test_compute_state_diff_reports_string_format_difference_by_default(self):
+        """Without the flag, a string-format-only diff is still reported (and the
+        per-task hash flag, not this report, decides the verdict)."""
         golden = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.00"}]}
         trial = {"d365_api_cases": [{"case_id": "CAS-1", "custom_refund_amount": "130.0"}]}
+        diff = compute_state_diff(trial, golden)
+        assert diff.summary != "States match"
+
+    def test_compute_state_diff_ignores_numeric_type_format(self):
+        """Numeric-TYPE representation (72 vs 72.0) is not reported as a diff."""
+        golden = {"t": [{"id": "R1", "qty": 72}]}
+        trial = {"t": [{"id": "R1", "qty": 72.0}]}
         diff = compute_state_diff(trial, golden)
         assert diff.summary == "States match", f"expected match, got: {diff.summary}"
 

--- a/tests/unit/grading/test_grading_correctness.py
+++ b/tests/unit/grading/test_grading_correctness.py
@@ -891,12 +891,16 @@ class TestNumericCanonicalization:
         assert consistent_hash(to_hashable(72)) == consistent_hash(to_hashable(Decimal("72.00")))
 
     def test_numeric_strings_do_not_fold_by_default(self):
-        """Numeric-looking STRINGS stay distinct without the per-task flag."""
+        """Numeric-looking STRINGS stay distinct unless a field opts them in."""
         assert consistent_hash(to_hashable("130.00")) != consistent_hash(to_hashable("130.0"))
         assert consistent_hash(to_hashable("72.00")) != consistent_hash(to_hashable(72))
 
-    def test_numeric_strings_fold_with_flag(self):
-        """canonical_number(normalize_strings=True) folds decimal string formats."""
+    def test_numeric_strings_fold_when_normalized(self):
+        """canonical_number(normalize_strings=True) folds decimal string formats.
+
+        This value-level flag is what the per-field ``numeric_string_fields``
+        set turns on for a listed field's values.
+        """
         from tolokaforge.core.hash import canonical_number
 
         assert canonical_number("130.00", normalize_strings=True) == canonical_number(

--- a/tests/unit/grading/test_hash.py
+++ b/tests/unit/grading/test_hash.py
@@ -142,3 +142,46 @@ class TestComputeStableHash:
         filter_unstable_fields(state, ["tickets.subject"])
 
         assert state == original, "filter_unstable_fields must not mutate the original dict"
+
+
+class TestComputeStableHashNumericCanonicalization:
+    """Numerically-equal state values must hash identically (grading false-fail fix).
+
+    Regression: the DB round-trips ``Decimal`` columns through strings, so the
+    same amount surfaces as ``"130.00"`` on one side and ``"130.0"`` on the
+    other; the old JSON hash treated that pure formatting difference as a state
+    change and false-failed correct trials (OTS ``custom_refund_amount`` etc.).
+    """
+
+    def test_decimal_trailing_zeros_hash_equal(self):
+        a = {"cases": [{"id": "C1", "refund": "130.00"}]}
+        b = {"cases": [{"id": "C1", "refund": "130.0"}]}
+        assert compute_stable_hash(a) == compute_stable_hash(b)
+
+    def test_int_vs_decimal_string_hash_equal(self):
+        a = {"cases": [{"id": "C1", "qty": 72}]}
+        b = {"cases": [{"id": "C1", "qty": "72.00"}]}
+        assert compute_stable_hash(a) == compute_stable_hash(b)
+
+    def test_genuine_numeric_difference_hashes_differently(self):
+        a = {"cases": [{"id": "C1", "refund": "790.00"}]}
+        b = {"cases": [{"id": "C1", "refund": "0.0"}]}
+        assert compute_stable_hash(a) != compute_stable_hash(b)
+
+    def test_leading_zero_identifier_not_collapsed(self):
+        a = {"cases": [{"code": "00123"}]}
+        b = {"cases": [{"code": "123"}]}
+        assert compute_stable_hash(a) != compute_stable_hash(b)
+
+    def test_bool_not_collapsed_to_int(self):
+        a = {"flags": [{"active": True}]}
+        b = {"flags": [{"active": 1}]}
+        assert compute_stable_hash(a) != compute_stable_hash(b)
+
+    def test_opt_out_preserves_legacy_byte_exact_behavior(self):
+        a = {"cases": [{"id": "C1", "refund": "130.00"}]}
+        b = {"cases": [{"id": "C1", "refund": "130.0"}]}
+        # Legacy mcp_core-exact behavior: without canonicalization the strings differ.
+        assert compute_stable_hash(a, canonicalize_numbers=False) != compute_stable_hash(
+            b, canonicalize_numbers=False
+        )

--- a/tests/unit/grading/test_hash.py
+++ b/tests/unit/grading/test_hash.py
@@ -246,3 +246,75 @@ class TestComputeStableHashNumericCanonicalization:
         assert compute_stable_hash(
             {"t": [{"amt": 130}]}, numeric_string_fields=["amt"]
         ) != compute_stable_hash({"t": [{"amt": crafted}]}, numeric_string_fields=["amt"])
+
+
+def _load_standalone_fallback_hash():
+    """Import the json_db_service standalone ``compute_stable_hash`` fallback.
+
+    The service prefers ``tolokaforge.core.hash`` and only defines the local
+    fallback when that import fails (standalone/testing). Force the ImportError
+    branch by poisoning ``sys.modules`` so we exercise the vendored copy, then
+    restore the real module so no other test is affected.
+    """
+    import builtins
+    import importlib
+    import sys
+
+    real_import = builtins.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "tolokaforge.core.hash":
+            raise ImportError("forced for parity test")
+        return real_import(name, *args, **kwargs)
+
+    saved = {m: sys.modules[m] for m in list(sys.modules) if "json_db_service" in m}
+    for m in saved:
+        del sys.modules[m]
+    builtins.__import__ = blocking_import
+    try:
+        app = importlib.import_module("tolokaforge.env.json_db_service.app")
+        fn = app.compute_stable_hash
+        # Guard: make sure we actually got the vendored fallback (defined in
+        # app.py), not the real core function — otherwise this parity test would
+        # silently compare the real implementation against itself.
+        assert (
+            fn.__module__ == "tolokaforge.env.json_db_service.app"
+        ), "fallback poisoning failed; got the real core.hash function"
+        return fn
+    finally:
+        builtins.__import__ = real_import
+        for m in list(sys.modules):
+            if "json_db_service" in m:
+                del sys.modules[m]
+        sys.modules.update(saved)
+
+
+class TestStandaloneFallbackParity:
+    """The json_db_service standalone fallback must stay byte-identical to the
+    real core ``compute_stable_hash`` (the only current sync guard is a comment).
+    """
+
+    def test_fallback_matches_core_across_cases(self):
+        fallback = _load_standalone_fallback_hash()
+
+        cases = [
+            # (state, kwargs)
+            ({"cases": [{"id": "C1", "qty": 72}]}, {}),
+            ({"cases": [{"id": "C1", "qty": 72.0}]}, {}),
+            ({"t": [{"amt": "130.00", "ver": "1.10"}]}, {"numeric_string_fields": ["amt"]}),
+            ({"t": [{"amt": "130.0", "ver": "1.1"}]}, {"numeric_string_fields": ["amt"]}),
+            (
+                {"t": [{"amt": "130.00", "ver": "1.10"}]},
+                {"numeric_string_fields": ["amt", "ver"]},
+            ),
+            ({"cases": [{"code": "00123"}]}, {"numeric_string_fields": ["code"]}),
+            ({"flags": [{"active": True}]}, {"numeric_string_fields": ["active"]}),
+            ({"t": [{"amt": "-0.00"}]}, {"numeric_string_fields": ["amt"]}),
+            ({"t": [{"amt": "\x00tf-num:130"}]}, {"numeric_string_fields": ["amt"]}),
+            ({"cases": [{"id": "C1", "qty": 72}]}, {"canonicalize_numbers": False}),
+        ]
+        for state, kwargs in cases:
+            assert fallback(state, **kwargs) == compute_stable_hash(state, **kwargs), (
+                state,
+                kwargs,
+            )

--- a/tests/unit/grading/test_hash.py
+++ b/tests/unit/grading/test_hash.py
@@ -9,7 +9,7 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from tolokaforge.core.hash import compute_stable_hash, filter_unstable_fields
+from tolokaforge.core.hash import canonical_number, compute_stable_hash, filter_unstable_fields
 
 # ---------------------------------------------------------------------------
 # Test 7: filter_unstable_fields handles nested table.field patterns
@@ -184,4 +184,18 @@ class TestComputeStableHashNumericCanonicalization:
         # Legacy mcp_core-exact behavior: without canonicalization the strings differ.
         assert compute_stable_hash(a, canonicalize_numbers=False) != compute_stable_hash(
             b, canonicalize_numbers=False
+        )
+
+    def test_tagged_string_does_not_collide_with_number(self):
+        # A crafted string byte-equal to a numeric token must not equal the number.
+        crafted = "\x00tf-num:130"
+        assert canonical_number(crafted) != canonical_number(130)
+        assert compute_stable_hash({"t": [{"amt": 130}]}) != compute_stable_hash(
+            {"t": [{"amt": crafted}]}
+        )
+
+    def test_negative_zero_collapses_to_zero(self):
+        assert canonical_number("-0.00") == canonical_number(0)
+        assert compute_stable_hash({"t": [{"amt": "-0.00"}]}) == compute_stable_hash(
+            {"t": [{"amt": "0.0"}]}
         )

--- a/tests/unit/grading/test_hash.py
+++ b/tests/unit/grading/test_hash.py
@@ -145,32 +145,28 @@ class TestComputeStableHash:
 
 
 class TestComputeStableHashNumericCanonicalization:
-    """Numerically-equal state values must hash identically (grading false-fail fix).
+    """Two-tier numeric canonicalization in state hashing.
 
-    Regression: the DB round-trips ``Decimal`` columns through strings, so the
-    same amount surfaces as ``"130.00"`` on one side and ``"130.0"`` on the
-    other; the old JSON hash treated that pure formatting difference as a state
-    change and false-failed correct trials (OTS ``custom_refund_amount`` etc.).
+    Tier 1 (default): numerically-equal NUMERIC-TYPE values hash identically
+    (72 == 72.0 == Decimal("72.00")) — the type declares number-ness, generic
+    and safe. Tier 2 (opt-in ``normalize_numeric_strings``): numeric-looking
+    STRINGS also fold ("130.00" == "130.0") — per-task flag because exact
+    string representation can carry meaning (versions, codes).
     """
 
-    def test_decimal_trailing_zeros_hash_equal(self):
+    # ---- tier 1: numeric types, default behavior ----
+
+    def test_numeric_types_fold_by_default(self):
+        from decimal import Decimal
+
+        a = {"cases": [{"id": "C1", "qty": 72}]}
+        b = {"cases": [{"id": "C1", "qty": 72.0}]}
+        c = {"cases": [{"id": "C1", "qty": Decimal("72.00")}]}
+        assert compute_stable_hash(a) == compute_stable_hash(b) == compute_stable_hash(c)
+
+    def test_numeric_strings_do_NOT_fold_by_default(self):
         a = {"cases": [{"id": "C1", "refund": "130.00"}]}
         b = {"cases": [{"id": "C1", "refund": "130.0"}]}
-        assert compute_stable_hash(a) == compute_stable_hash(b)
-
-    def test_int_vs_decimal_string_hash_equal(self):
-        a = {"cases": [{"id": "C1", "qty": 72}]}
-        b = {"cases": [{"id": "C1", "qty": "72.00"}]}
-        assert compute_stable_hash(a) == compute_stable_hash(b)
-
-    def test_genuine_numeric_difference_hashes_differently(self):
-        a = {"cases": [{"id": "C1", "refund": "790.00"}]}
-        b = {"cases": [{"id": "C1", "refund": "0.0"}]}
-        assert compute_stable_hash(a) != compute_stable_hash(b)
-
-    def test_leading_zero_identifier_not_collapsed(self):
-        a = {"cases": [{"code": "00123"}]}
-        b = {"cases": [{"code": "123"}]}
         assert compute_stable_hash(a) != compute_stable_hash(b)
 
     def test_bool_not_collapsed_to_int(self):
@@ -179,23 +175,57 @@ class TestComputeStableHashNumericCanonicalization:
         assert compute_stable_hash(a) != compute_stable_hash(b)
 
     def test_opt_out_preserves_legacy_byte_exact_behavior(self):
-        a = {"cases": [{"id": "C1", "refund": "130.00"}]}
-        b = {"cases": [{"id": "C1", "refund": "130.0"}]}
-        # Legacy mcp_core-exact behavior: without canonicalization the strings differ.
+        from decimal import Decimal
+
+        a = {"cases": [{"id": "C1", "qty": 72}]}
+        b = {"cases": [{"id": "C1", "qty": Decimal("72.00")}]}
+        # Legacy mcp_core-exact behavior: str(72) != str(Decimal("72.00")).
         assert compute_stable_hash(a, canonicalize_numbers=False) != compute_stable_hash(
             b, canonicalize_numbers=False
         )
 
+    # ---- tier 2: numeric strings, behind the per-task flag ----
+
+    def test_decimal_string_formats_fold_with_flag(self):
+        a = {"cases": [{"id": "C1", "refund": "130.00"}]}
+        b = {"cases": [{"id": "C1", "refund": "130.0"}]}
+        assert compute_stable_hash(a, normalize_numeric_strings=True) == compute_stable_hash(
+            b, normalize_numeric_strings=True
+        )
+
+    def test_int_vs_decimal_string_folds_with_flag(self):
+        a = {"cases": [{"id": "C1", "qty": 72}]}
+        b = {"cases": [{"id": "C1", "qty": "72.00"}]}
+        assert compute_stable_hash(a, normalize_numeric_strings=True) == compute_stable_hash(
+            b, normalize_numeric_strings=True
+        )
+
+    def test_genuine_numeric_difference_differs_even_with_flag(self):
+        a = {"cases": [{"id": "C1", "refund": "790.00"}]}
+        b = {"cases": [{"id": "C1", "refund": "0.0"}]}
+        assert compute_stable_hash(a, normalize_numeric_strings=True) != compute_stable_hash(
+            b, normalize_numeric_strings=True
+        )
+
+    def test_leading_zero_identifier_not_collapsed_even_with_flag(self):
+        a = {"cases": [{"code": "00123"}]}
+        b = {"cases": [{"code": "123"}]}
+        assert compute_stable_hash(a, normalize_numeric_strings=True) != compute_stable_hash(
+            b, normalize_numeric_strings=True
+        )
+
+    def test_negative_zero_collapses_to_zero_with_flag(self):
+        assert canonical_number("-0.00", normalize_strings=True) == canonical_number(0)
+        assert compute_stable_hash(
+            {"t": [{"amt": "-0.00"}]}, normalize_numeric_strings=True
+        ) == compute_stable_hash({"t": [{"amt": "0.0"}]}, normalize_numeric_strings=True)
+
+    # ---- guards independent of the flag ----
+
     def test_tagged_string_does_not_collide_with_number(self):
         # A crafted string byte-equal to a numeric token must not equal the number.
         crafted = "\x00tf-num:130"
-        assert canonical_number(crafted) != canonical_number(130)
-        assert compute_stable_hash({"t": [{"amt": 130}]}) != compute_stable_hash(
-            {"t": [{"amt": crafted}]}
-        )
-
-    def test_negative_zero_collapses_to_zero(self):
-        assert canonical_number("-0.00") == canonical_number(0)
-        assert compute_stable_hash({"t": [{"amt": "-0.00"}]}) == compute_stable_hash(
-            {"t": [{"amt": "0.0"}]}
-        )
+        assert canonical_number(crafted, normalize_strings=True) != canonical_number(130)
+        assert compute_stable_hash(
+            {"t": [{"amt": 130}]}, normalize_numeric_strings=True
+        ) != compute_stable_hash({"t": [{"amt": crafted}]}, normalize_numeric_strings=True)

--- a/tests/unit/grading/test_hash.py
+++ b/tests/unit/grading/test_hash.py
@@ -149,9 +149,10 @@ class TestComputeStableHashNumericCanonicalization:
 
     Tier 1 (default): numerically-equal NUMERIC-TYPE values hash identically
     (72 == 72.0 == Decimal("72.00")) — the type declares number-ness, generic
-    and safe. Tier 2 (opt-in ``normalize_numeric_strings``): numeric-looking
-    STRINGS also fold ("130.00" == "130.0") — per-task flag because exact
-    string representation can carry meaning (versions, codes).
+    and safe. Tier 2 (opt-in ``numeric_string_fields``): numeric-looking
+    STRINGS also fold ("130.00" == "130.0") but ONLY under a record key listed
+    in that per-field set, because exact string representation can carry meaning
+    (versions, codes).
     """
 
     # ---- tier 1: numeric types, default behavior ----
@@ -184,48 +185,64 @@ class TestComputeStableHashNumericCanonicalization:
             b, canonicalize_numbers=False
         )
 
-    # ---- tier 2: numeric strings, behind the per-task flag ----
+    # ---- tier 2: numeric strings, only under a listed field ----
 
-    def test_decimal_string_formats_fold_with_flag(self):
+    def test_decimal_string_formats_fold_for_listed_field(self):
         a = {"cases": [{"id": "C1", "refund": "130.00"}]}
         b = {"cases": [{"id": "C1", "refund": "130.0"}]}
-        assert compute_stable_hash(a, normalize_numeric_strings=True) == compute_stable_hash(
-            b, normalize_numeric_strings=True
+        assert compute_stable_hash(a, numeric_string_fields=["refund"]) == compute_stable_hash(
+            b, numeric_string_fields=["refund"]
         )
 
-    def test_int_vs_decimal_string_folds_with_flag(self):
+    def test_int_vs_decimal_string_folds_for_listed_field(self):
         a = {"cases": [{"id": "C1", "qty": 72}]}
         b = {"cases": [{"id": "C1", "qty": "72.00"}]}
-        assert compute_stable_hash(a, normalize_numeric_strings=True) == compute_stable_hash(
-            b, normalize_numeric_strings=True
+        assert compute_stable_hash(a, numeric_string_fields=["qty"]) == compute_stable_hash(
+            b, numeric_string_fields=["qty"]
         )
 
-    def test_genuine_numeric_difference_differs_even_with_flag(self):
+    def test_unlisted_field_does_NOT_fold_even_with_a_sibling_listed(self):
+        # The whole point of per-field: a version string in the same record as a
+        # listed money field must NOT fold just because the money field is listed.
+        a = {"cases": [{"refund": "130.00", "version": "1.10"}]}
+        b = {"cases": [{"refund": "130.0", "version": "1.1"}]}
+        # "version" is not listed → its "1.10" vs "1.1" difference is preserved,
+        # so the two states stay distinct even though "refund" folds.
+        assert compute_stable_hash(a, numeric_string_fields=["refund"]) != compute_stable_hash(
+            b, numeric_string_fields=["refund"]
+        )
+        # Listing "version" too collapses both, confirming the difference was the
+        # version field alone.
+        assert compute_stable_hash(
+            a, numeric_string_fields=["refund", "version"]
+        ) == compute_stable_hash(b, numeric_string_fields=["refund", "version"])
+
+    def test_genuine_numeric_difference_differs_even_when_listed(self):
         a = {"cases": [{"id": "C1", "refund": "790.00"}]}
         b = {"cases": [{"id": "C1", "refund": "0.0"}]}
-        assert compute_stable_hash(a, normalize_numeric_strings=True) != compute_stable_hash(
-            b, normalize_numeric_strings=True
+        assert compute_stable_hash(a, numeric_string_fields=["refund"]) != compute_stable_hash(
+            b, numeric_string_fields=["refund"]
         )
 
-    def test_leading_zero_identifier_not_collapsed_even_with_flag(self):
+    def test_leading_zero_identifier_not_collapsed_even_when_listed(self):
         a = {"cases": [{"code": "00123"}]}
         b = {"cases": [{"code": "123"}]}
-        assert compute_stable_hash(a, normalize_numeric_strings=True) != compute_stable_hash(
-            b, normalize_numeric_strings=True
+        assert compute_stable_hash(a, numeric_string_fields=["code"]) != compute_stable_hash(
+            b, numeric_string_fields=["code"]
         )
 
-    def test_negative_zero_collapses_to_zero_with_flag(self):
+    def test_negative_zero_collapses_to_zero_when_listed(self):
         assert canonical_number("-0.00", normalize_strings=True) == canonical_number(0)
         assert compute_stable_hash(
-            {"t": [{"amt": "-0.00"}]}, normalize_numeric_strings=True
-        ) == compute_stable_hash({"t": [{"amt": "0.0"}]}, normalize_numeric_strings=True)
+            {"t": [{"amt": "-0.00"}]}, numeric_string_fields=["amt"]
+        ) == compute_stable_hash({"t": [{"amt": "0.0"}]}, numeric_string_fields=["amt"])
 
-    # ---- guards independent of the flag ----
+    # ---- guards independent of the field set ----
 
     def test_tagged_string_does_not_collide_with_number(self):
         # A crafted string byte-equal to a numeric token must not equal the number.
         crafted = "\x00tf-num:130"
         assert canonical_number(crafted, normalize_strings=True) != canonical_number(130)
         assert compute_stable_hash(
-            {"t": [{"amt": 130}]}, normalize_numeric_strings=True
-        ) != compute_stable_hash({"t": [{"amt": crafted}]}, normalize_numeric_strings=True)
+            {"t": [{"amt": 130}]}, numeric_string_fields=["amt"]
+        ) != compute_stable_hash({"t": [{"amt": crafted}]}, numeric_string_fields=["amt"])

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -4,6 +4,7 @@ import pytest
 
 from tolokaforge.core.grading.state_checks import (
     StateChecker,
+    canonical_number,
     consistent_hash,
     to_hashable,
 )
@@ -16,30 +17,40 @@ class TestHashFunctions:
     """Test hash normalization and computation"""
 
     def test_to_hashable_dict(self):
-        """Test dict normalization"""
+        """Test dict normalization (scalars pass through canonical_number)."""
         data = {"b": 2, "a": 1, "c": 3}
         result = to_hashable(data)
-        assert result == (("a", 1), ("b", 2), ("c", 3))
+        assert result == (
+            ("a", canonical_number(1)),
+            ("b", canonical_number(2)),
+            ("c", canonical_number(3)),
+        )
 
     def test_to_hashable_list(self):
         """Test list normalization"""
         data = [3, 1, 2]
         result = to_hashable(data)
-        assert result == (3, 1, 2)
+        assert result == (canonical_number(3), canonical_number(1), canonical_number(2))
 
     def test_to_hashable_set(self):
         """Test set normalization"""
         data = {3, 1, 2}
         result = to_hashable(data)
-        assert result == (1, 2, 3)
+        assert result == (canonical_number(1), canonical_number(2), canonical_number(3))
 
     def test_to_hashable_nested(self):
         """Test nested structure normalization"""
         data = {"users": [{"id": 2, "name": "bob"}, {"id": 1, "name": "alice"}], "count": 2}
         result = to_hashable(data)
         expected = (
-            ("count", 2),
-            ("users", ((("id", 2), ("name", "bob")), (("id", 1), ("name", "alice")))),
+            ("count", canonical_number(2)),
+            (
+                "users",
+                (
+                    (("id", canonical_number(2)), ("name", "bob")),
+                    (("id", canonical_number(1)), ("name", "alice")),
+                ),
+            ),
         )
         assert result == expected
 

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -38,6 +38,17 @@ class TestHashFunctions:
         result = to_hashable(data)
         assert result == (canonical_number(1), canonical_number(2), canonical_number(3))
 
+    def test_to_hashable_set_mixed_bool_and_number(self):
+        """Type-stable set sort must not raise when a bool and a number coexist.
+
+        Canonicalized numbers become tagged strings while bool stays bool; a bare
+        sort over that mix is a TypeError, so the sort uses a type-stable key.
+        """
+        result = to_hashable({True, 2})
+        assert len(result) == 2
+        assert True in result
+        assert canonical_number(2) in result
+
     def test_to_hashable_nested(self):
         """Test nested structure normalization"""
         data = {"users": [{"id": 2, "name": "bob"}, {"id": 1, "name": "alice"}], "count": 2}

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -626,6 +626,9 @@ class NativeAdapter(BaseAdapter):
                     jsonpath_checks=state_checks_data.get("jsonpaths", []),
                     env_assertions=env_assertions,
                     db_probes=db_probes,
+                    numeric_string_normalization=bool(
+                        state_checks_data.get("numeric_string_normalization", False)
+                    ),
                 )
 
             # Build transcript rules

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -626,9 +626,7 @@ class NativeAdapter(BaseAdapter):
                     jsonpath_checks=state_checks_data.get("jsonpaths", []),
                     env_assertions=env_assertions,
                     db_probes=db_probes,
-                    numeric_string_normalization=bool(
-                        state_checks_data.get("numeric_string_normalization", False)
-                    ),
+                    numeric_string_fields=list(state_checks_data.get("numeric_string_fields", [])),
                 )
 
             # Build transcript rules

--- a/tolokaforge/core/evaluators/environment_evaluator.py
+++ b/tolokaforge/core/evaluators/environment_evaluator.py
@@ -199,7 +199,12 @@ class EnvironmentEvaluator:
                 try:
                     # Compute hash of agent DB state
                     agent_db = agent_env_state.get("db", agent_env_state)
-                    actual_hash = consistent_hash(to_hashable(agent_db))
+                    string_fields = (
+                        frozenset(state_checks_config.numeric_string_fields)
+                        if state_checks_config.numeric_string_fields
+                        else None
+                    )
+                    actual_hash = consistent_hash(to_hashable(agent_db, string_fields))
                     db_hash_match = actual_hash == hash_to_check
 
                     if db_hash_match:

--- a/tolokaforge/core/grading/combine.py
+++ b/tolokaforge/core/grading/combine.py
@@ -136,6 +136,7 @@ class GradingEngine:
                         jsonpath_assertions=self.config.state_checks.jsonpaths,
                         expected_hash=expected_hash,
                         hash_weight=hash_weight,
+                        numeric_string_fields=self.config.state_checks.numeric_string_fields,
                     )
                 # Use tau-style grading if golden_actions are present and MCP context available
                 elif (
@@ -160,6 +161,7 @@ class GradingEngine:
                                 mcp_server_path=self.task_mcp_server,
                                 task_domain=self.task_domain,
                                 hash_weight=hash_weight,
+                                numeric_string_fields=self.config.state_checks.numeric_string_fields,
                             )
                         )
                 else:
@@ -169,6 +171,7 @@ class GradingEngine:
                         jsonpath_assertions=self.config.state_checks.jsonpaths,
                         expected_hash=None,
                         hash_weight=hash_weight,
+                        numeric_string_fields=self.config.state_checks.numeric_string_fields,
                     )
 
                 if state_reasons:

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -9,6 +9,7 @@ from typing import Any, Union
 
 from jsonpath_ng.ext import parse
 
+from tolokaforge.core.hash import canonical_number
 from tolokaforge.core.logging import get_logger
 from tolokaforge.core.utils.diff import calculate_state_diff, format_diff_summary
 
@@ -18,7 +19,12 @@ Hashable = Union[str, int, float, tuple["Hashable"], tuple[tuple[str, "Hashable"
 
 
 def to_hashable(item: ToHashable) -> Hashable:
-    """Convert item to hashable representation (tau-bench compatible)"""
+    """Convert item to hashable representation (tau-bench compatible).
+
+    Scalar values pass through :func:`canonical_number` so numerically-equal
+    representations (``"130.00"`` / ``"130.0"`` / ``130``) hash identically and
+    a pure decimal-formatting difference is not graded as a state change.
+    """
     if isinstance(item, dict):
         return tuple((key, to_hashable(value)) for key, value in sorted(item.items()))
     elif isinstance(item, list):
@@ -26,7 +32,7 @@ def to_hashable(item: ToHashable) -> Hashable:
     elif isinstance(item, set):
         return tuple(sorted(to_hashable(element) for element in item))
     else:
-        return item
+        return canonical_number(item)
 
 
 def consistent_hash(value: Hashable) -> str:

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -18,28 +18,57 @@ ToHashable = Union[str, int, float, dict[str, "ToHashable"], list["ToHashable"],
 Hashable = Union[str, int, float, tuple["Hashable"], tuple[tuple[str, "Hashable"]]]
 
 
-def to_hashable(item: ToHashable) -> Hashable:
+def to_hashable(
+    item: ToHashable,
+    string_fields: frozenset[str] | None = None,
+    *,
+    _normalize_strings: bool = False,
+) -> Hashable:
     """Convert item to hashable representation (tau-bench compatible).
 
     Scalar values pass through :func:`canonical_number` so numerically-equal
-    representations (``"130.00"`` / ``"130.0"`` / ``130``) hash identically and
-    a pure decimal-formatting difference is not graded as a state change.
+    NUMERIC-TYPE representations (``130`` / ``130.0`` / ``Decimal("130.00")``)
+    hash identically and a pure formatting difference is not graded as a state
+    change.
+
+    Numeric-looking STRINGS (``"130.00"`` == ``"130.0"``) fold only for a value
+    sitting under a record key named in ``string_fields`` — the per-field opt-in
+    that mirrors :func:`tolokaforge.core.hash.compute_stable_hash`. Key-aware
+    exactly like ``_canonicalize_numbers``: ``_normalize_strings`` carries the
+    per-key decision down through enclosing list(s)/set(s); a nested dict
+    re-decides per its own keys.
     """
     if isinstance(item, dict):
-        return tuple((key, to_hashable(value)) for key, value in sorted(item.items()))
+        return tuple(
+            (
+                key,
+                to_hashable(
+                    value,
+                    string_fields,
+                    _normalize_strings=(string_fields is not None and key in string_fields),
+                ),
+            )
+            for key, value in sorted(item.items())
+        )
     elif isinstance(item, list):
-        return tuple(to_hashable(element) for element in item)
+        return tuple(
+            to_hashable(element, string_fields, _normalize_strings=_normalize_strings)
+            for element in item
+        )
     elif isinstance(item, set):
         # Type-stable sort key: canonicalized scalars can mix bool with tagged
         # numeric/str tokens, which are not mutually orderable under a bare sort.
         return tuple(
             sorted(
-                (to_hashable(element) for element in item),
+                (
+                    to_hashable(element, string_fields, _normalize_strings=_normalize_strings)
+                    for element in item
+                ),
                 key=lambda x: (type(x).__name__, str(x)),
             )
         )
     else:
-        return canonical_number(item)
+        return canonical_number(item, normalize_strings=_normalize_strings)
 
 
 def consistent_hash(value: Hashable) -> str:
@@ -255,6 +284,8 @@ class StateChecker:
         self,
         state: dict[str, Any],
         expected_hash: str,
+        *,
+        numeric_string_fields: list[str] | None = None,
     ) -> tuple[float, str]:
         """
         Check state hash against expected using tau-bench algorithm
@@ -262,13 +293,16 @@ class StateChecker:
         Args:
             state: Final environment state
             expected_hash: Expected SHA256 hash of normalized state
+            numeric_string_fields: Record field names whose numeric-looking
+                string values fold when hashing (per-field opt-in).
 
         Returns:
             (score 0 or 1, reason)
         """
         try:
             # Use tau-bench compatible hashing
-            actual_hash = consistent_hash(to_hashable(state))
+            string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
+            actual_hash = consistent_hash(to_hashable(state, string_fields))
 
             if actual_hash == expected_hash:
                 return 1.0, "State hash matches (tau-bench algorithm)"
@@ -286,6 +320,8 @@ class StateChecker:
         jsonpath_assertions: list[dict[str, Any]],
         expected_hash: str | None = None,
         hash_weight: float = 0.5,
+        *,
+        numeric_string_fields: list[str] | None = None,
     ) -> tuple[float, str]:
         """
         Grade state with combination of JSONPath and hash checks
@@ -295,6 +331,8 @@ class StateChecker:
             jsonpath_assertions: JSONPath assertions
             expected_hash: Optional expected state hash
             hash_weight: Weight for hash check vs JSONPath
+            numeric_string_fields: Record field names whose numeric-looking
+                string values fold when hashing (per-field opt-in).
 
         Returns:
             (score 0-1, reasons)
@@ -302,7 +340,9 @@ class StateChecker:
         jsonpath_score, jsonpath_reasons = self.check_jsonpaths(state, jsonpath_assertions)
 
         if expected_hash:
-            hash_score, hash_reason = self.check_hash(state, expected_hash)
+            hash_score, hash_reason = self.check_hash(
+                state, expected_hash, numeric_string_fields=numeric_string_fields
+            )
             # Weighted combination
             final_score = (jsonpath_score * (1 - hash_weight)) + (hash_score * hash_weight)
             reasons = jsonpath_reasons + [hash_reason]
@@ -400,6 +440,8 @@ class StateChecker:
         initial_state_path: str,
         mcp_server_path: str,
         task_domain: str,
+        *,
+        numeric_string_fields: list[str] | None = None,
     ) -> str:
         """
         Compute expected hash by executing golden actions on fresh data (tau-bench style).
@@ -415,6 +457,8 @@ class StateChecker:
             initial_state_path: Path to initial state JSON file (relative to task_dir)
             mcp_server_path: Path to MCP server module (relative to task_dir)
             task_domain: Domain name (e.g., "airline", "retail")
+            numeric_string_fields: Record field names whose numeric-looking
+                string values fold when hashing (per-field opt-in).
 
         Returns:
             Expected SHA256 hash of state after executing golden actions
@@ -422,7 +466,8 @@ class StateChecker:
         data = self._execute_golden_actions(
             golden_actions, task_dir, initial_state_path, mcp_server_path, task_domain
         )
-        return consistent_hash(to_hashable(data))
+        string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
+        return consistent_hash(to_hashable(data, string_fields))
 
     def grade_tau_style(
         self,
@@ -434,6 +479,8 @@ class StateChecker:
         mcp_server_path: str,
         task_domain: str,
         hash_weight: float = 1.0,
+        *,
+        numeric_string_fields: list[str] | None = None,
     ) -> tuple[float, str, dict[str, Any] | None]:
         """
         Grade state using tau-bench style with diff calculation.
@@ -473,8 +520,9 @@ class StateChecker:
         db_state = state.get("db", state.get("agent", state))
 
         # Compute hashes
-        expected_hash = consistent_hash(to_hashable(expected_state))
-        actual_hash = consistent_hash(to_hashable(db_state))
+        string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
+        expected_hash = consistent_hash(to_hashable(expected_state, string_fields))
+        actual_hash = consistent_hash(to_hashable(db_state, string_fields))
 
         # Calculate diff if states don't match
         diff_result = None

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -30,7 +30,14 @@ def to_hashable(item: ToHashable) -> Hashable:
     elif isinstance(item, list):
         return tuple(to_hashable(element) for element in item)
     elif isinstance(item, set):
-        return tuple(sorted(to_hashable(element) for element in item))
+        # Type-stable sort key: canonicalized scalars can mix bool with tagged
+        # numeric/str tokens, which are not mutually orderable under a bare sort.
+        return tuple(
+            sorted(
+                (to_hashable(element) for element in item),
+                key=lambda x: (type(x).__name__, str(x)),
+            )
+        )
     else:
         return canonical_number(item)
 

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -3,8 +3,10 @@
 This module provides a single, standardized hash function. With
 ``canonicalize_numbers=False`` it matches
 mcp_core.utils.validation.calculate_database_hash(); the default (True)
-additionally folds numerically-equal representations ("130.00" == "130.0")
-together, so it intentionally diverges from that byte-for-byte output.
+additionally folds numerically-equal NUMERIC-TYPE values (72 == 72.0) together,
+so it intentionally diverges from that byte-for-byte output. Numeric-looking
+STRINGS ("130.00" == "130.0") fold only with the opt-in
+``normalize_numeric_strings`` flag — see :func:`canonical_number`.
 
 All hash computations across the codebase should use compute_stable_hash()
 to ensure consistent results.
@@ -57,19 +59,31 @@ def _looks_like_plain_decimal(s: str) -> bool:
     return not (len(int_part) > 1 and int_part[0] == "0")
 
 
-def canonical_number(value: Any) -> Any:
+def canonical_number(value: Any, *, normalize_strings: bool = False) -> Any:
     """Collapse numerically-equal representations of a value to one token.
 
     State grading compares field values for equality — via this module's
     :func:`compute_stable_hash` and via
-    :func:`tolokaforge.core.grading.state_checks.to_hashable`. Databases
-    round-trip ``Decimal`` columns through strings, so the *same* amount
-    surfaces as ``"130.00"`` on one side and ``"130.0"`` (or ``130``) on the
-    other; a naive string/JSON comparison then treats a pure formatting
+    :func:`tolokaforge.core.grading.state_checks.to_hashable`. The same amount
+    can surface as ``72`` on one side and ``72.0`` (or ``Decimal("72.00")``) on
+    the other; a naive string/JSON comparison then treats a pure representation
     difference as a state change — a grading false-fail.
 
-    This maps every representation of one number to a single canonical token so
-    those format-only differences compare equal, while preserving correctness:
+    Two tiers of folding:
+
+    * **Numeric types** (``int`` / ``float`` / ``Decimal``) — always folded to
+      one token. The type itself declares the value is a number, so this is a
+      safe, generic improvement (``72 == 72.0 == Decimal("72.00")``).
+    * **Numeric-looking strings** (``"130.00"`` vs ``"130.0"``) — folded ONLY
+      when ``normalize_strings=True``. This is deliberately opt-in and
+      DANGEROUS as a default: a string that merely looks numeric may carry
+      meaning in its exact representation (version numbers like ``"1.10"`` vs
+      ``"1.1"``, codes, zero-padded ids), and folding those would false-PASS a
+      genuinely wrong state. Enable it per task via the grading config
+      (``state_checks.numeric_string_normalization``) for domains whose string
+      fields are genuinely numeric (e.g. DB-round-tripped Decimal columns).
+
+    Correctness guards in both tiers:
 
     * ``bool`` is left untouched (``True == 1`` in Python, undesirable here);
     * identifier-like strings with leading zeros (``"00123"``) are left untouched
@@ -79,9 +93,10 @@ def canonical_number(value: Any) -> Any:
       so it cannot masquerade as a numeric token;
     * non-numeric values pass through unchanged.
 
-    Leniency note: surrounding whitespace and a leading ``+`` are ignored, and a
-    numeric string collapses with its bare-number twin (``"123"`` == ``123`` ==
-    ``"123.0"``); numeric-string ids are protected only by the leading-zero rule.
+    Leniency note (string tier): surrounding whitespace and a leading ``+`` are
+    ignored, and a numeric string collapses with its bare-number twin
+    (``"123"`` == ``123`` == ``"123.0"``); numeric-string ids are protected only
+    by the leading-zero rule.
     """
     if isinstance(value, bool):
         return value
@@ -91,12 +106,13 @@ def canonical_number(value: Any) -> Any:
         except (InvalidOperation, ValueError):
             return value
     if isinstance(value, str):
-        s = value.strip()
-        if 0 < len(s) <= _MAX_NUMERIC_LEN and _looks_like_plain_decimal(s):
-            try:
-                return _numeric_token(Decimal(s))
-            except InvalidOperation:
-                pass
+        if normalize_strings:
+            s = value.strip()
+            if 0 < len(s) <= _MAX_NUMERIC_LEN and _looks_like_plain_decimal(s):
+                try:
+                    return _numeric_token(Decimal(s))
+                except InvalidOperation:
+                    pass
         # A genuine string beginning with the reserved NUL would otherwise be
         # byte-identical to a numeric token; escape it so the two can't collide.
         if value.startswith("\x00"):
@@ -104,15 +120,20 @@ def canonical_number(value: Any) -> Any:
     return value
 
 
-def _canonicalize_numbers(data: Any) -> Any:
+def _canonicalize_numbers(data: Any, *, normalize_strings: bool = False) -> Any:
     """Recursively apply :func:`canonical_number` to every scalar in a state."""
     if isinstance(data, dict):
-        return {key: _canonicalize_numbers(value) for key, value in data.items()}
+        return {
+            key: _canonicalize_numbers(value, normalize_strings=normalize_strings)
+            for key, value in data.items()
+        }
     if isinstance(data, list):
-        return [_canonicalize_numbers(item) for item in data]
+        return [_canonicalize_numbers(item, normalize_strings=normalize_strings) for item in data]
     if isinstance(data, tuple):
-        return tuple(_canonicalize_numbers(item) for item in data)
-    return canonical_number(data)
+        return tuple(
+            _canonicalize_numbers(item, normalize_strings=normalize_strings) for item in data
+        )
+    return canonical_number(data, normalize_strings=normalize_strings)
 
 
 def _convert_datetime_to_str(data: Any) -> Any:
@@ -216,6 +237,7 @@ def compute_stable_hash(
     unstable_fields: list[str] | None = None,
     *,
     canonicalize_numbers: bool = True,
+    normalize_numeric_strings: bool = False,
 ) -> str:
     """
     Compute a stable SHA-256 hash of the state dictionary.
@@ -235,10 +257,19 @@ def compute_stable_hash(
         state: State dictionary to hash
         unstable_fields: Optional list of field names to exclude from hash
         canonicalize_numbers: When True (default), collapse numerically-equal
-            representations ("130.00" == "130.0" == 130) before hashing so a
-            pure decimal-formatting difference is not a spurious state mismatch.
-            Pass False to reproduce the legacy byte-for-byte
+            NUMERIC-TYPE values (72 == 72.0 == Decimal("72.00")) before hashing.
+            Generic and safe — the type declares the value is a number. Pass
+            False to reproduce the legacy byte-for-byte
             mcp_core.calculate_database_hash() output.
+        normalize_numeric_strings: When True, ALSO collapse numeric-looking
+            STRINGS ("130.00" == "130.0" == "130"). Default False — this is an
+            opt-in, per-task feature (grading config
+            ``state_checks.numeric_string_normalization``), NOT a generic
+            improvement: exact string representation can be meaningful
+            (versions "1.10" vs "1.1", codes), and folding those would
+            false-pass a wrong state. Enable only for domains whose string
+            fields are DB-round-tripped decimals. Ignored when
+            canonicalize_numbers is False.
 
     Returns:
         Hexadecimal string of the SHA-256 hash
@@ -259,10 +290,14 @@ def compute_stable_hash(
     # Convert datetime objects to strings
     serializable_state = _convert_datetime_to_str(state)
 
-    # Collapse numerically-equal representations ("130.00" == "130.0" == 130) so
-    # a pure decimal-formatting difference is not graded as a state change.
+    # Collapse numerically-equal representations so a pure representation
+    # difference is not graded as a state change: numeric TYPES always
+    # (72 == 72.0), numeric-looking STRINGS only when the per-task flag opts in
+    # ("130.00" == "130.0" — see the normalize_numeric_strings docstring).
     if canonicalize_numbers:
-        serializable_state = _canonicalize_numbers(serializable_state)
+        serializable_state = _canonicalize_numbers(
+            serializable_state, normalize_strings=normalize_numeric_strings
+        )
 
     # Serialize with canonical format matching mcp_core
     json_str = json.dumps(serializable_state, sort_keys=True, separators=(",", ":"), default=str)

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -5,8 +5,8 @@ This module provides a single, standardized hash function. With
 mcp_core.utils.validation.calculate_database_hash(); the default (True)
 additionally folds numerically-equal NUMERIC-TYPE values (72 == 72.0) together,
 so it intentionally diverges from that byte-for-byte output. Numeric-looking
-STRINGS ("130.00" == "130.0") fold only with the opt-in
-``normalize_numeric_strings`` flag — see :func:`canonical_number`.
+STRINGS ("130.00" == "130.0") fold only for the per-field opt-in set
+``numeric_string_fields`` — see :func:`compute_stable_hash`.
 
 All hash computations across the codebase should use compute_stable_hash()
 to ensure consistent results.
@@ -15,6 +15,7 @@ to ensure consistent results.
 import hashlib
 import json
 import logging
+from collections.abc import Iterable
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -79,9 +80,10 @@ def canonical_number(value: Any, *, normalize_strings: bool = False) -> Any:
       DANGEROUS as a default: a string that merely looks numeric may carry
       meaning in its exact representation (version numbers like ``"1.10"`` vs
       ``"1.1"``, codes, zero-padded ids), and folding those would false-PASS a
-      genuinely wrong state. Enable it per task via the grading config
-      (``state_checks.numeric_string_normalization``) for domains whose string
-      fields are genuinely numeric (e.g. DB-round-tripped Decimal columns).
+      genuinely wrong state. Enabled per FIELD via the grading config
+      (``state_checks.numeric_string_fields``) for the specific money / quantity
+      fields that are genuinely numeric (e.g. DB-round-tripped Decimal columns),
+      not as a blanket per-task switch.
 
     Correctness guards in both tiers:
 
@@ -120,20 +122,41 @@ def canonical_number(value: Any, *, normalize_strings: bool = False) -> Any:
     return value
 
 
-def _canonicalize_numbers(data: Any, *, normalize_strings: bool = False) -> Any:
-    """Recursively apply :func:`canonical_number` to every scalar in a state."""
+def _canonicalize_numbers(
+    data: Any,
+    string_fields: frozenset[str] | None = None,
+    *,
+    _normalize_strings: bool = False,
+) -> Any:
+    """Recursively fold numerically-equal values in a state.
+
+    Numeric TYPES (int/float/Decimal) always fold. Numeric-looking STRINGS fold
+    only for a value sitting under a record key named in ``string_fields`` — the
+    per-field opt-in. ``_normalize_strings`` carries that per-key decision down
+    through the value's enclosing list(s); a nested dict re-decides per its own
+    keys. So a version/code string field is never folded merely because a
+    sibling money field in the same record is listed.
+    """
     if isinstance(data, dict):
         return {
-            key: _canonicalize_numbers(value, normalize_strings=normalize_strings)
+            key: _canonicalize_numbers(
+                value,
+                string_fields,
+                _normalize_strings=(string_fields is not None and key in string_fields),
+            )
             for key, value in data.items()
         }
     if isinstance(data, list):
-        return [_canonicalize_numbers(item, normalize_strings=normalize_strings) for item in data]
+        return [
+            _canonicalize_numbers(item, string_fields, _normalize_strings=_normalize_strings)
+            for item in data
+        ]
     if isinstance(data, tuple):
         return tuple(
-            _canonicalize_numbers(item, normalize_strings=normalize_strings) for item in data
+            _canonicalize_numbers(item, string_fields, _normalize_strings=_normalize_strings)
+            for item in data
         )
-    return canonical_number(data, normalize_strings=normalize_strings)
+    return canonical_number(data, normalize_strings=_normalize_strings)
 
 
 def _convert_datetime_to_str(data: Any) -> Any:
@@ -237,7 +260,7 @@ def compute_stable_hash(
     unstable_fields: list[str] | None = None,
     *,
     canonicalize_numbers: bool = True,
-    normalize_numeric_strings: bool = False,
+    numeric_string_fields: Iterable[str] | None = None,
 ) -> str:
     """
     Compute a stable SHA-256 hash of the state dictionary.
@@ -261,15 +284,14 @@ def compute_stable_hash(
             Generic and safe — the type declares the value is a number. Pass
             False to reproduce the legacy byte-for-byte
             mcp_core.calculate_database_hash() output.
-        normalize_numeric_strings: When True, ALSO collapse numeric-looking
-            STRINGS ("130.00" == "130.0" == "130"). Default False — this is an
-            opt-in, per-task feature (grading config
-            ``state_checks.numeric_string_normalization``), NOT a generic
-            improvement: exact string representation can be meaningful
-            (versions "1.10" vs "1.1", codes), and folding those would
-            false-pass a wrong state. Enable only for domains whose string
-            fields are DB-round-tripped decimals. Ignored when
-            canonicalize_numbers is False.
+        numeric_string_fields: Record-level field names whose numeric-looking
+            STRING values should ALSO fold ("130.00" == "130.0" == "130"). This
+            is deliberately PER-FIELD, not global: a string that looks numeric
+            can carry meaning in its exact representation (versions "1.10" vs
+            "1.1", zero-padded codes), so folding is opt-in only for the money /
+            quantity fields a task declares here (grading config
+            ``state_checks.numeric_string_fields``). Matched by the immediate
+            record key at any depth. Ignored when canonicalize_numbers is False.
 
     Returns:
         Hexadecimal string of the SHA-256 hash
@@ -292,12 +314,11 @@ def compute_stable_hash(
 
     # Collapse numerically-equal representations so a pure representation
     # difference is not graded as a state change: numeric TYPES always
-    # (72 == 72.0), numeric-looking STRINGS only when the per-task flag opts in
-    # ("130.00" == "130.0" — see the normalize_numeric_strings docstring).
+    # (72 == 72.0); numeric-looking STRINGS only in the opt-in per-field set
+    # ("130.00" == "130.0" — see numeric_string_fields).
     if canonicalize_numbers:
-        serializable_state = _canonicalize_numbers(
-            serializable_state, normalize_strings=normalize_numeric_strings
-        )
+        string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
+        serializable_state = _canonicalize_numbers(serializable_state, string_fields)
 
     # Serialize with canonical format matching mcp_core
     json_str = json.dumps(serializable_state, sort_keys=True, separators=(",", ":"), default=str)

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -10,18 +10,37 @@ to ensure consistent results.
 import hashlib
 import json
 import logging
-import re
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# A plain decimal / integer literal with NO leading zeros on the integer part.
-# Leading zeros ("00123", "007") smell like a string identifier and must never be
-# collapsed to a number. Matches e.g. "130", "130.00", "-5.50", "0", "0.0", ".5".
-_DECIMAL_LITERAL_RE = re.compile(r"[+-]?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$|[+-]?\.[0-9]+$")
+# Cap the work spent deciding whether a string is a number: no real amount,
+# quantity, or id is this long, and it bounds pathological inputs.
+_MAX_NUMERIC_LEN = 64
 _NUMERIC_TAG = "\x00tf-num:"
+
+
+def _looks_like_plain_decimal(s: str) -> bool:
+    """Whether ``s`` is a plain decimal / integer literal we should canonicalize.
+
+    Linear-time and regex-free (so it cannot backtrack). Accepts ``"130"``,
+    ``"130.00"``, ``"-5.50"``, ``"0"``, ``"0.0"``, ``".5"``; rejects leading-zero
+    integer parts (``"00123"``, ``"007"`` — they smell like string identifiers),
+    scientific notation (``"1e3"``), and anything non-ASCII or non-numeric.
+    """
+    body = s[1:] if s[:1] in ("+", "-") else s
+    int_part, dot, frac_part = body.partition(".")
+    if dot:  # exactly one '.'; the fractional side must be >= 1 ASCII digit
+        if not (frac_part.isascii() and frac_part.isdigit()):
+            return False
+        if int_part and not (int_part.isascii() and int_part.isdigit()):
+            return False
+    elif not (int_part.isascii() and int_part.isdigit()):
+        return False
+    # Reject leading-zero integer parts; allow a lone "0" and "0.x".
+    return not (len(int_part) > 1 and int_part[0] == "0")
 
 
 def canonical_number(value: Any) -> Any:
@@ -53,7 +72,7 @@ def canonical_number(value: Any) -> Any:
             return value
     if isinstance(value, str):
         s = value.strip()
-        if s and _DECIMAL_LITERAL_RE.match(s):
+        if 0 < len(s) <= _MAX_NUMERIC_LEN and _looks_like_plain_decimal(s):
             try:
                 return _NUMERIC_TAG + format(Decimal(s).normalize(), "f")
             except InvalidOperation:

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -10,10 +10,66 @@ to ensure consistent results.
 import hashlib
 import json
 import logging
+import re
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# A plain decimal / integer literal with NO leading zeros on the integer part.
+# Leading zeros ("00123", "007") smell like a string identifier and must never be
+# collapsed to a number. Matches e.g. "130", "130.00", "-5.50", "0", "0.0", ".5".
+_DECIMAL_LITERAL_RE = re.compile(r"[+-]?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$|[+-]?\.[0-9]+$")
+_NUMERIC_TAG = "\x00tf-num:"
+
+
+def canonical_number(value: Any) -> Any:
+    """Collapse numerically-equal representations of a value to one token.
+
+    State grading compares field values for equality — via this module's
+    :func:`compute_stable_hash` and via
+    :func:`tolokaforge.core.grading.state_checks.to_hashable`. Databases
+    round-trip ``Decimal`` columns through strings, so the *same* amount
+    surfaces as ``"130.00"`` on one side and ``"130.0"`` (or ``130``) on the
+    other; a naive string/JSON comparison then treats a pure formatting
+    difference as a state change — a grading false-fail.
+
+    This maps every representation of one number to a single canonical token so
+    those format-only differences compare equal, while preserving correctness:
+
+    * ``bool`` is left untouched (``True == 1`` in Python, undesirable here);
+    * identifier-like strings with leading zeros (``"00123"``) are left untouched
+      so two distinct ids are never numerically equated;
+    * genuinely different numbers (``"790.00"`` vs ``"0.0"``) stay different;
+    * non-numeric values pass through unchanged.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, Decimal)):
+        try:
+            return _NUMERIC_TAG + format(Decimal(str(value)).normalize(), "f")
+        except (InvalidOperation, ValueError):
+            return value
+    if isinstance(value, str):
+        s = value.strip()
+        if s and _DECIMAL_LITERAL_RE.match(s):
+            try:
+                return _NUMERIC_TAG + format(Decimal(s).normalize(), "f")
+            except InvalidOperation:
+                return value
+    return value
+
+
+def _canonicalize_numbers(data: Any) -> Any:
+    """Recursively apply :func:`canonical_number` to every scalar in a state."""
+    if isinstance(data, dict):
+        return {key: _canonicalize_numbers(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_canonicalize_numbers(item) for item in data]
+    if isinstance(data, tuple):
+        return tuple(_canonicalize_numbers(item) for item in data)
+    return canonical_number(data)
 
 
 def _convert_datetime_to_str(data: Any) -> Any:
@@ -115,6 +171,8 @@ def filter_unstable_fields(
 def compute_stable_hash(
     state: dict[str, Any],
     unstable_fields: list[str] | None = None,
+    *,
+    canonicalize_numbers: bool = True,
 ) -> str:
     """
     Compute a stable SHA-256 hash of the state dictionary.
@@ -131,6 +189,11 @@ def compute_stable_hash(
     Args:
         state: State dictionary to hash
         unstable_fields: Optional list of field names to exclude from hash
+        canonicalize_numbers: When True (default), collapse numerically-equal
+            representations ("130.00" == "130.0" == 130) before hashing so a
+            pure decimal-formatting difference is not a spurious state mismatch.
+            Pass False to reproduce the legacy byte-for-byte
+            mcp_core.calculate_database_hash() output.
 
     Returns:
         Hexadecimal string of the SHA-256 hash
@@ -150,6 +213,11 @@ def compute_stable_hash(
 
     # Convert datetime objects to strings
     serializable_state = _convert_datetime_to_str(state)
+
+    # Collapse numerically-equal representations ("130.00" == "130.0" == 130) so
+    # a pure decimal-formatting difference is not graded as a state change.
+    if canonicalize_numbers:
+        serializable_state = _canonicalize_numbers(serializable_state)
 
     # Serialize with canonical format matching mcp_core
     json_str = json.dumps(serializable_state, sort_keys=True, separators=(",", ":"), default=str)

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -1,7 +1,10 @@
 """Canonical hash computation for stable state comparison.
 
-This module provides a single, standardized hash function that matches
-the implementation in mcp_core.utils.validation.calculate_database_hash().
+This module provides a single, standardized hash function. With
+``canonicalize_numbers=False`` it matches
+mcp_core.utils.validation.calculate_database_hash(); the default (True)
+additionally folds numerically-equal representations ("130.00" == "130.0")
+together, so it intentionally diverges from that byte-for-byte output.
 
 All hash computations across the codebase should use compute_stable_hash()
 to ensure consistent results.
@@ -20,6 +23,17 @@ logger = logging.getLogger(__name__)
 # quantity, or id is this long, and it bounds pathological inputs.
 _MAX_NUMERIC_LEN = 64
 _NUMERIC_TAG = "\x00tf-num:"
+# Escape prefix for a genuine string that itself begins with the reserved NUL,
+# so a crafted value like "\x00tf-num:130" can never collide with a numeric token.
+_ESCAPE_TAG = "\x00tf-esc:"
+
+
+def _numeric_token(d: Decimal) -> str:
+    """Canonical token for a Decimal: trailing zeros stripped, -0 folded to 0."""
+    d = d.normalize()
+    if d.is_zero():  # collapse "-0" and "0"
+        d = abs(d)
+    return _NUMERIC_TAG + format(d, "f")
 
 
 def _looks_like_plain_decimal(s: str) -> bool:
@@ -61,22 +75,32 @@ def canonical_number(value: Any) -> Any:
     * identifier-like strings with leading zeros (``"00123"``) are left untouched
       so two distinct ids are never numerically equated;
     * genuinely different numbers (``"790.00"`` vs ``"0.0"``) stay different;
+    * a genuine string that itself begins with the reserved NUL prefix is escaped
+      so it cannot masquerade as a numeric token;
     * non-numeric values pass through unchanged.
+
+    Leniency note: surrounding whitespace and a leading ``+`` are ignored, and a
+    numeric string collapses with its bare-number twin (``"123"`` == ``123`` ==
+    ``"123.0"``); numeric-string ids are protected only by the leading-zero rule.
     """
     if isinstance(value, bool):
         return value
     if isinstance(value, (int, float, Decimal)):
         try:
-            return _NUMERIC_TAG + format(Decimal(str(value)).normalize(), "f")
+            return _numeric_token(Decimal(str(value)))
         except (InvalidOperation, ValueError):
             return value
     if isinstance(value, str):
         s = value.strip()
         if 0 < len(s) <= _MAX_NUMERIC_LEN and _looks_like_plain_decimal(s):
             try:
-                return _NUMERIC_TAG + format(Decimal(s).normalize(), "f")
+                return _numeric_token(Decimal(s))
             except InvalidOperation:
-                return value
+                pass
+        # A genuine string beginning with the reserved NUL would otherwise be
+        # byte-identical to a numeric token; escape it so the two can't collide.
+        if value.startswith("\x00"):
+            return _ESCAPE_TAG + value
     return value
 
 
@@ -196,8 +220,10 @@ def compute_stable_hash(
     """
     Compute a stable SHA-256 hash of the state dictionary.
 
-    This function produces the same output as mcp_core.utils.validation.calculate_database_hash()
-    for identical state dictionaries.
+    With ``canonicalize_numbers=False`` this produces the same output as
+    mcp_core.utils.validation.calculate_database_hash() for identical state
+    dictionaries. The default (True) additionally folds numerically-equal
+    representations, intentionally diverging from that byte-for-byte output.
 
     Algorithm:
     1. Filter out unstable fields (if specified)

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1250,6 +1250,12 @@ class StateChecksConfig(BaseModel):
     env_assertions: list[EnvAssertion] = Field(default_factory=list)  # NEW
     db_hash_check: bool = False  # NEW - compare final DB hash
     db_probes: list[dict[str, Any]] = Field(default_factory=list)
+    # Opt-in, per-field: record field names whose numeric-looking STRING values
+    # fold ("130.00" == "130.0") when hashing state. Mirrors the runner-side
+    # StateChecksConfig so the same grading.yaml key behaves identically on the
+    # core GradingEngine path (to_hashable) and the runner path
+    # (compute_stable_hash). See core/hash.py compute_stable_hash.
+    numeric_string_fields: list[str] = Field(default_factory=list)
 
 
 class CommunicateInfo(BaseModel):

--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -107,18 +107,20 @@ except ImportError:
         unstable_fields: list[str] | None = None,
         *,
         canonicalize_numbers: bool = True,
-        normalize_numeric_strings: bool = False,
+        numeric_string_fields: list[str] | None = None,
     ) -> str:
         """Compute a stable SHA-256 hash of the state dictionary.
 
         Standalone fallback — mirrors tolokaforge.core.hash.compute_stable_hash,
-        including the two-tier numeric canonicalization (numeric TYPES always;
-        numeric-looking STRINGS only when ``normalize_numeric_strings``).
-        Keep the two in sync.
+        including the two-tier numeric canonicalization: numeric TYPES always
+        fold; numeric-looking STRINGS fold only under a record key listed in
+        ``numeric_string_fields``. Keep the two in sync.
         """
         from decimal import Decimal, InvalidOperation
 
-        def _canon(v: Any) -> Any:
+        string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
+
+        def _canon(v: Any, normalize_strings: bool) -> Any:
             if isinstance(v, bool):
                 return v
             if isinstance(v, (int, float, Decimal)):
@@ -128,7 +130,7 @@ except ImportError:
                 except (InvalidOperation, ValueError):
                     return v
             if isinstance(v, str):
-                if normalize_numeric_strings:
+                if normalize_strings:
                     s = v.strip()
                     body = s[1:] if s[:1] in ("+", "-") else s
                     ip, dot, fp = body.partition(".")
@@ -151,14 +153,17 @@ except ImportError:
                     return "\x00tf-esc:" + v
             return v
 
-        def _walk(data: Any) -> Any:
+        def _walk(data: Any, normalize_strings: bool = False) -> Any:
             if isinstance(data, dict):
-                return {k: _walk(x) for k, x in data.items()}
+                return {
+                    k: _walk(x, string_fields is not None and k in string_fields)
+                    for k, x in data.items()
+                }
             if isinstance(data, list):
-                return [_walk(x) for x in data]
+                return [_walk(x, normalize_strings) for x in data]
             if isinstance(data, tuple):
-                return tuple(_walk(x) for x in data)
-            return _canon(data)
+                return tuple(_walk(x, normalize_strings) for x in data)
+            return _canon(data, normalize_strings)
 
         if unstable_fields:
             state = filter_unstable_fields(state, unstable_fields)
@@ -493,11 +498,11 @@ class TrialState(BaseModel):
         """Compute hash of full state (including unstable fields)."""
         return compute_stable_hash(self.data)
 
-    def compute_stable_hash(self, *, normalize_numeric_strings: bool = False) -> str:
+    def compute_stable_hash(self, *, numeric_string_fields: list[str] | None = None) -> str:
         """Compute hash of stable state (unstable fields filtered)."""
         unstable_list = self.get_unstable_field_list()
         return compute_stable_hash(
-            self.data, unstable_list, normalize_numeric_strings=normalize_numeric_strings
+            self.data, unstable_list, numeric_string_fields=numeric_string_fields
         )
 
     def cleanup(self):
@@ -766,12 +771,15 @@ async def get_stable_state(trial_id: str) -> dict[str, Any]:
 
 
 @app.get("/trials/{trial_id}/state/hash")
-async def get_state_hash(trial_id: str, normalize_numeric_strings: bool = False) -> dict[str, Any]:
+async def get_state_hash(
+    trial_id: str,
+    numeric_string_fields: list[str] | None = Query(default=None),
+) -> dict[str, Any]:
     """Get SHA-256 hash of the stable state.
 
-    ``normalize_numeric_strings`` is the opt-in per-task grading flag that
-    folds numeric-looking strings ("130.00" == "130.0") — see
-    core/hash.py canonical_number.
+    ``numeric_string_fields`` is the opt-in per-field grading list: record
+    field names whose numeric-looking string values fold ("130.00" == "130.0")
+    — see core/hash.py compute_stable_hash.
     """
     try:
         trial = db_service.get_trial(trial_id)
@@ -780,9 +788,7 @@ async def get_state_hash(trial_id: str, normalize_numeric_strings: bool = False)
 
     with trial._lock:
         return {
-            "stable_hash": trial.compute_stable_hash(
-                normalize_numeric_strings=normalize_numeric_strings
-            ),
+            "stable_hash": trial.compute_stable_hash(numeric_string_fields=numeric_string_fields),
             "full_hash": trial.compute_full_hash(),
             "version": trial.version,
         }

--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -107,11 +107,14 @@ except ImportError:
         unstable_fields: list[str] | None = None,
         *,
         canonicalize_numbers: bool = True,
+        normalize_numeric_strings: bool = False,
     ) -> str:
         """Compute a stable SHA-256 hash of the state dictionary.
 
         Standalone fallback — mirrors tolokaforge.core.hash.compute_stable_hash,
-        including the numeric canonicalization. Keep the two in sync.
+        including the two-tier numeric canonicalization (numeric TYPES always;
+        numeric-looking STRINGS only when ``normalize_numeric_strings``).
+        Keep the two in sync.
         """
         from decimal import Decimal, InvalidOperation
 
@@ -125,24 +128,25 @@ except ImportError:
                 except (InvalidOperation, ValueError):
                     return v
             if isinstance(v, str):
-                s = v.strip()
-                body = s[1:] if s[:1] in ("+", "-") else s
-                ip, dot, fp = body.partition(".")
-                if dot:
-                    numeric = (
-                        fp.isascii()
-                        and fp.isdigit()
-                        and (not ip or (ip.isascii() and ip.isdigit()))
-                    )
-                else:
-                    numeric = ip.isascii() and ip.isdigit()
-                numeric = numeric and not (len(ip) > 1 and ip[0] == "0")
-                if 0 < len(s) <= 64 and numeric:
-                    try:
-                        d = Decimal(s).normalize()
-                        return "\x00tf-num:" + format(abs(d) if d.is_zero() else d, "f")
-                    except InvalidOperation:
-                        pass
+                if normalize_numeric_strings:
+                    s = v.strip()
+                    body = s[1:] if s[:1] in ("+", "-") else s
+                    ip, dot, fp = body.partition(".")
+                    if dot:
+                        numeric = (
+                            fp.isascii()
+                            and fp.isdigit()
+                            and (not ip or (ip.isascii() and ip.isdigit()))
+                        )
+                    else:
+                        numeric = ip.isascii() and ip.isdigit()
+                    numeric = numeric and not (len(ip) > 1 and ip[0] == "0")
+                    if 0 < len(s) <= 64 and numeric:
+                        try:
+                            d = Decimal(s).normalize()
+                            return "\x00tf-num:" + format(abs(d) if d.is_zero() else d, "f")
+                        except InvalidOperation:
+                            pass
                 if v.startswith("\x00"):
                     return "\x00tf-esc:" + v
             return v
@@ -489,10 +493,12 @@ class TrialState(BaseModel):
         """Compute hash of full state (including unstable fields)."""
         return compute_stable_hash(self.data)
 
-    def compute_stable_hash(self) -> str:
+    def compute_stable_hash(self, *, normalize_numeric_strings: bool = False) -> str:
         """Compute hash of stable state (unstable fields filtered)."""
         unstable_list = self.get_unstable_field_list()
-        return compute_stable_hash(self.data, unstable_list)
+        return compute_stable_hash(
+            self.data, unstable_list, normalize_numeric_strings=normalize_numeric_strings
+        )
 
     def cleanup(self):
         """Clean up resources."""
@@ -760,8 +766,13 @@ async def get_stable_state(trial_id: str) -> dict[str, Any]:
 
 
 @app.get("/trials/{trial_id}/state/hash")
-async def get_state_hash(trial_id: str) -> dict[str, Any]:
-    """Get SHA-256 hash of the stable state."""
+async def get_state_hash(trial_id: str, normalize_numeric_strings: bool = False) -> dict[str, Any]:
+    """Get SHA-256 hash of the stable state.
+
+    ``normalize_numeric_strings`` is the opt-in per-task grading flag that
+    folds numeric-looking strings ("130.00" == "130.0") — see
+    core/hash.py canonical_number.
+    """
     try:
         trial = db_service.get_trial(trial_id)
     except TrialNotFoundError as e:
@@ -769,7 +780,9 @@ async def get_state_hash(trial_id: str) -> dict[str, Any]:
 
     with trial._lock:
         return {
-            "stable_hash": trial.compute_stable_hash(),
+            "stable_hash": trial.compute_stable_hash(
+                normalize_numeric_strings=normalize_numeric_strings
+            ),
             "full_hash": trial.compute_full_hash(),
             "version": trial.version,
         }

--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -129,8 +129,10 @@ except ImportError:
                 body = s[1:] if s[:1] in ("+", "-") else s
                 ip, dot, fp = body.partition(".")
                 if dot:
-                    numeric = fp.isascii() and fp.isdigit() and (
-                        not ip or (ip.isascii() and ip.isdigit())
+                    numeric = (
+                        fp.isascii()
+                        and fp.isdigit()
+                        and (not ip or (ip.isascii() and ip.isdigit()))
                     )
                 else:
                     numeric = ip.isascii() and ip.isdigit()

--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -105,12 +105,61 @@ except ImportError:
     def compute_stable_hash(
         state: dict[str, Any],
         unstable_fields: list[str] | None = None,
+        *,
+        canonicalize_numbers: bool = True,
     ) -> str:
-        """Compute a stable SHA-256 hash of the state dictionary."""
+        """Compute a stable SHA-256 hash of the state dictionary.
+
+        Standalone fallback — mirrors tolokaforge.core.hash.compute_stable_hash,
+        including the numeric canonicalization. Keep the two in sync.
+        """
+        from decimal import Decimal, InvalidOperation
+
+        def _canon(v: Any) -> Any:
+            if isinstance(v, bool):
+                return v
+            if isinstance(v, (int, float, Decimal)):
+                try:
+                    d = Decimal(str(v)).normalize()
+                    return "\x00tf-num:" + format(abs(d) if d.is_zero() else d, "f")
+                except (InvalidOperation, ValueError):
+                    return v
+            if isinstance(v, str):
+                s = v.strip()
+                body = s[1:] if s[:1] in ("+", "-") else s
+                ip, dot, fp = body.partition(".")
+                if dot:
+                    numeric = fp.isascii() and fp.isdigit() and (
+                        not ip or (ip.isascii() and ip.isdigit())
+                    )
+                else:
+                    numeric = ip.isascii() and ip.isdigit()
+                numeric = numeric and not (len(ip) > 1 and ip[0] == "0")
+                if 0 < len(s) <= 64 and numeric:
+                    try:
+                        d = Decimal(s).normalize()
+                        return "\x00tf-num:" + format(abs(d) if d.is_zero() else d, "f")
+                    except InvalidOperation:
+                        pass
+                if v.startswith("\x00"):
+                    return "\x00tf-esc:" + v
+            return v
+
+        def _walk(data: Any) -> Any:
+            if isinstance(data, dict):
+                return {k: _walk(x) for k, x in data.items()}
+            if isinstance(data, list):
+                return [_walk(x) for x in data]
+            if isinstance(data, tuple):
+                return tuple(_walk(x) for x in data)
+            return _canon(data)
+
         if unstable_fields:
             state = filter_unstable_fields(state, unstable_fields)
 
         serializable_state = _convert_datetime_to_str(state)
+        if canonicalize_numbers:
+            serializable_state = _walk(serializable_state)
         json_str = json.dumps(
             serializable_state, sort_keys=True, separators=(",", ":"), default=str
         )

--- a/tolokaforge/runner/db_client.py
+++ b/tolokaforge/runner/db_client.py
@@ -401,7 +401,9 @@ class DBServiceClient:
             self._handle_error_response(response)
             return StableStateResponse.model_validate(response.json())
 
-    async def get_stable_hash(self, trial_id: str) -> str:
+    async def get_stable_hash(
+        self, trial_id: str, *, normalize_numeric_strings: bool = False
+    ) -> str:
         """
         Get SHA-256 hash of the stable state.
 
@@ -409,6 +411,9 @@ class DBServiceClient:
 
         Args:
             trial_id: Trial identifier
+            normalize_numeric_strings: Opt-in per-task flag — fold
+                numeric-looking strings ("130.00" == "130.0") when hashing.
+                See core/hash.py canonical_number.
 
         Returns:
             The stable_hash string
@@ -418,7 +423,10 @@ class DBServiceClient:
         """
         async with self._create_client() as client:
             try:
-                response = await client.get(f"/trials/{trial_id}/state/hash")
+                response = await client.get(
+                    f"/trials/{trial_id}/state/hash",
+                    params={"normalize_numeric_strings": normalize_numeric_strings},
+                )
             except httpx.ConnectError as e:
                 raise ConnectionError(f"Failed to connect to DB Service: {e}")
 

--- a/tolokaforge/runner/db_client.py
+++ b/tolokaforge/runner/db_client.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import logging
+from collections.abc import Iterable
 from typing import Any
 
 import httpx
@@ -402,7 +403,7 @@ class DBServiceClient:
             return StableStateResponse.model_validate(response.json())
 
     async def get_stable_hash(
-        self, trial_id: str, *, normalize_numeric_strings: bool = False
+        self, trial_id: str, *, numeric_string_fields: Iterable[str] | None = None
     ) -> str:
         """
         Get SHA-256 hash of the stable state.
@@ -411,9 +412,9 @@ class DBServiceClient:
 
         Args:
             trial_id: Trial identifier
-            normalize_numeric_strings: Opt-in per-task flag — fold
-                numeric-looking strings ("130.00" == "130.0") when hashing.
-                See core/hash.py canonical_number.
+            numeric_string_fields: Opt-in per-field list — record field names
+                whose numeric-looking string values fold ("130.00" == "130.0")
+                when hashing. See core/hash.py compute_stable_hash.
 
         Returns:
             The stable_hash string
@@ -421,11 +422,16 @@ class DBServiceClient:
         Raises:
             TrialNotFoundError: If trial not found
         """
+        params = (
+            {"numeric_string_fields": list(numeric_string_fields)}
+            if numeric_string_fields
+            else None
+        )
         async with self._create_client() as client:
             try:
                 response = await client.get(
                     f"/trials/{trial_id}/state/hash",
-                    params={"normalize_numeric_strings": normalize_numeric_strings},
+                    params=params,
                 )
             except httpx.ConnectError as e:
                 raise ConnectionError(f"Failed to connect to DB Service: {e}")

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from jsonpath_ng.ext import parse
 
+from tolokaforge.core.hash import canonical_number
 from tolokaforge.runner.models import (
     StateDiff,
     TableDiff,
@@ -69,6 +70,20 @@ def compute_state_diff(trial_state: dict[str, Any], golden_state: dict[str, Any]
     return StateDiff(tables=tables_diff, summary=summary)
 
 
+def _make_hashable(value: Any) -> Any:
+    """Make a value hashable for comparison.
+
+    Scalars pass through :func:`canonical_number` so numerically-equal
+    representations (``"130.00"`` / ``"130.0"`` / ``130``) compare equal and a
+    pure decimal-formatting difference is not reported as a row/field change.
+    """
+    if isinstance(value, dict):
+        return tuple(sorted((k, _make_hashable(v)) for k, v in value.items()))
+    elif isinstance(value, list):
+        return tuple(_make_hashable(v) for v in value)
+    return canonical_number(value)
+
+
 def _compare_table_records(
     trial_records: list[dict[str, Any]], golden_records: list[dict[str, Any]]
 ) -> TableDiff:
@@ -93,14 +108,6 @@ def _compare_table_records(
     def record_to_tuple(record: dict[str, Any]) -> tuple:
         """Convert record to hashable tuple for comparison."""
         return tuple(sorted((k, _make_hashable(v)) for k, v in record.items()))
-
-    def _make_hashable(value: Any) -> Any:
-        """Make a value hashable for comparison."""
-        if isinstance(value, dict):
-            return tuple(sorted((k, _make_hashable(v)) for k, v in value.items()))
-        elif isinstance(value, list):
-            return tuple(_make_hashable(v) for v in value)
-        return value
 
     trial_tuples = {record_to_tuple(r): r for r in trial_records}
     golden_tuples = {record_to_tuple(r): r for r in golden_records}
@@ -181,7 +188,9 @@ def _get_field_diffs(expected: dict[str, Any], actual: dict[str, Any]) -> list[d
     for field in sorted(all_fields):
         exp_val = expected.get(field)
         act_val = actual.get(field)
-        if exp_val != act_val:
+        # Compare via canonical form so a numerically-equal value in a different
+        # decimal format ("130.00" vs "130.0") is not reported as a field diff.
+        if _make_hashable(exp_val) != _make_hashable(act_val):
             diffs.append({"field": field, "expected": exp_val, "actual": act_val})
 
     return diffs

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -168,7 +168,10 @@ def _records_might_match(record1: dict[str, Any], record2: dict[str, Any]) -> bo
     id_fields = sorted(f for f in common_keys if f == "id" or f.endswith("_id"))
 
     # Match on the first shared ID field (most specific). Compare via the same
-    # canonical form as the record hashing so a numeric id "123" pairs with 123.
+    # canonical form as the record hashing, so numeric-TYPE ids pair across
+    # representations (123 == 123.0 == Decimal("123")). A numeric-looking STRING
+    # id ("123") is NOT equated with the number 123 here: string folding is the
+    # opt-in per-field tier, off on this reason-only diff path.
     for field in id_fields:
         if record1[field] is not None and record2[field] is not None:
             return _make_hashable(record1[field]) == _make_hashable(record2[field])

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -167,16 +167,19 @@ def _records_might_match(record1: dict[str, Any], record2: dict[str, Any]) -> bo
     common_keys = set(record1.keys()) & set(record2.keys())
     id_fields = sorted(f for f in common_keys if f == "id" or f.endswith("_id"))
 
-    # Match on the first shared ID field (most specific)
+    # Match on the first shared ID field (most specific). Compare via the same
+    # canonical form as the record hashing so a numeric id "123" pairs with 123.
     for field in id_fields:
         if record1[field] is not None and record2[field] is not None:
-            return record1[field] == record2[field]
+            return _make_hashable(record1[field]) == _make_hashable(record2[field])
 
     # Fallback: check if they share at least 50% of fields with same values
     if not common_keys:
         return False
 
-    matching_values = sum(1 for f in common_keys if record1[f] == record2[f])
+    matching_values = sum(
+        1 for f in common_keys if _make_hashable(record1[f]) == _make_hashable(record2[f])
+    )
     return matching_values >= len(common_keys) * 0.5
 
 

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -301,10 +301,11 @@ class StateChecksConfig(BaseModel):
     hash_enabled: bool = False
     expected_hash: str | None = None  # Pre-computed (if available)
     golden_actions: list[GoldenAction] = Field(default_factory=list)
-    # Opt-in, per-task: fold numeric-looking STRINGS ("130.00" == "130.0") when
-    # hashing state. Dangerous as a default (versions/codes carry meaning in
-    # their exact representation) — see core/hash.py canonical_number.
-    numeric_string_normalization: bool = False
+    # Opt-in, PER-FIELD: record field names whose numeric-looking STRING values
+    # fold ("130.00" == "130.0") when hashing state. Per-field (not a global
+    # switch) because a numeric-looking string can carry meaning in its exact
+    # representation (versions/codes) — see core/hash.py compute_stable_hash.
+    numeric_string_fields: list[str] = Field(default_factory=list)
 
     # JSONPath assertions
     jsonpath_checks: list[dict[str, Any]] = Field(default_factory=list)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -301,6 +301,10 @@ class StateChecksConfig(BaseModel):
     hash_enabled: bool = False
     expected_hash: str | None = None  # Pre-computed (if available)
     golden_actions: list[GoldenAction] = Field(default_factory=list)
+    # Opt-in, per-task: fold numeric-looking STRINGS ("130.00" == "130.0") when
+    # hashing state. Dangerous as a default (versions/codes carry meaning in
+    # their exact representation) — see core/hash.py canonical_number.
+    numeric_string_normalization: bool = False
 
     # JSONPath assertions
     jsonpath_checks: list[dict[str, Any]] = Field(default_factory=list)

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1036,7 +1036,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     trial_id,
                     trial_context,
                     golden_actions,
-                    normalize_numeric_strings=state_checks_config.numeric_string_normalization,
+                    numeric_string_fields=state_checks_config.numeric_string_fields,
                 )
                 components.hash_match = hash_result.hash_match
                 components.hash_score = hash_result.hash_score
@@ -1498,7 +1498,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         trial_context: TrialContextRuntime,
         golden_actions: list[GoldenAction],
         *,
-        normalize_numeric_strings: bool = False,
+        numeric_string_fields: list[str] | None = None,
     ) -> HashGradingResult:
         """
         Execute hash-based grading algorithm.
@@ -1541,7 +1541,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 raise
 
         trial_hash = await self.db_client.get_stable_hash(
-            trial_id, normalize_numeric_strings=normalize_numeric_strings
+            trial_id, numeric_string_fields=numeric_string_fields
         )
         logger.debug(f"GradeTrial: Trial hash = {trial_hash[:16]}...")
 
@@ -1638,7 +1638,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # 6. Get golden stable hash
         # get_stable_hash returns the hash string directly
         golden_hash = await self.db_client.get_stable_hash(
-            trial_id, normalize_numeric_strings=normalize_numeric_strings
+            trial_id, numeric_string_fields=numeric_string_fields
         )
         logger.debug(f"GradeTrial: Golden hash = {golden_hash[:16]}...")
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1033,7 +1033,10 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             )
             try:
                 hash_result = await self._execute_hash_grading(
-                    trial_id, trial_context, golden_actions
+                    trial_id,
+                    trial_context,
+                    golden_actions,
+                    normalize_numeric_strings=state_checks_config.numeric_string_normalization,
                 )
                 components.hash_match = hash_result.hash_match
                 components.hash_score = hash_result.hash_score
@@ -1494,6 +1497,8 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         trial_id: str,
         trial_context: TrialContextRuntime,
         golden_actions: list[GoldenAction],
+        *,
+        normalize_numeric_strings: bool = False,
     ) -> HashGradingResult:
         """
         Execute hash-based grading algorithm.
@@ -1535,7 +1540,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 logger.error(f"GradeTrial: Failed to sync MCP state before trial_hash: {e}")
                 raise
 
-        trial_hash = await self.db_client.get_stable_hash(trial_id)
+        trial_hash = await self.db_client.get_stable_hash(
+            trial_id, normalize_numeric_strings=normalize_numeric_strings
+        )
         logger.debug(f"GradeTrial: Trial hash = {trial_hash[:16]}...")
 
         # 2. Snapshot current state
@@ -1630,7 +1637,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
 
         # 6. Get golden stable hash
         # get_stable_hash returns the hash string directly
-        golden_hash = await self.db_client.get_stable_hash(trial_id)
+        golden_hash = await self.db_client.get_stable_hash(
+            trial_id, normalize_numeric_strings=normalize_numeric_strings
+        )
         logger.debug(f"GradeTrial: Golden hash = {golden_hash[:16]}...")
 
         # 7. Restore trial state


### PR DESCRIPTION
## Problem

State grading hashes the trial's final DB state and the golden state and passes
iff the two hashes match. Field values were compared as **raw strings / JSON**,
so a `Decimal` column that round-trips through the DB as `"130.00"` on one side
and `"130.0"` (or `72` vs `"72.00"`) on the other was graded a **state
mismatch** — a false-fail on an otherwise-correct trial.

This is not cosmetic. On a full arena eval it false-failed **258 trials in one
OTS domain alone** (`custom_refund_amount`), dragging its raw pass@1 from a true
~40% down to ~2%, plus a payroll `amount` field in a second domain. Because the
leaderboard ranks by `pass^5`, the raw number badly mis-ranks any model whose
only "error" is a trailing-zero formatting difference.

## Root cause

Two independent hashing paths compared values literally:

- `core/hash.py:compute_stable_hash` — JSON-serializes the state then SHA-256.
  Used by the **frozen-mcp-core adapter** (OTS / arena domains).
- `core/grading/state_checks.py:to_hashable` — folds state into a hashed tuple.
  Used by the **native / tau** adapter + env-evaluator.

`"130.00" != "130.0"` as strings → different hash → mismatch → fail.

## Fix

A shared `canonical_number()` maps every representation of a number to one token
before hashing, applied on **both** paths and in the human-readable
`runner/grading.py` diff. Two tiers:

- **Numeric TYPES** (`int` / `float` / `Decimal`) always fold
  (`72 == 72.0 == Decimal("72.00")`). Generic and safe — the type declares
  number-ness. On by default.
- **Numeric-looking STRINGS** (`"130.00" == "130.0"`) fold ONLY for values under
  a record key listed in `state_checks.numeric_string_fields` (a per-field
  allow-list), because a string that merely looks numeric can carry meaning in
  its exact form (versions `"1.10"` vs `"1.1"`, codes, zero-padded ids). The
  canonicalizer is key-aware: a value folds strings only when its immediate
  record key is listed, and a nested dict re-decides per its own keys.

Guards in both tiers: `bool` is left untouched (`True == 1` is undesirable for
grading); leading-zero identifier strings (`"00123"`) are not collapsed;
genuinely different numbers stay different; a genuine string that begins with the
reserved numeric-token prefix is escaped so it cannot masquerade as a token; the
string parser is a linear (ReDoS-safe) scan with a length cap.

`compute_stable_hash` gains a `canonicalize_numbers` flag (**default True**) so a
caller needing byte-exact `mcp_core.calculate_database_hash()` output can opt out
with `canonicalize_numbers=False`. The string tier is off unless a caller passes
`numeric_string_fields`.

`numeric_string_fields` is honored **identically on both grading substrates** —
the core `GradingEngine` (`to_hashable`) path and the runner gRPC
(`compute_stable_hash`) path — so a task grades the same regardless of how it is
run.

## Why this is safe (no stored hash invalidated)

Grading is **engine-vs-engine**: both the expected hash (replay golden actions on
fresh state) and the actual hash are computed at grade time with the same
function, so the change is **symmetric** — it can only flip a decimal-format
false-fail to a correct pass, never break a real pass.

No production task stores a precomputed hash: a scan of the task-pack clones
found **0** grading configs with an `expected_state_hash` literal (arena OTS +
tau all replay golden actions live). The only stored hashes in the tree are 3
`tau_retail_mini` test fixtures, re-pinned here. `to_hashable` has no byte-parity
contract to preserve, but note that any hash literal precomputed before this
change must be recomputed (documented in `docs/GRADING.md`).

## Testing

Grading / hash / canonical suites pass on the frozen engine venv (`283` in
`tests/unit/grading`, `444` in `tests/canonical`, plus json_db_service / native
adapter / grader / golden-replay). New coverage:

- Two-tier canonicalization: types fold by default; strings fold only for a
  listed field; a **selectivity test** proves an unlisted sibling (`version`
  `"1.10"` vs `"1.1"`) is preserved while the listed money field folds — on both
  the `compute_stable_hash` and `to_hashable` paths.
- Guards: leading-zero id, bool, `-0`, tag-collision escape, opt-out.
- A **parity test** verifies the standalone `json_db_service` fallback is
  byte-identical to core `compute_stable_hash` (force-loads the fallback via a
  guarded poisoned import).

## Independent review

An independent adversarial review (~120 executed probes) returned
**APPROVE-WITH-NITS** with no primary-path grading bug. All findings addressed:
the per-field key is now threaded through the core `GradingEngine` path (was a
silent no-op there); the stored-hash scan (0 hits) is recorded; the
`json_db_service` fallback has a parity test; a misleading diff-path comment and
the stale `docs/GRADING*.md` are fixed, and `numeric_string_fields` is documented.

## Configuration

```yaml
state_checks:
  hash: { enabled: true, weight: 1.0 }
  numeric_string_fields:      # per-field; matched by record key at any depth
    - custom_refund_amount    # only genuinely-numeric money/quantity fields;
                              # never list ids / codes (payment_method_last4, id)
```

Companion: tolokaforge-tasks#38 enables it for the two d365 money domains
(`[custom_refund_amount]` for travel_marketplace, `[amount]` for logistics). A
one-line frozen-mcp-core adapter mapping (tolokaforge-tools) carries the key from
grading.yaml into the runner `StateChecksConfig`.

## Follow-up (not in this PR)

Cut an engine release, repin it in `tolokaforge-tasks`, land the adapter mapping,
and **regrade** the affected saved trajectories (the fix changes grades, so
existing results must be re-graded, not just re-run).

## Regrade impact (measured on saved results)

Offline reclassification from each trial's saved final state + `state_diff` — no
model re-run. A trial flips to pass iff its only state differences are
numerically-equal but differently-formatted values on the configured fields.
Every measured flip had a **single-field signature** on exactly
`custom_refund_amount` (travel_marketplace) or `amount` (logistics), so the
per-field lists preserve 100% of the benefit.

**Muse 1.1** (surfaced the bug) — materially affected:

| domain | pass@1 before → after | flips |
|---|---|---|
| ots_travel_marketplace_external_support | 1.6% → **39.9%** | 258 |
| ots_07_logistics_internal | 74.3% → 75.5% | 9 |
| other 5 domains | unchanged | 0 |
| **micro** | **46.4% → 52.8%** (+6.4pp) | 267 |

**Other existing models** — the defect is model-agnostic (false-failed 9 models
across 8 vendors on the same two money fields), but retroactively small: **86
flips across 90,450 trials (0.16% of failures)**.

| model | largest domain move | overall pass@1 |
|---|---|---|
| glm_51 | travel +6.2pp (42 trials) | +1.0pp |
| minimax_27 | travel +2.7 / logistics +1.4 | +0.7pp |
| kimi_k2.7_code | logistics +0.8 | +0.1pp |
| grok_45, glm_52, gemma_4_31b, hy3, kimi_k3, nemotron_ultra | 1–2 trials | ≤ +0.15pp |

**No pair of models crosses — the leaderboard order is unchanged.** Regrading the
fleet is a correctness / consistency exercise, not a board-mover; Muse is the
only model whose standing materially depends on the fix.
