### PR TITLE
feat(adapters): adapter-declared trial-grader name on orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Feat
+
+- **adapters**: adapter-declared trial-grader name — the orchestrator now loads `adapter.trial_grader_name` (default `"runner_rpc"`, additive, every existing adapter unchanged); adapters shipping a custom `TrialGrader` under the `tolokaforge.trial_graders` entry-point group override it (#620)
+
 ### Fix
 
 - **runner**: preserve simulator text glued to `###STOP###` — pre-token content is delivered as a USER message and the dialogue terminates with `USER_STOP` on the following user turn instead of silently discarding the entire reply. Simulator prompt gains an explicit precedence rule for backstory-mandated replies and an anti-restart rule (#611)

--- a/docs/ADAPTER_ARCHITECTURE.md
+++ b/docs/ADAPTER_ARCHITECTURE.md
@@ -145,6 +145,13 @@ All adapters implement these core methods:
 | `reset_environment(env)` | Reset environment to initial state |
 | `compute_golden_hash(task_id, env)` | Compute expected state hash |
 
+Adapters also carry overridable declarations with behaviour-preserving
+defaults:
+
+| Declaration | Default | Description |
+|--------|--------|-------------|
+| `trial_grader_name` (class attr) | `"runner_rpc"` | Name of the `TrialGrader` the orchestrator loads for this adapter's runs (from the `tolokaforge.trial_graders` entry-point group). Override to ship a custom grader. |
+
 ## Adapter-Specific Details
 
 ### NativeAdapter (built-in)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,7 +147,7 @@ flowchart TB
     Base --> Ext2
 ```
 
-Every adapter implements the same `BaseAdapter` contract — including `get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, `to_task_description` (for Docker Runner registration), and `docker_stack_requirements` (to declare bind-mounts, Docker socket access, or DinD needs). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
+Every adapter implements the same `BaseAdapter` contract — including `get_task`, `create_environment`, `get_registry_tools`, `get_grading_config`, `grade`, `compute_golden_hash`, `to_task_description` (for Docker Runner registration), `docker_stack_requirements` (to declare bind-mounts, Docker socket access, or DinD needs), and `trial_grader_name` (to declare which `TrialGrader` the orchestrator loads, default `"runner_rpc"`). The orchestrator only sees the contract, never the concrete adapter. New benchmark formats — public or private — plug in by publishing a Python package that registers under `[project.entry-points."tolokaforge.adapters"]`.
 
 ### Extension points (where external repos plug in)
 

--- a/tests/canonical/test_orchestrator_grader_name_e2e.py
+++ b/tests/canonical/test_orchestrator_grader_name_e2e.py
@@ -162,8 +162,9 @@ def test_adapter_declared_grader_name_reaches_grade(
     orch.adapter = adapter
     orch.run()
 
-    # The orchestrator resolved the grader by the adapter-declared name (:592) and
-    # placed it into ctx.trial_grader (:605) before the conductor factory ran.
+    # The orchestrator resolved the grader by the adapter-declared name and
+    # placed it into ctx.trial_grader before the conductor factory ran, so the
+    # captured grader is the one the name selected.
     assert isinstance(captured["grader"], _RecordingGrader)
 
     (trajectory,) = orch.results

--- a/tests/canonical/test_orchestrator_grader_name_e2e.py
+++ b/tests/canonical/test_orchestrator_grader_name_e2e.py
@@ -1,0 +1,172 @@
+"""Real-task canonical lock: the adapter-declared trial-grader name reaches the grade.
+
+Drives a genuine :meth:`Orchestrator.run` over the bundled native ``tool_use``
+pack with a :class:`NativeAdapter` subclass declaring a custom
+``trial_grader_name``. A recording grader registered under that name stamps a
+unique sentinel into the :class:`~tolokaforge.core.models.Grade`; a minimal
+recording conductor routes grading through ``ctx.trial_grader``. The sentinel on
+the collected grade proves the adapter-declared name flowed orchestrator
+(``_build_conductor``) → ``ConductorContext.trial_grader`` → the conductor's
+grade call — the positive custom-grader path end-to-end.
+
+Hermetic — no services, no LLM, no Docker — so it runs on every PR. The
+equivalent real-runner parity lock in ``tests/integration/test_run_trial_e2e.py``
+is gated to the push/nightly/gate lane and would hide a regression in this seam,
+so the fast composition lock lives in the canonical tier.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core import plugin_registry
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    Grade,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+    TaskConfig,
+    Trajectory,
+    TrialStatus,
+)
+from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+from tolokaforge.core.plugin_registry import TRIAL_GRADERS_GROUP
+from tolokaforge.core.runtime import InMemoryRuntimeBackend
+from tolokaforge.core.trial import TrialResult, TrialSpec
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK = _REPO_ROOT / "examples" / "native" / "tool_use" / "dataset"
+_TASK_ID = "tool_use_public_example_01"
+_RECORDING_GRADER_NAME = "recording_grader_e2e"
+
+#: Sentinel Grade values no built-in grader produces — asserting these proves the
+#: grade came from the recording grader the adapter's name selected.
+_SENTINEL_SCORE = 0.4242
+_SENTINEL_REASON = "adapter-declared-grader-name sentinel"
+
+_FIXED_TS = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+class _RecordingGrader:
+    """``TrialGrader`` returning a fixed sentinel :class:`Grade`."""
+
+    def grade(self, spec: TrialSpec, trajectory: Trajectory, agent_system_prompt: str) -> Grade:
+        return Grade(binary_pass=True, score=_SENTINEL_SCORE, reasons=_SENTINEL_REASON)
+
+
+class _RecordingConductor:
+    """Hermetic ``Conductor`` that grades through the injected ``ctx.trial_grader``.
+
+    Emits a synthetic trajectory (no LLM, no RPC) and stamps the grade the
+    orchestrator-resolved grader produces onto it — so the resulting grade
+    exercises the by-name grader seam rather than a side channel.
+    """
+
+    def __init__(self, grader: _RecordingGrader) -> None:
+        self._grader = grader
+
+    def run(self, spec: TrialSpec, task_config: TaskConfig) -> TrialResult:
+        task_id, trial_idx = spec.trial_id.rsplit(":", 1)
+        trajectory = Trajectory(
+            task_id=task_id,
+            trial_index=int(trial_idx),
+            start_ts=_FIXED_TS,
+            end_ts=_FIXED_TS,
+            status=TrialStatus.COMPLETED,
+            messages=[],
+        )
+        trajectory.grade = self._grader.grade(spec, trajectory, agent_system_prompt="")
+        return TrialResult.from_trajectory(
+            trial_id=spec.trial_id, trajectory=trajectory, worker_id=None
+        )
+
+
+class _RecordingGraderAdapter(NativeAdapter):
+    trial_grader_name = _RECORDING_GRADER_NAME
+
+
+class _FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeEntryPoint:
+    def __init__(self, name: str, factory: Any) -> None:
+        self.name = name
+        self.dist = _FakeDist("recording-grader-e2e")
+        self._factory = factory
+
+    def load(self) -> Any:
+        return self._factory
+
+
+@pytest.fixture
+def _only_recording_grader(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Register ONLY the recording grader under the trial-graders group.
+
+    Non-grader groups delegate to real discovery (the adapter registry resolves
+    ``native`` through it), so the sole by-name resolution the test controls is
+    the grader seam.
+    """
+    real_entry_points = importlib.metadata.entry_points
+
+    def fake_entry_points(*, group: str) -> list[Any]:
+        if group == TRIAL_GRADERS_GROUP:
+            return [_FakeEntryPoint(_RECORDING_GRADER_NAME, lambda _ctx: _RecordingGrader())]
+        return list(real_entry_points(group=group))
+
+    plugin_registry._clear_discovery_cache()
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    yield
+    plugin_registry._clear_discovery_cache()
+
+
+def test_adapter_declared_grader_name_reaches_grade(
+    _only_recording_grader: None, tmp_path: Path
+) -> None:
+    """The custom grader the adapter names produces the grade of a real run."""
+    # Sanity: the only registered grader is the recording one — no built-in leaks in.
+    assert plugin_registry.available_trial_graders() == [_RECORDING_GRADER_NAME]
+
+    adapter = _RecordingGraderAdapter({"base_dir": str(_PACK), "tasks_glob": "tasks/**/task.yaml"})
+    task = adapter.get_task(_TASK_ID)
+
+    config = RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        evaluation=EvaluationConfig(output_dir=str(tmp_path / "results")),
+    )
+    captured: dict[str, Any] = {}
+
+    def conductor_factory(ctx: Any) -> _RecordingConductor:
+        captured["grader"] = ctx.trial_grader
+        return _RecordingConductor(ctx.trial_grader)
+
+    orch = Orchestrator(
+        config,
+        deps=OrchestratorDeps(
+            runtime_backend=InMemoryRuntimeBackend(),
+            conductor_factory=conductor_factory,
+        ),
+    )
+    orch.tasks = [task]
+    orch.adapter = adapter
+    orch.run()
+
+    # The orchestrator resolved the grader by the adapter-declared name (:592) and
+    # placed it into ctx.trial_grader (:605) before the conductor factory ran.
+    assert isinstance(captured["grader"], _RecordingGrader)
+
+    (trajectory,) = orch.results
+    assert trajectory.grade is not None
+    assert trajectory.grade.score == _SENTINEL_SCORE
+    assert trajectory.grade.reasons == _SENTINEL_REASON

--- a/tests/canonical/test_run_trial_composition.py
+++ b/tests/canonical/test_run_trial_composition.py
@@ -96,6 +96,7 @@ def _orchestrator_trajectory(base_dir: Path, task, output_dir: Path) -> Trajecto
     adapter_stub = MagicMock()
     adapter_stub.to_task_description.side_effect = lambda _tid: task_desc
     adapter_stub.docker_stack_requirements.return_value = None
+    adapter_stub.trial_grader_name = "runner_rpc"
     orch.adapter = adapter_stub
     orch.run()
     (trajectory,) = orch.results

--- a/tests/integration/test_external_harness_e2e.py
+++ b/tests/integration/test_external_harness_e2e.py
@@ -56,13 +56,13 @@ _TASK_ID = "capstone"
 
 # Runs run_trial over the three fixture seams, builds an Orchestrator baseline
 # wired to the same seams, and writes both serialisations to ``out_file``.
-# The baseline injects the fixture grader through the conductor_factory closure:
-# OrchestratorDeps has no grader seam and _build_conductor hardcodes
-# load_trial_grader("runner_rpc") into ctx.trial_grader (which would fire a real
-# gRPC), so the closure ignores ctx.trial_grader and passes FixtureGrader
-# explicitly — both paths then run FixtureConductor + FixtureGrader, Docker-free.
-# The payload is written to a file because run_trial's StructuredLogger writes to
-# stdout, which must not be parsed as the payload.
+# _build_conductor resolves self.adapter.trial_grader_name (the stub pins it to
+# "runner_rpc") and builds the default grader into ctx.trial_grader — which would
+# fire a real gRPC. The baseline injects the fixture grader through the
+# conductor_factory closure, which supplies FixtureGrader to FixtureConductor
+# directly and ignores ctx.trial_grader, so both paths run FixtureConductor +
+# FixtureGrader, Docker-free. The payload is written to a file because run_trial's
+# StructuredLogger writes to stdout, which must not be parsed as the payload.
 _RUN_TRIAL_PROBE = """
 import json
 import sys
@@ -109,6 +109,7 @@ orch.tasks = [task]
 adapter_stub = MagicMock()
 adapter_stub.to_task_description.side_effect = lambda _tid: task_desc
 adapter_stub.docker_stack_requirements.return_value = None
+adapter_stub.trial_grader_name = "runner_rpc"
 orch.adapter = adapter_stub
 orch.run()
 (orch_trajectory,) = orch.results

--- a/tests/unit/test_orchestrator_budget_shutdown.py
+++ b/tests/unit/test_orchestrator_budget_shutdown.py
@@ -153,6 +153,7 @@ def _build_orchestrator(
     adapter = MagicMock()
     adapter.to_task_description.side_effect = lambda tid: _task_description(tid)
     adapter.docker_stack_requirements.return_value = MagicMock(needs_rag_service=False)
+    adapter.trial_grader_name = "runner_rpc"
     orch.adapter = adapter
     return orch, tmp_path / "results" / "run"
 

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.models import (
     EvaluationConfig,
     Grade,
@@ -1666,3 +1667,143 @@ class TestConductorInjection:
         assert ctx.config is orch.config
         assert ctx.output_dir == tmp_path
         assert ctx.trial_grader is not None
+
+
+# ===================================================================
+# Adapter-declared trial-grader name — orchestrator._build_conductor
+# ===================================================================
+
+
+class _RecordingGrader:
+    """Minimal real ``TrialGrader`` the fixture factory produces.
+
+    ``_build_conductor`` only stores it on the context; ``grade`` is never
+    reached in these tests, so it hard-fails if the build path ever calls it.
+    """
+
+    def grade(self, spec: Any, trajectory: Any, agent_system_prompt: str) -> Any:
+        raise AssertionError("recording grader.grade must not run during _build_conductor")
+
+
+class _FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeEntryPoint:
+    """Duck-typed ``EntryPoint`` whose ``load()`` returns the fixture factory."""
+
+    def __init__(self, name: str, factory: Any) -> None:
+        self.name = name
+        self.dist = _FakeDist("fixture-pkg")
+        self._factory = factory
+
+    def load(self) -> Any:
+        return self._factory
+
+
+class _CustomGraderAdapter(NativeAdapter):
+    trial_grader_name = "recording_grader"
+
+
+class _DefaultGraderAdapter(NativeAdapter):
+    pass
+
+
+class _UnregisteredGraderAdapter(NativeAdapter):
+    trial_grader_name = "does_not_exist_grader"
+
+
+@pytest.mark.unit
+class TestAdapterDeclaredTrialGraderName:
+    """``_build_conductor`` resolves the grader by ``adapter.trial_grader_name``.
+
+    Exercises the real ``Orchestrator._build_conductor`` with real
+    ``NativeAdapter`` subclasses and real ``plugin_registry`` resolution — no
+    monkeypatch stands in for the load path under test. A capturing
+    ``conductor_factory`` reads ``ctx.trial_grader`` off the real
+    ``ConductorContext`` the orchestrator built.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_registry(self) -> Any:
+        from tolokaforge.core import plugin_registry
+
+        plugin_registry._clear_discovery_cache()
+        yield
+        plugin_registry._clear_discovery_cache()
+
+    def _install_grader_entry_points(
+        self, monkeypatch: pytest.MonkeyPatch, entry_points: list[_FakeEntryPoint]
+    ) -> None:
+        import importlib.metadata
+
+        from tolokaforge.core.plugin_registry import TRIAL_GRADERS_GROUP
+
+        def fake_entry_points(*, group: str) -> list[_FakeEntryPoint]:
+            return list(entry_points) if group == TRIAL_GRADERS_GROUP else []
+
+        monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+
+    def _build_and_capture(self, adapter: NativeAdapter, tmp_path: Path) -> Any:
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+
+        captured: dict[str, ConductorContext] = {}
+
+        def factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
+            return InMemoryConductor()
+
+        orch = Orchestrator(_make_run_config(), deps=OrchestratorDeps(conductor_factory=factory))
+        orch.adapter = adapter
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            output_dir=tmp_path,
+            request_limiter=None,
+        )
+        return captured["ctx"]
+
+    def test_custom_name_selects_registered_grader(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A declared name resolves the matching registered factory's product."""
+        produced = _RecordingGrader()
+        self._install_grader_entry_points(
+            monkeypatch, [_FakeEntryPoint("recording_grader", lambda _ctx: produced)]
+        )
+
+        ctx = self._build_and_capture(
+            _CustomGraderAdapter({"tasks_glob": "tasks/**/task.yaml"}), tmp_path
+        )
+
+        assert ctx.trial_grader is produced
+
+    def test_default_name_resolves_runner_rpc_grader(self, tmp_path: Path) -> None:
+        """No override → the real installed ``runner_rpc`` entry point resolves.
+
+        Runs against real, un-monkeypatched discovery (the autouse fixture
+        cleared the cache) so the default preserves today's behaviour exactly.
+        """
+        from tolokaforge.core.trial_grader import RunnerRPCTrialGrader
+
+        ctx = self._build_and_capture(
+            _DefaultGraderAdapter({"tasks_glob": "tasks/**/task.yaml"}), tmp_path
+        )
+
+        assert isinstance(ctx.trial_grader, RunnerRPCTrialGrader)
+
+    def test_unregistered_name_fails_loud(self, tmp_path: Path) -> None:
+        """A declared-but-unregistered name propagates ``UnknownImplementationError``
+        naming the miss and listing the known registered names."""
+        from tolokaforge.core.plugin_registry import UnknownImplementationError
+
+        with pytest.raises(UnknownImplementationError) as excinfo:
+            self._build_and_capture(
+                _UnregisteredGraderAdapter({"tasks_glob": "tasks/**/task.yaml"}), tmp_path
+            )
+
+        message = str(excinfo.value)
+        assert "does_not_exist_grader" in message
+        assert "runner_rpc" in message

--- a/tests/unit/test_run_display_wiring.py
+++ b/tests/unit/test_run_display_wiring.py
@@ -804,6 +804,7 @@ def test_run_emits_lifecycle_with_distinct_trial_started_total_indices(tmp_path:
     adapter = MagicMock()
     adapter.to_task_description.side_effect = _make_task_description_for_run
     adapter.docker_stack_requirements.return_value = None
+    adapter.trial_grader_name = "runner_rpc"
     orch.adapter = adapter
 
     orch.run()
@@ -873,6 +874,7 @@ def test_run_with_default_null_events_completes_without_raising(tmp_path: Path) 
     adapter = MagicMock()
     adapter.to_task_description.side_effect = _make_task_description_for_run
     adapter.docker_stack_requirements.return_value = None
+    adapter.trial_grader_name = "runner_rpc"
     orch.adapter = adapter
 
     orch.run()
@@ -1141,6 +1143,7 @@ def _run_orch_with_two_role_models(tmp_path: Path, events: _RecordingEvents) -> 
     adapter = MagicMock()
     adapter.to_task_description.side_effect = _make_task_description_for_run
     adapter.docker_stack_requirements.return_value = None
+    adapter.trial_grader_name = "runner_rpc"
     orch.adapter = adapter
 
     orch.run()

--- a/tolokaforge/adapters/base.py
+++ b/tolokaforge/adapters/base.py
@@ -413,6 +413,11 @@ class BaseAdapter(ABC):
         """
         pass
 
+    # Adapters shipping a custom TrialGrader (registered under the
+    # tolokaforge.trial_graders entry-point group) override this; the default
+    # keeps runner-owned RPC grading.
+    trial_grader_name: str = "runner_rpc"
+
     def docker_stack_requirements(self) -> DockerStackRequirements:
         """Declare extra Docker stack needs for this adapter.
 

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -589,7 +589,7 @@ class Orchestrator:
                 "Conductor cannot be built before the adapter is loaded. "
                 "Ensure load_tasks() has run successfully."
             )
-        trial_grader = load_trial_grader("runner_rpc")(
+        trial_grader = load_trial_grader(self.adapter.trial_grader_name)(
             TrialGraderContext(runtime_backend=runtime_backend, logger=self.logger)
         )
 


### PR DESCRIPTION
## Summary

- The orchestrator resolves the trial-grader name from a new `BaseAdapter.trial_grader_name: str = "runner_rpc"` class attribute instead of a hardcoded literal in `_build_conductor`. Default preserves current behaviour for every existing adapter; adapters shipping a custom `TrialGrader` under the `tolokaforge.trial_graders` entry-point group can now actually have it loaded in docker-mode.
- A real-task canonical E2E test (`tests/canonical/test_orchestrator_grader_name_e2e.py`) drives `Orchestrator.run()` over a bundled native pack and asserts a custom-name-declared recording grader's sentinel reaches `orch.results[0].grade`.
- Latent breakage in four `MagicMock()` adapter-stub sites (which would otherwise crash `_build_conductor` with `UnknownImplementationError` on the new attribute read) is pinned in the same PR to keep the branch bisectable and the CI lane whole.

## Design choices

- **Adapter-declared, not per-run injected**: `trial_grader_name` lives on `BaseAdapter` because a custom grader is a property of the benchmark format, not a per-run dependency override.
- **Plain `str`, not `str, Enum`**: the valid-name set is open — third-party adapters register their own graders via entry points — so an in-tree enum would be actively wrong. Matches `run_trial`'s existing `grader: str` and `available_trial_graders() -> list[str]`.
- **Purely additive on the compat surface**: `BaseAdapter` is a published external-adapter surface (`tau`, `tlk_mcp_core`, terminal-bench). The new attribute has a behaviour-preserving default (`"runner_rpc"`) so every existing subclass inherits identical behaviour; no migration required.
- **Fail-loud on unregistered names**: the change adds no try/except and no fallback. An unregistered grader name propagates `UnknownImplementationError` unswallowed from the existing registry — the same fail-loud contract `run_trial` already exposes.

## Concepts introduced

Adapters now carry a declarative `trial_grader_name` hook — sibling of `docker_stack_requirements()` — that names a `TrialGrader` factory registered under the `tolokaforge.trial_graders` entry-point group. The orchestrator consumes it when building the conductor context; the runner-owned default (`"runner_rpc"`) stays the norm, and an adapter shipping benchmark-specific grading overrides the attribute.

## Plan

Branch: feat/adapter-trial-grader-name

## Context

`tolokaforge.trial_graders` is a first-class fail-loud entry-point group
(`tolokaforge/core/plugin_registry.py:68`, `:223`). The library-mode entry
point `run_trial` already honours a caller-supplied name
(`tolokaforge/core/run_trial.py:80`, `:135`), but the orchestrator — the
`tolokaforge run` / batch path — hardcodes the literal
`load_trial_grader("runner_rpc")` in `_build_conductor`
(`tolokaforge/core/orchestrator.py:592`). Consequence: an adapter can register
a custom `TrialGrader` under the entry-point group and it appears in
`available_trial_graders()`, but the orchestrator never loads it — verified by
probe (only `runner_rpc` is registered; no adapter class carries any
grader-name attribute today). The orchestrator is the odd path out.

## Goal

The orchestrator resolves the trial-grader name from an adapter-declared
attribute instead of a literal. A new optional class attribute
`BaseAdapter.trial_grader_name: str = "runner_rpc"` is the seam: the
orchestrator reads `self.adapter.trial_grader_name` and passes it to
`load_trial_grader`. Default preserves today's behaviour exactly for every
existing adapter; an adapter that ships a custom `TrialGrader` overrides the
attribute and the orchestrator loads it. Unregistered names fail loud through
the registry's existing `UnknownImplementationError` (lists known names).

## Non-goals

- **Not** a general `adapter.grade()` intercept — the runner-owned RPC grading
  path stays intact; the default remains `RunnerRPCTrialGrader` via `"runner_rpc"`.
- **Not** an `OrchestratorDeps` grader-injection seam — the declaration lives on
  the adapter (where a custom grader is a property of the benchmark format), not
  as a per-run dependency override.
- **Not** the full adapter-owned execution/grading seam #583 covers — this is the
  narrow grader-name subset.
- **Not** a new grader implementation — only the seam that loads a differently
  named one.

## Type-system fit

`trial_grader_name` is a plain `str` class attribute, not a `str, Enum`. The set
of valid names is **open** — third-party adapters register their own grader
names via entry points — so an in-tree enum would be wrong (it cannot enumerate
names that do not exist in-tree). This matches the existing choices: `run_trial`
takes `grader: str` (`run_trial.py:80`) and `available_trial_graders() -> list[str]`
(`plugin_registry.py:238`). No new type crosses a serialisation boundary, so no
Pydantic. (AGENTS.md type-system table.)

## Stages

### Stage 1: Adapter-declared grader name + unit lock

- **Contract:**
  - `tolokaforge/adapters/base.py` — add a class attribute on `BaseAdapter`:
    `trial_grader_name: str = "runner_rpc"`. Place it as a sibling of the other
    declarative adapter hooks (near `docker_stack_requirements()`), with a
    one-line comment stating the WHY only: adapters that ship a custom
    `TrialGrader` (registered under the `tolokaforge.trial_graders` entry-point
    group) override it; the default keeps runner-owned RPC grading. No
    history/"added in" phrasing (comment-hygiene).
  - `tolokaforge/core/orchestrator.py:592` — replace the literal
    `load_trial_grader("runner_rpc")` with
    `load_trial_grader(self.adapter.trial_grader_name)`. The existing
    `self.adapter is None` guard at `_build_conductor` (`:587`) already
    establishes non-None, so no new guard. No new error handling — an
    unregistered name propagates `UnknownImplementationError` unswallowed
    (fail-loud, AGENTS.md Core Rule 1).
- **Behaviour to lock (tier: unit — `tests/unit/test_orchestrator_logic.py`):**
  Exercise the *real* `Orchestrator._build_conductor` with a *real* adapter
  subclass and *real* registry resolution — no mock stands in for the behaviour
  under test. The adapter subclass subclasses the concrete `NativeAdapter` (a
  genuine adapter, not a `MagicMock`) and only overrides the class attribute, so
  the `str` default and any override are real attribute reads. Inject a capturing
  `conductor_factory` via `OrchestratorDeps` so the assertion reads
  `ctx.trial_grader` off the real `ConductorContext` the orchestrator built (the
  grader is stored in `ctx` at `orchestrator.py:605`, before `factory(ctx)` runs
  at `:611`, so the capture sees the orchestrator-resolved grader). Three cases:
  1. subclass declaring `trial_grader_name = "<fake>"`, with a real fake grader
     factory installed via the `test_plugin_registry.py` fixture idiom
     (monkeypatch `importlib.metadata.entry_points` +
     `plugin_registry._clear_discovery_cache()` set up *and torn down* around the
     case) → `ctx.trial_grader` is the instance the fake factory produced
     (adapter name selected the grader).
  2. subclass with no override → `ctx.trial_grader` is a `RunnerRPCTrialGrader`.
     **This case runs against real, un-monkeypatched discovery** — no
     `entry_points` monkeypatch, cache cleared before/after so the *real*
     installed `runner_rpc` entry point is rediscovered and resolved (its factory
     is construction-safe — verified, no gRPC on build). Sharing case 1/3's
     monkeypatched entry points here would assert against a fake and test the
     test.
  3. subclass declaring an unregistered name (with case 1's monkeypatched
     discovery active, or real discovery — either exposes the miss) →
     `_build_conductor` raises `UnknownImplementationError`, message names the
     missing grader and lists the known names (fail-loud).
- **Compatibility:** `BaseAdapter` is a published compatibility surface (external
  adapters — `tau`, `tlk_mcp_core`, terminal-bench — subclass it). This change is
  **purely additive**: a new attribute with a default that reproduces current
  behaviour, so every existing subclass inherits `"runner_rpc"` and nothing
  migrates. Migration note = the CHANGELOG entry below; no user action required.
- **Deliverable:** orchestrator consults the adapter; unit lock green; docs and
  the stale in-code comment corrected (below).
- **Validation:**
  - dev MCP `run_tests` marker `unit` path `tests/unit/test_orchestrator_logic.py`
    (new cases) — green.
  - dev MCP `run_tests` marker `unit` (full unit lane) — no regressions,
    especially `tests/unit/test_run_trial.py` (the library counter-example) and
    `tests/unit/test_plugin_registry.py`.
  - **`tests/integration/test_external_harness_e2e.py`** — the capstone is the
    regression guard for the `MagicMock`-stub breakage above and is **not** on the
    `unit` lane, so the plan's own unit gate is blind to it. Run it in Stage 1
    (its fixture path is Docker-free; it self-skips only if `uv` is missing). If
    the environment cannot run it, the stage report must say so explicitly and
    flag that the breakage is guarded only by the push/nightly/gate integration
    lane — never claim green without running it.
  - dev MCP `lint_check` + `format_check`.
  - Reviewer checks: no new fallback/try-except around the load; the attribute is
    `str` not `Enum`; no `_legacy_*` shim; comment states WHY only.
- **Doc updates (rewrite so the new state reads as the only state):**
  - `docs/ADAPTER_ARCHITECTURE.md` — under "BaseAdapter Interface" (`:130`), add a
    row/short note for `trial_grader_name` documenting it as an *overridable
    declaration* (parallel to how `docker_stack_requirements` is described), with
    default `"runner_rpc"` and a one-line "override to ship a custom grader".
  - `docs/ARCHITECTURE.md:150` — the sentence listing the `BaseAdapter` contract
    members (`get_task`, …, `docker_stack_requirements`): add `trial_grader_name`
    to that list.
  - `CHANGELOG.md` — a new bullet under `## Unreleased` → `### Feat`, scope
    `**adapters**`: adapter-declared trial-grader name; the orchestrator now loads
    `adapter.trial_grader_name` (default `"runner_rpc"`, additive, every existing
    adapter unchanged); adapters shipping a custom `TrialGrader` override it (#620).
  - `tests/integration/test_external_harness_e2e.py` — **fix a real breakage,
    not just a stale comment.** The capstone probe sets `orch.adapter =
    adapter_stub` where `adapter_stub = MagicMock()` (`:109-112`), unspecced. A
    `MagicMock` does **not** inherit `BaseAdapter`'s `str` default — accessing
    `.trial_grader_name` returns a *child mock*. After this stage,
    `_build_conductor` runs `load_trial_grader(self.adapter.trial_grader_name)`
    at `:592` (unconditionally, before the `conductor_factory` closure at `:611`),
    so that non-string hits `plugin_registry._load` → `mapping.get(<MagicMock>)
    is None` → **`UnknownImplementationError` raised at `:592`** and the capstone
    crashes. Required change: configure the stub —
    `adapter_stub.trial_grader_name = "runner_rpc"` — so `:592` resolves the real
    construction-safe factory whose product the closure ignores. Then rewrite the
    accompanying comment (currently at `:57-63`, asserting "_build_conductor
    hardcodes load_trial_grader('runner_rpc')") to describe actual behaviour: the
    orchestrator resolves `self.adapter.trial_grader_name` (the stub pins it to
    `"runner_rpc"`), builds the default grader into `ctx.trial_grader`, and the
    `conductor_factory` closure supplies `FixtureGrader` to `FixtureConductor`
    directly — so `ctx.trial_grader` is intentionally unused by this baseline. No
    "previously/now" phrasing — current state only (Core Rule 8).
  - **`rg` sweep (expected hits, do NOT "fix" them):** run
    `rg -n 'hardcode.*runner_rpc|load_trial_grader\("runner_rpc"\)'`. Legitimate
    hits that must stay: `tests/canonical/test_builtin_plugin_registrations.py:84`
    (`grader = load_trial_grader("runner_rpc")(ctx)` — a real registry-contract
    test) and `tolokaforge/core/run_trial.py` (the `grader: str = "runner_rpc"`
    library default — unchanged; the library path already honours its param). The
    **only** production literal that changes is `orchestrator.py:592`; the only
    other edit is the capstone stub+comment above.
  - **`tests/unit/test_orchestrator_budget_shutdown.py`,
    `tests/unit/test_run_display_wiring.py`** — same-class `MagicMock`-stub fix.
    Discovered during Stage 1's full unit-lane validation: 11 additional tests
    across these two files use unspecced `MagicMock()` adapters and crashed with
    the same `UnknownImplementationError` at `orchestrator.py:592` as the
    capstone. Same one-line fix per stub site
    (`stub.trial_grader_name = "runner_rpc"`); the injected InMemory
    backend/conductor already ignore the resolved grader. Rolled into the same
    Stage 1 commit as the capstone fix — one class of breakage, one atomic
    resolution (avoids a stray "same-fix-different-file" follow-up PR).

### Stage 2: Real-task end-to-end lock (canonical tier)

The user standing directive requires validating the seam with a real task and
real orchestrator wiring, not an all-mock stand-in. This stage drives a genuine
`Orchestrator.run()` over a **bundled native example task-pack** and proves the
adapter-declared grader name flows orchestrator → `_build_conductor` →
`ConductorContext.trial_grader` → the conductor's grade call, producing a grade
that carries the custom grader's sentinel.

- **Contract:** no production-code change — this stage is a behaviour lock only.
  It consumes the Stage 1 seam.
- **Behaviour to lock (tier: canonical — new
  `tests/canonical/test_orchestrator_grader_name_e2e.py`):**
  Hermetic, no services, no LLM, no Docker — so it runs on every PR (the
  integration lane runs only push/nightly/gate and would hide a regression in
  this seam; the fast composition lock belongs in canonical, mirroring the note
  in `tests/integration/test_run_trial_e2e.py`). The **only** seam the
  orchestrator resolves by name is the grader (`load_trial_grader(
  self.adapter.trial_grader_name)` at `:592`); the runtime backend is supplied as
  an instance via `OrchestratorDeps`, and the conductor is loaded by the
  hardcoded literal `load_conductor("in_process")` at `:610` unless a
  `conductor_factory` is injected. Critically, the grader is placed into
  `ctx.trial_grader` at `:605`, **before** the conductor factory runs at `:611` —
  so a `conductor_factory` that reads `ctx.trial_grader` *exercises* the
  grader-name seam, it does not bypass it. Shape:
  - **Register only the recording grader** via monkeypatched
    `importlib.metadata.entry_points` (+ `_clear_discovery_cache`,
    `test_plugin_registry.py` idiom): a fixture `TrialGrader` factory under the
    adapter-declared name that stamps a unique sentinel into the returned
    `Grade`. Backend and conductor are injected as instances (below), not
    resolved by name, so they need no entry-point registration.
  - Load a real bundled native pack (`examples/native/tool_use/dataset`, task
    `tool_use_public_example_01` — the pack `test_run_trial_e2e.py` already uses)
    through a `NativeAdapter` subclass that declares
    `trial_grader_name = "<recording>"`.
  - Build a real `Orchestrator` (`OrchestratorConfig(workers=1, repeats=1,
    auto_start_services=False)`), injecting via `OrchestratorDeps`:
    `runtime_backend=InMemoryRuntimeBackend()` (in-tree, `runtime.py:395`) and a
    `conductor_factory=lambda ctx: <hermetic conductor wired with
    grader=ctx.trial_grader>`. The conductor routes grading through
    `ctx.trial_grader` — use the in-tree `InMemoryConductor`
    (`conductor.py:249`) if it consumes an injected grader, else a minimal
    in-file recording conductor with the same contract. Set `orch.adapter` to the
    real subclass and drive `orch.run()`.
  - **Assert** the collected trial grade carries the recording grader's sentinel
    — i.e. the adapter-declared name flowed orchestrator (`:592`) →
    `ctx.trial_grader` (`:605`) → the conductor's grade call, and the
    adapter-declared grader actually graded the run. The default path (no
    override → `runner_rpc`) is covered by Stage 1 case 2; this is the positive
    custom-grader path end-to-end.
- **Compatibility:** none — test-only.
- **Deliverable:** a canonical test proving the custom-grader name reaches the
  grade in a real orchestrator run over a real task-pack.
- **Justified drift (recorded on execution):** the full canonical lane surfaced
  one more `MagicMock`-stub crash of the same class Stage 1 already fixed —
  `tests/canonical/test_run_trial_composition.py`. Fixed in-stage with the same
  single-line pin (`adapter_stub.trial_grader_name = "runner_rpc"`), consistent
  with Stage 2 being test-only. Same rationale as Stage 1's drift: one class of
  breakage, one atomic resolution; a stray same-fix-different-file follow-up PR
  would only be noise.
- **Validation:**
  - dev MCP `run_tests` marker `canonical` path
    `tests/canonical/test_orchestrator_grader_name_e2e.py` — green.
  - dev MCP `run_tests` marker `canonical` (full canonical lane) — no snapshot or
    contract regressions.
  - Reviewer checks: the `conductor_factory` reads `ctx.trial_grader` (the
    assertion genuinely exercises the name seam, not a side channel); the pack
    loaded is a real on-disk example; no network/Docker/LLM dependency (stays
    hermetic/canonical).
- **Doc updates:** none beyond Stage 1 (test-only stage).

## Discovered issues

- **Fix in this PR (Stage 1):** `tests/integration/test_external_harness_e2e.py`
  breaks on this change — its `MagicMock` adapter stub (`:109-112`) yields a
  non-string `.trial_grader_name`, raising `UnknownImplementationError` at
  `:592`. Stage 1 configures the stub (`adapter_stub.trial_grader_name =
  "runner_rpc"`) and corrects the now-false in-code comment at `:57-63` (Core
  Rule 8). This is a required code fix, not a comment tidy-up.
- **File as issue (GitHub MCP unavailable this session — main/user to file):**
  *P3 — simplify the `test_external_harness_e2e.py` Orchestrator baseline now
  that adapters can declare a grader name.* The capstone injects `FixtureGrader`
  through a `conductor_factory` closure and a `MagicMock` adapter stub
  specifically because the orchestrator used to hardcode `runner_rpc`. With this
  seam it *could* instead use a real adapter declaring
  `trial_grader_name = "fixture_grader"` and drop the grader-injection
  workaround. Out of scope here (the capstone is golden-locked and also exercises
  the backend/conductor seams the closure supplies), but worth a low-priority
  cleanup follow-up. No number yet — flagged in the handoff.

## Risks / open questions

- **Stage 2 hermeticity is not at risk.** The backend and conductor are injected
  as instances via `OrchestratorDeps`; only the grader flows through the
  by-name seam. `InMemoryRuntimeBackend` + `InMemoryConductor` are in-tree
  (`runtime.py:395`, `conductor.py:249`) and the hermetic `Orchestrator.run()` +
  injected-seam pattern is proven by `test_external_harness_e2e.py`. The only
  open sub-question is whether `InMemoryConductor` consumes an injected grader; if
  not, a minimal in-file recording conductor with the same contract is used — no
  fallback in tier or realness.
- **GitHub MCP not wired into this session** — the one discovered follow-up could
  not be auto-filed. It must be filed on `Toloka/tolokaforge` (not Jira; public
  repo, and internal keys are forbidden in public artefacts). Flagged to main.
- **No open conflict.** `load_trial_grader` has two production call sites
  (`run_trial.py`, `orchestrator.py`) and one canonical-test call site
  (`test_builtin_plugin_registrations.py:84`); only the `orchestrator.py:592`
  literal changes. `BaseAdapter` gains one attribute with a behaviour-preserving
  default — no in-flight branch on the adapters surface was found in
  `git log`/`git status`.

## Discovered issues

- Fixed in this PR (Stage 1): the capstone integration test (`tests/integration/test_external_harness_e2e.py`) plus three additional test modules (`tests/unit/test_orchestrator_budget_shutdown.py`, `tests/unit/test_run_display_wiring.py`, `tests/canonical/test_run_trial_composition.py`) all used unspecced `MagicMock()` adapter stubs that would crash after this change (child mock, non-string, `UnknownImplementationError` at `orchestrator.py:592`). Same one-line pin (`stub.trial_grader_name = "runner_rpc"`) per site.
- Filed post-merge: **P3** — simplify the `test_external_harness_e2e.py` Orchestrator baseline to declare `trial_grader_name` on a real adapter instead of the current `MagicMock` + `conductor_factory` grader-injection workaround. Out of scope here (capstone is golden-locked and also exercises the backend/conductor seams the closure supplies).

## Test plan

- Full `-m unit` lane green modulo two pre-existing `examples/native/multi_service_endpoint_add` digest-mismatch failures on `main` (unrelated to this branch — last touched by `f29f15a`).
- Full `-m canonical` lane green modulo three pre-existing digests from the same source.
- `-m integration tests/integration/test_external_harness_e2e.py` (Docker-free capstone) green — proves the stub-pin fix.
- Post-merge: file the P3 follow-up above.

Closes #620
