### PR TITLE
M14-E: hoist deferred adapter import out of the runner + strengthen boundary lock

### DIFF
--- a/tests/canonical/test_runner_capabilities.py
+++ b/tests/canonical/test_runner_capabilities.py
@@ -1,0 +1,25 @@
+"""Honesty lock for the runner's advertised adapter surface.
+
+``BUILTIN_ADAPTERS`` is a runner-owned constant so the runner never imports
+``tolokaforge.adapters`` to report its capabilities. These tests pin it to the
+built-in native adapter and confirm native stays resolvable by the adapters
+package, so the runner can never advertise an adapter the host cannot resolve.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.adapters import available_adapters
+from tolokaforge.runner.capabilities import BUILTIN_ADAPTERS
+from tolokaforge.runner.models import AdapterType
+
+pytestmark = pytest.mark.canonical
+
+
+def test_builtin_adapters_is_exactly_native() -> None:
+    assert tuple(BUILTIN_ADAPTERS) == (AdapterType.NATIVE.value,)
+
+
+def test_builtin_adapters_are_resolvable_by_adapters_package() -> None:
+    assert set(BUILTIN_ADAPTERS) <= set(available_adapters())

--- a/tests/canonical/test_runner_import_boundary.py
+++ b/tests/canonical/test_runner_import_boundary.py
@@ -28,12 +28,15 @@ is reported with the first-party import chain that pulled it.
 
 3. **Static-AST forbidden-import-statement guard.** A source-level walk of every
    ``*.py`` under ``tolokaforge/runner/`` flags any ``import`` / ``from … import``
-   statement whose target is under a forbidden prefix, *at any nesting depth* —
-   including deferred function-body imports that never execute at module load
-   and so slip past locks 1 and 2. Both absolute (``from tolokaforge.adapters
-   import …``) and relative (``from ..adapters import …``) forms are resolved.
-   It matches statements only; ``importlib.import_module("<target>")`` string
-   indirection is out of this guard's scope.
+   statement that names a module under a forbidden prefix, *at any nesting depth*
+   — including deferred function-body imports that never execute at module load
+   and so slip past locks 1 and 2. A module is named either by the ``from``
+   target (``from tolokaforge.adapters import …``, absolute or relative
+   ``from ..adapters import …``) or by an imported name resolved against a
+   non-forbidden parent (``from tolokaforge import adapters`` reaches the
+   forbidden ``tolokaforge.adapters`` leaf). It matches statements only;
+   ``importlib.import_module("<target>")`` string indirection is out of this
+   guard's scope.
 
 All three consume one ``FORBIDDEN_PREFIXES`` definition: locks 1/2 receive it as
 a literal in the subprocess source, lock 3 imports it directly.
@@ -248,12 +251,16 @@ def _forbidden_imports_in_source(
     """Return ``(lineno, target)`` for each forbidden import statement in *source*.
 
     Every ``ast.Import`` / ``ast.ImportFrom`` at any nesting depth is collected;
-    a target under a ``FORBIDDEN_PREFIXES`` entry is a violation. *module_qualname*
-    is the file's dotted module name (e.g. ``tolokaforge.runner.service``);
-    *is_package* is True for an ``__init__`` module. Relative imports resolve
-    against the module's package: a non-package module's own name is dropped
-    first, so ``from ..adapters`` in ``tolokaforge.runner.foo`` targets
-    ``tolokaforge.adapters`` — not ``tolokaforge.runner.adapters``.
+    a target under a ``FORBIDDEN_PREFIXES`` entry is a violation. For a
+    ``from … import`` whose module target is not itself forbidden, each imported
+    name is also checked as a submodule of that target, so
+    ``from tolokaforge import adapters`` is flagged as ``tolokaforge.adapters``.
+    *module_qualname* is the file's dotted module name (e.g.
+    ``tolokaforge.runner.service``); *is_package* is True for an ``__init__``
+    module. Relative imports resolve against the module's package: a non-package
+    module's own name is dropped first, so ``from ..adapters`` in
+    ``tolokaforge.runner.foo`` targets ``tolokaforge.adapters`` — not
+    ``tolokaforge.runner.adapters``.
     """
     package = module_qualname if is_package else module_qualname.rpartition(".")[0]
     violations: list[tuple[int, str]] = []
@@ -264,8 +271,15 @@ def _forbidden_imports_in_source(
                     violations.append((node.lineno, alias.name))
         elif isinstance(node, ast.ImportFrom):
             target = _resolve_import_from(node, package)
-            if target and _matches_forbidden(target):
+            if not target:
+                continue
+            if _matches_forbidden(target):
                 violations.append((node.lineno, target))
+            else:
+                for alias in node.names:
+                    full = f"{target}.{alias.name}"
+                    if _matches_forbidden(full):
+                        violations.append((node.lineno, full))
     return violations
 
 
@@ -302,3 +316,13 @@ def test_forbidden_import_detector_flags_deferred_imports() -> None:
     assert _forbidden_imports_in_source(
         relative_deferred, "tolokaforge.runner.submodule", is_package=False
     ) == [(2, "tolokaforge.adapters")]
+
+    parent_import_leaf = "def _init():\n    from tolokaforge import adapters\n"
+    assert _forbidden_imports_in_source(
+        parent_import_leaf, "tolokaforge.runner.service", is_package=False
+    ) == [(2, "tolokaforge.adapters")]
+
+    parent_import_forbidden_leaf = "def _init():\n    from tolokaforge.core import orchestrator\n"
+    assert _forbidden_imports_in_source(
+        parent_import_forbidden_leaf, "tolokaforge.runner.service", is_package=False
+    ) == [(2, "tolokaforge.core.orchestrator")]

--- a/tests/canonical/test_runner_import_boundary.py
+++ b/tests/canonical/test_runner_import_boundary.py
@@ -1,6 +1,10 @@
 """Import-boundary lock for the ``tolokaforge.runner`` surface.
 
-Two locks, both run in a *clean subprocess* — the pytest process has already
+Three locks enforce that the runner sits *below* the orchestration / adapter /
+CLI / docker-build surfaces and never drags them (or their deps) into the
+runner image, inverting the dependency direction.
+
+Locks 1 and 2 run in a *clean subprocess* — the pytest process has already
 imported much of ``tolokaforge`` (conftest, sibling tests), so an in-process
 footprint would be polluted and prove nothing. The subprocess imports only
 ``tolokaforge.runner.__main__`` + ``tolokaforge.runner.service`` (the runner's
@@ -11,23 +15,33 @@ is reported with the first-party import chain that pulled it.
    pulls at module load must lie inside the transitive-requires closure of
    ``[project.dependencies] ∪ [project.optional-dependencies].runner`` — the
    deps the runner image installs. A new ``import pandas`` in a runner module
-   would fail here loud, naming the chain.
+   would fail here loud, naming the chain. The closure follows every requires
+   edge (including extra-guarded ones): a deliberate over-approximation of the
+   *allowed* side, so a legitimate transitive dep of a declared package never
+   trips the test, while a genuinely foreign package still does.
 
-2. **First-party forbidden-surface.** The runner's transitive first-party
-   closure must not reach the orchestration / adapter / CLI / docker-build
-   surfaces (a runner that imported the orchestrator would drag those and their
-   deps into the image and invert the dependency direction). Allowed core
-   surfaces are ``core.grading.*``, ``core.llm.*``, ``core.models``,
-   ``core.trial``, ``core.deprecations``, and ``secrets``.
+2. **First-party module-load forbidden-surface.** The runner's transitive
+   first-party closure *at module load* must not reach the orchestration /
+   adapter / CLI / docker-build surfaces. Allowed core surfaces are
+   ``core.grading.*``, ``core.llm.*``, ``core.models``, ``core.trial``,
+   ``core.deprecations``, and ``secrets``.
 
-The closure follows every requires edge (including extra-guarded ones): it is a
-deliberate over-approximation of the *allowed* side, so a legitimate transitive
-dep of a declared package never trips the test, while a genuinely foreign
-package — related to no declared dep — still does.
+3. **Static-AST forbidden-import-statement guard.** A source-level walk of every
+   ``*.py`` under ``tolokaforge/runner/`` flags any ``import`` / ``from … import``
+   statement whose target is under a forbidden prefix, *at any nesting depth* —
+   including deferred function-body imports that never execute at module load
+   and so slip past locks 1 and 2. Both absolute (``from tolokaforge.adapters
+   import …``) and relative (``from ..adapters import …``) forms are resolved.
+   It matches statements only; ``importlib.import_module("<target>")`` string
+   indirection is out of this guard's scope.
+
+All three consume one ``FORBIDDEN_PREFIXES`` definition: locks 1/2 receive it as
+a literal in the subprocess source, lock 3 imports it directly.
 """
 
 from __future__ import annotations
 
+import ast
 import json
 import subprocess
 import sys
@@ -38,6 +52,18 @@ import pytest
 pytestmark = pytest.mark.canonical
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_ROOT = REPO_ROOT / "tolokaforge" / "runner"
+
+FORBIDDEN_PREFIXES = (
+    "tolokaforge.core.orchestrator",
+    "tolokaforge.core.per_trial_runtime",
+    "tolokaforge.core.shared_stack_runtime",
+    "tolokaforge.core.compose_materialisation",
+    "tolokaforge.adapters",
+    "tolokaforge.cli",
+    "tolokaforge.docker",
+    "tolokaforge.runtime.reset_recipes",
+)
 
 _ANALYSIS = r"""
 import builtins
@@ -57,17 +83,6 @@ REPO_ROOT = Path(sys.argv[1])
 # absent from the slim runner image, so its presence here is not a runner-
 # surface violation. grpc_reflection is the same shape.
 GUARDED_OPTIONAL = {"grpc_tools", "grpc_reflection"}
-
-FORBIDDEN_PREFIXES = (
-    "tolokaforge.core.orchestrator",
-    "tolokaforge.core.per_trial_runtime",
-    "tolokaforge.core.shared_stack_runtime",
-    "tolokaforge.core.compose_materialisation",
-    "tolokaforge.adapters",
-    "tolokaforge.cli",
-    "tolokaforge.docker",
-    "tolokaforge.runtime.reset_recipes",
-)
 
 
 def norm(name):
@@ -164,10 +179,14 @@ json.dump(
 )
 """
 
+# Feed the single FORBIDDEN_PREFIXES definition into the subprocess as a literal
+# so locks 1/2 and lock 3 share one source of truth (no duplicated string list).
+_SUBPROCESS_SOURCE = f"FORBIDDEN_PREFIXES = {FORBIDDEN_PREFIXES!r}\n{_ANALYSIS}"
+
 
 def _run_analysis() -> dict:
     result = subprocess.run(
-        [sys.executable, "-c", _ANALYSIS, str(REPO_ROOT)],
+        [sys.executable, "-c", _SUBPROCESS_SOURCE, str(REPO_ROOT)],
         capture_output=True,
         text=True,
     )
@@ -200,3 +219,86 @@ def test_runner_does_not_import_forbidden_first_party_surface(analysis: dict) ->
     assert not violations, "runner's first-party closure reaches a forbidden surface:\n" + _format(
         violations
     )
+
+
+def _matches_forbidden(target: str) -> bool:
+    return any(target == f or target.startswith(f + ".") for f in FORBIDDEN_PREFIXES)
+
+
+def _resolve_import_from(node: ast.ImportFrom, package: str) -> str | None:
+    """Resolve an ``ast.ImportFrom`` to its absolute dotted target, or None.
+
+    Absolute imports (``level == 0``) return ``node.module`` verbatim. Relative
+    imports resolve against *package* the way CPython does: strip ``level - 1``
+    trailing components, then append ``node.module``. None when the import
+    reaches beyond the top-level package (unresolvable).
+    """
+    if node.level == 0:
+        return node.module
+    bits = package.rsplit(".", node.level - 1)
+    if len(bits) < node.level:
+        return None
+    base = bits[0]
+    return f"{base}.{node.module}" if node.module else base
+
+
+def _forbidden_imports_in_source(
+    source: str, module_qualname: str, is_package: bool
+) -> list[tuple[int, str]]:
+    """Return ``(lineno, target)`` for each forbidden import statement in *source*.
+
+    Every ``ast.Import`` / ``ast.ImportFrom`` at any nesting depth is collected;
+    a target under a ``FORBIDDEN_PREFIXES`` entry is a violation. *module_qualname*
+    is the file's dotted module name (e.g. ``tolokaforge.runner.service``);
+    *is_package* is True for an ``__init__`` module. Relative imports resolve
+    against the module's package: a non-package module's own name is dropped
+    first, so ``from ..adapters`` in ``tolokaforge.runner.foo`` targets
+    ``tolokaforge.adapters`` — not ``tolokaforge.runner.adapters``.
+    """
+    package = module_qualname if is_package else module_qualname.rpartition(".")[0]
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _matches_forbidden(alias.name):
+                    violations.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            target = _resolve_import_from(node, package)
+            if target and _matches_forbidden(target):
+                violations.append((node.lineno, target))
+    return violations
+
+
+def _module_qualname(path: Path) -> tuple[str, bool]:
+    """Return ``(dotted module name, is_package)`` for a repo source file."""
+    parts = list(path.relative_to(REPO_ROOT).with_suffix("").parts)
+    is_package = parts[-1] == "__init__"
+    if is_package:
+        parts = parts[:-1]
+    return ".".join(parts), is_package
+
+
+def test_runner_has_no_forbidden_import_statements() -> None:
+    violations: list[str] = []
+    for path in sorted(RUNNER_ROOT.rglob("*.py")):
+        module_qualname, is_package = _module_qualname(path)
+        for lineno, target in _forbidden_imports_in_source(
+            path.read_text(encoding="utf-8"), module_qualname, is_package
+        ):
+            violations.append(f"{path.relative_to(REPO_ROOT)}:{lineno} imports {target!r}")
+    assert not violations, (
+        "runner source has import statements to a forbidden surface "
+        "(deferred/function-body imports included):\n" + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+def test_forbidden_import_detector_flags_deferred_imports() -> None:
+    absolute_deferred = "def _init():\n    from tolokaforge.adapters import available_adapters\n"
+    assert _forbidden_imports_in_source(
+        absolute_deferred, "tolokaforge.runner.service", is_package=False
+    ) == [(2, "tolokaforge.adapters")]
+
+    relative_deferred = "def _init():\n    from ..adapters import available_adapters\n"
+    assert _forbidden_imports_in_source(
+        relative_deferred, "tolokaforge.runner.submodule", is_package=False
+    ) == [(2, "tolokaforge.adapters")]

--- a/tolokaforge/runner/capabilities.py
+++ b/tolokaforge/runner/capabilities.py
@@ -1,0 +1,12 @@
+"""Adapter surface the runner advertises.
+
+The runner advertises the built-in native adapter; it does not perform adapter
+translation. External adapters are host-side entry-point plugins outside the
+runner's advertised surface, so this list is sourced from a runner-owned
+constant rather than the adapters package — the runner never reaches
+``tolokaforge.adapters``.
+"""
+
+from tolokaforge.runner.models import AdapterType
+
+BUILTIN_ADAPTERS: tuple[str, ...] = (AdapterType.NATIVE.value,)

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -42,6 +42,7 @@ from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.core.trial_grader import split_leading_system_message
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner import runner_pb2_grpc
+from tolokaforge.runner.capabilities import BUILTIN_ADAPTERS
 from tolokaforge.runner.db_client import (
     DBServiceClient,
     DBServiceError,
@@ -257,11 +258,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         self.db_client = db_client
         self.rag_client = rag_client
         self.trials: dict[str, TrialContextRuntime] = {}
-        # Report the adapters actually registered (built-in + entry-point plugins),
-        # not a hardcoded list, so capabilities reflect what's installed.
-        from tolokaforge.adapters import available_adapters
-
-        self._available_adapters = available_adapters()
+        self._available_adapters = list(BUILTIN_ADAPTERS)
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup
 
         # Create a dedicated event loop thread for async operations.


### PR DESCRIPTION
## Summary

- Removes the deferred `from tolokaforge.adapters import available_adapters` inside `RunnerServiceImpl.__init__` — a function-body import that let the runner reach *up* into `tolokaforge.adapters` (wrong dependency direction) while slipping past the boundary lock (which only tracked module-load imports).
- The runner now advertises its built-in adapter surface from a runner-owned constant (`tolokaforge/runner/capabilities.py`), never importing the adapters package.
- Strengthens `test_runner_import_boundary.py` with a static-AST guard that catches forbidden imports at any nesting depth (module-level, function body, class body) — the deferred class the two existing runtime-tracking locks miss.

## Design choices

- **Runner-owned constant, not a registration seam.** A Protocol seam where the adapters package registers into a runner registry would report `[]` in the deployment target — the runner process never imports adapters, so registration would never fire. The constant `BUILTIN_ADAPTERS = (AdapterType.NATIVE.value,)` is behaviour-preserving.
- **Anchored on `AdapterType.NATIVE`, not `available_adapters()`.** The dynamic call is environment-dependent (`['native','terminal_bench']` in dev, `['native']` in the image); anchoring the honesty test on the stable built-in avoids a test that's wrong in one environment.
- **Static-AST guard is additive, not a replacement.** The two runtime-tracking locks catch a different class (transitive third-party footprint + first-party module-load closure); the AST guard catches deferred/function-body forbidden import *statements* at any nesting. It resolves relative `level` imports and (after review) also flags `from <parent> import <forbidden-leaf>` — so `from tolokaforge import adapters` is caught, not just `from tolokaforge.adapters import X`.
- **`importlib.import_module(<str literal>)` is deliberately out of scope** (tracked as #618) so the guard doesn't collide with M14-C's lazy `__getattr__` re-export in `runner/__init__.py` (an `ast.Call`, not an import statement).

## Concepts introduced

`tolokaforge/runner/capabilities.py` — a runner-owned capability surface (currently just `BUILTIN_ADAPTERS`). The runner advertises the built-in native adapter; it performs no adapter translation (a host-side concern), and external adapters are host-side entry-point plugins outside the runner's advertised surface.

## Plan

Full staged plan: `~/.claude/plans/toloka-tolokaforge/issue-606-hoist-deferred-import.md` (Stage 1: capabilities module + hoist; Stage 2: AST boundary-lock strengthening).

## Discovered issues

- Filed: #618 (the AST guard covers statement-form imports but not `importlib.import_module(<str literal>)` indirection — a decision deferred so it doesn't fight M14-C's lazy re-export; P3, no actual leak today).
- Fixed in this PR: the stale `service.py` "not a hardcoded list" comment (now false) removed; a review-round gap where the AST guard checked the resolved module but not imported leaf names.

## Test plan

- Canonical `test_runner_capabilities.py` — `BUILTIN_ADAPTERS` is exactly `('native',)` and is a subset of `available_adapters()` (catches a native rename/removal).
- Canonical `test_runner_import_boundary.py` — three locks (two runtime-tracking kept + one new static-AST) plus a negative self-test with four cases: absolute deferred, relative deferred (`level`, non-`__init__` anchor), `from <parent> import <forbidden-leaf>`, and `from <parent.sub> import <forbidden-leaf>`. Regression-proven: re-adding a deferred `from tolokaforge import adapters` to a runner file fails the guard naming file:line; reverted.
- `HealthCheckResponse.available_adapters` unchanged in the runner image (`['native']`); no proto change.

Closes #606