### PR TITLE
feat(automation): report gateway availability and accept a route directive

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -40,6 +40,13 @@ on:
         description: "what triggered it (e.g. slack); informational only"
         required: false
         default: manual
+      route:
+        description: >-
+          transport for the candidate's probes: "openrouter" (default) or "litellm" to go
+          through the LLM gateway. The gateway route needs the ARENA_AUTOMATION_LLM_PROXY_*
+          secrets; without them the run falls back to OpenRouter rather than failing.
+        required: false
+        default: openrouter
 
 permissions:
   contents: write
@@ -187,7 +194,24 @@ jobs:
         # metacharacters can never be command-substituted.
         env:
           ARENA_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
-        run: printf '%s\n' "OPENROUTER_API_KEY=$ARENA_KEY" > .env
+          ROUTE: ${{ inputs.route || 'openrouter' }}
+          PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
+          PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
+        # OPENROUTER_API_KEY is always written: it is the fallback, and the probes' own pricing
+        # lookups use it even on the gateway route. LLM_PROXY_* is added only when the gateway
+        # route was requested AND configured -- writing a base URL without a key would silently
+        # forward the OpenRouter key to the gateway host (see docs/LLM_LAYER.md § proxy).
+        run: |
+          printf '%s\n' "OPENROUTER_API_KEY=$ARENA_KEY" > .env
+          if [ "$ROUTE" = "litellm" ]; then
+            if [ -n "$PROXY_BASE_URL" ] && [ -n "$PROXY_API_KEY" ]; then
+              printf '%s\n' "LLM_PROXY_BASE_URL=$PROXY_BASE_URL" >> .env
+              printf '%s\n' "LLM_PROXY_API_KEY=$PROXY_API_KEY" >> .env
+              echo "candidate probes will run through the LLM gateway"
+            else
+              echo "::warning title=Gateway route unavailable::route=litellm was requested but ARENA_AUTOMATION_LLM_PROXY_BASE_URL / _API_KEY are not set; probing over OpenRouter instead"
+            fi
+          fi
 
       - name: Resolve candidate model_id slug
         id: slug

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -42,11 +42,16 @@ on:
         default: manual
       route:
         description: >-
-          transport for the candidate's probes: "openrouter" (default) or "litellm" to go
-          through the LLM gateway. The gateway route needs the ARENA_AUTOMATION_LLM_PROXY_*
-          secrets; without them the run falls back to OpenRouter rather than failing.
+          transport for EVERY openrouter/openai call this run makes -- the candidate's probes
+          AND the wire-probes' user simulator (openrouter/anthropic/claude-sonnet-4.6). "litellm"
+          needs the ARENA_AUTOMATION_LLM_PROXY_* secrets AND a gateway that serves both models;
+          without the secrets the run falls back to OpenRouter rather than failing.
         required: false
         default: openrouter
+        type: choice
+        options:
+          - openrouter
+          - litellm
 
 permissions:
   contents: write
@@ -197,17 +202,20 @@ jobs:
           ROUTE: ${{ inputs.route || 'openrouter' }}
           PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
           PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-        # OPENROUTER_API_KEY is always written: it is the fallback, and the probes' own pricing
-        # lookups use it even on the gateway route. LLM_PROXY_* is added only when the gateway
-        # route was requested AND configured -- writing a base URL without a key would silently
-        # forward the OpenRouter key to the gateway host (see docs/LLM_LAYER.md § proxy).
+        # OPENROUTER_API_KEY is always written: it is what the non-gateway route uses, and the
+        # OpenRouter pricing/catalog HTTP calls need it on either route. LLM_PROXY_* is added
+        # only when the gateway route was requested AND configured -- writing a base URL without
+        # a key would silently forward the OpenRouter key to the gateway host (see
+        # docs/LLM_LAYER.md § proxy). Note this is job-wide, not per-role: it routes the user
+        # simulator too, so the gateway must serve BOTH models.
         run: |
+          set -euo pipefail
           printf '%s\n' "OPENROUTER_API_KEY=$ARENA_KEY" > .env
           if [ "$ROUTE" = "litellm" ]; then
             if [ -n "$PROXY_BASE_URL" ] && [ -n "$PROXY_API_KEY" ]; then
               printf '%s\n' "LLM_PROXY_BASE_URL=$PROXY_BASE_URL" >> .env
               printf '%s\n' "LLM_PROXY_API_KEY=$PROXY_API_KEY" >> .env
-              echo "candidate probes will run through the LLM gateway"
+              echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"
             else
               echo "::warning title=Gateway route unavailable::route=litellm was requested but ARENA_AUTOMATION_LLM_PROXY_BASE_URL / _API_KEY are not set; probing over OpenRouter instead"
             fi

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -58,6 +58,11 @@ jobs:
       # Optional comma-separated Slack user-id allowlist. Empty => anyone in the channel may
       # trigger (channel membership is the authz gate; GitHub only ever sees github-actions[bot]).
       ALLOWED_USERS: ${{ vars.ARENA_AUTOMATION_SLACK_ALLOWED_USERS }}
+      # LLM gateway, both optional. Present => the poller reports whether each resolved model
+      # is ALSO reachable there, and honours an explicit "via litellm" in the request. Absent
+      # => availability is "unknown" and every request integrates over OpenRouter as before.
+      LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
+      LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -73,7 +78,8 @@ jobs:
 
       - name: Poll the channel and resolve requests
         # Reads history, resolves each @bot integrate request, posts one threaded reply per
-        # request, and writes plan.json = [{slug, requester, message_ts}] for the resolved models.
+        # request, and writes plan.json = [{slug, requester, message_ts, route, gateway}] for the
+        # resolved models. `route` is the requested integration route (default openrouter).
         run: |
           uv run automation slack-poll \
             --channel "$SLACK_CHANNEL" \
@@ -119,7 +125,8 @@ jobs:
             [ -n "$PR_NUM" ] || { echo "could not parse PR number from '$PR_URL'"; return 1; }
             echo "opened PR #${PR_NUM} for ${SLUG} (${PR_URL})"
             gh workflow run integrate-model.yml -R "$REPO" --ref "$BASE_REF" \
-              -f pr="$PR_NUM" -f head_ref="$BRANCH" -f model="$SLUG" -f source=slack || return 1
+              -f pr="$PR_NUM" -f head_ref="$BRANCH" -f model="$SLUG" -f source=slack \
+              -f route="$ROUTE" || return 1
             echo "dispatched integrate-model.yml for PR #${PR_NUM} (${SLUG})"
             # Confirm in the requester's own thread, WITH the PR link (the poll-step reply was
             # posted before the PR existed; the engine's progress thread is a separate root).
@@ -133,6 +140,8 @@ jobs:
             SLUG="$(printf '%s' "$row" | jq -r '.slug')"
             REQUESTER="$(printf '%s' "$row" | jq -r '.requester')"
             TS="$(printf '%s' "$row" | jq -r '.message_ts')"
+            # Default in the reader too, so a plan written by an older poller still dispatches.
+            ROUTE="$(printf '%s' "$row" | jq -r '.route // "openrouter"')"
             git checkout -q "$BASE_REF" 2>/dev/null || git checkout -q -B "$BASE_REF" "origin/${BASE_REF}"
             if ! bootstrap "$SLUG" "$REQUESTER" "$TS"; then
               echo "::warning title=Integration bootstrap failed::could not start integration for ${SLUG} (see log); continuing"

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -142,6 +142,7 @@ jobs:
             TS="$(printf '%s' "$row" | jq -r '.message_ts')"
             # Default in the reader too, so a plan written by an older poller still dispatches.
             ROUTE="$(printf '%s' "$row" | jq -r '.route // "openrouter"')"
+            case "$ROUTE" in openrouter|litellm) ;; *) ROUTE=openrouter ;; esac
             git checkout -q "$BASE_REF" 2>/dev/null || git checkout -q -B "$BASE_REF" "origin/${BASE_REF}"
             if ! bootstrap "$SLUG" "$REQUESTER" "$TS"; then
               echo "::warning title=Integration bootstrap failed::could not start integration for ${SLUG} (see log); continuing"

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -162,25 +162,39 @@ advisory on purpose: a gateway route may be backed by a *different upstream* for
 name, which is a comparability decision for a human, not a transport detail the automaton should
 take on itself.
 
+The name looked up is the one that actually reaches the gateway: litellm strips exactly one
+provider prefix, so this run's `provider: openrouter` + `name: <slug>` config puts the **bare
+slug** on the wire. An `openrouter/<slug>` (or `openrouter/*`) catalog entry is therefore *not*
+evidence for this run — reaching a prefixed route needs the gateway-named config in
+[`docs/LLM_LAYER.md` § the model name must be the gateway's route name](LLM_LAYER.md#the-model-name-must-be-the-gateways-route-name),
+which this workflow does not use.
+
 The report distinguishes two strengths, because they are not equally trustworthy:
 
 | Reply says | Means |
 |---|---|
-| `also on the gateway as <route>` | an explicit catalog entry — someone configured this model |
-| `probably reachable … (matched a passthrough)` | only a `<prefix>/*` wildcard covers it; a live call is the real proof |
+| `also on the gateway as <route>` | an explicit catalog entry for the bare slug — someone configured this model |
+| `probably reachable … (matched a passthrough)` | only a wildcard over the slug's own namespace (`x-ai/*`, or a bare `*`) covers it; a live call is the real proof |
 | `not on the gateway` | the catalog was read and does not cover it |
 
 A requester can choose the route with `via litellm` / `via openrouter` (also `through the
 gateway`, `using the proxy`, `via OR`). The directive is stripped before model-phrase parsing,
 so `integrate Grok 4.5 via litellm` still resolves the model as `Grok 4.5`. The chosen route
 travels in `plan.json` and is passed to `integrate-model.yml` as its `route` input; on the
-gateway route that workflow adds `LLM_PROXY_*` to the candidate's `.env`, so the probes run over
-the gateway (see [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway)).
+gateway route that workflow adds `LLM_PROXY_*` to the candidate's `.env`. That is **job-wide,
+not per-role**: `proxy.py` routes every `openrouter`/`openai` call, so the wire probes' user
+simulator (`openrouter/anthropic/claude-sonnet-4.6`) is proxied too and the gateway must serve
+it as well — otherwise observe goes infra-dirty in the user simulator, not in the candidate
+(see [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway)).
 
 Everything here degrades to the previous behaviour when the gateway is not configured: the
 availability lookup returns "unknown", nothing is reported, and `route` stays `openrouter`.
-Asking for `via litellm` without the secrets logs a workflow warning and probes over OpenRouter
-rather than failing the run.
+A `via litellm` request the poller cannot confirm (availability `unknown` or `not on the
+gateway`, for *any* model in the message) is **downgraded to `openrouter` with a warning in the
+reply** rather than dispatched — a run over a gateway that does not serve the model would fail
+every probe and read as a model failure. On a manual `workflow_dispatch` with `route: litellm`
+but no secrets, `integrate-model.yml` logs a workflow warning and probes over OpenRouter rather
+than failing the run.
 
 It runs entirely on the `github-actions[bot]` `GITHUB_TOKEN` (no PAT, no GitHub App): a bot
 token cannot be reached from outside GitHub, so the initiative comes from INSIDE (the workflow

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -112,6 +112,14 @@ Both the AGENT and the CANDIDATE run on the OpenRouter budget (`ARENA_AUTOMATION
 | `RESOLVE_WIRE_K` | 10 | reserved for the final wire-verification pass (not yet wired) |
 | `ARENA_AUTOMATION_AUTO_MERGE_ENABLED` | (unset = off) | When `true` (case-insensitive), squash-merge the integration PR on a clean success. Never merges a `test/*` de-integration branch; a data-scope needs-human path never merges; any merge error (branch protection, draft, perms, conflict) leaves the PR open. `false` / missing / error => nothing merges. |
 
+Two **secrets** gate the optional gateway route (both, or neither — a base URL without a key
+would forward the OpenRouter key to the gateway host):
+
+| Secret | Meaning |
+|---|---|
+| `ARENA_AUTOMATION_LLM_PROXY_BASE_URL` | Gateway base URL, including the path its OpenAI-compatible route lives under (commonly `/v1`). A secret rather than a variable because the hostname is usually internal and this repo is public. |
+| `ARENA_AUTOMATION_LLM_PROXY_API_KEY` | Gateway credential. |
+
 ## Labels (the state machine)
 
 `automation:integrate-model` (trigger) -> `automation:integrate-running` (observe) ->
@@ -126,6 +134,8 @@ Instead of opening the PR by hand, tag the bot in the automation channel:
 
 ```
 @delivery-tech-bot integrate <model>       e.g. "integrate Grok 4.5 and GPT 5.6"
+@delivery-tech-bot integrate <model> via litellm      route the probes through the gateway
+@delivery-tech-bot integrate <model> via openrouter   the default, stated explicitly
 ```
 
 A scheduled workflow (`.github/workflows/slack-integrate.yml`) polls the channel and, per
@@ -138,6 +148,39 @@ request, resolves each free-text model phrase to an OpenRouter slug DETERMINISTI
   `integrate-model.yml` on it via `workflow_dispatch`, then replies in-thread with the PR link;
 - **ambiguous** (several slugs match) -> replies in-thread with the exact slugs to choose from;
 - **unknown** (no catalog match) -> replies that it could not find the model.
+
+### Integration route (OpenRouter vs the LLM gateway)
+
+**OpenRouter is the default and stays it.** The leaderboard is calibrated on the OpenRouter
+serving path, so a request that does not name a route must never change it.
+
+When the gateway secrets are configured (`ARENA_AUTOMATION_LLM_PROXY_BASE_URL` +
+`ARENA_AUTOMATION_LLM_PROXY_API_KEY`), the poller additionally reports, per resolved model,
+whether that model is **also** reachable through the gateway — see
+[`automation/gateway_catalog.py`](../tools/automation/src/automation/gateway_catalog.py). It is
+advisory on purpose: a gateway route may be backed by a *different upstream* for the same model
+name, which is a comparability decision for a human, not a transport detail the automaton should
+take on itself.
+
+The report distinguishes two strengths, because they are not equally trustworthy:
+
+| Reply says | Means |
+|---|---|
+| `also on the gateway as <route>` | an explicit catalog entry — someone configured this model |
+| `probably reachable … (matched a passthrough)` | only a `<prefix>/*` wildcard covers it; a live call is the real proof |
+| `not on the gateway` | the catalog was read and does not cover it |
+
+A requester can choose the route with `via litellm` / `via openrouter` (also `through the
+gateway`, `using the proxy`, `via OR`). The directive is stripped before model-phrase parsing,
+so `integrate Grok 4.5 via litellm` still resolves the model as `Grok 4.5`. The chosen route
+travels in `plan.json` and is passed to `integrate-model.yml` as its `route` input; on the
+gateway route that workflow adds `LLM_PROXY_*` to the candidate's `.env`, so the probes run over
+the gateway (see [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway)).
+
+Everything here degrades to the previous behaviour when the gateway is not configured: the
+availability lookup returns "unknown", nothing is reported, and `route` stays `openrouter`.
+Asking for `via litellm` without the secrets logs a workflow warning and probes over OpenRouter
+rather than failing the run.
 
 It runs entirely on the `github-actions[bot]` `GITHUB_TOKEN` (no PAT, no GitHub App): a bot
 token cannot be reached from outside GitHub, so the initiative comes from INSIDE (the workflow

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -1,0 +1,141 @@
+"""Is a candidate model also reachable through an LLM gateway?
+
+The Slack-triggered integration flow resolves a request to an **OpenRouter slug**
+and integrates it over OpenRouter. That stays the default. This module answers a
+second, advisory question: *could this model also be served by the deployment's
+LLM gateway (a LiteLLM proxy or equivalent)?* — so the reply can say so, and a
+requester can ask for that route explicitly.
+
+Why it is worth reporting rather than switching automatically: a gateway route
+may be backed by a different upstream than OpenRouter for the same model name.
+That changes the serving path, which is a leaderboard-comparability decision, not
+a transport detail. The automaton surfaces the option; a human picks it.
+
+Route-name convention
+---------------------
+
+A gateway that fronts OpenRouter typically exposes the slug under an
+``openrouter/`` prefix (``openrouter/x-ai/grok-4.5``), because that is how the
+underlying library namespaces it. Some gateways also register a wildcard
+passthrough (``openrouter/*``) that covers every slug without listing it.
+
+Those two are **not** equally strong evidence, so they are reported separately:
+an exact entry means someone configured this model; a wildcard means the gateway
+will *probably* accept it, and only a live call proves it. Nothing here calls the
+model — availability is a catalog lookup.
+
+Requires no credentials to be useful: with no gateway configured, every lookup
+returns ``unknown`` and the flow is unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import urllib.error
+import urllib.request
+
+#: Route identifiers accepted in a request and threaded into the integration run.
+ROUTE_OPENROUTER = "openrouter"
+ROUTE_GATEWAY = "litellm"
+
+#: The default route. OpenRouter is what the leaderboard is calibrated on, so a
+#: request that does not say otherwise must not silently change serving path.
+DEFAULT_ROUTE = ROUTE_OPENROUTER
+
+STATUS_EXACT = "exact"
+STATUS_WILDCARD = "wildcard"
+STATUS_ABSENT = "absent"
+STATUS_UNKNOWN = "unknown"
+
+
+@dataclasses.dataclass(frozen=True)
+class Availability:
+    """Whether a slug is reachable on the gateway, and under what route name.
+
+    ``status`` is one of :data:`STATUS_EXACT` (a catalog entry names this model),
+    :data:`STATUS_WILDCARD` (a passthrough covers it), :data:`STATUS_ABSENT` (the
+    catalog was read and does not cover it), or :data:`STATUS_UNKNOWN` (no
+    gateway configured, or the catalog could not be read).
+    """
+
+    slug: str
+    status: str
+    route: str | None = None
+
+    @property
+    def reachable(self) -> bool:
+        """True when the gateway can plausibly serve this model."""
+        return self.status in (STATUS_EXACT, STATUS_WILDCARD)
+
+
+def fetch_gateway_catalog(
+    base_url: str | None, api_key: str | None, timeout: int = 15
+) -> list[str] | None:
+    """Route ids the gateway serves, or ``None`` when it cannot be read.
+
+    ``None`` is not an error to propagate: an unconfigured or unreachable gateway
+    must leave the integration flow exactly as it was, so callers treat it as
+    "no information" rather than failing the poll.
+    """
+    if not base_url or not base_url.strip():
+        return None
+    url = base_url.strip().rstrip("/") + "/models"
+    headers = {"Accept": "application/json"}
+    if api_key and api_key.strip():
+        headers["Authorization"] = f"Bearer {api_key.strip()}"
+    try:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+    entries = data.get("data")
+    if not isinstance(entries, list):
+        return None
+    return sorted(
+        str(entry["id"]) for entry in entries if isinstance(entry, dict) and entry.get("id")
+    )
+
+
+def lookup(slug: str, catalog: list[str] | None) -> Availability:
+    """Classify how (or whether) ``slug`` is reachable on the gateway.
+
+    Checks, in descending strength: the prefixed route, the bare slug, then a
+    prefix wildcard.
+    """
+    if catalog is None:
+        return Availability(slug=slug, status=STATUS_UNKNOWN)
+
+    entries = set(catalog)
+    prefixed = f"{ROUTE_OPENROUTER}/{slug}"
+    if prefixed in entries:
+        return Availability(slug=slug, status=STATUS_EXACT, route=prefixed)
+    if slug in entries:
+        return Availability(slug=slug, status=STATUS_EXACT, route=slug)
+    if f"{ROUTE_OPENROUTER}/*" in entries:
+        return Availability(slug=slug, status=STATUS_WILDCARD, route=prefixed)
+    return Availability(slug=slug, status=STATUS_ABSENT)
+
+
+def describe(availability: Availability) -> str:
+    """One-line Slack mrkdwn phrase for a reply. Empty when there is nothing to say."""
+    if availability.status == STATUS_EXACT:
+        return f"also on the gateway as `{availability.route}`"
+    if availability.status == STATUS_WILDCARD:
+        return (
+            f"probably reachable on the gateway as `{availability.route}` "
+            f"(matched a passthrough, not an explicit entry)"
+        )
+    if availability.status == STATUS_ABSENT:
+        return "not on the gateway"
+    return ""
+
+
+def as_dict(availability: Availability) -> dict:
+    """JSON-friendly view for the plan / CLI."""
+    return {
+        "slug": availability.slug,
+        "status": availability.status,
+        "route": availability.route,
+    }

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -11,18 +11,22 @@ may be backed by a different upstream than OpenRouter for the same model name.
 That changes the serving path, which is a leaderboard-comparability decision, not
 a transport detail. The automaton surfaces the option; a human picks it.
 
-Route-name convention
----------------------
+Which name reaches the gateway
+------------------------------
 
-A gateway that fronts OpenRouter typically exposes the slug under an
-``openrouter/`` prefix (``openrouter/x-ai/grok-4.5``), because that is how the
-underlying library namespaces it. Some gateways also register a wildcard
-passthrough (``openrouter/*``) that covers every slug without listing it.
+The name that reaches the gateway is **not** the engine's litellm model string.
+litellm strips exactly one provider prefix, so the integration's ``provider:
+openrouter`` + ``name: x-ai/grok-4.5`` sends the bare ``x-ai/grok-4.5`` — an
+``openrouter/x-ai/grok-4.5`` entry is a route this run cannot reach without the
+gateway-named config in ``docs/LLM_LAYER.md`` § "The model name must be the
+gateway's route name". So the lookup is keyed on the bare slug, and the wildcard
+that counts is one covering the slug's own namespace (``x-ai/*``), not
+``openrouter/*``.
 
-Those two are **not** equally strong evidence, so they are reported separately:
-an exact entry means someone configured this model; a wildcard means the gateway
-will *probably* accept it, and only a live call proves it. Nothing here calls the
-model — availability is a catalog lookup.
+An exact entry and a wildcard are **not** equally strong evidence, so they are
+reported separately: an exact entry means someone configured this model; a
+wildcard means the gateway will *probably* accept it, and only a live call proves
+it. Nothing here calls the model — availability is a catalog lookup.
 
 Requires no credentials to be useful: with no gateway configured, every lookup
 returns ``unknown`` and the flow is unchanged.
@@ -101,20 +105,23 @@ def fetch_gateway_catalog(
 def lookup(slug: str, catalog: list[str] | None) -> Availability:
     """Classify how (or whether) ``slug`` is reachable on the gateway.
 
-    Checks, in descending strength: the prefixed route, the bare slug, then a
-    prefix wildcard.
+    The name checked is the one that actually reaches the gateway. litellm strips
+    exactly one provider prefix, so the integration's ``provider: openrouter`` +
+    ``name: <slug>`` config puts the BARE ``<slug>`` on the wire -- an
+    ``openrouter/<slug>`` catalog entry is NOT evidence for this run. Reaching a
+    prefixed route needs the gateway-named config in ``docs/LLM_LAYER.md`` under
+    "The model name must be the gateway's route name", which the integration
+    workflow does not use.
     """
     if catalog is None:
         return Availability(slug=slug, status=STATUS_UNKNOWN)
 
     entries = set(catalog)
-    prefixed = f"{ROUTE_OPENROUTER}/{slug}"
-    if prefixed in entries:
-        return Availability(slug=slug, status=STATUS_EXACT, route=prefixed)
     if slug in entries:
         return Availability(slug=slug, status=STATUS_EXACT, route=slug)
-    if f"{ROUTE_OPENROUTER}/*" in entries:
-        return Availability(slug=slug, status=STATUS_WILDCARD, route=prefixed)
+    namespace = slug.split("/", 1)[0]
+    if f"{namespace}/*" in entries or "*" in entries:
+        return Availability(slug=slug, status=STATUS_WILDCARD, route=slug)
     return Availability(slug=slug, status=STATUS_ABSENT)
 
 

--- a/tools/automation/src/automation/model_resolver.py
+++ b/tools/automation/src/automation/model_resolver.py
@@ -29,6 +29,8 @@ import json
 import re
 import urllib.request
 
+from automation import gateway_catalog
+
 _OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 # Maximal alpha runs (keeping a trailing "+", so "a+" != "a" and Cohere "A+" never collapses
 # onto "command-a") OR dotted-number runs; splits glued names ("gpt5.6" -> gpt, 5.6) and
@@ -37,6 +39,23 @@ _TOKEN_RE = re.compile(r"[a-z]+\+?|\d+(?:\.\d+)*")
 _CONNECTOR_RE = re.compile(r"\s*(?:,|&|\band\b|\bplus\b)\s*", re.IGNORECASE)
 _MENTION_RE = re.compile(r"<@[^>]+>")
 _INTEGRATE_RE = re.compile(r"\bintegrate\b", re.IGNORECASE)
+# Optional route directive: "integrate Grok 4.5 via litellm". Stripped BEFORE the phrases are
+# split, otherwise "Grok 4.5 via litellm" becomes the model phrase and resolves to nothing.
+# Accepts the gateway's product name and the generic words for it, since a requester types
+# whichever they think in.
+_ROUTE_RE = re.compile(
+    r"\b(?:via|through|over|using)\s+(?:the\s+)?"
+    r"(?P<route>litellm(?:\s+proxy)?|gateway|proxy|openrouter|or)\b",
+    re.IGNORECASE,
+)
+_ROUTE_ALIASES = {
+    "litellm": gateway_catalog.ROUTE_GATEWAY,
+    "litellm proxy": gateway_catalog.ROUTE_GATEWAY,
+    "gateway": gateway_catalog.ROUTE_GATEWAY,
+    "proxy": gateway_catalog.ROUTE_GATEWAY,
+    "openrouter": gateway_catalog.ROUTE_OPENROUTER,
+    "or": gateway_catalog.ROUTE_OPENROUTER,
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -78,14 +97,29 @@ def _slug_model_alpha(slug: str) -> frozenset[str]:
     return _tokenize(slug.split("/", 1)[-1]).alpha
 
 
+def parse_route(text: str) -> str | None:
+    """The explicitly requested integration route, or ``None`` for "not stated".
+
+    ``None`` deliberately differs from :data:`gateway_catalog.DEFAULT_ROUTE`: the
+    caller needs to know whether a human chose OpenRouter or merely did not ask,
+    because only the first justifies overriding a gateway-only model.
+    """
+    match = _ROUTE_RE.search(_MENTION_RE.sub(" ", text))
+    if not match:
+        return None
+    return _ROUTE_ALIASES.get(" ".join(match.group("route").lower().split()))
+
+
 def parse_command(text: str) -> list[str]:
-    """Extract the model phrases from a free-text integrate request. Drops any bot mention,
-    keeps everything after the first ``integrate`` keyword, and splits on and / & / , / plus.
+    """Extract the model phrases from a free-text integrate request. Drops any bot mention
+    and any ``via <route>`` directive, keeps everything after the first ``integrate`` keyword,
+    and splits on and / & / , / plus.
     Returns ``[]`` when the message is not an integrate request (no keyword)."""
-    match = _INTEGRATE_RE.search(_MENTION_RE.sub(" ", text))
+    cleaned = _ROUTE_RE.sub(" ", _MENTION_RE.sub(" ", text))
+    match = _INTEGRATE_RE.search(cleaned)
     if not match:
         return []
-    tail = _MENTION_RE.sub(" ", text)[match.end() :]
+    tail = cleaned[match.end() :]
     return [phrase for chunk in _CONNECTOR_RE.split(tail) if (phrase := chunk.strip(" .\t\r\n"))]
 
 
@@ -128,13 +162,35 @@ def resolve_all(
     return [resolve(phrase, catalog, aliases) for phrase in parse_command(text)]
 
 
-def format_resolution_reply(requester_id: str, resolutions: list[Resolution]) -> str:
+def format_resolution_reply(
+    requester_id: str,
+    resolutions: list[Resolution],
+    availability: dict[str, gateway_catalog.Availability] | None = None,
+    requested_route: str | None = None,
+) -> str:
     """Slack mrkdwn reply: what started, and which phrases need an exact slug. The requester
-    is pinged at the top so the ambiguous re-request lands on the right person."""
+    is pinged at the top so the ambiguous re-request lands on the right person.
+
+    When ``availability`` is supplied, each resolved model also reports whether the
+    deployment's LLM gateway could serve it — advisory only, since a gateway route may be
+    backed by a different upstream and that is a comparability call for a human.
+    ``requested_route`` echoes an explicit ``via <route>`` directive so the requester can
+    see it was honoured; absent, the default route is used and named."""
     lines = [f"<@{requester_id}> here is what I could resolve from your request:", ""]
+    effective_route = requested_route or gateway_catalog.DEFAULT_ROUTE
     for r in resolutions:
         if r.status == "resolved":
-            lines.append(f":white_check_mark: *{r.query}*: starting integration as `{r.slug}`")
+            lines.append(
+                f":white_check_mark: *{r.query}*: starting integration as `{r.slug}` "
+                f"via *{effective_route}*"
+            )
+            note = (
+                gateway_catalog.describe(availability[r.slug])
+                if availability and r.slug in availability
+                else ""
+            )
+            if note:
+                lines.append(f"    ◦ {note}")
         elif r.status == "ambiguous":
             lines.append(
                 f":warning: *{r.query}* is ambiguous ({len(r.candidates)} matches). "
@@ -145,6 +201,14 @@ def format_resolution_reply(requester_id: str, resolutions: list[Resolution]) ->
             lines.append(
                 f":x: *{r.query}*: no matching model on OpenRouter. Check the name and version."
             )
+    if requested_route is None and availability:
+        reachable = [s for s, a in availability.items() if a.reachable]
+        if reachable:
+            lines += [
+                "",
+                f"_Default route is *{gateway_catalog.DEFAULT_ROUTE}*. To use the gateway "
+                f"instead, re-request with `via litellm`._",
+            ]
     return "\n".join(lines)
 
 

--- a/tools/automation/src/automation/model_resolver.py
+++ b/tools/automation/src/automation/model_resolver.py
@@ -45,17 +45,15 @@ _INTEGRATE_RE = re.compile(r"\bintegrate\b", re.IGNORECASE)
 # whichever they think in.
 _ROUTE_RE = re.compile(
     r"\b(?:via|through|over|using)\s+(?:the\s+)?"
-    r"(?P<route>litellm(?:\s+proxy)?|gateway|proxy|openrouter|or)\b",
+    r"(?P<route>litellm(?:[\s-]+(?:proxy|gateway))?"
+    r"|(?:litellm[\s-]+)?(?:gateway|proxy)"
+    r"|openrouter|or)\b",
     re.IGNORECASE,
 )
-_ROUTE_ALIASES = {
-    "litellm": gateway_catalog.ROUTE_GATEWAY,
-    "litellm proxy": gateway_catalog.ROUTE_GATEWAY,
-    "gateway": gateway_catalog.ROUTE_GATEWAY,
-    "proxy": gateway_catalog.ROUTE_GATEWAY,
-    "openrouter": gateway_catalog.ROUTE_OPENROUTER,
-    "or": gateway_catalog.ROUTE_OPENROUTER,
-}
+# Any of these words in the matched phrase means the gateway. Word-based rather than an
+# exact-string table so widening the regex cannot silently stop mapping a form it matches.
+_GATEWAY_WORDS = frozenset({"litellm", "gateway", "proxy"})
+_OPENROUTER_WORDS = frozenset({"openrouter", "or"})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -102,12 +100,24 @@ def parse_route(text: str) -> str | None:
 
     ``None`` deliberately differs from :data:`gateway_catalog.DEFAULT_ROUTE`: the
     caller needs to know whether a human chose OpenRouter or merely did not ask,
-    because only the first justifies overriding a gateway-only model.
+    because only the first justifies overriding a gateway-only model. Several
+    directives that DISAGREE in one message also return ``None`` ("not stated"):
+    one message-level route cannot honour both, so the default applies.
     """
-    match = _ROUTE_RE.search(_MENTION_RE.sub(" ", text))
-    if not match:
+    routes: set[str] = set()
+    for match in _ROUTE_RE.finditer(_MENTION_RE.sub(" ", text)):
+        words = set(match.group("route").lower().replace("-", " ").split())
+        if words & _GATEWAY_WORDS:
+            routes.add(gateway_catalog.ROUTE_GATEWAY)
+        elif words & _OPENROUTER_WORDS:
+            routes.add(gateway_catalog.ROUTE_OPENROUTER)
+    if len(routes) != 1:
+        # Nothing asked, or several directives disagreeing in one message. One message-level
+        # route cannot honour both, and guessing could move a model whose route was stated as
+        # (or left at) OpenRouter onto the gateway -- so treat it as "not stated" and let the
+        # calibrated default apply.
         return None
-    return _ROUTE_ALIASES.get(" ".join(match.group("route").lower().split()))
+    return next(iter(routes))
 
 
 def parse_command(text: str) -> list[str]:
@@ -202,8 +212,7 @@ def format_resolution_reply(
                 f":x: *{r.query}*: no matching model on OpenRouter. Check the name and version."
             )
     if requested_route is None and availability:
-        reachable = [s for s, a in availability.items() if a.reachable]
-        if reachable:
+        if any(a.reachable for a in availability.values()):
             lines += [
                 "",
                 f"_Default route is *{gateway_catalog.DEFAULT_ROUTE}*. To use the gateway "

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -259,9 +259,11 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
                     "requester": requester,
                     "message_ts": ts,
                     "route": route,
-                    "gateway": gateway_catalog.as_dict(availability[slug])
-                    if slug in availability
-                    else None,
+                    "gateway": (
+                        gateway_catalog.as_dict(availability[slug])
+                        if slug in availability
+                        else None
+                    ),
                 }
             )
 

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -231,10 +231,13 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
         # clarify reply here, not be confirmed and then dropped by resolved_slugs() below.
         resolutions = [demote_unsafe_slug(r) for r in resolutions]
         requested_route = model_resolver.parse_route(text)
-        route = requested_route or gateway_catalog.DEFAULT_ROUTE
         # Advisory gateway lookup. Fetched lazily and once; an unconfigured or unreachable
         # gateway yields None, which reports as "unknown" and changes nothing.
         if gateway_models is _UNFETCHED:
+            # Read from os.environ, not SecretManager (AGENTS.md § Secrets): the poller is a CI-only
+            # entrypoint whose credentials come from workflow `env:`, and DotEnvProvider's `.env`
+            # precedence would let a developer's local gateway leak into a real poll. Same rationale
+            # as SLACK_BOT_TOKEN above. Revisit if this tool ever gains a SecretManager bootstrap.
             gateway_models = gateway_catalog.fetch_gateway_catalog(
                 os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
             )
@@ -243,9 +246,27 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             for r in resolutions
             if r.status == "resolved" and r.slug
         }
+        # Never promise a route the deployment cannot serve. With no readable catalog the run
+        # would fall back to OpenRouter anyway (integrate-model.yml), and with the model absent
+        # every probe would fail against a gateway we already know does not serve it -- either
+        # way a reply saying "via litellm" would misrecord the serving path. Refuse in the
+        # reply instead of dispatching a run whose outcome would read as a model failure.
+        route_warning = ""
+        if requested_route == gateway_catalog.ROUTE_GATEWAY and not all(
+            availability[r.slug].reachable for r in resolutions if r.slug in availability
+        ):
+            requested_route = None
+            route_warning = (
+                ":warning: I could not confirm the gateway serves every model above "
+                f"(see the notes), so this runs over *{gateway_catalog.DEFAULT_ROUTE}*. "
+                "Add the model to the gateway (or check its secrets) and re-request."
+            )
+        route = requested_route or gateway_catalog.DEFAULT_ROUTE
         reply = model_resolver.format_resolution_reply(
             requester, resolutions, availability, requested_route
         )
+        if route_warning:
+            reply = f"{reply}\n\n{route_warning}"
         if not slack._post_message(channel, reply, token, thread_ts=ts):
             # No durable processed-marker landed => do NOT add to the plan; retry next poll.
             # (Dispatching without a marker would double-run on the following poll.)

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -34,7 +34,7 @@ import time
 
 import typer
 
-from automation import model_resolver, slack
+from automation import gateway_catalog, model_resolver, slack
 
 # Opaque internal shortnames whose OpenRouter slug shares NO substring with the phrase go here
 # (lowercased phrase -> exact slug). Intentionally empty: almost everything resolves by token
@@ -47,6 +47,11 @@ ALIASES: dict[str, str] = {}
 # PR title/body, `gh workflow run -f model=`); a slug with a shell metacharacter is dropped, never
 # interpolated. Defence-in-depth behind the resolver's own "only ever returns a catalog entry".
 _SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+# Sentinel for "the gateway catalog has not been fetched yet". Distinct from None, which is a
+# *fetched* answer meaning "no gateway configured or unreachable" — without it, an unreachable
+# gateway would be re-fetched (and re-timed-out) once per request in the poll.
+_UNFETCHED: list[str] = []
 
 
 # --- pure helpers (unit-tested) ------------------------------------------------
@@ -197,6 +202,8 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
 
     allowed = parse_allowed(allowed_users)
     catalog: list[str] | None = None
+    # Distinct from None: None is a *fetched* answer meaning "no gateway info".
+    gateway_models: list[str] | None = _UNFETCHED
     for message in messages:
         if not is_request(message, bot_id):
             continue
@@ -216,13 +223,29 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             continue
         if catalog is None:  # fetch once, lazily - only when there is real work to resolve
             catalog = model_resolver.fetch_openrouter_catalog()
-        resolutions = model_resolver.resolve_all(message.get("text", ""), catalog, ALIASES)
+        text = message.get("text", "")
+        resolutions = model_resolver.resolve_all(text, catalog, ALIASES)
         if not resolutions:  # mention + "integrate" but no parseable model phrase
             continue
         # Charset-guard BEFORE the reply: a resolved-but-unsafe slug (a ':variant') must become a
         # clarify reply here, not be confirmed and then dropped by resolved_slugs() below.
         resolutions = [demote_unsafe_slug(r) for r in resolutions]
-        reply = model_resolver.format_resolution_reply(requester, resolutions)
+        requested_route = model_resolver.parse_route(text)
+        route = requested_route or gateway_catalog.DEFAULT_ROUTE
+        # Advisory gateway lookup. Fetched lazily and once; an unconfigured or unreachable
+        # gateway yields None, which reports as "unknown" and changes nothing.
+        if gateway_models is _UNFETCHED:
+            gateway_models = gateway_catalog.fetch_gateway_catalog(
+                os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
+            )
+        availability = {
+            r.slug: gateway_catalog.lookup(r.slug, gateway_models)
+            for r in resolutions
+            if r.status == "resolved" and r.slug
+        }
+        reply = model_resolver.format_resolution_reply(
+            requester, resolutions, availability, requested_route
+        )
         if not slack._post_message(channel, reply, token, thread_ts=ts):
             # No durable processed-marker landed => do NOT add to the plan; retry next poll.
             # (Dispatching without a marker would double-run on the following poll.)
@@ -230,7 +253,17 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             slack._note_failure("Slack reply failed; integration not dispatched (will retry)")
             continue
         for slug in resolved_slugs(resolutions):
-            plan.append({"slug": slug, "requester": requester, "message_ts": ts})
+            plan.append(
+                {
+                    "slug": slug,
+                    "requester": requester,
+                    "message_ts": ts,
+                    "route": route,
+                    "gateway": gateway_catalog.as_dict(availability[slug])
+                    if slug in availability
+                    else None,
+                }
+            )
 
     _write_plan(out_path, plan)
     slack._log(f"poll complete: {len(plan)} model(s) queued for integration")

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -16,6 +16,8 @@ import json
 import pytest
 from automation import gateway_catalog, model_resolver, poller, slack
 
+pytestmark = pytest.mark.unit
+
 _CATALOG = [
     "anthropic/claude-sonnet-4-5",
     "azure_ai/cohere-command-a-plus-05-2026",

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -1,0 +1,205 @@
+"""Tests for the advisory gateway-availability lookup and the route directive.
+
+Two behaviours carry real risk and are pinned hardest:
+
+* **OpenRouter stays the default.** A request that does not name a route must not
+  change serving path, because the leaderboard is calibrated on OpenRouter.
+* **A wildcard is weaker evidence than an explicit entry.** Reporting a
+  passthrough match as if someone had configured the model would invite a human
+  to pick a route that then 404s at eval time.
+"""
+
+from __future__ import annotations
+
+import pytest
+from automation import gateway_catalog, model_resolver
+
+_CATALOG = [
+    "anthropic/claude-sonnet-4-5",
+    "azure_ai/cohere-command-a-plus-05-2026",
+    "openrouter/*",
+    "openrouter/anthropic/claude-opus-4.7",
+]
+
+
+class TestLookup:
+    def test_exact_prefixed_entry_wins(self) -> None:
+        found = gateway_catalog.lookup("anthropic/claude-opus-4.7", _CATALOG)
+        assert found.status == gateway_catalog.STATUS_EXACT
+        assert found.route == "openrouter/anthropic/claude-opus-4.7"
+        assert found.reachable
+
+    def test_bare_slug_entry_also_counts_as_exact(self) -> None:
+        found = gateway_catalog.lookup("azure_ai/cohere-command-a-plus-05-2026", _CATALOG)
+        assert found.status == gateway_catalog.STATUS_EXACT
+        assert found.route == "azure_ai/cohere-command-a-plus-05-2026"
+
+    def test_wildcard_is_reported_separately_from_exact(self) -> None:
+        """A passthrough means 'probably', and the reply must not overstate it."""
+        found = gateway_catalog.lookup("x-ai/grok-4.5", _CATALOG)
+        assert found.status == gateway_catalog.STATUS_WILDCARD
+        assert found.route == "openrouter/x-ai/grok-4.5"
+        assert found.reachable
+        assert "passthrough" in gateway_catalog.describe(found)
+
+    def test_absent_when_catalog_covers_nothing(self) -> None:
+        found = gateway_catalog.lookup("x-ai/grok-4.5", ["anthropic/claude-sonnet-4-5"])
+        assert found.status == gateway_catalog.STATUS_ABSENT
+        assert not found.reachable
+        assert found.route is None
+
+    def test_unfetched_catalog_is_unknown_not_absent(self) -> None:
+        """No gateway configured must not read as 'the model is missing'."""
+        found = gateway_catalog.lookup("x-ai/grok-4.5", None)
+        assert found.status == gateway_catalog.STATUS_UNKNOWN
+        assert not found.reachable
+        assert gateway_catalog.describe(found) == ""
+
+
+class TestFetchDegradesQuietly:
+    def test_no_base_url_returns_none(self) -> None:
+        assert gateway_catalog.fetch_gateway_catalog(None, "sk-x") is None
+        assert gateway_catalog.fetch_gateway_catalog("   ", "sk-x") is None
+
+    def test_unreachable_gateway_returns_none_rather_than_raising(self) -> None:
+        """A notification path must never break the poll."""
+        assert (
+            gateway_catalog.fetch_gateway_catalog("http://127.0.0.1:9/v1", "sk-x", timeout=1)
+            is None
+        )
+
+
+class TestRouteDirective:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<@U1> integrate Grok 4.5 via litellm",
+            "<@U1> integrate Grok 4.5 via LiteLLM proxy",
+            "<@U1> integrate Grok 4.5 through the gateway",
+            "<@U1> integrate Grok 4.5 using the proxy",
+        ],
+    )
+    def test_gateway_route_is_recognised(self, text: str) -> None:
+        assert model_resolver.parse_route(text) == gateway_catalog.ROUTE_GATEWAY
+
+    @pytest.mark.parametrize(
+        "text",
+        ["<@U1> integrate Grok 4.5 via openrouter", "<@U1> integrate Grok 4.5 via OR"],
+    )
+    def test_openrouter_route_is_recognised(self, text: str) -> None:
+        assert model_resolver.parse_route(text) == gateway_catalog.ROUTE_OPENROUTER
+
+    def test_no_directive_is_none_not_the_default(self) -> None:
+        """The caller must distinguish 'chose OpenRouter' from 'did not ask'."""
+        assert model_resolver.parse_route("<@U1> integrate Grok 4.5") is None
+
+    def test_default_route_is_openrouter(self) -> None:
+        assert gateway_catalog.DEFAULT_ROUTE == gateway_catalog.ROUTE_OPENROUTER
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<@U1> integrate Grok 4.5 via litellm",
+            "<@U1> integrate Grok 4.5 via openrouter",
+        ],
+    )
+    def test_directive_is_stripped_from_the_model_phrase(self, text: str) -> None:
+        """Otherwise 'Grok 4.5 via litellm' becomes the phrase and resolves to nothing."""
+        assert model_resolver.parse_command(text) == ["Grok 4.5"]
+
+    def test_directive_stripped_with_several_models(self) -> None:
+        phrases = model_resolver.parse_command(
+            "<@U1> integrate Grok 4.5 and GPT 5.6 via the gateway"
+        )
+        assert phrases == ["Grok 4.5", "GPT 5.6"]
+
+    def test_a_model_named_or_is_not_mistaken_for_a_route(self) -> None:
+        """The directive needs a via/through/over/using lead-in, so plain names are safe."""
+        assert model_resolver.parse_route("<@U1> integrate openrouter/x-ai/grok-4.5") is None
+        assert model_resolver.parse_command("<@U1> integrate openrouter/x-ai/grok-4.5") == [
+            "openrouter/x-ai/grok-4.5"
+        ]
+
+
+class TestReply:
+    def _resolved(self, slug: str) -> model_resolver.Resolution:
+        return model_resolver.Resolution(query=slug, status="resolved", slug=slug)
+
+    def test_reply_names_the_effective_route_and_the_gateway_note(self) -> None:
+        slug = "anthropic/claude-opus-4.7"
+        reply = model_resolver.format_resolution_reply(
+            "U1",
+            [self._resolved(slug)],
+            {slug: gateway_catalog.lookup(slug, _CATALOG)},
+            None,
+        )
+        assert "via *openrouter*" in reply
+        assert "openrouter/anthropic/claude-opus-4.7" in reply
+        # Unrequested-but-available => tell the requester how to ask for it.
+        assert "via litellm" in reply
+
+    def test_explicit_gateway_request_is_echoed(self) -> None:
+        slug = "anthropic/claude-opus-4.7"
+        reply = model_resolver.format_resolution_reply(
+            "U1",
+            [self._resolved(slug)],
+            {slug: gateway_catalog.lookup(slug, _CATALOG)},
+            gateway_catalog.ROUTE_GATEWAY,
+        )
+        assert "via *litellm*" in reply
+        # No nudge when the requester already chose.
+        assert "re-request with" not in reply.lower()
+
+    def test_reply_without_availability_is_unchanged_shape(self) -> None:
+        """Back-compat: the pre-existing two-argument call still works."""
+        reply = model_resolver.format_resolution_reply("U1", [self._resolved("x-ai/grok-4.5")])
+        assert "starting integration as `x-ai/grok-4.5`" in reply
+        assert "gateway" not in reply
+
+
+class TestPlanRows:
+    """The plan is the contract with the workflow, so its new fields need pinning."""
+
+    def _row(self, text: str, gateway: list[str] | None) -> dict:
+        """Reproduce the poller's per-request plan row without Slack or the network."""
+        from automation import poller
+
+        catalog = ["x-ai/grok-4.5"]
+        resolutions = model_resolver.resolve_all(text, catalog, poller.ALIASES)
+        route = model_resolver.parse_route(text) or gateway_catalog.DEFAULT_ROUTE
+        availability = {
+            r.slug: gateway_catalog.lookup(r.slug, gateway)
+            for r in resolutions
+            if r.status == "resolved" and r.slug
+        }
+        slug = poller.resolved_slugs(resolutions)[0]
+        return {
+            "slug": slug,
+            "requester": "U1",
+            "message_ts": "1.0",
+            "route": route,
+            "gateway": gateway_catalog.as_dict(availability[slug])
+            if slug in availability
+            else None,
+        }
+
+    def test_unstated_route_defaults_to_openrouter(self) -> None:
+        row = self._row("<@U1> integrate Grok 4.5", ["openrouter/*"])
+        assert row["route"] == "openrouter"
+
+    def test_explicit_gateway_route_reaches_the_plan(self) -> None:
+        row = self._row("<@U1> integrate Grok 4.5 via litellm", ["openrouter/*"])
+        assert row["route"] == "litellm"
+
+    def test_gateway_verdict_is_carried_for_the_dispatch_log(self) -> None:
+        row = self._row("<@U1> integrate Grok 4.5", ["openrouter/x-ai/grok-4.5"])
+        assert row["gateway"] == {
+            "slug": "x-ai/grok-4.5",
+            "status": "exact",
+            "route": "openrouter/x-ai/grok-4.5",
+        }
+
+    def test_no_gateway_configured_still_produces_a_dispatchable_row(self) -> None:
+        row = self._row("<@U1> integrate Grok 4.5", None)
+        assert row["route"] == "openrouter"
+        assert row["gateway"]["status"] == "unknown"

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -11,25 +11,27 @@ Two behaviours carry real risk and are pinned hardest:
 
 from __future__ import annotations
 
+import json
+
 import pytest
-from automation import gateway_catalog, model_resolver
+from automation import gateway_catalog, model_resolver, poller, slack
 
 _CATALOG = [
     "anthropic/claude-sonnet-4-5",
     "azure_ai/cohere-command-a-plus-05-2026",
-    "openrouter/*",
+    "x-ai/*",
     "openrouter/anthropic/claude-opus-4.7",
 ]
 
 
 class TestLookup:
-    def test_exact_prefixed_entry_wins(self) -> None:
+    def test_prefixed_entry_is_not_evidence_for_this_run(self) -> None:
+        """litellm strips `openrouter/`, so the run asks for the BARE slug (LLM_LAYER.md)."""
         found = gateway_catalog.lookup("anthropic/claude-opus-4.7", _CATALOG)
-        assert found.status == gateway_catalog.STATUS_EXACT
-        assert found.route == "openrouter/anthropic/claude-opus-4.7"
-        assert found.reachable
+        assert found.status == gateway_catalog.STATUS_ABSENT
+        assert not found.reachable
 
-    def test_bare_slug_entry_also_counts_as_exact(self) -> None:
+    def test_bare_slug_entry_is_the_exact_match(self) -> None:
         found = gateway_catalog.lookup("azure_ai/cohere-command-a-plus-05-2026", _CATALOG)
         assert found.status == gateway_catalog.STATUS_EXACT
         assert found.route == "azure_ai/cohere-command-a-plus-05-2026"
@@ -38,7 +40,7 @@ class TestLookup:
         """A passthrough means 'probably', and the reply must not overstate it."""
         found = gateway_catalog.lookup("x-ai/grok-4.5", _CATALOG)
         assert found.status == gateway_catalog.STATUS_WILDCARD
-        assert found.route == "openrouter/x-ai/grok-4.5"
+        assert found.route == "x-ai/grok-4.5"
         assert found.reachable
         assert "passthrough" in gateway_catalog.describe(found)
 
@@ -61,12 +63,60 @@ class TestFetchDegradesQuietly:
         assert gateway_catalog.fetch_gateway_catalog(None, "sk-x") is None
         assert gateway_catalog.fetch_gateway_catalog("   ", "sk-x") is None
 
-    def test_unreachable_gateway_returns_none_rather_than_raising(self) -> None:
-        """A notification path must never break the poll."""
-        assert (
-            gateway_catalog.fetch_gateway_catalog("http://127.0.0.1:9/v1", "sk-x", timeout=1)
-            is None
+    def test_unreachable_gateway_returns_none_rather_than_raising(self, monkeypatch) -> None:
+        """A notification path must never break the poll (no real socket: stub the transport)."""
+
+        def fake_urlopen(request, timeout=None):
+            raise gateway_catalog.urllib.error.URLError("boom")
+
+        monkeypatch.setattr(gateway_catalog.urllib.request, "urlopen", fake_urlopen)
+        assert gateway_catalog.fetch_gateway_catalog("http://gw.invalid/v1", "sk-x") is None
+
+    def test_catalog_is_parsed_and_sorted_from_the_models_route(self, monkeypatch) -> None:
+        seen = {}
+
+        class _Resp:
+            def read(self):
+                return json.dumps(
+                    {"data": [{"id": "x-ai/grok-4.5"}, {"id": "x-ai/*"}, {}, {"id": None}]}
+                ).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(request, timeout=None):
+            seen["url"] = request.full_url
+            seen["auth"] = request.headers.get("Authorization")
+            return _Resp()
+
+        monkeypatch.setattr(gateway_catalog.urllib.request, "urlopen", fake_urlopen)
+        assert gateway_catalog.fetch_gateway_catalog("https://gw.invalid/v1/", "sk-x") == [
+            "x-ai/*",
+            "x-ai/grok-4.5",
+        ]
+        assert seen["url"] == "https://gw.invalid/v1/models"
+        assert seen["auth"] == "Bearer sk-x"
+
+    def test_non_list_data_is_no_information_not_an_empty_catalog(self, monkeypatch) -> None:
+        """An empty list would read as 'the gateway serves nothing'; None reads as 'unknown'."""
+
+        class _Resp:
+            def read(self):
+                return json.dumps({"data": {"x-ai/grok-4.5": {}}}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            gateway_catalog.urllib.request, "urlopen", lambda request, timeout=None: _Resp()
         )
+        assert gateway_catalog.fetch_gateway_catalog("https://gw.invalid/v1", "sk-x") is None
 
 
 class TestRouteDirective:
@@ -120,13 +170,32 @@ class TestRouteDirective:
             "openrouter/x-ai/grok-4.5"
         ]
 
+    def test_conflicting_directives_fall_back_to_the_default(self) -> None:
+        """One message, two routes: guessing could put an OpenRouter ask on the gateway."""
+        assert (
+            model_resolver.parse_route("<@U1> integrate Grok 4.5 via litellm and GPT 5.6 via OR")
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<@U1> integrate Grok 4.5 through the LiteLLM gateway",
+            "<@U1> integrate Grok 4.5 via litellm-proxy",
+        ],
+    )
+    def test_route_noun_is_fully_absorbed(self, text: str) -> None:
+        """A leftover 'gateway'/'proxy' token makes the model resolve to nothing."""
+        assert model_resolver.parse_route(text) == gateway_catalog.ROUTE_GATEWAY
+        assert model_resolver.parse_command(text) == ["Grok 4.5"]
+
 
 class TestReply:
     def _resolved(self, slug: str) -> model_resolver.Resolution:
         return model_resolver.Resolution(query=slug, status="resolved", slug=slug)
 
     def test_reply_names_the_effective_route_and_the_gateway_note(self) -> None:
-        slug = "anthropic/claude-opus-4.7"
+        slug = "azure_ai/cohere-command-a-plus-05-2026"
         reply = model_resolver.format_resolution_reply(
             "U1",
             [self._resolved(slug)],
@@ -134,7 +203,7 @@ class TestReply:
             None,
         )
         assert "via *openrouter*" in reply
-        assert "openrouter/anthropic/claude-opus-4.7" in reply
+        assert "azure_ai/cohere-command-a-plus-05-2026" in reply
         # Unrequested-but-available => tell the requester how to ask for it.
         assert "via litellm" in reply
 
@@ -158,48 +227,130 @@ class TestReply:
 
 
 class TestPlanRows:
-    """The plan is the contract with the workflow, so its new fields need pinning."""
+    """The plan is the contract with the workflow, so its new fields need pinning.
 
-    def _row(self, text: str, gateway: list[str] | None) -> dict:
-        """Reproduce the poller's per-request plan row without Slack or the network."""
-        from automation import poller
+    These drive the REAL :func:`poller.run`, not a reproduction of its body: a
+    reproduction keeps passing while the poller writes something else.
+    """
 
-        catalog = ["x-ai/grok-4.5"]
-        resolutions = model_resolver.resolve_all(text, catalog, poller.ALIASES)
-        route = model_resolver.parse_route(text) or gateway_catalog.DEFAULT_ROUTE
-        availability = {
-            r.slug: gateway_catalog.lookup(r.slug, gateway)
-            for r in resolutions
-            if r.status == "resolved" and r.slug
-        }
-        slug = poller.resolved_slugs(resolutions)[0]
-        return {
-            "slug": slug,
+    def _plan(
+        self, monkeypatch, tmp_path, text: str, gateway: list[str] | None
+    ) -> tuple[list[dict], list[str]]:
+        fetches = {"gateway": 0}
+        posted: list[str] = []
+
+        def fake_gateway(base_url, api_key, timeout=15):
+            fetches["gateway"] += 1
+            return gateway
+
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+        monkeypatch.setenv("LLM_PROXY_BASE_URL", "https://gateway.invalid/v1")
+        monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-test")
+        monkeypatch.setattr(poller, "_auth_test", lambda token: "B1")
+        monkeypatch.setattr(poller, "_already_handled", lambda *a, **k: False)
+        monkeypatch.setattr(
+            slack,
+            "_history",
+            lambda channel, token, oldest=None: [
+                {"ts": "1.0", "user": "U1", "text": text},
+                {"ts": "2.0", "user": "U1", "text": text},
+            ],
+        )
+        monkeypatch.setattr(
+            slack,
+            "_post_message",
+            lambda channel, text, token, thread_ts=None: (posted.append(text), True)[1],
+        )
+        monkeypatch.setattr(model_resolver, "fetch_openrouter_catalog", lambda: ["x-ai/grok-4.5"])
+        monkeypatch.setattr(gateway_catalog, "fetch_gateway_catalog", fake_gateway)
+
+        out = tmp_path / "plan.json"
+        assert poller.run("C1", None, str(out)) == 0
+        # The gateway catalog is fetched once for the whole poll, not once per request:
+        # an unreachable gateway must not re-time-out for every message in the window.
+        assert fetches["gateway"] == 1
+        return json.loads(out.read_text()), posted
+
+    def test_unstated_route_defaults_to_openrouter(self, monkeypatch, tmp_path) -> None:
+        """The leaderboard is calibrated on OpenRouter: silence must never mean the gateway."""
+        plan, posted = self._plan(monkeypatch, tmp_path, "<@B1> integrate Grok 4.5", ["x-ai/*"])
+        assert [row["route"] for row in plan] == ["openrouter", "openrouter"]
+        assert "via *openrouter*" in posted[0]
+
+    def test_explicit_gateway_route_reaches_the_plan(self, monkeypatch, tmp_path) -> None:
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["x-ai/*"]
+        )
+        assert [row["route"] for row in plan] == ["litellm", "litellm"]
+        # The reply must state the route it actually queued, not the default.
+        assert "via *litellm*" in posted[0]
+
+    def test_row_shape_is_the_workflow_contract(self, monkeypatch, tmp_path) -> None:
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5", ["x-ai/grok-4.5"]
+        )
+        assert "on the gateway as `x-ai/grok-4.5`" in posted[0]
+        assert plan[0] == {
+            "slug": "x-ai/grok-4.5",
             "requester": "U1",
             "message_ts": "1.0",
-            "route": route,
-            "gateway": (
-                gateway_catalog.as_dict(availability[slug]) if slug in availability else None
-            ),
+            "route": "openrouter",
+            "gateway": {"slug": "x-ai/grok-4.5", "status": "exact", "route": "x-ai/grok-4.5"},
         }
 
-    def test_unstated_route_defaults_to_openrouter(self) -> None:
-        row = self._row("<@U1> integrate Grok 4.5", ["openrouter/*"])
-        assert row["route"] == "openrouter"
+    def test_no_gateway_configured_still_produces_a_dispatchable_row(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        plan, _ = self._plan(monkeypatch, tmp_path, "<@B1> integrate Grok 4.5", None)
+        assert plan[0]["route"] == "openrouter"
+        assert plan[0]["gateway"]["status"] == "unknown"
 
-    def test_explicit_gateway_route_reaches_the_plan(self) -> None:
-        row = self._row("<@U1> integrate Grok 4.5 via litellm", ["openrouter/*"])
-        assert row["route"] == "litellm"
 
-    def test_gateway_verdict_is_carried_for_the_dispatch_log(self) -> None:
-        row = self._row("<@U1> integrate Grok 4.5", ["openrouter/x-ai/grok-4.5"])
-        assert row["gateway"] == {
-            "slug": "x-ai/grok-4.5",
-            "status": "exact",
-            "route": "openrouter/x-ai/grok-4.5",
-        }
+class TestUnconfirmedGatewayIsDowngraded:
+    """An unconfirmable ``via litellm`` must not be dispatched as if it were fine.
 
-    def test_no_gateway_configured_still_produces_a_dispatchable_row(self) -> None:
-        row = self._row("<@U1> integrate Grok 4.5", None)
-        assert row["route"] == "openrouter"
-        assert row["gateway"]["status"] == "unknown"
+    Dispatching it costs an hour of runner time and then blames the candidate for
+    an infra failure the poller could already see coming; the Slack thread — the
+    audit trail for the serving path — would also record a route the run did not
+    use. Driven through the real :func:`poller.run` for the same reason as
+    :class:`TestPlanRows`.
+    """
+
+    def _plan(self, monkeypatch, tmp_path, text: str, gateway: list[str] | None):
+        return TestPlanRows()._plan(monkeypatch, tmp_path, text, gateway)
+
+    def test_absent_model_downgrades_to_the_default_and_says_so(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        # Gateway readable, but nothing covers x-ai/grok-4.5.
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["anthropic/*"]
+        )
+        assert [row["route"] for row in plan] == ["openrouter", "openrouter"]
+        assert "via *openrouter*" in posted[0]
+        assert "could not confirm the gateway serves every model" in posted[0]
+
+    def test_unreadable_catalog_downgrades_to_the_default(self, monkeypatch, tmp_path) -> None:
+        """ "unknown" is not "reachable" — an unconfigured gateway must not be promised."""
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", None
+        )
+        assert plan[0]["route"] == "openrouter"
+        assert "could not confirm the gateway serves every model" in posted[0]
+
+    def test_confirmed_model_keeps_the_gateway_and_stays_quiet(self, monkeypatch, tmp_path) -> None:
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["x-ai/grok-4.5"]
+        )
+        assert plan[0]["route"] == "litellm"
+        assert "could not confirm" not in posted[0]
+
+    def test_an_openrouter_request_is_never_downgraded_or_warned(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The guard is gateway-only; it must not editorialise the default route."""
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via openrouter", ["anthropic/*"]
+        )
+        assert plan[0]["route"] == "openrouter"
+        assert "could not confirm" not in posted[0]

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -178,9 +178,9 @@ class TestPlanRows:
             "requester": "U1",
             "message_ts": "1.0",
             "route": route,
-            "gateway": gateway_catalog.as_dict(availability[slug])
-            if slug in availability
-            else None,
+            "gateway": (
+                gateway_catalog.as_dict(availability[slug]) if slug in availability else None
+            ),
         }
 
     def test_unstated_route_defaults_to_openrouter(self) -> None:


### PR DESCRIPTION
> **Stacked on #718** (`feat/configurable-llm-proxy-transport`). Base is that branch, not
> `main`, because this uses the gateway transport it adds. Review #718 first; this diff is
> only the automation layer.

## Summary

Teaches the Slack-triggered integration flow about the LLM gateway, in two opt-in ways:

1. **Reports availability.** When the gateway secrets are configured, the poller says, per
   resolved model, whether that model is *also* reachable through the gateway.
2. **Accepts a route directive.** `integrate Grok 4.5 via litellm` (also `through the
   gateway`, `using the proxy`, `via openrouter`, `via OR`). The choice travels in
   `plan.json` and reaches `integrate-model.yml` as a new `route` input, which adds
   `LLM_PROXY_*` to the candidate's `.env` so its probes run over the gateway.

**OpenRouter remains the default**, and the reply now names the effective route explicitly.

## Why availability is advisory, not automatic

A gateway route can be backed by a *different upstream* for the same model name. Verified
during #718: `provider: openrouter` + `anthropic/claude-opus-4.7` reached a gateway's
catch-all `anthropic/*` route, which was **Bedrock**, not OpenRouter. It failed loudly only
because that Bedrock model rejects `temperature=0.0`; a closer-matching route would have
silently evaluated a different serving path.

That makes the route a leaderboard-comparability decision, not a transport detail. The
automaton surfaces the option; a human picks it.

## Two report strengths, deliberately distinguished

| Reply says | Means |
|---|---|
| `also on the gateway as <route>` | an explicit catalog entry — someone configured this model |
| `probably reachable … (matched a passthrough)` | only a `<prefix>/*` wildcard covers it; a live call is the real proof |
| `not on the gateway` | the catalog was read and does not cover it |

Presenting a wildcard match as a configured model would invite a human to pick a route that
then 404s at eval time.

## Example reply

```
<@U1> here is what I could resolve from your request:

:white_check_mark: *Grok 4.5*: starting integration as `x-ai/grok-4.5` via *openrouter*
    ◦ probably reachable on the gateway as `openrouter/x-ai/grok-4.5` (matched a passthrough, not an explicit entry)
:white_check_mark: *Claude Opus 4.7*: starting integration as `anthropic/claude-opus-4.7` via *openrouter*
    ◦ also on the gateway as `openrouter/anthropic/claude-opus-4.7`

_Default route is *openrouter*. To use the gateway instead, re-request with `via litellm`._
```

## Details worth a reviewer's eye

- **`parse_route` returns `None`, not the default**, when nothing was asked. Callers need to
  tell "chose OpenRouter" from "did not ask" — only the former justifies overriding a
  gateway-only model.
- **The directive is stripped before the phrases are split.** Without that, `Grok 4.5 via
  litellm` becomes the model phrase and resolves to nothing, i.e. a valid request would come
  back as an unknown model. Pinned by a test.
- **A model literally named `or`/`openrouter` is not mistaken for a directive** — the regex
  requires a `via`/`through`/`over`/`using` lead-in. Also pinned.
- **Fetch failures are swallowed.** A notification path must never break the poll, so an
  unreachable gateway yields `unknown`. A sentinel distinguishes "not fetched yet" from
  "fetched, no info", so one unreachable gateway is not re-timed-out per request in a poll.
- **The base URL is a secret, not a variable**, because the hostname is typically internal
  and this repo is public.
- **`integrate-model.yml` requires both gateway secrets or neither.** A base URL without a
  key would make litellm fall through to the provider env lookup and forward the *OpenRouter*
  key to the gateway host.

## Degradation

No gateway configured → the lookup returns `unknown`, nothing is reported, `route` stays
`openrouter`, and the flow is byte-identical to today. Asking for `via litellm` without the
secrets logs a workflow warning and probes over OpenRouter rather than failing the run. The
plan reader defaults `route` too, so a plan written by an older poller still dispatches.

## Testing

```
tools/automation/tests/test_gateway_catalog.py    26 passed
tools/automation full suite                      157 passed
ruff check / ruff format --check                 clean
both workflows                                   re-validated as YAML
```

26 new tests: lookup strengths, quiet fetch degradation, the route directive (including the
strip and the false-positive guard), reply shape with and without availability, and 4 pinning
the `plan.json` row since that is the contract with the workflow.

The reply path was also exercised end-to-end in-process against four realistic requests
(unstated / `via litellm` / `via openrouter` / two models + `through the gateway`).

## Not in scope

The gateway route changes the candidate's *probe* transport. It does not yet add a
`pricing.json` entry for gateway-routed model strings, so `cost_source` can be `unknown` on
that path — noted in #718 and harmless for the probes, which do not gate on cost.
