### PR TITLE
feat(grading): finish runner-side custom_checks as a Pattern-A extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **grading**: runner-side `custom_checks` execution — a pack declaring `custom_checks.enabled: true` with a `checks.py` now has its `@init` + `@check` functions executed inside the runner container over the trial's `CheckContext` (initial/final state + transcript + task metadata). Per-check verdicts ride the wire as `CustomCheckResult` entries (`Grade.custom_checks_details`), the aggregate score fills `Grade.components.custom_checks`, and the `combine.weights.custom_checks` weight is applied to the final score alongside `state_checks` / `transcript_rules` / `llm_judge`. An unsupported `interface_version` or a broken `checks.py` module now rejects the trial at `RegisterTrial` (before the agent loop) instead of at trial end. `checks.py` is bundled into `TaskDescription.tool_artifacts` for packs with or without an MCP server. The `CheckExecutor` Protocol seam ([ADR-0012](docs/adr/0012-custom-checks-extension.md)) lifts the executor to ADR-0011 Pattern A with `CheckRunner` as the in-process production impl and `InMemoryCheckExecutor` as the test fixture; no public class was renamed. See [docs/custom_checks.md](docs/custom_checks.md) and [`examples/native/custom_checks/`](examples/native/custom_checks/) — the runnable reference pack that reconciles a customer ledger arithmetically. Closes #669, #406, #217.
+
 ## v0.13.0 (2026-07-30)
 
 ### Feat

--- a/docs/FUTURE_DEVELOPMENT.md
+++ b/docs/FUTURE_DEVELOPMENT.md
@@ -172,7 +172,7 @@ Test each configured provider:
 | Transcript rules | calc_custom_checks | `transcript_checks.required_phrases` pattern matching |
 | State assertions | tool_use_public_example_01 | `state_checks.assertions` JSONPath checks |
 | LLM judge | (create test task) | `judge` config calls LLM and returns structured score |
-| Custom checks | order_modify_with_checks | `custom_checks.script` executes Python grading logic |
+| Custom checks | reconcile_ledger (`examples/native/custom_checks/`) | `custom_checks.enabled: true` + `custom_checks.file` runs the pack's `checks.py`; the aggregate score fills `Grade.components.custom_checks` and per-check `CustomCheckResult`s ride the wire |
 | Combined grading | (create test task) | Multiple grading methods compose correctly |
 
 ### 12.2 Unstable fields verification

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -1,10 +1,14 @@
 # Grading System
 
-Tolokaforge evaluates agent performance across three dimensions:
+Tolokaforge evaluates agent performance across four dimensions:
 
 1. **State Checks** - Final environment state verification (hash-based or JSONPath)
 2. **Transcript Rules** - Process constraints (required phrases, tool usage, turn limits)
 3. **LLM Judge** - Per-criterion rubric grading by a read-only agentic judge
+4. **Custom Checks** - Author-written Python `@check` functions for the
+   deterministic-Python gap the other three don't express (arithmetic
+   over final state, transcript patterns tied to computed values). See
+   [custom_checks.md](custom_checks.md).
 
 Scores are weighted and combined into a final score. See [REFERENCE.md](REFERENCE.md) for `grading.yaml` schema.
 
@@ -424,6 +428,41 @@ scored as it was). See [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md).
 
 ---
 
+## Custom Checks
+
+The `custom_checks` component runs author-written Python `@check`
+functions from a pack's `checks.py`. It's the deterministic-Python gap
+the other three components don't express: arithmetic over final DB
+rows, invariants that span multiple tables, transcript patterns tied to
+computed values. Each `@check` returns `CheckPassed` / `CheckFailed` /
+`CheckSkipped`; per-check results ride the wire as `CustomCheckResult`
+entries and the aggregate `CheckResultSet.aggregate_score` fills the
+`custom_checks` component.
+
+```yaml
+custom_checks:
+  enabled: true
+  file: "checks.py"
+  interface_version: "1.0"
+  timeout_seconds: 30
+  weight: 1.0
+  fail_on_error: true
+```
+
+The full authoring API (`@init`, `@check`, `CheckContext`), the network
+doctrine (checks may not initiate network — the runner container's
+`no_internet` policy enforces at the container boundary; #673 tracks
+per-check sandboxing), and the delivery mechanics (`checks.py` bundled
+into `TaskDescription.tool_artifacts`) live in
+[custom_checks.md](custom_checks.md). The seam itself is
+[ADR-0012](adr/0012-custom-checks-extension.md).
+[`examples/native/custom_checks/`](../examples/native/custom_checks/)
+is the runnable reference — a ledger-reconciliation task that verifies
+`balance == opening + sum(credits) - sum(debits)` and combines that
+with `state_checks` under `combine.weights.custom_checks`.
+
+---
+
 ## pass@k Metrics
 
 Estimates probability that at least 1 of k attempts succeeds.
@@ -535,8 +574,11 @@ probe passes only for the one the after-hours policy permits.
 Final score formula:
 
 ```
-final_score = (state_score * W_state + transcript_score * W_transcript + judge_score * W_judge)
-              / (W_state + W_transcript + W_judge)
+final_score = (state_score       * W_state
+             + transcript_score  * W_transcript
+             + judge_score       * W_judge
+             + custom_score      * W_custom)
+              / (W_state + W_transcript + W_judge + W_custom)
 
 binary_pass = (final_score >= pass_threshold) AND (no required rubric criterion gated)
 ```
@@ -544,7 +586,9 @@ binary_pass = (final_score >= pass_threshold) AND (no required rubric criterion 
 A component that was not evaluated is **excluded** from both the numerator and
 the denominator — this includes an `llm_judge` component whose judge ERRORED
 (see [LLM Judge](#llm-judge-rubric-grading)): a broken judge is never folded in
-as a `0.0`.
+as a `0.0`. A `custom_checks`-only pack whose score comes back absent still
+fails loud (empty active set with a configured `custom_checks` weight ⇒
+`(0.0, False)`, not a silent `(1.0, True)`).
 
 ### Weighting Strategies
 
@@ -560,6 +604,13 @@ combine:
 combine:
   weights: { state_checks: 0.6, transcript_rules: 0.3, llm_judge: 0.1 }
   pass_threshold: 0.75
+```
+
+**Outcome + deterministic-Python check:**
+```yaml
+combine:
+  weights: { state_checks: 0.4, custom_checks: 0.6 }
+  pass_threshold: 0.8
 ```
 
 ### Inheriting `combine` from the project
@@ -641,5 +692,6 @@ state_checks:
 ## See Also
 
 - [REFERENCE.md](REFERENCE.md) - Configuration schemas
-- [CUSTOM_CHECKS.md](CUSTOM_CHECKS.md) - Custom Python validation
+- [custom_checks.md](custom_checks.md) - Custom Python validation
+- [ADR-0012](adr/0012-custom-checks-extension.md) - `CheckExecutor` Protocol seam
 - [TASKS.md](TASKS.md) - Task authoring guide with difficulty design patterns

--- a/docs/GRADING_VERIFICATION.md
+++ b/docs/GRADING_VERIFICATION.md
@@ -244,13 +244,7 @@ Output files are written by [`tolokaforge/core/output_writer.py`](../tolokaforge
 
 ---
 
-## C) What's Missing / Placeholder
-
-### Custom Checks placeholder
-
-```python
-custom_checks=-1.0,  # Not implemented yet
-```
+## C) Optional Components
 
 ### Transcript Rules
 
@@ -266,20 +260,33 @@ custom_checks=-1.0,  # Not implemented yet
 - `max_turns` - Verify conversation under turn limit
 
 **Current behavior:**
-- `transcript_rules` field in `GradeComponents` is usually `null`
-- Rules are evaluated if configured in `grading.yaml`
+- `transcript_rules` field in `GradeComponents` is `null` when the pack ships
+  no `transcript_rules` block.
+- Rules are evaluated when configured in `grading.yaml`.
 
 ### Custom Checks
 
-**Status: Implemented but not used in Docker architecture**
+**Status: Live in the runner grading path.**
 
 **Implementation at:**
-- [`tolokaforge/core/grading/check_runner.py`](../tolokaforge/core/grading/check_runner.py) - `CheckRunner`, `run_custom_checks()`
-- [`tolokaforge/core/grading/checks_interface.py`](../tolokaforge/core/grading/checks_interface.py) - Interface definitions
+- [`tolokaforge/core/grading/check_runner.py`](../tolokaforge/core/grading/check_runner.py) — `CheckRunner` (in-process production impl of the `CheckExecutor` Protocol).
+- [`tolokaforge/core/grading/checks_interface.py`](../tolokaforge/core/grading/checks_interface.py) — authoring API (`@init`, `@check`, `CheckContext`, `CustomChecksConfig`).
+- [`tolokaforge/core/grading/checks_helpers.py`](../tolokaforge/core/grading/checks_helpers.py) — `build_check_context` shared by both grading paths.
+- [`tolokaforge/runner/service.py`](../tolokaforge/runner/service.py) — `RunnerService.GradeTrial` runs the executor when `grading.custom_checks.enabled`.
 
 **Current behavior:**
-- `custom_checks` field in `GradeComponents` is always `null`
-- Runner service sets `custom_checks=-1.0` (not implemented)
+- `RegisterTrial` validates `custom_checks.file` at startup — an
+  unsupported `interface_version` or a broken module rejects the trial
+  before the agent loop runs.
+- `GradeTrial` runs each `@check`, fills `GradeComponents.custom_checks`
+  with the aggregate score, and rides per-check `CustomCheckResult`s on
+  `Grade.custom_checks` (the host maps them into
+  `Grade.custom_checks_details`).
+
+See [GRADING.md § Custom Checks](GRADING.md#custom-checks) for the mechanism,
+[custom_checks.md](custom_checks.md) for the authoring API + network doctrine,
+and [ADR-0012](adr/0012-custom-checks-extension.md) for the `CheckExecutor`
+seam.
 
 ---
 

--- a/docs/GRADING_VERIFICATION.md
+++ b/docs/GRADING_VERIFICATION.md
@@ -10,7 +10,7 @@ The grading system has been verified to work correctly for:
 - ✅ Results saved correctly to grade.yaml and trajectory.yaml
 - ⚠️ LLM judge (placeholder - not implemented)
 - ⚠️ Transcript rules (implemented but rarely used)
-- ⚠️ Custom checks (implemented but rarely used)
+- ✅ Custom checks (live in the runner grading path — see §C)
 
 ---
 

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -846,6 +846,60 @@ layers.
   reads `true` under the default. See
   [`docs/GRADING.md`](GRADING.md#gating-the-agents-policy-out-of-the-judges-evidence).
 
+### Custom-checks fields
+
+`components.custom_checks` and `custom_checks_details` are populated only when
+the pack sets `grading.custom_checks.enabled: true` and delivers a `checks.py`
+alongside the task. See [`docs/GRADING.md`](GRADING.md#custom-checks) for how
+the aggregate combines with the other three components and
+[`docs/custom_checks.md`](custom_checks.md) for the `@init` + `@check`
+authoring API.
+
+* `components.custom_checks` — aggregate score over every `@check` the pack
+  emitted, in `[0.0, 1.0]`. `null` when the pack has no `custom_checks` block
+  (or set `enabled: false`); when the executor errored under `fail_on_error:
+  false` the component is also excluded from the weighted combine. See
+  [`docs/custom_checks.md`](custom_checks.md#grade-output) for the scoring
+  rules.
+* `custom_checks_details` — one `CustomCheckDetail` entry per `@check` the
+  pack emitted. `null` when no custom checks ran; `[]` is distinct (the
+  executor ran but produced no per-check results). Each entry carries:
+    * `check_name` — the `@check` function name; the reserved sentinel
+      `__executor__` marks a top-level executor failure (module load error,
+      timeout, crash) so the audit survives even when no per-check ran.
+    * `status` — `"passed"` | `"failed"` | `"skipped"` | `"error"`.
+    * `score` — `[0.0, 1.0]`; `skipped` checks are excluded from the
+      aggregate.
+    * `message` — human-readable one-liner from the check's return value.
+    * `details` — optional dict of arbitrary structured detail the check
+      attached (decoded from the wire `details_json`); `null` when empty.
+
+Populated sample:
+
+```yaml
+components:
+  state_checks: 1.0
+  transcript_rules: null
+  llm_judge: null
+  custom_checks: 1.0
+custom_checks_details:
+  - check_name: balance_matches_transaction_net
+    status: passed
+    score: 1.0
+    message: "balance 700 == opening 500 + credits 260 - debits 60"
+    details:
+      actual: 700
+      expected: 700
+      opening_balance: 500
+      credits: 260
+      debits: 60
+  - check_name: transcript_enumerates_credit_transactions
+    status: passed
+    score: 1.0
+    message: "all credit transaction ids enumerated: ['T-1', 'T-3', 'T-5']"
+    details: null
+```
+
 ## `trials/{task_id}/{trial_index}/judge_trajectory.yaml`
 
 The rubric judge's own message transcript — written **only** when an LLM

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -861,6 +861,13 @@ authoring API.
   false` the component is also excluded from the weighted combine. See
   [`docs/custom_checks.md`](custom_checks.md#grade-output) for the scoring
   rules.
+
+  **Field-overload note**: tasks graded via the alternate test-execution
+  reward path (a `test.sh` grader, not `custom_checks.enabled: true`) also
+  write to `components.custom_checks` — carrying the reward score in the
+  same float. Unambiguous within a single grading mode: only one of the two
+  paths writes the field per grade, and `custom_checks_details` is `null`
+  under the reward path.
 * `custom_checks_details` — one `CustomCheckDetail` entry per `@check` the
   pack emitted. `null` when no custom checks ran; `[]` is distinct (the
   executor ran but produced no per-check results). Each entry carries:

--- a/docs/adr/0012-custom-checks-extension.md
+++ b/docs/adr/0012-custom-checks-extension.md
@@ -1,0 +1,212 @@
+# 0012. `CheckExecutor` Protocol — the custom-checks extension seam
+
+- **Status:** Accepted
+- **Date:** 2026-07-30
+- **Deciders:** Tolokaforge maintainers
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Custom Python checks are the deterministic grading extension for task authors: a
+task pack declares `custom_checks.enabled: true` in its grading config, ships a
+`checks.py` with `@init` + `@check` decorated functions, and the harness runs
+those checks against the trial's evidence (initial/final state, transcript, task
+metadata) and folds the per-check verdicts into the grade. The authoring API —
+the `@init`/`@check` decorators, `CheckContext`, `CheckPassed`/`CheckFailed`/
+`CheckSkipped`, `CustomChecksConfig` — is already Pattern B strict Pydantic and
+untouched by this ADR.
+
+The **executor** that loads `checks.py`, resolves relative imports, runs the
+decorated functions under a timeout, and returns a `CheckResultSet` was a single
+concrete class (`CheckRunner`) with no Protocol seam and no `InMemory*` fixture.
+Every runtime sibling — `RuntimeBackend` (ADR-0007), `Conductor` (ADR-0008),
+`TrialGrader` (ADR-0014), `Judge` (ADR-0020) — already follows Pattern A
+(ADR-0011): a `@runtime_checkable` Protocol, a production implementation, an
+`InMemory*` fixture with a call-log + failure knobs, and a canonical contract
+test pinning the boundary. ADR-0011's Follow-ups called for lifts of exactly
+this shape when a second variant becomes realistic.
+
+A second variant is realistic **now**, driven by two follow-ups the runner-side
+wire uncovers:
+
+- **#673 (harden custom-checks execution isolation)** — the current in-process
+  ThreadPoolExecutor is not a sandbox: a runaway thread cannot be killed by
+  `timeout`, checks run with container-network + filesystem access, and there is
+  no per-check resource cap. A subprocess/namespace-isolated executor is a
+  named second variant, blocked today by the missing seam.
+- **Runner-side test injection** — the runner-side wire (issue #669, this PR)
+  needs to unit-test `RunnerService.GradeTrial`'s custom-checks path without a
+  live checks module: today the only route is a `unittest.mock.MagicMock`
+  around `CheckRunner`, which pins mock shape instead of executor behaviour
+  (AGENTS Rule 5: test behaviour, not code).
+
+The problem this ADR resolves: **which shape does the executor take so the
+subprocess variant lands without forking runner-side wire, and so tests inject
+a real fixture instead of a mock — without a public-API break to the 27
+`CheckRunner()` instantiation sites?**
+
+## Decision Drivers
+
+- **Pattern A (ADR-0011).** Every runtime seam is `Protocol` + production impl +
+  `InMemory*` fixture + canonical contract test. The custom-checks executor is
+  the last first-class grading-plane runtime component that pre-dates the
+  pattern.
+- **Zero public-API break.** `CheckRunner` is a *published class* re-exported at
+  27 instantiation sites across 5 files (`combine.py`, `check_runner.py` incl.
+  `run_custom_checks`, `tests/unit/grading/test_custom_checks_runner.py`,
+  `tests/unit/grading/test_custom_checks.py`, `tests/canonical/
+  test_custom_checks_canon.py`). A repoint of the name to a Protocol would turn
+  every one into `TypeError` and force a rename migration for aesthetics.
+- **The evidence surface is the invariant worth pinning.** An executor must
+  never accept the deterministic-oracle fields of `GradingConfig`
+  (`golden_actions`, `expected_hash`, `jsonpath_checks`, `grading_config`); the
+  Protocol carries only `(checks_file, task_dir, ctx, config)` so those fields
+  cannot leak in.
+- **A subprocess-isolated variant must not be forced to accept the current
+  in-process knobs.** `executor_type` / `max_workers` are meaningful to the
+  ThreadPoolExecutor impl only; they cannot sit on the shared contract.
+- **Behaviour preservation.** The `CheckRunner.run` output must be byte-for-byte
+  the same as the pre-lift class — a structural lift, not a semantic change.
+
+## Considered Options
+
+1. **`CheckExecutor` Protocol capturing the existing `CheckRunner.run` surface;
+   `CheckRunner` stays the concrete in-process production impl; new
+   `InMemoryCheckExecutor` fixture + canonical contract test.** No rename, no
+   public churn.
+2. **Repoint `CheckRunner` to a Protocol; rename the concrete class to
+   `ThreadedCheckRunner` (or similar) as the production impl.** Names match the
+   `Judge`/`LLMJudge` symmetry ADR-0020 established.
+3. **Keep the executor as a concrete class — no seam.** The one-impl status quo.
+
+## Decision
+
+We adopt **Option 1**: a `CheckExecutor` Protocol capturing the existing
+`CheckRunner.run` surface, with `CheckRunner` unchanged as the production impl
+and a new `InMemoryCheckExecutor` fixture.
+
+```python
+@runtime_checkable
+class CheckExecutor(Protocol):
+    def run(
+        self,
+        checks_file: Path,
+        task_dir: Path,
+        ctx: CheckContext,
+        config: CustomChecksConfig,
+    ) -> CheckResultSet: ...
+```
+
+**The evidence-only `run()` surface is the load-bearing choice.** How an
+executor is *built* — the isolation strategy, worker-pool sizing, an injected
+logger — lives on the concrete implementation's constructor. What an executor
+*runs* — the per-trial evidence — is the `run()` surface. This mirrors `Judge`
+(ADR-0020), `TrialGrader` (ADR-0014), and `Conductor` (ADR-0008): construction
+captures the how, the method carries the what. A future subprocess-isolated
+`SubprocessCheckExecutor` (#673) satisfies the same Protocol with a completely
+different construction surface (subprocess cgroups, syscall filter, resource
+caps) and drops in without touching `RunnerService.GradeTrial`.
+
+`InMemoryCheckExecutor` is the real (non-mock) fixture: it records each `run()`
+on a `CheckExecutorCallLog` and returns a configurable `CheckResultSet`.
+Failure knobs — `raise_on_run=…` and `return_error=…` — exercise the two shapes
+the production runner surfaces on trouble (an unexpected top-level exception,
+and a `CheckResultSet` whose `error` field carries a module-load or timeout
+message). The three knobs (`result_set`, `raise_on_run`, `return_error`) are
+mutually exclusive and rejected at construction so tests cannot silently
+misconfigure the fixture.
+
+### Naming decision
+
+We do **not** repoint the name `CheckRunner` to the Protocol.
+
+ADR-0011 requires *Protocol + prod impl + `InMemory*` + contract test*; it
+does **not** require the Protocol take the "clean" name. Unlike ADR-0020 —
+where the concrete surface was a top-level *function* `run_rubric_judge` (not
+a class, not on any `__all__`), leaving `Judge` free — the name `CheckRunner`
+is an already-published *class* instantiated at 27 sites across 5 files. A
+repoint to a Protocol would turn every `CheckRunner()` call into `TypeError`,
+force a rename of every site, and create a published-API migration line for
+aesthetics.
+
+`CheckExecutor` (Protocol) + `CheckRunner` (in-process production impl)
+delivers the full Pattern A boundary at zero public churn. The Protocol name
+reads correctly on the seam side (`CheckExecutor.run` is what a grader calls);
+the concrete name reads correctly on the production side (`CheckRunner`
+constructs a ThreadPoolExecutor and runs a checks module). Future variants
+follow the `<mechanism>CheckExecutor` pattern (`SubprocessCheckExecutor`,
+`ReplayCheckExecutor`, …) — the Protocol name is the intent, not one of the
+mechanisms.
+
+Option 2 (repoint + rename) is rejected: the symmetry with `Judge`/`LLMJudge`
+does not justify a published-API break, and the ADR-0011 boundary is fully
+satisfied either way.
+
+## Consequences
+
+### Positive
+
+- The executor is a named, swappable component, matching the rest of the
+  grading plane. Runner-side tests isolate it with `InMemoryCheckExecutor`
+  instead of scripting a mock.
+- The narrow-evidence-surface invariant is pinned at the contract: the
+  canonical test asserts `CheckExecutor.run` carries only
+  `(checks_file, task_dir, ctx, config)` — no `GradingConfig`, no oracle
+  fields.
+- The subprocess-isolated variant (#673) has a Protocol to slot into without
+  touching any caller.
+- Zero migration: no rename, no `_legacy_*` alias, no CHANGELOG line — the 27
+  `CheckRunner()` sites keep working exactly as before.
+
+### Negative / Trade-offs
+
+- The Protocol name (`CheckExecutor`) does not match the concrete class
+  (`CheckRunner`). The distinction is intentional (see Naming decision), but
+  contributors browsing the module see two names for what looks like the same
+  thing at first read. Mitigated by the module docstring, the `__init__.py`
+  re-export block, and this ADR.
+- Callers that want a Protocol-typed variable annotate as
+  `executor: CheckExecutor = CheckRunner()` — one extra line vs. the concrete
+  annotation. Acceptable — that is exactly the shape the seam is for.
+
+### Follow-ups
+
+- Code changes required: none beyond this lift; #673's subprocess executor
+  lands as a new `CheckExecutor` implementation.
+- Documentation to update: this ADR is the new source of truth for the seam;
+  `docs/custom_checks.md` describes the *authoring* surface (unchanged) and
+  points at this ADR for the executor boundary (Stage 5 of the enclosing PR).
+- Tests to add: `tests/canonical/test_check_executor_contract.py` pins the
+  Protocol boundary + `InMemoryCheckExecutor` semantics (added with this
+  lift).
+
+## Alternatives considered
+
+**Repoint `CheckRunner` to a Protocol (Option 2).** Rejected: 27 instantiation
+sites across 5 files break with `TypeError`, forcing a rename migration + a
+CHANGELOG line for a public-API break with no user-visible benefit. The
+`Judge` / `LLMJudge` naming symmetry it would deliver is aesthetic; the
+ADR-0011 boundary is fully satisfied by Option 1.
+
+**Keep the executor as a concrete class (Option 3).** Rejected: no seam for
+the second variant (#673), and runner-side wire tests would grow their own
+`MagicMock(CheckRunner)` glue — the exact "test the mock, not the behaviour"
+pattern AGENTS Rule 5 rejects.
+
+## Links
+
+- Related ADRs: ADR-0011 (seam + declaration conventions; Pattern A whose
+  Follow-ups named this lift), ADR-0020 (`Judge` Protocol — the closest
+  structural precedent; note the naming rationale for why `Judge` could take
+  the clean name and `CheckExecutor` cannot).
+- Related code: `tolokaforge/core/grading/check_runner.py`
+  (`CheckExecutor` / `CheckRunner` / `InMemoryCheckExecutor` /
+  `CheckExecutorCallLog`), `tolokaforge/core/grading/checks_interface.py`
+  (the authoring surface — unchanged);
+  `tests/canonical/test_check_executor_contract.py`.
+- External references: GH #669 (finish runner-side custom checks — this ADR
+  is Stage 1 of that PR), #406 (finish or delete the custom-checks seam),
+  #217 (dead-plumbing follow-up), #673 (subprocess-isolated executor —
+  first named second variant), #674 (remove dead `run_custom_checks` /
+  `result_to_score` convenience helpers).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0009](0009-environment-manifest.md) | `EnvironmentManifest` — typed schema for per-trial multicontainer environments | Accepted |
 | [0010](0010-runtime-backend-provisioning-contract.md) | `RuntimeBackend` provisioning contract — `provision` / `await_ready` / `endpoints` / `teardown` | Accepted |
 | [0011](0011-seam-and-declaration-conventions.md) | Seam-definition and data-declaration conventions for new components | Accepted |
+| [0012](0012-custom-checks-extension.md) | `CheckExecutor` Protocol — the custom-checks extension seam | Accepted |
 | [0013](0013-runtime-backend-per-trial-rpc-methods.md) | `RuntimeBackend` owns per-trial RPC methods — collapse `DockerRunnerAdapter` | Accepted |
 | [0014](0014-trial-grader-protocol.md) | `TrialGrader` Protocol — swappable trial-grading strategy | Accepted |
 | [0015](0015-trial-executor-protocol.md) | `TrialExecutor` Protocol — per-trial substrate-lifecycle seam | Accepted |

--- a/docs/custom_checks.md
+++ b/docs/custom_checks.md
@@ -156,7 +156,7 @@ Two consequences follow:
   checks share the runner container's filesystem + Python process.
   Author checks defensively (no monkey-patching, no shared mutable
   globals across checks). True per-check sandboxing is tracked in
-  [#673](https://github.com/tolokasoft1/tolokaforge/issues/673); a
+  [#673](https://github.com/Toloka/tolokaforge/issues/673); a
   subprocess-isolated `CheckExecutor` lands as a new implementation of
   the ADR-0012 Protocol without touching any caller.
 
@@ -216,5 +216,5 @@ unit tier is for the framework, not the pack's grader.
 - [`examples/native/custom_checks/`](../examples/native/custom_checks/)
   — runnable reference pack (ledger reconciliation).
 - [ADR-0012 — the `CheckExecutor` Protocol seam](adr/0012-custom-checks-extension.md).
-- [ADR-0018 — network policy (`no_internet` invariant)](adr/0018-network-policy.md).
+- [ADR-0018 — network policy (`no_internet` invariant)](adr/0018-multi-container-under-shared-runtime.md).
 - [GRADING.md — the four-component grade](GRADING.md#custom-checks).

--- a/docs/custom_checks.md
+++ b/docs/custom_checks.md
@@ -1,37 +1,220 @@
 # Custom Checks
 
-Tolokaforge supports Python-based custom checks for grading beyond JSONPath and transcript rules.
+`custom_checks` is the deterministic-Python grading extension. A task pack
+declares a `checks.py` next to `task.yaml`, wires it in via `grading.yaml`,
+and the runner executes those checks over the trial's `CheckContext`
+(initial/final state + transcript + task metadata). Per-check results and
+an aggregate score land on the grade next to `state_checks`,
+`transcript_rules`, and `llm_judge`; the weight declared in
+`combine.weights.custom_checks` scales that score in the weighted final.
+See [GRADING.md](GRADING.md#custom-checks) for how the four components
+combine.
 
-## Usage
+Use `custom_checks` for the scoring shape no declarative primitive
+expresses — arithmetic over final DB rows, invariants that span multiple
+tables, transcript patterns tied to computed values. Reach for
+`state_checks.jsonpaths` first (JSONPath equals/contains is enough for
+most tasks) and reserve `custom_checks` for the deterministic-Python gap.
 
-Add a `checks.py` file in your task directory and reference it in `grading.yaml`:
+> **Live reference:** `examples/native/custom_checks/` ships a runnable
+> pack that reconciles a customer balance from a transaction list and
+> asserts the arithmetic result — the shape this seam exists for.
+
+## Schema
+
+`custom_checks:` is a sibling of `state_checks:` / `transcript_rules:` /
+`llm_judge:` under `grading.yaml`.
 
 ```yaml
 custom_checks:
-  enabled: true
-  checks_file: "checks.py"
-  timeout_s: 30
+  enabled: true             # required; false (default) disables the block
+  file: "checks.py"         # relative to task dir (default: "checks.py")
+  interface_version: "1.0"  # required to match SUPPORTED_VERSIONS
+  timeout_seconds: 30       # per-check wall clock (default: 30.0)
+  weight: 1.0               # weight in the aggregate CheckResultSet (default: 1.0)
+  fail_on_error: true       # true (default): executor errors ⇒ 0.0; false ⇒ excluded
+  relative_imports:         # extra sys.path entries (relative to task dir)
+    - "../.."
 ```
 
-Inside `checks.py`, implement functions that receive a `CheckContext` and return `CheckResult` objects.
+The block is validated into
+[`CustomChecksConfig`](../tolokaforge/core/grading/checks_interface.py)
+at both `RegisterTrial` and `GradeTrial` time.
 
-See `tolokaforge/core/grading/checks_interface.py` for the API.
+## Authoring API — `@init` + `@check`
+
+Import the decorators, `CheckContext`, and the result types from
+`tolokaforge.core.grading.checks_interface`. Import the framework helpers
+(`find_by_key`, `tool_was_called`, `text_contains_any`, …) from
+`tolokaforge.core.grading.checks_helpers`.
+
+```python
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext, CheckPassed, CheckFailed, CheckSkipped, check, init,
+)
+from tolokaforge.core.grading.checks_helpers import find_by_key, tool_was_called
+
+_ctx: CheckContext | None = None
+
+
+@init(interface_version="1.0")
+def _load_context(ctx: CheckContext) -> None:
+    global _ctx
+    _ctx = ctx
+
+
+@check
+def balance_matches_transaction_net() -> CheckPassed | CheckFailed:
+    assert _ctx is not None
+    customers = _ctx.final_state.data.get("customers", [])
+    transactions = _ctx.final_state.data.get("transactions", [])
+    customer = find_by_key(customers, "id", "C-1")
+    if customer is None:
+        return CheckFailed("customer 'C-1' missing")
+
+    net = sum(
+        (t["amount"] if t["kind"] == "credit" else -t["amount"])
+        for t in transactions
+    )
+    expected = customer["opening_balance"] + net
+    if customer["balance"] == expected:
+        return CheckPassed(f"balance {customer['balance']} == {expected}")
+    return CheckFailed(
+        f"balance {customer['balance']} != {expected}",
+        details={"expected": expected, "actual": customer["balance"]},
+    )
+```
+
+The rules:
+
+- `@init(interface_version="1.0")` marks a single module-level setup
+  function. It receives the `CheckContext` once, before any `@check`
+  runs, and typically stashes it as module state for the `@check`
+  functions to read.
+- `@check` marks a zero-argument function that returns one of
+  `CheckPassed`, `CheckFailed`, or `CheckSkipped`. The function name
+  becomes the `check_name` on the result. Each `@check` is executed
+  under the configured `timeout_seconds`.
+- `CheckPassed(message, score=1.0, details={})` and
+  `CheckFailed(message, score=0.0, details={})` accept a positional
+  message and optional score / details dict. `CheckSkipped(message)` is
+  excluded from the aggregate score. Scores are clamped `[0, 1]`.
+- `SUPPORTED_VERSIONS` lives in
+  `tolokaforge.core.grading.checks_interface`. A declared
+  `interface_version` outside that set is rejected at `RegisterTrial`
+  (see below).
+
+### `CheckContext` — the evidence surface
+
+`CheckContext` is the sole input to `@init`. It carries:
+
+| Field | Shape | Source |
+|---|---|---|
+| `initial_state` | `EnvironmentState(data=dict)` | Author-declared `initial_state.json_db` at task load. |
+| `final_state` | `EnvironmentState(data=dict)` | Runner-side: `db_client.get_state(trial_id)` post-trial. |
+| `transcript` | `Transcript(messages=[Message])` | `llm_messages_json` decoded to `Message`/`ToolCall`. |
+| `task` | `TaskContext(task_id, name, description, domain, tags)` | `TaskDescription` metadata. |
+
+`ctx.final_state.data` is shaped by the canonical transform in
+[`build_check_context`](../tolokaforge/core/grading/checks_helpers.py):
+when the runner returns a nested state, an `"agent"` dict wins over a
+`"db"` dict, else the flat wire dict is used; a `"filesystem"` key is
+merged in when the chosen level lacks one. Both the host `GradingEngine`
+and the runner call the same helper, so a check reads identical evidence
+from either grading path.
+
+`ctx.effects` is a legacy alias for `ctx.final_state.data`.
+`ctx.tool_calls` is `ctx.transcript.all_tool_calls`. `ctx.response` is
+the last assistant message content.
 
 ## Interface version contract
 
-`checks.py` declares its authoring interface via the `@init` decorator:
+When `custom_checks.enabled` is `true`, `RegisterTrial` loads `checks.py`
+far enough to read the declared `@init(interface_version=…)` and rejects
+the trial *before* the agent loop runs if the version is outside
+`SUPPORTED_VERSIONS` or the module (or any `relative_imports` target)
+fails to load. The rejection error names both the declared version and
+the supported set so the pack author sees exactly what to change.
 
-```python
-@init(interface_version="1.0")
-def setup(ctx):
-    ...
+## Network doctrine — checks do not initiate network
+
+Custom checks are pure functions over `CheckContext`: the harness hands
+each check state dicts, a transcript, and task metadata, and nothing
+else. Do not construct HTTP clients, open sockets, or shell out to
+network tools inside a `@check`. The enforcement boundary is the runner
+container's `no_internet` NetworkPolicy (ADR-0018 / #581): external
+egress is denied at the container level, so a check that tries an
+outbound call fails loudly rather than reaching the internet.
+
+Two consequences follow:
+
+- Checks must not depend on external services being reachable. A check
+  reading a config from a remote endpoint would fail on the runner even
+  when the config is correct — because the boundary denies the request.
+- The in-process executor is **not** a per-check sandbox: `timeout` runs
+  through a `ThreadPoolExecutor` that cannot kill a runaway thread, and
+  checks share the runner container's filesystem + Python process.
+  Author checks defensively (no monkey-patching, no shared mutable
+  globals across checks). True per-check sandboxing is tracked in
+  [#673](https://github.com/tolokasoft1/tolokaforge/issues/673); a
+  subprocess-isolated `CheckExecutor` lands as a new implementation of
+  the ADR-0012 Protocol without touching any caller.
+
+## Delivery — `checks.py` travels in `tool_artifacts`
+
+`NativeAdapter` bundles `checks.py` (and every `relative_imports` target
+directory) into `TaskDescription.tool_artifacts` whenever
+`custom_checks.enabled` is true — independent of whether the task also
+ships an MCP server. The runner extracts the bundle to the trial's
+`artifacts_dir`, adds that directory to `sys.path`, and resolves
+`custom_checks.file` against it. Packs work identically with or without
+`tools.agent.mcp_server`.
+
+## Grade output
+
+Each `@check` produces one `CustomCheckResult` on the wire:
+
+```
+message CustomCheckResult {
+  string check_name = 1;   // the @check function name
+  string status = 2;       // "passed" | "failed" | "error" | "skipped"
+  double score = 3;        // [0, 1]; skipped checks are excluded
+  string message = 4;      // human-readable one-liner
+  string details_json = 5; // JSON-encoded details dict, "" when empty
+}
 ```
 
-The runner validates this at **trial registration**, not at trial end. When a
-pack sets `custom_checks.enabled: true`, `RegisterTrial` loads `checks.py` far
-enough to read the declared `interface_version` — an unsupported version (or a
-module that fails to import) rejects the trial immediately, before the agent
-loop runs. The rejection error names both the declared version and the runner's
-`SUPPORTED_VERSIONS` set so the pack author sees exactly what to change.
+The host parses that list into `Grade.custom_checks_details`
+(`core/models.py:373`) alongside the aggregate score on
+`Grade.components.custom_checks`. When the top-level executor errors
+(module load failure, timeout, executor crash), a sentinel result under
+`check_name="__executor__"` preserves the audit and the aggregate score
+follows `fail_on_error`: `0.0` when true, excluded from the combine when
+false.
 
-Supported versions live in `tolokaforge.core.grading.checks_interface.SUPPORTED_VERSIONS`.
+## Choosing a test tier
+
+- **Unit** (`tests/unit/grading/`) — pin the *check logic itself*
+  against a hand-built `CheckContext` and the in-process `CheckRunner`
+  (see `test_custom_checks_runner.py`). This is where per-check
+  arithmetic lives; the executor runs in-process, no runner needed.
+- **Canonical** (`tests/canonical/`) — pin the *seam*
+  (`test_check_executor_contract.py` pins the `CheckExecutor` Protocol
+  boundary + `InMemoryCheckExecutor` semantics per ADR-0012).
+- **Integration** (`tests/integration/`, `@pytest.mark.requires_docker`)
+  — pin the *wire*
+  (`test_custom_checks_e2e.py` drives the reference pack through the
+  Docker runner and asserts per-check `CustomCheckResult`s, aggregate
+  score, and the applied weight — the acceptance criterion for the
+  seam).
+
+`checks.py` itself belongs to the *task pack*, not the test suite; the
+unit tier is for the framework, not the pack's grader.
+
+## See also
+
+- [`examples/native/custom_checks/`](../examples/native/custom_checks/)
+  — runnable reference pack (ledger reconciliation).
+- [ADR-0012 — the `CheckExecutor` Protocol seam](adr/0012-custom-checks-extension.md).
+- [ADR-0018 — network policy (`no_internet` invariant)](adr/0018-network-policy.md).
+- [GRADING.md — the four-component grade](GRADING.md#custom-checks).

--- a/docs/custom_checks.md
+++ b/docs/custom_checks.md
@@ -16,3 +16,22 @@ custom_checks:
 Inside `checks.py`, implement functions that receive a `CheckContext` and return `CheckResult` objects.
 
 See `tolokaforge/core/grading/checks_interface.py` for the API.
+
+## Interface version contract
+
+`checks.py` declares its authoring interface via the `@init` decorator:
+
+```python
+@init(interface_version="1.0")
+def setup(ctx):
+    ...
+```
+
+The runner validates this at **trial registration**, not at trial end. When a
+pack sets `custom_checks.enabled: true`, `RegisterTrial` loads `checks.py` far
+enough to read the declared `interface_version` — an unsupported version (or a
+module that fails to import) rejects the trial immediately, before the agent
+loop runs. The rejection error names both the declared version and the runner's
+`SUPPORTED_VERSIONS` set so the pack author sees exactly what to change.
+
+Supported versions live in `tolokaforge.core.grading.checks_interface.SUPPORTED_VERSIONS`.

--- a/examples/native/custom_checks/README.md
+++ b/examples/native/custom_checks/README.md
@@ -1,0 +1,32 @@
+# Custom checks example — ledger reconciliation
+
+Reference pack that exercises the `custom_checks` grading extension:
+`grading.yaml` declares `custom_checks.enabled: true` and a `checks.py` next
+to the task. The runner runs those checks over the trial's final state +
+transcript and folds a `custom_checks` component into the weighted grade
+alongside `state_checks`. See [docs/custom_checks.md](../../../docs/custom_checks.md).
+
+The task's grader computes the customer balance from the transaction list
+(sum of credits minus sum of debits) and asserts the final DB balance
+matches — arithmetic scoring on state + transcript that no declarative
+`state_checks` primitive expresses. This is the deterministic-Python gap
+the `custom_checks` seam exists for.
+
+## Validate
+
+```bash
+uv run tolokaforge validate --tasks "examples/native/custom_checks/dataset/**/task.yaml"
+```
+
+## Run
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/custom_checks/run_config.yaml
+```
+
+## Tasks included
+
+- `dataset/tasks/reconcile_ledger/` — reconcile customer `C-1`'s balance
+  against a five-transaction list. `checks.py` verifies
+  `balance == sum(credits) - sum(debits)` and that the agent's transcript
+  enumerates every credit-transaction id.

--- a/examples/native/custom_checks/dataset/tasks/reconcile_ledger/checks.py
+++ b/examples/native/custom_checks/dataset/tasks/reconcile_ledger/checks.py
@@ -1,0 +1,114 @@
+"""Arithmetic custom checks for the ledger-reconciliation reference task.
+
+The two checks together exercise the deterministic-Python gap the
+`custom_checks` seam exists for: arithmetic scoring on the final DB state
+combined with transcript evidence that no declarative state / transcript
+primitive expresses.
+
+    1. `balance_matches_transaction_net` — sums the `transactions` table
+       (credits positive, debits negative), adds the recorded opening
+       balance, and asserts `customers[id='C-1'].balance` equals the
+       computed total.
+    2. `transcript_enumerates_credit_transactions` — verifies the agent
+       actually inspected the ledger by looking for every credit
+       transaction id in the transcript's tool-call arguments or message
+       content, and that at least one `db_query` was issued.
+"""
+
+from __future__ import annotations
+
+from tolokaforge.core.grading.checks_helpers import find_by_key, tool_was_called
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext,
+    CheckFailed,
+    CheckPassed,
+    check,
+    init,
+)
+
+_CREDIT_TXN_IDS = ("T-1", "T-3", "T-5")
+
+_ctx: CheckContext | None = None
+
+
+@init(interface_version="1.0")
+def _load_context(ctx: CheckContext) -> None:
+    global _ctx
+    _ctx = ctx
+
+
+def _final_state_data() -> dict:
+    assert _ctx is not None, "checks accessed before @init ran"
+    return _ctx.final_state.data
+
+
+def _transcript_haystack() -> str:
+    """Concatenate every content string + every tool-call argument value.
+
+    The runner-side transcript builder decodes wire tool calls into
+    `ToolCall(name, arguments)` (result is not carried on the wire), so the
+    haystack must look at both message content and tool-call argument
+    dicts to reflect what evidence a check actually has access to.
+    """
+    assert _ctx is not None, "checks accessed before @init ran"
+    parts: list[str] = []
+    for msg in _ctx.transcript.messages:
+        parts.append(msg.content or "")
+        for tc in msg.tool_calls:
+            for value in (tc.arguments or {}).values():
+                parts.append(str(value))
+    return "\n".join(parts)
+
+
+@check
+def balance_matches_transaction_net() -> CheckPassed | CheckFailed:
+    """`balance == opening_balance + sum(credits) - sum(debits)`."""
+    state = _final_state_data()
+    customers = state.get("customers", [])
+    transactions = state.get("transactions", [])
+    customer = find_by_key(customers, "id", "C-1")
+    if customer is None:
+        return CheckFailed("customer 'C-1' missing from final state")
+
+    opening = customer.get("opening_balance")
+    if not isinstance(opening, (int, float)):
+        return CheckFailed(
+            f"customer.opening_balance not numeric: {opening!r}",
+            details={"opening_balance": opening},
+        )
+
+    credits = sum(t["amount"] for t in transactions if t.get("kind") == "credit")
+    debits = sum(t["amount"] for t in transactions if t.get("kind") == "debit")
+    expected = opening + credits - debits
+    actual = customer.get("balance")
+    if actual == expected:
+        return CheckPassed(
+            f"balance {actual} == opening {opening} + credits {credits} - debits {debits}"
+        )
+    return CheckFailed(
+        f"balance {actual!r} != opening {opening} + credits {credits} - debits {debits} = {expected}",
+        details={
+            "actual": actual,
+            "expected": expected,
+            "opening_balance": opening,
+            "credits": credits,
+            "debits": debits,
+        },
+    )
+
+
+@check
+def transcript_enumerates_credit_transactions() -> CheckPassed | CheckFailed:
+    """Every credit transaction id must appear in the transcript."""
+    assert _ctx is not None, "checks accessed before @init ran"
+    if not tool_was_called(_ctx.tool_calls, "db_query"):
+        return CheckFailed("no db_query call in transcript — ledger not inspected")
+
+    haystack = _transcript_haystack()
+    missing = [tid for tid in _CREDIT_TXN_IDS if tid not in haystack]
+    if missing:
+        return CheckFailed(
+            f"credit transactions not enumerated in transcript: {missing}",
+            details={"missing": missing, "expected": list(_CREDIT_TXN_IDS)},
+        )
+    return CheckPassed(f"all credit transaction ids enumerated: {list(_CREDIT_TXN_IDS)}")

--- a/examples/native/custom_checks/dataset/tasks/reconcile_ledger/grading.yaml
+++ b/examples/native/custom_checks/dataset/tasks/reconcile_ledger/grading.yaml
@@ -1,0 +1,18 @@
+combine:
+  method: weighted
+  weights:
+    state_checks: 0.4
+    custom_checks: 0.6
+  pass_threshold: 0.8
+state_checks:
+  jsonpaths:
+    - path: "$.db.customers[0].balance"
+      equals: 700
+      description: "Customer balance reflects the reconciled total"
+custom_checks:
+  enabled: true
+  file: "checks.py"
+  interface_version: "1.0"
+  timeout_seconds: 30
+  weight: 1.0
+  fail_on_error: true

--- a/examples/native/custom_checks/dataset/tasks/reconcile_ledger/initial_state.json
+++ b/examples/native/custom_checks/dataset/tasks/reconcile_ledger/initial_state.json
@@ -3,7 +3,7 @@
     {
       "id": "C-1",
       "opening_balance": 500,
-      "balance": 700
+      "balance": 500
     }
   ],
   "transactions": [

--- a/examples/native/custom_checks/dataset/tasks/reconcile_ledger/initial_state.json
+++ b/examples/native/custom_checks/dataset/tasks/reconcile_ledger/initial_state.json
@@ -1,0 +1,16 @@
+{
+  "customers": [
+    {
+      "id": "C-1",
+      "opening_balance": 500,
+      "balance": 700
+    }
+  ],
+  "transactions": [
+    {"id": "T-1", "customer_id": "C-1", "kind": "credit", "amount": 120},
+    {"id": "T-2", "customer_id": "C-1", "kind": "debit",  "amount": 45},
+    {"id": "T-3", "customer_id": "C-1", "kind": "credit", "amount": 60},
+    {"id": "T-4", "customer_id": "C-1", "kind": "debit",  "amount": 15},
+    {"id": "T-5", "customer_id": "C-1", "kind": "credit", "amount": 80}
+  ]
+}

--- a/examples/native/custom_checks/dataset/tasks/reconcile_ledger/task.yaml
+++ b/examples/native/custom_checks/dataset/tasks/reconcile_ledger/task.yaml
@@ -1,0 +1,33 @@
+task_id: "reconcile_ledger"
+name: "Reconcile Customer Ledger"
+category: "custom_checks"
+description: >
+  Reconcile customer C-1's balance against the pending transaction list:
+  read every transaction, sum credits and debits, and update the customer
+  record so `balance == sum(credit.amount) - sum(debit.amount)` starting
+  from the recorded opening balance.
+initial_user_message: >
+  Customer `C-1` has an opening balance of 500 and five pending
+  transactions in the `transactions` table. Read every transaction, sum
+  the credits minus debits, and update `customers[id='C-1'].balance` so
+  it matches the reconciled total. Confirm the new balance in your reply
+  and list the transaction ids you applied.
+initial_state:
+  json_db: "initial_state.json"
+tools:
+  agent:
+    enabled: ["db_query", "db_update"]
+  user:
+    enabled: []
+actors:
+  user:
+    backstory: >
+      Operations reviewer verifying the agent reconciled every listed
+      transaction and updated the balance. Acknowledge and end with
+      ###STOP### once the reconciled balance and the applied
+      transaction ids are quoted.
+policies:
+  guidance:
+    - "Enumerate every transaction — cite each id in your reply."
+    - "Compute the net effect explicitly (sum of credits minus sum of debits)."
+grading: "grading.yaml"

--- a/examples/native/custom_checks/project.yaml
+++ b/examples/native/custom_checks/project.yaml
@@ -1,0 +1,28 @@
+# Project spec for the custom-checks reference pack.
+#
+# One deterministic-Python task: reconcile a customer's ledger by summing
+# per-transaction credits/debits and verifying the balance matches. The
+# scoring is arithmetic on final state + transcript evidence — the gap
+# `custom_checks` exists for (see docs/custom_checks.md, ADR-0012).
+# No Docker substrate: state lives in `initial_state.json_db`.
+
+name: "custom-checks-ledger"
+version: 1
+description: >
+  Custom-checks reference: reconcile a customer's ledger from a list of
+  transactions and verify the balance arithmetically. Demonstrates
+  `custom_checks.enabled: true` alongside `state_checks.jsonpaths`, with
+  the weight declared in `combine.weights` applied to the final score.
+
+tasks:
+  reconcile_ledger:
+    glob: "dataset/tasks/**/task.yaml"
+
+# ── Task defaults — base for every task ─────────────────────────
+task_defaults:
+  adapter_type: "native"
+  max_turns: 6
+  actors:
+    user:
+      mode: "llm"
+      persona: "cooperative"

--- a/examples/native/custom_checks/run_config.yaml
+++ b/examples/native/custom_checks/run_config.yaml
@@ -1,0 +1,25 @@
+# Custom-checks reference pack — reconcile a customer's ledger.
+# Requires a real LLM provider key in .env. Run via
+#   scripts/with_env.sh uv run tolokaforge run --config examples/native/custom_checks/run_config.yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.0
+    max_tokens: 4096
+  user:
+    provider: "openrouter"
+    name: "anthropic/claude-sonnet-4-6"
+    temperature: 0.2
+
+orchestrator:
+  workers: 1
+  repeats: 1
+  max_turns: 6
+  queue_backend: sqlite
+
+evaluation:
+  projects:
+    - "examples/native/custom_checks/dataset"
+  tasks_glob: "**/task.yaml"
+  output_dir: "results/custom_checks_example"

--- a/tests/canonical/snapshots/tbench_echo_hello/task_description.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_description.json
@@ -50,6 +50,7 @@
   "generated_at": null,
   "grading": {
     "combine_method": "weighted",
+    "custom_checks": null,
     "grading_method": "test_execution",
     "llm_judge": null,
     "pass_threshold": 0.5,

--- a/tests/canonical/test_check_executor_contract.py
+++ b/tests/canonical/test_check_executor_contract.py
@@ -1,0 +1,244 @@
+"""Pin the ``CheckExecutor`` Protocol contract (ADR-0012, Pattern A).
+
+Two implementations must satisfy the Protocol: :class:`CheckRunner` (the
+in-process production impl — constructed here but its per-trial ``run()``
+is exercised by ``tests/unit/grading/test_custom_checks_runner.py`` and
+``tests/canonical/test_custom_checks_canon.py`` against a real
+``checks.py``) and :class:`InMemoryCheckExecutor` (the deterministic test
+fixture; its call-log and failure-knob semantics are pinned here).
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import (
+    CheckExecutor,
+    CheckExecutorCallLog,
+    CheckRunner,
+    InMemoryCheckExecutor,
+)
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext,
+    CheckResult,
+    CheckResultSet,
+    CheckStatus,
+    CustomChecksConfig,
+    EnvironmentState,
+    Message,
+    TaskContext,
+    Transcript,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _ctx(*, task_id: str = "task-42", final: dict | None = None, msgs: int = 0) -> CheckContext:
+    """Synthetic :class:`CheckContext` — deterministic, no file I/O.
+
+    The fixture never inspects the checks module, so the initial/final/
+    transcript shapes matter only for the call-log echo — the contract
+    test asserts on presence + surface, not per-check behaviour.
+    """
+    return CheckContext(
+        initial_state=EnvironmentState(data={}),
+        final_state=EnvironmentState(data=final or {}),
+        transcript=Transcript(
+            messages=[Message(role="user", content=f"m{i}") for i in range(msgs)]
+        ),
+        task=TaskContext(task_id=task_id),
+    )
+
+
+def _cfg() -> CustomChecksConfig:
+    return CustomChecksConfig(
+        enabled=True,
+        file="checks.py",
+        interface_version="1.0",
+        timeout_seconds=7.5,
+        fail_on_error=False,
+    )
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; both implementations satisfy it
+    via ``isinstance`` (not just by structural type-hint compatibility)."""
+
+    def test_check_runner_passes_isinstance(self) -> None:
+        assert isinstance(CheckRunner(), CheckExecutor)
+
+    def test_in_memory_check_executor_passes_isinstance(self) -> None:
+        assert isinstance(InMemoryCheckExecutor(), CheckExecutor)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotACheckExecutor:
+            pass
+
+        assert not isinstance(_NotACheckExecutor(), CheckExecutor)
+
+    def test_object_with_matching_shape_passes_isinstance(self) -> None:
+        class _DuckExecutor:
+            def run(
+                self,
+                checks_file: Path,
+                task_dir: Path,
+                ctx: CheckContext,
+                config: CustomChecksConfig,
+            ) -> CheckResultSet:  # pragma: no cover — never called
+                return CheckResultSet()
+
+        assert isinstance(_DuckExecutor(), CheckExecutor)
+
+
+class TestRunMethodSignature:
+    """All three surfaces expose the same ``run()`` parameter names AND defaults
+    (drop-in substitutability — an impl that drops or renames a positional param
+    would force call-site edits at every construction site)."""
+
+    def test_run_signatures_match_across_protocol_and_impls(self) -> None:
+        def _shape(fn) -> list[tuple[str, object]]:
+            return [(p.name, p.default) for p in inspect.signature(fn).parameters.values()]
+
+        protocol_shape = _shape(CheckExecutor.run)
+        assert protocol_shape == _shape(CheckRunner.run)
+        assert protocol_shape == _shape(InMemoryCheckExecutor.run)
+
+    def test_run_carries_the_four_evidence_params(self) -> None:
+        params = list(inspect.signature(CheckExecutor.run).parameters)
+        assert params == ["self", "checks_file", "task_dir", "ctx", "config"]
+
+
+class TestInMemoryExecutorSemantics:
+    """The in-memory executor records every ``run()`` and returns a configurable
+    :class:`CheckResultSet` — no file I/O, no thread pool, no module load."""
+
+    def test_default_run_returns_empty_result_set_and_records_call(self) -> None:
+        executor = InMemoryCheckExecutor()
+        result = executor.run(
+            checks_file=Path("/does/not/exist/checks.py"),
+            task_dir=Path("/does/not/exist"),
+            ctx=_ctx(task_id="t-1", final={"agent": {"x": 1}}, msgs=3),
+            config=_cfg(),
+        )
+        assert isinstance(result, CheckResultSet)
+        assert result.results == []
+        assert result.error is None
+        assert executor.call_log.runs == [
+            {
+                "checks_file": Path("/does/not/exist/checks.py"),
+                "task_dir": Path("/does/not/exist"),
+                "interface_version": "1.0",
+                "timeout_seconds": 7.5,
+                "fail_on_error": False,
+                "task_id": "t-1",
+                "transcript_len": 3,
+                "final_state_keys": ("agent",),
+            }
+        ]
+
+    def test_configured_result_set_is_returned_verbatim(self) -> None:
+        preset = CheckResultSet(
+            results=[
+                CheckResult(
+                    check_name="my_check",
+                    status=CheckStatus.PASSED,
+                    score=0.75,
+                    message="fixture verdict",
+                )
+            ],
+            execution_time_ms=1.5,
+        )
+        executor = InMemoryCheckExecutor(result_set=preset)
+        result = executor.run(
+            checks_file=Path("/x/checks.py"),
+            task_dir=Path("/x"),
+            ctx=_ctx(),
+            config=_cfg(),
+        )
+        assert result is preset
+        assert result.results[0].check_name == "my_check"
+        assert result.results[0].score == 0.75
+
+    def test_return_error_populates_result_set_error_and_records_the_call(self) -> None:
+        executor = InMemoryCheckExecutor(return_error="module not found")
+        result = executor.run(
+            checks_file=Path("/x/checks.py"),
+            task_dir=Path("/x"),
+            ctx=_ctx(),
+            config=_cfg(),
+        )
+        assert result.error == "module not found"
+        assert result.results == []
+        assert len(executor.call_log.runs) == 1
+
+    def test_raise_on_run_propagates_and_records_the_call_first(self) -> None:
+        boom = RuntimeError("simulated executor crash")
+        executor = InMemoryCheckExecutor(raise_on_run=boom)
+        with pytest.raises(RuntimeError, match="simulated executor crash"):
+            executor.run(
+                checks_file=Path("/x/checks.py"),
+                task_dir=Path("/x"),
+                ctx=_ctx(),
+                config=_cfg(),
+            )
+        # Call is recorded before the raise so a test can assert what the
+        # caller submitted even on a crash.
+        assert len(executor.call_log.runs) == 1
+
+    def test_call_log_accumulates_across_multiple_runs(self) -> None:
+        executor = InMemoryCheckExecutor()
+        for i in range(3):
+            executor.run(
+                checks_file=Path(f"/x/{i}/checks.py"),
+                task_dir=Path(f"/x/{i}"),
+                ctx=_ctx(task_id=f"t-{i}"),
+                config=_cfg(),
+            )
+        assert [r["task_id"] for r in executor.call_log.runs] == ["t-0", "t-1", "t-2"]
+
+    def test_fresh_executor_has_empty_call_log(self) -> None:
+        assert InMemoryCheckExecutor().call_log == CheckExecutorCallLog()
+
+    def test_mutually_exclusive_failure_knobs_reject_at_construction(self) -> None:
+        with pytest.raises(ValueError):
+            InMemoryCheckExecutor(raise_on_run=RuntimeError("x"), return_error="y")
+        with pytest.raises(ValueError):
+            InMemoryCheckExecutor(raise_on_run=RuntimeError("x"), result_set=CheckResultSet())
+        with pytest.raises(ValueError):
+            InMemoryCheckExecutor(return_error="y", result_set=CheckResultSet())
+
+
+class TestProductionImplConstructs:
+    """The published :class:`CheckRunner` constructor accepts zero required
+    arguments — callers that construct it as ``CheckRunner()`` must keep
+    working, and its defaults land on the in-process ThreadPoolExecutor."""
+
+    def test_check_runner_no_arg_construct_still_works(self) -> None:
+        runner = CheckRunner()
+        assert runner.executor_type == "thread"
+        assert runner.max_workers == 1
+
+
+class TestBothImplsExported:
+    """``tolokaforge.core.grading`` re-exports the seam surface so downstream
+    callers reach it via the package (``from tolokaforge.core.grading import
+    CheckExecutor, InMemoryCheckExecutor, CheckRunner``)."""
+
+    def test_seam_symbols_are_exported_from_package(self) -> None:
+        from tolokaforge.core import grading as grading_pkg
+
+        assert grading_pkg.CheckExecutor is CheckExecutor
+        assert grading_pkg.CheckRunner is CheckRunner
+        assert grading_pkg.InMemoryCheckExecutor is InMemoryCheckExecutor
+        assert grading_pkg.CheckExecutorCallLog is CheckExecutorCallLog
+
+    def test_seam_symbols_are_listed_in_dunder_all(self) -> None:
+        from tolokaforge.core import grading as grading_pkg
+
+        assert "CheckExecutor" in grading_pkg.__all__
+        assert "CheckExecutorCallLog" in grading_pkg.__all__
+        assert "CheckRunner" in grading_pkg.__all__
+        assert "InMemoryCheckExecutor" in grading_pkg.__all__

--- a/tests/canonical/test_grading_custom_checks_canon.py
+++ b/tests/canonical/test_grading_custom_checks_canon.py
@@ -6,10 +6,8 @@ not silently regress:
 1. :func:`combine_grade_components` includes the ``custom_checks`` score
    as a weighted contributor when it is present (``>= 0``).
 2. A custom-checks-only pack whose executor produced no score falls into
-   the empty-active-components guard — returns ``(0.0, False)``, NOT the
-   ``(1.0, True)`` silent-pass the pre-Stage-2 runner emitted. This is
-   the exact regression this stage exists to close (AGENTS.md Rule 1 —
-   surface failures, don't drop them).
+   the empty-active-components guard — returns ``(0.0, False)`` rather
+   than a silent ``(1.0, True)`` (AGENTS.md Rule 1: surface failures).
 3. :func:`_parse_grade_result` decodes the wire ``custom_checks`` list
    into :class:`~tolokaforge.core.models.CustomCheckDetail` on the host
    :class:`~tolokaforge.core.models.Grade`, including the
@@ -81,15 +79,14 @@ class TestCombineGradeComponentsRoutesCustomChecks:
 
 
 class TestCombineGradeComponentsGuardsAgainstSilentPass:
-    """Regression lock for the silent-pass that shipped before Stage 2.
+    """A custom-checks-only pack whose score comes back absent fails loud.
 
-    Pre-Stage-2: a custom-checks-only pack whose score came back absent
-    (``-1.0`` — the "Not implemented yet" stub) yielded an empty
-    ``active_components`` set. Because ``custom_checks`` was not in the
-    fail-loud ``actually_configured`` guard, the function returned
-    ``(1.0, True)`` — a false success. Stage 2 closes both halves: the
-    score is really computed AND the guard recognises custom_checks as a
-    configured component.
+    Empty ``active_components`` + a configured ``custom_checks`` weight
+    must yield ``(0.0, False)`` via the fail-loud
+    ``actually_configured`` guard — not a silent ``(1.0, True)``
+    (AGENTS Rule 1). Both halves are load-bearing: the score is really
+    computed AND the guard recognises ``custom_checks`` as a configured
+    component.
     """
 
     def test_custom_checks_only_config_absent_score_fails_via_guard(self) -> None:

--- a/tests/canonical/test_grading_custom_checks_canon.py
+++ b/tests/canonical/test_grading_custom_checks_canon.py
@@ -1,6 +1,6 @@
 """Pin custom_checks routing through the runner-side grading path.
 
-Locks three behaviours that a future refactor of the grade pipeline must
+Locks four behaviours that a future refactor of the grade pipeline must
 not silently regress:
 
 1. :func:`combine_grade_components` includes the ``custom_checks`` score
@@ -14,16 +14,27 @@ not silently regress:
    into :class:`~tolokaforge.core.models.CustomCheckDetail` on the host
    :class:`~tolokaforge.core.models.Grade`, including the
    ``details_json`` → dict round-trip.
+4. ``RunnerService.RegisterTrial`` fails-loud on an unsupported
+   ``interface_version`` (or a ``checks.py`` that fails to load) BEFORE
+   the trial runs — the actionable error names both the offending
+   version and ``SUPPORTED_VERSIONS``. A supported version registers
+   cleanly; a pack with ``enabled: false`` skips validation entirely.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 
 import pytest
 
+from tolokaforge.core.grading.checks_interface import SUPPORTED_VERSIONS
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
 from tolokaforge.core.trial_grader import _parse_grade_result
+from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.grading import combine_grade_components
+from tolokaforge.runner.models import TaskDescription
 
 pytestmark = [pytest.mark.canonical, pytest.mark.grading]
 
@@ -176,3 +187,170 @@ class TestParseGradeResultMapsCustomCheckDetails:
         assert len(parsed.custom_checks_details) == 1
         assert parsed.custom_checks_details[0].check_name == "produced_bad_json"
         assert parsed.custom_checks_details[0].details is None
+
+
+# =============================================================================
+# RegisterTrial fail-loud on unsupported ``interface_version``
+# =============================================================================
+
+
+_CHECKS_PY_TEMPLATE = """\
+from tolokaforge.core.grading.checks_interface import CheckPassed, check, init
+
+
+@init(interface_version="{version}")
+def setup(ctx):
+    pass
+
+
+@check
+def dummy():
+    return CheckPassed(message="ok")
+"""
+
+
+def _checks_py_artifact(version: str) -> dict[str, str]:
+    """Base64-encoded ``checks.py`` artifact declaring ``interface_version``."""
+    source = _CHECKS_PY_TEMPLATE.format(version=version).encode("utf-8")
+    return {"checks.py": base64.b64encode(source).decode("ascii")}
+
+
+def _custom_checks_task(
+    *,
+    enabled: bool,
+    interface_version: str,
+    artifacts: dict[str, str] | None,
+) -> dict:
+    """Minimal :class:`TaskDescription` dict wiring ``custom_checks``."""
+    return {
+        "task_id": "custom_checks_register_test",
+        "name": "Custom checks register test",
+        "category": "test",
+        "description": "Exercises RegisterTrial custom_checks validation.",
+        "adapter_type": "tau",
+        "system_prompt": "You are a test assistant.",
+        "initial_state": {"tables": {}, "schemas": []},
+        "agent_tools": [],
+        "user_tools": [],
+        "tool_artifacts": artifacts or {},
+        "grading": {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+            "custom_checks": {
+                "enabled": enabled,
+                "file": "checks.py",
+                "interface_version": interface_version,
+            },
+        },
+    }
+
+
+def _trial_spec_json(task_dict: dict, trial_id: str) -> str:
+    """Build a valid :class:`TrialSpec` JSON wrapping ``task_dict``."""
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="canon_run",
+        task=TaskDescription.model_validate(task_dict),
+        agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
+    ).model_dump_json()
+
+
+class TestRegisterTrialValidatesCustomChecksInterfaceVersion:
+    """Fail-loud contract for the pack-authored ``interface_version``.
+
+    Moves the version check from the load-time ``ValueError`` at trial end
+    (``check_runner.load_checks_module``) to trial startup: an unsupported
+    version rejects the registration BEFORE the (expensive) agent loop
+    runs. The pre-existing runtime error remains as defense-in-depth for
+    edge cases the startup validator might miss.
+    """
+
+    def test_unsupported_version_rejects_at_register_with_actionable_message(
+        self, runner_service, mock_grpc_context
+    ) -> None:
+        trial_id = "custom_checks_unsupported:0"
+        task = _custom_checks_task(
+            enabled=True,
+            interface_version="9.9",
+            artifacts=_checks_py_artifact("9.9"),
+        )
+        request = pb2.RegisterTrialRequest(
+            trial_id=trial_id,
+            trial_spec_json=_trial_spec_json(task, trial_id=trial_id),
+        )
+
+        response = runner_service.RegisterTrial(request, mock_grpc_context)
+
+        assert response.success is False
+        assert "9.9" in response.error
+        assert str(SUPPORTED_VERSIONS) in response.error
+        assert trial_id not in runner_service.trials
+
+    def test_supported_version_registers_cleanly(self, runner_service, mock_grpc_context) -> None:
+        trial_id = "custom_checks_supported:0"
+        task = _custom_checks_task(
+            enabled=True,
+            interface_version="1.0",
+            artifacts=_checks_py_artifact("1.0"),
+        )
+        request = pb2.RegisterTrialRequest(
+            trial_id=trial_id,
+            trial_spec_json=_trial_spec_json(task, trial_id=trial_id),
+        )
+
+        response = runner_service.RegisterTrial(request, mock_grpc_context)
+
+        assert response.success is True, f"Registration failed: {response.error}"
+        assert response.error == ""
+        assert trial_id in runner_service.trials
+
+    def test_disabled_custom_checks_skips_validation(
+        self, runner_service, mock_grpc_context
+    ) -> None:
+        """``enabled: false`` short-circuits validation — a ``checks.py`` that
+        would otherwise reject at startup (unsupported ``9.9``) does not
+        prevent registration when the pack has opted out.
+        """
+        trial_id = "custom_checks_disabled:0"
+        task = _custom_checks_task(
+            enabled=False,
+            interface_version="9.9",
+            artifacts=_checks_py_artifact("9.9"),
+        )
+        request = pb2.RegisterTrialRequest(
+            trial_id=trial_id,
+            trial_spec_json=_trial_spec_json(task, trial_id=trial_id),
+        )
+
+        response = runner_service.RegisterTrial(request, mock_grpc_context)
+
+        assert response.success is True, f"Registration failed: {response.error}"
+        assert trial_id in runner_service.trials
+
+    def test_enabled_without_delivered_checks_file_rejects(
+        self, runner_service, mock_grpc_context
+    ) -> None:
+        """``enabled: true`` with no ``tool_artifacts`` is a delivery bug that
+        must surface at startup — no silent-pass at trial end.
+        """
+        trial_id = "custom_checks_missing_delivery:0"
+        task = _custom_checks_task(
+            enabled=True,
+            interface_version="1.0",
+            artifacts=None,
+        )
+        request = pb2.RegisterTrialRequest(
+            trial_id=trial_id,
+            trial_spec_json=_trial_spec_json(task, trial_id=trial_id),
+        )
+
+        response = runner_service.RegisterTrial(request, mock_grpc_context)
+
+        assert response.success is False
+        assert "checks.py" in response.error or "custom_checks" in response.error
+        assert trial_id not in runner_service.trials

--- a/tests/canonical/test_grading_custom_checks_canon.py
+++ b/tests/canonical/test_grading_custom_checks_canon.py
@@ -287,6 +287,10 @@ class TestRegisterTrialValidatesCustomChecksInterfaceVersion:
         assert "9.9" in response.error
         assert str(SUPPORTED_VERSIONS) in response.error
         assert trial_id not in runner_service.trials
+        # Extraction ran before validation, so a rejected trial must release
+        # the tmp dir + drop it from ``sys.path``. A retry from the client
+        # would otherwise leak a fresh tmp dir per attempt.
+        assert trial_id not in runner_service._artifact_dirs
 
     def test_supported_version_registers_cleanly(self, runner_service, mock_grpc_context) -> None:
         trial_id = "custom_checks_supported:0"

--- a/tests/canonical/test_grading_custom_checks_canon.py
+++ b/tests/canonical/test_grading_custom_checks_canon.py
@@ -1,0 +1,178 @@
+"""Pin custom_checks routing through the runner-side grading path.
+
+Locks three behaviours that a future refactor of the grade pipeline must
+not silently regress:
+
+1. :func:`combine_grade_components` includes the ``custom_checks`` score
+   as a weighted contributor when it is present (``>= 0``).
+2. A custom-checks-only pack whose executor produced no score falls into
+   the empty-active-components guard — returns ``(0.0, False)``, NOT the
+   ``(1.0, True)`` silent-pass the pre-Stage-2 runner emitted. This is
+   the exact regression this stage exists to close (AGENTS.md Rule 1 —
+   surface failures, don't drop them).
+3. :func:`_parse_grade_result` decodes the wire ``custom_checks`` list
+   into :class:`~tolokaforge.core.models.CustomCheckDetail` on the host
+   :class:`~tolokaforge.core.models.Grade`, including the
+   ``details_json`` → dict round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tolokaforge.core.trial_grader import _parse_grade_result
+from tolokaforge.runner.grading import combine_grade_components
+
+pytestmark = [pytest.mark.canonical, pytest.mark.grading]
+
+
+class TestCombineGradeComponentsRoutesCustomChecks:
+    """The custom_checks score participates in the weighted combine just
+    like the other components — added to ``active_components`` when
+    ``>= 0`` and weighted per ``combine.weights``.
+    """
+
+    def test_custom_checks_score_is_a_weighted_contributor(self) -> None:
+        """state_checks=1.0 (w .5) + custom_checks=0.4 (w .5) -> 0.7."""
+        components = {
+            "hash_score": 1.0,
+            "custom_checks_score": 0.4,
+        }
+        grading_config = {
+            "combine_method": "weighted",
+            "weights": {"state_checks": 0.5, "custom_checks": 0.5},
+            "pass_threshold": 0.75,
+            "custom_checks": {"enabled": True, "file": "checks.py"},
+            "state_checks": {"jsonpaths": []},
+        }
+
+        score, binary_pass = combine_grade_components(components, grading_config)
+
+        assert score == pytest.approx(0.7)
+        assert binary_pass is False
+
+    def test_custom_checks_only_pack_passes_when_score_meets_threshold(self) -> None:
+        """A pack with only custom_checks configured passes when the score clears the bar."""
+        components = {"custom_checks_score": 1.0}
+        grading_config = {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+            "custom_checks": {"enabled": True, "file": "checks.py"},
+        }
+
+        score, binary_pass = combine_grade_components(components, grading_config)
+
+        assert score == pytest.approx(1.0)
+        assert binary_pass is True
+
+
+class TestCombineGradeComponentsGuardsAgainstSilentPass:
+    """Regression lock for the silent-pass that shipped before Stage 2.
+
+    Pre-Stage-2: a custom-checks-only pack whose score came back absent
+    (``-1.0`` — the "Not implemented yet" stub) yielded an empty
+    ``active_components`` set. Because ``custom_checks`` was not in the
+    fail-loud ``actually_configured`` guard, the function returned
+    ``(1.0, True)`` — a false success. Stage 2 closes both halves: the
+    score is really computed AND the guard recognises custom_checks as a
+    configured component.
+    """
+
+    def test_custom_checks_only_config_absent_score_fails_via_guard(self) -> None:
+        components: dict = {}  # no custom_checks_score present -> not in active
+        grading_config = {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 1.0,
+            "custom_checks": {"enabled": True, "file": "checks.py"},
+        }
+
+        score, binary_pass = combine_grade_components(components, grading_config)
+
+        assert score == 0.0
+        assert binary_pass is False
+
+
+class TestParseGradeResultMapsCustomCheckDetails:
+    """The wire ``custom_checks`` list decodes into ``Grade.custom_checks_details``."""
+
+    def test_populates_per_check_details_from_raw_list(self) -> None:
+        raw_grade = {
+            "binary_pass": True,
+            "score": 0.75,
+            "components": {"custom_checks": 0.75},
+            "reasons": "",
+            "custom_checks": [
+                {
+                    "check_name": "workflow_completed",
+                    "status": "passed",
+                    "score": 1.0,
+                    "message": "workflow finished",
+                    "details_json": json.dumps({"steps": 3}),
+                },
+                {
+                    "check_name": "final_state_matches",
+                    "status": "failed",
+                    "score": 0.5,
+                    "message": "counter off by one",
+                    "details_json": "",
+                },
+            ],
+        }
+
+        parsed = _parse_grade_result(raw_grade)
+
+        assert parsed.custom_checks_details is not None
+        assert [d.check_name for d in parsed.custom_checks_details] == [
+            "workflow_completed",
+            "final_state_matches",
+        ]
+        assert parsed.custom_checks_details[0].status == "passed"
+        assert parsed.custom_checks_details[0].score == 1.0
+        assert parsed.custom_checks_details[0].details == {"steps": 3}
+        assert parsed.custom_checks_details[1].status == "failed"
+        assert parsed.custom_checks_details[1].score == 0.5
+        assert parsed.custom_checks_details[1].details is None
+
+    def test_absent_custom_checks_yields_none(self) -> None:
+        raw_grade = {
+            "binary_pass": True,
+            "score": 1.0,
+            "components": {},
+            "reasons": "",
+        }
+
+        parsed = _parse_grade_result(raw_grade)
+
+        assert parsed.custom_checks_details is None
+
+    def test_malformed_details_json_drops_details_but_keeps_check(self) -> None:
+        """A malformed ``details_json`` string (bad JSON) drops the details payload
+        to ``None`` rather than failing the whole grade parse — the audit of *which*
+        check produced the malformed payload is preserved on the entry itself.
+        """
+        raw_grade = {
+            "binary_pass": True,
+            "score": 1.0,
+            "components": {"custom_checks": 1.0},
+            "reasons": "",
+            "custom_checks": [
+                {
+                    "check_name": "produced_bad_json",
+                    "status": "passed",
+                    "score": 1.0,
+                    "message": "",
+                    "details_json": "{not-json",
+                }
+            ],
+        }
+
+        parsed = _parse_grade_result(raw_grade)
+
+        assert parsed.custom_checks_details is not None
+        assert len(parsed.custom_checks_details) == 1
+        assert parsed.custom_checks_details[0].check_name == "produced_bad_json"
+        assert parsed.custom_checks_details[0].details is None

--- a/tests/integration/test_custom_checks_e2e.py
+++ b/tests/integration/test_custom_checks_e2e.py
@@ -1,0 +1,219 @@
+"""End-to-end lock for runner-side custom checks over real gRPC.
+
+Drives the `examples/native/custom_checks` reference pack through the
+Docker runner: `NativeAdapter` builds the `TaskDescription` (bundling
+`checks.py` into `tool_artifacts`), the runner registers the trial (which
+extracts the artifacts and validates `interface_version`), and
+`GradeTrial` runs the executor against synthetic transcript evidence + the
+initial DB state.
+
+Two cases lock the seam:
+
+- **Positive** — transcript enumerates every credit transaction id and
+  contains a `db_query` call; both checks pass, `custom_checks == 1.0`,
+  and the declared `custom_checks: 0.6` weight combined with
+  `state_checks: 0.4` yields `final_score == 1.0` (`binary_pass`).
+
+- **Negative** — same registered trial pack with an empty transcript
+  (no tool calls, no content). The arithmetic balance check still passes
+  because the DB balance equals the reconciled total, but the
+  transcript-enumeration check fails: `custom_checks == 0.5`. With
+  `state_checks: 0.4` * 1.0 + `custom_checks: 0.6` * 0.5 == 0.7, the
+  weighted score drops below `pass_threshold: 0.8` and `binary_pass` is
+  False. This pins that the declared `custom_checks` weight is applied
+  to the final score, not silently dropped.
+
+Deterministic and network-free: the test drives `register_trial` +
+`grade_trial` directly (like `test_docker_grading_jsonpath.py`) rather
+than running an agent loop, so no LLM provider key is required. The
+runner's `db_client.get_state` output feeds the shared
+`build_check_context` helper — this is the sole real-shape check on
+that path, and any regression in it fails
+`balance_matches_transaction_net`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_ROOT = _REPO_ROOT / "examples" / "native" / "custom_checks"
+_DATASET = _PACK_ROOT / "dataset"
+_TASK_ID = "reconcile_ledger"
+
+
+def _docker_running() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=5).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+@pytest.fixture(scope="module")
+def task_description():
+    """Build the `TaskDescription` from the reference pack's `NativeAdapter`.
+
+    Exercises the same adapter path the orchestrator drives, so this test
+    catches a `custom_checks`-related regression in `NativeAdapter` (bundling
+    `checks.py` into `tool_artifacts`, propagating `custom_checks` into
+    `GradingConfig`) as well as in the runner.
+    """
+    adapter = NativeAdapter(
+        {
+            "tasks_glob": "tasks/**/task.yaml",
+            "task_packs": [str(_DATASET)],
+        }
+    )
+    return adapter.to_task_description(_TASK_ID)
+
+
+def _trial_spec_json(task_description, trial_id: str) -> str:
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="custom_checks_e2e_run",
+        task=task_description,
+        agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
+    ).model_dump_json()
+
+
+@pytest.fixture
+def runner_client(runner_container) -> GrpcRunnerClient:
+    host = runner_container.get_container_host_ip()
+    port = runner_container.get_exposed_port(50051)
+    client = GrpcRunnerClient(runner_address=f"{host}:{port}")
+    client.connect()
+    yield client
+    client.close()
+
+
+_ASSISTANT_ENUMERATION_TEXT = (
+    "Transactions for C-1: credits T-1 (+120), T-3 (+60), T-5 (+80) sum to 260. "
+    "Debits T-2 (-45), T-4 (-15) sum to 60. Net 200. Reconciled balance = 500 + 200 = 700."
+)
+
+
+def _synthetic_llm_messages_positive() -> list[dict[str, Any]]:
+    """Wire-shaped `llm_messages` enumerating every credit transaction id."""
+    return [
+        {"role": "user", "content": "Reconcile customer C-1's balance."},
+        {
+            "role": "assistant",
+            "content": "Fetching every transaction for C-1.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "db_query",
+                        "arguments": '{"jsonpath": "$.transactions"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "name": "db_query", "content": "[…transaction rows…]"},
+        {"role": "assistant", "content": _ASSISTANT_ENUMERATION_TEXT},
+    ]
+
+
+def _synthetic_llm_messages_negative() -> list[dict[str, Any]]:
+    """Empty transcript — no db_query call, no credit-txn ids anywhere."""
+    return [
+        {"role": "user", "content": "Reconcile customer C-1's balance."},
+        {"role": "assistant", "content": "Done."},
+    ]
+
+
+def _register_and_grade(
+    runner_client: GrpcRunnerClient,
+    trial_id: str,
+    trial_spec_json: str,
+    llm_messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    registered = runner_client.register_trial(trial_id=trial_id, trial_spec_json=trial_spec_json)
+    assert registered["success"] is True, registered["error"]
+    try:
+        result = runner_client.grade_trial(
+            trial_id=trial_id, llm_messages_json=json.dumps(llm_messages)
+        )
+    finally:
+        runner_client.cleanup_trial(trial_id=trial_id)
+    assert result["success"] is True, result["error"]
+    assert result["grade"] is not None, result
+    return result["grade"]
+
+
+@pytest.mark.skipif(not _docker_running(), reason="Docker daemon not available")
+class TestCustomChecksE2E:
+    def test_positive_case_scores_green_with_custom_checks_weight_applied(
+        self,
+        runner_client: GrpcRunnerClient,
+        task_description,
+    ) -> None:
+        """Both checks pass — custom_checks = 1.0; weighted final = 1.0; pass."""
+        trial_id = f"{_TASK_ID}_pos:0"
+        grade = _register_and_grade(
+            runner_client,
+            trial_id,
+            _trial_spec_json(task_description, trial_id),
+            _synthetic_llm_messages_positive(),
+        )
+
+        assert grade["components"]["custom_checks"] == pytest.approx(1.0)
+        assert grade["components"]["state_checks"] == pytest.approx(1.0)
+        assert grade["score"] == pytest.approx(1.0)
+        assert grade["binary_pass"] is True
+
+        custom_checks = grade["custom_checks"]
+        by_name = {c["check_name"]: c for c in custom_checks}
+        assert set(by_name) == {
+            "balance_matches_transaction_net",
+            "transcript_enumerates_credit_transactions",
+        }, custom_checks
+        for name, entry in by_name.items():
+            assert entry["status"] == "passed", f"{name}: {entry}"
+            assert entry["score"] == pytest.approx(1.0), f"{name}: {entry}"
+
+    def test_negative_case_failing_check_drags_weighted_score_below_threshold(
+        self,
+        runner_client: GrpcRunnerClient,
+        task_description,
+    ) -> None:
+        """Transcript-enumeration fails; weighted score drops below pass_threshold."""
+        trial_id = f"{_TASK_ID}_neg:0"
+        grade = _register_and_grade(
+            runner_client,
+            trial_id,
+            _trial_spec_json(task_description, trial_id),
+            _synthetic_llm_messages_negative(),
+        )
+
+        # state_checks JSONPath still passes (initial DB balance == 700).
+        assert grade["components"]["state_checks"] == pytest.approx(1.0)
+        # custom_checks aggregate: 1 pass + 1 fail = 0.5.
+        assert grade["components"]["custom_checks"] == pytest.approx(0.5)
+        # Weighted final: 0.4*1.0 + 0.6*0.5 = 0.7, below pass_threshold 0.8.
+        assert grade["score"] == pytest.approx(0.7)
+        assert grade["binary_pass"] is False
+
+        by_name = {c["check_name"]: c for c in grade["custom_checks"]}
+        assert by_name["balance_matches_transaction_net"]["status"] == "passed"
+        assert by_name["transcript_enumerates_credit_transactions"]["status"] == "failed"

--- a/tests/integration/test_custom_checks_e2e.py
+++ b/tests/integration/test_custom_checks_e2e.py
@@ -4,31 +4,41 @@ Drives the `examples/native/custom_checks` reference pack through the
 Docker runner: `NativeAdapter` builds the `TaskDescription` (bundling
 `checks.py` into `tool_artifacts`), the runner registers the trial (which
 extracts the artifacts and validates `interface_version`), and
-`GradeTrial` runs the executor against synthetic transcript evidence + the
-initial DB state.
+`GradeTrial` runs the executor against synthetic transcript evidence +
+the DB state the executed tool calls leave behind.
+
+The pack's `initial_state.json` seeds `customers[0].balance = 500` (the
+unreconciled opening balance). Only an agent (or the test acting as the
+agent) that issues the correct `db_update` call raises the balance to
+`700` (= `500 + 260 - 60`). This makes every graded dimension gate on
+real agent behaviour — no dimension trivially passes on the initial
+state.
 
 Two cases lock the seam:
 
-- **Positive** — transcript enumerates every credit transaction id and
-  contains a `db_query` call; both checks pass, `custom_checks == 1.0`,
-  and the declared `custom_checks: 0.6` weight combined with
-  `state_checks: 0.4` yields `final_score == 1.0` (`binary_pass`).
+- **Positive** — the test drives one `db_update` tool call to reconcile
+  `balance` to `700`, then grades with a transcript enumerating every
+  credit transaction id and a `db_query` call. State-check `equals 700`
+  passes, both custom checks pass: `custom_checks == 1.0`. Combined with
+  `state_checks: 0.4` * 1.0 + `custom_checks: 0.6` * 1.0 == 1.0
+  (`binary_pass`).
 
-- **Negative** — same registered trial pack with an empty transcript
-  (no tool calls, no content). The arithmetic balance check still passes
-  because the DB balance equals the reconciled total, but the
-  transcript-enumeration check fails: `custom_checks == 0.5`. With
-  `state_checks: 0.4` * 1.0 + `custom_checks: 0.6` * 0.5 == 0.7, the
-  weighted score drops below `pass_threshold: 0.8` and `binary_pass` is
-  False. This pins that the declared `custom_checks` weight is applied
-  to the final score, not silently dropped.
+- **Negative** — no `db_update`, no transcript enumeration. The DB
+  balance stays at `500`, so the JSONPath `equals 700` fails
+  (`state_checks == 0.0`), `balance_matches_transaction_net` fails
+  (500 != 500 + 260 - 60 = 700), and
+  `transcript_enumerates_credit_transactions` fails
+  (`custom_checks == 0.0`). The weighted final is 0.0 — well below
+  `pass_threshold: 0.8` — and `binary_pass` is False. This pins that
+  the declared `custom_checks` weight is applied to the final score,
+  not silently dropped.
 
 Deterministic and network-free: the test drives `register_trial` +
-`grade_trial` directly (like `test_docker_grading_jsonpath.py`) rather
-than running an agent loop, so no LLM provider key is required. The
-runner's `db_client.get_state` output feeds the shared
-`build_check_context` helper — this is the sole real-shape check on
-that path, and any regression in it fails
+`execute_tool` + `grade_trial` directly (like
+`test_docker_grading_jsonpath.py`) rather than running an agent loop,
+so no LLM provider key is required. The runner's `db_client.get_state`
+output feeds the shared `build_check_context` helper — this is the
+sole real-shape check on that path, and any regression in it fails
 `balance_matches_transaction_net`.
 """
 
@@ -147,10 +157,30 @@ def _register_and_grade(
     trial_id: str,
     trial_spec_json: str,
     llm_messages: list[dict[str, Any]],
+    *,
+    reconcile_balance: bool,
 ) -> dict[str, Any]:
+    """Register the trial, optionally reconcile the DB, then grade.
+
+    ``reconcile_balance=True`` drives a single ``db_update`` tool call to
+    raise ``customers[0].balance`` from the seeded 500 to the reconciled
+    700 — the transformation an agent would perform. Skipping it leaves
+    the DB at the seeded value so the grade dimensions reflect a no-op.
+    """
     registered = runner_client.register_trial(trial_id=trial_id, trial_spec_json=trial_spec_json)
     assert registered["success"] is True, registered["error"]
     try:
+        if reconcile_balance:
+            tool_result = runner_client.execute_tool(
+                trial_id=trial_id,
+                tool_name="db_update",
+                arguments={
+                    "ops": [
+                        {"op": "replace", "path": "/customers/0/balance", "value": 700},
+                    ]
+                },
+            )
+            assert tool_result.success is True, tool_result.error
         result = runner_client.grade_trial(
             trial_id=trial_id, llm_messages_json=json.dumps(llm_messages)
         )
@@ -168,13 +198,14 @@ class TestCustomChecksE2E:
         runner_client: GrpcRunnerClient,
         task_description,
     ) -> None:
-        """Both checks pass — custom_checks = 1.0; weighted final = 1.0; pass."""
+        """Reconcile the DB + enumerate credits → both dimensions pass."""
         trial_id = f"{_TASK_ID}_pos:0"
         grade = _register_and_grade(
             runner_client,
             trial_id,
             _trial_spec_json(task_description, trial_id),
             _synthetic_llm_messages_positive(),
+            reconcile_balance=True,
         )
 
         assert grade["components"]["custom_checks"] == pytest.approx(1.0)
@@ -192,28 +223,30 @@ class TestCustomChecksE2E:
             assert entry["status"] == "passed", f"{name}: {entry}"
             assert entry["score"] == pytest.approx(1.0), f"{name}: {entry}"
 
-    def test_negative_case_failing_check_drags_weighted_score_below_threshold(
+    def test_negative_case_failing_checks_drag_weighted_score_below_threshold(
         self,
         runner_client: GrpcRunnerClient,
         task_description,
     ) -> None:
-        """Transcript-enumeration fails; weighted score drops below pass_threshold."""
+        """No reconciliation, no transcript enumeration — every dimension fails."""
         trial_id = f"{_TASK_ID}_neg:0"
         grade = _register_and_grade(
             runner_client,
             trial_id,
             _trial_spec_json(task_description, trial_id),
             _synthetic_llm_messages_negative(),
+            reconcile_balance=False,
         )
 
-        # state_checks JSONPath still passes (initial DB balance == 700).
-        assert grade["components"]["state_checks"] == pytest.approx(1.0)
-        # custom_checks aggregate: 1 pass + 1 fail = 0.5.
-        assert grade["components"]["custom_checks"] == pytest.approx(0.5)
-        # Weighted final: 0.4*1.0 + 0.6*0.5 = 0.7, below pass_threshold 0.8.
-        assert grade["score"] == pytest.approx(0.7)
+        # DB stayed at balance=500 → JSONPath `equals 700` fails.
+        assert grade["components"]["state_checks"] == pytest.approx(0.0)
+        # Both custom checks fail: balance != reconciled total AND transcript
+        # lacks a db_query call / credit-txn enumeration.
+        assert grade["components"]["custom_checks"] == pytest.approx(0.0)
+        # Weighted final: 0.4*0.0 + 0.6*0.0 = 0.0, below pass_threshold 0.8.
+        assert grade["score"] == pytest.approx(0.0)
         assert grade["binary_pass"] is False
 
         by_name = {c["check_name"]: c for c in grade["custom_checks"]}
-        assert by_name["balance_matches_transaction_net"]["status"] == "passed"
+        assert by_name["balance_matches_transaction_net"]["status"] == "failed"
         assert by_name["transcript_enumerates_credit_transactions"]["status"] == "failed"

--- a/tests/unit/adapters/test_native_adapter_custom_checks.py
+++ b/tests/unit/adapters/test_native_adapter_custom_checks.py
@@ -1,0 +1,204 @@
+"""``NativeAdapter.to_task_description`` delivers ``checks.py`` to the runner
+and propagates ``grading.custom_checks`` onto the wire.
+
+A pack whose ``grading.yaml`` sets ``custom_checks.enabled: true`` requires two
+things at trial-launch time: (1) ``checks.py`` and every ``relative_imports``
+target must land in ``TaskDescription.tool_artifacts`` so the runner can
+extract them into the trial's ``artifacts_dir``, and (2) the ``custom_checks``
+config block must ride the wire ``GradingConfig.custom_checks`` so
+``RunnerService._grade_custom_checks`` reads a real config rather than
+short-circuiting. Both must hold whether the pack ships an MCP server or not.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.canonical._factories import write_yaml_file
+from tolokaforge.adapters.native import NativeAdapter
+
+pytestmark = pytest.mark.unit
+
+
+_CHECKS_PY = """from tolokaforge.core.grading.checks_interface import (
+    CheckContext, CheckPassed, check, init,
+)
+
+
+@init(interface_version="1.0")
+def setup(ctx: CheckContext) -> None:
+    pass
+
+
+@check(name="always_ok")
+def always_ok(ctx: CheckContext) -> CheckPassed:
+    return CheckPassed(message="ok")
+"""
+
+
+_HELPERS_PY = "SHARED_MARKER = 'from-helpers'\n"
+
+
+def _mcp_less_pack(
+    tmp_path: Path,
+    *,
+    custom_checks: dict | None,
+    include_helpers_import: bool = False,
+) -> NativeAdapter:
+    """Build an MCP-less pack — no ``mcp_server`` key, no enabled agent tools.
+
+    When *custom_checks* is None the pack has no ``custom_checks:`` block; the
+    adapter must ship an empty ``tool_artifacts`` (regression lock on the
+    no-op path).
+    """
+    task_dir = tmp_path / "tasks" / "cc_pack"
+    task_dir.mkdir(parents=True)
+    (task_dir / "system_prompt.md").write_text("system\n")
+    (task_dir / "initial_state.json").write_text("{}")
+    (task_dir / "checks.py").write_text(_CHECKS_PY)
+    if include_helpers_import:
+        helpers_dir = task_dir / "helpers"
+        helpers_dir.mkdir()
+        (helpers_dir / "shared.py").write_text(_HELPERS_PY)
+
+    write_yaml_file(
+        task_dir / "task.yaml",
+        {
+            "task_id": "cc_pack",
+            "name": "cc_pack",
+            "category": "tool_use",
+            "description": "custom checks pack",
+            "initial_state": {"json_db": "initial_state.json"},
+            "tools": {"agent": {"enabled": []}, "user": {"enabled": []}},
+            "actors": {"user": {"mode": "llm", "persona": "cooperative"}},
+            "grading": "grading.yaml",
+            "system_prompt": "system_prompt.md",
+        },
+    )
+    grading: dict = {
+        "combine": {
+            "method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+        },
+    }
+    if custom_checks is not None:
+        grading["custom_checks"] = custom_checks
+    write_yaml_file(task_dir / "grading.yaml", grading)
+    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+
+
+def _mcp_pack(tmp_path: Path, *, custom_checks: dict) -> NativeAdapter:
+    """Build an MCP pack — ``mcp_server.py`` present, ``fixtures/tools.json``
+    pre-baked so ``to_task_description`` avoids the live MCP subprocess.
+    """
+    task_dir = tmp_path / "tasks" / "cc_mcp_pack"
+    task_dir.mkdir(parents=True)
+    (task_dir / "system_prompt.md").write_text("system\n")
+    (task_dir / "initial_state.json").write_text("{}")
+    (task_dir / "mcp_server.py").write_text("# stub\n")
+    (task_dir / "checks.py").write_text(_CHECKS_PY)
+    (task_dir / "fixtures").mkdir()
+    (task_dir / "fixtures" / "tools.json").write_text(json.dumps([]))
+
+    write_yaml_file(
+        task_dir / "task.yaml",
+        {
+            "task_id": "cc_mcp_pack",
+            "name": "cc_mcp_pack",
+            "category": "tool_use",
+            "description": "custom checks + MCP pack",
+            "initial_state": {"json_db": "initial_state.json"},
+            "tools": {
+                "agent": {"mcp_server": "mcp_server.py", "enabled": []},
+                "user": {"enabled": []},
+            },
+            "actors": {"user": {"mode": "llm", "persona": "cooperative"}},
+            "grading": "grading.yaml",
+            "system_prompt": "system_prompt.md",
+        },
+    )
+    write_yaml_file(
+        task_dir / "grading.yaml",
+        {
+            "combine": {
+                "method": "weighted",
+                "weights": {"custom_checks": 1.0},
+                "pass_threshold": 0.5,
+            },
+            "custom_checks": custom_checks,
+        },
+    )
+    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "tasks/**/task.yaml"})
+
+
+class TestMcpLessBundleAndPropagate:
+    def test_enabled_bundles_checks_and_propagates_config(self, tmp_path: Path) -> None:
+        cc_config = {
+            "enabled": True,
+            "file": "checks.py",
+            "interface_version": "1.0",
+            "timeout_seconds": 10,
+            "weight": 1.0,
+            "fail_on_error": True,
+            "relative_imports": ["helpers"],
+        }
+        adapter = _mcp_less_pack(tmp_path, custom_checks=cc_config, include_helpers_import=True)
+        td = adapter.to_task_description("cc_pack")
+
+        # (1) checks.py + relative_imports target ship as tool_artifacts.
+        assert "checks.py" in td.tool_artifacts
+        assert "helpers/shared.py" in td.tool_artifacts
+        decoded = base64.b64decode(td.tool_artifacts["checks.py"]).decode()
+        assert "@check" in decoded
+        assert "always_ok" in decoded
+
+        # (2) The custom_checks config rides the wire GradingConfig so the
+        # runner reads a real dict rather than short-circuiting on None.
+        assert td.grading.custom_checks == cc_config
+
+    def test_disabled_ships_no_artifacts_and_no_config(self, tmp_path: Path) -> None:
+        # Regression lock: the empty-tool_artifacts baseline for MCP-less
+        # packs must survive the Stage 3 un-gate. Only ``custom_checks.enabled``
+        # should flip bundling on.
+        adapter = _mcp_less_pack(tmp_path, custom_checks=None)
+        td = adapter.to_task_description("cc_pack")
+
+        assert td.tool_artifacts == {}
+        assert td.grading.custom_checks is None
+
+    def test_enabled_false_ships_no_artifacts(self, tmp_path: Path) -> None:
+        # A ``custom_checks:`` block with ``enabled: false`` is a bystander —
+        # the pack does not need ``checks.py`` shipped, and the wire config
+        # still carries the dict so downstream consumers see the author's
+        # explicit opt-out (rather than an ambiguous ``None``).
+        cc_config = {"enabled": False, "file": "checks.py"}
+        adapter = _mcp_less_pack(tmp_path, custom_checks=cc_config)
+        td = adapter.to_task_description("cc_pack")
+
+        assert td.tool_artifacts == {}
+        assert td.grading.custom_checks == cc_config
+
+
+class TestMcpPackNoRegression:
+    def test_mcp_pack_still_bundles_and_propagates(self, tmp_path: Path) -> None:
+        cc_config = {
+            "enabled": True,
+            "file": "checks.py",
+            "interface_version": "1.0",
+            "relative_imports": [],
+        }
+        adapter = _mcp_pack(tmp_path, custom_checks=cc_config)
+        td = adapter.to_task_description("cc_mcp_pack")
+
+        # MCP tasks bundle the whole task dir already; adding custom_checks
+        # must not disturb that — checks.py and mcp_server.py both ride.
+        assert "checks.py" in td.tool_artifacts
+        assert "mcp_server.py" in td.tool_artifacts
+
+        # Config propagates on the MCP path too.
+        assert td.grading.custom_checks == cc_config

--- a/tests/unit/adapters/test_native_adapter_custom_checks.py
+++ b/tests/unit/adapters/test_native_adapter_custom_checks.py
@@ -162,9 +162,8 @@ class TestMcpLessBundleAndPropagate:
         assert td.grading.custom_checks == cc_config
 
     def test_disabled_ships_no_artifacts_and_no_config(self, tmp_path: Path) -> None:
-        # Regression lock: the empty-tool_artifacts baseline for MCP-less
-        # packs must survive the Stage 3 un-gate. Only ``custom_checks.enabled``
-        # should flip bundling on.
+        # Regression lock: an MCP-less pack with no custom_checks block ships an
+        # empty tool_artifacts bundle. Only ``custom_checks.enabled`` flips bundling on.
         adapter = _mcp_less_pack(tmp_path, custom_checks=None)
         td = adapter.to_task_description("cc_pack")
 

--- a/tests/unit/grading/test_build_check_context.py
+++ b/tests/unit/grading/test_build_check_context.py
@@ -1,0 +1,189 @@
+"""Lock the shared :func:`build_check_context` state-shape transform.
+
+Both grading paths — host
+:class:`~tolokaforge.core.grading.combine.GradingEngine` and runner
+:class:`~tolokaforge.runner.service.RunnerServiceImpl` — build their
+:class:`CheckContext` through this one helper so a check reads identical
+evidence from either. These parametrised cases pin the precedence rule
+verbatim from ``combine.py``:
+
+* ``initial_state.data`` = the initial ``json_db`` dict when it is one,
+  else ``{}``.
+* ``final_state.data`` picks from ``final_env_state`` by precedence —
+  the ``"agent"`` dict wins, then the ``"db"`` dict, else the flat map.
+* When ``final_env_state`` carries a ``"filesystem"`` key and the chosen
+  level lacks one, the filesystem is merged into ``final_state.data``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.checks_helpers import build_check_context
+from tolokaforge.core.grading.checks_interface import TaskContext, Transcript
+
+pytestmark = pytest.mark.unit
+
+
+def _task() -> TaskContext:
+    return TaskContext(task_id="t1", task_name="t1", domain="general")
+
+
+class TestInitialStateResolution:
+    """``initial_state.data`` is the initial ``json_db`` dict when one is
+    supplied, else empty. Non-dict values (str path, ``None``) do not
+    surface as data — the host reads ``.json_db``, not ``.tables``, and a
+    path-style value would need file I/O which the helper deliberately
+    does not perform.
+    """
+
+    def test_dict_initial_state_is_used_as_data(self) -> None:
+        initial = {"users": [{"id": "u1"}], "orders": []}
+
+        ctx = build_check_context(
+            initial_state_json_db=initial,
+            final_env_state={},
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.initial_state.data == initial
+
+    def test_none_initial_state_yields_empty_data(self) -> None:
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={},
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.initial_state.data == {}
+
+
+@pytest.mark.parametrize(
+    ("final_env_state", "expected"),
+    [
+        pytest.param(
+            {
+                "agent": {"counter": 5, "orders": [{"id": "o1"}]},
+                "db": {"counter": 999},  # loses to agent
+                "user": {"noise": True},
+            },
+            {"counter": 5, "orders": [{"id": "o1"}]},
+            id="agent_wins_over_db_and_flat",
+        ),
+        pytest.param(
+            {"db": {"counter": 7, "status": "done"}, "user": {"noise": True}},
+            {"counter": 7, "status": "done"},
+            id="db_used_when_no_agent",
+        ),
+        pytest.param(
+            {"counter": 3, "status": "pending"},
+            {"counter": 3, "status": "pending"},
+            id="flat_state_used_when_no_agent_no_db",
+        ),
+        pytest.param(
+            {"agent": None, "db": {"counter": 1}},
+            {"counter": 1},
+            id="agent_key_present_but_not_dict_falls_through_to_db",
+        ),
+    ],
+)
+def test_final_state_precedence(final_env_state: dict, expected: dict) -> None:
+    ctx = build_check_context(
+        initial_state_json_db=None,
+        final_env_state=final_env_state,
+        transcript=Transcript(messages=[]),
+        task=_task(),
+    )
+
+    assert ctx.final_state.data == expected
+
+
+class TestFilesystemPassthrough:
+    """A ``"filesystem"`` key at the top of ``final_env_state`` is merged
+    into whatever level ``final_state.data`` resolved to (agent / db /
+    flat) so a check can read agent-produced files alongside DB rows.
+    """
+
+    def test_filesystem_merged_into_agent_level(self) -> None:
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={
+                "agent": {"counter": 5},
+                "filesystem": {"/work/out.txt": "hello"},
+            },
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.final_state.data == {
+            "counter": 5,
+            "filesystem": {"/work/out.txt": "hello"},
+        }
+
+    def test_filesystem_merged_into_db_level(self) -> None:
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={
+                "db": {"counter": 5},
+                "filesystem": {"/work/out.txt": "hello"},
+            },
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.final_state.data == {
+            "counter": 5,
+            "filesystem": {"/work/out.txt": "hello"},
+        }
+
+    def test_filesystem_merged_into_flat_state(self) -> None:
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={"counter": 3, "filesystem": {"/work/out.txt": "hi"}},
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.final_state.data == {
+            "counter": 3,
+            "filesystem": {"/work/out.txt": "hi"},
+        }
+
+    def test_existing_filesystem_at_chosen_level_is_not_overwritten(self) -> None:
+        """A pre-existing ``filesystem`` at the chosen level wins; the
+        top-level ``filesystem`` does NOT clobber it. This mirrors the
+        host: the merge is a fill-in, not a replace."""
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={
+                "agent": {"filesystem": {"/work/a.txt": "agent-level"}},
+                "filesystem": {"/work/b.txt": "top-level"},
+            },
+            transcript=Transcript(messages=[]),
+            task=_task(),
+        )
+
+        assert ctx.final_state.data == {"filesystem": {"/work/a.txt": "agent-level"}}
+
+
+class TestTranscriptAndTaskArePassedThrough:
+    """The helper owns only the state-shape transform — ``transcript``
+    and ``task`` travel through unchanged; each grading path builds them
+    from its own source (rich ``Trajectory`` on the host, wire message
+    dicts on the runner)."""
+
+    def test_transcript_and_task_are_verbatim(self) -> None:
+        transcript = Transcript(messages=[])
+        task = TaskContext(task_id="t42", task_name="t42", domain="airline")
+
+        ctx = build_check_context(
+            initial_state_json_db=None,
+            final_env_state={},
+            transcript=transcript,
+            task=task,
+        )
+
+        assert ctx.transcript is transcript
+        assert ctx.task is task

--- a/tests/unit/grading/test_check_runner_concurrency.py
+++ b/tests/unit/grading/test_check_runner_concurrency.py
@@ -73,7 +73,7 @@ class TestConcurrentModuleLoad:
         def _run(pack: Path, expected_check: str) -> list[str]:
             runner = CheckRunner()
             observed: list[str] = []
-            for _ in range(10):
+            for _ in range(50):
                 result = runner.run(pack, pack.parent, ctx, config)
                 if result.error is not None:
                     raise AssertionError(f"unexpected executor error: {result.error}")

--- a/tests/unit/grading/test_check_runner_concurrency.py
+++ b/tests/unit/grading/test_check_runner_concurrency.py
@@ -1,0 +1,95 @@
+"""Registry-race lock for :class:`CheckRunner.load_checks_module`.
+
+The check registry in
+:mod:`~tolokaforge.core.grading.checks_interface` is module-global —
+``@check`` and ``@init`` fire at import time and have no reference to a
+runner instance. The gRPC handler pool serves concurrent trials; without
+serialisation, two of them calling ``load_checks_module`` in parallel
+would interleave ``reset_registry → exec_module → get_registered_checks``
+and each caller would see a merged/partial registry.
+:data:`~tolokaforge.core.grading.check_runner._CHECKS_MODULE_LOAD_LOCK`
+serialises the sequence per-process so every caller sees only its own
+module's checks.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import CheckRunner
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext,
+    CustomChecksConfig,
+    EnvironmentState,
+    TaskContext,
+    Transcript,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_PACK_TEMPLATE = """
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext, CheckPassed, init, check
+)
+
+@init(interface_version="1.0")
+def setup(ctx: CheckContext):
+    pass
+
+@check
+def check_only_in_{name}():
+    return CheckPassed("ok")
+"""
+
+
+def _write_pack(root: Path, name: str) -> Path:
+    """Write a minimal ``checks.py`` under ``root`` with a uniquely-named check."""
+    pack_dir = root / f"pack_{name}"
+    pack_dir.mkdir()
+    checks = pack_dir / "checks.py"
+    checks.write_text(_PACK_TEMPLATE.format(name=name))
+    return checks
+
+
+class TestConcurrentModuleLoad:
+    def test_concurrent_runs_do_not_cross_contaminate(self, tmp_path: Path) -> None:
+        """Two threads, two distinct packs, N iterations each — each caller
+        sees only its own check name in every :class:`CheckResultSet`.
+        """
+        checks_a = _write_pack(tmp_path, "alpha")
+        checks_b = _write_pack(tmp_path, "beta")
+        config = CustomChecksConfig(enabled=True, timeout_seconds=5, interface_version="1.0")
+        ctx = CheckContext(
+            initial_state=EnvironmentState(data={}),
+            final_state=EnvironmentState(data={}),
+            transcript=Transcript(messages=[]),
+            task=TaskContext(task_id="race"),
+        )
+
+        def _run(pack: Path, expected_check: str) -> list[str]:
+            runner = CheckRunner()
+            observed: list[str] = []
+            for _ in range(10):
+                result = runner.run(pack, pack.parent, ctx, config)
+                if result.error is not None:
+                    raise AssertionError(f"unexpected executor error: {result.error}")
+                names = sorted(r.check_name for r in result.results)
+                observed.append(",".join(names))
+                if names != [expected_check]:
+                    raise AssertionError(
+                        f"cross-contamination: expected [{expected_check}] but saw {names}"
+                    )
+            return observed
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            fut_a = pool.submit(_run, checks_a, "check_only_in_alpha")
+            fut_b = pool.submit(_run, checks_b, "check_only_in_beta")
+            observed_a = fut_a.result(timeout=30)
+            observed_b = fut_b.result(timeout=30)
+
+        assert all(entry == "check_only_in_alpha" for entry in observed_a)
+        assert all(entry == "check_only_in_beta" for entry in observed_b)

--- a/tests/unit/grading/test_check_runner_reserved_names.py
+++ b/tests/unit/grading/test_check_runner_reserved_names.py
@@ -1,0 +1,103 @@
+"""Reserved-name contract for :meth:`CheckRunner.load_checks_module`.
+
+A pack author who writes ``@check\\ndef __executor__(...)`` would produce a
+wire ``custom_checks`` list where two entries share ``check_name`` — the
+author's check *and* the sentinel emitted by ``_executor_error_to_wire``
+on a top-level executor failure. The loader refuses the ambiguity at load
+time so the sentinel remains unambiguous end-to-end.
+
+The reserved set lives in
+:data:`tolokaforge.core.grading.check_runner._RESERVED_CHECK_NAMES`, with
+the sentinel value in :data:`_CHECK_EXECUTOR_ERROR_NAME` (the single
+source of truth also referenced from :mod:`tolokaforge.runner.service`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import (
+    _CHECK_EXECUTOR_ERROR_NAME,
+    CheckRunner,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_RESERVED_ONLY_PACK = """
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext, CheckPassed, init, check
+)
+
+@init(interface_version="1.0")
+def setup(ctx: CheckContext):
+    pass
+
+@check
+def __executor__():
+    return CheckPassed("nope")
+"""
+
+
+_NORMAL_PLUS_RESERVED_PACK = """
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext, CheckPassed, init, check
+)
+
+@init(interface_version="1.0")
+def setup(ctx: CheckContext):
+    pass
+
+@check
+def ordinary_check():
+    return CheckPassed("ok")
+
+@check
+def __executor__():
+    return CheckPassed("nope")
+"""
+
+
+def _write_pack(root: Path, body: str) -> Path:
+    checks = root / "checks.py"
+    checks.write_text(body)
+    return checks
+
+
+class TestReservedNameCollision:
+    def test_reserved_only_check_rejected_with_named_message(self, tmp_path: Path) -> None:
+        checks_file = _write_pack(tmp_path, _RESERVED_ONLY_PACK)
+        runner = CheckRunner()
+
+        with pytest.raises(ValueError) as excinfo:
+            runner.load_checks_module(
+                checks_file,
+                tmp_path,
+                relative_imports=[],
+                expected_version="1.0",
+            )
+
+        message = str(excinfo.value)
+        assert _CHECK_EXECUTOR_ERROR_NAME in message
+        assert "reserved" in message.lower()
+
+    def test_ordinary_check_next_to_reserved_still_raises_on_reserved(self, tmp_path: Path) -> None:
+        # The loader must report the reserved-name collision regardless of
+        # decoration order: an unrelated ``@check`` next to the reserved one
+        # neither hides nor swallows the failure.
+        checks_file = _write_pack(tmp_path, _NORMAL_PLUS_RESERVED_PACK)
+        runner = CheckRunner()
+
+        with pytest.raises(ValueError) as excinfo:
+            runner.load_checks_module(
+                checks_file,
+                tmp_path,
+                relative_imports=[],
+                expected_version="1.0",
+            )
+
+        message = str(excinfo.value)
+        assert _CHECK_EXECUTOR_ERROR_NAME in message
+        assert "ordinary_check" not in message

--- a/tests/unit/test_runner_custom_checks_errors.py
+++ b/tests/unit/test_runner_custom_checks_errors.py
@@ -1,0 +1,192 @@
+"""Executor-error branches of ``RunnerServiceImpl._grade_custom_checks``.
+
+The seam ``check_executor: CheckExecutor | None = None`` on
+``RunnerServiceImpl.__init__`` exists to make these branches testable
+without a real ``checks.py`` file or a running executor. The three shapes
+this locks:
+
+1. Missing ``artifacts_dir`` (the pack claimed ``custom_checks.enabled``
+   but no artifacts were delivered) with ``fail_on_error=True`` — score
+   is the 0.0 sentinel and one ``__executor__`` wire entry carries the
+   error message.
+2. Executor returns a top-level ``error`` (module-load failure, timeout,
+   crash) with ``fail_on_error=True`` — score is 0.0 and one
+   ``__executor__`` wire entry carries the message.
+3. Same, with ``fail_on_error=False`` — score is the -1.0 "not evaluated"
+   sentinel so ``combine_grade_components`` excludes it from the weighted
+   total; the ``__executor__`` audit entry is still emitted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import InMemoryCheckExecutor
+from tolokaforge.core.grading.checks_interface import CheckResultSet
+from tolokaforge.runner.models import GradingConfig, InitialStateConfig
+from tolokaforge.runner.service import RunnerServiceImpl
+
+pytestmark = pytest.mark.unit
+
+
+class _StubDBClient:
+    """Minimal db_client stub — only ``get_state`` is exercised by the seam."""
+
+    def __init__(self, state: dict[str, Any] | None = None) -> None:
+        self._state = state or {}
+
+    async def get_state(self, trial_id: str) -> Any:
+        return SimpleNamespace(data=self._state)
+
+
+def _trial_context(*, custom_checks: dict[str, Any]) -> SimpleNamespace:
+    """Build a bare ``TrialContextRuntime`` shape for the branches under test."""
+    task_description = SimpleNamespace(
+        task_id="reconcile:0",
+        name="reconcile",
+        description="",
+        category="",
+        initial_state=InitialStateConfig(),
+    )
+    grading_config = GradingConfig(custom_checks=custom_checks)
+    return SimpleNamespace(
+        task_description=task_description,
+        grading_config=grading_config,
+    )
+
+
+def _build_servicer(*, check_executor: Any) -> RunnerServiceImpl:
+    """Construct a real ``RunnerServiceImpl`` so ``self._loop`` is wired."""
+    return RunnerServiceImpl(db_client=_StubDBClient(), check_executor=check_executor)
+
+
+def _await(servicer: RunnerServiceImpl, coro: Any) -> Any:
+    """Drive ``_grade_custom_checks`` on the servicer's dedicated loop."""
+    return servicer._run_async(coro)
+
+
+class TestGradeCustomChecksExecutorErrors:
+    def test_missing_artifacts_dir_fail_on_error_true_emits_zero_sentinel(self) -> None:
+        servicer = _build_servicer(check_executor=InMemoryCheckExecutor())
+        try:
+            trial_id = "reconcile:0"
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": True,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks(trial_id, trial_context, llm_messages=[]),
+            )
+
+            assert score == 0.0
+            assert len(wire) == 1
+            entry = wire[0]
+            assert entry.check_name == "__executor__"
+            assert entry.status == "error"
+            assert "no artifacts_dir" in entry.message
+            assert trial_id in entry.message
+        finally:
+            servicer.shutdown()
+
+    def test_missing_artifacts_dir_fail_on_error_false_emits_negative_sentinel(self) -> None:
+        servicer = _build_servicer(check_executor=InMemoryCheckExecutor())
+        try:
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": False,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks("reconcile:0", trial_context, llm_messages=[]),
+            )
+
+            assert score == -1.0
+            assert len(wire) == 1
+            assert wire[0].check_name == "__executor__"
+            assert wire[0].status == "error"
+        finally:
+            servicer.shutdown()
+
+    def test_executor_error_fail_on_error_true_emits_zero_sentinel(self, tmp_path: Path) -> None:
+        executor = InMemoryCheckExecutor(return_error="module load failed: syntax error at :12")
+        servicer = _build_servicer(check_executor=executor)
+        try:
+            trial_id = "reconcile:0"
+            # Artifacts dir must exist so the seam gets past the missing-dir branch
+            # and dispatches to the executor.
+            servicer._artifact_dirs[trial_id] = tmp_path
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": True,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks(trial_id, trial_context, llm_messages=[]),
+            )
+
+            assert score == 0.0
+            assert len(wire) == 1
+            entry = wire[0]
+            assert entry.check_name == "__executor__"
+            assert entry.status == "error"
+            assert "module load failed" in entry.message
+            # The executor was actually dispatched.
+            assert len(executor.call_log.runs) == 1
+        finally:
+            servicer.shutdown()
+
+    def test_executor_error_fail_on_error_false_emits_negative_sentinel(
+        self, tmp_path: Path
+    ) -> None:
+        executor = InMemoryCheckExecutor(
+            result_set=CheckResultSet(error="timeout after 30s", execution_time_ms=30_000)
+        )
+        # ``return_error`` and ``result_set`` are mutually exclusive on the fixture,
+        # but a preset ``result_set`` with ``error`` set carries the same shape.
+        servicer = _build_servicer(check_executor=executor)
+        try:
+            trial_id = "reconcile:0"
+            servicer._artifact_dirs[trial_id] = tmp_path
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": False,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks(trial_id, trial_context, llm_messages=[]),
+            )
+
+            assert score == -1.0
+            assert len(wire) == 1
+            entry = wire[0]
+            assert entry.check_name == "__executor__"
+            assert entry.status == "error"
+            assert "timeout after 30s" in entry.message
+            assert len(executor.call_log.runs) == 1
+        finally:
+            servicer.shutdown()

--- a/tests/unit/test_runner_custom_checks_errors.py
+++ b/tests/unit/test_runner_custom_checks_errors.py
@@ -190,3 +190,72 @@ class TestGradeCustomChecksExecutorErrors:
             assert len(executor.call_log.runs) == 1
         finally:
             servicer.shutdown()
+
+    def test_executor_raises_fail_on_error_true_emits_zero_sentinel(self, tmp_path: Path) -> None:
+        # An executor that raises rather than capturing the error into
+        # :class:`CheckResultSet` is a contract violation; the seam converts
+        # the exception to the sentinel-entry shape so the audit survives
+        # and does not escape to the outer trial handler.
+        boom = RuntimeError("boom: executor crashed mid-run")
+        executor = InMemoryCheckExecutor(raise_on_run=boom)
+        servicer = _build_servicer(check_executor=executor)
+        try:
+            trial_id = "reconcile:0"
+            servicer._artifact_dirs[trial_id] = tmp_path
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": True,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks(trial_id, trial_context, llm_messages=[]),
+            )
+
+            assert score == 0.0
+            assert len(wire) == 1
+            entry = wire[0]
+            assert entry.check_name == "__executor__"
+            assert entry.status == "error"
+            assert "boom: executor crashed mid-run" in entry.message
+            # Dispatch happened; the call is recorded even though it raised.
+            assert len(executor.call_log.runs) == 1
+        finally:
+            servicer.shutdown()
+
+    def test_executor_raises_fail_on_error_false_emits_negative_sentinel(
+        self, tmp_path: Path
+    ) -> None:
+        boom = RuntimeError("boom: executor crashed mid-run")
+        executor = InMemoryCheckExecutor(raise_on_run=boom)
+        servicer = _build_servicer(check_executor=executor)
+        try:
+            trial_id = "reconcile:0"
+            servicer._artifact_dirs[trial_id] = tmp_path
+            trial_context = _trial_context(
+                custom_checks={
+                    "enabled": True,
+                    "file": "checks.py",
+                    "interface_version": "1.0",
+                    "fail_on_error": False,
+                },
+            )
+
+            score, wire = _await(
+                servicer,
+                servicer._grade_custom_checks(trial_id, trial_context, llm_messages=[]),
+            )
+
+            assert score == -1.0
+            assert len(wire) == 1
+            entry = wire[0]
+            assert entry.check_name == "__executor__"
+            assert entry.status == "error"
+            assert "boom: executor crashed mid-run" in entry.message
+            assert len(executor.call_log.runs) == 1
+        finally:
+            servicer.shutdown()

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -744,6 +744,7 @@ class NativeAdapter(BaseAdapter):
         effective_combine = resolve_effective_grading_combine(
             self._project_combine_defaults(), combine_data
         )
+        custom_checks_data = grading_data.get("custom_checks") if grading_data else None
         grading_config = RunnerGradingConfig(
             combine_method=effective_combine.method,
             weights=effective_combine.weights,
@@ -751,6 +752,7 @@ class NativeAdapter(BaseAdapter):
             state_checks=state_checks,
             transcript_rules=transcript_rules,
             llm_judge=llm_judge_config,
+            custom_checks=custom_checks_data,
         )
 
         # Build user simulator config
@@ -799,7 +801,13 @@ class NativeAdapter(BaseAdapter):
         # Bundle task directory files as base64 artifacts for Docker Runner.
         # The Runner runs in a separate container without access to the host
         # filesystem, so we transfer all necessary files via gRPC/TaskDescription.
-        tool_artifacts = self._bundle_task_artifacts(task_dir) if mcp_server_ref else {}
+        # Custom checks packs (with or without an MCP server) also need the
+        # bundle so the runner can resolve ``custom_checks.file`` and every
+        # ``relative_imports`` path under the trial's ``artifacts_dir``.
+        custom_checks_enabled = bool(custom_checks_data and custom_checks_data.get("enabled"))
+        tool_artifacts = (
+            self._bundle_task_artifacts(task_dir) if mcp_server_ref or custom_checks_enabled else {}
+        )
 
         # mcp_server.py loads its initial state from ``initial_state.json``
         # next to itself (see ``create_server`` in tools_interface.py). For the

--- a/tolokaforge/core/grading/__init__.py
+++ b/tolokaforge/core/grading/__init__.py
@@ -9,11 +9,18 @@ Modules:
 - combine: Combines multiple grading methods
 - checks_interface: Custom Python checks Pydantic models and decorators
 - checks_helpers: Generic helper functions for custom checks
-- check_runner: Execution engine for custom checks
+- check_runner: :class:`CheckExecutor` Protocol + :class:`CheckRunner` prod impl
+  + :class:`InMemoryCheckExecutor` fixture (see ADR-0012)
 - fuzzy_compare: Field-level fuzzy state comparison
 """
 
-from tolokaforge.core.grading.check_runner import CheckRunner, run_custom_checks
+from tolokaforge.core.grading.check_runner import (
+    CheckExecutor,
+    CheckExecutorCallLog,
+    CheckRunner,
+    InMemoryCheckExecutor,
+    run_custom_checks,
+)
 from tolokaforge.core.grading.checks_interface import (
     CHECKS_INTERFACE_VERSION,
     SUPPORTED_VERSIONS,
@@ -74,8 +81,11 @@ __all__ = [
     "reset_registry",
     # Config
     "CustomChecksConfig",
-    # Runner
+    # Executor seam (ADR-0012 / Pattern A)
+    "CheckExecutor",
+    "CheckExecutorCallLog",
     "CheckRunner",
+    "InMemoryCheckExecutor",
     "run_custom_checks",
     # State comparison
     "ComparisonResult",

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -1,16 +1,17 @@
-"""
-CheckRunner - Safely loads and executes custom check modules.
+"""Custom-checks execution seam (Pattern A per ADR-0011; see ADR-0012).
 
-This module provides the CheckRunner class that handles loading checks.py
-files from tasks, managing relative imports, and executing checks with
-timeout protection.
+The seam is: given a task-authored ``checks.py`` and a :class:`CheckContext`
+built from a trial's evidence, run the module's ``@init`` + ``@check`` functions
+and return a :class:`CheckResultSet`. The Protocol is :class:`CheckExecutor`;
+the production impl is :class:`CheckRunner` (in-process ThreadPoolExecutor);
+the deterministic test fixture is :class:`InMemoryCheckExecutor`.
 
 Usage:
     from tolokaforge.core.grading.check_runner import CheckRunner
     from tolokaforge.core.grading.checks_interface import CheckContext, CustomChecksConfig
 
-    runner = CheckRunner()
-    result = runner.run(
+    executor: CheckExecutor = CheckRunner()
+    result = executor.run(
         checks_file=Path("path/to/task/checks.py"),
         task_dir=Path("path/to/task"),
         ctx=check_context,
@@ -27,9 +28,10 @@ import traceback
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from tolokaforge.core.grading.checks_interface import (
     SUPPORTED_VERSIONS,
@@ -48,6 +50,31 @@ from tolokaforge.core.grading.checks_interface import (
     reset_registry,
 )
 from tolokaforge.core.logging import get_logger
+
+
+@runtime_checkable
+class CheckExecutor(Protocol):
+    """Run task-authored custom checks against a trial's evidence.
+
+    The per-trial *evidence* surface only. How an executor is built —
+    isolation strategy, worker pool sizing, injected logger — is a
+    construction-time concern of the concrete impl, NOT part of this
+    contract, so a future subprocess/namespace-isolated executor (#673)
+    or offline replay executor need not accept the current
+    ``executor_type``/``max_workers`` knobs.
+
+    ``run()`` never raises for check failures; it captures them into the
+    :class:`CheckResultSet` (per-check ``ERROR``/``FAILED`` results or a
+    top-level ``error`` on module-load failure or timeout).
+    """
+
+    def run(
+        self,
+        checks_file: Path,
+        task_dir: Path,
+        ctx: CheckContext,
+        config: CustomChecksConfig,
+    ) -> CheckResultSet: ...
 
 
 class CheckRunner:
@@ -617,10 +644,108 @@ def run_custom_checks(
 
 
 # =============================================================================
+# InMemoryCheckExecutor — non-executing test fixture (records calls,
+# returns configurable results, exercises failure knobs)
+# =============================================================================
+
+
+@dataclass
+class CheckExecutorCallLog:
+    """Records every :meth:`CheckExecutor.run` call an :class:`InMemoryCheckExecutor` saw.
+
+    Tests assert on this directly instead of mocking the executor. Each entry
+    captures the resolved ``checks_file`` / ``task_dir`` paths, the config's
+    ``interface_version`` + ``timeout_seconds`` + ``fail_on_error``, the
+    context's ``task_id``, and the transcript length + final-state key surface
+    handed in — enough for a caller to assert *what* was submitted to the
+    executor without inspecting a real file.
+    """
+
+    runs: list[dict[str, Any]] = field(default_factory=list)
+
+
+class InMemoryCheckExecutor:
+    """Non-executing :class:`CheckExecutor` fixture — deterministic, no file I/O.
+
+    Records every ``run()`` on :attr:`call_log` and returns a configurable
+    :class:`CheckResultSet`. By default returns an empty result set (no
+    checks defined). Failure knobs cover the two shapes the production
+    impl produces on trouble:
+
+    * ``raise_on_run`` — raise the supplied ``Exception`` from ``run()``.
+      Simulates an executor that itself crashes (never expected of
+      :class:`CheckRunner`, but the Protocol allows it and callers must
+      handle it).
+    * ``return_error`` — return a :class:`CheckResultSet` whose ``error``
+      field carries the given string and whose ``results`` are empty.
+      Simulates module-load failure, timeout, or any top-level error the
+      production runner surfaces via ``CheckResultSet.error``.
+
+    A caller may also pass ``result_set=`` to return an arbitrary
+    pre-built :class:`CheckResultSet`. Production never constructs this —
+    it is a test seam only.
+    """
+
+    def __init__(
+        self,
+        *,
+        result_set: CheckResultSet | None = None,
+        raise_on_run: Exception | None = None,
+        return_error: str | None = None,
+    ) -> None:
+        if raise_on_run is not None and return_error is not None:
+            raise ValueError(
+                "InMemoryCheckExecutor: pass at most one of raise_on_run / return_error."
+            )
+        if raise_on_run is not None and result_set is not None:
+            raise ValueError(
+                "InMemoryCheckExecutor: raise_on_run and result_set are mutually exclusive."
+            )
+        if return_error is not None and result_set is not None:
+            raise ValueError(
+                "InMemoryCheckExecutor: return_error and result_set are mutually exclusive."
+            )
+        self._result_set = result_set
+        self._raise_on_run = raise_on_run
+        self._return_error = return_error
+        self.call_log = CheckExecutorCallLog()
+
+    def run(
+        self,
+        checks_file: Path,
+        task_dir: Path,
+        ctx: CheckContext,
+        config: CustomChecksConfig,
+    ) -> CheckResultSet:
+        self.call_log.runs.append(
+            {
+                "checks_file": checks_file,
+                "task_dir": task_dir,
+                "interface_version": config.interface_version,
+                "timeout_seconds": config.timeout_seconds,
+                "fail_on_error": config.fail_on_error,
+                "task_id": ctx.task.task_id,
+                "transcript_len": len(ctx.transcript.messages),
+                "final_state_keys": tuple(ctx.final_state.data.keys()),
+            }
+        )
+        if self._raise_on_run is not None:
+            raise self._raise_on_run
+        if self._return_error is not None:
+            return CheckResultSet(error=self._return_error, execution_time_ms=0.0)
+        if self._result_set is not None:
+            return self._result_set
+        return CheckResultSet(results=[], execution_time_ms=0.0)
+
+
+# =============================================================================
 # Public API exports
 # =============================================================================
 
 __all__ = [
+    "CheckExecutor",
+    "CheckExecutorCallLog",
     "CheckRunner",
+    "InMemoryCheckExecutor",
     "run_custom_checks",
 ]

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import threading
 import time
 import traceback
 from collections.abc import Callable
@@ -50,6 +51,16 @@ from tolokaforge.core.grading.checks_interface import (
     reset_registry,
 )
 from tolokaforge.core.logging import get_logger
+
+# The check registry in ``checks_interface`` (``_check_registry``, ``_init_func``,
+# ``_interface_version``) is module-global — it must be, because the decorators
+# ``@check`` and ``@init`` fire at import time and have no way to reach a
+# runner instance. The gRPC handler pool serves concurrent trials; two of them
+# calling ``load_checks_module`` in parallel would interleave
+# ``reset_registry() → exec_module() → get_registered_checks()`` and hand each
+# caller a merged/partial registry. This lock serialises the sequence
+# per-process so every caller sees only its own module's checks.
+_CHECKS_MODULE_LOAD_LOCK = threading.Lock()
 
 
 @runtime_checkable
@@ -218,64 +229,69 @@ class CheckRunner:
         if not checks_file.exists():
             raise ValueError(f"Checks file not found: {checks_file}")
 
-        # Reset the registry before loading to ensure clean state
-        reset_registry()
+        # The ``reset → exec_module → get_registered_checks`` sequence walks
+        # module-level state in ``checks_interface`` (see
+        # ``_CHECKS_MODULE_LOAD_LOCK``); serialise the whole sequence so
+        # concurrent callers never observe a merged registry.
+        with _CHECKS_MODULE_LOAD_LOCK:
+            # Reset the registry before loading to ensure clean state
+            reset_registry()
 
-        # Clear potentially stale cached modules that might conflict
-        # (e.g., check_helpers from a different project)
-        self._clear_cached_modules(["check_helpers", "task_helpers", "helpers"])
+            # Clear potentially stale cached modules that might conflict
+            # (e.g., check_helpers from a different project)
+            self._clear_cached_modules(["check_helpers", "task_helpers", "helpers"])
 
-        # Add import paths
-        added_paths = self._add_import_paths(task_dir, relative_imports)
+            # Add import paths
+            added_paths = self._add_import_paths(task_dir, relative_imports)
 
-        try:
-            # Load module dynamically
-            spec = importlib.util.spec_from_file_location("task_checks", checks_file)
-            if not spec or not spec.loader:
-                raise ValueError(f"Could not create module spec for: {checks_file}")
-
-            module: ModuleType = importlib.util.module_from_spec(spec)
-
-            # Add to sys.modules temporarily so relative imports work
-            sys.modules["task_checks"] = module
             try:
-                spec.loader.exec_module(module)
+                # Load module dynamically
+                spec = importlib.util.spec_from_file_location("task_checks", checks_file)
+                if not spec or not spec.loader:
+                    raise ValueError(f"Could not create module spec for: {checks_file}")
+
+                module: ModuleType = importlib.util.module_from_spec(spec)
+
+                # Add to sys.modules temporarily so relative imports work
+                sys.modules["task_checks"] = module
+                try:
+                    spec.loader.exec_module(module)
+                finally:
+                    # Remove from sys.modules to avoid pollution
+                    if "task_checks" in sys.modules:
+                        del sys.modules["task_checks"]
+
+                # Get registered functions from decorators
+                init_func = get_init_func()
+                checks = get_registered_checks()
+                version = get_interface_version()
+
+                self.logger.debug(
+                    "Loaded checks module",
+                    file=str(checks_file),
+                    init_found=init_func is not None,
+                    check_count=len(checks),
+                    version=version,
+                )
+
+                # Validate version
+                if version not in SUPPORTED_VERSIONS:
+                    raise ValueError(
+                        f"Unsupported interface version: {version}. Supported: {SUPPORTED_VERSIONS}"
+                    )
+
+                if expected_version != version:
+                    self.logger.warning(
+                        "Version mismatch between config and module",
+                        expected=expected_version,
+                        actual=version,
+                    )
+
+                return init_func, checks, version
+
             finally:
-                # Remove from sys.modules to avoid pollution
-                if "task_checks" in sys.modules:
-                    del sys.modules["task_checks"]
-
-            # Get registered functions from decorators
-            init_func = get_init_func()
-            checks = get_registered_checks()
-            version = get_interface_version()
-
-            self.logger.debug(
-                "Loaded checks module",
-                file=str(checks_file),
-                init_found=init_func is not None,
-                check_count=len(checks),
-                version=version,
-            )
-
-            # Validate version
-            if version not in SUPPORTED_VERSIONS:
-                raise ValueError(
-                    f"Unsupported interface version: {version}. Supported: {SUPPORTED_VERSIONS}"
-                )
-
-            if expected_version != version:
-                self.logger.warning(
-                    "Version mismatch between config and module",
-                    expected=expected_version,
-                    actual=version,
-                )
-
-            return init_func, checks, version
-
-        finally:
-            # Clean up import paths even if error occurred
-            self._remove_import_paths(added_paths)
+                # Clean up import paths even if error occurred
+                self._remove_import_paths(added_paths)
 
     def _execute_checks(
         self,

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -62,6 +62,14 @@ from tolokaforge.core.logging import get_logger
 # per-process so every caller sees only its own module's checks.
 _CHECKS_MODULE_LOAD_LOCK = threading.Lock()
 
+# Sentinel check name used by :mod:`tolokaforge.runner.service` to attach a
+# top-level executor error (module-load failure, timeout, crash) to the wire
+# ``custom_checks`` list. Task-authored ``@check`` functions may not adopt
+# this name; :meth:`CheckRunner.load_checks_module` raises ``ValueError`` on
+# collision so the sentinel remains unambiguous end-to-end.
+_CHECK_EXECUTOR_ERROR_NAME = "__executor__"
+_RESERVED_CHECK_NAMES = frozenset({_CHECK_EXECUTOR_ERROR_NAME})
+
 
 @runtime_checkable
 class CheckExecutor(Protocol):
@@ -273,6 +281,14 @@ class CheckRunner:
                     check_count=len(checks),
                     version=version,
                 )
+
+                reserved_collisions = sorted(_RESERVED_CHECK_NAMES & checks.keys())
+                if reserved_collisions:
+                    raise ValueError(
+                        f"@check name(s) collide with reserved sentinel(s): "
+                        f"{reserved_collisions}. Reserved names: "
+                        f"{sorted(_RESERVED_CHECK_NAMES)}. Rename the check."
+                    )
 
                 # Validate version
                 if version not in SUPPORTED_VERSIONS:

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -574,6 +574,42 @@ class CheckRunner:
 
 
 # =============================================================================
+# Startup-time validation helper — RegisterTrial calls this to fail-loud on
+# an unsupported ``interface_version`` or a broken ``checks.py`` BEFORE the
+# (expensive) trial runs.
+# =============================================================================
+
+
+def validate_checks_module(
+    *,
+    checks_file: Path,
+    task_dir: Path,
+    config: CustomChecksConfig,
+) -> None:
+    """Load ``checks_file`` far enough to validate its ``@init(interface_version=…)``.
+
+    Raises:
+        ValueError: If the file is missing, the module fails to import
+            (broken/missing ``relative_imports`` targets, syntax error,
+            import error), or the declared ``interface_version`` is not in
+            :data:`~tolokaforge.core.grading.checks_interface.SUPPORTED_VERSIONS`.
+            The message names the declared version and ``SUPPORTED_VERSIONS``
+            for the unsupported-version case.
+    """
+    try:
+        CheckRunner().load_checks_module(
+            checks_file=checks_file,
+            task_dir=task_dir,
+            relative_imports=config.relative_imports,
+            expected_version=config.interface_version,
+        )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Failed to load checks module {checks_file}: {exc}") from exc
+
+
+# =============================================================================
 # Convenience function for simple usage
 # =============================================================================
 
@@ -748,4 +784,5 @@ __all__ = [
     "CheckRunner",
     "InMemoryCheckExecutor",
     "run_custom_checks",
+    "validate_checks_module",
 ]

--- a/tolokaforge/core/grading/checks_helpers.py
+++ b/tolokaforge/core/grading/checks_helpers.py
@@ -1,11 +1,19 @@
 """
-Generic helper functions for custom checks.
+Shared helpers for custom checks — two distinct audiences.
 
-These are domain-agnostic utilities that can be used by any task's checks.py.
-Domain-specific helpers should be defined at the project level (e.g.,
-tasks/airline/check_helpers.py).
+Author-facing utilities (``check_dict_params``, ``last_tool_name``,
+``text_contains_any``, …) are imported by a task's ``checks.py`` to compare
+dicts, inspect tool-call sequences, and pattern-match text. Domain-specific
+helpers should be defined at the project level (e.g. ``tasks/airline/
+check_helpers.py``).
 
-Usage in checks.py:
+Framework-internal utility (``build_check_context``) is called by BOTH grading
+paths — :class:`~tolokaforge.core.grading.combine.GradingEngine` on the host
+and the runner-side :class:`~tolokaforge.runner.service.RunnerServiceImpl` —
+so the two builders cannot diverge on the ``final_env_state`` shape transform
+custom checks depend on.
+
+Usage in ``checks.py``:
     from tolokaforge.core.grading.checks_helpers import (
         check_dict_params, last_tool_name, text_contains_any
     )
@@ -16,6 +24,68 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from typing import Any
+
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext,
+    EnvironmentState,
+    TaskContext,
+    Transcript,
+)
+
+# =============================================================================
+# Framework-internal: shared CheckContext builder (used by both grading paths)
+# =============================================================================
+
+
+def build_check_context(
+    *,
+    initial_state_json_db: dict[str, Any] | None,
+    final_env_state: dict[str, Any],
+    transcript: Transcript,
+    task: TaskContext,
+) -> CheckContext:
+    """Build a :class:`CheckContext` with the canonical state-shape transform.
+
+    Encodes the single rule both grading paths must apply so that a check
+    written against one path reads identical evidence from the other:
+
+    * ``initial_state.data`` = ``initial_state_json_db`` when it is a dict, else
+      an empty dict. Author-declared initial DB rows only; other init sources
+      (filesystem, mock_web) are not surfaced here.
+    * ``final_state.data`` is picked from ``final_env_state`` by precedence —
+      the ``"agent"`` dict wins over the ``"db"`` dict, and the flat
+      ``final_env_state`` is used if neither key holds a dict. This mirrors the
+      adapter convention that ``final_env_state["agent"]`` carries the mutated
+      state after tool calls.
+    * When ``final_env_state`` supplies a ``"filesystem"`` key and the chosen
+      level lacks one, ``filesystem`` is merged into ``final_state.data`` so a
+      check can read agent-produced files alongside the DB rows it just
+      inspected.
+
+    ``transcript`` and ``task`` are passed through — each grading path owns
+    its own transcript/task construction (rich :class:`Trajectory` on the host,
+    wire message dicts + :class:`~tolokaforge.runner.models.TaskDescription`
+    on the runner).
+    """
+    initial_data = initial_state_json_db if isinstance(initial_state_json_db, dict) else {}
+
+    if isinstance(final_env_state.get("agent"), dict):
+        final_state_data = final_env_state["agent"]
+    elif isinstance(final_env_state.get("db"), dict):
+        final_state_data = final_env_state["db"]
+    else:
+        final_state_data = final_env_state
+
+    if "filesystem" in final_env_state and "filesystem" not in final_state_data:
+        final_state_data = {**final_state_data, "filesystem": final_env_state["filesystem"]}
+
+    return CheckContext(
+        initial_state=EnvironmentState(data=initial_data),
+        final_state=EnvironmentState(data=final_state_data),
+        transcript=transcript,
+        task=task,
+    )
+
 
 # =============================================================================
 # Dictionary / Data Comparison Helpers

--- a/tolokaforge/core/grading/combine.py
+++ b/tolokaforge/core/grading/combine.py
@@ -8,10 +8,10 @@ from tolokaforge.core.evaluators.action_evaluator import ActionEvaluator
 from tolokaforge.core.evaluators.communicate_evaluator import CommunicateEvaluator
 from tolokaforge.core.evaluators.environment_evaluator import EnvironmentEvaluator
 from tolokaforge.core.grading.check_runner import CheckRunner
+from tolokaforge.core.grading.checks_helpers import build_check_context
 from tolokaforge.core.grading.checks_interface import (
     CheckContext,
     CustomChecksConfig,
-    EnvironmentState,
     TaskContext,
     ToolCallStatus,
     Transcript,
@@ -383,17 +383,13 @@ class GradingEngine:
         trajectory: Trajectory,
         final_env_state: dict[str, Any],
     ) -> CheckContext:
-        """
-        Build CheckContext from trajectory and final state.
+        """Build the host-side :class:`CheckContext` from a :class:`Trajectory`.
 
-        Args:
-            trajectory: Trial trajectory
-            final_env_state: Final environment state
-
-        Returns:
-            CheckContext for custom checks
+        Owns the transcript-from-``Trajectory`` transform (rich :class:`Message`
+        objects → author-facing :class:`CheckMessage`); the state-shape rule
+        is delegated to :func:`build_check_context` so the runner path applies
+        the same precedence by construction.
         """
-        # Build transcript with tool calls
         messages: list[CheckMessage] = []
         for msg in trajectory.messages:
             tool_calls = []
@@ -403,7 +399,7 @@ class GradingEngine:
                         CheckToolCall(
                             name=tc.name,
                             arguments=tc.arguments,
-                            result=None,  # We don't have results stored in messages
+                            result=None,
                             status=ToolCallStatus.SUCCESS,
                         )
                     )
@@ -415,35 +411,14 @@ class GradingEngine:
                 )
             )
 
-        transcript = Transcript(messages=messages)
+        initial_json_db: dict[str, Any] | None = None
+        if self.task_initial_state and isinstance(self.task_initial_state.json_db, dict):
+            initial_json_db = self.task_initial_state.json_db
 
-        # Get initial state from task_initial_state if available
-        initial_data = {}
-        if self.task_initial_state and self.task_initial_state.json_db:
-            if isinstance(self.task_initial_state.json_db, dict):
-                initial_data = self.task_initial_state.json_db
-            # If it's a path, we'd need to load it - for now, leave empty
-
-        # Handle nested state structure (agent/user/db) or flat state
-        # Custom checks need flat state data, so extract from appropriate level
-        if "agent" in final_env_state and isinstance(final_env_state.get("agent"), dict):
-            # Use agent state which contains the mutated data from tool calls
-            final_state_data = final_env_state["agent"]
-        elif "db" in final_env_state and isinstance(final_env_state.get("db"), dict):
-            # Fallback to db state
-            final_state_data = final_env_state["db"]
-        else:
-            # Use as-is (flat state)
-            final_state_data = final_env_state
-
-        # Pass filesystem state through so custom checks can access agent-produced files
-        if "filesystem" in final_env_state and "filesystem" not in final_state_data:
-            final_state_data = {**final_state_data, "filesystem": final_env_state["filesystem"]}
-
-        return CheckContext(
-            initial_state=EnvironmentState(data=initial_data),
-            final_state=EnvironmentState(data=final_state_data),
-            transcript=transcript,
+        return build_check_context(
+            initial_state_json_db=initial_json_db,
+            final_env_state=final_env_state,
+            transcript=Transcript(messages=messages),
             task=TaskContext(
                 task_id=trajectory.task_id,
                 task_name=trajectory.task_id,

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from tolokaforge.core.models import (
     CriterionResult,
+    CustomCheckDetail,
     Grade,
     GradeComponents,
     JudgeInputs,
@@ -246,6 +247,35 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
     if raw_criterion_results:
         criterion_results = [CriterionResult(**cr) for cr in raw_criterion_results]
 
+    # Per-check custom-checks breakdown. The wire carries the ``details``
+    # payload JSON-encoded (proto ``string details_json``) so it can hold
+    # arbitrary check-defined data; decode back to a dict, or leave ``None``
+    # when the check emitted none. Malformed JSON is dropped to ``None``
+    # rather than failing the whole grade parse.
+    custom_checks_details: list[CustomCheckDetail] | None = None
+    raw_custom_checks = raw_grade.get("custom_checks")
+    if raw_custom_checks:
+        custom_checks_details = []
+        for entry in raw_custom_checks:
+            details_payload: dict[str, Any] | None = None
+            raw_details_json = entry.get("details_json") or ""
+            if raw_details_json:
+                try:
+                    parsed_details = json.loads(raw_details_json)
+                except (json.JSONDecodeError, TypeError):
+                    parsed_details = None
+                if isinstance(parsed_details, dict):
+                    details_payload = parsed_details
+            custom_checks_details.append(
+                CustomCheckDetail(
+                    check_name=entry.get("check_name", ""),
+                    status=entry.get("status", ""),
+                    score=float(entry.get("score", 0.0)),
+                    message=entry.get("message", ""),
+                    details=details_payload,
+                )
+            )
+
     judge_usage: JudgeUsage | None = None
     judge_transcript: list[dict[str, Any]] | None = None
     judge_kb_gating: JudgeKbGating | None = None
@@ -298,6 +328,7 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
         ),
         reasons=raw_grade.get("reasons", ""),
         state_diff=state_diff_parsed,
+        custom_checks_details=custom_checks_details,
         criterion_results=criterion_results,
         judge_status=JudgeStatus.from_proto(raw_grade.get("judge_status", 0)),
         judge_usage=judge_usage,

--- a/tolokaforge/runner/grading.py
+++ b/tolokaforge/runner/grading.py
@@ -855,6 +855,11 @@ def combine_grade_components(
     if llm_judge_score >= 0:
         active_components["llm_judge"] = llm_judge_score
 
+    # Custom Python checks
+    custom_checks_score = components.get("custom_checks_score", -1.0)
+    if custom_checks_score >= 0:
+        active_components["custom_checks"] = custom_checks_score
+
     # If no components are active but grading was configured, fail explicitly.
     # This prevents refusal tasks (empty golden_actions) or misconfigured
     # grading from silently passing with score=1.0.
@@ -870,6 +875,8 @@ def combine_grade_components(
             actually_configured.add("transcript_rules")
         if "llm_judge" in weights and grading_config.get("llm_judge") is not None:
             actually_configured.add("llm_judge")
+        if "custom_checks" in weights and grading_config.get("custom_checks") is not None:
+            actually_configured.add("custom_checks")
 
         if actually_configured:
             logger.warning(

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -608,6 +608,14 @@ class GradingConfig(BaseModel):
     transcript_rules: TranscriptRulesConfig | None = None
     llm_judge: LLMJudgeConfig | None = None
 
+    # Custom Python checks (``@init`` + ``@check`` in a pack's ``checks.py``).
+    # Loose ``dict[str, Any]`` here — the runner validates it into
+    # :class:`~tolokaforge.core.grading.checks_interface.CustomChecksConfig` at
+    # ``GradeTrial`` time (and, once Stage 4 lands, at ``RegisterTrial`` too);
+    # mirrors the host-side :class:`~tolokaforge.core.models.GradingConfig`
+    # so an unchanged ``task.yaml`` round-trips through both.
+    custom_checks: dict[str, Any] | None = None
+
     model_config = {"extra": "forbid"}
 
 
@@ -1810,6 +1818,7 @@ class GradeComponents(BaseModel):
     transcript_score: float = -1.0
     llm_judge_score: float = -1.0  # -1.0 means not evaluated
     llm_judge_reasons: str = ""
+    custom_checks_score: float = -1.0  # -1.0 means not evaluated
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -611,9 +611,10 @@ class GradingConfig(BaseModel):
     # Custom Python checks (``@init`` + ``@check`` in a pack's ``checks.py``).
     # Loose ``dict[str, Any]`` here — the runner validates it into
     # :class:`~tolokaforge.core.grading.checks_interface.CustomChecksConfig` at
-    # ``GradeTrial`` time (and, once Stage 4 lands, at ``RegisterTrial`` too);
-    # mirrors the host-side :class:`~tolokaforge.core.models.GradingConfig`
-    # so an unchanged ``task.yaml`` round-trips through both.
+    # both ``RegisterTrial`` (fail-loud on interface_version / module load) and
+    # ``GradeTrial`` (before executor dispatch); mirrors the host-side
+    # :class:`~tolokaforge.core.models.GradingConfig` so an unchanged
+    # ``task.yaml`` round-trips through both.
     custom_checks: dict[str, Any] | None = None
 
     model_config = {"extra": "forbid"}

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -33,6 +33,22 @@ from typing import Any
 import grpc
 from pydantic import ValidationError
 
+from tolokaforge.core.grading.check_runner import CheckExecutor, CheckRunner
+from tolokaforge.core.grading.checks_helpers import build_check_context
+from tolokaforge.core.grading.checks_interface import (
+    CheckResult,
+    CheckResultSet,
+    CustomChecksConfig,
+    TaskContext,
+    ToolCallStatus,
+    Transcript,
+)
+from tolokaforge.core.grading.checks_interface import (
+    Message as CheckMessage,
+)
+from tolokaforge.core.grading.checks_interface import (
+    ToolCall as CheckToolCall,
+)
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, LLMJudge
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
@@ -101,6 +117,86 @@ AGENT_WORK_DIR = "/work"
 # judge's "harness-owned allowlist" rule (no generic MCP-tool passthrough — we
 # cannot classify arbitrary MCP tools' read-only-ness).
 _SEARCH_POLICY_TOOL_NAME = "search_policy"
+
+# Sentinel check name for a top-level :class:`CheckResultSet` error (module
+# load failure, timeout, executor crash). The host surfaces it in the wire
+# ``custom_checks`` list so the audit is preserved end-to-end.
+_CHECK_EXECUTOR_ERROR_NAME = "__executor__"
+
+
+def _build_runner_check_transcript(
+    llm_messages: list[dict[str, Any]],
+) -> Transcript:
+    """Build a :class:`Transcript` from the runner's wire ``llm_messages``.
+
+    Wire ``tool_calls`` are OpenAI-shaped
+    (``{"function": {"name", "arguments": <json_str>}}``); this decodes them
+    back into :class:`ToolCall` with ``result=None`` (results are not carried in
+    ``llm_messages_json``), mirroring the host-side transcript build so a check
+    reads identical evidence from either grading path.
+    """
+    check_messages: list[CheckMessage] = []
+    for msg in llm_messages:
+        role = str(msg.get("role", ""))
+        content = str(msg.get("content", "") or "")
+        raw_tool_calls = msg.get("tool_calls") or []
+        tool_calls: list[CheckToolCall] = []
+        for raw_tc in raw_tool_calls:
+            fn = raw_tc.get("function") or {}
+            name = str(fn.get("name") or raw_tc.get("name") or "")
+            raw_args: Any = fn.get("arguments", raw_tc.get("arguments"))
+            if isinstance(raw_args, str):
+                try:
+                    args_dict = json.loads(raw_args) if raw_args else {}
+                except (json.JSONDecodeError, TypeError):
+                    args_dict = {}
+            elif isinstance(raw_args, dict):
+                args_dict = raw_args
+            else:
+                args_dict = {}
+            tool_calls.append(
+                CheckToolCall(
+                    name=name,
+                    arguments=args_dict,
+                    result=None,
+                    status=ToolCallStatus.SUCCESS,
+                )
+            )
+        check_messages.append(CheckMessage(role=role, content=content, tool_calls=tool_calls))
+    return Transcript(messages=check_messages)
+
+
+def _check_result_to_wire(result: CheckResult) -> "pb2.CustomCheckResult":
+    """Convert a :class:`CheckResult` to the wire ``pb2.CustomCheckResult``.
+
+    ``details`` (arbitrary dict) is JSON-encoded into the proto's
+    ``details_json`` string; empty when the check emitted no details.
+    """
+    status_str = result.status.value if hasattr(result.status, "value") else str(result.status)
+    details_json = json.dumps(result.details) if result.details else ""
+    return pb2.CustomCheckResult(
+        check_name=result.check_name,
+        status=status_str,
+        score=result.score,
+        message=result.message,
+        details_json=details_json,
+    )
+
+
+def _executor_error_to_wire(error: str) -> "pb2.CustomCheckResult":
+    """Wrap a top-level :class:`CheckResultSet` error as a wire result.
+
+    The audit — module-load failure / timeout / executor crash — travels to
+    the host under the reserved :data:`_CHECK_EXECUTOR_ERROR_NAME` sentinel
+    so the reasons string is not the only place it survives.
+    """
+    return pb2.CustomCheckResult(
+        check_name=_CHECK_EXECUTOR_ERROR_NAME,
+        status="error",
+        score=0.0,
+        message=error,
+        details_json="",
+    )
 
 
 # =============================================================================
@@ -247,6 +343,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         self,
         db_client: DBServiceClient,
         rag_client: RAGServiceClient | None = None,
+        check_executor: CheckExecutor | None = None,
     ):
         """
         Initialize the Runner service.
@@ -254,9 +351,13 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         Args:
             db_client: HTTP client for DB Service communication
             rag_client: Optional RAG service client for search tools
+            check_executor: Executor for the pack's ``checks.py``. Defaults to the
+                in-process :class:`CheckRunner`; tests inject
+                :class:`InMemoryCheckExecutor`.
         """
         self.db_client = db_client
         self.rag_client = rag_client
+        self.check_executor: CheckExecutor = check_executor or CheckRunner()
         self.trials: dict[str, TrialContextRuntime] = {}
         self._available_adapters = list(BUILTIN_ADAPTERS)
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup
@@ -1203,6 +1304,15 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             else:
                 logger.info(f"GradeTrial: {trial_id} - Skipping LLM judge (no transcript messages)")
 
+        # B.3) CUSTOM PYTHON CHECKS — the pack's ``checks.py`` executes runner-side
+        # when ``grading.custom_checks.enabled``; the aggregate score fills
+        # ``components.custom_checks`` and the per-check breakdown rides
+        # ``Grade.custom_checks`` (see ADR-0012).
+        custom_checks_score, custom_check_wire_results = await self._grade_custom_checks(
+            trial_id, trial_context, llm_messages
+        )
+        components.custom_checks_score = custom_checks_score
+
         # C) COMBINE SCORES
         components_dict = components.model_dump()
         grading_config_dict = grading_config.model_dump()
@@ -1251,10 +1361,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     state_checks=state_checks_component,
                     transcript_rules=components.transcript_score,
                     llm_judge=components.llm_judge_score,
-                    custom_checks=-1.0,  # Not implemented yet
+                    custom_checks=components.custom_checks_score,
                 ),
                 reasons=reasons,
                 state_diff_json=json.dumps(state_diff_dict) if state_diff_dict else "",
+                custom_checks=custom_check_wire_results,
                 criterion_results=[
                     pb2.CriterionResult(
                         id=cr.id, met=cr.met, score=cr.score, justification=cr.justification
@@ -1391,6 +1502,93 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             )
 
         return await loop.run_in_executor(None, _run)
+
+    async def _grade_custom_checks(
+        self,
+        trial_id: str,
+        trial_context: TrialContextRuntime,
+        llm_messages: list[dict[str, Any]],
+    ) -> tuple[float, list["pb2.CustomCheckResult"]]:
+        """Run the pack's ``checks.py`` against the trial's evidence.
+
+        Returns ``(score, wire_results)``. A missing/disabled config returns
+        ``(-1.0, [])`` so :func:`combine_grade_components` treats the
+        component as not-evaluated (the empty-active-set guard then fires
+        for a custom-checks-only pack instead of silently passing).
+
+        On executor error (missing ``checks.py``, module load failure,
+        timeout): a sentinel wire entry preserves the audit, and the score
+        follows ``fail_on_error`` — ``0.0`` when true (contributes to the
+        weighted total as a fail), ``-1.0`` when false (component not
+        evaluated).
+        """
+        grading_config = trial_context.grading_config
+        custom_config_raw = grading_config.custom_checks if grading_config else None
+        if not custom_config_raw or not custom_config_raw.get("enabled", False):
+            return -1.0, []
+
+        config = CustomChecksConfig(**custom_config_raw)
+
+        artifacts_dir = self._artifact_dirs.get(trial_id)
+        if artifacts_dir is None:
+            error_msg = (
+                f"custom_checks.enabled but no artifacts_dir for trial {trial_id!r} "
+                "(checks.py was not delivered by the adapter)"
+            )
+            logger.error("GradeTrial: %s - %s", trial_id, error_msg)
+            score = 0.0 if config.fail_on_error else -1.0
+            return score, [_executor_error_to_wire(error_msg)]
+        checks_file = artifacts_dir / config.file
+
+        task_description = trial_context.task_description
+        initial_tables = task_description.initial_state.tables
+        initial_state_json_db: dict[str, Any] | None = (
+            dict(initial_tables) if initial_tables else None
+        )
+
+        final_state_response = await self.db_client.get_state(trial_id)
+        final_env_state: dict[str, Any] = final_state_response.data
+
+        ctx = build_check_context(
+            initial_state_json_db=initial_state_json_db,
+            final_env_state=final_env_state,
+            transcript=_build_runner_check_transcript(llm_messages),
+            task=TaskContext(
+                task_id=task_description.task_id,
+                task_name=task_description.name,
+                task_description=task_description.description,
+                domain=task_description.category or "",
+            ),
+        )
+
+        logger.info(f"GradeTrial: {trial_id} - Running custom checks from {checks_file}")
+        result: CheckResultSet = await self._loop.run_in_executor(
+            None,
+            lambda: self.check_executor.run(
+                checks_file=checks_file,
+                task_dir=artifacts_dir,
+                ctx=ctx,
+                config=config,
+            ),
+        )
+
+        wire_results = [_check_result_to_wire(r) for r in result.results]
+
+        if result.error:
+            logger.error(
+                "GradeTrial: %s - custom checks executor error: %s",
+                trial_id,
+                result.error,
+            )
+            wire_results.append(_executor_error_to_wire(result.error))
+            score = 0.0 if config.fail_on_error else -1.0
+            return score, wire_results
+
+        logger.info(
+            f"GradeTrial: {trial_id} - custom checks: "
+            f"{result.passed}/{result.total} passed, score={result.aggregate_score:.2f}"
+        )
+        return result.aggregate_score, wire_results
 
     async def _build_judge_state_diff(
         self, trial_id: str, trial_context: TrialContextRuntime

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -660,6 +660,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             trial_id, task_description, artifacts_dir
         )
         if custom_checks_error is not None:
+            # Extraction ran before validation, so a failing config leaves the
+            # tmp dir on disk + on ``sys.path``. Clean up before returning so a
+            # client-side retry does not compound the leak (or shadow later
+            # imports of the same relative path from an unrelated trial).
+            self._cleanup_trial_artifacts(trial_id)
             return pb2.RegisterTrialResponse(success=False, error=custom_checks_error)
 
         # Initialise mcp_core TypeSense registry so search_policy tools work.

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -33,7 +33,11 @@ from typing import Any
 import grpc
 from pydantic import ValidationError
 
-from tolokaforge.core.grading.check_runner import CheckExecutor, CheckRunner
+from tolokaforge.core.grading.check_runner import (
+    CheckExecutor,
+    CheckRunner,
+    validate_checks_module,
+)
 from tolokaforge.core.grading.checks_helpers import build_check_context
 from tolokaforge.core.grading.checks_interface import (
     CheckResult,
@@ -542,6 +546,58 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         except Exception as e:
             logger.warning(f"Failed to clean up artifact dir {artifact_dir}: {e}")
 
+    def _validate_custom_checks_startup(
+        self,
+        trial_id: str,
+        task_description: "TaskDescription",
+        artifacts_dir: Path | None,
+    ) -> str | None:
+        """Fail-loud validation of ``custom_checks`` before the trial runs.
+
+        Returns ``None`` when the pack has no ``custom_checks`` config, has it
+        disabled, or the config validates and ``checks.py`` loads with a
+        supported ``interface_version``. Returns a human-readable error string
+        naming the offending version and :data:`SUPPORTED_VERSIONS` (or the
+        module-load failure) when the pack claims custom checks but the module
+        cannot be loaded — the caller turns that into a
+        ``RegisterTrialResponse(success=False, error=…)``.
+        """
+        grading = task_description.grading
+        custom_checks_raw = grading.custom_checks if grading else None
+        if not custom_checks_raw or not custom_checks_raw.get("enabled", False):
+            return None
+
+        try:
+            custom_config = CustomChecksConfig(**custom_checks_raw)
+        except ValidationError as exc:
+            logger.error(f"RegisterTrial: {trial_id} - invalid custom_checks config: {exc}")
+            return f"Invalid custom_checks config: {exc}"
+
+        if artifacts_dir is None:
+            error = (
+                f"custom_checks.enabled but no tool_artifacts were delivered "
+                f"(expected `{custom_config.file}` under the trial's artifacts dir)"
+            )
+            logger.error(f"RegisterTrial: {trial_id} - {error}")
+            return error
+
+        checks_file = artifacts_dir / custom_config.file
+        try:
+            validate_checks_module(
+                checks_file=checks_file,
+                task_dir=artifacts_dir,
+                config=custom_config,
+            )
+        except ValueError as exc:
+            logger.error(f"RegisterTrial: {trial_id} - custom_checks validation failed: {exc}")
+            return f"custom_checks validation failed: {exc}"
+
+        logger.info(
+            f"RegisterTrial: {trial_id} - custom_checks validated "
+            f"(interface_version={custom_config.interface_version}, file={custom_config.file})"
+        )
+        return None
+
     # =========================================================================
     # RegisterTrial - Initialize trial with TaskDescription
     # =========================================================================
@@ -595,6 +651,16 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             # relative filename (e.g. "mcp_server.py") so the TaskDescription
             # stays portable across machines; the Runner fixes up the path here.
             self._resolve_mcp_server_scripts(task_description, artifacts_dir)
+
+        # Reject an unsupported ``interface_version`` or a broken ``checks.py``
+        # BEFORE DB init, tool reconstruction, and the agent loop — the load
+        # cost of validation is bounded, the cost of running a trial to grade
+        # time only to reject on version isn't.
+        custom_checks_error = self._validate_custom_checks_startup(
+            trial_id, task_description, artifacts_dir
+        )
+        if custom_checks_error is not None:
+            return pb2.RegisterTrialResponse(success=False, error=custom_checks_error)
 
         # Initialise mcp_core TypeSense registry so search_policy tools work.
         # Documents are already indexed by the host-side adapter; we just

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -34,6 +34,7 @@ import grpc
 from pydantic import ValidationError
 
 from tolokaforge.core.grading.check_runner import (
+    _CHECK_EXECUTOR_ERROR_NAME,
     CheckExecutor,
     CheckRunner,
     validate_checks_module,
@@ -121,11 +122,6 @@ AGENT_WORK_DIR = "/work"
 # judge's "harness-owned allowlist" rule (no generic MCP-tool passthrough — we
 # cannot classify arbitrary MCP tools' read-only-ness).
 _SEARCH_POLICY_TOOL_NAME = "search_policy"
-
-# Sentinel check name for a top-level :class:`CheckResultSet` error (module
-# load failure, timeout, executor crash). The host surfaces it in the wire
-# ``custom_checks`` list so the audit is preserved end-to-end.
-_CHECK_EXECUTOR_ERROR_NAME = "__executor__"
 
 
 def _build_runner_check_transcript(
@@ -1633,15 +1629,28 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         )
 
         logger.info(f"GradeTrial: {trial_id} - Running custom checks from {checks_file}")
-        result: CheckResultSet = await self._loop.run_in_executor(
-            None,
-            lambda: self.check_executor.run(
-                checks_file=checks_file,
-                task_dir=artifacts_dir,
-                ctx=ctx,
-                config=config,
-            ),
-        )
+        try:
+            result: CheckResultSet = await self._loop.run_in_executor(
+                None,
+                lambda: self.check_executor.run(
+                    checks_file=checks_file,
+                    task_dir=artifacts_dir,
+                    ctx=ctx,
+                    config=config,
+                ),
+            )
+        except Exception as exc:
+            # An executor that raises rather than capturing into
+            # :class:`CheckResultSet` is a contract violation; convert it to
+            # the same sentinel-entry shape as ``result.error`` so the audit
+            # survives and the whole trial's grade is not lost to the outer
+            # handler.
+            logger.exception(
+                "GradeTrial: %s - custom checks executor raised",
+                trial_id,
+            )
+            score = 0.0 if config.fail_on_error else -1.0
+            return score, [_executor_error_to_wire(str(exc))]
 
         wire_results = [_check_result_to_wire(r) for r in result.results]
 


### PR DESCRIPTION
## Summary

tolokaforge's grading pipeline has always documented four dimensions — state checks, transcript rules, LLM judge, and custom Python checks. Three were live. The fourth was declared in schema, tested in isolation, and silently dropped end-to-end in the only production grading path since the initial open-source release (verbatim `custom_checks=-1.0  # Not implemented yet` in the runner service). A pack declaring `custom_checks:` got no error and no effect.

This PR closes that gap AND formalises the check executor as a Pattern A extension surface (ADR-0012). The seam is now a place where the platform grows.

## The problem this solves

Three of the grading dimensions are declarative primitives — JSONPath assertions on state, regex/keyword rules on transcripts, LLM-graded rubrics. They cover a wide set of graders. They don't cover *arbitrary Python over both the transcript and the final state* — arithmetic scoring, per-domain deterministic verifiers, tool-call sequence analysis. That shape needs code, not YAML.

Authors hitting that shape had three bad options:

- **Force it into `LLMJudge`.** Wrong tool: non-deterministic, token-expensive, wrong for arithmetic scoring.
- **Monkeypatch `RunnerRPCTrialGrader` at install time.** Forks the grading pipeline; adapter-owned but a one-off in-repo pattern.
- **Ship a new `TrialGrader` class per adapter.** Highest coupling, most sprawl, and the exact opposite of the platform's declarative-primitives direction (see the recent `db_probes` primitive shipment in #400 as the counter-example).

None of those actually filled the gap: a first-class *deterministic-Python check* dimension. `custom_checks:` was designed to be that dimension — it just never got wired to the docker path.

## The solution

Finish the wire, and formalise the executor as a Pattern A seam. The surface stays honest under real conditions:

- The check executes runner-side, where the trial's state and transcript live post-multi-container.
- Delivery reuses the existing `tool_artifacts` transport — no new mechanism.
- Interface-version validation moves to trial startup so unsupported packs reject before burning a trial.
- A composite-grade guard prevents a `custom_checks`-only pack from silently passing when the executor produces no score.
- Concurrent module loads across trials no longer cross-contaminate.
- Executor exceptions route through an audit-trail wire entry, not the whole-trial `success=False` bucket.

A deterministic, network-free reference pack proves the whole pipeline end-to-end on real Docker + real gRPC.

## What this opens up

The value of this PR isn't the wire fix — it's what the seam enables.

**For task-pack authors.** A real, honest extension point for deterministic Python grading. Ship a `checks.py` alongside `task.yaml`; the runner picks it up. Grading logic stays in the task pack — not in adapters, not in framework code. This is AGENTS.md Rule 2 made concrete (harness generic, task-specific logic in task packs).

**For adapters.** The pattern "my benchmark needs per-domain grading logic" no longer requires a new `TrialGrader` class, a monkeypatch of the built-in grader, or an abuse of `LLMJudge`. The adapter contributes *nothing* to the grading pipeline — it ships packs with `checks.py` and the framework does the rest. Coupling drops; adapter cohesion goes up. New benchmarks land as task packs, not as framework code.

**For platform evolution.** The `CheckExecutor` Protocol (ADR-0012) is where new executor variants plug in without touching the pipeline. Concrete candidates already visible:

- **`SubprocessCheckExecutor`** — real sandbox with enforceable timeouts, per-check process isolation, no shared filesystem/network with the runner. Closes the doctrine gap #673 tracks.
- **`ReplayCheckExecutor`** — offline replay against captured grading transcripts for regression testing and audit.
- **`RemoteCheckExecutor`** — dispatch to an isolated service if a benchmark family wants its scoring separated.
- **Language-agnostic executors** — WASM or shell-contract variants that break the "runner-must-be-Python" coupling (ADR-0022 territory).

None of these need to touch `RunnerService`, the combiner, or the trial protocol. They plug in behind the same Protocol boundary.

**For the four-dimension model itself.** `custom_checks` now lives on the correct side of the multi-container split (M8, #511) — the runner is the source of truth for the trial's transcript and state, and this dimension now runs there. When patterns of custom checks stabilise into common shapes, they graduate into typed primitives (the way `db_probes` did in #400). Custom checks *incubate*; primitives *graduate*. The pipeline gets a clean elevator between the two.

**Complementary, not competing, with #583** (adapter-owned execution/grading seam). That's for cases needing full grader replacement — separate concern, larger granularity. This seam sits at check-level, well below.

## What is NOT in scope

- **True per-check sandboxing** (#673). The in-process thread executor is not a sandbox; doctrine is enforced at the runner container's `no_internet` boundary (ADR-0018) for the trusted first-customer scope.
- **Deletion of the in-process `GradingEngine`.** #217 asked "finish or delete"; this PR closes it in the *finish* direction. Dead convenience helpers separated to #674.
- **Non-Python check languages** — ADR-0022 territory.
- **Full grader-swap seam** — #583.

## Verification

- **Canonical**: Protocol contract, combiner routing, silent-pass regression, host-side per-check mapping, RegisterTrial validation, cleanup-on-rejection, reserved-name collision.
- **Unit**: shared context-builder shape (parametrised), concurrent module load, executor-error branches (both `CheckResultSet.error` and executor-raise paths), adapter delivery + config propagation.
- **Integration** (`requires_docker`): full end-to-end grading of the reference pack on real Docker + real gRPC (positive + negative cases).

Full staged plan preserved at `~/.claude/plans/toloka-tolokaforge/issue-669-custom-checks.md`; commits map to stages.

Closes #669
Closes #406
Closes #217