### PR TITLE
feat(tools): PersistentShellTool + DockerComposePersistentShellTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
-- **tools**: session-lifetime bash tool matching Anthropic `bash_20250124` — new `bash_session` schema (input: `command` string + `restart` bool) with subprocess variant. Docker-compose provider variant lands in follow-up. Additive; existing `bash` builtin unchanged.
+- **tools**: session-lifetime bash tool matching Anthropic `bash_20250124` — new `bash_session` schema (input: `command` string + `restart` bool) with two providers selectable purely by tool config: a local subprocess and a docker-compose `docker exec` into a running service (`tool_config: {service, compose_project_prefix}`). Identical wire schema either way. Additive; existing `bash` builtin unchanged.
 
 ## v0.9.3 (2026-07-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **tools**: session-lifetime bash tool matching Anthropic `bash_20250124` — new `bash_session` schema (input: `command` string + `restart` bool) with subprocess variant. Docker-compose provider variant lands in follow-up. Additive; existing `bash` builtin unchanged.
+
 ## v0.9.3 (2026-07-22)
 
 ## v0.9.2 (2026-07-21)

--- a/tests/canonical/test_persistent_shell_dispatch.py
+++ b/tests/canonical/test_persistent_shell_dispatch.py
@@ -1,0 +1,71 @@
+"""Canonical wiring lock for the ``bash_session`` provider config axis (#566).
+
+Daemon-free: asserts only that the wrapper *selects* the right backend from
+``tool_config`` and *resolves* the compose container name from the per-trial
+project convention. The concrete ``docker exec`` behaviour is proved on a real
+daemon in ``tests/integration/test_persistent_shell_compose.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import PersistentShellToolWrapper
+from tolokaforge.tools.persistent_shell import DockerComposeBashSession, LocalBashSession
+
+pytestmark = pytest.mark.canonical
+
+
+def _wrapper(tool_config: dict | None) -> PersistentShellToolWrapper:
+    kwargs = {"tool_config": tool_config} if tool_config is not None else {}
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        **kwargs,
+    )
+    return PersistentShellToolWrapper(schema)
+
+
+def test_service_config_selects_compose_backend():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "tolokaforge_"})
+    wrapper._trial_id = "t0"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+
+
+def test_no_service_selects_local_backend():
+    wrapper = _wrapper(None)
+    wrapper._trial_id = "t0"
+    session = wrapper._new_session()
+    assert isinstance(session, LocalBashSession)
+
+
+def test_container_name_resolved_from_trial_service_and_prefix():
+    name = PersistentShellToolWrapper._resolve_container_name(
+        trial_id="abc123", service="app", project_prefix="tolokaforge_"
+    )
+    assert name == "tolokaforge_abc123_app"
+
+
+def test_container_name_sanitises_colon_in_trial_id():
+    name = PersistentShellToolWrapper._resolve_container_name(
+        trial_id="run:abc", service="main", project_prefix="tbench_"
+    )
+    assert name == "tbench_run_abc_main"
+
+
+def test_service_without_prefix_fails_loud():
+    from tolokaforge.runner.tool_factory import ToolConfigurationError
+
+    with pytest.raises(ToolConfigurationError):
+        _wrapper({"service": "app"})
+
+
+def test_compose_backend_wires_resolved_name_into_session():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "tolokaforge_"})
+    wrapper._trial_id = "abc123"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+    assert session.container_name == "tolokaforge_abc123_app"

--- a/tests/integration/test_persistent_shell_compose.py
+++ b/tests/integration/test_persistent_shell_compose.py
@@ -1,0 +1,123 @@
+"""Behaviour-parity lock for the compose ``bash_session`` engine (#566).
+
+Runs the same behaviours Stage 1 locks for the local engine, but against a real
+``docker exec`` into a running container — proving the compose provider is
+behaviour-identical to the local one (modulo the documented orphan limitation
+on timeout, where pre-timeout state is not preserved).
+
+No mocks: a one-service container is brought up in ``setup`` and torn down after.
+Skips cleanly when the Docker daemon is unavailable; a failed assertion is a real
+failure, never a silent skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import PersistentShellToolWrapper, ToolLifecycleContext
+from tolokaforge.tools.persistent_shell import DockerComposeBashSession
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_IMAGE = "bash:5"
+_PREFIX = "tf_test_"
+_TRIAL_ID = "s2parity"
+_SERVICE = "app"
+_CONTAINER = PersistentShellToolWrapper._resolve_container_name(_TRIAL_ID, _SERVICE, _PREFIX)
+
+
+@pytest.fixture(scope="module")
+def running_container():
+    """Bring up a single bash container the compose engine can exec into."""
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+    subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+    up = subprocess.run(
+        ["docker", "run", "-d", "--name", _CONTAINER, _IMAGE, "sleep", "3600"],
+        capture_output=True,
+        text=True,
+    )
+    if up.returncode != 0:
+        pytest.skip(f"could not start test container: {up.stderr.strip()}")
+    try:
+        yield _CONTAINER
+    finally:
+        subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+
+
+@pytest.fixture
+def session(running_container):
+    s = DockerComposeBashSession(running_container)
+    s.open(None)
+    yield s
+    s.close()
+
+
+def test_cwd_persists_across_calls(session):
+    session.run("mkdir -p /tmp/sub", 10)
+    session.run("cd /tmp/sub", 10)
+    assert session.run("pwd", 10).output.strip() == "/tmp/sub"
+
+
+def test_env_persists_across_calls(session):
+    session.run("export FOO=bar", 10)
+    assert session.run("echo $FOO", 10).output.strip() == "bar"
+
+
+def test_shell_functions_persist_across_calls(session):
+    session.run("greet() { echo hello-fn; }", 10)
+    assert session.run("greet", 10).output.strip() == "hello-fn"
+
+
+def test_restart_yields_fresh_shell(running_container):
+    s = DockerComposeBashSession(running_container)
+    s.open(None)
+    try:
+        s.run("export FOO=bar", 10)
+        assert s.run("echo $FOO", 10).output.strip() == "bar"
+        s.close()
+        s.open(None)
+        assert s.run("echo $FOO", 10).output.strip() == ""
+    finally:
+        s.close()
+
+
+def test_timeout_is_kill_safe_and_session_usable(session):
+    """Orphan limitation: the runaway is abandoned and the in-container session
+    restarted, so the next command works (pre-timeout state is not preserved)."""
+    result = session.run("sleep 300", 3)
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert session.run("echo alive", 10).output.strip() == "alive"
+
+
+def test_output_is_middle_truncated_with_grep_hint(session):
+    result = session.run("for i in $(seq 1 20000); do printf X; done", 15)
+    out = result.output
+    assert len(out) < 20000
+    assert "truncated" in out
+    assert "grep" in out
+
+
+async def test_wrapper_drives_compose_backend_end_to_end(running_container):
+    """Full wrapper path: config selects the compose backend, resolves the
+    running container's name, and runs a command against the real daemon."""
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={"service": _SERVICE, "compose_project_prefix": _PREFIX},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id=_TRIAL_ID))
+    try:
+        await wrapper.execute({"command": "export TOKEN=xyz"})
+        assert (await wrapper.execute({"command": "echo $TOKEN"})).strip() == "xyz"
+        assert "restarted" in await wrapper.execute({"restart": True})
+        assert (await wrapper.execute({"command": "echo $TOKEN"})).strip() == ""
+    finally:
+        wrapper.stop()

--- a/tests/unit/test_builtin_registry.py
+++ b/tests/unit/test_builtin_registry.py
@@ -32,6 +32,8 @@ def test_list_builtins_covers_every_consumer_today():
         # executor side (was builtin_tool_factories, 10 entries)
         "list_dir",
         "search_kb",
+        # session-lifetime persistent shell (#566)
+        "bash_session",
     }
     assert expected == set(registry.list_builtins())
 
@@ -40,12 +42,21 @@ def test_dispatch_groups_are_disjoint_and_exhaustive():
     generic = registry.list_for_dispatch(registry.Dispatch.GENERIC)
     files = registry.list_for_dispatch(registry.Dispatch.FILES)
     rag = registry.list_for_dispatch(registry.Dispatch.RAG)
+    shell = registry.list_for_dispatch(registry.Dispatch.PERSISTENT_SHELL)
+    groups = [generic, files, rag, shell]
     # Disjoint
-    assert generic.isdisjoint(files)
-    assert generic.isdisjoint(rag)
-    assert files.isdisjoint(rag)
+    for i, a in enumerate(groups):
+        for b in groups[i + 1 :]:
+            assert a.isdisjoint(b)
     # Exhaustive
-    assert generic | files | rag == registry.list_builtins()
+    assert generic | files | rag | shell == registry.list_builtins()
+
+
+def test_bash_session_routes_to_persistent_shell_dispatch():
+    from tolokaforge.tools.persistent_shell import PersistentShellTool
+
+    assert registry.get_dispatch("bash_session") is registry.Dispatch.PERSISTENT_SHELL
+    assert registry.get_class("bash_session") is PersistentShellTool
 
 
 def test_bash_is_generic_not_files():

--- a/tests/unit/test_persistent_shell_local.py
+++ b/tests/unit/test_persistent_shell_local.py
@@ -1,0 +1,170 @@
+"""Behaviour lock for the local ``bash_session`` persistent shell (#566).
+
+Real bash subprocesses, no mocks. Covers state persistence (cwd, env,
+functions), restart, kill-safe timeout with state survival (mechanism M1:
+PTY + job control), output truncation, and the wrapper's config-driven
+timeout. Also locks that the schema provider advertises ``command`` +
+``restart`` even when a compose ``service`` config is present.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import psutil
+import pytest
+
+from tolokaforge.adapters.native import _builtin_tool_schemas
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import (
+    PersistentShellToolWrapper,
+    ToolLifecycleContext,
+)
+from tolokaforge.tools.persistent_shell import LocalBashSession
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def session(tmp_path):
+    s = LocalBashSession()
+    s.open(str(tmp_path))
+    yield s
+    s.close()
+
+
+def test_cwd_persists_across_calls(session, tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    session.run(f"cd {sub}", 5)
+    result = session.run("pwd", 5)
+    assert result.output.strip() == os.path.realpath(str(sub))
+
+
+def test_env_persists_across_calls(session):
+    session.run("export FOO=bar", 5)
+    result = session.run("echo $FOO", 5)
+    assert result.output.strip() == "bar"
+
+
+def test_shell_functions_persist_across_calls(session):
+    session.run("greet() { echo hello-fn; }", 5)
+    result = session.run("greet", 5)
+    assert result.output.strip() == "hello-fn"
+
+
+def test_restart_yields_fresh_shell(tmp_path):
+    session = LocalBashSession()
+    session.open(str(tmp_path))
+    try:
+        session.run("export FOO=bar", 5)
+        assert session.run("echo $FOO", 5).output.strip() == "bar"
+        session.close()
+        session.open(str(tmp_path))
+        assert session.run("echo $FOO", 5).output.strip() == ""
+    finally:
+        session.close()
+
+
+def test_timeout_is_kill_safe_and_state_survives(session):
+    """M1: the runaway is terminated, no process leaks, the session stays
+    usable, and env set before the timeout survives (same session)."""
+    session.run("export SURVIVES=yes", 5)
+    proc = psutil.Process(session.pid)
+
+    start = time.monotonic()
+    result = session.run("sleep 300", 3)
+    elapsed = time.monotonic() - start
+
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert elapsed < 15  # enforced near the 3s budget, not left to run 300s
+
+    # No leaked runaway: the shell has no surviving children.
+    assert proc.children(recursive=True) == []
+
+    # Session still usable and pre-timeout state survived (M1 guarantee).
+    assert session.run("echo alive", 5).output.strip() == "alive"
+    assert session.run("echo $SURVIVES", 5).output.strip() == "yes"
+
+
+def test_output_is_middle_truncated_with_grep_hint(session):
+    result = session.run("for i in $(seq 1 20000); do printf X; done", 15)
+    out = result.output
+    assert len(out) < 20000
+    assert out.startswith("X" * 100)
+    assert out.endswith("X" * 100)
+    assert "truncated" in out
+    assert "grep" in out
+
+
+async def test_wrapper_timeout_resolved_from_tool_config(tmp_path):
+    """A 5s ``tool_config`` timeout is enforced — proves the wrapper reads
+    tool_config, not self.timeout_s (pinned to 30s by the adapter)."""
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={"timeout_s": 5},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        start = time.monotonic()
+        output = await wrapper.execute({"command": "sleep 300"})
+        elapsed = time.monotonic() - start
+        assert 4 < elapsed < 20
+        assert "timed out" in output
+    finally:
+        wrapper.stop()
+
+
+async def test_wrapper_restart_resets_state(tmp_path):
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        await wrapper.execute({"command": "export FOO=bar"})
+        assert (await wrapper.execute({"command": "echo $FOO"})).strip() == "bar"
+        assert "restarted" in await wrapper.execute({"restart": True})
+        assert (await wrapper.execute({"command": "echo $FOO"})).strip() == ""
+    finally:
+        wrapper.stop()
+
+
+async def test_wrapper_requires_command_or_restart(tmp_path):
+    from tolokaforge.runner.tool_factory import ToolExecutionError
+
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        with pytest.raises(ToolExecutionError):
+            await wrapper.execute({})
+    finally:
+        wrapper.stop()
+
+
+def test_schema_advertises_command_and_restart_locally():
+    schemas = _builtin_tool_schemas(["bash_session"], {})
+    assert "bash_session" in schemas
+    props = schemas["bash_session"]["parameters"]["properties"]
+    assert set(props) == {"command", "restart"}
+
+
+def test_schema_advertised_when_compose_service_configured():
+    """The schema provider tolerates the compose ``service`` kwarg, so the
+    tool is not dropped from the LLM's view for a compose task."""
+    schemas = _builtin_tool_schemas(["bash_session"], {"bash_session": {"service": "app"}})
+    assert "bash_session" in schemas
+    props = schemas["bash_session"]["parameters"]["properties"]
+    assert set(props) == {"command", "restart"}

--- a/tests/unit/test_persistent_shell_local.py
+++ b/tests/unit/test_persistent_shell_local.py
@@ -99,6 +99,26 @@ def test_output_is_middle_truncated_with_grep_hint(session):
     assert "grep" in out
 
 
+def test_large_command_survives_short_writes(session, monkeypatch):
+    """``os.write`` on the PTY master may write fewer bytes than requested, so
+    ``_write`` must loop until the buffer drains. Cap every write at 4096 bytes
+    to force that short-write condition deterministically, then round-trip a
+    large heredoc: a single un-looped write would drop the command tail (the
+    heredoc terminator never arrives → timeout), while the loop delivers it in
+    full. ``wc -c`` keeps the output under the 16 KB truncation budget so the
+    write path is what's under test."""
+    import tolokaforge.tools.persistent_shell as ps
+
+    real_write = os.write
+    monkeypatch.setattr(ps.os, "write", lambda fd, buf: real_write(fd, buf[:4096]))
+
+    payload = "A" * 100_000
+    result = session.run(f"cat <<'EOF' | wc -c\n{payload}\nEOF", 15)
+    assert result.timed_out is False
+    assert result.exit_code == 0
+    assert result.output.strip() == str(len(payload) + 1)
+
+
 async def test_wrapper_timeout_resolved_from_tool_config(tmp_path):
     """A 5s ``tool_config`` timeout is enforced — proves the wrapper reads
     tool_config, not self.timeout_s (pinned to 30s by the adapter)."""

--- a/tests/unit/test_runner_builtin_dispatch.py
+++ b/tests/unit/test_runner_builtin_dispatch.py
@@ -21,6 +21,7 @@ from tolokaforge.runner.models import ToolSchema
 from tolokaforge.runner.tool_factory import (
     BuiltinFileToolWrapper,
     BuiltinGenericToolWrapper,
+    PersistentShellToolWrapper,
     ToolConfigurationError,
     ToolFactory,
 )
@@ -53,6 +54,17 @@ def test_read_file_routes_to_file_wrapper(factory):
     )
     wrapper = factory._create_wrapper(schema)
     assert isinstance(wrapper, BuiltinFileToolWrapper)
+
+
+def test_bash_session_routes_to_persistent_shell_wrapper(factory):
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = factory._create_wrapper(schema)
+    assert isinstance(wrapper, PersistentShellToolWrapper)
+    assert wrapper.has_lifecycle is True
 
 
 def test_mobile_end_to_end_through_native_adapter(factory):

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -52,6 +52,7 @@ from tolokaforge.runner.rag_client import (
 from tolokaforge.tools.persistent_shell import (
     BashSession,
     CommandResult,
+    DockerComposeBashSession,
     LocalBashSession,
 )
 
@@ -1178,12 +1179,26 @@ class PersistentShellToolWrapper(ToolWrapper):
         # every builtin's ToolSchema.timeout_s to 30.0, so self.timeout_s can
         # never carry the ADR-locked 120s default or a task's configured value.
         self._timeout_s = float(tool_config.get("timeout_s", 120.0))
+        # Provider is a config axis: a `service` key selects the compose backend
+        # (docker exec into a running service container); its absence selects the
+        # local subprocess backend. The wire schema is identical either way.
+        self._service: str | None = tool_config.get("service")
+        self._project_prefix: str | None = tool_config.get("compose_project_prefix")
+        if self._service is not None and not self._project_prefix:
+            raise ToolConfigurationError(
+                self.name,
+                "bash_session with a 'service' requires 'compose_project_prefix' to "
+                "resolve the running container name (the per-trial compose project "
+                "prefix used to bring the stack up)",
+            )
+        self._trial_id: str | None = None
         self._session: BashSession | None = None
         self._cwd: str | None = None
 
     def start(self, ctx: "ToolLifecycleContext") -> None:
+        self._trial_id = ctx.trial_id
         self._cwd = ctx.work_dir if ctx.work_dir and os.path.isdir(ctx.work_dir) else None
-        session = LocalBashSession()
+        session = self._new_session()
         session.open(self._cwd)
         self._session = session
 
@@ -1209,11 +1224,32 @@ class PersistentShellToolWrapper(ToolWrapper):
         result = await loop.run_in_executor(None, self._session.run, command, self._timeout_s)
         return self._format_result(result)
 
+    def _new_session(self) -> BashSession:
+        """Construct (but do not open) the backend session from config."""
+        if self._service is None:
+            return LocalBashSession()
+        assert self._trial_id is not None and self._project_prefix is not None
+        container = self._resolve_container_name(
+            self._trial_id, self._service, self._project_prefix
+        )
+        return DockerComposeBashSession(container)
+
+    @staticmethod
+    def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:
+        """Container name for *service* in the per-trial compose stack.
+
+        Mirrors the per-trial project convention the compose lifecycle consumer
+        uses (project ``{prefix}{trial_id}``, container ``{project}_{service}``),
+        so the exec targets the same running container the stack brought up.
+        """
+        project = f"{project_prefix}{trial_id.replace(':', '_')}"
+        return f"{project}_{service}"
+
     async def _restart(self) -> str:
         assert self._session is not None
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, self._session.close)
-        session = LocalBashSession()
+        session = self._new_session()
         await loop.run_in_executor(None, session.open, self._cwd)
         self._session = session
         return "Shell session restarted; working directory and environment reset."

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -22,6 +22,7 @@ import asyncio
 import importlib
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -47,6 +48,11 @@ from tolokaforge.runner.rag_client import (
     RAGServiceClient,
     RAGServiceError,
     SearchResponse,
+)
+from tolokaforge.tools.persistent_shell import (
+    BashSession,
+    CommandResult,
+    LocalBashSession,
 )
 
 logger = logging.getLogger(__name__)
@@ -1150,6 +1156,78 @@ class DockerComposeExecToolWrapper(ToolWrapper):
 
 
 # =============================================================================
+# Persistent Shell Tool Wrapper
+# =============================================================================
+
+
+class PersistentShellToolWrapper(ToolWrapper):
+    """Runner-side executor for the session-lifetime ``bash_session`` tool.
+
+    Holds one bash session for the trial: ``start()`` opens it (seeding the
+    working directory from :class:`ToolLifecycleContext`), ``execute()`` runs
+    commands or restarts the shell, and ``stop()`` tears it down. State (cwd,
+    environment, functions) persists across ``execute()`` calls.
+    """
+
+    has_lifecycle = True
+
+    def __init__(self, tool_schema: ToolSchemaModel):
+        super().__init__(tool_schema)
+        tool_config = tool_schema.tool_config or {}
+        # Resolve from tool_config, not self.timeout_s: the native adapter pins
+        # every builtin's ToolSchema.timeout_s to 30.0, so self.timeout_s can
+        # never carry the ADR-locked 120s default or a task's configured value.
+        self._timeout_s = float(tool_config.get("timeout_s", 120.0))
+        self._session: BashSession | None = None
+        self._cwd: str | None = None
+
+    def start(self, ctx: "ToolLifecycleContext") -> None:
+        self._cwd = ctx.work_dir if ctx.work_dir and os.path.isdir(ctx.work_dir) else None
+        session = LocalBashSession()
+        session.open(self._cwd)
+        self._session = session
+
+    def stop(self) -> None:
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def cleanup(self) -> None:
+        self.stop()
+
+    async def execute(self, arguments: dict[str, Any]) -> str:
+        if self._session is None:
+            raise ToolExecutionError(self.name, "bash session not started")
+        if arguments.get("restart"):
+            return await self._restart()
+        command = arguments.get("command")
+        if command is None:
+            raise ToolExecutionError(
+                self.name, "bash_session requires either 'command' or 'restart'"
+            )
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, self._session.run, command, self._timeout_s)
+        return self._format_result(result)
+
+    async def _restart(self) -> str:
+        assert self._session is not None
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._session.close)
+        session = LocalBashSession()
+        await loop.run_in_executor(None, session.open, self._cwd)
+        self._session = session
+        return "Shell session restarted; working directory and environment reset."
+
+    def _format_result(self, result: CommandResult) -> str:
+        if result.timed_out:
+            suffix = f"\n[timed out after {self._timeout_s:g}s; command terminated]"
+            return result.output + suffix
+        if result.exit_code not in (0, None):
+            return f"{result.output}\n[exit code: {result.exit_code}]"
+        return result.output
+
+
+# =============================================================================
 # Tool Factory
 # =============================================================================
 
@@ -1273,6 +1351,8 @@ class ToolFactory:
                 return self._create_rag_search_wrapper(schema)
             if dispatch is builtin_registry.Dispatch.FILES:
                 return BuiltinFileToolWrapper(schema)
+            if dispatch is builtin_registry.Dispatch.PERSISTENT_SHELL:
+                return PersistentShellToolWrapper(schema)
             return BuiltinGenericToolWrapper(schema)
 
         source = schema.source

--- a/tolokaforge/tools/builtin/registry.py
+++ b/tolokaforge/tools/builtin/registry.py
@@ -32,12 +32,15 @@ class Dispatch(StrEnum):
     choice. ``GENERIC`` tools receive ``ToolSchema.tool_config`` as
     constructor kwargs; ``FILES`` tools take ``WORK_DIR`` from the runner
     container layout; ``RAG`` tools take a ``rag_client`` + ``trial_id``
-    bound by the runner factory.
+    bound by the runner factory; ``PERSISTENT_SHELL`` tools are lifecycle
+    wrappers that hold a bash session for the trial, selecting a local or
+    compose backend from ``tool_config`` without a second dispatch branch.
     """
 
     GENERIC = "generic"
     FILES = "files"
     RAG = "rag"
+    PERSISTENT_SHELL = "persistent_shell"
 
 
 _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
@@ -84,6 +87,10 @@ _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
     "search_kb": (
         BuiltinToolEntry("tolokaforge.tools.builtin.rag_search", "SearchKBTool"),
         Dispatch.RAG,
+    ),
+    "bash_session": (
+        BuiltinToolEntry("tolokaforge.tools.persistent_shell", "PersistentShellTool"),
+        Dispatch.PERSISTENT_SHELL,
     ),
 }
 

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -1,19 +1,25 @@
 """Session-lifetime bash tool matching Anthropic's ``bash_20250124`` contract.
 
-Two roles live here:
+Three roles live here:
 
 - :class:`PersistentShellTool` is the *schema provider*. The builtin registry
   advertises its ``get_schema()`` to the LLM; it is never executed (the runner
   drives execution through ``PersistentShellToolWrapper``).
-- :class:`LocalBashSession` is the *engine*: a single ``bash`` subprocess held
-  for the trial. Working directory, exported environment, and shell functions
-  persist across :meth:`run` calls; :meth:`close` + re-:meth:`open` yields a
-  clean shell.
+- :class:`LocalBashSession` is the local *engine*: a single ``bash`` subprocess
+  held for the trial.
+- :class:`DockerComposeBashSession` is the compose *engine*: a held
+  ``docker exec`` into an already-running service container.
 
-The session opens ``bash`` under a PTY with job control (``set -m``) enabled. A
-per-command timeout is kill-safe: the runaway command runs in its own
-foreground process group, so terminating that group leaves the session leader
-(``bash``) alive with its accumulated state intact.
+Both engines share the sentinel protocol, per-command timeout, and 16 KB
+middle-truncation via :class:`_PtyBashSession`; they differ only in how the
+bash pipe is opened and how a runaway command is terminated on timeout.
+Working directory, exported environment, and shell functions persist across
+:meth:`run` calls; :meth:`close` + re-:meth:`open` yields a clean shell.
+
+The local session opens ``bash`` under a PTY with job control (``set -m``)
+enabled: the runaway command runs in its own foreground process group, so
+terminating that group leaves the session leader (``bash``) alive with its
+accumulated state intact.
 """
 
 from __future__ import annotations
@@ -21,6 +27,7 @@ from __future__ import annotations
 import os
 import pty
 import select
+import shlex
 import signal
 import subprocess
 import termios
@@ -90,12 +97,18 @@ def _truncate_middle(text: str) -> str:
     return text[:_HEAD_CHARS] + marker + text[-_TAIL_CHARS:]
 
 
-class LocalBashSession:
-    """A local ``bash`` subprocess held for the trial (PTY + job control)."""
+class _PtyBashSession:
+    """Shared engine for a bash pipe held under a host PTY.
+
+    Subclasses provide the process spawn (:meth:`_popen`) and the per-command
+    timeout kill strategy (:meth:`_terminate_runaway`); the sentinel protocol,
+    timeout loop, and output truncation are shared here.
+    """
 
     def __init__(self) -> None:
         self._proc: subprocess.Popen[bytes] | None = None
         self._master_fd: int | None = None
+        self._cwd: str | None = None
 
     @property
     def pid(self) -> int:
@@ -106,25 +119,13 @@ class LocalBashSession:
     def open(self, cwd: str | None) -> None:
         if self._proc is not None:
             raise RuntimeError("bash session is already open")
-        master, slave = pty.openpty()
-        attrs = termios.tcgetattr(slave)
-        attrs[3] &= ~termios.ECHO  # drop terminal echo so output is command stdout only
-        termios.tcsetattr(slave, termios.TCSANOW, attrs)
-        self._proc = subprocess.Popen(
-            ["bash", "--norc", "--noprofile"],
-            stdin=slave,
-            stdout=slave,
-            stderr=slave,
-            preexec_fn=os.setsid,
-            cwd=cwd,
-            close_fds=True,
-        )
-        os.close(slave)
-        self._master_fd = master
+        self._cwd = cwd
+        self._spawn(cwd)
         self._write("set -m; PS1=''; PS2=''\n")
         # Sentinel round-trip flushes shell-init output and confirms readiness.
         if self.run(":", timeout_s=_OPEN_TIMEOUT_S).timed_out:
             raise RuntimeError("bash session failed to become ready")
+        self._seed_cwd(cwd)
 
     def run(self, command: str, timeout_s: float) -> CommandResult:
         if self._master_fd is None:
@@ -171,6 +172,32 @@ class LocalBashSession:
                 pass
             self._master_fd = None
 
+    # -- spawn / cwd hooks ----------------------------------------------------
+
+    def _spawn(self, cwd: str | None) -> None:
+        master, slave = pty.openpty()
+        attrs = termios.tcgetattr(slave)
+        attrs[3] &= ~termios.ECHO  # drop terminal echo so output is command stdout only
+        termios.tcsetattr(slave, termios.TCSANOW, attrs)
+        self._proc = self._popen(cwd, slave)
+        os.close(slave)
+        self._master_fd = master
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        raise NotImplementedError
+
+    def _seed_cwd(self, cwd: str | None) -> None:
+        """Seed the working directory when the pipe can't at spawn time.
+
+        The local engine passes ``cwd`` straight to ``Popen`` and needs no
+        seeding; the compose engine overrides this to ``cd`` inside the
+        container after the shell is ready.
+        """
+
+    def _terminate_runaway(self) -> None:
+        """Terminate a timed-out command, leaving the session usable."""
+        raise NotImplementedError
+
     # -- internals ------------------------------------------------------------
 
     @staticmethod
@@ -189,27 +216,10 @@ class LocalBashSession:
         return output, exit_code
 
     def _on_timeout(self, buf: bytes) -> CommandResult:
-        self._terminate_foreground()
+        self._terminate_runaway()
         buf += self._drain(0.3)
         output = buf.decode("utf-8", errors="replace").replace("\r\n", "\n")
         return CommandResult(output=_truncate_middle(output), exit_code=None, timed_out=True)
-
-    def _terminate_foreground(self) -> None:
-        """Kill the foreground command's process group, never the shell itself."""
-        assert self._master_fd is not None and self._proc is not None
-        try:
-            foreground = os.tcgetpgrp(self._master_fd)
-        except OSError:
-            return
-        shell_pgid = os.getpgid(self._proc.pid)
-        if foreground <= 0 or foreground == shell_pgid:
-            return  # only the shell is in the foreground — nothing to terminate
-        for sig in (signal.SIGINT, signal.SIGKILL):
-            try:
-                os.killpg(foreground, sig)
-            except ProcessLookupError:
-                return
-            time.sleep(0.2)
 
     def _kill_process_group(self, sig: int) -> None:
         assert self._proc is not None
@@ -230,7 +240,8 @@ class LocalBashSession:
             return b""
 
     def _drain(self, timeout_s: float) -> bytes:
-        assert self._master_fd is not None
+        if self._master_fd is None:
+            return b""
         out = b""
         end = time.monotonic() + timeout_s
         while time.monotonic() < end:
@@ -244,6 +255,110 @@ class LocalBashSession:
         return out
 
 
+class LocalBashSession(_PtyBashSession):
+    """A local ``bash`` subprocess held for the trial (PTY + job control)."""
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        return subprocess.Popen(
+            ["bash", "--norc", "--noprofile"],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=os.setsid,
+            cwd=cwd,
+            close_fds=True,
+        )
+
+    def _terminate_runaway(self) -> None:
+        """Kill the foreground command's process group, never the shell itself.
+
+        Job control (``set -m``) puts the external command in its own
+        foreground process group that owns the tty; signalling that group
+        leaves ``bash`` (the session leader) alive with its state intact.
+        """
+        assert self._master_fd is not None and self._proc is not None
+        try:
+            foreground = os.tcgetpgrp(self._master_fd)
+        except OSError:
+            return
+        shell_pgid = os.getpgid(self._proc.pid)
+        if foreground <= 0 or foreground == shell_pgid:
+            return  # only the shell is in the foreground — nothing to terminate
+        for sig in (signal.SIGINT, signal.SIGKILL):
+            try:
+                os.killpg(foreground, sig)
+            except ProcessLookupError:
+                return
+            time.sleep(0.2)
+
+
+class DockerComposeBashSession(_PtyBashSession):
+    """A held ``docker exec -i <container> bash`` into a running service.
+
+    Targets an *already-running* container (brought up by the environment /
+    another lifecycle consumer); this engine only holds an exec session for the
+    trial, it never brings the stack up or down. State (cwd, environment,
+    functions) persists across :meth:`run` calls exactly as for the local
+    engine.
+
+    Kill-safety is weaker than the local engine: a signal to the host-side
+    ``docker exec`` process group does not reach the command running inside the
+    container. When a per-command timeout fires we kill the host ``docker exec``
+    client and restart the in-container session to regain a clean prompt; the
+    container may briefly hold the orphaned command. This is a documented
+    limitation — subsequent commands still run, but session state accumulated
+    before a timed-out command is lost (unlike the local engine, which
+    preserves it).
+    """
+
+    def __init__(self, container_name: str) -> None:
+        super().__init__()
+        self._container_name = container_name
+
+    @property
+    def container_name(self) -> str:
+        return self._container_name
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        return subprocess.Popen(
+            ["docker", "exec", "-i", self._container_name, "bash", "--norc", "--noprofile"],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=os.setsid,
+            close_fds=True,
+        )
+
+    def _seed_cwd(self, cwd: str | None) -> None:
+        if cwd:
+            self.run(f"cd {shlex.quote(cwd)} 2>/dev/null || true", timeout_s=_OPEN_TIMEOUT_S)
+
+    def _terminate_runaway(self) -> None:
+        """Kill the host ``docker exec`` client and restart the in-container session.
+
+        The runaway command may briefly survive as an in-container orphan (see
+        the class docstring); killing the client and reopening restores a usable
+        prompt for the next command.
+        """
+        self._kill_process_group(signal.SIGKILL)
+        if self._proc is not None:
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            self._proc = None
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+        self._spawn(self._cwd)
+        self._write("set -m; PS1=''; PS2=''\n")
+        self.run(":", timeout_s=_OPEN_TIMEOUT_S)
+        self._seed_cwd(self._cwd)
+
+
 class PersistentShellTool(Tool):
     """Schema provider for the ``bash_session`` tool.
 
@@ -252,15 +367,17 @@ class PersistentShellTool(Tool):
     by the runner-side wrapper, not here.
 
     ``__init__`` accepts and ignores the ``tool_config`` keys the wrapper
-    consumes (``service``, ``timeout_s``): the adapter builds the schema
-    provider as ``cls(**tool_config)``, so an unexpected keyword would raise
-    inside schema extraction and drop the tool from the LLM's view.
+    consumes (``service``, ``timeout_s``, ``compose_project_prefix``): the
+    adapter builds the schema provider as ``cls(**tool_config)``, so an
+    unexpected keyword would raise inside schema extraction and drop the tool
+    from the LLM's view.
     """
 
     def __init__(
         self,
         service: str | None = None,
         timeout_s: float | None = None,
+        compose_project_prefix: str | None = None,
         **_: object,
     ) -> None:
         super().__init__(

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -230,7 +230,9 @@ class _PtyBashSession:
 
     def _write(self, data: str) -> None:
         assert self._master_fd is not None
-        os.write(self._master_fd, data.encode())
+        buf = data.encode()
+        while buf:
+            buf = buf[os.write(self._master_fd, buf) :]
 
     def _read(self) -> bytes:
         assert self._master_fd is not None
@@ -330,6 +332,9 @@ class DockerComposeBashSession(_PtyBashSession):
         )
 
     def _seed_cwd(self, cwd: str | None) -> None:
+        # Host work_dir need not exist inside the container; swallow the cd
+        # failure so the session still opens (the local engine's isdir guard
+        # has no in-container equivalent here).
         if cwd:
             self.run(f"cd {shlex.quote(cwd)} 2>/dev/null || true", timeout_s=_OPEN_TIMEOUT_S)
 

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -1,0 +1,305 @@
+"""Session-lifetime bash tool matching Anthropic's ``bash_20250124`` contract.
+
+Two roles live here:
+
+- :class:`PersistentShellTool` is the *schema provider*. The builtin registry
+  advertises its ``get_schema()`` to the LLM; it is never executed (the runner
+  drives execution through ``PersistentShellToolWrapper``).
+- :class:`LocalBashSession` is the *engine*: a single ``bash`` subprocess held
+  for the trial. Working directory, exported environment, and shell functions
+  persist across :meth:`run` calls; :meth:`close` + re-:meth:`open` yields a
+  clean shell.
+
+The session opens ``bash`` under a PTY with job control (``set -m``) enabled. A
+per-command timeout is kill-safe: the runaway command runs in its own
+foreground process group, so terminating that group leaves the session leader
+(``bash``) alive with its accumulated state intact.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import signal
+import subprocess
+import termios
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from tolokaforge.tools.registry import Tool, ToolCategory, ToolPolicy, ToolResult
+
+_DEFAULT_TIMEOUT_S = 120.0
+_OPEN_TIMEOUT_S = 15.0
+
+# Middle-truncation budget for a single command's output.
+_MAX_OUTPUT_CHARS = 16384
+_HEAD_CHARS = 8192
+_TAIL_CHARS = 8192
+
+_SENTINEL_PREFIX = "__DONE_"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Outcome of one command in a persistent shell session."""
+
+    output: str
+    exit_code: int | None
+    timed_out: bool
+
+
+@runtime_checkable
+class BashSession(Protocol):
+    """A held bash pipe whose state persists across commands.
+
+    Implementations differ only in *how* the pipe is opened (a local
+    subprocess vs. an exec into a running container); the sentinel protocol,
+    per-command timeout, and output truncation are shared behaviour.
+    """
+
+    @property
+    def pid(self) -> int:
+        """PID of the session-leader shell process (for kill-safety checks)."""
+        ...
+
+    def open(self, cwd: str | None) -> None:
+        """Start the shell, optionally seeding its working directory."""
+        ...
+
+    def run(self, command: str, timeout_s: float) -> CommandResult:
+        """Run *command*, returning its output, exit code, and timeout flag."""
+        ...
+
+    def close(self) -> None:
+        """Terminate the shell and release its resources."""
+        ...
+
+
+def _truncate_middle(text: str) -> str:
+    """Return *text* unchanged, or head+marker+tail when over budget."""
+    if len(text) <= _MAX_OUTPUT_CHARS:
+        return text
+    elided = len(text) - _HEAD_CHARS - _TAIL_CHARS
+    marker = (
+        f"\n...[truncated: {elided} chars elided; re-run a narrower "
+        f"command or grep for the pattern you need]...\n"
+    )
+    return text[:_HEAD_CHARS] + marker + text[-_TAIL_CHARS:]
+
+
+class LocalBashSession:
+    """A local ``bash`` subprocess held for the trial (PTY + job control)."""
+
+    def __init__(self) -> None:
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._master_fd: int | None = None
+
+    @property
+    def pid(self) -> int:
+        if self._proc is None:
+            raise RuntimeError("bash session is not open")
+        return self._proc.pid
+
+    def open(self, cwd: str | None) -> None:
+        if self._proc is not None:
+            raise RuntimeError("bash session is already open")
+        master, slave = pty.openpty()
+        attrs = termios.tcgetattr(slave)
+        attrs[3] &= ~termios.ECHO  # drop terminal echo so output is command stdout only
+        termios.tcsetattr(slave, termios.TCSANOW, attrs)
+        self._proc = subprocess.Popen(
+            ["bash", "--norc", "--noprofile"],
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            preexec_fn=os.setsid,
+            cwd=cwd,
+            close_fds=True,
+        )
+        os.close(slave)
+        self._master_fd = master
+        self._write("set -m; PS1=''; PS2=''\n")
+        # Sentinel round-trip flushes shell-init output and confirms readiness.
+        if self.run(":", timeout_s=_OPEN_TIMEOUT_S).timed_out:
+            raise RuntimeError("bash session failed to become ready")
+
+    def run(self, command: str, timeout_s: float) -> CommandResult:
+        if self._master_fd is None:
+            raise RuntimeError("bash session is not open")
+        sentinel = f"{_SENTINEL_PREFIX}{uuid.uuid4().hex}__"
+        marker = sentinel.encode()
+        self._write(f"{command}\n")
+        self._write(f"printf '%s %d\\n' {sentinel} $?\n")
+
+        buf = b""
+        deadline = time.monotonic() + timeout_s
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return self._on_timeout(buf)
+            ready, _, _ = select.select([self._master_fd], [], [], min(remaining, 0.2))
+            if not ready:
+                continue
+            chunk = self._read()
+            if not chunk:
+                return self._on_timeout(buf)
+            buf += chunk
+            parsed = self._split_on_sentinel(buf, marker)
+            if parsed is not None:
+                output, exit_code = parsed
+                return CommandResult(
+                    output=_truncate_middle(output),
+                    exit_code=exit_code,
+                    timed_out=False,
+                )
+
+    def close(self) -> None:
+        if self._proc is not None:
+            self._kill_process_group(signal.SIGKILL)
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            self._proc = None
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+
+    # -- internals ------------------------------------------------------------
+
+    @staticmethod
+    def _split_on_sentinel(buf: bytes, marker: bytes) -> tuple[str, int | None] | None:
+        """Return (output, exit_code) once the full sentinel line has arrived."""
+        idx = buf.find(marker)
+        if idx == -1:
+            return None
+        after = buf[idx + len(marker) :]
+        newline = after.find(b"\n")
+        if newline == -1:
+            return None  # exit-code line not fully received yet
+        token = after[:newline].strip()
+        exit_code = int(token) if token.isdigit() else None
+        output = buf[:idx].decode("utf-8", errors="replace").replace("\r\n", "\n")
+        return output, exit_code
+
+    def _on_timeout(self, buf: bytes) -> CommandResult:
+        self._terminate_foreground()
+        buf += self._drain(0.3)
+        output = buf.decode("utf-8", errors="replace").replace("\r\n", "\n")
+        return CommandResult(output=_truncate_middle(output), exit_code=None, timed_out=True)
+
+    def _terminate_foreground(self) -> None:
+        """Kill the foreground command's process group, never the shell itself."""
+        assert self._master_fd is not None and self._proc is not None
+        try:
+            foreground = os.tcgetpgrp(self._master_fd)
+        except OSError:
+            return
+        shell_pgid = os.getpgid(self._proc.pid)
+        if foreground <= 0 or foreground == shell_pgid:
+            return  # only the shell is in the foreground — nothing to terminate
+        for sig in (signal.SIGINT, signal.SIGKILL):
+            try:
+                os.killpg(foreground, sig)
+            except ProcessLookupError:
+                return
+            time.sleep(0.2)
+
+    def _kill_process_group(self, sig: int) -> None:
+        assert self._proc is not None
+        try:
+            os.killpg(os.getpgid(self._proc.pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+    def _write(self, data: str) -> None:
+        assert self._master_fd is not None
+        os.write(self._master_fd, data.encode())
+
+    def _read(self) -> bytes:
+        assert self._master_fd is not None
+        try:
+            return os.read(self._master_fd, 65536)
+        except OSError:
+            return b""
+
+    def _drain(self, timeout_s: float) -> bytes:
+        assert self._master_fd is not None
+        out = b""
+        end = time.monotonic() + timeout_s
+        while time.monotonic() < end:
+            ready, _, _ = select.select([self._master_fd], [], [], 0.1)
+            if not ready:
+                continue
+            chunk = self._read()
+            if not chunk:
+                break
+            out += chunk
+        return out
+
+
+class PersistentShellTool(Tool):
+    """Schema provider for the ``bash_session`` tool.
+
+    Publishes the Anthropic ``bash_20250124`` input schema (``command`` +
+    ``restart``) so the native adapter can advertise it. Execution is handled
+    by the runner-side wrapper, not here.
+
+    ``__init__`` accepts and ignores the ``tool_config`` keys the wrapper
+    consumes (``service``, ``timeout_s``): the adapter builds the schema
+    provider as ``cls(**tool_config)``, so an unexpected keyword would raise
+    inside schema extraction and drop the tool from the LLM's view.
+    """
+
+    def __init__(
+        self,
+        service: str | None = None,
+        timeout_s: float | None = None,
+        **_: object,
+    ) -> None:
+        super().__init__(
+            name="bash_session",
+            description=(
+                "Run commands in a persistent bash shell. The working directory, "
+                "exported environment variables, and shell functions persist "
+                "across calls. Set restart=true to reset the shell to a clean "
+                "state (omit command when restarting)."
+            ),
+            policy=ToolPolicy(timeout_s=_DEFAULT_TIMEOUT_S, category=ToolCategory.COMPUTE),
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The bash command to run in the persistent session.",
+                        },
+                        "restart": {
+                            "type": "boolean",
+                            "description": "Restart the shell, discarding all session state.",
+                        },
+                    },
+                    "required": [],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        raise NotImplementedError(
+            "PersistentShellTool is a schema provider; execution is handled by "
+            "PersistentShellToolWrapper on the runner."
+        )


### PR DESCRIPTION
## Summary

Third sub-issue of Milestone 25. Ships the session-lifetime `bash_session` tool per ADR 0017 §(b) + (d): input schema matches Anthropic's `bash_20250124` (`command` string + `restart` bool); state (cwd, exported env, shell functions) persists across `execute()` calls; both subprocess-backed and docker-compose provider variants ship in one PR.

Three commits: Stage 1 (local), Stage 2 (compose variant), reviewer corrections (PTY write-loop + compose cwd comment).

## What changes

- `tolokaforge/tools/persistent_shell.py` (new): `PersistentShellTool` schema-provider (accepts+ignores wrapper config keys — critical, since `_builtin_tool_schemas` calls `cls(**tool_configs[name])` and silently swallows `TypeError`), plus `BashSession` Protocol + `LocalBashSession` + `DockerComposeBashSession` engines.
- `tolokaforge/runner/tool_factory.py` (+120 net): `PersistentShellToolWrapper(ToolWrapper)` with `has_lifecycle=True`, branching on `tool_config["service"]` — local vs compose engine. Per-command timeout sourced from `tool_config.get("timeout_s", 120.0)` (not `self.timeout_s`, which the native adapter pins at 30.0). Fail-loud when `service` is set without `compose_project_prefix`.
- `tolokaforge/tools/builtin/registry.py` (+9): `Dispatch.PERSISTENT_SHELL` variant, wires `bash_session` builtin → the wrapper.
- `tests/unit/test_persistent_shell_local.py` (+190): 12 tests including cwd/env/functions/restart persistence, kill-safety, output truncation, timeout-from-config, schema-under-compose-config round-trip, large-command write-loop.
- `tests/canonical/test_persistent_shell_dispatch.py` (new): backend selection + container-name resolution (no argv assertions).
- `tests/integration/test_persistent_shell_compose.py` (new): `integration + requires_docker`, exercises the 7 behaviours against a real compose service.
- `CHANGELOG.md`: `Unreleased/Feat` entry.

## Kill-safety mechanism

**M1 (PTY + `set -m` job control + SIGINT→SIGKILL to foreground pgroup) LOCKED**, empirically probed on bash 3.2 (darwin) and bash 5.2 (linux). A runaway command that traps SIGINT runs in its own foreground process group; the wrapper signals only that group and leaves the session leader alive with pre-timeout env + cwd intact. M2 (transparent restart) is the documented fallback but wasn't needed.

Compose variant is weaker: signalling the host `docker exec` process group doesn't kill the in-container command, so the compose engine falls back to session-restart on timeout. Documented in `DockerComposeBashSession` docstring.

## Plan

Plan file at `~/.claude/plans/toloka-tolokaforge/2026-07-22-issue-566-persistent-shell-tool.md` (scratch, outside repo per milestone workflow).

## Discovered issues

- **Filed as #571** (earlier, by A2): single-source the `/work` agent working-root literal across `bash.py` / `tool_factory.py` / `service.py` / `grading.py`. Independent refactor.
- **Filed as #577** (earlier, by A3): `_builtin_tool_schemas` silently swallows schema-extraction failures. Fail-loud violation adjacent to this work; A3 pattern (`**_` catch-all in `__init__`) works around it.

## Backward compatibility

- Additive: existing legacy `bash` builtin (per-call, in-process, allowlisted) stays for legacy consumers. New `bash_session` is a distinct registry name.
- `ToolLifecycleContext.work_dir` (from A2 #565) consumed as-is — no further evolution.
- Compose provider name resolution takes `compose_project_prefix` from `tool_config` — not hardcoded `tbench_` (which is terminal-bench-specific). Works with any task-pack's compose naming convention.

## Test plan

- `uv run pytest tests/unit/test_persistent_shell_local.py -v` — 12 passed (7 core + wrapper config + schema-under-compose + large-command write-loop + wrapper restart + wrapper command-or-restart validation).
- `uv run pytest tests/canonical/test_persistent_shell_dispatch.py -v` — 6 passed (backend selection + name resolution + fail-loud on missing prefix).
- `uv run pytest tests/ -m unit -q` — 2676 passed (pre-existing `multi_service_endpoint_add` failures unrelated).
- `uv run pytest tests/ -m canonical -q` — 529 passed (pre-existing `test_endpoint_add_pack_wiring` failures unrelated to this diff, same set A2 documented).
- `uv run ruff check tolokaforge tests && uv run ruff format --check tolokaforge tests` — clean.
- Integration test (`test_persistent_shell_compose.py`) runs opt-in behind `requires_docker`.

Closes #566.