### PR TITLE
feat(llm): route LLM calls through a gateway (LiteLLM proxy), env-configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # VERTEXAI_PROJECT=your-gcp-project-id
 # VERTEXAI_LOCATION=us-central1
 
-# OpenAI-compatible gateway (LiteLLM proxy, Portkey, internal API management).
+# LLM gateway (a LiteLLM proxy or a gateway presenting the same surface).
 # Set the base URL to route calls through the gateway instead of calling
 # providers directly; model names and configs stay unchanged.
 # See docs/LLM_LAYER.md § proxy.

--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,18 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 # VERTEXAI_PROJECT=your-gcp-project-id
 # VERTEXAI_LOCATION=us-central1
+
+# OpenAI-compatible gateway (LiteLLM proxy, Portkey, internal API management).
+# Set the base URL to route calls through the gateway instead of calling
+# providers directly; model names and configs stay unchanged.
+# See docs/LLM_LAYER.md § proxy.
+# LLM_PROXY_BASE_URL=https://gateway.example.com
+# LLM_PROXY_API_KEY=your-gateway-key-here
+# Static attribution headers your gateway requires, as a JSON object:
+# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Cost-Center":"42"}
+# Header name to fill with a fresh UUID per request:
+# LLM_PROXY_REQUEST_ID_HEADER=X-Request-Id
+# Which providers to route. Default is openrouter,openai — the only ones whose
+# litellm transport sends an OpenAI-envelope request. Widen this only if your
+# gateway also serves the other provider's native route (see docs).
+# LLM_PROXY_PROVIDERS=openrouter,openai

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -391,10 +391,10 @@ Common keys:
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 - `OLLAMA_API_BASE`
 
-Routing every call through an OpenAI-compatible gateway instead of calling
-providers directly (`LLM_PROXY_BASE_URL`, `LLM_PROXY_API_KEY`,
+Routing calls through an LLM gateway (a LiteLLM proxy or equivalent) instead of
+calling providers directly (`LLM_PROXY_BASE_URL`, `LLM_PROXY_API_KEY`,
 `LLM_PROXY_HEADERS`, `LLM_PROXY_REQUEST_ID_HEADER`, `LLM_PROXY_PROVIDERS`) is
-documented in [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-every-call-through-an-openai-compatible-gateway).
+documented in [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway).
 
 ## Output Structure
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -391,6 +391,11 @@ Common keys:
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 - `OLLAMA_API_BASE`
 
+Routing every call through an OpenAI-compatible gateway instead of calling
+providers directly (`LLM_PROXY_BASE_URL`, `LLM_PROXY_API_KEY`,
+`LLM_PROXY_HEADERS`, `LLM_PROXY_REQUEST_ID_HEADER`, `LLM_PROXY_PROVIDERS`) is
+documented in [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-every-call-through-an-openai-compatible-gateway).
+
 ## Output Structure
 
 ```

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -23,7 +23,7 @@ for the design rationale and the canonical litellm surface.
 | [`response_policy.py`](../tolokaforge/core/llm/response_policy.py) | Tool-call argument post-processing |
 | [`capabilities.py`](../tolokaforge/core/llm/capabilities.py) | `ModelCapabilities` frozen dataclass |
 | [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
-| [`proxy.py`](../tolokaforge/core/llm/proxy.py) | Optional OpenAI-compatible gateway transport (`ProxyConfig`), configured entirely by env |
+| [`proxy.py`](../tolokaforge/core/llm/proxy.py) | Optional LLM-gateway transport (`ProxyConfig`), e.g. a LiteLLM proxy; configured entirely by env |
 | [`client.py`](../tolokaforge/core/llm/client.py) | `LLMClient`, `GenerationResult`, `UserSimulator` |
 
 ## `reasoning`
@@ -390,17 +390,28 @@ Vertex AI, hosted vLLM, and WatsonX. Our `StrictSchema` and `DictMapHints`
 policies in `tolokaforge/core/llm/` handle **all** GPT-5 tool-schema
 adaptation independently of litellm, so this gap is transparent to callers.
 
-## `proxy` — routing every call through an OpenAI-compatible gateway
+## `proxy` — routing calls through an LLM gateway
 
-Some deployments forbid direct provider access: calls must go through an
-OpenAI-compatible gateway (LiteLLM proxy, Portkey, an internal API-management
-layer) that holds the upstream keys, enforces budgets, and attributes spend.
+Some deployments forbid direct provider access: calls must go through a gateway
+that holds the upstream keys, enforces budgets, and attributes spend. A
+[LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) is the reference
+target; any gateway presenting the same surface works.
 
 [`tolokaforge/core/llm/proxy.py`](../tolokaforge/core/llm/proxy.py) resolves
-that transport from the environment. It is vendor-neutral — the module knows
-nothing about any specific gateway or organisation. Everything
+that transport from the environment. It is deployment-neutral — the module knows
+nothing about any specific gateway product or organisation. Everything
 deployment-specific, including the attribution headers a given gateway
 demands, is supplied as configuration.
+
+**"The same surface" is a narrower contract than "OpenAI-compatible".** What is
+actually required is: *for each routed provider, the gateway serves the route
+that litellm's transport for that provider targets.* This layer only overrides
+the base URL — litellm decides the path, the auth header, and the body shape,
+per provider. That is why routing is an allow-list rather than a blanket
+redirect, and why the allow-list is pinned against the installed litellm by
+[`tests/canonical/test_llm_gateway_envelope_contract.py`](../tests/canonical/test_llm_gateway_envelope_contract.py):
+a dependency bump that changes a provider's transport fails there instead of
+posting to a route the gateway does not serve.
 
 | Variable | Meaning |
 |---|---|

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -23,6 +23,7 @@ for the design rationale and the canonical litellm surface.
 | [`response_policy.py`](../tolokaforge/core/llm/response_policy.py) | Tool-call argument post-processing |
 | [`capabilities.py`](../tolokaforge/core/llm/capabilities.py) | `ModelCapabilities` frozen dataclass |
 | [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
+| [`proxy.py`](../tolokaforge/core/llm/proxy.py) | Optional OpenAI-compatible gateway transport (`ProxyConfig`), configured entirely by env |
 | [`client.py`](../tolokaforge/core/llm/client.py) | `LLMClient`, `GenerationResult`, `UserSimulator` |
 
 ## `reasoning`
@@ -388,6 +389,101 @@ unchanged — litellm's native `_remove_additional_properties` only runs for
 Vertex AI, hosted vLLM, and WatsonX. Our `StrictSchema` and `DictMapHints`
 policies in `tolokaforge/core/llm/` handle **all** GPT-5 tool-schema
 adaptation independently of litellm, so this gap is transparent to callers.
+
+## `proxy` — routing every call through an OpenAI-compatible gateway
+
+Some deployments forbid direct provider access: calls must go through an
+OpenAI-compatible gateway (LiteLLM proxy, Portkey, an internal API-management
+layer) that holds the upstream keys, enforces budgets, and attributes spend.
+
+[`tolokaforge/core/llm/proxy.py`](../tolokaforge/core/llm/proxy.py) resolves
+that transport from the environment. It is vendor-neutral — the module knows
+nothing about any specific gateway or organisation. Everything
+deployment-specific, including the attribution headers a given gateway
+demands, is supplied as configuration.
+
+| Variable | Meaning |
+|---|---|
+| `LLM_PROXY_BASE_URL` | Gateway base URL. **Setting this enables the transport**; everything else is optional. |
+| `LLM_PROXY_API_KEY` | Credential presented to the gateway. Omit only for gateways that authenticate by network position — litellm then falls through to its provider-env lookup and forwards the *provider's* key to the gateway host instead. |
+| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. |
+| `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
+| `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
+
+All five resolve through `SecretManager`, so `.env`, the process environment,
+and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
+A malformed value raises `ProxyConfigError` at the first `LLMClient`
+construction rather than running a whole evaluation with unattributed spend.
+Setting any companion variable while `LLM_PROXY_BASE_URL` is empty also raises,
+so a typo in the base-URL name cannot silently fall back to direct provider
+access.
+
+### Which providers can be routed
+
+**Setting `api_base` does not make litellm speak OpenAI to that URL — it makes
+litellm speak that provider's native protocol to that URL.** Captured against
+litellm 1.87.0:
+
+| provider | request litellm sends to the gateway |
+|---|---|
+| `openrouter/…` | `POST {base}/chat/completions`, bearer auth |
+| `openai/…` | `POST {base}/chat/completions`, bearer auth |
+| `anthropic/…` | `POST {base}/v1/messages`, `x-api-key` |
+| `gemini/…` | `POST {base}/models/<m>:generateContent`, `x-goog-api-key` |
+
+Only the first two are an OpenAI-envelope request, so `DEFAULT_ROUTED_PROVIDERS`
+is exactly `{openrouter, openai}`. Naming another provider in
+`LLM_PROXY_PROVIDERS` is allowed and means "my gateway also serves that
+provider's native route" — true of a LiteLLM proxy's `/v1/messages`
+passthrough, false of a plain OpenAI-compatible gateway.
+
+`mock` and `nova` are in `UNROUTABLE_PROVIDERS` and are rejected even when
+named explicitly. `mock` never reaches the wire. `nova` depends on
+`_call_with_key_rotation` rewriting its bare model name into `openai/<name>`
+next to its own hardcoded base URL; a gateway replaces the base URL but not the
+rewrite, so litellm would get a provider-less model string and raise
+`BadRequestError` before sending anything.
+
+**This is a transport swap and nothing else.** `_build_kwargs` sets `api_base`,
+`api_key`, and `extra_headers`; the litellm model string keeps its original
+`<provider>/<name>` shape. That invariant is load-bearing in two places:
+
+- Preset `match:` globs resolve off `ModelConfig.name` and the `providers:`
+  overlay off `ModelConfig.provider` (see [`presets`](#presets)). Re-prefixing
+  the model, or renaming the provider to something gateway-specific, silently
+  drops the matched preset and the `reasoning_via_extra_body` overlay — the
+  reported `effective_preset` would not change, but the reasoning wire format
+  would.
+- [`normalize_model_name`](../tolokaforge/core/pricing.py) strips exactly one
+  leading `openrouter/` and then returns any remaining slash-bearing name
+  verbatim. A second prefix guarantees a pricing-table miss, degrading
+  `cost_source` to `"unknown"` and tripping `Capability.COST_USD_POPULATED`.
+
+Because the provider string is untouched, provider-specific request shaping
+still applies on top of the gateway: OpenRouter's `HTTP-Referer` / `X-Title`
+headers and its `extra_body.provider` upstream pinning both survive. On a
+header-name collision the gateway's configured header wins, since that is
+explicit operator configuration and the other is an engine default.
+
+### Key rotation under a gateway
+
+Rotation stays bound to the provider key chain (`OPENROUTER_API_KEYS` and
+friends), and whether it still applies depends on **one** thing: is a gateway
+key pinned?
+
+- **`LLM_PROXY_API_KEY` set** — rotation is skipped. `_rotate_key` republishes
+  `OPENROUTER_API_KEY` into the environment, but the pinned `api_key` kwarg
+  takes precedence in litellm, so rotating would resend byte-identical requests
+  and then report an exhausted key chain that was never in play. A gateway
+  quota or authorization rejection raises an error naming the gateway URL
+  instead.
+- **`LLM_PROXY_API_KEY` unset** (gateway authenticates by network position) —
+  rotation works and is left alone, because litellm reads the provider env var
+  that `_rotate_key` rewrites. Suppressing it here would abort a trial with
+  unused keys still in the chain.
+
+The guard mirrors exactly the condition under which `_build_kwargs` pins the
+key, so the two can't drift.
 
 ## `cache_policy`
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -485,8 +485,8 @@ name: azure_ai/cohere-command-a-plus-05-2026
 
 List the routes a gateway serves with `GET {base_url}/models`.
 
-Gateway-specific names have two consequences, both following from the
-model-string coupling described below:
+Gateway-specific names have two consequences, both following from the naming
+couplings described below:
 
 - **Cost may be unknown.** `normalize_model_name` cannot map
   `openai/openrouter/anthropic/claude-opus-4.7` to a `pricing.json` key, so
@@ -501,7 +501,8 @@ model-string coupling described below:
 
 **This is a transport swap and nothing else.** `_build_kwargs` sets `api_base`,
 `api_key`, and `extra_headers`; the litellm model string keeps its original
-`<provider>/<name>` shape. That invariant is load-bearing in two places:
+`<provider>/<name>` shape. Two distinct couplings hang off model naming, and
+only the second is to that formatted string:
 
 - Preset `match:` globs resolve off `ModelConfig.name` and the `providers:`
   overlay off `ModelConfig.provider` (see [`presets`](#presets)). Re-prefixing

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -455,6 +455,50 @@ next to its own hardcoded base URL; a gateway replaces the base URL but not the
 rewrite, so litellm would get a provider-less model string and raise
 `BadRequestError` before sending anything.
 
+### The model name must be the gateway's route name
+
+Enabling the gateway is **not** a drop-in for existing run configs. litellm
+strips exactly one provider prefix before sending, so `provider: openrouter` +
+`name: anthropic/claude-opus-4.7` puts `anthropic/claude-opus-4.7` on the wire.
+A gateway resolves that against *its own* model table, which need not mean what
+the provider would mean by it.
+
+Observed on a real LiteLLM proxy: that name matched the gateway's catch-all
+`anthropic/*` route, which is backed by **Bedrock**, so the request was served
+by a different upstream than the config asked for. It failed loudly there only
+because that particular Bedrock model rejects `temperature=0.0`; a
+closer-matching route would have silently evaluated a different serving path.
+For a leaderboard that is a comparability break, not a transport detail.
+
+So name the model the way the gateway names it, and pick the provider so that
+litellm's prefix strip leaves that name intact:
+
+```yaml
+# Gateway route "openrouter/anthropic/claude-opus-4.7"
+provider: openai                              # wire: openrouter/anthropic/claude-opus-4.7
+name: openrouter/anthropic/claude-opus-4.7
+
+# Gateway route "azure_ai/cohere-command-a-plus-05-2026"
+provider: openai                              # wire: azure_ai/cohere-command-a-plus-05-2026
+name: azure_ai/cohere-command-a-plus-05-2026
+```
+
+List the routes a gateway serves with `GET {base_url}/models`.
+
+Gateway-specific names have two consequences, both following from the
+model-string coupling described below:
+
+- **Cost may be unknown.** `normalize_model_name` cannot map
+  `openai/openrouter/anthropic/claude-opus-4.7` to a `pricing.json` key, so
+  `cost_usd` depends on the gateway returning cost in the response. Measured on
+  a LiteLLM proxy: its `azure_ai/…` route did (`cost_source="litellm"`), its
+  `openrouter/…` route did not (`cost_source="unknown"`). Add a `pricing.json`
+  entry keyed on the exact formatted model string when the gateway is silent.
+- **`provider: openai` does not get the `providers.openrouter` preset overlay**,
+  so reasoning routes through `reasoning_effort` rather than
+  `extra_body.reasoning`. That is correct for an OpenAI-shaped gateway endpoint,
+  but verify it for reasoning models before trusting a run.
+
 **This is a transport swap and nothing else.** `_build_kwargs` sets `api_base`,
 `api_key`, and `extra_headers`; the litellm model string keeps its original
 `<provider>/<name>` shape. That invariant is load-bearing in two places:

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -520,6 +520,29 @@ headers and its `extra_body.provider` upstream pinning both survive. On a
 header-name collision the gateway's configured header wins, since that is
 explicit operator configuration and the other is an engine default.
 
+### Verifying a gateway from CI
+
+[`tests/integration/llm/test_gateway_live.py`](../tests/integration/llm/test_gateway_live.py)
+answers what unit tests structurally cannot: whether a real gateway accepts what
+this engine sends it. The unit suite stops at the kwargs dict, and the two
+failure modes that matter most — a gateway resolving our model name to a route we
+did not intend, and a gateway rejecting a request shape litellm produced — both
+live past that boundary.
+
+It runs in the normal `tests/integration/` lane and **skips unless its own
+credential is present**, so a checkout without the secret is quiet:
+
+| Variable | Meaning |
+|---|---|
+| `LLM_PROXY_INT_TEST_API_KEY` | *Required.* Gateway credential dedicated to integration testing. The fixture overrides `LLM_PROXY_API_KEY` with it for the test's duration, so CI spend stays on its own budget and a local `.env` cannot charge the production key. |
+| `LLM_PROXY_INT_TEST_MODEL` | *Required.* The model name **as the gateway routes it**. Required rather than defaulted: a wrong guess would exercise the gateway's fallback behaviour instead of this transport. |
+| `LLM_PROXY_INT_TEST_BASE_URL` | Optional; falls back to `LLM_PROXY_BASE_URL`. |
+| `LLM_PROXY_INT_TEST_PROVIDER` | Optional, default `openai` — see the model-naming section above. |
+
+Three tests: one asserts the transport is applied and billed to the test key
+without spending, two make one small call each (a completion and a tool call,
+capped at 256 output tokens).
+
 ### Key rotation under a gateway
 
 Rotation stays bound to the provider key chain (`OPENROUTER_API_KEYS` and

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -532,16 +532,23 @@ live past that boundary.
 It runs in the normal `tests/integration/` lane and **skips unless its own
 credential is present**, so a checkout without the secret is quiet:
 
-| Variable | Meaning |
-|---|---|
-| `LLM_PROXY_INT_TEST_API_KEY` | *Required.* Gateway credential dedicated to integration testing. The fixture overrides `LLM_PROXY_API_KEY` with it for the test's duration, so CI spend stays on its own budget and a local `.env` cannot charge the production key. |
-| `LLM_PROXY_INT_TEST_MODEL` | *Required.* The model name **as the gateway routes it**. Required rather than defaulted: a wrong guess would exercise the gateway's fallback behaviour instead of this transport. |
-| `LLM_PROXY_INT_TEST_BASE_URL` | Optional; falls back to `LLM_PROXY_BASE_URL`. |
-| `LLM_PROXY_INT_TEST_PROVIDER` | Optional, default `openai` — see the model-naming section above. |
+| Variable | Secret? | Meaning |
+|---|---|---|
+| `LLM_PROXY_INT_TEST_API_KEY` | **yes** | Gateway credential dedicated to integration testing. Its presence is the on-switch. The fixture overrides `LLM_PROXY_API_KEY` with it for the test's duration, so CI spend stays on its own budget and a local `.env` cannot charge the production key. |
+| `LLM_PROXY_INT_TEST_MODEL` | no | The model name **as the gateway routes it**. Required rather than defaulted: a wrong guess would exercise the gateway's fallback behaviour instead of this transport. Plain config — belongs in a workflow's `env:`. |
+| `LLM_PROXY_INT_TEST_BASE_URL` | depends | Gateway base URL; falls back to `LLM_PROXY_BASE_URL`. Keep it out of a public workflow file if the hostname is internal. |
+| `LLM_PROXY_INT_TEST_PROVIDER` | no | Optional, default `openai` — see the model-naming section above. |
 
 Three tests: one asserts the transport is applied and billed to the test key
 without spending, two make one small call each (a completion and a tool call,
 capped at 256 output tokens).
+
+**The gating is asymmetric on purpose.** No credential → skip, quietly, which is
+the state of any checkout without the secret. Credential present but a companion
+missing → **fail**. Holding the key is an explicit statement that this
+environment means to run the test, so a missing route name is a misconfiguration
+rather than an opt-out. Skipping there would let a pipeline report green while
+testing nothing.
 
 ### Key rotation under a gateway
 

--- a/tests/canonical/test_llm_gateway_envelope_contract.py
+++ b/tests/canonical/test_llm_gateway_envelope_contract.py
@@ -1,0 +1,90 @@
+"""Contract: the gateway allow-list matches litellm's OpenAI-envelope providers.
+
+:data:`~tolokaforge.core.llm.proxy.DEFAULT_ROUTED_PROVIDERS` is not a
+preference. It is exactly the set of providers whose litellm transport, handed
+an ``api_base``, targets ``{api_base}/chat/completions`` — the shape a LiteLLM
+proxy (or any gateway presenting the same surface) serves.
+
+That makes the allow-list an assumption about a *third-party library*, which is
+the fragile kind: a litellm bump could change a provider's transport and the
+gateway would start posting to a route the gateway does not serve, with nothing
+in our own code changing. Every trial would fail at the wire with no hint that a
+dependency moved. This test pins the assumption so the break is loud and lands
+here instead.
+
+If a test here fails after a litellm upgrade, the fix is a deliberate decision,
+not a patch: either widen / narrow ``DEFAULT_ROUTED_PROVIDERS`` to match the new
+reality, or pin litellm. Do not adjust the expected URL to whatever litellm now
+returns without checking what the gateway actually serves.
+
+The ``ProviderConfigManager`` entry point is litellm-internal enough that it may
+itself move between versions. That is acceptable and intentional: an ImportError
+here is also a signal worth reading.
+"""
+
+from __future__ import annotations
+
+import pytest
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+from tolokaforge.core.llm.proxy import DEFAULT_ROUTED_PROVIDERS
+
+pytestmark = pytest.mark.unit
+
+_GATEWAY_BASE = "https://gateway.example.com"
+
+#: A representative model per provider. litellm picks a transport config from
+#: the provider, but some configs inspect the model name, so use realistic ones.
+_REPRESENTATIVE_MODEL = {
+    "openrouter": "anthropic/claude-opus-4.7",
+    "openai": "gpt-5.6",
+    "anthropic": "claude-opus-4.7",
+    "gemini": "gemini-2.5-pro",
+}
+
+
+def _complete_url(provider: str, model: str) -> str:
+    config = ProviderConfigManager.get_provider_chat_config(
+        model=model, provider=LlmProviders(provider)
+    )
+    assert config is not None, f"litellm has no chat config for provider {provider!r}"
+    return config.get_complete_url(
+        api_base=_GATEWAY_BASE,
+        api_key="sk-not-a-real-key",
+        model=model,
+        optional_params={},
+        litellm_params={},
+    )
+
+
+@pytest.mark.parametrize("provider", sorted(DEFAULT_ROUTED_PROVIDERS))
+def test_routed_providers_target_the_openai_chat_completions_path(provider: str) -> None:
+    """Every allow-listed provider must post the OpenAI envelope to the gateway."""
+    model = _REPRESENTATIVE_MODEL[provider]
+    assert _complete_url(provider, model) == f"{_GATEWAY_BASE}/chat/completions", (
+        f"litellm no longer sends {provider!r} to {{api_base}}/chat/completions. "
+        f"Routing it through a gateway would target a route the gateway does not "
+        f"serve. Re-check DEFAULT_ROUTED_PROVIDERS against the new transport."
+    )
+
+
+def test_every_routed_provider_has_a_representative_model() -> None:
+    """Guard against a widened allow-list silently skipping coverage above."""
+    missing = sorted(DEFAULT_ROUTED_PROVIDERS - _REPRESENTATIVE_MODEL.keys())
+    assert not missing, f"add a representative model for {missing} so it is covered here"
+
+
+@pytest.mark.parametrize("provider", ["anthropic", "gemini"])
+def test_native_protocol_providers_are_not_openai_shaped(provider: str) -> None:
+    """Document why the allow-list excludes these, and notice if that changes.
+
+    These providers append their own route (``/v1/messages``,
+    ``/models/<m>:generateContent``) downstream of ``get_complete_url``, so they
+    never resolve to the OpenAI chat-completions path. A failure here means
+    litellm made them OpenAI-shaped and the allow-list *could* be widened.
+    """
+    assert provider not in DEFAULT_ROUTED_PROVIDERS
+    assert _complete_url(provider, _REPRESENTATIVE_MODEL[provider]) != (
+        f"{_GATEWAY_BASE}/chat/completions"
+    )

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -1,0 +1,213 @@
+"""Live integration test for the LLM gateway transport.
+
+Answers one question that unit tests structurally cannot: *does a real gateway
+accept what this engine sends it?* Everything in
+``tests/unit/llm/test_llm_proxy.py`` stops at the kwargs dict, and the two
+failure modes that matter most in production live past that boundary — the
+gateway resolving our model name to a route we did not intend, and a gateway
+rejecting a request shape litellm produced.
+
+Spend isolation
+---------------
+
+This test bills to its **own** credential, ``LLM_PROXY_INT_TEST_API_KEY``, not to
+whatever ``LLM_PROXY_API_KEY`` the ambient environment holds. The fixture
+installs a SecretManager that overrides that name for the test's duration, so a
+CI budget for integration tests stays separate from a deployment's production
+gateway budget, and a local ``.env`` cannot accidentally charge the wrong key.
+
+Two calls reach the network, each capped at a few dozen output tokens.
+
+Environment contract
+--------------------
+
+``LLM_PROXY_INT_TEST_API_KEY`` (required)
+    Gateway credential dedicated to integration testing. Absent → every test
+    here skips, which is the state of any checkout without the secret.
+
+``LLM_PROXY_INT_TEST_MODEL`` (required)
+    Model name **as the gateway routes it**, e.g. a LiteLLM proxy's
+    ``openrouter/<vendor>/<model>``. Required rather than defaulted because
+    every gateway names its routes differently, and a wrong guess would test
+    the gateway's fallback behaviour instead of this transport. Discover the
+    available names with ``GET {base_url}/models``.
+
+``LLM_PROXY_INT_TEST_BASE_URL`` (optional)
+    Gateway base URL. Falls back to ``LLM_PROXY_BASE_URL``. Must include
+    whatever path prefix the gateway serves its OpenAI-compatible route under
+    (commonly ``/v1``) — litellm appends ``/chat/completions`` to it.
+
+``LLM_PROXY_INT_TEST_PROVIDER`` (optional, default ``openai``)
+    Provider whose litellm transport carries the request. ``openai`` is the
+    default because litellm strips exactly one provider prefix, so
+    ``provider=openai`` + a gateway route name leaves that name intact on the
+    wire. See ``docs/LLM_LAYER.md`` § proxy.
+
+``LLM_PROXY_HEADERS`` / ``LLM_PROXY_REQUEST_ID_HEADER`` (optional)
+    Carried over from the ambient environment, so gateways that mandate
+    attribution headers are exercised as configured.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.llm.proxy import (
+    ENV_API_KEY,
+    ENV_BASE_URL,
+    ENV_HEADERS,
+    ENV_REQUEST_ID_HEADER,
+)
+from tolokaforge.core.llm.reasoning import ReasoningConfig
+from tolokaforge.core.models import Message, MessageRole, ModelConfig
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import manager as secrets_manager
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_api]
+
+ENV_TEST_API_KEY = "LLM_PROXY_INT_TEST_API_KEY"
+ENV_TEST_MODEL = "LLM_PROXY_INT_TEST_MODEL"
+ENV_TEST_BASE_URL = "LLM_PROXY_INT_TEST_BASE_URL"
+ENV_TEST_PROVIDER = "LLM_PROXY_INT_TEST_PROVIDER"
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Look up the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"},
+                "unit": {"type": "string", "enum": ["c", "f"]},
+            },
+            "required": ["city", "unit"],
+        },
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def gateway_client() -> Iterator[LLMClient]:
+    """An ``LLMClient`` pointed at the gateway, billed to the test credential.
+
+    Skips unless the dedicated key and a gateway route name are both present, so
+    a checkout without the CI secret is quiet rather than failing.
+    """
+    api_key = os.environ.get(ENV_TEST_API_KEY, "").strip()
+    if not api_key:
+        pytest.skip(f"{ENV_TEST_API_KEY} not set — skipping live gateway test.")
+
+    model = os.environ.get(ENV_TEST_MODEL, "").strip()
+    if not model:
+        pytest.skip(
+            f"{ENV_TEST_MODEL} not set — the gateway's own route name is required; "
+            f"list candidates with GET {{base_url}}/models."
+        )
+
+    base_url = (
+        os.environ.get(ENV_TEST_BASE_URL, "").strip() or os.environ.get(ENV_BASE_URL, "").strip()
+    )
+    if not base_url:
+        pytest.skip(f"neither {ENV_TEST_BASE_URL} nor {ENV_BASE_URL} is set.")
+
+    # Override the gateway credential so this run bills to the test budget even
+    # when a production LLM_PROXY_API_KEY is present in .env or the environment.
+    secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: api_key}
+    for passthrough in (ENV_HEADERS, ENV_REQUEST_ID_HEADER):
+        value = os.environ.get(passthrough, "").strip()
+        if value:
+            secrets[passthrough] = value
+
+    original = secrets_manager._default_manager
+    secrets_manager._default_manager = SecretManager([DictProvider(secrets)])
+    try:
+        client = LLMClient(
+            ModelConfig(
+                provider=os.environ.get(ENV_TEST_PROVIDER, "openai").strip() or "openai",
+                name=model,
+                temperature=0.0,
+                # Enough headroom for a tool call from a model that emits
+                # preamble or reasoning text first. At 64 a Cohere model
+                # truncated before emitting the call, which surfaces as an empty
+                # response and reads like a gateway fault rather than a cap.
+                max_tokens=256,
+                reasoning=ReasoningConfig(mode="off"),
+            )
+        )
+        assert client._proxy is not None, (
+            "gateway did not claim this provider; check LLM_PROXY_INT_TEST_PROVIDER "
+            "against DEFAULT_ROUTED_PROVIDERS"
+        )
+        yield client
+    finally:
+        secrets_manager._default_manager = original
+
+
+def test_request_is_addressed_to_the_gateway(gateway_client: LLMClient) -> None:
+    """The transport is applied and billed to the test key. No network spend."""
+    kwargs = gateway_client._build_kwargs(
+        system="Be terse.",
+        messages=[Message(role=MessageRole.USER, content="ping")],
+        tools=None,
+        tool_choice=None,
+        temperature=None,
+        seed=None,
+        reasoning=None,
+        top_p=None,
+        max_tokens=None,
+    )
+
+    assert kwargs["api_base"] == gateway_client._proxy.base_url
+    assert kwargs["api_key"] == os.environ[ENV_TEST_API_KEY].strip()
+
+    # The model string must survive intact — re-prefixing it would silently
+    # break preset resolution and pricing lookup (see docs/LLM_LAYER.md § proxy).
+    assert kwargs["model"].endswith(gateway_client.config.name)
+
+    for header in gateway_client._proxy.headers:
+        assert header in kwargs["extra_headers"]
+    if gateway_client._proxy.request_id_header:
+        assert kwargs["extra_headers"][gateway_client._proxy.request_id_header]
+
+
+def test_gateway_serves_a_completion(gateway_client: LLMClient) -> None:
+    """The gateway accepts what litellm sends and returns usable text."""
+    result = gateway_client.generate(
+        system="Answer with a single word.",
+        messages=[Message(role=MessageRole.USER, content="Say OK")],
+    )
+
+    assert result.text.strip(), "gateway returned empty text"
+    assert result.usage.prompt_tokens > 0, "no prompt tokens reported"
+    assert result.usage.completion_tokens > 0, "no completion tokens reported"
+
+    # cost_source is recorded either way. Which value depends on whether the
+    # gateway reports cost in the response; a gateway that does not leaves
+    # "unknown" unless a pricing.json entry covers the formatted model string.
+    sources = [call.cost_source for call in result.usage.calls]
+    assert sources, "no per-call usage recorded"
+
+
+def test_gateway_serves_a_tool_call(gateway_client: LLMClient) -> None:
+    """Tool calling round-trips — the arena's actual requirement of a gateway."""
+    result = gateway_client.generate(
+        system="Use the provided tool to answer. Fill every required field.",
+        messages=[Message(role=MessageRole.USER, content="Weather in Budapest, in celsius?")],
+        tools=[_WEATHER_TOOL],
+    )
+
+    assert result.tool_calls, f"no tool call; model replied {result.text!r}"
+    call = result.tool_calls[0]
+    assert call.name == "get_weather", f"unexpected tool {call.name!r}"
+
+    arguments = call.arguments
+    assert isinstance(arguments, dict), f"arguments not parsed into a dict: {arguments!r}"
+    # Both fields are `required` in the schema, so a gateway that mangles the
+    # tool payload shows up as a missing key rather than a silent pass.
+    assert "city" in arguments
+    assert "unit" in arguments

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -198,8 +198,16 @@ def test_request_is_addressed_to_the_gateway(gateway_client: LLMClient, gateway_
     assert kwargs["api_key"] == gateway_key
 
     # The model string must survive intact — re-prefixing it would silently
-    # break preset resolution and pricing lookup (see docs/LLM_LAYER.md § proxy).
-    assert kwargs["model"].endswith(gateway_client.config.name)
+    # miss the pricing table (see docs/LLM_LAYER.md § proxy).
+    expected_model = (
+        gateway_client.config.name
+        if gateway_client.config.name.startswith(f"{gateway_client.config.provider}/")
+        else f"{gateway_client.config.provider}/{gateway_client.config.name}"
+    )
+    assert kwargs["model"] == expected_model, (
+        f"model string was rewritten: {kwargs['model']!r} != {expected_model!r}; "
+        f"a re-prefix breaks normalize_model_name and degrades cost_source"
+    )
 
     for header in gateway_client._proxy.headers:
         assert header in kwargs["extra_headers"]

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -25,12 +25,17 @@ Environment contract
     Gateway credential dedicated to integration testing. Absent → every test
     here skips, which is the state of any checkout without the secret.
 
-``LLM_PROXY_INT_TEST_MODEL`` (required)
+``LLM_PROXY_INT_TEST_MODEL`` (required once the key is set)
     Model name **as the gateway routes it**, e.g. a LiteLLM proxy's
     ``openrouter/<vendor>/<model>``. Required rather than defaulted because
     every gateway names its routes differently, and a wrong guess would test
     the gateway's fallback behaviour instead of this transport. Discover the
     available names with ``GET {base_url}/models``.
+
+    Not a credential — in CI this belongs in the workflow's ``env:``, not in a
+    secret. Missing it while the key *is* present **fails** rather than skips:
+    otherwise a pipeline holding the secret would report green while testing
+    nothing.
 
 ``LLM_PROXY_INT_TEST_BASE_URL`` (optional)
     Gateway base URL. Falls back to ``LLM_PROXY_BASE_URL``. Must include
@@ -117,16 +122,26 @@ def gateway_client(gateway_key: str) -> Iterator[LLMClient]:
     Skips unless the dedicated key and a gateway route name are both present, so
     a checkout without the CI secret is quiet rather than failing.
     """
+    # Past this point the credential exists, which is an explicit signal that
+    # this environment intends to run the test. A missing companion is therefore
+    # a misconfiguration, not an opt-out, and must fail rather than skip — a
+    # pipeline that holds the secret but lacks the route name would otherwise go
+    # green while testing nothing.
     model = _secret(ENV_TEST_MODEL)
     if not model:
-        pytest.skip(
-            f"{ENV_TEST_MODEL} not set — the gateway's own route name is required; "
-            f"list candidates with GET {{base_url}}/models."
+        pytest.fail(
+            f"{ENV_TEST_API_KEY} is set but {ENV_TEST_MODEL} is not. The gateway's own "
+            f"route name is required — list candidates with GET {{base_url}}/models. "
+            f"Unset {ENV_TEST_API_KEY} to disable this test deliberately."
         )
 
     base_url = _secret(ENV_TEST_BASE_URL) or _secret(ENV_BASE_URL)
     if not base_url:
-        pytest.skip(f"neither {ENV_TEST_BASE_URL} nor {ENV_BASE_URL} is set.")
+        pytest.fail(
+            f"{ENV_TEST_API_KEY} is set but neither {ENV_TEST_BASE_URL} nor "
+            f"{ENV_BASE_URL} is. Set a gateway base URL, or unset "
+            f"{ENV_TEST_API_KEY} to disable this test deliberately."
+        )
 
     provider = _secret(ENV_TEST_PROVIDER) or "openai"
 

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -50,7 +50,6 @@ Environment contract
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
 
 import pytest
@@ -64,7 +63,7 @@ from tolokaforge.core.llm.proxy import (
 )
 from tolokaforge.core.llm.reasoning import ReasoningConfig
 from tolokaforge.core.models import Message, MessageRole, ModelConfig
-from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import DictProvider, SecretManager, get_default
 from tolokaforge.secrets import manager as secrets_manager
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_api]
@@ -91,35 +90,51 @@ _WEATHER_TOOL = {
 }
 
 
+def _secret(name: str) -> str:
+    """Read a configuration value through ``SecretManager``.
+
+    Not ``os.environ``: the repo's secrets contract routes credential reads
+    through ``SecretManager`` (see ``AGENTS.md``), and it also means a value
+    living only in ``.env`` resolves deterministically rather than depending on
+    a dependency's import-time ``load_dotenv`` side effect.
+    """
+    return (get_default().get_secret(name) or "").strip()
+
+
 @pytest.fixture(scope="module")
-def gateway_client() -> Iterator[LLMClient]:
+def gateway_key() -> str:
+    """The dedicated integration-test credential, or skip."""
+    api_key = _secret(ENV_TEST_API_KEY)
+    if not api_key:
+        pytest.skip(f"{ENV_TEST_API_KEY} not set — skipping live gateway test.")
+    return api_key
+
+
+@pytest.fixture(scope="module")
+def gateway_client(gateway_key: str) -> Iterator[LLMClient]:
     """An ``LLMClient`` pointed at the gateway, billed to the test credential.
 
     Skips unless the dedicated key and a gateway route name are both present, so
     a checkout without the CI secret is quiet rather than failing.
     """
-    api_key = os.environ.get(ENV_TEST_API_KEY, "").strip()
-    if not api_key:
-        pytest.skip(f"{ENV_TEST_API_KEY} not set — skipping live gateway test.")
-
-    model = os.environ.get(ENV_TEST_MODEL, "").strip()
+    model = _secret(ENV_TEST_MODEL)
     if not model:
         pytest.skip(
             f"{ENV_TEST_MODEL} not set — the gateway's own route name is required; "
             f"list candidates with GET {{base_url}}/models."
         )
 
-    base_url = (
-        os.environ.get(ENV_TEST_BASE_URL, "").strip() or os.environ.get(ENV_BASE_URL, "").strip()
-    )
+    base_url = _secret(ENV_TEST_BASE_URL) or _secret(ENV_BASE_URL)
     if not base_url:
         pytest.skip(f"neither {ENV_TEST_BASE_URL} nor {ENV_BASE_URL} is set.")
 
+    provider = _secret(ENV_TEST_PROVIDER) or "openai"
+
     # Override the gateway credential so this run bills to the test budget even
     # when a production LLM_PROXY_API_KEY is present in .env or the environment.
-    secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: api_key}
+    secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: gateway_key}
     for passthrough in (ENV_HEADERS, ENV_REQUEST_ID_HEADER):
-        value = os.environ.get(passthrough, "").strip()
+        value = _secret(passthrough)
         if value:
             secrets[passthrough] = value
 
@@ -128,7 +143,7 @@ def gateway_client() -> Iterator[LLMClient]:
     try:
         client = LLMClient(
             ModelConfig(
-                provider=os.environ.get(ENV_TEST_PROVIDER, "openai").strip() or "openai",
+                provider=provider,
                 name=model,
                 temperature=0.0,
                 # Enough headroom for a tool call from a model that emits
@@ -148,7 +163,7 @@ def gateway_client() -> Iterator[LLMClient]:
         secrets_manager._default_manager = original
 
 
-def test_request_is_addressed_to_the_gateway(gateway_client: LLMClient) -> None:
+def test_request_is_addressed_to_the_gateway(gateway_client: LLMClient, gateway_key: str) -> None:
     """The transport is applied and billed to the test key. No network spend."""
     kwargs = gateway_client._build_kwargs(
         system="Be terse.",
@@ -163,7 +178,9 @@ def test_request_is_addressed_to_the_gateway(gateway_client: LLMClient) -> None:
     )
 
     assert kwargs["api_base"] == gateway_client._proxy.base_url
-    assert kwargs["api_key"] == os.environ[ENV_TEST_API_KEY].strip()
+    # Spend isolation: the call carries the test credential, not whatever
+    # production gateway key the ambient environment holds.
+    assert kwargs["api_key"] == gateway_key
 
     # The model string must survive intact — re-prefixing it would silently
     # break preset resolution and pricing lookup (see docs/LLM_LAYER.md § proxy).

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -1,0 +1,515 @@
+"""Tests for the configurable OpenAI-compatible gateway transport.
+
+Covers the two halves of the feature:
+
+* :mod:`tolokaforge.core.llm.proxy` — resolving and validating the env
+  contract.
+* :class:`~tolokaforge.core.llm.client.LLMClient` — applying it as a *transport
+  swap only*, which is the load-bearing invariant: the litellm model string
+  must keep its ``<provider>/<name>`` shape so preset resolution and pricing
+  normalisation stay untouched.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.llm import client as client_module
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.llm.proxy import (
+    UNROUTABLE_PROVIDERS,
+    ProxyConfig,
+    ProxyConfigError,
+    resolve_proxy_config,
+)
+from tolokaforge.core.models import Message, MessageRole, ModelConfig
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import manager as secrets_manager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def install_secrets() -> Iterator[Any]:
+    """Install a dict-backed SecretManager singleton and isolate ``os.environ``.
+
+    The env snapshot is not incidental. ``LLMClient`` construction reaches
+    ``os.environ.setdefault`` for provider base URLs, and ``_rotate_key``
+    republishes a provider key, so without a restore these tests would leak
+    ``OPENROUTER_API_BASE`` / ``NOVA_API_BASE`` / ``OPENROUTER_API_KEY`` into
+    the rest of the session. CI runs the whole suite in one interpreter, and a
+    stale ``OPENROUTER_API_BASE`` silently redirects every later litellm
+    openrouter call — an order-dependent failure that looks like a network
+    problem.
+    """
+    original_manager = secrets_manager._default_manager
+    original_env = dict(os.environ)
+
+    def _install(secrets: dict[str, str]) -> None:
+        secrets_manager._default_manager = SecretManager([DictProvider(secrets)])
+
+    try:
+        yield _install
+    finally:
+        secrets_manager._default_manager = original_manager
+        os.environ.clear()
+        os.environ.update(original_env)
+
+
+def _clear_env(name: str) -> None:
+    """Drop ``name`` so a test starts from a known-absent state.
+
+    Safe because the ``install_secrets`` fixture restores ``os.environ``.
+    """
+    os.environ.pop(name, None)
+
+
+def _build_kwargs(config: ModelConfig) -> dict[str, Any]:
+    """Return the kwargs ``LLMClient`` would hand to litellm for one call."""
+    client = LLMClient(config)
+    return client._build_kwargs(
+        system="You are a test.",
+        messages=[Message(role=MessageRole.USER, content="hi")],
+        tools=None,
+        tool_choice=None,
+        temperature=None,
+        seed=None,
+        reasoning=None,
+        top_p=None,
+        max_tokens=None,
+    )
+
+
+class TestResolveProxyConfig:
+    """The env contract: presence of the base URL is the on-switch."""
+
+    def test_disabled_when_base_url_absent(self, install_secrets) -> None:
+        install_secrets({"OPENROUTER_API_KEY": "sk-or-test"})
+        assert resolve_proxy_config() is None
+
+    def test_blank_base_url_is_treated_as_disabled(self, install_secrets) -> None:
+        install_secrets({"LLM_PROXY_BASE_URL": "   "})
+        assert resolve_proxy_config() is None
+
+    def test_base_url_only_is_enough(self, install_secrets) -> None:
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.base_url == "https://gateway.example.com"
+        assert proxy.api_key is None
+        assert proxy.headers == {}
+        assert proxy.request_id_header is None
+        assert proxy.providers is None
+
+    def test_trailing_slash_is_normalised(self, install_secrets) -> None:
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com/"})
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.base_url == "https://gateway.example.com"
+
+    def test_full_contract_resolves(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_API_KEY": "sk-gateway",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research", "X-Cost-Center": 42}',
+                "LLM_PROXY_REQUEST_ID_HEADER": "X-Request-Id",
+                "LLM_PROXY_PROVIDERS": "openrouter, anthropic",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.api_key == "sk-gateway"
+        # Scalar JSON values are coerced to strings — headers are wire strings.
+        assert proxy.headers == {"X-Team-Id": "research", "X-Cost-Center": "42"}
+        assert proxy.request_id_header == "X-Request-Id"
+        assert proxy.providers == frozenset({"openrouter", "anthropic"})
+
+
+class TestProxyConfigValidation:
+    """Malformed configuration fails loudly rather than running unattributed."""
+
+    def test_headers_not_json_raises(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": "X-Team-Id=research",
+            }
+        )
+        with pytest.raises(ProxyConfigError, match="LLM_PROXY_HEADERS"):
+            resolve_proxy_config()
+
+    def test_headers_json_array_raises(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '["X-Team-Id"]',
+            }
+        )
+        with pytest.raises(ProxyConfigError, match="must be a JSON object"):
+            resolve_proxy_config()
+
+    def test_header_object_value_raises(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": {"nested": true}}',
+            }
+        )
+        with pytest.raises(ProxyConfigError, match="must be a scalar"):
+            resolve_proxy_config()
+
+    def test_providers_set_but_empty_raises(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_PROVIDERS": " , ,",
+            }
+        )
+        with pytest.raises(ProxyConfigError, match="contains no provider names"):
+            resolve_proxy_config()
+
+    def test_unroutable_provider_in_allow_list_raises(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_PROVIDERS": "openrouter,nova",
+            }
+        )
+        with pytest.raises(ProxyConfigError, match="cannot be routed"):
+            resolve_proxy_config()
+
+    @pytest.mark.parametrize(
+        "orphan",
+        [
+            "LLM_PROXY_API_KEY",
+            "LLM_PROXY_HEADERS",
+            "LLM_PROXY_REQUEST_ID_HEADER",
+            "LLM_PROXY_PROVIDERS",
+        ],
+    )
+    def test_companion_without_base_url_raises(self, install_secrets, orphan: str) -> None:
+        """A typo in the base-URL name must not silently bypass the gateway."""
+        install_secrets({orphan: "openrouter" if orphan.endswith("PROVIDERS") else "value"})
+        with pytest.raises(ProxyConfigError, match="LLM_PROXY_BASE_URL"):
+            resolve_proxy_config()
+
+    def test_no_gateway_vars_at_all_is_silent(self, install_secrets) -> None:
+        """The default path stays quiet — this is not a required feature."""
+        install_secrets({"OPENROUTER_API_KEY": "sk-or-test"})
+        assert resolve_proxy_config() is None
+
+
+class TestProviderScoping:
+    """Which providers the gateway claims."""
+
+    def test_default_scope_is_the_openai_envelope_providers(self) -> None:
+        """Only providers whose litellm transport POSTs /chat/completions."""
+        proxy = ProxyConfig(base_url="https://gateway.example.com")
+        assert proxy.applies_to("openrouter")
+        assert proxy.applies_to("openai")
+
+    def test_default_scope_excludes_native_protocol_providers(self) -> None:
+        """anthropic/gemini would get their native route appended, not OpenAI's."""
+        proxy = ProxyConfig(base_url="https://gateway.example.com")
+        assert not proxy.applies_to("anthropic")
+        assert not proxy.applies_to("gemini")
+        assert not proxy.applies_to("vertex_ai")
+
+    def test_compound_provider_matches_first_segment(self) -> None:
+        proxy = ProxyConfig(base_url="https://gateway.example.com")
+        assert proxy.applies_to("openrouter/google")
+
+    def test_explicit_allow_list_replaces_the_default(self) -> None:
+        proxy = ProxyConfig(
+            base_url="https://gateway.example.com",
+            providers=frozenset({"anthropic"}),
+        )
+        assert proxy.applies_to("anthropic")
+        assert not proxy.applies_to("openrouter")
+
+    def test_unroutable_providers_never_match(self) -> None:
+        """Even an explicit allow-list cannot route these."""
+        proxy = ProxyConfig(
+            base_url="https://gateway.example.com",
+            providers=frozenset(UNROUTABLE_PROVIDERS),
+        )
+        for provider in UNROUTABLE_PROVIDERS:
+            assert not proxy.applies_to(provider), provider
+
+    def test_empty_provider_string_never_matches(self) -> None:
+        proxy = ProxyConfig(base_url="https://gateway.example.com")
+        assert not proxy.applies_to("")
+
+
+class TestRequestHeaders:
+    """Static headers plus an optional per-request correlation id."""
+
+    def test_static_headers_are_returned(self) -> None:
+        proxy = ProxyConfig(
+            base_url="https://gateway.example.com",
+            headers={"X-Team-Id": "research"},
+        )
+        assert proxy.request_headers() == {"X-Team-Id": "research"}
+
+    def test_request_id_is_fresh_per_call(self) -> None:
+        proxy = ProxyConfig(
+            base_url="https://gateway.example.com",
+            request_id_header="X-Request-Id",
+        )
+        first = proxy.request_headers()["X-Request-Id"]
+        second = proxy.request_headers()["X-Request-Id"]
+        assert first != second
+
+    def test_request_headers_does_not_mutate_static_headers(self) -> None:
+        proxy = ProxyConfig(
+            base_url="https://gateway.example.com",
+            headers={"X-Team-Id": "research"},
+            request_id_header="X-Request-Id",
+        )
+        proxy.request_headers()
+        assert proxy.headers == {"X-Team-Id": "research"}
+
+
+class TestClientAppliesProxy:
+    """``LLMClient`` treats the gateway as a transport swap and nothing more."""
+
+    def test_kwargs_carry_base_url_and_key(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_API_KEY": "sk-gateway",
+            }
+        )
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert kwargs["api_base"] == "https://gateway.example.com"
+        assert kwargs["api_key"] == "sk-gateway"
+
+    def test_model_string_is_unchanged(self, install_secrets) -> None:
+        """The invariant that keeps presets and pricing working."""
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        config = ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7")
+        kwargs = _build_kwargs(config)
+        assert kwargs["model"] == "openrouter/anthropic/claude-opus-4.7"
+
+    def test_configured_headers_reach_the_request(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research"}',
+                "LLM_PROXY_REQUEST_ID_HEADER": "X-Request-Id",
+            }
+        )
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        headers = kwargs["extra_headers"]
+        assert headers["X-Team-Id"] == "research"
+        assert headers["X-Request-Id"]
+
+    def test_openrouter_headers_survive_alongside_gateway_headers(self, install_secrets) -> None:
+        """The gateway must not drop OpenRouter's own attribution headers."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research"}',
+            }
+        )
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        headers = kwargs["extra_headers"]
+        assert headers["X-Team-Id"] == "research"
+        assert "HTTP-Referer" in headers
+        assert "X-Title" in headers
+
+    def test_provider_order_extra_body_is_preserved(self, install_secrets) -> None:
+        """Gateway routing must not silently drop upstream provider pinning."""
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        config = ModelConfig(
+            provider="openrouter",
+            name="anthropic/claude-opus-4.7",
+            openrouter={"provider_order": ["Together"], "allow_fallbacks": False},
+        )
+        kwargs = _build_kwargs(config)
+        assert kwargs["extra_body"]["provider"] == {
+            "order": ["Together"],
+            "allow_fallbacks": False,
+        }
+
+    def test_no_proxy_kwargs_when_disabled(self, install_secrets) -> None:
+        install_secrets({"OPENROUTER_API_KEY": "sk-or-test"})
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert "api_base" not in kwargs
+        assert "api_key" not in kwargs
+
+    def test_out_of_scope_provider_is_not_routed(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_PROVIDERS": "anthropic",
+            }
+        )
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert "api_base" not in kwargs
+
+    def test_native_provider_is_not_routed_by_default(self, install_secrets) -> None:
+        """A native-protocol provider is not routed by the default scope."""
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        kwargs = _build_kwargs(ModelConfig(provider="anthropic", name="claude-opus-4.7"))
+        assert "api_base" not in kwargs
+
+    def test_no_api_key_kwarg_when_gateway_key_unset(self, install_secrets) -> None:
+        """Without a gateway key, litellm keeps its own key resolution."""
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert kwargs["api_base"] == "https://gateway.example.com"
+        assert "api_key" not in kwargs
+
+    def test_gateway_header_wins_over_engine_default(self, install_secrets) -> None:
+        """Explicit operator config beats the engine's own OpenRouter defaults."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Title": "gateway-owned"}',
+            }
+        )
+        kwargs = _build_kwargs(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert kwargs["extra_headers"]["X-Title"] == "gateway-owned"
+        # The non-colliding OpenRouter defaults still ride along.
+        assert "HTTP-Referer" in kwargs["extra_headers"]
+
+    def test_malformed_config_raises_from_client_construction(self, install_secrets) -> None:
+        """The fail-fast claim, asserted where operators actually hit it."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": "not-json",
+            }
+        )
+        with pytest.raises(ProxyConfigError):
+            LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+
+
+class TestNonProxyPathUnchanged:
+    """The constructor refactor must not disturb the direct-provider path.
+
+    Nothing in the suite covered ``_configure_openrouter_base_url`` or
+    ``_configure_nova_base_url`` before, so a regression here would have been
+    invisible.
+    """
+
+    def test_openrouter_base_url_override_still_applies(self, install_secrets) -> None:
+        _clear_env("OPENROUTER_API_BASE")
+        install_secrets({"OPENROUTER_BASE_URL": "https://or-mirror.example.com"})
+        LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert os.environ.get("OPENROUTER_API_BASE") == "https://or-mirror.example.com"
+
+    def test_gateway_suppresses_the_openrouter_override(self, install_secrets) -> None:
+        """With the gateway on, the explicit api_base kwarg is the only base URL."""
+        _clear_env("OPENROUTER_API_BASE")
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "OPENROUTER_BASE_URL": "https://or-mirror.example.com",
+            }
+        )
+        LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert os.environ.get("OPENROUTER_API_BASE") is None
+
+    def test_nova_base_url_still_applies(self, install_secrets) -> None:
+        _clear_env("NOVA_API_BASE")
+        install_secrets({"NOVA_API_KEY": "nova-test"})
+        LLMClient(ModelConfig(provider="nova", name="busan-v1"))
+        assert os.environ.get("NOVA_API_BASE") == "https://api.nova.amazon.com/v1"
+
+    def test_nova_keeps_its_own_transport_even_with_gateway_configured(
+        self, install_secrets
+    ) -> None:
+        """``nova`` is unroutable, so the gateway must not claim it."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "NOVA_API_KEY": "nova-test",
+            }
+        )
+        client = LLMClient(ModelConfig(provider="nova", name="busan-v1"))
+        assert client._proxy is None
+
+        captured: dict[str, Any] = {}
+
+        def _fake_completion(**kwargs: Any) -> str:
+            captured.update(kwargs)
+            return "ok"
+
+        original = client_module.completion
+        client_module.completion = _fake_completion  # type: ignore[assignment]
+        try:
+            client._call_with_key_rotation({"model": "nova/busan-v1", "messages": []})
+        finally:
+            client_module.completion = original  # type: ignore[assignment]
+
+        assert captured["api_base"] == "https://api.nova.amazon.com/v1"
+        # The rewrite that makes the bare Nova name routable is still in place.
+        assert captured["model"] == "openai/busan-v1"
+        assert captured["custom_llm_provider"] == "openai"
+
+
+class TestGatewayQuotaRejection:
+    """A gateway rejection must not be reported as a provider key-chain problem."""
+
+    def _raise_quota(self, client: LLMClient) -> BaseException:
+        def _fake_completion(**_: Any) -> str:
+            raise RuntimeError('litellm.AuthenticationError {"code":403} budget exceeded')
+
+        original = client_module.completion
+        client_module.completion = _fake_completion  # type: ignore[assignment]
+        try:
+            with pytest.raises(RuntimeError) as excinfo:
+                client._call_with_key_rotation({"model": "x", "messages": []})
+        finally:
+            client_module.completion = original  # type: ignore[assignment]
+        return excinfo.value
+
+    def test_gateway_rejection_names_the_gateway(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_API_KEY": "sk-gateway",
+                # A provider chain exists; rotating it would be useless here
+                # because the gateway key is pinned as an explicit kwarg.
+                "OPENROUTER_API_KEYS": "k1,k2,k3",
+            }
+        )
+        client = LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        message = str(self._raise_quota(client))
+        assert "gateway.example.com" in message
+        assert "exhausted" not in message.lower()
+
+    def test_direct_path_still_reports_key_exhaustion(self, install_secrets) -> None:
+        install_secrets({"OPENROUTER_API_KEY": "sk-or-only"})
+        client = LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert "All API keys exhausted" in str(self._raise_quota(client))
+
+    def test_rotation_survives_a_gateway_without_its_own_key(self, install_secrets) -> None:
+        """A gateway authenticating by network position leaves rotation working.
+
+        Without ``LLM_PROXY_API_KEY`` nothing pins ``api_key``, so litellm reads
+        the provider env var that ``_rotate_key`` republishes. Suppressing
+        rotation here would abort a trial with unused keys still in the chain.
+        """
+        _clear_env("OPENROUTER_API_KEY")
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "OPENROUTER_API_KEYS": "k1,k2,k3",
+            }
+        )
+        client = LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
+        assert client._proxy is not None and client._proxy.api_key is None
+
+        message = str(self._raise_quota(client))
+        # Rotation ran through the whole chain instead of blaming the gateway.
+        assert client._current_key_index == 2
+        assert os.environ.get("OPENROUTER_API_KEY") == "k3"
+        assert "All API keys exhausted" in message

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -483,7 +483,8 @@ class TestGatewayQuotaRejection:
         )
         client = LLMClient(ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7"))
         message = str(self._raise_quota(client))
-        assert "gateway.example.com" in message
+        assert message.startswith("LLM gateway at https://gateway.example.com rejected the request")
+        assert "Provider key rotation does not apply" in message
         assert "exhausted" not in message.lower()
 
     def test_direct_path_still_reports_key_exhaustion(self, install_secrets) -> None:

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -37,7 +37,7 @@ from tenacity import (
 from tolokaforge.core.llm.capabilities import ModelCapabilities
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.llm.prompt_policy import detect_dict_maps
-from tolokaforge.core.llm.proxy import resolve_proxy_config
+from tolokaforge.core.llm.proxy import UNROUTABLE_PROVIDERS, resolve_proxy_config
 from tolokaforge.core.llm.reasoning import ReasoningConfig, StructuredReasoning
 from tolokaforge.core.llm.usage import CostSource, Usage, UsageExtractor
 from tolokaforge.core.logging import get_logger
@@ -411,14 +411,16 @@ class LLMClient:
         # ``is None`` test. See ``tolokaforge/core/llm/proxy.py``.
         self._proxy = resolve_proxy_config()
         if self._proxy is not None and not self._proxy.applies_to(self.provider):
-            # Warn rather than drop quietly: a deployment that configured a
-            # gateway for compliance reasons needs to see which roles still
-            # reach providers directly.
-            self.logger.warning(
-                "Gateway configured but this provider is out of scope; calling provider directly",
-                base_url=self._proxy.base_url,
-                provider=self.provider,
-            )
+            if self.provider.split("/")[0] not in UNROUTABLE_PROVIDERS:
+                # Warn rather than drop quietly: a deployment that configured a
+                # gateway for compliance reasons needs to see which roles still
+                # reach providers directly.
+                self.logger.warning(
+                    "Gateway configured but this provider is out of scope; "
+                    "calling provider directly",
+                    base_url=self._proxy.base_url,
+                    provider=self.provider,
+                )
             self._proxy = None
 
         self._openrouter_headers = (
@@ -432,6 +434,13 @@ class LLMClient:
                 static_header_count=len(self._proxy.headers),
                 request_id_header=self._proxy.request_id_header,
             )
+            if self._proxy.api_key is None:
+                self.logger.warning(
+                    "Gateway has no LLM_PROXY_API_KEY; litellm will forward the "
+                    "PROVIDER credential to the gateway host. Set LLM_PROXY_API_KEY "
+                    "unless this gateway authenticates by network position.",
+                    base_url=self._proxy.base_url,
+                )
         elif self.provider.startswith("openrouter"):
             self._configure_openrouter_base_url()
         elif self.provider == "nova":

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -37,6 +37,7 @@ from tenacity import (
 from tolokaforge.core.llm.capabilities import ModelCapabilities
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.llm.prompt_policy import detect_dict_maps
+from tolokaforge.core.llm.proxy import resolve_proxy_config
 from tolokaforge.core.llm.reasoning import ReasoningConfig, StructuredReasoning
 from tolokaforge.core.llm.usage import CostSource, Usage, UsageExtractor
 from tolokaforge.core.logging import get_logger
@@ -403,14 +404,38 @@ class LLMClient:
         # Load API key chain for rotation on key exhaustion
         self._api_keys = self._load_api_keys()
         self._current_key_index = 0
-        if self.provider.startswith("openrouter"):
-            self._openrouter_headers = self._configure_openrouter_headers()
-            self._configure_openrouter_base_url()
-        elif self.provider == "nova":
-            self._configure_nova_base_url()
+
+        # Optional OpenAI-compatible gateway in front of every provider. Held
+        # as ``None`` both when unconfigured and when configured but out of
+        # scope for this provider, so downstream checks are a single
+        # ``is None`` test. See ``tolokaforge/core/llm/proxy.py``.
+        self._proxy = resolve_proxy_config()
+        if self._proxy is not None and not self._proxy.applies_to(self.provider):
+            # Warn rather than drop quietly: a deployment that configured a
+            # gateway for compliance reasons needs to see which roles still
+            # reach providers directly.
+            self.logger.warning(
+                "Gateway configured but this provider is out of scope; calling provider directly",
+                base_url=self._proxy.base_url,
+                provider=self.provider,
+            )
+            self._proxy = None
+
         self._openrouter_headers = (
             self._configure_openrouter_headers() if self.provider.startswith("openrouter") else {}
         )
+        if self._proxy is not None:
+            self.logger.info(
+                "Routing LLM calls through gateway",
+                base_url=self._proxy.base_url,
+                provider=self.provider,
+                static_header_count=len(self._proxy.headers),
+                request_id_header=self._proxy.request_id_header,
+            )
+        elif self.provider.startswith("openrouter"):
+            self._configure_openrouter_base_url()
+        elif self.provider == "nova":
+            self._configure_nova_base_url()
 
         self._api_call_timeout_s = self._load_api_timeout()
         self._api_timeout_retries = self._load_api_timeout_retries()
@@ -1270,6 +1295,22 @@ class LLMClient:
                     "allow_fallbacks": or_cfg.allow_fallbacks,
                 }
 
+        if self._proxy is not None:
+            # Transport swap only. ``model`` keeps its ``<provider>/<name>``
+            # shape so preset resolution and pricing normalisation are
+            # untouched — see the module docstring in ``llm/proxy.py``.
+            kwargs["api_base"] = self._proxy.base_url
+            if self._proxy.api_key:
+                kwargs["api_key"] = self._proxy.api_key
+            existing_headers = kwargs.get("extra_headers")
+            merged_headers = dict(existing_headers) if isinstance(existing_headers, dict) else {}
+            # Gateway headers win on a name collision: they are explicit
+            # operator configuration, whereas the headers already in the dict
+            # are this engine's own provider defaults (OpenRouter's
+            # ``HTTP-Referer`` / ``X-Title`` / opt-out trio).
+            merged_headers.update(self._proxy.request_headers())
+            kwargs["extra_headers"] = merged_headers
+
         return kwargs
 
     def _is_timeout_error(self, exc: BaseException) -> bool:
@@ -1450,6 +1491,27 @@ class LLMClient:
                     or '"code":403' in error_str
                     or '"code":402' in error_str
                 ):
+                    if self._proxy is not None and self._proxy.api_key:
+                        # Rotation cannot help *when a gateway key is pinned*:
+                        # ``_rotate_key`` republishes ``OPENROUTER_API_KEY``
+                        # into the environment, but the pinned ``api_key``
+                        # kwarg takes precedence in litellm. Rotating would
+                        # resend byte-identical requests and then report an
+                        # exhausted key chain that was never in play. The
+                        # condition mirrors exactly where ``_build_kwargs``
+                        # pins the key — without a gateway key litellm reads
+                        # the provider env var, so rotation still works and
+                        # must be left alone.
+                        self.logger.error(
+                            "Gateway rejected the request as over quota or unauthorized",
+                            base_url=self._proxy.base_url,
+                        )
+                        raise RuntimeError(
+                            f"LLM gateway at {self._proxy.base_url} rejected the request "
+                            f"(quota or authorization). Provider key rotation does not apply "
+                            f"to gateway-routed calls; check the gateway credential and its "
+                            f"budget: {e}"
+                        ) from e
                     if self._rotate_key():
                         self.logger.warning(
                             "API key exhausted, rotated to next key",

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -1,0 +1,272 @@
+"""Generic OpenAI-compatible LLM gateway (proxy) transport.
+
+Some deployments do not let the engine talk to model providers directly.
+Instead every call goes through an OpenAI-compatible gateway (LiteLLM proxy,
+Portkey, an internal API-management layer, ...) that owns the upstream
+credentials, enforces per-team budgets, and attributes spend.
+
+This module resolves that transport from the environment. It is deliberately
+**vendor-neutral**: nothing here knows about any particular organisation. A
+deployment supplies its own base URL, key, and whatever attribution headers
+its gateway requires.
+
+Environment contract
+--------------------
+
+All values are read through :class:`~tolokaforge.secrets.SecretManager`, so a
+``.env`` file, the process environment, and the runner container's
+``TOLOKAFORGE_SECRETS_JSON`` all work identically.
+
+``LLM_PROXY_BASE_URL``
+    Gateway base URL, e.g. ``https://gateway.example.com``. **Setting this is
+    what enables the proxy transport** — every other variable is optional.
+
+``LLM_PROXY_API_KEY``
+    Credential presented to the gateway, sent as the request's API key. Leave
+    it unset only for gateways that authenticate by network position: litellm
+    then falls through to its normal provider-env lookup and would forward the
+    *provider's* key to the gateway host instead.
+
+``LLM_PROXY_HEADERS``
+    JSON object of static headers added to every request, e.g.
+    ``{"X-Team-Id": "research", "X-Cost-Center": "42"}``. Gateways commonly
+    require attribution headers of this shape; keeping them as opaque
+    configuration is what stops that requirement from leaking into engine code.
+
+``LLM_PROXY_REQUEST_ID_HEADER``
+    Optional header **name**. When set, each request gets that header with a
+    fresh UUID4 value. Needed by gateways that want a per-request correlation
+    id; a static env var cannot express "new value per call".
+
+``LLM_PROXY_PROVIDERS``
+    Optional comma-separated override of which ``provider`` values to route
+    (matched against the config's ``provider``, and against its first path
+    segment so ``openrouter/google`` matches ``openrouter``). When unset,
+    only :data:`DEFAULT_ROUTED_PROVIDERS` are routed. Read the warning below
+    before widening it.
+
+Which providers can actually be routed
+--------------------------------------
+
+**Setting ``api_base`` does not make litellm speak OpenAI to that URL — it
+makes litellm speak that provider's native protocol to that URL.** Verified
+against litellm 1.87.0 by capturing the wire:
+
+===================  ==========================================================
+provider             request litellm sends to the gateway
+===================  ==========================================================
+``openrouter/…``     ``POST {base}/chat/completions``, bearer auth
+``openai/…``         ``POST {base}/chat/completions``, bearer auth
+``anthropic/…``      ``POST {base}/v1/messages``, ``x-api-key``
+``gemini/…``         ``POST {base}/models/<m>:generateContent``, ``x-goog-api-key``
+===================  ==========================================================
+
+Only the first two produce an OpenAI-envelope request, which is why
+:data:`DEFAULT_ROUTED_PROVIDERS` contains exactly those. Naming another
+provider in ``LLM_PROXY_PROVIDERS`` is allowed but means "my gateway also
+serves this provider's native route" — true for a LiteLLM proxy's
+``/v1/messages`` passthrough, false for a plain OpenAI-compatible gateway.
+:data:`UNROUTABLE_PROVIDERS` cannot be opted in at all and are rejected
+loudly, because no gateway can serve them (see that constant).
+
+Why the model name is left alone
+--------------------------------
+
+:meth:`LLMClient._build_kwargs` applies this transport by setting ``api_base``
+and ``api_key`` only. The litellm model string keeps its original
+``<provider>/<name>`` shape, which is load-bearing: preset ``match:`` globs
+resolve off the config's ``name``, and :func:`tolokaforge.core.pricing.
+normalize_model_name` keys off the formatted model string. Re-prefixing the
+model would silently drop presets and silently miss the pricing table, so the
+gateway is a pure transport swap and nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+ENV_BASE_URL = "LLM_PROXY_BASE_URL"
+ENV_API_KEY = "LLM_PROXY_API_KEY"
+ENV_HEADERS = "LLM_PROXY_HEADERS"
+ENV_REQUEST_ID_HEADER = "LLM_PROXY_REQUEST_ID_HEADER"
+ENV_PROVIDERS = "LLM_PROXY_PROVIDERS"
+
+#: Providers routed when ``LLM_PROXY_PROVIDERS`` is unset.
+#:
+#: Deliberately an allow-list, not an exclusion list: these are the providers
+#: whose litellm transport emits an OpenAI-envelope ``POST
+#: {base}/chat/completions``, which is what an OpenAI-compatible gateway
+#: serves. See the module docstring for the wire capture behind this.
+DEFAULT_ROUTED_PROVIDERS = frozenset({"openrouter", "openai"})
+
+#: Providers that can never be routed, even explicitly.
+#:
+#: ``mock`` never reaches the wire, so routing it is meaningless. ``nova``
+#: relies on :meth:`LLMClient._call_with_key_rotation` rewriting its bare model
+#: name into ``openai/<name>`` alongside its own hardcoded ``api_base``; a
+#: gateway replaces the base URL but not the rewrite, leaving litellm with a
+#: provider-less model string that raises ``BadRequestError`` before any
+#: request is sent. Rejected at config time rather than failing per trial.
+UNROUTABLE_PROVIDERS = frozenset({"mock", "nova"})
+
+
+class ProxyConfigError(RuntimeError):
+    """Raised when the proxy environment contract is set but malformed.
+
+    Fail-fast by design: a gateway deployment whose attribution headers fail
+    to parse would otherwise run a whole evaluation with unattributed spend.
+    """
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    """Resolved gateway transport settings.
+
+    Attributes
+    ----------
+    base_url:
+        Gateway base URL passed to litellm as ``api_base``.
+    api_key:
+        Credential passed to litellm as ``api_key``. ``None`` leaves key
+        resolution to litellm's normal provider-env lookup, which is useful for
+        gateways that authenticate by network position rather than by token.
+    headers:
+        Static headers added to every request. Treated as read-only.
+    request_id_header:
+        Header name that receives a fresh UUID4 per request, or ``None``.
+    providers:
+        Explicit provider allow-list, or ``None`` for
+        :data:`DEFAULT_ROUTED_PROVIDERS`.
+    """
+
+    base_url: str
+    api_key: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    request_id_header: str | None = None
+    providers: frozenset[str] | None = None
+
+    def applies_to(self, provider: str) -> bool:
+        """Return whether ``provider`` should be routed through the gateway.
+
+        Compound providers match on their first path segment too, so
+        ``openrouter/google`` is covered by an allow-list entry of
+        ``openrouter``.
+        """
+        normalized = (provider or "").strip().lower()
+        base_segment = normalized.split("/")[0]
+        if not base_segment or base_segment in UNROUTABLE_PROVIDERS:
+            return False
+        allowed = self.providers if self.providers is not None else DEFAULT_ROUTED_PROVIDERS
+        return normalized in allowed or base_segment in allowed
+
+    def request_headers(self) -> dict[str, str]:
+        """Build this request's gateway headers.
+
+        Returns a fresh dict every call because ``request_id_header`` must get
+        a new value per request.
+        """
+        headers = dict(self.headers)
+        if self.request_id_header:
+            headers[self.request_id_header] = str(uuid.uuid4())
+        return headers
+
+
+def _parse_headers(raw: str | None) -> dict[str, str]:
+    """Parse ``LLM_PROXY_HEADERS`` (a JSON object of string values)."""
+    if raw is None or not raw.strip():
+        return {}
+    try:
+        parsed: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProxyConfigError(
+            f"{ENV_HEADERS} must be a JSON object of header name to value, "
+            f"but it is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ProxyConfigError(
+            f"{ENV_HEADERS} must be a JSON object of header name to value, "
+            f"got {type(parsed).__name__}"
+        )
+    headers: dict[str, str] = {}
+    for name, value in parsed.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ProxyConfigError(f"{ENV_HEADERS} contains a non-string or empty header name")
+        if not isinstance(value, str | int | float | bool):
+            raise ProxyConfigError(
+                f"{ENV_HEADERS} value for {name!r} must be a scalar, got {type(value).__name__}"
+            )
+        headers[name.strip()] = str(value)
+    return headers
+
+
+def _parse_providers(raw: str | None) -> frozenset[str] | None:
+    """Parse ``LLM_PROXY_PROVIDERS`` (comma-separated) into an allow-list."""
+    if raw is None or not raw.strip():
+        return None
+    entries = {item.strip().lower() for item in raw.split(",") if item.strip()}
+    if not entries:
+        raise ProxyConfigError(
+            f"{ENV_PROVIDERS} is set but contains no provider names; "
+            f"unset it to use the default ({', '.join(sorted(DEFAULT_ROUTED_PROVIDERS))}), "
+            f"or list at least one"
+        )
+    unroutable = sorted(entries & UNROUTABLE_PROVIDERS)
+    if unroutable:
+        raise ProxyConfigError(
+            f"{ENV_PROVIDERS} names {', '.join(unroutable)}, which cannot be routed "
+            f"through a gateway. 'mock' never reaches the wire; 'nova' needs a model-name "
+            f"rewrite that the gateway path does not perform, so litellm would reject the "
+            f"request before sending it. Remove it from {ENV_PROVIDERS}."
+        )
+    return frozenset(entries)
+
+
+def resolve_proxy_config() -> ProxyConfig | None:
+    """Resolve the gateway transport from the environment.
+
+    Returns
+    -------
+    ProxyConfig | None
+        ``None`` when ``LLM_PROXY_BASE_URL`` is unset, i.e. the engine talks to
+        providers directly (the default).
+
+    Raises
+    ------
+    ProxyConfigError
+        When the gateway is enabled but a companion variable is malformed, or
+        when companion variables are set while the base URL is missing.
+    """
+    from tolokaforge.secrets import get_default
+
+    secrets = get_default()
+
+    base_url = (secrets.get_secret(ENV_BASE_URL) or "").strip()
+    if not base_url:
+        # A companion variable without a base URL means someone intended to
+        # route through a gateway and it silently did not happen — exactly the
+        # unattributed-spend outcome this module exists to prevent. A typo in
+        # the base-URL name lands here, so refuse rather than fall back to
+        # direct provider access.
+        orphans = sorted(
+            name
+            for name in (ENV_API_KEY, ENV_HEADERS, ENV_REQUEST_ID_HEADER, ENV_PROVIDERS)
+            if (secrets.get_secret(name) or "").strip()
+        )
+        if orphans:
+            raise ProxyConfigError(
+                f"{', '.join(orphans)} is set but {ENV_BASE_URL} is empty, so calls would go "
+                f"straight to the providers and bypass the gateway. Set {ENV_BASE_URL}, or "
+                f"unset the others to disable the gateway deliberately."
+            )
+        return None
+
+    return ProxyConfig(
+        base_url=base_url.rstrip("/"),
+        api_key=(secrets.get_secret(ENV_API_KEY) or "").strip() or None,
+        headers=_parse_headers(secrets.get_secret(ENV_HEADERS)),
+        request_id_header=(secrets.get_secret(ENV_REQUEST_ID_HEADER) or "").strip() or None,
+        providers=_parse_providers(secrets.get_secret(ENV_PROVIDERS)),
+    )

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -1,14 +1,27 @@
-"""Generic OpenAI-compatible LLM gateway (proxy) transport.
+"""LLM gateway (proxy) transport, configured entirely from the environment.
 
 Some deployments do not let the engine talk to model providers directly.
-Instead every call goes through an OpenAI-compatible gateway (LiteLLM proxy,
-Portkey, an internal API-management layer, ...) that owns the upstream
+Instead every call goes through a gateway — a `LiteLLM proxy
+<https://docs.litellm.ai/docs/simple_proxy>`_ is the reference target, and any
+gateway presenting the same surface works — which owns the upstream
 credentials, enforces per-team budgets, and attributes spend.
 
 This module resolves that transport from the environment. It is deliberately
-**vendor-neutral**: nothing here knows about any particular organisation. A
-deployment supplies its own base URL, key, and whatever attribution headers
-its gateway requires.
+**deployment-neutral**: nothing here knows about any particular organisation or
+gateway product. A deployment supplies its own base URL, key, and whatever
+attribution headers its gateway requires.
+
+What "the same surface" means, precisely
+----------------------------------------
+
+Not "the gateway is OpenAI-compatible" — the narrower and more accurate
+contract is: *for each routed provider, the gateway serves the route that
+litellm's transport for that provider targets.* This module only overrides the
+base URL; **litellm decides the path, the auth header, and the body shape**, and
+that decision is per-provider. See the routing table below and
+:data:`DEFAULT_ROUTED_PROVIDERS`, whose membership is pinned against the
+installed litellm by
+``tests/canonical/test_llm_gateway_envelope_contract.py``.
 
 Environment contract
 --------------------
@@ -49,8 +62,8 @@ Which providers can actually be routed
 --------------------------------------
 
 **Setting ``api_base`` does not make litellm speak OpenAI to that URL — it
-makes litellm speak that provider's native protocol to that URL.** Verified
-against litellm 1.87.0 by capturing the wire:
+makes litellm speak that provider's native protocol to that URL.** Verified by
+capturing the wire (litellm 1.87.0):
 
 ===================  ==========================================================
 provider             request litellm sends to the gateway
@@ -68,6 +81,12 @@ serves this provider's native route" — true for a LiteLLM proxy's
 ``/v1/messages`` passthrough, false for a plain OpenAI-compatible gateway.
 :data:`UNROUTABLE_PROVIDERS` cannot be opted in at all and are rejected
 loudly, because no gateway can serve them (see that constant).
+
+Widening the default to *every* provider would need this module to force the
+OpenAI envelope (``custom_llm_provider="openai"`` on routed calls, as the Nova
+path already does) rather than only swapping the base URL. That is a larger
+change than a transport swap — it collides with the ``custom_llm_provider`` the
+OpenRouter branch sets — and is deliberately not attempted here.
 
 Why the model name is left alone
 --------------------------------
@@ -98,8 +117,14 @@ ENV_PROVIDERS = "LLM_PROXY_PROVIDERS"
 #:
 #: Deliberately an allow-list, not an exclusion list: these are the providers
 #: whose litellm transport emits an OpenAI-envelope ``POST
-#: {base}/chat/completions``, which is what an OpenAI-compatible gateway
-#: serves. See the module docstring for the wire capture behind this.
+#: {base}/chat/completions``, which is what a LiteLLM proxy and comparable
+#: gateways serve. See the module docstring for the wire capture behind this.
+#:
+#: This set is a claim about the *installed litellm*, not about gateways in
+#: general, so it is pinned by
+#: ``tests/canonical/test_llm_gateway_envelope_contract.py``. A litellm upgrade
+#: that changes a provider's transport fails that test rather than silently
+#: posting to a route the gateway does not serve.
 DEFAULT_ROUTED_PROVIDERS = frozenset({"openrouter", "openai"})
 
 #: Providers that can never be routed, even explicitly.

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -93,11 +93,13 @@ Why the model name is left alone
 
 :meth:`LLMClient._build_kwargs` applies this transport by setting ``api_base``
 and ``api_key`` only. The litellm model string keeps its original
-``<provider>/<name>`` shape, which is load-bearing: preset ``match:`` globs
-resolve off the config's ``name``, and :func:`tolokaforge.core.pricing.
-normalize_model_name` keys off the formatted model string. Re-prefixing the
-model would silently drop presets and silently miss the pricing table, so the
-gateway is a pure transport swap and nothing else.
+``<provider>/<name>`` shape. Only one thing depends on that string:
+:func:`tolokaforge.core.pricing.normalize_model_name` keys off it, and it
+returns any second-prefixed name verbatim, guaranteeing a pricing-table miss
+that degrades ``cost_source`` to ``"unknown"``. Presets are *not* coupled to it
+— ``build_capabilities`` resolves off ``ModelConfig.name`` / ``.provider``
+directly — but renaming *those* to gateway-specific values does drop the
+matched preset and the ``providers:`` overlay. See ``docs/LLM_LAYER.md`` § proxy.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds optional support for routing LLM calls through a **gateway** instead of
calling providers directly. A [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy)
is the reference target; any gateway presenting the same surface works. Such a
gateway holds the upstream credentials, enforces per-team budgets, and
attributes spend.

Setting `LLM_PROXY_BASE_URL` enables it. Model names, run configs, presets,
certificates, and pricing are untouched. With the variable unset — the default —
behaviour is byte-identical to today.

Nothing in the engine knows about any particular gateway product or
organisation. Deployment specifics, including whatever attribution headers a
given gateway demands, are supplied entirely as configuration.

### What "the same surface" means

Deliberately **not** "the gateway is OpenAI-compatible" — that overclaims. This
layer only overrides the base URL; **litellm decides the path, the auth header,
and the body shape, per provider.** So the real contract is: for each routed
provider, the gateway must serve the route that litellm's transport for that
provider targets. That is why routing is an allow-list rather than a blanket
redirect, and why the allow-list is a claim about the *installed litellm* — which
is pinned by a canonical test rather than left to drift on a dependency bump.

## Environment contract

| Variable | Meaning |
|---|---|
| `LLM_PROXY_BASE_URL` | Gateway base URL. **Setting this enables the transport**; everything else is optional. |
| `LLM_PROXY_API_KEY` | Credential presented to the gateway. Omit only for gateways that authenticate by network position — litellm then falls through to its provider-env lookup and forwards the *provider's* key to the gateway host instead. |
| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request. Wins over the engine's own provider headers on a name collision. |
| `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
| `LLM_PROXY_PROVIDERS` | Provider allow-list, replacing the default. See the routing table below before widening it. |

All five resolve through `SecretManager`, so `.env`, the process environment,
and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.

## Which providers can be routed

**Setting `api_base` does not make litellm speak OpenAI to that URL — it makes
litellm speak that provider's native protocol to that URL.** Captured against
litellm 1.87.0:

| provider | request litellm sends to the gateway |
|---|---|
| `openrouter/…` | `POST {base}/chat/completions`, bearer auth |
| `openai/…` | `POST {base}/chat/completions`, bearer auth |
| `anthropic/…` | `POST {base}/v1/messages`, `x-api-key` |
| `gemini/…` | `POST {base}/models/<m>:generateContent`, `x-goog-api-key` |

Only the first two are an OpenAI-envelope request, so routing is an **allow-list**
defaulting to `{openrouter, openai}`, pinned against the installed litellm by
`tests/canonical/test_llm_gateway_envelope_contract.py`. Other providers can be
named explicitly, meaning "my gateway also serves that provider's native route" —
true of a LiteLLM proxy's `/v1/messages` passthrough, false of a plain
OpenAI-compatible gateway.

Widening the default to *every* provider would require forcing the OpenAI
envelope (`custom_llm_provider="openai"` on routed calls, as the Nova path
already does) rather than only swapping the base URL. That collides with the
`custom_llm_provider` the OpenRouter branch sets and is more than a transport
swap, so it is deliberately left out of this PR.

`mock` and `nova` are in `UNROUTABLE_PROVIDERS` and rejected even when named
explicitly. `mock` never reaches the wire. `nova` depends on
`_call_with_key_rotation` rewriting its bare model name into `openai/<name>`
next to its own hardcoded base URL; a gateway replaces the base URL but not the
rewrite, so litellm would raise `BadRequestError` before sending anything.

## Design: transport swap only

`_build_kwargs` sets `api_base`, `api_key`, and `extra_headers`. The litellm
model string keeps its `<provider>/<name>` shape. That invariant is deliberate —
the obvious alternative (a new `provider: litellm_proxy` with a re-prefixed
model name) breaks two subsystems **silently**:

1. **Presets.** `match:` globs resolve off `ModelConfig.name` and the
   `providers:` overlay off `ModelConfig.provider`. Renaming the provider drops
   the `providers.openrouter` overlay, so `reasoning_via_extra_body` flips to
   `False` and the reasoning wire format changes — while the reported
   `effective_preset` stays the same. Exact-glob presets stop matching too,
   re-opening the documented `recursive_ref` and `dict_map` regressions.
2. **Pricing.** `normalize_model_name` strips exactly one leading
   `openrouter/`, then returns any remaining slash-bearing name verbatim. A
   second prefix guarantees a pricing-table miss, degrading `cost_source` to
   `"unknown"` and tripping `Capability.COST_USD_POPULATED`, which is
   `required` on every certificate.

Because the provider string is untouched, provider-specific request shaping
still applies on top of the gateway: OpenRouter's `HTTP-Referer` / `X-Title`
headers and its `extra_body.provider` upstream pinning both survive.

## Key rotation

Rotation stays bound to the provider key chain, and whether it applies depends
on one thing: is a gateway key pinned?

- **`LLM_PROXY_API_KEY` set** — rotation is skipped. `_rotate_key` republishes
  `OPENROUTER_API_KEY` into the environment, but the pinned `api_key` kwarg wins
  in litellm, so rotating would resend byte-identical requests and then report
  an exhausted key chain that was never in play. A gateway quota rejection
  raises an error naming the gateway URL instead.
- **`LLM_PROXY_API_KEY` unset** — rotation works and is left alone, because
  litellm reads the provider env var that `_rotate_key` rewrites. Suppressing it
  would abort a trial with unused keys still in the chain.

The guard mirrors exactly the condition under which `_build_kwargs` pins the
key, so the two cannot drift.

## Fail-fast

A malformed value raises `ProxyConfigError` at the first `LLMClient`
construction rather than running a whole evaluation with unattributed spend.
Setting any companion `LLM_PROXY_*` variable while `LLM_PROXY_BASE_URL` is empty
also raises, so a typo in the base-URL name cannot silently fall back to direct
provider access. A configured-but-out-of-scope provider logs a warning rather
than dropping to the direct path silently.

## Testing

`tests/unit/llm/test_llm_proxy.py` — 42 tests covering env-contract resolution,
validation failures, provider scoping, per-request header freshness, kwargs
application, the rotation split, and the non-proxy path.

The load-bearing invariants each have an explicit regression test, since those
are what a future refactor would break: the model string staying intact,
OpenRouter header coexistence, `extra_body.provider` preservation, and
`_configure_openrouter_base_url` / `_configure_nova_base_url` still running when
no gateway is configured (previously uncovered by any test).

`tests/canonical/test_llm_gateway_envelope_contract.py` — 5 tests pinning the
allow-list against the installed litellm, so a dependency bump that changes a
provider's transport fails there instead of posting to a route the gateway does
not serve. Verified to have teeth: adding `anthropic` to the allow-list fails
two of them.

```
tests/unit/llm/test_llm_proxy.py                       42 passed
tests/canonical/test_llm_gateway_envelope_contract.py   5 passed
tests/unit/llm/ + test_llm_providers + test_model_client + secrets   716 passed
ruff check / ruff format --check                       clean
mypy tolokaforge/core/llm/proxy.py                     clean
```

Full `tests/unit` + `tests/canonical` on the author's machine:

```
baseline (main):   43 failed, 4210 passed, 3 errors
this branch:       43 failed, 4257 passed, 3 errors
```

The 43 failures and 3 errors are pre-existing in that working copy and
unrelated (an unsynced venv leaves plugin entry points unregistered and
`click_repl` missing). Identical before and after; the delta is exactly the 47
new tests.

## Review notes

This branch went through two rounds of adversarial review, including wire-level
capture against a local HTTP server and mutation testing of the new tests (each
fix reverted in source to confirm the corresponding test fails). Two findings
were accepted as out of scope: proxy config is validated per-`LLMClient` rather
than at CLI startup (a startup hook belongs in a change that touches the CLI),
and the gateway base URL is logged at INFO (operator-supplied configuration,
comparable to what `_load_api_keys` already logs).

## Docs

- `docs/LLM_LAYER.md` — new `proxy` section: the surface contract, env table, the
  routing table above, the transport-swap rationale, and the rotation split.
  Added to the module map.
- `docs/CONFIG.md` — pointer from § Environment Variables.
- `.env.example` — commented block for the five variables.
