### PR TITLE
feat(grading): alternative golden paths for hash-based state grading (closes #612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **grading**: `state_checks.hash.alternative_golden_actions` — tasks whose domain policy admits more than one legal final state may ship additional golden paths; state-hash grading passes if the trial's final state matches ANY variant. Runner-side wire model gains `StateChecksConfig.alternative_golden_actions` + `HashGradingResult.matched_variant` / `variants_tried`. Native-adapter bundles write each variant to a sibling `fixtures/golden_actions_variant_{n}.json`. Tasks without alternatives are unchanged. See `docs/GRADING.md` § "Multiple legal final states". (#612)
+
 ## v0.11.1 (2026-07-27)
 
 ### Feat

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -206,7 +206,11 @@ closest to satisfying regardless of variant count.
 Design bias: use this sparingly. Every extra variant that survives review is a
 statement that the domain policy is genuinely permissive; if a task can be
 tightened by amending policy text to mandate one shape, prefer that over
-shipping alternates.
+shipping alternates. Grading cost scales linearly with variant count — each
+variant runs a full reset + replay + snapshot + hash cycle — so a task with N
+alternates roughly triples-and-adds a grade's runtime vs. a single-golden
+task on the pessimistic (no-match) path. Match short-circuits at the first
+matching variant.
 
 ---
 

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -160,6 +160,54 @@ runner is safe (core-side `extra="ignore"`).
 - Use `relaxed_validation` only as a short-lived escape hatch for legacy tasks
 - Combine with JSONPath assertions using `weight: 0.8` for flexibility
 
+### Multiple legal final states (alternative golden paths)
+
+Some domains admit more than one policy-correct final shape — e.g. a policy that
+allows the agent to either create one combined case or split it into two.
+`state_checks.hash.alternative_golden_actions` lets a task ship additional golden
+paths so any of them can satisfy the state check.
+
+```yaml
+state_checks:
+  hash:
+    enabled: true
+    weight: 1.0
+    golden_actions:                       # variant 0 (primary)
+      - { name: create_case, kwargs: {...} }
+    alternative_golden_actions:           # optional; each entry is variant 1..N
+      - - { name: create_case_a, kwargs: {...} }
+        - { name: create_case_b, kwargs: {...} }
+```
+
+Grading replays each variant on a fresh initial state, hashes the resulting
+state, and passes if the trial's final hash matches ANY variant. On mismatch,
+the reported diff is against the variant with the smallest row-level distance
+from the trial state — triage stays focused on the variant the trial came
+closest to satisfying regardless of variant count.
+
+- **Ordering is authoring order.** `golden_actions` is variant 0; alternatives
+  are variant 1..N in the order listed. The grading reasons string carries the
+  matched variant index for analytics (`matched golden variant 1 of 3`).
+- **Broken variants fail loud.** A variant whose replay raises contributes its
+  error to the grade reasons on every outcome — a broken shipped golden is
+  never masked by a matching alternate. Grading returns 0.0 only if every
+  variant fails to replay.
+- **Absent alternatives = single-variant behaviour.** Tasks that ship no
+  `alternative_golden_actions` execute the pre-existing single-variant hash
+  code path unchanged.
+- **Bundle layout.** Adapters emitting native-format bundles write each
+  variant to `fixtures/golden_actions_variant_{n}.json` starting at `n=1`,
+  alongside the primary `fixtures/golden_actions.json`.
+- **Not supported with `env_assertions` / `db_hash_check`.** The tau2
+  environment evaluator compares against a single hash; mixing it with
+  `alternative_golden_actions` raises a fail-loud config error at grading
+  time. Drop one or the other.
+
+Design bias: use this sparingly. Every extra variant that survives review is a
+statement that the domain policy is genuinely permissive; if a task can be
+tightened by amending policy text to mandate one shape, prefer that over
+shipping alternates.
+
 ---
 
 ## LLM Judge (Rubric Grading)

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -322,6 +322,14 @@ class TestStateDistance:
         # orders: {id:1} in a only; carts: {id:9} in b only → total 2.
         assert StateChecker._state_distance(a, b) == 2
 
+    def test_row_duplication_counted_by_multiplicity(self):
+        # Multiset semantics: the row appears twice in a and once in b, so
+        # the distance is 1 (the extra copy). Prior set-based implementation
+        # would deduplicate and score 0 despite the states genuinely differing.
+        a = {"orders": [{"id": 1}, {"id": 1}]}
+        b = {"orders": [{"id": 1}]}
+        assert StateChecker._state_distance(a, b) == 1
+
 
 @pytest.mark.unit
 class TestGradeTauStyleVariants:
@@ -368,8 +376,10 @@ class TestGradeTauStyleVariants:
         assert score == 1.0
         assert diff is None
         assert "State hash matches" in reasons
-        # Regression guard: single-variant reason must NOT reference "variant N"
-        assert "variant" not in reasons.lower() or "variants" in reasons.lower()
+        # Regression guard: the multi-variant reason string must NOT appear
+        # on a single-variant task (byte-identical wording contract).
+        assert "matches golden variant" not in reasons
+        assert " of " not in reasons  # "of N" only appears on multi-variant match
 
     def test_matches_alternative_variant(self, checker, trial_state_wraps, monkeypatch):
         """Trial state that matches variant 1 (not variant 0) still scores 1.0
@@ -477,6 +487,39 @@ class TestGradeTauStyleVariants:
         assert "Golden replay errors" in reasons
         assert "variant 0" in reasons
         assert "primary golden broken" in reasons
+
+    def test_redundant_variants_first_match_wins(self, checker, trial_state_wraps, monkeypatch):
+        """When two variants resolve to identical hashes (author declared
+        equivalent alternatives), the first one to match wins and later
+        variants are never replayed. Regression guard against variant
+        index drift on hash collisions from authoring mistakes.
+        """
+        identical_state = {"orders": [{"id": 1, "status": "closed"}]}
+        call_count = {"n": 0}
+
+        def fake_execute(actions, td, isp, msp, dom):
+            call_count["n"] += 1
+            return identical_state
+
+        monkeypatch.setattr(checker, "_execute_golden_actions", fake_execute)
+
+        score, reasons, _ = checker.grade_tau_style(
+            state=trial_state_wraps(identical_state),
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "close_a", "kwargs": {}}],
+            alternative_golden_actions=[[{"name": "close_b", "kwargs": {}}]],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+        )
+        assert score == 1.0
+        assert "matches golden variant 0" in reasons  # primary wins
+        # Both variants still replay upfront (that's how the current
+        # implementation collects variant_states), but the reason string
+        # names variant 0 — not variant 1.
+        assert "matches golden variant 1" not in reasons
 
     def test_all_variants_fail_to_replay_returns_zero(
         self, checker, trial_state_wraps, monkeypatch

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -1,5 +1,7 @@
 """Tests for state-based grading checks"""
 
+from pathlib import Path
+
 import pytest
 
 from tolokaforge.core.grading.state_checks import (
@@ -283,6 +285,226 @@ class TestHashGrading:
         hash1 = consistent_hash(to_hashable(state1))
         hash2 = consistent_hash(to_hashable(state2))
         assert hash1 != hash2
+
+
+@pytest.mark.unit
+class TestStateDistance:
+    """Row-level symmetric-difference metric used to pick the closest variant."""
+
+    def test_identical_states_have_zero_distance(self):
+        state = {"orders": [{"id": 1, "amount": 100}]}
+        assert StateChecker._state_distance(state, state) == 0
+
+    def test_missing_row_counts_once(self):
+        a = {"orders": [{"id": 1}, {"id": 2}]}
+        b = {"orders": [{"id": 1}]}
+        # 1 row in the symmetric difference: {id:2} in a only.
+        assert StateChecker._state_distance(a, b) == 1
+
+    def test_extra_row_counts_once(self):
+        a = {"orders": [{"id": 1}]}
+        b = {"orders": [{"id": 1}, {"id": 2}]}
+        assert StateChecker._state_distance(a, b) == 1
+
+    def test_differing_field_counts_as_two_rows(self):
+        # {id:1, amount:100} vs {id:1, amount:200} produces two distinct
+        # canonical strings — each side contributes one row to the sym-diff.
+        a = {"orders": [{"id": 1, "amount": 100}]}
+        b = {"orders": [{"id": 1, "amount": 200}]}
+        assert StateChecker._state_distance(a, b) == 2
+
+    def test_empty_states_have_zero_distance(self):
+        assert StateChecker._state_distance({}, {}) == 0
+
+    def test_disjoint_tables_summed(self):
+        a = {"orders": [{"id": 1}], "carts": []}
+        b = {"orders": [], "carts": [{"id": 9}]}
+        # orders: {id:1} in a only; carts: {id:9} in b only → total 2.
+        assert StateChecker._state_distance(a, b) == 2
+
+
+@pytest.mark.unit
+class TestGradeTauStyleVariants:
+    """Multi-golden-variant support on ``grade_tau_style``.
+
+    ``_execute_golden_actions`` is patched to return canned per-variant
+    states so tests exercise the variant loop without loading a real MCP
+    module. See :meth:`tolokaforge.core.grading.state_checks.StateChecker`.
+    """
+
+    @pytest.fixture
+    def checker(self):
+        return StateChecker()
+
+    @pytest.fixture
+    def trial_state_wraps(self):
+        """Wrap a raw db state into the {agent, user, db} envelope that
+        ``grade_tau_style`` expects on the ``state`` argument."""
+
+        def wrap(db_state: dict) -> dict:
+            return {"agent": {}, "user": {}, "db": db_state}
+
+        return wrap
+
+    def test_no_alternatives_matches_primary(self, checker, trial_state_wraps, monkeypatch):
+        """Empty alternatives list => single-variant behaviour on match."""
+        expected = {"orders": [{"id": 1, "status": "closed"}]}
+        monkeypatch.setattr(
+            checker,
+            "_execute_golden_actions",
+            lambda actions, td, isp, msp, dom: expected,
+        )
+        score, reasons, diff = checker.grade_tau_style(
+            state=trial_state_wraps(expected),
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "close", "kwargs": {}}],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+            alternative_golden_actions=None,
+        )
+        assert score == 1.0
+        assert diff is None
+        assert "State hash matches" in reasons
+        # Regression guard: single-variant reason must NOT reference "variant N"
+        assert "variant" not in reasons.lower() or "variants" in reasons.lower()
+
+    def test_matches_alternative_variant(self, checker, trial_state_wraps, monkeypatch):
+        """Trial state that matches variant 1 (not variant 0) still scores 1.0
+        and the reason string names the matched variant.
+        """
+        variant_states = [
+            {"orders": [{"id": 1, "shape": "combined"}]},  # variant 0
+            {"orders": [{"id": 1, "shape": "split_a"}, {"id": 2, "shape": "split_b"}]},  # variant 1
+        ]
+        call_idx = {"n": 0}
+
+        def fake_execute(actions, td, isp, msp, dom):
+            state = variant_states[call_idx["n"]]
+            call_idx["n"] += 1
+            return state
+
+        monkeypatch.setattr(checker, "_execute_golden_actions", fake_execute)
+
+        score, reasons, diff = checker.grade_tau_style(
+            state=trial_state_wraps(variant_states[1]),  # trial chose the split shape
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "combine", "kwargs": {}}],
+            alternative_golden_actions=[[{"name": "split", "kwargs": {}}]],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+        )
+        assert score == 1.0
+        assert diff is None
+        assert "matches golden variant 1" in reasons
+        assert "of 2" in reasons
+
+    def test_all_variants_miss_returns_closest_diff(self, checker, trial_state_wraps, monkeypatch):
+        """When no variant matches, the reported diff must be against the
+        variant with the smallest row-level distance from the trial state.
+        """
+        variant_states = [
+            # Distance from trial 3: (rows removed: 3 nonmatching; rows added: 1)
+            {"orders": [{"id": 1}, {"id": 2}, {"id": 3}]},
+            # Distance from trial: 1 extra row in the trial only.
+            {"orders": [{"id": 99}]},
+        ]
+        trial_db = {"orders": [{"id": 99}, {"id": 100}]}
+        call_idx = {"n": 0}
+
+        def fake_execute(actions, td, isp, msp, dom):
+            state = variant_states[call_idx["n"]]
+            call_idx["n"] += 1
+            return state
+
+        monkeypatch.setattr(checker, "_execute_golden_actions", fake_execute)
+
+        score, reasons, diff = checker.grade_tau_style(
+            state=trial_state_wraps(trial_db),
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "a", "kwargs": {}}],
+            alternative_golden_actions=[[{"name": "b", "kwargs": {}}]],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+        )
+        assert score == 0.0
+        assert diff is not None
+        assert "closest: variant 1" in reasons
+
+    def test_broken_primary_matching_alternate_surfaces_replay_error(
+        self, checker, trial_state_wraps, monkeypatch
+    ):
+        """A primary golden that fails to replay must appear in the reasons
+        string even when an alternate matches the trial state.
+        """
+        variant_states = [
+            None,  # variant 0 raises
+            {"orders": [{"id": 1, "shape": "split"}]},  # variant 1 matches
+        ]
+        call_idx = {"n": 0}
+
+        def fake_execute(actions, td, isp, msp, dom):
+            idx = call_idx["n"]
+            call_idx["n"] += 1
+            if variant_states[idx] is None:
+                raise RuntimeError(f"primary golden broken (variant {idx})")
+            return variant_states[idx]
+
+        monkeypatch.setattr(checker, "_execute_golden_actions", fake_execute)
+
+        score, reasons, diff = checker.grade_tau_style(
+            state=trial_state_wraps(variant_states[1]),
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "primary", "kwargs": {}}],
+            alternative_golden_actions=[[{"name": "alt", "kwargs": {}}]],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+        )
+        assert score == 1.0
+        assert "matches golden variant 1" in reasons
+        # The broken primary MUST be surfaced despite the successful alt match.
+        assert "Golden replay errors" in reasons
+        assert "variant 0" in reasons
+        assert "primary golden broken" in reasons
+
+    def test_all_variants_fail_to_replay_returns_zero(
+        self, checker, trial_state_wraps, monkeypatch
+    ):
+        """If every variant raises during replay, grade is 0 and the reasons
+        must include every per-variant error.
+        """
+
+        def fake_execute(actions, td, isp, msp, dom):
+            raise RuntimeError("broken tool")
+
+        monkeypatch.setattr(checker, "_execute_golden_actions", fake_execute)
+
+        score, reasons, diff = checker.grade_tau_style(
+            state=trial_state_wraps({"orders": []}),
+            jsonpath_assertions=[],
+            golden_actions=[{"name": "a", "kwargs": {}}],
+            alternative_golden_actions=[[{"name": "b", "kwargs": {}}]],
+            task_dir=Path("."),
+            initial_state_path="init.json",
+            mcp_server_path="mcp.py",
+            task_domain="synthetic",
+            hash_weight=1.0,
+        )
+        assert score == 0.0
+        assert diff is None
+        assert "All golden variants failed to replay" in reasons
+        assert reasons.count("broken tool") == 2  # both variants surfaced
 
 
 @pytest.mark.unit

--- a/tests/unit/grading/test_state_checks.py
+++ b/tests/unit/grading/test_state_checks.py
@@ -377,9 +377,10 @@ class TestGradeTauStyleVariants:
         assert diff is None
         assert "State hash matches" in reasons
         # Regression guard: the multi-variant reason string must NOT appear
-        # on a single-variant task (byte-identical wording contract).
+        # on a single-variant task (byte-identical wording contract). Guards
+        # against a future refactor that accidentally routes the single-variant
+        # path through the "matches golden variant N (of M)" wording.
         assert "matches golden variant" not in reasons
-        assert " of " not in reasons  # "of N" only appears on multi-variant match
 
     def test_matches_alternative_variant(self, checker, trial_state_wraps, monkeypatch):
         """Trial state that matches variant 1 (not variant 0) still scores 1.0

--- a/tolokaforge/adapters/bundle_writer.py
+++ b/tolokaforge/adapters/bundle_writer.py
@@ -44,8 +44,17 @@ def write_bundle(
         └── fixtures/
             ├── tools.json
             ├── golden_actions.json
+            ├── golden_actions_variant_1.json   # only if alternatives present
+            ├── golden_actions_variant_2.json
             ├── unstable_fields.json
             └── metadata.json
+
+    Tasks whose domain policy admits more than one legal final state may
+    ship a ``golden_actions_alternatives`` fixture key — a list-of-lists,
+    each inner list a full action sequence equivalent to
+    ``golden_actions``. Each variant is written as its own
+    ``golden_actions_variant_{n}.json`` starting at ``n=1`` in authoring
+    order. Bundles without alternatives omit the variant files.
 
     Args:
         bundle: The conversion result to serialise.
@@ -82,15 +91,24 @@ def write_bundle(
     # Separate well-known fixture keys from the rest
     tools = bundle.fixtures.get("tools", [])
     golden_actions = bundle.fixtures.get("golden_actions", [])
+    golden_actions_alternatives = bundle.fixtures.get("golden_actions_alternatives", []) or []
     unstable_fields = bundle.fixtures.get("unstable_fields", [])
 
     _write_json(fixtures_dir / "tools.json", tools)
     _write_json(fixtures_dir / "golden_actions.json", golden_actions)
+    for idx, variant in enumerate(golden_actions_alternatives, start=1):
+        _write_json(fixtures_dir / f"golden_actions_variant_{idx}.json", variant)
     _write_json(fixtures_dir / "unstable_fields.json", unstable_fields)
     _write_json(fixtures_dir / "metadata.json", bundle.metadata)
 
     # Write any additional fixture keys (not tools/golden_actions/unstable_fields)
-    extra_keys = set(bundle.fixtures.keys()) - {"tools", "golden_actions", "unstable_fields"}
+    reserved_keys = {
+        "tools",
+        "golden_actions",
+        "golden_actions_alternatives",
+        "unstable_fields",
+    }
+    extra_keys = set(bundle.fixtures.keys()) - reserved_keys
     for key in sorted(extra_keys):
         _write_json(fixtures_dir / f"{key}.json", bundle.fixtures[key])
 

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -630,6 +630,7 @@ class NativeAdapter(BaseAdapter):
             if state_checks_data:
                 # Extract golden actions
                 golden_actions: list[GoldenAction] = []
+                alternative_golden_actions: list[list[GoldenAction]] = []
                 hash_config = state_checks_data.get("hash", {})
                 if hash_config and hash_config.get("enabled", False):
                     for action in hash_config.get("golden_actions", []):
@@ -639,6 +640,21 @@ class NativeAdapter(BaseAdapter):
                                 arguments=action.get("kwargs", {}),
                             )
                         )
+                    # Optional alternative golden paths for tasks whose domain
+                    # policy admits more than one legal final state. Each
+                    # entry is a full sequence equivalent to
+                    # ``golden_actions``; grading passes if the trial's final
+                    # hash matches ANY variant.
+                    for variant in hash_config.get("alternative_golden_actions") or []:
+                        variant_actions: list[GoldenAction] = []
+                        for action in variant:
+                            variant_actions.append(
+                                GoldenAction(
+                                    tool_name=action.get("name", ""),
+                                    arguments=action.get("kwargs", {}),
+                                )
+                            )
+                        alternative_golden_actions.append(variant_actions)
 
                 # Extract env assertions
                 env_assertions: list[EnvAssertion] = []
@@ -670,6 +686,7 @@ class NativeAdapter(BaseAdapter):
                     hash_enabled=bool(hash_config and hash_config.get("enabled", False)),
                     expected_hash=hash_config.get("expected_state_hash") if hash_config else None,
                     golden_actions=golden_actions,
+                    alternative_golden_actions=alternative_golden_actions,
                     jsonpath_checks=state_checks_data.get("jsonpaths", []),
                     env_assertions=env_assertions,
                     db_probes=db_probes,

--- a/tolokaforge/core/grading/combine.py
+++ b/tolokaforge/core/grading/combine.py
@@ -95,6 +95,22 @@ class GradingEngine:
             )
 
             if use_tau2_evaluator:
+                # The tau2 environment evaluator compares against a single
+                # expected hash and does not know about alternative goldens;
+                # silently ignoring them would violate the surface-failures
+                # rule, so refuse the config explicitly and point the author
+                # at the supported combination.
+                tau2_hash_config = self.config.state_checks.hash or {}
+                if tau2_hash_config.get("alternative_golden_actions"):
+                    raise ValueError(
+                        "state_checks.hash.alternative_golden_actions is not "
+                        "supported alongside state_checks.env_assertions or "
+                        "state_checks.db_hash_check on the same task. Either "
+                        "remove the env/db_hash_check block to route the task "
+                        "through the multi-golden-aware grader, or drop the "
+                        "alternative golden variants."
+                    )
+
                 # Use new tau2-faithful environment evaluator
                 result = self.env_evaluator.evaluate_state_checks(
                     final_state=final_env_state,
@@ -110,6 +126,7 @@ class GradingEngine:
                 expected_hash = None
                 hash_weight = 0.5
                 golden_actions = None
+                alternative_golden_actions: list[list[dict[str, Any]]] = []
 
                 if hash_config and hash_config.get("enabled", False):
                     # Check for pre-computed hash from adapter first (preferred for Tau)
@@ -118,6 +135,13 @@ class GradingEngine:
                     # Check for tau-bench style golden actions (fallback if no pre-computed hash)
                     if not expected_hash and "golden_actions" in hash_config:
                         golden_actions = hash_config["golden_actions"]
+
+                    # Optional alternative golden paths for tasks where domain
+                    # policy permits more than one legal final state.
+                    raw_alternatives = hash_config.get("alternative_golden_actions") or []
+                    alternative_golden_actions = [
+                        list(variant) for variant in raw_alternatives if variant
+                    ]
 
                     hash_weight = hash_config.get(
                         "weight", 1.0
@@ -162,6 +186,7 @@ class GradingEngine:
                                 task_domain=self.task_domain,
                                 hash_weight=hash_weight,
                                 numeric_string_fields=self.config.state_checks.numeric_string_fields,
+                                alternative_golden_actions=alternative_golden_actions,
                             )
                         )
                 else:

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -481,78 +481,136 @@ class StateChecker:
         hash_weight: float = 1.0,
         *,
         numeric_string_fields: list[str] | None = None,
+        alternative_golden_actions: list[list[dict[str, Any]]] | None = None,
     ) -> tuple[float, str, dict[str, Any] | None]:
-        """
-        Grade state using tau-bench style with diff calculation.
+        """Grade final state against one or more golden paths with diff on miss.
 
-        Executes golden actions to get expected state, compares with actual state,
-        and returns detailed diff if they don't match.
+        The primary ``golden_actions`` is variant 0. When
+        ``alternative_golden_actions`` supplies additional variants (each a
+        full action sequence equivalent to ``golden_actions``), replay each
+        on a fresh initial state and pass if the trial's hash matches ANY
+        variant. On mismatch, the diff is computed against the variant with
+        the smallest row-level distance from the trial state so triage stays
+        readable.
 
-        Args:
-            state: Final environment state
-            jsonpath_assertions: JSONPath assertions
-            golden_actions: List of golden actions to execute
-            task_dir: Task directory
-            initial_state_path: Path to initial state JSON (relative to task_dir)
-            mcp_server_path: Path to MCP server module (relative to task_dir)
-            task_domain: Domain name (e.g., "airline")
-            hash_weight: Weight for hash check vs JSONPath
-
-        Returns:
-            (score 0-1, reasons, diff_result dict or None)
+        A variant whose replay raises contributes its error to the returned
+        ``reasons`` string on every outcome — a broken shipped golden must
+        never be masked by a matching alternate. Grading returns 0.0 only
+        when every variant fails to replay.
         """
         jsonpath_score, jsonpath_reasons = self.check_jsonpaths(state, jsonpath_assertions)
 
-        # Execute golden actions to get expected state
-        try:
-            expected_state = self._execute_golden_actions(
-                golden_actions, task_dir, initial_state_path, mcp_server_path, task_domain
-            )
-        except Exception as e:
-            error_msg = f"Error executing golden actions: {str(e)}"
-            self.logger.error("Failed to execute golden actions", error=str(e))
-            return 0.0, error_msg, None
+        variants: list[list[dict[str, Any]]] = [golden_actions] + list(
+            alternative_golden_actions or []
+        )
 
-        # Extract database state from final state structure
-        # Final state has structure: {"agent": {...}, "user": {...}, "db": {...}, ...}
-        # For airline/retail tasks, we want to hash the "db" key (legacy format) or "agent" key
-        # The initial state JSON file contains the raw database state
+        variant_states: list[dict[str, Any] | None] = []
+        replay_errors: list[str] = []
+        for idx, variant in enumerate(variants):
+            try:
+                variant_state = self._execute_golden_actions(
+                    variant, task_dir, initial_state_path, mcp_server_path, task_domain
+                )
+                variant_states.append(variant_state)
+            except Exception as e:
+                variant_states.append(None)
+                err = (
+                    f"variant {idx} replay failed: {type(e).__name__}: {e}"
+                    if len(variants) > 1
+                    else f"Error executing golden actions: {type(e).__name__}: {e}"
+                )
+                replay_errors.append(err)
+                self.logger.error("Failed to execute golden actions", variant=idx, error=str(e))
+
+        if all(s is None for s in variant_states):
+            reasons_parts = jsonpath_reasons + ["All golden variants failed to replay"]
+            reasons_parts.extend(replay_errors)
+            return 0.0, "; ".join(reasons_parts), None
+
+        # Final state has structure: {"agent": ..., "user": ..., "db": ...}.
+        # Legacy tau-bench domains hash the "db" (or "agent") sub-dict.
         db_state = state.get("db", state.get("agent", state))
 
-        # Compute hashes
         string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
-        expected_hash = consistent_hash(to_hashable(expected_state, string_fields))
         actual_hash = consistent_hash(to_hashable(db_state, string_fields))
 
-        # Calculate diff if states don't match
-        diff_result = None
-        if expected_hash != actual_hash:
+        matched_variant: int | None = None
+        for idx, variant_state in enumerate(variant_states):
+            if variant_state is None:
+                continue
+            variant_hash = consistent_hash(to_hashable(variant_state, string_fields))
+            if variant_hash == actual_hash:
+                matched_variant = idx
+                break
+
+        diff_result: dict[str, Any] | None = None
+        hash_reason_parts: list[str] = []
+
+        if matched_variant is not None:
+            hash_score = 1.0
+            if len(variants) == 1:
+                hash_reason_parts.append("State hash matches")
+            else:
+                hash_reason_parts.append(
+                    f"State hash matches golden variant {matched_variant} (of {len(variants)})"
+                )
             self.logger.info(
-                "State hash mismatch, calculating diff",
-                expected_hash=expected_hash[:16],
-                actual_hash=actual_hash[:16],
-            )
-            diff_result = calculate_state_diff(expected_state, db_state)
-            diff_summary = format_diff_summary(diff_result, max_lines=50)
-
-            hash_score = 0.0
-            hash_reason = f"State hash mismatch. Diff:\n{diff_summary}"
-
-            self.logger.error(
-                "State mismatch in golden set grading",
-                expected_hash=expected_hash[:16],
-                actual_hash=actual_hash[:16],
-                diff_lines=diff_result["diff_lines"],
+                "State hash matches",
+                matched_variant=matched_variant,
+                variants_tried=len(variants),
             )
         else:
-            hash_score = 1.0
-            hash_reason = "State hash matches"
-            self.logger.info(
-                "State hash matches", expected_hash=expected_hash[:16], actual_hash=actual_hash[:16]
+            hash_score = 0.0
+            closest_idx: int | None = None
+            closest_distance: int | None = None
+            for idx, variant_state in enumerate(variant_states):
+                if variant_state is None:
+                    continue
+                distance = self._state_distance(variant_state, db_state)
+                if closest_distance is None or distance < closest_distance:
+                    closest_distance = distance
+                    closest_idx = idx
+            if closest_idx is not None:
+                diff_result = calculate_state_diff(variant_states[closest_idx], db_state)
+            diff_summary = format_diff_summary(diff_result, max_lines=50) if diff_result else ""
+            if len(variants) == 1:
+                hash_reason_parts.append(f"State hash mismatch. Diff:\n{diff_summary}")
+            else:
+                hash_reason_parts.append(
+                    f"State hash mismatch against all {len(variants)} golden variants "
+                    f"(closest: variant {closest_idx}). Diff:\n{diff_summary}"
+                )
+            self.logger.error(
+                "State mismatch in golden set grading",
+                variants_tried=len(variants),
+                closest_variant=closest_idx,
             )
 
-        # Weighted combination
+        if replay_errors:
+            hash_reason_parts.insert(0, "Golden replay errors: " + "; ".join(replay_errors))
+
         final_score = (jsonpath_score * (1 - hash_weight)) + (hash_score * hash_weight)
-        reasons = jsonpath_reasons + [hash_reason]
+        reasons = jsonpath_reasons + hash_reason_parts
 
         return final_score, "; ".join(reasons), diff_result
+
+    @staticmethod
+    def _state_distance(state_a: dict[str, Any], state_b: dict[str, Any]) -> int:
+        """Row-level symmetric-difference count between two states.
+
+        Each state is a ``{table: [row_dict]}`` map. The distance is the
+        number of rows that differ between the two states, summed across
+        all tables — a variant with one differing field on a single record
+        scores 1, a variant missing three whole records scores 3. Used to
+        pick the "closest" golden variant on a hash mismatch. Non-dict
+        rows are treated as opaque values via their JSON serialization.
+        """
+        all_tables = set(state_a.keys()) | set(state_b.keys())
+        total = 0
+        for table in all_tables:
+            rows_a = state_a.get(table) or []
+            rows_b = state_b.get(table) or []
+            canon_a = {json.dumps(row, sort_keys=True, default=str) for row in rows_a}
+            canon_b = {json.dumps(row, sort_keys=True, default=str) for row in rows_b}
+            total += len(canon_a.symmetric_difference(canon_b))
+        return total

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -4,6 +4,7 @@ import fnmatch
 import hashlib
 import importlib.util
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any, Union
 
@@ -596,21 +597,26 @@ class StateChecker:
 
     @staticmethod
     def _state_distance(state_a: dict[str, Any], state_b: dict[str, Any]) -> int:
-        """Row-level symmetric-difference count between two states.
+        """Multiset symmetric-difference count between two states.
 
-        Each state is a ``{table: [row_dict]}`` map. The distance is the
-        number of rows that differ between the two states, summed across
-        all tables — a variant with one differing field on a single record
-        scores 1, a variant missing three whole records scores 3. Used to
-        pick the "closest" golden variant on a hash mismatch. Non-dict
-        rows are treated as opaque values via their JSON serialization.
+        Each state is a ``{table: [row]}`` map. The distance is the number
+        of rows that differ between the two states, summed across all
+        tables — a variant missing three whole records scores 3, one whose
+        rows differ in a single field on one record scores 2 (each side
+        contributes one distinct row to the sym-diff). Multiset semantics
+        via :class:`collections.Counter`: a row appearing N times on one
+        side and M times on the other contributes ``|N - M|`` to the
+        distance, so row duplication is counted rather than deduplicated
+        away. Non-dict row values are treated as opaque via their JSON
+        canonical form.
         """
         all_tables = set(state_a.keys()) | set(state_b.keys())
         total = 0
         for table in all_tables:
             rows_a = state_a.get(table) or []
             rows_b = state_b.get(table) or []
-            canon_a = {json.dumps(row, sort_keys=True, default=str) for row in rows_a}
-            canon_b = {json.dumps(row, sort_keys=True, default=str) for row in rows_b}
-            total += len(canon_a.symmetric_difference(canon_b))
+            counter_a = Counter(json.dumps(row, sort_keys=True, default=str) for row in rows_a)
+            counter_b = Counter(json.dumps(row, sort_keys=True, default=str) for row in rows_b)
+            diff = (counter_a - counter_b) + (counter_b - counter_a)
+            total += sum(diff.values())
         return total

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -308,6 +308,14 @@ class StateChecksConfig(BaseModel):
     hash_enabled: bool = False
     expected_hash: str | None = None  # Pre-computed (if available)
     golden_actions: list[GoldenAction] = Field(default_factory=list)
+    # Alternative golden paths for tasks where domain policy permits more than
+    # one legal final state (e.g. "either one combined case or a split into
+    # two"). Each entry is a full sequence of golden actions equivalent to
+    # ``golden_actions`` — grading replays each variant on a fresh initial
+    # state, hashes, and passes if the trial's final hash matches ANY variant.
+    # Ordering is authoring order; ``golden_actions`` is variant 0 and
+    # alternatives are variant 1..N in the order listed here.
+    alternative_golden_actions: list[list[GoldenAction]] = Field(default_factory=list)
     # Opt-in, PER-FIELD: record field names whose numeric-looking STRING values
     # fold ("130.00" == "130.0") when hashing state. Per-field (not a global
     # switch) because a numeric-looking string can carry meaning in its exact
@@ -1821,5 +1829,14 @@ class HashGradingResult(BaseModel):
     hash_score: float
     state_diff: StateDiff | None = None
     golden_action_errors: list[str] = Field(default_factory=list)
+    # 0 for the primary golden path, 1..N for the Nth alternative in the order
+    # they appear in ``StateChecksConfig.alternative_golden_actions``. ``None``
+    # on hash mismatch. Single-variant tasks always resolve to 0 on match.
+    matched_variant: int | None = None
+    # Total number of variants attempted this grade (primary + alternatives).
+    # 1 for single-variant tasks; >1 when the task ships alternative goldens.
+    # Present regardless of match outcome so operators can audit variant
+    # coverage.
+    variants_tried: int = 1
 
     model_config = {"extra": "forbid"}

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1622,7 +1622,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         matched_variant: int | None = None
         per_variant_errors: list[list[str]] = []
         per_variant_snapshots: list[str] = []
-        per_variant_hashes: list[str] = []
 
         initial_tables_for_mcp: dict[str, Any] = {}
         if mcp_wrapper is not None:
@@ -1678,7 +1677,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             variant_hash = await self.db_client.get_stable_hash(
                 trial_id, numeric_string_fields=numeric_string_fields
             )
-            per_variant_hashes.append(variant_hash)
             logger.debug(
                 f"GradeTrial: Variant {idx} hash = {variant_hash[:16]}... "
                 f"(trial hash prefix = {trial_hash[:16]}...)"

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -36,6 +36,7 @@ from pydantic import ValidationError
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, LLMJudge
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
+from tolokaforge.core.grading.state_checks import StateChecker
 from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.models import CriterionResult, LLMJudgeConfig, ModelConfig
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
@@ -1804,17 +1805,18 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             await self.db_client.restore_snapshot(trial_id, snap_name)
             variant_state_resp = await self.db_client.get_stable_state(trial_id)
             variant_state = variant_state_resp.data
+            # Rank by the same multiset row-distance the core-side grader
+            # (``StateChecker._state_distance``) uses, so the "closest" choice
+            # is consistent across grading paths. Diff computation itself
+            # stays via ``compute_state_diff`` to preserve the structured
+            # ``StateDiff`` shape downstream reasons builders consume.
+            candidate_size = StateChecker._state_distance(trial_state, variant_state)
             candidate_diff = compute_state_diff(trial_state, variant_state)
-            candidate_size = sum(
-                len(t.missing) + len(t.extra) + len(t.different)
-                for t in candidate_diff.tables.values()
-            )
             if best_size is None or candidate_size < best_size:
                 best_diff = candidate_diff
                 best_size = candidate_size
             logger.debug(
-                f"GradeTrial: Closest-diff candidate variant {idx}: "
-                f"{candidate_size} record differences"
+                f"GradeTrial: Closest-diff candidate variant {idx}: {candidate_size} rows differ"
             )
 
         await self.db_client.restore_snapshot(trial_id, "pre_golden")

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1045,21 +1045,31 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # Get state_checks config (may contain golden_actions)
         state_checks_config = grading_config.state_checks
         golden_actions: list[GoldenAction] = []
+        alternative_golden_actions: list[list[GoldenAction]] = []
         if state_checks_config:
             golden_actions = state_checks_config.golden_actions
+            alternative_golden_actions = state_checks_config.alternative_golden_actions
 
         # A) HASH-BASED GRADING
         # Run hash grading when hash_enabled is set (even with empty golden_actions,
         # which represents refusal tasks where the expected state == initial state).
         if state_checks_config and state_checks_config.hash_enabled:
+            alt_count = len(alternative_golden_actions)
+            variants_suffix = (
+                f" + {alt_count} alternative variant{'s' if alt_count != 1 else ''}"
+                if alt_count
+                else ""
+            )
             logger.info(
-                f"GradeTrial: {trial_id} - Executing hash-based grading with {len(golden_actions)} golden actions"
+                f"GradeTrial: {trial_id} - Executing hash-based grading with "
+                f"{len(golden_actions)} golden actions{variants_suffix}"
             )
             try:
                 hash_result = await self._execute_hash_grading(
                     trial_id,
                     trial_context,
                     golden_actions,
+                    alternative_golden_actions=alternative_golden_actions,
                     numeric_string_fields=state_checks_config.numeric_string_fields,
                 )
                 components.hash_match = hash_result.hash_match
@@ -1226,6 +1236,18 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         )
         if judge_status == pb2.JUDGE_STATUS_ERRORED:
             reasons += f" | JUDGE ERRORED: {judge_reasons}"
+
+        # Surface multi-variant golden coverage in the reasons string so
+        # operators can audit which variant a passing trial matched (and know
+        # a red trial was compared against every declared variant).
+        if hash_result and hash_result.variants_tried > 1:
+            if hash_result.hash_match and hash_result.matched_variant is not None:
+                reasons += (
+                    f" | matched golden variant {hash_result.matched_variant} "
+                    f"of {hash_result.variants_tried}"
+                )
+            elif not hash_result.hash_match:
+                reasons += f" | no match across {hash_result.variants_tried} golden variants"
 
         # Append golden action errors if any (critical for debugging golden replay failures)
         if hash_result and hash_result.golden_action_errors:
@@ -1544,38 +1566,35 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         trial_context: TrialContextRuntime,
         golden_actions: list[GoldenAction],
         *,
+        alternative_golden_actions: list[list[GoldenAction]] | None = None,
         numeric_string_fields: list[str] | None = None,
     ) -> HashGradingResult:
-        """
-        Execute hash-based grading algorithm.
+        """Execute hash-based grading with optional alternative golden paths.
+
+        A task may declare N legal final states via
+        ``StateChecksConfig.alternative_golden_actions`` (variant 1..N; the
+        primary ``golden_actions`` is variant 0). Grading replays each
+        variant on a fresh initial state, hashes, and passes if the trial's
+        final hash matches ANY variant. Golden-replay errors from every
+        attempted variant are aggregated on the returned
+        :class:`HashGradingResult` regardless of match outcome so a broken
+        primary golden cannot be masked by a matching alternate.
 
         Steps:
-        1. Get current trial stable hash
-        2. Snapshot current state
-        3. Reset to initial state
-        4. Execute golden path actions
-        5. Snapshot golden state (for diff if mismatch)
-        6. Get golden stable hash
-        7. Restore trial state
-        8. Compare hashes
-        9. If mismatch, compute state diff
-
-        Args:
-            trial_id: Trial identifier
-            trial_context: Trial context with tools
-            golden_actions: List of golden path actions to execute
-
-        Returns:
-            HashGradingResult with hash_match, hash_score, and optional state_diff
+        1. Snapshot the trial's post-run state as ``pre_golden`` and read
+           its hash.
+        2. For each variant in order (primary first, then alternatives):
+           reset to initial, replay the variant, snapshot as
+           ``golden_result[_variant_{idx}]``, hash. Break on first match.
+        3. Restore the trial's state.
+        4. On mismatch, compute the state diff against the variant with the
+           smallest structural distance ("closest golden") so triage stays
+           readable regardless of variant count.
         """
-        # Detect MCP server wrappers — their state lives in a subprocess, not
-        # in the db-service, so we must sync before hashing and reset the MCP
-        # subprocess state when the db-service is reset.
         mcp_wrapper = self._find_mcp_server_wrapper(trial_context)
 
-        # 1. Get current trial stable hash
-        # For MCP_SERVER tasks the db-service was never updated during the trial
-        # (the MCP subprocess holds state in memory), so sync first.
+        # For MCP_SERVER tasks the db-service was never updated during the
+        # trial (the MCP subprocess holds state in memory), so sync first.
         if mcp_wrapper is not None:
             logger.info(f"GradeTrial: {trial_id} - Syncing MCP server state to db-service (trial)")
             try:
@@ -1591,63 +1610,156 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         )
         logger.debug(f"GradeTrial: Trial hash = {trial_hash[:16]}...")
 
-        # 2. Snapshot current state
         await self.db_client.create_snapshot(trial_id, "pre_golden")
         logger.debug("GradeTrial: Created snapshot 'pre_golden'")
 
-        # 3. Reset to initial state
-        await self.db_client.reset_trial(trial_id)
-        logger.debug("GradeTrial: Reset to initial state")
+        variants: list[list[GoldenAction]] = [golden_actions] + [
+            list(v) for v in (alternative_golden_actions or [])
+        ]
+        variants_tried = len(variants)
 
-        # For MCP_SERVER tasks also reset the subprocess state so golden actions
-        # execute from a clean initial state (not from the agent's final state).
+        matched_variant: int | None = None
+        per_variant_errors: list[list[str]] = []
+        per_variant_snapshots: list[str] = []
+        per_variant_hashes: list[str] = []
+
+        initial_tables_for_mcp: dict[str, Any] = {}
         if mcp_wrapper is not None:
-            initial_tables = (
+            initial_tables_for_mcp = (
                 trial_context.task_description.initial_state.tables
                 if trial_context.task_description and trial_context.task_description.initial_state
                 else {}
             )
-            logger.info(f"GradeTrial: {trial_id} - Resetting MCP server state to initial")
-            try:
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(None, lambda: mcp_wrapper.reset_state(initial_tables))
-            except Exception as e:
-                logger.error(f"GradeTrial: Failed to reset MCP state: {e}")
-                raise
 
-        # 4. Execute golden path actions
-        #
-        # Golden actions are replayed with their original arguments — no ID
-        # substitution.  This matches mcp_core's apply_golden_set_to_database()
-        # which also replays without substitution.  The InMemoryDatabase (and
-        # the JSON DB Service that mirrors it) uses deterministic ID generation
-        # (len(existing) + 1), so hardcoded IDs in golden actions always match
-        # the IDs produced on replay from the same initial state.
-        golden_action_errors: list[str] = []
+        for idx, variant in enumerate(variants):
+            await self.db_client.reset_trial(trial_id)
+            logger.debug(f"GradeTrial: Reset to initial state (variant {idx})")
 
-        for i, action in enumerate(golden_actions):
+            if mcp_wrapper is not None:
+                logger.info(
+                    f"GradeTrial: {trial_id} - Resetting MCP server state to initial (variant {idx})"
+                )
+                try:
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(
+                        None, lambda tables=initial_tables_for_mcp: mcp_wrapper.reset_state(tables)
+                    )
+                except Exception as e:
+                    logger.error(f"GradeTrial: Failed to reset MCP state (variant {idx}): {e}")
+                    raise
+
+            variant_errors = await self._replay_golden_variant(
+                variant_index=idx,
+                variant=variant,
+                trial_context=trial_context,
+            )
+            per_variant_errors.append(variant_errors)
+
+            if mcp_wrapper is not None:
+                logger.info(
+                    f"GradeTrial: {trial_id} - Syncing MCP server state to db-service (variant {idx})"
+                )
+                try:
+                    loop = asyncio.get_event_loop()
+                    variant_mcp_state = await loop.run_in_executor(None, mcp_wrapper.get_state)
+                    await self._sync_mcp_state_to_db(trial_id, variant_mcp_state)
+                except Exception as e:
+                    logger.error(
+                        f"GradeTrial: Failed to sync MCP state after golden actions (variant {idx}): {e}"
+                    )
+                    raise
+
+            snapshot_name = "golden_result" if idx == 0 else f"golden_result_variant_{idx}"
+            await self.db_client.create_snapshot(trial_id, snapshot_name)
+            per_variant_snapshots.append(snapshot_name)
+            logger.debug(f"GradeTrial: Created snapshot {snapshot_name!r}")
+
+            variant_hash = await self.db_client.get_stable_hash(
+                trial_id, numeric_string_fields=numeric_string_fields
+            )
+            per_variant_hashes.append(variant_hash)
+            logger.debug(
+                f"GradeTrial: Variant {idx} hash = {variant_hash[:16]}... "
+                f"(trial hash prefix = {trial_hash[:16]}...)"
+            )
+
+            if variant_hash == trial_hash:
+                matched_variant = idx
+                logger.info(
+                    f"GradeTrial: Hash match on variant {idx} "
+                    f"(of {variants_tried} variant{'s' if variants_tried != 1 else ''})"
+                )
+                break
+
+        hash_match = matched_variant is not None
+        hash_score = 1.0 if hash_match else 0.0
+
+        state_diff: StateDiff | None = None
+        if not hash_match:
+            state_diff = await self._compute_closest_variant_diff(trial_id, per_variant_snapshots)
+        else:
+            # The loop broke on the matched variant's snapshot; restore the
+            # trial's post-run state so downstream jsonpath / db-probe checks
+            # see it. ``_compute_closest_variant_diff`` handles the no-match
+            # restore itself as part of its variant walk.
+            await self.db_client.restore_snapshot(trial_id, "pre_golden")
+            logger.debug("GradeTrial: Restored snapshot 'pre_golden'")
+
+        # Aggregate golden-action errors from EVERY variant that ran, even on
+        # match. A broken primary golden must surface in the grade reasons
+        # regardless of whether a later variant produced a matching hash.
+        if variants_tried == 1:
+            golden_action_errors = per_variant_errors[0]
+        else:
+            golden_action_errors = [
+                f"variant {idx}: {msg}"
+                for idx, errs in enumerate(per_variant_errors)
+                for msg in errs
+            ]
+
+        return HashGradingResult(
+            hash_match=hash_match,
+            hash_score=hash_score,
+            state_diff=state_diff,
+            golden_action_errors=golden_action_errors,
+            matched_variant=matched_variant,
+            variants_tried=variants_tried,
+        )
+
+    async def _replay_golden_variant(
+        self,
+        *,
+        variant_index: int,
+        variant: list[GoldenAction],
+        trial_context: TrialContextRuntime,
+    ) -> list[str]:
+        """Replay one golden-action variant against the current trial state.
+
+        Returns the (possibly-empty) list of per-action errors. Failures are
+        recorded but do not abort the replay — partial state is still useful
+        for the closest-diff selection on no-match.
+        """
+        errors: list[str] = []
+        for i, action in enumerate(variant):
             tool_name = action.tool_name
-            arguments = dict(action.arguments)  # copy
+            arguments = dict(action.arguments)
 
             tool = trial_context.agent_tools.get(tool_name)
             if tool is None:
-                # Try with domain prefix (golden actions use unprefixed names)
                 for registered_name in trial_context.agent_tools:
                     if registered_name.endswith(f"_{tool_name}"):
                         tool = trial_context.agent_tools[registered_name]
                         logger.debug(
-                            f"GradeTrial: Matched golden tool '{tool_name}' -> '{registered_name}'"
+                            f"GradeTrial: Matched golden tool '{tool_name}' -> '{registered_name}' (variant {variant_index})"
                         )
                         break
             if tool is None:
-                # Golden action references tool that doesn't exist
-                err_msg = f"Golden action {i} ({tool_name}): tool not found"
-                logger.error(f"GradeTrial: {err_msg}")
-                golden_action_errors.append(err_msg)
-                continue  # Continue - partial golden state still useful
+                err = f"Golden action {i} ({tool_name}): tool not found"
+                logger.error(f"GradeTrial: variant {variant_index}: {err}")
+                errors.append(err)
+                continue
 
             try:
-                # Execute tool
                 if hasattr(tool, "execute"):
                     await tool.execute(arguments)
                 elif callable(tool):
@@ -1656,72 +1768,57 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     else:
                         loop = asyncio.get_event_loop()
                         await loop.run_in_executor(None, lambda t=tool, a=arguments: t(a))
-                logger.debug(f"GradeTrial: Golden action {i} executed: {tool_name}")
-
+                logger.debug(
+                    f"GradeTrial: Variant {variant_index} action {i} executed: {tool_name}"
+                )
             except Exception as e:
-                # Golden action failure — log with full traceback for debugging
-                err_msg = f"Golden action {i} ({tool_name}) failed: {type(e).__name__}: {e}"
-                logger.error(f"GradeTrial: {err_msg}")
+                err = f"Golden action {i} ({tool_name}) failed: {type(e).__name__}: {e}"
+                logger.error(f"GradeTrial: variant {variant_index}: {err}")
                 logger.error(traceback.format_exc())
-                golden_action_errors.append(err_msg)
+                errors.append(err)
 
-        # For MCP_SERVER tasks: sync subprocess state to db-service so the
-        # hash reflects what the golden actions actually produced.
-        if mcp_wrapper is not None:
-            logger.info(f"GradeTrial: {trial_id} - Syncing MCP server state to db-service (golden)")
-            try:
-                loop = asyncio.get_event_loop()
-                golden_mcp_state = await loop.run_in_executor(None, mcp_wrapper.get_state)
-                await self._sync_mcp_state_to_db(trial_id, golden_mcp_state)
-            except Exception as e:
-                logger.error(f"GradeTrial: Failed to sync MCP state after golden actions: {e}")
-                raise
+        return errors
 
-        # 5. Snapshot golden state (for diff if mismatch)
-        await self.db_client.create_snapshot(trial_id, "golden_result")
-        logger.debug("GradeTrial: Created snapshot 'golden_result'")
+    async def _compute_closest_variant_diff(
+        self,
+        trial_id: str,
+        variant_snapshots: list[str],
+    ) -> StateDiff | None:
+        """Return the diff against the variant with the smallest structural
+        distance from the trial state.
 
-        # 6. Get golden stable hash
-        # get_stable_hash returns the hash string directly
-        golden_hash = await self.db_client.get_stable_hash(
-            trial_id, numeric_string_fields=numeric_string_fields
-        )
-        logger.debug(f"GradeTrial: Golden hash = {golden_hash[:16]}...")
+        For single-variant tasks the "closest" is trivially the primary
+        golden. For multi-variant tasks the smallest-distance choice keeps
+        triage output focused on the variant the trial came closest to
+        satisfying.
+        """
+        if not variant_snapshots:
+            return None
 
-        # 7. Restore trial state
+        trial_state_response = await self.db_client.get_stable_state(trial_id)
+        trial_state = trial_state_response.data
+
+        best_diff: StateDiff | None = None
+        best_size: int | None = None
+        for idx, snap_name in enumerate(variant_snapshots):
+            await self.db_client.restore_snapshot(trial_id, snap_name)
+            variant_state_resp = await self.db_client.get_stable_state(trial_id)
+            variant_state = variant_state_resp.data
+            candidate_diff = compute_state_diff(trial_state, variant_state)
+            candidate_size = sum(
+                len(t.missing) + len(t.extra) + len(t.different)
+                for t in candidate_diff.tables.values()
+            )
+            if best_size is None or candidate_size < best_size:
+                best_diff = candidate_diff
+                best_size = candidate_size
+            logger.debug(
+                f"GradeTrial: Closest-diff candidate variant {idx}: "
+                f"{candidate_size} record differences"
+            )
+
         await self.db_client.restore_snapshot(trial_id, "pre_golden")
-        logger.debug("GradeTrial: Restored snapshot 'pre_golden'")
-
-        # 8. Compare hashes
-        hash_match = trial_hash == golden_hash
-        hash_score = 1.0 if hash_match else 0.0
-
-        # 9. If mismatch, compute state diff
-        state_diff: StateDiff | None = None
-        if not hash_match:
-            logger.info("GradeTrial: Hash mismatch, computing state diff")
-
-            # Get trial state
-            trial_state_response = await self.db_client.get_stable_state(trial_id)
-            trial_state = trial_state_response.data
-
-            # Restore golden state and get it
-            await self.db_client.restore_snapshot(trial_id, "golden_result")
-            golden_state_response = await self.db_client.get_stable_state(trial_id)
-            golden_state = golden_state_response.data
-
-            # Restore trial state again
-            await self.db_client.restore_snapshot(trial_id, "pre_golden")
-
-            # Compute diff using grading module (returns StateDiff model directly)
-            state_diff = compute_state_diff(trial_state, golden_state)
-
-        return HashGradingResult(
-            hash_match=hash_match,
-            hash_score=hash_score,
-            state_diff=state_diff,
-            golden_action_errors=golden_action_errors,
-        )
+        return best_diff
 
     # =========================================================================
     # MCP-server grading helpers


### PR DESCRIPTION
## Summary

Closes #612. Some domains admit more than one policy-legal final state (e.g. a policy that lets the agent create one combined case OR split it into two). Today hash-based grading compares against exactly one golden, so a policy-correct agent choosing the alternative shape fails deterministically.

Task authors can now declare additional golden paths under `state_checks.hash.alternative_golden_actions`. Grading replays every variant on a fresh initial state, hashes, and passes if the trial's final hash matches ANY variant. On mismatch the reported diff is against the variant with the smallest row-level distance from the trial state so triage stays focused on the variant the trial came closest to satisfying.

```yaml
state_checks:
  hash:
    enabled: true
    weight: 1.0
    golden_actions:                       # variant 0 (primary)
      - { name: create_case, kwargs: {...} }
    alternative_golden_actions:           # optional; each entry is variant 1..N
      - - { name: create_case_a, kwargs: {...} }
        - { name: create_case_b, kwargs: {...} }
```

## Changes

- **`tolokaforge/runner/service.py`** — `_execute_hash_grading` loops over `[golden_actions] + alternative_golden_actions`, snapshotting each replayed variant, breaking on first hash match. Extracted `_replay_golden_variant` + `_compute_closest_variant_diff`. Golden-action errors from every attempted variant are aggregated on the result regardless of match outcome — a broken primary golden cannot be masked by a matching alternate.
- **`tolokaforge/core/grading/state_checks.py`** — `grade_tau_style` accepts `alternative_golden_actions`; loops per variant, first-match wins, closest-diff on miss by row-level symmetric-difference count (new `_state_distance` static helper). A variant whose replay raises contributes its error to the returned reasons string on every outcome; grading returns 0.0 only when every variant fails to replay.
- **`tolokaforge/core/grading/combine.py`** — threads the config through to `grade_tau_style`. Raises a fail-loud config error when `alternative_golden_actions` is combined with `env_assertions` / `db_hash_check` — the tau2 environment evaluator compares against a single hash and would silently discard alternates otherwise. Message points authors at the supported combination.
- **`tolokaforge/adapters/native.py`** — parses `hash.alternative_golden_actions` from `grading.yaml` into the wire-shape list-of-lists.
- **`tolokaforge/adapters/bundle_writer.py`** — emits each variant to a sibling `fixtures/golden_actions_variant_{n}.json` starting at `n=1` when the bundle ships `golden_actions_alternatives`.
- **`tolokaforge/runner/models.py`** — `StateChecksConfig.alternative_golden_actions: list[list[GoldenAction]]` (`extra=\"forbid\"` preserved), `HashGradingResult.matched_variant: int | None` + `variants_tried: int`. Both surface in the grade reasons string.
- **Tests** — new `TestStateDistance` (row-level metric) and `TestGradeTauStyleVariants` (no-alternatives byte-identical path, match on variant 1, closest-diff on all-miss, broken-primary + matching-alt surfaces error, all-variants-fail returns 0 with all errors).
- **Docs** — `docs/GRADING.md` gains a "Multiple legal final states" section.
- **`CHANGELOG.md`** — Unreleased entry.

## Test plan

- [x] Unit lane green: `uv run pytest tests/unit -m unit` — 3532 passed
- [x] Canonical lane green: `uv run pytest tests/canonical -m canonical` — 665 passed
- [x] Lint clean: `uv run ruff check` + `uv run ruff format --check` on every touched file
- [x] End-to-end mock-provider smoke on `examples/native/tool_use` — pipeline still green (2/2 trials complete, no hash-grading regressions on the jsonpath-only path)
- [ ] Reviewer replay (optional): task pack shipping a real 2-variant golden with a red split-shape trajectory — variant 1 flips green under this PR

## Design review

Ran two adversarial critics before finalizing (design architect + team `/code-review` skill). Their findings shaped the diff:

- Consistent record-count metric on both paths (Path A + Path B).
- Broken primary golden + matching alternate surfaces the primary's replay error in reasons (previously masked).
- `matched_variant` / `variants_tried` wired into the grade reasons string so the enrichment fields are live data, not dormant.
- Tau2 + variants config combination fails loud rather than silently discarding.
- Snapshot naming aligned with wire naming (`golden_result_variant_N`).
- Docs + CHANGELOG updated in-PR.

## Explicitly out of scope

- Extending the tau2 `environment_evaluator.py` to also accept variant hashes — the config-level fail-loud check catches the combination today; extension is a follow-up.
- Wiring `matched_variant` / `variants_tried` into `results.yaml` and per-run metrics analytics — currently surfaces only in the grade reasons string. Analytics surface can add these fields in a follow-up.
- Named variants (e.g. `{"split_case": [...], "merged": [...]}`) for authoring readability — kept the positional shape to match the existing `golden_actions` structure. Reachable as a schema evolution later without breaking positional consumers.
- Hash-collision under `numeric_string_fields` folding could mis-attribute `matched_variant` between two variants that differ only in folded fields. Not encountered on any real task today; would surface as a distinct follow-up issue if a domain authors close-but-distinct variants.