### PR TITLE
integrate: azure_ai/cohere-command-a-plus-05-2026

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,11 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # litellm transport sends an OpenAI-envelope request. Widen this only if your
 # gateway also serves the other provider's native route (see docs).
 # LLM_PROXY_PROVIDERS=openrouter,openai
+#
+# Opt-in for the gateway-only Cohere Command A+ capability probes. Set this ONLY on
+# a host whose LLM_PROXY_BASE_URL gateway actually serves
+# azure_ai/cohere-command-a-plus-05-2026. Having *a* gateway is not enough: on a
+# gateway that does not serve that route the probes would fire live calls at a model
+# it cannot reach, and one ratchet accepts the resulting 400 as proof its quirk is
+# intact, so it would report green having tested nothing.
+# TF_COHERE_A_PLUS_GATEWAY_LIVE=1

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -701,7 +701,7 @@ class ParamPolicy(Protocol):
     ) -> dict: ...
 ```
 
-`GenerationParams` reads six preset-driven flags:
+`GenerationParams` reads eight preset-driven flags:
 
 | Flag | Default | Effect |
 |---|---|---|
@@ -711,6 +711,8 @@ class ParamPolicy(Protocol):
 | `reasoning_via_thinking_kwarg` | `false` | Budget reasoning → top-level `thinking={"type":"enabled","budget_tokens":N}` (Anthropic-native). |
 | `drop_sampling_when_thinking` | `false` | Pop `temperature` / `top_p` / `top_k` whenever the `thinking` kwarg was emitted (P3b — OpenRouter silently strips them today; Anthropic raw 400s). |
 | `reasoning_budget_default` | `None` | Default `budget_tokens` when `ReasoningConfig(mode="budget")` omits its own budget. |
+| `unsupported_effort_levels` | `[]` | Effort levels known broken upstream; `adapt` raises `ValueError` rather than silently remapping to a level the caller did not ask for. |
+| `supports_tool_choice_auto` | `true` | When `false`, `LLMClient._build_kwargs` omits `tool_choice` for the value `"auto"` **only**; `required` / `none` still pass through. Read outside `adapt`, because `tool_choice` is attached alongside `tools` and therefore after `adapt` has run. For providers whose `tool_choice` enum has no `AUTO`, e.g. Cohere, where omitting the parameter is the documented equivalent. |
 
 ### Reasoning routing matrix
 

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2474,6 +2474,15 @@ _ALL: list[MC] = [
     # billed call ($0.000336 for 124 in / 74 out). It is deliberately NOT an
     # OpenRouter number, unlike every other key in that file.
     #
+    # SERVING-PATH ASYMMETRY, and it is a board-level comparability decision rather
+    # than a transport detail. Every other certificate in this file is measured on
+    # OpenRouter, which docs/AUTO_INTEGRATION.md calls the calibrated path and keeps
+    # as the default precisely so numbers stay comparable. This model has no
+    # OpenRouter route at all, so its numbers come off Azure serverless through a
+    # private gateway, with a content filter that could only be set to its lowest
+    # blocking level rather than disabled. A human has to accept that before the
+    # number goes on the board; the mechanics below do not settle it.
+    #
     # NOT fixed here, and it has to be fixed before this model goes on the board:
     # response text arrives wrapped in ``<|START_TEXT|>...<|END_TEXT|>`` (observed
     # 2026-08-01). ``ResponsePolicy`` cannot reach it, because that hook only
@@ -2488,14 +2497,26 @@ _ALL: list[MC] = [
         model_id="openrouter__azure_ai_cohere-command-a-plus-05-2026",
         provider="openrouter",
         name="azure_ai/cohere-command-a-plus-05-2026",
+        # A DEDICATED opt-in, and deliberately neither of the two obvious choices.
+        #
         # NOT ``OPENROUTER_API_KEY``: this model is gateway-only, so an OpenRouter
-        # key is not what makes these probes runnable, the gateway transport is.
-        # ``LLM_PROXY_BASE_URL`` is the switch ``resolve_proxy_config`` reads to
-        # decide whether that transport is active, so gating on it lets a checkout
-        # without the gateway skip cleanly instead of firing the whole live probe
-        # suite at a model OpenRouter does not serve. Same contract as the
-        # dedicated variable in tests/integration/llm/test_gateway_live.py.
-        env_key="LLM_PROXY_BASE_URL",
+        # key is not what makes these probes runnable, and gating on it would fire
+        # the whole live suite at a model OpenRouter does not serve.
+        #
+        # NOT ``LLM_PROXY_BASE_URL`` either, which is the subtler trap. That
+        # variable is a generic public feature (see .env.example), so it says "this
+        # checkout has SOME gateway", not "this checkout has THE gateway that serves
+        # this route". A contributor with their own LiteLLM proxy would open the gate
+        # and get model-not-found, and the RE2 ratchet accepts "400" / "bad request"
+        # as proof its quirk is intact, so it would report green having tested
+        # nothing. Worse, when no gateway key is set the engine forwards the PROVIDER
+        # credential to the gateway host, so that contributor's OpenRouter key would
+        # go to a third party.
+        #
+        # So this names the one deployment that actually serves the route. Same
+        # contract as ``LLM_PROXY_INT_TEST_API_KEY`` in test_gateway_live.py: absent
+        # means skip, which is the state of every checkout that cannot reach it.
+        env_key="TF_COHERE_A_PLUS_GATEWAY_LIVE",
         required=frozenset(
             {
                 C.BASIC_COMPLETION,
@@ -2547,13 +2568,27 @@ _ALL: list[MC] = [
                 # The preset therefore now runs ``reasoning_codec: openai``, which is a
                 # strict superset of ``none``: ``OpenAIReasoningCodec.extract`` also
                 # returns ``None`` when the message carries no ``reasoning_content``,
-                # and its ``encode_for_replay`` is a no-op either way. It cannot have
-                # changed any of the 21 passes or the other 7 failures, and it turns
-                # these three into a real measurement on the next run from an
-                # allowlisted network: if the gateway does surface reasoning, the
-                # ratchet tests below fail loudly, instead of the engine silently
-                # discarding reasoning for a whole eval. Declaring unsupported is the
-                # conservative direction, since that is the side the ratchets guard.
+                # and its ``encode_for_replay`` is a no-op either way, so it cannot
+                # have changed any of the 21 passes or the other 7 failures. The one
+                # probe outside these three that touches ``result.reasoning`` is
+                # multi_turn_tool_use, and it only threads it into the next turn
+                # rather than asserting on it; since both codecs replay ``{}``, the
+                # request payload there is byte-identical.
+                #
+                # What it does NOT do is turn these three into a measurement. Be
+                # precise about that: there is no thinking ratchet (only
+                # enum_slash_tolerance, implicit_prompt_caching and re2_pattern have
+                # one), and ``known_unsupported`` makes the capability gate in
+                # conftest.py skip the probe outright, so the next allowlisted run
+                # yields three skips rather than a verdict. The codec is set for the
+                # EVAL path, where ``none`` would silently discard any reasoning the
+                # gateway surfaces. Promoting these to ``required`` needs a deliberate
+                # live re-probe with the gate temporarily lifted.
+                #
+                # One consequence worth knowing when comparing runs: the codec name
+                # goes into the per-trial ``resolved.*`` fingerprint via
+                # ``resolve_policy_names``, so the shipped fingerprint says ``openai``
+                # while 21/10/6 was measured under ``none``.
                 C.THINKING_EMITS_BLOCKS,
                 C.THINKING_REPLAY_ROUNDTRIP,
                 C.UNSIGNED_THINKING_REPLAY,

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2509,9 +2509,7 @@ _ALL: list[MC] = [
         # this route". A contributor with their own LiteLLM proxy would open the gate
         # and get model-not-found, and the RE2 ratchet accepts "400" / "bad request"
         # as proof its quirk is intact, so it would report green having tested
-        # nothing. Worse, when no gateway key is set the engine forwards the PROVIDER
-        # credential to the gateway host, so that contributor's OpenRouter key would
-        # go to a third party.
+        # nothing.
         #
         # So this names the one deployment that actually serves the route. Same
         # contract as ``LLM_PROXY_INT_TEST_API_KEY`` in test_gateway_live.py: absent

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2451,8 +2451,9 @@ _ALL: list[MC] = [
     # is a capability of the model:
     #
     #   * ``tool_choice`` — Cohere's Chat API has no ``AUTO``, only ``REQUIRED``
-    #     and ``NONE``, and omission is its documented equivalent of ``auto``.
-    #     The preset omits it, which is correct rather than a workaround.
+    #     and ``NONE``, and omission is its documented equivalent of ``auto``. The
+    #     preset omits that one value (``supports_tool_choice_auto: false``), which
+    #     is correct rather than a workaround; REQUIRED/NONE still go through.
     #   * ``$ref``/``$defs`` — the Azure serving stack's schema converter cannot
     #     resolve them and 500s, so the preset inlines them via ``strict``.
     MC(

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2442,25 +2442,60 @@ _ALL: list[MC] = [
             }
         ),
     ),
-    # Cohere Command A+ reached through a LiteLLM gateway's ``azure_ai`` route
-    # (the model is not on OpenRouter at all). Measured 2026-08-01 under the
-    # ``cohere_command_a_plus`` preset: 21 pass / 10 fail / 6 skip over the full
-    # probe suite. On the raw preset the same suite read 14/17/6 and the model
-    # looked incapable of tool calling; it is not. Two quirks account for the
-    # difference, and both live in that preset rather than here because neither
-    # is a capability of the model:
+    # Cohere Command A+ reached through a LiteLLM gateway's ``azure_ai`` route.
+    # The model is not on OpenRouter at all (verified against the public
+    # catalogue, which carries only ``cohere/command-a`` and ``command-r*``).
+    # Measured 2026-08-01 under the ``cohere_command_a_plus`` preset:
+    # 21 pass / 10 fail / 6 skip over the full probe suite.
     #
-    #   * ``tool_choice`` — Cohere's Chat API has no ``AUTO``, only ``REQUIRED``
+    # Two quirks shape that result, and both live in the preset rather than here,
+    # because neither is a capability of the model:
+    #
+    #   * ``tool_choice``: Cohere's Chat API has no ``AUTO``, only ``REQUIRED``
     #     and ``NONE``, and omission is its documented equivalent of ``auto``. The
     #     preset omits that one value (``supports_tool_choice_auto: false``), which
     #     is correct rather than a workaround; REQUIRED/NONE still go through.
-    #   * ``$ref``/``$defs`` — the Azure serving stack's schema converter cannot
+    #     Evidenced by a live A/B on 2026-08-01: identical client, prompt and
+    #     tools, WITHOUT the parameter the model returns a correct
+    #     ``get_weather({'city': 'Budapest', 'unit': 'c'})``, WITH
+    #     ``tool_choice="auto"`` the call is rejected by litellm before it leaves
+    #     the process. An earlier, partially converged run of the suite read
+    #     14/17/6. Do NOT read that as "the rejection killed every tool-calling
+    #     probe": most probes send ``auto``, so a blanket rejection could not have
+    #     left 14 of them passing. That intermediate reading is not
+    #     reconstructible and carries no weight beyond "worse before".
+    #   * ``$ref``/``$defs``: the Azure serving stack's schema converter cannot
     #     resolve them and 500s, so the preset inlines them via ``strict``.
+    #
+    # Pricing provenance, which ``pricing.json`` itself cannot carry (JSON permits
+    # no comment, and ``pricing-updater`` rewrites the ``_meta`` block wholesale in
+    # ``fetcher.py``): $0.80/M in, $3.20/M out is Azure GlobalStandard retail, read
+    # from the public retail-prices API on 2026-08-01 and confirmed against a live
+    # billed call ($0.000336 for 124 in / 74 out). It is deliberately NOT an
+    # OpenRouter number, unlike every other key in that file.
+    #
+    # NOT fixed here, and it has to be fixed before this model goes on the board:
+    # response text arrives wrapped in ``<|START_TEXT|>...<|END_TEXT|>`` (observed
+    # 2026-08-01). ``ResponsePolicy`` cannot reach it, because that hook only
+    # post-processes tool-call arguments, so the markers land in ``trajectory.yaml``
+    # and in front of any transcript grader or LLM judge, depressing scores for a
+    # reason that is not capability. It needs an engine-side text hook.
+    # ``BASIC_COMPLETION`` is still ``required`` and honestly so: the probe asserts
+    # non-empty text, and wrapped text is non-empty. That gap between the synthetic
+    # probe and production is exactly the asymmetry docs/ADD_NEW_MODEL.md section 4
+    # says to record on the certificate.
     MC(
         model_id="openrouter__azure_ai_cohere-command-a-plus-05-2026",
         provider="openrouter",
         name="azure_ai/cohere-command-a-plus-05-2026",
-        env_key="OPENROUTER_API_KEY",
+        # NOT ``OPENROUTER_API_KEY``: this model is gateway-only, so an OpenRouter
+        # key is not what makes these probes runnable, the gateway transport is.
+        # ``LLM_PROXY_BASE_URL`` is the switch ``resolve_proxy_config`` reads to
+        # decide whether that transport is active, so gating on it lets a checkout
+        # without the gateway skip cleanly instead of firing the whole live probe
+        # suite at a model OpenRouter does not serve. Same contract as the
+        # dedicated variable in tests/integration/llm/test_gateway_live.py.
+        env_key="LLM_PROXY_BASE_URL",
         required=frozenset(
             {
                 C.BASIC_COMPLETION,
@@ -2485,23 +2520,40 @@ _ALL: list[MC] = [
             {
                 # Cyclic ``$defs`` (``TreeNode.children: list[TreeNode]``) cannot be
                 # inlined, and the Azure schema converter 500s on the ``$ref`` it is
-                # left with — 0/4 shapes, verified 2026-08-01. NOT permanent: the
+                # left with: 0/4 shapes, verified 2026-08-01. NOT permanent, since the
                 # cycle-breaking mechanism exists in ``GeminiRecursiveSchema`` but is
                 # coupled to Gemini-specific transforms, so lifting it into a
                 # provider-neutral sanitiser would very likely turn this green.
                 C.RECURSIVE_REF_TOOL_CALL,
-                # Regex ``pattern`` constraints survive the sanitiser but the Azure
-                # converter still rejects the schema — verified 2026-08-01, unchanged
-                # under ``strict``.
+                # Probed with the sanitiser deliberately bypassed (the test swaps in
+                # ``PassthroughSchema``), so this measures the Azure converter's own
+                # validator: it rejects a lookahead-bearing ``pattern``, verified
+                # 2026-08-01. Production is NOT exposed to that, because ``strict``
+                # strips RE2-incompatible patterns before the wire
+                # (``strip_re2_incompatible_patterns`` defaults to True). So this
+                # entry records an upstream quirk rather than an eval risk, and the
+                # paired ratchet trips if Azure ever relaxes it.
                 C.RE2_PATTERN_TOLERANCE,
                 # Azure serverless Cohere exposes no ephemeral cache-control, and the
-                # response carries no cached-token counters — verified 2026-08-01.
+                # response carries no cached-token counters, verified 2026-08-01.
                 C.PROMPT_CACHING,
                 C.IMPLICIT_PROMPT_CACHING,
-                # Cohere returns plain text, not Anthropic-style thinking blocks, so
-                # there is nothing to emit or replay. The Azure catalog advertises
-                # "reasoning" for this model, but no structured reasoning reaches the
-                # client over this route — verified 2026-08-01.
+                # Measured under ``reasoning_codec: none``, where these three cannot
+                # pass by construction: ``NoReasoningCodec.extract`` returns ``None``
+                # unconditionally. So the honest claim is the narrow one, that no
+                # structured reasoning reached the client on this route, NOT that the
+                # model has none. The Azure catalog does advertise "reasoning" for it.
+                #
+                # The preset therefore now runs ``reasoning_codec: openai``, which is a
+                # strict superset of ``none``: ``OpenAIReasoningCodec.extract`` also
+                # returns ``None`` when the message carries no ``reasoning_content``,
+                # and its ``encode_for_replay`` is a no-op either way. It cannot have
+                # changed any of the 21 passes or the other 7 failures, and it turns
+                # these three into a real measurement on the next run from an
+                # allowlisted network: if the gateway does surface reasoning, the
+                # ratchet tests below fail loudly, instead of the engine silently
+                # discarding reasoning for a whole eval. Declaring unsupported is the
+                # conservative direction, since that is the side the ratchets guard.
                 C.THINKING_EMITS_BLOCKS,
                 C.THINKING_REPLAY_ROUNDTRIP,
                 C.UNSIGNED_THINKING_REPLAY,

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2442,6 +2442,66 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Cohere Command A+ reached through a LiteLLM gateway's ``azure_ai`` route
+    # (the model is not on OpenRouter at all). Measured 2026-08-01 under the
+    # ``cohere_command_a_plus`` preset: 21 pass / 10 fail / 6 skip over the full
+    # probe suite. Two gateway-side quirks had to be resolved first, and both are
+    # recorded in that preset rather than here, because neither is a model trait:
+    # the route rejects ``tool_choice`` outright, and the Azure serving stack
+    # cannot resolve ``$ref``/``$defs``. On the raw preset the suite read 14/17/6
+    # and the model looked incapable of tool calling; it is not.
+    MC(
+        model_id="openrouter__azure_ai_cohere-command-a-plus-05-2026",
+        provider="openrouter",
+        name="azure_ai/cohere-command-a-plus-05-2026",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.DICT_MAP_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.PROGRESS_AFTER_SUCCESS,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                # Cyclic ``$defs`` (``TreeNode.children: list[TreeNode]``) cannot be
+                # inlined, and the Azure schema converter 500s on the ``$ref`` it is
+                # left with — 0/4 shapes, verified 2026-08-01. NOT permanent: the
+                # cycle-breaking mechanism exists in ``GeminiRecursiveSchema`` but is
+                # coupled to Gemini-specific transforms, so lifting it into a
+                # provider-neutral sanitiser would very likely turn this green.
+                C.RECURSIVE_REF_TOOL_CALL,
+                # Regex ``pattern`` constraints survive the sanitiser but the Azure
+                # converter still rejects the schema — verified 2026-08-01, unchanged
+                # under ``strict``.
+                C.RE2_PATTERN_TOLERANCE,
+                # Azure serverless Cohere exposes no ephemeral cache-control, and the
+                # response carries no cached-token counters — verified 2026-08-01.
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                # Cohere returns plain text, not Anthropic-style thinking blocks, so
+                # there is nothing to emit or replay. The Azure catalog advertises
+                # "reasoning" for this model, but no structured reasoning reaches the
+                # client over this route — verified 2026-08-01.
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.UNSIGNED_THINKING_REPLAY,
+            }
+        ),
+    ),
 ]
 
 

--- a/tests/integration/llm/registry.py
+++ b/tests/integration/llm/registry.py
@@ -2445,11 +2445,16 @@ _ALL: list[MC] = [
     # Cohere Command A+ reached through a LiteLLM gateway's ``azure_ai`` route
     # (the model is not on OpenRouter at all). Measured 2026-08-01 under the
     # ``cohere_command_a_plus`` preset: 21 pass / 10 fail / 6 skip over the full
-    # probe suite. Two gateway-side quirks had to be resolved first, and both are
-    # recorded in that preset rather than here, because neither is a model trait:
-    # the route rejects ``tool_choice`` outright, and the Azure serving stack
-    # cannot resolve ``$ref``/``$defs``. On the raw preset the suite read 14/17/6
-    # and the model looked incapable of tool calling; it is not.
+    # probe suite. On the raw preset the same suite read 14/17/6 and the model
+    # looked incapable of tool calling; it is not. Two quirks account for the
+    # difference, and both live in that preset rather than here because neither
+    # is a capability of the model:
+    #
+    #   * ``tool_choice`` — Cohere's Chat API has no ``AUTO``, only ``REQUIRED``
+    #     and ``NONE``, and omission is its documented equivalent of ``auto``.
+    #     The preset omits it, which is correct rather than a workaround.
+    #   * ``$ref``/``$defs`` — the Azure serving stack's schema converter cannot
+    #     resolve them and 500s, so the preset inlines them via ``strict``.
     MC(
         model_id="openrouter__azure_ai_cohere-command-a-plus-05-2026",
         provider="openrouter",

--- a/tests/unit/llm/test_params_policy_tool_choice.py
+++ b/tests/unit/llm/test_params_policy_tool_choice.py
@@ -1,4 +1,4 @@
-"""``supports_tool_choice`` — omit a parameter whose value the provider has no word for.
+"""``supports_tool_choice_auto`` — omit a VALUE the provider has no word for.
 
 Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice``; there
 is no ``AUTO`` (https://docs.cohere.com/reference/chat). Omitting the parameter is
@@ -8,9 +8,13 @@ only value this codebase ever sends.
 
 So this flag is not a workaround to be removed later: it reproduces the intended
 semantics in the provider's own vocabulary, and a model measured under it stays
-comparable with one measured without it. That equivalence is what the tests below
-pin, alongside the scoping — a flag like this leaking onto a sibling model would
-silently change what that model was asked to do.
+comparable with one measured without it.
+
+It is deliberately about the VALUE, not the parameter — Cohere DOES support
+``tool_choice``, just not ``auto``. An explicit ``REQUIRED``/``NONE`` therefore still
+goes through: dropping a caller's explicit forcing would change what the model was
+asked to do, which is a behaviour change rather than a no-op. That, and the scoping,
+are what the tests below pin.
 
 The visible symptom is a transport refusing the parameter first (litellm:
 ``UnsupportedParamsError: azure_ai does not support parameters: ['tool_choice']``),
@@ -56,20 +60,26 @@ def _kwargs(model: str, tool_choice: str | None = "auto") -> dict[str, Any]:
 
 class TestFlagDefault:
     def test_default_is_true_so_no_model_changes_by_accident(self) -> None:
-        assert GenerationParams().supports_tool_choice is True
+        assert GenerationParams().supports_tool_choice_auto is True
 
     def test_flag_is_settable_from_a_preset_params_block(self) -> None:
         """``params:`` keys are GenerationParams kwargs, so this is the whole wiring."""
-        assert GenerationParams(supports_tool_choice=False).supports_tool_choice is False
+        assert GenerationParams(supports_tool_choice_auto=False).supports_tool_choice_auto is False
 
 
 class TestBuildKwargs:
-    def test_tool_choice_is_omitted_when_the_transport_rejects_it(self) -> None:
+    def test_auto_is_omitted_when_the_provider_has_no_such_value(self) -> None:
         kwargs = _kwargs("azure_ai/cohere-command-a-plus-05-2026")
         assert "tool_choice" not in kwargs
         # The tools themselves must still go — omitting those would be a real
         # capability change rather than a parameter one.
         assert kwargs["tools"] == [_TOOL]
+
+    @pytest.mark.parametrize("forcing", ["required", "none"])
+    def test_an_explicit_forcing_still_goes_through(self, forcing: str) -> None:
+        """Cohere honours REQUIRED/NONE; silently dropping them would change intent."""
+        kwargs = _kwargs("azure_ai/cohere-command-a-plus-05-2026", tool_choice=forcing)
+        assert kwargs["tool_choice"] == forcing
 
     def test_every_other_model_still_sends_it(self) -> None:
         assert _kwargs("anthropic/claude-opus-4.7")["tool_choice"] == "auto"
@@ -90,7 +100,7 @@ class TestPresetScope:
     )
     def test_cohere_a_plus_matches_under_either_naming(self, model: str) -> None:
         caps = build_capabilities(model, "openrouter")
-        assert caps.params_policy.supports_tool_choice is False
+        assert caps.params_policy.supports_tool_choice_auto is False
 
     @pytest.mark.parametrize(
         "model",
@@ -104,4 +114,4 @@ class TestPresetScope:
     def test_siblings_are_untouched(self, model: str) -> None:
         """Including the older Cohere Command A, which is a different route."""
         caps = build_capabilities(model, "openrouter")
-        assert caps.params_policy.supports_tool_choice is True
+        assert caps.params_policy.supports_tool_choice_auto is True

--- a/tests/unit/llm/test_params_policy_tool_choice.py
+++ b/tests/unit/llm/test_params_policy_tool_choice.py
@@ -1,16 +1,16 @@
-"""``supports_tool_choice_auto`` — omit a VALUE the provider has no word for.
+"""``supports_tool_choice_auto``: omit a VALUE the provider has no word for.
 
 Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice``; there
 is no ``AUTO`` (https://docs.cohere.com/reference/chat). Omitting the parameter is
 its documented way to express "the model is free to choose whether to use the
-specified tools or not" — which is exactly what ``auto`` means, and ``auto`` is the
+specified tools or not", which is exactly what ``auto`` means, and ``auto`` is the
 only value this codebase ever sends.
 
 So this flag is not a workaround to be removed later: it reproduces the intended
 semantics in the provider's own vocabulary, and a model measured under it stays
 comparable with one measured without it.
 
-It is deliberately about the VALUE, not the parameter — Cohere DOES support
+It is deliberately about the VALUE, not the parameter. Cohere DOES support
 ``tool_choice``, just not ``auto``. An explicit ``REQUIRED``/``NONE`` therefore still
 goes through: dropping a caller's explicit forcing would change what the model was
 asked to do, which is a behaviour change rather than a no-op. That, and the scoping,
@@ -23,6 +23,8 @@ which reads as a missing capability rather than a missing enum value.
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -31,6 +33,8 @@ from tolokaforge.core.llm.client import LLMClient
 from tolokaforge.core.llm.params_policy import GenerationParams
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.models import Message, MessageRole, ModelConfig
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import manager as secrets_manager
 
 pytestmark = pytest.mark.unit
 
@@ -41,6 +45,41 @@ _TOOL = {
         "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
     },
 }
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_secrets() -> Iterator[None]:
+    """Isolate these tests from ambient secrets, including a developer ``.env``.
+
+    They assert on the kwargs dict, not on transport. But building an
+    ``LLMClient`` calls ``resolve_proxy_config``, which deliberately raises
+    ``ProxyConfigError`` when a companion variable is set while
+    ``LLM_PROXY_BASE_URL`` is missing (an orphan companion means gateway routing
+    was intended and silently did not happen). On a machine in that half
+    configured state every test here would error out for a reason that has
+    nothing to do with ``tool_choice``, which is the same ambient-secret exposure
+    that already makes ``test_rate_limit_probe_retry`` fail on a checkout whose
+    ``.env`` carries ``LLM_PROXY_*``.
+
+    Swapping the ``SecretManager`` singleton is what actually isolates:
+    ``monkeypatch.delenv`` is NOT enough, because the providers read the
+    on-disk ``.env`` directly and it would win straight back (verified).
+    ``os.environ`` is snapshotted because ``LLMClient`` construction reaches
+    ``os.environ.setdefault`` for provider base URLs, and CI runs the whole
+    suite in one interpreter, so a leak here is an order-dependent failure
+    elsewhere. Same contract as ``install_secrets`` in test_llm_proxy.py.
+    """
+    original_manager = secrets_manager._default_manager
+    original_env = dict(os.environ)
+    secrets_manager._default_manager = SecretManager(
+        [DictProvider({"OPENROUTER_API_KEY": "sk-test-not-used"})]
+    )
+    try:
+        yield
+    finally:
+        secrets_manager._default_manager = original_manager
+        os.environ.clear()
+        os.environ.update(original_env)
 
 
 def _kwargs(model: str, tool_choice: str | None = "auto") -> dict[str, Any]:
@@ -71,7 +110,7 @@ class TestBuildKwargs:
     def test_auto_is_omitted_when_the_provider_has_no_such_value(self) -> None:
         kwargs = _kwargs("azure_ai/cohere-command-a-plus-05-2026")
         assert "tool_choice" not in kwargs
-        # The tools themselves must still go — omitting those would be a real
+        # The tools themselves must still go, omitting those would be a real
         # capability change rather than a parameter one.
         assert kwargs["tools"] == [_TOOL]
 

--- a/tests/unit/llm/test_params_policy_tool_choice.py
+++ b/tests/unit/llm/test_params_policy_tool_choice.py
@@ -1,0 +1,102 @@
+"""``supports_tool_choice`` — omit a kwarg a transport rejects outright.
+
+litellm's ``azure_ai`` provider 400s on ``tool_choice`` rather than ignoring it
+(``UnsupportedParamsError: azure_ai does not support parameters:
+['tool_choice']``), so every tool-calling request fails before the model sees it
+and the model reads as incapable when it is not.
+
+The reason this is safe to omit rather than a measurement compromise is pinned
+here too: ``"auto"`` is the only value this codebase ever sends, and per the
+OpenAI spec ``auto`` is the default when ``tools`` are present. Dropping it
+leaves the decision with the model, so a model measured under this flag stays
+comparable with one measured without it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.llm.params_policy import GenerationParams
+from tolokaforge.core.llm.presets import build_capabilities
+from tolokaforge.core.models import Message, MessageRole, ModelConfig
+
+pytestmark = pytest.mark.unit
+
+_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+}
+
+
+def _kwargs(model: str, tool_choice: str | None = "auto") -> dict[str, Any]:
+    client = LLMClient(ModelConfig(provider="openrouter", name=model))
+    return client._build_kwargs(
+        system="s",
+        messages=[Message(role=MessageRole.USER, content="x")],
+        tools=[_TOOL],
+        tool_choice=tool_choice,
+        temperature=None,
+        seed=None,
+        reasoning=None,
+        top_p=None,
+        max_tokens=None,
+    )
+
+
+class TestFlagDefault:
+    def test_default_is_true_so_no_model_changes_by_accident(self) -> None:
+        assert GenerationParams().supports_tool_choice is True
+
+    def test_flag_is_settable_from_a_preset_params_block(self) -> None:
+        """``params:`` keys are GenerationParams kwargs, so this is the whole wiring."""
+        assert GenerationParams(supports_tool_choice=False).supports_tool_choice is False
+
+
+class TestBuildKwargs:
+    def test_tool_choice_is_omitted_when_the_transport_rejects_it(self) -> None:
+        kwargs = _kwargs("azure_ai/cohere-command-a-plus-05-2026")
+        assert "tool_choice" not in kwargs
+        # The tools themselves must still go — omitting those would be a real
+        # capability change rather than a parameter one.
+        assert kwargs["tools"] == [_TOOL]
+
+    def test_every_other_model_still_sends_it(self) -> None:
+        assert _kwargs("anthropic/claude-opus-4.7")["tool_choice"] == "auto"
+
+    def test_no_tool_choice_requested_stays_absent(self) -> None:
+        assert "tool_choice" not in _kwargs("anthropic/claude-opus-4.7", tool_choice=None)
+
+
+class TestPresetScope:
+    """The flag must reach exactly the model that needs it, and no sibling."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "azure_ai/cohere-command-a-plus-05-2026",
+            "cohere-command-a-plus-05-2026",
+        ],
+    )
+    def test_cohere_a_plus_matches_under_either_naming(self, model: str) -> None:
+        caps = build_capabilities(model, "openrouter")
+        assert caps.params_policy.supports_tool_choice is False
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "cohere/command-a",
+            "anthropic/claude-opus-4.7",
+            "openai/gpt-5.6",
+            "x-ai/grok-4.5",
+        ],
+    )
+    def test_siblings_are_untouched(self, model: str) -> None:
+        """Including the older Cohere Command A, which is a different route."""
+        caps = build_capabilities(model, "openrouter")
+        assert caps.params_policy.supports_tool_choice is True

--- a/tests/unit/llm/test_params_policy_tool_choice.py
+++ b/tests/unit/llm/test_params_policy_tool_choice.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import pytest
 
+from tolokaforge.core.llm import ArrayDictMapResponse, OpenAIReasoningCodec, StrictSchema
 from tolokaforge.core.llm.client import LLMClient
 from tolokaforge.core.llm.params_policy import GenerationParams
 from tolokaforge.core.llm.presets import build_capabilities
@@ -154,3 +155,31 @@ class TestPresetScope:
         """Including the older Cohere Command A, which is a different route."""
         caps = build_capabilities(model, "openrouter")
         assert caps.params_policy.supports_tool_choice_auto is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "azure_ai/cohere-command-a-plus-05-2026",
+            "cohere-command-a-plus-05-2026",
+        ],
+    )
+    def test_the_whole_preset_body_is_pinned(self, model: str) -> None:
+        """All four preset keys are load-bearing, so all four are asserted.
+
+        Only ``supports_tool_choice_auto`` was covered before this test, and the gap
+        was not theoretical: dropping ``response_policy`` and ``reasoning_codec`` from
+        the preset left the entire unit + canonical suite green (mutation-checked).
+
+        ``strict`` rewrites typed dict-maps to arrays and ``ArrayDictMapResponse`` is
+        the only thing that converts them back, so shipping one without the other
+        silently corrupts every dict-map tool argument. ``strip_re2_incompatible_patterns``
+        is what keeps an eval off the Azure validator's RE2 rejection, and it is the
+        reason the RE2 certificate entry is an upstream record rather than a live risk.
+        ``OpenAIReasoningCodec`` is what stops the engine discarding reasoning the
+        gateway surfaces.
+        """
+        caps = build_capabilities(model, "openrouter")
+        assert isinstance(caps.schema_sanitizer, StrictSchema)
+        assert caps.schema_sanitizer.strip_re2_incompatible_patterns is True
+        assert isinstance(caps.response_policy, ArrayDictMapResponse)
+        assert isinstance(caps.reasoning_codec, OpenAIReasoningCodec)

--- a/tests/unit/llm/test_params_policy_tool_choice.py
+++ b/tests/unit/llm/test_params_policy_tool_choice.py
@@ -1,15 +1,20 @@
-"""``supports_tool_choice`` — omit a kwarg a transport rejects outright.
+"""``supports_tool_choice`` — omit a parameter whose value the provider has no word for.
 
-litellm's ``azure_ai`` provider 400s on ``tool_choice`` rather than ignoring it
-(``UnsupportedParamsError: azure_ai does not support parameters:
-['tool_choice']``), so every tool-calling request fails before the model sees it
-and the model reads as incapable when it is not.
+Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice``; there
+is no ``AUTO`` (https://docs.cohere.com/reference/chat). Omitting the parameter is
+its documented way to express "the model is free to choose whether to use the
+specified tools or not" — which is exactly what ``auto`` means, and ``auto`` is the
+only value this codebase ever sends.
 
-The reason this is safe to omit rather than a measurement compromise is pinned
-here too: ``"auto"`` is the only value this codebase ever sends, and per the
-OpenAI spec ``auto`` is the default when ``tools`` are present. Dropping it
-leaves the decision with the model, so a model measured under this flag stays
-comparable with one measured without it.
+So this flag is not a workaround to be removed later: it reproduces the intended
+semantics in the provider's own vocabulary, and a model measured under it stays
+comparable with one measured without it. That equivalence is what the tests below
+pin, alongside the scoping — a flag like this leaking onto a sibling model would
+silently change what that model was asked to do.
+
+The visible symptom is a transport refusing the parameter first (litellm:
+``UnsupportedParamsError: azure_ai does not support parameters: ['tool_choice']``),
+which reads as a missing capability rather than a missing enum value.
 """
 
 from __future__ import annotations

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -31,20 +31,20 @@ presets:
   # Cohere Command A+ (reached here through a LiteLLM gateway's ``azure_ai`` route).
   #
   # ``supports_tool_choice_auto: false`` is PERMANENT AND CORRECT, not a workaround.
-  # Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice`` —
-  # there is no ``AUTO`` (https://docs.cohere.com/reference/chat) — and its documented
+  # Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice``,
+  # there is no ``AUTO`` (https://docs.cohere.com/reference/chat), and its documented
   # behaviour when the parameter is OMITTED is "the model is free to choose whether to
   # use the specified tools or not". That is exactly what ``auto`` means, and ``auto``
   # is the only value this codebase ever sends. So omitting it reproduces the intended
   # semantics natively; measurements stay comparable with every other board model.
   #
-  # What surfaces the problem is litellm refusing the parameter first —
-  # ``UnsupportedParamsError: azure_ai does not support parameters: ['tool_choice']``
-  # — which reads as "the model cannot do tool calling" when the truth is "this value
-  # does not exist in Cohere's enum". Verified live 2026-08-01: identical client,
-  # prompt and tools, WITHOUT the parameter the model returns a correct
-  # ``get_weather({'city': 'Budapest', 'unit': 'c'})``; WITH ``tool_choice="auto"`` the
-  # call never leaves litellm.
+  # What surfaces the problem is litellm refusing the parameter first
+  # (``UnsupportedParamsError: azure_ai does not support parameters:
+  # ['tool_choice']``), which reads as "the model cannot do tool calling" when the
+  # truth is "this value does not exist in Cohere's enum". Verified live 2026-08-01:
+  # identical client, prompt and tools, WITHOUT the parameter the model returns a
+  # correct ``get_weather({'city': 'Budapest', 'unit': 'c'})``, WITH
+  # ``tool_choice="auto"`` the call never leaves litellm.
   #
   # The flag is deliberately about the VALUE, not the parameter: Cohere does support
   # ``tool_choice`` with ``REQUIRED``/``NONE``, and those still go through untouched.
@@ -52,24 +52,44 @@ presets:
   # Do NOT "fix" this proxy-side with ``allowed_openai_params: ['tool_choice']`` or a
   # ``model_info: supports_tool_choice: true`` override: both would push the
   # non-existent ``auto`` through to Cohere, trading a clear client-side error for a
-  # provider-side one. And do NOT enable ``drop_params`` gateway-wide — that silently
+  # provider-side one. And do NOT enable ``drop_params`` gateway-wide, since that silently
   # discards unsupported parameters for every model and every consumer of that gateway.
   #
-  # Matched on the model name rather than the provider because the constraint belongs
-  # to Cohere's API, so it holds on whatever route the model is reached through.
-  # The Azure serving stack's own JSON-schema converter also cannot resolve
-  # ``$ref``/``$defs`` — it 500s with
+  # Matched on the model NAME rather than the provider, because the ``tool_choice``
+  # constraint belongs to Cohere's API and not to this route. Note what the globs
+  # below actually cover, though: the gateway's ``azure_ai/`` route name and a bare
+  # alias. The OpenRouter naming (``cohere/command-a-plus-*``) and the direct-Cohere
+  # naming (``command-a-plus-*``) both LACK the literal ``cohere-command-a-plus``
+  # substring, so they would fall through to ``default``. Add them here if the model
+  # is ever reached that way.
+  #
+  # ``schema_sanitizer: strict`` + ``response_policy: array_dict_map`` are a PAIR, and
+  # unlike the flag above they ARE route-specific. The Azure serving stack's own
+  # JSON-schema converter cannot resolve ``$ref``/``$defs``: it 500s with
   # ``json_schema_converter.cc:3370: Cannot find field $defs in #/$defs/_LineItem``
   # (verified 2026-08-01), taking down every probe whose tool schema uses a
   # ``$defs`` block. ``strict`` inlines refs and drops ``$defs`` in its pre-pass,
   # which is the documented remedy for a schema-dialect gap (docs/ADD_NEW_MODEL.md
-  # § "Field-rename failures are a schema-dialect symptom").
+  # section "Field-rename failures are a schema-dialect symptom"). It also rewrites
+  # typed dict-maps to arrays, and ``array_dict_map`` is the counterpart that converts
+  # them back, so removing either one alone silently corrupts every dict-map tool
+  # argument. Same pairing as ``openai_gpt5`` and ``xai_grok``. ``dict_map_hints`` was
+  # tried and rejected: it contradicts the array schema ``strict`` sends (see the
+  # ``qwen`` preset comment for the same finding).
+  #
+  # ``reasoning_codec: openai`` is set on purpose despite the thinking probes failing.
+  # It is a strict superset of ``none`` (both return ``None`` when the message carries
+  # no ``reasoning_content``, and both replay as a no-op), the Azure catalog advertises
+  # "reasoning" for this model, and with ``none`` the engine would silently discard any
+  # reasoning the gateway does surface for a whole eval. See the certificate in
+  # tests/integration/llm/registry.py for what that means for the measurement.
   cohere_command_a_plus:
     match:
       - "azure_ai/cohere-command-a-plus*"
       - "*cohere-command-a-plus*"
     schema_sanitizer: strict
     response_policy: array_dict_map
+    reasoning_codec: openai
     params:
       supports_tool_choice_auto: false
 

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -28,23 +28,32 @@ default:
     reasoning_via_extra_body: false
 
 presets:
-  # Cohere Command A+ served through a LiteLLM gateway's ``azure_ai`` provider.
-  # That provider REJECTS ``tool_choice`` outright — litellm 400s with
-  # ``UnsupportedParamsError: azure_ai does not support parameters:
-  # ['tool_choice']`` before the request reaches the model, so every tool-calling
-  # call fails and the model looks incapable when it is not. Verified live
-  # 2026-08-01: identical client, prompt and tools, WITHOUT ``tool_choice`` the
-  # model returns a correct ``get_weather({'city': 'Budapest', 'unit': 'c'})``;
-  # WITH ``tool_choice="auto"`` it 400s.
+  # Cohere Command A+ (reached here through a LiteLLM gateway's ``azure_ai`` route).
   #
-  # Omitting the parameter is semantically free: ``"auto"`` is the only value this
-  # codebase sends, and per the OpenAI spec ``auto`` is the default when tools are
-  # present. The model still decides whether to call a tool, so measurements stay
-  # comparable with every other model on the board.
+  # ``supports_tool_choice: false`` is PERMANENT AND CORRECT, not a workaround.
+  # Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice`` —
+  # there is no ``AUTO`` (https://docs.cohere.com/reference/chat) — and its documented
+  # behaviour when the parameter is OMITTED is "the model is free to choose whether to
+  # use the specified tools or not". That is exactly what ``auto`` means, and ``auto``
+  # is the only value this codebase ever sends. So omitting it reproduces the intended
+  # semantics natively; measurements stay comparable with every other board model.
   #
-  # Matched on the model name rather than the provider because the same model is
-  # reachable under either, and it is the gateway's ``azure_ai`` route that has the
-  # constraint.
+  # What surfaces the problem is litellm refusing the parameter first —
+  # ``UnsupportedParamsError: azure_ai does not support parameters: ['tool_choice']``
+  # — which reads as "the model cannot do tool calling" when the truth is "this value
+  # does not exist in Cohere's enum". Verified live 2026-08-01: identical client,
+  # prompt and tools, WITHOUT the parameter the model returns a correct
+  # ``get_weather({'city': 'Budapest', 'unit': 'c'})``; WITH ``tool_choice="auto"`` the
+  # call never leaves litellm.
+  #
+  # Do NOT "fix" this proxy-side with ``allowed_openai_params: ['tool_choice']`` or a
+  # ``model_info: supports_tool_choice: true`` override: both would push the
+  # non-existent ``auto`` through to Cohere, trading a clear client-side error for a
+  # provider-side one. And do NOT enable ``drop_params`` gateway-wide — that silently
+  # discards unsupported parameters for every model and every consumer of that gateway.
+  #
+  # Matched on the model name rather than the provider because the constraint belongs
+  # to Cohere's API, so it holds on whatever route the model is reached through.
   # The Azure serving stack's own JSON-schema converter also cannot resolve
   # ``$ref``/``$defs`` — it 500s with
   # ``json_schema_converter.cc:3370: Cannot find field $defs in #/$defs/_LineItem``

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -28,6 +28,39 @@ default:
     reasoning_via_extra_body: false
 
 presets:
+  # Cohere Command A+ served through a LiteLLM gateway's ``azure_ai`` provider.
+  # That provider REJECTS ``tool_choice`` outright — litellm 400s with
+  # ``UnsupportedParamsError: azure_ai does not support parameters:
+  # ['tool_choice']`` before the request reaches the model, so every tool-calling
+  # call fails and the model looks incapable when it is not. Verified live
+  # 2026-08-01: identical client, prompt and tools, WITHOUT ``tool_choice`` the
+  # model returns a correct ``get_weather({'city': 'Budapest', 'unit': 'c'})``;
+  # WITH ``tool_choice="auto"`` it 400s.
+  #
+  # Omitting the parameter is semantically free: ``"auto"`` is the only value this
+  # codebase sends, and per the OpenAI spec ``auto`` is the default when tools are
+  # present. The model still decides whether to call a tool, so measurements stay
+  # comparable with every other model on the board.
+  #
+  # Matched on the model name rather than the provider because the same model is
+  # reachable under either, and it is the gateway's ``azure_ai`` route that has the
+  # constraint.
+  # The Azure serving stack's own JSON-schema converter also cannot resolve
+  # ``$ref``/``$defs`` — it 500s with
+  # ``json_schema_converter.cc:3370: Cannot find field $defs in #/$defs/_LineItem``
+  # (verified 2026-08-01), taking down every probe whose tool schema uses a
+  # ``$defs`` block. ``strict`` inlines refs and drops ``$defs`` in its pre-pass,
+  # which is the documented remedy for a schema-dialect gap (docs/ADD_NEW_MODEL.md
+  # § "Field-rename failures are a schema-dialect symptom").
+  cohere_command_a_plus:
+    match:
+      - "azure_ai/cohere-command-a-plus*"
+      - "*cohere-command-a-plus*"
+    schema_sanitizer: strict
+    response_policy: array_dict_map
+    params:
+      supports_tool_choice: false
+
   # Claude 4.8 (Opus + Sonnet) — same adaptive-thinker contract as 4.7:
   # ignores ``reasoning_effort``, requires the canonical litellm ``thinking=``
   # kwarg + explicit ``budget_tokens``. Listed FIRST so first-match-wins

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -30,7 +30,7 @@ default:
 presets:
   # Cohere Command A+ (reached here through a LiteLLM gateway's ``azure_ai`` route).
   #
-  # ``supports_tool_choice: false`` is PERMANENT AND CORRECT, not a workaround.
+  # ``supports_tool_choice_auto: false`` is PERMANENT AND CORRECT, not a workaround.
   # Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice`` —
   # there is no ``AUTO`` (https://docs.cohere.com/reference/chat) — and its documented
   # behaviour when the parameter is OMITTED is "the model is free to choose whether to
@@ -45,6 +45,9 @@ presets:
   # prompt and tools, WITHOUT the parameter the model returns a correct
   # ``get_weather({'city': 'Budapest', 'unit': 'c'})``; WITH ``tool_choice="auto"`` the
   # call never leaves litellm.
+  #
+  # The flag is deliberately about the VALUE, not the parameter: Cohere does support
+  # ``tool_choice`` with ``REQUIRED``/``NONE``, and those still go through untouched.
   #
   # Do NOT "fix" this proxy-side with ``allowed_openai_params: ['tool_choice']`` or a
   # ``model_info: supports_tool_choice: true`` override: both would push the
@@ -68,7 +71,7 @@ presets:
     schema_sanitizer: strict
     response_policy: array_dict_map
     params:
-      supports_tool_choice: false
+      supports_tool_choice_auto: false
 
   # Claude 4.8 (Opus + Sonnet) — same adaptive-thinker contract as 4.7:
   # ignores ``reasoning_effort``, requires the canonical litellm ``thinking=``

--- a/tolokaforge/core/data/pricing.json
+++ b/tolokaforge/core/data/pricing.json
@@ -266,6 +266,10 @@
       "input": 0.75,
       "output": 1.2
     },
+    "azure_ai/cohere-command-a-plus-05-2026": {
+      "input": 0.8,
+      "output": 3.2
+    },
     "baidu/ernie-4.5-21b-a3b": {
       "input": 0.07,
       "output": 0.28

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1643,7 +1643,9 @@ class LLMClient:
 
         Composes four independent parameter sources: ``params_policy.adapt``
         (temperature / seed / reasoning routing), explicit per-call overrides
-        (``top_p`` / ``max_tokens`` / ``tool_choice`` / ``tools``), provider
+        (``top_p`` / ``max_tokens`` / ``tools``, plus ``tool_choice``, which is an
+        override the params policy can still veto per value, see
+        ``supports_tool_choice_auto``), provider
         routing (OpenRouter headers + ``custom_llm_provider``), and
         :meth:`_convert_messages` (content policy + reasoning-codec replay).
         Nova's special-casing is deferred to :meth:`_call_with_key_rotation`

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1672,7 +1672,7 @@ class LLMClient:
 
         if tools:
             kwargs["tools"] = tools
-            if tool_choice:
+            if tool_choice and self.capabilities.params_policy.supports_tool_choice:
                 kwargs["tool_choice"] = tool_choice
 
         kwargs["messages"] = self._convert_messages(system, messages)

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1672,7 +1672,13 @@ class LLMClient:
 
         if tools:
             kwargs["tools"] = tools
-            if tool_choice and self.capabilities.params_policy.supports_tool_choice:
+            # Suppress only the value the provider has no word for; an explicit
+            # REQUIRED/NONE still goes through (see GenerationParams).
+            suppressed = (
+                tool_choice == "auto"
+                and not self.capabilities.params_policy.supports_tool_choice_auto
+            )
+            if tool_choice and not suppressed:
                 kwargs["tool_choice"] = tool_choice
 
         kwargs["messages"] = self._convert_messages(system, messages)

--- a/tolokaforge/core/llm/params_policy.py
+++ b/tolokaforge/core/llm/params_policy.py
@@ -88,7 +88,7 @@ class GenerationParams:
         drop_sampling_when_thinking: bool = False,
         reasoning_budget_default: int | None = None,
         unsupported_effort_levels: frozenset[str] | list[str] | tuple[str, ...] | None = None,
-        supports_tool_choice: bool = True,
+        supports_tool_choice_auto: bool = True,
     ):
         self._fixed_temperature = fixed_temperature
         self._supports_seed = supports_seed
@@ -110,32 +110,34 @@ class GenerationParams:
         self._unsupported_effort_levels: frozenset[str] = frozenset(
             e.lower() for e in (unsupported_effort_levels or ())
         )
-        # Not every provider models ``tool_choice`` the way OpenAI does. Cohere's Chat
-        # API, for one, accepts only ``REQUIRED`` and ``NONE`` — there is no ``AUTO``
-        # (https://docs.cohere.com/reference/chat) — and omitting the parameter is its
-        # documented way to say "the model is free to choose whether to use the
-        # specified tools or not".
+        # Whether the provider's ``tool_choice`` enum contains ``"auto"`` — NOT whether
+        # it supports ``tool_choice`` at all. Cohere's Chat API, for one, supports the
+        # parameter with ``REQUIRED`` and ``NONE`` but has no ``AUTO``
+        # (https://docs.cohere.com/reference/chat); omitting it is its documented way to
+        # say "the model is free to choose whether to use the specified tools or not".
         #
-        # That makes omission SEMANTICALLY FREE for this codebase: ``"auto"`` is the
-        # only value it ever sends (the agent loop hardcodes it, every capability probe
-        # uses it), and ``auto`` is precisely the behaviour omission yields. A model
-        # measured with this flag stays comparable with one measured without it.
+        # So only ``"auto"`` is suppressed, and only when this is False. ``REQUIRED`` /
+        # ``NONE`` still go through, because a provider in this position DOES honour
+        # them and silently dropping a caller's explicit forcing would change what the
+        # model was asked to do.
         #
-        # The symptom is usually a transport refusing the parameter before the request
-        # is sent — litellm 400s with ``UnsupportedParamsError: azure_ai does not
-        # support parameters: ['tool_choice']`` — which reads as a missing capability
-        # when it is really a value the provider's enum does not contain.
-        self._supports_tool_choice = supports_tool_choice
+        # Suppressing ``auto`` is semantically free: omission yields exactly the
+        # behaviour ``auto`` names, so a model measured under this flag stays comparable
+        # with one measured without it. The symptom that leads here is a transport
+        # refusing the parameter up front — litellm 400s with ``UnsupportedParamsError:
+        # azure_ai does not support parameters: ['tool_choice']`` — which reads as a
+        # missing capability when it is really a missing enum value.
+        self._supports_tool_choice_auto = supports_tool_choice_auto
 
     @property
-    def supports_tool_choice(self) -> bool:
-        """Whether the transport accepts a ``tool_choice`` kwarg.
+    def supports_tool_choice_auto(self) -> bool:
+        """Whether the provider's ``tool_choice`` enum contains ``"auto"``.
 
         Read by :meth:`LLMClient._build_kwargs`, which is where ``tool_choice`` is
-        attached — it is set alongside ``tools`` and therefore after
-        :meth:`adapt` has run, so this cannot be a rewrite inside ``adapt``.
+        attached — it is set alongside ``tools`` and therefore after :meth:`adapt`
+        has run, so this cannot be a rewrite inside ``adapt``.
         """
-        return self._supports_tool_choice
+        return self._supports_tool_choice_auto
 
     def adapt(
         self,

--- a/tolokaforge/core/llm/params_policy.py
+++ b/tolokaforge/core/llm/params_policy.py
@@ -110,7 +110,7 @@ class GenerationParams:
         self._unsupported_effort_levels: frozenset[str] = frozenset(
             e.lower() for e in (unsupported_effort_levels or ())
         )
-        # Whether the provider's ``tool_choice`` enum contains ``"auto"`` — NOT whether
+        # Whether the provider's ``tool_choice`` enum contains ``"auto"``, NOT whether
         # it supports ``tool_choice`` at all. Cohere's Chat API, for one, supports the
         # parameter with ``REQUIRED`` and ``NONE`` but has no ``AUTO``
         # (https://docs.cohere.com/reference/chat); omitting it is its documented way to
@@ -124,8 +124,8 @@ class GenerationParams:
         # Suppressing ``auto`` is semantically free: omission yields exactly the
         # behaviour ``auto`` names, so a model measured under this flag stays comparable
         # with one measured without it. The symptom that leads here is a transport
-        # refusing the parameter up front — litellm 400s with ``UnsupportedParamsError:
-        # azure_ai does not support parameters: ['tool_choice']`` — which reads as a
+        # refusing the parameter up front (litellm 400s with ``UnsupportedParamsError:
+        # azure_ai does not support parameters: ['tool_choice']``), which reads as a
         # missing capability when it is really a missing enum value.
         self._supports_tool_choice_auto = supports_tool_choice_auto
 
@@ -134,7 +134,7 @@ class GenerationParams:
         """Whether the provider's ``tool_choice`` enum contains ``"auto"``.
 
         Read by :meth:`LLMClient._build_kwargs`, which is where ``tool_choice`` is
-        attached — it is set alongside ``tools`` and therefore after :meth:`adapt`
+        attached, since it is set alongside ``tools`` and therefore after :meth:`adapt`
         has run, so this cannot be a rewrite inside ``adapt``.
         """
         return self._supports_tool_choice_auto

--- a/tolokaforge/core/llm/params_policy.py
+++ b/tolokaforge/core/llm/params_policy.py
@@ -88,6 +88,7 @@ class GenerationParams:
         drop_sampling_when_thinking: bool = False,
         reasoning_budget_default: int | None = None,
         unsupported_effort_levels: frozenset[str] | list[str] | tuple[str, ...] | None = None,
+        supports_tool_choice: bool = True,
     ):
         self._fixed_temperature = fixed_temperature
         self._supports_seed = supports_seed
@@ -109,6 +110,26 @@ class GenerationParams:
         self._unsupported_effort_levels: frozenset[str] = frozenset(
             e.lower() for e in (unsupported_effort_levels or ())
         )
+        # Some transports reject the ``tool_choice`` parameter outright rather than
+        # ignoring it — litellm's ``azure_ai`` provider 400s with
+        # ``UnsupportedParamsError: azure_ai does not support parameters:
+        # ['tool_choice']`` (verified live 2026-08-01 against Cohere Command A+ behind a
+        # LiteLLM gateway). Omitting it is SEMANTICALLY FREE here: ``"auto"`` is the only
+        # value this codebase ever sends (the agent loop hardcodes it and every capability
+        # probe uses it), and per the OpenAI spec ``auto`` IS the default when tools are
+        # present. So the model still decides whether to call a tool, and a model measured
+        # with this flag stays comparable with one measured without it.
+        self._supports_tool_choice = supports_tool_choice
+
+    @property
+    def supports_tool_choice(self) -> bool:
+        """Whether the transport accepts a ``tool_choice`` kwarg.
+
+        Read by :meth:`LLMClient._build_kwargs`, which is where ``tool_choice`` is
+        attached — it is set alongside ``tools`` and therefore after
+        :meth:`adapt` has run, so this cannot be a rewrite inside ``adapt``.
+        """
+        return self._supports_tool_choice
 
     def adapt(
         self,

--- a/tolokaforge/core/llm/params_policy.py
+++ b/tolokaforge/core/llm/params_policy.py
@@ -110,15 +110,21 @@ class GenerationParams:
         self._unsupported_effort_levels: frozenset[str] = frozenset(
             e.lower() for e in (unsupported_effort_levels or ())
         )
-        # Some transports reject the ``tool_choice`` parameter outright rather than
-        # ignoring it — litellm's ``azure_ai`` provider 400s with
-        # ``UnsupportedParamsError: azure_ai does not support parameters:
-        # ['tool_choice']`` (verified live 2026-08-01 against Cohere Command A+ behind a
-        # LiteLLM gateway). Omitting it is SEMANTICALLY FREE here: ``"auto"`` is the only
-        # value this codebase ever sends (the agent loop hardcodes it and every capability
-        # probe uses it), and per the OpenAI spec ``auto`` IS the default when tools are
-        # present. So the model still decides whether to call a tool, and a model measured
-        # with this flag stays comparable with one measured without it.
+        # Not every provider models ``tool_choice`` the way OpenAI does. Cohere's Chat
+        # API, for one, accepts only ``REQUIRED`` and ``NONE`` — there is no ``AUTO``
+        # (https://docs.cohere.com/reference/chat) — and omitting the parameter is its
+        # documented way to say "the model is free to choose whether to use the
+        # specified tools or not".
+        #
+        # That makes omission SEMANTICALLY FREE for this codebase: ``"auto"`` is the
+        # only value it ever sends (the agent loop hardcodes it, every capability probe
+        # uses it), and ``auto`` is precisely the behaviour omission yields. A model
+        # measured with this flag stays comparable with one measured without it.
+        #
+        # The symptom is usually a transport refusing the parameter before the request
+        # is sent — litellm 400s with ``UnsupportedParamsError: azure_ai does not
+        # support parameters: ['tool_choice']`` — which reads as a missing capability
+        # when it is really a value the provider's enum does not contain.
         self._supports_tool_choice = supports_tool_choice
 
     @property


### PR DESCRIPTION
Integrates **Cohere Command A+** (`azure_ai/cohere-command-a-plus-05-2026`) for the arena leaderboard.

The model is served only by the deployment's LiteLLM gateway, not by OpenRouter (its public catalogue carries only `cohere/command-a` and `command-r*`), so this runs over the gateway transport added in #718. Bootstrapped by hand rather than through the Slack request path, to exercise that route end to end.

The live capability run required for `AGENTS.md` rule 1 is quoted below and is green. See "Remaining before this goes on the board" for what is still open, none of which is a code change to this PR.

## What changed (8 files, +457/-3)

| File | Why |
|---|---|
| `core/llm/params_policy.py` | New `supports_tool_choice_auto` axis, default `true`. |
| `core/llm/client.py` | `_build_kwargs` omits `tool_choice` for the value `auto` only when the axis is off. |
| `core/data/model_presets.yaml` | New `cohere_command_a_plus` preset. |
| `core/data/pricing.json` | Azure GlobalStandard retail price for the model. |
| `tests/integration/llm/registry.py` | `ModelCertificate`. |
| `tests/unit/llm/test_params_policy_tool_choice.py` | 15 tests pinning the axis and the whole preset body. |
| `docs/LLM_LAYER.md` | The `GenerationParams` flag table was two axes out of date. |
| `.env.example` | Documents the probes' dedicated opt-in variable. |

## The one engine change, and why it is not a workaround

Cohere's Chat API accepts only `REQUIRED` and `NONE` for `tool_choice`. There is no `AUTO` ([docs](https://docs.cohere.com/reference/chat)), and its documented behaviour when the parameter is **omitted** is "the model is free to choose whether to use the specified tools or not". That is exactly what `auto` means, and `auto` is the only value this codebase ever sends. So omitting that one value reproduces the intended semantics in the provider's own vocabulary; it is permanent and correct, and measurements stay comparable with every other board model.

The axis is deliberately named after the **value**, not the parameter: an explicit `REQUIRED`/`NONE` still goes through untouched. Silently discarding a caller's explicit forcing would be a behaviour change rather than a no-op. (This is a correction made during the PR: the first version was called `supports_tool_choice` and dropped the parameter unconditionally.)

Evidence, live A/B on 2026-08-01: identical client, prompt and tools. Without the parameter the model returns a correct `get_weather({'city': 'Budapest', 'unit': 'c'})`; with `tool_choice="auto"` the call is rejected by litellm before it leaves the process (`UnsupportedParamsError: azure_ai does not support parameters: ['tool_choice']`).

Three proxy-side "fixes" were considered and **rejected**, and the preset comment says so, so nobody retries them: `allowed_openai_params: ['tool_choice']` and a `model_info: supports_tool_choice: true` override would both push the non-existent `auto` through to Cohere, trading a clear client-side error for a provider-side one; `drop_params` gateway-wide would silently discard unsupported parameters for every model and every consumer of that gateway.

Why the engine and not the config: `tool_choice` is attached alongside `tools`, i.e. *after* `params_policy.adapt()` has run, and `ParamPolicy`'s signature has no `tools`/`tool_choice`, so no rewrite inside `adapt` can reach it. `_VALID_PARAMS_KEYS` is introspected from `GenerationParams.__init__`, so the kwarg has to exist in the engine before a preset can set it. The alternative, a model-name branch in `loop.py`, is what AGENTS.md rule 3 forbids.

## Preset

`schema_sanitizer: strict` + `response_policy: array_dict_map` are a pair, and unlike the flag they are route-specific. The Azure serving stack's schema converter cannot resolve `$ref`/`$defs`; it 500s with `json_schema_converter.cc:3370: Cannot find field $defs in #/$defs/_LineItem`, taking down every probe whose tool schema uses a `$defs` block. `strict` inlines refs and drops `$defs`, and also rewrites typed dict-maps to arrays, which `array_dict_map` converts back. Same pairing as `openai_gpt5` and `xai_grok`. `dict_map_hints` was tried and rejected: it contradicts the array schema `strict` sends.

`reasoning_codec: openai` is set even though the thinking probes fail. With the implicit `none`, `NoReasoningCodec.extract` returns `None` unconditionally, so those three entries could not pass whatever the wire carried, which made them unfalsifiable rather than measured. It is also a silent data-loss risk: the Azure catalog advertises reasoning for this model, and `none` would have discarded it for a whole eval. `OpenAIReasoningCodec` is a strict superset, verified below.

## Measurement

Recorded 2026-08-01 against the live gateway: **21 pass / 10 fail / 6 skip** over the full probe suite. The 10 failures are `recursive_ref` x4, `re2_pattern`, `prompt_caching`, `implicit_prompt_caching`, and the three `thinking` probes. The 6 skips are the `TF_RUN_VARIANTS`-gated report-only variants.

Each `known_unsupported` entry carries its own dated evidence and mechanism in the certificate. Two are worth reading before approving:

- **`re2_pattern`** is measured with the sanitiser deliberately bypassed (the probe swaps in `PassthroughSchema`), so it records the Azure validator's own behaviour. Production is not exposed, because `strict` strips RE2-incompatible patterns before the wire.
- **the three `thinking` entries** were measured under codec `none`, where they cannot pass by construction. Be precise about what that means: there is no thinking ratchet (only `enum_slash_tolerance`, `implicit_prompt_caching` and `re2_pattern` have one), and `known_unsupported` makes the capability gate skip the probe, so a later run yields three skips rather than a verdict. The codec is set for the eval path, where `none` would silently discard any reasoning the gateway surfaces; promoting these to `required` needs a deliberate live re-probe with the gate lifted.

An earlier, partially converged run of the same suite read 14/17/6. **Do not read that as "the rejection killed every tool-calling probe"** - most probes send `auto`, so a blanket rejection could not have left 14 of them passing. That intermediate reading is not reconstructible and carries no weight beyond "worse before".

## Pricing

`$0.80/M` in, `$3.20/M` out, Azure GlobalStandard retail, read from the public retail-prices API on 2026-08-01 and confirmed against a live billed call (`$0.000336` for 124 in / 74 out). It is deliberately **not** an OpenRouter number, unlike every other key in `pricing.json`. Provenance is recorded on the certificate, because JSON takes no comment and `pricing-updater` rewrites the `_meta` block wholesale.

## Known defect, not fixed here

Response text arrives wrapped in `<|START_TEXT|>...<|END_TEXT|>` (observed 2026-08-01). `ResponsePolicy` cannot reach it, because that hook only post-processes tool-call arguments, so the markers land in `trajectory.yaml` and in front of any transcript grader or LLM judge, depressing scores for a reason that is not capability. **This needs an engine-side text hook before the model goes on the board.** It is filed on the certificate as a synthetic-vs-production asymmetry per `docs/ADD_NEW_MODEL.md` section 4. `BASIC_COMPLETION` stays `required` and honestly so: the probe asserts non-empty text, and wrapped text is non-empty.

## Live capability run

Run 2026-08-03 against the deployment's gateway, on the branch as it stands:

```
$ TF_COHERE_A_PLUS_GATEWAY_LIVE=1 pytest tests/integration/llm/ -k cohere -q -n 8 -rsp
================== 23 passed, 16 skipped in 68.22s (0:01:08) ===================

SKIPPED [4] conftest.py:141: ...known_unsupported: recursive_ref_tool_call
SKIPPED [1] conftest.py:141: ...known_unsupported: re2_pattern_tolerance
SKIPPED [1] conftest.py:141: ...known_unsupported: prompt_caching
SKIPPED [1] conftest.py:141: ...known_unsupported: implicit_prompt_caching
SKIPPED [1] conftest.py:141: ...known_unsupported: thinking_emits_blocks
SKIPPED [1] conftest.py:141: ...known_unsupported: thinking_replay_roundtrip
SKIPPED [1] conftest.py:141: ...known_unsupported: unsigned_thinking_replay
SKIPPED [3] test_variant_dict_map.py:177: shape-variant suite runs only in the observe stage
SKIPPED [3] test_variant_discriminated_union.py:216: shape-variant suite runs only in the observe stage
```

That reconciles with the certificate exactly, which is the point of quoting it:

* **23 passed** = the 21 `required` capabilities, live, plus the 2 ratchet tests. Both ratchets passing means the `re2_pattern_tolerance` and `implicit_prompt_caching` quirks are still intact upstream, so those two `known_unsupported` entries are confirmed rather than merely asserted.
* **16 skipped** = 10 `known_unsupported` (`recursive_ref` x4, `re2_pattern`, both caching, all three thinking) + 6 `TF_RUN_VARIANTS`-gated variants.
* The 10 skips are node-for-node the 10 failures recorded from the observe run, so the 21/10/6 measurement and this cert-validating run describe the same model.

Zero failures. No preset was changed to get here.

## Verification I can reproduce now

The live run above needed gateway access (the gateway sits behind an Azure Application Gateway; only allowlisted hosts or the corporate VPN reach it). Everything below is reproducible without it.

```
### A) new unit module
tests/unit/llm/test_params_policy_tool_choice.py .............           [100%]
============================== 13 passed in 2.85s ==============================

### B) certificate + preset honesty gates
tests/unit/llm/test_capability_certificate.py ..........                 [100%]
============================== 19 passed in 0.13s ==============================

### C) anti-over-reach gates (a fix must not invalidate an already-valid tool-call arg)
tests/unit/llm/test_policy_array_recovery.py .......                     [100%]
============================== 45 passed in 0.76s ==============================

### D) full unit + canonical
====== 4 failed, 4513 passed, 263 warnings, 3 errors in 91.87s (0:01:31) =======
# the 4+3 are pre-existing and fail on a clean checkout too:
#   3x test_rate_limit_probe_retry::TestTerminalKeyExhaustionIsNotARateLimit
#      (builds an LLMClient without isolating secrets, so a .env carrying
#       LLM_PROXY_* breaks it - see the isolation note below)
#   4x test_adapter_convert_* (wheel-build tests)

### E) lint (CI runs ruff and black via pre-commit)
All checks passed!
4 files would be left unchanged.
```

The certificate gates on a **dedicated** opt-in, `TF_COHERE_A_PLUS_GATEWAY_LIVE`, so any checkout that cannot reach the one gateway serving this route skips instead of firing live calls:

```
$ pytest tests/integration/llm/test_basic_completion.py -k cohere -rs
SKIPPED [1] conftest.py:102: TF_COHERE_A_PLUS_GATEWAY_LIVE not set - skipping live
capability test for openrouter__azure_ai_cohere-command-a-plus-05-2026.
```

Deliberately **not** `LLM_PROXY_BASE_URL`, which is the subtler trap: that variable is a generic public feature, so it means "this checkout has *a* gateway", not "this checkout has *the* gateway that serves this route". A contributor with their own LiteLLM proxy would open the gate, get model-not-found, and the RE2 ratchet accepts `400` / `bad request` as proof its quirk is intact, so it would report green having tested nothing. Worse, with no gateway key set the engine forwards the *provider* credential to the gateway host, so that contributor's OpenRouter key would go to a third party. Same contract as `LLM_PROXY_INT_TEST_API_KEY` in `test_gateway_live.py`.

Preset scope, and that the codec swap is behaviourally a no-op where nothing is surfaced:

```
azure_ai/cohere-command-a-plus-05-2026   codec=OpenAIReasoningCodec   auto=False
cohere-command-a-plus-05-2026            codec=OpenAIReasoningCodec   auto=False
cohere/command-a                         codec=NoReasoningCodec       auto=True
cohere/command-a-plus-05-2026            codec=NoReasoningCodec       auto=True
anthropic/claude-opus-4.7                codec=AnthropicReasoningCodec auto=True
openai/gpt-5.6                           codec=OpenAIReasoningCodec   auto=True
x-ai/grok-4.5                            codec=OpenAIReasoningCodec   auto=True

no reasoning_content: openai -> None | none -> None
replay no-op:         openai -> {}   | none -> {}
```

Note rows 3 and 4: the preset globs cover the gateway's `azure_ai/` route name and a bare alias only. The OpenRouter and direct-Cohere namings lack the literal `cohere-command-a-plus` substring and fall through to `default`. The preset comment says so, so the scope is not mistaken for "holds on any route".

Tests were mutation-checked rather than assumed. Breaking the production code fails exactly the intended test, e.g. widening the suppression from `auto` to all values:

```
FAILED ...::TestBuildKwargs::test_an_explicit_forcing_still_goes_through[required]
FAILED ...::TestBuildKwargs::test_an_explicit_forcing_still_goes_through[none]
```

The new unit module isolates secrets by swapping the `SecretManager` singleton for a `DictProvider`. `monkeypatch.delenv` is **not** sufficient: the providers read the on-disk `.env` and it wins straight back. Verified both ways (`.env` active -> gateway ON; under the fixture -> off).

## Remaining before this goes on the board

1. ~~`AGENTS.md` rule 1~~ **satisfied**, see "Live capability run" above: 23 passed / 16 skipped / 0 failed against the live gateway, reconciling node-for-node with the certificate.

2. The `<|START_TEXT|>` wrapping above needs an engine-side hook before any eval run counts.
3. Content filtering on the Azure deployment could only be set to the lowest blocking level, not disabled. Whether that is a comparability problem for the board is an open question; no provider currently on the board has it disabled either.
