### PR TITLE
chore(ci): fix access-test — pull base image before Docker Hub login

### DIFF
--- a/.github/workflows/access-test-docker-hub.yml
+++ b/.github/workflows/access-test-docker-hub.yml
@@ -49,6 +49,14 @@ jobs:
           - rag-service
           - mock-web
     steps:
+      # Pull the base image BEFORE logging in to Docker Hub. Once we log in
+      # with a repo-scoped OIDC token, `docker pull` uses that token for
+      # every Docker Hub call — including `library/alpine`, which the token
+      # is NOT scoped for (it's scoped to `tolokasoft1/tolokaforge-*` only).
+      # Anonymous pull works fine BEFORE login and avoids the scope conflict.
+      - name: Pull tiny base image (anonymous, pre-login)
+        run: docker pull alpine:3.19
+
       - name: Mint Docker Hub OIDC token
         id: docker_oidc
         uses: docker/oidc-action@v1
@@ -60,9 +68,6 @@ jobs:
         with:
           username: tolokasoft1
           password: ${{ steps.docker_oidc.outputs.token }}
-
-      - name: Pull tiny base image
-        run: docker pull alpine:3.19
 
       - name: Retag and push to Docker Hub
         env:


### PR DESCRIPTION
## Summary

The access-test workflow (#601, merged) got OIDC + login working end-to-end but failed at \`docker pull alpine:3.19\` with:

> \`unauthorized: access token has insufficient scopes\`

Root cause: the OIDC token is scoped to \`tolokasoft1/tolokaforge-*\`. Once \`docker login\` runs, subsequent \`docker pull library/alpine\` uses that token — which lacks scope for \`library/*\` — and Docker Hub rejects.

Fix: pull the base image first (anonymous, no auth), then log in, then push. The final \"verify pushed image is pullable\" pull works because the token DOES have read scope for the \`tolokasoft1/tolokaforge-*\` repos it just pushed to.

## What we learned from the failed run

OIDC + env-gating chain works end-to-end for \`pre-stable\`:
- ✓ Set up job
- ✓ Mint Docker Hub OIDC token
- ✓ Docker Hub login
- ✗ Pull tiny base image (this fix)

So Leonid's OIDC connection, the \`pre-stable\` claim scope, and the tag-triggered env resolution all authenticate correctly. Only the step ordering needs adjustment.

## Test plan

- [ ] Merge this PR.
- [ ] Delete existing test tag: \`git push origin :refs/tags/image-v0.0.0-rc.1\`.
- [ ] Recreate + push: \`git tag image-v0.0.0-rc.1 && git push origin image-v0.0.0-rc.1\`.
- [ ] Verify workflow goes green across all 4 matrix jobs.
- [ ] Push \`image-v0.0.0\` for release-env test.