### PR TITLE
fix(docker): widen rag-service healthcheck start-period for model load

### DIFF
--- a/tests/canonical/test_rag_healthcheck.py
+++ b/tests/canonical/test_rag_healthcheck.py
@@ -1,0 +1,44 @@
+"""Guards the rag-service Docker HEALTHCHECK grace period.
+
+rag-service eagerly loads the ``all-MiniLM-L6-v2`` embedding model at startup
+(~45s standalone, longer under container contention). Docker only begins
+counting probe failures toward ``--retries`` once ``--start-period`` elapses, so
+a too-short grace makes ``docker compose up --wait`` declare the still-loading
+container unhealthy and abort the whole stack bring-up. This pins the grace at
+a model-load-safe floor so a regression to the old 5s trips CI without a Docker
+daemon.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RAG_DOCKERFILE = _REPO_ROOT / "tolokaforge" / "docker" / "dockerfiles" / "rag.Dockerfile"
+
+_MIN_START_PERIOD_SECONDS = 90
+
+_START_PERIOD_RE = re.compile(r"--start-period=(\d+)s\b")
+
+
+def test_rag_healthcheck_start_period_covers_model_load() -> None:
+    text = _RAG_DOCKERFILE.read_text()
+    assert "HEALTHCHECK" in text, f"{_RAG_DOCKERFILE} has no HEALTHCHECK to guard"
+
+    match = _START_PERIOD_RE.search(text)
+    assert match is not None, (
+        f"{_RAG_DOCKERFILE.name} HEALTHCHECK has no `--start-period=<n>s` — the probe would "
+        "start enforcing immediately and fail the stack while the embedding model loads"
+    )
+
+    start_period = int(match.group(1))
+    assert start_period >= _MIN_START_PERIOD_SECONDS, (
+        f"{_RAG_DOCKERFILE.name} HEALTHCHECK --start-period={start_period}s is below the "
+        f"{_MIN_START_PERIOD_SECONDS}s model-load floor — `compose up --wait` would mark rag "
+        "unhealthy before all-MiniLM-L6-v2 finishes loading"
+    )

--- a/tolokaforge/docker/dockerfiles/rag.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/rag.Dockerfile
@@ -36,7 +36,13 @@ ENV PYTHONUNBUFFERED=1
 EXPOSE 8001
 
 # python-urllib probe avoids a curl dependency on the slim base.
-HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=5s \
+# start-period is long because the service eagerly loads the all-MiniLM-L6-v2
+# embedding model at startup (~45s standalone, longer under container
+# contention). Probe failures during start-period don't count toward retries,
+# so a healthy rag still flips to healthy the instant /health returns 200 — the
+# only effect of the wide grace is to stop `compose up --wait` from declaring a
+# still-loading container unhealthy before the model finishes.
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=120s \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
## Summary
- rag-service eagerly loads the `all-MiniLM-L6-v2` model at startup (~45s+, longer under contention), but its `HEALTHCHECK` had `--start-period=5s` (interval 10s, retries 3) — Docker marked it **unhealthy at ~35s**, before the model loaded. `docker compose up --wait` fails *fast* on any unhealthy container, so the standalone stack bring-up flakes ("rag-service is unhealthy") for cold users **and** for every deploy-suite local paid trial (the existing bundled trial too — reproduced during #649).
- Raise `--start-period` to `120s` (other healthcheck params + probe unchanged).

## Design choices
- **`start-period` only delays *enforcement***: failures during it don't count toward `retries`, and a healthy rag still reports healthy the instant `/health` returns 200 — so a longer grace has no downside for a healthy start, it only prevents the premature-unhealthy race.
- **Keyless lock with a 90s floor, not an exact pin**: `tests/canonical/test_rag_healthcheck.py` asserts start-period ≥ 90s (safely above the ~45s cold load), so a regression to a too-short grace trips CI without pinning the exact value.

## Impact
- Fixes the **next** rag image build; the already-published `v0.11.2` rag still ships `start-period=5s` (fixed on next release). db-service/mock-web/runner load nothing heavy at startup — their 5s is correct and untouched.

## Test plan
- `tests/canonical/test_rag_healthcheck.py` (keyless canonical) — negative-checked: fails on `5s`, passes on `120s`.

Closes #659