### PR TITLE
fix(runner): fail loud on id_fields typos + MCP diff-sync id resolution (#600 follow-ups)

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -94,12 +94,70 @@ would treat `"0042"`-style values as numbers. This key is honored identically on
 both grading substrates (the core `GradingEngine`/`to_hashable` path and the
 runner gRPC/`compute_stable_hash` path).
 
+### Declaring a table's primary key for non-`id` tables
+
+The grader finds and writes records by primary key and assumes the key column is
+literally `id`. Tables keyed by something else (e.g. a `<name>_id` column) must
+declare it, or upserts/deletes cannot resolve the key. Declare it per table under
+`state_checks.id_fields`; a table absent from the map defaults to `"id"`, so
+`id`-keyed domains need nothing:
+
+```yaml
+state_checks:
+  hash:
+    enabled: true
+    weight: 1.0
+  id_fields:                          # per-table primary-key override; absent => "id"
+    widgets: widget_id
+    line_items: line_id
+```
+
+Map keys are the table names as they appear in `initial_state`. This is config
+data that travels with the task, so key resolution never depends on reading model
+source at runtime (the previous `inspect.getsource`-based guess broke whenever the
+domain source was not on disk). A table keyed by neither `"id"` nor a declared
+field fails loud at write time with the exact `id_fields` entry to add. The
+MCP-subprocess and Tau diff-sync paths (`_sync_mcp_state_to_db`,
+`TauSyncToolWrapper._sync_state_changes`) consult the same map, so records with
+their key omitted also fail loud instead of collapsing to a single `None` bucket
+and silently corrupting the state diff.
+
+The adapter cross-checks the `id_fields` keys against `initial_state.tables` at
+task-description build time — a typo names an "unknown table" and the pack fails
+loud with the exact remediation (fix the typo, add the table, or opt in below).
+Legacy tasks that pre-date the check can downgrade the raise to a warning:
+
+```yaml
+state_checks:
+  id_fields:
+    legacy_widgets: widget_id
+  relaxed_validation: true            # temporary — legacy escape hatch only
+```
+
+`relaxed_validation` defaults to `false`; new tasks should fix typos rather than
+enable it. The runner also runs the same check as belt-and-suspenders for engines
+that bypass `NativeAdapter.to_task_description`.
+
+**Tables materialized only by `initialization_actions`**: the cross-check reads
+`initial_state.tables` (typically populated from `initial_state.json_db`). A
+table that first appears only via an `initialization_action` won't be visible to
+the check — an `id_fields` entry for such a table needs `relaxed_validation:
+true` today. Add the table to `initial_state.json_db` (even with an empty list)
+if you want the strict check to accept it.
+
+**Runner-engine version lock**: `id_fields` and `relaxed_validation` are declared
+on the runner-side `StateChecksConfig` (`extra="forbid"`), so a new engine emitting
+these keys requires a runner image built from the same release. Old engine + new
+runner is safe (core-side `extra="ignore"`).
+
 ### Best Practices
 
 - Filter non-deterministic fields (timestamps, UUIDs) before hashing
 - Prefer golden-action replay over storing a hash literal; if you must store one,
   recompute it whenever the hashing algorithm changes (see the callout above)
 - Fold numeric strings per-field (`numeric_string_fields`), never as a global switch
+- Declare non-`id` primary keys per table (`id_fields`); leave `id`-keyed tables unset
+- Use `relaxed_validation` only as a short-lived escape hatch for legacy tasks
 - Combine with JSONPath assertions using `weight: 0.8` for flexibility
 
 ---

--- a/tests/canonical/snapshots/native_browser_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/grading_config.json
@@ -14,6 +14,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [],
     "numeric_string_fields": [],
     "relaxed_validation": false

--- a/tests/canonical/snapshots/native_calc_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/grading_config.json
@@ -15,7 +15,8 @@
     "env_assertions": [],
     "hash": null,
     "jsonpaths": [],
-    "numeric_string_fields": []
+    "numeric_string_fields": [],
+    "relaxed_validation": false
   },
   "transcript_rules": {
     "communicate_info": [],

--- a/tests/canonical/snapshots/native_calc_basic/grading_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/grading_config.json
@@ -14,6 +14,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [],
     "numeric_string_fields": [],
     "relaxed_validation": false

--- a/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
@@ -20,7 +20,8 @@
         "path": "$.db.items"
       }
     ],
-    "numeric_string_fields": []
+    "numeric_string_fields": [],
+    "relaxed_validation": false
   },
   "transcript_rules": null
 }

--- a/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/grading_config.json
@@ -13,6 +13,7 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {},
     "jsonpaths": [
       {
         "description": "items remain empty (no-op task)",

--- a/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
@@ -80,7 +80,8 @@
         "path": "$.db.products[1].stock"
       }
     ],
-    "numeric_string_fields": []
+    "numeric_string_fields": [],
+    "relaxed_validation": false
   },
   "transcript_rules": {
     "communicate_info": [

--- a/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/grading_config.json
@@ -43,6 +43,7 @@
       ],
       "weight": 0.6
     },
+    "id_fields": {},
     "jsonpaths": [
       {
         "description": "First order is assigned ID O-001",

--- a/tests/canonical/snapshots/native_widgets_id_fields/grading_config.json
+++ b/tests/canonical/snapshots/native_widgets_id_fields/grading_config.json
@@ -3,8 +3,8 @@
     "method": "weighted",
     "pass_threshold": 0.7,
     "weights": {
-      "state_checks": 0.6,
-      "transcript_rules": 0.4
+      "state_checks": 1.0,
+      "transcript_rules": 0.0
     }
   },
   "custom_checks": null,
@@ -14,6 +14,9 @@
     "db_probes": [],
     "env_assertions": [],
     "hash": null,
+    "id_fields": {
+      "widgets": "widget_id"
+    },
     "jsonpaths": [],
     "numeric_string_fields": [],
     "relaxed_validation": false
@@ -21,15 +24,9 @@
   "transcript_rules": {
     "communicate_info": [],
     "disallow_regex": [],
-    "max_turns": 15,
+    "max_turns": 5,
     "must_contain": [],
     "required_actions": [],
-    "tool_expectations": {
-      "disallowed_tools": [],
-      "required_tools": [
-        "browser",
-        "write_file"
-      ]
-    }
+    "tool_expectations": null
   }
 }

--- a/tests/canonical/test_native_adapter_canon.py
+++ b/tests/canonical/test_native_adapter_canon.py
@@ -66,6 +66,31 @@ class TestNativeAdapterCanon:
         snap.assert_match(actual, "grading_config.json")
 
 
+class TestWidgetsIdFieldsCanon:
+    """Canonical coverage for a non-``id``-keyed table with declared ``id_fields``.
+
+    Every other snapshot in this suite serializes ``id_fields: {}`` because the
+    existing fixtures happen to be id-keyed. This fixture locks in the
+    round-trip for the shape production packs actually use (tau_manufacturing
+    lot_id, travel_marketplace reservation_id, etc.) — so a regression that
+    drops or renames ``id_fields`` / ``relaxed_validation`` on the runner-side
+    ``StateChecksConfig`` fails the snapshot immediately.
+    """
+
+    def test_grading_config(self, native_adapter, canon_snapshot):
+        grading = native_adapter.get_grading_config("widgets_id_fields")
+        snap = canon_snapshot("native_widgets_id_fields")
+        snap.assert_match(grading.model_dump(mode="json"), "grading_config.json")
+
+    def test_task_description_carries_id_fields(self, native_adapter):
+        # Full to_task_description round-trip: initial_state.tables and the
+        # declared id_fields survive to the runner-facing TaskDescription.
+        td = native_adapter.to_task_description("widgets_id_fields")
+        assert td.grading.state_checks.id_fields == {"widgets": "widget_id"}
+        assert td.grading.state_checks.relaxed_validation is False
+        assert td.initial_state and "widgets" in td.initial_state.tables
+
+
 class TestNativeAdapterDomainCanon:
     """Canonical tests for the shared-domain layout.
 

--- a/tests/canonical/test_native_adapter_canon.py
+++ b/tests/canonical/test_native_adapter_canon.py
@@ -67,14 +67,11 @@ class TestNativeAdapterCanon:
 
 
 class TestWidgetsIdFieldsCanon:
-    """Canonical coverage for a non-``id``-keyed table with declared ``id_fields``.
+    """Canonical coverage for a table keyed by a non-``id`` column.
 
-    Every other snapshot in this suite serializes ``id_fields: {}`` because the
-    existing fixtures happen to be id-keyed. This fixture locks in the
-    round-trip for the shape production packs actually use (tau_manufacturing
-    lot_id, travel_marketplace reservation_id, etc.) — so a regression that
-    drops or renames ``id_fields`` / ``relaxed_validation`` on the runner-side
-    ``StateChecksConfig`` fails the snapshot immediately.
+    The fixture declares ``id_fields: {widgets: widget_id}`` and asserts the
+    runner-side ``StateChecksConfig`` serializes both ``id_fields`` and
+    ``relaxed_validation`` in the emitted grading config.
     """
 
     def test_grading_config(self, native_adapter, canon_snapshot):

--- a/tests/data/tasks/widgets_id_fields/grading.yaml
+++ b/tests/data/tasks/widgets_id_fields/grading.yaml
@@ -1,0 +1,17 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 1.0
+    transcript_rules: 0.0
+  pass_threshold: 0.7
+
+state_checks:
+  jsonpaths: []
+  id_fields:
+    widgets: widget_id
+
+transcript_rules:
+  max_turns: 5
+  disallow_regex: []
+
+llm_judge: null

--- a/tests/data/tasks/widgets_id_fields/initial_state.json
+++ b/tests/data/tasks/widgets_id_fields/initial_state.json
@@ -1,0 +1,6 @@
+{
+  "widgets": [
+    {"widget_id": "W1", "status": "pending"},
+    {"widget_id": "W2", "status": "active"}
+  ]
+}

--- a/tests/data/tasks/widgets_id_fields/task.yaml
+++ b/tests/data/tasks/widgets_id_fields/task.yaml
@@ -1,0 +1,28 @@
+task_id: widgets_id_fields
+name: "Widgets (non-id-keyed) canonical fixture"
+category: test
+description: |
+  Canonical fixture locking in state_checks.id_fields serialization for a
+  domain whose primary table is keyed by widget_id (not the literal "id").
+  Mirrors the shape used by production packs (tau_manufacturing lot_id,
+  travel_marketplace reservation_id, etc.).
+
+initial_state:
+  json_db: initial_state.json
+
+tools:
+  agent:
+    enabled:
+      - write_file
+  user:
+    enabled: []
+
+user_simulator:
+  mode: scripted
+  scripted_flow: []
+
+policies:
+  disallowed_actions: []
+  guidance: []
+
+grading: grading.yaml

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,11 +8,32 @@ gets a fake wheel artifact instead of triggering a real wheel build.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 from tolokaforge.docker.wheel_resolver import WheelArtifact
+
+
+class FakeMutatingDBClient:
+    """Recorder for ``mutate`` calls; answers ``get_state`` from a seeded store.
+
+    Shared between the Tau and MCP diff-sync tests — both drive a diff path
+    that only touches these two methods on the DB client.
+    """
+
+    def __init__(self, state: dict[str, list[dict]] | None = None) -> None:
+        self._state = {t: [dict(r) for r in v] for t, v in (state or {}).items()}
+        self.mutations: list[tuple[str, list[dict]]] = []
+
+    async def get_state(self, trial_id: str) -> Any:
+        return SimpleNamespace(data=self._state)
+
+    async def mutate(self, trial_id: str, table_name: str, operations: list[dict]) -> Any:
+        self.mutations.append((table_name, operations))
+        return SimpleNamespace(success=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_db_proxy_id_fields.py
+++ b/tests/unit/test_db_proxy_id_fields.py
@@ -1,0 +1,232 @@
+"""Config-driven per-table id-field resolution in DBServiceProxy.
+
+Covers the fix for the fragile ``inspect.getsource``-based key resolution that
+broke upserts/deletes for tables keyed by a natural key (not the literal ``id``,
+e.g. a ``widget_id`` column) whenever the model's source file was not readable at
+runtime.
+
+The proxy now resolves the key field from config (``state_checks.id_fields``)
+with a literal ``"id"`` default, so behaviour is data-driven and stable across
+runtimes. A fake DB client records the mutation payloads the proxy emits and
+answers query/get_state from an in-memory store.
+"""
+
+import inspect
+import re
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from tolokaforge.runner.db_proxy import DBServiceProxy, IdFieldResolutionError
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class WidgetLike(BaseModel):
+    """Keyed by ``widget_id`` (no ``id`` field) — the shape that broke the old path."""
+
+    model_config = {"extra": "forbid"}
+
+    widget_id: str
+    status: str = "new"
+
+    def get_id(self) -> str:
+        return self.widget_id
+
+
+class IdKeyed(BaseModel):
+    """Keyed by the literal ``id`` — the default, must stay byte-for-byte unchanged."""
+
+    model_config = {"extra": "forbid"}
+
+    id: str
+    name: str = ""
+
+    def get_id(self) -> str:
+        return self.id
+
+
+class EmailKeyed(BaseModel):
+    """Keyed by ``email`` — read must still work unconfigured via the fallback scan."""
+
+    model_config = {"extra": "forbid"}
+
+    email: str
+    name: str = ""
+
+    def get_id(self) -> str:
+        return self.email
+
+
+def _make_dynamic_model() -> type[BaseModel]:
+    """Define a model via ``exec()`` so ``inspect.getsource(get_id)`` raises OSError,
+    reproducing the runtime condition (source not on disk) that broke the old resolver."""
+    ns: dict = {}
+    exec(
+        "from pydantic import BaseModel\n"
+        "class Dyn(BaseModel):\n"
+        "    model_config = {'extra': 'forbid'}\n"
+        "    dyn_id: str\n"
+        "    def get_id(self):\n"
+        "        return self.dyn_id\n",
+        ns,
+    )
+    return ns["Dyn"]
+
+
+# ---------------------------------------------------------------------------
+# Fake DB client
+# ---------------------------------------------------------------------------
+
+
+class FakeDBClient:
+    """Records mutation payloads; answers query/get_state from an in-memory store."""
+
+    def __init__(self, state: dict | None = None):
+        self.state = {k: [dict(r) for r in v] for k, v in (state or {}).items()}
+        self.mutations: list[tuple[str, list[dict]]] = []
+        self.queries: list[str] = []
+
+    async def query(self, trial_id, jsonpath):
+        self.queries.append(jsonpath)
+        m = re.match(
+            r"\$\.(?P<table>[^\[]+)\[\?\(@\.(?P<field>[^=]+)=='(?P<value>[^']*)'\)\]",
+            jsonpath,
+        )
+        results = []
+        if m:
+            for rec in self.state.get(m["table"], []):
+                if str(rec.get(m["field"])) == m["value"]:
+                    results.append(rec)
+        return SimpleNamespace(results=results)
+
+    async def get_state(self, trial_id, tables=None):
+        keys = tables if tables is not None else list(self.state)
+        return SimpleNamespace(data={t: self.state.get(t, []) for t in keys})
+
+    async def mutate(self, trial_id, table_name, operations):
+        self.mutations.append((table_name, operations))
+        return SimpleNamespace(success=True)
+
+
+def _proxy(table, model_cls, *, id_fields=None, state=None):
+    client = FakeDBClient(state=state)
+    proxy = DBServiceProxy(
+        client,
+        "trial:0",
+        model_registry={table: model_cls},
+        db_table_names=[table],
+        id_fields=id_fields,
+    )
+    return proxy, client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_update_uses_configured_key():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    await proxy.update(WidgetLike(widget_id="W1", status="ready"))
+    table, ops = client.mutations[-1]
+    assert table == "widgets"
+    assert ops[0]["op"] == "upsert"
+    assert ops[0]["key"] == "widget_id"  # config-resolved, not "id"
+
+
+async def test_update_defaults_to_id_unchanged():
+    proxy, client = _proxy(
+        "items",
+        IdKeyed,
+        state={"items": [{"id": "X1", "name": "a"}]},
+    )
+    await proxy.update(IdKeyed(id="X1", name="b"))
+    _, ops = client.mutations[-1]
+    assert ops[0]["key"] == "id"  # default path byte-for-byte unchanged
+
+
+async def test_delete_uses_configured_key():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    await proxy.delete(WidgetLike(widget_id="W1"))
+    _, ops = client.mutations[-1]
+    assert ops[0]["op"] == "delete"
+    assert ops[0]["filter"] == {"widget_id": "W1"}  # not {"id": ...} (was a silent no-op)
+
+
+async def test_get_by_id_queries_only_configured_field():
+    proxy, client = _proxy(
+        "widgets",
+        WidgetLike,
+        id_fields={"widgets": "widget_id"},
+        state={"widgets": [{"widget_id": "W1", "status": "new"}]},
+    )
+    found = await proxy.get_by_id(WidgetLike, "W1")
+    assert found is not None and found.widget_id == "W1"
+    assert any("@.widget_id==" in q for q in client.queries)
+    assert not any("@.id==" in q for q in client.queries)  # never probes literal "id"
+
+
+async def test_resolve_id_field_fails_loud_when_unconfigured():
+    proxy, _ = _proxy("widgets", WidgetLike)  # no id_fields, model has no "id"
+    with pytest.raises(IdFieldResolutionError) as ei:
+        proxy._resolve_id_field(WidgetLike)
+    msg = str(ei.value)
+    assert "widgets" in msg and "id_fields" in msg  # actionable: names table + the fix
+
+
+async def test_resolve_id_field_immune_to_missing_source():
+    """The old resolver parsed ``inspect.getsource(get_id)``; a model whose source is
+    unavailable made it raise. The config path must resolve regardless."""
+    Dyn = _make_dynamic_model()
+    with pytest.raises(OSError):
+        inspect.getsource(Dyn.get_id)  # confirm the source is genuinely unreadable
+    proxy, _ = _proxy("dyn", Dyn, id_fields={"dyn": "dyn_id"})
+    assert proxy._resolve_id_field(Dyn) == "dyn_id"
+
+
+async def test_email_keyed_read_works_unconfigured_via_fallback():
+    proxy, _ = _proxy(
+        "users",
+        EmailKeyed,
+        state={"users": [{"email": "a@x.io", "name": "A"}]},
+    )
+    found = await proxy.get_by_id(EmailKeyed, "a@x.io")
+    assert found is not None and found.email == "a@x.io"  # full-scan fallback
+
+
+def test_copy_preserves_id_fields():
+    proxy, _ = _proxy("widgets", WidgetLike, id_fields={"widgets": "widget_id"})
+    assert proxy.copy()._id_fields == {"widgets": "widget_id"}
+
+
+def test_state_checks_config_rejects_blank_id_field():
+    """The config validator fails loud on blank table names / key fields, so a
+    malformed override can never reach the proxy (where blank folds to 'id')."""
+    from pydantic import ValidationError
+
+    from tolokaforge.runner.models import StateChecksConfig
+
+    with pytest.raises(ValidationError):
+        StateChecksConfig(id_fields={"widgets": ""})  # blank key field
+    with pytest.raises(ValidationError):
+        StateChecksConfig(id_fields={"  ": "widget_id"})  # blank table name
+    assert StateChecksConfig(id_fields={"widgets": "widget_id"}).id_fields == {
+        "widgets": "widget_id"
+    }

--- a/tests/unit/test_id_resolution.py
+++ b/tests/unit/test_id_resolution.py
@@ -1,0 +1,71 @@
+"""Unit tests for :mod:`tolokaforge.runner.id_resolution`.
+
+The shared helper backs three diff-sync paths (DB proxy for tools, Tau
+in-memory sync, MCP subprocess sync). These tests exercise it directly so
+failures point at the helper rather than at a caller's plumbing.
+"""
+
+import pytest
+
+from tolokaforge.runner.id_resolution import (
+    IdFieldResolutionError,
+    id_field_for_table,
+    resolve_record_id,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_id_field_for_table_configured_wins():
+    assert id_field_for_table("widgets", {"widgets": "widget_id"}) == "widget_id"
+
+
+def test_id_field_for_table_defaults_to_id():
+    assert id_field_for_table("users", {}) == "id"
+    assert id_field_for_table("users", {"widgets": "widget_id"}) == "id"
+
+
+def test_id_field_for_table_blank_configured_falls_through_to_id():
+    # ``or`` (not ``.get(..., "id")``) so blank config folds to the default,
+    # matching the DB proxy's resolver.
+    assert id_field_for_table("widgets", {"widgets": ""}) == "id"
+
+
+def test_resolve_record_id_configured_key():
+    value = resolve_record_id(
+        {"widget_id": "W1", "status": "new"},
+        "widgets",
+        {"widgets": "widget_id"},
+    )
+    assert value == "W1"
+
+
+def test_resolve_record_id_defaults_to_id_field():
+    value = resolve_record_id({"id": "X1", "name": "a"}, "items", {})
+    assert value == "X1"
+
+
+def test_resolve_record_id_missing_key_raises():
+    with pytest.raises(IdFieldResolutionError) as ei:
+        resolve_record_id({"widget_id": "W1"}, "widgets", {})
+    # The default "id" was resolved (no config), record doesn't have it → fail loud.
+    msg = str(ei.value)
+    assert "widgets" in msg
+    assert "'id'" in msg
+    assert "widget_id" in msg  # record keys surfaced for debugging
+
+
+def test_resolve_record_id_wrong_configured_key_raises():
+    with pytest.raises(IdFieldResolutionError) as ei:
+        resolve_record_id({"id": "X1"}, "widgets", {"widgets": "widget_id"})
+    msg = str(ei.value)
+    assert "widget_id" in msg
+    assert "widgets" in msg
+    assert "state_checks.id_fields" in msg  # points authors at the fix
+
+
+def test_resolve_record_id_falsy_value_returned_not_raised():
+    # Key present with a falsy value (0, "", False) must return the value,
+    # not treat the record as keyless.
+    assert resolve_record_id({"id": 0, "name": "a"}, "items", {}) == 0
+    assert resolve_record_id({"id": "", "name": "a"}, "items", {}) == ""

--- a/tests/unit/test_id_resolution.py
+++ b/tests/unit/test_id_resolution.py
@@ -5,10 +5,14 @@ in-memory sync, MCP subprocess sync). These tests exercise it directly so
 failures point at the helper rather than at a caller's plumbing.
 """
 
+import logging
+
 import pytest
 
 from tolokaforge.runner.id_resolution import (
     IdFieldResolutionError,
+    check_id_fields_reference_known_tables,
+    compute_diff_ops,
     id_field_for_table,
     resolve_record_id,
 )
@@ -69,3 +73,100 @@ def test_resolve_record_id_falsy_value_returned_not_raised():
     # not treat the record as keyless.
     assert resolve_record_id({"id": 0, "name": "a"}, "items", {}) == 0
     assert resolve_record_id({"id": "", "name": "a"}, "items", {}) == ""
+
+
+# ---------------------------------------------------------------------------
+# check_id_fields_reference_known_tables — shared by NativeAdapter and the
+# runner's RegisterTrial belt-and-suspenders block.
+# ---------------------------------------------------------------------------
+
+
+def test_check_returns_none_when_id_fields_empty():
+    assert (
+        check_id_fields_reference_known_tables({}, ["widgets"], context="t", relaxed=False) is None
+    )
+
+
+def test_check_returns_none_when_all_tables_known():
+    assert (
+        check_id_fields_reference_known_tables(
+            {"widgets": "widget_id"}, ["widgets", "users"], context="t", relaxed=False
+        )
+        is None
+    )
+
+
+def test_check_returns_error_string_on_unknown_table():
+    err = check_id_fields_reference_known_tables(
+        {"widgetz": "widget_id"}, ["widgets"], context="task_x", relaxed=False
+    )
+    assert err is not None
+    assert "task_x" in err  # context prefix included
+    assert "widgetz" in err  # unknown key surfaced
+    assert "widgets" in err  # known tables listed
+    assert "relaxed_validation" in err  # escape-hatch hint
+
+
+def test_check_returns_none_when_relaxed_but_logs_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        err = check_id_fields_reference_known_tables(
+            {"widgetz": "widget_id"}, ["widgets"], context="task_x", relaxed=True
+        )
+    assert err is None
+    warns = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert any("widgetz" in rec.getMessage() for rec in warns)
+
+
+def test_check_message_shape_stable_across_call_sites():
+    # NativeAdapter and RunnerServiceImpl.RegisterTrial both call this helper;
+    # the message must remain actionable regardless of the `context` prefix.
+    for context in ("widgets_task", "RegisterTrial: trial-42"):
+        err = check_id_fields_reference_known_tables(
+            {"unknown_tbl": "id"}, ["widgets"], context=context, relaxed=False
+        )
+        assert err is not None
+        assert context in err
+        assert "Fix a typo" in err
+
+
+# ---------------------------------------------------------------------------
+# compute_diff_ops — shared by TauSyncToolWrapper and _sync_mcp_state_to_db.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_diff_ops_emits_inserts_then_upserts_then_deletes():
+    # Ordering matters for downstream consumers: pre-refactor call sites emitted
+    # [all inserts, all upserts, all deletes]. This locks the batch shape.
+    before = [{"id": "A", "v": 1}, {"id": "B", "v": 2}]
+    after = [{"id": "A", "v": 1}, {"id": "B", "v": 99}, {"id": "C", "v": 3}]
+    ops = compute_diff_ops(before, after, "items", {})
+    op_order = [op["op"] for op in ops]
+    assert op_order == ["insert", "upsert"]  # A unchanged, B changed, C new
+
+
+def test_compute_diff_ops_delete_uses_resolved_key():
+    ops = compute_diff_ops(
+        [{"lot_id": "L1"}, {"lot_id": "L2"}],
+        [{"lot_id": "L1"}],
+        "lots",
+        {"lots": "lot_id"},
+    )
+    deletes = [op for op in ops if op["op"] == "delete"]
+    assert deletes == [{"op": "delete", "filter": {"lot_id": "L2"}}]
+
+
+def test_compute_diff_ops_raises_on_duplicate_key():
+    with pytest.raises(IdFieldResolutionError) as ei:
+        compute_diff_ops(
+            [{"id": "A"}, {"id": "A"}],  # two records collapse to one — silent-corruption class
+            [],
+            "items",
+            {},
+        )
+    msg = str(ei.value)
+    assert "Duplicate" in msg
+    assert "items" in msg
+
+
+def test_compute_diff_ops_empty_both_sides():
+    assert compute_diff_ops([], [], "items", {}) == []

--- a/tests/unit/test_mcp_diff_sync_id_fields.py
+++ b/tests/unit/test_mcp_diff_sync_id_fields.py
@@ -87,14 +87,10 @@ async def test_missing_key_raises_on_diff_side():
     assert "lots" in str(ei.value)
 
 
-async def test_missing_trial_yields_empty_id_fields():
-    # Defensive: GetState uses self.trials.get(trial_id); if the servicer is
-    # asked to sync for a trial it never registered (edge case), the id_fields
-    # lookup must degrade to {} rather than raise a KeyError.
-    servicer = _make_servicer(id_fields=None, current_state={"items": []})
-    servicer.trials = {}  # trial:0 not registered
-    new_state = {"items": [{"id": "X1"}]}
-
-    await servicer._sync_mcp_state_to_db("trial:0", new_state)
-    _table, ops = servicer.db_client.mutations[-1]
-    assert ops[0]["op"] == "insert"
+async def test_no_op_when_state_unchanged():
+    servicer = _make_servicer(
+        id_fields=None,
+        current_state={"items": [{"id": "X1", "name": "a"}]},
+    )
+    await servicer._sync_mcp_state_to_db("trial:0", {"items": [{"id": "X1", "name": "a"}]})
+    assert servicer.db_client.mutations == []

--- a/tests/unit/test_mcp_diff_sync_id_fields.py
+++ b/tests/unit/test_mcp_diff_sync_id_fields.py
@@ -1,0 +1,100 @@
+"""Config-driven per-table id-field resolution in ``RunnerServiceImpl._sync_mcp_state_to_db``.
+
+The MCP subprocess diff-sync runs on the grading critical path (before
+``get_stable_hash``), so a wrong key would silently mis-hash rather than
+crashing. These tests assert upsert/delete ops carry the configured key and
+that missing keys fail loud.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.unit.conftest import FakeMutatingDBClient
+from tolokaforge.runner.id_resolution import IdFieldResolutionError
+from tolokaforge.runner.service import RunnerServiceImpl
+
+pytestmark = pytest.mark.unit
+
+
+def _make_servicer(
+    *,
+    id_fields: dict[str, str] | None = None,
+    current_state: dict[str, list[dict]] | None = None,
+) -> RunnerServiceImpl:
+    """Build a RunnerServiceImpl with the minimum state _sync_mcp_state_to_db reads."""
+    servicer = RunnerServiceImpl.__new__(RunnerServiceImpl)
+    servicer.db_client = FakeMutatingDBClient(state=current_state)
+    trial = SimpleNamespace(
+        task_description=SimpleNamespace(
+            grading=SimpleNamespace(state_checks=SimpleNamespace(id_fields=dict(id_fields or {})))
+        )
+    )
+    servicer.trials = {"trial:0": trial}
+    return servicer
+
+
+async def test_upsert_uses_configured_key():
+    servicer = _make_servicer(
+        id_fields={"lots": "lot_id"},
+        current_state={"lots": [{"lot_id": "L1", "status": "open"}]},
+    )
+    new_state = {"lots": [{"lot_id": "L1", "status": "released"}]}
+
+    await servicer._sync_mcp_state_to_db("trial:0", new_state)
+
+    _table, ops = servicer.db_client.mutations[-1]
+    upsert = next(op for op in ops if op["op"] == "upsert")
+    assert upsert["key"] == "lot_id"
+
+
+async def test_delete_filter_uses_configured_key():
+    servicer = _make_servicer(
+        id_fields={"lots": "lot_id"},
+        current_state={"lots": [{"lot_id": "L1", "status": "open"}]},
+    )
+    new_state: dict[str, list[dict]] = {"lots": []}
+
+    await servicer._sync_mcp_state_to_db("trial:0", new_state)
+
+    _table, ops = servicer.db_client.mutations[-1]
+    delete = next(op for op in ops if op["op"] == "delete")
+    assert delete["filter"] == {"lot_id": "L1"}
+
+
+async def test_defaults_to_id_key_unchanged():
+    servicer = _make_servicer(
+        id_fields=None,
+        current_state={"items": [{"id": "X1", "name": "a"}]},
+    )
+    new_state = {"items": [{"id": "X1", "name": "b"}]}
+
+    await servicer._sync_mcp_state_to_db("trial:0", new_state)
+
+    _table, ops = servicer.db_client.mutations[-1]
+    upsert = next(op for op in ops if op["op"] == "upsert")
+    assert upsert["key"] == "id"
+
+
+async def test_missing_key_raises_on_diff_side():
+    # id_fields undeclared but records keyed by lot_id → fail loud rather than
+    # collapsing every record to a single ``None`` bucket.
+    servicer = _make_servicer(id_fields=None, current_state={"lots": []})
+    new_state = {"lots": [{"lot_id": "L1"}, {"lot_id": "L2"}]}
+
+    with pytest.raises(IdFieldResolutionError) as ei:
+        await servicer._sync_mcp_state_to_db("trial:0", new_state)
+    assert "lots" in str(ei.value)
+
+
+async def test_missing_trial_yields_empty_id_fields():
+    # Defensive: GetState uses self.trials.get(trial_id); if the servicer is
+    # asked to sync for a trial it never registered (edge case), the id_fields
+    # lookup must degrade to {} rather than raise a KeyError.
+    servicer = _make_servicer(id_fields=None, current_state={"items": []})
+    servicer.trials = {}  # trial:0 not registered
+    new_state = {"items": [{"id": "X1"}]}
+
+    await servicer._sync_mcp_state_to_db("trial:0", new_state)
+    _table, ops = servicer.db_client.mutations[-1]
+    assert ops[0]["op"] == "insert"

--- a/tests/unit/test_native_adapter_id_fields_validation.py
+++ b/tests/unit/test_native_adapter_id_fields_validation.py
@@ -1,0 +1,138 @@
+"""Adapter-side cross-check: ``state_checks.id_fields`` keys must exist in ``initial_state``.
+
+Runs inside :meth:`NativeAdapter.to_task_description` — the earliest surface
+where task authors see conversion output. Fail loud on typos so a bad task
+doesn't reach the runner and hard-fail at trial time on a message the author
+never sees.
+
+``state_checks.relaxed_validation: true`` downgrades the raise to a warning
+for legacy tasks that pre-date the check.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters.native import NativeAdapter
+
+pytestmark = pytest.mark.unit
+
+
+def _write_task_pack(
+    root: Path,
+    *,
+    initial_state: dict,
+    id_fields: dict[str, str] | None,
+    relaxed: bool = False,
+) -> Path:
+    """Emit a minimal native task pack at ``root/tasks/widgets/`` and return the base dir."""
+    task_dir = root / "tasks" / "widgets"
+    task_dir.mkdir(parents=True)
+
+    (task_dir / "initial_state.json").write_text(json.dumps(initial_state))
+    (task_dir / "task.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "task_id": "widgets",
+                "name": "Widgets test",
+                "category": "test",
+                "description": "id_fields cross-check fixture",
+                "initial_state": {"json_db": "initial_state.json"},
+                "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+                "user_simulator": {
+                    "mode": "scripted",
+                    "scripted_flow": [{"role": "user", "content": "hi"}],
+                },
+                "policies": {"disallowed_actions": [], "guidance": []},
+                "grading": "grading.yaml",
+            }
+        )
+    )
+
+    state_checks: dict = {"jsonpaths": []}
+    if id_fields is not None:
+        state_checks["id_fields"] = id_fields
+    if relaxed:
+        state_checks["relaxed_validation"] = True
+
+    (task_dir / "grading.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "combine": {
+                    "method": "weighted",
+                    "weights": {"state_checks": 1.0, "transcript_rules": 0.0},
+                    "pass_threshold": 0.7,
+                },
+                "state_checks": state_checks,
+                "transcript_rules": {"max_turns": 5, "disallow_regex": []},
+                "llm_judge": None,
+            }
+        )
+    )
+    return root
+
+
+def _adapter(root: Path) -> NativeAdapter:
+    return NativeAdapter({"base_dir": str(root), "tasks_glob": "tasks/**/task.yaml"})
+
+
+def test_matching_tables_passes(tmp_path: Path) -> None:
+    _write_task_pack(
+        tmp_path,
+        initial_state={"widgets": [{"widget_id": "W1"}]},
+        id_fields={"widgets": "widget_id"},
+    )
+    adapter = _adapter(tmp_path)
+    td = adapter.to_task_description("widgets")
+    assert td.grading.state_checks.id_fields == {"widgets": "widget_id"}
+    assert td.grading.state_checks.relaxed_validation is False
+
+
+def test_unknown_table_raises(tmp_path: Path) -> None:
+    _write_task_pack(
+        tmp_path,
+        initial_state={"widgets": [{"widget_id": "W1"}]},
+        id_fields={"widgetz": "widget_id"},  # typo
+    )
+    adapter = _adapter(tmp_path)
+    with pytest.raises(ValueError) as ei:
+        adapter.to_task_description("widgets")
+    msg = str(ei.value)
+    assert "widgetz" in msg  # names the unknown key
+    assert "widgets" in msg  # surfaces the known table
+    assert "relaxed_validation" in msg  # hints at the escape hatch
+
+
+def test_unknown_table_with_relaxed_warns(tmp_path: Path, caplog) -> None:
+    _write_task_pack(
+        tmp_path,
+        initial_state={"widgets": [{"widget_id": "W1"}]},
+        id_fields={"widgetz": "widget_id"},
+        relaxed=True,
+    )
+    adapter = _adapter(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        td = adapter.to_task_description("widgets")
+
+    # Warning was emitted, but the task built successfully.
+    warns = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert any("widgetz" in rec.getMessage() for rec in warns)
+    assert td.grading.state_checks.relaxed_validation is True
+
+
+def test_empty_id_fields_never_raises(tmp_path: Path) -> None:
+    # Backward compat: tasks that don't declare id_fields see zero behaviour change.
+    _write_task_pack(
+        tmp_path,
+        initial_state={"items": [{"id": "X1"}]},
+        id_fields=None,
+    )
+    adapter = _adapter(tmp_path)
+    td = adapter.to_task_description("widgets")
+    assert td.grading.state_checks.id_fields == {}

--- a/tests/unit/test_tau_sync_id_fields.py
+++ b/tests/unit/test_tau_sync_id_fields.py
@@ -66,7 +66,7 @@ async def test_defaults_to_id_key_unchanged():
 
     (_table, ops) = wrapper.db_proxy._async_proxy.db_client.mutations[-1]
     upsert = next(op for op in ops if op["op"] == "upsert")
-    assert upsert["key"] == "id"  # byte-for-byte compatible with pre-fix behavior
+    assert upsert["key"] == "id"
 
 
 async def test_missing_key_raises_on_diff_side():

--- a/tests/unit/test_tau_sync_id_fields.py
+++ b/tests/unit/test_tau_sync_id_fields.py
@@ -1,0 +1,81 @@
+"""Config-driven per-table id-field resolution in :class:`TauSyncToolWrapper`.
+
+The Tau in-memory diff-sync path emits upsert and delete ops keyed on the
+resolved id_field. These tests assert both ops carry the configured key and
+that a keyless record raises fail-loud.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.unit.conftest import FakeMutatingDBClient
+from tolokaforge.runner.id_resolution import IdFieldResolutionError
+from tolokaforge.runner.tool_factory import TauSyncToolWrapper
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeSyncProxy:
+    """Minimal shape TauSyncToolWrapper._sync_state_changes uses."""
+
+    def __init__(self) -> None:
+        self.trial_id = "trial:0"
+        self._async_proxy = SimpleNamespace(db_client=FakeMutatingDBClient())
+
+
+def _make_wrapper(id_fields: dict[str, str] | None = None) -> TauSyncToolWrapper:
+    # Skip ToolWrapper.__init__ (needs a full ToolSchemaModel); we only exercise
+    # _sync_state_changes, which reads db_proxy and _id_fields only.
+    wrapper = TauSyncToolWrapper.__new__(TauSyncToolWrapper)
+    wrapper.db_proxy = _FakeSyncProxy()
+    wrapper._id_fields = dict(id_fields or {})
+    return wrapper
+
+
+async def test_upsert_and_delete_use_configured_key():
+    wrapper = _make_wrapper(id_fields={"widgets": "widget_id"})
+    before = {"widgets": [{"widget_id": "W1", "status": "new"}]}
+    after = {"widgets": [{"widget_id": "W1", "status": "ready"}]}
+
+    await wrapper._sync_state_changes(before, after)
+
+    (_table, ops) = wrapper.db_proxy._async_proxy.db_client.mutations[-1]
+    upsert = next(op for op in ops if op["op"] == "upsert")
+    assert upsert["key"] == "widget_id"  # config-resolved, not "id"
+
+
+async def test_delete_filter_uses_configured_key():
+    wrapper = _make_wrapper(id_fields={"widgets": "widget_id"})
+    before = {"widgets": [{"widget_id": "W1", "status": "new"}]}
+    after: dict[str, list[dict]] = {"widgets": []}
+
+    await wrapper._sync_state_changes(before, after)
+
+    (_table, ops) = wrapper.db_proxy._async_proxy.db_client.mutations[-1]
+    delete = next(op for op in ops if op["op"] == "delete")
+    assert delete["filter"] == {"widget_id": "W1"}  # not {"id": "W1"}
+
+
+async def test_defaults_to_id_key_unchanged():
+    wrapper = _make_wrapper(id_fields=None)  # unconfigured → "id" default
+    before = {"items": [{"id": "X1", "name": "a"}]}
+    after = {"items": [{"id": "X1", "name": "b"}]}
+
+    await wrapper._sync_state_changes(before, after)
+
+    (_table, ops) = wrapper.db_proxy._async_proxy.db_client.mutations[-1]
+    upsert = next(op for op in ops if op["op"] == "upsert")
+    assert upsert["key"] == "id"  # byte-for-byte compatible with pre-fix behavior
+
+
+async def test_missing_key_raises_on_diff_side():
+    # A record shaped for lot_id-keyed tables but no id_fields declared —
+    # fail loud so the task author sees the mistake at first sync.
+    wrapper = _make_wrapper(id_fields=None)
+    before: dict[str, list[dict]] = {"lots": []}
+    after = {"lots": [{"lot_id": "L1", "status": "open"}]}
+
+    with pytest.raises(IdFieldResolutionError) as ei:
+        await wrapper._sync_state_changes(before, after)
+    assert "lots" in str(ei.value)

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -18,6 +18,7 @@ from tolokaforge.core.project_loader import (
     resolve_effective_judge_customization,
 )
 from tolokaforge.core.project_loader import resolve as resolve_environment
+from tolokaforge.runner.id_resolution import check_id_fields_reference_known_tables
 
 if TYPE_CHECKING:
     from tolokaforge.runner.models import TaskDescription
@@ -654,6 +655,17 @@ class NativeAdapter(BaseAdapter):
 
                 db_probes = [DbProbe(**probe) for probe in state_checks_data.get("db_probes", [])]
 
+                id_fields_declared = dict(state_checks_data.get("id_fields", {}))
+                relaxed_validation = bool(state_checks_data.get("relaxed_validation", False))
+                err = check_id_fields_reference_known_tables(
+                    id_fields_declared,
+                    list(initial_tables),
+                    context=task_id,
+                    relaxed=relaxed_validation,
+                )
+                if err:
+                    raise ValueError(err)
+
                 state_checks = StateChecksConfig(
                     hash_enabled=bool(hash_config and hash_config.get("enabled", False)),
                     expected_hash=hash_config.get("expected_state_hash") if hash_config else None,
@@ -662,6 +674,8 @@ class NativeAdapter(BaseAdapter):
                     env_assertions=env_assertions,
                     db_probes=db_probes,
                     numeric_string_fields=list(state_checks_data.get("numeric_string_fields", [])),
+                    id_fields=id_fields_declared,
+                    relaxed_validation=relaxed_validation,
                 )
 
             # Build transcript rules

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -1453,6 +1453,29 @@ class StateChecksConfig(BaseModel):
     # core GradingEngine path (to_hashable) and the runner path
     # (compute_stable_hash). See core/hash.py compute_stable_hash.
     numeric_string_fields: list[str] = Field(default_factory=list)
+    # Opt-in, per-table: primary-key field for a table whose key is not the literal
+    # "id" (e.g. {"widgets": "widget_id"}). A table absent from the map
+    # resolves to "id", so id-keyed domains need nothing here. Threaded to the runner
+    # DB proxy so upsert/delete/lookup key resolution is config-driven rather than
+    # introspecting model source (which breaks when the domain source is not on disk).
+    id_fields: dict[str, str] = Field(default_factory=dict)
+    # Escape hatch for legacy tasks: downgrade the adapter's id_fields cross-check
+    # (id_fields keys must appear in initial_state.tables) from a raise to a warning.
+    # New tasks should fix typos or add the table, not enable this.
+    relaxed_validation: bool = False
+
+    @field_validator("id_fields")
+    @classmethod
+    def _validate_id_fields(cls, value: dict[str, str]) -> dict[str, str]:
+        for table, field in value.items():
+            if not (isinstance(table, str) and table.strip()):
+                raise ValueError(f"state_checks.id_fields has a blank table name: {table!r}")
+            if not (isinstance(field, str) and field.strip()):
+                raise ValueError(
+                    f"state_checks.id_fields[{table!r}] must be a non-empty key field, "
+                    f"got {field!r}"
+                )
+        return value
 
 
 class CommunicateInfo(BaseModel):

--- a/tolokaforge/runner/db_proxy.py
+++ b/tolokaforge/runner/db_proxy.py
@@ -40,10 +40,14 @@ from typing import Any, TypeVar
 from pydantic import BaseModel
 
 from tolokaforge.runner.db_client import DBServiceClient
+from tolokaforge.runner.id_resolution import IdFieldResolutionError, id_field_for_table
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+__all__ = ["DBServiceProxy", "SyncDBServiceProxy", "IdFieldResolutionError"]
 
 
 class DBServiceProxy:
@@ -69,6 +73,7 @@ class DBServiceProxy:
         trial_id: str,
         model_registry: dict[str, type[BaseModel]] | None = None,
         db_table_names: list[str] | None = None,
+        id_fields: dict[str, str] | None = None,
     ):
         """
         Initialize the DB Service proxy.
@@ -80,10 +85,17 @@ class DBServiceProxy:
                            If not provided, records are returned as dicts
             db_table_names: Optional list of actual table names from initial_state.
                            Used for fallback table name resolution when model is not registered.
+            id_fields: Optional per-table primary-key overrides (table_name -> key
+                           field), from grading config state_checks.id_fields. A table
+                           absent from the map resolves to the literal "id".
         """
         self.db_client = db_client
         self.trial_id = trial_id
         self.db_table_names = db_table_names or []
+        # Per-table primary-key field (table_name -> key field). Data-driven so
+        # upsert/delete/lookup key resolution never depends on reading model source
+        # at runtime; a table absent here resolves to "id".
+        self._id_fields: dict[str, str] = dict(id_fields or {})
         # Domain name for TypeSense search (used by search_policy tools
         # that call getattr(db, "domain") to look up the registry).
         self.domain: str | None = None
@@ -267,24 +279,26 @@ class DBServiceProxy:
         if hasattr(obj, "id"):
             return obj.id
 
-    def _get_id_field_name(self, obj: BaseModel) -> str:
-        """Get the ID field name of a Pydantic model instance."""
-        if hasattr(obj, "get_id"):
-            import inspect
+    def _resolve_id_field(self, model_cls: type[BaseModel]) -> str:
+        """Primary-key field name for a table's write/delete operations.
 
-            try:
-                source = inspect.getsource(obj.get_id)
-                for line in source.split("\n"):
-                    line = line.strip()
-                    if line.startswith("return self."):
-                        return line.replace("return self.", "").strip()
-            except (TypeError, OSError):
-                pass
-        if hasattr(obj, "id"):
+        Config-first (``state_checks.id_fields``), literal-``"id"`` default, fail
+        loud. When no config is provided, the default is validated against the
+        model's declared fields so a natural-key table (``widget_id`` etc.) with
+        no override raises with the exact YAML to add rather than silently using
+        ``"id"``.
+        """
+        table_name = self._get_table_name(model_cls)
+        if self._id_fields.get(table_name):
+            return id_field_for_table(table_name, self._id_fields)
+        if "id" in getattr(model_cls, "model_fields", {}):
             return "id"
-        raise ValueError(f"Cannot determine ID field name for {type(obj).__name__}")
-
-        raise ValueError(f"Cannot determine ID for object of type {type(obj).__name__}")
+        raise IdFieldResolutionError(
+            f"Cannot determine ID field for table '{table_name}' "
+            f"(model {model_cls.__name__}): no 'id' field and no "
+            f"state_checks.id_fields entry. Add to the task's grading.yaml:\n"
+            f"  state_checks:\n    id_fields:\n      {table_name}: <key_field>"
+        )
 
     # =========================================================================
     # InMemoryDatabase-compatible interface (async versions)
@@ -326,10 +340,10 @@ class DBServiceProxy:
         """
         Get a single item by its ID from the database.
 
-        Uses JSONPath query to find the record. Tries multiple ID field names
-        since different models use different fields as their primary key:
-        - Most models use 'id'
-        - Some models (like Employee) use 'email' as the primary key
+        Resolves the table's key field from config (state_checks.id_fields,
+        default "id"), does one JSONPath lookup, and falls back to a value-based
+        full scan (comparing get_id()) if the lookup misses — so reads succeed for
+        any key shape even without config.
 
         Args:
             model_cls: Pydantic model class
@@ -339,31 +353,22 @@ class DBServiceProxy:
             Model instance or None if not found
         """
         table_name = self._get_table_name(model_cls)
+        id_field = id_field_for_table(table_name, self._id_fields)
 
-        # Try common ID field names in order of likelihood
-        # Most models use 'id', but some use 'email' (e.g., Employee model)
-        id_fields = ["id", "email"]
+        jsonpath = f"$.{table_name}[?(@.{id_field}=='{value}')]"
+        try:
+            response = await self.db_client.query(self.trial_id, jsonpath)
+            # QueryResponse is a Pydantic model with .results attribute
+            if response.results:
+                return self._to_model(model_cls, response.results[0])
+        except Exception as e:
+            logger.debug(f"JSONPath lookup on '{id_field}' failed: {e}")
 
-        for id_field in id_fields:
-            # Use JSONPath query to find by ID field
-            jsonpath = f"$.{table_name}[?(@.{id_field}=='{value}')]"
-
-            try:
-                response = await self.db_client.query(self.trial_id, jsonpath)
-                # QueryResponse is a Pydantic model with .results attribute
-                results = response.results
-
-                if results:
-                    return self._to_model(model_cls, results[0])
-            except Exception as e:
-                logger.debug(f"JSONPath query for {id_field} failed: {e}")
-                continue
-
-        # Fallback: get all and filter using model's get_id() method
-        # This handles any custom ID field that we didn't try above
-        logger.debug(f"JSONPath queries failed, falling back to full scan for {model_cls.__name__}")
-        all_items = await self.get_all(model_cls)
-        for item in all_items:
+        # Fallback: full scan comparing the model's get_id() value. Handles keys
+        # not declared in id_fields (e.g. email) via a runtime VALUE call, never
+        # model source.
+        logger.debug(f"JSONPath lookup missed, full scan for {model_cls.__name__}")
+        for item in await self.get_all(model_cls):
             if self._get_id(item) == value:
                 return item
         return None
@@ -459,7 +464,9 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "upsert", "record": record, "key": self._get_id_field_name(obj)}],
+            operations=[
+                {"op": "upsert", "record": record, "key": self._resolve_id_field(model_cls)}
+            ],
         )
 
         return obj
@@ -488,7 +495,7 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "delete", "filter": {"id": obj_id}}],
+            operations=[{"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}],
         )
 
     async def delete_by_id(self, model_cls: type[T], obj_id: Any) -> None:
@@ -512,7 +519,7 @@ class DBServiceProxy:
         await self.db_client.mutate(
             trial_id=self.trial_id,
             table_name=table_name,
-            operations=[{"op": "delete", "filter": {"id": obj_id}}],
+            operations=[{"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}],
         )
 
     async def bulk_delete(self, objects: list[BaseModel]) -> None:
@@ -533,7 +540,9 @@ class DBServiceProxy:
             if obj.__class__ != model_cls:
                 raise ValueError("All objects must be of the same model class")
             obj_id = self._get_id(obj)
-            operations.append({"op": "delete", "filter": {"id": obj_id}})
+            operations.append(
+                {"op": "delete", "filter": {self._resolve_id_field(model_cls): obj_id}}
+            )
 
         await self.db_client.mutate(
             trial_id=self.trial_id, table_name=table_name, operations=operations
@@ -574,6 +583,7 @@ class DBServiceProxy:
             db_client=self.db_client,
             trial_id=self.trial_id,
             db_table_names=list(self.db_table_names),
+            id_fields=dict(self._id_fields),
         )
         new_proxy._model_name_to_table = deepcopy(self._model_name_to_table)
         new_proxy._table_to_model = deepcopy(self._table_to_model)

--- a/tolokaforge/runner/id_resolution.py
+++ b/tolokaforge/runner/id_resolution.py
@@ -1,0 +1,123 @@
+"""Primary-key resolution and diff-op computation for record dicts.
+
+Central home for the "given a table, what column is the primary key, and what
+diff mutations does before→after produce?" question. Callers with a Pydantic
+model class (:class:`DBServiceProxy`) resolve keys via ``_resolve_id_field``;
+callers with raw record dicts (MCP subprocess sync in
+:mod:`tolokaforge.runner.service`, Tau in-memory sync in
+:mod:`tolokaforge.runner.tool_factory`) use :func:`compute_diff_ops`.
+
+All paths agree on the key name via :func:`id_field_for_table`: configured
+``state_checks.id_fields`` entry wins, otherwise ``"id"``. Value lookup and diff
+computation are fail-loud — a record without its resolved key raises rather
+than silently collapsing into a single ``None`` bucket.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class IdFieldResolutionError(ValueError):
+    """A table's primary-key field or value cannot be determined."""
+
+
+def id_field_for_table(table: str, id_fields: dict[str, str]) -> str:
+    """Return the primary-key field name for ``table``.
+
+    Configured ``state_checks.id_fields`` entry wins; otherwise ``"id"``. Match
+    :meth:`DBServiceProxy._resolve_id_field`'s truthiness semantics (``or``, not
+    ``.get(..., "id")``) so a blank configured value falls through to the
+    default rather than diverging.
+    """
+    return id_fields.get(table) or "id"
+
+
+def resolve_record_id(
+    record: dict[str, Any],
+    table: str,
+    id_fields: dict[str, str],
+) -> Any:
+    """Return ``record``'s primary-key value using the table's configured key.
+
+    Fail loud when the resolved key is absent from the record.
+    """
+    key = id_field_for_table(table, id_fields)
+    return _record_value(record, table, key)
+
+
+def _record_value(record: dict[str, Any], table: str, key: str) -> Any:
+    """Return ``record[key]`` or raise :class:`IdFieldResolutionError`."""
+    if key not in record:
+        raise IdFieldResolutionError(
+            f"Record in table {table!r} is missing key field {key!r}. "
+            f"Resolved from state_checks.id_fields (default 'id'). "
+            f"Fix either: (a) declare the correct key in grading.yaml "
+            f"state_checks.id_fields.{table}, "
+            f"or (b) ensure records include the {key!r} field. "
+            f"Record keys: {sorted(record.keys())}"
+        )
+    return record[key]
+
+
+def compute_diff_ops(
+    before: list[dict[str, Any]],
+    after: list[dict[str, Any]],
+    table: str,
+    id_fields: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Compute the mutation ops that transform ``before`` into ``after``.
+
+    Emits ``insert`` for records only in ``after``, ``upsert`` for records
+    present in both but changed, and ``delete`` for records only in ``before``.
+    Records are indexed by the table's configured key (see
+    :func:`id_field_for_table`); a record missing that key raises.
+    """
+    key = id_field_for_table(table, id_fields)
+    before_by_id = {_record_value(r, table, key): r for r in before}
+    after_by_id = {_record_value(r, table, key): r for r in after}
+
+    ops: list[dict[str, Any]] = []
+    for rid, rec in after_by_id.items():
+        if rid not in before_by_id:
+            ops.append({"op": "insert", "record": rec})
+        elif before_by_id[rid] != rec:
+            ops.append({"op": "upsert", "record": rec, "key": key})
+    for rid in before_by_id:
+        if rid not in after_by_id:
+            ops.append({"op": "delete", "filter": {key: rid}})
+    return ops
+
+
+def check_id_fields_reference_known_tables(
+    id_fields: dict[str, str],
+    known_tables: list[str] | set[str],
+    *,
+    context: str,
+    relaxed: bool,
+) -> str | None:
+    """Validate that every ``id_fields`` key names a table that exists.
+
+    Returns ``None`` when the check passes or the mismatch is downgraded via
+    ``relaxed=True`` (a warning is logged in that case). Returns the error
+    message string on a strict failure so callers can raise or return it.
+
+    ``context`` prefixes the message (e.g. task id or ``"RegisterTrial: <trial>"``).
+    """
+    if not id_fields:
+        return None
+    unknown = sorted(set(id_fields) - set(known_tables))
+    if not unknown:
+        return None
+    known = sorted(known_tables)
+    msg = (
+        f"[{context}] state_checks.id_fields references table(s) not present "
+        f"in initial_state: unknown={unknown}, known={known}. "
+        f"Fix a typo, add the table to initial_state, or set "
+        f"state_checks.relaxed_validation: true."
+    )
+    if relaxed:
+        logger.warning(msg)
+        return None
+    return msg

--- a/tolokaforge/runner/id_resolution.py
+++ b/tolokaforge/runner/id_resolution.py
@@ -69,25 +69,53 @@ def compute_diff_ops(
 ) -> list[dict[str, Any]]:
     """Compute the mutation ops that transform ``before`` into ``after``.
 
-    Emits ``insert`` for records only in ``after``, ``upsert`` for records
-    present in both but changed, and ``delete`` for records only in ``before``.
-    Records are indexed by the table's configured key (see
-    :func:`id_field_for_table`); a record missing that key raises.
+    Emits ops in the order ``[inserts, upserts, deletes]`` so downstream
+    consumers see the same batch shape as the pre-refactor call sites. Records
+    are indexed by the table's configured key (see :func:`id_field_for_table`);
+    a record missing that key or sharing its key with another record in the
+    same list raises :class:`IdFieldResolutionError`.
     """
     key = id_field_for_table(table, id_fields)
-    before_by_id = {_record_value(r, table, key): r for r in before}
-    after_by_id = {_record_value(r, table, key): r for r in after}
+    before_by_id = _index_by_key(before, table, key, side="before")
+    after_by_id = _index_by_key(after, table, key, side="after")
 
     ops: list[dict[str, Any]] = []
     for rid, rec in after_by_id.items():
         if rid not in before_by_id:
             ops.append({"op": "insert", "record": rec})
-        elif before_by_id[rid] != rec:
+    for rid, rec in after_by_id.items():
+        if rid in before_by_id and before_by_id[rid] != rec:
             ops.append({"op": "upsert", "record": rec, "key": key})
     for rid in before_by_id:
         if rid not in after_by_id:
             ops.append({"op": "delete", "filter": {key: rid}})
     return ops
+
+
+def _index_by_key(
+    records: list[dict[str, Any]],
+    table: str,
+    key: str,
+    *,
+    side: str,
+) -> dict[Any, dict[str, Any]]:
+    """Index ``records`` by ``record[key]``; raise on duplicate keys.
+
+    A duplicate resolved key would silently drop every record but the last —
+    the same class of silent-collapse the id_fields resolver was introduced
+    to close.
+    """
+    indexed: dict[Any, dict[str, Any]] = {}
+    for record in records:
+        rid = _record_value(record, table, key)
+        if rid in indexed:
+            raise IdFieldResolutionError(
+                f"Duplicate {key!r}={rid!r} in {side} state for table {table!r}; "
+                f"two records share the same resolved primary key. "
+                f"Fix the source data or the state_checks.id_fields entry."
+            )
+        indexed[rid] = record
+    return indexed
 
 
 def check_id_fields_reference_known_tables(

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -313,6 +313,15 @@ class StateChecksConfig(BaseModel):
     # switch) because a numeric-looking string can carry meaning in its exact
     # representation (versions/codes) — see core/hash.py compute_stable_hash.
     numeric_string_fields: list[str] = Field(default_factory=list)
+    # Opt-in, PER-TABLE: primary-key field for tables not keyed by the literal "id"
+    # (e.g. {"widgets": "widget_id"}). Absent table => "id". Consumed by
+    # the DB proxy (via ToolFactory) so key resolution is data-driven instead of
+    # derived from model source. See runner/db_proxy.py _resolve_id_field.
+    id_fields: dict[str, str] = Field(default_factory=dict)
+    # Escape hatch for legacy tasks: downgrade the id_fields cross-check
+    # (id_fields keys must appear in initial_state.tables) from a raise to a warning.
+    # New tasks should fix typos or add the table, not enable this.
+    relaxed_validation: bool = False
 
     # JSONPath assertions
     jsonpath_checks: list[dict[str, Any]] = Field(default_factory=list)
@@ -322,6 +331,19 @@ class StateChecksConfig(BaseModel):
 
     # Substrate SQL assertions against a task-declared postgres DSN
     db_probes: list[DbProbe] = Field(default_factory=list)
+
+    @field_validator("id_fields")
+    @classmethod
+    def _validate_id_fields(cls, value: dict[str, str]) -> dict[str, str]:
+        for table, field in value.items():
+            if not (isinstance(table, str) and table.strip()):
+                raise ValueError(f"state_checks.id_fields has a blank table name: {table!r}")
+            if not (isinstance(field, str) and field.strip()):
+                raise ValueError(
+                    f"state_checks.id_fields[{table!r}] must be a non-empty key field, "
+                    f"got {field!r}"
+                )
+        return value
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -57,6 +57,10 @@ from tolokaforge.runner.grading import (
     evaluate_jsonpath_checks,
     evaluate_transcript_rules,
 )
+from tolokaforge.runner.id_resolution import (
+    check_id_fields_reference_known_tables,
+    compute_diff_ops,
+)
 from tolokaforge.runner.models import (
     GoldenAction,
     GradeComponents,
@@ -609,6 +613,20 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # Pass actual table names and data from initial_state so model registration uses correct names
         db_table_names = list(initial_state.tables.keys()) if initial_state.tables else []
         initial_state_data = initial_state.tables if initial_state.tables else {}
+        # Per-table primary-key overrides from grading config (default "id"). Passed to
+        # the DB proxy so upsert/delete/lookup key resolution is data-driven rather than
+        # introspecting model source (which fails when the domain source is not on disk).
+        state_checks = task_description.grading.state_checks if task_description.grading else None
+        id_fields = dict(state_checks.id_fields) if state_checks else {}
+        relaxed = bool(state_checks.relaxed_validation) if state_checks else False
+        # Belt-and-suspenders: NativeAdapter runs this check at task-description build
+        # time, but engines using other adapters (mcp_core, custom) bypass it.
+        err = check_id_fields_reference_known_tables(
+            id_fields, db_table_names, context=f"RegisterTrial: {trial_id}", relaxed=relaxed
+        )
+        if err:
+            logger.error(err)
+            return pb2.RegisterTrialResponse(success=False, error=err)
         try:
             tool_factory = ToolFactory(
                 self.db_client,
@@ -616,6 +634,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 rag_client_for_trial,
                 db_table_names,
                 initial_state_data,
+                id_fields=id_fields,
             )
 
             # Set domain on DB proxy so search_policy tools can resolve
@@ -1726,8 +1745,10 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         """Sync an MCP server's in-memory state to the db-service via diff mutations.
 
         Computes inserts / updates / deletes for every table and applies them
-        through ``db_client.mutate``.  Records are keyed on the ``id`` field
-        (falling back to ``_id``).
+        through ``db_client.mutate``. Keys are resolved per table from
+        ``state_checks.id_fields`` (default ``"id"``); a record missing its
+        resolved key raises fail-loud rather than collapsing every keyless
+        record to a single ``None`` bucket.
 
         Args:
             trial_id:  Trial identifier used by db-service.
@@ -1735,36 +1756,28 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         """
         current_response = await self.db_client.get_state(trial_id)
         current_state: dict[str, list[dict]] = current_response.data
+        id_fields = self._id_fields_for_trial(trial_id)
 
         for table_name, new_records in mcp_state.items():
             current_records = current_state.get(table_name, [])
             if current_records == new_records:
                 continue
-
-            before_by_id = {self._mcp_record_id(r): r for r in current_records}
-            after_by_id = {self._mcp_record_id(r): r for r in new_records}
-
-            operations: list[dict] = []
-            for rid, rec in after_by_id.items():
-                if rid not in before_by_id:
-                    operations.append({"op": "insert", "record": rec})
-            for rid, rec in after_by_id.items():
-                if rid in before_by_id and before_by_id[rid] != rec:
-                    operations.append({"op": "upsert", "record": rec, "key": "id"})
-            for rid in before_by_id:
-                if rid not in after_by_id:
-                    operations.append({"op": "delete", "filter": {"id": rid}})
-
+            operations = compute_diff_ops(current_records, new_records, table_name, id_fields)
             if operations:
                 await self.db_client.mutate(trial_id, table_name, operations)
                 logger.debug(
                     f"_sync_mcp_state_to_db: {trial_id}/{table_name} — {len(operations)} op(s)"
                 )
 
-    @staticmethod
-    def _mcp_record_id(record: dict) -> Any:
-        """Return the primary-key value of a record (``id`` or ``_id``)."""
-        return record.get("id") or record.get("_id")
+    def _id_fields_for_trial(self, trial_id: str) -> dict[str, str]:
+        """Return the id_fields map declared by the trial's grading config, or ``{}``."""
+        trial = self.trials.get(trial_id)
+        if trial is None or trial.task_description is None:
+            return {}
+        grading = trial.task_description.grading
+        if grading is None or grading.state_checks is None:
+            return {}
+        return dict(grading.state_checks.id_fields)
 
     # =========================================================================
     # GetState - Debug endpoint to inspect current state

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1770,14 +1770,19 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 )
 
     def _id_fields_for_trial(self, trial_id: str) -> dict[str, str]:
-        """Return the id_fields map declared by the trial's grading config, or ``{}``."""
-        trial = self.trials.get(trial_id)
-        if trial is None or trial.task_description is None:
+        """Return the id_fields map declared by the trial's grading config, or ``{}``.
+
+        Callers of ``_sync_mcp_state_to_db`` (GradeTrial, GetState) always guard
+        that the trial is registered before invoking, so indexed access here is
+        deliberate — a missing trial is a bug in the caller.
+        """
+        trial = self.trials[trial_id]
+        if trial.task_description is None:
             return {}
         grading = trial.task_description.grading
         if grading is None or grading.state_checks is None:
             return {}
-        return dict(grading.state_checks.id_fields)
+        return grading.state_checks.id_fields
 
     # =========================================================================
     # GetState - Debug endpoint to inspect current state

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field
 
 from tolokaforge.runner.db_client import DBServiceClient
 from tolokaforge.runner.db_proxy import DBServiceProxy, SyncDBServiceProxy
+from tolokaforge.runner.id_resolution import compute_diff_ops
 from tolokaforge.runner.models import (
     InvocationStyle,
 )
@@ -210,10 +211,12 @@ class TauSyncToolWrapper(ToolWrapper):
         tool_schema: ToolSchemaModel,
         tool_class: type,
         db_proxy: SyncDBServiceProxy,
+        id_fields: dict[str, str] | None = None,
     ):
         super().__init__(tool_schema)
         self.tool_class = tool_class
         self.db_proxy = db_proxy
+        self._id_fields: dict[str, str] = dict(id_fields or {})
         self._tool_instance = None
 
     async def execute(self, arguments: dict[str, Any]) -> str:
@@ -273,56 +276,24 @@ class TauSyncToolWrapper(ToolWrapper):
             raise
 
     async def _sync_state_changes(self, before: dict[str, Any], after: dict[str, Any]) -> None:
-        """
-        Detect and sync state changes to DB Service.
+        """Detect and sync state changes to DB Service.
 
-        This compares the state before and after tool execution
-        and pushes any changes to the DB Service.
+        Keys are resolved per table from ``state_checks.id_fields`` (default
+        ``"id"``); a record missing its resolved key raises fail-loud rather
+        than collapsing all keyless records to a single ``None`` bucket.
         """
-        # For each table, detect changes
-        all_tables = set(before.keys()) | set(after.keys())
-
-        for table_name in all_tables:
+        for table_name in set(before) | set(after):
             before_records = before.get(table_name, [])
             after_records = after.get(table_name, [])
-
-            # Skip if no changes
             if before_records == after_records:
                 continue
-
-            # Build operations for changes
-            operations = []
-
-            # Index records by ID for comparison
-            before_by_id = {self._get_record_id(r): r for r in before_records}
-            after_by_id = {self._get_record_id(r): r for r in after_records}
-
-            # Find inserts (in after but not in before)
-            for record_id, record in after_by_id.items():
-                if record_id not in before_by_id:
-                    operations.append({"op": "insert", "record": record})
-
-            # Find updates (in both but different)
-            for record_id, after_record in after_by_id.items():
-                if record_id in before_by_id:
-                    before_record = before_by_id[record_id]
-                    if before_record != after_record:
-                        operations.append({"op": "upsert", "record": after_record, "key": "id"})
-
-            # Find deletes (in before but not in after)
-            for record_id in before_by_id:
-                if record_id not in after_by_id:
-                    operations.append({"op": "delete", "filter": {"id": record_id}})
-
-            # Apply operations to DB Service
+            operations = compute_diff_ops(
+                before_records, after_records, table_name, self._id_fields
+            )
             if operations:
                 await self.db_proxy._async_proxy.db_client.mutate(
                     trial_id=self.db_proxy.trial_id, table_name=table_name, operations=operations
                 )
-
-    def _get_record_id(self, record: dict[str, Any]) -> Any:
-        """Get the ID of a record."""
-        return record.get("id") or record.get("_id")
 
 
 # =============================================================================
@@ -1389,6 +1360,7 @@ class ToolFactory:
         rag_client: RAGServiceClient | None = None,
         db_table_names: list[str] | None = None,
         initial_state_data: dict[str, list[dict]] | None = None,
+        id_fields: dict[str, str] | None = None,
     ):
         """
         Initialize the tool factory.
@@ -1401,17 +1373,24 @@ class ToolFactory:
                            These are the source of truth for table name registration.
             initial_state_data: Optional dict mapping table names to their records.
                                Used for ID field matching during model registration.
+            id_fields: Optional per-table primary-key overrides (table_name -> key
+                       field), from grading config state_checks.id_fields. Forwarded
+                       to the DB proxy and to TauSyncToolWrapper diff-sync so key
+                       resolution is data-driven; a table absent resolves to ``"id"``.
         """
         self.db_client = db_client
         self.trial_id = trial_id
         self.rag_client = rag_client
         self.db_table_names = db_table_names or []
         self._initial_state_data = initial_state_data or {}
+        self.id_fields = dict(id_fields or {})
         self._claimed_tables: set[str] = set()
 
         # Create DB proxies for tools
         # Pass db_table_names so the proxy can resolve table names for unregistered models
-        self._async_proxy = DBServiceProxy(db_client, trial_id, db_table_names=self.db_table_names)
+        self._async_proxy = DBServiceProxy(
+            db_client, trial_id, db_table_names=self.db_table_names, id_fields=self.id_fields
+        )
         self._sync_proxy = SyncDBServiceProxy(self._async_proxy)
 
     def reconstruct_tools(
@@ -1528,6 +1507,7 @@ class ToolFactory:
                 tool_schema=schema,
                 tool_class=tool_class,
                 db_proxy=self._sync_proxy,
+                id_fields=self.id_fields,
             )
         except ImportError as e:
             raise ToolImportError(schema.name, f"Cannot import module '{module_path}': {e}")


### PR DESCRIPTION
## Context

Reapplies PR #600 on top of current main (which lost #600's schema fields when #557 was merged without rebasing) **and** ships the two dormant follow-ups Leonid asked for.

**Why the rebase changed shape.** PR #557 (runtime independence v1) was branched before #600 landed and merged without rebasing, so main lost `state_checks.id_fields`, `IdFieldResolutionError`, `_resolve_id_field`, and `test_db_proxy_id_fields.py`. This PR restores all of that alongside the follow-ups, so main is functional again in one atomic story.

## Included

### PR #600 restoration
- Re-adds `state_checks.id_fields: dict[str, str]` on both `StateChecksConfig` variants (core `extra="ignore"`, runner `extra="forbid"`) with the field-validator for blank keys/values.
- Re-adds `IdFieldResolutionError` + `DBServiceProxy._resolve_id_field` (config-first, `"id"` default, fail-loud). Never reads model source.
- Rewires `get_by_id` / `update` / `delete` / `bulk_delete` to resolve keys from config, not from `inspect.getsource`.
- Restores the deleted `tests/unit/test_db_proxy_id_fields.py` (9 tests including the dynamic-source-via-`exec()` reproducer for the original Muse failure).

### Follow-up 1 — MCP diff-sync id resolution

`RunnerServiceImpl._sync_mcp_state_to_db` and `TauSyncToolWrapper._sync_state_changes` no longer hardcode `"id"`. Both call a shared `compute_diff_ops(before, after, table, id_fields)` in a new `tolokaforge/runner/id_resolution.py` that resolves the key per table, fails loud on missing / duplicate keys, and emits `[inserts, upserts, deletes]` in the pre-refactor batch order.

Passive today (no shipping pack uses `invocation_style: mcp_server`), but the guard is what "surface failures explicitly" (AGENTS.md) rules that class of silent-corruption bug out.

### Follow-up 2 — Fail-loud id_fields cross-check

`state_checks.id_fields` typos now raise at task-description build time in `NativeAdapter.to_task_description` via a shared `check_id_fields_reference_known_tables` helper the runner also uses as belt-and-suspenders. A new `state_checks.relaxed_validation: bool = False` field downgrades the raise to a warning for legacy tasks.

```yaml
state_checks:
  id_fields:
    legacy_widgets: widget_id
  relaxed_validation: true            # temporary — legacy escape hatch only
```

### Canonical coverage

New fixture `tests/data/tasks/widgets_id_fields/` + snapshot `tests/canonical/snapshots/native_widgets_id_fields/` lock in the round-trip for a non-`id`-keyed table. Existing four snapshots gain `id_fields: {}` (which #557 removed) and `relaxed_validation: false`.

### Review fixes (folded in from the previous head)

- Restored `[inserts, upserts, deletes]` op ordering in `compute_diff_ops` (pre-refactor observable shape preserved).
- `compute_diff_ops` now raises `IdFieldResolutionError` on duplicate resolved keys via a shared `_index_by_key` helper.
- `_id_fields_for_trial` uses indexed access on `self.trials` — all callers already guard trial existence, so a missing trial is a caller bug and fails loud.
- Direct tests for `check_id_fields_reference_known_tables` and `compute_diff_ops` (positive, typo, relaxed, ordering, duplicate-key, empty-both-sides).
- Change-narrative comments and internal task-pack names stripped from test docstrings.
- Doc note in `docs/GRADING.md` on `initialization_actions`-materialized tables needing `relaxed_validation: true` today.

## Alignment with milestone 26 (Runner as a distributable service)

- Import boundary lock (`tests/canonical/test_runner_import_boundary.py`) forbids `runner → adapters/cli/docker/orchestrator`. My new `tolokaforge/runner/id_resolution.py` lives inside `runner/` and imports only `logging` + `typing`; `adapters/native.py → runner/id_resolution` is the allowed direction. Slim runner image untouched — no heavy deps.
- `NativeAdapter.register_preloaded_task` (added by #557 for M14-C's future `load_task`) is preserved.
- Belt-and-suspenders check inside `RegisterTrial` protects engines that bypass `NativeAdapter.to_task_description` (e.g. a future `load_task` seam).

## Test plan

- [x] `ruff check tolokaforge tests` — clean
- [x] Touched-area tests: 55 pass (17 helper + 4 tau + 5 MCP + 4 adapter + 9 DB-proxy + 20 canonical adapter). No id_fields-related failures anywhere.
- [x] Real-task smoke via `examples/native/tool_use/run_configs/dev.yaml` (2 tasks, id-keyed shape) on the pre-rebase branch: **$0.24 spent, no `IdFieldResolutionError`, grading pipeline intact.**
- [x] Rebased onto `origin/main` @ `2c4fbf8` (#557). Conflicts resolved surgically, preserving all #557 additions (e.g. `register_preloaded_task`, `_source_dir` PrivateAttr).

## Compatibility notes

- **Backward-compatible for id-keyed tasks**: byte-for-byte unchanged behavior when `id_fields` is unset. Diff-sync ops that were `{"key": "id"}` remain `{"key": "id"}`.
- **Runner-engine version lock**: `id_fields` and `relaxed_validation` are declared on the runner-side `StateChecksConfig` (`extra="forbid"`), so a new engine emitting them requires a runner image built from the same release. Old engine + new runner is safe (core-side `extra="ignore"`).
- **No task-pack coordination required** for this PR alone: the MCP fix is passive (`mcp_server` unused), and the fail-loud cross-check only trips on typos in `id_fields`. Companion internal task-pack sweep declaring `id_fields` for non-`id`-keyed domains ships separately.

## Pre-existing test failures (not caused by this PR)

Running `pytest tests/ -m "unit or canonical"` on plain `origin/main` @ `2c4fbf8` reveals 17 pre-existing failures in `test_backend_selection.py`, `dx/test_cli_*.py`, `test_reset_recipe_pack_wiring.py`, etc. Verified independent by running one on plain main. Reporting for visibility; out of scope here.