### PR TITLE
test(deploy): functionally cover mock-web through the standalone stack (#649)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ by adapter type.
     ├── native/                          # default `native` adapter
     │   ├── browser_task/                # browser tool + mock-web fixtures
     │   ├── coding/                      # file-write grading
+    │   ├── mock_web_booking/            # http_request against the mock-web service
     │   ├── native_shared_domain/        # _shared/domain.yaml pattern (FastMCP)
     │   └── tool_use/                    # structured tool-call grading
     └── terminal_bench/                  # `terminal_bench` adapter (Docker compose)
@@ -19,6 +20,9 @@ by adapter type.
 - **Tool-heavy tasks**: see `native/tool_use/` or `native/native_shared_domain/`
   (the latter shows the `_shared/domain.yaml` + FastMCP `mcp_server.py` pattern
   for sharing tools across test-cases).
+- **HTTP against a service**: see `native/mock_web_booking/` — `http_request`
+  drives the mock-web service and grading locks a mock-web-issued token (needs
+  Docker for mock-web).
 - **Browser tasks**: see `native/browser_task/` (needs Docker for mock-web).
 - **Terminal-bench tasks** (Docker compose + `tests/test.sh`): see
   `terminal_bench/`.

--- a/examples/native/mock_web_booking/README.md
+++ b/examples/native/mock_web_booking/README.md
@@ -1,0 +1,73 @@
+# Mock-web booking — `http_request` against a first-party service
+
+A single-task native pack that drives the first-party **mock-web** service over
+the `http_request` builtin. The agent books a hotel room through an HTML form
+and reports the confirmation number mock-web issues; grading is deterministic
+and keyless-gradable in shape — it asserts the booking round-trip happened and
+that the mock-web-issued confirmation number appears in the transcript.
+
+```
+agent → http_request → mock-web:8080  (/booking form → POST /booking/confirm)
+```
+
+## What this example demonstrates
+
+- **`http_request` against a composed peer, no `environment_manifest`.** The
+  task enables only `http_request` (allow-listed to `mock-web:8080`) and
+  declares no environment manifest. mock-web is reached by Docker DNS on the
+  standalone stack (`deploy/standalone/docker-compose.yaml`), exactly the way
+  the bundled `tool_use` pack reaches db-service — the runner's own network
+  wires the peer, not a per-task manifest.
+- **A form round-trip, not a JSON API.** `/booking/confirm` reads an HTML form
+  submission (`request.form()`), so the agent must GET `/booking` to learn the
+  fields (`name`, `hotel`, `checkin`, `checkout`) and POST them as **form
+  data** — a JSON body would not populate the form and the booking would fail.
+- **Deterministic grading on a non-guessable, agent-produced outcome.** The
+  confirmation number `BKSEA12345` is derived by mock-web from the submitted
+  hotel (`BK<hotel[:3].upper()>12345`); it cannot be produced without the POST
+  response. Grading is transcript-only:
+
+  | Check | What it asserts |
+  |---|---|
+  | `required_actions` (POST) | the agent POSTed over `http_request` — the booking round-trip actually happened |
+  | `must_contain: BKSEA12345` | the mock-web-issued confirmation number is reported |
+
+  Both are product-scored under `transcript_rules` with `pass_threshold: 1.0`,
+  so dropping either — a GET-only trajectory, or a guessed/omitted confirmation
+  number — fails the task.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/mock_web_booking/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/mock_web_booking/run_configs/dev.yaml
+```
+
+Needs a running Docker daemon with the standalone stack up (so `mock-web:8080`
+is reachable on the runner network) and `OPENROUTER_API_KEY` in `.env`.
+
+## Layout
+
+```
+examples/native/mock_web_booking/
+├── run_configs/dev.yaml          # haiku agent + user, no judge
+├── project.yaml                  # discovery glob + native defaults
+├── README.md                     # this file
+└── dataset/tasks/booking_01/
+    ├── task.yaml                 # http_request-only, allow-listed to mock-web:8080
+    └── grading.yaml              # transcript-only: POST gate + confirmation-number token
+```
+
+## Related
+
+- [`docs/GRADING.md`](../../../docs/GRADING.md) — grading families, including
+  `transcript_rules.required_actions` and `must_contain`
+- [`../tool_use/README.md`](../tool_use/README.md) — structured tool-call
+  grading without a Docker substrate
+- [`docs/STANDALONE_RUNNER.md`](../../../docs/STANDALONE_RUNNER.md) — the
+  composed standalone stack this pack runs against

--- a/examples/native/mock_web_booking/README.md
+++ b/examples/native/mock_web_booking/README.md
@@ -22,10 +22,12 @@ agent → http_request → mock-web:8080  (/booking form → POST /booking/confi
   submission (`request.form()`), so the agent must GET `/booking` to learn the
   fields (`name`, `hotel`, `checkin`, `checkout`) and POST them as **form
   data** — a JSON body would not populate the form and the booking would fail.
-- **Deterministic grading on a non-guessable, agent-produced outcome.** The
-  confirmation number `BKSEA12345` is derived by mock-web from the submitted
-  hotel (`BK<hotel[:3].upper()>12345`); it cannot be produced without the POST
-  response. Grading is transcript-only:
+- **Deterministic grading on the site-issued booking outcome.** mock-web issues
+  the confirmation number `BKSEA12345` from the submitted hotel
+  (`BK<hotel[:3].upper()>12345`). The round-trip is enforced by the
+  `required_actions` POST gate together with reporting that site-issued token —
+  not by the token being unguessable (the template is public). Grading is
+  transcript-only:
 
   | Check | What it asserts |
   |---|---|
@@ -33,8 +35,8 @@ agent → http_request → mock-web:8080  (/booking form → POST /booking/confi
   | `must_contain: BKSEA12345` | the mock-web-issued confirmation number is reported |
 
   Both are product-scored under `transcript_rules` with `pass_threshold: 1.0`,
-  so dropping either — a GET-only trajectory, or a guessed/omitted confirmation
-  number — fails the task.
+  so dropping either — a GET-only trajectory, or a missing confirmation number —
+  fails the task.
 
 ## Validate
 

--- a/examples/native/mock_web_booking/dataset/tasks/booking_01/grading.yaml
+++ b/examples/native/mock_web_booking/dataset/tasks/booking_01/grading.yaml
@@ -5,9 +5,10 @@
 #   required_actions — the agent POSTed over http_request (the booking round-trip
 #     to mock-web actually happened; a GET-only or no-call trajectory fails).
 #   must_contain      — the confirmation number `BKSEA12345` appears in the
-#     transcript. The site derives it from the submitted hotel (BK<hotel[:3]>12345
-#     → BKSEA12345 for Seaside Resort); it cannot be guessed without the POST
-#     response, so it is an agent-produced outcome of the round-trip.
+#     transcript. The site issues it from the submitted hotel (BK<hotel[:3]>12345
+#     → BKSEA12345 for Seaside Resort). Paired with the required_actions POST gate
+#     above, this locks the round-trip to the site-issued token — it does not rest
+#     on token entropy (the derivation template is public).
 combine:
   method: weighted
   weights:

--- a/examples/native/mock_web_booking/dataset/tasks/booking_01/grading.yaml
+++ b/examples/native/mock_web_booking/dataset/tasks/booking_01/grading.yaml
@@ -1,0 +1,26 @@
+# Deterministic, keyless-gradable grading for booking_01.
+#
+# transcript_rules is the only family (weight 1.0, pass_threshold 1.0), and its
+# two checks are product-scored so BOTH must hold for a pass:
+#   required_actions — the agent POSTed over http_request (the booking round-trip
+#     to mock-web actually happened; a GET-only or no-call trajectory fails).
+#   must_contain      — the confirmation number `BKSEA12345` appears in the
+#     transcript. The site derives it from the submitted hotel (BK<hotel[:3]>12345
+#     → BKSEA12345 for Seaside Resort); it cannot be guessed without the POST
+#     response, so it is an agent-produced outcome of the round-trip.
+combine:
+  method: weighted
+  weights:
+    transcript_rules: 1.0
+  pass_threshold: 1.0
+
+transcript_rules:
+  max_turns: 6
+  must_contain:
+    - "BKSEA12345"
+  required_actions:
+    - action_id: "submit_booking_over_http"
+      requestor: assistant
+      name: http_request
+      arguments: {method: "POST"}
+      compare_args: ["method"]

--- a/examples/native/mock_web_booking/dataset/tasks/booking_01/task.yaml
+++ b/examples/native/mock_web_booking/dataset/tasks/booking_01/task.yaml
@@ -1,0 +1,31 @@
+task_id: "booking_01"
+name: "Book a Hotel Room over the Mock-Web Booking Site"
+category: "mock_web"
+description: "The agent books a hotel room through the mock-web booking site using only the http_request tool: GET the form to learn its fields, POST the booking as form data, and report the confirmation number the site issues."
+max_turns: 6
+adapter_type: "native"
+initial_user_message: |
+  Hi — can you book a room for me on our booking site? It's at
+  http://mock-web:8080/booking. I want the Seaside Resort, checking in on
+  2026-08-01 and checking out on 2026-08-04, under the name Dana Rivera.
+
+  Once it's booked, tell me the confirmation number the site gives back — I
+  need it for my records.
+tools:
+  agent:
+    enabled: ["http_request"]
+    http_request:
+      allowed_hosts: ["mock-web:8080"]
+  user:
+    enabled: []
+actors:
+  user:
+    mode: llm
+    persona: cooperative
+    backstory: "You are booking a hotel room and rely on the agent to drive the booking site for you. Answer brief clarifying questions plainly with the details already given (Seaside Resort, 2026-08-01 to 2026-08-04, name Dana Rivera); do not describe the HTTP calls or spell out the form. End with ###STOP### once the agent reports the confirmation number."
+policies:
+  guidance:
+    - "Reach the booking site with the `http_request` tool against `http://mock-web:8080`. GET `/booking` first to read the form and learn its fields before submitting."
+    - "Submit the booking by POSTing to `/booking/confirm` as the form's own fields (`name`, `hotel`, `checkin`, `checkout`) — send them as form data, not a JSON body, since the site reads an HTML form submission."
+    - "Read the POST response and report back the confirmation number the site issues; do not invent one."
+grading: "grading.yaml"

--- a/examples/native/mock_web_booking/project.yaml
+++ b/examples/native/mock_web_booking/project.yaml
@@ -1,0 +1,29 @@
+# Project spec for the mock_web_booking example.
+#
+# A single native task that drives the first-party mock-web service over the
+# `http_request` builtin: the agent GETs a booking form, POSTs the booking as
+# form data, and reports the confirmation number mock-web issues. The task
+# declares no `environment_manifest` — mock-web is reached by Docker DNS on the
+# composed standalone stack (deploy/standalone/docker-compose.yaml), the same
+# way the bundled `tool_use` pack reaches db-service.
+#
+# See docs/PROJECTS.md for the full Project model.
+
+name: "mock-web-booking"
+version: 1
+description: >
+  Single-task project demonstrating http_request against the first-party
+  mock-web service: the agent completes a hotel booking over an HTML form and
+  reports the confirmation number, graded deterministically on that
+  mock-web-issued token.
+
+tasks:
+  discovery:
+    glob: "tasks/**/task.yaml"
+
+task_defaults:
+  adapter_type: "native"
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/mock_web_booking/project.yaml
+++ b/examples/native/mock_web_booking/project.yaml
@@ -19,7 +19,7 @@ description: >
 
 tasks:
   discovery:
-    glob: "tasks/**/task.yaml"
+    glob: "dataset/tasks/**/task.yaml"
 
 task_defaults:
   adapter_type: "native"

--- a/examples/native/mock_web_booking/run_configs/dev.yaml
+++ b/examples/native/mock_web_booking/run_configs/dev.yaml
@@ -1,0 +1,38 @@
+# Mock-web booking example — http_request against the first-party mock-web
+# service, deterministic confirmation-number grading.
+#
+#   agent → http_request → mock-web:8080 (/booking form → /booking/confirm)
+#
+# Two model roles: the `agent` under test and the `user` simulator. Grading is
+# transcript-only (no judge), so no judge model is needed.
+#
+# Requirements:
+#   - Docker daemon running with the standalone stack up (mock-web reachable on
+#     the runner network at mock-web:8080).
+#   - OPENROUTER_API_KEY in .env.
+#
+# Run:
+#   scripts/with_env.sh uv run tolokaforge run --config examples/native/mock_web_booking/run_configs/dev.yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 6
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  projects:
+    - "examples/native/mock_web_booking/dataset"
+  tasks_glob: "tasks/booking_01/task.yaml"
+  output_dir: "results/mock_web_booking_example"

--- a/tests/canonical/test_mock_web_example_pack.py
+++ b/tests/canonical/test_mock_web_example_pack.py
@@ -1,0 +1,106 @@
+"""Keyless shape lock for the ``mock_web_booking`` example pack.
+
+The pack (``examples/native/mock_web_booking/``) drives the first-party
+mock-web service over ``http_request`` and grades on the confirmation number
+mock-web issues. This guard runs on every PR without Docker or a provider key:
+it loads the pack through the same loaders the CLI uses and asserts the load-
+bearing shape — the ``http_request`` allow-list, the mock-web endpoint the task
+targets, and the two transcript gates that make grading meaningful. It is a
+*shape* lock; the paid behaviour lock (a graded ``TrialResult`` through the
+composed stack) lives in the deploy integration lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.models import GradingConfig
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_ROOT = _REPO_ROOT / "examples" / "native" / "mock_web_booking"
+_TASK_YAML = _PACK_ROOT / "dataset" / "tasks" / "booking_01" / "task.yaml"
+_GRADING_YAML = _PACK_ROOT / "dataset" / "tasks" / "booking_01" / "grading.yaml"
+
+_MOCK_WEB_HOST = "mock-web:8080"
+_BOOKING_URL = "http://mock-web:8080/booking"
+_CONFIRMATION_TOKEN = "BKSEA12345"
+
+
+def test_task_loads_and_enables_http_request_to_mock_web() -> None:
+    """The task validates and grants only ``http_request`` allow-listed to mock-web.
+
+    Locks the tool contract: the pack drives mock-web through ``http_request``
+    (not a browser or a bespoke tool), and the allow-list names the peer — so
+    dropping the tool or repointing the host trips CI keylessly.
+    """
+    assert _TASK_YAML.is_file(), f"pack task.yaml is missing: {_TASK_YAML}"
+    task, _ = load_task_yaml(_TASK_YAML)
+
+    agent_tools = task.tools.agent
+    enabled = agent_tools.get("enabled")
+    assert enabled == ["http_request"], f"agent must enable only http_request, got: {enabled!r}"
+    hosts = agent_tools.get("http_request", {}).get("allowed_hosts", [])
+    assert _MOCK_WEB_HOST in hosts, f"allow-list must include {_MOCK_WEB_HOST!r}, got: {hosts!r}"
+
+
+def test_task_targets_the_mock_web_booking_endpoint() -> None:
+    """The task text points the agent at the mock-web booking site.
+
+    Combines the initial user message and the policy guidance and requires the
+    ``/booking`` URL — so repointing the pack away from mock-web trips here.
+    """
+    task, _ = load_task_yaml(_TASK_YAML)
+    guidance = task.policies.get("guidance", [])
+    task_text = "\n".join([task.initial_user_message or "", *guidance])
+    assert _BOOKING_URL in task_text, f"task text must target {_BOOKING_URL!r}"
+
+
+def _load_grading() -> tuple[dict, GradingConfig]:
+    raw = yaml.safe_load(_GRADING_YAML.read_text())
+    return raw, GradingConfig(**raw)
+
+
+def test_grading_is_transcript_only_with_both_gates() -> None:
+    """Grading validates and locks the two product-scored transcript gates.
+
+    Asserts the confirmation-number token, the POST ``required_actions`` gate,
+    and that ``combine`` weights only ``transcript_rules`` — so dropping either
+    gate, repointing the graded value, or adding a keyed family (llm_judge /
+    state_checks) that a keyless run cannot satisfy trips CI without Docker.
+    """
+    assert _GRADING_YAML.is_file(), f"pack grading.yaml is missing: {_GRADING_YAML}"
+    raw, grading = _load_grading()
+
+    assert set(grading.combine.weights) == {"transcript_rules"}, (
+        "grading must weight only transcript_rules (no llm_judge / state_checks a "
+        f"keyless run cannot satisfy), got weights: {grading.combine.weights!r}"
+    )
+    assert grading.state_checks is None, "grading must not use state_checks"
+    assert grading.llm_judge is None, "grading must not use an llm_judge"
+
+    rules = grading.transcript_rules
+    assert rules is not None, "grading must define transcript_rules"
+    assert _CONFIRMATION_TOKEN in rules.must_contain, (
+        f"grading must require the mock-web confirmation token {_CONFIRMATION_TOKEN!r} in "
+        f"must_contain, got: {rules.must_contain!r}"
+    )
+
+    post_gates = [
+        action
+        for action in rules.required_actions
+        if action.name == "http_request" and action.arguments.get("method") == "POST"
+    ]
+    assert post_gates, (
+        "grading must gate on an http_request POST required_action (proves the booking "
+        f"round-trip happened), got: {rules.required_actions!r}"
+    )
+    assert "method" in (post_gates[0].compare_args or []), (
+        "the POST gate must compare the method argument, else it is a silent no-op; "
+        f"got compare_args: {post_gates[0].compare_args!r}"
+    )

--- a/tests/integration/deploy/test_standalone_compose.py
+++ b/tests/integration/deploy/test_standalone_compose.py
@@ -15,9 +15,11 @@ Two modes drive the same recipe:
   brings the same recipe up against it; skip-guarded on tag availability (absent
   until the first stable publish), mirroring the parity suite's published source.
 
-A third, gated test drives one real bundled trial through the composed runner over
-the ADR-0024 ``run-trial`` exec wire (``requires_api``), proving a trial reaches a
-graded ``TrialResult`` through the stack.
+Two gated tests each drive one real trial through the composed runner over the
+ADR-0024 ``run-trial`` exec wire (``requires_api``): a bundled db-service trial
+(the ``tool_use`` pack) and a mock-web booking trial (``http_request`` → mock-web),
+each proving its peer functionally participates in a graded ``TrialResult`` through
+the stack.
 
 ``docker compose up --wait`` blocks on all four healthchecks. rag-service loads
 ``all-MiniLM-L6-v2`` eagerly and downloads it from HuggingFace on a cold cache, so
@@ -30,7 +32,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -43,6 +46,9 @@ from tests.integration.deploy.conftest import (
     pull_published,
 )
 from tests.utils.docker_helpers import wait_for_health
+
+if TYPE_CHECKING:
+    from tolokaforge.core.trial import TrialResult
 
 pytestmark = [
     pytest.mark.integration,
@@ -63,6 +69,10 @@ _PAID_TASK = (
     REPO_ROOT
     / "examples/native/tool_use/dataset/tasks/tool_use/tool_use_public_example_01/task.yaml"
 )
+
+# A native http_request-only pack that books a room on mock-web and reports the
+# site-issued confirmation number — the trial that functionally drives mock-web.
+_MOCK_WEB_TASK = REPO_ROOT / "examples/native/mock_web_booking/dataset/tasks/booking_01/task.yaml"
 
 
 @pytest.fixture(scope="module", params=["local", "published"])
@@ -144,19 +154,16 @@ def _models(provider: str, model: str) -> dict[str, dict[str, Any]]:
     }
 
 
-@pytest.mark.requires_api
-@pytest.mark.llm
-def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> None:
-    """One real bundled trial drives to a graded ``TrialResult`` through the stack.
+def _run_trial_through_stack(handle: StackHandle, task_path: Path) -> TrialResult:
+    """Drive one real trial to a ``TrialResult`` through the composed runner.
 
-    The trial runs over the ADR-0024 ``run-trial`` exec wire inside the composed
-    runner: the task pack is copied into the container so the wire task's relative
-    file assets resolve, and ``EXECUTOR_ADDRESS`` points the shared runtime at the
-    runner's own gRPC server. Exactly one ``result`` wire line must carry a
-    completed, graded ``TrialResult``.
+    Skips unless the stack is local-mode and a provider key is available. Copies
+    the task pack into the runner so the wire task's relative file assets resolve,
+    runs ``tolokaforge run-trial`` with ``EXECUTOR_ADDRESS`` pointed at the runner's
+    own gRPC server, and returns the single ``result`` wire line's ``TrialResult``.
     """
-    if composed_stack.mode != "local":
-        pytest.skip("the paid bundled trial runs against the local-mode stack")
+    if handle.mode != "local":
+        pytest.skip("the paid trial runs against the local-mode stack")
     provider = _pick_provider()
     if provider is None:
         pytest.skip("needs an ANTHROPIC or OPENROUTER key")
@@ -164,7 +171,7 @@ def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> No
     from tolokaforge.adapters._task_loader import load_task_yaml
     from tolokaforge.core.trial import TrialResult
 
-    task, task_dir = load_task_yaml(_PAID_TASK)
+    task, task_dir = load_task_yaml(task_path)
     start = {
         "v": 1,
         "type": "start",
@@ -175,13 +182,11 @@ def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> No
     }
 
     container_task_dir = f"/tmp/{task_dir.name}"
-    copied = compose(
-        composed_stack.project, ["cp", str(task_dir), "runner:/tmp/"], composed_stack.tag
-    )
+    copied = compose(handle.project, ["cp", str(task_dir), "runner:/tmp/"], handle.tag)
     assert copied.returncode == 0, f"copying the task pack into the runner failed: {copied.stderr}"
 
     proc = compose(
-        composed_stack.project,
+        handle.project,
         [
             "exec",
             "-T",
@@ -193,7 +198,7 @@ def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> No
             "tolokaforge",
             "run-trial",
         ],
-        composed_stack.tag,
+        handle.tag,
         input_text=json.dumps(start) + "\n",
     )
     assert proc.returncode == 0, (
@@ -204,6 +209,40 @@ def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> No
     assert len(lines) == 1, f"expected exactly one wire line, got: {proc.stdout!r}"
     envelope = json.loads(lines[0])
     assert envelope["type"] == "result", f"trial did not reach a result: {envelope!r}"
-    result = TrialResult.model_validate(envelope["result"])
+    return TrialResult.model_validate(envelope["result"])
+
+
+@pytest.mark.requires_api
+@pytest.mark.llm
+def test_bundled_trial_through_composed_stack(composed_stack: StackHandle) -> None:
+    """One real bundled db-service trial drives to a graded ``TrialResult``.
+
+    The ``tool_use`` pack exercises db_query/db_update plus the filesystem tools
+    over the ``run-trial`` exec wire, proving db-service participates in a real
+    graded trial through the composed stack.
+    """
+    result = _run_trial_through_stack(composed_stack, _PAID_TASK)
     assert result.trajectory.status.value == "completed", result.trajectory.status
     assert result.trajectory.grade is not None, "trial produced no grade"
+
+
+@pytest.mark.requires_api
+@pytest.mark.llm
+def test_mock_web_trial_through_composed_stack(composed_stack: StackHandle) -> None:
+    """One real mock-web booking trial drives to a graded pass through the stack.
+
+    The ``mock_web_booking`` pack gives the agent only ``http_request``; it books a
+    room on mock-web and reports the site-issued confirmation number. A graded pass
+    proves mock-web functionally participated — and the trajectory must show the
+    ``http_request`` round-trip to ``mock-web`` and the confirmation token, so a
+    grading regression that passes for the wrong reason is caught.
+    """
+    result = _run_trial_through_stack(composed_stack, _MOCK_WEB_TASK)
+    assert result.trajectory.status.value == "completed", result.trajectory.status
+    grade = result.trajectory.grade
+    assert grade is not None, "trial produced no grade"
+    assert grade.binary_pass is True, f"mock-web trial did not grade as a pass: {grade.reasons}"
+
+    transcript = json.dumps(result.trajectory.model_dump(mode="json"))
+    assert "mock-web" in transcript, "no http_request to mock-web appears in the trajectory"
+    assert "BKSEA12345" in transcript, "confirmation token absent — graded pass may be spurious"

--- a/tests/integration/deploy/test_standalone_compose.py
+++ b/tests/integration/deploy/test_standalone_compose.py
@@ -48,6 +48,7 @@ from tests.integration.deploy.conftest import (
 from tests.utils.docker_helpers import wait_for_health
 
 if TYPE_CHECKING:
+    from tolokaforge.core.models import Trajectory
     from tolokaforge.core.trial import TrialResult
 
 pytestmark = [
@@ -133,6 +134,26 @@ def test_stack_runner_health_check_serving(composed_stack: StackHandle) -> None:
         client.close()
     assert health["status"] == "healthy", f"runner HealthCheck not serving: {health}"
     assert health["db_service_connected"], f"runner reports db-service disconnected: {health}"
+
+
+def _agent_posted_to_mock_web(trajectory: Trajectory) -> bool:
+    """True when an assistant ``http_request`` tool call POSTed to mock-web.
+
+    Walks the assistant tool calls the grader's ``required_actions`` gate scores
+    (``Message.tool_calls`` on assistant messages) and matches the booking
+    submission itself: ``name == "http_request"``, ``method == "POST"``, target
+    host ``mock-web``. This is the round-trip, not its echo in the seed message.
+    """
+    from tolokaforge.core.models import MessageRole
+
+    for message in trajectory.messages:
+        if message.role is not MessageRole.ASSISTANT or not message.tool_calls:
+            continue
+        for call in message.tool_calls:
+            if call.name == "http_request" and call.arguments.get("method") == "POST":
+                if "mock-web" in str(call.arguments.get("url", "")):
+                    return True
+    return False
 
 
 def _pick_provider() -> tuple[str, str] | None:
@@ -233,9 +254,11 @@ def test_mock_web_trial_through_composed_stack(composed_stack: StackHandle) -> N
 
     The ``mock_web_booking`` pack gives the agent only ``http_request``; it books a
     room on mock-web and reports the site-issued confirmation number. A graded pass
-    proves mock-web functionally participated — and the trajectory must show the
-    ``http_request`` round-trip to ``mock-web`` and the confirmation token, so a
-    grading regression that passes for the wrong reason is caught.
+    proves mock-web functionally participated. The assertions then independently
+    re-check the round-trip so a grading regression that passes for the wrong reason
+    is caught: an assistant ``http_request`` POST to ``mock-web`` must appear in the
+    tool calls (not merely the seed-message URL), and the site-issued confirmation
+    token — which enters the transcript only via the POST response — must be present.
     """
     result = _run_trial_through_stack(composed_stack, _MOCK_WEB_TASK)
     assert result.trajectory.status.value == "completed", result.trajectory.status
@@ -243,6 +266,9 @@ def test_mock_web_trial_through_composed_stack(composed_stack: StackHandle) -> N
     assert grade is not None, "trial produced no grade"
     assert grade.binary_pass is True, f"mock-web trial did not grade as a pass: {grade.reasons}"
 
+    assert _agent_posted_to_mock_web(result.trajectory), (
+        "no assistant http_request POST to mock-web in the tool calls — "
+        "the booking round-trip did not happen"
+    )
     transcript = json.dumps(result.trajectory.model_dump(mode="json"))
-    assert "mock-web" in transcript, "no http_request to mock-web appears in the trajectory"
     assert "BKSEA12345" in transcript, "confirmation token absent — graded pass may be spurious"


### PR DESCRIPTION
## Summary
- The four first-party images were only health-probed end-to-end; **mock-web** was never functionally driven by a real trial through the composed stack. This adds that coverage.
- New native pack `examples/native/mock_web_booking/`: the agent has **only `http_request`**, books a room on the standalone `mock-web` peer (`http://mock-web:8080/booking`, submitted as form fields), and reports the site-issued confirmation number.
- Keyless canonical shape lock + a gated deploy integration test that drives the pack through the composed stack over the `run-trial` exec wire and asserts a **graded pass** with the round-trip evidence.

## Scope note — rag deferred
#649 asked for rag-service coverage too, but that is **hard-blocked by #107** (the native adapter hardcodes `SearchConfig(enabled=False)`, so `search_kb`'s per-trial index is never populated) — a feature, not coverage. Deferred behind #107; this PR delivers the mock-web half. (Also filed: #652 vestigial rag config in the recipe.)

## Design choices
- **Deterministic transcript grading, not lot_ops's precedent**: `combine: {weights: {transcript_rules: 1.0}, pass_threshold: 1.0}` — NO `state_checks`/`llm_judge` (an http_request-only agent can't satisfy a db-probe/judge → would be a permanent red). Two product-scored gates: a `method: POST` required-action gate (not exact-URL, which is brittle) + `must_contain: BKSEA12345`.
- **Confirmation token as the graded value**: `BKSEA12345` only appears in the mock-web POST response, so a pass proves the round-trip happened (not guessable).
- **DRY**: a shared `_run_trial_through_stack` helper backs both the bundled db-service trial and the new mock-web trial.

## Concepts introduced
None beyond an additive example pack + its tests. No harness/service/recipe change.

## Test plan
- Keyless canonical `tests/canonical/test_mock_web_example_pack.py` (3 tests) — pack shape/grading lock, every PR.
- Gated `tests/integration/deploy/test_standalone_compose.py::test_mock_web_trial_through_composed_stack` (`requires_api`+`requires_docker`+`slow`+`llm`).
- **Verified locally: `1 passed`** — the agent booked via `http_request`, the trial reached `completed` with `binary_pass is True`, and the trajectory contained `mock-web` + `BKSEA12345`.

## Dependency for the gated trial
The gated trial's stack bring-up needs rag-service healthy. rag's healthcheck `start-period` is too tight (**#659**) — it flakes "unhealthy" under a 4-container cold start (hits the existing bundled trial too). #659 should land for reliable bring-up. (Local verification here used a widened rag healthcheck override, not committed.) On arm64 dev hosts the local lane also needs `TOLOKAFORGE_PLATFORM=linux/arm64` (**#658**).

Closes #649