### PR TITLE
fix(docker): scope mock-web build context to its service dir

### DIFF
--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -183,6 +183,34 @@ def test_expected_image_ref_matches_real_content_hash() -> None:
     assert expected_image_ref("runner") == f"{definition['name']}:{content_hash[:8]}"
 
 
+def test_mock_web_context_scoped_to_service_files() -> None:
+    """The real ``mock-web`` definition assembles an isolated context holding
+    only its service files, so its content-hash moves with mock-web's own
+    inputs and nothing else.
+
+    Drives the real ``IMAGE_DEFINITIONS['mock-web']`` (no stubbing) through
+    ``_prepared_build_context``. Assertion (3) is load-bearing: if no repo-root
+    file (e.g. ``pyproject.toml``) reaches the context, then only
+    ``tolokaforge/env/mock_web_service/**`` can move the content-hash — which is
+    what makes the hash stable against unrelated repo edits. No Docker daemon.
+    """
+    from tolokaforge.docker.builder import _prepared_build_context
+
+    with _prepared_build_context("mock-web") as (dockerfile, context, _name, _build_args):
+        build_dir = Path(context)
+        # (1) An assembled temp dir, not the literal repo ".".
+        assert context != "."
+        assert "tolokaforge-build-" in context
+        # (2) The service files the Dockerfile COPYs are present, and the
+        #     yielded Dockerfile path resolves under the assembled context.
+        assert (build_dir / "tolokaforge/env/mock_web_service/requirements.txt").exists()
+        assert (build_dir / "tolokaforge/env/mock_web_service/app.py").exists()
+        assert dockerfile.startswith(context)
+        assert Path(dockerfile).exists()
+        # (3) No repo-root file leaks into the context.
+        assert not (build_dir / "pyproject.toml").exists()
+
+
 @pytest.mark.usefixtures("_mock_wheel")
 def test_runner_build_context_contains_wheel() -> None:
     """The runner image context should contain the resolved wheel (not source)."""

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -126,7 +126,9 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
         "name": "tolokaforge-mock-web",
         "dockerfile": "tolokaforge/docker/dockerfiles/mock_web.Dockerfile",
         "context": ".",
-        "context_files": [],
+        "context_files": [
+            "tolokaforge/env/mock_web_service/",
+        ],
         "build_args": dict(_PYTHON_BUILD_ARGS),
     },
 }


### PR DESCRIPTION
## Summary
- `IMAGE_DEFINITIONS["mock-web"]` declared `context="."` with empty `context_files`, so mock-web's content-hash was computed over the whole repo — any unrelated edit churned the mock-web image tag and forced needless rebuilds.
- Scope `context_files` to `["tolokaforge/env/mock_web_service/"]` (the only path `mock_web.Dockerfile` COPYs), routing mock-web through the same assembled-context path db-service/runner/rag-service already use. Fixes a drift: `stacks/full.py`'s ServiceDefinition already scoped this correctly.

## Design choices
- **One-line dict edit, no dedup**: the builder `IMAGE_DEFINITIONS` and stack `ServiceDefinition` declare `context_files` twice with nothing enforcing agreement — deduping to one SSOT is filed as #653, out of scope here.

## Concepts introduced
None — content-hash now covers only the Dockerfile + `tolokaforge/env/mock_web_service/**`.

## Impact
- **No published-release impact**: `publish-images.yml` builds mock-web with `docker build`/`context: .`/semver tags (not the content-hash tag); the Dockerfile is untouched, so the v0.11.2 published digest is unaffected. Only effect: a one-time local re-tag on the next `make docker-build`; image content byte-identical.

## Test plan
- `tests/unit/test_docker_build_context.py::test_mock_web_context_scoped_to_service_files` (keyless unit) — drives the real `IMAGE_DEFINITIONS["mock-web"]` through `_prepared_build_context`, asserts the assembled context contains `mock_web_service/requirements.txt`+`app.py`, resolves the Dockerfile, and excludes repo-root `pyproject.toml` (the bug's direct encoding). 12/12 in the file pass.

Closes #627