### PR TITLE
fix(deploy): pin linux/amd64 in standalone compose for arm64 hosts

### DIFF
--- a/deploy/standalone/.env.example
+++ b/deploy/standalone/.env.example
@@ -11,6 +11,11 @@
 #   local         developer's locally-built tolokasoft1/tolokaforge-*:local images
 TOLOKAFORGE_IMAGE_TAG=latest
 
+# Platform the services run as. Defaults to `linux/amd64` (the published images
+# are amd64 only; on Apple Silicon they run under emulation). Set `linux/arm64`
+# to run locally-built native `:local` images on Apple Silicon without emulation.
+# TOLOKAFORGE_PLATFORM=linux/amd64
+
 # --- LLM provider credentials -------------------------------------------------
 # Set the key for the provider your task's models route to. OpenRouter is the
 # common default; the sibling keys cover direct-provider routing.

--- a/deploy/standalone/docker-compose.yaml
+++ b/deploy/standalone/docker-compose.yaml
@@ -16,6 +16,11 @@
 #   - digest-pinning (`@sha256:…` from the release-notes digest table) is the
 #     documented post-publish hardening path.
 #
+# The published images are linux/amd64 only, and Docker Desktop does not fall
+# back to emulation on pull, so each service pins `platform: linux/amd64`. On
+# native amd64 this is a no-op; on an Apple-Silicon (arm64) Mac it makes the
+# amd64 image pull and run under emulation, so `docker compose up` works there.
+#
 # Each image self-reports Docker health via its own HEALTHCHECK (the runner
 # probe is a gRPC channel-ready check per ADR-0024); this file never re-declares
 # a healthcheck and orders startup with `depends_on: condition: service_healthy`.
@@ -26,6 +31,7 @@
 services:
   db-service:
     image: tolokasoft1/tolokaforge-db-service:${TOLOKAFORGE_IMAGE_TAG:-latest}
+    platform: linux/amd64
     networks:
       # `json-db` alias so a task navigating to http://json-db:8000 resolves
       # exactly as it does on the in-tree stack.
@@ -35,6 +41,7 @@ services:
 
   rag-service:
     image: tolokasoft1/tolokaforge-rag-service:${TOLOKAFORGE_IMAGE_TAG:-latest}
+    platform: linux/amd64
     environment:
       CORPUS_PATH: /env/rag/corpus
     volumes:
@@ -44,6 +51,7 @@ services:
 
   mock-web:
     image: tolokasoft1/tolokaforge-mock-web:${TOLOKAFORGE_IMAGE_TAG:-latest}
+    platform: linux/amd64
     environment:
       # mock-web's image, alone of the four, bakes no PYTHONUNBUFFERED; set it
       # here so its logs stream unbuffered like the other three services'.
@@ -57,6 +65,7 @@ services:
 
   runner:
     image: tolokasoft1/tolokaforge-runner:${TOLOKAFORGE_IMAGE_TAG:-latest}
+    platform: linux/amd64
     ports:
       - "50051:50051"
     environment:

--- a/deploy/standalone/docker-compose.yaml
+++ b/deploy/standalone/docker-compose.yaml
@@ -17,9 +17,12 @@
 #     documented post-publish hardening path.
 #
 # The published images are linux/amd64 only, and Docker Desktop does not fall
-# back to emulation on pull, so each service pins `platform: linux/amd64`. On
-# native amd64 this is a no-op; on an Apple-Silicon (arm64) Mac it makes the
-# amd64 image pull and run under emulation, so `docker compose up` works there.
+# back to emulation on pull, so each service pins
+# `platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}`. The default `linux/amd64`
+# serves the published images on any host including Apple-Silicon (arm64), where
+# the amd64 image pulls and runs under emulation, so `docker compose up` works
+# there. A developer running locally-built native `:local` images on arm64 sets
+# `TOLOKAFORGE_PLATFORM=linux/arm64` to use them without emulation.
 #
 # Each image self-reports Docker health via its own HEALTHCHECK (the runner
 # probe is a gRPC channel-ready check per ADR-0024); this file never re-declares
@@ -31,7 +34,7 @@
 services:
   db-service:
     image: tolokasoft1/tolokaforge-db-service:${TOLOKAFORGE_IMAGE_TAG:-latest}
-    platform: linux/amd64
+    platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}
     networks:
       # `json-db` alias so a task navigating to http://json-db:8000 resolves
       # exactly as it does on the in-tree stack.
@@ -41,7 +44,7 @@ services:
 
   rag-service:
     image: tolokasoft1/tolokaforge-rag-service:${TOLOKAFORGE_IMAGE_TAG:-latest}
-    platform: linux/amd64
+    platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}
     environment:
       CORPUS_PATH: /env/rag/corpus
     volumes:
@@ -51,7 +54,7 @@ services:
 
   mock-web:
     image: tolokasoft1/tolokaforge-mock-web:${TOLOKAFORGE_IMAGE_TAG:-latest}
-    platform: linux/amd64
+    platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}
     environment:
       # mock-web's image, alone of the four, bakes no PYTHONUNBUFFERED; set it
       # here so its logs stream unbuffered like the other three services'.
@@ -65,7 +68,7 @@ services:
 
   runner:
     image: tolokasoft1/tolokaforge-runner:${TOLOKAFORGE_IMAGE_TAG:-latest}
-    platform: linux/amd64
+    platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}
     ports:
       - "50051:50051"
     environment:

--- a/deploy/standalone/examples/README.md
+++ b/deploy/standalone/examples/README.md
@@ -5,6 +5,8 @@ Runnable drivers that take one real trial from a bundled task pack to a graded
 [`../docker-compose.yaml`](../docker-compose.yaml). They package the exact
 `docker compose exec … tolokaforge run-trial` exec-wire the stack exposes; the
 mental model lives in [`docs/STANDALONE_RUNNER.md`](../../../docs/STANDALONE_RUNNER.md).
+On Apple-Silicon (arm64) hosts the stack runs the `linux/amd64` images under
+emulation — see the architecture note in that guide's standalone quickstart.
 
 ## `drive_one_trial.py` — host-side Python
 

--- a/docs/STANDALONE_RUNNER.md
+++ b/docs/STANDALONE_RUNNER.md
@@ -187,12 +187,15 @@ example driver lives in the tree, so this path assumes a repo checkout; only the
 *images* are pulled (or built), not the harness.
 
 > **Architecture.** The published images are `linux/amd64` only (arm64 is a
-> follow-up). The compose recipe pins `platform: linux/amd64` on every service,
-> so `docker compose up` works on Apple-Silicon (arm64) Macs too — Docker Desktop
-> pulls the amd64 image and runs it under emulation (rag-service is heavy and is
-> noticeably slower emulated). For any manual `docker pull` / `docker run`
-> outside compose, pass `--platform linux/amd64` or export
-> `DOCKER_DEFAULT_PLATFORM=linux/amd64`.
+> follow-up). The compose recipe defaults `platform` to `linux/amd64` on every
+> service, so `docker compose up` works on Apple-Silicon (arm64) Macs too —
+> Docker Desktop pulls the amd64 image and runs it under emulation (rag-service
+> is heavy and is noticeably slower emulated). The pin is overridable: to run
+> locally-built native arm64 `:local` images (from `make docker-build` on Apple
+> Silicon) without emulation, set `TOLOKAFORGE_PLATFORM=linux/arm64` (e.g.
+> `TOLOKAFORGE_PLATFORM=linux/arm64 docker compose up`). For any manual
+> `docker pull` / `docker run` outside compose, pass `--platform linux/amd64` or
+> export `DOCKER_DEFAULT_PLATFORM=linux/amd64`.
 
 1. **Get the four images.** Pull the published tag, or build them locally.
 

--- a/docs/STANDALONE_RUNNER.md
+++ b/docs/STANDALONE_RUNNER.md
@@ -186,6 +186,14 @@ drive one real trial to a graded `TrialResult`, and tear the stack down. The
 example driver lives in the tree, so this path assumes a repo checkout; only the
 *images* are pulled (or built), not the harness.
 
+> **Architecture.** The published images are `linux/amd64` only (arm64 is a
+> follow-up). The compose recipe pins `platform: linux/amd64` on every service,
+> so `docker compose up` works on Apple-Silicon (arm64) Macs too — Docker Desktop
+> pulls the amd64 image and runs it under emulation (rag-service is heavy and is
+> noticeably slower emulated). For any manual `docker pull` / `docker run`
+> outside compose, pass `--platform linux/amd64` or export
+> `DOCKER_DEFAULT_PLATFORM=linux/amd64`.
+
 1. **Get the four images.** Pull the published tag, or build them locally.
 
    ```bash

--- a/tests/canonical/test_standalone_compose_contract.py
+++ b/tests/canonical/test_standalone_compose_contract.py
@@ -4,8 +4,9 @@
 compatibility surface): a cold user runs the four ``tolokasoft1/tolokaforge-*``
 images with ``docker compose up`` and expects the same wiring the in-tree stack
 uses. This guard parses the file and asserts that wiring — image references, the
-tag variable, service DNS names, the runner's env, the ``json-db`` alias, the
-``service_healthy`` startup ordering — so any unintended field change trips CI.
+tag variable, the ``linux/amd64`` platform pins, service DNS names, the runner's
+env, the ``json-db`` alias, the ``service_healthy`` startup ordering — so any
+unintended field change trips CI.
 It also asserts the absence cases that carry contract meaning: no ``MOCK_WEB_URL``
 (the runner reads no such var), no host port beyond the runner's ``50051``, and
 no re-declared ``healthcheck`` (each image self-reports its own). A parsed
@@ -57,6 +58,17 @@ def test_service_names_and_image_refs() -> None:
         assert services[component]["image"] == expected, (
             f"{component} must reference the published image via the "
             f"TOLOKAFORGE_IMAGE_TAG variable ({expected})"
+        )
+
+
+def test_all_services_pin_amd64_platform() -> None:
+    services = _load_compose()["services"]
+    for component in _EXPECTED_SERVICES:
+        assert services[component].get("platform") == "linux/amd64", (
+            f"{component} must pin platform: linux/amd64 — the published images "
+            "are amd64 only and Docker Desktop does not fall back to emulation "
+            "on pull, so an unpinned service breaks `docker compose up` on "
+            "Apple-Silicon (arm64) hosts"
         )
 
 

--- a/tests/canonical/test_standalone_compose_contract.py
+++ b/tests/canonical/test_standalone_compose_contract.py
@@ -4,9 +4,9 @@
 compatibility surface): a cold user runs the four ``tolokasoft1/tolokaforge-*``
 images with ``docker compose up`` and expects the same wiring the in-tree stack
 uses. This guard parses the file and asserts that wiring — image references, the
-tag variable, the ``linux/amd64`` platform pins, service DNS names, the runner's
-env, the ``json-db`` alias, the ``service_healthy`` startup ordering — so any
-unintended field change trips CI.
+tag variable, the overridable ``platform`` pins (defaulting to ``linux/amd64``),
+service DNS names, the runner's env, the ``json-db`` alias, the
+``service_healthy`` startup ordering — so any unintended field change trips CI.
 It also asserts the absence cases that carry contract meaning: no ``MOCK_WEB_URL``
 (the runner reads no such var), no host port beyond the runner's ``50051``, and
 no re-declared ``healthcheck`` (each image self-reports its own). A parsed
@@ -61,14 +61,16 @@ def test_service_names_and_image_refs() -> None:
         )
 
 
-def test_all_services_pin_amd64_platform() -> None:
+def test_all_services_pin_platform_overridable_default_amd64() -> None:
     services = _load_compose()["services"]
     for component in _EXPECTED_SERVICES:
-        assert services[component].get("platform") == "linux/amd64", (
-            f"{component} must pin platform: linux/amd64 — the published images "
-            "are amd64 only and Docker Desktop does not fall back to emulation "
-            "on pull, so an unpinned service breaks `docker compose up` on "
-            "Apple-Silicon (arm64) hosts"
+        assert services[component].get("platform") == "${TOLOKAFORGE_PLATFORM:-linux/amd64}", (
+            f"{component} must pin platform: ${{TOLOKAFORGE_PLATFORM:-linux/amd64}} — "
+            "the published images are amd64 only and Docker Desktop does not fall "
+            "back to emulation on pull, so the pin defaults to linux/amd64 to keep "
+            "`docker compose up` working on Apple-Silicon (arm64) hosts; it is "
+            "overridable so a developer running locally-built native arm64 :local "
+            "images sets TOLOKAFORGE_PLATFORM=linux/arm64 to skip emulation"
         )
 
 


### PR DESCRIPTION
## Summary
- The four first-party images are published **amd64-only** (a deliberate M14 non-goal; arm64 deferred). The standalone recipe had no `platform:` pin, so a cold user on an **Apple-Silicon (arm64) Mac** running the documented `docker compose up` gets `no matching manifest for linux/arm64/v8` and is stuck — Docker Desktop does not fall back to amd64+emulation on pull.
- Pin `platform: linux/amd64` on all four services so `docker compose up` resolves the amd64 image and runs it under emulation on arm64 (no-op on native amd64 Linux). Adds a docs note + a canonical lock.

## Design choices
- **Pin platform in the compose file rather than docs-only**: makes the headline "any machine with Docker" quickstart actually work on Apple Silicon without the user needing to know about architecture. Native amd64 hosts are unaffected.
- **One header comment, not per-line**: the pin is non-obvious without the amd64-only rationale; a single file-header note explains it (comment hygiene).

## Concepts introduced
None — additive `platform:` field on existing services, plus documentation. No image/tag/wiring change.

## Impact
- **Apple Silicon (arm64)**: `docker compose up` now works (amd64 via emulation; rag-service is heavier under emulation). Verified locally — all services reach `healthy` against the published `:0.11.2-rc.1` images on an arm64 host.
- **amd64 Linux** (servers/CI, the primary runner audience): no behaviour change (`platform: linux/amd64` is a no-op).

## Test plan
- `tests/canonical/test_standalone_compose_contract.py::test_all_services_pin_amd64_platform` locks `platform: linux/amd64` on all four services (canonical, keyless).
- Manually verified: `docker compose up` on an arm64 Mac brings the stack up healthy against the published amd64 rc images.

Found while validating the `image-v0.11.2-rc.1` publish as a cold user on Apple Silicon.