### PR TITLE
fix(grading): decode wire tool calls in run_custom_checks instead of …

### DIFF
--- a/tests/unit/grading/test_run_custom_checks_wire.py
+++ b/tests/unit/grading/test_run_custom_checks_wire.py
@@ -133,3 +133,20 @@ def test_a_malformed_wire_entry_raises_naming_the_message(
 
     with pytest.raises(ValueError, match="wire message 0"):
         _run(checks_file, tmp_path, malformed)
+
+
+def test_a_wire_entry_without_id_raises_naming_the_message(
+    checks_file: Path, tmp_path: Path
+) -> None:
+    without_id = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "update_counter", "arguments": json.dumps({"delta": 7})}}
+            ],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="wire message 0"):
+        _run(checks_file, tmp_path, without_id)

--- a/tests/unit/grading/test_run_custom_checks_wire.py
+++ b/tests/unit/grading/test_run_custom_checks_wire.py
@@ -1,0 +1,135 @@
+"""Behaviour lock for :func:`run_custom_checks` tool-call handling (issue #706).
+
+A grade-time wire ``tool_calls`` entry is ``{"id": …, "function": {"name": …,
+"arguments": "<json>"}}``. The helper used to read ``tc.get("name", "")`` /
+``tc.get("arguments", {})`` off that shape, so every call arrived empty and a
+tool-call-sequence check judged an empty view with no error anywhere. The fix
+is dual-shape: an entry carrying ``"function"`` decodes as wire (real name,
+parsed arguments, malformed entries raise naming the message), while the flat
+``{"name", "arguments", "result"}`` shape keeps its long-standing behaviour so
+existing callers of this public API are untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import run_custom_checks
+from tolokaforge.core.grading.checks_interface import CheckStatus
+from tolokaforge.core.grading.transcript_wire import encode_transcript_wire
+from tolokaforge.core.models import Message, MessageRole, ToolCall, Trajectory
+
+pytestmark = pytest.mark.unit
+
+_CHECKS = """
+from tolokaforge.core.grading.checks_interface import (
+    CheckContext,
+    CheckFailed,
+    CheckPassed,
+    check,
+    init,
+)
+
+_seen = {}
+
+
+@init(interface_version="1.0")
+def setup(ctx: CheckContext):
+    _seen["calls"] = [
+        (tc.name, tc.arguments)
+        for m in ctx.transcript.messages
+        for tc in m.tool_calls
+    ]
+
+
+@check
+def tool_calls_carry_names_and_arguments():
+    if _seen["calls"] == [("update_counter", {"delta": 7})]:
+        return CheckPassed("saw the call with its name and arguments")
+    return CheckFailed(f"saw {_seen['calls']!r}")
+"""
+
+
+@pytest.fixture
+def checks_file(tmp_path: Path) -> Path:
+    path = tmp_path / "checks.py"
+    path.write_text(_CHECKS)
+    return path
+
+
+def _wire_payload() -> list[dict[str, Any]]:
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    trajectory = Trajectory(
+        task_id="wire_lock",
+        trial_index=0,
+        start_ts=ts,
+        end_ts=ts,
+        messages=[
+            Message(
+                role=MessageRole.ASSISTANT,
+                content="",
+                tool_calls=[ToolCall(id="toolu_1", name="update_counter", arguments={"delta": 7})],
+            ),
+            Message(role=MessageRole.TOOL, content="ok", tool_call_id="toolu_1"),
+        ],
+    )
+    return json.loads(encode_transcript_wire(trajectory, "agent policy"))
+
+
+def _run(checks_file: Path, tmp_path: Path, transcript_messages: list[dict[str, Any]]):
+    return run_custom_checks(
+        checks_file=checks_file,
+        task_dir=tmp_path,
+        initial_state={},
+        final_state={},
+        transcript_messages=transcript_messages,
+        task_id="wire_lock",
+    )
+
+
+def test_wire_tool_calls_reach_checks_with_names_and_arguments(
+    checks_file: Path, tmp_path: Path
+) -> None:
+    result = _run(checks_file, tmp_path, _wire_payload())
+
+    assert result.error is None
+    [check_result] = result.results
+    assert check_result.status == CheckStatus.PASSED, check_result.message
+
+
+def test_flat_tool_calls_keep_their_long_standing_behaviour(
+    checks_file: Path, tmp_path: Path
+) -> None:
+    flat = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"name": "update_counter", "arguments": {"delta": 7}}],
+        }
+    ]
+
+    result = _run(checks_file, tmp_path, flat)
+
+    assert result.error is None
+    [check_result] = result.results
+    assert check_result.status == CheckStatus.PASSED, check_result.message
+
+
+def test_a_malformed_wire_entry_raises_naming_the_message(
+    checks_file: Path, tmp_path: Path
+) -> None:
+    malformed = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "toolu_1", "function": {"name": "update_counter"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="wire message 0"):
+        _run(checks_file, tmp_path, malformed)

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -686,11 +686,11 @@ def run_custom_checks(
         ToolCall,
         Transcript,
     )
-    from tolokaforge.core.grading.transcript_wire import _decode_tool_call
+    from tolokaforge.core.grading.transcript_wire import decode_tool_call
 
     def _tool_call(tc: dict[str, Any], message_index: int) -> ToolCall:
         if "function" in tc:
-            decoded = _decode_tool_call(tc, message_index)
+            decoded = decode_tool_call(tc, message_index)
             return ToolCall(name=decoded.name, arguments=decoded.arguments)
         return ToolCall(
             name=tc.get("name", ""),

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -665,12 +665,19 @@ def run_custom_checks(
         task_dir: Task directory
         initial_state: Initial state dictionary
         final_state: Final state dictionary
-        transcript_messages: List of message dictionaries
+        transcript_messages: List of message dictionaries. A ``tool_calls``
+            entry may be either flat (``{"name", "arguments", "result"}``) or
+            grade-time wire shaped (``{"id", "function": {"name",
+            "arguments"}}``; see :mod:`tolokaforge.core.grading.transcript_wire`)
         task_id: Task identifier
         config: Optional config (default: enabled with 30s timeout)
 
     Returns:
         CheckResultSet with results
+
+    Raises:
+        ValueError: If a wire-shaped ``tool_calls`` entry is malformed; the
+            message names the offending entry.
     """
     from tolokaforge.core.grading.checks_interface import (
         EnvironmentState,
@@ -679,6 +686,17 @@ def run_custom_checks(
         ToolCall,
         Transcript,
     )
+    from tolokaforge.core.grading.transcript_wire import _decode_tool_call
+
+    def _tool_call(tc: dict[str, Any], message_index: int) -> ToolCall:
+        if "function" in tc:
+            decoded = _decode_tool_call(tc, message_index)
+            return ToolCall(name=decoded.name, arguments=decoded.arguments)
+        return ToolCall(
+            name=tc.get("name", ""),
+            arguments=tc.get("arguments", {}),
+            result=tc.get("result"),
+        )
 
     # Build context from raw data
     ctx = CheckContext(
@@ -689,16 +707,9 @@ def run_custom_checks(
                 Message(
                     role=m.get("role", "user"),
                     content=m.get("content", ""),
-                    tool_calls=[
-                        ToolCall(
-                            name=tc.get("name", ""),
-                            arguments=tc.get("arguments", {}),
-                            result=tc.get("result"),
-                        )
-                        for tc in m.get("tool_calls", [])
-                    ],
+                    tool_calls=[_tool_call(tc, i) for tc in m.get("tool_calls", [])],
                 )
-                for m in transcript_messages
+                for i, m in enumerate(transcript_messages)
             ]
         ),
         task=TaskContext(task_id=task_id),

--- a/tolokaforge/core/grading/transcript_wire.py
+++ b/tolokaforge/core/grading/transcript_wire.py
@@ -26,6 +26,7 @@ from typing import Any
 from tolokaforge.core.models import Message, MessageRole, ToolCall, Trajectory
 
 __all__ = [
+    "decode_tool_call",
     "decode_transcript_wire",
     "encode_transcript_wire",
     "split_leading_system_message",
@@ -87,12 +88,19 @@ def _decode_entry(entry: dict[str, Any], index: int) -> Message:
     return Message(
         role=MessageRole(entry["role"]),
         content=entry["content"],
-        tool_calls=[_decode_tool_call(raw, index) for raw in raw_calls] or None,
+        tool_calls=[decode_tool_call(raw, index) for raw in raw_calls] or None,
         tool_call_id=entry.get("tool_call_id"),
     )
 
 
-def _decode_tool_call(raw: dict[str, Any], message_index: int) -> ToolCall:
+def decode_tool_call(raw: dict[str, Any], message_index: int) -> ToolCall:
+    """Decode a single wire-shaped ``tool_calls`` entry into a :class:`ToolCall`.
+
+    Raises :class:`ValueError` naming ``message_index`` on any missing key,
+    absent id, or unparseable ``arguments`` JSON. Shared by
+    :func:`decode_transcript_wire` and by the grading check runner so both
+    paths reject the same malformed shapes.
+    """
     if "function" not in raw:
         raise ValueError(
             f"wire message {message_index}: tool call has no 'function'; "


### PR DESCRIPTION
Fixes #706: a wire `tool_calls` entry is `{"id", "function": {"name",
"arguments"}}`, but `run_custom_checks` read `name`/`arguments` flat with
`.get` defaults — so every wire call arrived empty and a tool-call check
judged an empty view with no error anywhere.

Fix is dual-shape, per entry:
- `"function"` present → decode as wire (real name, parsed arguments);
  malformed entries raise `ValueError` naming the message.
- Otherwise → the long-standing flat path, unchanged, so existing callers
  of this public API are untouched (deliberate deviation from the issue's
  "remove the defaults everywhere" — flat is compat surface).

New `test_run_custom_checks_wire.py` locks all three: encoder-produced wire
payload reaches checks with names+arguments (fails on old code), flat shape
unchanged, malformed wire raises. 108 adjacent tests pass; ruff clean.

Closes #706