### PR TITLE
feat(secrets): resolve ${secret:NAME} references in config values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # LLM_PROXY_API_KEY=your-gateway-key-here
 # Static attribution headers your gateway requires, as a JSON object:
 # LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Cost-Center":"42"}
+# A value may reference another secret as $NAME or ${NAME}, resolved the same way
+# every other secret here is. That keeps this string reviewable, and safe to keep in
+# a plain CI *variable*, even when one of the headers carries something sensitive
+# (an account id, or the admission credential some gateways want instead of an IP
+# allowlist) -- the string only ever shows the placeholder:
+# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$SUNDAY_ORDER_ID"}
+# SUNDAY_ORDER_ID=...
+# An unset name is a startup error, never an empty header. Use $$ for a literal $.
 # Header name to fill with a fresh UUID per request:
 # LLM_PROXY_REQUEST_ID_HEADER=X-Request-Id
 # Which providers to route. Default is openrouter,openai — the only ones whose

--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,9 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # LLM_PROXY_API_KEY=your-gateway-key-here
 # Static attribution headers your gateway requires, as a JSON object:
 # LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Cost-Center":"42"}
-# A value may reference another secret as $NAME or ${NAME}, so this string stays
-# non-secret even when a header carries something sensitive. See docs/LLM_LAYER.md.
-# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$ORDER_ID"}
+# A value may reference a secret as ${secret:NAME}, so this string stays non-secret
+# even when a header carries something sensitive. See docs/LLM_LAYER.md.
+# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"${secret:ORDER_ID}"}
 # ORDER_ID=...
 # Header name to fill with a fresh UUID per request:
 # LLM_PROXY_REQUEST_ID_HEADER=X-Request-Id

--- a/.env.example
+++ b/.env.example
@@ -31,14 +31,10 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # LLM_PROXY_API_KEY=your-gateway-key-here
 # Static attribution headers your gateway requires, as a JSON object:
 # LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Cost-Center":"42"}
-# A value may reference another secret as $NAME or ${NAME}, resolved the same way
-# every other secret here is. That keeps this string reviewable, and safe to keep in
-# a plain CI *variable*, even when one of the headers carries something sensitive
-# (an account id, or the admission credential some gateways want instead of an IP
-# allowlist) -- the string only ever shows the placeholder:
-# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$SUNDAY_ORDER_ID"}
-# SUNDAY_ORDER_ID=...
-# An unset name is a startup error, never an empty header. Use $$ for a literal $.
+# A value may reference another secret as $NAME or ${NAME}, so this string stays
+# non-secret even when a header carries something sensitive. See docs/LLM_LAYER.md.
+# LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$ORDER_ID"}
+# ORDER_ID=...
 # Header name to fill with a fresh UUID per request:
 # LLM_PROXY_REQUEST_ID_HEADER=X-Request-Id
 # Which providers to route. Default is openrouter,openai — the only ones whose

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -115,8 +115,8 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
-      # Values the $NAME placeholders in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve to.
-      # Job-level is safe for these: unlike LLM_PROXY_*, an unused one is inert.
+      # Values the ${secret:NAME} references in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve
+      # to. Job-level is safe for these: unlike LLM_PROXY_*, an unused one is inert.
       SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
       GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
       # Run + PR permalinks, passed to the Slack notifier as <url|label> links.

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -115,15 +115,19 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
-      # Values the ${secret:NAME} references in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve
-      # to. Job-level because the .env step and `automation reprobe` both need them, and
-      # unlike LLM_PROXY_* an unused one here is inert rather than a half-configured
-      # gateway. But job-level also means every step, so the two agent invocations and
-      # the litellm proxy scrub them with `env -u`, the same way they scrub GH_TOKEN:
-      # GATEWAY_RUNNER_KEY is a network-admission credential, not a budget-bounded one.
-      # Grep `env -u` before adding a third.
-      SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
-      GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
+      # Values the ${secret:NAME} references in the LLM_PROXY_HEADERS variable resolve to.
+      # Named LLM_PROXY_* because they are gateway configuration, not automation config;
+      # they are NOT companions in the resolve_proxy_config sense (that check names only
+      # _API_KEY / _HEADERS / _REQUEST_ID_HEADER / _PROVIDERS), so an unused one is inert.
+      #
+      # Job-level because the .env step and `automation reprobe` both need them, but that
+      # means every step, so the two agent invocations and the litellm proxy scrub them
+      # with `env -u`. The runner key is a network-admission credential rather than a
+      # budget-bounded one. Note `env -u` denies them to those processes, not to code the
+      # agent may have written: later `uv run automation` commands in the same step still
+      # carry them, so keep these rotate-friendly. Grep `env -u` before adding a third.
+      LLM_PROXY_SUNDAY_ORDER_ID: ${{ secrets.LLM_PROXY_SUNDAY_ORDER_ID }}
+      LLM_PROXY_GATEWAY_RUNNER_KEY: ${{ secrets.LLM_PROXY_GATEWAY_RUNNER_KEY }}
       # Run + PR permalinks, passed to the Slack notifier as <url|label> links.
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr }}
@@ -220,7 +224,7 @@ jobs:
           PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
           PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
           # A VARIABLE, not a secret: see the note in slack-integrate.yml.
-          PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
+          PROXY_HEADERS: ${{ vars.LLM_PROXY_HEADERS }}
         # OPENROUTER_API_KEY is always written: it is what the non-gateway route uses, and the
         # OpenRouter pricing/catalog HTTP calls need it on either route. LLM_PROXY_* is added
         # only when the gateway route was requested AND configured -- writing a base URL without
@@ -492,7 +496,8 @@ jobs:
           # Pinned to the litellm version in uv.lock (repro + supply-chain: an unpinned latest could
           # ship a broken/hostile release that runs with secrets in env). Scrub the job's write-token
           # and Slack token from the proxy's environment - it only needs OPENROUTER_API_KEY.
-          env -u GH_TOKEN -u SLACK_BOT_TOKEN -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+          env -u GH_TOKEN -u SLACK_BOT_TOKEN \
+            -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY \
             nohup uvx --from 'litellm[proxy]==1.87.0' litellm \
             --config /tmp/litellm.config.yaml --host 127.0.0.1 --port 4000 \
             > /tmp/litellm.log 2>&1 &
@@ -574,7 +579,7 @@ jobs:
             # include candidate-model output, and GATEWAY_RUNNER_KEY is a network-admission
             # credential rather than a budget-bounded one. The step needs those values only
             # for `automation reprobe`, not for the agent.
-            env -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+            env -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY \
               claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
               --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
@@ -657,7 +662,7 @@ jobs:
           fill "$P/resolve_finalize.md" > /tmp/finalize.md
           # `|| true`: if the agent hits --max-turns it exits non-zero; do not abort - the commit
           # step below decides success by whether files changed.
-          env -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+          env -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY \
             claude -p "$(cat /tmp/finalize.md)" --model "$AGENT_MODEL" \
             --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
             --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -237,6 +237,12 @@ jobs:
               # Only inside this branch: a companion without a base URL is a hard error,
               # so a job-level env var here would break the openrouter route.
               #
+              # The ${secret:NAME} references inside the value stay LITERAL here, because
+              # bash does not rescan the result of a parameter expansion. Never inline one
+              # into this script's text instead: bash reads ${secret:X} as substring
+              # syntax and silently yields an empty string, so the engine would never see
+              # the reference and its hard-error guard could not fire.
+              #
               # jq COMPACTS, and that is load-bearing, not tidiness: the dotenv parser's
               # unquoted-value branch is ``[^\s#]*``, so a value containing a space or a
               # '#' fails the line match and the line is SKIPPED at debug level. Pretty

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -116,7 +116,12 @@ jobs:
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
       # Values the ${secret:NAME} references in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve
-      # to. Job-level is safe for these: unlike LLM_PROXY_*, an unused one is inert.
+      # to. Job-level because the .env step and `automation reprobe` both need them, and
+      # unlike LLM_PROXY_* an unused one here is inert rather than a half-configured
+      # gateway. But job-level also means every step, so the two agent invocations and
+      # the litellm proxy scrub them with `env -u`, the same way they scrub GH_TOKEN:
+      # GATEWAY_RUNNER_KEY is a network-admission credential, not a budget-bounded one.
+      # Grep `env -u` before adding a third.
       SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
       GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
       # Run + PR permalinks, passed to the Slack notifier as <url|label> links.
@@ -230,9 +235,16 @@ jobs:
               printf '%s\n' "LLM_PROXY_BASE_URL=$PROXY_BASE_URL" >> .env
               printf '%s\n' "LLM_PROXY_API_KEY=$PROXY_API_KEY" >> .env
               # Only inside this branch: a companion without a base URL is a hard error,
-              # so a job-level env var here would break the openrouter route. Bare JSON
-              # (no surrounding quotes) is what the dotenv provider expects.
+              # so a job-level env var here would break the openrouter route.
+              #
+              # jq COMPACTS, and that is load-bearing, not tidiness: the dotenv parser's
+              # unquoted-value branch is ``[^\s#]*``, so a value containing a space or a
+              # '#' fails the line match and the line is SKIPPED at debug level. Pretty
+              # printed JSON pasted into the variable would silently produce no headers,
+              # with the base URL still set so no orphan error fires either. ``-e`` also
+              # makes malformed JSON fail the step here rather than at resolve time.
               if [ -n "$PROXY_HEADERS" ]; then
+                PROXY_HEADERS="$(jq -ce . <<<"$PROXY_HEADERS")"
                 printf '%s\n' "LLM_PROXY_HEADERS=$PROXY_HEADERS" >> .env
               fi
               echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"
@@ -474,7 +486,8 @@ jobs:
           # Pinned to the litellm version in uv.lock (repro + supply-chain: an unpinned latest could
           # ship a broken/hostile release that runs with secrets in env). Scrub the job's write-token
           # and Slack token from the proxy's environment - it only needs OPENROUTER_API_KEY.
-          env -u GH_TOKEN -u SLACK_BOT_TOKEN nohup uvx --from 'litellm[proxy]==1.87.0' litellm \
+          env -u GH_TOKEN -u SLACK_BOT_TOKEN -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+            nohup uvx --from 'litellm[proxy]==1.87.0' litellm \
             --config /tmp/litellm.config.yaml --host 127.0.0.1 --port 4000 \
             > /tmp/litellm.log 2>&1 &
           echo $! > /tmp/litellm.pid
@@ -551,7 +564,12 @@ jobs:
             # this step runs under `bash -e`; without the guard that non-zero would abort the
             # WHOLE resolve instead of degrading to the no-overlay path below. A stuck iteration
             # must fall through to the next one (and ultimately to needs-human), not hard-fail.
-            claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
+            # Scrubbed like GH_TOKEN above, and for the same reason: this agent's inputs
+            # include candidate-model output, and GATEWAY_RUNNER_KEY is a network-admission
+            # credential rather than a budget-bounded one. The step needs those values only
+            # for `automation reprobe`, not for the agent.
+            env -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+              claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
               --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
             # Agent-requested escalation: if it lacks the data to produce a CORRECT policy (a
@@ -633,7 +651,8 @@ jobs:
           fill "$P/resolve_finalize.md" > /tmp/finalize.md
           # `|| true`: if the agent hits --max-turns it exits non-zero; do not abort - the commit
           # step below decides success by whether files changed.
-          claude -p "$(cat /tmp/finalize.md)" --model "$AGENT_MODEL" \
+          env -u SUNDAY_ORDER_ID -u GATEWAY_RUNNER_KEY \
+            claude -p "$(cat /tmp/finalize.md)" --model "$AGENT_MODEL" \
             --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
             --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
 

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -477,7 +477,10 @@ jobs:
 
       - name: Install Claude Code CLI
         if: steps.gate.outputs.clean == 'yes'
-        run: npm install -g @anthropic-ai/claude-code
+        # Scrubbed like the agent steps: an install script runs arbitrary code, and
+        # these two are gateway credentials the CLI install has no use for.
+        run: env -u LLM_PROXY_SUNDAY_ORDER_ID -u LLM_PROXY_GATEWAY_RUNNER_KEY
+          npm install -g @anthropic-ai/claude-code
 
       - name: Start LiteLLM gateway (Anthropic /v1/messages -> OpenRouter; agent on the OpenRouter budget)
         # The resolve + finalize agent is the Claude Code CLI, which speaks the Anthropic Messages

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -115,10 +115,8 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
-      # Values that the $NAME placeholders in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve
-      # to. Job-level so every engine step sees them, which is safe because these are
-      # ordinary secret names: unlike LLM_PROXY_*, an unused one here is inert rather
-      # than a half-configured gateway. Add one line per placeholder used.
+      # Values the $NAME placeholders in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve to.
+      # Job-level is safe for these: unlike LLM_PROXY_*, an unused one is inert.
       SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
       GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
       # Run + PR permalinks, passed to the Slack notifier as <url|label> links.
@@ -216,8 +214,7 @@ jobs:
           ROUTE: ${{ inputs.route || 'openrouter' }}
           PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
           PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-          # A VARIABLE, not a secret: see the note in slack-integrate.yml. Sensitive
-          # halves are $NAME placeholders resolved from the secrets below.
+          # A VARIABLE, not a secret: see the note in slack-integrate.yml.
           PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
         # OPENROUTER_API_KEY is always written: it is what the non-gateway route uses, and the
         # OpenRouter pricing/catalog HTTP calls need it on either route. LLM_PROXY_* is added
@@ -232,11 +229,9 @@ jobs:
             if [ -n "$PROXY_BASE_URL" ] && [ -n "$PROXY_API_KEY" ]; then
               printf '%s\n' "LLM_PROXY_BASE_URL=$PROXY_BASE_URL" >> .env
               printf '%s\n' "LLM_PROXY_API_KEY=$PROXY_API_KEY" >> .env
-              # Written ONLY inside this branch, never on its own: resolve_proxy_config
-              # treats a companion without a base URL as a hard error, on purpose, so
-              # a job-level env var here would break the openrouter route outright.
-              # Bare JSON, no surrounding quotes, is what the dotenv provider expects;
-              # any $NAME inside it resolves from the job-level secrets below.
+              # Only inside this branch: a companion without a base URL is a hard error,
+              # so a job-level env var here would break the openrouter route. Bare JSON
+              # (no surrounding quotes) is what the dotenv provider expects.
               if [ -n "$PROXY_HEADERS" ]; then
                 printf '%s\n' "LLM_PROXY_HEADERS=$PROXY_HEADERS" >> .env
               fi

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -241,20 +241,19 @@ jobs:
               # Only inside this branch: a companion without a base URL is a hard error,
               # so a job-level env var here would break the openrouter route.
               #
-              # The ${secret:NAME} references inside the value stay LITERAL here, because
-              # bash does not rescan the result of a parameter expansion. Never inline one
-              # into this script's text instead: bash reads ${secret:X} as substring
-              # syntax and silently yields an empty string, so the engine would never see
-              # the reference and its hard-error guard could not fire.
-              #
-              # jq COMPACTS, and that is load-bearing, not tidiness: the dotenv parser's
-              # unquoted-value branch is ``[^\s#]*``, so a value containing a space or a
-              # '#' fails the line match and the line is SKIPPED at debug level. Pretty
-              # printed JSON pasted into the variable would silently produce no headers,
-              # with the base URL still set so no orphan error fires either. ``-e`` also
-              # makes malformed JSON fail the step here rather than at resolve time.
+              # References stay literal through the shell; never inline one in the
+              # script text. jq compacts because the dotenv parser drops a line whose
+              # unquoted value has whitespace. Both: docs/CONFIG.md § secrets.
               if [ -n "$PROXY_HEADERS" ]; then
                 PROXY_HEADERS="$(jq -ce . <<<"$PROXY_HEADERS")"
+                # jq cannot help a space or '#' inside a name/value; refuse rather
+                # than run with no headers. docs/CONFIG.md § secrets.
+                case "$PROXY_HEADERS" in
+                  *[[:space:]\#]*)
+                    echo "::error title=LLM_PROXY_HEADERS not representable in .env::a header name or value contains whitespace or '#'; the dotenv parser would drop the line"
+                    exit 1
+                    ;;
+                esac
                 printf '%s\n' "LLM_PROXY_HEADERS=$PROXY_HEADERS" >> .env
               fi
               echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -115,6 +115,12 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.ARENA_AUTOMATION_SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ vars.ARENA_AUTOMATION_SLACK_CHANNEL }}
       SLACK_MENTIONS: ${{ vars.ARENA_AUTOMATION_SLACK_MENTIONS }}
+      # Values that the $NAME placeholders in ARENA_AUTOMATION_LLM_PROXY_HEADERS resolve
+      # to. Job-level so every engine step sees them, which is safe because these are
+      # ordinary secret names: unlike LLM_PROXY_*, an unused one here is inert rather
+      # than a half-configured gateway. Add one line per placeholder used.
+      SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
+      GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
       # Run + PR permalinks, passed to the Slack notifier as <url|label> links.
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr }}
@@ -210,6 +216,9 @@ jobs:
           ROUTE: ${{ inputs.route || 'openrouter' }}
           PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
           PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
+          # A VARIABLE, not a secret: see the note in slack-integrate.yml. Sensitive
+          # halves are $NAME placeholders resolved from the secrets below.
+          PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
         # OPENROUTER_API_KEY is always written: it is what the non-gateway route uses, and the
         # OpenRouter pricing/catalog HTTP calls need it on either route. LLM_PROXY_* is added
         # only when the gateway route was requested AND configured -- writing a base URL without
@@ -223,6 +232,14 @@ jobs:
             if [ -n "$PROXY_BASE_URL" ] && [ -n "$PROXY_API_KEY" ]; then
               printf '%s\n' "LLM_PROXY_BASE_URL=$PROXY_BASE_URL" >> .env
               printf '%s\n' "LLM_PROXY_API_KEY=$PROXY_API_KEY" >> .env
+              # Written ONLY inside this branch, never on its own: resolve_proxy_config
+              # treats a companion without a base URL as a hard error, on purpose, so
+              # a job-level env var here would break the openrouter route outright.
+              # Bare JSON, no surrounding quotes, is what the dotenv provider expects;
+              # any $NAME inside it resolves from the job-level secrets below.
+              if [ -n "$PROXY_HEADERS" ]; then
+                printf '%s\n' "LLM_PROXY_HEADERS=$PROXY_HEADERS" >> .env
+              fi
               echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"
             else
               echo "::warning title=Gateway route unavailable::route=litellm was requested but ARENA_AUTOMATION_LLM_PROXY_BASE_URL / _API_KEY are not set; probing over OpenRouter instead"

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -72,17 +72,10 @@ jobs:
       # => availability is "unknown" and every request integrates over OpenRouter as before.
       LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
       LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-      # A repository VARIABLE on purpose, so the headers this automation sends stay
-      # readable in the repo settings and in this log. Any sensitive half is written as
-      # a $NAME placeholder and resolved from a secret at runtime (see
-      # docs/LLM_LAYER.md), so the variable itself carries nothing to protect.
-      #
-      # Without it the poller cannot reach a gateway that admits callers by a
-      # shared-secret header rather than by source IP, which hosted-runner egress
-      # cannot satisfy. Every model then comes back "not on the gateway" for a
-      # transport reason rather than a catalogue one.
+      # A VARIABLE, not a secret: sensitive halves are written as $NAME placeholders and
+      # resolved from the secrets below. See docs/LLM_LAYER.md § proxy.
       LLM_PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
-      # Values the placeholders above resolve to. Add one line per placeholder used.
+      # One line per placeholder used above.
       SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
       GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
     steps:

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -72,12 +72,21 @@ jobs:
       # => availability is "unknown" and every request integrates over OpenRouter as before.
       LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
       LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-      # A VARIABLE, not a secret: sensitive halves are written as ${secret:NAME}
-      # references and resolved from the secrets below. See docs/LLM_LAYER.md § proxy.
-      LLM_PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
-      # One line per ${secret:NAME} referenced above.
-      SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
-      GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
+      # Headers are deliberately NOT passed here yet. This job reaches the gateway
+      # through ``automation.gateway_catalog``, which reads the two names above from
+      # ``os.environ`` directly and by design (see its comment: routing through
+      # ``DotEnvProvider`` would let a developer's local ``.env`` answer a real poll).
+      # So it would ignore LLM_PROXY_HEADERS, and passing it would be dead config.
+      #
+      # The fix is not to teach that module about one more variable: the gateway
+      # contract already has a model (``ProxyConfig``), and this module reimplements
+      # two thirds of it, which is why it drifts. It should consume a ``ProxyConfig``
+      # built from an env-only ``SecretManager``. Tracked separately, because it needs
+      # an injectable manager on ``resolve_proxy_config``.
+      #
+      # Consequence until then: on a gateway that admits callers by a shared-secret
+      # header, this poll cannot read the catalog, so every model reports as absent
+      # from the gateway for a transport reason rather than a catalogue one.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -72,10 +72,10 @@ jobs:
       # => availability is "unknown" and every request integrates over OpenRouter as before.
       LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
       LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-      # A VARIABLE, not a secret: sensitive halves are written as $NAME placeholders and
-      # resolved from the secrets below. See docs/LLM_LAYER.md § proxy.
+      # A VARIABLE, not a secret: sensitive halves are written as ${secret:NAME}
+      # references and resolved from the secrets below. See docs/LLM_LAYER.md § proxy.
       LLM_PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
-      # One line per placeholder used above.
+      # One line per ${secret:NAME} referenced above.
       SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
       GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
     steps:

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -72,6 +72,19 @@ jobs:
       # => availability is "unknown" and every request integrates over OpenRouter as before.
       LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
       LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
+      # A repository VARIABLE on purpose, so the headers this automation sends stay
+      # readable in the repo settings and in this log. Any sensitive half is written as
+      # a $NAME placeholder and resolved from a secret at runtime (see
+      # docs/LLM_LAYER.md), so the variable itself carries nothing to protect.
+      #
+      # Without it the poller cannot reach a gateway that admits callers by a
+      # shared-secret header rather than by source IP, which hosted-runner egress
+      # cannot satisfy. Every model then comes back "not on the gateway" for a
+      # transport reason rather than a catalogue one.
+      LLM_PROXY_HEADERS: ${{ vars.ARENA_AUTOMATION_LLM_PROXY_HEADERS }}
+      # Values the placeholders above resolve to. Add one line per placeholder used.
+      SUNDAY_ORDER_ID: ${{ secrets.ARENA_AUTOMATION_SUNDAY_ORDER_ID }}
+      GATEWAY_RUNNER_KEY: ${{ secrets.ARENA_AUTOMATION_GATEWAY_RUNNER_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Tolokaforge is an LLM tool-use benchmarking harness.
 **Allowed:**
 - `from tolokaforge.secrets import get_default`, then `get_default().get_secret("OPENAI_API_KEY")` (and the `get_secret_or_raise` / `validate_required` variants)
 - Adding a new `SecretProvider` subclass when integrating a new secret backend (Vault, AWS Secrets Manager, etc.) — never a one-off call site
+- `expand_secret_refs` when a **non-secret** config string must carry a secret value: it resolves `${secret:NAME}` inside that string. This is the only sanctioned expansion mechanism: do not hand-roll a second reference dialect at a new call site, and do not move expansion into `get_secret` (that path also feeds the log-redaction set and the container serializer, which resolve every enumerable key, so it would apply this syntax to credentials that legitimately contain `$`). See [`docs/LLM_LAYER.md`](docs/LLM_LAYER.md) § "Values may reference secrets".
 - `SecretManager.export_to_environ(keys)` *only* when a subprocess (e.g. litellm SDK) demands `os.environ`; called inside the smallest possible scope, never sprinkled
 
 `tolokaforge run` calls `init_default()` once at startup. Inside the runner container, `init_default_from(...)` is reconstructed from `TOLOKAFORGE_SECRETS_JSON`. There is no other initialization path. The CI test [`tests/unit/secrets/test_no_raw_secret_access.py`](tests/unit/secrets/test_no_raw_secret_access.py) static-greps for these patterns; adding a new violation will fail CI.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -505,7 +505,29 @@ Common keys:
 Routing calls through an LLM gateway (a LiteLLM proxy or equivalent) instead of
 calling providers directly (`LLM_PROXY_BASE_URL`, `LLM_PROXY_API_KEY`,
 `LLM_PROXY_HEADERS`, `LLM_PROXY_REQUEST_ID_HEADER`, `LLM_PROXY_PROVIDERS`) is
-documented in [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway).
+documented in [`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway),
+including how a value may reference a secret as `${secret:NAME}`.
+
+### Writing `.env` by hand or from a script
+
+`DotEnvProvider` accepts `KEY=value`, `KEY="value"` and `KEY='value'`. The
+unquoted form is `[^\s#]*`, so **an unquoted value containing whitespace or `#`
+does not parse and the whole line is dropped.** Anything that depended on that
+key then reads as unset. The provider logs a warning naming the key (never the
+value) when it drops a line, so check the log if a variable you are sure you set
+appears missing. Quote the value, or keep it free of whitespace.
+
+This bites hardest with JSON values such as `LLM_PROXY_HEADERS`: pretty-printed
+JSON is dropped, compact JSON is fine. A workflow that writes one should pipe it
+through `jq -ce` and refuse outright if a name or value still contains whitespace,
+since a silently header-less gateway call bills to nobody or fails admission far
+from the cause. `.github/workflows/integrate-model.yml` does both.
+
+Two shell notes for the same case. A `${secret:NAME}` reference survives being
+written through a shell **variable**, because bash does not rescan the result of a
+parameter expansion. Inlined into script text instead, bash reads `${secret:X}` as
+substring syntax and silently yields an empty string, so the engine never sees the
+reference and cannot raise on it.
 
 ## Output Structure
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -417,7 +417,7 @@ posting to a route the gateway does not serve.
 |---|---|
 | `LLM_PROXY_BASE_URL` | Gateway base URL. **Setting this enables the transport**; everything else is optional. |
 | `LLM_PROXY_API_KEY` | Credential presented to the gateway. Omit only for gateways that authenticate by network position — litellm then falls through to its provider-env lookup and forwards the *provider's* key to the gateway host instead. |
-| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. |
+| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. A value may reference another secret, see below. |
 | `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
 | `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
 
@@ -425,6 +425,35 @@ All five resolve through `SecretManager`, so `.env`, the process environment,
 and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
 A malformed value raises `ProxyConfigError` at the first `LLMClient`
 construction rather than running a whole evaluation with unattributed spend.
+
+### Header values may reference other secrets
+
+A value in `LLM_PROXY_HEADERS` may contain `$NAME` or `${NAME}`, resolved through the
+same `SecretManager`:
+
+```
+LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$SUNDAY_ORDER_ID"}
+SUNDAY_ORDER_ID=10000458
+```
+
+This exists so the JSON does not have to be a secret just because one header carries
+something sensitive. The header *names* and the overall shape stay legible, which is
+what a reviewer needs to see (what is this run telling the gateway about itself?),
+while the sensitive halves stay indirect. In CI that means the JSON can live in a
+plain repository **variable** without printing a secret into a public workflow log,
+because the variable only ever holds the placeholder.
+
+Two deliberate rules:
+
+* **An unresolved name is a hard error**, never an empty substitution. A blank
+  attribution header bills the call to nobody and a blank admission header fails at
+  the gateway, and both surface a long way from the misconfigured line. The error
+  names the header and the missing variable, and it fires at resolve time, before
+  any request goes out.
+* **`$$` is a literal `$`**, so a value that genuinely needs one is still writable.
+
+Only string values are expanded; a JSON number or boolean keeps its existing
+stringify path.
 Setting any companion variable while `LLM_PROXY_BASE_URL` is empty also raises,
 so a typo in the base-URL name cannot silently fall back to direct provider
 access.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -417,7 +417,7 @@ posting to a route the gateway does not serve.
 |---|---|
 | `LLM_PROXY_BASE_URL` | Gateway base URL. **Setting this enables the transport**; everything else is optional. |
 | `LLM_PROXY_API_KEY` | Credential presented to the gateway. Omit only for gateways that authenticate by network position — litellm then falls through to its provider-env lookup and forwards the *provider's* key to the gateway host instead. |
-| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. A value may reference another secret, see below. |
+| `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. A value may reference a secret as `${secret:NAME}`, see below. |
 | `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
 | `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
 
@@ -426,14 +426,15 @@ and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
 A malformed value raises `ProxyConfigError` at the first `LLMClient`
 construction rather than running a whole evaluation with unattributed spend.
 
-### Header values may reference other secrets
+### Values may reference secrets
 
-A value in `LLM_PROXY_HEADERS` may contain `$NAME` or `${NAME}`, resolved through the
-same `SecretManager`:
+A value in `LLM_PROXY_HEADERS` may contain `${secret:NAME}`, resolved through
+`SecretManager` by
+[`expand_secret_refs`](../tolokaforge/secrets/expand.py):
 
 ```
-LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"$SUNDAY_ORDER_ID"}
-SUNDAY_ORDER_ID=10000458
+LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"${secret:ORDER_ID}"}
+ORDER_ID=9000123
 ```
 
 This exists so the JSON does not have to be a secret just because one header carries
@@ -441,19 +442,54 @@ something sensitive. The header *names* and the overall shape stay legible, whic
 what a reviewer needs to see (what is this run telling the gateway about itself?),
 while the sensitive halves stay indirect. In CI that means the JSON can live in a
 plain repository **variable** without printing a secret into a public workflow log,
-because the variable only ever holds the placeholder.
+because the variable only ever holds the reference.
 
-Two deliberate rules:
+`${secret:...}` resolves by NAME through the normal provider chain, so what matters
+is that the name is set, not whether it is "a secret". A GitHub repository variable
+and a GitHub secret both arrive as ordinary environment variables; the difference is
+only that GitHub masks the secret's value in the log, which is the point.
 
+#### Rules
+
+* **The form is typed, not shell-style.** A bare `$NAME` would match inside real
+  credential text, and plenty of credentials contain a dollar sign: argon2
+  (`$argon2id$v=19$...`), bcrypt (`$2b$12$...`), Postgres SCRAM verifiers, generated
+  passwords. Under `${secret:NAME}` a lone `$` is never special, so no escape is
+  needed and `Pa$$w0rd` passes through untouched.
 * **An unresolved name is a hard error**, never an empty substitution. A blank
   attribution header bills the call to nobody and a blank admission header fails at
   the gateway, and both surface a long way from the misconfigured line. The error
-  names the header and the missing variable, and it fires at resolve time, before
-  any request goes out.
-* **`$$` is a literal `$`**, so a value that genuinely needs one is still writable.
+  names the value and the missing name, and fires at resolve time, before any
+  request goes out.
+* **A malformed reference is a hard error too.** `${secret:NAME` (unclosed),
+  `${secret:}` and `${secret:bad-name}` are refused rather than passed through as
+  literal text, which would put `${secret:...}` on the wire, where a gateway either
+  bills the literal string as an account id or rejects the request in a way that
+  reads as network trouble.
+* **Expansion is single-level.** A resolved value is not rescanned, and a value that
+  itself contains a reference is refused by the malformed-reference rule rather than
+  silently emitted.
 
 Only string values are expanded; a JSON number or boolean keeps its existing
 stringify path.
+
+#### Why this is not inside `get_secret`
+
+`SecretManager.get_secret` stays a verbatim pass-through. It is the universal
+credential read path, and two bulk callers resolve *every enumerable key* rather
+than the keys the engine asked for: the log-redaction set
+([`log_filter.py`](../tolokaforge/secrets/log_filter.py)) and the container
+serializer. Expanding there would run this syntax over values nobody wrote for it,
+where failing loud takes down logging and failing empty corrupts a credential.
+Expansion is a composition concern, so the caller requests it explicitly.
+
+One consequence worth knowing: a referenced name is only carried across the
+host→container boundary if it is enumerable, which for the environment means its
+*name* matches one of the credential patterns in
+[`providers.py`](../tolokaforge/secrets/providers.py). `DotEnvProvider` enumerates
+every `.env` key unconditionally, so putting referenced names in `.env` is the way
+to make in-container resolution work if that is ever needed.
+
 Setting any companion variable while `LLM_PROXY_BASE_URL` is empty also raises,
 so a typo in the base-URL name cannot silently fall back to direct provider
 access.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -424,7 +424,9 @@ posting to a route the gateway does not serve.
 All five resolve through `SecretManager`, so `.env`, the process environment,
 and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
 A malformed value raises `ProxyConfigError` at the first `LLMClient`
-construction rather than running a whole evaluation with unattributed spend.
+construction rather than running a whole evaluation with unattributed spend. Setting
+any companion variable while `LLM_PROXY_BASE_URL` is empty also raises, so a typo in
+the base-URL name cannot silently fall back to direct provider access.
 
 ### Values may reference secrets
 
@@ -490,9 +492,6 @@ host→container boundary if it is enumerable, which for the environment means i
 every `.env` key unconditionally, so putting referenced names in `.env` is the way
 to make in-container resolution work if that is ever needed.
 
-Setting any companion variable while `LLM_PROXY_BASE_URL` is empty also raises,
-so a typo in the base-URL name cannot silently fall back to direct provider
-access.
 
 ### Which providers can be routed
 

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -276,12 +276,7 @@ class TestRequestHeaders:
 
 
 class TestHeaderPlaceholders:
-    """Header VALUES may reference other secrets, so the JSON itself need not be one.
-
-    The point is to keep ``LLM_PROXY_HEADERS`` reviewable. A reader (or a public CI log)
-    sees which headers the gateway is being told and that one of them is an indirection,
-    without seeing the sensitive half.
-    """
+    """Header VALUES may reference other secrets, so the JSON itself need not be one."""
 
     def test_a_placeholder_resolves_from_the_secret_manager(self, install_secrets: Any) -> None:
         install_secrets(
@@ -293,7 +288,6 @@ class TestHeaderPlaceholders:
         )
         proxy = resolve_proxy_config()
         assert proxy is not None
-        # The literal half is untouched and the indirect half is resolved.
         assert proxy.headers == {"X-Team-Id": "research", "X-Order-Id": "10000458"}
 
     def test_the_braced_form_works_and_composes_with_surrounding_text(
@@ -324,7 +318,6 @@ class TestHeaderPlaceholders:
         assert proxy.headers == {"X-Pair": "a/b"}
 
     def test_double_dollar_escapes_a_literal_dollar(self, install_secrets: Any) -> None:
-        """Otherwise a value that genuinely needs a ``$`` would be unwritable."""
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",
@@ -356,13 +349,7 @@ class TestHeaderPlaceholders:
     def test_an_unresolved_placeholder_is_a_hard_error(
         self, install_secrets: Any, secrets_extra: dict[str, str], case: str
     ) -> None:
-        """Never an empty substitution.
-
-        A blank attribution header bills the call to nobody, and a blank admission
-        header fails at the gateway. Both surface far from this line, and neither
-        looks like a configuration mistake when it does. So refuse at resolve time,
-        which is before a single request goes out.
-        """
+        """Never an empty substitution: refused at resolve time, before any request."""
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",
@@ -373,18 +360,12 @@ class TestHeaderPlaceholders:
         with pytest.raises(ProxyConfigError) as excinfo:
             resolve_proxy_config()
         message = str(excinfo.value)
-        # Name the header AND the missing variable: with several headers configured,
-        # "something is unset" is not actionable.
+        # Both, because "something is unset" is not actionable with several headers.
         assert "X-Order-Id" in message, case
         assert "ORDER_ID" in message, case
 
     def test_the_placeholder_never_reaches_the_wire_unresolved(self, install_secrets: Any) -> None:
-        """The failure mode this guards: a literal ``$NAME`` sent as the header value.
-
-        A gateway receiving that does not error usefully. It either bills the literal
-        string as an account id or rejects the request for a reason that reads as
-        network trouble.
-        """
+        """Guards the literal ``$NAME``-on-the-wire case: no gateway errors usefully."""
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",
@@ -399,7 +380,7 @@ class TestHeaderPlaceholders:
     def test_a_non_string_value_still_works_and_takes_no_placeholder(
         self, install_secrets: Any
     ) -> None:
-        """JSON scalars keep their existing stringify path, unchanged by expansion."""
+        """JSON scalars keep their existing stringify path."""
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -275,6 +275,142 @@ class TestRequestHeaders:
         assert proxy.headers == {"X-Team-Id": "research"}
 
 
+class TestHeaderPlaceholders:
+    """Header VALUES may reference other secrets, so the JSON itself need not be one.
+
+    The point is to keep ``LLM_PROXY_HEADERS`` reviewable. A reader (or a public CI log)
+    sees which headers the gateway is being told and that one of them is an indirection,
+    without seeing the sensitive half.
+    """
+
+    def test_a_placeholder_resolves_from_the_secret_manager(self, install_secrets: Any) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research", "X-Order-Id": "$ORDER_ID"}',
+                "ORDER_ID": "10000458",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        # The literal half is untouched and the indirect half is resolved.
+        assert proxy.headers == {"X-Team-Id": "research", "X-Order-Id": "10000458"}
+
+    def test_the_braced_form_works_and_composes_with_surrounding_text(
+        self, install_secrets: Any
+    ) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Trace": "run-${RUN_ID}-end"}',
+                "RUN_ID": "42",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.headers == {"X-Trace": "run-42-end"}
+
+    def test_several_placeholders_in_one_value(self, install_secrets: Any) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Pair": "$LEFT/$RIGHT"}',
+                "LEFT": "a",
+                "RIGHT": "b",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.headers == {"X-Pair": "a/b"}
+
+    def test_double_dollar_escapes_a_literal_dollar(self, install_secrets: Any) -> None:
+        """Otherwise a value that genuinely needs a ``$`` would be unwritable."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Budget": "$$100"}',
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.headers == {"X-Budget": "$100"}
+
+    def test_a_value_without_placeholders_is_untouched(self, install_secrets: Any) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research"}',
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.headers == {"X-Team-Id": "research"}
+
+    @pytest.mark.parametrize(
+        ("secrets_extra", "case"),
+        [
+            ({}, "not set at all"),
+            ({"ORDER_ID": "   "}, "set but blank"),
+        ],
+    )
+    def test_an_unresolved_placeholder_is_a_hard_error(
+        self, install_secrets: Any, secrets_extra: dict[str, str], case: str
+    ) -> None:
+        """Never an empty substitution.
+
+        A blank attribution header bills the call to nobody, and a blank admission
+        header fails at the gateway. Both surface far from this line, and neither
+        looks like a configuration mistake when it does. So refuse at resolve time,
+        which is before a single request goes out.
+        """
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Order-Id": "$ORDER_ID"}',
+                **secrets_extra,
+            }
+        )
+        with pytest.raises(ProxyConfigError) as excinfo:
+            resolve_proxy_config()
+        message = str(excinfo.value)
+        # Name the header AND the missing variable: with several headers configured,
+        # "something is unset" is not actionable.
+        assert "X-Order-Id" in message, case
+        assert "ORDER_ID" in message, case
+
+    def test_the_placeholder_never_reaches_the_wire_unresolved(self, install_secrets: Any) -> None:
+        """The failure mode this guards: a literal ``$NAME`` sent as the header value.
+
+        A gateway receiving that does not error usefully. It either bills the literal
+        string as an account id or rejects the request for a reason that reads as
+        network trouble.
+        """
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Order-Id": "$ORDER_ID"}',
+                "ORDER_ID": "10000458",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert "$" not in "".join(proxy.request_headers().values())
+
+    def test_a_non_string_value_still_works_and_takes_no_placeholder(
+        self, install_secrets: Any
+    ) -> None:
+        """JSON scalars keep their existing stringify path, unchanged by expansion."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Cost-Center": 42, "X-On": true}',
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert proxy.headers == {"X-Cost-Center": "42", "X-On": "True"}
+
+
 class TestClientAppliesProxy:
     """``LLMClient`` treats the gateway as a transport swap and nothing more."""
 

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -275,111 +275,54 @@ class TestRequestHeaders:
         assert proxy.headers == {"X-Team-Id": "research"}
 
 
-class TestHeaderPlaceholders:
-    """Header VALUES may reference other secrets, so the JSON itself need not be one."""
+class TestHeaderSecretRefs:
+    """The wire-level half of ``${secret:NAME}``; the syntax itself is pinned in
+    tests/unit/secrets/test_expand.py."""
 
-    def test_a_placeholder_resolves_from_the_secret_manager(self, install_secrets: Any) -> None:
+    def test_a_reference_is_resolved_into_the_header(self, install_secrets: Any) -> None:
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research", "X-Order-Id": "$ORDER_ID"}',
-                "ORDER_ID": "10000458",
+                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research", "X-Order-Id": "${secret:ORDER_ID}"}',
+                "ORDER_ID": "9000123",
             }
         )
         proxy = resolve_proxy_config()
         assert proxy is not None
-        assert proxy.headers == {"X-Team-Id": "research", "X-Order-Id": "10000458"}
+        assert proxy.headers == {"X-Team-Id": "research", "X-Order-Id": "9000123"}
 
-    def test_the_braced_form_works_and_composes_with_surrounding_text(
+    def test_no_reference_reaches_the_wire(self, install_secrets: Any) -> None:
+        """A literal ``${secret:...}`` sent as a header value is the failure this
+        guards: no gateway errors on it usefully."""
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_HEADERS": '{"X-Order-Id": "${secret:ORDER_ID}"}',
+                "ORDER_ID": "9000123",
+            }
+        )
+        proxy = resolve_proxy_config()
+        assert proxy is not None
+        assert "${secret:" not in "".join(proxy.request_headers().values())
+
+    def test_an_unresolved_reference_surfaces_as_a_gateway_config_error(
         self, install_secrets: Any
     ) -> None:
+        """Callers catch one exception type for "the gateway is misconfigured", so the
+        secrets-layer error is translated rather than leaking through."""
         install_secrets(
             {
                 "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Trace": "run-${RUN_ID}-end"}',
-                "RUN_ID": "42",
-            }
-        )
-        proxy = resolve_proxy_config()
-        assert proxy is not None
-        assert proxy.headers == {"X-Trace": "run-42-end"}
-
-    def test_several_placeholders_in_one_value(self, install_secrets: Any) -> None:
-        install_secrets(
-            {
-                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Pair": "$LEFT/$RIGHT"}',
-                "LEFT": "a",
-                "RIGHT": "b",
-            }
-        )
-        proxy = resolve_proxy_config()
-        assert proxy is not None
-        assert proxy.headers == {"X-Pair": "a/b"}
-
-    def test_double_dollar_escapes_a_literal_dollar(self, install_secrets: Any) -> None:
-        install_secrets(
-            {
-                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Budget": "$$100"}',
-            }
-        )
-        proxy = resolve_proxy_config()
-        assert proxy is not None
-        assert proxy.headers == {"X-Budget": "$100"}
-
-    def test_a_value_without_placeholders_is_untouched(self, install_secrets: Any) -> None:
-        install_secrets(
-            {
-                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Team-Id": "research"}',
-            }
-        )
-        proxy = resolve_proxy_config()
-        assert proxy is not None
-        assert proxy.headers == {"X-Team-Id": "research"}
-
-    @pytest.mark.parametrize(
-        ("secrets_extra", "case"),
-        [
-            ({}, "not set at all"),
-            ({"ORDER_ID": "   "}, "set but blank"),
-        ],
-    )
-    def test_an_unresolved_placeholder_is_a_hard_error(
-        self, install_secrets: Any, secrets_extra: dict[str, str], case: str
-    ) -> None:
-        """Never an empty substitution: refused at resolve time, before any request."""
-        install_secrets(
-            {
-                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Order-Id": "$ORDER_ID"}',
-                **secrets_extra,
+                "LLM_PROXY_HEADERS": '{"X-Order-Id": "${secret:ORDER_ID}"}',
             }
         )
         with pytest.raises(ProxyConfigError) as excinfo:
             resolve_proxy_config()
         message = str(excinfo.value)
-        # Both, because "something is unset" is not actionable with several headers.
-        assert "X-Order-Id" in message, case
-        assert "ORDER_ID" in message, case
+        assert "X-Order-Id" in message
+        assert "ORDER_ID" in message
 
-    def test_the_placeholder_never_reaches_the_wire_unresolved(self, install_secrets: Any) -> None:
-        """Guards the literal ``$NAME``-on-the-wire case: no gateway errors usefully."""
-        install_secrets(
-            {
-                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
-                "LLM_PROXY_HEADERS": '{"X-Order-Id": "$ORDER_ID"}',
-                "ORDER_ID": "10000458",
-            }
-        )
-        proxy = resolve_proxy_config()
-        assert proxy is not None
-        assert "$" not in "".join(proxy.request_headers().values())
-
-    def test_a_non_string_value_still_works_and_takes_no_placeholder(
-        self, install_secrets: Any
-    ) -> None:
+    def test_a_non_string_value_takes_no_reference(self, install_secrets: Any) -> None:
         """JSON scalars keep their existing stringify path."""
         install_secrets(
             {

--- a/tests/unit/secrets/test_expand.py
+++ b/tests/unit/secrets/test_expand.py
@@ -104,6 +104,17 @@ class TestFailsLoud:
         with pytest.raises(UnresolvedReferenceError, match="malformed"):
             _expand(value, ORDER_ID="9000123", X="v")
 
+    @pytest.mark.parametrize("value", ["${SECRET:X}", "${Secret:X}"])
+    def test_a_case_variant_is_treated_as_a_typo_and_refused(self, value: str) -> None:
+        """Letting it through would put the literal text on the wire."""
+        with pytest.raises(UnresolvedReferenceError, match="malformed"):
+            _expand(value, X="v")
+
+    @pytest.mark.parametrize("value", ["${notsecret:X}", "${secrets:X}"])
+    def test_a_different_word_is_not_a_typo_of_this_syntax(self, value: str) -> None:
+        """The word boundary keeps unrelated ``${...}`` text passing through."""
+        assert _expand(value, X="v") == value
+
     def test_a_resolved_value_is_not_rescanned(self) -> None:
         """Expansion is single-level, and a nested reference is refused.
 

--- a/tests/unit/secrets/test_expand.py
+++ b/tests/unit/secrets/test_expand.py
@@ -72,15 +72,21 @@ class TestFailsLoud:
     def test_an_unresolved_name_raises(self, secrets: dict[str, str], case: str) -> None:
         with pytest.raises(UnresolvedReferenceError) as excinfo:
             _expand("${secret:ORDER_ID}", **secrets)
+        message = str(excinfo.value)
         # Both the location and the name: "something is unset" is not actionable.
-        assert "TEST_VALUE" in str(excinfo.value), case
-        assert "ORDER_ID" in str(excinfo.value), case
+        assert "TEST_VALUE" in message, case
+        assert "ORDER_ID" in message, case
         assert excinfo.value.names == ("ORDER_ID",), case
+        # The negation, pinned: an earlier revision said "which IS set" and then told
+        # the operator to set it, which is the opposite of the truth in the one message
+        # this whole feature depends on being clear.
+        assert "which is not set" in message, case
 
     def test_every_missing_name_is_reported_at_once(self) -> None:
         with pytest.raises(UnresolvedReferenceError) as excinfo:
             _expand("${secret:A}/${secret:B}")
         assert excinfo.value.names == ("A", "B")
+        assert "none of which are set" in str(excinfo.value)
 
     @pytest.mark.parametrize(
         ("value", "case"),

--- a/tests/unit/secrets/test_expand.py
+++ b/tests/unit/secrets/test_expand.py
@@ -1,0 +1,126 @@
+"""``${secret:NAME}`` expansion: the sanctioned way for a non-secret string to
+carry a secret value.
+
+The reference form is typed rather than a bare ``$NAME`` so it cannot collide with
+a literal dollar sign in real credential text (argon2 and bcrypt hashes, generated
+passwords). Those collision cases are pinned below, because they are the reason
+this syntax was chosen over the shell-familiar one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets.expand import UnresolvedReferenceError, expand_secret_refs
+
+pytestmark = pytest.mark.unit
+
+
+def _expand(value: str, **secrets: str) -> str:
+    return expand_secret_refs(value, SecretManager([DictProvider(secrets)]), where="TEST_VALUE")
+
+
+class TestResolution:
+    def test_a_reference_is_replaced_by_its_value(self) -> None:
+        assert _expand("${secret:ORDER_ID}", ORDER_ID="9000123") == "9000123"
+
+    def test_it_composes_with_surrounding_text(self) -> None:
+        assert _expand("run-${secret:RUN_ID}-end", RUN_ID="42") == "run-42-end"
+
+    def test_several_references_in_one_value(self) -> None:
+        assert _expand("${secret:L}/${secret:R}", L="a", R="b") == "a/b"
+
+    def test_a_value_with_no_reference_is_returned_unchanged(self) -> None:
+        assert _expand("research") == "research"
+
+
+class TestLiteralDollarsSurvive:
+    """The whole point of the typed form: real credentials keep their dollars.
+
+    A bare ``$NAME`` syntax would have matched inside every one of these, either
+    erroring on a valid credential or silently corrupting it.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Pa$$w0rd",
+            "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ",
+            "$2b$12$KIXQ4Ea1eKu0Xr9wCkFmXe",
+            "pa$word9",
+            "cost$100",
+            "$",
+            "${notsecret:X}",
+        ],
+    )
+    def test_untouched(self, value: str) -> None:
+        assert _expand(value) == value
+
+    def test_the_old_bare_form_is_now_literal_text(self) -> None:
+        """Pins the syntax change: ``$NAME`` is no longer special."""
+        assert _expand("$ORDER_ID", ORDER_ID="9000123") == "$ORDER_ID"
+
+
+class TestFailsLoud:
+    """Never an empty substitution, and never a reference left on the wire."""
+
+    @pytest.mark.parametrize(
+        ("secrets", "case"),
+        [({}, "not set at all"), ({"ORDER_ID": "   "}, "set but blank")],
+    )
+    def test_an_unresolved_name_raises(self, secrets: dict[str, str], case: str) -> None:
+        with pytest.raises(UnresolvedReferenceError) as excinfo:
+            _expand("${secret:ORDER_ID}", **secrets)
+        # Both the location and the name: "something is unset" is not actionable.
+        assert "TEST_VALUE" in str(excinfo.value), case
+        assert "ORDER_ID" in str(excinfo.value), case
+        assert excinfo.value.names == ("ORDER_ID",), case
+
+    def test_every_missing_name_is_reported_at_once(self) -> None:
+        with pytest.raises(UnresolvedReferenceError) as excinfo:
+            _expand("${secret:A}/${secret:B}")
+        assert excinfo.value.names == ("A", "B")
+
+    @pytest.mark.parametrize(
+        ("value", "case"),
+        [
+            ("${secret:ORDER_ID", "unclosed brace"),
+            ("${secret:}", "empty name"),
+            ("${secret:bad-name}", "invalid character in the name"),
+            ("${secret}", "no name at all"),
+            ("prefix ${secret:X", "unclosed after valid text"),
+        ],
+    )
+    def test_a_malformed_reference_raises_rather_than_passing_through(
+        self, value: str, case: str
+    ) -> None:
+        """A malformed reference used to survive as literal text.
+
+        That put ``${secret:...}`` on the wire, where a gateway either bills the
+        literal string as an account id or rejects the request in a way that reads
+        as network trouble.
+        """
+        with pytest.raises(UnresolvedReferenceError, match="malformed"):
+            _expand(value, ORDER_ID="9000123", X="v")
+
+    def test_a_resolved_value_is_not_rescanned(self) -> None:
+        """Expansion is single-level, and a nested reference is refused.
+
+        Not silently passed through: if a referenced value itself contains a
+        reference, that is a configuration mistake worth surfacing, and refusing
+        keeps the "no reference reaches the wire" guarantee absolute.
+        """
+        with pytest.raises(UnresolvedReferenceError, match="malformed"):
+            _expand("${secret:OUTER}", OUTER="${secret:INNER}", INNER="v")
+
+
+class TestWhereIsReportedVerbatim:
+    def test_the_caller_supplied_location_names_the_offending_value(self) -> None:
+        secrets = SecretManager([DictProvider({})])
+        with pytest.raises(UnresolvedReferenceError) as excinfo:
+            expand_secret_refs(
+                "${secret:X}", secrets, where="LLM_PROXY_HEADERS value for 'X-Order-Id'"
+            )
+        assert excinfo.value.where == "LLM_PROXY_HEADERS value for 'X-Order-Id'"
+        assert "X-Order-Id" in str(excinfo.value)

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -105,10 +105,11 @@ matched preset and the ``providers:`` overlay. See ``docs/LLM_LAYER.md`` § prox
 from __future__ import annotations
 
 import json
-import re
 import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+from tolokaforge.secrets.expand import UnresolvedReferenceError, expand_secret_refs
 
 if TYPE_CHECKING:
     from tolokaforge.secrets import SecretManager
@@ -205,45 +206,11 @@ class ProxyConfig:
         return headers
 
 
-#: ``$$`` (a literal ``$``), ``${NAME}`` or ``$NAME`` in a header value.
-_PLACEHOLDER_RE = re.compile(
-    r"\$(?:(\$)|\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))",
-)
-
-
-def _expand_placeholders(value: str, header: str, secrets: SecretManager) -> str:
-    """Resolve ``$NAME`` / ``${NAME}`` in a header value through ``secrets``.
-
-    See ``docs/LLM_LAYER.md`` § "Header values may reference other secrets" for the
-    rationale and the rules an unresolved name follows.
-    """
-    missing: list[str] = []
-
-    def _sub(match: re.Match[str]) -> str:
-        if match.group(1):
-            return "$"
-        name = match.group(2) or match.group(3)
-        resolved = secrets.get_secret(name)
-        if resolved is None or not resolved.strip():
-            missing.append(name)
-            return ""
-        return resolved
-
-    expanded = _PLACEHOLDER_RE.sub(_sub, value)
-    if missing:
-        raise ProxyConfigError(
-            f"{ENV_HEADERS} value for {header!r} references "
-            f"{', '.join(sorted(set(missing)))}, which is not set. Set it, or write the "
-            f"value literally, or use $$ for a literal dollar sign. It is never "
-            f"substituted as empty: see docs/LLM_LAYER.md § proxy."
-        )
-    return expanded
-
-
 def _parse_headers(raw: str | None, secrets: SecretManager) -> dict[str, str]:
     """Parse ``LLM_PROXY_HEADERS`` (a JSON object of string values).
 
-    Values may reference other secrets, see :func:`_expand_placeholders`.
+    A value may reference a secret as ``${secret:NAME}``, resolved by
+    :func:`tolokaforge.secrets.expand_secret_refs`.
     """
     if raw is None or not raw.strip():
         return {}
@@ -260,20 +227,26 @@ def _parse_headers(raw: str | None, secrets: SecretManager) -> dict[str, str]:
             f"got {type(parsed).__name__}"
         )
     headers: dict[str, str] = {}
-    for name, value in parsed.items():
-        if not isinstance(name, str) or not name.strip():
+    for raw_name, value in parsed.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
             raise ProxyConfigError(f"{ENV_HEADERS} contains a non-string or empty header name")
+        name = raw_name.strip()
         if not isinstance(value, str | int | float | bool):
             raise ProxyConfigError(
                 f"{ENV_HEADERS} value for {name!r} must be a scalar, got {type(value).__name__}"
             )
-        # Only strings expand; a JSON number/bool keeps its plain stringify path.
-        resolved = (
-            _expand_placeholders(value, name.strip(), secrets)
-            if isinstance(value, str)
-            else str(value)
-        )
-        headers[name.strip()] = resolved
+        if not isinstance(value, str):
+            # A JSON number/bool cannot carry a reference; keep the stringify path.
+            headers[name] = str(value)
+            continue
+        try:
+            headers[name] = expand_secret_refs(
+                value, secrets, where=f"{ENV_HEADERS} value for {name!r}"
+            )
+        except UnresolvedReferenceError as exc:
+            # Re-raised as the gateway's own error type so callers keep catching one
+            # exception for "the gateway is misconfigured".
+            raise ProxyConfigError(str(exc)) from exc
     return headers
 
 

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -205,9 +205,7 @@ class ProxyConfig:
         return headers
 
 
-#: One placeholder in a header VALUE: ``$$`` (a literal ``$``), ``${NAME}`` or ``$NAME``.
-#: Shell-style on purpose, so the same string is readable to anyone who has met an env
-#: file. Names follow the identifier rule env vars already obey.
+#: ``$$`` (a literal ``$``), ``${NAME}`` or ``$NAME`` in a header value.
 _PLACEHOLDER_RE = re.compile(
     r"\$(?:(\$)|\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))",
 )
@@ -216,20 +214,8 @@ _PLACEHOLDER_RE = re.compile(
 def _expand_placeholders(value: str, header: str, secrets: SecretManager) -> str:
     """Resolve ``$NAME`` / ``${NAME}`` in a header value through ``secrets``.
 
-    This is what lets ``LLM_PROXY_HEADERS`` stay a plain, reviewable, non-secret
-    string while the values it carries come from somewhere secret::
-
-        {"X-Tlk-Business-Id": "data-business", "X-Tlk-Sunday-Order-Id": "$SUNDAY_ORDER_ID"}
-
-    The header NAMES and the shape stay legible in the variable (so a reviewer can see
-    what the gateway is being told), and only the sensitive halves are indirect. In CI
-    that means the JSON can live in a repository *variable* and still not print a secret
-    into a public workflow log, since the log only ever shows the placeholder.
-
-    An unresolved name is a hard error, never an empty substitution: a header silently
-    sent as ``""`` (or worse, as the literal ``$SUNDAY_ORDER_ID``) misattributes cost or
-    fails admission at the gateway, and both surface far from the cause. ``$$`` escapes a
-    literal ``$`` for the rare value that needs one.
+    See ``docs/LLM_LAYER.md`` § "Header values may reference other secrets" for the
+    rationale and the rules an unresolved name follows.
     """
     missing: list[str] = []
 
@@ -247,11 +233,9 @@ def _expand_placeholders(value: str, header: str, secrets: SecretManager) -> str
     if missing:
         raise ProxyConfigError(
             f"{ENV_HEADERS} value for {header!r} references "
-            f"{', '.join(sorted(set(missing)))}, which is not set. Either set it (as an "
-            f"env var or a secret) or write the value literally. It is not substituted "
-            f"as empty on purpose: a blank attribution or admission header fails at the "
-            f"gateway, or bills to nobody, far away from this line. Use $$ for a "
-            f"literal dollar sign."
+            f"{', '.join(sorted(set(missing)))}, which is not set. Set it, or write the "
+            f"value literally, or use $$ for a literal dollar sign. It is never "
+            f"substituted as empty: see docs/LLM_LAYER.md § proxy."
         )
     return expanded
 
@@ -283,9 +267,7 @@ def _parse_headers(raw: str | None, secrets: SecretManager) -> dict[str, str]:
             raise ProxyConfigError(
                 f"{ENV_HEADERS} value for {name!r} must be a scalar, got {type(value).__name__}"
             )
-        # Only string values are expanded. A JSON number/bool cannot carry a
-        # placeholder, and stringifying one first would just invent a way to write
-        # ``$NAME`` that looks different from every other way.
+        # Only strings expand; a JSON number/bool keeps its plain stringify path.
         resolved = (
             _expand_placeholders(value, name.strip(), secrets)
             if isinstance(value, str)

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -105,9 +105,13 @@ matched preset and the ``providers:`` overlay. See ``docs/LLM_LAYER.md`` § prox
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tolokaforge.secrets import SecretManager
 
 ENV_BASE_URL = "LLM_PROXY_BASE_URL"
 ENV_API_KEY = "LLM_PROXY_API_KEY"
@@ -201,8 +205,62 @@ class ProxyConfig:
         return headers
 
 
-def _parse_headers(raw: str | None) -> dict[str, str]:
-    """Parse ``LLM_PROXY_HEADERS`` (a JSON object of string values)."""
+#: One placeholder in a header VALUE: ``$$`` (a literal ``$``), ``${NAME}`` or ``$NAME``.
+#: Shell-style on purpose, so the same string is readable to anyone who has met an env
+#: file. Names follow the identifier rule env vars already obey.
+_PLACEHOLDER_RE = re.compile(
+    r"\$(?:(\$)|\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))",
+)
+
+
+def _expand_placeholders(value: str, header: str, secrets: SecretManager) -> str:
+    """Resolve ``$NAME`` / ``${NAME}`` in a header value through ``secrets``.
+
+    This is what lets ``LLM_PROXY_HEADERS`` stay a plain, reviewable, non-secret
+    string while the values it carries come from somewhere secret::
+
+        {"X-Tlk-Business-Id": "data-business", "X-Tlk-Sunday-Order-Id": "$SUNDAY_ORDER_ID"}
+
+    The header NAMES and the shape stay legible in the variable (so a reviewer can see
+    what the gateway is being told), and only the sensitive halves are indirect. In CI
+    that means the JSON can live in a repository *variable* and still not print a secret
+    into a public workflow log, since the log only ever shows the placeholder.
+
+    An unresolved name is a hard error, never an empty substitution: a header silently
+    sent as ``""`` (or worse, as the literal ``$SUNDAY_ORDER_ID``) misattributes cost or
+    fails admission at the gateway, and both surface far from the cause. ``$$`` escapes a
+    literal ``$`` for the rare value that needs one.
+    """
+    missing: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        if match.group(1):
+            return "$"
+        name = match.group(2) or match.group(3)
+        resolved = secrets.get_secret(name)
+        if resolved is None or not resolved.strip():
+            missing.append(name)
+            return ""
+        return resolved
+
+    expanded = _PLACEHOLDER_RE.sub(_sub, value)
+    if missing:
+        raise ProxyConfigError(
+            f"{ENV_HEADERS} value for {header!r} references "
+            f"{', '.join(sorted(set(missing)))}, which is not set. Either set it (as an "
+            f"env var or a secret) or write the value literally. It is not substituted "
+            f"as empty on purpose: a blank attribution or admission header fails at the "
+            f"gateway, or bills to nobody, far away from this line. Use $$ for a "
+            f"literal dollar sign."
+        )
+    return expanded
+
+
+def _parse_headers(raw: str | None, secrets: SecretManager) -> dict[str, str]:
+    """Parse ``LLM_PROXY_HEADERS`` (a JSON object of string values).
+
+    Values may reference other secrets, see :func:`_expand_placeholders`.
+    """
     if raw is None or not raw.strip():
         return {}
     try:
@@ -225,7 +283,15 @@ def _parse_headers(raw: str | None) -> dict[str, str]:
             raise ProxyConfigError(
                 f"{ENV_HEADERS} value for {name!r} must be a scalar, got {type(value).__name__}"
             )
-        headers[name.strip()] = str(value)
+        # Only string values are expanded. A JSON number/bool cannot carry a
+        # placeholder, and stringifying one first would just invent a way to write
+        # ``$NAME`` that looks different from every other way.
+        resolved = (
+            _expand_placeholders(value, name.strip(), secrets)
+            if isinstance(value, str)
+            else str(value)
+        )
+        headers[name.strip()] = resolved
     return headers
 
 
@@ -293,7 +359,7 @@ def resolve_proxy_config() -> ProxyConfig | None:
     return ProxyConfig(
         base_url=base_url.rstrip("/"),
         api_key=(secrets.get_secret(ENV_API_KEY) or "").strip() or None,
-        headers=_parse_headers(secrets.get_secret(ENV_HEADERS)),
+        headers=_parse_headers(secrets.get_secret(ENV_HEADERS), secrets),
         request_id_header=(secrets.get_secret(ENV_REQUEST_ID_HEADER) or "").strip() or None,
         providers=_parse_providers(secrets.get_secret(ENV_PROVIDERS)),
     )

--- a/tolokaforge/secrets/__init__.py
+++ b/tolokaforge/secrets/__init__.py
@@ -17,6 +17,7 @@ runner container, ``init_default_from(...)`` is reconstructed from the
 """
 
 from tolokaforge.secrets.config import SecretConfig, SecretSource
+from tolokaforge.secrets.expand import UnresolvedReferenceError, expand_secret_refs
 from tolokaforge.secrets.log_filter import install_global_redactor
 from tolokaforge.secrets.manager import (
     MissingSecretError,
@@ -47,4 +48,6 @@ __all__ = [
     "get_default",
     "get_default_or_none",
     "install_global_redactor",
+    "expand_secret_refs",
+    "UnresolvedReferenceError",
 ]

--- a/tolokaforge/secrets/expand.py
+++ b/tolokaforge/secrets/expand.py
@@ -86,9 +86,9 @@ def expand_secret_refs(value: str, secrets: SecretManager, *, where: str) -> str
         refs = ", ".join(f"${{secret:{name}}}" for name in names)
         raise UnresolvedReferenceError(
             f"{where} references {refs}, "
-            f"{'which is' if len(names) == 1 else 'none of which are'} set. Set it, or "
-            f"write the value literally. It is never substituted as empty: see "
-            f"docs/LLM_LAYER.md.",
+            f"{'which is not' if len(names) == 1 else 'none of which are'} set. Set "
+            f"{'it' if len(names) == 1 else 'them'}, or write the value literally. It is "
+            f"never substituted as empty: see docs/LLM_LAYER.md.",
             where=where,
             names=names,
         )

--- a/tolokaforge/secrets/expand.py
+++ b/tolokaforge/secrets/expand.py
@@ -28,8 +28,11 @@ _REF_RE = re.compile(r"\$\{secret:([A-Za-z_][A-Za-z0-9_]*)\}")
 
 #: Anything that opens a reference. Whatever survives substitution is malformed,
 #: so an unclosed or misspelled reference is refused instead of being passed
-#: through as literal text.
-_PARTIAL_RE = re.compile(r"\$\{secret\b")
+#: through as literal text. Case-insensitive on purpose: ``${SECRET:X}`` is a
+#: plausible typo, and letting it through would put it on the wire verbatim.
+#: ``${notsecret:X}`` and ``${secrets:X}`` still pass through, since the word
+#: boundary keeps them from reading as a misspelling of this syntax.
+_PARTIAL_RE = re.compile(r"\$\{secret\b", re.IGNORECASE)
 
 
 class UnresolvedReferenceError(Exception):
@@ -82,8 +85,10 @@ def expand_secret_refs(value: str, secrets: SecretManager, *, where: str) -> str
         names = tuple(sorted(set(missing)))
         refs = ", ".join(f"${{secret:{name}}}" for name in names)
         raise UnresolvedReferenceError(
-            f"{where} references {refs}, which is not set. Set it, or write the value "
-            f"literally. It is never substituted as empty: see docs/LLM_LAYER.md.",
+            f"{where} references {refs}, "
+            f"{'which is' if len(names) == 1 else 'none of which are'} set. Set it, or "
+            f"write the value literally. It is never substituted as empty: see "
+            f"docs/LLM_LAYER.md.",
             where=where,
             names=names,
         )
@@ -91,9 +96,10 @@ def expand_secret_refs(value: str, secrets: SecretManager, *, where: str) -> str
     if _PARTIAL_RE.search(expanded):
         raise UnresolvedReferenceError(
             f"{where} contains a malformed secret reference. The only accepted form is "
-            f"${{secret:NAME}}, with NAME matching [A-Za-z_][A-Za-z0-9_]*. A partial or "
-            f"misspelled reference is refused rather than passed through as literal "
-            f"text, which would put ${{secret:...}} on the wire.",
+            f"${{secret:NAME}}, with NAME matching [A-Za-z_][A-Za-z0-9_]*. Either the "
+            f"reference is partial or misspelled, or one appeared inside a RESOLVED "
+            f"value (expansion is single-level). Refused rather than passed through as "
+            f"literal text, which would put ${{secret:...}} on the wire.",
             where=where,
         )
 

--- a/tolokaforge/secrets/expand.py
+++ b/tolokaforge/secrets/expand.py
@@ -1,0 +1,100 @@
+"""Resolve ``${secret:NAME}`` references inside a configuration value.
+
+This is the only sanctioned way to make a non-secret configuration string carry a
+secret value. See ``docs/LLM_LAYER.md`` § "Values may reference secrets" for the
+rationale, the failure rules, and why the reference form is typed rather than a
+bare ``$NAME``.
+
+Deliberately NOT part of :meth:`SecretManager.get_secret`: that method is the
+universal credential read path, and it also feeds the log-redaction set and the
+container serializer, both of which resolve every enumerable key. Expanding there
+would run this syntax over values the engine never asked for, where a literal
+``$`` in a real credential (argon2, bcrypt, generated passwords) is common.
+Expansion is a composition concern, so the caller asks for it explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tolokaforge.secrets.manager import SecretManager
+
+__all__ = ["UnresolvedReferenceError", "expand_secret_refs"]
+
+#: A well-formed reference. ``NAME`` follows the identifier rule env vars obey.
+_REF_RE = re.compile(r"\$\{secret:([A-Za-z_][A-Za-z0-9_]*)\}")
+
+#: Anything that opens a reference. Whatever survives substitution is malformed,
+#: so an unclosed or misspelled reference is refused instead of being passed
+#: through as literal text.
+_PARTIAL_RE = re.compile(r"\$\{secret\b")
+
+
+class UnresolvedReferenceError(Exception):
+    """A ``${secret:NAME}`` reference could not be resolved to a value.
+
+    Attributes:
+        where: Human-readable location of the offending value, for the message.
+        names: Reference names that failed to resolve; empty for a syntax error.
+    """
+
+    def __init__(self, message: str, *, where: str, names: tuple[str, ...] = ()) -> None:
+        super().__init__(message)
+        self.where = where
+        self.names = names
+
+
+def expand_secret_refs(value: str, secrets: SecretManager, *, where: str) -> str:
+    """Replace every ``${secret:NAME}`` in ``value`` with its resolved secret.
+
+    Args:
+        value: The configuration string, which may contain zero or more references.
+        secrets: Manager used to resolve each referenced name.
+        where: What this value is, named in any error (e.g. ``"LLM_PROXY_HEADERS
+            value for 'X-Order-Id'"``).
+
+    Returns:
+        ``value`` with every reference replaced. A string containing no reference
+        is returned unchanged, including one that contains a literal ``$``.
+
+    Raises:
+        UnresolvedReferenceError: A referenced name is unset or blank, or the
+            string contains a malformed reference. Neither is substituted with an
+            empty string: a blank value fails or misattributes far from the
+            misconfigured line, and a literal ``${secret:...}`` on the wire is
+            worse still.
+    """
+    missing: list[str] = []
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        resolved = secrets.get_secret(name)
+        if resolved is None or not resolved.strip():
+            missing.append(name)
+            return ""
+        return resolved
+
+    expanded = _REF_RE.sub(_sub, value)
+
+    if missing:
+        names = tuple(sorted(set(missing)))
+        refs = ", ".join(f"${{secret:{name}}}" for name in names)
+        raise UnresolvedReferenceError(
+            f"{where} references {refs}, which is not set. Set it, or write the value "
+            f"literally. It is never substituted as empty: see docs/LLM_LAYER.md.",
+            where=where,
+            names=names,
+        )
+
+    if _PARTIAL_RE.search(expanded):
+        raise UnresolvedReferenceError(
+            f"{where} contains a malformed secret reference. The only accepted form is "
+            f"${{secret:NAME}}, with NAME matching [A-Za-z_][A-Za-z0-9_]*. A partial or "
+            f"misspelled reference is refused rather than passed through as literal "
+            f"text, which would put ${{secret:...}} on the wire.",
+            where=where,
+        )
+
+    return expanded

--- a/tolokaforge/secrets/providers.py
+++ b/tolokaforge/secrets/providers.py
@@ -243,10 +243,14 @@ class DotEnvProvider(SecretProvider):
 
             match = self._LINE_PATTERN.match(line)
             if not match:
-                logger.debug(
-                    "DotEnvProvider: skipping invalid line %d: %r",
+                # Warned, not debug: a dropped line reads as "unset" downstream. Only
+                # the key is logged, never the value. See docs/CONFIG.md § secrets.
+                name, _, _ = stripped.partition("=")
+                logger.warning(
+                    "DotEnvProvider: dropping unparseable line %d (key %r); if the "
+                    "value contains whitespace or '#', quote it",
                     line_num,
-                    line[:50],
+                    name.strip()[:64],
                 )
                 continue
 


### PR DESCRIPTION
A value in a configuration string may reference a secret as `${secret:NAME}`, resolved through the same `SecretManager` as everything else:

```
LLM_PROXY_HEADERS={"X-Team-Id":"research","X-Order-Id":"${secret:ORDER_ID}"}
ORDER_ID=9000123
```

The mechanism is `expand_secret_refs` in `tolokaforge/secrets/expand.py`. Its one caller today is `LLM_PROXY_HEADERS`.

## Why

Today the whole JSON has to become a secret the moment any single header carries something sensitive, and that costs real reviewability. The header names and the shape are exactly what a reviewer wants to see, because they are what a run tells the gateway about itself. Turning the object opaque to hide one account id hides the interesting part along with it.

It matters most in CI, where the object can stay a repository **variable**, readable in settings and in a public workflow log, because the variable only ever holds the reference. This repo had that exact exposure: the automation's attribution JSON sat in a plain variable with a billing identifier in it.

## Why the reference form is typed

A shell-style `$NAME` matches inside real credential text, and plenty of credentials carry a dollar sign: argon2 (`$argon2id$v=19$...`), bcrypt (`$2b$12$...`), Postgres SCRAM verifiers, generated passwords. Under `${secret:NAME}` a lone `$` is never special, so nothing needs escaping and `Pa$$w0rd` passes through untouched. Seven real credential shapes are pinned as untouched.

## Three rules

**An unresolved name is a hard error, never an empty substitution.** A blank attribution header bills the call to nobody; a blank admission header fails at the gateway. Both surface a long way from the misconfigured line. The error names the value and the missing name, and fires at resolve time, before any request goes out.

**A malformed reference is a hard error too.** `${secret:NAME` (unclosed), `${secret:}`, `${secret:bad-name}` and case variants like `${SECRET:X}` are refused rather than passed through as literal text. Passing through would put `${secret:...}` on the wire, where a gateway either bills the literal string as an account id or rejects the request in a way that reads as network trouble. `${notsecret:X}` and `${secrets:X}` still pass through: the word boundary keeps them from reading as a misspelling of this syntax.

**Expansion is single-level**, and a nested reference is refused by the malformed rule rather than emitted, so "no reference reaches the wire" holds absolutely.

Only string values are expanded; JSON numbers and booleans keep their existing stringify path.

## Where this lives, and why not in `get_secret`

`SecretManager.get_secret` stays a verbatim pass-through. Two bulk callers resolve *every enumerable key* rather than the keys the engine asked for: the log-redaction set (`log_filter.py`, installed as a global log-record factory) and the container serializer. Expanding there would run this syntax over values nobody wrote for it. Measured: with a `DATABASE_URL` containing a literal `$` present only in the shell environment (swept in because `BASE_URL` is a substring of its *name*, `providers.py`), an unrelated `logger.warning()` raises. Fail-empty instead corrupts the credential. Expansion is a composition concern, so the caller requests it explicitly.

One contract detail worth stating, since it surprises people: `${secret:...}` resolves by **name** through the normal provider chain, so what matters is that the name is set, not whether it is "a secret". A repository variable and a repository secret both arrive as ordinary environment variables; only the log masking differs, which is the point of the feature.

Not done, and recorded rather than half-built: having the helper register composed values with the log redactor. There is no public API for that today, only a module-global cache keyed on the manager instance, so it needs a redactor change rather than a call from here.

## Verified against the live gateway

Not only in fixtures. A full engine call to a gateway-only model, with the real secrets, where every sensitive header value is a `${secret:...}` reference:

```
full engine call, references resolved   SUCCESS   126 in / 52 out
resolution checked by length            8 / 20 / 13 chars, per referenced name
no unresolved reference in any value    True
```

That also cleared a real blocker elsewhere: a gateway-only model's capability suite now runs green (23 passed, 16 skipped, 0 failed) with its attribution and admission headers carried by references.

**What is NOT verified, stated plainly because an earlier revision of this description overclaimed it:** every one of those runs came from a host the gateway admits by network position. A bare request with no headers gets `401`, not `403`, from here, so the edge is passing on position rather than on the admission header. Whether that header alone admits a host outside the allowlist, which is the case CI is in, has not been demonstrated. The expansion mechanism is verified end to end; the deployment's admission policy is not this PR's claim to make.

## CI wiring, and what it does not cover

`integrate-model.yml` already carried the gateway base URL and key but never the headers, so a gateway that admits callers by a shared-secret request header was unreachable from it. That is the only thing such a gateway can do for a hosted runner: GitHub publishes ~7300 CIDR blocks (~27.9M addresses) for Actions egress and rotates them, so allowlisting is not available.

The header JSON is written **only inside the `litellm` branch** of the `.env` step, never as a job-level env var: `resolve_proxy_config` treats a companion without a base URL as a hard error, on purpose, so a job-level value would break the `openrouter` route outright.

The referenced secrets *are* job-level, because the `.env` step and `automation reprobe` both need them, and unlike `LLM_PROXY_BASE_URL` and friends they are not companions in that check's sense, so an unused one is inert. Job-level also means every step, so both `claude -p --dangerously-skip-permissions` invocations, the litellm proxy and the CLI install scrub them with `env -u`, the way that workflow already scrubs `GH_TOKEN`. Note what that does and does not buy: it denies the values to those processes, not to code an agent may have written, since later `uv run automation` commands in the same step still carry them. Keep these credentials rotate-friendly.

**Not covered: the Slack poller.** `slack-integrate.yml` reaches the gateway through `automation.gateway_catalog`, which reads the two `LLM_PROXY_*` names from `os.environ` directly and by design (routing through `DotEnvProvider` would let a developer's local `.env` answer a real poll). It ignores `LLM_PROXY_HEADERS`, so on a header-admission gateway that poll still cannot read the catalog and every model reports as absent from the gateway for a transport reason rather than a catalogue one.

That is left for a separate change on purpose. Teaching `gateway_catalog` about one more variable would bake in the real defect: `ProxyConfig` already models the gateway contract and that module reimplements two thirds of it, which is why it drifts. It should consume a `ProxyConfig` built from an env-only `SecretManager`, which needs an injectable manager on `resolve_proxy_config`. The workflow carries a comment saying so.

## A silent-loss path closed on the way

`DotEnvProvider`'s unquoted-value branch is `[^\s#]*`, so a value containing whitespace or `#` fails the line match and the line was dropped at DEBUG. For a JSON value that meant no headers at all, with the base URL still set so no orphan error fired either, and nothing in the log. Reproduced for pretty-printed JSON, for `arena eval` and for `run#42`.

Closed at both ends. The engine now **warns** when it drops an unparseable line, naming the key and never the value (a line that failed to parse is exactly the line whose value was never registered for redaction). The workflow pipes the JSON through `jq -ce` and refuses outright if a name or value still contains whitespace or `#`, rather than running a gateway eval with no headers. `docs/CONFIG.md` documents the quoting rule and the two shell notes that go with it.

## Verification

```
$ pytest tests/unit/secrets tests/unit/llm/test_llm_proxy.py -q
108 passed

$ pytest tests/unit tests/canonical -q
4 failed, 5161 passed, 3 errors
#   the 4+3 are pre-existing on a clean checkout: 3x test_rate_limit_probe_retry
#   (builds an LLMClient without isolating secrets, so a .env carrying LLM_PROXY_*
#   breaks it) and 4x test_adapter_convert_* (wheel-build tests)

$ ruff check tolokaforge/ tests/     All checks passed!
$ black --check                      clean
both workflow YAMLs                  parse
```

Behaviour across every case:

```
reference + literal         {'X-Team-Id': 'research', 'X-Order-Id': '9000123'}
mid-string                  {'X-Trace': 'run-42-end'}
two references              {'X-Pair': 'a/b'}
literal $$ untouched        {'X-Budget': 'Pa$$w0rd'}
argon2 hash untouched       {'X-B': '$argon2id$v=19$m=65536'}
bare $NAME is literal now   {'A': '$ORDER_ID'}
missing name                ... references ${secret:MISSING}, which is not set
unclosed brace              ... contains a malformed secret reference
empty name / bad chars      ... contains a malformed secret reference
case variant ${SECRET:X}    ... contains a malformed secret reference
nested reference            ... contains a malformed secret reference
```

Mutation-checked rather than assumed. Each load-bearing behaviour fails exactly the tests written for it: empty-substitution-instead-of-raise, malformed-passed-through, the regex widened back to bare `$NAME` (which fails the credential-collision pins specifically), the feature disconnected at the call site, and a blank value accepted as resolved.

## Deployment

The variable and both secrets are already set on this repo, so the wiring is live on merge rather than inert. Two operational notes for whoever merges:

1. The variable must hold **compact** JSON with no whitespace or `#` in any name or value. `jq -ce` compacts, and the step now fails loudly rather than silently on the rest.
2. **Rotate any identifier that previously sat in a plain variable.** The pre-existing `LLM_PROXY_HEADERS` variable held its value in the clear, so treat it as exposed rather than merely migrated.

## Operator note

Existing configurations are unaffected: a value containing no `${secret:` behaves exactly as before, including one that contains a literal `$`. To adopt the indirection, replace the sensitive half with `${secret:NAME}` and supply that name as a secret, then add one env line per reference in the workflow.
