### PR TITLE
fix(runtime): repair two #557 regressions breaking unit + canonical tests

### DIFF
--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -551,7 +551,7 @@ The three orchestrator seams — `RuntimeBackend`, `TrialGrader`, and `Conductor
 
 | Group | Factory type | Context |
 | --- | --- | --- |
-| `tolokaforge.runtime_backends` | `Callable[[RuntimeBackendBuildContext], RuntimeBackend]` | `runner_address`, `env_manifest`, `run_id`, `seeds`, `log_capture` |
+| `tolokaforge.runtime_backends` | `Callable[[RuntimeBackendBuildContext], RuntimeBackend]` | `runner_address`, `env_manifest`, `run_id`, `seeds`, `log_capture`, `events` |
 | `tolokaforge.trial_graders` | `Callable[[TrialGraderContext], TrialGrader]` | `runtime_backend`, `logger` |
 | `tolokaforge.conductors` | `Callable[[ConductorContext], Conductor]` | per-run deps (adapter, writer, config, agent client, runtime backend, grader, …) |
 

--- a/tests/unit/test_backend_selection.py
+++ b/tests/unit/test_backend_selection.py
@@ -31,7 +31,10 @@ from tolokaforge.core.per_trial_runtime import (
     PerTrialRuntimeBackend,
     per_trial_runtime_backend_factory,
 )
-from tolokaforge.core.plugin_registry import UnknownImplementationError
+from tolokaforge.core.plugin_registry import (
+    RuntimeBackendBuildContext,
+    UnknownImplementationError,
+)
 from tolokaforge.core.shared_stack_runtime import (
     SharedStackRuntimeBackend,
     shared_runtime_backend_factory,
@@ -266,3 +269,49 @@ class TestUnknownRuntimeName:
         assert "bogus" in message
         for name in known:
             assert name in message
+
+
+class TestRunDisplayEventsPropagation:
+    """The orchestrator's display-events sink must reach the runner client.
+
+    ``SharedStackRuntimeBackend`` forwards its ``events`` sink to
+    :class:`GrpcRunnerClient`, which is what publishes the runner's
+    ``component_registered`` / ``component_status_changed`` /
+    ``component_log_appended`` rows (ADR-0021). Nothing else asserts that
+    chain end to end, so a break degrades silently to a null sink: no
+    exception, no failing test, just an Engine Components panel that never
+    shows the runner. PR #557 broke exactly this by dropping the ``events``
+    field from ``RuntimeBackendBuildContext`` while the orchestrator kept
+    passing the kwarg.
+    """
+
+    def test_orchestrator_events_reach_the_runner_client(self) -> None:
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared())
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        sentinel = MagicMock()
+        orch._events = sentinel
+
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+
+        assert isinstance(backend, SharedStackRuntimeBackend)
+        assert backend._events is sentinel
+        assert backend.runner_client._events is sentinel
+
+    def test_build_context_defaults_events_to_a_null_sink(self) -> None:
+        """A factory that omits ``events`` still gets a usable no-op sink."""
+        ctx = RuntimeBackendBuildContext(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+            seeds={},
+            log_capture=None,
+        )
+
+        ctx.events.component_status_changed(component_id="probe", status="healthy")

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -851,6 +851,7 @@ class Orchestrator:
                 run_id=run_id,
                 seeds=self._project_seed_registry(),
                 log_capture=log_capture,
+                events=self._events,
             )
         )
         self.logger.info(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -851,7 +851,6 @@ class Orchestrator:
                 run_id=run_id,
                 seeds=self._project_seed_registry(),
                 log_capture=log_capture,
-                events=self._events,
             )
         )
         self.logger.info(

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -31,10 +31,11 @@ from __future__ import annotations
 
 import importlib.metadata
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from tolokaforge.core.conductor import ConductorFactory
+from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
 from tolokaforge.core.runtime import RuntimeBackend
 from tolokaforge.core.trial_grader import TrialGrader
 
@@ -133,6 +134,7 @@ class RuntimeBackendBuildContext:
     run_id: str
     seeds: dict[str, SeedRef]
     log_capture: LogCaptureConfig | None
+    events: RunDisplayEvents = field(default_factory=_NullRunDisplayEvents)
 
 
 @dataclass(frozen=True)

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -1303,9 +1303,11 @@ def shared_runtime_backend_factory(
             run_id=ctx.run_id,
             seeds=ctx.seeds,
             log_capture=ctx.log_capture,
+            events=ctx.events,
         )
     return SharedStackRuntimeBackend(
         runner_address=ctx.runner_address,
         endpoints=_build_env_endpoints(ctx.runner_address),
         seeds=ctx.seeds,
+        events=ctx.events,
     )

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -164,6 +164,9 @@ class _GroupedCommandsGroup(click.Group):
     COMMAND_GROUPS: dict[str, str] = {
         "repl": "Interactive",
         "run": "Runs",
+        # Hidden, so this heading never renders; the entry exists because the
+        # registered-vs-mapped contract inspects ``cli.commands``, which
+        # includes hidden commands.
         "run-trial": "Runs",
         "prepare": "Runs",
         "worker": "Runs",

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -164,6 +164,7 @@ class _GroupedCommandsGroup(click.Group):
     COMMAND_GROUPS: dict[str, str] = {
         "repl": "Interactive",
         "run": "Runs",
+        "run-trial": "Runs",
         "prepare": "Runs",
         "worker": "Runs",
         "status": "Runs",

--- a/tolokaforge/dx/cli/run_trial_command.py
+++ b/tolokaforge/dx/cli/run_trial_command.py
@@ -218,7 +218,7 @@ def _reroute_stdout_to_stderr() -> TextIO:
     return os.fdopen(wire_fd, "w", encoding="utf-8")
 
 
-@click.command(name="run-trial")
+@click.command(name="run-trial", hidden=True)
 def run_trial() -> None:
     """Run one trial as a subprocess over a JSON-Lines pipe.
 


### PR DESCRIPTION
## What

Two independent breakages landed together in #557 (`2c4fbf8`, runtime independence v1) and have kept **every** unit + canonical run on `main` red since 2026-07-24.

> **Revised after review.** The first push "fixed" the second issue by deleting the `events` kwarg. That was wrong and is corrected in `4b41c39`; see the section below. The original PR body claimed no sibling context dataclass carried an `events` field. That claim was **false** (`ConductorContext` does), and it was the load-bearing argument for the deletion.

### 1. `run-trial` registered but unmapped (9 tests)

`main.py` registers the command via `cli.add_command(run_trial)`, but it is absent from `_GroupedCommandsGroup.COMMAND_GROUPS`. The group's deliberate fail-loud guard then raises `RuntimeError: no group heading for command 'run-trial'` on **every** `--help` render, so anything touching help output dies: `test_cli_browse`, `test_cli_commands` (2), `test_cli_grouped_help` (4), `test_logging_cli_flags`, `test_repl`.

The guard worked exactly as designed. Only the map entry was missing.

**Fix: `hidden=True` *and* a map entry.** Both are required:

* `test_all_registered_commands_are_mapped` compares against `cli.commands.keys()`, which includes hidden commands, so hiding alone still fails it.
* `test_commands_within_section_are_alphabetical` asserts an *exact* 7-element list for the Runs section, so mapping it visibly would fail that instead. (An earlier version of this description cited `test_help_output_places_commands_under_correct_headings` here; that one is a subset check and would have tolerated it.)

Hiding is also correct on the merits: per its own docstring `run-trial` is a JSON-Lines subprocess wire protocol over stdin/stdout, not a human-facing verb. Known cost: hidden commands drop out of shell and REPL completion. Acceptable for a machine protocol, but a conscious call.

### 2. `RuntimeBackendBuildContext` is missing the `events` field (8 tests)

`Orchestrator._construct_runtime_backend` passes `events=self._events`, but the frozen dataclass created in the same PR declares only `runner_address`, `env_manifest`, `run_id`, `seeds`, `log_capture`. Construction is unconditional and precedes the factory call, so **every** backend raised `TypeError`, including `in_memory`. That is 4 tests in `test_backend_selection.py` plus 4 canonical pack-wiring tests.

**Fix: restore the seam, do not delete the kwarg.** The kwarg is preserved intent with missing plumbing, not residue:

* Pre-#557 the orchestrator passed `events=self._events` to **both** `SharedStackRuntimeBackend` constructions.
* That backend still accepts the sink, stores it, and forwards it to `GrpcRunnerClient`, which publishes `component_registered`, `component_status_changed` and `component_log_appended`.
* ADR-0021 (Accepted) specifies exactly this wiring, and `docs/RUNTIME_BACKENDS.md` calls it the reference implementation.

#557 collapsed the two constructions into one context build, carried the kwarg over, then omitted **both** the context field and the factory forwarding. Deleting the kwarg would have made that accidental regression permanent, silently degrading runner telemetry to a null sink: no exception, no failing test, just an Engine Components panel that never shows the runner.

Restored end to end:

* `RuntimeBackendBuildContext` gains `events`, defaulted to a null sink so existing 5-field construction sites stay valid. Mirrors `ConductorContext`, which already uses this exact idiom.
* `shared_runtime_backend_factory` forwards `ctx.events` on both returns.
* The orchestrator keeps passing `self._events`.

`PerTrialRuntimeBackend` and `InMemoryRuntimeBackend` accept no events sink, so nothing is threaded to them.

## Tests

The propagation gap is why this was invisible, so this adds the missing coverage:

* `test_orchestrator_events_reach_the_runner_client` pins orchestrator sink to context to factory to backend to runner-client identity.
* `test_build_context_defaults_events_to_a_null_sink` pins the default.

Verified the pair fails against `3a905f5` (the deletion) and passes here, so it genuinely guards the behavior rather than restating the implementation.

## Verification

Local `tests/unit` + `tests/canonical` against `origin/main`:

| | baseline | this PR |
|---|---|---|
| failed | 52 | **41** |
| passed | 4130 | **4143** |

The 12 targeted tests flip and the new default-sink test passes. The single local-only failure is the propagation test, which cannot run in this sandbox because no `tolokaforge.runtime_backends` entry points are registered there; the same artifact accounts for the 4 canonical pack-wiring tests that fail identically on both sides. The full chain was verified directly instead, bypassing the entry-point loader:

```
with fix:     backend._events is orchestrator sink -> True
              runner_client._events is orchestrator sink -> True
without fix:  RuntimeBackendBuildContext.__init__() got an unexpected keyword argument 'events'
```

`ruff` and `black` clean.

## Notes

* No CHANGELOG entry, matching recent `fix(...)` PRs.
* Worth a separate look: because the unit + canonical step fails first, the `test-full` job has been **skipping** the tool tests, the Docker image build and the entire integration suite since 2026-07-24. Whatever state those are in is currently unmeasured.