### PR TITLE
docs(tools): TOOLS.md + examples + ADR index for persistent shell + editor tools

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -7,6 +7,8 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
 - `browser`: Playwright-based browser automation (coordinate actions).
 - `mobile`: Mobile app interaction tool (tap/type/scroll/app switching).
 - `bash`: Allowlisted shell execution.
+- `bash_session`: Persistent bash shell; cwd, environment, and functions persist across calls.
+- `str_replace_editor`: View, create, and edit files with `view`/`create`/`str_replace`/`insert`.
 - `read_file`: Read from `/env/fs/agent-visible`.
 - `write_file`: Write to `/env/fs/agent-visible`.
 - `list_dir`: List files in `/env/fs/agent-visible`.
@@ -33,6 +35,119 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
 
 See [BROWSER_TOOLS.md](BROWSER_TOOLS.md) for action schemas, examples, and coordinate behavior.
 
+## Persistent Shell and Editor Tools
+
+`bash_session` and `str_replace_editor` mirror Anthropic's agent tool contracts.
+Each has two provider variants — a local variant and a docker-compose variant —
+selected purely by `tool_config`: pass a `service` key to route into a container,
+omit it to run locally. The wire schema the LLM sees is identical for both
+variants. Both tools are wrapped by the runner, which drives their per-trial
+lifecycle (see [RUNNER.md § Tool Lifecycle](RUNNER.md#tool-lifecycle)) and the
+design rationale in [ADR 0017](adr/0017-persistent-agent-shell-and-editor-tools.md).
+
+### `bash_session`
+
+Session-lifetime shell matching Anthropic's `bash_20250124` contract.
+
+**Input schema**
+
+- `command` (string): the bash command to run.
+- `restart` (boolean): reset the shell to a clean state; omit `command` when
+  restarting (`{"restart": true}`).
+
+Both fields are optional at the schema level; a call must supply one or the
+other, and a call with neither fails loud.
+
+**Session semantics.** The working directory, exported environment variables,
+shell functions, and aliases persist across `execute()` calls for the life of
+the trial. `restart` discards that state and yields a clean shell.
+
+**Timeout.** Per-command timeout defaults to 120 s, configurable via
+`tool_config.timeout_s`. On timeout the command is terminated and a
+`[timed out after <n>s; command terminated]` note is appended to the output.
+
+**Output.** Middle-truncated at 16384 characters (an elision marker names the
+elided character count and hints to re-run a narrower command or `grep` for the
+pattern). Non-zero
+exit codes are surfaced as an `[exit code: <n>]` suffix.
+
+**Provider variants**
+
+- **Local** (no `service` key): a `bash` subprocess held under a PTY with job
+  control (`set -m`). A timed-out command runs in its own foreground process
+  group; terminating that group (SIGINT then SIGKILL) leaves the session-leader
+  shell alive, so session state survives a per-command timeout.
+- **Compose** (`service` + `compose_project_prefix`): a held
+  `docker exec` into an already-running service container. It never brings the
+  compose stack up or down — the environment / another lifecycle consumer owns
+  that. Kill-safety is weaker than the local variant: signalling the host-side
+  `docker exec` process group does not reach the command running inside the
+  container, so on a per-command timeout the host exec client is killed and the
+  in-container session is restarted. Session state accumulated before a
+  timed-out command is lost (unlike the local variant, which preserves it), and
+  the runaway command may briefly survive as an in-container orphan.
+
+The compose variant resolves its target container as
+`<compose_project_prefix><trial_id>_<service>`, with any `:` in the trial id
+replaced by `_`; both compose tools share this resolution so they target the
+identical container.
+
+**When to use.** Prefer `bash_session` for multi-step workflows that need a
+persistent cwd, environment, or shell functions across turns. Use the legacy
+per-call [`bash`](#built-in-tools) for one-shot allowlisted commands.
+
+### `str_replace_editor`
+
+File editor matching Anthropic's `str_replace_based_edit_tool` contract (the
+`text_editor_20250429` / `text_editor_20250728` shape — parameter-identical;
+`text_editor_20250728` adds a `max_characters` view-truncation knob). `undo_edit`
+is absent, as in those Claude-4 variants.
+
+**Input schema.** `command` (enum: `view`/`create`/`str_replace`/`insert`) and
+`path` are required; the remaining fields apply per command: `view_range`,
+`file_text`, `old_str`, `new_str`, `insert_line`, `insert_text`.
+
+**Commands**
+
+- `view` — `path` plus optional `view_range: [start, end]` (1-indexed; `-1` for
+  end of file). Renders `cat -n`-style line-numbered content for a file, or a
+  directory listing 2 levels deep (hidden entries and `__pycache__` skipped).
+  An out-of-range `view_range` fails loud.
+- `create` — `path` + `file_text`. **Fails loud if the path already exists**
+  (a deliberate deviation from Anthropic's reference, which overwrites).
+- `str_replace` — `path` + `old_str` + `new_str`. Replaces the single unique
+  occurrence of `old_str`; fails loud on zero matches or more than one (the
+  error reports the match count).
+- `insert` — `path` + `insert_line` + **`insert_text`** (note: `insert` uses
+  `insert_text`, not `str_replace`'s `new_str`). `insert_line: 0` inserts before
+  the first line; a positive `N` inserts after line `N`.
+
+**Fail-loud framing.** Ambiguous, destructive, or out-of-range operations raise,
+and the error reaches the LLM for self-correction. Mutating commands
+(`create`/`str_replace`/`insert`) require valid UTF-8 and fail loud on a
+non-UTF-8 file (which cannot be safely round-tripped); `view` reads with
+replacement characters for display only.
+
+**Path validation.** Paths resolve to their realpath and must stay contained in
+the working root (`/work`); a symlink escape or a `..` component that leaves the
+root fails loud.
+
+**Provider variants**
+
+- **Local** (no `service` key): in-process file operations rooted at the runner
+  container's `/work`. Writes go to a temp file and are renamed into place
+  (single-process temp+rename).
+- **Compose** (`service` + `compose_project_prefix`): every command runs through
+  `docker exec` into an already-running service container. File content is piped
+  on stdin (never interpolated into the shell command string) and paths are
+  passed as positional arguments, so agent-controlled bytes cannot inject shell
+  commands. Path containment is validated **inside the container** via
+  `realpath`; if `realpath` is absent from the target image the engine fails
+  loud rather than silently skipping validation. Write atomicity is weaker than
+  the local variant: a completed temp-file+`mv` is atomic, but an exec
+  interrupted mid-write can leave the temp file behind. The editor has no
+  configurable per-command timeout.
+
 ## Enabling Tools
 
 ```yaml
@@ -42,6 +157,44 @@ tools:
   user:
     enabled: []
 ```
+
+### Persistent shell and editor
+
+List the tool in `enabled` to get its local variant — no kwargs block is needed:
+
+```yaml
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+```
+
+To select the compose variant, add a per-tool kwargs block under
+`tools.agent.<name>` naming the target `service` and the `compose_project_prefix`
+used to bring the stack up. `bash_session` additionally accepts `timeout_s`; the
+editor has no configurable per-command timeout:
+
+```yaml
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+    bash_session:
+      service: main
+      compose_project_prefix: env_
+      timeout_s: 120
+    str_replace_editor:
+      service: main
+      compose_project_prefix: env_
+```
+
+> **Compose-variant network isolation.** Under `network_policy: no_internet` /
+> `limited_internet`, the engine attaches every compose service to a single
+> injected internal network. If a task pack co-locates env services (e.g. a DB)
+> with the agent-side compose service that `bash_session` /
+> `str_replace_editor` executes into, the agent can reach those services
+> directly and bypass wrapped tools. Tracked as
+> [#581](https://github.com/Toloka/tolokaforge/issues/581). Until that lands, do
+> not co-locate env services with the `bash_session` / `str_replace_editor`
+> target service. The local variants are unaffected.
 
 ## MCP Tools
 

--- a/examples/native/persistent_tools/README.md
+++ b/examples/native/persistent_tools/README.md
@@ -1,0 +1,31 @@
+# Persistent shell and editor example
+
+Self-contained dataset with one public task that enables both persistent
+agent tools in their local variants:
+
+- `bash_session` — a held bash shell whose working directory, environment,
+  and functions persist across calls.
+- `str_replace_editor` — a file editor with `view` / `create` /
+  `str_replace` / `insert` commands.
+
+The agent establishes a working directory in the session, patches a
+changelog draft with a single `str_replace`, authors a release-notes file,
+and confirms the result by relying on the session's persisted state. Both
+tools operate on the runner's `/work`, so no Docker substrate is required.
+See `docs/TOOLS.md` for the full tool contracts.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/persistent_tools/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/persistent_tools/run_configs/dev.yaml
+```
+
+## Tasks included
+
+- `dataset/tasks/persistent_tools/persistent_tools_public_example_01/`

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/fixtures/CHANGELOG_DRAFT.md
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/fixtures/CHANGELOG_DRAFT.md
@@ -1,0 +1,7 @@
+# Project Changelog
+
+## Unreleased
+
+- STATUS: PENDING
+- Persistent bash session available for multi-step shell workflows.
+- File editor available for creating and patching files in place.

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/grading.yaml
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/grading.yaml
@@ -1,0 +1,32 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.6
+    transcript_rules: 0.4
+  pass_threshold: 0.8
+state_checks:
+  jsonpaths:
+    - path: "$.filesystem['/env/fs/agent-visible/CHANGELOG_DRAFT.md']"
+      contains: "STATUS: READY"
+      description: "Changelog placeholder finalized to READY via str_replace"
+    - path_glob: "/env/fs/agent-visible/release/*"
+      contains_ci: "changelog"
+      description: "Release notes authored under the persisted release/ directory"
+transcript_rules:
+  max_turns: 12
+  disallow_regex:
+    - "(?i)(cannot complete|unable to complete|i refuse)"
+  required_actions:
+    - action_id: "establish_session_state"
+      requestor: assistant
+      name: bash_session
+      arguments: {}
+      compare_args: []
+    - action_id: "edit_with_str_replace_editor"
+      requestor: assistant
+      name: str_replace_editor
+      arguments: {}
+      compare_args: []
+  communicate_info:
+    - info: "READY"
+      required: true

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/task.yaml
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/task.yaml
@@ -1,0 +1,23 @@
+task_id: "persistent_tools_public_example_01"
+name: "Release Notes Finalization"
+category: "persistent_tools"
+description: "Use a persistent bash session to establish a working directory, then edit and author files with the str_replace editor, relying on the session's persisted state across calls."
+initial_user_message: "Finalize the release notes. First use `bash_session` to create a `release` directory under `/work` and `cd` into it (later steps rely on this persisted working directory). Then use `str_replace_editor` to edit `/work/CHANGELOG_DRAFT.md`, replacing `STATUS: PENDING` with `STATUS: READY`. Next use `str_replace_editor` to create `/work/release/NOTES.md` summarizing the finalized changelog (mention it is derived from the changelog). Finally use `bash_session` to list the persisted `release` directory and view `NOTES.md` to confirm it was written there. Report `STATUS: READY` when done."
+initial_state:
+  filesystem:
+    copy:
+      - from: "fixtures/CHANGELOG_DRAFT.md"
+        to: "/env/fs/agent-visible/CHANGELOG_DRAFT.md"
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+  user:
+    enabled: []
+actors:
+  user:
+    backstory: "You are a release manager verifying that the assistant can hold shell state across calls and edit files safely. Acknowledge completion and end with ###STOP### once the assistant reports the release is READY and both files are in place."
+policies:
+  guidance:
+    - "Rely on the persisted working directory rather than re-establishing it in every command."
+    - "Prefer a targeted str_replace over rewriting the whole changelog."
+grading: "grading.yaml"

--- a/examples/native/persistent_tools/project.yaml
+++ b/examples/native/persistent_tools/project.yaml
@@ -1,0 +1,28 @@
+# Project spec for the persistent-tools example.
+#
+# One public task that drives the persistent shell (`bash_session`) and
+# the file editor (`str_replace_editor`) in their local variants. No
+# Docker substrate — both tools operate on the runner's `/work`, so
+# `default_environment` is omitted. See docs/PROJECTS.md for the full
+# Project model and docs/TOOLS.md for the tool contracts.
+
+name: "persistent-tools"
+version: 1
+description: >
+  Persistent shell and editor evaluation: the agent establishes working
+  state in a held bash session, then edits and creates files with the
+  str_replace editor, relying on the session's persisted working
+  directory across calls.
+
+tasks:
+  discovery:
+    glob: "dataset/tasks/**/task.yaml"
+
+# ── Task defaults — base for every task ─────────────────────────
+task_defaults:
+  adapter_type: "native"
+  max_turns: 12
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/persistent_tools/run_configs/dev.yaml
+++ b/examples/native/persistent_tools/run_configs/dev.yaml
@@ -1,0 +1,26 @@
+# Persistent-tools example — one public task exercising the persistent
+# shell (`bash_session`) and the str_replace editor. Requires a real LLM
+# provider key in .env. Run via
+#   scripts/with_env.sh uv run tolokaforge run --config examples/native/persistent_tools/run_configs/dev.yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 12
+  queue_backend: sqlite
+
+evaluation:
+  projects:
+    - "examples/native/persistent_tools/dataset"
+  tasks_glob: "**/task.yaml"
+  output_dir: "results/persistent_tools_example"

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -14,11 +14,12 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.adapters.native import NativeAdapter, _builtin_tool_schemas
 
 pytestmark = pytest.mark.unit
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "tasks"
+_PERSISTENT_PACK = Path(__file__).resolve().parents[2] / "examples" / "native" / "persistent_tools"
 
 
 @pytest.fixture
@@ -76,3 +77,87 @@ def test_non_dict_per_tool_config_raises():
     )
     with pytest.raises(ValueError, match="tools.agent.mobile must be a mapping"):
         adapter.to_task_description("bad_mobile")
+
+
+@pytest.fixture
+def persistent_tools_adapter() -> NativeAdapter:
+    from tolokaforge.core.project_loader import load_project_config
+
+    project = load_project_config(_PERSISTENT_PACK / "project.yaml")
+    defaults = project.task_defaults.model_dump(exclude_defaults=True) or None
+    return NativeAdapter(
+        {
+            "tasks_glob": "dataset/tasks/**/task.yaml",
+            "base_dir": str(_PERSISTENT_PACK),
+            "project_task_defaults": defaults,
+        }
+    )
+
+
+def _agent_tool(td, name: str):
+    return next(t for t in td.agent_tools if t.name == name)
+
+
+def test_persistent_pack_advertises_bash_session_schema(persistent_tools_adapter):
+    """The example pack's ``bash_session: {}`` config must load through the
+    adapter as a source-less builtin advertising the full wire schema."""
+    td = persistent_tools_adapter.to_task_description("persistent_tools_public_example_01")
+    bash = _agent_tool(td, "bash_session")
+
+    assert bash.source is None
+    props = bash.parameters["properties"]
+    assert set(props) == {"command", "restart"}
+    assert props["command"]["type"] == "string"
+    assert props["restart"]["type"] == "boolean"
+    assert bash.parameters["required"] == []
+
+
+def test_persistent_pack_advertises_str_replace_editor_schema(persistent_tools_adapter):
+    """The editor's full parameter set (including the four-command enum and
+    the insert-specific ``insert_text``) must reach the built ToolSchema."""
+    td = persistent_tools_adapter.to_task_description("persistent_tools_public_example_01")
+    editor = _agent_tool(td, "str_replace_editor")
+
+    assert editor.source is None
+    props = editor.parameters["properties"]
+    assert set(props) == {
+        "command",
+        "path",
+        "view_range",
+        "file_text",
+        "old_str",
+        "new_str",
+        "insert_line",
+        "insert_text",
+    }
+    assert props["command"]["enum"] == ["view", "create", "str_replace", "insert"]
+    assert editor.parameters["required"] == ["command", "path"]
+    # ``insert`` carries its text in ``insert_text`` — not ``new_str`` (that
+    # is the ``str_replace`` replacement). Both must be advertised distinctly.
+    assert "insert_text" in props
+    assert "new_str" in props
+
+
+def test_builtin_schemas_survive_compose_tool_config():
+    """``_builtin_tool_schemas`` must extract full schemas for both tools even
+    under a compose ``tool_config`` — guards against a schema-extraction
+    failure being swallowed and a tool shipping an empty schema (#577)."""
+    compose_configs = {
+        "bash_session": {"service": "main", "compose_project_prefix": "trial-xyz"},
+        "str_replace_editor": {"service": "main", "compose_project_prefix": "trial-xyz"},
+    }
+    schemas = _builtin_tool_schemas(["bash_session", "str_replace_editor"], compose_configs)
+
+    assert set(schemas["bash_session"]["parameters"]["properties"]) == {"command", "restart"}
+    editor_props = schemas["str_replace_editor"]["parameters"]["properties"]
+    assert set(editor_props) == {
+        "command",
+        "path",
+        "view_range",
+        "file_text",
+        "old_str",
+        "new_str",
+        "insert_line",
+        "insert_text",
+    }
+    assert editor_props["command"]["enum"] == ["view", "create", "str_replace", "insert"]


### PR DESCRIPTION
## Summary

Fifth sub-issue of Milestone 25. Documents `bash_session` + `str_replace_editor` in `docs/TOOLS.md` (Anthropic compatibility, wire schemas, both provider variants, when-to-use) with a known-limitation callout for the compose variants. Ships a runnable native example pack demonstrating both tools + extends the existing native-dispatch test to lock both tools' full schemas.

Two commits, one per stage.

## What changes

### Stage 1 — `docs/TOOLS.md`

- `bash_session` section: `bash_20250124` compat, input schema, 120s default timeout config, 16384-char middle-truncation, local kill-safety mechanism (PTY + `set -m` + SIGINT→SIGKILL to foreground pgroup), compose weaker kill-safety + state-loss caveat, container-name resolution.
- `str_replace_editor` section: `str_replace_based_edit_tool` compat (`text_editor_20250429`/`20250728`), four commands with full param list (`insert` uses `insert_text`, NOT `new_str`), fail-loud semantics, compose weaker atomicity + `realpath` requirement.
- Enablement recipes: `tools.agent.<name>: {}` (local) OR `{service, compose_project_prefix, timeout_s}` for `bash_session` OR `{service, compose_project_prefix}` for `str_replace_editor` (editor has no `timeout_s`).
- Known-limitation callout linking [#581](https://github.com/Toloka/tolokaforge/issues/581) (compose network-isolation gap).
- Cross-references to `docs/RUNNER.md` `## Tool Lifecycle` and ADR 0017.

### Stage 2 — example pack + loader lock

- `examples/native/persistent_tools/` — modelled on `examples/native/tool_use/`. Local variants only. `project.yaml` + `dataset/tasks/persistent_tools_public_example_01/` + `run_configs/dev.yaml` + `README.md` + `fixtures/CHANGELOG_DRAFT.md` seed file for grading.
- `tests/unit/test_native_adapter_builtin_dispatch.py` — extended (not duplicated) with 3 new assertions: `bash_session` full schema, `str_replace_editor` full schema (including `insert_text` NOT `new_str`), both survive `_builtin_tool_schemas` under compose tool_config.

## Anthropic spec fidelity claims verified

- `bash_session`: schema anchored to `bash_20250124`; `command` required unless `restart` set; restart call is `{"restart": true}` with no command; state persists (cwd/env/functions).
- `str_replace_editor`: four commands (view/create/str_replace/insert) matching Anthropic; no `undo_edit` (removed in Claude-4 variants); `insert` uses `insert_text`.

## Related work referenced

- [#581](https://github.com/Toloka/tolokaforge/issues/581) — compose network-isolation gap (blocks agent-inside-manifest patterns; documented limitation until fix lands).
- [#577](https://github.com/Toloka/tolokaforge/issues/577) — `_builtin_tool_schemas` silently swallows schema-extraction failures; the compose-config test in Stage 2 guards against it.

## Test plan

- `uv run pytest tests/unit/test_native_adapter_builtin_dispatch.py -v` — 7 pass (existing + 3 new).
- `uv run pytest tests/ -m unit -q` — 2682 passed (2 pre-existing `multi_service_endpoint_add` failures unrelated).
- Example pack structurally loads via `NativeAdapter` (locked by extended test).

Closes #568.