### PR TITLE
fix(runner): preserve simulator text glued to ###STOP### (closes #611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fix
+
+- **runner**: preserve simulator text glued to `###STOP###` — pre-token content is delivered as a USER message and the dialogue terminates with `USER_STOP` on the following user turn instead of silently discarding the entire reply. Simulator prompt gains an explicit precedence rule for backstory-mandated replies and an anti-restart rule (#611)
+
 ## v0.11.1 (2026-07-27)
 
 ### Feat

--- a/tests/unit/test_runner_logic.py
+++ b/tests/unit/test_runner_logic.py
@@ -36,10 +36,15 @@ def _make_tool_executor() -> MagicMock:
 
 
 def _make_user_simulator() -> MagicMock:
-    """Create a mock UserSimulator."""
+    """Create a mock UserSimulator.
+
+    Default reply is a bare ``###STOP###`` so tests that don't care about the
+    stop-token split path get the immediate-terminate branch. Tests exercising
+    the split-on-final-reply path override the reply explicitly.
+    """
     sim = MagicMock()
     sim.reply.return_value = GenerationResult(
-        text="Thanks, that answers my question. ###STOP###",
+        text="###STOP###",
         tool_calls=[],
     )
     return sim
@@ -325,7 +330,7 @@ class TestTrialRunnerRun:
         assert traj.metrics.usage.completion_tokens == 50
 
     def test_user_stop_signal(self) -> None:
-        """Agent responds normally, then user sends ###STOP###."""
+        """Agent responds normally, then user sends a bare ###STOP###."""
         agent = _make_agent_client(
             [
                 GenerationResult(
@@ -337,13 +342,63 @@ class TestTrialRunnerRun:
         )
         user_sim = _make_user_simulator()
         user_sim.reply.return_value = GenerationResult(
-            text="Thanks! ###STOP###",
+            text="###STOP###",
             tool_calls=[],
         )
         runner = _make_runner(agent_client=agent, user_simulator=user_sim)
         traj = runner.run("System prompt", "Hello")
 
         assert traj.termination_reason == TerminationReason.USER_STOP
+
+    def test_user_stop_with_final_reply_is_delivered_first(self) -> None:
+        """Simulator glues a substantive reply to ``###STOP###`` in one message.
+
+        The pre-token text is delivered to the agent as a USER message, the
+        agent gets one more turn to react, and the dialogue ends with
+        ``USER_STOP``. Pre-fix, the entire text (including the mandated reply)
+        was discarded on the ``###STOP###`` substring match.
+        """
+        agent = _make_agent_client(
+            [
+                GenerationResult(
+                    text="I understand. I'll close this case now.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=100, completion_tokens=50),
+                    cost_usd=0.01,
+                ),
+                GenerationResult(
+                    text="Case closed. Reference CASE-12345.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=120, completion_tokens=40),
+                    cost_usd=0.01,
+                ),
+            ]
+        )
+        user_sim = _make_user_simulator()
+        user_sim.reply.side_effect = [
+            GenerationResult(
+                text=(
+                    "That's okay, I'll handle the payment through the online portal "
+                    "instead — please go ahead and close this request. ###STOP###"
+                ),
+                tool_calls=[],
+            ),
+        ]
+        runner = _make_runner(agent_client=agent, user_simulator=user_sim)
+        traj = runner.run("System", "I'd like to make a payment")
+
+        assert traj.termination_reason == TerminationReason.USER_STOP
+        assert traj.metrics.api_calls == 2
+
+        user_messages = [m for m in traj.messages if m.role == MessageRole.USER]
+        # The final reply must be delivered to the agent verbatim (sans token).
+        delivered = [m.content for m in user_messages]
+        assert any("handle the payment through the online portal" in text for text in delivered)
+        # The stop token itself must NOT survive on any user message.
+        assert not any("###STOP###" in text for text in delivered)
+        # Exactly one simulator call — pending flag terminates the next user turn
+        # without another simulator invocation.
+        assert user_sim.reply.call_count == 1
 
     def test_initial_user_message_used_directly(self) -> None:
         """When initial_user_message is provided, it's used directly."""

--- a/tests/unit/test_runner_logic.py
+++ b/tests/unit/test_runner_logic.py
@@ -399,6 +399,115 @@ class TestTrialRunnerRun:
         # Exactly one simulator call — pending flag terminates the next user turn
         # without another simulator invocation.
         assert user_sim.reply.call_count == 1
+        # The pending flag must reset after the terminating turn so an
+        # (unlikely) re-use of the runner instance doesn't abort turn 1.
+        assert runner._user_stop_pending is False
+
+    def test_user_stop_whitespace_only_pre_token_terminates_immediately(self) -> None:
+        """Whitespace-only text before the token routes through the bare-stop
+        branch — no extra agent turn, no pending flag.
+        """
+        agent = _make_agent_client(
+            [
+                GenerationResult(
+                    text="Working on it.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=10, completion_tokens=5),
+                ),
+            ]
+        )
+        user_sim = _make_user_simulator()
+        user_sim.reply.return_value = GenerationResult(
+            text="   \n\t  ###STOP###",
+            tool_calls=[],
+        )
+        runner = _make_runner(agent_client=agent, user_simulator=user_sim)
+        traj = runner.run("System", "Do the task")
+
+        assert traj.termination_reason == TerminationReason.USER_STOP
+        assert traj.metrics.api_calls == 1  # Only the initial agent turn
+        assert runner._user_stop_pending is False
+
+    def test_user_stop_first_token_wins_when_multiple(self) -> None:
+        """When the simulator reply contains ``###STOP###`` more than once,
+        ``str.partition`` splits on the first occurrence; the remainder
+        (including any additional tokens) is discarded, and the pre-token
+        text is delivered as a USER message.
+        """
+        agent = _make_agent_client(
+            [
+                GenerationResult(
+                    text="Acknowledged.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=10, completion_tokens=5),
+                ),
+                GenerationResult(
+                    text="Done.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=10, completion_tokens=5),
+                ),
+            ]
+        )
+        user_sim = _make_user_simulator()
+        user_sim.reply.side_effect = [
+            GenerationResult(
+                text="first reply ###STOP### middle chunk ###STOP### tail",
+                tool_calls=[],
+            ),
+        ]
+        runner = _make_runner(agent_client=agent, user_simulator=user_sim)
+        traj = runner.run("System", "Hello")
+
+        assert traj.termination_reason == TerminationReason.USER_STOP
+        user_messages = [m for m in traj.messages if m.role == MessageRole.USER]
+        delivered = [m.content for m in user_messages]
+        # First-occurrence split: the delivered user message keeps ONLY the
+        # pre-first-token text; downstream chunks are dropped even if they
+        # contain a second token.
+        assert any(text == "first reply" for text in delivered)
+        assert not any("middle chunk" in text for text in delivered)
+        assert not any("tail" in text for text in delivered)
+        assert not any("###STOP###" in text for text in delivered)
+
+    def test_user_stop_with_final_reply_preserves_tool_calls(self) -> None:
+        """Simulator reply with both tool_calls and text-glued ``###STOP###``.
+
+        The stop-token strip must not drop the ``tool_calls`` — they still
+        need to reach ``ActionEvaluator`` for required-action tracking.
+        """
+        sim_tool_call = ToolCall(id="uc1", name="user_lookup", arguments={"id": "42"})
+        agent = _make_agent_client(
+            [
+                GenerationResult(
+                    text="I'll check that for you.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=10, completion_tokens=5),
+                ),
+                GenerationResult(
+                    text="Case closed.",
+                    tool_calls=[],
+                    usage=Usage(prompt_tokens=10, completion_tokens=5),
+                ),
+            ]
+        )
+        user_sim = _make_user_simulator()
+        user_sim.reply.side_effect = [
+            GenerationResult(
+                text="Please close it. ###STOP###",
+                tool_calls=[sim_tool_call],
+            ),
+        ]
+        runner = _make_runner(agent_client=agent, user_simulator=user_sim)
+        traj = runner.run("System", "Hi")
+
+        assert traj.termination_reason == TerminationReason.USER_STOP
+        user_messages = [m for m in traj.messages if m.role == MessageRole.USER]
+        # Find the delivered user message (not the initial one).
+        delivered = next(m for m in user_messages if "Please close it" in (m.content or ""))
+        assert "###STOP###" not in delivered.content
+        assert delivered.tool_calls is not None
+        assert len(delivered.tool_calls) == 1
+        assert delivered.tool_calls[0].id == "uc1"
 
     def test_initial_user_message_used_directly(self) -> None:
         """When initial_user_message is provided, it's used directly."""

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1722,7 +1722,8 @@ Rules:
 - When the agent asks "anything else?" or "Is there anything else I can help you with?", check if you have remaining steps. If yes, continue with the next step.
 - Do not claim that you completed a required step yourself. Wait for the agent to complete steps, and only acknowledge completion after the agent explicitly confirms it.
 - Only generate '###STOP###' when you have completed EVERY step in your instruction and the entire goal is satisfied, not partway through.
-- Once the agent delivers the requested artifact/output, do not introduce new goals or remediation steps. Acknowledge completion and end with '###STOP###'.
+- If your Instruction still specifies an unsent mandatory reply (e.g. a verbal decline, confirmation, or acknowledgement you MUST say to the agent), send that reply first. A terminal-looking message from the agent — case reference, summary, apology, goodbye — does NOT release you from that reply. '###STOP###' may only accompany or follow the reply, never precede or replace it.
+- Once the agent has substantively addressed your request, do not re-state or restart the original opening as if it had not been answered. Send at most one short acknowledgement and end with '###STOP###'; do not introduce new goals or remediation steps.
 - Do not repeat the exact instruction in the conversation. Instead, use your own words to convey the same information.
 - Try to make the conversation as natural as possible, and stick to the personalities in the instruction.
 - Never mention that this is a simulation, test, benchmark, prompt, or that you are an AI/model.{tool_guidance}"""

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -89,6 +89,12 @@ class TrialRunner:
         # :meth:`UserSimulator.reply` for tests that drive the runner's helper
         # methods directly.
         self._user_observation: LLMCallObservation | None = None
+        # Set when the simulator emits a substantive final reply glued to the
+        # ``###STOP###`` token in the same message. On the next user turn the
+        # runner terminates before calling the simulator so the agent gets
+        # exactly one more turn to act on the delivered reply, then the loop
+        # ends with ``USER_STOP``.
+        self._user_stop_pending: bool = False
 
     @property
     def effective_system_prompt(self) -> str | None:
@@ -411,17 +417,45 @@ class TrialRunner:
         Embeds user tool-call results in the user message text (Anthropic does
         not support ``tool_use`` from the USER role) while preserving the
         original ``tool_calls`` so ``ActionEvaluator`` can track required actions.
-        """
-        user_result = self.user_simulator.reply(messages, observation=self._user_observation)
 
-        if "###STOP###" in user_result.text:
-            self.logger.info("User signaled completion (###STOP###)")
+        Stop-token handling has two shapes:
+
+        * Bare ``###STOP###`` (or the token with only whitespace before it) —
+          terminate immediately with ``USER_STOP``.
+        * Substantive text glued to ``###STOP###`` in one message — deliver the
+          pre-token text as a normal USER message, set a pending flag, and
+          terminate on the following user turn. Guarantees the agent sees the
+          final reply (e.g. a backstory-mandated verbal decline) before the
+          dialogue ends.
+        """
+        if self._user_stop_pending:
+            self.logger.info("User signaled completion (###STOP### after final reply)")
+            self._user_stop_pending = False
             return UserTurnResult(
                 termination=TerminationDecision(
                     reason=TerminationReason.USER_STOP,
-                    system_message="User signaled stop (###STOP###). Dialogue ended.",
+                    system_message="User signaled stop (###STOP### after final reply). Dialogue ended.",
                 )
             )
+
+        user_result = self.user_simulator.reply(messages, observation=self._user_observation)
+
+        if "###STOP###" in user_result.text:
+            pre_stop_text, _, _ = user_result.text.partition("###STOP###")
+            pre_stop_text = pre_stop_text.rstrip()
+            if not pre_stop_text:
+                self.logger.info("User signaled completion (###STOP###)")
+                return UserTurnResult(
+                    termination=TerminationDecision(
+                        reason=TerminationReason.USER_STOP,
+                        system_message="User signaled stop (###STOP###). Dialogue ended.",
+                    )
+                )
+            self.logger.info(
+                "User sent final reply with ###STOP### — delivering reply, stop pending"
+            )
+            self._user_stop_pending = True
+            user_result.text = pre_stop_text
 
         user_message_text = user_result.text
         if user_result.tool_calls and self.user_tool_executor:


### PR DESCRIPTION
## Summary

Fixes #611. The user-simulator's stop-token handling in `TrialRunner._agent_user_turn` currently treats any occurrence of `###STOP###` in the simulator's reply as "discard the entire text and terminate." When the simulator glues a substantive final reply and the token into the same message — e.g. `"That's okay, I'll handle the payment through the online portal instead — please go ahead and close this request. ###STOP###"` — the whole reply is swallowed, the agent never sees the message it was waiting on, and the trial ends mid-task. In the reporter's data this fires in ~50% of trials on hardened backstories across every evaluated model.

The reporter's own investigation (replay of 20 recorded failure contexts through the real sim, sonnet-4.6 @ temp 0.2) shows the simulator DOES emit the mandated line 20/20 — it's the runner-side swallow, not the sim's compliance, that is the killer. This PR fixes the runner-side swallow and shores up the sim prompt so the two failure polarities (premature stop; restart after resolution) are less likely to trigger in the first place.

## Changes

- **`tolokaforge/core/runner.py`** — `TrialRunner._agent_user_turn` now splits the simulator reply on `###STOP###`:
  - Bare `###STOP###` (or the token with only whitespace before it) — terminate immediately as before.
  - Substantive text glued to `###STOP###` in one message — deliver the pre-token text as a normal USER message, set `_user_stop_pending=True`, and terminate with `USER_STOP` on the following user turn. Guarantees the agent sees the final reply before the dialogue ends.
- **`tolokaforge/core/llm/client.py`** — `UserSimulator._build_system_prompt` gains two rules with an explicit precedence contract:
  - An Instruction-mandated unsent reply blocks premature `###STOP###` — a terminal-looking agent message (case reference, summary, apology, goodbye) does not release the simulator from that reply.
  - Once the agent has substantively addressed the request, the simulator sends at most one short acknowledgement rather than re-stating the original opening (covers the "restart after resolution" polarity).
- **`tests/unit/test_runner_logic.py`** — existing `test_agent_response_then_user_stop` / `test_user_stop_signal` fixtures switch to bare `###STOP###` (they always exercised the immediate-terminate path, not the glued-reply path). New `test_user_stop_with_final_reply_is_delivered_first` covers the split-delivery + pending-flag flow end-to-end.
- **`CHANGELOG.md`** — Unreleased entry.

The runner change and the prompt change are independent — the runner alone fixes the swallow; the prompt refines when the simulator emits the token in the first place. If regression pressure ever forces a reduction, drop the prompt rules and keep the runner split-on-STOP.

## Test plan

- [x] Unit lane green: `uv run pytest tests/unit -m unit` — 3522 passed
- [x] Canonical lane green: `uv run pytest tests/canonical -m canonical` — 665 passed
- [x] Lint clean: `uv run ruff check` + `uv run ruff format --check` on all touched files
- [x] End-to-end smoke on public `examples/native/tool_use` with the mock provider — both trials report `turns=2`, deliver the pre-token text as a real USER message, retain no `###STOP###` on any USER message, and terminate cleanly via `USER_STOP` after the agent's final reaction. Sample trajectory excerpt:
  ```
  - role: user
    content: "Thanks, that answers my question."
  - role: assistant
    content: "Acknowledged. Task complete."
  - role: system
    content: "User signaled stop (###STOP### after final reply). Dialogue ended."
  termination_reason: user_stop
  ```
- [ ] Reviewer replay (optional, held by reporter): fix-set of 20 recorded failure contexts should now show pre-token text delivered on every trial (`said_mandated: true` retained; `stop: true` retained but no longer swallows the reply).

## Notes for reviewers

- **Independence from in-flight branches.** Checked against every open PR + local integration branch touching runner-adjacent code: `feat/open-agent-loop` (PR #445) refactors the `ToolCallingLoop(...)` construction in `run()` and adds observer/intervention seams but does NOT touch `_agent_user_turn`, `_is_done`, `_agent_termination`, or stop-token semantics; `feat/distributable-runner` (Milestone 14 integration) touches only `tolokaforge/adapters/_task_loader.py`, `tolokaforge/docker/`, `tolokaforge/runner/__init__.py`, docs, examples, and orthogonal tests. No textual or semantic conflict either direction; both compose over the modified `TrialRunner` and inherit the fix for free.
- **Adjacent bug identified but not fixed here** — `TrialRunner._is_done` lowercases the assistant text and searches for uppercase `###STOP###`, so `TerminationReason.AGENT_DONE` never fires from an agent-emitted `###STOP###`. The existing `TestIsDone.test_stop_marker_case_mismatch` at `test_runner_logic.py:259-289` explicitly pins that buggy behavior. Not causing the #611 symptom (agents in the reporter's data don't emit `###STOP###`) — a real defect worth a separate follow-up issue since fixing it changes behavior and requires the pinned tests to be rewritten.