### PR TITLE
docs: fix broken ADR-0019 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install "tolokaforge[browser]"     # + Playwright
 pip install "tolokaforge[all]"         # everything
 ```
 
-The `[dx]` extras install the terminal front-end that owns the `tolokaforge` CLI — Rich panels, banners, and the Click command tree. Without them the library still imports (`from tolokaforge.core.orchestrator import Orchestrator`), and the `tolokaforge` console script prints an install hint pointing at `pip install 'tolokaforge[dx]'`. Front-end pluggability is recorded in [ADR-0019](docs/architecture/adr/0019-front-end-plugin-namespace.md).
+The `[dx]` extras install the terminal front-end that owns the `tolokaforge` CLI — Rich panels, banners, and the Click command tree. Without them the library still imports (`from tolokaforge.core.orchestrator import Orchestrator`), and the `tolokaforge` console script prints an install hint pointing at `pip install 'tolokaforge[dx]'`. Front-end pluggability is recorded in [ADR-0019](docs/adr/0019-front-end-plugin-namespace.md).
 
 Dev install:
 


### PR DESCRIPTION
## Summary
README line 25 linked `docs/architecture/adr/0019-front-end-plugin-namespace.md`, but ADRs live under `docs/adr/` (no `docs/architecture/` dir exists) — the link 404s. Corrected to `docs/adr/0019-front-end-plugin-namespace.md` (verified the file exists). It was the only `docs/architecture/adr` ref in the repo; the sibling ADR-0018 link (line 176) already used the correct path.

## Concepts introduced
None — one broken-link correction.

Closes #657