### PR TITLE
docs(automation): treat frozen-pack known issues as accepted circumstances, not work items

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -481,7 +481,8 @@ jobs:
               -e "s|{{MODEL}}|${TF_NAME}|g" -e "s|{{ENGINE_VERSION}}|${GITHUB_SHA}|g" \
               -e "s|{{BASE_DIR}}|observation|g" -e "s|{{DOMAINS_WITH_COUNTS}}|see findings.json|g" \
               -e "s|{{TOTAL_TRIALS}}|see findings.json|g" -e "s|{{ANCHORS}}|none|g" \
-              -e "s|{{INFRA_THRESHOLD}}|0.05|g" -e "s|{{GO_BOUNDARY}}|observe mode|g" "$1"
+              -e "s|{{INFRA_THRESHOLD}}|0.05|g" -e "s|{{GO_BOUNDARY}}|observe mode|g" \
+              -e "s|{{KNOWN_ISSUES}}|n/a (observe mode: no frozen task pack, no registry)|g" "$1"
           }
           CONVERGED=no
           # Per-iteration outcome log; the needs-human step turns it into a "why it did not

--- a/tools/automation/src/automation/prompts/_shared_context.md
+++ b/tools/automation/src/automation/prompts/_shared_context.md
@@ -111,10 +111,14 @@ NOT the engine's `failure_attribution.py` `failure_class` labels (which are a di
    artifacts) from the raw failures. If it is material, the raw number is NOT a faithful
    capability reading -> fix / footnote / regrade / re-run. The true-capability micro pass@1
    = raw + net recoverable pp; compare it (and pass^5) to the GO boundary {{GO_BOUNDARY}}.
-   Split the recoverable pp three ways, ACCEPTED / NEW-pack / HARNESS (see "Accepted
-   circumstances"): all three count toward true capability, but only the last two are work items.
-   The aggregate verdict must not list an accepted circumstance as something to fix before
-   publishing, and must not bury a live harness bug inside the accepted share.
+   Split the ORACLE share of the recoverable pp three ways, ACCEPTED / NEW-pack / HARNESS (see
+   "Accepted circumstances"; FORMATTING and INFRA pp keep their own lines and belong to none of the
+   three): all three count toward true capability, but only the last two are work items. The
+   aggregate verdict must not list an accepted circumstance as something to fix before publishing,
+   and must not bury a live harness bug inside the accepted share. If two dimensions disagree on
+   the sub-label for the SAME pp, four-bucket still owns the magnitude, but the LOUDER routing
+   governs the reporting (HARNESS > NEW > ACCEPTED) until the human resolves it: never resolve a
+   label conflict toward silence.
 4. OBSERVE mode (fixability): the verdict is the policy to SET or CREATE for the FORMATTING
    failures (proved by `reprobe.py`) plus the residual GENUINE ceiling; a candidate is
    integrable when the fixable share is closed and the ceiling is acceptable.
@@ -126,9 +130,10 @@ if unset, report the numbers and defer the call to the human owner.
 ## Accepted circumstances: what the frozen board has already decided
 MODE: EVAL only. The registry for this run is `{{KNOWN_ISSUES}}`. If that reads "n/a" (OBSERVE
 mode runs synthetic probes, not the frozen pack), skip this section: every finding is live.
-If it is unfilled or unreadable, treat EVERY non-model finding as NEW and say the registry was
-not provided. Never go looking for a registry yourself: it is branch-local, and a sibling
-branch's version has a different accepted set, so the wrong file mislabels findings both ways.
+If it is unfilled or unreadable, say so and degrade safely: the ACCEPTED class is simply
+unavailable, so report a pack-side finding as NEW. Harness/engine findings do not depend on the
+registry and stay loud, never NEW. Never go looking for a registry yourself: it is branch-local,
+and a sibling branch's version has a different accepted set, so the wrong file mislabels both ways.
 
 The leaderboard task pack is FROZEN, and for the same comparability reason the engine version is
 pinned per board. Dozens of models are already published against both, so editing a task, a
@@ -161,10 +166,19 @@ lists live bugs that are still open work. Route every non-model finding into one
   affect every domain at once, and a fix here is cheap. Never soften one of these into a
   circumstance just because its symptom looks like a task defect.
 
-Two entry kinds are not findings at all. A METHODOLOGY note (how to compare, how to count cost,
-a task-set change) is a rule to FOLLOW while analysing, so obey it and do not report it. An entry
-marked FIXED is history: cite it only if the symptom actually recurs on a version that claims the
-fix, and if it does, that is a loud finding, not a circumstance.
+A METHODOLOGY note (how to compare, how to count cost, a task-set change) is not a finding at all:
+it is a rule to FOLLOW while analysing, so obey it and do not report it.
+
+A FIXED marker is VERSION-RELATIVE, so evaluate it against the engine this run actually used,
+{{ENGINE_VERSION}}, and never against the marker alone:
+- fix IS in this run's version -> history. Cite it only if the symptom recurs anyway, and that
+  recurrence is a loud regression finding, not a circumstance.
+- fixed only in a LATER version AND the entry carries a keep-as-is decision for the pinned one
+  -> ACCEPTED. This combination is common and is precisely what test (ii) exists for.
+- fixed only in a later version with NO such decision -> live harness bug, report it loud.
+Match every marker CASE-INSENSITIVELY: "DECISION" and "Decision", "FIXED" and "fixed in vX", are
+the same marker. A decision reads as a line naming the eval owner with a keep / do-not-change
+imperative, in any casing; do not decide an entry's status from its title alone.
 
 Three things this does NOT license:
 - It does not license silence about magnitude. If an accepted circumstance is large enough to

--- a/tools/automation/src/automation/prompts/_shared_context.md
+++ b/tools/automation/src/automation/prompts/_shared_context.md
@@ -178,7 +178,10 @@ A FIXED marker is VERSION-RELATIVE, so evaluate it against the engine this run a
 - fixed only in a later version with NO such decision -> live harness bug, report it loud.
 Match every marker CASE-INSENSITIVELY: "DECISION" and "Decision", "FIXED" and "fixed in vX", are
 the same marker. A decision reads as a line naming the eval owner with a keep / do-not-change
-imperative, in any casing; do not decide an entry's status from its title alone.
+imperative, in any casing; do not decide an entry's status from its title alone. If containment is
+genuinely undeterminable from the version string (a fix that spans repos, e.g. an engine change
+plus an adapter bump), decide by SYMPTOM instead: the symptom present under a claimed fix is a
+loud regression, absent is nothing to report.
 
 Three things this does NOT license:
 - It does not license silence about magnitude. If an accepted circumstance is large enough to

--- a/tools/automation/src/automation/prompts/_shared_context.md
+++ b/tools/automation/src/automation/prompts/_shared_context.md
@@ -111,6 +111,9 @@ NOT the engine's `failure_attribution.py` `failure_class` labels (which are a di
    artifacts) from the raw failures. If it is material, the raw number is NOT a faithful
    capability reading -> fix / footnote / regrade / re-run. The true-capability micro pass@1
    = raw + net recoverable pp; compare it (and pass^5) to the GO boundary {{GO_BOUNDARY}}.
+   Split the recoverable pp into ACCEPTED (registry, frozen pack) and NEW/FIXABLE: both count
+   toward true capability, but only the second is a work item. The aggregate verdict must not
+   list an accepted circumstance as something to fix before publishing.
 4. OBSERVE mode (fixability): the verdict is the policy to SET or CREATE for the FORMATTING
    failures (proved by `reprobe.py`) plus the residual GENUINE ceiling; a candidate is
    integrable when the fixable share is closed and the ceiling is acceptable.
@@ -118,6 +121,39 @@ NOT the engine's `failure_attribution.py` `failure_class` labels (which are a di
 
 {{GO_BOUNDARY}} and {{INFRA_THRESHOLD}} are HUMAN-OWNED policy inputs (do not invent them);
 if unset, report the numbers and defer the call to the human owner.
+
+## Accepted circumstances: the frozen task pack is not yours to fix
+MODE: EVAL only. The registry for this run is `{{KNOWN_ISSUES}}`. If that reads "n/a" (OBSERVE
+mode runs synthetic probes, not the frozen pack), skip this section: every finding is live.
+
+The leaderboard task pack is FROZEN. Dozens of models are already published against it, so
+editing a task, a golden or a simulator prompt would break comparability and force a
+board-wide regrade. Known defects in it are therefore ACCEPTED CIRCUMSTANCES, not work items.
+
+`{{KNOWN_ISSUES}}` is the registry of what has already been triaged and accepted. **Read it
+before you report anything**, and route every non-model finding into one of three classes:
+
+- **ACCEPTED (in the registry, task-pack side).** Still MEASURE it and still attribute its pp:
+  it is a real non-model cause, so it belongs in the oracle bucket and in the true-capability
+  number. But report it as a one-line *footnote referencing the registry entry*. Do NOT propose
+  a task/golden/simulator edit, do NOT recommend a regrade, and do NOT present it to the reader
+  as outstanding work. It is the environment every model ran in.
+- **NEW task-pack defect (not in the registry).** Report it in full, with the evidence, and
+  propose the registry entry it should become. Still do not propose editing the pack; the
+  decision to accept, footnote or exclude belongs to the human owner.
+- **HARNESS / ENGINE / ADAPTER side (any side that is NOT the frozen pack).** Unchanged:
+  report loudly and actionably. These ARE fixable without touching the pack, they usually
+  affect every domain at once, and a fix here is cheap. Never soften one of these into a
+  circumstance just because its symptom looks like a task defect.
+
+Two things this does NOT license:
+- It does not license silence about magnitude. If an accepted circumstance is large enough to
+  change the reading of a domain, say so plainly with the number. "Accepted" means "not a
+  work item", not "not worth mentioning".
+- It does not license assuming uniformity. An accepted circumstance is comparability-safe only
+  while it hits every model equally. If your evidence suggests a defect hits some models much
+  harder than others, that is RANK-DISTORTING and must be surfaced as a finding even though
+  the underlying defect is in the registry.
 
 ## Interpretive traps (do not fall in)
 - Bimodal quirk frequency: a preset-COVERED quirk reads ~0%, an UNcovered one is domain-fatal.
@@ -134,6 +170,9 @@ if unset, report the numbers and defer the call to the human owner.
 - `task-design-oracle` is EVAL-mode only (synthetic observe probes carry their own assert as
   the oracle, so there is no oracle false-failure to hunt). `consistency-passk` in OBSERVE
   mode degrades to a per-PROBE flaky/solid/hard band over the K repeats, not the board pass^k.
+- "Accepted circumstances" is EVAL-mode only too: OBSERVE runs synthetic probes, not the frozen
+  pack, so there is no registry to consult and every finding is live and actionable, which is
+  the point of that mode.
 
 ## Efficiency rules (MANDATORY - a prior 12-agent parallel run stalled on I/O)
 - Shell-first: Bash with grep/rg/python/jq for ALL bulk work. NEVER loop the Read tool over

--- a/tools/automation/src/automation/prompts/_shared_context.md
+++ b/tools/automation/src/automation/prompts/_shared_context.md
@@ -111,9 +111,10 @@ NOT the engine's `failure_attribution.py` `failure_class` labels (which are a di
    artifacts) from the raw failures. If it is material, the raw number is NOT a faithful
    capability reading -> fix / footnote / regrade / re-run. The true-capability micro pass@1
    = raw + net recoverable pp; compare it (and pass^5) to the GO boundary {{GO_BOUNDARY}}.
-   Split the recoverable pp into ACCEPTED (registry, frozen pack) and NEW/FIXABLE: both count
-   toward true capability, but only the second is a work item. The aggregate verdict must not
-   list an accepted circumstance as something to fix before publishing.
+   Split the recoverable pp three ways, ACCEPTED / NEW-pack / HARNESS (see "Accepted
+   circumstances"): all three count toward true capability, but only the last two are work items.
+   The aggregate verdict must not list an accepted circumstance as something to fix before
+   publishing, and must not bury a live harness bug inside the accepted share.
 4. OBSERVE mode (fixability): the verdict is the policy to SET or CREATE for the FORMATTING
    failures (proved by `reprobe.py`) plus the residual GENUINE ceiling; a candidate is
    integrable when the fixable share is closed and the ceiling is acceptable.
@@ -122,38 +123,62 @@ NOT the engine's `failure_attribution.py` `failure_class` labels (which are a di
 {{GO_BOUNDARY}} and {{INFRA_THRESHOLD}} are HUMAN-OWNED policy inputs (do not invent them);
 if unset, report the numbers and defer the call to the human owner.
 
-## Accepted circumstances: the frozen task pack is not yours to fix
+## Accepted circumstances: what the frozen board has already decided
 MODE: EVAL only. The registry for this run is `{{KNOWN_ISSUES}}`. If that reads "n/a" (OBSERVE
 mode runs synthetic probes, not the frozen pack), skip this section: every finding is live.
+If it is unfilled or unreadable, treat EVERY non-model finding as NEW and say the registry was
+not provided. Never go looking for a registry yourself: it is branch-local, and a sibling
+branch's version has a different accepted set, so the wrong file mislabels findings both ways.
 
-The leaderboard task pack is FROZEN. Dozens of models are already published against it, so
-editing a task, a golden or a simulator prompt would break comparability and force a
-board-wide regrade. Known defects in it are therefore ACCEPTED CIRCUMSTANCES, not work items.
+The leaderboard task pack is FROZEN, and for the same comparability reason the engine version is
+pinned per board. Dozens of models are already published against both, so editing a task, a
+golden or a simulator prompt (or silently adopting an engine fix for one model) would break
+comparability and force a board-wide regrade. What the eval owner has already decided to live
+with is therefore an ACCEPTED CIRCUMSTANCE, not a work item.
 
-`{{KNOWN_ISSUES}}` is the registry of what has already been triaged and accepted. **Read it
-before you report anything**, and route every non-model finding into one of three classes:
+`{{KNOWN_ISSUES}}` is the registry of what has already been triaged. **Read it before you report
+anything.** ACCEPTED is decided by the entry, NOT by mere presence in the file: the registry also
+lists live bugs that are still open work. Route every non-model finding into one of three classes:
 
-- **ACCEPTED (in the registry, task-pack side).** Still MEASURE it and still attribute its pp:
-  it is a real non-model cause, so it belongs in the oracle bucket and in the true-capability
-  number. But report it as a one-line *footnote referencing the registry entry*. Do NOT propose
-  a task/golden/simulator edit, do NOT recommend a regrade, and do NOT present it to the reader
-  as outstanding work. It is the environment every model ran in.
-- **NEW task-pack defect (not in the registry).** Report it in full, with the evidence, and
-  propose the registry entry it should become. Still do not propose editing the pack; the
-  decision to accept, footnote or exclude belongs to the human owner.
-- **HARNESS / ENGINE / ADAPTER side (any side that is NOT the frozen pack).** Unchanged:
-  report loudly and actionably. These ARE fixable without touching the pack, they usually
+- **ACCEPTED.** Either (i) the entry is task-pack side (a task/golden/simulator/data defect: the
+  pack is frozen, so it cannot be fixed for this run), or (ii) the entry carries an explicit
+  eval-owner decision to keep the current behaviour (typically "keep running on <pinned engine>"
+  for board consistency), whatever side it is on. Still MEASURE it and still attribute its pp: it
+  is a real non-model cause, so it belongs in the oracle bucket and in the true-capability number.
+  But report it as a one-line *footnote citing the registry entry ID and its measured pp in THIS
+  run*. Do NOT propose a task/golden/simulator edit, do NOT propose moving off the pinned engine,
+  do NOT recommend a regrade, and do NOT present it as outstanding work. It is the environment
+  every model ran in.
+- **NEW task-pack defect (no entry covers it).** Report it in full, with the evidence, and propose
+  the registry entry it should become. Still do not propose editing the pack; the decision to
+  accept, footnote or exclude belongs to the human owner. Match on the entry's own SCOPE (domain +
+  field/symptom + mechanism), not on a loose family resemblance; where an entry ENUMERATES task
+  IDs, only those IDs are covered, so a new task failing the same way is NEW and merely cites the
+  entry as related.
+- **HARNESS / ENGINE / ADAPTER with no keep-as-is decision.** Unchanged: report loudly and
+  actionably, whether or not the registry already names the bug. An open registry entry is a
+  known bug, not an accepted one. These are fixable without touching the pack, they usually
   affect every domain at once, and a fix here is cheap. Never soften one of these into a
   circumstance just because its symptom looks like a task defect.
 
-Two things this does NOT license:
+Two entry kinds are not findings at all. A METHODOLOGY note (how to compare, how to count cost,
+a task-set change) is a rule to FOLLOW while analysing, so obey it and do not report it. An entry
+marked FIXED is history: cite it only if the symptom actually recurs on a version that claims the
+fix, and if it does, that is a loud finding, not a circumstance.
+
+Three things this does NOT license:
 - It does not license silence about magnitude. If an accepted circumstance is large enough to
   change the reading of a domain, say so plainly with the number. "Accepted" means "not a
   work item", not "not worth mentioning".
 - It does not license assuming uniformity. An accepted circumstance is comparability-safe only
-  while it hits every model equally. If your evidence suggests a defect hits some models much
-  harder than others, that is RANK-DISTORTING and must be surfaced as a finding even though
-  the underlying defect is in the registry.
+  while it hits every model equally. Compare THIS run's exposure against the board-wide rate the
+  entry documents; a large excess is evidence of RANK DISTORTION and must be surfaced as a
+  finding even though the underlying defect is accepted. (A single-model run has no cross-model
+  data of its own, so the entry's own numbers are the comparator.)
+- It does not license silent re-attribution. If routing a finding to ACCEPTED puts pp in a
+  different bucket than earlier analyses of the same defect used, say so: the adjusted /
+  true-capability number stops being comparable with those analyses, which is a synthesis-level
+  caveat, not a detail.
 
 ## Interpretive traps (do not fall in)
 - Bimodal quirk frequency: a preset-COVERED quirk reads ~0%, an UNcovered one is domain-fatal.

--- a/tools/automation/src/automation/prompts/four_bucket.md
+++ b/tools/automation/src/automation/prompts/four_bucket.md
@@ -35,9 +35,17 @@ oracle pp and formatting pp reported here are the SAME pp that `task-design-orac
 `preset-codec-leak` describe in detail; emit them as separate labeled lines so the
 synthesizer maps them 1:1 and never sums across dimensions.
 
+The oracle bucket mixes two kinds of cause with the same pp weight but different consequences:
+defects already accepted for the frozen pack, and new/fixable ones. Split the oracle line
+accordingly (see the shared block's "Accepted circumstances"): both count toward the
+recoverable pp and the true-capability number, but only the NEW/fixable part is a work item.
+Never re-label an accepted circumstance as GENUINE-MODEL to keep the story tidy - the pp is
+non-model either way.
+
 RETURN (compact markdown):
 - bucket split (bucket x count x % of failures x approx pp of micro), one line per bucket
-  labeled infra / oracle / formatting / genuine so pp are attributable
+  labeled infra / oracle / formatting / genuine so pp are attributable, with the oracle line
+  further split ACCEPTED (registry) vs NEW
 - dominant genuine-model sub-patterns with rough frequency
 - FORMATTING (preset-fixable) count stated explicitly (expect ~0 for a clean-native model;
   remember a ~0 may be a preset masking a dormant quirk - see the shared traps note)

--- a/tools/automation/src/automation/prompts/four_bucket.md
+++ b/tools/automation/src/automation/prompts/four_bucket.md
@@ -35,17 +35,22 @@ oracle pp and formatting pp reported here are the SAME pp that `task-design-orac
 `preset-codec-leak` describe in detail; emit them as separate labeled lines so the
 synthesizer maps them 1:1 and never sums across dimensions.
 
-The oracle bucket mixes two kinds of cause with the same pp weight but different consequences:
-defects already accepted for the frozen pack, and new/fixable ones. Split the oracle line
-accordingly (see the shared block's "Accepted circumstances"): both count toward the
-recoverable pp and the true-capability number, but only the NEW/fixable part is a work item.
-Never re-label an accepted circumstance as GENUINE-MODEL to keep the story tidy - the pp is
-non-model either way.
+This bucket is HARNESS / TASK-DESIGN / ORACLE, so it mixes three kinds of cause with the same pp
+weight but very different consequences: already-ACCEPTED circumstances, NEW pack defects, and
+live HARNESS/engine/adapter bugs. Split the line three ways on exactly the labels the shared
+block's "Accepted circumstances" defines, and use its test (the entry decides, not mere presence
+in the registry) so this dimension and `task-design-oracle` emit the SAME label set and the
+synthesizer can map them 1:1. All three count toward the recoverable pp and the true-capability
+number; only NEW and HARNESS are work items. Never re-label an accepted circumstance as
+GENUINE-MODEL to keep the story tidy (the pp is non-model either way), and never park a live
+harness bug under ACCEPTED or NEW: NEW ends in "propose a registry entry", which would
+institutionalise a bug that is simply fixable.
 
 RETURN (compact markdown):
 - bucket split (bucket x count x % of failures x approx pp of micro), one line per bucket
   labeled infra / oracle / formatting / genuine so pp are attributable, with the oracle line
-  further split ACCEPTED (registry) vs NEW
+  further split ACCEPTED / NEW / HARNESS; the owned oracle total is all three summed, and each
+  sub-label must be stated even when it is 0.0pp
 - dominant genuine-model sub-patterns with rough frequency
 - FORMATTING (preset-fixable) count stated explicitly (expect ~0 for a clean-native model;
   remember a ~0 may be a preset masking a dormant quirk - see the shared traps note)

--- a/tools/automation/src/automation/prompts/index.yaml
+++ b/tools/automation/src/automation/prompts/index.yaml
@@ -7,7 +7,10 @@
 # these prompts interpret them, reprobe verifies the fix.
 #
 # HOW TO USE (reader agent):
-#   1. Fill the placeholders (see `placeholders`) into `_shared_context.md`.
+#   1. Fill the placeholders (see `placeholders`) into `_shared_context.md`. Point KNOWN_ISSUES at
+#      the registry ON the eval branch the run came from; it is branch-local, and a sibling
+#      branch's copy has a different accepted set. Leaving it unfilled is safe-by-design (the
+#      agents then treat every non-model finding as NEW) but costs the accepted/new distinction.
 #   2. For each dimension you need, dispatch ONE background general-purpose sub-agent
 #      with:  _shared_context.md  +  the dimension's `file`. (Each sub-agent sees ONLY
 #      the shared block + its one dimension, never this index or its siblings, so any
@@ -17,10 +20,11 @@
 #   4. Synthesize the per-dimension verdicts into one aggregate GO / No-Go using the
 #      "Aggregate synthesis" precedence in _shared_context.md (infra is a precondition;
 #      recoverable pp is owned once by four-bucket and never summed across dimensions).
-#   5. Point KNOWN_ISSUES at the eval branch the run came from. The frozen task pack is not
-#      editable, so registry-listed defects are ACCEPTED circumstances: still measured and
-#      still counted toward true capability, but footnoted rather than reported as work.
-#      Harness/engine/adapter findings are NOT circumstances and stay actionable.
+#   5. Read the accepted-vs-new split in the results. The frozen pack (and the pinned engine) are
+#      not editable for one model, so a defect the eval owner has decided to live with is an
+#      ACCEPTED circumstance: still measured and still counted toward true capability, but
+#      footnoted rather than reported as work. A registry entry that is merely KNOWN and still
+#      open (typically harness/engine) is NOT accepted and stays actionable.
 
 version: 1
 
@@ -43,11 +47,13 @@ placeholders:
   # Human-owned policy inputs for the aggregate GO/No-Go (do NOT let the agent invent them):
   GO_BOUNDARY: "adjusted-pass@1 (and pass^5) threshold for GO; owner: human / leaderboard policy"
   INFRA_THRESHOLD: "max infra-attributable failure share that still counts as infra-CLEAN"
-  KNOWN_ISSUES: "path to the eval branch's KNOWN_ISSUES.md, the registry of already-triaged,
-    ACCEPTED defects in the frozen task pack. Agents measure and attribute these but must
-    report them as footnoted circumstances, never as work items; see _shared_context.md
-    'Accepted circumstances'. Point it at the KNOWN_ISSUES.md on the SAME eval branch the run
-    came from, since the registry is branch-local and evolves."
+  KNOWN_ISSUES: "path to the eval branch's KNOWN_ISSUES.md, the registry of already-triaged
+    defects. Entries are NOT uniformly accepted: task-pack-side ones are (the pack is frozen),
+    and so are entries carrying an eval-owner keep-as-is decision, but an open harness/engine
+    entry stays actionable. Agents measure and attribute accepted ones but report them as
+    footnoted circumstances rather than work items; see _shared_context.md 'Accepted
+    circumstances' for the routing test. Branch-local, so it must come from the SAME eval
+    branch as the run; if unfilled the agents treat every non-model finding as NEW."
   # Resolve-agent placeholders (the fix-loop agent, resolve_agent.md):
   OBS_DIR: "the observe artifact dir the resolve agent reads (findings.json + probes)"
   PROVIDER: "candidate provider, e.g. openrouter"
@@ -91,8 +97,9 @@ prompts:
     purpose: "Find FALSE failures (correct action graded fail) + unwinnable/ambiguous tasks,
       and separate the ones already ACCEPTED for the frozen pack from genuinely new ones."
     reads: [grade.yaml (reasons/state_diff), task.yaml, prompts.yaml, trajectory.yaml, KNOWN_ISSUES.md]
-    gates: "publishability - footnote vs regrade"
-    verdict: "footnote-only or oracle fix + regrade"
+    gates: "publishability - footnote vs human triage vs regrade"
+    verdict: "footnote-only (incl. all-accepted) OR material NEW defect needing human triage
+      OR fix + regrade; says plainly when the highest-impact fix is harness-side, not pack-side"
 
 # Dimensions intentionally NOT in this core library yet:
 not_included:

--- a/tools/automation/src/automation/prompts/index.yaml
+++ b/tools/automation/src/automation/prompts/index.yaml
@@ -94,8 +94,9 @@ prompts:
 
   - name: task-design-oracle
     file: task_design_oracle.md
-    purpose: "Find FALSE failures (correct action graded fail) + unwinnable/ambiguous tasks,
-      and separate the ones already ACCEPTED for the frozen pack from genuinely new ones."
+    purpose: "Find FALSE failures (correct action graded fail) + unwinnable/ambiguous tasks, and
+      route each into ACCEPTED (already decided for the frozen board) / NEW pack defect / live
+      harness bug, so only the last two reach the reader as work."
     reads: [grade.yaml (reasons/state_diff), task.yaml, prompts.yaml, trajectory.yaml, KNOWN_ISSUES.md]
     gates: "publishability - footnote vs human triage vs regrade"
     verdict: "footnote-only (incl. all-accepted) OR material NEW defect needing human triage

--- a/tools/automation/src/automation/prompts/index.yaml
+++ b/tools/automation/src/automation/prompts/index.yaml
@@ -17,6 +17,10 @@
 #   4. Synthesize the per-dimension verdicts into one aggregate GO / No-Go using the
 #      "Aggregate synthesis" precedence in _shared_context.md (infra is a precondition;
 #      recoverable pp is owned once by four-bucket and never summed across dimensions).
+#   5. Point KNOWN_ISSUES at the eval branch the run came from. The frozen task pack is not
+#      editable, so registry-listed defects are ACCEPTED circumstances: still measured and
+#      still counted toward true capability, but footnoted rather than reported as work.
+#      Harness/engine/adapter findings are NOT circumstances and stay actionable.
 
 version: 1
 
@@ -39,6 +43,11 @@ placeholders:
   # Human-owned policy inputs for the aggregate GO/No-Go (do NOT let the agent invent them):
   GO_BOUNDARY: "adjusted-pass@1 (and pass^5) threshold for GO; owner: human / leaderboard policy"
   INFRA_THRESHOLD: "max infra-attributable failure share that still counts as infra-CLEAN"
+  KNOWN_ISSUES: "path to the eval branch's KNOWN_ISSUES.md, the registry of already-triaged,
+    ACCEPTED defects in the frozen task pack. Agents measure and attribute these but must
+    report them as footnoted circumstances, never as work items; see _shared_context.md
+    'Accepted circumstances'. Point it at the KNOWN_ISSUES.md on the SAME eval branch the run
+    came from, since the registry is branch-local and evolves."
   # Resolve-agent placeholders (the fix-loop agent, resolve_agent.md):
   OBS_DIR: "the observe artifact dir the resolve agent reads (findings.json + probes)"
   PROVIDER: "candidate provider, e.g. openrouter"
@@ -79,8 +88,9 @@ prompts:
 
   - name: task-design-oracle
     file: task_design_oracle.md
-    purpose: "Find FALSE failures (correct action graded fail) + unwinnable/ambiguous tasks."
-    reads: [grade.yaml (reasons/state_diff), task.yaml, prompts.yaml, trajectory.yaml]
+    purpose: "Find FALSE failures (correct action graded fail) + unwinnable/ambiguous tasks,
+      and separate the ones already ACCEPTED for the frozen pack from genuinely new ones."
+    reads: [grade.yaml (reasons/state_diff), task.yaml, prompts.yaml, trajectory.yaml, KNOWN_ISSUES.md]
     gates: "publishability - footnote vs regrade"
     verdict: "footnote-only or oracle fix + regrade"
 

--- a/tools/automation/src/automation/prompts/task_design_oracle.md
+++ b/tools/automation/src/automation/prompts/task_design_oracle.md
@@ -47,7 +47,10 @@ registry (the registry also lists live, open bugs). The frozen pack is not yours
   conclusion where the harness delivers X and then discards it. Check which side owns the cause,
   and whether the owner has decided to live with it, before you classify. Where a task-pack entry
   attributes its own mechanism to a harness entry, the routing follows that harness entry's
-  decision status, so read both before you pick a label.
+  decision status, so read both before you pick a label. Follow it only for the pp attributable to
+  THAT mechanism: a finding with two causes (say a pack entry that is also hit by an open harness
+  bug) splits its pp and each part takes its own label, so neither the loud part goes quiet nor the
+  accepted part goes loud.
 
 RETURN (compact markdown):
 - table of oracle/task-design issues (issue x domain x est. trials x est. pp domain+micro x

--- a/tools/automation/src/automation/prompts/task_design_oracle.md
+++ b/tools/automation/src/automation/prompts/task_design_oracle.md
@@ -31,30 +31,38 @@ from the trajectory alone. For each issue estimate the affected trial count and 
 an ordering artifact.
 
 Before reporting, classify every finding against `{{KNOWN_ISSUES}}` per the shared block's
-"Accepted circumstances" rules. The frozen pack is not yours to fix, so:
-- a finding already in the registry is an ACCEPTED circumstance: measure it, attribute its pp,
-  cite the registry entry, and stop there. No task/golden/simulator edit, no regrade
-  recommendation, and do not list it as outstanding work;
-- a finding NOT in the registry is a NEW task-pack defect: report it fully and propose the
-  registry entry it should become, leaving the accept/footnote/exclude call to the human owner;
-- a finding that is really harness/engine/adapter side is NOT a circumstance - report it
-  actionably even when its symptom looks like a task defect. Two symptom classes that have
-  fooled this dimension before: an expected state that looks authored-wrong but is actually a
-  broken golden replay, and a "the task never delivers X" conclusion where the harness
-  delivers X and then discards it. Check which side owns the cause before you classify.
+"Accepted circumstances" rules, whose test is that the ENTRY decides, not mere presence in the
+registry (the registry also lists live, open bugs). The frozen pack is not yours to fix, so:
+- ACCEPTED (a covering entry that is task-pack side, or carries an eval-owner keep-as-is
+  decision): measure it, attribute its pp, footnote the entry ID and this run's pp, and stop
+  there. No task/golden/simulator edit, no engine-version change, no regrade recommendation,
+  and do not list it as outstanding work;
+- NEW task-pack defect (no entry covers it by domain + symptom + mechanism): report it fully and
+  propose the registry entry it should become, leaving the accept/footnote/exclude call to the
+  human owner. An entry that enumerates task IDs covers only those IDs;
+- HARNESS/ENGINE/ADAPTER with no keep-as-is decision is NOT a circumstance - report it actionably
+  even when its symptom looks like a task defect, and even when the registry already names it.
+  Two symptom classes that have fooled this dimension before: an expected state that looks
+  authored-wrong but is actually a broken golden replay, and a "the task never delivers X"
+  conclusion where the harness delivers X and then discards it. Check which side owns the cause,
+  and whether the owner has decided to live with it, before you classify. Where a task-pack entry
+  attributes its own mechanism to a harness entry, the routing follows that harness entry's
+  decision status, so read both before you pick a label.
 
 RETURN (compact markdown):
 - table of oracle/task-design issues (issue x domain x est. trials x est. pp domain+micro x
   ACCEPTED/NEW/HARNESS)
-- total estimated FALSE-failure pp on the micro number, split ACCEPTED vs NEW (this pp is the
-  ORACLE share that `four-bucket` also reports - it is the same pp, not additional)
+- total estimated FALSE-failure pp on the micro number, split ACCEPTED / NEW / HARNESS on the
+  same three labels `four-bucket` uses, so the totals reconcile 1:1 (this pp is the ORACLE share
+  that `four-bucket` also reports - it is the same pp, not additional)
 - for any unwinnable claim, cite the specific input field you searched in `task.yaml` and
   found absent. Prefer per-task evidence over inference: if the data covers other models,
   a task no model has ever solved is the defensible unwinnable class, while one that someone
   solved is winnable however punishing
 - explicitly flag any finding whose burden looks UNEVEN across models - that is rank-distorting
   and stays a finding even if the underlying defect is accepted
-- VERDICT: footnote-only (including the accepted-circumstance case), or an oracle fix + regrade
-  needed before publishing; name the single highest-impact fix, and say plainly if the highest-
-  impact fix is on the harness side rather than in the pack. If every finding is accepted, say
-  "footnote-only, all accepted" rather than inventing work.
+- VERDICT, one of three: (a) footnote-only, including the case where every finding is accepted
+  (say "footnote-only, all accepted" rather than inventing work); (b) material NEW defect, human
+  triage required, with the proposed registry entry attached and no pack edit proposed; (c) fix +
+  regrade needed before publishing. Name the single highest-impact fix, and say plainly if it is
+  on the harness side rather than in the pack.

--- a/tools/automation/src/automation/prompts/task_design_oracle.md
+++ b/tools/automation/src/automation/prompts/task_design_oracle.md
@@ -30,11 +30,31 @@ from the trajectory alone. For each issue estimate the affected trial count and 
 (per-domain and micro). Be strict: a dropped/added set member is a GENUINE content error, not
 an ordering artifact.
 
+Before reporting, classify every finding against `{{KNOWN_ISSUES}}` per the shared block's
+"Accepted circumstances" rules. The frozen pack is not yours to fix, so:
+- a finding already in the registry is an ACCEPTED circumstance: measure it, attribute its pp,
+  cite the registry entry, and stop there. No task/golden/simulator edit, no regrade
+  recommendation, and do not list it as outstanding work;
+- a finding NOT in the registry is a NEW task-pack defect: report it fully and propose the
+  registry entry it should become, leaving the accept/footnote/exclude call to the human owner;
+- a finding that is really harness/engine/adapter side is NOT a circumstance - report it
+  actionably even when its symptom looks like a task defect. Two symptom classes that have
+  fooled this dimension before: an expected state that looks authored-wrong but is actually a
+  broken golden replay, and a "the task never delivers X" conclusion where the harness
+  delivers X and then discards it. Check which side owns the cause before you classify.
+
 RETURN (compact markdown):
-- table of oracle/task-design issues (issue x domain x est. trials x est. pp domain+micro)
-- total estimated FALSE-failure pp on the micro number (this pp is the ORACLE share that
-  `four-bucket` also reports - it is the same pp, not additional)
+- table of oracle/task-design issues (issue x domain x est. trials x est. pp domain+micro x
+  ACCEPTED/NEW/HARNESS)
+- total estimated FALSE-failure pp on the micro number, split ACCEPTED vs NEW (this pp is the
+  ORACLE share that `four-bucket` also reports - it is the same pp, not additional)
 - for any unwinnable claim, cite the specific input field you searched in `task.yaml` and
-  found absent
-- VERDICT: footnote-only, or an oracle fix + regrade needed before publishing; name the
-  single highest-impact fix.
+  found absent. Prefer per-task evidence over inference: if the data covers other models,
+  a task no model has ever solved is the defensible unwinnable class, while one that someone
+  solved is winnable however punishing
+- explicitly flag any finding whose burden looks UNEVEN across models - that is rank-distorting
+  and stays a finding even if the underlying defect is accepted
+- VERDICT: footnote-only (including the accepted-circumstance case), or an oracle fix + regrade
+  needed before publishing; name the single highest-impact fix, and say plainly if the highest-
+  impact fix is on the harness side rather than in the pack. If every finding is accepted, say
+  "footnote-only, all accepted" rather than inventing work.


### PR DESCRIPTION
## Problem

The trajectory-analysis prompts have no notion of "already triaged, and cannot be fixed anyway".

Every oracle / task-design finding comes back as a **work item**, so each eval re-reports the same registry-listed defects as blockers to fix before publishing. Two current examples, both hit on the Opus 5 canary:

- `bank_hr` `closed` vs `resolved` (D1): 32.1% of all bank_hr trials board-wide, 42/43 models.
- the airlines/`ots_19` tag-order oracle: ~0.3pp, footnoted on every model since Sonnet 5.

The leaderboard task pack is **frozen**, and for the same comparability reason the engine version is pinned per board. Dozens of published models ran against both, so editing a task/golden/simulator, or silently adopting an engine fix for one model, would break comparability and force a board-wide regrade. "Fix it" is not an available move, and an analysis that keeps recommending it costs a human triage pass every single eval.

## What changes

`KNOWN_ISSUES` becomes an input the agents read *before* reporting. The routing test is that **the entry decides, not its presence in the file**: the registry deliberately also holds live, open bugs, and its own legend says most entries are harness/engine.

| class | test | reported as |
|---|---|---|
| **ACCEPTED** | entry is task-pack side (pack is frozen), **or** carries an explicit eval-owner keep-as-is decision (e.g. H4 "keep running on v0.11.1"), whatever side it is on | one-line footnote citing the entry ID **and this run's measured pp** |
| **NEW pack defect** | no entry covers it by domain + symptom + mechanism (an entry that enumerates task IDs covers only those IDs) | full report + proposed registry entry; the accept/footnote/exclude call stays with the human owner |
| **HARNESS / ENGINE / ADAPTER, no keep-as-is decision** | anything else, *including a bug the registry already names* | unchanged: loud and actionable |

Attribution does not change: all three count toward the true-capability number and stay in the oracle bucket. Only the *reporting* changes, so a clean eval reads "footnote-only, all accepted" instead of a fix list nobody can act on.

A `FIXED` marker is **version-relative** and is evaluated against the run's own `{{ENGINE_VERSION}}`, because the two statuses overlap in practice: H4 is titled "fixed in v0.11.2" *and* carries "keep running on v0.11.1". Fix present in this run's version = history (a recurrence is a loud regression); fixed only in a later version **plus** a keep-as-is decision = ACCEPTED; fixed later with no decision = live harness bug. Markers match case-insensitively, since H4 writes "Decision" and D1 writes "DECISION", and status never comes from a title alone. A methodology note is not a finding at all, just a rule to follow.

Verified by mechanically applying the rule to all 9 real entries at `v0.11.1`: **H1/H2 loud, H3 history, H4/D1/D2 accepted, M1-M3 not findings.** (H3 routed loud before the version-aware rule, which was wrong: its fix is in.)

Three things this deliberately does **not** license, all written into the prompt:

1. **No silence about magnitude.** A circumstance big enough to change a domain's reading is stated with the number. "Accepted" means "not a work item", not "not worth mentioning".
2. **No assuming uniformity.** An accepted defect is comparability-safe only while it burdens every model equally, so the run's exposure is compared against the board-wide rate the entry documents. A large excess is **rank distortion** and stays a finding. (Named explicitly because a single-model run has no cross-model data of its own, so without the entry as comparator this guardrail could never fire.)
3. **No silent re-attribution.** If routing a finding to ACCEPTED puts pp in a different bucket than earlier analyses of the same defect used, the adjusted number stops being comparable with those analyses, and that is a synthesis-level caveat.

## Files

- `_shared_context.md`: the routing test, the version-relative status rules, an EVAL-mode gate, and safe degradation when `KNOWN_ISSUES` is unfilled (the ACCEPTED class becomes unavailable so pack findings report as NEW, harness findings stay loud, and agents are forbidden from locating a registry themselves since a sibling branch's copy has a different accepted set). Aggregate synthesis splits the **oracle share** of recoverable pp three ways (formatting and infra pp keep their own lines) and gains a tie-break: four-bucket owns the magnitude, but a label conflict resolves to the louder routing (HARNESS > NEW > ACCEPTED), never toward silence.
- `task_design_oracle.md`: pre-report classification, an ACCEPTED/NEW/HARNESS column, per-task evidence required for an "unwinnable" claim (a task *someone* solved is winnable however punishing), a third verdict arm for a material NEW defect needing human triage, and the two symptom traps that have previously mis-attributed harness bugs to the pack: an expected state that looks authored-wrong but is a broken golden replay, and a "the task never delivers X" conclusion where the harness delivers X and then discards it. Both were real misreads this cycle (H3 `id_fields` golden replay, H4 `###STOP###` drop). Also: where a pack entry attributes its mechanism to a harness entry, the routing follows that harness entry's decision status, per-mechanism, so a two-cause finding splits its pp instead of the whole finding taking one label.
- `four_bucket.md`: the bucket is HARNESS/TASK-DESIGN/ORACLE, so the line splits three ways on the same labels the oracle dimension uses, keeping the 1:1 mapping that the sole-owner-of-the-pp-split rule depends on. Explicit bans on re-labeling an accepted circumstance as GENUINE-MODEL, and on parking a live harness bug under NEW (whose endpoint is "propose a registry entry", which would institutionalise a fixable bug).
- `index.yaml`: the `KNOWN_ISSUES` placeholder with the non-uniformity of entries spelled out, fill-time guidance moved into step 1, and the task-design-oracle `gates`/`verdict` lines aligned with the new three-arm verdict.
- `integrate-model.yml`: fill `KNOWN_ISSUES` on the observe path. Without this the new placeholder leaks **literally** into the composed observe/resolve prompt, since that path substitutes placeholders by `sed` from a fixed list.

## Verification

- `index.yaml` and the workflow parse; every `{{PLACEHOLDER}}` used in the shared block is declared (the one `{{PLACEHOLDER}}` leftover is a pre-existing literal meta-reference on `main`, not a real placeholder).
- Ran the workflow's `fill()` over all prompt files: no unsubstituted placeholder survives on the observe path.
- Rendered the new section in **both** modes and read it back: the observe rendering resolves to "n/a" and hits the skip gate rather than instructing the agent to read a registry that does not exist there.
- Mechanically applied the routing test to all 9 registry entries and checked each landed in the intended class (see above).
- Docs/prompt-only plus one workflow `sed` line. No engine or adapter code touched.

## Known follow-ups (not in this PR, both tasks-repo side)

1. The registry is referenced by path, so a checkout sitting on a different eval branch can diverge from the run being analysed. The robust fix is to materialise it into the run artifacts at collection time (`git show <eval-branch>:KNOWN_ISSUES.md` into `BASE_DIR`) so path and run cannot disagree. Until then the unfilled case degrades safely and the prompt forbids self-locating a registry.
2. Entry status is currently prose that an agent has to read (hence the case-insensitive matching and the "not from the title alone" rule). A normalised per-entry `Status:` line in `KNOWN_ISSUES.md` (`accepted-by-decision <date>` / `open` / `fixed-in <version>`) would turn the judgement into a lookup and make casing irrelevant.
