### PR TITLE
M14-A: provenance-correct runner-image size lock + toolchain-absence guard

### DIFF
--- a/tests/integration/docker/test_runner_image_size.py
+++ b/tests/integration/docker/test_runner_image_size.py
@@ -1,29 +1,19 @@
 """Size budget for the built ``tolokaforge-runner`` image (ADR-0022 §4b).
 
-Enforces the uncompressed-size ceiling the slim-runner work commits to. Reads
-the size of the locally built runner image straight from the Docker daemon and
-asserts it stays under a single named ceiling.
+Enforces the uncompressed-size ceiling the slim-runner work commits to. The
+lock measures the image the *current tree's* runner definition produces,
+resolved by the builder's content-hash SSOT (``current_runner_image_id`` →
+``builder.expected_image_ref("runner")``), not by build timestamp — so a fat
+image another worktree/branch built into the shared ``tolokaforge-runner`` name
+can never be the one measured. It inspects that exact ref's size straight from
+the Docker daemon and asserts it stays under a single named ceiling.
 
-Recorded baseline (provenance, mirroring ADR-0022 §4b):
-
-- **659 MB** — measured 2026-07-20 via ``docker images`` on a freshly built
-  ``tolokaforge-runner`` (image ID ``325b9be60fa8``), matching the ADR baseline.
-- Layer breakdown (``docker history``):
-  - base ``python:3.12-slim`` ≈ 144 MB (fixed floor)
-  - apt ``curl``/``git``/``ca-certificates`` ~104 MB (build-only — the runner
-    never clones)
-  - ``docker-ce-cli`` + compose-plugin 74.7 MB (only terminal-bench shells out
-    to docker)
-  - ``pip install wheel[docker]`` 298 MB (the dead ``[docker]`` extra pulls the
-    full base wheel)
-  - 11 hand-listed extra deps 37 MB
-  - site-packages 371 MB total (includes ``litellm``/proxy, ``pip``,
-    ``setuptools``, ``grpc_tools`` build-time compiler, and ``*.pyc`` bytecode)
-
-The multi-stage runner Dockerfile achieves the reduction (build-only apt +
+The current multi-stage runner Dockerfile measures ~391 MB, a 40.8% reduction
+from the pre-slim 659 MB baseline recorded in ADR-0022 §4b (build-only apt +
 docker CLI kept out of the runtime stage, wheel installed with ``--no-compile``,
-the pip/setuptools toolchain stripped); this module is the behaviour lock that
-proves it stays real.
+the pip/setuptools toolchain stripped). This module is the behaviour lock that
+proves the reduction stays real; the SSOT-consistency lock below proves the
+resolver keeps agreeing with what a real build tags.
 """
 
 from __future__ import annotations
@@ -32,7 +22,7 @@ import subprocess
 
 import pytest
 
-from tests.utils.docker_helpers import is_docker_daemon_available, newest_image_id
+from tests.utils.docker_helpers import current_runner_image_id, is_docker_daemon_available
 from tolokaforge.docker import builder
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
@@ -44,13 +34,6 @@ The slim image measures 390.2 MB (40.8% under the 659 MB baseline); the ceiling
 is that measurement plus ~15 MB slack, which absorbs future minor dependency
 bumps without a spurious CI break while still catching a real size regression.
 """
-
-
-def _resolve_runner_image_id() -> str | None:
-    # Read the image name from the builder's static definition table rather
-    # than get_image_definition — the latter triggers wheel resolution as a
-    # side effect, which a size lock has no need for.
-    return newest_image_id(builder.IMAGE_DEFINITIONS["runner"]["name"])
 
 
 def _image_size_mb(image_id: str) -> float:
@@ -67,9 +50,29 @@ def _image_size_mb(image_id: str) -> float:
 def test_runner_image_within_size_ceiling() -> None:
     if not is_docker_daemon_available():
         pytest.skip("Docker daemon not available")
-    image_id = _resolve_runner_image_id()
+    image_id = current_runner_image_id()
     if image_id is None:
         pytest.skip("tolokaforge-runner image not built; size lock needs a built engine image")
     size_mb = _image_size_mb(image_id)
     message = f"runner image {size_mb:.1f} MB exceeds ceiling {RUNNER_IMAGE_SIZE_CEILING_MB} MB"
     assert size_mb <= RUNNER_IMAGE_SIZE_CEILING_MB, message
+
+
+def test_current_runner_image_id_matches_real_build() -> None:
+    """The content-hash resolver agrees with what a real build tags.
+
+    A cache hit after the lane's ``make docker-build`` (``build_image`` returns
+    the existing image id), so this is cheap. It FAILS — not skips — if the
+    resolver's predicted ref and a real build ever diverge, so a hashing-path
+    bug can never masquerade as the legitimate ``None``-then-skip case.
+    """
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+    resolved = current_runner_image_id()
+    if resolved is None:
+        pytest.skip("tolokaforge-runner image not built")
+    built = builder.build_image("runner")
+    drift = (
+        f"resolver id {resolved!r} != real build id {built.image_id!r} — content-hash SSOT drift"
+    )
+    assert resolved == built.image_id, drift

--- a/tests/integration/docker/test_runner_image_size.py
+++ b/tests/integration/docker/test_runner_image_size.py
@@ -35,6 +35,15 @@ is that measurement plus ~15 MB slack, which absorbs future minor dependency
 bumps without a spurious CI break while still catching a real size regression.
 """
 
+STRIPPED_TOOLCHAIN_MODULES = ("pip", "setuptools", "wheel", "pkg_resources")
+"""The install-toolchain modules ``runner.Dockerfile`` strips from the runtime venv.
+
+The runtime never installs packages, so the venv-seeded pip/setuptools/wheel
+footprint is removed after build. Probed one module per ``docker run`` because
+``import pip, setuptools, wheel`` short-circuits on the first missing name — a
+partial re-inclusion excluding only that first name would slip a combined probe.
+"""
+
 
 def _image_size_mb(image_id: str) -> float:
     """Uncompressed image size in MB (SI, matching ``docker images`` SIZE)."""
@@ -76,3 +85,38 @@ def test_current_runner_image_id_matches_real_build() -> None:
         f"resolver id {resolved!r} != real build id {built.image_id!r} — content-hash SSOT drift"
     )
     assert resolved == built.image_id, drift
+
+
+def test_runner_image_has_no_pip_toolchain() -> None:
+    """The install toolchain is absent from the runtime venv (``runner.Dockerfile`` strip).
+
+    Locks the strip invariant: pip/setuptools/wheel/pkg_resources must not be
+    importable inside the runner image. Each module is probed in its own
+    ``docker run --entrypoint python -c "import <mod>"``; a combined import would
+    short-circuit on the first missing name and let a partial re-inclusion pass.
+
+    A bare non-zero exit is not enough — a failed entrypoint override, a bad
+    image id, or a container that never starts also exit non-zero and would pass
+    green for the wrong reason. So each probe additionally asserts the module's
+    absence signature (``ModuleNotFoundError`` / ``No module named``) in stderr,
+    which rules out spurious failures and names the offending module on regression.
+    """
+    if not is_docker_daemon_available():
+        pytest.skip("Docker daemon not available")
+    image_id = current_runner_image_id()
+    if image_id is None:
+        pytest.skip("tolokaforge-runner image not built; toolchain guard needs a built image")
+    for module in STRIPPED_TOOLCHAIN_MODULES:
+        result = subprocess.run(
+            ["docker", "run", "--rm", "--entrypoint", "python", image_id, "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+        )
+        importable = f"{module!r} is importable in the runner image — the toolchain strip regressed"
+        assert result.returncode != 0, importable
+        signature = "ModuleNotFoundError" in result.stderr or "No module named" in result.stderr
+        wrong_reason = (
+            f"import {module} exited non-zero without a module-not-found signature "
+            f"(guard would pass for the wrong reason); stderr:\n{result.stderr}"
+        )
+        assert signature, wrong_reason

--- a/tests/integration/docker/test_runner_image_size.py
+++ b/tests/integration/docker/test_runner_image_size.py
@@ -8,7 +8,7 @@ image another worktree/branch built into the shared ``tolokaforge-runner`` name
 can never be the one measured. It inspects that exact ref's size straight from
 the Docker daemon and asserts it stays under a single named ceiling.
 
-The current multi-stage runner Dockerfile measures ~391 MB, a 40.8% reduction
+The current multi-stage runner Dockerfile measures ~390.2 MB, a 40.8% reduction
 from the pre-slim 659 MB baseline recorded in ADR-0022 §4b (build-only apt +
 docker CLI kept out of the runtime stage, wheel installed with ``--no-compile``,
 the pip/setuptools toolchain stripped). This module is the behaviour lock that
@@ -70,17 +70,23 @@ def test_runner_image_within_size_ceiling() -> None:
 def test_current_runner_image_id_matches_real_build() -> None:
     """The content-hash resolver agrees with what a real build tags.
 
-    A cache hit after the lane's ``make docker-build`` (``build_image`` returns
-    the existing image id), so this is cheap. It FAILS — not skips — if the
-    resolver's predicted ref and a real build ever diverge, so a hashing-path
-    bug can never masquerade as the legitimate ``None``-then-skip case.
+    Builds first (a cache hit after the lane's ``make docker-build``, so cheap),
+    which proves both that the daemon is up and that a current-tree runner image
+    exists. Once that build succeeds a ``None`` from the resolver is no longer
+    "not built" — it is SSOT drift between ``expected_image_ref`` and what the
+    build tags — so it FAILS, never skips. Divergence surfacing as a missing ref
+    (resolver returns ``None``) is caught by the non-None assertion; divergence
+    surfacing as a different id is caught by the equality assertion.
     """
     if not is_docker_daemon_available():
         pytest.skip("Docker daemon not available")
-    resolved = current_runner_image_id()
-    if resolved is None:
-        pytest.skip("tolokaforge-runner image not built")
     built = builder.build_image("runner")
+    resolved = current_runner_image_id()
+    missing = (
+        "real build exists but resolver found nothing at the expected ref — "
+        "SSOT drift between expected_image_ref and build_image, not 'not built'"
+    )
+    assert resolved is not None, missing
     drift = (
         f"resolver id {resolved!r} != real build id {built.image_id!r} — content-hash SSOT drift"
     )

--- a/tests/integration/docker/test_slim_runner_image_e2e.py
+++ b/tests/integration/docker/test_slim_runner_image_e2e.py
@@ -32,8 +32,7 @@ from typing import Any
 
 import pytest
 
-from tests.utils.docker_helpers import is_docker_daemon_available, newest_image_id
-from tolokaforge.docker import builder
+from tests.utils.docker_helpers import current_runner_image_id, is_docker_daemon_available
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 
@@ -50,7 +49,7 @@ _DOMAIN_DEP_IMPORTS = "import asyncpg, sqlalchemy, alembic, jose, fastapi, uvico
 def runner_image_id() -> str:
     if not is_docker_daemon_available():
         pytest.skip("Docker daemon not available")
-    image_id = newest_image_id(builder.IMAGE_DEFINITIONS["runner"]["name"])
+    image_id = current_runner_image_id()
     if image_id is None:
         pytest.skip("tolokaforge-runner image not built")
     return image_id

--- a/tests/integration/test_rubric_judge_live.py
+++ b/tests/integration/test_rubric_judge_live.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests.utils.docker_helpers import is_docker_daemon_available, newest_image_id
+from tests.utils.docker_helpers import current_runner_image_id, is_docker_daemon_available
 from tolokaforge.core.grading.judge import (
     JudgeStatus,
     LLMJudge,
@@ -31,7 +31,6 @@ from tolokaforge.core.grading.judge import (
 )
 from tolokaforge.core.grading.kb_search import SearchHit
 from tolokaforge.core.grading.rubric import SubmitReportValidationError, parse_submit_report
-from tolokaforge.docker import builder
 from tolokaforge.runner.models import Rubric
 
 pytestmark = [
@@ -385,7 +384,7 @@ def test_rubric_judge_runs_inside_slim_runner_image():
     """
     if not is_docker_daemon_available():
         pytest.skip("Docker daemon not available")
-    image_id = newest_image_id(builder.IMAGE_DEFINITIONS["runner"]["name"])
+    image_id = current_runner_image_id()
     if image_id is None:
         pytest.skip("tolokaforge-runner image not built")
 

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -151,9 +151,13 @@ def test_expected_image_ref_matches_real_content_hash() -> None:
     """``expected_image_ref('runner')`` equals ``name:hash8`` from the real
     context-assembly + content-hash path — driven here, not stubbed.
 
-    Locks the SSOT: a drift in ``wheel_resolver``, ``assemble_build_context``,
-    or ``_compute_content_hash``'s input set breaks this equality. It fails; it
-    does not skip — no Docker daemon involved.
+    Locks the plumbing: ``expected_image_ref`` assembles the real runner build
+    context (``wheel_resolver`` + ``assemble_build_context``), routes it through
+    the real ``_compute_content_hash``, slices ``[:8]``, and prefixes the image
+    name (``name:hash[:8]``) — not a stub or a shortcut. Both sides call the same
+    hash, so this does not catch a symmetric change to the hash's input set; it
+    catches ``expected_image_ref`` diverging from that path or the tag format. It
+    fails; it does not skip — no Docker daemon involved.
     """
     from tolokaforge.docker.builder import (
         assemble_build_context,

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -147,6 +147,39 @@ def test_isolated_context_hash_stable_across_unrelated_changes(
 
 
 @pytest.mark.usefixtures("_mock_wheel")
+def test_expected_image_ref_matches_real_content_hash() -> None:
+    """``expected_image_ref('runner')`` equals ``name:hash8`` from the real
+    context-assembly + content-hash path — driven here, not stubbed.
+
+    Locks the SSOT: a drift in ``wheel_resolver``, ``assemble_build_context``,
+    or ``_compute_content_hash``'s input set breaks this equality. It fails; it
+    does not skip — no Docker daemon involved.
+    """
+    from tolokaforge.docker.builder import (
+        assemble_build_context,
+        expected_image_ref,
+        get_image_definition,
+        repo_root,
+    )
+
+    definition = get_image_definition("runner")
+    build_context = assemble_build_context(
+        repo_root=repo_root(),
+        dockerfile=definition["dockerfile"],
+        context_files=definition["context_files"],
+    )
+    try:
+        dockerfile_path = build_context / definition["dockerfile"]
+        content_hash = Image._compute_content_hash(
+            dockerfile_path, build_context, definition["build_args"]
+        )
+    finally:
+        shutil.rmtree(build_context, ignore_errors=True)
+
+    assert expected_image_ref("runner") == f"{definition['name']}:{content_hash[:8]}"
+
+
+@pytest.mark.usefixtures("_mock_wheel")
 def test_runner_build_context_contains_wheel() -> None:
     """The runner image context should contain the resolved wheel (not source)."""
     runner_def = get_image_definition("runner")

--- a/tests/utils/docker_helpers.py
+++ b/tests/utils/docker_helpers.py
@@ -75,34 +75,30 @@ def is_docker_daemon_available() -> bool:
         return False
 
 
-def newest_image_id(image_name: str) -> str | None:
-    """ID of the most recently built image tagged ``image_name``, or ``None``.
+def current_runner_image_id() -> str | None:
+    """Docker id of the runner image the *current tree* produces, or ``None``.
 
-    The newest image by build time is the one the current Dockerfile produces
-    (and what a ``:local``/``:latest`` alias points at after a build), so tests
-    that lock the freshly-built image resolve it this way rather than trusting a
-    possibly-stale tag.
+    Resolves the exact content-hash ref ``builder.expected_image_ref("runner")``
+    — the tag a real ``build_image("runner")`` assigns — and inspects that one
+    ref. It is a single exact-ref lookup: no ``docker images`` enumeration, no
+    ``.Created`` ranking, no candidate filtering. A foreign image built from a
+    different Dockerfile hashes to a different tag, so it cannot match the ref;
+    provenance-correctness is structural, not a heuristic.
+
+    ``None`` means the current-tree image is not built (the legitimate skip
+    case). The full ``sha256:...`` digest is returned so it compares equal to
+    the Docker SDK's ``Image.image_id``.
     """
     import subprocess
 
-    listing = subprocess.run(
-        ["docker", "images", image_name, "--format", "{{.ID}}"],
+    from tolokaforge.docker import builder
+
+    ref = builder.expected_image_ref("runner")
+    result = subprocess.run(
+        ["docker", "image", "inspect", ref, "--format", "{{.Id}}"],
         capture_output=True,
         text=True,
-        check=True,
     )
-    image_ids = list(dict.fromkeys(line for line in listing.stdout.split() if line))
-    if not image_ids:
+    if result.returncode != 0:
         return None
-    newest_id: str | None = None
-    newest_created = ""
-    for image_id in image_ids:
-        created = subprocess.run(
-            ["docker", "image", "inspect", image_id, "--format", "{{.Created}}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-        if created > newest_created:
-            newest_created, newest_id = created, image_id
-    return newest_id
+    return result.stdout.strip() or None

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import logging
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -293,57 +294,75 @@ def build_image(
         >>> image.exists()
         True
     """
-    definition = get_image_definition(service_name)
-    context_files = definition.get("context_files", [])
-    build_args = definition.get("build_args")
-
-    if context_files:
-        build_context = assemble_build_context(
-            repo_root=repo_root(),
-            dockerfile=definition["dockerfile"],
-            context_files=context_files,
-        )
-        dockerfile_path = build_context / definition["dockerfile"]
-        try:
-            if force:
-                logger.info("Force building image for '%s' with isolated context", service_name)
-                return Image.build(
-                    dockerfile=str(dockerfile_path),
-                    context=str(build_context),
-                    name=definition["name"],
-                    build_args=build_args,
-                )
-
-            if registry is None:
-                registry = ImageRegistry()
-
-            return registry.get_or_build(
-                name=definition["name"],
-                dockerfile=str(dockerfile_path),
-                context=str(build_context),
+    with _prepared_build_context(service_name) as (dockerfile, context, name, build_args):
+        if force:
+            logger.info("Force building image for '%s'", service_name)
+            return Image.build(
+                dockerfile=dockerfile,
+                context=context,
+                name=name,
                 build_args=build_args,
             )
-        finally:
-            shutil.rmtree(build_context, ignore_errors=True)
 
-    if force:
-        logger.info("Force building image for '%s'", service_name)
-        return Image.build(
-            dockerfile=definition["dockerfile"],
-            context=definition["context"],
-            name=definition["name"],
+        if registry is None:
+            registry = ImageRegistry()
+
+        return registry.get_or_build(
+            name=name,
+            dockerfile=dockerfile,
+            context=context,
             build_args=build_args,
         )
 
-    if registry is None:
-        registry = ImageRegistry()
 
-    return registry.get_or_build(
-        name=definition["name"],
+@contextmanager
+def _prepared_build_context(
+    service_name: str,
+) -> Iterator[tuple[str, str, str, dict[str, str]]]:
+    """Yield ``(dockerfile, context, name, build_args)`` for a service build.
+
+    For services that declare ``context_files`` (runner, rag-service) this
+    assembles an isolated temp build context and removes it on exit; otherwise
+    it yields the static repo-relative paths. Both ``build_image`` and
+    ``expected_image_ref`` consume this so a real build and its predicted ref
+    hash exactly the same inputs.
+    """
+    definition = get_image_definition(service_name)
+    context_files = definition.get("context_files", [])
+    build_args = definition.get("build_args") or {}
+    name = definition["name"]
+
+    if not context_files:
+        yield definition["dockerfile"], definition["context"], name, build_args
+        return
+
+    build_context = assemble_build_context(
+        repo_root=repo_root(),
         dockerfile=definition["dockerfile"],
-        context=definition["context"],
-        build_args=build_args,
+        context_files=context_files,
     )
+    try:
+        dockerfile_path = build_context / definition["dockerfile"]
+        yield str(dockerfile_path), str(build_context), name, build_args
+    finally:
+        shutil.rmtree(build_context, ignore_errors=True)
+
+
+def expected_image_ref(service_name: str) -> str:
+    """The exact ``name:tag`` that ``build_image(service_name)`` would assign.
+
+    Computed via the same context-assembly + content-hash path a real build
+    uses (``Image.expected_ref`` shares ``Image._content_hash_and_tag`` with
+    ``Image.build``), so the returned ref matches a real build by construction.
+    Does not build.
+    """
+    with _prepared_build_context(service_name) as (dockerfile, context, name, build_args):
+        return Image.expected_ref(
+            dockerfile=dockerfile,
+            context=context,
+            name=name,
+            build_args=build_args,
+        )
 
 
 def assemble_build_context(

--- a/tolokaforge/docker/image.py
+++ b/tolokaforge/docker/image.py
@@ -258,8 +258,7 @@ class Image(BaseModel):
             name = f"tolokaforge-{name}"
 
         # Compute content hash
-        content_hash = cls._compute_content_hash(dockerfile_path, context_path, build_args)
-        tag = content_hash[:8]  # Use first 8 chars of hash as tag
+        content_hash, tag = cls._content_hash_and_tag(dockerfile_path, context_path, build_args)
 
         logger.info(
             "Building image '%s:%s' from %s (context: %s)",
@@ -374,6 +373,36 @@ class Image(BaseModel):
         except APIError:
             # Treat API errors as "not found" - caller will attempt to build
             return None  # noqa: BLE001 - Lookup function, None is valid "not found"
+
+    @classmethod
+    def _content_hash_and_tag(
+        cls,
+        dockerfile_path: Path,
+        context_path: Path,
+        build_args: dict[str, str],
+    ) -> tuple[str, str]:
+        """SSOT for the content-hash → tag derivation.
+
+        Both ``build`` and ``builder.expected_image_ref`` route the tag through
+        this one method, so a resolver that predicts a build's tag cannot drift
+        from what the build actually assigns.
+        """
+        content_hash = cls._compute_content_hash(dockerfile_path, context_path, build_args)
+        return content_hash, content_hash[:8]
+
+    @classmethod
+    def expected_ref(
+        cls,
+        dockerfile: str,
+        context: str,
+        name: str,
+        build_args: dict[str, str] | None = None,
+    ) -> str:
+        """The exact ``name:tag`` a build of these inputs would assign, without building."""
+        _content_hash, tag = cls._content_hash_and_tag(
+            Path(dockerfile), Path(context), build_args or {}
+        )
+        return f"{name}:{tag}"
 
     @classmethod
     def _compute_content_hash(


### PR DESCRIPTION
## Summary

- The runner-image size test was provenance-blind — it selected the newest `tolokaforge-runner`-tagged image by build timestamp, which in a multi-worktree checkout intermittently measured a foreign ~660 MB image built by a sibling git worktree running a pre-M13 single-stage Dockerfile. The current `runner.Dockerfile` never regressed; the "lock" did.
- Fix: resolve the image by the builder's content-hash SSOT (`builder.expected_image_ref` + `tests/utils/docker_helpers.current_runner_image_id`), never by timestamp. A foreign Dockerfile has a different content hash → different tag → cannot match the exact ref, so provenance-correctness is structural.
- Adds `test_runner_image_has_no_pip_toolchain` — locks the Dockerfile strip block (`runner.Dockerfile:99-110`) so a future re-inclusion of `pip`/`setuptools`/`wheel`/`pkg_resources` fails loud on the specific broken invariant, not just on total size.

## Design choices

- **Single shared hash→tag computation** (`Image._content_hash_and_tag`, called by both `build_image` and `expected_image_ref`): the predicted ref equals what a real build tags *by construction* — no parallel hashing path to drift. Verified holding across both the force and registry build paths.
- **Resolver returns `str | None`**: `None` models only the legitimate "not built" case. The SSOT-consistency test builds first, so post-build a `None` is SSOT drift and hard-fails (never skips) — closing the silent-degradation this ticket exists to eliminate.
- **Per-module toolchain probes with a double assertion** (`returncode != 0` AND stderr carries `ModuleNotFoundError`/`No module named`): a combined import would short-circuit on the first missing name; the stderr-signature check rules out a non-zero exit for the wrong reason (failed entrypoint override, container that never starts).
- **Convert all three provenance-blind call sites**, not just the size test — leaving `test_slim_runner_image_omits_docker_cli_by_default` on the blind selector would knowingly ship a lock that fails against a foreign fat image.

## Concepts introduced

`builder.expected_image_ref(service_name) -> str` and `current_runner_image_id() -> str | None` — the content-hash-pinned way tests name "the image the *current tree* produces," independent of what other worktrees built into the shared local `tolokaforge-runner` name. Both internal (test-support + internal builder helper); no published surface, no CHANGELOG.

## Plan

Full staged plan: `~/.claude/plans/toloka-tolokaforge/issue-604-runner-image-regression.md` (Stage 1 provenance-correct resolution; Stage 2 toolchain-absence guard).

## Discovered issues

- Filed: #613 (runner image builds share a global `tolokaforge-runner` tag namespace — worktree/branch builds collide in the local daemon; P3, dev-environmental only — this PR neutralises the observable symptom).
- Fixed in this PR: converted all three provenance-blind runner-image call sites (not just the size lock).

## Test plan

- `uv run pytest tests/unit/test_docker_build_context.py -m unit` → 11 passed (incl. the daemon-free SSOT-plumbing lock).
- `make docker-build` then `scripts/with_env.sh uv run pytest tests/integration/docker/test_runner_image_size.py -m integration` → 3 passed (size ceiling 391 MB ≤ 405, SSOT-consistency lock, toolchain-absence guard) — deterministic with fat worktree images present in the daemon.

Closes #604