### PR TITLE
fix(automation): resolve a request against both catalogs, and route every reply icon through the registry

### DIFF
--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -3,8 +3,9 @@ name: Slack-triggered integration poller
 # Turns a Slack request ("@delivery-tech-bot integrate Grok 4.5 and Hy3") into integration
 # runs, with NO new app and NO PAT - only the github-actions[bot] GITHUB_TOKEN. A bot token
 # cannot be reached from outside GitHub, so the initiative comes from INSIDE: this workflow
-# POLLS the channel (the existing bot token, read-only history), resolves each model phrase to
-# an OpenRouter slug DETERMINISTICALLY (automation.model_resolver - no LLM guessing), and:
+# POLLS the channel (the existing bot token, read-only history), resolves each model phrase
+# DETERMINISTICALLY (automation.model_resolver - no LLM guessing) against the OpenRouter catalog
+# and, for a phrase OpenRouter cannot match, the deployment's gateway catalog, and:
 #   * clearly-identified model  -> opens a draft integration PR + dispatches integrate-model.yml
 #   * ambiguous / unknown model -> replies in-thread asking for an exact slug (no run started)
 #
@@ -87,7 +88,8 @@ jobs:
       - name: Poll the channel and resolve requests
         # Reads history, resolves each @bot integrate request, posts one threaded reply per
         # request, and writes plan.json = [{slug, requester, message_ts, route, gateway}] for the
-        # resolved models. `route` is the requested integration route (default openrouter).
+        # resolved models. `route` is PER MODEL: the requested route (default openrouter), except
+        # a model that exists only on the gateway, which can run nowhere else.
         run: |
           uv run automation slack-poll \
             --channel "$SLACK_CHANNEL" \
@@ -128,7 +130,7 @@ jobs:
             git push -q -u origin "$BRANCH" || return 1
             PR_URL="$(gh pr create -R "$REPO" --draft --base "$BASE_REF" --head "$BRANCH" \
               --title "integrate: ${SLUG}" \
-              --body "Auto-opened from a Slack request by <@${REQUESTER}> (message ts ${TS}). The poller resolved the model deterministically against the OpenRouter catalog; this draft PR is the human review gate. The integration engine runs via workflow_dispatch on this PR." )" || return 1
+              --body "Auto-opened from a Slack request by <@${REQUESTER}> (message ts ${TS}). The poller resolved the model deterministically (OpenRouter catalog first, then the LLM gateway's); this draft PR is the human review gate. The integration engine runs via workflow_dispatch on this PR." )" || return 1
             PR_NUM="$(printf '%s' "$PR_URL" | grep -oE '[0-9]+$')"
             [ -n "$PR_NUM" ] || { echo "could not parse PR number from '$PR_URL'"; return 1; }
             echo "opened PR #${PR_NUM} for ${SLUG} (${PR_URL})"

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -139,7 +139,7 @@ Instead of opening the PR by hand, tag the bot in the automation channel:
 ```
 
 A scheduled workflow (`.github/workflows/slack-integrate.yml`) polls the channel and, per
-request, resolves each free-text model phrase to an OpenRouter slug DETERMINISTICALLY
+request, resolves each free-text model phrase to a model slug DETERMINISTICALLY
 (`automation resolve-models` / `model_resolver`, no LLM guessing - strict version discipline, so
 "Grok 4.5" never resolves to `grok-4` or `grok-4.3`), then:
 
@@ -147,7 +147,16 @@ request, resolves each free-text model phrase to an OpenRouter slug DETERMINISTI
   commit carrying the request metadata - no artifact is committed) and dispatches
   `integrate-model.yml` on it via `workflow_dispatch`, then replies in-thread with the PR link;
 - **ambiguous** (several slugs match) -> replies in-thread with the exact slugs to choose from;
-- **unknown** (no catalog match) -> replies that it could not find the model.
+- **unknown** (no match in either catalog) -> replies that it could not find the model, naming
+  which catalogs were actually searched.
+
+**Two catalogs, OpenRouter first.** A phrase is matched against the OpenRouter catalog and, only
+if that matches NOTHING, against the deployment's gateway catalog. A fallback rather than a union,
+deliberately: every phrase that resolves (or is ambiguous) against OpenRouter behaves exactly as
+before, so the calibrated default route never moves and a gateway that lists the same model under
+a second route name cannot turn a working request into a clarify reply. The fallback is what makes
+a gateway-ONLY model requestable at all - `integrate azure_ai/cohere-command-a-plus-05-2026` used
+to come back "no matching model on OpenRouter" even when the gateway served it.
 
 ### Integration route (OpenRouter vs the LLM gateway)
 
@@ -187,10 +196,19 @@ simulator (`openrouter/anthropic/claude-sonnet-4.6`) is proxied too and the gate
 it as well — otherwise observe goes infra-dirty in the user simulator, not in the candidate
 (see [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway)).
 
+The route is chosen **per model, not per message**, because the two sides of one request can
+disagree. A model that resolved only from the gateway catalog pins the gateway: OpenRouter does
+not carry it, so the calibrated default is not an option and an explicit `via openrouter` for it
+is reported as not honourable instead of being dispatched onto a name OpenRouter would reject.
+Everything else in the same message keeps the default. This is not a comparability loophole: a
+model OpenRouter carries is never moved to the gateway unless a human asks with `via litellm`.
+
 Everything here degrades to the previous behaviour when the gateway is not configured: the
-availability lookup returns "unknown", nothing is reported, and `route` stays `openrouter`.
+availability lookup returns "unknown", nothing is reported, resolution searches OpenRouter alone
+(and says so when it fails), and `route` stays `openrouter`.
 A `via litellm` request the poller cannot confirm (availability `unknown` or `not on the
-gateway`, for *any* model in the message) is **downgraded to `openrouter` with a warning in the
+gateway`, for any model in the message that OpenRouter *does* carry - a gateway-only model is not
+evidence against the gateway) is **downgraded to `openrouter` with a warning in the
 reply** rather than dispatched — a run over a gateway that does not serve the model would fail
 every probe and read as a model failure. On a manual `workflow_dispatch` with `route: litellm`
 but no secrets, `integrate-model.yml` logs a workflow warning and probes over OpenRouter rather
@@ -245,8 +263,12 @@ those pairs separate icons - one entry would restyle them all.
 `automation.icons.DEFAULT_ICONS` is the registry, and its defaults reproduce
 exactly what the flow sends today, so an unset variable changes nothing.
 
-Every message site names its role (`slack reply --icon <role>`), so the emoji is
-no longer in the message text.
+Every message site names its role, so no emoji is left in message text: the workflow-driven
+notifications pass `slack reply --icon <role>`, and the messages the poller BUILDS in Python
+(its reply to a request) call `icons.icon(role, overrides)` per line. Both are swept by
+`tools/automation/tests/test_icons.py`, which fails on a literal shortcode in either the
+workflows or the automation sources - the poller's reply shipped with four hardcoded icons
+because that sweep originally covered the workflows only.
 
 Four behaviours worth knowing:
 
@@ -263,6 +285,11 @@ Four behaviours worth knowing:
 
 This does not extend to reactions: `reactions.add` fails with `invalid_name` on
 an emoji the workspace lacks, so a reaction vocabulary has to stay standard.
+
+An unknown role costs only the STYLING: the message is sent unstyled and the bad role is raised
+as a workflow annotation. `icons.icon()` itself still raises (a role is written by this codebase,
+so a bad one is a bug here, not a user typo), but the CLI wrappers catch everything and exit 0,
+which would otherwise turn that raise into a silently dropped notification on a green step.
 
 Messages are emoji-prefixed and carry the run URL. `mention` = the `SLACK_MENTIONS` users are
 pinged (terminal / attention states only):

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -152,11 +152,26 @@ request, resolves each free-text model phrase to a model slug DETERMINISTICALLY
 
 **Two catalogs, OpenRouter first.** A phrase is matched against the OpenRouter catalog and, only
 if that matches NOTHING, against the deployment's gateway catalog. A fallback rather than a union,
-deliberately: every phrase that resolves (or is ambiguous) against OpenRouter behaves exactly as
-before, so the calibrated default route never moves and a gateway that lists the same model under
+deliberately: a phrase that resolves (or is ambiguous) against OpenRouter is unaffected by the
+gateway, so the calibrated default route cannot move and a gateway that lists the same model under
 a second route name cannot turn a working request into a clarify reply. The fallback is what makes
-a gateway-ONLY model requestable at all - `integrate azure_ai/cohere-command-a-plus-05-2026` used
-to come back "no matching model on OpenRouter" even when the gateway served it.
+a gateway-ONLY model such as `azure_ai/cohere-command-a-plus-05-2026` requestable.
+
+A gateway catalog is a routing table rather than a model list, so only part of it is a candidate: a
+wildcard (`x-ai/*`) is a passthrough, an id the OpenRouter catalog already carries (bare or under
+one route prefix) is the same model under a second name, and an id outside the slug charset can
+never be integrated because a slug reaches the shell.
+
+**Known limits of the gateway-only path.** Two things do not follow automatically, and both surface
+in the reply rather than being discovered mid-run:
+
+- `automation ensure-pricing` resolves a price by exact id against the OpenRouter catalog, so a
+  gateway-only id never matches. Without a `pricing.json` entry, `COST_USD_POPULATED` (a
+  non-opt-out CORE capability) fails in observe.
+- the run's gateway `.env` is job-wide, so the gateway must also serve the wire probes' user
+  simulator (`anthropic/claude-sonnet-4.6`). The poller checks it and downgrades an explicit
+  `via litellm` when it is missing; a gateway-only model has no route to downgrade to, so it is
+  warned about instead.
 
 ### Integration route (OpenRouter vs the LLM gateway)
 
@@ -203,9 +218,9 @@ is reported as not honourable instead of being dispatched onto a name OpenRouter
 Everything else in the same message keeps the default. This is not a comparability loophole: a
 model OpenRouter carries is never moved to the gateway unless a human asks with `via litellm`.
 
-Everything here degrades to the previous behaviour when the gateway is not configured: the
-availability lookup returns "unknown", nothing is reported, resolution searches OpenRouter alone
-(and says so when it fails), and `route` stays `openrouter`.
+With no gateway configured the flow is OpenRouter-only: the availability lookup returns
+"unknown", nothing is reported, resolution searches OpenRouter alone (and says so when it fails),
+and `route` stays `openrouter`.
 A `via litellm` request the poller cannot confirm (availability `unknown` or `not on the
 gateway`, for any model in the message that OpenRouter *does* carry - a gateway-only model is not
 evidence against the gateway) is **downgraded to `openrouter` with a warning in the
@@ -266,9 +281,9 @@ exactly what the flow sends today, so an unset variable changes nothing.
 Every message site names its role, so no emoji is left in message text: the workflow-driven
 notifications pass `slack reply --icon <role>`, and the messages the poller BUILDS in Python
 (its reply to a request) call `icons.icon(role, overrides)` per line. Both are swept by
-`tools/automation/tests/test_icons.py`, which fails on a literal shortcode in either the
-workflows or the automation sources - the poller's reply shipped with four hardcoded icons
-because that sweep originally covered the workflows only.
+`tools/automation/tests/test_icons.py`, which fails on an emoji literal in either the workflows or
+the automation sources. It is a tripwire rather than a proof: it sees literals and unicode emoji
+characters, so an emoji assembled at runtime would still need catching by review.
 
 Four behaviours worth knowing:
 

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -6,7 +6,6 @@ the logic stays unit-testable and the GitHub Actions workflow is a thin caller.
 from __future__ import annotations
 
 import json
-import os
 
 import typer
 
@@ -152,13 +151,10 @@ def resolve_models(
     """Deterministically resolve the model phrases in a Slack request to model slugs.
     Prints a JSON list of {query, status, slug, candidates, source} for the poller to act on.
 
-    Searches the same two catalogs as the poller - OpenRouter, then the gateway from
-    ``LLM_PROXY_BASE_URL`` / ``LLM_PROXY_API_KEY`` - so debugging a request by hand cannot
-    disagree with what the poll actually did."""
+    Searches the same two catalogs as the poller, through the same accessor, so debugging a
+    request by hand cannot disagree with what the poll actually did."""
     catalog = model_resolver.fetch_openrouter_catalog()
-    gateway_entries = gateway_catalog.fetch_gateway_catalog(
-        os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
-    )
+    gateway_entries = gateway_catalog.fetch_configured_catalog()
     resolutions = model_resolver.resolve_all(request, catalog, gateway_entries=gateway_entries)
     typer.echo(json.dumps([model_resolver.as_dict(r) for r in resolutions], indent=2))
 

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -6,11 +6,13 @@ the logic stays unit-testable and the GitHub Actions workflow is a thin caller.
 from __future__ import annotations
 
 import json
+import os
 
 import typer
 
 from automation import (
     cert,
+    gateway_catalog,
     greencheck,
     model_resolver,
     observe,
@@ -147,10 +149,17 @@ def resolve_models(
         ..., help="free-text integrate request, e.g. 'integrate Grok 4.5 and GPT 5.6'"
     ),
 ) -> None:
-    """Deterministically resolve the model phrases in a Slack request to OpenRouter slugs.
-    Prints a JSON list of {query, status, slug, candidates} for the poller to act on."""
+    """Deterministically resolve the model phrases in a Slack request to model slugs.
+    Prints a JSON list of {query, status, slug, candidates, source} for the poller to act on.
+
+    Searches the same two catalogs as the poller - OpenRouter, then the gateway from
+    ``LLM_PROXY_BASE_URL`` / ``LLM_PROXY_API_KEY`` - so debugging a request by hand cannot
+    disagree with what the poll actually did."""
     catalog = model_resolver.fetch_openrouter_catalog()
-    resolutions = model_resolver.resolve_all(request, catalog)
+    gateway_entries = gateway_catalog.fetch_gateway_catalog(
+        os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
+    )
+    resolutions = model_resolver.resolve_all(request, catalog, gateway_entries=gateway_entries)
     typer.echo(json.dumps([model_resolver.as_dict(r) for r in resolutions], indent=2))
 
 

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import urllib.error
 import urllib.request
 
@@ -100,6 +101,31 @@ def fetch_gateway_catalog(
     return sorted(
         str(entry["id"]) for entry in entries if isinstance(entry, dict) and entry.get("id")
     )
+
+
+#: Env names carrying the gateway contract. Read from ``os.environ`` rather than through
+#: ``SecretManager`` (AGENTS.md § Secrets) for one reason that applies to every caller here: this
+#: package is a standalone workspace member without the engine's secrets stack, and the entry
+#: points are CI-only, where the credential arrives through the workflow's ``env:``. Going through
+#: ``DotEnvProvider`` would additionally give a developer's local ``.env`` precedence, which is
+#: how a dev gateway would end up answering a real poll.
+ENV_BASE_URL = "LLM_PROXY_BASE_URL"
+ENV_API_KEY = "LLM_PROXY_API_KEY"
+
+#: The user simulator the wire probes run, from ``integrate-model.yml``. On the gateway route that
+#: workflow's ``.env`` is JOB-WIDE, so the simulator is proxied too and the gateway must serve it
+#: as well - otherwise observe goes infra-dirty in the simulator rather than in the candidate.
+#: Pinned against the workflow by a test, since a rename there would silently void that check.
+USER_SIMULATOR_SLUG = "anthropic/claude-sonnet-4.6"
+
+
+def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
+    """The gateway catalog for THIS deployment, or ``None`` when there is no readable gateway.
+
+    The single owner of the environment read, so every caller sees the same catalog the poll
+    does; a hand-run diagnostic that disagreed with the poll would be worse than no diagnostic.
+    """
+    return fetch_gateway_catalog(os.environ.get(ENV_BASE_URL), os.environ.get(ENV_API_KEY), timeout)
 
 
 def lookup(slug: str, catalog: list[str] | None) -> Availability:

--- a/tools/automation/src/automation/icons.py
+++ b/tools/automation/src/automation/icons.py
@@ -55,6 +55,16 @@ DEFAULT_ICONS: dict[str, str] = {
     "needs_human_agent": ":raising_hand:",
     "pipeline_error": ":rotating_light:",
     "dispatch_failed": ":x:",
+    # Request intake: the poller's in-thread reply to an "@bot integrate ..." message. These
+    # address the REQUESTER, before any PR exists, which is why none of them reuses a
+    # pipeline-stage role that happens to share a glyph today - `dispatch_failed` (:x:) is an
+    # infra failure AFTER resolution succeeded, while `request_unresolved` is a name that matched
+    # nothing, and a workspace will want to tell those apart.
+    "request_resolved": ":white_check_mark:",
+    "request_ambiguous": ":warning:",
+    "request_unresolved": ":x:",
+    # A `via <route>` directive that could not be honoured.
+    "route_downgraded": ":warning:",
 }
 
 # Slack emoji names are lowercase letters, digits, and - _ +. Anything else

--- a/tools/automation/src/automation/model_resolver.py
+++ b/tools/automation/src/automation/model_resolver.py
@@ -18,6 +18,17 @@ Then 0 matches -> none; 1 -> resolved; >1 -> if exactly one candidate's MODEL-pa
 tokens equal the phrase's alpha tokens, resolve to it (so "gpt 5.6 sol" picks ``gpt-5.6-sol``
 over ``gpt-5.6-sol-pro``); otherwise AMBIGUOUS with every candidate listed.
 
+Which catalogs are searched
+---------------------------
+
+OpenRouter first; the deployment's LLM-gateway catalog is a FALLBACK, consulted only for a
+phrase OpenRouter cannot match at all. Fallback rather than a union, deliberately: every
+phrase that resolves (or is ambiguous) against OpenRouter today behaves identically, so the
+calibrated default route never moves and a gateway listing the same model under a second
+route name cannot turn a working request into a clarify reply. The fallback is the only way
+a gateway-ONLY model can be requested at all - before it existed, ``azure_ai/cohere-...``
+came back as "no matching model on OpenRouter" even though the gateway served it.
+
 Only the network fetch (:func:`fetch_openrouter_catalog`) does I/O; everything the tests
 care about is pure and catalog-injected.
 """
@@ -29,14 +40,20 @@ import json
 import re
 import urllib.request
 
-from automation import gateway_catalog
+from automation import gateway_catalog, icons
 
 _OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 # Maximal alpha runs (keeping a trailing "+", so "a+" != "a" and Cohere "A+" never collapses
 # onto "command-a") OR dotted-number runs; splits glued names ("gpt5.6" -> gpt, 5.6) and
 # ignores every other separator (space / _ / - / /).
 _TOKEN_RE = re.compile(r"[a-z]+\+?|\d+(?:\.\d+)*")
-_CONNECTOR_RE = re.compile(r"\s*(?:,|&|\band\b|\bplus\b)\s*", re.IGNORECASE)
+# Request connectors, for "integrate a and b". The WORD connectors require
+# surrounding whitespace; `\band\b` / `\bplus\b` alone would fire inside a slug,
+# because a hyphen is a regex word boundary. That tore
+# `azure_ai/cohere-command-a-plus-05-2026` into two halves and, worse, silently
+# reduced `cohere/command-a-plus` to `cohere/command-a-` - a DIFFERENT model name
+# that could go on to match something real.
+_CONNECTOR_RE = re.compile(r"\s*(?:,|&)\s*|\s+(?:and|plus)\s+", re.IGNORECASE)
 _MENTION_RE = re.compile(r"<@[^>]+>")
 _INTEGRATE_RE = re.compile(r"\bintegrate\b", re.IGNORECASE)
 # Optional route directive: "integrate Grok 4.5 via litellm". Stripped BEFORE the phrases are
@@ -56,6 +73,13 @@ _GATEWAY_WORDS = frozenset({"litellm", "gateway", "proxy"})
 _OPENROUTER_WORDS = frozenset({"openrouter", "or"})
 
 
+#: Which catalog held a resolved slug. This decides the ROUTE: a model OpenRouter carries
+#: keeps the calibrated OpenRouter path, while one that exists only on the gateway can run
+#: nowhere else, so it pins its own route (:func:`route_for`).
+SOURCE_OPENROUTER = "openrouter"
+SOURCE_GATEWAY = "gateway"
+
+
 @dataclasses.dataclass(frozen=True)
 class _Tokens:
     alpha: frozenset[str]
@@ -70,6 +94,10 @@ class Resolution:
     status: str
     slug: str | None = None
     candidates: tuple[str, ...] = ()
+    #: Which catalog the slug came from (:data:`SOURCE_OPENROUTER` / :data:`SOURCE_GATEWAY`).
+    #: Defaults to OpenRouter, which is what every resolution meant before the gateway
+    #: fallback existed.
+    source: str = SOURCE_OPENROUTER
 
 
 def _tokenize(text: str) -> _Tokens:
@@ -133,10 +161,82 @@ def parse_command(text: str) -> list[str]:
     return [phrase for chunk in _CONNECTOR_RE.split(tail) if (phrase := chunk.strip(" .\t\r\n"))]
 
 
-def resolve(query: str, catalog: list[str], aliases: dict[str, str] | None = None) -> Resolution:
-    """Deterministically resolve one phrase against ``catalog`` (list of OpenRouter slugs).
-    ``aliases`` (lowercased phrase -> slug) covers opaque internal shortnames like ``hy3`` that
-    no string match can reach; it is consulted first."""
+def _gateway_candidates(entries: list[str] | None, openrouter_slugs: set[str]) -> list[str]:
+    """The gateway route ids that are model names in their own right.
+
+    A gateway catalog is a routing table, not a model list, so most of it must not become a
+    resolution candidate:
+
+    * a wildcard (``x-ai/*``, ``*``) is a passthrough, not a model name;
+    * an id the OpenRouter catalog already carries adds no new candidate - the fallback only
+      runs when OpenRouter matched nothing, so such an entry cannot match either;
+    * an id that is an OpenRouter slug under a route prefix (``openrouter/x-ai/grok-4.5``) is
+      the SAME model under a second name, and :func:`gateway_catalog.lookup` documents that
+      prefixed route as one this flow cannot reach anyway.
+
+    What survives is exactly what OpenRouter does not carry - a gateway-only route such as
+    ``azure_ai/cohere-command-a-plus-05-2026``.
+    """
+    if not entries:
+        return []
+    candidates = []
+    for entry in entries:
+        slug = entry.strip()
+        if not slug or "*" in slug or slug in openrouter_slugs:
+            continue
+        if slug.split("/", 1)[-1] in openrouter_slugs:  # an OpenRouter slug under a route prefix
+            continue
+        candidates.append(slug)
+    return candidates
+
+
+def route_for(resolution: Resolution, requested_route: str | None = None) -> str:
+    """The route a resolved phrase must run over.
+
+    A gateway-only model pins the gateway even when nothing was requested: OpenRouter does not
+    carry it, so the calibrated default is not an option and an explicit ``via openrouter``
+    cannot be honoured (the caller says so in the reply). Everything else keeps the requested
+    route, or the calibrated default.
+    """
+    if resolution.source == SOURCE_GATEWAY:
+        return gateway_catalog.ROUTE_GATEWAY
+    return requested_route or gateway_catalog.DEFAULT_ROUTE
+
+
+def resolve(
+    query: str,
+    catalog: list[str],
+    aliases: dict[str, str] | None = None,
+    gateway_entries: list[str] | None = None,
+) -> Resolution:
+    """Deterministically resolve one phrase, OpenRouter first and the gateway as a fallback.
+
+    ``catalog`` is the OpenRouter slug list; ``gateway_entries`` the deployment's gateway
+    catalog (``None`` when there is no gateway or it could not be read). The gateway is only
+    consulted for a phrase OpenRouter matched NOTHING for - see the module docstring for why
+    this is a fallback and not a union. ``aliases`` (lowercased phrase -> slug) covers opaque
+    internal shortnames like ``hy3`` that no string match can reach; it is consulted first.
+    """
+    primary = _resolve_against(query, catalog, aliases)
+    gateway = _gateway_candidates(gateway_entries, set(catalog))
+    if primary.status == "resolved":
+        # Only reachable through an alias: the token path returns catalog members only. An alias
+        # pointing at a gateway-only route must still be routed there.
+        if primary.slug not in set(catalog) and primary.slug in set(gateway):
+            return dataclasses.replace(primary, source=SOURCE_GATEWAY)
+        return primary
+    if primary.status != "none" or not gateway:
+        return primary
+    fallback = _resolve_against(query, gateway, None)
+    if fallback.status == "none":
+        return primary  # nothing anywhere; keep the primary answer
+    return dataclasses.replace(fallback, source=SOURCE_GATEWAY)
+
+
+def _resolve_against(
+    query: str, catalog: list[str], aliases: dict[str, str] | None = None
+) -> Resolution:
+    """One phrase against ONE catalog. The matching rule in the module docstring, verbatim."""
     stripped = query.strip()
     if aliases and (alias_slug := aliases.get(stripped.lower())):
         return Resolution(query, "resolved", slug=alias_slug)
@@ -166,10 +266,13 @@ def resolve(query: str, catalog: list[str], aliases: dict[str, str] | None = Non
 
 
 def resolve_all(
-    text: str, catalog: list[str], aliases: dict[str, str] | None = None
+    text: str,
+    catalog: list[str],
+    aliases: dict[str, str] | None = None,
+    gateway_entries: list[str] | None = None,
 ) -> list[Resolution]:
     """Parse a command and resolve every phrase in it."""
-    return [resolve(phrase, catalog, aliases) for phrase in parse_command(text)]
+    return [resolve(phrase, catalog, aliases, gateway_entries) for phrase in parse_command(text)]
 
 
 def format_resolution_reply(
@@ -177,6 +280,8 @@ def format_resolution_reply(
     resolutions: list[Resolution],
     availability: dict[str, gateway_catalog.Availability] | None = None,
     requested_route: str | None = None,
+    gateway_searched: bool = False,
+    overrides: dict[str, str] | None = None,
 ) -> str:
     """Slack mrkdwn reply: what started, and which phrases need an exact slug. The requester
     is pinged at the top so the ambiguous re-request lands on the right person.
@@ -185,34 +290,62 @@ def format_resolution_reply(
     deployment's LLM gateway could serve it — advisory only, since a gateway route may be
     backed by a different upstream and that is a comparability call for a human.
     ``requested_route`` echoes an explicit ``via <route>`` directive so the requester can
-    see it was honoured; absent, the default route is used and named."""
+    see it was honoured; absent, the default route is used and named. The route is named PER
+    MODEL, because a gateway-only model pins its own (:func:`route_for`).
+
+    Every icon here comes from the role registry, so a workspace override restyles the whole
+    reply; ``overrides`` is injectable for tests and resolved once otherwise.
+
+    ``gateway_searched`` says whether the gateway catalog was readable, so a failure can name
+    what was actually consulted. Reporting "no matching model on OpenRouter" when a configured
+    gateway had never been searched is what sent a requester chasing a name that was fine."""
+    # Resolved ONCE: icons.icon() re-reads and re-parses the env JSON whenever it is handed
+    # None, and this function emits one icon per requested model.
+    if overrides is None:
+        overrides = icons.load_icon_overrides()
     lines = [f"<@{requester_id}> here is what I could resolve from your request:", ""]
-    effective_route = requested_route or gateway_catalog.DEFAULT_ROUTE
+    searched = "OpenRouter or the gateway" if gateway_searched else "OpenRouter"
     for r in resolutions:
         if r.status == "resolved":
             lines.append(
-                f":white_check_mark: *{r.query}*: starting integration as `{r.slug}` "
-                f"via *{effective_route}*"
+                f"{icons.icon('request_resolved', overrides)} *{r.query}*: starting "
+                f"integration as `{r.slug}` via *{route_for(r, requested_route)}*"
             )
+            if r.source == SOURCE_GATEWAY:
+                lines.append(
+                    "    ◦ only on the gateway, not on OpenRouter, so it can run nowhere else"
+                )
+            # Suppressed for a gateway-sourced model: "ALSO on the gateway" reads as "in
+            # addition to OpenRouter", which is exactly what is not true, and the line above
+            # already said where it lives.
             note = (
                 gateway_catalog.describe(availability[r.slug])
-                if availability and r.slug in availability
+                if availability and r.slug in availability and r.source == SOURCE_OPENROUTER
                 else ""
             )
             if note:
                 lines.append(f"    ◦ {note}")
         elif r.status == "ambiguous":
             lines.append(
-                f":warning: *{r.query}* is ambiguous ({len(r.candidates)} matches). "
-                "Re-request with one of these exact slugs:"
+                f"{icons.icon('request_ambiguous', overrides)} *{r.query}* is ambiguous "
+                f"({len(r.candidates)} matches). Re-request with one of these exact slugs:"
             )
             lines += [f"    • `{slug}`" for slug in r.candidates]
         else:
+            unsearched = (
+                ""
+                if gateway_searched
+                else " (no gateway catalog was readable, so only OpenRouter was searched)"
+            )
             lines.append(
-                f":x: *{r.query}*: no matching model on OpenRouter. Check the name and version."
+                f"{icons.icon('request_unresolved', overrides)} *{r.query}*: no matching "
+                f"model on {searched}. Check the name and version.{unsearched}"
             )
     if requested_route is None and availability:
-        if any(a.reachable for a in availability.values()):
+        openrouter_sourced = [r for r in resolutions if r.source == SOURCE_OPENROUTER and r.slug]
+        if openrouter_sourced and any(
+            availability[r.slug].reachable for r in openrouter_sourced if r.slug in availability
+        ):
             lines += [
                 "",
                 f"_Default route is *{gateway_catalog.DEFAULT_ROUTE}*. To use the gateway "
@@ -228,6 +361,7 @@ def as_dict(resolution: Resolution) -> dict:
         "status": resolution.status,
         "slug": resolution.slug,
         "candidates": list(resolution.candidates),
+        "source": resolution.source,
     }
 
 

--- a/tools/automation/src/automation/model_resolver.py
+++ b/tools/automation/src/automation/model_resolver.py
@@ -22,12 +22,11 @@ Which catalogs are searched
 ---------------------------
 
 OpenRouter first; the deployment's LLM-gateway catalog is a FALLBACK, consulted only for a
-phrase OpenRouter cannot match at all. Fallback rather than a union, deliberately: every
-phrase that resolves (or is ambiguous) against OpenRouter today behaves identically, so the
-calibrated default route never moves and a gateway listing the same model under a second
-route name cannot turn a working request into a clarify reply. The fallback is the only way
-a gateway-ONLY model can be requested at all - before it existed, ``azure_ai/cohere-...``
-came back as "no matching model on OpenRouter" even though the gateway served it.
+phrase OpenRouter cannot match at all. Fallback rather than a union, deliberately: a phrase
+that resolves (or is ambiguous) against OpenRouter is unaffected by the gateway, so the
+calibrated default route cannot move and a gateway listing the same model under a second
+route name cannot turn a working request into a clarify reply. The fallback is what makes a
+gateway-ONLY model (``azure_ai/cohere-command-a-plus-05-2026``) requestable.
 
 Only the network fetch (:func:`fetch_openrouter_catalog`) does I/O; everything the tests
 care about is pure and catalog-injected.
@@ -47,13 +46,23 @@ _OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 # onto "command-a") OR dotted-number runs; splits glued names ("gpt5.6" -> gpt, 5.6) and
 # ignores every other separator (space / _ / - / /).
 _TOKEN_RE = re.compile(r"[a-z]+\+?|\d+(?:\.\d+)*")
-# Request connectors, for "integrate a and b". The WORD connectors require
-# surrounding whitespace; `\band\b` / `\bplus\b` alone would fire inside a slug,
-# because a hyphen is a regex word boundary. That tore
-# `azure_ai/cohere-command-a-plus-05-2026` into two halves and, worse, silently
-# reduced `cohere/command-a-plus` to `cohere/command-a-` - a DIFFERENT model name
-# that could go on to match something real.
-_CONNECTOR_RE = re.compile(r"\s*(?:,|&)\s*|\s+(?:and|plus)\s+", re.IGNORECASE)
+# Request connectors, for "integrate a, b and c". Two rules do the work:
+#
+#  * a WORD connector must be delimited by whitespace (or the end of the request). A hyphen is a
+#    regex word boundary, so a bare `\band\b` / `\bplus\b` also fires INSIDE a slug and turns
+#    `cohere/command-a-plus` into `cohere/command-a-` - a different model name that may still
+#    match something real.
+#  * punctuation may carry a word connector with it, because `a, b, and c` is how English writes
+#    a list. Punctuation consumes the space after itself, so the following `and` has no
+#    whitespace on its left and has to be matched here rather than by the word rule.
+_CONNECTOR_RE = re.compile(
+    r"\s*[,&]\s*(?:(?:and|plus)(?:\s+|$))?|\s+(?:and|plus)(?:\s+|$)", re.IGNORECASE
+)
+# The charset a model slug may use. OpenRouter ids are strict slugs, but a gateway catalog is a
+# deployment's own routing table and its ids are free-form, while a slug flows into shell (branch
+# name, PR title, `gh workflow run -f model=`). A candidate that fails this cannot be integrated,
+# and offering it back as a "re-request with this exact slug" clarification would loop forever.
+SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
 _MENTION_RE = re.compile(r"<@[^>]+>")
 _INTEGRATE_RE = re.compile(r"\bintegrate\b", re.IGNORECASE)
 # Optional route directive: "integrate Grok 4.5 via litellm". Stripped BEFORE the phrases are
@@ -95,8 +104,7 @@ class Resolution:
     slug: str | None = None
     candidates: tuple[str, ...] = ()
     #: Which catalog the slug came from (:data:`SOURCE_OPENROUTER` / :data:`SOURCE_GATEWAY`).
-    #: Defaults to OpenRouter, which is what every resolution meant before the gateway
-    #: fallback existed.
+    #: Defaults to OpenRouter, the calibrated route.
     source: str = SOURCE_OPENROUTER
 
 
@@ -168,13 +176,15 @@ def _gateway_candidates(entries: list[str] | None, openrouter_slugs: set[str]) -
     resolution candidate:
 
     * a wildcard (``x-ai/*``, ``*``) is a passthrough, not a model name;
-    * an id the OpenRouter catalog already carries adds no new candidate - the fallback only
-      runs when OpenRouter matched nothing, so such an entry cannot match either;
-    * an id that is an OpenRouter slug under a route prefix (``openrouter/x-ai/grok-4.5``) is
-      the SAME model under a second name, and :func:`gateway_catalog.lookup` documents that
-      prefixed route as one this flow cannot reach anyway.
+    * an id outside :data:`SAFE_SLUG_RE` can never be integrated (a slug reaches the shell), so
+      offering it as a candidate could only produce a clarification nobody can satisfy;
+    * an id the OpenRouter catalog already carries, bare or under one route prefix
+      (``openrouter/x-ai/grok-4.5``), is the same model under a second name. Letting one model
+      resolve under two names is a serving-path decision, not a transport detail. Only ONE prefix
+      is stripped, so a doubly-prefixed alias survives - unreachable in practice, since the
+      fallback runs only for a phrase no OpenRouter slug matched.
 
-    What survives is exactly what OpenRouter does not carry - a gateway-only route such as
+    What survives is what OpenRouter does not carry - a gateway-only route such as
     ``azure_ai/cohere-command-a-plus-05-2026``.
     """
     if not entries:
@@ -182,9 +192,9 @@ def _gateway_candidates(entries: list[str] | None, openrouter_slugs: set[str]) -
     candidates = []
     for entry in entries:
         slug = entry.strip()
-        if not slug or "*" in slug or slug in openrouter_slugs:
+        if not slug or "*" in slug or not SAFE_SLUG_RE.match(slug):
             continue
-        if slug.split("/", 1)[-1] in openrouter_slugs:  # an OpenRouter slug under a route prefix
+        if slug in openrouter_slugs or slug.split("/", 1)[-1] in openrouter_slugs:
             continue
         candidates.append(slug)
     return candidates
@@ -217,12 +227,15 @@ def resolve(
     this is a fallback and not a union. ``aliases`` (lowercased phrase -> slug) covers opaque
     internal shortnames like ``hy3`` that no string match can reach; it is consulted first.
     """
+    openrouter_slugs = set(catalog)
     primary = _resolve_against(query, catalog, aliases)
-    gateway = _gateway_candidates(gateway_entries, set(catalog))
+    gateway = _gateway_candidates(gateway_entries, openrouter_slugs)
     if primary.status == "resolved":
-        # Only reachable through an alias: the token path returns catalog members only. An alias
-        # pointing at a gateway-only route must still be routed there.
-        if primary.slug not in set(catalog) and primary.slug in set(gateway):
+        # Reachable only through an alias, since the token path returns catalog members. A slug
+        # OpenRouter does not carry cannot run there whatever the gateway catalog says - or fails
+        # to say, when it could not be read - so membership of the OPENROUTER catalog is what
+        # decides the route.
+        if primary.slug not in openrouter_slugs:
             return dataclasses.replace(primary, source=SOURCE_GATEWAY)
         return primary
     if primary.status != "none" or not gateway:
@@ -282,6 +295,7 @@ def format_resolution_reply(
     requested_route: str | None = None,
     gateway_searched: bool = False,
     overrides: dict[str, str] | None = None,
+    route_downgraded: bool = False,
 ) -> str:
     """Slack mrkdwn reply: what started, and which phrases need an exact slug. The requester
     is pinged at the top so the ambiguous re-request lands on the right person.
@@ -296,9 +310,12 @@ def format_resolution_reply(
     Every icon here comes from the role registry, so a workspace override restyles the whole
     reply; ``overrides`` is injectable for tests and resolved once otherwise.
 
-    ``gateway_searched`` says whether the gateway catalog was readable, so a failure can name
-    what was actually consulted. Reporting "no matching model on OpenRouter" when a configured
-    gateway had never been searched is what sent a requester chasing a name that was fine."""
+    ``route_downgraded`` says a ``via <route>`` directive could not be honoured, which is the
+    other reason ``requested_route`` can arrive as ``None``; the closing default-route hint is
+    suppressed then, since the downgrade warning covers it.
+
+    ``gateway_searched`` says whether the gateway catalog was readable, so a failure names what
+    was actually consulted rather than sending a requester to check a name that is fine."""
     # Resolved ONCE: icons.icon() re-reads and re-parses the env JSON whenever it is handed
     # None, and this function emits one icon per requested model.
     if overrides is None:
@@ -312,8 +329,12 @@ def format_resolution_reply(
                 f"integration as `{r.slug}` via *{route_for(r, requested_route)}*"
             )
             if r.source == SOURCE_GATEWAY:
+                # About the NAME, not the model: a gateway route can be the same model under
+                # another vendor prefix, and which upstream serves a model is a comparability
+                # call for a human rather than a claim to make here.
                 lines.append(
-                    "    ◦ only on the gateway, not on OpenRouter, so it can run nowhere else"
+                    "    ◦ no OpenRouter slug matched this name; it resolved from the gateway "
+                    "catalog, so it runs there"
                 )
             # Suppressed for a gateway-sourced model: "ALSO on the gateway" reads as "in
             # addition to OpenRouter", which is exactly what is not true, and the line above
@@ -341,7 +362,11 @@ def format_resolution_reply(
                 f"{icons.icon('request_unresolved', overrides)} *{r.query}*: no matching "
                 f"model on {searched}. Check the name and version.{unsearched}"
             )
-    if requested_route is None and availability:
+    # Suppressed after a downgrade: `requested_route` is None either because nothing was asked
+    # or because a `via litellm` could not be honoured, and in the second case this hint would
+    # tell a requester who just asked for the gateway to ask for the gateway. The downgrade
+    # warning already says what to do instead.
+    if requested_route is None and availability and not route_downgraded:
         openrouter_sourced = [r for r in resolutions if r.source == SOURCE_OPENROUTER and r.slug]
         if openrouter_sourced and any(
             availability[r.slug].reachable for r in openrouter_sourced if r.slug in availability

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -42,11 +42,12 @@ from automation import gateway_catalog, icons, model_resolver, slack
 # for a genuinely opaque codename, added here when one appears.
 ALIASES: dict[str, str] = {}
 
-# The charset a real OpenRouter slug ever uses. A resolved slug is always a live catalog id so it
-# passes, but the catalog is an EXTERNAL untrusted source and slugs flow into shell (branch name,
-# PR title/body, `gh workflow run -f model=`); a slug with a shell metacharacter is dropped, never
-# interpolated. Defence-in-depth behind the resolver's own "only ever returns a catalog entry".
-_SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+# The charset a model slug may use, shared with the resolver so there is one rule rather than two
+# copies to drift. A resolved slug is always a live catalog id so it passes, but a catalog is an
+# EXTERNAL untrusted source and slugs flow into shell (branch name, PR title/body, `gh workflow
+# run -f model=`); a slug with a shell metacharacter is dropped, never interpolated.
+# Defence-in-depth behind the resolver's own "only ever returns a catalog entry".
+_SAFE_SLUG_RE = model_resolver.SAFE_SLUG_RE
 
 # Sentinel for "the gateway catalog has not been fetched yet". Distinct from None, which is a
 # *fetched* answer meaning "no gateway configured or unreachable" — without it, an unreachable
@@ -117,6 +118,10 @@ class RoutePlan:
     routes: dict[str, str]
     warnings: tuple[str, ...]
     requested_route: str | None
+    #: True when a stated route could not be honoured. Both that and "nothing was asked" leave
+    #: ``requested_route`` as ``None``, and the reply has to tell them apart: only the second one
+    #: should go on to offer the gateway as an option.
+    downgraded: bool = False
 
 
 def route_plan(
@@ -124,6 +129,7 @@ def route_plan(
     availability: dict[str, gateway_catalog.Availability],
     requested_route: str | None,
     overrides: dict[str, str] | None = None,
+    simulator: gateway_catalog.Availability | None = None,
 ) -> RoutePlan:
     """Decide the route PER MODEL, and the warnings that make a non-honoured directive visible.
 
@@ -139,25 +145,43 @@ def route_plan(
       model failure. Only models OpenRouter CARRIES are considered here; a gateway-only model is
       not evidence against the gateway.
     * ``via openrouter`` for a model OpenRouter does not carry at all.
+
+    ``simulator`` is the gateway availability of the wire probes' user simulator. It belongs in
+    the same evidence, because the integration run's gateway ``.env`` is JOB-WIDE: the simulator
+    is proxied too, so a gateway that does not serve it sends observe infra-dirty in the
+    SIMULATOR rather than in the candidate. It can veto an explicit ``via litellm`` (that route
+    has a working alternative), but it cannot veto a gateway-only model, which has none - there
+    the requester is told what to fix before the run burns.
     """
     if overrides is None:
         overrides = icons.load_icon_overrides()
     warning_icon = icons.icon("route_downgraded", overrides)
     warnings: list[str] = []
+    downgraded = False
     gateway_only = [r for r in resolutions if r.source == model_resolver.SOURCE_GATEWAY and r.slug]
     downgradable = [
         r
         for r in resolutions
         if r.slug in availability and r.source != model_resolver.SOURCE_GATEWAY
     ]
-    if requested_route == gateway_catalog.ROUTE_GATEWAY and not all(
-        availability[r.slug].reachable for r in downgradable
+    simulator_unreachable = simulator is not None and not simulator.reachable
+    if requested_route == gateway_catalog.ROUTE_GATEWAY and (
+        simulator_unreachable or not all(availability[r.slug].reachable for r in downgradable)
     ):
         requested_route = None
+        downgraded = True
+        # The model-level reason first: it is the one the requester can see in the notes above.
+        # The simulator is only named when the requested models ARE covered, since then it is the
+        # whole reason and blaming "every model above" would send someone checking a fine name.
+        missing = (
+            "every model above (see the notes)"
+            if not all(availability[r.slug].reachable for r in downgradable)
+            else f"the wire probes' user simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`)"
+        )
         warnings.append(
-            f"{warning_icon} I could not confirm the gateway serves every model above "
-            f"(see the notes), so this runs over *{gateway_catalog.DEFAULT_ROUTE}*. "
-            "Add the model to the gateway (or check its secrets) and re-request."
+            f"{warning_icon} I could not confirm the gateway serves {missing}, so the models "
+            f"OpenRouter carries run over *{gateway_catalog.DEFAULT_ROUTE}*. Add it to the "
+            "gateway (or check its secrets) and re-request."
         )
     if requested_route == gateway_catalog.ROUTE_OPENROUTER and gateway_only:
         names = ", ".join(f"`{r.slug}`" for r in gateway_only)
@@ -170,7 +194,22 @@ def route_plan(
         for r in resolutions
         if r.status == "resolved" and r.slug
     }
-    return RoutePlan(routes=routes, warnings=tuple(warnings), requested_route=requested_route)
+    if simulator_unreachable and gateway_catalog.ROUTE_GATEWAY in routes.values():
+        # Reached only by a gateway-ONLY model, which the downgrade above cannot help: there is no
+        # OpenRouter route for it. Say what will go wrong and what fixes it, since the run itself
+        # would report a user-simulator failure that reads like nothing to do with the gateway.
+        warnings.append(
+            f"{warning_icon} I could not confirm the gateway serves the wire probes' user "
+            f"simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`). The integration run proxies "
+            "it too, so observe may go infra-dirty in the simulator rather than in the "
+            "candidate. Add it to the gateway if that happens."
+        )
+    return RoutePlan(
+        routes=routes,
+        warnings=tuple(warnings),
+        requested_route=requested_route,
+        downgraded=downgraded,
+    )
 
 
 def resolved_slugs(resolutions: list[model_resolver.Resolution]) -> list[str]:
@@ -294,15 +333,7 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             # Fetched BEFORE resolution, not after: resolution falls back to this catalog for a
             # phrase OpenRouter cannot match, which is the only way a gateway-only model
             # (`azure_ai/...`) can be requested at all.
-            #
-            # Read from os.environ, not SecretManager (AGENTS.md § Secrets): the poller is a
-            # CI-only entrypoint whose credentials come from workflow `env:`, and DotEnvProvider's
-            # `.env` precedence would let a developer's local gateway leak into a real poll. Same
-            # rationale as SLACK_BOT_TOKEN above. Revisit if this tool ever gains a SecretManager
-            # bootstrap.
-            gateway_models = gateway_catalog.fetch_gateway_catalog(
-                os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
-            )
+            gateway_models = gateway_catalog.fetch_configured_catalog()
         text = message.get("text", "")
         resolutions = model_resolver.resolve_all(text, catalog, ALIASES, gateway_models)
         if not resolutions:  # mention + "integrate" but no parseable model phrase
@@ -323,13 +354,19 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
         # every probe would fail against a gateway we already know does not serve it -- either
         # way a reply saying "via litellm" would misrecord the serving path. Refuse in the
         # reply instead of dispatching a run whose outcome would read as a model failure.
-        plan_routes = route_plan(resolutions, availability, requested_route)
+        plan_routes = route_plan(
+            resolutions,
+            availability,
+            requested_route,
+            simulator=gateway_catalog.lookup(gateway_catalog.USER_SIMULATOR_SLUG, gateway_models),
+        )
         reply = model_resolver.format_resolution_reply(
             requester,
             resolutions,
             availability,
             plan_routes.requested_route,
             gateway_searched=gateway_models is not None,
+            route_downgraded=plan_routes.downgraded,
         )
         if plan_routes.warnings:
             reply = "\n\n".join([reply, *plan_routes.warnings])

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -209,11 +209,17 @@ def route_plan(
                 "a model only the gateway carries still runs there, so observe may go "
                 "infra-dirty in the simulator rather than in the candidate"
             )
+        # Two consequences point in opposite directions - one model falls back, another cannot -
+        # so they go on their own lines rather than into one sentence.
+        detail = (
+            f" {consequences[0]}."
+            if len(consequences) == 1
+            else "\n" + "\n".join(f"    • {clause}" for clause in consequences)
+        )
         warnings.append(
             f"{warning_icon} I could not confirm the gateway serves the wire probes' user "
             f"simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`), which the integration run "
-            f"proxies too: {'; '.join(consequences)}. Add it to the gateway (or check its "
-            "secrets)."
+            f"proxies too:{detail}\nAdd it to the gateway (or check its secrets)."
         )
     return RoutePlan(
         routes=routes,

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -164,25 +164,24 @@ def route_plan(
         for r in resolutions
         if r.slug in availability and r.source != model_resolver.SOURCE_GATEWAY
     ]
-    simulator_unreachable = simulator is not None and not simulator.reachable
+    models_unconfirmed = not all(availability[r.slug].reachable for r in downgradable)
+    simulator_unconfirmed = simulator is not None and not simulator.reachable
+    # Named in a message only when the catalog was READ and does not cover it. With no readable
+    # gateway there is nothing specific to say about one model, and pointing at the simulator
+    # would send someone checking a name that is fine.
+    simulator_absent = simulator is not None and simulator.status == gateway_catalog.STATUS_ABSENT
     if requested_route == gateway_catalog.ROUTE_GATEWAY and (
-        simulator_unreachable or not all(availability[r.slug].reachable for r in downgradable)
+        models_unconfirmed or simulator_unconfirmed
     ):
         requested_route = None
         downgraded = True
-        # The model-level reason first: it is the one the requester can see in the notes above.
-        # The simulator is only named when the requested models ARE covered, since then it is the
-        # whole reason and blaming "every model above" would send someone checking a fine name.
-        missing = (
-            "every model above (see the notes)"
-            if not all(availability[r.slug].reachable for r in downgradable)
-            else f"the wire probes' user simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`)"
-        )
-        warnings.append(
-            f"{warning_icon} I could not confirm the gateway serves {missing}, so the models "
-            f"OpenRouter carries run over *{gateway_catalog.DEFAULT_ROUTE}*. Add it to the "
-            "gateway (or check its secrets) and re-request."
-        )
+        if models_unconfirmed or not simulator_absent:
+            warnings.append(
+                f"{warning_icon} I could not confirm the gateway serves every model above "
+                f"(see the notes), so the models OpenRouter carries run over "
+                f"*{gateway_catalog.DEFAULT_ROUTE}*. Add the model to the gateway (or check its "
+                "secrets) and re-request."
+            )
     if requested_route == gateway_catalog.ROUTE_OPENROUTER and gateway_only:
         names = ", ".join(f"`{r.slug}`" for r in gateway_only)
         warnings.append(
@@ -194,15 +193,27 @@ def route_plan(
         for r in resolutions
         if r.status == "resolved" and r.slug
     }
-    if simulator_unreachable and gateway_catalog.ROUTE_GATEWAY in routes.values():
-        # Reached only by a gateway-ONLY model, which the downgrade above cannot help: there is no
-        # OpenRouter route for it. Say what will go wrong and what fixes it, since the run itself
-        # would report a user-simulator failure that reads like nothing to do with the gateway.
+    gateway_pinned = gateway_catalog.ROUTE_GATEWAY in routes.values()
+    if simulator_absent and (downgraded or gateway_pinned):
+        # ONE warning for one fact with two consequences: a model OpenRouter carries falls back,
+        # a gateway-only model cannot. Two warnings here read as the bot repeating itself, and a
+        # gateway-only model needs saying either way - the run would report a user-simulator
+        # failure that looks like nothing to do with the gateway.
+        consequences = []
+        if downgraded:
+            consequences.append(
+                f"the models OpenRouter carries run over *{gateway_catalog.DEFAULT_ROUTE}*"
+            )
+        if gateway_pinned:
+            consequences.append(
+                "a model only the gateway carries still runs there, so observe may go "
+                "infra-dirty in the simulator rather than in the candidate"
+            )
         warnings.append(
             f"{warning_icon} I could not confirm the gateway serves the wire probes' user "
-            f"simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`). The integration run proxies "
-            "it too, so observe may go infra-dirty in the simulator rather than in the "
-            "candidate. Add it to the gateway if that happens."
+            f"simulator (`{gateway_catalog.USER_SIMULATOR_SLUG}`), which the integration run "
+            f"proxies too: {'; '.join(consequences)}. Add it to the gateway (or check its "
+            "secrets)."
         )
     return RoutePlan(
         routes=routes,

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -34,7 +34,7 @@ import time
 
 import typer
 
-from automation import gateway_catalog, model_resolver, slack
+from automation import gateway_catalog, icons, model_resolver, slack
 
 # Opaque internal shortnames whose OpenRouter slug shares NO substring with the phrase go here
 # (lowercased phrase -> exact slug). Intentionally empty: almost everything resolves by token
@@ -104,6 +104,73 @@ def history_oldest(now: float, window_hours: float) -> str:
     if window_hours <= 0:
         return ""
     return f"{now - window_hours * 3600:.6f}"
+
+
+@dataclasses.dataclass(frozen=True)
+class RoutePlan:
+    """Which route each resolved model runs over, plus what to tell the requester.
+
+    ``requested_route`` is the directive AFTER any downgrade, so the reply reports the route
+    that will actually be used rather than the one that was asked for.
+    """
+
+    routes: dict[str, str]
+    warnings: tuple[str, ...]
+    requested_route: str | None
+
+
+def route_plan(
+    resolutions: list[model_resolver.Resolution],
+    availability: dict[str, gateway_catalog.Availability],
+    requested_route: str | None,
+    overrides: dict[str, str] | None = None,
+) -> RoutePlan:
+    """Decide the route PER MODEL, and the warnings that make a non-honoured directive visible.
+
+    Per model rather than per message because the two sides of a request can disagree: a
+    gateway-only model can run nowhere but the gateway, while everything else must keep the
+    calibrated OpenRouter default (changing a model's serving path silently is a
+    leaderboard-comparability decision, not a transport detail).
+
+    Two directives cannot be honoured, and each says so rather than being dropped:
+
+    * ``via litellm`` when the gateway is not confirmed to serve every downgradable model - the
+      run would fail against a gateway we already know lacks it, and the outcome would read as a
+      model failure. Only models OpenRouter CARRIES are considered here; a gateway-only model is
+      not evidence against the gateway.
+    * ``via openrouter`` for a model OpenRouter does not carry at all.
+    """
+    if overrides is None:
+        overrides = icons.load_icon_overrides()
+    warning_icon = icons.icon("route_downgraded", overrides)
+    warnings: list[str] = []
+    gateway_only = [r for r in resolutions if r.source == model_resolver.SOURCE_GATEWAY and r.slug]
+    downgradable = [
+        r
+        for r in resolutions
+        if r.slug in availability and r.source != model_resolver.SOURCE_GATEWAY
+    ]
+    if requested_route == gateway_catalog.ROUTE_GATEWAY and not all(
+        availability[r.slug].reachable for r in downgradable
+    ):
+        requested_route = None
+        warnings.append(
+            f"{warning_icon} I could not confirm the gateway serves every model above "
+            f"(see the notes), so this runs over *{gateway_catalog.DEFAULT_ROUTE}*. "
+            "Add the model to the gateway (or check its secrets) and re-request."
+        )
+    if requested_route == gateway_catalog.ROUTE_OPENROUTER and gateway_only:
+        names = ", ".join(f"`{r.slug}`" for r in gateway_only)
+        warnings.append(
+            f"{warning_icon} {names} is not on OpenRouter, so `via openrouter` cannot be "
+            f"honoured for it; it runs over *{gateway_catalog.ROUTE_GATEWAY}*."
+        )
+    routes = {
+        r.slug: model_resolver.route_for(r, requested_route)
+        for r in resolutions
+        if r.status == "resolved" and r.slug
+    }
+    return RoutePlan(routes=routes, warnings=tuple(warnings), requested_route=requested_route)
 
 
 def resolved_slugs(resolutions: list[model_resolver.Resolution]) -> list[str]:
@@ -223,24 +290,29 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             continue
         if catalog is None:  # fetch once, lazily - only when there is real work to resolve
             catalog = model_resolver.fetch_openrouter_catalog()
+        if gateway_models is _UNFETCHED:
+            # Fetched BEFORE resolution, not after: resolution falls back to this catalog for a
+            # phrase OpenRouter cannot match, which is the only way a gateway-only model
+            # (`azure_ai/...`) can be requested at all.
+            #
+            # Read from os.environ, not SecretManager (AGENTS.md § Secrets): the poller is a
+            # CI-only entrypoint whose credentials come from workflow `env:`, and DotEnvProvider's
+            # `.env` precedence would let a developer's local gateway leak into a real poll. Same
+            # rationale as SLACK_BOT_TOKEN above. Revisit if this tool ever gains a SecretManager
+            # bootstrap.
+            gateway_models = gateway_catalog.fetch_gateway_catalog(
+                os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
+            )
         text = message.get("text", "")
-        resolutions = model_resolver.resolve_all(text, catalog, ALIASES)
+        resolutions = model_resolver.resolve_all(text, catalog, ALIASES, gateway_models)
         if not resolutions:  # mention + "integrate" but no parseable model phrase
             continue
         # Charset-guard BEFORE the reply: a resolved-but-unsafe slug (a ':variant') must become a
         # clarify reply here, not be confirmed and then dropped by resolved_slugs() below.
         resolutions = [demote_unsafe_slug(r) for r in resolutions]
         requested_route = model_resolver.parse_route(text)
-        # Advisory gateway lookup. Fetched lazily and once; an unconfigured or unreachable
-        # gateway yields None, which reports as "unknown" and changes nothing.
-        if gateway_models is _UNFETCHED:
-            # Read from os.environ, not SecretManager (AGENTS.md § Secrets): the poller is a CI-only
-            # entrypoint whose credentials come from workflow `env:`, and DotEnvProvider's `.env`
-            # precedence would let a developer's local gateway leak into a real poll. Same rationale
-            # as SLACK_BOT_TOKEN above. Revisit if this tool ever gains a SecretManager bootstrap.
-            gateway_models = gateway_catalog.fetch_gateway_catalog(
-                os.environ.get("LLM_PROXY_BASE_URL"), os.environ.get("LLM_PROXY_API_KEY")
-            )
+        # Gateway lookup for the reply: advisory for an OpenRouter-sourced model, and simply
+        # confirmation for a gateway-sourced one (it came out of this catalog).
         availability = {
             r.slug: gateway_catalog.lookup(r.slug, gateway_models)
             for r in resolutions
@@ -251,22 +323,16 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
         # every probe would fail against a gateway we already know does not serve it -- either
         # way a reply saying "via litellm" would misrecord the serving path. Refuse in the
         # reply instead of dispatching a run whose outcome would read as a model failure.
-        route_warning = ""
-        if requested_route == gateway_catalog.ROUTE_GATEWAY and not all(
-            availability[r.slug].reachable for r in resolutions if r.slug in availability
-        ):
-            requested_route = None
-            route_warning = (
-                ":warning: I could not confirm the gateway serves every model above "
-                f"(see the notes), so this runs over *{gateway_catalog.DEFAULT_ROUTE}*. "
-                "Add the model to the gateway (or check its secrets) and re-request."
-            )
-        route = requested_route or gateway_catalog.DEFAULT_ROUTE
+        plan_routes = route_plan(resolutions, availability, requested_route)
         reply = model_resolver.format_resolution_reply(
-            requester, resolutions, availability, requested_route
+            requester,
+            resolutions,
+            availability,
+            plan_routes.requested_route,
+            gateway_searched=gateway_models is not None,
         )
-        if route_warning:
-            reply = f"{reply}\n\n{route_warning}"
+        if plan_routes.warnings:
+            reply = "\n\n".join([reply, *plan_routes.warnings])
         if not slack._post_message(channel, reply, token, thread_ts=ts):
             # No durable processed-marker landed => do NOT add to the plan; retry next poll.
             # (Dispatching without a marker would double-run on the following poll.)
@@ -279,7 +345,7 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
                     "slug": slug,
                     "requester": requester,
                     "message_ts": ts,
-                    "route": route,
+                    "route": plan_routes.routes.get(slug, gateway_catalog.DEFAULT_ROUTE),
                     "gateway": (
                         gateway_catalog.as_dict(availability[slug])
                         if slug in availability

--- a/tools/automation/src/automation/slack.py
+++ b/tools/automation/src/automation/slack.py
@@ -211,20 +211,24 @@ def _note_failure(what: str) -> None:
 
 
 def _prefixed(role: str, text: str) -> str:
-    """:func:`icons.prefix`, except that an unknown ROLE must not cost the whole message.
+    """:func:`icons.prefix`, except that an unknown ROLE costs only the STYLING.
 
-    ``icons.icon`` raises on an unknown role, which is right - a role is written by this
-    codebase, so a bad one is a bug here rather than a user's typo. But both CLI wrappers catch
-    every exception and exit 0, so that raise became a DROPPED notification on a GREEN step: in
-    :func:`cmd_reply` the thread root is posted BEFORE the prefix is applied, leaving a root with
-    no reply under it. The role error is still surfaced as a workflow annotation; the message
-    goes out unstyled rather than not at all, which is what "a notification must never fail the
-    job it reports on" has to mean here.
+    ``icons.icon`` raises on an unknown role, which is right: a role is written by this codebase,
+    so a bad one is a bug here rather than a user's typo. But the CLI wrappers below catch every
+    exception and exit 0, so an escaping raise loses the whole notification on a green step - and
+    in :func:`cmd_reply`, where the thread root is posted before the prefix is applied, leaves a
+    root with nothing under it. "A notification must never fail the job it reports on" has to
+    mean the message still goes out.
+
+    Reported on BOTH channels, because they have different reach: the stderr line is the only
+    record outside CI (:func:`_note_failure` prints nothing without ``GITHUB_ACTIONS``), and the
+    annotation is what makes a passing job visibly flag it.
     """
     try:
         return icons.prefix(role, text)
     except ValueError as exc:
-        _note_failure(f"unknown icon role {role!r}: sending the message unstyled ({exc})")
+        _log(f"unknown icon role {role!r}: sending the message unstyled ({exc})")
+        _note_failure(f"unknown icon role {role!r}: message sent unstyled")
         return text
 
 

--- a/tools/automation/src/automation/slack.py
+++ b/tools/automation/src/automation/slack.py
@@ -210,6 +210,24 @@ def _note_failure(what: str) -> None:
         print(f"::warning title=Slack notification skipped::{what} (see [slack_notify] logs)")
 
 
+def _prefixed(role: str, text: str) -> str:
+    """:func:`icons.prefix`, except that an unknown ROLE must not cost the whole message.
+
+    ``icons.icon`` raises on an unknown role, which is right - a role is written by this
+    codebase, so a bad one is a bug here rather than a user's typo. But both CLI wrappers catch
+    every exception and exit 0, so that raise became a DROPPED notification on a GREEN step: in
+    :func:`cmd_reply` the thread root is posted BEFORE the prefix is applied, leaving a root with
+    no reply under it. The role error is still surfaced as a workflow annotation; the message
+    goes out unstyled rather than not at all, which is what "a notification must never fail the
+    job it reports on" has to mean here.
+    """
+    try:
+        return icons.prefix(role, text)
+    except ValueError as exc:
+        _note_failure(f"unknown icon role {role!r}: sending the message unstyled ({exc})")
+        return text
+
+
 def _ready(channel: str) -> str | None:
     """Return the bot token if a real post is possible, else None (dry-run)."""
     token = os.environ.get("SLACK_BOT_TOKEN")
@@ -250,7 +268,7 @@ def cmd_reply(
         _note_failure("could not post the thread reply (no root)")
         return
     body = append_footer(
-        icons.prefix(role, text), pr_comment=pr_comment, pr_url=pr_url, run_url=run_url
+        _prefixed(role, text), pr_comment=pr_comment, pr_url=pr_url, run_url=run_url
     )
     if mention:
         body += build_mention_suffix(os.environ.get("SLACK_MENTIONS"))
@@ -299,7 +317,7 @@ def post_thread(
     report that starting it failed - the PR-keyed ``reply`` above threads on a different root."""
     try:
         token = _ready(channel)
-        text = icons.prefix(icon, text)
+        text = _prefixed(icon, text)
         if token and not _post_message(channel, text, token, thread_ts=thread_ts):
             _note_failure("could not post the threaded follow-up")
     except Exception as exc:  # a notification must never fail the job

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -12,6 +12,8 @@ Two behaviours carry real risk and are pinned hardest:
 from __future__ import annotations
 
 import json
+import pathlib
+import re
 
 import pytest
 from automation import gateway_catalog, model_resolver, poller, slack
@@ -280,8 +282,13 @@ class TestPlanRows:
         assert "via *openrouter*" in posted[0]
 
     def test_explicit_gateway_route_reaches_the_plan(self, monkeypatch, tmp_path) -> None:
+        # The catalog covers the user simulator too: the integration run's gateway `.env` is
+        # job-wide, so a gateway serving only `x-ai/*` could not serve this run at all.
         plan, posted = self._plan(
-            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["x-ai/*"]
+            monkeypatch,
+            tmp_path,
+            "<@B1> integrate Grok 4.5 via litellm",
+            ["x-ai/*", gateway_catalog.USER_SIMULATOR_SLUG],
         )
         assert [row["route"] for row in plan] == ["litellm", "litellm"]
         # The reply must state the route it actually queued, not the default.
@@ -342,10 +349,41 @@ class TestUnconfirmedGatewayIsDowngraded:
 
     def test_confirmed_model_keeps_the_gateway_and_stays_quiet(self, monkeypatch, tmp_path) -> None:
         plan, posted = self._plan(
-            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["x-ai/grok-4.5"]
+            monkeypatch,
+            tmp_path,
+            "<@B1> integrate Grok 4.5 via litellm",
+            ["x-ai/grok-4.5", gateway_catalog.USER_SIMULATOR_SLUG],
         )
         assert plan[0]["route"] == "litellm"
         assert "could not confirm" not in posted[0]
+
+    def test_an_unserved_user_simulator_also_downgrades(self, monkeypatch, tmp_path) -> None:
+        """The candidate is covered, the simulator is not - and the run proxies both.
+
+        The integration run writes the gateway credentials JOB-WIDE, so `via litellm` with a
+        gateway that lacks `anthropic/claude-sonnet-4.6` sends observe infra-dirty in the
+        SIMULATOR. Nothing in the reply would point at the gateway, so the poller has to.
+        """
+        plan, posted = self._plan(
+            monkeypatch, tmp_path, "<@B1> integrate Grok 4.5 via litellm", ["x-ai/grok-4.5"]
+        )
+        assert [row["route"] for row in plan] == ["openrouter", "openrouter"]
+        assert "user simulator" in posted[0]
+        assert gateway_catalog.USER_SIMULATOR_SLUG in posted[0]
+
+    def test_a_gateway_only_model_cannot_be_downgraded_so_it_warns_instead(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """No OpenRouter route exists for it, so the honest outcome is a warning, not a move."""
+        plan, posted = self._plan(
+            monkeypatch,
+            tmp_path,
+            "<@B1> integrate azure_ai/cohere-command-a-plus-05-2026",
+            ["azure_ai/cohere-command-a-plus-05-2026"],
+        )
+        assert [row["route"] for row in plan] == ["litellm", "litellm"]
+        assert "user simulator" in posted[0]
+        assert "infra-dirty in the simulator" in posted[0]
 
     def test_an_openrouter_request_is_never_downgraded_or_warned(
         self, monkeypatch, tmp_path
@@ -356,3 +394,25 @@ class TestUnconfirmedGatewayIsDowngraded:
         )
         assert plan[0]["route"] == "openrouter"
         assert "could not confirm" not in posted[0]
+
+
+class TestTheSimulatorConstantTracksTheWorkflow:
+    """`USER_SIMULATOR_SLUG` is a copy of a value that lives in the workflow.
+
+    The gateway evidence check is only as good as that name, and a rename in the workflow would
+    leave the check silently looking up a model nobody runs - green, and useless. So the copy is
+    pinned to its source here rather than trusted.
+    """
+
+    def test_the_constant_is_the_model_the_workflow_actually_runs(self) -> None:
+        workflow = (
+            pathlib.Path(__file__).resolve().parents[3]
+            / ".github"
+            / "workflows"
+            / "integrate-model.yml"
+        )
+        text = workflow.read_text()
+        # The user-simulator block in the generated model config: `user:` then its `name:`.
+        match = re.search(r"^\s*user:\s*$.*?^\s*name:\s*\"(?P<slug>[^\"]+)\"", text, re.M | re.S)
+        assert match, "could not find the user simulator's name in integrate-model.yml"
+        assert match.group("slug") == gateway_catalog.USER_SIMULATOR_SLUG

--- a/tools/automation/tests/test_icons.py
+++ b/tools/automation/tests/test_icons.py
@@ -93,9 +93,15 @@ class TestResolution:
 SOURCES = Path(icons.__file__).parent
 SOURCE_FILES = sorted(p for p in SOURCES.glob("*.py") if p.name != "icons.py")
 
-#: A Slack emoji shortcode. `::error::` / `::warning::` are GitHub Actions annotations printed
-#: to stdout, not Slack emoji, so a colon-pair on either side is excluded.
-_EMOJI_LITERAL_RE = re.compile(r"(?<!:):([a-z0-9_+-]+):(?!:)")
+#: A Slack emoji shortcode. Two exclusions keep it honest: a colon-pair on either side is a
+#: GitHub Actions annotation (`::error::`), and a name must contain a LETTER, so a time or a ratio
+#: in a message ("12:30:45", "1:2") is not mistaken for an emoji.
+_EMOJI_LITERAL_RE = re.compile(r"(?<!:):([a-z0-9_+-]*[a-z][a-z0-9_+-]*):(?!:)")
+
+#: Unicode ranges that RENDER as emoji in Slack, for the literals a shortcode sweep cannot see.
+#: Deliberately narrow - the pictographic and dingbat blocks - so the typographic characters these
+#: messages legitimately use (the U+25E6 bullet in a reply) are not swept up.
+_EMOJI_CHAR_RE = re.compile(r"[\U0001F000-\U0001FAFF\u2600-\u27bf\ufe0f]")
 
 
 def _emoji_in_code(path: Path) -> list[str]:
@@ -124,6 +130,8 @@ def _emoji_in_code(path: Path) -> list[str]:
             continue
         for match in _EMOJI_LITERAL_RE.finditer(node.value):
             found.append(f"{path.name}:{node.lineno}: {match.group(0)}")
+        for match in _EMOJI_CHAR_RE.finditer(node.value):
+            found.append(f"{path.name}:{node.lineno}: {match.group(0)!r} (unicode emoji)")
     return found
 
 
@@ -163,12 +171,15 @@ class TestTheWorkflowsAndTheRegistryAgree:
             assert not re.search(r"""(MSG|SLACK)=['"]?:[a-z_]+:""", text), name
 
     def test_no_python_built_message_still_hardcodes_an_emoji(self):
-        """The same guard over the SOURCES, which is where four icons hid.
+        """The same guard over the SOURCES, not just the workflows.
 
-        The workflow-only sweep above passed while the poller's whole reply - resolved,
-        ambiguous, unknown, route-downgraded - carried literal shortcodes, so a workspace with
-        the full override JSON still saw stock emoji on the first message the flow ever sends.
-        Any emoji in a source file must come from the registry.
+        A message built in Python is as Slack-visible as one built in YAML, so an emoji literal
+        in a source file is an icon no override can reach.
+
+        A tripwire, not a proof: it sees literals (including the constant parts of an f-string)
+        and unicode emoji characters, so an emoji assembled at runtime - `":" + name + ":"`,
+        `f":{name}:"`, `.format()` - still gets through. Those are worth catching by review;
+        this catches the shape that actually shipped.
         """
         offenders = [item for source in SOURCE_FILES for item in _emoji_in_code(source)]
         assert offenders == [], (
@@ -277,28 +288,71 @@ class TestEveryIconCallSiteReachesACommandThatAcceptsIt:
 
 
 class TestAnUnknownRoleDoesNotCostTheMessage:
-    """A role typo is a bug in this codebase, but losing the notification is a worse one.
+    """A role typo is a bug in this codebase; losing the notification is a worse one.
 
-    `icon()` raises, and the CLI wrappers catch everything and exit 0 - so before this, a bad
-    role meant no message at all on a green step (and, in `reply`, a thread root with nothing
-    under it).
+    `icon()` raises and the CLI wrappers catch everything then exit 0, so an escaping raise
+    costs the whole message on a green step - and in `reply`, where the thread root is posted
+    first, leaves a root with nothing under it.
+
+    Driven through the COMMANDS rather than through the helper: a test that calls `_prefixed`
+    directly still passes with both call sites reverted to `icons.prefix`, which is exactly the
+    regression it is supposed to catch.
     """
 
-    def test_the_message_still_goes_out_unstyled(self, monkeypatch):
+    @staticmethod
+    def _capture(monkeypatch) -> tuple[dict, list[str]]:
         import automation.slack as slack
 
-        noted: list[str] = []
-        monkeypatch.setattr(slack, "_note_failure", noted.append)
-        assert slack._prefixed("not_a_role", "Observe started") == "Observe started"
-        assert len(noted) == 1
-        assert "not_a_role" in noted[0]
-
-    def test_a_good_role_is_untouched(self):
-        import automation.slack as slack
-
-        assert slack._prefixed("observe_started", "Observe started") == (
-            ":arrow_forward: Observe started"
+        sent: dict = {}
+        logged: list[str] = []
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+        monkeypatch.setattr(slack, "_ready", lambda channel: "xoxb-test")
+        monkeypatch.setattr(slack, "_find_or_create_root", lambda *a, **k: "1.0")
+        monkeypatch.setattr(slack, "_log", logged.append)
+        monkeypatch.setattr(
+            slack,
+            "_post_message",
+            lambda ch, text, tok, thread_ts=None: sent.setdefault("t", text) or True,
         )
+        return sent, logged
+
+    def test_reply_still_posts_under_its_root(self, monkeypatch):
+        import automation.slack as slack
+
+        sent, logged = self._capture(monkeypatch)
+        slack.cmd_reply("C1", 42, "Integrated: preset committed.", "m", False, role="not_a_role")
+        assert sent.get("t", "").startswith("Integrated: preset committed.")
+        assert any("not_a_role" in line for line in logged)
+
+    def test_post_thread_still_posts(self, monkeypatch):
+        import automation.slack as slack
+        from typer.testing import CliRunner
+
+        sent, logged = self._capture(monkeypatch)
+        result = CliRunner().invoke(
+            slack.app,
+            [
+                "post-thread",
+                "--channel",
+                "C1",
+                "--thread-ts",
+                "1.0",
+                "--text",
+                "Dispatch failed",
+                "--icon",
+                "not_a_role",
+            ],
+        )
+        assert result.exit_code == 0
+        assert sent.get("t", "").startswith("Dispatch failed")
+        assert any("not_a_role" in line for line in logged)
+
+    def test_a_good_role_is_still_applied(self, monkeypatch):
+        import automation.slack as slack
+
+        sent, _ = self._capture(monkeypatch)
+        slack.cmd_reply("C1", 42, "Observe started", "m", False, role="observe_started")
+        assert sent["t"].startswith(":arrow_forward: Observe started")
 
 
 class TestAFullOverrideRestylesEveryMessage:

--- a/tools/automation/tests/test_icons.py
+++ b/tools/automation/tests/test_icons.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 from pathlib import Path
 
 import automation.icons as icons
 import pytest
+from automation import gateway_catalog
 
 pytestmark = pytest.mark.unit
 
@@ -86,8 +88,47 @@ class TestResolution:
         assert icons.prefix("", "already led") == "already led"
 
 
+#: Every module that can put text into a Slack message. `icons.py` is excluded: it is the
+#: registry, so the defaults live there by definition.
+SOURCES = Path(icons.__file__).parent
+SOURCE_FILES = sorted(p for p in SOURCES.glob("*.py") if p.name != "icons.py")
+
+#: A Slack emoji shortcode. `::error::` / `::warning::` are GitHub Actions annotations printed
+#: to stdout, not Slack emoji, so a colon-pair on either side is excluded.
+_EMOJI_LITERAL_RE = re.compile(r"(?<!:):([a-z0-9_+-]+):(?!:)")
+
+
+def _emoji_in_code(path: Path) -> list[str]:
+    """Emoji shortcodes in the STRING LITERALS of *path*, docstrings excluded.
+
+    An AST walk rather than a line scan, because docstrings are full of Sphinx cross-reference
+    roles (``:func:``, ``:data:``) that look exactly like a shortcode and can never reach Slack.
+    What CAN reach Slack is a literal in executable code, including the constant parts of an
+    f-string, which is what this collects.
+    """
+    tree = ast.parse(path.read_text())
+    scopes = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, scopes) and node.body:
+            first = node.body[0]
+            if isinstance(first, ast.Expr) and isinstance(
+                getattr(first, "value", None), ast.Constant
+            ):
+                docstrings.add(id(first.value))
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in docstrings:
+            continue
+        for match in _EMOJI_LITERAL_RE.finditer(node.value):
+            found.append(f"{path.name}:{node.lineno}: {match.group(0)}")
+    return found
+
+
 class TestTheWorkflowsAndTheRegistryAgree:
-    """Every role the workflows name must exist, and every declared role should be
+    """Every role a caller names must exist, and every declared role should be
     reachable - a role nothing uses is either a typo or dead weight."""
 
     @staticmethod
@@ -97,21 +138,43 @@ class TestTheWorkflowsAndTheRegistryAgree:
             text = (WORKFLOWS / name).read_text()
             used |= set(re.findall(r"--icon ([a-z_]+)", text))
             used |= set(re.findall(r"ICON_ROLE=([a-z_]+)", text))
+        # Roles named in Python too: a message built in code (the poller's reply to a request)
+        # names its role at the call site, not through a CLI flag.
+        for source in SOURCE_FILES:
+            used |= set(
+                re.findall(
+                    r"""icons\.(?:icon|prefix)\(\s*["']([a-z0-9_]+)["']""", source.read_text()
+                )
+            )
         return used
 
-    def test_no_workflow_names_an_unknown_role(self):
+    def test_no_caller_names_an_unknown_role(self):
         assert self._used() - set(icons.DEFAULT_ICONS) == set()
 
     def test_every_declared_role_is_used(self):
         assert set(icons.DEFAULT_ICONS) - self._used() == set()
 
-    def test_no_message_still_hardcodes_an_emoji(self):
+    def test_no_workflow_message_still_hardcodes_an_emoji(self):
         """The emoji left the text when the role arrived; a leftover would be an
         icon no override can reach."""
         for name in ("slack-integrate.yml", "integrate-model.yml"):
             text = (WORKFLOWS / name).read_text()
             assert not re.search(r"""--text ['"]:[a-z_]+:""", text), name
             assert not re.search(r"""(MSG|SLACK)=['"]?:[a-z_]+:""", text), name
+
+    def test_no_python_built_message_still_hardcodes_an_emoji(self):
+        """The same guard over the SOURCES, which is where four icons hid.
+
+        The workflow-only sweep above passed while the poller's whole reply - resolved,
+        ambiguous, unknown, route-downgraded - carried literal shortcodes, so a workspace with
+        the full override JSON still saw stock emoji on the first message the flow ever sends.
+        Any emoji in a source file must come from the registry.
+        """
+        offenders = [item for source in SOURCE_FILES for item in _emoji_in_code(source)]
+        assert offenders == [], (
+            "hardcoded Slack emoji found; give each one a role in icons.DEFAULT_ICONS and emit "
+            f"it with icons.icon(role, overrides): {offenders}"
+        )
 
 
 class TestTheReplyPathAppliesTheRole:
@@ -211,3 +274,78 @@ class TestEveryIconCallSiteReachesACommandThatAcceptsIt:
         )
         assert result.exit_code == 0
         assert sent["text"] == ":tf-pr: Opened PR #42"
+
+
+class TestAnUnknownRoleDoesNotCostTheMessage:
+    """A role typo is a bug in this codebase, but losing the notification is a worse one.
+
+    `icon()` raises, and the CLI wrappers catch everything and exit 0 - so before this, a bad
+    role meant no message at all on a green step (and, in `reply`, a thread root with nothing
+    under it).
+    """
+
+    def test_the_message_still_goes_out_unstyled(self, monkeypatch):
+        import automation.slack as slack
+
+        noted: list[str] = []
+        monkeypatch.setattr(slack, "_note_failure", noted.append)
+        assert slack._prefixed("not_a_role", "Observe started") == "Observe started"
+        assert len(noted) == 1
+        assert "not_a_role" in noted[0]
+
+    def test_a_good_role_is_untouched(self):
+        import automation.slack as slack
+
+        assert slack._prefixed("observe_started", "Observe started") == (
+            ":arrow_forward: Observe started"
+        )
+
+
+class TestAFullOverrideRestylesEveryMessage:
+    """The requirement in one assertion: with the full role map set, NO stock emoji survives.
+
+    Built over the poller's request reply because that is where the coverage gap was - it is the
+    first message the flow ever sends, it carries all three intake outcomes plus a route warning,
+    and every one of those icons used to be a literal.
+    """
+
+    CATALOG = ["x-ai/grok-4.5", "openai/gpt-5.6-sol", "openai/gpt-5.6-terra"]
+
+    @staticmethod
+    def _full_override() -> str:
+        return json.dumps(
+            {role: f":arena-{role.replace('_', '-')}:" for role in icons.DEFAULT_ICONS}
+        )
+
+    def _reply_with_every_outcome(self) -> str:
+        import automation.model_resolver as mr
+        import automation.poller as poller
+
+        # resolved + ambiguous + unknown in one message, so all three intake icons appear.
+        resolutions = mr.resolve_all(
+            "<@U1> integrate x-ai/grok-4.5, gpt 5.6 and nope/nothing-9", self.CATALOG
+        )
+        availability = {
+            r.slug: gateway_catalog.lookup(r.slug, [])  # catalog read, nothing in it
+            for r in resolutions
+            if r.status == "resolved" and r.slug
+        }
+        plan = poller.route_plan(resolutions, availability, gateway_catalog.ROUTE_GATEWAY)
+        reply = mr.format_resolution_reply(
+            "U1", resolutions, availability, plan.requested_route, gateway_searched=True
+        )
+        assert plan.warnings, "expected a route warning to be part of the message under test"
+        return "\n\n".join([reply, *plan.warnings])
+
+    def test_stock_glyphs_are_present_without_an_override(self, monkeypatch):
+        monkeypatch.delenv(icons.ICON_OVERRIDES_ENV, raising=False)
+        found = set(_EMOJI_LITERAL_RE.findall(self._reply_with_every_outcome()))
+        # The unset case must be unchanged: today's glyphs, in all three intake states.
+        assert {"white_check_mark", "warning", "x"} <= found
+
+    def test_no_stock_glyph_survives_the_full_override(self, monkeypatch):
+        monkeypatch.setenv(icons.ICON_OVERRIDES_ENV, self._full_override())
+        text = self._reply_with_every_outcome()
+        found = sorted(set(_EMOJI_LITERAL_RE.findall(text)))
+        assert found, "the message under test must contain icons"
+        assert [name for name in found if not name.startswith("arena-")] == [], text

--- a/tools/automation/tests/test_model_resolver.py
+++ b/tools/automation/tests/test_model_resolver.py
@@ -225,10 +225,27 @@ class TestConnectorInsideAModelName:
             "<@U1> integrate grok 4.5, gpt 5.6 sol",
             "<@U1> integrate grok 4.5,gpt 5.6 sol",
             "<@U1> integrate grok 4.5 & gpt 5.6 sol",
+            # Punctuation carrying a word connector: how English writes a list, and the form a
+            # whitespace-only word rule silently swallows into the model phrase, since the comma
+            # has already consumed the space to the left of "and".
+            "<@U1> integrate grok 4.5, and gpt 5.6 sol",
+            "<@U1> integrate grok 4.5, plus gpt 5.6 sol",
+            "<@U1> integrate grok 4.5 & and gpt 5.6 sol",
         ],
     )
     def test_real_connectors_still_split(self, text):
         assert parse_command(text) == ["grok 4.5", "gpt 5.6 sol"]
+
+    def test_an_oxford_comma_list_keeps_every_phrase(self):
+        assert parse_command("<@U1> integrate grok 4.5, gpt 5.6 sol, and sonnet 5") == [
+            "grok 4.5",
+            "gpt 5.6 sol",
+            "sonnet 5",
+        ]
+
+    @pytest.mark.parametrize("tail", ["and", "and ", "plus", ","])
+    def test_a_dangling_connector_is_not_a_model_phrase(self, tail):
+        assert parse_command(f"<@U1> integrate grok 4.5 {tail}") == ["grok 4.5"]
 
 
 class TestGatewayFallback:
@@ -242,9 +259,19 @@ class TestGatewayFallback:
             model_resolver.SOURCE_GATEWAY,
         )
 
-    def test_gateway_only_model_resolves_from_free_text(self):
-        r = resolve("cohere command a plus 05 2026", CATALOG, gateway_entries=GATEWAY_ENTRIES)
+    def test_a_loose_phrase_reaches_a_gateway_route_by_token_match(self):
+        # Resolution only: through a real request this spelling is two phrases, because ` plus `
+        # between words IS a connector. See TestConnectorInsideAModelName for that half.
+        r = resolve("cohere command a 05 2026", CATALOG, gateway_entries=GATEWAY_ENTRIES)
         assert (r.slug, r.source) == (GATEWAY_ONLY, model_resolver.SOURCE_GATEWAY)
+
+    def test_a_space_separated_plus_is_still_a_connector_in_a_request(self):
+        # The honest end-to-end outcome for the spaced spelling: two phrases, one of which is a
+        # bare version and resolves to nothing. Typing the slug is what works.
+        assert parse_command("<@U1> integrate cohere command a plus 05 2026") == [
+            "cohere command a",
+            "05 2026",
+        ]
 
     def test_only_real_model_names_become_candidates(self):
         # A gateway catalog is a routing table: a wildcard is not a model, and an OpenRouter slug
@@ -267,6 +294,20 @@ class TestGatewayFallback:
     def test_without_a_usable_gateway_the_answer_is_unchanged(self, entries):
         assert resolve(GATEWAY_ONLY, CATALOG, gateway_entries=entries).status == "none"
 
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "claude sonnet 5 (azure)",  # a LiteLLM model_name alias: spaces and parentheses
+            "vendor/model:free",  # a variant suffix the shell must never receive
+            "vendor/model;rm -rf",  # a shell metacharacter
+        ],
+    )
+    def test_an_unusable_route_id_is_not_offered_as_a_candidate(self, entry):
+        # A candidate outside the safe charset cannot be integrated, and offering it back as
+        # "re-request with this exact slug" is a clarification nobody can satisfy: the same
+        # request would resolve to the same unusable id every time.
+        assert model_resolver._gateway_candidates([entry], set(CATALOG)) == []
+
     def test_an_alias_to_a_gateway_route_is_routed_there(self):
         r = resolve(
             "cohere-a-plus",
@@ -286,6 +327,19 @@ class TestRouteFor:
             model_resolver.route_for(r, gateway_catalog.ROUTE_OPENROUTER)
             == gateway_catalog.ROUTE_GATEWAY
         )
+
+    def test_an_alias_off_openrouter_pins_the_gateway_even_when_it_is_unreadable(self):
+        # Membership of the OPENROUTER catalog decides the route: a slug OpenRouter does not
+        # carry cannot run there whatever the gateway says, so an unreadable gateway must not
+        # send it down the OpenRouter path.
+        r = resolve(
+            "cohere-a-plus",
+            CATALOG,
+            aliases={"cohere-a-plus": GATEWAY_ONLY},
+            gateway_entries=None,
+        )
+        assert (r.slug, r.source) == (GATEWAY_ONLY, model_resolver.SOURCE_GATEWAY)
+        assert model_resolver.route_for(r) == gateway_catalog.ROUTE_GATEWAY
 
     def test_openrouter_model_keeps_the_calibrated_default(self):
         r = resolve("sonnet 5", CATALOG, gateway_entries=GATEWAY_ENTRIES)
@@ -320,7 +374,9 @@ class TestFailureNamesWhatWasSearched:
         )
         assert f"`{GATEWAY_ONLY}`" in text
         assert f"via *{gateway_catalog.ROUTE_GATEWAY}*" in text
-        assert "only on the gateway, not on OpenRouter" in text
+        # Deliberately a claim about the NAME: a gateway route can be the same model under
+        # another vendor prefix, so "not on OpenRouter" would not always be true.
+        assert "no OpenRouter slug matched this name" in text
 
     def test_the_live_request_resolves_end_to_end(self):
         resolutions = model_resolver.resolve_all(

--- a/tools/automation/tests/test_model_resolver.py
+++ b/tools/automation/tests/test_model_resolver.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import automation.model_resolver as model_resolver
 import pytest
+from automation import gateway_catalog
 
 pytestmark = pytest.mark.unit
 
@@ -176,3 +177,153 @@ class TestFormatReply:
         assert "is ambiguous (6 matches)" in text  # the GPT 5.6 one
         for slug in GPT_56:
             assert f"`{slug}`" in text
+
+
+# --- the live incident -----------------------------------------------------------------------
+#
+# Request: "@arena-automation Integrate azure_ai/cohere-command-a-plus-05-2026". Two independent
+# defects hit the same message, and each on its own made it unanswerable:
+#   1. `\bplus\b` split the phrase INSIDE the slug (a hyphen is a regex word boundary), so the
+#      resolver was handed 'azure_ai/cohere-command-a-' and '-05-2026';
+#   2. only the OpenRouter catalog was searched, so a model served solely by the deployment's
+#      gateway could not resolve however it was spelled.
+
+#: A gateway route id that OpenRouter does not carry - the shape at the heart of the incident.
+GATEWAY_ONLY = "azure_ai/cohere-command-a-plus-05-2026"
+
+#: A realistic gateway catalog: the gateway-only route, a passthrough wildcard, an OpenRouter slug
+#: under a route prefix, and a plain duplicate of an OpenRouter slug.
+GATEWAY_ENTRIES = [
+    GATEWAY_ONLY,
+    "x-ai/*",
+    "openrouter/x-ai/grok-4.5",
+    "anthropic/claude-sonnet-5",
+]
+
+
+class TestConnectorInsideAModelName:
+    """A connector word must be a word BETWEEN phrases, never a syllable inside one."""
+
+    def test_plus_inside_a_slug_is_not_a_connector(self):
+        assert parse_command(f"<@U1> Integrate {GATEWAY_ONLY}") == [GATEWAY_ONLY]
+
+    def test_trailing_plus_is_kept_not_dropped(self):
+        # The worse half of the bug: no error, just a silently DIFFERENT model name, which could
+        # then match something real.
+        assert parse_command("<@U1> integrate cohere/command-a-plus") == ["cohere/command-a-plus"]
+
+    def test_and_inside_a_slug_is_not_a_connector(self):
+        assert parse_command("<@U1> integrate vendor/command-and-conquer-2") == [
+            "vendor/command-and-conquer-2"
+        ]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<@U1> integrate grok 4.5 and gpt 5.6 sol",
+            "<@U1> integrate grok 4.5 plus gpt 5.6 sol",
+            "<@U1> integrate grok 4.5, gpt 5.6 sol",
+            "<@U1> integrate grok 4.5,gpt 5.6 sol",
+            "<@U1> integrate grok 4.5 & gpt 5.6 sol",
+        ],
+    )
+    def test_real_connectors_still_split(self, text):
+        assert parse_command(text) == ["grok 4.5", "gpt 5.6 sol"]
+
+
+class TestGatewayFallback:
+    """OpenRouter first, the gateway only for what OpenRouter cannot match at all."""
+
+    def test_gateway_only_model_resolves(self):
+        r = resolve(GATEWAY_ONLY, CATALOG, gateway_entries=GATEWAY_ENTRIES)
+        assert (r.status, r.slug, r.source) == (
+            "resolved",
+            GATEWAY_ONLY,
+            model_resolver.SOURCE_GATEWAY,
+        )
+
+    def test_gateway_only_model_resolves_from_free_text(self):
+        r = resolve("cohere command a plus 05 2026", CATALOG, gateway_entries=GATEWAY_ENTRIES)
+        assert (r.slug, r.source) == (GATEWAY_ONLY, model_resolver.SOURCE_GATEWAY)
+
+    def test_only_real_model_names_become_candidates(self):
+        # A gateway catalog is a routing table: a wildcard is not a model, and an OpenRouter slug
+        # (bare or under a route prefix) is not a NEW model - keeping either would let a phrase
+        # resolve to a second name for a model that already resolved, or to a passthrough.
+        assert model_resolver._gateway_candidates(GATEWAY_ENTRIES, set(CATALOG)) == [GATEWAY_ONLY]
+
+    def test_an_openrouter_hit_is_never_disturbed(self):
+        r = resolve("sonnet 5", CATALOG, gateway_entries=GATEWAY_ENTRIES)
+        assert (r.slug, r.source) == (
+            "anthropic/claude-sonnet-5",
+            model_resolver.SOURCE_OPENROUTER,
+        )
+
+    def test_openrouter_ambiguity_does_not_fall_through(self):
+        # Falling through on "ambiguous" would turn a clarify reply into a wrong resolution.
+        assert resolve("GPT 5.6", CATALOG, gateway_entries=GATEWAY_ENTRIES).status == "ambiguous"
+
+    @pytest.mark.parametrize("entries", [None, [], ["x-ai/*"]])
+    def test_without_a_usable_gateway_the_answer_is_unchanged(self, entries):
+        assert resolve(GATEWAY_ONLY, CATALOG, gateway_entries=entries).status == "none"
+
+    def test_an_alias_to_a_gateway_route_is_routed_there(self):
+        r = resolve(
+            "cohere-a-plus",
+            CATALOG,
+            aliases={"cohere-a-plus": GATEWAY_ONLY},
+            gateway_entries=GATEWAY_ENTRIES,
+        )
+        assert (r.slug, r.source) == (GATEWAY_ONLY, model_resolver.SOURCE_GATEWAY)
+
+
+class TestRouteFor:
+    def test_gateway_only_pins_the_gateway(self):
+        r = resolve(GATEWAY_ONLY, CATALOG, gateway_entries=GATEWAY_ENTRIES)
+        assert model_resolver.route_for(r) == gateway_catalog.ROUTE_GATEWAY
+        # ... even against an explicit "via openrouter", which cannot be honoured at all.
+        assert (
+            model_resolver.route_for(r, gateway_catalog.ROUTE_OPENROUTER)
+            == gateway_catalog.ROUTE_GATEWAY
+        )
+
+    def test_openrouter_model_keeps_the_calibrated_default(self):
+        r = resolve("sonnet 5", CATALOG, gateway_entries=GATEWAY_ENTRIES)
+        assert model_resolver.route_for(r) == gateway_catalog.DEFAULT_ROUTE
+        assert (
+            model_resolver.route_for(r, gateway_catalog.ROUTE_GATEWAY)
+            == gateway_catalog.ROUTE_GATEWAY
+        )
+
+
+class TestFailureNamesWhatWasSearched:
+    def test_gateway_unreadable_says_so(self):
+        resolutions = model_resolver.resolve_all("<@U1> integrate nope/nothing-9", CATALOG)
+        text = model_resolver.format_resolution_reply("U1", resolutions, gateway_searched=False)
+        assert "no matching model on OpenRouter" in text
+        assert "no gateway catalog was readable" in text
+
+    def test_gateway_searched_names_both(self):
+        resolutions = model_resolver.resolve_all(
+            "<@U1> integrate nope/nothing-9", CATALOG, gateway_entries=GATEWAY_ENTRIES
+        )
+        text = model_resolver.format_resolution_reply("U1", resolutions, gateway_searched=True)
+        assert "no matching model on OpenRouter or the gateway" in text
+        assert "no gateway catalog was readable" not in text
+
+    def test_gateway_only_resolution_says_where_it_runs(self):
+        resolutions = model_resolver.resolve_all(
+            f"<@U1> Integrate {GATEWAY_ONLY}", CATALOG, gateway_entries=GATEWAY_ENTRIES
+        )
+        text = model_resolver.format_resolution_reply(
+            "U1", resolutions, gateway_searched=True, requested_route=None
+        )
+        assert f"`{GATEWAY_ONLY}`" in text
+        assert f"via *{gateway_catalog.ROUTE_GATEWAY}*" in text
+        assert "only on the gateway, not on OpenRouter" in text
+
+    def test_the_live_request_resolves_end_to_end(self):
+        resolutions = model_resolver.resolve_all(
+            f"<@U0AB1948PC0> Integrate {GATEWAY_ONLY}", CATALOG, gateway_entries=GATEWAY_ENTRIES
+        )
+        assert [(r.status, r.slug) for r in resolutions] == [("resolved", GATEWAY_ONLY)]

--- a/tools/automation/tests/test_poller.py
+++ b/tools/automation/tests/test_poller.py
@@ -329,6 +329,9 @@ class TestRoutePlan:
         assert gateway_catalog.USER_SIMULATOR_SLUG in warning
         assert "the models OpenRouter carries run over" in warning
         assert "infra-dirty in the simulator" in warning
+        # The two consequences point in opposite directions, so they are not run into one
+        # sentence: each gets its own line.
+        assert warning.count("\n    \u2022 ") == 2
         # ... and the routes still say what each model actually does.
         assert plan.routes == {
             "x-ai/grok-4.5": gateway_catalog.ROUTE_OPENROUTER,

--- a/tools/automation/tests/test_poller.py
+++ b/tools/automation/tests/test_poller.py
@@ -311,6 +311,45 @@ class TestRoutePlan:
         assert plan.warnings, "grok is absent from the gateway, so the directive is refused"
         assert "the models OpenRouter carries run over" in plan.warnings[0]
 
+    def test_one_simulator_warning_covers_both_of_its_consequences(self):
+        # `via litellm` + a gateway-only model + a reachable OpenRouter model + an absent
+        # simulator makes both the downgrade and the gateway-only risk true at once. One fact
+        # gets one warning; two would read as the bot repeating itself.
+        entries = [self.GATEWAY_ONLY, "x-ai/grok-4.5"]  # no user simulator
+        text = f"<@{BOT}> integrate grok 4.5 and {self.GATEWAY_ONLY} via litellm"
+        resolutions = self._resolutions(text, gateway_entries=entries)
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, entries),
+            mr.parse_route(text),
+            simulator=gateway_catalog.lookup(gateway_catalog.USER_SIMULATOR_SLUG, entries),
+        )
+        assert len(plan.warnings) == 1
+        warning = plan.warnings[0]
+        assert gateway_catalog.USER_SIMULATOR_SLUG in warning
+        assert "the models OpenRouter carries run over" in warning
+        assert "infra-dirty in the simulator" in warning
+        # ... and the routes still say what each model actually does.
+        assert plan.routes == {
+            "x-ai/grok-4.5": gateway_catalog.ROUTE_OPENROUTER,
+            self.GATEWAY_ONLY: gateway_catalog.ROUTE_GATEWAY,
+        }
+
+    def test_an_unreadable_gateway_is_not_blamed_on_the_simulator(self):
+        # "unknown" still refuses the route, but naming one model would send someone checking a
+        # name that is fine: there is no readable catalog at all.
+        text = f"<@{BOT}> integrate grok 4.5 via litellm"
+        resolutions = self._resolutions(text)
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, None),
+            mr.parse_route(text),
+            simulator=gateway_catalog.lookup(gateway_catalog.USER_SIMULATOR_SLUG, None),
+        )
+        assert len(plan.warnings) == 1
+        assert "every model above" in plan.warnings[0]
+        assert gateway_catalog.USER_SIMULATOR_SLUG not in plan.warnings[0]
+
     def test_unresolved_phrases_never_reach_the_plan(self):
         resolutions = self._resolutions(f"<@{BOT}> integrate nope/nothing-9 and grok 4.5")
         plan = poller.route_plan(resolutions, self._availability(resolutions, None), None)

--- a/tools/automation/tests/test_poller.py
+++ b/tools/automation/tests/test_poller.py
@@ -259,6 +259,58 @@ class TestRoutePlan:
         assert plan.routes == {self.GATEWAY_ONLY: gateway_catalog.ROUTE_GATEWAY}
         assert plan.warnings == ()
 
+    def test_a_downgrade_does_not_then_suggest_the_route_it_refused(self):
+        # `requested_route` arrives as None both when nothing was asked and when a directive was
+        # refused. Without that distinction the reply tells a requester who just asked for the
+        # gateway to re-request with the gateway.
+        import automation.model_resolver as resolver
+
+        entries = ["x-ai/grok-4.5"]  # gateway has grok but not hy3
+        resolutions = self._resolutions(
+            f"<@{BOT}> integrate grok 4.5 and hy3 via litellm", gateway_entries=entries
+        )
+        availability = self._availability(resolutions, entries)
+        plan = poller.route_plan(resolutions, availability, gateway_catalog.ROUTE_GATEWAY)
+        assert plan.downgraded is True
+        reply = resolver.format_resolution_reply(
+            "U1",
+            resolutions,
+            availability,
+            plan.requested_route,
+            gateway_searched=True,
+            route_downgraded=plan.downgraded,
+        )
+        assert "re-request with `via litellm`" not in reply
+        # ... while the un-asked case still offers the option.
+        plain = poller.route_plan(resolutions, availability, None)
+        assert plain.downgraded is False
+        assert "re-request with `via litellm`" in resolver.format_resolution_reply(
+            "U1",
+            resolutions,
+            availability,
+            plain.requested_route,
+            gateway_searched=True,
+            route_downgraded=plain.downgraded,
+        )
+
+    def test_the_downgrade_warning_does_not_speak_for_a_gateway_only_model(self):
+        # A mixed request downgrades only what OpenRouter carries, so a warning saying the whole
+        # message runs over openrouter would contradict the route written to plan.json.
+        entries = [self.GATEWAY_ONLY]
+        resolutions = self._resolutions(
+            f"<@{BOT}> integrate grok 4.5 and {self.GATEWAY_ONLY} via litellm",
+            gateway_entries=entries,
+        )
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, entries),
+            gateway_catalog.ROUTE_GATEWAY,
+        )
+        assert plan.routes[self.GATEWAY_ONLY] == gateway_catalog.ROUTE_GATEWAY
+        assert plan.routes["x-ai/grok-4.5"] == gateway_catalog.ROUTE_OPENROUTER
+        assert plan.warnings, "grok is absent from the gateway, so the directive is refused"
+        assert "the models OpenRouter carries run over" in plan.warnings[0]
+
     def test_unresolved_phrases_never_reach_the_plan(self):
         resolutions = self._resolutions(f"<@{BOT}> integrate nope/nothing-9 and grok 4.5")
         plan = poller.route_plan(resolutions, self._availability(resolutions, None), None)

--- a/tools/automation/tests/test_poller.py
+++ b/tools/automation/tests/test_poller.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import automation.model_resolver as mr
 import automation.poller as poller
 import pytest
+from automation import gateway_catalog
 
 pytestmark = pytest.mark.unit
 
@@ -183,3 +184,82 @@ class TestResolvedSlugsPlan:
         assert poller.demote_unsafe_slug(amb) is amb
         # A demoted variant is excluded from the plan (status != resolved).
         assert poller.resolved_slugs([out]) == []
+
+
+class TestRoutePlan:
+    """The route is decided PER MODEL, and a directive that cannot be honoured is stated.
+
+    The two sides of one request can disagree: a gateway-only model can run nowhere but the
+    gateway, while an OpenRouter model must keep the calibrated default, because moving a model's
+    serving path is a leaderboard-comparability decision.
+    """
+
+    GATEWAY_ONLY = "azure_ai/cohere-command-a-plus-05-2026"
+
+    def _resolutions(self, text, gateway_entries=None):
+        return mr.resolve_all(text, CATALOG, gateway_entries=gateway_entries)
+
+    def _availability(self, resolutions, catalog):
+        return {
+            r.slug: gateway_catalog.lookup(r.slug, catalog)
+            for r in resolutions
+            if r.status == "resolved" and r.slug
+        }
+
+    def test_mixed_request_routes_each_model_where_it_can_run(self):
+        entries = [self.GATEWAY_ONLY]
+        resolutions = self._resolutions(
+            f"<@{BOT}> integrate grok 4.5 and {self.GATEWAY_ONLY}", gateway_entries=entries
+        )
+        plan = poller.route_plan(resolutions, self._availability(resolutions, entries), None)
+        assert plan.routes == {
+            "x-ai/grok-4.5": gateway_catalog.ROUTE_OPENROUTER,
+            self.GATEWAY_ONLY: gateway_catalog.ROUTE_GATEWAY,
+        }
+        assert plan.warnings == ()
+
+    def test_via_openrouter_cannot_be_honoured_for_a_gateway_only_model(self):
+        entries = [self.GATEWAY_ONLY]
+        resolutions = self._resolutions(
+            f"<@{BOT}> integrate {self.GATEWAY_ONLY}", gateway_entries=entries
+        )
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, entries),
+            gateway_catalog.ROUTE_OPENROUTER,
+        )
+        assert plan.routes == {self.GATEWAY_ONLY: gateway_catalog.ROUTE_GATEWAY}
+        assert len(plan.warnings) == 1
+        assert "cannot be honoured" in plan.warnings[0]
+        assert self.GATEWAY_ONLY in plan.warnings[0]
+
+    def test_via_litellm_is_downgraded_when_the_gateway_lacks_the_model(self):
+        resolutions = self._resolutions(f"<@{BOT}> integrate grok 4.5")
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, []),  # catalog read, model absent
+            gateway_catalog.ROUTE_GATEWAY,
+        )
+        assert plan.routes == {"x-ai/grok-4.5": gateway_catalog.ROUTE_OPENROUTER}
+        assert plan.requested_route is None  # the reply must report the route actually used
+        assert "could not confirm the gateway serves every model" in plan.warnings[0]
+
+    def test_a_gateway_only_model_does_not_trigger_the_downgrade(self):
+        # It came OUT of the gateway catalog, so it is not evidence against the gateway; a
+        # downgrade here would have reported OpenRouter for a model OpenRouter does not carry.
+        entries = [self.GATEWAY_ONLY]
+        resolutions = self._resolutions(
+            f"<@{BOT}> integrate {self.GATEWAY_ONLY} via litellm", gateway_entries=entries
+        )
+        plan = poller.route_plan(
+            resolutions,
+            self._availability(resolutions, entries),
+            gateway_catalog.ROUTE_GATEWAY,
+        )
+        assert plan.routes == {self.GATEWAY_ONLY: gateway_catalog.ROUTE_GATEWAY}
+        assert plan.warnings == ()
+
+    def test_unresolved_phrases_never_reach_the_plan(self):
+        resolutions = self._resolutions(f"<@{BOT}> integrate nope/nothing-9 and grok 4.5")
+        plan = poller.route_plan(resolutions, self._availability(resolutions, None), None)
+        assert plan.routes == {"x-ai/grok-4.5": gateway_catalog.ROUTE_OPENROUTER}


### PR DESCRIPTION
## What broke

One live Slack request, `@arena-automation Integrate azure_ai/cohere-command-a-plus-05-2026`, came back as two failures that are both impossible to act on:

```
:x: azure_ai/cohere-command-a-: no matching model on OpenRouter. Check the name and version.
:x: -05-2026: no matching model on OpenRouter. Check the name and version.
```

Three independent defects were involved, and each on its own made that request unanswerable.

## 1. A connector word split the phrase inside the slug

`_CONNECTOR_RE` matched `\bplus\b`, and a hyphen is a regex word boundary, so the model name was cut in half. Reproduced on `main`:

```
integrate azure_ai/cohere-command-a-plus-05-2026  ->  ['azure_ai/cohere-command-a-', '-05-2026']
integrate cohere/command-a-plus                   ->  ['cohere/command-a-']
integrate vendor/command-and-conquer-2            ->  ['vendor/command-', '-conquer-2']
```

The second line is the quieter half and the worse one: no error, just a silently **different** model name that could go on to match something real.

A word connector now has to be delimited by whitespace or the end of the request, and punctuation may carry one with it, because `a, b, and c` is how English writes a list. Both halves matter: whitespace-only was the first attempt here, and it swallowed the `and` after a comma into the model phrase (see the review round below).

## 2. Only OpenRouter was ever searched

A model served solely by the deployment's LLM gateway could not resolve however it was spelled, and the reply blamed OpenRouter without saying that a configured gateway had never been consulted.

Resolution is now **OpenRouter first, gateway as a fallback** - deliberately a fallback and not a union, so a phrase that resolves (or is ambiguous) against OpenRouter is unaffected by the gateway. That keeps two invariants: the calibrated default route cannot move, and a gateway listing the same model under a second route name cannot turn a working request into a clarify reply.

A gateway catalog is a routing table rather than a model list, so only part of it is a candidate: a wildcard (`x-ai/*`) is a passthrough, an id OpenRouter already carries (bare or under one route prefix) is the same model under a second name, and an id outside the slug charset can never be integrated because a slug reaches the shell.

The route follows from that, **per model rather than per message**, because the two sides of one request can disagree:

| Case | Route | Reply |
|---|---|---|
| on OpenRouter | `openrouter` (unchanged) | unchanged |
| on OpenRouter, `via litellm` asked, gateway not confirmed | downgraded to `openrouter` | warning, scoped to the models OpenRouter carries |
| gateway only | `litellm` | says no OpenRouter slug matched the name |
| gateway only, `via openrouter` asked | `litellm` | says the directive cannot be honoured |

A model OpenRouter carries is never moved to the gateway unless a human asks.

No new provider-routability gate was needed: `integrate-model.yml` sets `provider=openrouter` for every integration (line 188), which is in `proxy.DEFAULT_ROUTED_PROVIDERS`, and litellm strips exactly one provider prefix - so the bare slug on the wire is precisely the gateway's route name.

## 3. The reply ignored the icon override entirely

The poller's reply built its emoji as literals, so a workspace with the full `ARENA_AUTOMATION_SLACK_ICON_OVERRIDE` map still saw stock glyphs on the **first message the flow ever sends**. Four roles added, each defaulting to the glyph it replaces, so an unset variable renders identically: `request_resolved`, `request_ambiguous`, `request_unresolved`, `route_downgraded`.

None reuses a pipeline-stage role that shares a glyph today: `dispatch_failed` (`:x:`) is an infra failure *after* resolution succeeded, while `request_unresolved` is a name that matched nothing, and a workspace will want to tell those apart.

The guard swept the workflow YAML only. It now also sweeps the automation sources - AST-based, so docstring Sphinx roles (`:func:`) and `::error::` annotations are not false positives - and a test asserts that a full override map leaves no stock glyph anywhere in the reply, with its counterpart asserting the unset case still renders today's glyphs.

## Also

An unknown icon role costs only the styling. `icon()` still raises (a role is written by this codebase, so a bad one is a bug here rather than a user's typo), but the CLI wrappers catch everything and `exit 0`, so an escaping raise loses the whole notification on a green step - and in `reply`, where the thread root is posted before the prefix is applied, leaves a root with nothing under it.

## Review round

An independent review and the CI review between them found two blockers and a set of notes. All are addressed in `e509c69`; the two that were real defects:

- **The Oxford comma regressed.** `integrate grok 4.5, gpt 5.6, and sonnet 5` asked for a model named `and sonnet 5` and was told it does not exist - and since the reply is the dedup marker, it would not have retried. The comma alternative consumes the space after itself, leaving the following `and` without whitespace on its left. Now covered by a parametrized case per form plus a dangling-connector case.
- **Migration history in source-of-truth docs**, which AGENTS.md Core Rule 8 makes a blocker rather than a nit. Docs and docstrings state the present system; the narrative lives here.

Behaviour and hygiene notes taken:

- a gateway route id outside the slug charset is no longer a candidate. A LiteLLM proxy's `/models` returns free-form `model_name` aliases, and `demote_unsafe_slug` derives its "re-request this instead" candidate by splitting on `:`, so an unsafe id with no colon came back as itself - a clarification nobody could satisfy;
- the **user simulator** is part of the gateway evidence. The run's gateway `.env` is job-wide, so the simulator is proxied too and a gateway that does not serve it sends observe infra-dirty in the simulator, not the candidate. `USER_SIMULATOR_SLUG` is pinned to the workflow by a test;
- an alias to a slug OpenRouter does not carry pins the gateway on OpenRouter-catalog membership alone; requiring gateway membership too sent it down the OpenRouter path whenever the gateway was unreadable;
- the reply no longer asserts a gateway-only model is "not on OpenRouter" - a gateway route can be the same model under another vendor prefix;
- a downgrade no longer suggests the route it just refused, and its warning no longer speaks for a gateway-only model in the same message;
- one accessor owns the gateway environment read, with one documented rationale, so a hand-run diagnostic cannot disagree with the poll. That also resolves the CI review's note on `os.environ.get` for `LLM_PROXY_API_KEY`: the automation package is a standalone workspace member without the engine's secrets stack, its entry points are CI-only, and `DotEnvProvider` precedence is exactly how a developer's local gateway would answer a real poll. It is a scoped, documented exception rather than an oversight;
- `_prefixed` logs to stderr as well as annotating: `_note_failure` prints nothing outside GitHub Actions;
- one fact gets one warning. A request that asks for the gateway, carries a gateway-only model and hits a gateway without the simulator made the downgrade path and the gateway-only path both true, so the requester got two near-identical simulator warnings; it is now one warning stating both consequences. The simulator is also not named when the catalog could not be READ at all - "unknown" still refuses the route, but pointing at one model when there is no readable catalog sends someone checking a name that is fine.

Tests the review earned:

- the unknown-role guard now drives `cmd_reply` and the `post-thread` CLI. Calling `_prefixed` directly still passed with both call sites reverted, which is the regression it exists to catch; reverting them now fails two tests;
- the emoji sweep requires a letter in a shortcode (so `12:30:45` is not an emoji) and also flags unicode emoji characters, while leaving the typographic bullets these replies use alone. Its docstring now says it is a tripwire rather than a proof - a shortcode assembled at runtime still gets through;
- the free-text resolution test no longer implies an end-to-end property: the spaced spelling really is two phrases, and a second test states that.

### Answers to the reviewer's open questions

1. **Is a gateway-only integration expected to work end to end today?** Resolution and routing are in scope here; two downstream limits are not, and are now documented rather than left to be discovered mid-run: `ensure-pricing` resolves a price by exact id against the OpenRouter catalog, so a gateway-only id never matches and `COST_USD_POPULATED` degrades without a `pricing.json` entry; and the gateway must also serve the user simulator.
2. **Should a gateway id whose model-part matches an OpenRouter slug under any vendor prefix be refused?** No - the requester typed the vendor, so they meant it. The reply states only what is known (no OpenRouter slug matched this name), and the comparability call stays with a human.
3. **Should the simulator gate the automatic `litellm` pin, or just warn?** It vetoes an explicit `via litellm`, which has a working alternative, and warns for a gateway-only model, which has none. Refusing the second would leave a resolved request permanently unqueued, since the reply is the dedup marker.

## Evidence

- 246 automation unit tests pass, up from 192 on `main`.
- **Two existing tests changed**, both fixtures rather than assertions: they described a gateway serving only `x-ai/*`, which cannot serve the run at all now that the simulator is part of the evidence. Every other existing test passes untouched, which is the backward-compatibility claim stated as evidence.
- The reviewer's revert experiments were re-run: reverting the connector regex, the gateway fallback or the four registry icons fails 15 tests, and reverting the two `_prefixed` call sites now fails 2 (it failed 0 before this round).
- The emoji guard was verified to fail on an injected `f":white_check_mark: ..."`, on `"✅"` and on `"\U0001f680"`, and not on `"12:30:45"`, `"::error::"` or the `◦` bullet.
- `ruff check` and `ruff format` clean over `tools/automation/`.
- The one canonical failure in this tree (`test_shop_orders_02_behavior_canon.py::TestShopOrders02McpTransport`) reproduces on unmodified `origin/main` at `d888784` and is unrelated to this diff.
