### PR TITLE
feat(tools): configurable working_root on str_replace_editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **tools**: `str_replace_editor` gains `tool_config.working_root` (default `/work`, additive, every current task pack unchanged); a missing or non-directory root fails loud on first use (#637)
+
 ## v0.11.2 (2026-07-27)
 
 ### Feat

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -140,24 +140,29 @@ non-UTF-8 file (which cannot be safely round-tripped); `view` reads with
 replacement characters for display only.
 
 **Path validation.** Paths resolve to their realpath and must stay contained in
-the working root (`/work`); a symlink escape or a `..` component that leaves the
-root fails loud.
+the working root; a symlink escape or a `..` component that leaves the root
+fails loud. The root defaults to `/work` and is set per task via
+`tool_config.working_root` (see [Enabling Tools](#enabling-tools)); all four
+commands and the containment check bind to that effective root. A configured
+root that does not exist or is not a directory fails loud on first use, naming
+the root — the tool never silently creates it.
 
 **Provider variants**
 
-- **Local** (no `service` key): in-process file operations rooted at the runner
-  container's `/work`. Writes go to a temp file and are renamed into place
-  (single-process temp+rename).
+- **Local** (no `service` key): in-process file operations rooted at the
+  effective working root (`working_root`, default `/work`) on the runner
+  container. Writes go to a temp file and are renamed into place (single-process
+  temp+rename).
 - **Compose** (`service` + `compose_project_prefix`): every command runs through
-  `docker exec` into an already-running service container. File content is piped
-  on stdin (never interpolated into the shell command string) and paths are
-  passed as positional arguments, so agent-controlled bytes cannot inject shell
-  commands. Path containment is validated **inside the container** via
-  `realpath`; if `realpath` is absent from the target image the engine fails
-  loud rather than silently skipping validation. Write atomicity is weaker than
-  the local variant: a completed temp-file+`mv` is atomic, but an exec
-  interrupted mid-write can leave the temp file behind. The editor has no
-  configurable per-command timeout.
+  `docker exec` into an already-running service container, rooted at the same
+  effective working root. File content is piped on stdin (never interpolated
+  into the shell command string) and paths are passed as positional arguments,
+  so agent-controlled bytes cannot inject shell commands. Path containment is
+  validated **inside the container** via `realpath`; if `realpath` is absent
+  from the target image the engine fails loud rather than silently skipping
+  validation. Write atomicity is weaker than the local variant: a completed
+  temp-file+`mv` is atomic, but an exec interrupted mid-write can leave the temp
+  file behind. The editor has no configurable per-command timeout.
 
 ## Enabling Tools
 
@@ -181,8 +186,10 @@ tools:
 
 To select the compose variant, add a per-tool kwargs block under
 `tools.agent.<name>` naming the target `service` and the `compose_project_prefix`
-used to bring the stack up. `bash_session` additionally accepts `timeout_s`; the
-editor has no configurable per-command timeout:
+used to bring the stack up. `bash_session` additionally accepts `timeout_s`;
+`str_replace_editor` additionally accepts `working_root` (the absolute path all
+four commands resolve against, default `/work`; a missing or non-directory root
+fails loud on first use). The editor has no configurable per-command timeout:
 
 ```yaml
 tools:
@@ -195,7 +202,12 @@ tools:
     str_replace_editor:
       service: main
       compose_project_prefix: env_
+      working_root: /srv/agent  # optional; defaults to /work
 ```
+
+`working_root` applies to the local variant too: set it under the
+`str_replace_editor` block (no `service` key) to root the in-process editor at a
+non-default path.
 
 > **Compose-variant network isolation.** Under `network_policy: no_internet` /
 > `limited_internet`, the engine attaches every compose service to a single

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -184,12 +184,15 @@ tools:
     enabled: ["bash_session", "str_replace_editor"]
 ```
 
+To override the default working root (`/work`), add `working_root` under
+`tools.agent.str_replace_editor`. This applies to both the local and the compose
+variant; a missing or non-directory root fails loud on first use.
+
 To select the compose variant, add a per-tool kwargs block under
 `tools.agent.<name>` naming the target `service` and the `compose_project_prefix`
 used to bring the stack up. `bash_session` additionally accepts `timeout_s`;
-`str_replace_editor` additionally accepts `working_root` (the absolute path all
-four commands resolve against, default `/work`; a missing or non-directory root
-fails loud on first use). The editor has no configurable per-command timeout:
+`str_replace_editor` additionally accepts `working_root` (see above). The editor
+has no configurable per-command timeout:
 
 ```yaml
 tools:
@@ -204,10 +207,6 @@ tools:
       compose_project_prefix: env_
       working_root: /srv/agent  # optional; defaults to /work
 ```
-
-`working_root` applies to the local variant too: set it under the
-`str_replace_editor` block (no `service` key) to root the in-process editor at a
-non-default path.
 
 > **Compose-variant network isolation.** Under `network_policy: no_internet` /
 > `limited_internet`, the engine attaches every compose service to a single

--- a/tests/canonical/test_str_replace_editor_dispatch.py
+++ b/tests/canonical/test_str_replace_editor_dispatch.py
@@ -8,6 +8,8 @@ daemon in ``tests/integration/test_str_replace_editor_compose.py``.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tolokaforge.runner.models import ToolSchema
@@ -64,3 +66,28 @@ def test_compose_backend_wires_resolved_name_into_engine():
 def test_service_without_prefix_fails_loud():
     with pytest.raises(ToolConfigurationError):
         _wrapper({"service": "app"})
+
+
+def test_working_root_wires_into_local_backend(tmp_path):
+    root = str(tmp_path / "srv" / "agent")
+    wrapper = _wrapper({"working_root": root})
+    assert isinstance(wrapper._backend, LocalFilesystemEditor)
+    assert wrapper._backend._base == Path(root).resolve()
+
+
+def test_working_root_wires_into_compose_backend():
+    wrapper = _wrapper(
+        {"service": "app", "compose_project_prefix": "foo_", "working_root": "/srv/agent"}
+    )
+    assert isinstance(wrapper._backend, DockerComposeEditor)
+    assert wrapper._backend.base_path == "/srv/agent"
+
+
+def test_working_root_defaults_to_work_for_both_backends():
+    local = _wrapper(None)
+    assert isinstance(local._backend, LocalFilesystemEditor)
+    assert local._backend._base == Path("/work").resolve()
+
+    compose = _wrapper({"service": "app", "compose_project_prefix": "foo_"})
+    assert isinstance(compose._backend, DockerComposeEditor)
+    assert compose._backend.base_path == "/work"

--- a/tests/canonical/test_str_replace_editor_local.py
+++ b/tests/canonical/test_str_replace_editor_local.py
@@ -227,6 +227,26 @@ def test_nonexistent_root_fails_loud_on_create_and_leaves_tree_uncreated(tmp_pat
     assert not missing.exists()  # regression lock: no silent mkdir -p of the root tree
 
 
+def test_custom_root_escape_rejected_per_command(tmp_path):
+    """AC: escape rejection is verified per command. ``_resolve`` is the shared
+    chokepoint; this test locks that every command routes through it so a future
+    refactor moving containment into command-specific paths would break here."""
+    root = tmp_path / "srv" / "agent"
+    root.mkdir(parents=True)
+    (tmp_path / "secret.txt").write_text("secret\n", encoding="utf-8")
+    ed = _editor(root)
+    escape = "../secret.txt"
+
+    with pytest.raises(EditorError):
+        ed.view(escape)
+    with pytest.raises(EditorError):
+        ed.create(escape, "x\n")
+    with pytest.raises(EditorError):
+        ed.str_replace(escape, "a", "b")
+    with pytest.raises(EditorError):
+        ed.insert(escape, 1, "x")
+
+
 # -- schema advertisement -----------------------------------------------------
 
 _EXPECTED_PROPS = {

--- a/tests/canonical/test_str_replace_editor_local.py
+++ b/tests/canonical/test_str_replace_editor_local.py
@@ -177,6 +177,56 @@ def test_traversal_and_absolute_escape_fail_loud(tmp_path, escape):
         _editor(base).view(target)
 
 
+# -- configurable working root ------------------------------------------------
+
+
+def test_custom_root_resolves_all_four_commands_under_it(tmp_path):
+    root = tmp_path / "srv" / "agent"
+    root.mkdir(parents=True)
+    ed = _editor(root)
+
+    ed.create("notes.txt", "one\ntwo\n")
+    created = root / "notes.txt"
+    assert created.read_text(encoding="utf-8") == "one\ntwo\n"
+    assert ed.view("notes.txt") == "     1\tone\n     2\ttwo\n"
+
+    ed.str_replace("notes.txt", "one", "ONE")
+    ed.insert("notes.txt", 2, "three")
+    assert created.read_text(encoding="utf-8") == "ONE\ntwo\nthree\n"
+
+
+def test_custom_root_binds_symlink_and_traversal_containment(tmp_path):
+    root = tmp_path / "srv" / "agent"
+    root.mkdir(parents=True)
+    (tmp_path / "secret.txt").write_text("secret\n", encoding="utf-8")
+    (root / "link.txt").symlink_to(tmp_path / "secret.txt")
+
+    with pytest.raises(EditorError) as symlink_exc:
+        _editor(root).view("link.txt")
+    assert str(root.resolve()) in str(symlink_exc.value)
+
+    for escape in ("../secret.txt", "/etc/hostname"):
+        with pytest.raises(EditorError):
+            _editor(root).view(escape)
+
+
+def test_nonexistent_root_fails_loud_on_view_naming_root(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(EditorError) as exc:
+        _editor(missing).view("anything.txt")
+    msg = str(exc.value)
+    assert str(missing.resolve()) in msg
+    assert "file not found" not in msg
+
+
+def test_nonexistent_root_fails_loud_on_create_and_leaves_tree_uncreated(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(EditorError) as exc:
+        _editor(missing).create("new.txt", "hi\n")
+    assert str(missing.resolve()) in str(exc.value)
+    assert not missing.exists()  # regression lock: no silent mkdir -p of the root tree
+
+
 # -- schema advertisement -----------------------------------------------------
 
 _EXPECTED_PROPS = {

--- a/tests/integration/test_str_replace_editor_compose.py
+++ b/tests/integration/test_str_replace_editor_compose.py
@@ -1,9 +1,12 @@
-"""Behaviour-parity lock for the compose ``str_replace_editor`` engine (#567).
+"""Behaviour-parity lock for the compose ``str_replace_editor`` engine (#567, #637).
 
 Runs the four editor commands against a real ``docker exec`` into a running
 container — proving the compose provider is behaviour-identical to the local one
 (line-numbered view, unique str_replace, insert, fail-loud create/str_replace,
-container-side path containment).
+container-side path containment). The behaviour battery runs once per root
+(``/work`` and a non-default absolute root) so a configured ``working_root`` is
+proven equivalent to the default; escape rejection is checked per command against
+the custom root, and a root absent from the container fails loud naming the root.
 
 No mocks: a one-service container is brought up in the fixture and torn down
 after. Skips cleanly when the Docker daemon is unavailable; a failed assertion
@@ -12,6 +15,7 @@ is a real failure, never a silent skip.
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 import pytest
@@ -25,15 +29,21 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 
 _IMAGE = "alpine:latest"
 _PREFIX = "tf_test_editor_"
-_TRIAL_ID = "s2parity"
+# Worker-scoped trial id so each xdist worker owns a distinct container; without
+# this the shared name collides under -n auto and all-but-one worker skip.
+_TRIAL_ID = f"s2parity_{os.environ.get('PYTEST_XDIST_WORKER', 'serial')}"
 _SERVICE = "app"
 _CONTAINER = StrReplaceEditorToolWrapper._resolve_container_name(_TRIAL_ID, _SERVICE, _PREFIX)
 _WORK = "/work"
+_CUSTOM_ROOT = "/srv/agent"
+# The behaviour battery runs once per root so the compose engine is proven
+# behaviour-identical at the default /work and at a non-default absolute root.
+_ROOTS = [_WORK, _CUSTOM_ROOT]
 
 
 @pytest.fixture(scope="module")
 def running_container():
-    """Bring up a single container with a ``/work`` root to edit inside."""
+    """Bring up a single container with each editable root created inside it."""
     if not is_docker_daemon_available():
         pytest.skip("Docker daemon not available")
     subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
@@ -45,7 +55,7 @@ def running_container():
     if up.returncode != 0:
         pytest.skip(f"could not start test container: {up.stderr.strip()}")
     subprocess.run(
-        ["docker", "exec", _CONTAINER, "mkdir", "-p", _WORK], capture_output=True, check=True
+        ["docker", "exec", _CONTAINER, "mkdir", "-p", *_ROOTS], capture_output=True, check=True
     )
     try:
         yield _CONTAINER
@@ -53,13 +63,18 @@ def running_container():
         subprocess.run(["docker", "rm", "-f", _CONTAINER], capture_output=True, check=False)
 
 
+@pytest.fixture(params=_ROOTS)
+def root(request) -> str:
+    return request.param
+
+
 @pytest.fixture
-def editor(running_container) -> DockerComposeEditor:
-    return DockerComposeEditor(running_container, base_path=_WORK)
+def editor(running_container, root) -> DockerComposeEditor:
+    return DockerComposeEditor(running_container, base_path=root)
 
 
 def test_create_view_str_replace_insert_round_trip(editor):
-    path = f"{_WORK}/story.txt"
+    path = f"{editor.base_path}/story.txt"
     assert "created successfully" in editor.create(path, "the quick brown fox\ntail\n")
 
     assert editor.view(path) == "     1\tthe quick brown fox\n     2\ttail\n"
@@ -72,7 +87,7 @@ def test_create_view_str_replace_insert_round_trip(editor):
 
 
 def test_create_on_existing_path_fails_loud(editor):
-    path = f"{_WORK}/existing.txt"
+    path = f"{editor.base_path}/existing.txt"
     editor.create(path, "original\n")
     with pytest.raises(EditorError):
         editor.create(path, "overwrite\n")
@@ -80,7 +95,7 @@ def test_create_on_existing_path_fails_loud(editor):
 
 
 def test_str_replace_non_unique_fails_loud(editor):
-    path = f"{_WORK}/dup.txt"
+    path = f"{editor.base_path}/dup.txt"
     editor.create(path, "foo and foo\n")
     with pytest.raises(EditorError) as exc:
         editor.str_replace(path, "foo", "bar")
@@ -88,9 +103,51 @@ def test_str_replace_non_unique_fails_loud(editor):
     assert editor.view(path) == "     1\tfoo and foo\n"
 
 
-def test_absolute_path_outside_work_fails_loud(editor):
+def test_absolute_path_outside_root_fails_loud(editor):
     with pytest.raises(EditorError):
         editor.view("/etc/hostname")
+
+
+def test_symlink_escape_fails_loud(running_container):
+    """A symlink inside the custom root pointing outside it is rejected: the
+    in-container ``realpath`` follows it, so containment binds to the target."""
+    ed = DockerComposeEditor(running_container, base_path=_CUSTOM_ROOT)
+    subprocess.run(
+        [
+            "docker",
+            "exec",
+            running_container,
+            "ln",
+            "-sf",
+            "/etc/hostname",
+            f"{_CUSTOM_ROOT}/escape.txt",
+        ],
+        capture_output=True,
+        check=True,
+    )
+    with pytest.raises(EditorError) as exc:
+        ed.view(f"{_CUSTOM_ROOT}/escape.txt")
+    assert "escapes the working root" in str(exc.value)
+    assert _CUSTOM_ROOT in str(exc.value)
+
+
+def test_parent_traversal_escape_fails_loud(running_container):
+    ed = DockerComposeEditor(running_container, base_path=_CUSTOM_ROOT)
+    with pytest.raises(EditorError) as exc:
+        ed.view(f"{_CUSTOM_ROOT}/../../etc/hostname")
+    assert "escapes the working root" in str(exc.value)
+    assert _CUSTOM_ROOT in str(exc.value)
+
+
+def test_missing_compose_root_fails_loud(running_container):
+    """A configured root absent from the container fails loud on first command,
+    naming the root — not a misleading 'file not found'."""
+    ed = DockerComposeEditor(running_container, base_path="/srv/missing")
+    with pytest.raises(EditorError) as exc:
+        ed.view("anything.txt")
+    msg = str(exc.value)
+    assert "/srv/missing" in msg
+    assert "does not exist or is not a directory" in msg
 
 
 async def test_wrapper_drives_compose_backend_end_to_end(running_container):
@@ -104,6 +161,28 @@ async def test_wrapper_drives_compose_backend_end_to_end(running_container):
     )
     wrapper = StrReplaceEditorToolWrapper(schema, trial_id=_TRIAL_ID)
     path = f"{_WORK}/wrapper.txt"
+    assert "created successfully" in await wrapper.execute(
+        {"command": "create", "path": path, "file_text": "hello\n"}
+    )
+    view = await wrapper.execute({"command": "view", "path": path})
+    assert view == "     1\thello\n"
+
+
+async def test_wrapper_drives_compose_backend_with_custom_working_root(running_container):
+    """Full wrapper path with ``working_root`` set: the edit lands under the
+    custom root, not ``/work``."""
+    schema = ToolSchema(
+        name="str_replace_editor",
+        description="x",
+        parameters={"type": "object", "properties": {}},
+        tool_config={
+            "service": _SERVICE,
+            "compose_project_prefix": _PREFIX,
+            "working_root": _CUSTOM_ROOT,
+        },
+    )
+    wrapper = StrReplaceEditorToolWrapper(schema, trial_id=_TRIAL_ID)
+    path = f"{_CUSTOM_ROOT}/wrapper_custom.txt"
     assert "created successfully" in await wrapper.execute(
         {"command": "create", "path": path, "file_text": "hello\n"}
     )

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1255,17 +1255,20 @@ class StrReplaceEditorToolWrapper(ToolWrapper):
     """Runner-side executor for the ``str_replace_editor`` tool.
 
     Stateless (no per-trial session), so ``has_lifecycle`` stays False. The
-    working root is the runner container's ``/work`` (same directory the file
-    tools and the shell's workdir target). A ``service`` key in ``tool_config``
-    selects the compose backend; its absence selects the local filesystem
-    engine. The wire schema is identical either way.
+    working root defaults to ``/work`` (same directory the file tools and the
+    shell's workdir target) and is overridable per task via
+    ``tool_config.working_root``. A ``service`` key in ``tool_config`` selects
+    the compose backend; its absence selects the local filesystem engine. The
+    wire schema is identical either way.
     """
 
     has_lifecycle = False
 
-    # Hardcoded to match service.py's AGENT_WORK_DIR — this wrapper is
-    # has_lifecycle=False, so it never sees ToolLifecycleContext.work_dir.
-    AGENT_WORK_DIR = "/work"
+    # Default working root when tool_config omits ``working_root``. Must equal
+    # service.py's AGENT_WORK_DIR: this wrapper is has_lifecycle=False, so it
+    # never sees ToolLifecycleContext.work_dir and cannot learn the root at
+    # start() the way the lifecycle-managed shell does.
+    _DEFAULT_WORKING_ROOT = "/work"
 
     def __init__(self, tool_schema: ToolSchemaModel, trial_id: str):
         super().__init__(tool_schema)
@@ -1279,17 +1282,18 @@ class StrReplaceEditorToolWrapper(ToolWrapper):
                 "resolve the running container name (the per-trial compose project "
                 "prefix used to bring the stack up)",
             )
+        self._working_root: str = tool_config.get("working_root", self._DEFAULT_WORKING_ROOT)
         self._trial_id = trial_id
         self._backend = self._new_backend()
 
     def _new_backend(self) -> EditorBackend:
         if self._service is None:
-            return LocalFilesystemEditor(self.AGENT_WORK_DIR)
+            return LocalFilesystemEditor(self._working_root)
         assert self._project_prefix is not None  # validated in __init__
         container = self._resolve_container_name(
             self._trial_id, self._service, self._project_prefix
         )
-        return DockerComposeEditor(container, base_path=self.AGENT_WORK_DIR)
+        return DockerComposeEditor(container, base_path=self._working_root)
 
     @staticmethod
     def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:

--- a/tolokaforge/tools/str_replace_editor.py
+++ b/tolokaforge/tools/str_replace_editor.py
@@ -174,6 +174,8 @@ class LocalFilesystemEditor:
     # -- internals ------------------------------------------------------------
 
     def _resolve(self, path: str) -> Path:
+        if not self._base.is_dir():
+            raise EditorError(f"working root {self._base} does not exist or is not a directory")
         candidate = Path(path)
         if not candidate.is_absolute():
             candidate = self._base / candidate
@@ -229,8 +231,9 @@ class LocalFilesystemEditor:
 # missing-tail walk lets ``create`` resolve a not-yet-existing path the same way
 # the local engine's ``Path.resolve()`` does, while still following symlinks on
 # the existing prefix (so a symlink escape is caught inside the container).
-# ``$p`` is always absolute (the caller roots relative paths under ``/work``), so
-# no ``--`` end-of-options guard is needed — and busybox ``realpath`` rejects it.
+# ``$p`` is always absolute (the caller roots relative paths under the working
+# root), so no ``--`` end-of-options guard is needed — and busybox ``realpath``
+# rejects it.
 _REALPATH_SCRIPT = (
     "command -v realpath >/dev/null 2>&1 || exit 90\n"
     "p=$1\n"
@@ -285,9 +288,7 @@ class DockerComposeEditor:
     (the local engine's single-process temp+rename has no such window).
     """
 
-    def __init__(
-        self, container_name: str, base_path: str = "/work", timeout_s: float | None = None
-    ) -> None:
+    def __init__(self, container_name: str, base_path: str, timeout_s: float | None = None) -> None:
         self._container_name = container_name
         self._base = base_path
         self._timeout_s = timeout_s if timeout_s is not None else _DEFAULT_EXEC_TIMEOUT_S
@@ -296,6 +297,10 @@ class DockerComposeEditor:
     @property
     def container_name(self) -> str:
         return self._container_name
+
+    @property
+    def base_path(self) -> str:
+        return self._base
 
     def view(self, path: str, view_range: list[int] | None = None) -> str:
         resolved = self._resolve(path)
@@ -345,7 +350,10 @@ class DockerComposeEditor:
 
     def _resolve_base(self) -> str:
         if self._base_real is None:
-            self._base_real = self._container_realpath(self._base, self._base)
+            base_real = self._container_realpath(self._base, self._base)
+            if self._path_kind(base_real) != "dir":
+                raise EditorError(f"working root {self._base} does not exist or is not a directory")
+            self._base_real = base_real
         return self._base_real
 
     def _container_realpath(self, abs_path: str, path: str) -> str:
@@ -426,15 +434,18 @@ class StrReplaceEditorTool(Tool):
     not here.
 
     ``__init__`` accepts and ignores the ``tool_config`` keys the wrapper
-    consumes (``service``, ``compose_project_prefix``): the adapter builds the
-    schema provider as ``cls(**tool_config)``, so an unexpected keyword would
-    raise inside schema extraction and drop the tool from the LLM's view.
+    consumes (``service``, ``compose_project_prefix``, ``working_root``): the
+    adapter builds the schema provider as ``cls(**tool_config)``, so an
+    unexpected keyword would raise inside schema extraction and drop the tool
+    from the LLM's view. The schema itself is root-independent, so
+    ``working_root`` is accepted only to keep that surface self-documenting.
     """
 
     def __init__(
         self,
         service: str | None = None,
         compose_project_prefix: str | None = None,
+        working_root: str | None = None,
         **_: object,
     ) -> None:
         super().__init__(


### PR DESCRIPTION
## Summary

- `str_replace_editor` reads an optional `tool_config.working_root` (absolute path, default `/work`) and roots both the local and compose backends against it. Every current task pack is byte-identical (additive; no adapter or pack migration required); benchmarks whose container-side layout uses a different path can now declare their root inline instead of symlinking.
- A configured root that does not exist or is not a directory fails loud on the first command for both backends, with a message naming the root — closing a latent bug where the local engine silently `mkdir -p`'d the entire root tree on `create`.
- Real-container coverage: the existing compose behaviour battery is parametrized over root ∈ {`/work`, `/srv/agent`} and extended with symlink-escape, `..` traversal, and missing-root fail-loud cases against the custom root, so the compose variant is proven behaviour-identical at a non-default absolute root under real `docker exec`.

## Design choices

- **`tool_config` scalar, not a new tool variant or a Pydantic model**: `working_root` sits alongside sibling scalars (`service`, `compose_project_prefix`, `timeout_s`) on the same tool contract. `ToolSchema` is the strict boundary; individual `tool_config` keys are not separately modeled.
- **Purely additive default**: the `AGENT_WORK_DIR = "/work"` hardcode becomes `_DEFAULT_WORKING_ROOT = "/work"` — sourced for the default only, no `_legacy_*` alias. Every existing subclass and every current task pack inherits identical behaviour.
- **Fail-loud, lazy on first command, both backends**: eager `__init__` validation is rejected — it would raise during trial registration on hosts where `/work` is absent at construction time (dropping the tool from the LLM's view), and would break dispatch tests that construct `LocalFilesystemEditor("/work")` without running a command.
- **Backend `base_path` becomes required (removed `= "/work"` default)**: enforces a single source of truth for the default at the wrapper's `_DEFAULT_WORKING_ROOT`, verified by grep that both callers already pass `base_path` explicitly.
- **Extend, not clobber, the compose test file**: parametrize the existing fixtures over roots so the `/work` regression coverage from #587 is preserved and the custom root inherits the full battery.

## Concepts introduced

`tool_config.working_root` is a new task-pack-authored key that names the absolute filesystem path all four editor commands resolve against (default `/work`). It joins the existing `tool_config` scalar surface (`service`, `compose_project_prefix`, `timeout_s`) on the `str_replace_editor` tool. The tool's containment contract (`realpath` + `is_relative_to`) is unchanged; only the anchor it binds to becomes configurable.

## Plan

Branch: feat/str-replace-editor-working-root

## Context

The `str_replace_editor` tool resolves all four commands (`view` / `create` /
`str_replace` / `insert`) against a working root that is hardcoded to `/work` in
`StrReplaceEditorToolWrapper` (`tolokaforge/runner/tool_factory.py:1268`,
`AGENT_WORK_DIR = "/work"`, passed to both the local and compose backends).
Benchmarks whose container-side layout uses a different absolute path cannot
adopt the tool without a symlink workaround in the task pack. The tool's other
per-task configuration (`service`, `compose_project_prefix`) already rides
`tool_config`; the working root should follow the same idiom.

Two facts observed while reproducing current behaviour ground the design:

1. **The plumbing is already generic.** The native adapter lifts every
   `tools.agent.<name>: {...}` block into `ToolSchema.tool_config`
   (`tolokaforge/adapters/native.py:502-552`) with no allowlist, and the schema
   provider is built via `cls(**tool_config)` with a `**_` catch-all
   (`str_replace_editor.py:434-439`). A new `working_root` key therefore flows to
   the runner wrapper with **zero adapter changes** and is harmlessly absorbed by
   the schema provider.
2. **A missing root silently degrades today.** With a non-existent root,
   `LocalFilesystemEditor.view` returns a misleading `file not found`, and
   `create` **silently `mkdir -p`s the entire root tree** (verified via
   `run_python`: `create("/tmp/does_not_exist/new.txt")` materialised the tree).
   A `working_root` typo would thus silently create the wrong directory and let
   the agent edit outside the intended location — so fail-loud-on-unresolvable-
   root is a load-bearing part of the contract, not a nicety.

Baseline: the 24 canonical editor tests
(`test_str_replace_editor_local.py`, `test_str_replace_editor_dispatch.py`) pass
green before any change.

## Goal

`str_replace_editor` accepts an optional `tool_config.working_root` (absolute
path, default `/work`). All four commands and the path-containment check resolve
against the effective root, for both the local and the compose provider variant.
A configured root that does not exist or is not a directory fails loud on first
use with a message naming the root — no silent directory creation, no misleading
`file not found`. Omitting the key reproduces today's `/work` behaviour exactly.

## Non-goals

- No change to the containment algorithm itself — only the *effective root* it
  binds to becomes configurable.
- No change to `bash_session`'s working-directory handling (filed as #640).
- No multi-root support — the tool operates against exactly one root.
- No new tool variant — `working_root` is a `tool_config` key on the existing
  tool contract, exactly as `service` / `compose_project_prefix` are.

## Stages

### Stage 1: Configurable `working_root` + fail-loud root (code, local canonical + dispatch, docs)

Daemon-free. Contract, local-variant behaviour, wiring, and docs. The compose
variant's real-container proof is Stage 2.

- **Contract:**
  - `StrReplaceEditorToolWrapper.__init__` (`tolokaforge/runner/tool_factory.py`)
    reads `working_root` from `tool_schema.tool_config`, defaulting to `/work`,
    and passes it as the `base_path` of whichever backend `_new_backend()`
    builds (local or compose). The `AGENT_WORK_DIR = "/work"` hardcode is
    replaced by a single default constant (e.g. `_DEFAULT_WORKING_ROOT = "/work"`)
    sourced for the default only — **deleted cleanly, no `_legacy_*` alias**. The
    default must stay equal to `service.py`'s agent work dir; keep the comment
    that records that coupling, reworded to describe the *default*, not a
    hardcode.
  - `StrReplaceEditorTool.__init__` (schema provider, `str_replace_editor.py`)
    gains an explicit `working_root: str | None = None` parameter (still ignored
    — schema is root-independent) so the accepted `tool_config` surface is
    self-documenting alongside `service` / `compose_project_prefix`; its docstring
    (lines 428-432) is updated to name `working_root` among the keys it tolerates.
  - **Fail-loud root (new behaviour), part of the `EditorBackend` contract.**
    Validation is **lazy — on first command, never in `__init__`** — for *both*
    backends (see Risks for why eager local validation is forbidden):
    - `LocalFilesystemEditor`: on the first command, before any filesystem
      mutation — and specifically before `create`'s `parent.mkdir(...)` — the
      effective root must be validated as an existing directory; otherwise raise
      `EditorError` naming the configured root (e.g. `working root {root} does
      not exist or is not a directory`). Do **not** validate in `__init__`.
    - `DockerComposeEditor`: when resolving the base (`_resolve_base`, first
      command), the resolved root's kind must be `dir`; otherwise raise the
      same-shape `EditorError`. The existing `realpath`-absent fail-loud path is
      unchanged. (Verified: in-container `realpath` does **not** error on a
      missing directory, so this explicit dir-kind check is necessary.)
  - Comment freshness: `_REALPATH_SCRIPT`'s comment (`str_replace_editor.py:232-233`,
    "the caller roots relative paths under `/work`") is reworded to "under the
    working root".
  - Optional testability affordance: expose a read-only `base_path` property on
    `DockerComposeEditor` mirroring the existing `container_name` property, so the
    dispatch test can assert the wired root without reaching a private attribute.
  - **Justified drift (recorded on execution):** `DockerComposeEditor.base_path`
    lost its `="/work"` default and became a required arg. Rationale: the plan
    mandates a single default constant "sourced for the default only" (the
    wrapper's `_DEFAULT_WORKING_ROOT`); a second `/work` literal on the backend
    would violate DRY and split the source of truth. Verified via repo-wide grep
    that both callers (`tool_factory.py:1296` and `tests/integration/test_str_replace_editor_compose.py:58`)
    pass `base_path` explicitly. Makes the two backends uniform
    (`LocalFilesystemEditor` already required it). Internal signature refactor;
    no compat-surface change.

- **Behaviour to lock** (tier: **canonical**, real temp dir / no mocks):
  - In `test_str_replace_editor_local.py`: an editor rooted at a *custom* tmp
    directory (distinct from any default) resolves the four commands under it and
    binds symlink-escape / `..` / absolute-path rejection to *that* root.
  - A non-existent local root fails loud on the first `view` with a message
    naming the root (not `file not found`).
  - A non-existent local root fails loud on `create` **and leaves the root tree
    uncreated** — regression lock on the observed silent `mkdir -p`.
  - In `test_str_replace_editor_dispatch.py`: `tool_config={"working_root": X}`
    wires `X` into the local backend's root; into the compose backend's
    `base_path`; omitting the key defaults both backends to `/work`.

- **Compatibility:**
  - Wrapper/backend edits are internal refactors — delete the hardcode in place.
  - `tool_config.working_root` is an **additive task-pack config surface**
    (Core Rule 5). Default `/work` keeps every current task pack byte-identical;
    the bundled `examples/native/persistent_tools` pack (which enables the editor
    and omits the key) must keep `/work` behaviour. Migration = the CHANGELOG
    entry + `docs/TOOLS.md` below; **no adapter migration, no task-pack edits
    required.**

- **Deliverable:** `working_root` is honoured end-to-end for the local variant
  and wired for the compose variant; a bad root fails loud; canonical + dispatch
  tests green; docs current.

- **Validation:**
  - `uv run pytest -m canonical -k str_replace_editor`
  - `uv run ruff check` / `ruff format --check` on touched files
  - Sanity: `run_python` constructing the wrapper with and without `working_root`
    and asserting the backend root, plus a quick `tolokaforge validate` (or the
    free wiring smoke) over `examples/native/persistent_tools` to confirm the
    example still loads unchanged.

- **Doc updates:**
  - `docs/TOOLS.md` — rewrite the `str_replace_editor` **Path validation**
    paragraph (lines 142-144) and the **Provider variants** bullets (147-160) so
    they read as if a configurable root is the only state: the root defaults to
    `/work` and is set per task via `tool_config.working_root`; containment binds
    to the effective root; a missing/non-directory root fails loud on first use.
    Add `working_root` to the editor block in the **Persistent shell and editor**
    enabling example (lines 176-198), documenting the default and the fail-loud
    behaviour. No "previously X, now Y" phrasing.
  - `docs/adr/0017-...md` — §(c) already says "the *configured* working root" and
    §(c) Path validation already says "escape the configured working root", so
    the design lock is already accurate. **Verify only; change only if a specific
    sentence is now false.** Do not rewrite ADR history.
  - `CHANGELOG.md` — Unreleased → Feat: `str_replace_editor` gains
    `tool_config.working_root` (default `/work`, additive, every current task
    pack unchanged); a missing/non-directory root fails loud (#637).

### Stage 2: Real-container compose verification of a non-`/work` root

Adds integration coverage only — no production-code change. Locks the compose
provider variant against a real Docker daemon, as issue #637's acceptance
criteria require ("Behavior verified against a real container for the compose
provider variant").

- **Contract:** none new. Verifies Stage 1's contract on a real daemon.

- **Behaviour to lock** (tier: **integration**, real `docker exec`, no mocks).
  `tests/integration/test_str_replace_editor_compose.py` **already exists** on
  `main` (from #587: 5 tests, four-command round-trip + create-on-existing +
  non-unique `str_replace` + absolute-path escape, all against `/work`). This
  stage **extends** it — do **not** `Write` over it and lose the `/work`
  coverage. The move:
  - **Parametrize the `running_container` / `editor` fixtures over
    `root ∈ {"/work", "<non-/work>"}`** (e.g. `/srv/agent`) rather than
    duplicating the four-command battery. The container `mkdir -p`s the chosen
    root; the fixture builds `DockerComposeEditor(base_path=root)`. The existing
    behaviour battery then runs once per root, so the non-`/work` root inherits
    the full four-command + create-on-existing + non-unique-`str_replace`
    coverage and `/work` stays proven (default-root regression).
  - **Escape rejection per command against the non-`/work` root**, matching the
    AC's "symlink escape, `..` traversal … verified per command": add a
    **symlink-escape** case (a symlink inside the root pointing outside it — the
    compose backend's subtlest path, since in-container `realpath` follows
    symlinks on the existing prefix via `_REALPATH_SCRIPT`) and a **`..`
    traversal** case, both bound to the custom root, alongside the existing
    absolute-path case. These fail loud with the containment error.
  - **Full wrapper path** with
    `tool_config={"service": ..., "compose_project_prefix": ..., "working_root": "<non-/work>"}`:
    assert an edit lands under the custom root (extends the existing
    `test_wrapper_drives_compose_backend_end_to_end`).
  - **Missing compose root**: a configured root absent from the running
    container (e.g. `/srv/missing`) fails loud on first command with a message
    naming the root.
  Reuse the module's daemon-availability skip guard; a failed assertion is a real
  failure, never a silent skip.

- **Compatibility:** internal (tests only).

- **Deliverable:** the compose variant is proven behaviour-identical against a
  non-default root on a real container, and the missing-root fail-loud is proven
  container-side.

- **Validation:**
  `scripts/with_env.sh uv run pytest -m integration -k str_replace_editor_compose -n auto`
  on a Docker-capable host (the integration lane; main / the reviewer runs it).

- **Doc updates:** none (behaviour is documented in Stage 1).

## Discovered issues

- **Fix in this PR:** the schema-provider docstring and the `_REALPATH_SCRIPT`
  comment both mention `/work` as if hardcoded; both are updated in Stage 1 so
  the source reads as current state (folded into Stage 1, not a separate stage).
- **Filed as issues:** #640 — configurable working directory on `bash_session`
  for non-`/work` layouts. The sibling shell tool still roots at `/work`
  (local: lifecycle-seeded `cwd`; compose: container default), so a non-`/work`
  benchmark can root the editor but not the shell. Deferred deliberately: the
  shell's working-directory handling (lifecycle-seeded cwd, `restart` semantics)
  is a distinct surface from the editor's stateless per-command root and merits
  its own design — explicitly out of scope per #637.

## Risks / open questions

- **Root validation must be lazy for BOTH backends — eager local validation is
  forbidden.** It is tempting to validate the local root eagerly in `__init__`
  (the root lives on the runner container at construction), but this is wrong on
  two counts and the contract mandates lazy-on-first-command instead:
  1. **It would drop the tool in production.** The editor wrapper is
     `has_lifecycle=False` and constructs `LocalFilesystemEditor` in `__init__`,
     but `/work` is **not guaranteed to exist at construction time** (verified:
     `/work` is absent on the host). An eager `is_dir()` check would raise during
     trial registration and remove the tool from the LLM's view.
  2. **It would break a named existing test.**
     `tests/canonical/test_str_replace_editor_dispatch.py::test_no_service_selects_local_backend`
     (`:39-41`) constructs `LocalFilesystemEditor("/work")` via the wrapper and
     asserts only `isinstance` — it never runs a command. Eager `is_dir()` at
     construction raises there; lazy validation leaves it green (the local
     canonical tests root at a real `tmp_path`, so they never trip the check
     spuriously either).
  The compose backend is lazy for the independent reason that the target
  container may not be up when the stateless wrapper is constructed. Both fail
  loud with the same-shape message on first command; the backends stay uniform.
- **Dispatch test reaching into backend internals.** Asserting the wired root
  needs either a public `base_path` property on `DockerComposeEditor` (recommended,
  mirrors `container_name`) or a private-attr read (the existing dispatch test
  already reads `_backend`). Prefer the property to avoid coupling the test to a
  private field.
- **`view_range` / truncation constants unaffected** — the change is confined to
  the root binding and its validation; the rendering and containment algorithms
  are untouched, so the existing byte-for-byte output assertions remain valid.

## Discovered issues

- Fixed in this PR: (a) a latent bug where `LocalFilesystemEditor.create` silently `mkdir -p`'d the entire root tree when the configured root did not exist — regression-locked by a canonical test that asserts the tree is NOT created; (b) two stale `/work` comments in `str_replace_editor.py` (`_REALPATH_SCRIPT` + the schema-provider docstring) reworded to describe the configured root; (c) a pre-existing xdist container-name collision in the compose test file that Stage 2's parametrization made acute (12/13 tests silently skipping under `-n auto`).
- Filed as follow-up: **#640** — configurable working directory on `bash_session` for non-`/work` layouts. Deliberately out of scope for #637 (the sibling shell tool's cwd handling is a distinct surface).

## Test plan

- Full `-m canonical -k str_replace_editor` lane green (31 passed).
- Full `-m integration -k str_replace_editor_compose` lane green, including under `-n auto` (13 passed, 0 skipped — verifies the xdist fix).
- `tolokaforge validate` on the bundled `examples/native/persistent_tools` example pack (which omits the key) unchanged — proves the `/work` default preserves current behaviour.
- Post-merge: no additional filings required.

Closes #637
