### PR TITLE
chore(ci): tag-triggered access test for Docker Hub OIDC (pre-M14 gate)

### DIFF
--- a/.github/workflows/access-test-docker-hub.yml
+++ b/.github/workflows/access-test-docker-hub.yml
@@ -1,0 +1,96 @@
+# Access test — Docker Hub OIDC + environment gating verification.
+#
+# THROWAWAY workflow. Verifies that the Docker Hub OIDC connection
+# provisioned by Leonid (2026-07-23) — plus the `release` and `pre-stable`
+# GitHub environments — authenticate end-to-end and can push to the four
+# `tolokasoft1/tolokaforge-*` repos, BEFORE we invest in the real M14-B
+# publish workflow.
+#
+# Delete this workflow once M14-B lands. Its own `workflow_dispatch`
+# dry-run supersedes this test.
+#
+# Prerequisite (one-time, temporary):
+#   - Both `release` and `pre-stable` GitHub environments must transiently
+#     allow `main` as a deployment branch — otherwise `workflow_dispatch`
+#     from `main` fails the env's deployment-ref check before OIDC runs.
+#     Remove `main` from the allowed-branches lists after the test passes.
+#
+# Usage:
+#   1. From the Actions tab, pick "Access test — Docker Hub OIDC".
+#   2. Click "Run workflow", choose `env_name` + `target_repo`, run.
+#   3. Watch each step succeed. On failure, the failing step name pinpoints
+#      which link in the OIDC chain broke:
+#        - "Mint Docker Hub OIDC token" — connection ID or claim mismatch
+#        - "Docker Hub login" — token valid but Docker Hub rejects it
+#        - "Retag and push to Docker Hub" — auth OK but push scope wrong
+#        - "Verify pushed image is pullable" — push OK but pull failed
+#   4. Cleanup: delete the pushed `:access-test-*` tags from the Docker Hub
+#      UI (or leave them — they don't collide with semver-based tags).
+
+name: Access test — Docker Hub OIDC
+
+on:
+  workflow_dispatch:
+    inputs:
+      env_name:
+        description: GitHub environment to test
+        required: true
+        type: choice
+        options:
+          - release
+          - pre-stable
+      target_repo:
+        description: Which of the 4 image repos to push to
+        required: true
+        type: choice
+        options:
+          - runner
+          - db-service
+          - rag-service
+          - mock-web
+
+jobs:
+  test-access:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env_name }}
+    permissions:
+      id-token: write   # required for OIDC token minting
+      contents: read
+    steps:
+      - name: Mint Docker Hub OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@v1
+        with:
+          connection_id: "06a2983d-e4d1-473e-8dab-f1d6ead9bc8f"
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: tolokasoft1
+          password: ${{ steps.docker_oidc.outputs.token }}
+
+      - name: Pull tiny base image
+        run: docker pull alpine:3.19
+
+      - name: Retag and push to Docker Hub
+        env:
+          IMAGE: tolokasoft1/tolokaforge-${{ inputs.target_repo }}:access-test-${{ inputs.env_name }}
+        run: |
+          docker tag alpine:3.19 "$IMAGE"
+          docker push "$IMAGE"
+
+      - name: Verify pushed image is pullable
+        env:
+          IMAGE: tolokasoft1/tolokaforge-${{ inputs.target_repo }}:access-test-${{ inputs.env_name }}
+        run: |
+          docker rmi "$IMAGE"
+          docker pull "$IMAGE"
+
+      - name: Report
+        run: |
+          echo "OIDC -> push -> pull chain works for:"
+          echo "  env:  ${{ inputs.env_name }}"
+          echo "  repo: tolokasoft1/tolokaforge-${{ inputs.target_repo }}"
+          echo "  tag:  access-test-${{ inputs.env_name }}"
+          echo
+          echo "Cleanup: delete this tag from Docker Hub UI when done."

--- a/.github/workflows/access-test-docker-hub.yml
+++ b/.github/workflows/access-test-docker-hub.yml
@@ -1,61 +1,53 @@
 # Access test — Docker Hub OIDC + environment gating verification.
 #
 # THROWAWAY workflow. Verifies that the Docker Hub OIDC connection
-# provisioned by Leonid (2026-07-23) — plus the `release` and `pre-stable`
-# GitHub environments — authenticate end-to-end and can push to the four
-# `tolokasoft1/tolokaforge-*` repos, BEFORE we invest in the real M14-B
-# publish workflow.
+# provisioned by Leonid (2026-07-23), the `release` and `pre-stable`
+# GitHub environments, and the tag-based environment resolution
+# expression all authenticate and push end-to-end, using the SAME
+# trigger + resolution chain the real M14-B publish workflow will use.
+#
+# Trigger shape (matches production):
+#   - Push tag `image-v0.0.0-rc.1` → runs in `pre-stable` env
+#   - Push tag `image-v0.0.0`      → runs in `release` env
+#
+# The version `0.0.0` is universally understood as "test/init." Both tags
+# are semver-legal but obviously not a real release. Cleanup after:
+#   git push origin :refs/tags/image-v0.0.0-rc.1
+#   git push origin :refs/tags/image-v0.0.0
+#   (then delete the Docker Hub tags of the same names from the UI)
+#
+# Matrix: all four `tolokasoft1/tolokaforge-*` repos in one run — a single
+# tag push validates the OIDC glob across every repo it's supposed to cover.
 #
 # Delete this workflow once M14-B lands. Its own `workflow_dispatch`
 # dry-run supersedes this test.
-#
-# Prerequisite (one-time, temporary):
-#   - Both `release` and `pre-stable` GitHub environments must transiently
-#     allow `main` as a deployment branch — otherwise `workflow_dispatch`
-#     from `main` fails the env's deployment-ref check before OIDC runs.
-#     Remove `main` from the allowed-branches lists after the test passes.
-#
-# Usage:
-#   1. From the Actions tab, pick "Access test — Docker Hub OIDC".
-#   2. Click "Run workflow", choose `env_name` + `target_repo`, run.
-#   3. Watch each step succeed. On failure, the failing step name pinpoints
-#      which link in the OIDC chain broke:
-#        - "Mint Docker Hub OIDC token" — connection ID or claim mismatch
-#        - "Docker Hub login" — token valid but Docker Hub rejects it
-#        - "Retag and push to Docker Hub" — auth OK but push scope wrong
-#        - "Verify pushed image is pullable" — push OK but pull failed
-#   4. Cleanup: delete the pushed `:access-test-*` tags from the Docker Hub
-#      UI (or leave them — they don't collide with semver-based tags).
 
 name: Access test — Docker Hub OIDC
 
 on:
-  workflow_dispatch:
-    inputs:
-      env_name:
-        description: GitHub environment to test
-        required: true
-        type: choice
-        options:
-          - release
-          - pre-stable
-      target_repo:
-        description: Which of the 4 image repos to push to
-        required: true
-        type: choice
-        options:
-          - runner
-          - db-service
-          - rag-service
-          - mock-web
+  push:
+    tags:
+      # Restrict this workflow to the two test-only tags. Prevents accidental
+      # firing on any future real `image-v*` tag.
+      - image-v0.0.0
+      - image-v0.0.0-rc.*
 
 jobs:
   test-access:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.env_name }}
+    # Same environment-resolution expression the real M14-B workflow will use.
+    environment: ${{ contains(github.ref_name, '-rc.') && 'pre-stable' || 'release' }}
     permissions:
       id-token: write   # required for OIDC token minting
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - runner
+          - db-service
+          - rag-service
+          - mock-web
     steps:
       - name: Mint Docker Hub OIDC token
         id: docker_oidc
@@ -74,14 +66,14 @@ jobs:
 
       - name: Retag and push to Docker Hub
         env:
-          IMAGE: tolokasoft1/tolokaforge-${{ inputs.target_repo }}:access-test-${{ inputs.env_name }}
+          IMAGE: tolokasoft1/tolokaforge-${{ matrix.repo }}:${{ github.ref_name }}
         run: |
           docker tag alpine:3.19 "$IMAGE"
           docker push "$IMAGE"
 
       - name: Verify pushed image is pullable
         env:
-          IMAGE: tolokasoft1/tolokaforge-${{ inputs.target_repo }}:access-test-${{ inputs.env_name }}
+          IMAGE: tolokasoft1/tolokaforge-${{ matrix.repo }}:${{ github.ref_name }}
         run: |
           docker rmi "$IMAGE"
           docker pull "$IMAGE"
@@ -89,8 +81,6 @@ jobs:
       - name: Report
         run: |
           echo "OIDC -> push -> pull chain works for:"
-          echo "  env:  ${{ inputs.env_name }}"
-          echo "  repo: tolokasoft1/tolokaforge-${{ inputs.target_repo }}"
-          echo "  tag:  access-test-${{ inputs.env_name }}"
-          echo
-          echo "Cleanup: delete this tag from Docker Hub UI when done."
+          echo "  env:  ${{ contains(github.ref_name, '-rc.') && 'pre-stable' || 'release' }}"
+          echo "  tag:  ${{ github.ref_name }}"
+          echo "  repo: tolokasoft1/tolokaforge-${{ matrix.repo }}"


### PR DESCRIPTION
## Summary

Adds a **throwaway** tag-triggered workflow (`.github/workflows/access-test-docker-hub.yml`) that verifies the Docker Hub OIDC connection Leonid provisioned (2026-07-23), the `release` and `pre-stable` GitHub environments, and the tag-based environment resolution expression all authenticate and push end-to-end — using the SAME trigger + resolution chain M14-B will use in production.

**Delete this workflow file once M14-B lands.** Its own `workflow_dispatch` dry-run supersedes this test.

## Why tag-triggered (not workflow_dispatch)

The initial design used `workflow_dispatch`, which triggers from a branch and requires temporarily broadening both envs to allow `main`. That doesn't test the REAL production flow — it tests a modified version of it.

The current design fires from a real tag push matching `image-v0.0.0` or `image-v0.0.0-rc.*`. This exercises the exact same:

- Trigger mechanism (tag push, not branch dispatch)
- Environment resolution expression (`contains(github.ref_name, '-rc.')`)
- Env gating (the envs stay tag-restricted throughout, matching production)
- OIDC chain (connection → login → push → pull-back)

No env config changes required. What's tested is what will ship.

## Design choices

- **Test-only tag versions.** `image-v0.0.0` and `image-v0.0.0-rc.1` — semver-legal but universally understood as "test/init." No collision risk with real releases. Both are deletable from git and Docker Hub after the test.
- **Trigger restricted to these two exact tag patterns.** Prevents accidental firing on any future real `image-v*` tag once M14-B is running.
- **Matrix over all four repos in one run.** A single tag push validates the OIDC glob across every repo it's supposed to cover — no need to run the test 4× per env.
- **One step per link in the OIDC chain**, each with a distinct name. Failing step name pinpoints where the chain broke.

## Concepts introduced

None. CI-only utility that exercises the OIDC + Docker Hub auth chain end-to-end.

## Test plan

- [ ] Merge this PR.
- [ ] Push tag `image-v0.0.0-rc.1` from `main` — workflow fires, resolves to `pre-stable` env, matrix runs across 4 repos.
- [ ] Verify all 4 matrix jobs green. If any red, the failing step name tells us which link broke.
- [ ] Push tag `image-v0.0.0` from `main` — workflow fires, resolves to `release` env, matrix runs across 4 repos.
- [ ] Verify all 4 matrix jobs green.
- [ ] Cleanup:
  - `git push origin :refs/tags/image-v0.0.0-rc.1`
  - `git push origin :refs/tags/image-v0.0.0`
  - Delete the `image-v0.0.0*` tags from Docker Hub UI for all 4 repos.
- [ ] Once M14-B lands, delete this workflow file in the same PR.

## Failure diagnostics

| Failing step | Likely cause | Fix |
|---|---|---|
| "Mint Docker Hub OIDC token" | Connection ID or claim mismatch, or env-name typo in envs vs claim | Verify env exists exactly as `release` / `pre-stable`; ping Leonid with run URL |
| "Docker Hub login" | Token valid but Docker Hub rejects it | Ping Leonid with run URL |
| "Retag and push to Docker Hub" | Auth OK but push scope wrong (glob may not cover this repo) | Check claim glob; ping Leonid |
| "Verify pushed image is pullable" | Push OK but pull failed (repo not public, or Docker Hub caching lag) | Check repo visibility; retry once |