### PR TITLE
feat(tools): persistent agent shell + first-class editor tools (M25 consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **tools**: session-lifetime bash tool matching Anthropic `bash_20250124` — new `bash_session` schema (input: `command` string + `restart` bool) with two providers selectable purely by tool config: a local subprocess and a docker-compose `docker exec` into a running service (`tool_config: {service, compose_project_prefix}`). Identical wire schema either way. Additive; existing `bash` builtin unchanged.
+
 ## v0.9.3 (2026-07-22)
 
 ## v0.9.2 (2026-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Feat
 
 - **tools**: session-lifetime bash tool matching Anthropic `bash_20250124` — new `bash_session` schema (input: `command` string + `restart` bool) with two providers selectable purely by tool config: a local subprocess and a docker-compose `docker exec` into a running service (`tool_config: {service, compose_project_prefix}`). Identical wire schema either way. Additive; existing `bash` builtin unchanged.
+- **tools**: str_replace_editor builtin matching Anthropic `str_replace_based_edit_tool` (`text_editor_20250429`/`text_editor_20250728` variants, four commands `view`/`create`/`str_replace`/`insert`, no `undo_edit`). Two providers selectable purely by tool config: a local filesystem engine and a docker-compose engine that routes every command through `docker exec` into a running service (`tool_config: {service, compose_project_prefix}`). Identical wire schema either way; file content is piped on stdin (never shell-interpolated) and path containment is validated inside the container. Note: `create` fails loud on existing path (integrator-choice deviation from Anthropic's overwrite reference).
 
 ## v0.9.3 (2026-07-22)
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -64,6 +64,29 @@ provisioning them per the manifest's isolation rules. See
 [RUNTIME_BACKENDS.md](RUNTIME_BACKENDS.md) for
 the backend lifecycle.
 
+## Tool Lifecycle
+
+Some tools own per-trial resources — a compose stack, a long-lived
+subprocess — that must be provisioned when a trial starts and torn down when
+it resets. The runner manages this generically off a single capability, never
+off adapter identity: a `ToolWrapper` sets `has_lifecycle = True`, and the
+runner calls `start()` on `RegisterTrial` and `stop()` on `ResetTrial` for
+every tool that declares it. Tools without the capability are untouched.
+
+`start()` receives a `ToolLifecycleContext`:
+
+- `trial_id` — the trial the resource belongs to (used for per-trial naming).
+- `artifacts_dir` — the extracted task-artifacts path, or `None`.
+- `work_dir` — the per-trial session working root a tool seeds its
+  shell/subprocess `cwd` from, or `None`.
+
+The context is a frozen value object; tools read it, never mutate it.
+
+A session-lifetime tool follows one pattern: open its resource in `start()`
+(seeding `cwd` from `work_dir`), hold it across every `execute()` call, and
+tear it down in `stop()`. The resource — and its identity, e.g. a subprocess
+PID — is stable for the life of the trial and gone once `stop()` returns.
+
 ## Local Queue Run (SQLite)
 
 ```bash

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -7,6 +7,8 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
 - `browser`: Playwright-based browser automation (coordinate actions).
 - `mobile`: Mobile app interaction tool (tap/type/scroll/app switching).
 - `bash`: Allowlisted shell execution.
+- `bash_session`: Persistent bash shell; cwd, environment, and functions persist across calls.
+- `str_replace_editor`: View, create, and edit files with `view`/`create`/`str_replace`/`insert`.
 - `read_file`: Read from `/env/fs/agent-visible`.
 - `write_file`: Write to `/env/fs/agent-visible`.
 - `list_dir`: List files in `/env/fs/agent-visible`.
@@ -33,6 +35,119 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
 
 See [BROWSER_TOOLS.md](BROWSER_TOOLS.md) for action schemas, examples, and coordinate behavior.
 
+## Persistent Shell and Editor Tools
+
+`bash_session` and `str_replace_editor` mirror Anthropic's agent tool contracts.
+Each has two provider variants — a local variant and a docker-compose variant —
+selected purely by `tool_config`: pass a `service` key to route into a container,
+omit it to run locally. The wire schema the LLM sees is identical for both
+variants. Both tools are wrapped by the runner, which drives their per-trial
+lifecycle (see [RUNNER.md § Tool Lifecycle](RUNNER.md#tool-lifecycle)) and the
+design rationale in [ADR 0017](adr/0017-persistent-agent-shell-and-editor-tools.md).
+
+### `bash_session`
+
+Session-lifetime shell matching Anthropic's `bash_20250124` contract.
+
+**Input schema**
+
+- `command` (string): the bash command to run.
+- `restart` (boolean): reset the shell to a clean state; omit `command` when
+  restarting (`{"restart": true}`).
+
+Both fields are optional at the schema level; a call must supply one or the
+other, and a call with neither fails loud.
+
+**Session semantics.** The working directory, exported environment variables,
+shell functions, and aliases persist across `execute()` calls for the life of
+the trial. `restart` discards that state and yields a clean shell.
+
+**Timeout.** Per-command timeout defaults to 120 s, configurable via
+`tool_config.timeout_s`. On timeout the command is terminated and a
+`[timed out after <n>s; command terminated]` note is appended to the output.
+
+**Output.** Middle-truncated at 16384 characters (an elision marker names the
+elided character count and hints to re-run a narrower command or `grep` for the
+pattern). Non-zero
+exit codes are surfaced as an `[exit code: <n>]` suffix.
+
+**Provider variants**
+
+- **Local** (no `service` key): a `bash` subprocess held under a PTY with job
+  control (`set -m`). A timed-out command runs in its own foreground process
+  group; terminating that group (SIGINT then SIGKILL) leaves the session-leader
+  shell alive, so session state survives a per-command timeout.
+- **Compose** (`service` + `compose_project_prefix`): a held
+  `docker exec` into an already-running service container. It never brings the
+  compose stack up or down — the environment / another lifecycle consumer owns
+  that. Kill-safety is weaker than the local variant: signalling the host-side
+  `docker exec` process group does not reach the command running inside the
+  container, so on a per-command timeout the host exec client is killed and the
+  in-container session is restarted. Session state accumulated before a
+  timed-out command is lost (unlike the local variant, which preserves it), and
+  the runaway command may briefly survive as an in-container orphan.
+
+The compose variant resolves its target container as
+`<compose_project_prefix><trial_id>_<service>`, with any `:` in the trial id
+replaced by `_`; both compose tools share this resolution so they target the
+identical container.
+
+**When to use.** Prefer `bash_session` for multi-step workflows that need a
+persistent cwd, environment, or shell functions across turns. Use the legacy
+per-call [`bash`](#built-in-tools) for one-shot allowlisted commands.
+
+### `str_replace_editor`
+
+File editor matching Anthropic's `str_replace_based_edit_tool` contract (the
+`text_editor_20250429` / `text_editor_20250728` shape — parameter-identical;
+`text_editor_20250728` adds a `max_characters` view-truncation knob). `undo_edit`
+is absent, as in those Claude-4 variants.
+
+**Input schema.** `command` (enum: `view`/`create`/`str_replace`/`insert`) and
+`path` are required; the remaining fields apply per command: `view_range`,
+`file_text`, `old_str`, `new_str`, `insert_line`, `insert_text`.
+
+**Commands**
+
+- `view` — `path` plus optional `view_range: [start, end]` (1-indexed; `-1` for
+  end of file). Renders `cat -n`-style line-numbered content for a file, or a
+  directory listing 2 levels deep (hidden entries and `__pycache__` skipped).
+  An out-of-range `view_range` fails loud.
+- `create` — `path` + `file_text`. **Fails loud if the path already exists**
+  (a deliberate deviation from Anthropic's reference, which overwrites).
+- `str_replace` — `path` + `old_str` + `new_str`. Replaces the single unique
+  occurrence of `old_str`; fails loud on zero matches or more than one (the
+  error reports the match count).
+- `insert` — `path` + `insert_line` + **`insert_text`** (note: `insert` uses
+  `insert_text`, not `str_replace`'s `new_str`). `insert_line: 0` inserts before
+  the first line; a positive `N` inserts after line `N`.
+
+**Fail-loud framing.** Ambiguous, destructive, or out-of-range operations raise,
+and the error reaches the LLM for self-correction. Mutating commands
+(`create`/`str_replace`/`insert`) require valid UTF-8 and fail loud on a
+non-UTF-8 file (which cannot be safely round-tripped); `view` reads with
+replacement characters for display only.
+
+**Path validation.** Paths resolve to their realpath and must stay contained in
+the working root (`/work`); a symlink escape or a `..` component that leaves the
+root fails loud.
+
+**Provider variants**
+
+- **Local** (no `service` key): in-process file operations rooted at the runner
+  container's `/work`. Writes go to a temp file and are renamed into place
+  (single-process temp+rename).
+- **Compose** (`service` + `compose_project_prefix`): every command runs through
+  `docker exec` into an already-running service container. File content is piped
+  on stdin (never interpolated into the shell command string) and paths are
+  passed as positional arguments, so agent-controlled bytes cannot inject shell
+  commands. Path containment is validated **inside the container** via
+  `realpath`; if `realpath` is absent from the target image the engine fails
+  loud rather than silently skipping validation. Write atomicity is weaker than
+  the local variant: a completed temp-file+`mv` is atomic, but an exec
+  interrupted mid-write can leave the temp file behind. The editor has no
+  configurable per-command timeout.
+
 ## Enabling Tools
 
 ```yaml
@@ -42,6 +157,44 @@ tools:
   user:
     enabled: []
 ```
+
+### Persistent shell and editor
+
+List the tool in `enabled` to get its local variant — no kwargs block is needed:
+
+```yaml
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+```
+
+To select the compose variant, add a per-tool kwargs block under
+`tools.agent.<name>` naming the target `service` and the `compose_project_prefix`
+used to bring the stack up. `bash_session` additionally accepts `timeout_s`; the
+editor has no configurable per-command timeout:
+
+```yaml
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+    bash_session:
+      service: main
+      compose_project_prefix: env_
+      timeout_s: 120
+    str_replace_editor:
+      service: main
+      compose_project_prefix: env_
+```
+
+> **Compose-variant network isolation.** Under `network_policy: no_internet` /
+> `limited_internet`, the engine attaches every compose service to a single
+> injected internal network. If a task pack co-locates env services (e.g. a DB)
+> with the agent-side compose service that `bash_session` /
+> `str_replace_editor` executes into, the agent can reach those services
+> directly and bypass wrapped tools. Tracked as
+> [#581](https://github.com/Toloka/tolokaforge/issues/581). Until that lands, do
+> not co-locate env services with the `bash_session` / `str_replace_editor`
+> target service. The local variants are unaffected.
 
 ## MCP Tools
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -92,6 +92,17 @@ The compose variant resolves its target container as
 replaced by `_`; both compose tools share this resolution so they target the
 identical container.
 
+> **Compose runtime seam.** A default `docker compose up` names containers
+> `<project>-<service>-<N>` (hyphens plus an ordinal index) — that scheme does
+> not match the wrapper's `<compose_project_prefix><trial_id>_<service>`
+> resolution, so a generic per-trial runtime brings up containers the compose
+> tools cannot reach. Until this reconciles, a task pack enabling the compose
+> variant must pin `container_name:` on the target service to exactly what the
+> wrapper resolves, or the first `docker exec` fails with a no-such-container
+> error. Tracked as
+> [#585](https://github.com/Toloka/tolokaforge/issues/585). The local variants
+> are unaffected.
+
 **When to use.** Prefer `bash_session` for multi-step workflows that need a
 persistent cwd, environment, or shell functions across turns. Use the legacy
 per-call [`bash`](#built-in-tools) for one-shot allowlisted commands.

--- a/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
+++ b/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
@@ -230,7 +230,7 @@ tolokaforge targets current Claude models, the tool ships four commands:
 | `text_editor_20250728` | Claude-4 | `str_replace_based_edit_tool` | view, create, str_replace, insert |
 
 **Parameter names (locked):** `command`, `path`, `view_range`, `file_text`,
-`old_str`, `new_str`, `insert_line`.
+`old_str`, `new_str`, `insert_line`, `insert_text`.
 
 **Per-command semantics.**
 
@@ -241,7 +241,7 @@ tolokaforge targets current Claude models, the tool ships four commands:
   already exists**.
 - **`str_replace`** — replaces `old_str` (exact match, including whitespace)
   with `new_str`; **fail-loud on a non-unique match and on a missing match**.
-- **`insert`** — inserts `new_str` at `insert_line`, the line number **after
+- **`insert`** — inserts `insert_text` at `insert_line`, the line number **after
   which** to insert; `insert_line=0` inserts before the first line.
 
 **Path validation.** Reject symlinks that escape the configured working root.

--- a/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
+++ b/docs/adr/0017-persistent-agent-shell-and-editor-tools.md
@@ -1,0 +1,373 @@
+# 0017. Persistent agent shell + first-class editor tools + tool-lifecycle evolution
+
+- **Status:** Proposed
+- **Date:** 2026-07-22
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Tolokaforge ships two shell-tool flavours today, and **both are per-call
+fresh-shell**:
+
+- the in-process allowlisted `BashTool`
+  (`tolokaforge/tools/builtin/bash.py`, `has_lifecycle=False`, 30 s timeout,
+  regex allowlist), and
+- the runner-side `DockerComposeExecToolWrapper`
+  (`tolokaforge/runner/tool_factory.py`, `has_lifecycle=True`, per-call
+  `docker compose exec bash -c`).
+
+In both, **shell process state — cwd, exported environment, shell functions,
+aliases, subshell state — resets between tool calls.** Only container-level
+state (files written to disk, packages installed) survives from one call to the
+next. An agent that runs `cd /srv && export TOKEN=…` in one call finds itself
+back at the original cwd with `TOKEN` unset in the next.
+
+Anthropic's standard agent-tool contracts assume the opposite. The `bash` tool
+(`bash_20250124`) and the text-editor tool (`str_replace_based_edit_tool`) are
+defined around a **session-lifetime** shell: state persists across calls, and a
+`restart` command exists precisely because a fresh shell is otherwise never
+obtained. Agents prompted or trained against those contracts burn turns
+re-establishing state on tolokaforge's per-call shells, and there is **no
+`str_replace_based_edit_tool` equivalent at all** — agents that expect a
+first-class editor fall back to hand-rolled `sed`/`cat` heredocs through the
+shell.
+
+Separately, issue #63 flagged that the tool-lifecycle seam
+(`ToolLifecycleContext` + `ToolWrapper.start()`/`stop()` in
+`tolokaforge/runner/tool_factory.py`, driven off the `has_lifecycle` capability
+in `tolokaforge/runner/service.py`) is a deliberate minimum-viable interface:
+it was shaped around a single lifecycle tool and must be evolved the first time
+a **second** lifecycle tool lands. This milestone is that second tool — a
+session-lifetime persistent shell — and therefore the moment to evolve the
+seam.
+
+This ADR is the **design lock only — it introduces no runtime code and no
+tests.** It defines, at interface level, the contracts that the implementing
+sub-issues (A2–A6) each cite as their source of truth. Every named Decision
+sub-section below `(a)`–`(g)` is a contract one sub-issue owns.
+
+## Decision Drivers
+
+- **Drop-in compatibility.** The stated milestone goal is that an agent written
+  against Anthropic's `bash_20250124` + `str_replace_based_edit_tool` works
+  against tolokaforge unchanged. The wire schema must match those contracts, not
+  a homegrown approximation.
+- **Fail-loud.** No silent fallbacks: an editor `str_replace` with an ambiguous
+  or missing match, or a `create` onto an existing path, must error rather than
+  guess.
+- **The runner stays capability-driven.** Per ADR-0007, the runner drives tool
+  lifecycle off the `has_lifecycle` capability, never off tool or adapter
+  identity. The lifecycle evolution must preserve that invariant.
+- **Additive, backward-compatible.** Existing `BashTool` consumers and the
+  existing `DockerComposeExecToolWrapper` keep working byte-for-byte; new tools
+  are opt-in.
+- **Close #63 deliberately.** Evolve the lifecycle contract to exactly what the
+  two shipping tools force, and triage the remaining speculative gaps with
+  written rationale rather than reopening them reactively.
+
+## Considered Options
+
+1. **Adopt Anthropic's standard tool contracts verbatim** — a session-lifetime
+   `bash_20250124`-shaped shell tool and a `str_replace_based_edit_tool`-shaped
+   editor tool, each with base (local) and docker-compose provider variants.
+2. **Design a homegrown persistent-shell / editor schema** tuned to tolokaforge's
+   internals.
+3. **Extend `BashTool` in place** to hold a long-lived subprocess.
+
+## Decision
+
+We adopt **Option 1**. The LLM-facing schema of both new tools matches
+Anthropic's published contract exactly, so an agent prompted against the
+standard tools needs no interface adaptation. Option 2 is rejected because a
+homegrown schema reintroduces the interface-adaptation cost the milestone exists
+to remove. Option 3 is rejected because `BashTool` is lifecycle-free and
+in-process; a session-lifetime shell needs `start()`/`stop()`, which only a
+`ToolWrapper` subclass exposes, and because the per-call allowlisted `BashTool`
+is a compatibility surface that legacy callers still depend on.
+
+The decision body is split into seven named contract sub-sections. Each is the
+single source of truth for one implementing sub-issue.
+
+### (a) Lifecycle-contract evolution — closes #63
+
+`ToolLifecycleContext` stays a `@dataclass` in-process value object (the
+AGENTS.md type-system table lists it `@dataclass(frozen=True)`; the concrete
+live type is a plain `@dataclass` — whether to additionally freeze it is an
+implementation call for the sub-issue that touches the code, not a design
+constraint of this ADR). It is **not** promoted to Pydantic: it never crosses a
+serialisation boundary. Its existing fields `trial_id: str` and
+`artifacts_dir: str | None = None` are unchanged.
+
+**The evolution this ADR locks:** the context gains exactly the per-trial facts
+that the *runner* owns and that a tool cannot know at construction time.
+Concretely, it adds **one field**:
+
+```python
+work_dir: str | None = None
+```
+
+`work_dir` is the session working root. The base (local) persistent-shell tool
+seeds its shell `cwd` from it; the base editor tool validates paths against it.
+All fields are additive and defaulted, so the existing construction in
+`tolokaforge/runner/service.py`
+
+```python
+ToolLifecycleContext(trial_id=trial_id, artifacts_dir=…)
+```
+
+stays valid byte-for-byte.
+
+**The ADR explicitly rejects** putting a `service` name, a `compose_file`
+handle, or a runtime-backend handle into the context. Those are known at
+tool-construction time from the tool's own config: `DockerComposeExecToolWrapper`
+already takes `compose_file`/`service` as constructor arguments and derives its
+per-trial compose project name from `ctx.trial_id` inside `start()`. Keeping
+construction-time config out of the per-trial context preserves Core Rule 2 and
+the ADR-0007 invariant that the runner drives lifecycle off the `has_lifecycle`
+capability, never off tool or adapter identity.
+
+**#63 gap triage.** Issue #63 enumerated six candidate evolutions of the
+lifecycle seam. This ADR adopts one and defers five, each with a one-line
+reason:
+
+| # | Gap | Verdict | Rationale |
+|---|-----|---------|-----------|
+| 1 | Additive per-trial context field | **Adopt** | The persistent shell needs a session working root the tool cannot know at construction time. |
+| 2 | Async `start_async` | Defer | Both shipping tools' `start()` is a fast synchronous subprocess spawn; nothing awaits I/O long enough to need async. |
+| 3 | Lifecycle timeout / retry policy | Defer | A subprocess spawn either succeeds or raises immediately; there is no partial-readiness window to time out on. |
+| 4 | Suspend / snapshot / reset hooks | Defer | Neither tool has resumable mid-trial state worth snapshotting; `restart` (shell) and per-call statelessness (editor) cover the reset needs. |
+| 5 | Inter-tool ordering | Defer | The two tools are independent; neither `start()` depends on the other having started. |
+| 6 | Explicit readiness signal | Defer | "`start()` returned" is a sufficient readiness signal for a synchronous spawn. |
+
+Adopting gap 1 and triaging gaps 2–6 with reasons **is** what "closes #63"
+means: the seam is evolved deliberately to what the shipping tools force, and
+the speculative hooks are declined on the record rather than left open.
+
+**Backward-compatibility guarantee (stated verbatim).**
+`DockerComposeExecToolWrapper` behaviour is unchanged; the `has_lifecycle`
+dispatch in `tolokaforge/runner/service.py` is unchanged; new context fields are
+optional.
+
+### (b) `PersistentShellTool` contract
+
+This tool is anchored to Anthropic's **`bash` tool, type string `bash_20250124`**
+— the same way `(c)` anchors the editor to `str_replace_based_edit_tool`.
+`bash_20250124` is accepted by every current Claude model (the older
+`bash_20241022` is computer-use-beta only). Drop-in compatibility with that
+contract is the milestone's stated goal, so the ADR locks the exact wire schema
+rather than a homegrown one.
+
+**Input schema (locked).** Two fields, matching the Anthropic bash parameter
+table:
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `command` | string | Required **unless** `restart` is set | The bash command to run. |
+| `restart` | boolean | Optional | Set to `true` to restart the shell. |
+
+A restart call sends `{"restart": true}` with **no** `command`. This is the
+exact Anthropic bash schema, so an A3 implementer reading `(b)` alone has the
+full wire contract.
+
+**Tool shape.** The tool is a **`ToolWrapper` subclass with
+`has_lifecycle=True`**, living in the runner tool-factory layer (analogous to
+`DockerComposeExecToolWrapper`) — *not* a lifecycle-free `tools/builtin` tool
+routed through the generic builtin wrapper, because only `ToolWrapper` exposes
+`start()`/`stop()`. The ADR locks this constraint; the exact registration
+mechanism (a new invocation style, a new registry dispatch kind, or a dedicated
+factory method) is left to A3.
+
+**Registry-name coexistence.** The LLM-facing schema matches `bash_20250124`,
+but the tolokaforge registry name for this tool **must be distinct from the
+legacy `bash` builtin** so both coexist: a task enables one or the other in its
+`task.yaml`, and the old per-call `BashTool` stays for legacy callers per the
+compatibility surface `(e)`. The ADR locks the constraint (distinct name,
+additive coexistence); A3 picks the concrete name.
+
+**Lifecycle.** `start(ctx)` opens one session-lifetime `bash` subprocess with
+its `cwd` seeded from `ctx.work_dir`; `stop()` terminates it. State — cwd,
+exported environment, functions, aliases, subshell state — persists across
+`execute()` calls by construction of the long-lived process.
+
+**Sentinel command-boundary detection.** Each command is written to the shell's
+stdin followed by an echo of a per-command unique sentinel carrying the exit
+status (an `__DONE_<uuid>__ $?` pattern); the reader consumes stdout up to the
+sentinel line and parses the trailing exit code.
+
+**Per-command timeout.** Default **120 s**, configurable via tool config
+(`timeout_s`).
+
+**Kill-safety.** On timeout the running command is killed (a signal to the
+foreground command's process group) **without leaking the parent shell** —
+subsequent commands still run in the same session.
+
+**Output truncation.** 16 KB **middle-truncation**, with a grep-hint message
+for the elided middle (the Anthropic convention).
+
+**`restart` semantics.** `{"restart": true}` closes the current shell, opens a
+fresh one, and returns a confirmation `tool_result`. Per the Anthropic contract
+a restarted session **starts clean** — cwd, environment variables, and running
+processes are all gone — and subsequent commands run in the new shell.
+
+### (c) `StrReplaceEditorTool` contract
+
+This tool implements Anthropic's **`str_replace_based_edit_tool`** spec: exactly
+the four commands **`view` / `create` / `str_replace` / `insert`** and **no
+`undo_edit`**.
+
+`undo_edit` was **removed in the Claude-4 tool variants
+(`text_editor_20250429`, `text_editor_20250728`); present only in the
+pre-Claude-4 tools (`text_editor_20241022`, `text_editor_20250124`).** Because
+tolokaforge targets current Claude models, the tool ships four commands:
+
+| Tool `type` | Model era | Editor `name` | Commands |
+|-------------|-----------|---------------|----------|
+| `text_editor_20241022` | pre-Claude-4 | `str_replace_editor` | view, create, str_replace, insert, **undo_edit** |
+| `text_editor_20250124` | pre-Claude-4 | `str_replace_editor` | view, create, str_replace, insert, **undo_edit** |
+| `text_editor_20250429` | Claude-4 | `str_replace_based_edit_tool` | view, create, str_replace, insert |
+| `text_editor_20250728` | Claude-4 | `str_replace_based_edit_tool` | view, create, str_replace, insert |
+
+**Parameter names (locked):** `command`, `path`, `view_range`, `file_text`,
+`old_str`, `new_str`, `insert_line`.
+
+**Per-command semantics.**
+
+- **`view`** — a file (optional `view_range` = `[start, end]`, **1-indexed**,
+  `-1` for end = read to EOF; output is line-numbered) **or** a directory
+  listing. Oversized files are 16 KB middle-truncated with a grep-hint.
+- **`create`** — writes `file_text` to a new file; **fail-loud if the path
+  already exists**.
+- **`str_replace`** — replaces `old_str` (exact match, including whitespace)
+  with `new_str`; **fail-loud on a non-unique match and on a missing match**.
+- **`insert`** — inserts `new_str` at `insert_line`, the line number **after
+  which** to insert; `insert_line=0` inserts before the first line.
+
+**Path validation.** Reject symlinks that escape the configured working root.
+
+**Lifecycle.** Stateless — `has_lifecycle=False`.
+
+### (d) Docker-compose provider variants
+
+The base tools in `(b)`/`(c)` run against the local host. Two docker-compose
+provider variants run the same contract against a compose service:
+
+- **`DockerComposePersistentShellTool`** — opens `docker exec -i <service> bash`
+  in `start()`, holds it across the trial, closes it in `stop()`; `service`
+  comes from tool config. Same shell contract as `(b)`.
+- **`DockerComposeStrReplaceEditorTool`** — routes the four editor commands
+  through `docker exec` (`cat` for reads plus an in-place mutation helper for
+  writes). Same editor contract as `(c)`.
+
+**Provider is a configuration axis, not a contract change.** The LLM-facing tool
+schema is identical between a base tool and its compose variant; only *where the
+bytes live* (local host vs. inside a compose service) differs. An agent cannot
+tell which provider is behind the tool, and no sub-issue may let provider
+identity leak into the schema.
+
+### (e) Compatibility surface
+
+The change is **additive** to public tolokaforge:
+
+- `BashTool` (per-call, in-process, allowlisted) **stays** for legacy callers;
+  new consumers choose the persistent tools.
+- The lifecycle evolution in `(a)` preserves the existing
+  `DockerComposeExecToolWrapper` byte-for-byte.
+
+The migration surface — a CHANGELOG entry, the `docs/TOOLS.md` entries, and the
+task-config field that enables each new tool — is owned by the *implementing*
+PRs (A2–A4 for the code and the config field, A5 for `docs/TOOLS.md`). A1 edits
+none of them; it only specifies the additive contract those PRs implement.
+
+### (f) Docs + examples surface → A5
+
+A5 delivers the documentation and examples surface for the new tools:
+`docs/TOOLS.md` entries for the persistent shell and the editor (base and
+compose variants), one or more example tasks that enable them, and the ADR index
+row (Stage 2 of this issue adds the row; A5 owns `docs/TOOLS.md` and the
+examples). The lifecycle-evolution doc update in `docs/RUNNER.md` is owned by the
+PR that changes the lifecycle code (A2), not by A1 and not by A5.
+
+### (g) Integration-test contract → A6
+
+A6 delivers the end-to-end capstone: a real compose service against which
+**shell state persistence** (cwd and environment surviving across calls) and
+**editor round-trips** (create → view → str_replace → insert against a real
+file) are asserted. Tier: **integration**.
+
+## Consequences
+
+### Positive
+
+- **Agents built against the standard Anthropic tools work unchanged.** The
+  primary milestone goal: no interface-adaptation turns, no homegrown schema to
+  document.
+- **A first-class editor replaces shell heredocs.** Agents get typed
+  view/create/str_replace/insert with fail-loud match semantics instead of
+  hand-rolled `sed`/`cat` through the shell.
+- **The lifecycle seam is evolved once, deliberately.** #63 closes with an
+  additive context field and five gaps triaged on the record, so the next
+  lifecycle tool inherits a contract shaped by two real consumers rather than
+  one.
+
+### Negative / Trade-offs
+
+- **A long-lived subprocess is more state to manage than a per-call exec.**
+  Kill-safety on timeout (signalling the command's process group without leaking
+  the parent shell) and clean `restart` are load-bearing; they are locked in
+  `(b)` precisely because they are the hard parts.
+- **Two more tools, each with a base and a compose variant, widen the tool
+  matrix.** The `(d)` "provider is a config axis" rule keeps the LLM-facing
+  schema single, but there are now more wrappers to maintain.
+- **Registry-name coexistence is a small ongoing cost.** The persistent shell
+  and the legacy `BashTool` share the Anthropic-facing shape but must keep
+  distinct registry names indefinitely so tasks can select either.
+
+### Follow-ups
+
+- **Code changes required:** the lifecycle-context field and dispatch (A2), the
+  persistent-shell tool + compose variant (A3), the editor tool + compose
+  variant (A4).
+- **Documentation to update:** `docs/RUNNER.md` for the lifecycle evolution
+  (A2); `docs/TOOLS.md` and examples (A5); the ADR index row (Stage 2).
+- **Tests to add:** the integration capstone (A6), plus the unit/contract tests
+  each implementing PR owns for its own tool.
+
+## Alternatives considered
+
+- **Homegrown persistent-shell / editor schema.** Rejected: a bespoke schema
+  reintroduces the interface-adaptation cost the milestone exists to eliminate,
+  and gains nothing over the widely-supported Anthropic contract.
+- **Extend `BashTool` in place to hold a long-lived subprocess.** Rejected:
+  `BashTool` is in-process and lifecycle-free; a session-lifetime shell needs
+  `start()`/`stop()`, which only a `ToolWrapper` subclass exposes. Mutating
+  `BashTool` would also break the per-call allowlisted contract that legacy
+  callers depend on.
+- **Adopt all six #63 lifecycle evolutions now.** Rejected: five of the six are
+  not forced by either shipping tool; adopting them speculatively locks in an
+  interface shape ahead of a real second consumer. See the gap-triage table in
+  `(a)`.
+- **Put `service` / `compose_file` into `ToolLifecycleContext`.** Rejected:
+  those are construction-time tool config, not per-trial runner facts; placing
+  them in the context would couple the runner to tool identity and violate
+  ADR-0007. See `(a)`.
+
+## Links
+
+- Related ADRs:
+  - [ADR-0007](0007-runtime-backend-protocol.md) — `RuntimeBackend` Protocol
+    (runner drives off capability, not identity)
+  - [ADR-0016](0016-runtime-backend-comparison.md) — Runtime backend comparison
+    (lifecycle axis)
+  - [ADR-0018](0018-multi-container-under-shared-runtime.md) — Multi-container
+    under shared runtime (composition axis)
+- Related code:
+  - `tolokaforge/runner/tool_factory.py` — `ToolLifecycleContext`, `ToolWrapper`,
+    `DockerComposeExecToolWrapper`
+  - `tolokaforge/runner/service.py` — `has_lifecycle` dispatch and
+    `ToolLifecycleContext` construction
+  - `tolokaforge/tools/builtin/bash.py` — the legacy per-call `BashTool`
+- External references:
+  - Anthropic bash tool (`bash_20250124`) and text-editor tool
+    (`str_replace_based_edit_tool`) contracts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,4 +46,5 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0014](0014-trial-grader-protocol.md) | `TrialGrader` Protocol — swappable trial-grading strategy | Accepted |
 | [0015](0015-trial-executor-protocol.md) | `TrialExecutor` Protocol — per-trial substrate-lifecycle seam | Accepted |
 | [0016](0016-runtime-backend-comparison.md) | Runtime backend comparison: `shared` vs `per_trial` (lifecycle axis) | Accepted |
+| [0017](0017-persistent-agent-shell-and-editor-tools.md) | Persistent agent shell + first-class editor tools + tool-lifecycle evolution | Proposed |
 | [0018](0018-multi-container-under-shared-runtime.md) | Multi-container capability under shared runtime (composition axis) | Accepted |

--- a/examples/native/persistent_tools/README.md
+++ b/examples/native/persistent_tools/README.md
@@ -1,0 +1,31 @@
+# Persistent shell and editor example
+
+Self-contained dataset with one public task that enables both persistent
+agent tools in their local variants:
+
+- `bash_session` — a held bash shell whose working directory, environment,
+  and functions persist across calls.
+- `str_replace_editor` — a file editor with `view` / `create` /
+  `str_replace` / `insert` commands.
+
+The agent establishes a working directory in the session, patches a
+changelog draft with a single `str_replace`, authors a release-notes file,
+and confirms the result by relying on the session's persisted state. Both
+tools operate on the runner's `/work`, so no Docker substrate is required.
+See `docs/TOOLS.md` for the full tool contracts.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/persistent_tools/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/persistent_tools/run_configs/dev.yaml
+```
+
+## Tasks included
+
+- `dataset/tasks/persistent_tools/persistent_tools_public_example_01/`

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/fixtures/CHANGELOG_DRAFT.md
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/fixtures/CHANGELOG_DRAFT.md
@@ -1,0 +1,7 @@
+# Project Changelog
+
+## Unreleased
+
+- STATUS: PENDING
+- Persistent bash session available for multi-step shell workflows.
+- File editor available for creating and patching files in place.

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/grading.yaml
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/grading.yaml
@@ -1,0 +1,32 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.6
+    transcript_rules: 0.4
+  pass_threshold: 0.8
+state_checks:
+  jsonpaths:
+    - path: "$.filesystem['/env/fs/agent-visible/CHANGELOG_DRAFT.md']"
+      contains: "STATUS: READY"
+      description: "Changelog placeholder finalized to READY via str_replace"
+    - path_glob: "/env/fs/agent-visible/release/*"
+      contains_ci: "changelog"
+      description: "Release notes authored under the persisted release/ directory"
+transcript_rules:
+  max_turns: 12
+  disallow_regex:
+    - "(?i)(cannot complete|unable to complete|i refuse)"
+  required_actions:
+    - action_id: "establish_session_state"
+      requestor: assistant
+      name: bash_session
+      arguments: {}
+      compare_args: []
+    - action_id: "edit_with_str_replace_editor"
+      requestor: assistant
+      name: str_replace_editor
+      arguments: {}
+      compare_args: []
+  communicate_info:
+    - info: "READY"
+      required: true

--- a/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/task.yaml
+++ b/examples/native/persistent_tools/dataset/tasks/persistent_tools/persistent_tools_public_example_01/task.yaml
@@ -1,0 +1,23 @@
+task_id: "persistent_tools_public_example_01"
+name: "Release Notes Finalization"
+category: "persistent_tools"
+description: "Use a persistent bash session to establish a working directory, then edit and author files with the str_replace editor, relying on the session's persisted state across calls."
+initial_user_message: "Finalize the release notes. First use `bash_session` to create a `release` directory under `/work` and `cd` into it (later steps rely on this persisted working directory). Then use `str_replace_editor` to edit `/work/CHANGELOG_DRAFT.md`, replacing `STATUS: PENDING` with `STATUS: READY`. Next use `str_replace_editor` to create `/work/release/NOTES.md` summarizing the finalized changelog (mention it is derived from the changelog). Finally use `bash_session` to list the persisted `release` directory and view `NOTES.md` to confirm it was written there. Report `STATUS: READY` when done."
+initial_state:
+  filesystem:
+    copy:
+      - from: "fixtures/CHANGELOG_DRAFT.md"
+        to: "/env/fs/agent-visible/CHANGELOG_DRAFT.md"
+tools:
+  agent:
+    enabled: ["bash_session", "str_replace_editor"]
+  user:
+    enabled: []
+actors:
+  user:
+    backstory: "You are a release manager verifying that the assistant can hold shell state across calls and edit files safely. Acknowledge completion and end with ###STOP### once the assistant reports the release is READY and both files are in place."
+policies:
+  guidance:
+    - "Rely on the persisted working directory rather than re-establishing it in every command."
+    - "Prefer a targeted str_replace over rewriting the whole changelog."
+grading: "grading.yaml"

--- a/examples/native/persistent_tools/project.yaml
+++ b/examples/native/persistent_tools/project.yaml
@@ -1,0 +1,28 @@
+# Project spec for the persistent-tools example.
+#
+# One public task that drives the persistent shell (`bash_session`) and
+# the file editor (`str_replace_editor`) in their local variants. No
+# Docker substrate — both tools operate on the runner's `/work`, so
+# `default_environment` is omitted. See docs/PROJECTS.md for the full
+# Project model and docs/TOOLS.md for the tool contracts.
+
+name: "persistent-tools"
+version: 1
+description: >
+  Persistent shell and editor evaluation: the agent establishes working
+  state in a held bash session, then edits and creates files with the
+  str_replace editor, relying on the session's persisted working
+  directory across calls.
+
+tasks:
+  discovery:
+    glob: "dataset/tasks/**/task.yaml"
+
+# ── Task defaults — base for every task ─────────────────────────
+task_defaults:
+  adapter_type: "native"
+  max_turns: 12
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/persistent_tools/run_configs/dev.yaml
+++ b/examples/native/persistent_tools/run_configs/dev.yaml
@@ -1,0 +1,26 @@
+# Persistent-tools example — one public task exercising the persistent
+# shell (`bash_session`) and the str_replace editor. Requires a real LLM
+# provider key in .env. Run via
+#   scripts/with_env.sh uv run tolokaforge run --config examples/native/persistent_tools/run_configs/dev.yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 12
+  queue_backend: sqlite
+
+evaluation:
+  projects:
+    - "examples/native/persistent_tools/dataset"
+  tasks_glob: "**/task.yaml"
+  output_dir: "results/persistent_tools_example"

--- a/tests/canonical/test_persistent_shell_dispatch.py
+++ b/tests/canonical/test_persistent_shell_dispatch.py
@@ -1,0 +1,71 @@
+"""Canonical wiring lock for the ``bash_session`` provider config axis (#566).
+
+Daemon-free: asserts only that the wrapper *selects* the right backend from
+``tool_config`` and *resolves* the compose container name from the per-trial
+project convention. The concrete ``docker exec`` behaviour is proved on a real
+daemon in ``tests/integration/test_persistent_shell_compose.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import PersistentShellToolWrapper
+from tolokaforge.tools.persistent_shell import DockerComposeBashSession, LocalBashSession
+
+pytestmark = pytest.mark.canonical
+
+
+def _wrapper(tool_config: dict | None) -> PersistentShellToolWrapper:
+    kwargs = {"tool_config": tool_config} if tool_config is not None else {}
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        **kwargs,
+    )
+    return PersistentShellToolWrapper(schema)
+
+
+def test_service_config_selects_compose_backend():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "tolokaforge_"})
+    wrapper._trial_id = "t0"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+
+
+def test_no_service_selects_local_backend():
+    wrapper = _wrapper(None)
+    wrapper._trial_id = "t0"
+    session = wrapper._new_session()
+    assert isinstance(session, LocalBashSession)
+
+
+def test_container_name_resolved_from_trial_service_and_prefix():
+    name = PersistentShellToolWrapper._resolve_container_name(
+        trial_id="abc123", service="app", project_prefix="tolokaforge_"
+    )
+    assert name == "tolokaforge_abc123_app"
+
+
+def test_container_name_sanitises_colon_in_trial_id():
+    name = PersistentShellToolWrapper._resolve_container_name(
+        trial_id="run:abc", service="main", project_prefix="tbench_"
+    )
+    assert name == "tbench_run_abc_main"
+
+
+def test_service_without_prefix_fails_loud():
+    from tolokaforge.runner.tool_factory import ToolConfigurationError
+
+    with pytest.raises(ToolConfigurationError):
+        _wrapper({"service": "app"})
+
+
+def test_compose_backend_wires_resolved_name_into_session():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "tolokaforge_"})
+    wrapper._trial_id = "abc123"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+    assert session.container_name == "tolokaforge_abc123_app"

--- a/tests/canonical/test_str_replace_editor_dispatch.py
+++ b/tests/canonical/test_str_replace_editor_dispatch.py
@@ -1,0 +1,66 @@
+"""Canonical wiring lock for the ``str_replace_editor`` provider config axis (#567).
+
+Daemon-free: asserts only that the wrapper *selects* the right backend from
+``tool_config`` and *resolves* the compose container name from the per-trial
+project convention. The concrete ``docker exec`` behaviour is proved on a real
+daemon in ``tests/integration/test_str_replace_editor_compose.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import (
+    StrReplaceEditorToolWrapper,
+    ToolConfigurationError,
+)
+from tolokaforge.tools.str_replace_editor import DockerComposeEditor, LocalFilesystemEditor
+
+pytestmark = pytest.mark.canonical
+
+
+def _wrapper(tool_config: dict | None, trial_id: str = "t0") -> StrReplaceEditorToolWrapper:
+    kwargs = {"tool_config": tool_config} if tool_config is not None else {}
+    schema = ToolSchema(
+        name="str_replace_editor",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        **kwargs,
+    )
+    return StrReplaceEditorToolWrapper(schema, trial_id=trial_id)
+
+
+def test_service_config_selects_compose_backend():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "foo_"})
+    assert isinstance(wrapper._backend, DockerComposeEditor)
+
+
+def test_no_service_selects_local_backend():
+    wrapper = _wrapper(None)
+    assert isinstance(wrapper._backend, LocalFilesystemEditor)
+
+
+def test_container_name_resolved_from_trial_service_and_prefix():
+    name = StrReplaceEditorToolWrapper._resolve_container_name(
+        trial_id="abc", service="app", project_prefix="foo_"
+    )
+    assert name == "foo_abc_app"
+
+
+def test_container_name_sanitises_colon_in_trial_id():
+    name = StrReplaceEditorToolWrapper._resolve_container_name(
+        trial_id="run:abc", service="main", project_prefix="tbench_"
+    )
+    assert name == "tbench_run_abc_main"
+
+
+def test_compose_backend_wires_resolved_name_into_engine():
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "foo_"}, trial_id="abc")
+    assert isinstance(wrapper._backend, DockerComposeEditor)
+    assert wrapper._backend.container_name == "foo_abc_app"
+
+
+def test_service_without_prefix_fails_loud():
+    with pytest.raises(ToolConfigurationError):
+        _wrapper({"service": "app"})

--- a/tests/canonical/test_str_replace_editor_local.py
+++ b/tests/canonical/test_str_replace_editor_local.py
@@ -1,0 +1,211 @@
+"""Canonical behaviour lock for the local ``str_replace_editor`` engine (#567).
+
+Exercises :class:`LocalFilesystemEditor` against a real temp directory (no
+mocks): the four commands, their fail-loud conditions, path containment, and
+the schema the native adapter advertises. Line-numbered output is asserted
+byte-for-byte; the compose engine's ``docker exec`` behaviour is covered
+separately on a real daemon in the integration tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.adapters.native import _builtin_tool_schemas
+from tolokaforge.tools.str_replace_editor import (
+    _HEAD_CHARS,
+    _MAX_OUTPUT_CHARS,
+    _TAIL_CHARS,
+    EditorError,
+    LocalFilesystemEditor,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _editor(base) -> LocalFilesystemEditor:
+    return LocalFilesystemEditor(str(base))
+
+
+# -- view ---------------------------------------------------------------------
+
+
+def test_view_small_file_is_line_numbered(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    out = _editor(tmp_path).view(str(f))
+    assert out == "     1\talpha\n     2\tbeta\n     3\tgamma\n"
+
+
+def test_view_range_returns_one_indexed_slice(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("l1\nl2\nl3\nl4\nl5\nl6\n", encoding="utf-8")
+    out = _editor(tmp_path).view(str(f), view_range=[3, 5])
+    assert out == "     3\tl3\n     4\tl4\n     5\tl5\n"
+
+
+def test_view_range_negative_one_reads_to_eof(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("l1\nl2\nl3\n", encoding="utf-8")
+    out = _editor(tmp_path).view(str(f), view_range=[2, -1])
+    assert out == "     2\tl2\n     3\tl3\n"
+
+
+def test_view_large_file_is_middle_truncated_with_hint(tmp_path):
+    f = tmp_path / "big.txt"
+    f.write_text("".join(f"line number {i}\n" for i in range(20_000)), encoding="utf-8")
+    out = _editor(tmp_path).view(str(f))
+    assert "[truncated:" in out
+    assert "grep" in out
+    assert len(out) <= _MAX_OUTPUT_CHARS + (_MAX_OUTPUT_CHARS - _HEAD_CHARS - _TAIL_CHARS) + 200
+
+
+def test_view_directory_two_levels_skips_hidden_and_pycache(tmp_path):
+    (tmp_path / "visible.txt").write_text("x", encoding="utf-8")
+    (tmp_path / ".hidden.txt").write_text("x", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "nested.txt").write_text("x", encoding="utf-8")
+    deep = sub / "deeper"
+    deep.mkdir()
+    (deep / "too_deep.txt").write_text("x", encoding="utf-8")
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    (cache / "junk.pyc").write_text("x", encoding="utf-8")
+
+    out = _editor(tmp_path).view(str(tmp_path))
+
+    resolved = tmp_path.resolve()
+    assert str(resolved / "visible.txt") in out
+    assert str(resolved / "sub") in out
+    assert str(resolved / "sub" / "nested.txt") in out  # level 2 present
+    assert "deeper" in out  # the level-2 directory itself is listed
+    assert str(deep / "too_deep.txt") not in out  # level 3 omitted
+    assert str(resolved / ".hidden.txt") not in out
+    assert str(resolved / "__pycache__") not in out
+
+
+# -- create -------------------------------------------------------------------
+
+
+def test_create_writes_new_file(tmp_path):
+    f = tmp_path / "new.txt"
+    msg = _editor(tmp_path).create(str(f), "hello\nworld\n")
+    assert f.read_text(encoding="utf-8") == "hello\nworld\n"
+    assert "created successfully" in msg
+
+
+def test_create_on_existing_path_fails_loud(tmp_path):
+    f = tmp_path / "exists.txt"
+    f.write_text("original\n", encoding="utf-8")
+    with pytest.raises(EditorError):
+        _editor(tmp_path).create(str(f), "overwrite\n")
+    assert f.read_text(encoding="utf-8") == "original\n"
+
+
+# -- str_replace --------------------------------------------------------------
+
+
+def test_str_replace_unique_match_is_applied(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("the quick brown fox\n", encoding="utf-8")
+    _editor(tmp_path).str_replace(str(f), "quick brown", "slow red")
+    assert f.read_text(encoding="utf-8") == "the slow red fox\n"
+
+
+def test_str_replace_non_unique_fails_loud_with_count(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("foo and foo\n", encoding="utf-8")
+    with pytest.raises(EditorError) as exc:
+        _editor(tmp_path).str_replace(str(f), "foo", "bar")
+    assert "2" in str(exc.value)
+    assert f.read_text(encoding="utf-8") == "foo and foo\n"
+
+
+def test_str_replace_missing_match_fails_loud(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("hello world\n", encoding="utf-8")
+    with pytest.raises(EditorError):
+        _editor(tmp_path).str_replace(str(f), "absent", "x")
+
+
+# -- insert -------------------------------------------------------------------
+
+
+def test_insert_after_line_places_text_at_expected_position(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("line1\nline2\nline3\n", encoding="utf-8")
+    _editor(tmp_path).insert(str(f), 2, "INSERTED")
+    assert f.read_text(encoding="utf-8") == "line1\nline2\nINSERTED\nline3\n"
+
+
+def test_insert_at_zero_prepends_before_first_line(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("a\nb\n", encoding="utf-8")
+    _editor(tmp_path).insert(str(f), 0, "TOP")
+    assert f.read_text(encoding="utf-8") == "TOP\na\nb\n"
+
+
+def test_insert_past_eof_fails_loud(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("a\nb\n", encoding="utf-8")
+    with pytest.raises(EditorError):
+        _editor(tmp_path).insert(str(f), 99, "X")
+
+
+# -- path containment ---------------------------------------------------------
+
+
+def test_symlink_escape_fails_loud(tmp_path):
+    base = tmp_path / "work"
+    base.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret\n", encoding="utf-8")
+    link = base / "link.txt"
+    link.symlink_to(secret)
+    with pytest.raises(EditorError):
+        _editor(base).view(str(link))
+
+
+@pytest.mark.parametrize("escape", ["../secret.txt", "/etc/hostname"])
+def test_traversal_and_absolute_escape_fail_loud(tmp_path, escape):
+    base = tmp_path / "work"
+    base.mkdir()
+    (tmp_path / "secret.txt").write_text("secret\n", encoding="utf-8")
+    target = escape if escape.startswith("/") else str(base / escape)
+    with pytest.raises(EditorError):
+        _editor(base).view(target)
+
+
+# -- schema advertisement -----------------------------------------------------
+
+_EXPECTED_PROPS = {
+    "command",
+    "path",
+    "view_range",
+    "file_text",
+    "old_str",
+    "new_str",
+    "insert_line",
+    "insert_text",
+}
+
+
+def test_schema_advertises_full_parameter_set_locally():
+    schemas = _builtin_tool_schemas(["str_replace_editor"], {})
+    assert "str_replace_editor" in schemas
+    props = schemas["str_replace_editor"]["parameters"]["properties"]
+    assert set(props) == _EXPECTED_PROPS
+    assert props["command"]["enum"] == ["view", "create", "str_replace", "insert"]
+
+
+def test_schema_advertised_when_compose_service_configured():
+    """The schema provider tolerates the compose config kwargs, so the tool is
+    not dropped from the LLM's view for a compose task."""
+    schemas = _builtin_tool_schemas(
+        ["str_replace_editor"],
+        {"str_replace_editor": {"service": "app", "compose_project_prefix": "foo_"}},
+    )
+    assert "str_replace_editor" in schemas
+    props = schemas["str_replace_editor"]["parameters"]["properties"]
+    assert set(props) == _EXPECTED_PROPS

--- a/tests/integration/test_persistent_shell_compose.py
+++ b/tests/integration/test_persistent_shell_compose.py
@@ -1,0 +1,123 @@
+"""Behaviour-parity lock for the compose ``bash_session`` engine (#566).
+
+Runs the same behaviours Stage 1 locks for the local engine, but against a real
+``docker exec`` into a running container — proving the compose provider is
+behaviour-identical to the local one (modulo the documented orphan limitation
+on timeout, where pre-timeout state is not preserved).
+
+No mocks: a one-service container is brought up in ``setup`` and torn down after.
+Skips cleanly when the Docker daemon is unavailable; a failed assertion is a real
+failure, never a silent skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import PersistentShellToolWrapper, ToolLifecycleContext
+from tolokaforge.tools.persistent_shell import DockerComposeBashSession
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_IMAGE = "bash:5"
+_PREFIX = "tf_test_"
+_TRIAL_ID = "s2parity"
+_SERVICE = "app"
+_CONTAINER = PersistentShellToolWrapper._resolve_container_name(_TRIAL_ID, _SERVICE, _PREFIX)
+
+
+@pytest.fixture(scope="module")
+def running_container():
+    """Bring up a single bash container the compose engine can exec into."""
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+    subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+    up = subprocess.run(
+        ["docker", "run", "-d", "--name", _CONTAINER, _IMAGE, "sleep", "3600"],
+        capture_output=True,
+        text=True,
+    )
+    if up.returncode != 0:
+        pytest.skip(f"could not start test container: {up.stderr.strip()}")
+    try:
+        yield _CONTAINER
+    finally:
+        subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+
+
+@pytest.fixture
+def session(running_container):
+    s = DockerComposeBashSession(running_container)
+    s.open(None)
+    yield s
+    s.close()
+
+
+def test_cwd_persists_across_calls(session):
+    session.run("mkdir -p /tmp/sub", 10)
+    session.run("cd /tmp/sub", 10)
+    assert session.run("pwd", 10).output.strip() == "/tmp/sub"
+
+
+def test_env_persists_across_calls(session):
+    session.run("export FOO=bar", 10)
+    assert session.run("echo $FOO", 10).output.strip() == "bar"
+
+
+def test_shell_functions_persist_across_calls(session):
+    session.run("greet() { echo hello-fn; }", 10)
+    assert session.run("greet", 10).output.strip() == "hello-fn"
+
+
+def test_restart_yields_fresh_shell(running_container):
+    s = DockerComposeBashSession(running_container)
+    s.open(None)
+    try:
+        s.run("export FOO=bar", 10)
+        assert s.run("echo $FOO", 10).output.strip() == "bar"
+        s.close()
+        s.open(None)
+        assert s.run("echo $FOO", 10).output.strip() == ""
+    finally:
+        s.close()
+
+
+def test_timeout_is_kill_safe_and_session_usable(session):
+    """Orphan limitation: the runaway is abandoned and the in-container session
+    restarted, so the next command works (pre-timeout state is not preserved)."""
+    result = session.run("sleep 300", 3)
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert session.run("echo alive", 10).output.strip() == "alive"
+
+
+def test_output_is_middle_truncated_with_grep_hint(session):
+    result = session.run("for i in $(seq 1 20000); do printf X; done", 15)
+    out = result.output
+    assert len(out) < 20000
+    assert "truncated" in out
+    assert "grep" in out
+
+
+async def test_wrapper_drives_compose_backend_end_to_end(running_container):
+    """Full wrapper path: config selects the compose backend, resolves the
+    running container's name, and runs a command against the real daemon."""
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={"service": _SERVICE, "compose_project_prefix": _PREFIX},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id=_TRIAL_ID))
+    try:
+        await wrapper.execute({"command": "export TOKEN=xyz"})
+        assert (await wrapper.execute({"command": "echo $TOKEN"})).strip() == "xyz"
+        assert "restarted" in await wrapper.execute({"restart": True})
+        assert (await wrapper.execute({"command": "echo $TOKEN"})).strip() == ""
+    finally:
+        wrapper.stop()

--- a/tests/integration/test_persistent_shell_editor_capstone.py
+++ b/tests/integration/test_persistent_shell_editor_capstone.py
@@ -1,0 +1,261 @@
+"""Milestone capstone for the persistent shell + editor tools (#569).
+
+Brings up a real ``docker compose`` stack with one ``bash:5`` service and drives
+BOTH runner wrappers — :class:`PersistentShellToolWrapper` and
+:class:`StrReplaceEditorToolWrapper` — against it under a single shared
+``trial_id``. This locks the milestone-level contract A3/A4 do not cover: both
+wrappers resolve to the same container, they share that container's ``/work``
+filesystem (cross-tool observation), the shell's ``tool_config.timeout_s`` is
+kill-safe without corrupting the shared container, and the editor view is
+deterministic.
+
+No mocks: the compose stack is a real subprocess-managed daemon lifecycle, torn
+down in a ``finally`` even on assertion failure. Skips cleanly when the Docker
+daemon is unavailable; a failed assertion is a real failure, never a silent skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import (
+    PersistentShellToolWrapper,
+    StrReplaceEditorToolWrapper,
+    ToolLifecycleContext,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_IMAGE = "bash:5"
+_PREFIX = "tf_capstone_"
+_SERVICE = "app"
+_WORK = "/work"
+
+_COMPOSE_TEMPLATE = """\
+services:
+  {service}:
+    image: {image}
+    container_name: {container}
+    command: ["sh", "-c", "mkdir -p {work} && exec sleep infinity"]
+"""
+
+
+@dataclass(frozen=True)
+class ComposeStack:
+    """Identity shared by the fixture and both wrappers, by construction."""
+
+    trial_id: str
+    service: str
+    prefix: str
+    container: str
+
+
+def _compose(compose_file: Path, project: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", "compose", "-f", str(compose_file), "-p", project, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _wait_running(container: str, attempts: int = 30) -> bool:
+    for _ in range(attempts):
+        inspect = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Running}}", container],
+            capture_output=True,
+            text=True,
+        )
+        if inspect.returncode == 0 and inspect.stdout.strip() == "true":
+            return True
+        time.sleep(0.5)
+    return False
+
+
+@pytest.fixture(scope="module")
+def compose_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[ComposeStack]:
+    """Own the compose stack lifecycle for the module.
+
+    Unique per run (``trial_id`` + project + container name) so xdist workers and
+    re-runs never collide. The container name is resolved via the wrapper's own
+    helper, so the fixture and the tools agree by construction — never a
+    hand-copied string.
+    """
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+
+    trial_id = f"capstone_{uuid.uuid4().hex[:8]}"
+    container = PersistentShellToolWrapper._resolve_container_name(trial_id, _SERVICE, _PREFIX)
+    project = f"{_PREFIX}{trial_id}"
+
+    compose_file = tmp_path_factory.mktemp("capstone") / "docker-compose.yml"
+    compose_file.write_text(
+        _COMPOSE_TEMPLATE.format(service=_SERVICE, image=_IMAGE, container=container, work=_WORK)
+    )
+
+    subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False)
+    up = _compose(compose_file, project, "up", "-d", "--wait")
+    if up.returncode != 0:
+        # A healthcheck-less --wait can be rejected on some compose builds; fall
+        # back to a plain up plus a running-state poll.
+        up = _compose(compose_file, project, "up", "-d")
+        if up.returncode != 0:
+            pytest.skip(f"could not start compose stack: {up.stderr.strip()}")
+        if not _wait_running(container):
+            _compose(compose_file, project, "down", "-v", "--remove-orphans")
+            pytest.skip(f"compose service {container} never reached running state")
+
+    try:
+        yield ComposeStack(trial_id=trial_id, service=_SERVICE, prefix=_PREFIX, container=container)
+    finally:
+        _compose(compose_file, project, "down", "-v", "--remove-orphans")
+
+
+def _tool_config(stack: ComposeStack, **extra: object) -> dict[str, object]:
+    return {"service": stack.service, "compose_project_prefix": stack.prefix, **extra}
+
+
+@contextmanager
+def _shell(
+    stack: ComposeStack, timeout_s: float | None = None
+) -> Iterator[PersistentShellToolWrapper]:
+    config = (
+        _tool_config(stack, timeout_s=timeout_s) if timeout_s is not None else _tool_config(stack)
+    )
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config=config,
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id=stack.trial_id))
+    try:
+        yield wrapper
+    finally:
+        wrapper.stop()
+
+
+def _editor(stack: ComposeStack) -> StrReplaceEditorToolWrapper:
+    schema = ToolSchema(
+        name="str_replace_editor",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config=_tool_config(stack),
+    )
+    return StrReplaceEditorToolWrapper(schema, trial_id=stack.trial_id)
+
+
+def test_both_wrappers_target_the_same_container(compose_stack: ComposeStack):
+    shell_name = PersistentShellToolWrapper._resolve_container_name(
+        compose_stack.trial_id, compose_stack.service, compose_stack.prefix
+    )
+    editor_name = StrReplaceEditorToolWrapper._resolve_container_name(
+        compose_stack.trial_id, compose_stack.service, compose_stack.prefix
+    )
+    assert shell_name == editor_name == compose_stack.container
+
+
+async def test_shell_state_persists_across_wrapper_calls(compose_stack: ComposeStack):
+    with _shell(compose_stack) as shell:
+        await shell.execute({"command": "cd /work"})
+        await shell.execute({"command": "export FOO=bar"})
+        await shell.execute({"command": "mkdir -p sub"})
+        await shell.execute({"command": "cd sub"})
+        assert (await shell.execute({"command": "pwd"})).strip() == "/work/sub"
+        assert (await shell.execute({"command": "echo $FOO"})).strip() == "bar"
+
+        assert "restarted" in await shell.execute({"restart": True})
+        assert (await shell.execute({"command": "echo $FOO"})).strip() == ""
+        assert (await shell.execute({"command": "pwd"})).strip() != "/work/sub"
+
+
+async def test_editor_four_command_round_trip_through_wrapper(compose_stack: ComposeStack):
+    editor = _editor(compose_stack)
+    path = f"{_WORK}/story.txt"
+
+    assert "created successfully" in await editor.execute(
+        {"command": "create", "path": path, "file_text": "the quick brown fox\ntail\n"}
+    )
+    assert (
+        await editor.execute({"command": "view", "path": path})
+        == "     1\tthe quick brown fox\n     2\ttail\n"
+    )
+    await editor.execute(
+        {"command": "str_replace", "path": path, "old_str": "quick brown", "new_str": "slow red"}
+    )
+    assert (
+        await editor.execute({"command": "view", "path": path, "view_range": [1, 1]})
+        == "     1\tthe slow red fox\n"
+    )
+    await editor.execute(
+        {"command": "insert", "path": path, "insert_line": 1, "insert_text": "INSERTED"}
+    )
+    assert await editor.execute({"command": "view", "path": path}) == (
+        "     1\tthe slow red fox\n     2\tINSERTED\n     3\ttail\n"
+    )
+
+
+async def test_shell_and_editor_share_the_container_filesystem(compose_stack: ComposeStack):
+    editor = _editor(compose_stack)
+    from_editor = f"{_WORK}/from_editor.txt"
+    from_shell = f"{_WORK}/from_shell.txt"
+
+    await editor.execute(
+        {"command": "create", "path": from_editor, "file_text": "written-by-editor\n"}
+    )
+    with _shell(compose_stack) as shell:
+        assert (
+            await shell.execute({"command": f"cat {from_editor}"})
+        ).strip() == "written-by-editor"
+
+        await shell.execute({"command": f"printf 'written-by-shell\\n' > {from_shell}"})
+
+    assert (
+        await editor.execute({"command": "view", "path": from_shell})
+        == "     1\twritten-by-shell\n"
+    )
+    await editor.execute(
+        {
+            "command": "str_replace",
+            "path": from_shell,
+            "old_str": "written-by-shell",
+            "new_str": "edited-by-editor",
+        }
+    )
+    with _shell(compose_stack) as shell:
+        assert (await shell.execute({"command": f"cat {from_shell}"})).strip() == "edited-by-editor"
+
+
+async def test_shell_timeout_is_kill_safe_and_editor_unaffected(compose_stack: ComposeStack):
+    editor = _editor(compose_stack)
+    path = f"{_WORK}/after_timeout.txt"
+
+    with _shell(compose_stack, timeout_s=3) as shell:
+        result = await shell.execute({"command": "sleep 300"})
+        assert "timed out" in result
+
+        assert "created successfully" in await editor.execute(
+            {"command": "create", "path": path, "file_text": "still-here\n"}
+        )
+        assert await editor.execute({"command": "view", "path": path}) == "     1\tstill-here\n"
+
+        assert (await shell.execute({"command": "echo alive"})).strip() == "alive"
+
+
+async def test_repeated_view_is_byte_identical(compose_stack: ComposeStack):
+    editor = _editor(compose_stack)
+    path = f"{_WORK}/stable.txt"
+    await editor.execute({"command": "create", "path": path, "file_text": "line one\nline two\n"})
+    first = await editor.execute({"command": "view", "path": path})
+    second = await editor.execute({"command": "view", "path": path})
+    assert first == second

--- a/tests/integration/test_str_replace_editor_compose.py
+++ b/tests/integration/test_str_replace_editor_compose.py
@@ -1,0 +1,111 @@
+"""Behaviour-parity lock for the compose ``str_replace_editor`` engine (#567).
+
+Runs the four editor commands against a real ``docker exec`` into a running
+container — proving the compose provider is behaviour-identical to the local one
+(line-numbered view, unique str_replace, insert, fail-loud create/str_replace,
+container-side path containment).
+
+No mocks: a one-service container is brought up in the fixture and torn down
+after. Skips cleanly when the Docker daemon is unavailable; a failed assertion
+is a real failure, never a silent skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import StrReplaceEditorToolWrapper
+from tolokaforge.tools.str_replace_editor import DockerComposeEditor, EditorError
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_IMAGE = "alpine:latest"
+_PREFIX = "tf_test_editor_"
+_TRIAL_ID = "s2parity"
+_SERVICE = "app"
+_CONTAINER = StrReplaceEditorToolWrapper._resolve_container_name(_TRIAL_ID, _SERVICE, _PREFIX)
+_WORK = "/work"
+
+
+@pytest.fixture(scope="module")
+def running_container():
+    """Bring up a single container with a ``/work`` root to edit inside."""
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+    subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+    up = subprocess.run(
+        ["docker", "run", "-d", "--name", _CONTAINER, _IMAGE, "sleep", "3600"],
+        capture_output=True,
+        text=True,
+    )
+    if up.returncode != 0:
+        pytest.skip(f"could not start test container: {up.stderr.strip()}")
+    subprocess.run(
+        ["docker", "exec", _CONTAINER, "mkdir", "-p", _WORK], capture_output=True, check=True
+    )
+    try:
+        yield _CONTAINER
+    finally:
+        subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
+
+
+@pytest.fixture
+def editor(running_container) -> DockerComposeEditor:
+    return DockerComposeEditor(running_container, base_path=_WORK)
+
+
+def test_create_view_str_replace_insert_round_trip(editor):
+    path = f"{_WORK}/story.txt"
+    assert "created successfully" in editor.create(path, "the quick brown fox\ntail\n")
+
+    assert editor.view(path) == "     1\tthe quick brown fox\n     2\ttail\n"
+
+    editor.str_replace(path, "quick brown", "slow red")
+    assert editor.view(path, view_range=[1, 1]) == "     1\tthe slow red fox\n"
+
+    editor.insert(path, 1, "INSERTED")
+    assert editor.view(path) == ("     1\tthe slow red fox\n     2\tINSERTED\n     3\ttail\n")
+
+
+def test_create_on_existing_path_fails_loud(editor):
+    path = f"{_WORK}/existing.txt"
+    editor.create(path, "original\n")
+    with pytest.raises(EditorError):
+        editor.create(path, "overwrite\n")
+    assert editor.view(path) == "     1\toriginal\n"
+
+
+def test_str_replace_non_unique_fails_loud(editor):
+    path = f"{_WORK}/dup.txt"
+    editor.create(path, "foo and foo\n")
+    with pytest.raises(EditorError) as exc:
+        editor.str_replace(path, "foo", "bar")
+    assert "2" in str(exc.value)
+    assert editor.view(path) == "     1\tfoo and foo\n"
+
+
+def test_absolute_path_outside_work_fails_loud(editor):
+    with pytest.raises(EditorError):
+        editor.view("/etc/hostname")
+
+
+async def test_wrapper_drives_compose_backend_end_to_end(running_container):
+    """Full wrapper path: config selects the compose backend, resolves the
+    running container's name, and edits a file against the real daemon."""
+    schema = ToolSchema(
+        name="str_replace_editor",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={"service": _SERVICE, "compose_project_prefix": _PREFIX},
+    )
+    wrapper = StrReplaceEditorToolWrapper(schema, trial_id=_TRIAL_ID)
+    path = f"{_WORK}/wrapper.txt"
+    assert "created successfully" in await wrapper.execute(
+        {"command": "create", "path": path, "file_text": "hello\n"}
+    )
+    view = await wrapper.execute({"command": "view", "path": path})
+    assert view == "     1\thello\n"

--- a/tests/unit/test_builtin_registry.py
+++ b/tests/unit/test_builtin_registry.py
@@ -32,6 +32,8 @@ def test_list_builtins_covers_every_consumer_today():
         # executor side (was builtin_tool_factories, 10 entries)
         "list_dir",
         "search_kb",
+        # session-lifetime persistent shell (#566)
+        "bash_session",
     }
     assert expected == set(registry.list_builtins())
 
@@ -40,12 +42,21 @@ def test_dispatch_groups_are_disjoint_and_exhaustive():
     generic = registry.list_for_dispatch(registry.Dispatch.GENERIC)
     files = registry.list_for_dispatch(registry.Dispatch.FILES)
     rag = registry.list_for_dispatch(registry.Dispatch.RAG)
+    shell = registry.list_for_dispatch(registry.Dispatch.PERSISTENT_SHELL)
+    groups = [generic, files, rag, shell]
     # Disjoint
-    assert generic.isdisjoint(files)
-    assert generic.isdisjoint(rag)
-    assert files.isdisjoint(rag)
+    for i, a in enumerate(groups):
+        for b in groups[i + 1 :]:
+            assert a.isdisjoint(b)
     # Exhaustive
-    assert generic | files | rag == registry.list_builtins()
+    assert generic | files | rag | shell == registry.list_builtins()
+
+
+def test_bash_session_routes_to_persistent_shell_dispatch():
+    from tolokaforge.tools.persistent_shell import PersistentShellTool
+
+    assert registry.get_dispatch("bash_session") is registry.Dispatch.PERSISTENT_SHELL
+    assert registry.get_class("bash_session") is PersistentShellTool
 
 
 def test_bash_is_generic_not_files():

--- a/tests/unit/test_builtin_registry.py
+++ b/tests/unit/test_builtin_registry.py
@@ -34,6 +34,8 @@ def test_list_builtins_covers_every_consumer_today():
         "search_kb",
         # session-lifetime persistent shell (#566)
         "bash_session",
+        # str-replace editor (#567)
+        "str_replace_editor",
     }
     assert expected == set(registry.list_builtins())
 
@@ -43,13 +45,14 @@ def test_dispatch_groups_are_disjoint_and_exhaustive():
     files = registry.list_for_dispatch(registry.Dispatch.FILES)
     rag = registry.list_for_dispatch(registry.Dispatch.RAG)
     shell = registry.list_for_dispatch(registry.Dispatch.PERSISTENT_SHELL)
-    groups = [generic, files, rag, shell]
+    editor = registry.list_for_dispatch(registry.Dispatch.EDITOR)
+    groups = [generic, files, rag, shell, editor]
     # Disjoint
     for i, a in enumerate(groups):
         for b in groups[i + 1 :]:
             assert a.isdisjoint(b)
     # Exhaustive
-    assert generic | files | rag | shell == registry.list_builtins()
+    assert generic | files | rag | shell | editor == registry.list_builtins()
 
 
 def test_bash_session_routes_to_persistent_shell_dispatch():
@@ -57,6 +60,13 @@ def test_bash_session_routes_to_persistent_shell_dispatch():
 
     assert registry.get_dispatch("bash_session") is registry.Dispatch.PERSISTENT_SHELL
     assert registry.get_class("bash_session") is PersistentShellTool
+
+
+def test_str_replace_editor_routes_to_editor_dispatch():
+    from tolokaforge.tools.str_replace_editor import StrReplaceEditorTool
+
+    assert registry.get_dispatch("str_replace_editor") is registry.Dispatch.EDITOR
+    assert registry.get_class("str_replace_editor") is StrReplaceEditorTool
 
 
 def test_bash_is_generic_not_files():

--- a/tests/unit/test_native_adapter_builtin_dispatch.py
+++ b/tests/unit/test_native_adapter_builtin_dispatch.py
@@ -14,11 +14,12 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.adapters.native import NativeAdapter, _builtin_tool_schemas
 
 pytestmark = pytest.mark.unit
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "tasks"
+_PERSISTENT_PACK = Path(__file__).resolve().parents[2] / "examples" / "native" / "persistent_tools"
 
 
 @pytest.fixture
@@ -76,3 +77,87 @@ def test_non_dict_per_tool_config_raises():
     )
     with pytest.raises(ValueError, match="tools.agent.mobile must be a mapping"):
         adapter.to_task_description("bad_mobile")
+
+
+@pytest.fixture
+def persistent_tools_adapter() -> NativeAdapter:
+    from tolokaforge.core.project_loader import load_project_config
+
+    project = load_project_config(_PERSISTENT_PACK / "project.yaml")
+    defaults = project.task_defaults.model_dump(exclude_defaults=True) or None
+    return NativeAdapter(
+        {
+            "tasks_glob": "dataset/tasks/**/task.yaml",
+            "base_dir": str(_PERSISTENT_PACK),
+            "project_task_defaults": defaults,
+        }
+    )
+
+
+def _agent_tool(td, name: str):
+    return next(t for t in td.agent_tools if t.name == name)
+
+
+def test_persistent_pack_advertises_bash_session_schema(persistent_tools_adapter):
+    """The example pack's ``bash_session: {}`` config must load through the
+    adapter as a source-less builtin advertising the full wire schema."""
+    td = persistent_tools_adapter.to_task_description("persistent_tools_public_example_01")
+    bash = _agent_tool(td, "bash_session")
+
+    assert bash.source is None
+    props = bash.parameters["properties"]
+    assert set(props) == {"command", "restart"}
+    assert props["command"]["type"] == "string"
+    assert props["restart"]["type"] == "boolean"
+    assert bash.parameters["required"] == []
+
+
+def test_persistent_pack_advertises_str_replace_editor_schema(persistent_tools_adapter):
+    """The editor's full parameter set (including the four-command enum and
+    the insert-specific ``insert_text``) must reach the built ToolSchema."""
+    td = persistent_tools_adapter.to_task_description("persistent_tools_public_example_01")
+    editor = _agent_tool(td, "str_replace_editor")
+
+    assert editor.source is None
+    props = editor.parameters["properties"]
+    assert set(props) == {
+        "command",
+        "path",
+        "view_range",
+        "file_text",
+        "old_str",
+        "new_str",
+        "insert_line",
+        "insert_text",
+    }
+    assert props["command"]["enum"] == ["view", "create", "str_replace", "insert"]
+    assert editor.parameters["required"] == ["command", "path"]
+    # ``insert`` carries its text in ``insert_text`` — not ``new_str`` (that
+    # is the ``str_replace`` replacement). Both must be advertised distinctly.
+    assert "insert_text" in props
+    assert "new_str" in props
+
+
+def test_builtin_schemas_survive_compose_tool_config():
+    """``_builtin_tool_schemas`` must extract full schemas for both tools even
+    under a compose ``tool_config`` — guards against a schema-extraction
+    failure being swallowed and a tool shipping an empty schema (#577)."""
+    compose_configs = {
+        "bash_session": {"service": "main", "compose_project_prefix": "trial-xyz"},
+        "str_replace_editor": {"service": "main", "compose_project_prefix": "trial-xyz"},
+    }
+    schemas = _builtin_tool_schemas(["bash_session", "str_replace_editor"], compose_configs)
+
+    assert set(schemas["bash_session"]["parameters"]["properties"]) == {"command", "restart"}
+    editor_props = schemas["str_replace_editor"]["parameters"]["properties"]
+    assert set(editor_props) == {
+        "command",
+        "path",
+        "view_range",
+        "file_text",
+        "old_str",
+        "new_str",
+        "insert_line",
+        "insert_text",
+    }
+    assert editor_props["command"]["enum"] == ["view", "create", "str_replace", "insert"]

--- a/tests/unit/test_persistent_shell_local.py
+++ b/tests/unit/test_persistent_shell_local.py
@@ -1,0 +1,190 @@
+"""Behaviour lock for the local ``bash_session`` persistent shell (#566).
+
+Real bash subprocesses, no mocks. Covers state persistence (cwd, env,
+functions), restart, kill-safe timeout with state survival (mechanism M1:
+PTY + job control), output truncation, and the wrapper's config-driven
+timeout. Also locks that the schema provider advertises ``command`` +
+``restart`` even when a compose ``service`` config is present.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import psutil
+import pytest
+
+from tolokaforge.adapters.native import _builtin_tool_schemas
+from tolokaforge.runner.models import ToolSchema
+from tolokaforge.runner.tool_factory import (
+    PersistentShellToolWrapper,
+    ToolLifecycleContext,
+)
+from tolokaforge.tools.persistent_shell import LocalBashSession
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def session(tmp_path):
+    s = LocalBashSession()
+    s.open(str(tmp_path))
+    yield s
+    s.close()
+
+
+def test_cwd_persists_across_calls(session, tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    session.run(f"cd {sub}", 5)
+    result = session.run("pwd", 5)
+    assert result.output.strip() == os.path.realpath(str(sub))
+
+
+def test_env_persists_across_calls(session):
+    session.run("export FOO=bar", 5)
+    result = session.run("echo $FOO", 5)
+    assert result.output.strip() == "bar"
+
+
+def test_shell_functions_persist_across_calls(session):
+    session.run("greet() { echo hello-fn; }", 5)
+    result = session.run("greet", 5)
+    assert result.output.strip() == "hello-fn"
+
+
+def test_restart_yields_fresh_shell(tmp_path):
+    session = LocalBashSession()
+    session.open(str(tmp_path))
+    try:
+        session.run("export FOO=bar", 5)
+        assert session.run("echo $FOO", 5).output.strip() == "bar"
+        session.close()
+        session.open(str(tmp_path))
+        assert session.run("echo $FOO", 5).output.strip() == ""
+    finally:
+        session.close()
+
+
+def test_timeout_is_kill_safe_and_state_survives(session):
+    """M1: the runaway is terminated, no process leaks, the session stays
+    usable, and env set before the timeout survives (same session)."""
+    session.run("export SURVIVES=yes", 5)
+    proc = psutil.Process(session.pid)
+
+    start = time.monotonic()
+    result = session.run("sleep 300", 3)
+    elapsed = time.monotonic() - start
+
+    assert result.timed_out is True
+    assert result.exit_code is None
+    assert elapsed < 15  # enforced near the 3s budget, not left to run 300s
+
+    # No leaked runaway: the shell has no surviving children.
+    assert proc.children(recursive=True) == []
+
+    # Session still usable and pre-timeout state survived (M1 guarantee).
+    assert session.run("echo alive", 5).output.strip() == "alive"
+    assert session.run("echo $SURVIVES", 5).output.strip() == "yes"
+
+
+def test_output_is_middle_truncated_with_grep_hint(session):
+    result = session.run("for i in $(seq 1 20000); do printf X; done", 15)
+    out = result.output
+    assert len(out) < 20000
+    assert out.startswith("X" * 100)
+    assert out.endswith("X" * 100)
+    assert "truncated" in out
+    assert "grep" in out
+
+
+def test_large_command_survives_short_writes(session, monkeypatch):
+    """``os.write`` on the PTY master may write fewer bytes than requested, so
+    ``_write`` must loop until the buffer drains. Cap every write at 4096 bytes
+    to force that short-write condition deterministically, then round-trip a
+    large heredoc: a single un-looped write would drop the command tail (the
+    heredoc terminator never arrives → timeout), while the loop delivers it in
+    full. ``wc -c`` keeps the output under the 16 KB truncation budget so the
+    write path is what's under test."""
+    import tolokaforge.tools.persistent_shell as ps
+
+    real_write = os.write
+    monkeypatch.setattr(ps.os, "write", lambda fd, buf: real_write(fd, buf[:4096]))
+
+    payload = "A" * 100_000
+    result = session.run(f"cat <<'EOF' | wc -c\n{payload}\nEOF", 15)
+    assert result.timed_out is False
+    assert result.exit_code == 0
+    assert result.output.strip() == str(len(payload) + 1)
+
+
+async def test_wrapper_timeout_resolved_from_tool_config(tmp_path):
+    """A 5s ``tool_config`` timeout is enforced — proves the wrapper reads
+    tool_config, not self.timeout_s (pinned to 30s by the adapter)."""
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={"timeout_s": 5},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        start = time.monotonic()
+        output = await wrapper.execute({"command": "sleep 300"})
+        elapsed = time.monotonic() - start
+        assert 4 < elapsed < 20
+        assert "timed out" in output
+    finally:
+        wrapper.stop()
+
+
+async def test_wrapper_restart_resets_state(tmp_path):
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        await wrapper.execute({"command": "export FOO=bar"})
+        assert (await wrapper.execute({"command": "echo $FOO"})).strip() == "bar"
+        assert "restarted" in await wrapper.execute({"restart": True})
+        assert (await wrapper.execute({"command": "echo $FOO"})).strip() == ""
+    finally:
+        wrapper.stop()
+
+
+async def test_wrapper_requires_command_or_restart(tmp_path):
+    from tolokaforge.runner.tool_factory import ToolExecutionError
+
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = PersistentShellToolWrapper(schema)
+    wrapper.start(ToolLifecycleContext(trial_id="t", work_dir=str(tmp_path)))
+    try:
+        with pytest.raises(ToolExecutionError):
+            await wrapper.execute({})
+    finally:
+        wrapper.stop()
+
+
+def test_schema_advertises_command_and_restart_locally():
+    schemas = _builtin_tool_schemas(["bash_session"], {})
+    assert "bash_session" in schemas
+    props = schemas["bash_session"]["parameters"]["properties"]
+    assert set(props) == {"command", "restart"}
+
+
+def test_schema_advertised_when_compose_service_configured():
+    """The schema provider tolerates the compose ``service`` kwarg, so the
+    tool is not dropped from the LLM's view for a compose task."""
+    schemas = _builtin_tool_schemas(["bash_session"], {"bash_session": {"service": "app"}})
+    assert "bash_session" in schemas
+    props = schemas["bash_session"]["parameters"]["properties"]
+    assert set(props) == {"command", "restart"}

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -6,6 +6,10 @@ method), the open ``adapter_type`` string, and the host-side registry guard — 
 new adapter can be added as an entry-point package with zero engine edits.
 """
 
+import asyncio
+import dataclasses
+import subprocess
+
 import pytest
 
 from tolokaforge.adapters import (
@@ -75,6 +79,63 @@ class TestToolLifecycleCapability:
         # Must not raise — the runner calls these on every tool generically.
         tool.start(ToolLifecycleContext(trial_id="t:0"))
         tool.stop()
+
+    def test_context_defaults_optional_fields_to_none(self):
+        ctx = ToolLifecycleContext(trial_id="t:0")
+        assert ctx.artifacts_dir is None
+        assert ctx.work_dir is None
+
+    def test_context_carries_all_fields_and_is_frozen(self):
+        ctx = ToolLifecycleContext(trial_id="t:0", artifacts_dir="/a", work_dir="/work")
+        assert (ctx.trial_id, ctx.artifacts_dir, ctx.work_dir) == ("t:0", "/a", "/work")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.work_dir = "/other"
+
+    def test_session_lifetime_tool_holds_subprocess_across_execute(self, tmp_path):
+        """A session-lifetime tool opens a subprocess in start() seeded from
+        ctx.work_dir, holds it across execute() calls, and tears it down in stop()."""
+
+        from tolokaforge.runner.models import ToolSchema
+
+        class _SessionTool(ToolWrapper):
+            has_lifecycle = True
+
+            def __init__(self, schema):
+                super().__init__(schema)
+                self._process = None
+
+            def start(self, ctx):
+                self._process = subprocess.Popen(
+                    ["sh", "-c", "while :; do read line; echo pid=$$; done"],
+                    cwd=ctx.work_dir,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    text=True,
+                )
+
+            async def execute(self, arguments):
+                assert self._process is not None
+                self._process.stdin.write("go\n")
+                self._process.stdin.flush()
+                return self._process.stdout.readline().strip()
+
+            def stop(self):
+                if self._process is not None:
+                    self._process.terminate()
+                    self._process.wait(timeout=5)
+
+        tool = _SessionTool(ToolSchema(name="session", description="", parameters={}))
+        tool.start(ToolLifecycleContext(trial_id="t:0", work_dir=str(tmp_path)))
+        try:
+            first = asyncio.run(tool.execute({}))
+            second = asyncio.run(tool.execute({}))
+            assert first == second  # same long-lived process across calls
+            pid = tool._process.pid
+            assert tool._process.poll() is None  # still alive between calls
+        finally:
+            tool.stop()
+        assert tool._process.poll() is not None  # dead after stop()
+        assert f"pid={pid}" == first
 
 
 class TestHostSideAdapterTypeGuard:

--- a/tests/unit/test_runner_builtin_dispatch.py
+++ b/tests/unit/test_runner_builtin_dispatch.py
@@ -22,6 +22,7 @@ from tolokaforge.runner.tool_factory import (
     BuiltinFileToolWrapper,
     BuiltinGenericToolWrapper,
     PersistentShellToolWrapper,
+    StrReplaceEditorToolWrapper,
     ToolConfigurationError,
     ToolFactory,
 )
@@ -65,6 +66,17 @@ def test_bash_session_routes_to_persistent_shell_wrapper(factory):
     wrapper = factory._create_wrapper(schema)
     assert isinstance(wrapper, PersistentShellToolWrapper)
     assert wrapper.has_lifecycle is True
+
+
+def test_str_replace_editor_routes_to_editor_wrapper(factory):
+    schema = ToolSchema(
+        name="str_replace_editor",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = factory._create_wrapper(schema)
+    assert isinstance(wrapper, StrReplaceEditorToolWrapper)
+    assert wrapper.has_lifecycle is False
 
 
 def test_mobile_end_to_end_through_native_adapter(factory):

--- a/tests/unit/test_runner_builtin_dispatch.py
+++ b/tests/unit/test_runner_builtin_dispatch.py
@@ -21,6 +21,7 @@ from tolokaforge.runner.models import ToolSchema
 from tolokaforge.runner.tool_factory import (
     BuiltinFileToolWrapper,
     BuiltinGenericToolWrapper,
+    PersistentShellToolWrapper,
     ToolConfigurationError,
     ToolFactory,
 )
@@ -53,6 +54,17 @@ def test_read_file_routes_to_file_wrapper(factory):
     )
     wrapper = factory._create_wrapper(schema)
     assert isinstance(wrapper, BuiltinFileToolWrapper)
+
+
+def test_bash_session_routes_to_persistent_shell_wrapper(factory):
+    schema = ToolSchema(
+        name="bash_session",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+    )
+    wrapper = factory._create_wrapper(schema)
+    assert isinstance(wrapper, PersistentShellToolWrapper)
+    assert wrapper.has_lifecycle is True
 
 
 def test_mobile_end_to_end_through_native_adapter(factory):

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -84,6 +84,9 @@ logger = logging.getLogger(__name__)
 # Service version
 SERVICE_VERSION = "1.0.0"
 
+# Session working root handed to lifecycle tools as ``ToolLifecycleContext.work_dir``.
+AGENT_WORK_DIR = "/work"
+
 # The documented read-only mcp_core TypeSense KB connector the agent uses. The
 # judge is allowed to reuse this ONE reconstructed tool (read-only passthrough)
 # so it reads the same corpus the agent did. It is a closed (mcp_core) tool, not
@@ -661,6 +664,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         lifecycle_ctx = ToolLifecycleContext(
             trial_id=trial_id,
             artifacts_dir=str(artifacts_dir) if artifacts_dir is not None else None,
+            work_dir=AGENT_WORK_DIR,
         )
         for tool in trial_context.agent_tools.values():
             if getattr(tool, "has_lifecycle", False):

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -22,6 +22,7 @@ import asyncio
 import importlib
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -47,6 +48,12 @@ from tolokaforge.runner.rag_client import (
     RAGServiceClient,
     RAGServiceError,
     SearchResponse,
+)
+from tolokaforge.tools.persistent_shell import (
+    BashSession,
+    CommandResult,
+    DockerComposeBashSession,
+    LocalBashSession,
 )
 
 logger = logging.getLogger(__name__)
@@ -1150,6 +1157,113 @@ class DockerComposeExecToolWrapper(ToolWrapper):
 
 
 # =============================================================================
+# Persistent Shell Tool Wrapper
+# =============================================================================
+
+
+class PersistentShellToolWrapper(ToolWrapper):
+    """Runner-side executor for the session-lifetime ``bash_session`` tool.
+
+    Holds one bash session for the trial: ``start()`` opens it (seeding the
+    working directory from :class:`ToolLifecycleContext`), ``execute()`` runs
+    commands or restarts the shell, and ``stop()`` tears it down. State (cwd,
+    environment, functions) persists across ``execute()`` calls.
+    """
+
+    has_lifecycle = True
+
+    def __init__(self, tool_schema: ToolSchemaModel):
+        super().__init__(tool_schema)
+        tool_config = tool_schema.tool_config or {}
+        # Resolve from tool_config, not self.timeout_s: the native adapter pins
+        # every builtin's ToolSchema.timeout_s to 30.0, so self.timeout_s can
+        # never carry the ADR-locked 120s default or a task's configured value.
+        self._timeout_s = float(tool_config.get("timeout_s", 120.0))
+        # Provider is a config axis: a `service` key selects the compose backend
+        # (docker exec into a running service container); its absence selects the
+        # local subprocess backend. The wire schema is identical either way.
+        self._service: str | None = tool_config.get("service")
+        self._project_prefix: str | None = tool_config.get("compose_project_prefix")
+        if self._service is not None and not self._project_prefix:
+            raise ToolConfigurationError(
+                self.name,
+                "bash_session with a 'service' requires 'compose_project_prefix' to "
+                "resolve the running container name (the per-trial compose project "
+                "prefix used to bring the stack up)",
+            )
+        self._trial_id: str | None = None
+        self._session: BashSession | None = None
+        self._cwd: str | None = None
+
+    def start(self, ctx: "ToolLifecycleContext") -> None:
+        self._trial_id = ctx.trial_id
+        self._cwd = ctx.work_dir if ctx.work_dir and os.path.isdir(ctx.work_dir) else None
+        session = self._new_session()
+        session.open(self._cwd)
+        self._session = session
+
+    def stop(self) -> None:
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def cleanup(self) -> None:
+        self.stop()
+
+    async def execute(self, arguments: dict[str, Any]) -> str:
+        if self._session is None:
+            raise ToolExecutionError(self.name, "bash session not started")
+        if arguments.get("restart"):
+            return await self._restart()
+        command = arguments.get("command")
+        if command is None:
+            raise ToolExecutionError(
+                self.name, "bash_session requires either 'command' or 'restart'"
+            )
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, self._session.run, command, self._timeout_s)
+        return self._format_result(result)
+
+    def _new_session(self) -> BashSession:
+        """Construct (but do not open) the backend session from config."""
+        if self._service is None:
+            return LocalBashSession()
+        assert self._trial_id is not None and self._project_prefix is not None
+        container = self._resolve_container_name(
+            self._trial_id, self._service, self._project_prefix
+        )
+        return DockerComposeBashSession(container)
+
+    @staticmethod
+    def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:
+        """Container name for *service* in the per-trial compose stack.
+
+        Mirrors the per-trial project convention the compose lifecycle consumer
+        uses (project ``{prefix}{trial_id}``, container ``{project}_{service}``),
+        so the exec targets the same running container the stack brought up.
+        """
+        project = f"{project_prefix}{trial_id.replace(':', '_')}"
+        return f"{project}_{service}"
+
+    async def _restart(self) -> str:
+        assert self._session is not None
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._session.close)
+        session = self._new_session()
+        await loop.run_in_executor(None, session.open, self._cwd)
+        self._session = session
+        return "Shell session restarted; working directory and environment reset."
+
+    def _format_result(self, result: CommandResult) -> str:
+        if result.timed_out:
+            suffix = f"\n[timed out after {self._timeout_s:g}s; command terminated]"
+            return result.output + suffix
+        if result.exit_code not in (0, None):
+            return f"{result.output}\n[exit code: {result.exit_code}]"
+        return result.output
+
+
+# =============================================================================
 # Tool Factory
 # =============================================================================
 
@@ -1273,6 +1387,8 @@ class ToolFactory:
                 return self._create_rag_search_wrapper(schema)
             if dispatch is builtin_registry.Dispatch.FILES:
                 return BuiltinFileToolWrapper(schema)
+            if dispatch is builtin_registry.Dispatch.PERSISTENT_SHELL:
+                return PersistentShellToolWrapper(schema)
             return BuiltinGenericToolWrapper(schema)
 
         source = schema.source

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -98,7 +98,7 @@ class ToolExecutionError(Exception):
 # =============================================================================
 
 
-@dataclass
+@dataclass(frozen=True)
 class ToolLifecycleContext:
     """Per-trial context passed to a tool's ``start()``.
 
@@ -109,6 +109,7 @@ class ToolLifecycleContext:
 
     trial_id: str
     artifacts_dir: str | None = None
+    work_dir: str | None = None
 
 
 class ToolWrapper(ABC):

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1292,6 +1292,8 @@ class StrReplaceEditorToolWrapper(ToolWrapper):
 
     has_lifecycle = False
 
+    # Hardcoded to match service.py's AGENT_WORK_DIR — this wrapper is
+    # has_lifecycle=False, so it never sees ToolLifecycleContext.work_dir.
     AGENT_WORK_DIR = "/work"
 
     def __init__(self, tool_schema: ToolSchemaModel, trial_id: str):

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -55,8 +55,27 @@ from tolokaforge.tools.persistent_shell import (
     DockerComposeBashSession,
     LocalBashSession,
 )
+from tolokaforge.tools.str_replace_editor import (
+    DockerComposeEditor,
+    EditorBackend,
+    EditorError,
+    LocalFilesystemEditor,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_compose_container_name(trial_id: str, service: str, project_prefix: str) -> str:
+    """Container name for *service* in the per-trial compose stack.
+
+    Mirrors the per-trial project convention the compose lifecycle consumer
+    uses (project ``{prefix}{trial_id}``, container ``{project}_{service}``), so
+    an exec targets the same running container the stack brought up. The
+    ``bash_session`` and ``str_replace_editor`` compose backends share it so
+    both target the identical container.
+    """
+    project = f"{project_prefix}{trial_id.replace(':', '_')}"
+    return f"{project}_{service}"
 
 
 # =============================================================================
@@ -1236,14 +1255,7 @@ class PersistentShellToolWrapper(ToolWrapper):
 
     @staticmethod
     def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:
-        """Container name for *service* in the per-trial compose stack.
-
-        Mirrors the per-trial project convention the compose lifecycle consumer
-        uses (project ``{prefix}{trial_id}``, container ``{project}_{service}``),
-        so the exec targets the same running container the stack brought up.
-        """
-        project = f"{project_prefix}{trial_id.replace(':', '_')}"
-        return f"{project}_{service}"
+        return _resolve_compose_container_name(trial_id, service, project_prefix)
 
     async def _restart(self) -> str:
         assert self._session is not None
@@ -1261,6 +1273,93 @@ class PersistentShellToolWrapper(ToolWrapper):
         if result.exit_code not in (0, None):
             return f"{result.output}\n[exit code: {result.exit_code}]"
         return result.output
+
+
+# =============================================================================
+# Str-Replace Editor Tool Wrapper
+# =============================================================================
+
+
+class StrReplaceEditorToolWrapper(ToolWrapper):
+    """Runner-side executor for the ``str_replace_editor`` tool.
+
+    Stateless (no per-trial session), so ``has_lifecycle`` stays False. The
+    working root is the runner container's ``/work`` (same directory the file
+    tools and the shell's workdir target). A ``service`` key in ``tool_config``
+    selects the compose backend; its absence selects the local filesystem
+    engine. The wire schema is identical either way.
+    """
+
+    has_lifecycle = False
+
+    AGENT_WORK_DIR = "/work"
+
+    def __init__(self, tool_schema: ToolSchemaModel, trial_id: str):
+        super().__init__(tool_schema)
+        tool_config = tool_schema.tool_config or {}
+        self._service: str | None = tool_config.get("service")
+        self._project_prefix: str | None = tool_config.get("compose_project_prefix")
+        if self._service is not None and not self._project_prefix:
+            raise ToolConfigurationError(
+                self.name,
+                "str_replace_editor with a 'service' requires 'compose_project_prefix' to "
+                "resolve the running container name (the per-trial compose project "
+                "prefix used to bring the stack up)",
+            )
+        self._trial_id = trial_id
+        self._backend = self._new_backend()
+
+    def _new_backend(self) -> EditorBackend:
+        if self._service is None:
+            return LocalFilesystemEditor(self.AGENT_WORK_DIR)
+        assert self._project_prefix is not None  # validated in __init__
+        container = self._resolve_container_name(
+            self._trial_id, self._service, self._project_prefix
+        )
+        return DockerComposeEditor(container, base_path=self.AGENT_WORK_DIR)
+
+    @staticmethod
+    def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:
+        return _resolve_compose_container_name(trial_id, service, project_prefix)
+
+    async def execute(self, arguments: dict[str, Any]) -> str:
+        loop = asyncio.get_event_loop()
+        try:
+            return await loop.run_in_executor(None, self._dispatch, arguments)
+        except EditorError as exc:
+            raise ToolExecutionError(self.name, str(exc)) from exc
+
+    def _dispatch(self, arguments: dict[str, Any]) -> str:
+        command = arguments.get("command")
+        path = arguments.get("path")
+        if not path:
+            raise EditorError("'path' is required")
+        if command == "view":
+            return self._backend.view(path, arguments.get("view_range"))
+        if command == "create":
+            file_text = arguments.get("file_text")
+            if file_text is None:
+                raise EditorError("'file_text' is required for the 'create' command")
+            return self._backend.create(path, file_text)
+        if command == "str_replace":
+            old_str = arguments.get("old_str")
+            new_str = arguments.get("new_str")
+            if old_str is None or new_str is None:
+                raise EditorError(
+                    "'old_str' and 'new_str' are required for the 'str_replace' command"
+                )
+            return self._backend.str_replace(path, old_str, new_str)
+        if command == "insert":
+            insert_line = arguments.get("insert_line")
+            insert_text = arguments.get("insert_text")
+            if insert_line is None or insert_text is None:
+                raise EditorError(
+                    "'insert_line' and 'insert_text' are required for the 'insert' command"
+                )
+            return self._backend.insert(path, insert_line, insert_text)
+        raise EditorError(
+            f"unknown command: {command!r}; expected one of view/create/str_replace/insert"
+        )
 
 
 # =============================================================================
@@ -1389,6 +1488,8 @@ class ToolFactory:
                 return BuiltinFileToolWrapper(schema)
             if dispatch is builtin_registry.Dispatch.PERSISTENT_SHELL:
                 return PersistentShellToolWrapper(schema)
+            if dispatch is builtin_registry.Dispatch.EDITOR:
+                return StrReplaceEditorToolWrapper(schema, trial_id=self.trial_id)
             return BuiltinGenericToolWrapper(schema)
 
         source = schema.source

--- a/tolokaforge/tools/builtin/registry.py
+++ b/tolokaforge/tools/builtin/registry.py
@@ -35,12 +35,16 @@ class Dispatch(StrEnum):
     bound by the runner factory; ``PERSISTENT_SHELL`` tools are lifecycle
     wrappers that hold a bash session for the trial, selecting a local or
     compose backend from ``tool_config`` without a second dispatch branch.
+    ``EDITOR`` tools are stateless file editors matching Anthropic's
+    ``str_replace_based_edit_tool``, selecting a local or compose backend from
+    ``tool_config``.
     """
 
     GENERIC = "generic"
     FILES = "files"
     RAG = "rag"
     PERSISTENT_SHELL = "persistent_shell"
+    EDITOR = "editor"
 
 
 _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
@@ -91,6 +95,10 @@ _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
     "bash_session": (
         BuiltinToolEntry("tolokaforge.tools.persistent_shell", "PersistentShellTool"),
         Dispatch.PERSISTENT_SHELL,
+    ),
+    "str_replace_editor": (
+        BuiltinToolEntry("tolokaforge.tools.str_replace_editor", "StrReplaceEditorTool"),
+        Dispatch.EDITOR,
     ),
 }
 

--- a/tolokaforge/tools/builtin/registry.py
+++ b/tolokaforge/tools/builtin/registry.py
@@ -32,12 +32,15 @@ class Dispatch(StrEnum):
     choice. ``GENERIC`` tools receive ``ToolSchema.tool_config`` as
     constructor kwargs; ``FILES`` tools take ``WORK_DIR`` from the runner
     container layout; ``RAG`` tools take a ``rag_client`` + ``trial_id``
-    bound by the runner factory.
+    bound by the runner factory; ``PERSISTENT_SHELL`` tools are lifecycle
+    wrappers that hold a bash session for the trial, selecting a local or
+    compose backend from ``tool_config`` without a second dispatch branch.
     """
 
     GENERIC = "generic"
     FILES = "files"
     RAG = "rag"
+    PERSISTENT_SHELL = "persistent_shell"
 
 
 _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
@@ -84,6 +87,10 @@ _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
     "search_kb": (
         BuiltinToolEntry("tolokaforge.tools.builtin.rag_search", "SearchKBTool"),
         Dispatch.RAG,
+    ),
+    "bash_session": (
+        BuiltinToolEntry("tolokaforge.tools.persistent_shell", "PersistentShellTool"),
+        Dispatch.PERSISTENT_SHELL,
     ),
 }
 

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -1,0 +1,427 @@
+"""Session-lifetime bash tool matching Anthropic's ``bash_20250124`` contract.
+
+Three roles live here:
+
+- :class:`PersistentShellTool` is the *schema provider*. The builtin registry
+  advertises its ``get_schema()`` to the LLM; it is never executed (the runner
+  drives execution through ``PersistentShellToolWrapper``).
+- :class:`LocalBashSession` is the local *engine*: a single ``bash`` subprocess
+  held for the trial.
+- :class:`DockerComposeBashSession` is the compose *engine*: a held
+  ``docker exec`` into an already-running service container.
+
+Both engines share the sentinel protocol, per-command timeout, and 16 KB
+middle-truncation via :class:`_PtyBashSession`; they differ only in how the
+bash pipe is opened and how a runaway command is terminated on timeout.
+Working directory, exported environment, and shell functions persist across
+:meth:`run` calls; :meth:`close` + re-:meth:`open` yields a clean shell.
+
+The local session opens ``bash`` under a PTY with job control (``set -m``)
+enabled: the runaway command runs in its own foreground process group, so
+terminating that group leaves the session leader (``bash``) alive with its
+accumulated state intact.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import shlex
+import signal
+import subprocess
+import termios
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from tolokaforge.tools.registry import Tool, ToolCategory, ToolPolicy, ToolResult
+
+_DEFAULT_TIMEOUT_S = 120.0
+_OPEN_TIMEOUT_S = 15.0
+
+# Middle-truncation budget for a single command's output.
+_MAX_OUTPUT_CHARS = 16384
+_HEAD_CHARS = 8192
+_TAIL_CHARS = 8192
+
+_SENTINEL_PREFIX = "__DONE_"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Outcome of one command in a persistent shell session."""
+
+    output: str
+    exit_code: int | None
+    timed_out: bool
+
+
+@runtime_checkable
+class BashSession(Protocol):
+    """A held bash pipe whose state persists across commands.
+
+    Implementations differ only in *how* the pipe is opened (a local
+    subprocess vs. an exec into a running container); the sentinel protocol,
+    per-command timeout, and output truncation are shared behaviour.
+    """
+
+    @property
+    def pid(self) -> int:
+        """PID of the session-leader shell process (for kill-safety checks)."""
+        ...
+
+    def open(self, cwd: str | None) -> None:
+        """Start the shell, optionally seeding its working directory."""
+        ...
+
+    def run(self, command: str, timeout_s: float) -> CommandResult:
+        """Run *command*, returning its output, exit code, and timeout flag."""
+        ...
+
+    def close(self) -> None:
+        """Terminate the shell and release its resources."""
+        ...
+
+
+def _truncate_middle(text: str) -> str:
+    """Return *text* unchanged, or head+marker+tail when over budget."""
+    if len(text) <= _MAX_OUTPUT_CHARS:
+        return text
+    elided = len(text) - _HEAD_CHARS - _TAIL_CHARS
+    marker = (
+        f"\n...[truncated: {elided} chars elided; re-run a narrower "
+        f"command or grep for the pattern you need]...\n"
+    )
+    return text[:_HEAD_CHARS] + marker + text[-_TAIL_CHARS:]
+
+
+class _PtyBashSession:
+    """Shared engine for a bash pipe held under a host PTY.
+
+    Subclasses provide the process spawn (:meth:`_popen`) and the per-command
+    timeout kill strategy (:meth:`_terminate_runaway`); the sentinel protocol,
+    timeout loop, and output truncation are shared here.
+    """
+
+    def __init__(self) -> None:
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._master_fd: int | None = None
+        self._cwd: str | None = None
+
+    @property
+    def pid(self) -> int:
+        if self._proc is None:
+            raise RuntimeError("bash session is not open")
+        return self._proc.pid
+
+    def open(self, cwd: str | None) -> None:
+        if self._proc is not None:
+            raise RuntimeError("bash session is already open")
+        self._cwd = cwd
+        self._spawn(cwd)
+        self._write("set -m; PS1=''; PS2=''\n")
+        # Sentinel round-trip flushes shell-init output and confirms readiness.
+        if self.run(":", timeout_s=_OPEN_TIMEOUT_S).timed_out:
+            raise RuntimeError("bash session failed to become ready")
+        self._seed_cwd(cwd)
+
+    def run(self, command: str, timeout_s: float) -> CommandResult:
+        if self._master_fd is None:
+            raise RuntimeError("bash session is not open")
+        sentinel = f"{_SENTINEL_PREFIX}{uuid.uuid4().hex}__"
+        marker = sentinel.encode()
+        self._write(f"{command}\n")
+        self._write(f"printf '%s %d\\n' {sentinel} $?\n")
+
+        buf = b""
+        deadline = time.monotonic() + timeout_s
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return self._on_timeout(buf)
+            ready, _, _ = select.select([self._master_fd], [], [], min(remaining, 0.2))
+            if not ready:
+                continue
+            chunk = self._read()
+            if not chunk:
+                return self._on_timeout(buf)
+            buf += chunk
+            parsed = self._split_on_sentinel(buf, marker)
+            if parsed is not None:
+                output, exit_code = parsed
+                return CommandResult(
+                    output=_truncate_middle(output),
+                    exit_code=exit_code,
+                    timed_out=False,
+                )
+
+    def close(self) -> None:
+        if self._proc is not None:
+            self._kill_process_group(signal.SIGKILL)
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            self._proc = None
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+
+    # -- spawn / cwd hooks ----------------------------------------------------
+
+    def _spawn(self, cwd: str | None) -> None:
+        master, slave = pty.openpty()
+        attrs = termios.tcgetattr(slave)
+        attrs[3] &= ~termios.ECHO  # drop terminal echo so output is command stdout only
+        termios.tcsetattr(slave, termios.TCSANOW, attrs)
+        self._proc = self._popen(cwd, slave)
+        os.close(slave)
+        self._master_fd = master
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        raise NotImplementedError
+
+    def _seed_cwd(self, cwd: str | None) -> None:
+        """Seed the working directory when the pipe can't at spawn time.
+
+        The local engine passes ``cwd`` straight to ``Popen`` and needs no
+        seeding; the compose engine overrides this to ``cd`` inside the
+        container after the shell is ready.
+        """
+
+    def _terminate_runaway(self) -> None:
+        """Terminate a timed-out command, leaving the session usable."""
+        raise NotImplementedError
+
+    # -- internals ------------------------------------------------------------
+
+    @staticmethod
+    def _split_on_sentinel(buf: bytes, marker: bytes) -> tuple[str, int | None] | None:
+        """Return (output, exit_code) once the full sentinel line has arrived."""
+        idx = buf.find(marker)
+        if idx == -1:
+            return None
+        after = buf[idx + len(marker) :]
+        newline = after.find(b"\n")
+        if newline == -1:
+            return None  # exit-code line not fully received yet
+        token = after[:newline].strip()
+        exit_code = int(token) if token.isdigit() else None
+        output = buf[:idx].decode("utf-8", errors="replace").replace("\r\n", "\n")
+        return output, exit_code
+
+    def _on_timeout(self, buf: bytes) -> CommandResult:
+        self._terminate_runaway()
+        buf += self._drain(0.3)
+        output = buf.decode("utf-8", errors="replace").replace("\r\n", "\n")
+        return CommandResult(output=_truncate_middle(output), exit_code=None, timed_out=True)
+
+    def _kill_process_group(self, sig: int) -> None:
+        assert self._proc is not None
+        try:
+            os.killpg(os.getpgid(self._proc.pid), sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+    def _write(self, data: str) -> None:
+        assert self._master_fd is not None
+        buf = data.encode()
+        while buf:
+            buf = buf[os.write(self._master_fd, buf) :]
+
+    def _read(self) -> bytes:
+        assert self._master_fd is not None
+        try:
+            return os.read(self._master_fd, 65536)
+        except OSError:
+            return b""
+
+    def _drain(self, timeout_s: float) -> bytes:
+        if self._master_fd is None:
+            return b""
+        out = b""
+        end = time.monotonic() + timeout_s
+        while time.monotonic() < end:
+            ready, _, _ = select.select([self._master_fd], [], [], 0.1)
+            if not ready:
+                continue
+            chunk = self._read()
+            if not chunk:
+                break
+            out += chunk
+        return out
+
+
+class LocalBashSession(_PtyBashSession):
+    """A local ``bash`` subprocess held for the trial (PTY + job control)."""
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        return subprocess.Popen(
+            ["bash", "--norc", "--noprofile"],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=os.setsid,
+            cwd=cwd,
+            close_fds=True,
+        )
+
+    def _terminate_runaway(self) -> None:
+        """Kill the foreground command's process group, never the shell itself.
+
+        Job control (``set -m``) puts the external command in its own
+        foreground process group that owns the tty; signalling that group
+        leaves ``bash`` (the session leader) alive with its state intact.
+        """
+        assert self._master_fd is not None and self._proc is not None
+        try:
+            foreground = os.tcgetpgrp(self._master_fd)
+        except OSError:
+            return
+        shell_pgid = os.getpgid(self._proc.pid)
+        if foreground <= 0 or foreground == shell_pgid:
+            return  # only the shell is in the foreground — nothing to terminate
+        for sig in (signal.SIGINT, signal.SIGKILL):
+            try:
+                os.killpg(foreground, sig)
+            except ProcessLookupError:
+                return
+            time.sleep(0.2)
+
+
+class DockerComposeBashSession(_PtyBashSession):
+    """A held ``docker exec -i <container> bash`` into a running service.
+
+    Targets an *already-running* container (brought up by the environment /
+    another lifecycle consumer); this engine only holds an exec session for the
+    trial, it never brings the stack up or down. State (cwd, environment,
+    functions) persists across :meth:`run` calls exactly as for the local
+    engine.
+
+    Kill-safety is weaker than the local engine: a signal to the host-side
+    ``docker exec`` process group does not reach the command running inside the
+    container. When a per-command timeout fires we kill the host ``docker exec``
+    client and restart the in-container session to regain a clean prompt; the
+    container may briefly hold the orphaned command. This is a documented
+    limitation — subsequent commands still run, but session state accumulated
+    before a timed-out command is lost (unlike the local engine, which
+    preserves it).
+    """
+
+    def __init__(self, container_name: str) -> None:
+        super().__init__()
+        self._container_name = container_name
+
+    @property
+    def container_name(self) -> str:
+        return self._container_name
+
+    def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        return subprocess.Popen(
+            ["docker", "exec", "-i", self._container_name, "bash", "--norc", "--noprofile"],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            preexec_fn=os.setsid,
+            close_fds=True,
+        )
+
+    def _seed_cwd(self, cwd: str | None) -> None:
+        # Host work_dir need not exist inside the container; swallow the cd
+        # failure so the session still opens (the local engine's isdir guard
+        # has no in-container equivalent here).
+        if cwd:
+            self.run(f"cd {shlex.quote(cwd)} 2>/dev/null || true", timeout_s=_OPEN_TIMEOUT_S)
+
+    def _terminate_runaway(self) -> None:
+        """Kill the host ``docker exec`` client and restart the in-container session.
+
+        The runaway command may briefly survive as an in-container orphan (see
+        the class docstring); killing the client and reopening restores a usable
+        prompt for the next command.
+        """
+        self._kill_process_group(signal.SIGKILL)
+        if self._proc is not None:
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            self._proc = None
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+        self._spawn(self._cwd)
+        self._write("set -m; PS1=''; PS2=''\n")
+        self.run(":", timeout_s=_OPEN_TIMEOUT_S)
+        self._seed_cwd(self._cwd)
+
+
+class PersistentShellTool(Tool):
+    """Schema provider for the ``bash_session`` tool.
+
+    Publishes the Anthropic ``bash_20250124`` input schema (``command`` +
+    ``restart``) so the native adapter can advertise it. Execution is handled
+    by the runner-side wrapper, not here.
+
+    ``__init__`` accepts and ignores the ``tool_config`` keys the wrapper
+    consumes (``service``, ``timeout_s``, ``compose_project_prefix``): the
+    adapter builds the schema provider as ``cls(**tool_config)``, so an
+    unexpected keyword would raise inside schema extraction and drop the tool
+    from the LLM's view.
+    """
+
+    def __init__(
+        self,
+        service: str | None = None,
+        timeout_s: float | None = None,
+        compose_project_prefix: str | None = None,
+        **_: object,
+    ) -> None:
+        super().__init__(
+            name="bash_session",
+            description=(
+                "Run commands in a persistent bash shell. The working directory, "
+                "exported environment variables, and shell functions persist "
+                "across calls. Set restart=true to reset the shell to a clean "
+                "state (omit command when restarting)."
+            ),
+            policy=ToolPolicy(timeout_s=_DEFAULT_TIMEOUT_S, category=ToolCategory.COMPUTE),
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The bash command to run in the persistent session.",
+                        },
+                        "restart": {
+                            "type": "boolean",
+                            "description": "Restart the shell, discarding all session state.",
+                        },
+                    },
+                    "required": [],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        raise NotImplementedError(
+            "PersistentShellTool is a schema provider; execution is handled by "
+            "PersistentShellToolWrapper on the runner."
+        )

--- a/tolokaforge/tools/str_replace_editor.py
+++ b/tolokaforge/tools/str_replace_editor.py
@@ -1,0 +1,516 @@
+"""File-editor tool matching Anthropic's ``str_replace_based_edit_tool`` contract.
+
+Four roles live here, mirroring :mod:`tolokaforge.tools.persistent_shell`:
+
+- :class:`StrReplaceEditorTool` is the *schema provider*. The builtin registry
+  advertises its ``get_schema()`` to the LLM; it is never executed (the runner
+  drives execution through ``StrReplaceEditorToolWrapper``).
+- :class:`EditorBackend` is the engine :class:`typing.Protocol` — the shape both
+  the local and the compose engines implement.
+- :class:`LocalFilesystemEditor` is the local engine: in-process file operations
+  rooted at a working directory.
+- :class:`DockerComposeEditor` is the compose engine: the same four commands
+  routed through ``docker exec`` into an already-running service container.
+
+The four commands ``view`` / ``create`` / ``str_replace`` / ``insert`` match the
+Claude-4 editor variants (``text_editor_20250429`` / ``text_editor_20250728``);
+``undo_edit`` is absent, as in those variants. Every ambiguous or destructive
+operation fails loud by raising :class:`EditorError`. The command-level text
+transforms and view rendering are shared free functions so both engines apply
+identical semantics.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import subprocess
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol, runtime_checkable
+
+from tolokaforge.tools.registry import Tool, ToolCategory, ToolPolicy, ToolResult
+
+_EDITOR_COMMANDS = ("view", "create", "str_replace", "insert")
+
+# Middle-truncation budget for a single view's rendered output.
+_MAX_OUTPUT_CHARS = 16384
+_HEAD_CHARS = 8192
+_TAIL_CHARS = 8192
+
+_DEFAULT_EXEC_TIMEOUT_S = 30.0
+
+
+class EditorError(Exception):
+    """An editor operation failed loud (ambiguous, destructive, or out of range).
+
+    Raised by an :class:`EditorBackend`; the runner-side wrapper converts it to a
+    ``ToolExecutionError`` so the failure reaches the LLM for self-correction.
+    """
+
+
+@runtime_checkable
+class EditorBackend(Protocol):
+    """A file editor rooted at a working directory.
+
+    Implementations differ only in *where* the files live (the local filesystem
+    vs. a compose service container); the command semantics, path containment,
+    and fail-loud conditions are the shared contract.
+    """
+
+    def view(self, path: str, view_range: list[int] | None = None) -> str:
+        """Return line-numbered file content or a directory listing."""
+        ...
+
+    def create(self, path: str, file_text: str) -> str:
+        """Create a new file; fail loud if *path* already exists."""
+        ...
+
+    def str_replace(self, path: str, old_str: str, new_str: str) -> str:
+        """Replace the unique occurrence of *old_str*; fail loud on 0 or >1."""
+        ...
+
+    def insert(self, path: str, insert_line: int, insert_text: str) -> str:
+        """Insert *insert_text* after line *insert_line* (``0`` = before line 1)."""
+        ...
+
+
+def _truncate_middle(text: str) -> str:
+    """Return *text* unchanged, or head+marker+tail when over budget."""
+    if len(text) <= _MAX_OUTPUT_CHARS:
+        return text
+    elided = len(text) - _HEAD_CHARS - _TAIL_CHARS
+    marker = (
+        f"\n...[truncated: {elided} chars elided; view a narrower view_range "
+        f"or grep for the pattern you need]...\n"
+    )
+    return text[:_HEAD_CHARS] + marker + text[-_TAIL_CHARS:]
+
+
+def _render_view(text: str, view_range: list[int] | None, path: str) -> str:
+    """Render *text* as 1-indexed ``cat -n``-style line-numbered output."""
+    lines = text.splitlines(keepends=True)
+    start = 1
+    if view_range is not None:
+        if len(view_range) != 2:
+            raise EditorError("view_range must be [start, end]")
+        start, end = view_range
+        if start < 1 or start > len(lines):
+            raise EditorError(
+                f"view_range start {start} is out of range [1, {len(lines)}] for {path}"
+            )
+        if end == -1:
+            end = len(lines)
+        elif end < start:
+            raise EditorError(f"view_range end {end} is before start {start}")
+        else:
+            end = min(end, len(lines))
+        lines = lines[start - 1 : end]
+    return "".join(f"{i:>6}\t{line}" for i, line in enumerate(lines, start=start))
+
+
+def _replaced_once(content: str, old_str: str, new_str: str, path: str) -> str:
+    """Return *content* with the unique *old_str* replaced; fail loud on 0 or >1."""
+    count = content.count(old_str)
+    if count == 0:
+        raise EditorError(f"no match for old_str in {path}")
+    if count > 1:
+        raise EditorError(f"old_str is not unique in {path}: found {count} matches")
+    return content.replace(old_str, new_str, 1)
+
+
+def _inserted(content: str, insert_line: int, insert_text: str, path: str) -> str:
+    """Return *content* with *insert_text* spliced after line *insert_line*."""
+    lines = content.split("\n")
+    if insert_line < 0 or insert_line > len(lines):
+        raise EditorError(f"insert_line {insert_line} is out of range [0, {len(lines)}] for {path}")
+    new_lines = lines[:insert_line] + insert_text.split("\n") + lines[insert_line:]
+    return "\n".join(new_lines)
+
+
+class LocalFilesystemEditor:
+    """In-process editor rooted at *base_path* on the local filesystem.
+
+    Paths are resolved to their realpath and must stay contained in the resolved
+    root; symlink-escapes and ``..``-traversal are rejected. Relative paths are
+    interpreted under the root. ``view`` reads with ``errors="replace"`` (display
+    only); the mutating commands use strict UTF-8 and fail loud on a non-UTF-8
+    file, which cannot be safely round-tripped.
+    """
+
+    def __init__(self, base_path: str) -> None:
+        self._base = Path(base_path).resolve()
+
+    def view(self, path: str, view_range: list[int] | None = None) -> str:
+        resolved = self._resolve(path)
+        if resolved.is_dir():
+            if view_range is not None:
+                raise EditorError("view_range is not allowed when viewing a directory")
+            return _truncate_middle(self._view_directory(resolved))
+        if not resolved.is_file():
+            raise EditorError(f"file not found: {path}")
+        text = resolved.read_text(encoding="utf-8", errors="replace")
+        return _truncate_middle(_render_view(text, view_range, path))
+
+    def create(self, path: str, file_text: str) -> str:
+        resolved = self._resolve(path)
+        if resolved.exists():
+            raise EditorError(f"cannot create {path}: path already exists")
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(file_text, encoding="utf-8")
+        return f"File created successfully at {path}"
+
+    def str_replace(self, path: str, old_str: str, new_str: str) -> str:
+        resolved = self._resolve(path)
+        content = self._read_strict(resolved, path)
+        self._atomic_write(resolved, _replaced_once(content, old_str, new_str, path))
+        return f"Successfully replaced text in {path}"
+
+    def insert(self, path: str, insert_line: int, insert_text: str) -> str:
+        resolved = self._resolve(path)
+        content = self._read_strict(resolved, path)
+        self._atomic_write(resolved, _inserted(content, insert_line, insert_text, path))
+        return f"Successfully inserted text at line {insert_line} in {path}"
+
+    # -- internals ------------------------------------------------------------
+
+    def _resolve(self, path: str) -> Path:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self._base / candidate
+        resolved = candidate.resolve()
+        if not resolved.is_relative_to(self._base):
+            raise EditorError(f"path {path} escapes the working root {self._base}")
+        return resolved
+
+    def _read_strict(self, resolved: Path, path: str) -> str:
+        if not resolved.is_file():
+            raise EditorError(f"file not found: {path}")
+        try:
+            return resolved.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise EditorError(f"cannot edit non-UTF-8 file {path}: {exc}") from exc
+
+    @staticmethod
+    def _atomic_write(resolved: Path, content: str) -> None:
+        tmp = resolved.with_suffix(resolved.suffix + ".tmp")
+        tmp.write_text(content, encoding="utf-8")
+        tmp.replace(resolved)
+
+    @staticmethod
+    def _view_directory(resolved: Path) -> str:
+        entries = LocalFilesystemEditor._walk_two_levels(resolved)
+        header = (
+            f"Here are the files and directories up to 2 levels deep in {resolved}, "
+            f"excluding hidden items and __pycache__:"
+        )
+        return "\n".join([header, *entries])
+
+    @staticmethod
+    def _walk_two_levels(root: Path) -> list[str]:
+        entries: list[str] = []
+        for level1 in sorted(root.iterdir()):
+            if LocalFilesystemEditor._skip(level1):
+                continue
+            entries.append(str(level1))
+            if level1.is_dir():
+                for level2 in sorted(level1.iterdir()):
+                    if LocalFilesystemEditor._skip(level2):
+                        continue
+                    entries.append(str(level2))
+        return entries
+
+    @staticmethod
+    def _skip(entry: Path) -> bool:
+        return entry.name.startswith(".") or entry.name == "__pycache__"
+
+
+# ``realpath`` unavailable → exit 90; ``realpath`` present but resolution failed
+# → exit 91. Anything else the caller treats as a generic exec failure. The
+# missing-tail walk lets ``create`` resolve a not-yet-existing path the same way
+# the local engine's ``Path.resolve()`` does, while still following symlinks on
+# the existing prefix (so a symlink escape is caught inside the container).
+# ``$p`` is always absolute (the caller roots relative paths under ``/work``), so
+# no ``--`` end-of-options guard is needed — and busybox ``realpath`` rejects it.
+_REALPATH_SCRIPT = (
+    "command -v realpath >/dev/null 2>&1 || exit 90\n"
+    "p=$1\n"
+    "suffix=\n"
+    'while [ ! -e "$p" ] && [ "$p" != / ]; do\n'
+    '  suffix=/$(basename "$p")$suffix\n'
+    '  p=$(dirname "$p")\n'
+    "done\n"
+    'rp=$(realpath "$p") || exit 91\n'
+    'printf %s "$rp$suffix"\n'
+)
+
+_KIND_SCRIPT = (
+    'if [ -d "$1" ]; then printf dir; '
+    'elif [ -f "$1" ]; then printf file; '
+    'elif [ -e "$1" ]; then printf other; '
+    "else printf missing; fi\n"
+)
+
+_LIST_SCRIPT = (
+    'find "$1" -mindepth 1 -maxdepth 2 '
+    "'(' -name '.*' -o -name '__pycache__' ')' -prune -o -print\n"
+)
+
+_WRITE_SCRIPT = 'cat > "$2" && mv -- "$2" "$1"\n'
+
+_NO_REALPATH_EXIT = 90
+
+
+class DockerComposeEditor:
+    """Editor rooted at *base_path* inside an already-running compose service.
+
+    Implements the same :class:`EditorBackend` contract as
+    :class:`LocalFilesystemEditor`, but every command runs through
+    ``docker exec`` into *container_name* — an already-running service container
+    (brought up by the environment / another lifecycle consumer); this engine
+    never brings the stack up or down. File content
+    (``file_text``/``new_str``/``insert_text``) is piped on **stdin** to
+    ``docker exec -i``, never interpolated into the shell command string, and
+    paths are passed as positional ``sh`` arguments — so agent-controlled bytes
+    cannot inject shell commands.
+
+    Path resolution and containment run **inside the container** via
+    ``docker exec … realpath`` (a host realpath is meaningless for a container
+    path); a resolved path must stay under ``realpath(base_path)`` or the
+    operation fails loud. If ``realpath`` is absent from the target image the
+    engine fails loud rather than silently skipping validation.
+
+    Atomicity is weaker than the local engine: writes go to a temp file in the
+    target's directory and are ``mv``-swapped into place, so a completed write
+    is atomic, but an exec interrupted mid-write can leave the temp file behind
+    (the local engine's single-process temp+rename has no such window).
+    """
+
+    def __init__(
+        self, container_name: str, base_path: str = "/work", timeout_s: float | None = None
+    ) -> None:
+        self._container_name = container_name
+        self._base = base_path
+        self._timeout_s = timeout_s if timeout_s is not None else _DEFAULT_EXEC_TIMEOUT_S
+        self._base_real: str | None = None
+
+    @property
+    def container_name(self) -> str:
+        return self._container_name
+
+    def view(self, path: str, view_range: list[int] | None = None) -> str:
+        resolved = self._resolve(path)
+        kind = self._path_kind(resolved)
+        if kind == "dir":
+            if view_range is not None:
+                raise EditorError("view_range is not allowed when viewing a directory")
+            return _truncate_middle(self._list_directory(resolved))
+        if kind != "file":
+            raise EditorError(f"file not found: {path}")
+        return _truncate_middle(_render_view(self._read(resolved), view_range, path))
+
+    def create(self, path: str, file_text: str) -> str:
+        resolved = self._resolve(path)
+        if self._path_kind(resolved) != "missing":
+            raise EditorError(f"cannot create {path}: path already exists")
+        parent = posixpath.dirname(resolved)
+        self._exec('mkdir -p "$1"', parent)
+        self._write_atomic(resolved, file_text)
+        return f"File created successfully at {path}"
+
+    def str_replace(self, path: str, old_str: str, new_str: str) -> str:
+        resolved = self._resolve(path)
+        if self._path_kind(resolved) != "file":
+            raise EditorError(f"file not found: {path}")
+        content = self._read_strict(resolved, path)
+        self._write_atomic(resolved, _replaced_once(content, old_str, new_str, path))
+        return f"Successfully replaced text in {path}"
+
+    def insert(self, path: str, insert_line: int, insert_text: str) -> str:
+        resolved = self._resolve(path)
+        if self._path_kind(resolved) != "file":
+            raise EditorError(f"file not found: {path}")
+        content = self._read_strict(resolved, path)
+        self._write_atomic(resolved, _inserted(content, insert_line, insert_text, path))
+        return f"Successfully inserted text at line {insert_line} in {path}"
+
+    # -- internals ------------------------------------------------------------
+
+    def _resolve(self, path: str) -> str:
+        abs_path = path if path.startswith("/") else posixpath.join(self._base, path)
+        real = self._container_realpath(abs_path, path)
+        base_real = self._resolve_base()
+        if not PurePosixPath(real).is_relative_to(base_real):
+            raise EditorError(f"path {path} escapes the working root {self._base}")
+        return real
+
+    def _resolve_base(self) -> str:
+        if self._base_real is None:
+            self._base_real = self._container_realpath(self._base, self._base)
+        return self._base_real
+
+    def _container_realpath(self, abs_path: str, path: str) -> str:
+        result = self._exec(_REALPATH_SCRIPT, abs_path, allow_failure=True)
+        if result.returncode == _NO_REALPATH_EXIT:
+            raise EditorError(
+                f"'realpath' is unavailable in container {self._container_name}; "
+                f"cannot validate that {path} stays within {self._base}"
+            )
+        if result.returncode != 0:
+            raise EditorError(f"could not resolve path {path}: {self._stderr(result)}")
+        return result.stdout.decode("utf-8", errors="replace").strip()
+
+    def _path_kind(self, resolved: str) -> str:
+        return self._exec(_KIND_SCRIPT, resolved).stdout.decode("utf-8", "replace").strip()
+
+    def _list_directory(self, resolved: str) -> str:
+        raw = self._exec(_LIST_SCRIPT, resolved).stdout.decode("utf-8", "replace")
+        entries = sorted(line for line in raw.splitlines() if line)
+        header = (
+            f"Here are the files and directories up to 2 levels deep in {resolved}, "
+            f"excluding hidden items and __pycache__:"
+        )
+        return "\n".join([header, *entries])
+
+    def _read(self, resolved: str) -> str:
+        return self._read_bytes(resolved).decode("utf-8", errors="replace")
+
+    def _read_strict(self, resolved: str, path: str) -> str:
+        try:
+            return self._read_bytes(resolved).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise EditorError(f"cannot edit non-UTF-8 file {path}: {exc}") from exc
+
+    def _read_bytes(self, resolved: str) -> bytes:
+        return self._exec('cat -- "$1"', resolved).stdout
+
+    def _write_atomic(self, resolved: str, content: str) -> None:
+        tmp = posixpath.join(posixpath.dirname(resolved), f".tf-editor-{uuid.uuid4().hex}.tmp")
+        self._exec(_WRITE_SCRIPT, resolved, tmp, stdin=content.encode("utf-8"))
+
+    def _exec(
+        self,
+        script: str,
+        *args: str,
+        stdin: bytes | None = None,
+        allow_failure: bool = False,
+    ) -> subprocess.CompletedProcess[bytes]:
+        cmd = ["docker", "exec"]
+        if stdin is not None:
+            cmd.append("-i")
+        cmd += [self._container_name, "sh", "-c", script, "_", *args]
+        try:
+            result = subprocess.run(
+                cmd, input=stdin, capture_output=True, timeout=self._timeout_s, check=False
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise EditorError(
+                f"docker exec into {self._container_name} timed out after {self._timeout_s:g}s"
+            ) from exc
+        if not allow_failure and result.returncode != 0:
+            raise EditorError(
+                f"docker exec into {self._container_name} failed "
+                f"(exit {result.returncode}): {self._stderr(result)}"
+            )
+        return result
+
+    @staticmethod
+    def _stderr(result: subprocess.CompletedProcess[bytes]) -> str:
+        return result.stderr.decode("utf-8", errors="replace").strip()
+
+
+class StrReplaceEditorTool(Tool):
+    """Schema provider for the ``str_replace_editor`` tool.
+
+    Publishes the ``str_replace_based_edit_tool`` input schema so the native
+    adapter can advertise it. Execution is handled by the runner-side wrapper,
+    not here.
+
+    ``__init__`` accepts and ignores the ``tool_config`` keys the wrapper
+    consumes (``service``, ``compose_project_prefix``): the adapter builds the
+    schema provider as ``cls(**tool_config)``, so an unexpected keyword would
+    raise inside schema extraction and drop the tool from the LLM's view.
+    """
+
+    def __init__(
+        self,
+        service: str | None = None,
+        compose_project_prefix: str | None = None,
+        **_: object,
+    ) -> None:
+        super().__init__(
+            name="str_replace_editor",
+            description=(
+                "View, create, and edit files. Commands: 'view' shows "
+                "line-numbered file content (or a directory listing); 'create' "
+                "writes a new file and fails if the path already exists; "
+                "'str_replace' replaces a single unique occurrence of old_str "
+                "with new_str; 'insert' inserts insert_text after insert_line "
+                "(0 inserts before the first line)."
+            ),
+            policy=ToolPolicy(timeout_s=30.0, category=ToolCategory.WRITE),
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "enum": list(_EDITOR_COMMANDS),
+                            "description": "The editing command to run.",
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute path to the file or directory.",
+                        },
+                        "view_range": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "description": (
+                                "Optional [start, end] line range for 'view' "
+                                "(1-indexed; -1 for end of file)."
+                            ),
+                        },
+                        "file_text": {
+                            "type": "string",
+                            "description": "Content of the file to create (required for 'create').",
+                        },
+                        "old_str": {
+                            "type": "string",
+                            "description": (
+                                "Exact text to replace (required for 'str_replace'); "
+                                "must match a single unique occurrence."
+                            ),
+                        },
+                        "new_str": {
+                            "type": "string",
+                            "description": "Replacement text (required for 'str_replace').",
+                        },
+                        "insert_line": {
+                            "type": "integer",
+                            "description": (
+                                "Line number after which to insert; 0 inserts before "
+                                "the first line (required for 'insert')."
+                            ),
+                        },
+                        "insert_text": {
+                            "type": "string",
+                            "description": "Text to insert (required for 'insert').",
+                        },
+                    },
+                    "required": ["command", "path"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        raise NotImplementedError(
+            "StrReplaceEditorTool is a schema provider; execution is handled by "
+            "StrReplaceEditorToolWrapper on the runner."
+        )


### PR DESCRIPTION
## TL;DR

Ships two production-grade agent tools that match Anthropic's tool-use contracts drop-in: **`bash_session`** (session-lifetime bash matching `bash_20250124`) and **`str_replace_editor`** (four-command file editor matching `str_replace_based_edit_tool`), each in two provider variants (subprocess-backed local + `docker exec`-backed compose). Evolves the tool-lifecycle contract (`ToolLifecycleContext` gains `work_dir` + becomes frozen — closes #63) as the underlying seam. Additive on every compatibility surface: existing `BashTool` and file tools untouched; new tools land under distinct registry names. Additionally records the design decision in ADR-0017 and corrects a factual error in its editor spec that would have shipped a drop-in-compat break. Follow-ups filed and left for later (#577 fail-loud on schema-extraction failures; #581 compose network isolation; #585 compose container-naming seam) tighten the surface but don't gate the tools. Closes #63, #563, #564, #565, #566, #567, #568, #569.

## Impact on existing tasks — read this first

**Near-term (today):**
- Existing consumers of `BashTool` (per-call, in-process, allowlisted) are unaffected. That builtin stays; new agent workflows opt into `bash_session` by registry name.
- Existing `ToolLifecycleContext(trial_id="…")` construction is byte-for-byte valid; new `work_dir` field defaults to `None`, and the dataclass being frozen is a discipline improvement (matches what AGENTS.md already says) — no known consumer mutates it.
- New tools ship with fail-loud semantics: `bash_session` fails loud on missing `command`+`restart`; `str_replace_editor` fails loud on `create` for an existing path, non-unique `str_replace`, missing `old_str`, symlink escape, and (compose variant) missing `realpath` in the target image. All deliberate — matches AGENTS.md Core Rule 5.

**Compatibility surface commitments:**
- `bash_session` input schema is anchored to Anthropic's `bash_20250124`: `command` (string, required unless `restart` is set) + `restart` (bool). Restart call is `{"restart": true}` with no command. Locked by ADR-0017 §(b) and integration-tested end-to-end.
- `str_replace_editor` input schema is anchored to Anthropic's `str_replace_based_edit_tool` (`text_editor_20250429` / `text_editor_20250728` variants — parameter-identical): four commands (`view`/`create`/`str_replace`/`insert`), no `undo_edit`. Full parameter set (`command`, `path`, `view_range`, `file_text`, `old_str`, `new_str`, `insert_line`, `insert_text`) locked in ADR-0017 §(c). **`insert` uses `insert_text` — NOT `new_str`.**
- Tool-lifecycle contract now supports session-lifetime tools via the existing `has_lifecycle=True` seam. `ToolLifecycleContext.work_dir` populated at the sole construction site (`service.py:661`) via a named `AGENT_WORK_DIR = "/work"` constant.
- Provider is a config axis: passing `service` + `compose_project_prefix` in `tool_config` swaps the engine backend from local to `docker exec`-backed compose. No schema change; adapter reuse.

**Safety guards, still in force:**
- Local variant kill-safety on shell timeout uses **PTY + `set -m` job control + SIGINT→SIGKILL to the foreground process group**. Empirically probed on bash 3.2 (darwin) and bash 5.2 (linux) — pre-timeout cwd/env survive per-command timeout kills.
- Editor path validation uses `Path.resolve() + is_relative_to()` — NOT the legacy `files.py` `str.startswith` (which `/work-evil` bypasses).
- Local `PersistentBashSession` writes to the PTY master via an explicit short-write loop (avoids silently truncating multi-KB heredoc inputs).

**Follow-up tickets filed and left for later:**
- **#577** — `_builtin_tool_schemas` silently swallows schema-extraction failures at `native.py:58-59`. Fail-loud violation. Adapter mitigation in place (`**_` catch-all in `PersistentShellTool.__init__` and `StrReplaceEditorTool.__init__`); underlying swallow deserves its own fix.
- **#581** — compose network-isolation gap. Every service under `no_internet` / `limited_internet` shares one injected `tolokaforge_netpolicy_internal` net. Agent-inside-manifest patterns are topology-broken until a per-service network-exclusion primitive lands. Documented in `docs/TOOLS.md`. Blocks Migration Bench (and any similar benchmark) from co-locating env services with the tool's target service.
- **#585** — compose container-naming contract mismatch between wrapper (`{prefix}{trial_id}_{service}`) and per-trial runtime (`{project}-{service}-<N>` via testcontainers). Blocks any real-world use of the compose tool variants until reconciled. A6's capstone papers over via hardcoded `container_name`.

## Design walkthrough

```mermaid
flowchart TB
    subgraph M25["Milestone 25 — Persistent agent shell tools"]
        direction TB

        subgraph Foundation["Foundation (design + seam)"]
            A1["#564 A1: ADR-0017<br/>7 named contract sections (a)-(g)"]
            A2["#565 A2: ToolLifecycleContext<br/>+work_dir + frozen (closes #63)"]
        end

        subgraph ToolShell["bash_session tool"]
            A3S["Stage 1 - local:<br/>PersistentShellTool + LocalBashSession<br/>PTY + set -m + kill-safety"]
            A3D["Stage 2 - compose:<br/>DockerComposePersistentShellTool<br/>docker exec, weaker kill-safety"]
            A3S -.-> A3D
        end

        subgraph ToolEditor["str_replace_editor tool"]
            A4S["Stage 1 - local:<br/>StrReplaceEditorTool + LocalFilesystemEditor<br/>4 commands, fail-loud, ADR (c) fix"]
            A4D["Stage 2 - compose:<br/>DockerComposeStrReplaceEditor<br/>docker exec, atomicity caveat"]
            A4S -.-> A4D
        end

        subgraph Closer["Docs + capstone"]
            A5["#568 A5: docs/TOOLS.md<br/>+ examples/native/persistent_tools/<br/>+ dispatch test extension"]
            A6["#569 A6: capstone integration test<br/>6 tests, shared bash:5 container<br/>cross-tool observation"]
        end

        A1 --> A2
        A1 --> A3S
        A1 --> A4S
        A2 --> A3S
        A2 --> A4S
        A3D --> A5
        A4D --> A5
        A5 --> A6
    end

    subgraph Anthropic["Anthropic tool contracts (source of truth)"]
        BashSpec["bash_20250124<br/>command + restart"]
        EditSpec["str_replace_based_edit_tool<br/>view/create/str_replace/insert<br/>insert_text (NOT new_str)"]
    end

    BashSpec -.->|anchor| A3S
    EditSpec -.->|anchor| A4S

    subgraph Followups["Follow-ups filed (out-of-milestone)"]
        F577["#577: fail-loud schema-extraction"]
        F581["#581: compose network isolation"]
        F585["#585: container-naming seam"]
    end
```

## Key design choices

| Decision | Rationale |
|---|---|
| **Anchor tool contracts to Anthropic's actual live spec, not to what an ADR says internally.** ADR-0017 §(c) originally listed the `insert` command's text param as `new_str`; live docs confirm `insert_text`. Fixed ADR and implementation in the same PR. | Drop-in compatibility. Agents trained/prompted against the standard Anthropic tool contract shouldn't burn turns on interface adaptation. Shipping the ADR verbatim would have been a drop-in-compat break. |
| **`ToolLifecycleContext` evolution is exactly one field.** Add `work_dir: str \| None = None`. Reject `service` / `compose_file` / runtime-backend-handle from the context — those are construction-time tool config, and `DockerComposeExecToolWrapper` already proves that pattern. | Preserves Core Rule 2 + ADR-0007's runner-stays-adapter-agnostic invariant. The runner drives lifecycle off `has_lifecycle` capability, never off tool/adapter identity. #63's six gaps triaged: adopt gap 1 (additive context field), defer gaps 2-6 with per-gap rationale. |
| **Freeze the dataclass — fixes drift, not adds new discipline.** AGENTS.md line 313 already listed it `@dataclass(frozen=True)`; the code was a plain `@dataclass`. Freezing resolves the code↔doc drift. No AGENTS.md edit needed. | Both doc + rule already pointed here; only the code was late. Verified producer + consumers: only `service.py:661` constructs; nothing mutates post-construction. |
| **Provider variant is a configuration axis, not a contract change.** Same tool schema for local + compose variants; wrapper branches at `start()` time based on `tool_config["service"]` presence. | Any future provider (e.g., a Kubernetes-exec variant) is one more `EditorBackend` / `BashSession` implementation, not another tool contract. Locks the LLM-facing schema against provider proliferation. |
| **`BashSession` and `EditorBackend` Protocols separate the "how" from the "what".** Provider-agnostic engine interfaces; concrete `LocalBashSession` / `DockerComposeBashSession` / `LocalFilesystemEditor` / `DockerComposeEditor` implementations. | Cleanly separates the tool contract (`ToolWrapper` implements) from the substrate wiring (engine implementation). Command-logic invariants (unique-match validation, insert-line arithmetic, view-range slicing, middle-truncation) factored into shared free functions to prevent drift between variants. |
| **Schema-provider `__init__` MUST accept-and-ignore wrapper config keys.** `PersistentShellTool.__init__(service=None, timeout_s=None, **_: object)` + `StrReplaceEditorTool.__init__(service=None, compose_project_prefix=None, **_: object)`. | `_builtin_tool_schemas` at `native.py:49-50` calls `cls(**tool_configs[name])` and silently swallows `TypeError`. Without the catch-all a naive `__init__` (matching `BashTool`/`ReadFileTool` no-arg pattern) makes the tool disappear from the LLM's view whenever a compose task passes `service`. Real bug caught by the critic. |
| **Kill-safety M1 (PTY + `set -m` + SIGINT→SIGKILL) empirically-locked, not chosen from a menu.** Naive `killpg(shell_pgid)` and `setsid <cmd> &` both rejected by probe. | Verified on bash 3.2 (darwin) + bash 5.2 (linux): pre-timeout cwd/env survive per-command timeout kills. M2 (transparent restart) locked as the documented fallback if M1 flakes on a future platform; not needed on the probed set. |
| **Timeout sourced from `tool_config`, NOT `self.timeout_s`.** Native adapter pins `ToolSchema.timeout_s=30.0` for every builtin (`native.py:518`), so `self.timeout_s or 120.0` yields 30s (dead code). Wrapper resolves from `tool_config.get("timeout_s", 120.0)`. | Makes "configurable via tool config" genuine, not just declared. Timeout is a live task-pack concern, not a static schema pin. |
| **Fail-loud on `create` for existing path is a deliberate deviation from Anthropic's reference.** Documented honestly in CHANGELOG + rationale in code. | AGENTS.md Core Rule 5. Preserves file-safety at the cost of exact-parity with the reference — task packs opting in to `str_replace_editor` explicitly want file-write protection. |
| **`Path.is_relative_to()` for path validation, not `str.startswith`.** Legacy `files.py` uses `str.startswith`, which `/work-evil` bypasses. | The editor's implementation is the correct pattern; the legacy tools' bypass filed as a separate follow-up. Prevents inheriting the legacy bug. |
| **PTY master `_write()` loops until fully drained.** Single-shot `os.write()` on a blocking PTY master may return fewer bytes than requested. | Persistent shells invite large inputs (heredocs, pasted scripts). Silent truncation would corrupt commands + mangle the sentinel line. Latent edge caught by A3 reviewer; canonical short-write loop + large-command test locks it. |
| **Compose project prefix is a config input, not hardcoded.** `compose_project_prefix` in `tool_config`; wrapper fails loud when `service` is set without it. | The wrapper's target-container resolution must be robust across task-pack-defined naming schemes, not tied to any single benchmark's convention. Refuses to guess. |
| **ADR §(c) correction shipped in the same PR as the implementation that depends on it (A4).** Not as a separate ADR-amendment PR. | Design source of truth + code move together — no risk of one landing without the other. Same-PR trace preserves reviewer context. |
| **Docs honestly surface known limitations, not hidden.** TOOLS.md has a network-isolation callout linking #581 + orphan-limitation notes on both compose variants + atomicity/`realpath` caveats on the editor compose variant. | Silence would be dishonest. Users hitting the callouts know exactly what to avoid and where the fix lands. |
| **A5 example pack ships local variants only.** Compose variants get a docs mention but no separate example; end-to-end proof is A6's integration capstone. | A runnable compose example inside A5 would be fragile + overlap A6. ADR §(f) asks for "one or more example tasks" — one runnable local pack + A6's dedicated compose test hits the intent without duplication. |
| **A6 capstone drives the wrappers, not raw engines.** A3/A4 tests exercise engines directly; A6 targets the runner-side `ToolWrapper` seam. Fixture generates a compose file with explicit `container_name` matching the wrapper's resolver. | Proves the milestone-level altitude: two seams plugged into the substrate work together under real Docker. Fixture's hardcoded `container_name` papers over #585 (compose runtime's naming convention doesn't match the wrapper's) without pretending the env-to-tool seam is production-ready. |

## Industry precedents

- **Anthropic bash_20250124 + str_replace_based_edit_tool** (live docs at platform.claude.com). Both tool contracts anchored verbatim. What we borrowed: input schemas, command semantics, `restart` semantics, 16 KB middle-truncation convention, `insert_line=0` before-first-line rule, unique-match requirement for `str_replace`, `insert_text` (not `new_str`) for `insert`. What we deliberately deviated from: `create` fail-loud on existing path (Anthropic reference overwrites without backup — we deliberately refuse for file safety).
- **Anthropic reference bash implementation** (session-lifetime subprocess + sentinel command boundary + `start_new_session=True` for process-group timeout kill). Our M1 kill-safety follows the same shape — session leader on its own PGID, `set -m` gives commands their own foreground pgroup, SIGINT→SIGKILL that group only.

## Suggested review order

1. **#570 (A1 ADR)** — `817f587` — read the ADR first for the seven named contract sections that A2-A6 cite.
2. **#574 (A2 lifecycle)** — `dc8af38` — the seam evolution + `work_dir` field. Closes #63.
3. **#580 (A3 PersistentShellTool)** — `c474e5e` — the shell tool + both provider variants. Includes the M1 kill-safety probe evidence in the commit message.
4. **#582 (A4 StrReplaceEditorTool)** — `2446d96` — the editor tool + both provider variants + the ADR §(c) correction (`insert_text` fix).
5. **#584 (A5 docs + example pack)** — `f1a7bc3` — `docs/TOOLS.md` sections + `examples/native/persistent_tools/` + native-dispatch test extension.
6. **#586 (A6 integration capstone)** — `f0b6393` — 6 tests locking the milestone-level cross-tool invariants against a real Docker compose stack.

## Verification

**Per-issue CI:**
- Every sub-PR shipped with `lint` + `test-smoke` lanes green on `feat/persistent-agent-shell-tools`.
- `hygiene-review` fails on every PR (known-broken infra issue #425 from prior sessions — same as M8 and M13). Was NOT a merge gate; the two real lanes (`lint` + `test-smoke`) were.

**Behaviour-locking test tiers (all real, no mocks):**
- **A1**: N/A (design deliverable).
- **A2**: `unit` — extended `TestToolLifecycleCapability` with 4 assertions + real subprocess session-lifetime `ToolWrapper` subclass.
- **A3**: 12 `unit` tests + 6 `canonical` dispatch tests + 17 `integration + requires_docker` tests (compose variant end-to-end).
- **A4**: 18 `canonical` tests (local variant, one per command × edge case) + 6 `canonical` dispatch tests + `integration + requires_docker` compose tests.
- **A5**: doc-drift check (grep for no internal refs / no deleted symbols) + native-dispatch test extension locking both tools' full schemas + example pack structural validation.
- **A6**: 6 `integration + requires_docker` tests exercising both wrappers against a real `bash:5` compose stack.

**Full test suite green** on the integration branch (2682 unit passed + 529 canonical passed; the 5 pre-existing `multi_service_endpoint_add` asset-digest failures are unrelated to this milestone and identical on `main`).

**Empirical probes recorded in the branch:**
- A3 kill-safety M1 verified on bash 3.2 (darwin) + bash 5.2 (linux) — evidence in the commit message.
- A4 `insert_text` claim verified against live Anthropic docs — critic-A4 fetched + cited.

**Deliberately skipped:**
- No `test-full` or `test-gate` lanes triggered — path-gated and this milestone's changes don't match those gates. Not a coverage gap; those lanes exist for other subsystems.
- No LLM-scale end-to-end run — this is a tool contract + runner-seam milestone, not a model-dispatch change. Tools ship correct or incorrect regardless of which model uses them; unit + canonical + integration cover that.

## What's next

Three follow-ups filed and left open outside M25: **#577** (fail-loud on `_builtin_tool_schemas` extraction failures — mitigated in-milestone via `**_` catch-alls, but the underlying swallow is a fail-loud violation worth its own PR), **#581** (compose network isolation — blocks agent-inside-manifest patterns like Migration Bench's downstream milestone; a small upstream primitive for per-service network exclusion), and **#585** (compose container-naming seam mismatch — blocks any real-world use of the compose tool variants until wrapper resolution and per-trial runtime naming agree). Downstream Migration Bench adapter work in `tolokaforge-tools` can now consume `bash_session` + `str_replace_editor` under [TECHDEL-500](https://toloka.atlassian.net/browse/TECHDEL-500), once #581 + #585 land.


[TECHDEL-500]: https://toloka.atlassian.net/browse/TECHDEL-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ