### PR TITLE
feat(adapters): make rag-service search_kb functional for native tasks (#107)

### DIFF
--- a/docs/FINAL_AUDIT.md
+++ b/docs/FINAL_AUDIT.md
@@ -411,8 +411,7 @@ networks:
 
 ### Post-Merge (Future Work)
 
-1. **RAG Integration Test** - Add e2e test for search_kb tool
-2. **Structured Logging Migration** - Convert f-string logs to structured format
+1. **Structured Logging Migration** - Convert f-string logs to structured format
 
 ---
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -84,7 +84,15 @@ description: "Add a POST /orders endpoint backed by the orders table."
 - `json_db`: JSON file loaded into the JSON DB service. Use this for any task state that needs to be verified by grading.
 - `filesystem.copy`: files copied into `/env/fs/agent-visible`.
 - `mock_web.base_url`: base URL for mock web service (`http://mock-web:8080`).
-- `rag.corpus_dir`: directory of `.txt` files for RAG indexing.
+- `rag.corpus_dir`: directory of knowledge-base documents for per-trial RAG
+  indexing. The reader indexes the `.md` and `.txt` files sitting directly in
+  that directory (flat, non-recursive). Declaring `corpus_dir` requires
+  `search_kb` in `tools.agent.enabled` — the corpus files travel with the task,
+  the runner indexes them into the rag-service per trial, and the agent's
+  `search_kb` tool queries that index. The full stack must include the
+  rag-service (reached by DNS, like `db-service`/`mock-web`). Declaring
+  `corpus_dir` without `search_kb`, or pointing it at a directory that does not
+  exist, is rejected at validation time.
 
 ## Multi-container environments (`environment_manifest`)
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -16,7 +16,9 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
 - `db_update`: JSONPath updates against JSON DB service.
 - `sql_query`: SQL query against JSON DB service.
 - `get_db_schema`: SQL schema inspection for JSON DB tables.
-- `search_kb`: RAG search over indexed corpus.
+- `search_kb`: RAG search over a per-trial corpus index. Functional for native
+  tasks — declare `initial_state.rag.corpus_dir` and the runner indexes that
+  corpus into the rag-service per trial (see `docs/TASKS.md`).
 - `http_request`: Restricted HTTP client for mock web services.
 - `calculator`: Safe arithmetic calculator.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ by adapter type.
     │   ├── coding/                      # file-write grading
     │   ├── mock_web_booking/            # http_request against the mock-web service
     │   ├── native_shared_domain/        # _shared/domain.yaml pattern (FastMCP)
+    │   ├── rag_search/                  # search_kb against the rag-service
     │   └── tool_use/                    # structured tool-call grading
     └── terminal_bench/                  # `terminal_bench` adapter (Docker compose)
         ├── fix-billing-holds/
@@ -23,6 +24,9 @@ by adapter type.
 - **HTTP against a service**: see `native/mock_web_booking/` — `http_request`
   drives the mock-web service and grading locks a mock-web-issued token (needs
   Docker for mock-web).
+- **Knowledge-base retrieval**: see `native/rag_search/` — `search_kb` retrieves
+  a planted fact from a per-trial rag-service index and grading locks that
+  retrieval-only token (needs Docker with the full stack for the rag-service).
 - **Browser tasks**: see `native/browser_task/` (needs Docker for mock-web).
 - **Terminal-bench tasks** (Docker compose + `tests/test.sh`): see
   `terminal_bench/`.

--- a/examples/native/rag_search/README.md
+++ b/examples/native/rag_search/README.md
@@ -1,0 +1,76 @@
+# RAG search — `search_kb` against a first-party service
+
+A single-task native pack that drives the first-party **rag-service** over the
+`search_kb` builtin. The agent retrieves an operations fact from a per-trial
+knowledge-base index and reports it; grading is deterministic and
+keyless-gradable in shape — it asserts a knowledge-base search happened and that
+a retrieval-only fact appears in the transcript.
+
+```
+agent → search_kb → rag-service  (/trials/{id}/search over the per-trial index)
+```
+
+## What this example demonstrates
+
+- **`search_kb` against a composed peer, no `environment_manifest`.** The task
+  enables `search_kb` and declares its corpus via `initial_state.rag.corpus_dir`
+  (`rag/corpus`). The corpus's `.md` files travel with the task in
+  `tool_artifacts` and are indexed into the rag-service per trial; the
+  rag-service is reached by Docker DNS on the full standalone stack
+  (`deploy/standalone/docker-compose.yaml`), the same way `mock_web_booking`
+  reaches mock-web — the runner's own network wires the peer, not a per-task
+  manifest.
+- **A retrieval-only fact.** The Halden substation's emergency failover
+  authorization code, `HX49-QORVEN-7731`, lives in exactly one corpus document
+  and on no agent-visible surface — not the task text, not any initial state.
+  The only way the agent can obtain it is a real `search_kb` retrieval, so a
+  guessed or hallucinated answer cannot pass.
+- **Deterministic grading on the retrieval outcome.** Grading is
+  transcript-only:
+
+  | Check | What it asserts |
+  |---|---|
+  | `required_actions` (`search_kb`) | the agent searched the knowledge base — the rag-service round-trip actually happened |
+  | `must_contain: HX49-QORVEN-7731` | the retrieved authorization code is reported |
+
+  Both are product-scored under `transcript_rules` with `pass_threshold: 1.0`,
+  so dropping either — a no-search trajectory, or a missing code — fails the
+  task.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/rag_search/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/rag_search/run_configs/dev.yaml
+```
+
+Needs a running Docker daemon with the standalone stack up on the full profile
+(so the rag-service is reachable on the runner network) and `OPENROUTER_API_KEY`
+in `.env`.
+
+## Layout
+
+```
+examples/native/rag_search/
+├── run_configs/dev.yaml          # haiku agent + user, no judge
+├── project.yaml                  # discovery glob + native defaults
+├── README.md                     # this file
+└── dataset/tasks/kb_lookup_01/
+    ├── task.yaml                 # search_kb-only, corpus via initial_state.rag
+    ├── grading.yaml              # transcript-only: search_kb gate + retrieval-fact token
+    └── rag/corpus/               # tiny KB corpus; the planted fact is in one doc
+```
+
+## Related
+
+- [`docs/GRADING.md`](../../../docs/GRADING.md) — grading families, including
+  `transcript_rules.required_actions` and `must_contain`
+- [`docs/TASKS.md`](../../../docs/TASKS.md) — `initial_state.rag.corpus_dir` and
+  per-trial RAG indexing
+- [`docs/STANDALONE_RUNNER.md`](../../../docs/STANDALONE_RUNNER.md) — the
+  composed standalone stack this pack runs against

--- a/examples/native/rag_search/dataset/tasks/kb_lookup_01/grading.yaml
+++ b/examples/native/rag_search/dataset/tasks/kb_lookup_01/grading.yaml
@@ -1,0 +1,29 @@
+# Deterministic, keyless-gradable grading for kb_lookup_01.
+#
+# transcript_rules is the only family (weight 1.0, pass_threshold 1.0), and its
+# two checks are product-scored so BOTH must hold for a pass:
+#   required_actions — the agent called `search_kb` (proves the rag-service
+#     participated; a no-search trajectory fails). compare_args: [] gates on
+#     the call's presence, not any particular query string.
+#   must_contain     — the planted authorization code `HX49-QORVEN-7731`
+#     appears in the transcript. The code exists only in one corpus document
+#     and on no agent-visible surface (not the task text, not any initial
+#     state), so the agent can only obtain it through a real `search_kb`
+#     retrieval. Paired with the search_kb gate, this locks the answer to the
+#     rag-service round-trip.
+combine:
+  method: weighted
+  weights:
+    transcript_rules: 1.0
+  pass_threshold: 1.0
+
+transcript_rules:
+  max_turns: 5
+  must_contain:
+    - "HX49-QORVEN-7731"
+  required_actions:
+    - action_id: "searched_knowledge_base"
+      requestor: assistant
+      name: search_kb
+      arguments: {}
+      compare_args: []

--- a/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/contacts.md
+++ b/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/contacts.md
@@ -1,0 +1,12 @@
+# Operations Contacts
+
+On-call contacts for the northern grid operations desk.
+
+- **Grid operations desk (24/7):** extension 4400.
+- **Halden substation site lead:** extension 4412.
+- **Skjold substation site lead:** extension 4418.
+- **SCADA console support:** extension 4470.
+
+For any emergency failover, follow the substation emergency procedures and
+enter the substation's authorization code before calling the site lead to
+confirm. The operations desk cannot read authorization codes over the phone.

--- a/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/maintenance_windows.md
+++ b/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/maintenance_windows.md
@@ -1,0 +1,14 @@
+# Maintenance Windows
+
+Scheduled maintenance windows for the northern grid substations are planned
+quarterly and published to the operations calendar.
+
+- **Halden substation:** first Tuesday of each quarter, 02:00–05:00 local time.
+- **Skjold substation:** second Tuesday of each quarter, 02:00–05:00 local time.
+
+During a maintenance window the substation runs on its backup feeder. Operators
+should confirm the failover has completed cleanly before starting any work and
+should never begin maintenance on a substation still carrying primary load.
+
+Authorization codes and failover procedures are documented separately in the
+substation emergency procedures; this calendar covers timing only.

--- a/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/substation_procedures.md
+++ b/examples/native/rag_search/dataset/tasks/kb_lookup_01/rag/corpus/substation_procedures.md
@@ -1,0 +1,25 @@
+# Substation Emergency Procedures
+
+This document covers emergency operating procedures for the northern grid
+substations.
+
+## Halden Substation — Emergency Failover
+
+Before initiating a manual failover of the Halden substation, an operator must
+enter the substation's emergency failover authorization code into the SCADA
+console. This code gates the manual transfer to the backup feeder and is
+rotated each maintenance quarter.
+
+The current emergency failover authorization code for the Halden substation is
+**HX49-QORVEN-7731**. Enter it exactly as written; the console rejects
+transposed or truncated codes and locks the operator out after three failed
+attempts.
+
+Once the code is accepted, the console walks the operator through the feeder
+transfer sequence and logs the drill against the substation's compliance
+record.
+
+## Skjold Substation — Emergency Failover
+
+The Skjold substation uses a separate authorization flow tied to its regional
+control centre; see the regional operations handbook for its procedure.

--- a/examples/native/rag_search/dataset/tasks/kb_lookup_01/task.yaml
+++ b/examples/native/rag_search/dataset/tasks/kb_lookup_01/task.yaml
@@ -1,0 +1,31 @@
+task_id: "kb_lookup_01"
+name: "Retrieve the Halden Substation Failover Authorization Code from the Knowledge Base"
+category: "rag_search"
+description: "The agent answers an operations question that can only be resolved by searching the knowledge base: find and report the emergency failover authorization code for the Halden substation, a code that appears only in the KB corpus and on no other agent-visible surface."
+max_turns: 5
+adapter_type: "native"
+initial_user_message: |
+  We're prepping a failover drill for the Halden substation and I can't
+  remember the emergency failover authorization code — it lives in our
+  operations knowledge base, not anywhere I have to hand. Can you look it up
+  and tell me the exact code? Search the knowledge base for the Halden
+  substation's emergency failover procedure and report the authorization code
+  it lists.
+initial_state:
+  rag:
+    corpus_dir: "rag/corpus"
+tools:
+  agent:
+    enabled: ["search_kb"]
+  user:
+    enabled: []
+actors:
+  user:
+    mode: llm
+    persona: cooperative
+    backstory: "You are a grid operations engineer prepping a failover drill and need the Halden substation's emergency failover authorization code. That code lives only in the operations knowledge base — you do not know it yourself, so do not guess it or supply it. Answer brief clarifying questions plainly (it is the Halden substation, the emergency failover authorization code). End with ###STOP### once the agent reports the exact code."
+policies:
+  guidance:
+    - "The failover authorization code is not in this conversation — it lives only in the operations knowledge base. Use the `search_kb` tool to find the Halden substation's emergency failover procedure."
+    - "Report the exact authorization code the knowledge base lists; do not invent or approximate it."
+grading: "grading.yaml"

--- a/examples/native/rag_search/project.yaml
+++ b/examples/native/rag_search/project.yaml
@@ -1,0 +1,31 @@
+# Project spec for the rag_search example.
+#
+# A single native task that drives the first-party rag-service over the
+# `search_kb` builtin: the agent searches a per-trial knowledge-base index for
+# an operations fact and reports it. The task declares a corpus via
+# `initial_state.rag.corpus_dir`; the corpus travels with the task and is
+# indexed into the rag-service per trial. The task declares no
+# `environment_manifest` — the rag-service is reached by Docker DNS on the
+# composed standalone stack (deploy/standalone/docker-compose.yaml), the same
+# way the mock_web_booking pack reaches mock-web.
+#
+# See docs/PROJECTS.md for the full Project model.
+
+name: "rag-search"
+version: 1
+description: >
+  Single-task project demonstrating search_kb against the first-party
+  rag-service: the agent retrieves a planted operations fact from a per-trial
+  knowledge-base index and reports it, graded deterministically on that
+  retrieval-only token.
+
+tasks:
+  discovery:
+    glob: "dataset/tasks/**/task.yaml"
+
+task_defaults:
+  adapter_type: "native"
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/rag_search/run_configs/dev.yaml
+++ b/examples/native/rag_search/run_configs/dev.yaml
@@ -1,0 +1,38 @@
+# RAG search example — search_kb against the first-party rag-service,
+# deterministic retrieval-fact grading.
+#
+#   agent → search_kb → rag-service (/trials/{id}/search over the per-trial index)
+#
+# Two model roles: the `agent` under test and the `user` simulator. Grading is
+# transcript-only (no judge), so no judge model is needed.
+#
+# Requirements:
+#   - Docker daemon running with the standalone stack up on the full profile
+#     (rag-service reachable on the runner network).
+#   - OPENROUTER_API_KEY in .env.
+#
+# Run:
+#   scripts/with_env.sh uv run tolokaforge run --config examples/native/rag_search/run_configs/dev.yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-haiku-4-5"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 5
+  runtime: shared
+  queue_backend: sqlite
+
+evaluation:
+  projects:
+    - "examples/native/rag_search/dataset"
+  tasks_glob: "tasks/kb_lookup_01/task.yaml"
+  output_dir: "results/rag_search_example"

--- a/tests/canonical/test_native_rag_task_description.py
+++ b/tests/canonical/test_native_rag_task_description.py
@@ -1,0 +1,86 @@
+"""Keyless shape lock for the native RAG cross-stage contract.
+
+The ``TaskDescription`` a native RAG pack serializes is the wire the runner
+consumes to index the per-trial corpus (issue #107). This locks that contract at
+the serialization boundary — the shape Stage 2's runner resolves against:
+
+- ``search.enabled`` is ``True`` with ``documents_path`` equal to the pack's
+  declared ``corpus_dir`` **verbatim** (the pinned convention the runner resolves
+  as ``artifacts_dir / documents_path``);
+- the corpus ``.md``/``.txt`` files ride in ``tool_artifacts`` under that same
+  ``corpus_dir`` prefix, and nothing else does (never ``grading.yaml`` — it can
+  carry the planted retrieval fact);
+- the ``search_kb`` agent tool advertises the real ``{query, top_k, alpha}``
+  schema, source-less so the runner reconstructs it as a RAG wrapper.
+
+Keyless — trips on adapter rot without Docker or a provider key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.canonical._factories import write_yaml_file
+from tolokaforge.adapters.native import NativeAdapter
+
+pytestmark = pytest.mark.canonical
+
+_PLANTED_FACT = "Warehouse SKU QX-4410 ships in refrigerated crates only."
+
+
+def _write_rag_pack(tmp_path: Path) -> NativeAdapter:
+    task_dir = tmp_path / "tasks" / "rag_shape"
+    corpus_dir = task_dir / "rag" / "corpus"
+    corpus_dir.mkdir(parents=True)
+    (corpus_dir / "handbook.md").write_text(f"# Handbook\n\n{_PLANTED_FACT}\n")
+    (corpus_dir / "notes.txt").write_text("Cold-chain logistics notes.\n")
+    (task_dir / "system_prompt.md").write_text("system\n")
+    (task_dir / "initial_state.json").write_text("{}")
+    write_yaml_file(
+        task_dir / "task.yaml",
+        {
+            "task_id": "rag_shape",
+            "name": "rag shape",
+            "category": "rag_search",
+            "description": "rag shape lock",
+            "initial_state": {"json_db": "initial_state.json", "rag": {"corpus_dir": "rag/corpus"}},
+            "tools": {
+                "agent": {"enabled": ["search_kb", "submit_report"]},
+                "user": {"enabled": []},
+            },
+            "actors": {"user": {"mode": "llm", "persona": "cooperative"}},
+            "grading": "grading.yaml",
+            "system_prompt": "system_prompt.md",
+        },
+    )
+    write_yaml_file(
+        task_dir / "grading.yaml",
+        {
+            "combine": {
+                "method": "weighted",
+                "weights": {"state_checks": 1.0},
+                "pass_threshold": 0.5,
+            },
+            "components": {"state_checks": {"jsonpaths": []}},
+        },
+    )
+    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+
+
+def test_native_rag_pack_serializes_search_and_corpus(tmp_path: Path) -> None:
+    adapter = _write_rag_pack(tmp_path)
+    payload = adapter.to_task_description("rag_shape").model_dump(mode="json")
+
+    assert payload["search"]["enabled"] is True
+    assert payload["search"]["documents_path"] == "rag/corpus"
+    assert payload["search"]["domain_name"] == "rag_search"
+
+    artifacts = payload["tool_artifacts"]
+    assert set(artifacts) == {"rag/corpus/handbook.md", "rag/corpus/notes.txt"}
+
+    search_kb = next(t for t in payload["agent_tools"] if t["name"] == "search_kb")
+    assert search_kb["source"] is None
+    assert search_kb["parameters"]["required"] == ["query"]
+    assert set(search_kb["parameters"]["properties"]) == {"query", "top_k", "alpha"}

--- a/tests/canonical/test_native_rag_task_description.py
+++ b/tests/canonical/test_native_rag_task_description.py
@@ -1,8 +1,8 @@
 """Keyless shape lock for the native RAG cross-stage contract.
 
 The ``TaskDescription`` a native RAG pack serializes is the wire the runner
-consumes to index the per-trial corpus (issue #107). This locks that contract at
-the serialization boundary — the shape Stage 2's runner resolves against:
+consumes to index the per-trial corpus. This locks that contract at the
+serialization boundary — the shape the runner resolves against:
 
 - ``search.enabled`` is ``True`` with ``documents_path`` equal to the pack's
   declared ``corpus_dir`` **verbatim** (the pinned convention the runner resolves

--- a/tests/canonical/test_rag_example_pack.py
+++ b/tests/canonical/test_rag_example_pack.py
@@ -1,0 +1,132 @@
+"""Keyless shape lock for the ``rag_search`` example pack.
+
+The pack (``examples/native/rag_search/``) drives the first-party rag-service
+over ``search_kb`` and grades on a fact that lives only in the knowledge-base
+corpus. This guard runs on every PR without Docker or a provider key: it loads
+the pack through the same loaders the CLI uses and asserts the load-bearing
+shape — the ``search_kb`` tool, the corpus declaration and its non-empty
+contents, and the two transcript gates that make grading meaningful. Crucially
+it asserts the planted retrieval fact is on **no agent-visible surface**, so the
+task cannot be passed without a real retrieval. It is a *shape* lock; the paid
+behaviour lock (a graded ``TrialResult`` through the composed stack) lives in
+the deploy integration lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.models import GradingConfig
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_ROOT = _REPO_ROOT / "examples" / "native" / "rag_search"
+_TASK_YAML = _PACK_ROOT / "dataset" / "tasks" / "kb_lookup_01" / "task.yaml"
+_GRADING_YAML = _PACK_ROOT / "dataset" / "tasks" / "kb_lookup_01" / "grading.yaml"
+
+_PLANTED_FACT = "HX49-QORVEN-7731"
+
+
+def _corpus_files(task_dir: Path, corpus_dir: str) -> list[Path]:
+    corpus_path = task_dir / corpus_dir
+    return sorted(p for pat in ("*.md", "*.txt") for p in corpus_path.glob(pat))
+
+
+def test_task_loads_and_enables_search_kb_with_a_corpus() -> None:
+    """The task validates, enables ``search_kb``, and declares a non-empty corpus.
+
+    Locks the tool contract and the corpus declaration: the pack retrieves
+    through ``search_kb`` (not a browser or bespoke tool), the corpus_dir
+    resolves, and it holds documents — so dropping the tool, removing the
+    corpus, or emptying it trips CI keylessly.
+    """
+    assert _TASK_YAML.is_file(), f"pack task.yaml is missing: {_TASK_YAML}"
+    task, task_dir = load_task_yaml(_TASK_YAML)
+
+    enabled = task.tools.agent.get("enabled")
+    assert enabled == ["search_kb"], f"agent must enable only search_kb, got: {enabled!r}"
+    assert task.tools.user.get("enabled") == [], "user must enable no tools"
+    # No per-task manifest — the rag-service is reached by DNS on the full stack.
+    assert task.environment_manifest is None, "pack must not declare an environment_manifest"
+
+    corpus_dir = (task.initial_state.rag or {}).get("corpus_dir")
+    assert corpus_dir == "rag/corpus", f"corpus_dir must be 'rag/corpus', got: {corpus_dir!r}"
+    files = _corpus_files(task_dir, corpus_dir)
+    assert files, f"corpus at {task_dir / corpus_dir} must be non-empty"
+
+
+def _load_grading() -> tuple[dict, GradingConfig]:
+    raw = yaml.safe_load(_GRADING_YAML.read_text())
+    return raw, GradingConfig(**raw)
+
+
+def test_grading_is_transcript_only_with_both_gates() -> None:
+    """Grading validates and locks the two product-scored transcript gates.
+
+    Asserts the planted-fact token, the ``search_kb`` ``required_actions`` gate,
+    and that ``combine`` weights only ``transcript_rules`` — so dropping either
+    gate, repointing the graded value, or adding a keyed family (llm_judge /
+    state_checks) that a keyless run cannot satisfy trips CI without Docker.
+    """
+    assert _GRADING_YAML.is_file(), f"pack grading.yaml is missing: {_GRADING_YAML}"
+    _, grading = _load_grading()
+
+    assert set(grading.combine.weights) == {"transcript_rules"}, (
+        "grading must weight only transcript_rules (no llm_judge / state_checks a "
+        f"keyless run cannot satisfy), got weights: {grading.combine.weights!r}"
+    )
+    assert grading.state_checks is None, "grading must not use state_checks"
+    assert grading.llm_judge is None, "grading must not use an llm_judge"
+
+    rules = grading.transcript_rules
+    assert rules is not None, "grading must define transcript_rules"
+    assert _PLANTED_FACT in rules.must_contain, (
+        f"grading must require the planted retrieval fact {_PLANTED_FACT!r} in must_contain, "
+        f"got: {rules.must_contain!r}"
+    )
+
+    kb_gates = [action for action in rules.required_actions if action.name == "search_kb"]
+    assert kb_gates, (
+        "grading must gate on a search_kb required_action (proves the rag-service "
+        f"participated), got: {rules.required_actions!r}"
+    )
+
+
+def test_planted_fact_is_on_no_agent_visible_surface() -> None:
+    """The planted fact appears ONLY in the corpus — never where the agent can read it.
+
+    The agent's only channels to the fact are the task text, a system prompt,
+    initial filesystem/json_db state, and the ``search_kb`` retrieval. This
+    asserts the token is in exactly one corpus doc and on none of the
+    agent-visible surfaces, so the task is un-passable without a real retrieval;
+    a leak onto any of those surfaces makes it always-passable and fails here.
+    """
+    task, task_dir = load_task_yaml(_TASK_YAML)
+
+    corpus_hits = [
+        f for f in _corpus_files(task_dir, "rag/corpus") if _PLANTED_FACT in f.read_text()
+    ]
+    assert len(corpus_hits) == 1, (
+        f"the planted fact must live in exactly one corpus doc, found it in: "
+        f"{[f.name for f in corpus_hits]!r}"
+    )
+
+    # The raw task.yaml carries every agent-visible text field (description,
+    # initial_user_message, policies, the user backstory) — the token must not
+    # be in any of them.
+    assert (
+        _PLANTED_FACT not in _TASK_YAML.read_text()
+    ), "the planted fact leaked into task.yaml — the agent would see it without searching"
+
+    if task.system_prompt is not None:
+        prompt_text = (task_dir / task.system_prompt).read_text()
+        assert _PLANTED_FACT not in prompt_text, "the planted fact leaked into the system prompt"
+
+    # No agent-visible initial state carries the token either.
+    assert not task.initial_state.filesystem, "pack must not seed agent-visible filesystem state"
+    assert task.initial_state.json_db is None, "pack must not seed a json_db the agent could read"

--- a/tests/integration/deploy/test_standalone_compose.py
+++ b/tests/integration/deploy/test_standalone_compose.py
@@ -15,11 +15,11 @@ Two modes drive the same recipe:
   brings the same recipe up against it; skip-guarded on tag availability (absent
   until the first stable publish), mirroring the parity suite's published source.
 
-Two gated tests each drive one real trial through the composed runner over the
+Three gated tests each drive one real trial through the composed runner over the
 ADR-0024 ``run-trial`` exec wire (``requires_api``): a bundled db-service trial
-(the ``tool_use`` pack) and a mock-web booking trial (``http_request`` → mock-web),
-each proving its peer functionally participates in a graded ``TrialResult`` through
-the stack.
+(the ``tool_use`` pack), a mock-web booking trial (``http_request`` → mock-web),
+and a rag_search trial (``search_kb`` → rag-service), each proving its peer
+functionally participates in a graded ``TrialResult`` through the stack.
 
 ``docker compose up --wait`` blocks on all four healthchecks. rag-service loads
 ``all-MiniLM-L6-v2`` eagerly and downloads it from HuggingFace on a cold cache, so
@@ -74,6 +74,14 @@ _PAID_TASK = (
 # A native http_request-only pack that books a room on mock-web and reports the
 # site-issued confirmation number — the trial that functionally drives mock-web.
 _MOCK_WEB_TASK = REPO_ROOT / "examples/native/mock_web_booking/dataset/tasks/booking_01/task.yaml"
+
+# A native search_kb-only pack that retrieves a planted fact from a per-trial
+# rag-service index and reports it — the trial that functionally drives rag.
+_RAG_TASK = REPO_ROOT / "examples/native/rag_search/dataset/tasks/kb_lookup_01/task.yaml"
+
+# The planted authorization code lives only in the rag_search corpus; it enters
+# the transcript solely via a search_kb retrieval.
+_RAG_PLANTED_FACT = "HX49-QORVEN-7731"
 
 
 @pytest.fixture(scope="module", params=["local", "published"])
@@ -153,6 +161,24 @@ def _agent_posted_to_mock_web(trajectory: Trajectory) -> bool:
             if call.name == "http_request" and call.arguments.get("method") == "POST":
                 if "mock-web" in str(call.arguments.get("url", "")):
                     return True
+    return False
+
+
+def _agent_searched_kb(trajectory: Trajectory) -> bool:
+    """True when an assistant made a ``search_kb`` tool call.
+
+    Walks the assistant tool calls the grader's ``required_actions`` gate scores
+    and matches a knowledge-base search — the retrieval round-trip to the
+    rag-service, not merely the request's mention in the seed message.
+    """
+    from tolokaforge.core.models import MessageRole
+
+    for message in trajectory.messages:
+        if message.role is not MessageRole.ASSISTANT or not message.tool_calls:
+            continue
+        for call in message.tool_calls:
+            if call.name == "search_kb":
+                return True
     return False
 
 
@@ -272,3 +298,31 @@ def test_mock_web_trial_through_composed_stack(composed_stack: StackHandle) -> N
     )
     transcript = json.dumps(result.trajectory.model_dump(mode="json"))
     assert "BKSEA12345" in transcript, "confirmation token absent — graded pass may be spurious"
+
+
+@pytest.mark.requires_api
+@pytest.mark.llm
+def test_rag_trial_through_composed_stack(composed_stack: StackHandle) -> None:
+    """One real rag_search trial drives to a graded pass through the stack.
+
+    The ``rag_search`` pack gives the agent only ``search_kb``; it retrieves the
+    Halden substation's failover authorization code — a fact planted in exactly one
+    corpus doc and on no agent-visible surface — from the per-trial rag-service index
+    and reports it. A graded pass proves the rag-service functionally participated.
+    The assertions then independently re-check the retrieval so a grading regression
+    that passes for the wrong reason is caught: an assistant ``search_kb`` tool call
+    must appear in the tool calls, and the planted code — which enters the transcript
+    only via the retrieval — must be present.
+    """
+    result = _run_trial_through_stack(composed_stack, _RAG_TASK)
+    assert result.trajectory.status.value == "completed", result.trajectory.status
+    grade = result.trajectory.grade
+    assert grade is not None, "trial produced no grade"
+    assert grade.binary_pass is True, f"rag trial did not grade as a pass: {grade.reasons}"
+
+    assert _agent_searched_kb(result.trajectory), (
+        "no assistant search_kb tool call in the trajectory — "
+        "the knowledge-base retrieval did not happen"
+    )
+    transcript = json.dumps(result.trajectory.model_dump(mode="json"))
+    assert _RAG_PLANTED_FACT in transcript, "planted fact absent — graded pass may be spurious"

--- a/tests/unit/adapters/test_native_adapter_rag_search.py
+++ b/tests/unit/adapters/test_native_adapter_rag_search.py
@@ -1,0 +1,130 @@
+"""``NativeAdapter.to_task_description`` populates ``SearchConfig`` and
+bundles the RAG corpus from ``initial_state.rag``.
+
+A native task that declares ``initial_state.rag.corpus_dir`` and enables the
+``search_kb`` agent tool gets per-trial RAG indexing: ``search.enabled`` flips
+to ``True``, the corpus files travel in ``tool_artifacts`` under the declared
+``corpus_dir`` prefix (and nothing else — never ``task.yaml``/``grading.yaml``),
+and the ``search_kb`` agent tool carries the real ``{query, top_k, alpha}``
+schema. Tasks with no corpus keep search disabled and ship no corpus artifacts.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from tests.canonical._factories import write_yaml_file
+from tolokaforge.adapters.native import NativeAdapter
+
+pytestmark = pytest.mark.unit
+
+_PLANTED_FACT = "Refund policy code RX-7788 permits a 45-day window."
+
+
+def _build_adapter(
+    tmp_path: Path,
+    *,
+    enabled_agent_tools: list[str],
+    rag: dict | None = None,
+    write_corpus: bool = True,
+) -> NativeAdapter:
+    task_dir = tmp_path / "tasks" / "rag_task"
+    task_dir.mkdir(parents=True)
+    (task_dir / "system_prompt.md").write_text("system\n")
+    (task_dir / "initial_state.json").write_text("{}")
+    if write_corpus:
+        corpus_dir = task_dir / "rag" / "corpus"
+        corpus_dir.mkdir(parents=True)
+        (corpus_dir / "policies.md").write_text(f"# Policies\n\n{_PLANTED_FACT}\n")
+        (corpus_dir / "faq.txt").write_text("Q: What is the return window?\n")
+    task_yaml: dict = {
+        "task_id": "rag_task",
+        "name": "rag task",
+        "category": "rag_search",
+        "description": "rag task",
+        "initial_state": {"json_db": "initial_state.json"},
+        "tools": {"agent": {"enabled": enabled_agent_tools}, "user": {"enabled": []}},
+        "actors": {"user": {"mode": "llm", "persona": "cooperative"}},
+        "grading": "grading.yaml",
+        "system_prompt": "system_prompt.md",
+    }
+    if rag is not None:
+        task_yaml["initial_state"]["rag"] = rag
+    write_yaml_file(task_dir / "task.yaml", task_yaml)
+    write_yaml_file(
+        task_dir / "grading.yaml",
+        {
+            "combine": {
+                "method": "weighted",
+                "weights": {"state_checks": 1.0},
+                "pass_threshold": 0.5,
+            },
+            "components": {"state_checks": {"jsonpaths": []}},
+        },
+    )
+    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+
+
+class TestRagSearchEnabled:
+    def test_corpus_and_search_kb_enable_per_trial_rag(self, tmp_path: Path) -> None:
+        adapter = _build_adapter(
+            tmp_path,
+            enabled_agent_tools=["search_kb", "submit_report"],
+            rag={"corpus_dir": "rag/corpus"},
+        )
+        td = adapter.to_task_description("rag_task")
+
+        assert td.search.enabled is True
+        assert td.search.domain_name == "rag_search"
+        assert td.search.documents_path == "rag/corpus"
+
+        # Corpus files travel under the declared corpus_dir prefix, decoded
+        # back to their on-disk content.
+        assert "rag/corpus/policies.md" in td.tool_artifacts
+        assert "rag/corpus/faq.txt" in td.tool_artifacts
+        decoded = base64.b64decode(td.tool_artifacts["rag/corpus/policies.md"]).decode()
+        assert _PLANTED_FACT in decoded
+
+        # Only the corpus travels — never the task/grading yaml (the latter
+        # can carry a planted retrieval fact).
+        assert "task.yaml" not in td.tool_artifacts
+        assert "grading.yaml" not in td.tool_artifacts
+
+        # search_kb carries the real schema, not a parameter-less stub.
+        search_kb = next(t for t in td.agent_tools if t.name == "search_kb")
+        assert search_kb.parameters["required"] == ["query"]
+        assert set(search_kb.parameters["properties"]) == {"query", "top_k", "alpha"}
+
+
+class TestRagSearchDisabled:
+    def test_no_rag_block_keeps_search_disabled(self, tmp_path: Path) -> None:
+        adapter = _build_adapter(tmp_path, enabled_agent_tools=["submit_report"])
+        td = adapter.to_task_description("rag_task")
+
+        assert td.search.enabled is False
+        assert td.search.domain_name is None
+        assert td.search.documents_path is None
+        assert td.tool_artifacts == {}
+
+
+class TestRagSearchFailFast:
+    def test_corpus_without_search_kb_raises(self, tmp_path: Path) -> None:
+        adapter = _build_adapter(
+            tmp_path,
+            enabled_agent_tools=["submit_report"],
+            rag={"corpus_dir": "rag/corpus"},
+        )
+        with pytest.raises(ValueError, match="search_kb"):
+            adapter.to_task_description("rag_task")
+
+    def test_corpus_dir_that_does_not_resolve_raises(self, tmp_path: Path) -> None:
+        adapter = _build_adapter(
+            tmp_path,
+            enabled_agent_tools=["search_kb"],
+            rag={"corpus_dir": "rag/missing"},
+        )
+        with pytest.raises(ValueError, match="not a directory"):
+            adapter.to_task_description("rag_task")

--- a/tests/unit/test_runner_rag_indexing.py
+++ b/tests/unit/test_runner_rag_indexing.py
@@ -1,0 +1,115 @@
+"""``_index_documents_for_trial`` resolves the trial's corpus against the
+extracted artifacts dir and fails loud on an empty index.
+
+A native RAG task bundles its corpus into ``tool_artifacts`` under the declared
+``corpus_dir``; the runner extracts that to ``artifacts_dir`` and must resolve a
+relative ``documents_path`` as ``artifacts_dir / documents_path`` (mirroring the
+mcp_server_script resolver) before loading the documents. An absolute
+``documents_path`` is used literally. When search is enabled but the corpus
+resolves empty — the path is unresolvable or holds no documents — the runner
+raises ``RAGServiceError`` so the trial hard-fails rather than running against an
+empty index and masking a bundling bug as an agent failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.runner.models import SearchConfig
+from tolokaforge.runner.rag_client import RAGServiceError
+from tolokaforge.runner.service import RunnerServiceImpl
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingRagClient:
+    """Captures the documents handed to the rag-service without any network."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, list]] = []
+
+    async def index_documents(self, *, trial_id: str, domain_name: str, documents: list) -> None:
+        self.calls.append((trial_id, domain_name, documents))
+
+
+@pytest.fixture
+def service() -> RunnerServiceImpl:
+    rag_client = _RecordingRagClient()
+    svc = RunnerServiceImpl(db_client=MagicMock(), rag_client=rag_client)
+    yield svc
+    svc.shutdown()
+
+
+def _write_corpus(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "policies.md").write_text("# Policies\n\nRefund code RX-7788.\n")
+    (directory / "faq.txt").write_text("Q: return window?\n")
+
+
+def _index(service: RunnerServiceImpl, config: SearchConfig, artifacts_dir: Path | None) -> None:
+    service._run_async(
+        service._index_documents_for_trial(
+            trial_id="t:0",
+            search_config=config,
+            artifacts_dir=artifacts_dir,
+        )
+    )
+
+
+def test_relative_documents_path_resolves_against_artifacts_dir(
+    service: RunnerServiceImpl, tmp_path: Path
+) -> None:
+    _write_corpus(tmp_path / "rag" / "corpus")
+    config = SearchConfig(enabled=True, domain_name="rag_search", documents_path="rag/corpus")
+
+    _index(service, config, artifacts_dir=tmp_path)
+
+    assert len(service.rag_client.calls) == 1
+    trial_id, domain_name, documents = service.rag_client.calls[0]
+    assert trial_id == "t:0"
+    assert domain_name == "rag_search"
+    # Both the .md and .txt corpus files under artifacts_dir / documents_path
+    # were loaded — proving the resolution and the flat glob.
+    assert len(documents) == 2
+
+
+def test_absolute_documents_path_stays_literal(service: RunnerServiceImpl, tmp_path: Path) -> None:
+    corpus = tmp_path / "abs_corpus"
+    _write_corpus(corpus)
+    config = SearchConfig(enabled=True, domain_name="rag_search", documents_path=str(corpus))
+
+    # No artifacts_dir: an absolute path must not need one.
+    _index(service, config, artifacts_dir=None)
+
+    assert len(service.rag_client.calls) == 1
+    assert len(service.rag_client.calls[0][2]) == 2
+
+
+def test_relative_path_without_artifacts_dir_raises(
+    service: RunnerServiceImpl,
+) -> None:
+    config = SearchConfig(enabled=True, domain_name="rag_search", documents_path="rag/corpus")
+
+    with pytest.raises(RAGServiceError, match="cannot be resolved"):
+        _index(service, config, artifacts_dir=None)
+    assert service.rag_client.calls == []
+
+
+def test_unresolvable_dir_raises(service: RunnerServiceImpl, tmp_path: Path) -> None:
+    config = SearchConfig(enabled=True, domain_name="rag_search", documents_path="rag/missing")
+
+    with pytest.raises(RAGServiceError, match="no documents"):
+        _index(service, config, artifacts_dir=tmp_path)
+    assert service.rag_client.calls == []
+
+
+def test_empty_corpus_dir_raises(service: RunnerServiceImpl, tmp_path: Path) -> None:
+    (tmp_path / "rag" / "corpus").mkdir(parents=True)
+    config = SearchConfig(enabled=True, domain_name="rag_search", documents_path="rag/corpus")
+
+    with pytest.raises(RAGServiceError, match="no documents"):
+        _index(service, config, artifacts_dir=tmp_path)
+    assert service.rag_client.calls == []

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -21,7 +21,7 @@ from tolokaforge.core.project_loader import resolve as resolve_environment
 from tolokaforge.runner.id_resolution import check_id_fields_reference_known_tables
 
 if TYPE_CHECKING:
-    from tolokaforge.runner.models import TaskDescription
+    from tolokaforge.runner.models import SearchConfig, TaskDescription
 
 logger = get_logger(__name__)
 
@@ -39,9 +39,10 @@ def _builtin_tool_schemas(
     (``MobileTool.apps`` populates ``actions[].app_name.enum``) need the
     config; tools that take no args (bash, calculator) ignore it.
 
-    Tools requiring runtime context that's only available on the runner
-    side (file tools' ``base_path``, search_kb's RAG client) are skipped
-    quietly — the runner provides their schemas via its own machinery.
+    Tools whose construction needs runtime context only available on the
+    runner side (file tools' ``base_path``) are skipped quietly — the runner
+    provides their schemas via its own machinery. ``search_kb`` is handled
+    separately by :meth:`to_task_description` via ``create_search_kb_schema``.
     """
     from tolokaforge.tools.builtin import registry
 
@@ -438,7 +439,6 @@ class NativeAdapter(BaseAdapter):
             InitializationAction,
             InvocationStyle,
             RequiredAction,
-            SearchConfig,
             StateChecksConfig,
             TaskDescription,
             ToolSchema,
@@ -454,6 +454,7 @@ class NativeAdapter(BaseAdapter):
         from tolokaforge.runner.models import (
             UserSimulatorConfig as RunnerUserSimulatorConfig,
         )
+        from tolokaforge.runner.tool_factory import create_search_kb_schema
 
         logger.info(
             "Building TaskDescription", task_id=task_id, adapter_type=AdapterType.NATIVE.value
@@ -481,6 +482,8 @@ class NativeAdapter(BaseAdapter):
         agent_tools: list[ToolSchema] = []
         user_tools: list[ToolSchema] = []  # always empty: user.enabled is [] in all native tasks
 
+        enabled_agent_tools: list[str] = task.tools.agent.get("enabled", [])
+
         # Get MCP server path for agent tools
         mcp_server_ref: str | None = None
         if task.tools and task.tools.agent:
@@ -491,7 +494,7 @@ class NativeAdapter(BaseAdapter):
                     raise RuntimeError(f"MCP server script not found: {mcp_server_path}")
 
             # Build tool schemas for enabled agent tools
-            enabled_tools = task.tools.agent.get("enabled", [])
+            enabled_tools = enabled_agent_tools
 
             # Lift per-tool kwargs from ``tools.agent.<name>: {...}`` blocks so
             # they reach the runner via ``ToolSchema.tool_config`` and the
@@ -523,6 +526,12 @@ class NativeAdapter(BaseAdapter):
                 rich_schemas = _builtin_tool_schemas(enabled_tools, tool_configs)
 
             for tool_name in enabled_tools:
+                if tool_name == "search_kb":
+                    # The runner reconstructs search_kb as a RAGSearchToolWrapper
+                    # (source-less, RAG dispatch). Carry the canonical schema so
+                    # the LLM sees the real {query, top_k, alpha} parameters.
+                    agent_tools.append(create_search_kb_schema())
+                    continue
                 rich = rich_schemas.get(tool_name, {})
                 # Only wire up MCP_SERVER source when the task provides an mcp_server
                 # script. Builtin tools (read_file, write_file, bash, …) have no
@@ -812,6 +821,15 @@ class NativeAdapter(BaseAdapter):
                     "ascii"
                 )
 
+        # Resolve per-trial RAG search from ``initial_state.rag``. When a
+        # corpus is declared, its files travel in ``tool_artifacts`` (keyed
+        # under the declared ``corpus_dir``) so the runner can index them.
+        search_config = self._resolve_search_config(task, task_dir, task_id, enabled_agent_tools)
+        if search_config.documents_path:
+            tool_artifacts.update(
+                self._bundle_corpus_artifacts(task_dir, search_config.documents_path)
+            )
+
         # Bind the project's default_environment patch to the task's own
         # patch via :func:`resolve_environment`; the resolver merges them
         # (with the atomic-``stack`` rule) and constructs the
@@ -835,7 +853,7 @@ class NativeAdapter(BaseAdapter):
             initial_state=initial_state,
             initialization_actions=initialization_actions,
             user_simulator=user_simulator,
-            search=SearchConfig(enabled=False),
+            search=search_config,
             grading=grading_config,
             source_files=source_files,
             generated_at=datetime.now(timezone.utc),
@@ -1003,6 +1021,85 @@ class NativeAdapter(BaseAdapter):
                 )
 
         return schemas
+
+    def _resolve_search_config(
+        self,
+        task: TaskConfig,
+        task_dir: Path,
+        task_id: str,
+        enabled_agent_tools: list[str],
+    ) -> "SearchConfig":
+        """Build the trial's ``SearchConfig`` from ``initial_state.rag``.
+
+        A task that declares ``initial_state.rag.corpus_dir`` opts into
+        per-trial RAG indexing: the corpus files travel in ``tool_artifacts``
+        and the runner indexes them so ``search_kb`` returns the corpus's
+        documents. ``documents_path`` is the declared ``corpus_dir`` verbatim,
+        resolved runner-side against the extracted artifacts dir. Tasks that
+        declare no corpus keep search disabled.
+
+        Raises:
+            ValueError: if a corpus is declared without ``search_kb`` in the
+                agent tools (the corpus could never be searched), or the
+                declared ``corpus_dir`` does not resolve to a directory.
+        """
+        from tolokaforge.runner.models import SearchConfig
+
+        rag = task.initial_state.rag
+        corpus_dir = rag.get("corpus_dir") if rag else None
+        if not corpus_dir:
+            return SearchConfig(enabled=False)
+        if not isinstance(corpus_dir, str):
+            raise ValueError(
+                f"Task {task_id!r} initial_state.rag.corpus_dir must be a string path, "
+                f"got {type(corpus_dir).__name__}={corpus_dir!r}"
+            )
+
+        if "search_kb" not in enabled_agent_tools:
+            raise ValueError(
+                f"Task {task_id!r} declares initial_state.rag.corpus_dir "
+                f"{corpus_dir!r} but does not enable the 'search_kb' agent tool; "
+                f"the corpus would never be searchable. Add 'search_kb' to "
+                f"tools.agent.enabled or drop the rag corpus."
+            )
+
+        corpus_path = task_dir / corpus_dir
+        if not corpus_path.is_dir():
+            raise ValueError(
+                f"Task {task_id!r} declares initial_state.rag.corpus_dir "
+                f"{corpus_dir!r} but {corpus_path} is not a directory."
+            )
+
+        return SearchConfig(
+            enabled=True,
+            domain_name=task.category or task_id,
+            documents_path=corpus_dir,
+        )
+
+    def _bundle_corpus_artifacts(self, task_dir: Path, corpus_dir: str) -> dict[str, str]:
+        """Bundle the RAG corpus's ``.md``/``.txt`` files as base64 artifacts.
+
+        Only the corpus files travel, keyed under the declared *corpus_dir*
+        prefix, so the runner resolves ``artifacts_dir / documents_path`` to
+        the same tree. Globs are flat (non-recursive), matching
+        ``load_documents_from_directory``. The whole task directory is
+        deliberately NOT bundled — that would ship ``grading.yaml`` (which may
+        carry a planted retrieval fact) into the runner.
+
+        Raises:
+            ValueError: if the corpus directory holds no ``.md``/``.txt`` files.
+        """
+        corpus_path = task_dir / corpus_dir
+        artifacts: dict[str, str] = {}
+        for pattern in ("*.md", "*.txt"):
+            for file_path in sorted(corpus_path.glob(pattern)):
+                if not file_path.is_file():
+                    continue
+                rel_path = f"{corpus_dir}/{file_path.name}"
+                artifacts[rel_path] = base64.b64encode(file_path.read_bytes()).decode("ascii")
+        if not artifacts:
+            raise ValueError(f"RAG corpus at {corpus_path} contains no .md or .txt files to index.")
+        return artifacts
 
     def _bundle_task_artifacts(self, task_dir: Path) -> dict[str, str]:
         """Bundle task directory files as base64-encoded artifacts.

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -595,6 +595,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     self._index_documents_for_trial(
                         trial_id=trial_id,
                         search_config=search_config,
+                        artifacts_dir=artifacts_dir,
                     )
                 )
                 rag_client_for_trial = self.rag_client
@@ -2300,19 +2301,29 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         self,
         trial_id: str,
         search_config: Any,  # SearchConfig from models
+        artifacts_dir: Path | None,
     ) -> None:
         """
-        Index documents for a trial's search corpus.
+        Index a trial's search corpus into the RAG service.
 
-        Loads documents from the configured path and indexes them
-        in the RAG service for this trial.
+        The corpus travels in ``tool_artifacts`` and is extracted to
+        *artifacts_dir*; a relative ``documents_path`` (the pack's declared
+        ``corpus_dir``) is resolved against it as ``artifacts_dir /
+        documents_path``, mirroring :meth:`_resolve_mcp_server_scripts`. An
+        absolute ``documents_path`` is used literally (escape hatch).
 
         Args:
             trial_id: Unique trial identifier
             search_config: SearchConfig with documents_path and domain_name
+            artifacts_dir: Directory the trial's tool_artifacts were extracted
+                to, or ``None`` when the task shipped none
 
         Raises:
-            RAGServiceError: If indexing fails
+            RAGServiceError: if the RAG client is not configured, a relative
+                corpus path cannot be resolved, or the resolved directory
+                holds no documents — a declared corpus that indexes empty is a
+                bundling bug, not an agent failure, so the trial hard-fails
+                here rather than running against an empty index.
         """
         if self.rag_client is None:
             raise RAGServiceError("RAG client not configured")
@@ -2321,22 +2332,33 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         domain_name = search_config.domain_name or "default"
 
         if not documents_path:
-            logger.warning(f"No documents_path configured for trial {trial_id}")
-            return
+            raise RAGServiceError(
+                f"Trial {trial_id}: search is enabled but documents_path is unset"
+            )
 
-        # Load documents from directory
-        documents = load_documents_from_directory(documents_path, domain_name)
+        corpus_path = Path(documents_path)
+        if not corpus_path.is_absolute():
+            if artifacts_dir is None:
+                raise RAGServiceError(
+                    f"Trial {trial_id}: relative documents_path {documents_path!r} cannot be "
+                    f"resolved — the task shipped no extracted artifacts directory"
+                )
+            corpus_path = artifacts_dir / corpus_path
+
+        documents = load_documents_from_directory(str(corpus_path), domain_name)
 
         if not documents:
-            logger.warning(f"No documents found in {documents_path} for trial {trial_id}")
-            return
+            raise RAGServiceError(
+                f"Trial {trial_id}: no documents in resolved corpus {corpus_path} "
+                f"(documents_path={documents_path!r}) — corpus bundling is broken"
+            )
 
         logger.info(
             f"Indexing {len(documents)} documents for trial {trial_id}",
             extra={
                 "trial_id": trial_id,
                 "domain_name": domain_name,
-                "documents_path": documents_path,
+                "documents_path": str(corpus_path),
             },
         )
 


### PR DESCRIPTION
## Summary
- Makes rag-service `search_kb` **functional for native tasks** — previously the native adapter hardcoded `SearchConfig(enabled=False)`, so the per-trial RAG index was never built and `search_kb` always 404'd/returned empty.
- A native task that declares `initial_state.rag.corpus_dir` **and** enables `search_kb` now: bundles its corpus (`.md`/`.txt`) into the `TaskDescription`, the runner resolves+indexes it per-trial, and the agent's `search_kb` returns those documents. Fixes a live doc-vs-code lie (`docs/TASKS.md` already documented this as working).
- Ships a first-party `examples/native/rag_search/` pack + keyless canonical locks + a gated deploy trial that drives it end-to-end (**verified green: agent retrieved a planted fact via `search_kb` and graded a pass through the composed stack**).

## Design choices
- **Make it work, not deprecate (issue option 1):** rag-service `search_kb` is the *only* functional first-party KB path (TypeSense `search_policy` is a closed-source-gated stub, `NotImplementedError`); deprecating would orphan the just-published `tolokasoft1/tolokaforge-rag-service` image.
- **Additive, zero-migration:** no `TaskDescription` schema-shape change and no new task-pack field — `SearchConfig.{enabled,domain_name,documents_path}` and `initial_state.rag` already exist. Packs without `initial_state.rag` serialize byte-identically (`enabled=False`); no first-party pack set it.
- **Pinned corpus convention (cross-stage):** `documents_path == corpus_dir` (declared value); a **dedicated corpus-only bundling path** ships only the corpus files — never `task.yaml`/`grading.yaml` (so the graded fact stays host-side).
- **Fail loud (AGENTS.md Rule 1):** adapter errors on a dead/unresolvable corpus; the runner **raises `RAGServiceError`** (→ hard trial failure) when a corpus was declared but the index resolves empty — no silent empty index.
- **Deterministic grading (mock_web_booking template, not lot_ops):** transcript-only `combine` (`weights {transcript_rules: 1.0}`, `pass_threshold 1.0`, no `state_checks`/`llm_judge`); a `search_kb` `required_actions` gate + `must_contain` a **retrieval-only planted fact** present in exactly one corpus doc and on no agent-visible surface.

## Concepts introduced
No new abstraction or contract — this *activates* the already-documented `initial_state.rag.corpus_dir` task-pack field (previously inert) and populates existing `SearchConfig` fields. The only compatibility surface touched is the task-pack format, additively.

## Plan
Recommendation: make native `search_kb` work (issue #107 option 1). 4 stages, one PR (not milestone-sized):
1. **Native adapter** (`native.py`): emit `SearchConfig(enabled=True, domain_name, documents_path)` from `initial_state.rag.corpus_dir` when `search_kb` is enabled; corpus-only bundling into `tool_artifacts` (dedicated path, not `_bundle_task_artifacts`); real `create_search_kb_schema()`; fail-fast validation. unit + canonical.
2. **Runner** (`service.py::_index_documents_for_trial`): resolve relative `documents_path` against the extracted `artifacts_dir` (mirrors the mcp-script resolver); raise `RAGServiceError` on empty-when-enabled (replacing warning+return); propagates to `RegisterTrialResponse(success=False)`. unit.
3. **Example pack** `examples/native/rag_search/` (tiny 3-doc corpus, planted fact in one, 2 distractors) + keyless canonical shape lock incl. an anti-always-pass leak check. additive.
4. **Gated deploy trial** in `test_standalone_compose.py` (reuses the module-scoped `composed_stack` + `_run_trial_through_stack`): drives the pack through the composed stack, asserts `completed` + `grade.binary_pass is True` + a real `search_kb` tool call in the trajectory. `integration+requires_docker+requires_api+slow+llm`. Closes the rag half deferred by #649.

(Full staged plan with contracts/verification lived in `~/.claude/plans/toloka-tolokaforge/issue-107-rag-searchkb.md`; critique: 2 REVISE rounds → all findings fixed; sharded review: correctness + type-fit APPROVE, hygiene 1 Blocker [docstring attribution] fixed in `8cd609e`.)

## Discovered issues
- Filed: **#664** (dead in-process `env_state.rag_corpus_dir` — written, never read; separate path).
- Related/pre-existing: **#652** (vestigial `CORPUS_PATH`/`rag_data` in the standalone compose), out of scope.
- Non-blocking nits (reviewer, optional): adapter's empty-corpus check counts files while the runner also skips whitespace-only docs (still fails loud); minor scalar-assertion overlap between the unit + canonical adapter tests (justified tier split).

## Test plan
- Keyless every-PR: `tests/unit/adapters/test_native_adapter_rag_search.py`, `tests/unit/test_runner_rag_indexing.py`, `tests/canonical/test_native_rag_task_description.py`, `tests/canonical/test_rag_example_pack.py` (70 pass locally).
- Gated (requires_api + Docker, gate/nightly): `test_standalone_compose.py::test_rag_trial_through_composed_stack` — **verified green locally (1 passed, 118s)**: `completed` + `grade.binary_pass True` + `search_kb` call + planted `HX49-QORVEN-7731` in the transcript, on the rebased base with #661 (rag 120s start-period) + #662 (arm64 conftest platform).

Closes #107
