### PR TITLE
fix(runner): resolve DB primary-key field from config, not model source

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -94,12 +94,37 @@ would treat `"0042"`-style values as numbers. This key is honored identically on
 both grading substrates (the core `GradingEngine`/`to_hashable` path and the
 runner gRPC/`compute_stable_hash` path).
 
+### Declaring a table's primary key for non-`id` tables
+
+The grader finds and writes records by primary key and assumes the key column is
+literally `id`. Tables keyed by something else (e.g. a `<name>_id` column) must
+declare it, or upserts/deletes cannot resolve the key. Declare it per table under
+`state_checks.id_fields`; a table absent from the map defaults to `"id"`, so
+`id`-keyed domains need nothing:
+
+```yaml
+state_checks:
+  hash:
+    enabled: true
+    weight: 1.0
+  id_fields:                          # per-table primary-key override; absent => "id"
+    widgets: widget_id
+    line_items: line_id
+```
+
+Map keys are the table names as they appear in `initial_state`. This is config
+data that travels with the task, so key resolution never depends on reading model
+source at runtime (the previous `inspect.getsource`-based guess broke whenever the
+domain source was not on disk). A table keyed by neither `"id"` nor a declared
+field fails loud at write time with the exact `id_fields` entry to add.
+
 ### Best Practices
 
 - Filter non-deterministic fields (timestamps, UUIDs) before hashing
 - Prefer golden-action replay over storing a hash literal; if you must store one,
   recompute it whenever the hashing algorithm changes (see the callout above)
 - Fold numeric strings per-field (`numeric_string_fields`), never as a global switch
+- Declare non-`id` primary keys per table (`id_fields`); leave `id`-keyed tables unset
 - Combine with JSONPath assertions using `weight: 0.8` for flexibility
 
 ---

--- a/tests/canonical/snapshots/native_browser_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/grading_config.json
@@ -14,6 +14,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [],
     "numeric_string_fields": []
   },

--- a/tests/canonical/snapshots/native_calc_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/grading_config.json
@@ -14,6 +14,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [],
     "numeric_string_fields": []
   },

--- a/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
@@ -13,6 +13,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [
       {
         "description": "items remain empty (no-op task)",

--- a/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
@@ -43,6 +43,7 @@
       ],
       "weight": 0.6
     },
+    "id_fields": {},
     "jsonpaths": [
       {
         "description": "First order is assigned ID O-001",

--- a/tests/unit/test_db_proxy_id_fields.py
+++ b/tests/unit/test_db_proxy_id_fields.py
@@ -1,0 +1,232 @@
+"""Config-driven per-table id-field resolution in DBServiceProxy.
+
+Covers the fix for the fragile ``inspect.getsource``-based key resolution that
+broke upserts/deletes for tables keyed by a natural key (not the literal ``id``,
+e.g. a ``widget_id`` column) whenever the model's source file was not readable at
+runtime.
+
+The proxy now resolves the key field from config (``state_checks.id_fields``)
+with a literal ``"id"`` default, so behaviour is data-driven and stable across
+runtimes. A fake DB client records the mutation payloads the proxy emits and
+answers query/get_state from an in-memory store.
+"""
+
+import inspect
+import re
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from tolokaforge.runner.db_proxy import DBServiceProxy, IdFieldResolutionError
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class WidgetLike(BaseModel):
+    """Keyed by ``widget_id`` (no ``id`` field) — the shape that broke the old path."""
+
+    model_config = {"extra": "forbid"}
+
+    widget_id: str
+    status: str = "new"
+
+    def get_id(self) -> str:
+        return self.widget_id
+
+
+class IdKeyed(BaseModel):
+    """Keyed by the literal ``id`` — the default, must stay byte-for-byte unchanged."""
+
+    model_config = {"extra": "forbid"}
+
+    id: str
+    name: str = ""
+
+    def get_id(self) -> str:
+        return self.id
+
+
+class EmailKeyed(BaseModel):
+    """Keyed by ``email`` — read must still work unconfigured via the fallback scan."""
+
+    model_config = {"extra": "forbid"}
+
+    email: str
+    name: str = ""
+
+    def get_id(self) -> str:
+        return self.email
+
+
+def _make_dynamic_model() -> type[BaseModel]:
+    """Define a model via ``exec()`` so ``inspect.getsource(get_id)`` raises OSError,
+    reproducing the runtime condition (source not on disk) that broke the old resolver."""
+    ns: dict = {}
+    exec(
+        "from pydantic import BaseModel\n"
+        "class Dyn(BaseModel):\n"
+        "    model_config = {'extra': 'forbid'}\n"
+        "    dyn_id: str\n"
+        "    def get_id(self):\n"
+        "        return self.dyn_id\n",
+        ns,
+    )
+    return ns["Dyn"]
+
+
+# ---------------------------------------------------------------------------
+# Fake DB client
+# ---------------------------------------------------------------------------
+
+
+class FakeDBClient:
+    """Records mutation payloads; answers query/get_state from an in-memory store."""
+
+    def __init__(self, state: dict | None = None):
+        self.state = {k: [dict(r) for r in v] for k, v in (state or {}).items()}
+        self.mutations: list[tuple[str, list[dict]]] = []
+        self.queries: list[str] = []
+
+    async def query(self, trial_id, jsonpath):
+        self.queries.append(jsonpath)
+        m = re.match(
+            r"\$\.(?P<table>[^\[]+)\[\?\(@\.(?P<field>[^=]+)=='(?P<value>[^']*)'\)\]",
+            jsonpath,
+        )
+        results = []
+        if m:
+            for rec in self.state.get(m["table"], []):
+                if str(rec.get(m["field"])) == m["value"]:
+                    results.append(rec)
+        return SimpleNamespace(results=results)
+
+    async def get_state(self, trial_id, tables=None):
+        keys = tables if tables is not None else list(self.state)
+        return SimpleNamespace(data={t: self.state.get(t, []) for t in keys})
+
+    async def mutate(self, trial_id, table_name, operations):
+        self.mutations.append((table_name, operations))
+        return SimpleNamespace(success=True)
+
+
+def _proxy(table, model_cls, *, id_fields=None, state=None):
+    client = FakeDBClient(state=state)
+    proxy = DBServiceProxy(
+        client,
+        "trial:0",
+        model_registry={table: model_cls},
+        db_table_names=[table],
+        id_fields=id_fields,
+    )
+    return proxy, client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_update_uses_configured_key():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    await proxy.update(WidgetLike(widget_id="W1", status="ready"))
+    table, ops = client.mutations[-1]
+    assert table == "widgets"
+    assert ops[0]["op"] == "upsert"
+    assert ops[0]["key"] == "widget_id"  # config-resolved, not "id"
+
+
+async def test_update_defaults_to_id_unchanged():
+    proxy, client = _proxy(
+        "items",
+        IdKeyed,
+        state={"items": [{"id": "X1", "name": "a"}]},
+    )
+    await proxy.update(IdKeyed(id="X1", name="b"))
+    _, ops = client.mutations[-1]
+    assert ops[0]["key"] == "id"  # default path byte-for-byte unchanged
+
+
+async def test_delete_uses_configured_key():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    await proxy.delete(WidgetLike(widget_id="W1"))
+    _, ops = client.mutations[-1]
+    assert ops[0]["op"] == "delete"
+    assert ops[0]["filter"] == {"widget_id": "W1"}  # not {"id": ...} (was a silent no-op)
+
+
+async def test_get_by_id_queries_only_configured_field():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    found = await proxy.get_by_id(WidgetLike, "W1")
+    assert found is not None and found.widget_id == "W1"
+    assert any("@.widget_id==" in q for q in client.queries)
+    assert not any("@.id==" in q for q in client.queries)  # never probes literal "id"
+
+
+async def test_resolve_id_field_fails_loud_when_unconfigured():
+    proxy, _ = _proxy("widgets", WidgetLike)  # no id_fields, model has no "id"
+    with pytest.raises(IdFieldResolutionError) as ei:
+        proxy._resolve_id_field(WidgetLike)
+    msg = str(ei.value)
+    assert "widgets" in msg and "id_fields" in msg  # actionable: names table + the fix
+
+
+async def test_resolve_id_field_immune_to_missing_source():
+    """The old resolver parsed ``inspect.getsource(get_id)``; a model whose source is
+    unavailable made it raise. The config path must resolve regardless."""
+    Dyn = _make_dynamic_model()
+    with pytest.raises(OSError):
+        inspect.getsource(Dyn.get_id)  # confirm the source is genuinely unreadable
+    proxy, _ = _proxy("dyn", Dyn, id_fields={"dyn": "dyn_id"})
+    assert proxy._resolve_id_field(Dyn) == "dyn_id"
+
+
+async def test_email_keyed_read_works_unconfigured_via_fallback():
+    proxy, _ = _proxy(
+        "users",
+        EmailKeyed,
+        state={"users": [{"email": "a@x.io", "name": "A"}]},
+    )
+    found = await proxy.get_by_id(EmailKeyed, "a@x.io")
+    assert found is not None and found.email == "a@x.io"  # full-scan fallback
+
+
+def test_copy_preserves_id_fields():
+    proxy, _ = _proxy("widgets", WidgetLike, id_fields={"widgets": "widget_id"})
+    assert proxy.copy()._id_fields == {"widgets": "widget_id"}
+
+
+def test_state_checks_config_rejects_blank_id_field():
+    """The config validator fails loud on blank table names / key fields, so a
+    malformed override can never reach the proxy (where blank folds to 'id')."""
+    from pydantic import ValidationError
+
+    from tolokaforge.runner.models import StateChecksConfig
+
+    with pytest.raises(ValidationError):
+        StateChecksConfig(id_fields={"widgets": ""})  # blank key field
+    with pytest.raises(ValidationError):
+        StateChecksConfig(id_fields={"  ": "widget_id"})  # blank table name
+    assert StateChecksConfig(id_fields={"widgets": "widget_id"}).id_fields == {
+        "widgets": "widget_id"
+    }

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -632,6 +632,7 @@ class NativeAdapter(BaseAdapter):
                     env_assertions=env_assertions,
                     db_probes=db_probes,
                     numeric_string_fields=list(state_checks_data.get("numeric_string_fields", [])),
+                    id_fields=dict(state_checks_data.get("id_fields", {})),
                 )
 
             # Build transcript rules

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1341,6 +1341,25 @@ class StateChecksConfig(BaseModel):
     # core GradingEngine path (to_hashable) and the runner path
     # (compute_stable_hash). See core/hash.py compute_stable_hash.
     numeric_string_fields: list[str] = Field(default_factory=list)
+    # Opt-in, per-table: primary-key field for a table whose key is not the literal
+    # "id" (e.g. {"widgets": "widget_id"}). A table absent from the map
+    # resolves to "id", so id-keyed domains need nothing here. Threaded to the runner
+    # DB proxy so upsert/delete/lookup key resolution is config-driven rather than
+    # introspecting model source (which breaks when the domain source is not on disk).
+    id_fields: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("id_fields")
+    @classmethod
+    def _validate_id_fields(cls, value: dict[str, str]) -> dict[str, str]:
+        for table, field in value.items():
+            if not (isinstance(table, str) and table.strip()):
+                raise ValueError(f"state_checks.id_fields has a blank table name: {table!r}")
+            if not (isinstance(field, str) and field.strip()):
+                raise ValueError(
+                    f"state_checks.id_fields[{table!r}] must be a non-empty key field, "
+                    f"got {field!r}"
+                )
+        return value
 
 
 class CommunicateInfo(BaseModel):

--- a/tolokaforge/runner/db_proxy.py
+++ b/tolokaforge/runner/db_proxy.py
@@ -46,6 +46,15 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+class IdFieldResolutionError(ValueError):
+    """Raised when a table's primary-key field cannot be determined.
+
+    The proxy resolves the key field from config (state_checks.id_fields) with a
+    literal "id" default. If a table is keyed by neither "id" nor a configured
+    field, upsert/delete cannot proceed, so we fail loud with the exact fix.
+    """
+
+
 class DBServiceProxy:
     """
     Proxy that looks like InMemoryDatabase but talks to DB Service.
@@ -69,6 +78,7 @@ class DBServiceProxy:
         trial_id: str,
         model_registry: dict[str, type[BaseModel]] | None = None,
         db_table_names: list[str] | None = None,
+        id_fields: dict[str, str] | None = None,
     ):
         """
         Initialize the DB Service proxy.
@@ -80,10 +90,17 @@ class DBServiceProxy:
                            If not provided, records are returned as dicts
             db_table_names: Optional list of actual table names from initial_state.
                            Used for fallback table name resolution when model is not registered.
+            id_fields: Optional per-table primary-key overrides (table_name -> key
+                           field), from grading config state_checks.id_fields. A table
+                           absent from the map resolves to the literal "id".
         """
         self.db_client = db_client
         self.trial_id = trial_id
         self.db_table_names = db_table_names or []
+        # Per-table primary-key field (table_name -> key field). Data-driven so
+        # upsert/delete/lookup key resolution never depends on reading model source
+        # at runtime; a table absent here resolves to "id".
+        self._id_fields: dict[str, str] = dict(id_fields or {})
         # Domain name for TypeSense search (used by search_policy tools
         # that call getattr(db, "domain") to look up the registry).
         self.domain: str | None = None
@@ -267,24 +284,27 @@ class DBServiceProxy:
         if hasattr(obj, "id"):
             return obj.id
 
-    def _get_id_field_name(self, obj: BaseModel) -> str:
-        """Get the ID field name of a Pydantic model instance."""
-        if hasattr(obj, "get_id"):
-            import inspect
+    def _resolve_id_field(self, model_cls: type[BaseModel]) -> str:
+        """Primary-key field name for a table's write/delete operations.
 
-            try:
-                source = inspect.getsource(obj.get_id)
-                for line in source.split("\n"):
-                    line = line.strip()
-                    if line.startswith("return self."):
-                        return line.replace("return self.", "").strip()
-            except (TypeError, OSError):
-                pass
-        if hasattr(obj, "id"):
+        Config-first (state_checks.id_fields), literal-"id" default, fail loud.
+        Never reads model source: the old inspect.getsource path raised OSError
+        whenever the domain's source file was not on disk at runtime (e.g. code
+        loaded from a cleaned-up temp dir), silently breaking upserts/deletes.
+        Resolving from config data is stable across every runtime.
+        """
+        table_name = self._get_table_name(model_cls)
+        configured = self._id_fields.get(table_name)
+        if configured:
+            return configured
+        if "id" in getattr(model_cls, "model_fields", {}):
             return "id"
-        raise ValueError(f"Cannot determine ID field name for {type(obj).__name__}")
-
-        raise ValueError(f"Cannot determine ID for object of type {type(obj).__name__}")
+        raise IdFieldResolutionError(
+            f"Cannot determine ID field for table '{table_name}' "
+            f"(model {model_cls.__name__}): no 'id' field and no "
+            f"state_checks.id_fields entry. Add to the task's grading.yaml:\n"
+            f"  state_checks:\n    id_fields:\n      {table_name}: <key_field>"
+        )
 
     # =========================================================================
     # InMemoryDatabase-compatible interface (async versions)
@@ -326,10 +346,10 @@ class DBServiceProxy:
         """
         Get a single item by its ID from the database.
 
-        Uses JSONPath query to find the record. Tries multiple ID field names
-        since different models use different fields as their primary key:
-        - Most models use 'id'
-        - Some models (like Employee) use 'email' as the primary key
+        Resolves the table's key field from config (state_checks.id_fields,
+        default "id"), does one JSONPath lookup, and falls back to a value-based
+        full scan (comparing get_id()) if the lookup misses — so reads succeed for
+        any key shape even without config.
 
         Args:
             model_cls: Pydantic model class
@@ -339,31 +359,24 @@ class DBServiceProxy:
             Model instance or None if not found
         """
         table_name = self._get_table_name(model_cls)
+        # `or "id"` (not .get(..., "id")) so a blank override folds to the default,
+        # matching _resolve_id_field's truthiness — the two resolvers cannot diverge.
+        id_field = self._id_fields.get(table_name) or "id"
 
-        # Try common ID field names in order of likelihood
-        # Most models use 'id', but some use 'email' (e.g., Employee model)
-        id_fields = ["id", "email"]
+        jsonpath = f"$.{table_name}[?(@.{id_field}=='{value}')]"
+        try:
+            response = await self.db_client.query(self.trial_id, jsonpath)
+            # QueryResponse is a Pydantic model with .results attribute
+            if response.results:
+                return self._to_model(model_cls, response.results[0])
+        except Exception as e:
+            logger.debug(f"JSONPath lookup on '{id_field}' failed: {e}")
 
-        for id_field in id_fields:
-            # Use JSONPath query to find by ID field
-            jsonpath = f"$.{table_name}[?(@.{id_field}=='{value}')]"
-
-            try:
-                response = await self.db_client.query(self.trial_id, jsonpath)
-                # QueryResponse is a Pydantic model with .results attribute
-                results = response.results
-
-                if results:
-                    return self._to_model(model_cls, results[0])
-            except Exception as e:
-                logger.debug(f"JSONPath query for {id_field} failed: {e}")
-                continue
-
-        # Fallback: get all and filter using model's get_id() method
-        # This handles any custom ID field that we didn't try above
-        logger.debug(f"JSONPath queries failed, falling back to full scan for {model_cls.__name__}")
-        all_items = await self.get_all(model_cls)
-        for item in all_items:
+        # Fallback: full scan comparing the model's get_id() value. Handles keys
+        # not declared in id_fields (e.g. email) via a runtime VALUE call, never
+        # model source.
+        logger.debug(f"JSONPath lookup missed, full scan for {model_cls.__name__}")
+        for item in await self.get_all(model_cls):
             if self._get_id(item) == value:
                 return item
         return None
@@ -459,7 +472,9 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "upsert", "record": record, "key": self._get_id_field_name(obj)}],
+            operations=[
+                {"op": "upsert", "record": record, "key": self._resolve_id_field(model_cls)}
+            ],
         )
 
         return obj
@@ -488,7 +503,7 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "delete", "filter": {"id": obj_id}}],
+            operations=[{"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}],
         )
 
     async def delete_by_id(self, model_cls: type[T], obj_id: Any) -> None:
@@ -512,7 +527,7 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "delete", "filter": {"id": obj_id}}],
+            operations=[{"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}],
         )
 
     async def bulk_delete(self, objects: list[BaseModel]) -> None:
@@ -533,7 +548,9 @@ class DBServiceProxy:
             if obj.__class__ != model_cls:
                 raise ValueError("All objects must be of the same model class")
             obj_id = self._get_id(obj)
-            operations.append({"op": "delete", "filter": {"id": obj_id}})
+            operations.append(
+                {"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}
+            )
 
         await self.db_client.mutate(
             trial_id=self.trial_id, table_name=table_name, operations=operations
@@ -574,6 +591,7 @@ class DBServiceProxy:
             db_client=self.db_client,
             trial_id=self.trial_id,
             db_table_names=list(self.db_table_names),
+            id_fields=dict(self._id_fields),
         )
         new_proxy._model_name_to_table = deepcopy(self._model_name_to_table)
         new_proxy._table_to_model = deepcopy(self._table_to_model)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -312,6 +312,11 @@ class StateChecksConfig(BaseModel):
     # switch) because a numeric-looking string can carry meaning in its exact
     # representation (versions/codes) — see core/hash.py compute_stable_hash.
     numeric_string_fields: list[str] = Field(default_factory=list)
+    # Opt-in, PER-TABLE: primary-key field for tables not keyed by the literal "id"
+    # (e.g. {"widgets": "widget_id"}). Absent table => "id". Consumed by
+    # the DB proxy (via ToolFactory) so key resolution is data-driven instead of
+    # derived from model source. See runner/db_proxy.py _resolve_id_field.
+    id_fields: dict[str, str] = Field(default_factory=dict)
 
     # JSONPath assertions
     jsonpath_checks: list[dict[str, Any]] = Field(default_factory=list)
@@ -321,6 +326,19 @@ class StateChecksConfig(BaseModel):
 
     # Substrate SQL assertions against a task-declared postgres DSN
     db_probes: list[DbProbe] = Field(default_factory=list)
+
+    @field_validator("id_fields")
+    @classmethod
+    def _validate_id_fields(cls, value: dict[str, str]) -> dict[str, str]:
+        for table, field in value.items():
+            if not (isinstance(table, str) and table.strip()):
+                raise ValueError(f"state_checks.id_fields has a blank table name: {table!r}")
+            if not (isinstance(field, str) and field.strip()):
+                raise ValueError(
+                    f"state_checks.id_fields[{table!r}] must be a non-empty key field, "
+                    f"got {field!r}"
+                )
+        return value
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -605,6 +605,17 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # Pass actual table names and data from initial_state so model registration uses correct names
         db_table_names = list(initial_state.tables.keys()) if initial_state.tables else []
         initial_state_data = initial_state.tables if initial_state.tables else {}
+        # Per-table primary-key overrides from grading config (default "id"). Passed to
+        # the DB proxy so upsert/delete/lookup key resolution is data-driven rather than
+        # introspecting model source (which fails when the domain source is not on disk).
+        state_checks = task_description.grading.state_checks if task_description.grading else None
+        id_fields = dict(state_checks.id_fields) if state_checks else {}
+        unknown_tables = set(id_fields) - set(db_table_names)
+        if unknown_tables:
+            logger.warning(
+                f"RegisterTrial: {trial_id} - state_checks.id_fields names unknown "
+                f"table(s) (typo?): {sorted(unknown_tables)}"
+            )
         try:
             tool_factory = ToolFactory(
                 self.db_client,
@@ -612,6 +623,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 rag_client_for_trial,
                 db_table_names,
                 initial_state_data,
+                id_fields=id_fields,
             )
 
             # Set domain on DB proxy so search_policy tools can resolve

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1173,6 +1173,7 @@ class ToolFactory:
         rag_client: RAGServiceClient | None = None,
         db_table_names: list[str] | None = None,
         initial_state_data: dict[str, list[dict]] | None = None,
+        id_fields: dict[str, str] | None = None,
     ):
         """
         Initialize the tool factory.
@@ -1185,17 +1186,23 @@ class ToolFactory:
                            These are the source of truth for table name registration.
             initial_state_data: Optional dict mapping table names to their records.
                                Used for ID field matching during model registration.
+            id_fields: Optional per-table primary-key overrides (table_name -> key
+                       field), from grading config state_checks.id_fields. Forwarded
+                       to the DB proxy; a table absent from the map resolves to "id".
         """
         self.db_client = db_client
         self.trial_id = trial_id
         self.rag_client = rag_client
         self.db_table_names = db_table_names or []
         self._initial_state_data = initial_state_data or {}
+        self.id_fields = dict(id_fields or {})
         self._claimed_tables: set[str] = set()
 
         # Create DB proxies for tools
         # Pass db_table_names so the proxy can resolve table names for unregistered models
-        self._async_proxy = DBServiceProxy(db_client, trial_id, db_table_names=self.db_table_names)
+        self._async_proxy = DBServiceProxy(
+            db_client, trial_id, db_table_names=self.db_table_names, id_fields=self.id_fields
+        )
         self._sync_proxy = SyncDBServiceProxy(self._async_proxy)
 
     def reconstruct_tools(


### PR DESCRIPTION
## Problem

The runner DB proxy (`runner/db_proxy.py`) determined a table's primary-key field by **text-parsing the source of `get_id()`** via `inspect.getsource`, with a hardcoded `id`/`email` fallback. `inspect.getsource` raises `OSError` whenever a model's source file is not on disk at runtime — which happens in a long-lived runner process when tool code was loaded from a per-trial temp dir (`tempfile.mkdtemp`) that a later trial's cleanup removed.

When that fires, `_get_id_field_name` raised `ValueError: Cannot determine ID field name` for every `update`/`delete` on a table not keyed by the literal `id` (a table using a natural key such as a `<name>_id` column) — breaking **both** the agent's tools mid-episode **and** the golden-path replay at grade time, so the trial scored a fabricated `0.0` misattributed to the model.

## Fix

Resolve the key field from **config data** instead of model source:

- New per-table `state_checks.id_fields` (`{table_name: key_field}`), **default `"id"`** — a table absent from the map resolves to `"id"`, so `id`-keyed tasks need zero config and see zero behavior change.
- Threaded on the existing `numeric_string_fields` rail: grading.yaml → `StateChecksConfig` (core + runner) → `RegisterTrial` → `ToolFactory` → `DBServiceProxy`. Golden replay reuses the *same* configured proxy (verified — no separate proxy is built at grade time).
- `_get_id_field_name` (source-parsing) → `_resolve_id_field(model_cls)`: config-first, `"id"` default, **fail-loud** (`IdFieldResolutionError` naming the table + the exact `id_fields` entry to add) — never reads source, so it is stable across every runtime.
- Also fixes **silent no-op deletes** on non-`id` tables: `delete`/`delete_by_id`/`bulk_delete` previously hardcoded `{"id": obj_id}`.
- A config validator rejects blank table/key entries at load; `get_by_id` folds a blank override to `"id"` so it can never diverge from `_resolve_id_field`.

## Backward compatibility

- `id`-keyed tasks: byte-for-byte unchanged upsert/delete payloads and `get_by_id` probe.
- `email`-keyed reads keep working unconfigured via the value-based full-scan fallback.
- The 4 native canonical `grading_config.json` snapshots gain only `"id_fields": {}` (no other drift).
- Version skew: core config is `extra="ignore"` (old engine silently skips the key); runner config is `extra="forbid"` (engine + runner image ship together, as with `numeric_string_fields`).

## Verification

- New `tests/unit/test_db_proxy_id_fields.py` (9 tests): configured key on update/delete, default-`"id"` unchanged, `get_by_id` queries only the configured field, fail-loud message, source-unavailable immunity (model defined via `exec()` so `getsource` genuinely raises), email fallback, `copy()` propagation, blank-config rejection.
- Full `tests/unit` + `tests/canonical`: all green, no regressions from this change.
- `black` + `ruff` clean.

## ⚠️ Merge in lockstep with the task packs

The engine alone hard-fails any task whose tables are not `id`-keyed until that task's `grading.yaml` declares `id_fields`. Land the task-pack `id_fields` declarations together with this change.

## Follow-ups (out of scope)

- Two diff-sync write paths still hardcode `"id"` (`tool_factory.py`, `service.py`) — dormant for `id`-keyed tasks; should consult the same `id_fields` map.
- `tool_factory._get_id_field_name` still uses `inspect.getsource` for model→table *registration* (unaffected when a model declares a `table_name` ClassVar).
- Optional fail-loud: mark a trial ungradeable on golden-replay infrastructure errors instead of scoring `0.0`.