### PR TITLE
test(deploy): pin host platform for local-image stack bring-up (arm64)

### DIFF
--- a/tests/integration/deploy/conftest.py
+++ b/tests/integration/deploy/conftest.py
@@ -17,6 +17,7 @@ present locally instead of pulling from the registry.
 from __future__ import annotations
 
 import os
+import platform
 import re
 import subprocess
 import time
@@ -35,6 +36,17 @@ COMPOSE_FILE = REPO_ROOT / "deploy" / "standalone" / "docker-compose.yaml"
 HEALTHY_TIMEOUT_S = 120.0
 _POLL_INTERVAL_S = 2.0
 _TRUTHY = frozenset({"1", "true", "yes"})
+
+# Locally-built images are tagged ``:local`` and carry the build host's native
+# architecture, unlike the published amd64-only images the compose default
+# targets.
+_LOCAL_TAG = "local"
+_MACHINE_TO_PLATFORM: dict[str, str] = {
+    "arm64": "linux/arm64",
+    "aarch64": "linux/arm64",
+    "x86_64": "linux/amd64",
+    "amd64": "linux/amd64",
+}
 
 # The runner image's own HEALTHCHECK treats the gRPC server as serving once a
 # client channel becomes ready; reused verbatim so the debugging-runbook health
@@ -69,6 +81,31 @@ class StackHandle:
     tag: str
 
 
+def _host_platform() -> str:
+    """Docker platform string matching the host CPU (via ``platform.machine()``)."""
+    machine = platform.machine().lower()
+    try:
+        return _MACHINE_TO_PLATFORM[machine]
+    except KeyError:
+        raise RuntimeError(f"unsupported host architecture: {machine!r}") from None
+
+
+def _compose_env(tag: str) -> dict[str, str]:
+    """Subprocess env for ``docker compose`` at ``tag``.
+
+    ``TOLOKAFORGE_IMAGE_TAG`` rides the env (Compose interpolation reads it with
+    precedence over any sibling ``.env``), so the keyless lane needs no ``.env``
+    file — provider keys, when present, are inherited from ``os.environ`` the same
+    way. The ``:local`` tag holds native-arch images, so its platform is pinned to
+    the host arch to match; an explicit ``TOLOKAFORGE_PLATFORM`` is never
+    overridden, and other tags keep the recipe's amd64 default.
+    """
+    env = {**os.environ, "TOLOKAFORGE_IMAGE_TAG": tag}
+    if tag == _LOCAL_TAG and "TOLOKAFORGE_PLATFORM" not in os.environ:
+        env["TOLOKAFORGE_PLATFORM"] = _host_platform()
+    return env
+
+
 def compose(
     project: str,
     args: list[str],
@@ -77,14 +114,8 @@ def compose(
     input_text: str | None = None,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``docker compose`` against the standalone recipe for one project.
-
-    ``TOLOKAFORGE_IMAGE_TAG`` rides the subprocess env (Compose interpolation
-    reads it with precedence over any sibling ``.env``), so the keyless lane needs
-    no ``.env`` file — provider keys, when present, are inherited from
-    ``os.environ`` the same way.
-    """
-    env = {**os.environ, "TOLOKAFORGE_IMAGE_TAG": tag}
+    """Run ``docker compose`` against the standalone recipe for one project."""
+    env = _compose_env(tag)
     return subprocess.run(
         ["docker", "compose", "-p", project, "-f", str(COMPOSE_FILE), *args],
         capture_output=True,

--- a/tests/unit/test_deploy_compose_platform.py
+++ b/tests/unit/test_deploy_compose_platform.py
@@ -1,0 +1,52 @@
+"""Platform selection in the deploy suite's compose env assembly."""
+
+import pytest
+
+from tests.integration.deploy import conftest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("arm64", "linux/arm64"),
+        ("aarch64", "linux/arm64"),
+        ("ARM64", "linux/arm64"),
+        ("x86_64", "linux/amd64"),
+        ("amd64", "linux/amd64"),
+    ],
+)
+def test_host_platform_maps_machine(
+    monkeypatch: pytest.MonkeyPatch, machine: str, expected: str
+) -> None:
+    monkeypatch.setattr(conftest.platform, "machine", lambda: machine)
+    assert conftest._host_platform() == expected
+
+
+def test_host_platform_rejects_unknown_machine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(conftest.platform, "machine", lambda: "sparc")
+    with pytest.raises(RuntimeError, match="unsupported host architecture"):
+        conftest._host_platform()
+
+
+def test_local_tag_pins_host_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TOLOKAFORGE_PLATFORM", raising=False)
+    monkeypatch.setattr(conftest.platform, "machine", lambda: "arm64")
+    env = conftest._compose_env("local")
+    assert env["TOLOKAFORGE_IMAGE_TAG"] == "local"
+    assert env["TOLOKAFORGE_PLATFORM"] == "linux/arm64"
+
+
+def test_local_tag_preserves_explicit_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOLOKAFORGE_PLATFORM", "linux/amd64")
+    monkeypatch.setattr(conftest.platform, "machine", lambda: "arm64")
+    env = conftest._compose_env("local")
+    assert env["TOLOKAFORGE_PLATFORM"] == "linux/amd64"
+
+
+def test_published_tag_leaves_platform_to_recipe_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TOLOKAFORGE_PLATFORM", raising=False)
+    monkeypatch.setattr(conftest.platform, "machine", lambda: "arm64")
+    env = conftest._compose_env("latest")
+    assert "TOLOKAFORGE_PLATFORM" not in env


### PR DESCRIPTION
## Summary
- The deploy suite's `compose()` set `TOLOKAFORGE_IMAGE_TAG` but never `TOLOKAFORGE_PLATFORM`. The standalone recipe pins `platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}` (default amd64), and `build_and_tag_local()` builds images **natively** (arm64 on Apple Silicon) with no `--platform` — so `compose up` on an arm64 dev host demanded amd64, found arm64, and errored at the `composed_stack` fixture ("does not match the specified platform"). Every local-lane deploy test failed on arm64; CI (amd64) was unaffected (host arch already matched).
- Fix: `compose()` now injects `TOLOKAFORGE_PLATFORM = <host arch>` for the `:local` tag, so the requested platform matches the natively-built images.

## Design choices
- **Keyed on the `:local` tag** (the only path that reaches `compose()` with native-built images) — pulled published images (any other tag) keep the amd64 default, and the `TOLOKAFORGE_SMOKE_IMAGE_LOCAL` `docker run` path bypasses `compose()` entirely.
- **Explicit override preserved**: a pre-set `TOLOKAFORGE_PLATFORM` is never clobbered.
- **Fail-fast on unknown arch** (`_host_platform()` raises) rather than silently defaulting to amd64 and reintroducing the mismatch.
- **`_compose_env()` seam** makes the env assembly unit-testable without Docker.

## Impact
- CI (amd64): no change (host arch == amd64 == prior default).
- arm64 dev hosts: the deploy local lane now brings the stack up without a manual `TOLOKAFORGE_PLATFORM=linux/arm64` export. (Full local bring-up also needs the rag healthcheck fix #661/#659.)

## Test plan
- `tests/unit/test_deploy_compose_platform.py` (keyless unit, 9 cases): arch mapping (+ case-insensitivity), unknown-arch raises, `:local` pins host platform, explicit override preserved, non-local tag leaves the recipe default.

Closes #658