### PR TITLE
test(integration): repair Release-Gate integration-suite drift (#668)

### DIFF
--- a/tests/integration/test_docker_grading_jsonpath.py
+++ b/tests/integration/test_docker_grading_jsonpath.py
@@ -19,12 +19,14 @@ LLM), so the verdicts are pinned.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import pytest
 
+from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+from tolokaforge.runner.models import TaskDescription
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
 
@@ -83,6 +85,24 @@ def _task_description(jsonpath_checks: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _trial_spec_json(trial_id: str, jsonpath_checks: list[dict[str, Any]]) -> str:
+    """Build a valid ``TrialSpec`` JSON wrapping the JSONPath-graded task description.
+
+    The runner-side ``RegisterTrial`` handler validates the full ``TrialSpec``
+    (not just ``spec.task``), so the wire payload must be a complete spec.
+    """
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="jsonpath_state_e2e_run",
+        task=TaskDescription.model_validate(_task_description(jsonpath_checks)),
+        agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
+    ).model_dump_json()
+
+
 @pytest.fixture
 def runner_client(runner_container) -> GrpcRunnerClient:
     """RunnerClient connected to the testcontainer Runner over gRPC."""
@@ -100,8 +120,8 @@ def _register_and_grade(
     jsonpath_checks: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Register a trial with the given checks, grade it, clean up, return the grade."""
-    td_json = json.dumps(_task_description(jsonpath_checks))
-    registered = runner_client.register_trial(trial_id=trial_id, task_description_json=td_json)
+    spec_json = _trial_spec_json(trial_id, jsonpath_checks)
+    registered = runner_client.register_trial(trial_id=trial_id, trial_spec_json=spec_json)
     assert registered["success"] is True, registered["error"]
     try:
         result = runner_client.grade_trial(trial_id=trial_id)

--- a/tests/integration/test_preset_overlay_subprocess.py
+++ b/tests/integration/test_preset_overlay_subprocess.py
@@ -112,7 +112,9 @@ class TestSubprocessInheritance:
 
     def test_subprocess_reads_queue_state_overlay(self, tmp_path: Path) -> None:
         queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
-        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        write_engine_run_state(
+            tmp_path, run_id="overlay_subprocess_e2e", presets_file=queue_overlay
+        )
         result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=None)
         assert result["resolved"] == queue_overlay
         assert result["installed"] == queue_overlay
@@ -120,14 +122,18 @@ class TestSubprocessInheritance:
     def test_subprocess_cli_flag_beats_queue_state(self, tmp_path: Path) -> None:
         queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
         cli_overlay = _write_empty_overlay(tmp_path, "cli.yaml")
-        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        write_engine_run_state(
+            tmp_path, run_id="overlay_subprocess_e2e", presets_file=queue_overlay
+        )
         result = _run_resolver(run_dir=tmp_path, cli_value=cli_overlay, config_value=None)
         assert result["resolved"] == cli_overlay
 
     def test_subprocess_queue_state_beats_config_field(self, tmp_path: Path) -> None:
         queue_overlay = _write_empty_overlay(tmp_path, "queue.yaml")
         config_overlay = _write_empty_overlay(tmp_path, "config.yaml")
-        write_engine_run_state(tmp_path, presets_file=queue_overlay)
+        write_engine_run_state(
+            tmp_path, run_id="overlay_subprocess_e2e", presets_file=queue_overlay
+        )
         result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=config_overlay)
         assert result["resolved"] == queue_overlay
 
@@ -141,7 +147,7 @@ class TestSubprocessInheritance:
         # ``prepare`` ran without an overlay → persisted as null →
         # subprocess falls through to engine.presets_file.
         config_overlay = _write_empty_overlay(tmp_path, "config.yaml")
-        write_engine_run_state(tmp_path, presets_file=None)
+        write_engine_run_state(tmp_path, run_id="overlay_subprocess_e2e", presets_file=None)
         result = _run_resolver(run_dir=tmp_path, cli_value=None, config_value=config_overlay)
         assert result["resolved"] == config_overlay
 
@@ -196,7 +202,7 @@ class TestRealCLISubprocessConfigValidate:
         # We accept exit 0 (no errors) — API-key warnings don't fail validate
         # without --strict.
         assert proc.returncode == 0, f"validate failed unexpectedly:\n{proc.stdout}\n{proc.stderr}"
-        normalized = _collapse(proc.stdout)
+        normalized = _collapse(proc.stdout + proc.stderr)
         assert "PresetoverlayOK" in normalized
         assert _collapse(str(overlay)) in normalized
 
@@ -225,7 +231,7 @@ class TestRealCLISubprocessConfigValidate:
             check=False,
         )
         assert proc.returncode != 0, "validate should exit non-zero on bad overlay"
-        normalized = _collapse(proc.stdout)
+        normalized = _collapse(proc.stdout + proc.stderr)
         assert "unknownresponse_policy" in normalized
         # Error message must name the file path.
         assert _collapse(str(overlay)) in normalized
@@ -248,7 +254,7 @@ class TestRealCLISubprocessConfigValidate:
             check=False,
         )
         assert proc.returncode != 0
-        normalized = _collapse(proc.stdout).lower()
+        normalized = _collapse(proc.stdout + proc.stderr).lower()
         assert "notfound" in normalized or "does_not_exist" in normalized
 
 

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -56,13 +56,23 @@ class TestNetworkIsolation:
 
             # Now verify: runner can reach db-service on the internal network
             exit_code, output = runner_container.exec(
-                ["curl", "-f", "--max-time", "5", "http://db-service:8000/health"]
+                [
+                    "python",
+                    "-c",
+                    "import urllib.request,sys; urllib.request.urlopen(sys.argv[1], timeout=5)",
+                    "http://db-service:8000/health",
+                ]
             )
             assert exit_code == 0, f"Runner cannot reach db-service on internal network: {output}"
 
             # Verify: runner can NOT reach the external internet
             exit_code, output = runner_container.exec(
-                ["curl", "-f", "--max-time", "5", "http://google.com"]
+                [
+                    "python",
+                    "-c",
+                    "import urllib.request,sys; urllib.request.urlopen(sys.argv[1], timeout=5)",
+                    "http://google.com",
+                ]
             )
             assert exit_code != 0, (
                 "SECURITY VIOLATION: Runner container can access external internet. "


### PR DESCRIPTION
## Summary
Fixes the **tractable** (code/assumption-drift) Release-Gate integration failures from #668 — **10 of the 15**, all **test-only** (no production change). Each was an integration test that never migrated when a production contract changed.

- **`test_docker_grading_jsonpath` (2, closes #553):** `register_trial` changed in #148 (`task_description_json` raw-dict → `trial_spec_json` full `TrialSpec`). Migrated the test to build a `TrialSpec`, mirroring the already-migrated `test_runner_cleanup_trial_grpc.py`. No compat shim.
- **`test_preset_overlay_subprocess` — run_id (4):** `write_engine_run_state` gained a required kw-only `run_id` in #111 (prod + other tests pass it; only this file drifted). Added `run_id=…` to the 4 callers.
- **`test_preset_overlay_subprocess` — CLI validate (3):** `tolokaforge config validate` writes its ✓/✗ lines to the shared **stderr** Console (#460); the tests asserted on stdout. Now assert on `stdout+stderr`. Returncode assertions unchanged.
- **`test_security` network isolation (1):** the test exec-ed `curl` inside the slim runner (no curl → 127). Replaced with a `python -c "import urllib.request…"` probe, matching the runner's own HEALTHCHECK idiom; intent identical.

## Design choices
- **Fix the tests, not production**: every failure was a test lagging a deliberate prod contract change (#148/#111/#460) or a stale image assumption — production is correct. No shims that would re-introduce removed contracts.

## Concepts introduced
None — test-only migration of drifted integration tests.

## Verification (actually executed, not inferred)
- Item 2 (no Docker): `pytest test_preset_overlay_subprocess.py` → **10 passed**.
- Items 1+3 (Docker + runner testcontainer): `pytest test_docker_grading_jsonpath.py test_security.py::TestNetworkIsolation` → **3 passed**. (Local host needed Ryuk-disabled + a forced runner-image rebuild — host-only, not committed; CI builds fresh.)

## Scope / remaining
- Addresses 10/15 of #668's failures — the clear drifts. The remaining 5 (`test_per_trial_runtime_backend_integration` ×2, `test_component_log_streaming_integration`, `test_cache_debug_end_to_end`, `test_endpoint_add_end_to_end`) are docker-provisioning/timing-sensitive; left tracked under #668 for separate triage/quarantine. This PR does **not** fully close #668.

## Discovered issues
- Filed: **#670** — the test harness reuses a stale `tolokaforge-runner:latest` instead of rebuilding on schema skew (masked Item 1 locally).

## Test plan
- The three integration files' targeted tests pass (10 + 3 above). CHANGELOG untouched (cz-bump owns it).

Refs #668. Closes #553.