### PR TITLE
ci(release): auto-cut image-vX.Y.Z-rc.1 on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ name: Release (cz bump)
 # version in pyproject.toml, regenerates CHANGELOG.md from the Conventional
 # Commit history, commits, and pushes a vX.Y.Z tag. That tag then triggers
 # publish-tolokaforge.yml (PyPI trusted publishing + GitHub Release) and
-# release-gate.yml. No manual version/changelog edits required.
+# release-gate.yml. It also pushes the image-vX.Y.Z-rc.1 tag, which triggers
+# publish-images.yml to build and push the four :X.Y.Z-rc.1 images. No manual
+# version/changelog edits required.
 #
 # See CONTRIBUTING.md ("Cutting a Release").
 
@@ -118,3 +120,16 @@ jobs:
         if: ${{ !inputs.dry_run && steps.bump.outputs.released == 'true' }}
         run: |
           git push --atomic origin HEAD:main "refs/tags/${{ steps.bump.outputs.new_tag }}"
+
+      # Cut the release-candidate image tag so publish-images.yml builds and pushes
+      # the four :X.Y.Z-rc.1 images automatically. Pushed on its own, non-atomic
+      # push: a transient failure here must not abort the already-published PyPI
+      # release, so it fails loud (no `|| true`) and the operator re-pushes by hand.
+      - name: Push rc image tag
+        if: ${{ !inputs.dry_run && steps.bump.outputs.released == 'true' }}
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          rc_tag="image-${NEW_TAG}-rc.1"
+          git tag "$rc_tag" HEAD
+          git push origin "refs/tags/$rc_tag"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,12 +5,15 @@ each with its own GitHub Actions workflow:
 
 - **The PyPI package** — `vX.Y.Z` tags, cut automatically by the "Release (cz
   bump)" workflow.
-- **The Docker images** — `image-vX.Y.Z` tags, pushed by hand.
+- **The Docker images** — the `image-vX.Y.Z-rc.1` release-candidate tag is cut
+  automatically by the same "Release (cz bump)" workflow; the stable
+  `image-vX.Y.Z` tag is pushed by hand once the rc is verified.
 
 Both axes are locked to a single version number. The PyPI release sets that
 number (it owns `[project].version` in `pyproject.toml`); the image workflow
-refuses to publish unless the image tag agrees with it. Cut the package release
-first, then push the image tags.
+refuses to publish unless the image tag agrees with it. Cutting the package
+release also cuts the rc image tag; the stable image tag is pushed by hand
+afterwards.
 
 ## PyPI package — `vX.Y.Z` (automated)
 
@@ -49,15 +52,16 @@ Pushing the `vX.Y.Z` tag then triggers two tag-driven workflows automatically:
 If `auto` finds no releasable commits since the last tag, the workflow exits
 cleanly without cutting a release.
 
-## Docker images — `image-vX.Y.Z` (manual)
+## Docker images — `image-vX.Y.Z-rc.1` (auto) and `image-vX.Y.Z` (manual)
 
 The four first-party images —
 `tolokasoft1/tolokaforge-{runner,db-service,rag-service,mock-web}` — are published
-by [`publish-images.yml`](../.github/workflows/publish-images.yml). Nothing
-creates the `image-v*` tag for you; a human pushes it, which triggers the build.
-The workflow builds the wheel once; only the images that ship it — `runner` and
-`rag-service` — are layered from that artifact, while `db-service` and `mock-web`
-build without it.
+by [`publish-images.yml`](../.github/workflows/publish-images.yml), which fires on
+any pushed `image-v*` tag. The release workflow cuts the release-candidate tag
+`image-vX.Y.Z-rc.1` for you; the stable tag `image-vX.Y.Z` is pushed by hand once
+the rc is verified. The workflow builds the wheel once; only the images that ship
+it — `runner` and `rag-service` — are layered from that artifact, while
+`db-service` and `mock-web` build without it.
 
 Images are `linux/amd64` only. The standalone compose recipe pins
 `platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}`, so Apple-Silicon hosts run the
@@ -72,18 +76,13 @@ release. The two axes share one version number but are separate tag pushes.
 
 ### Release-candidate, then stable
 
-Every image release goes through a release candidate first. Do both steps:
+Every image release goes through a release candidate first.
 
-1. **Push the rc tag.**
-
-   ```bash
-   git tag image-vX.Y.Z-rc.1
-   git push origin image-vX.Y.Z-rc.1
-   ```
-
-   This routes through the `pre-stable` deployment environment, pushes the
-   immutable `:X.Y.Z-rc.1` tags, and runs a keyless rc-smoke against the
-   freshly-pushed images. It does **not** move `:latest` or `:X.Y`.
+1. **The rc tag is cut for you.** When "Release (cz bump)" cuts `vX.Y.Z`, it also
+   pushes `image-vX.Y.Z-rc.1`. That routes through the `pre-stable` deployment
+   environment, pushes the immutable `:X.Y.Z-rc.1` tags, and runs a keyless
+   rc-smoke against the freshly-pushed images. It does **not** move `:latest` or
+   `:X.Y`.
 
 2. **Verify the rc** — pull the `:X.Y.Z-rc.1` images and smoke them yourself.
 
@@ -107,11 +106,10 @@ Dockerfiles and wheel still build.
 
 ## Typical order
 
-1. Run "Release (cz bump)" to cut `vX.Y.Z` — this sets the version and publishes
-   the package.
-2. `git tag image-vX.Y.Z-rc.1 && git push origin image-vX.Y.Z-rc.1`.
-3. Verify the rc images.
-4. `git tag image-vX.Y.Z && git push origin image-vX.Y.Z` to publish the stable
+1. Run "Release (cz bump)" to cut `vX.Y.Z` — this sets the version, publishes the
+   package, and pushes `image-vX.Y.Z-rc.1` to build the rc images.
+2. Verify the rc images.
+3. `git tag image-vX.Y.Z && git push origin image-vX.Y.Z` to publish the stable
    images and move `:latest`.
 
 ## See also


### PR DESCRIPTION
## Summary
- Removes the PyPI↔image drift: after the "Release (cz bump)" workflow bumps the version and pushes `vX.Y.Z`, it now **also** pushes `image-vX.Y.Z-rc.1` — which triggers `publish-images.yml`'s rc path (build + push the four `:X.Y.Z-rc.1` images through `pre-stable` + keyless smoke, **no `:latest` move**).
- Stable promotion (`image-vX.Y.Z` → moves `:latest`) stays a deliberate manual push. `docs/RELEASING.md` + the workflow header rewritten to current-state.

## Design choices
- **Separate, non-atomic `git push`** (not folded into the `--atomic` commit+vtag push): a transient rc-tag failure must not abort the already-published PyPI release. Fails loud (no `|| true`); the manual `image-vX.Y.Z-rc.1` push remains the fallback.
- **`ci(release):` commit type** (not `feat`) so the next `cz bump auto` doesn't add a spurious minor bump for a CI-only change.
- **Fixed `rc.1`** — every release bumps to a fresh version, so no collision; re-cuts (`-rc.2`+) and stable stay manual.
- Env-var indirection (`NEW_TAG` env + quoted `"$VAR"`) keeps the step shellcheck-clean.

## Concepts introduced
None — one release-workflow step + docs. `publish-images.yml` unchanged (its `image-v*` trigger, version guard, and rc/stable routing are reused as-is).

## Safety (critic-verified against the repo)
- Deploy-key SSH push **does** trigger `publish-images.yml` (proven: the existing `v*` deploy-key push already triggers `publish-tolokaforge.yml`).
- Version guard passes (rc base == pyproject at the bump commit).
- dry-run / no-op release skip the step (guard byte-identical to the atomic step).
- rc **never** moves `:latest` nor double-publishes PyPI (`image-…-rc.1` doesn't match the `v*` glob; move-tags is stable-only).
- No `image-v*` tag-protection ruleset exists (`gh api …/rulesets` → only a `main` branch ruleset), so the deploy key can push the rc tag.

## Test plan
- Workflows aren't unit-testable here; `actionlint` on `release.yml` passes (pre-commit hook). CHANGELOG untouched (cz-bump owns it).
- **Manual verification on the next real release:** the success signal is watching `publish-images.yml` **actually fire** on the `pre-stable` path (not just "release.yml green"); `:latest` must stay put until the manual stable tag.

Closes #667