### PR TITLE
fix(docker): auto host ports for rag/mock-web; persist rag HF cache on volume

### DIFF
--- a/tests/unit/test_stack_health_probe_placeholder.py
+++ b/tests/unit/test_stack_health_probe_placeholder.py
@@ -7,8 +7,12 @@ port-8000 fallback — e.g. rag-service's long cold-start timeout, which a
 30s default probe would break on first-run model downloads.
 """
 
+import pytest
+
 from tolokaforge.docker.health import HealthProbe
 from tolokaforge.docker.stack import EngineStack
+
+pytestmark = pytest.mark.unit
 
 
 def test_placeholder_resolved_from_port_map():
@@ -19,9 +23,13 @@ def test_placeholder_resolved_from_port_map():
     assert resolved.timeout_s == 300.0  # custom timeout survives resolution
 
 
-def test_placeholder_with_unresolved_port_drops_probe():
+def test_placeholder_with_unresolved_port_raises():
+    # Every service declaring a placeholder also declares the matching
+    # PortConfig, so an unresolvable placeholder is a programming error —
+    # dropping the probe here would silently skip the health wait.
     probe = HealthProbe.http(url="http://localhost:{port:8001}/health")
-    assert EngineStack._resolve_health_probe(probe, {8000: 45678}) is None
+    with pytest.raises(ValueError, match="no resolved host mapping"):
+        EngineStack._resolve_health_probe(probe, {8000: 45678})
 
 
 def test_concrete_url_returned_unchanged():

--- a/tests/unit/test_stack_health_probe_placeholder.py
+++ b/tests/unit/test_stack_health_probe_placeholder.py
@@ -1,0 +1,36 @@
+"""Deferred host-port placeholders in health-probe URLs.
+
+Services created with auto-allocated host ports cannot know the port at
+definition time. ``{port:<container_port>}`` placeholders let them keep a
+rich probe (custom timeout/path) instead of losing it to the generic
+port-8000 fallback — e.g. rag-service's long cold-start timeout, which a
+30s default probe would break on first-run model downloads.
+"""
+
+from tolokaforge.docker.health import HealthProbe
+from tolokaforge.docker.stack import EngineStack
+
+
+def test_placeholder_resolved_from_port_map():
+    probe = HealthProbe.http(url="http://localhost:{port:8001}/health", timeout_s=300.0)
+    resolved = EngineStack._resolve_health_probe(probe, {8001: 45678})
+    assert resolved is not None
+    assert resolved.url == "http://localhost:45678/health"
+    assert resolved.timeout_s == 300.0  # custom timeout survives resolution
+
+
+def test_placeholder_with_unresolved_port_drops_probe():
+    probe = HealthProbe.http(url="http://localhost:{port:8001}/health")
+    assert EngineStack._resolve_health_probe(probe, {8000: 45678}) is None
+
+
+def test_concrete_url_returned_unchanged():
+    probe = HealthProbe.http(url="http://localhost:8001/health", timeout_s=120.0)
+    resolved = EngineStack._resolve_health_probe(probe, {8001: 45678})
+    assert resolved is probe
+
+
+def test_default_probe_still_built_for_port_8000():
+    resolved = EngineStack._resolve_health_probe(None, {8000: 39999})
+    assert resolved is not None
+    assert resolved.url == "http://localhost:39999/health"

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -29,6 +29,7 @@ Example:
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 from typing import Any
 
@@ -642,10 +643,33 @@ class EngineStack(BaseModel):
         construct a proper HTTP probe for every container port that has
         a ``/health`` endpoint on ``localhost``.
 
+        HTTP probes may also defer the host port explicitly with a
+        ``{port:<container_port>}`` placeholder in their URL (e.g.
+        ``http://localhost:{port:8001}/health``). This lets services with
+        auto-allocated host ports keep a rich probe definition — custom
+        timeouts, paths — instead of falling back to the generic default
+        below, which only understands the DB-service convention.
+
         For existing probes whose URL already contains a concrete port,
         this method returns them unchanged.
         """
         if probe is not None:
+            url = getattr(probe, "url", None)
+            if url is not None:
+                match = re.search(r"\{port:(\d+)\}", url)
+                if match:
+                    host_port = port_map.get(int(match.group(1)))
+                    if host_port is None:
+                        logger.warning(
+                            "Health probe URL %s references container port %s "
+                            "with no resolved host mapping; dropping probe",
+                            url,
+                            match.group(1),
+                        )
+                        return None
+                    return probe.model_copy(
+                        update={"url": url.replace(match.group(0), str(host_port))}
+                    )
             return probe
 
         # No explicit probe — try to build a default HTTP probe for port 8000

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -38,7 +38,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 from tolokaforge.core.run_display_events import build_component_id
 from tolokaforge.docker.config import DockerConfig
 from tolokaforge.docker.container import Container, ContainerStatus
-from tolokaforge.docker.health import HealthProbe, HealthProbeError
+from tolokaforge.docker.health import HealthProbe, HealthProbeError, HttpHealthProbe
 from tolokaforge.docker.image import Image
 from tolokaforge.docker.logging import LogRouter
 from tolokaforge.docker.mount import Mount
@@ -654,21 +654,21 @@ class EngineStack(BaseModel):
         this method returns them unchanged.
         """
         if probe is not None:
-            url = getattr(probe, "url", None)
-            if url is not None:
-                match = re.search(r"\{port:(\d+)\}", url)
+            if isinstance(probe, HttpHealthProbe):
+                match = re.search(r"\{port:(\d+)\}", probe.url)
                 if match:
                     host_port = port_map.get(int(match.group(1)))
                     if host_port is None:
-                        logger.warning(
-                            "Health probe URL %s references container port %s "
-                            "with no resolved host mapping; dropping probe",
-                            url,
-                            match.group(1),
+                        # A placeholder always comes with a matching
+                        # PortConfig on the same service, so this is a
+                        # programming/allocation error — dropping the probe
+                        # would silently skip the health wait.
+                        raise ValueError(
+                            f"Health probe URL {probe.url!r} references container "
+                            f"port {match.group(1)} with no resolved host mapping"
                         )
-                        return None
                     return probe.model_copy(
-                        update={"url": url.replace(match.group(0), str(host_port))}
+                        update={"url": probe.url.replace(match.group(0), str(host_port))}
                     )
             return probe
 

--- a/tolokaforge/docker/stacks/full.py
+++ b/tolokaforge/docker/stacks/full.py
@@ -30,8 +30,8 @@ def full_stack(
     config: DockerConfig | None = None,
     db_port: int | Literal["auto"] = "auto",
     runner_port: int | Literal["auto"] = "auto",
-    rag_port: int = 8001,
-    mock_web_port: int = 8080,
+    rag_port: int | Literal["auto"] = "auto",
+    mock_web_port: int | Literal["auto"] = "auto",
     enable_dind: bool = False,
     enable_playwright: bool = False,
     enable_docker_cli: bool = False,
@@ -51,8 +51,12 @@ def full_stack(
         config: Optional DockerConfig. Uses defaults if None.
         db_port: Host port for DB service (default: ``"auto"``).
         runner_port: Host port for Runner gRPC (default: ``"auto"``).
-        rag_port: Host port for RAG service (default: 8001).
-        mock_web_port: Host port for Mock Web service (default: 8080).
+        rag_port: Host port for RAG service (default: ``"auto"``).
+            Fixed ports collide with unrelated host processes and there is
+            no run-config plumbing to override them; in-stack consumers use
+            the ``rag-service`` network alias, not the host port.
+        mock_web_port: Host port for Mock Web service (default: ``"auto"``).
+            Same rationale — tasks reach it via the ``mock-web`` alias.
         enable_dind: Forwarded to ``core_stack``.
         enable_playwright: Forwarded to ``core_stack``.
         enable_docker_cli: Forwarded to ``core_stack``.
@@ -99,14 +103,23 @@ def full_stack(
         environment={
             "PYTHONUNBUFFERED": "1",
             "CORPUS_PATH": "/env/rag/corpus",
+            # Keep the HuggingFace cache on the rag_data volume: the default
+            # (~/.cache inside the container) is destroyed on every container
+            # recreation, so the sentence-transformers model was re-downloaded
+            # on each run and cold starts regularly blew the health timeout.
+            "HF_HOME": "/env/rag/hf_cache",
         },
         health_probe=HealthProbe.http(
-            url=f"http://localhost:{rag_port}/health",
+            # "{port:8001}" is a deferred host-port placeholder resolved by
+            # EngineStack._resolve_health_probe once auto-allocated ports are
+            # known — this keeps the custom timeout below, which the generic
+            # deferred-probe fallback (30s) would lose.
+            url="http://localhost:{port:8001}/health",
             # rag-service warmup loads sentence-transformers + tokenizer
-            # (downloads on first run, then cached). 30s is too short for a
-            # cold start; 120s comfortably covers the cold-cache case while
-            # the warm-cache case still resolves within a few seconds.
-            timeout_s=120.0,
+            # (downloads on first run, then cached on the rag_data volume).
+            # The first-ever download can exceed 120s on slow networks; warm
+            # starts still resolve within a few seconds.
+            timeout_s=300.0,
             interval_s=1.0,
         ),
         networks=["runner-net"],


### PR DESCRIPTION
## Problem

Hit in real benchmark runs from `tolokaforge-tools` (2026-07-30):

1. **`full_stack()` hardcodes host ports 8080 (mock-web) and 8001 (rag-service)** with no run-config plumbing to override them. Any unrelated host process on those ports (IDEs commonly hold 8080) kills the whole run with `PortAllocationError` — after up to an hour of image building. `db_port`/`runner_port` already default to `"auto"`.
2. **rag-service re-downloads its sentence-transformers model on every container recreation** — the HF cache defaults to `~/.cache` *inside* the container, so the `rag_data` volume never caches it despite the code comment claiming "downloads on first run, then cached". Cold starts regularly exceeded the 120s health timeout, failing runs.

## Changes

- `rag_port` / `mock_web_port` default to `"auto"` (consistent with db/runner). Nothing outside the stack consumes these host ports — in-stack consumers use the `mock-web` / `rag-service` network aliases.
- **`{port:<container_port>}` placeholder in HTTP probe URLs**, resolved by `EngineStack._resolve_health_probe` after port allocation. Without this, auto ports force `health_probe=None` and the deferred-probe fallback (port-8000 convention, fixed 30s) silently drops rag-service's long cold-start timeout.
- `HF_HOME=/env/rag/hf_cache` on the existing `rag_data` volume, making the model cache actually persistent; probe timeout 120→300s to cover the one remaining first-ever download on slow networks.

## Validation

- New unit tests for placeholder resolution (`tests/unit/test_stack_health_probe_placeholder.py`); targeted unit + canonical suites pass (80 tests), ruff clean.
- Both fixes were run in anger as local venv patches during a day of benchmark runs in `tolokaforge-tools` (see toloka-partners/tolokaforge-tools#56) — mock-web came up on an auto port with 8080 occupied, and rag-service went healthy in ~2 min cold / seconds warm with the volume-backed cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)