### PR TITLE
fix(ci): bind no environment for publish-images dry-run

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -59,9 +59,13 @@ jobs:
     # rc tags publish under pre-stable, stable tags under release. A tag that
     # resolves to the wrong tier fails OIDC claim resolution and blocks the push,
     # which is safer than an rc leaking onto the moving tags. A workflow_dispatch
-    # build binds no environment: both tiers carry tag-typed deployment policies,
-    # so a branch ref would be rejected at the env gate before the build runs.
-    environment: ${{ github.event_name == 'workflow_dispatch' && '' || (contains(github.ref_name, '-rc.') && 'pre-stable' || 'release') }}
+    # build binds no environment (empty string) so its dry-run is not gated by a
+    # tag-typed deployment policy. The push/tag branch is the `&&` operand and the
+    # empty string is the final `||` fallback: an empty string is falsy in an
+    # expression, so `workflow_dispatch && '' || …` would wrongly fall through to
+    # the tag branch and route the dry-run to `release` — reordering keeps `''` as
+    # the value actually returned for a workflow_dispatch.
+    environment: ${{ github.event_name != 'workflow_dispatch' && (contains(github.ref_name, '-rc.') && 'pre-stable' || 'release') || '' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- The manual `workflow_dispatch` dry-run of **Publish images to Docker Hub** fails at the environment gate: *"Branch main is not allowed to deploy to release."*
- Root cause is the publish job's `environment:` expression, which relied on `github.event_name == 'workflow_dispatch' && '' || (…)`. An empty string is **falsy** in a GitHub Actions expression, so `true && '' || (…)` collapses to `'' || (…)` and falls through to the tag branch — routing a dry-run on `main` to the `release` environment, which is (correctly) locked to release tags, not the `main` branch.
- Reordered so the push/tag computation is the `&&` operand and `''` is the final `||` fallback, so a `workflow_dispatch` returns the empty string (no environment) and its dry-run builds without an env gate.

## Design choices
- **Empty string as the terminal `||` fallback, not the `&&` value**: the only way an expression can *return* `''` is to make it the right-hand side of the outer `||`; used as a `&&` value it is swallowed by its own falsiness. This is the canonical GitHub Actions idiom for a conditionally-absent `environment:`.

## Concepts introduced
None — one-line expression reorder plus an explanatory comment. Behaviour of real tag pushes is unchanged.

## Impact
- **workflow_dispatch** (dry-run): now binds **no** environment → builds all four images, no login, no push, no env gate. Restores the intended no-push validation path.
- **rc tag push** (`image-v*-rc.*`) → `pre-stable`; **stable tag push** (`image-v*`) → `release`. Both unchanged (they never took the broken branch).

## Test plan
- After merge: **Actions → Publish images to Docker Hub → Run workflow** on `main` — the four publish jobs should build and finish green with no environment gate and no push.
- The real publish paths are exercised by pushing `image-v0.11.2-rc.1` (→ pre-stable) and later `image-v0.11.2` (→ release); unaffected by this change.

Discovered while validating the publish pipeline post-M14 (the dry-run could not be exercised until the workflow landed on `main`).