### PR TITLE
feat(runtime): Service Readiness Contract — first-class host-invokability boundary (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Feat
 
 - **runtime**: task packs may declare `services.<name>.readiness: {kind: grpc|http|tcp}`, an optional per-service client-reachability contract (default: none — the docker healthcheck stays the only readiness signal). Every existing pack validates unchanged (#803)
+- **runtime**: `PerTrialRuntimeBackend.provision` gates on host-side readiness before returning — the runner is always probed for gRPC channel-readiness on its published host port, and any service declaring `readiness:` is probed by its kind. A container that is Docker-healthy but host-unreachable (loopback-only or IPv6-only bind) now fails fast with a `ProvisionError` whose `diagnostic` names the resolved endpoint, probe outcome, and the container's actual listen addresses, instead of a downstream 30 s client-connect timeout (#803)
 
 ## v0.13.1 (2026-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **runtime**: task packs may declare `services.<name>.readiness: {kind: grpc|http|tcp}`, an optional per-service client-reachability contract (default: none — the docker healthcheck stays the only readiness signal). Every existing pack validates unchanged (#803)
+
 ## v0.13.1 (2026-08-03)
 
 ### Feat

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -1757,14 +1757,17 @@ default_environment:
 
 - **`kind`** — the only field in v1. Vocabulary and their port/path
   conventions:
-  - **`grpc`** — reachability is a gRPC channel reaching READY. Uses the
-    runner port (`stack.runner_port`) for the runner service, else the
+  - **`grpc`** — reachability is a gRPC channel reaching READY on the
     service's first published port.
   - **`http`** — `GET /health` on the service's first published port; a
     2xx response is reachable.
   - **`tcp`** — a TCP connect to the service's first published port.
 - **Omission** means the service declares **no explicit readiness
   contract** — the docker healthcheck remains its only readiness signal.
+- The **runner service cannot declare a `readiness` contract** — it is
+  always gated by the built-in gRPC probe on its host port
+  (`stack.runner_port`); a `readiness` entry on the runner service is
+  rejected at load. Declare it on a non-runner sibling instead.
 - `readiness` is orthogonal to `isolation`, `reset`, and `network_access`;
   every combination is legal. It deep-merges by name like every other
   `services.<name>` field — a task-side entry overrides the project-side

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -1738,6 +1738,38 @@ See [`docs/MULTI_CONTAINER_GUIDE.md`](MULTI_CONTAINER_GUIDE.md#partitioning-an-u
 for the walkthrough and [`docs/SECURITY.md`](SECURITY.md#task-declared-stack-case-b--case-c)
 for the threat-model treatment.
 
+### Readiness — declaring a client-reachability contract
+
+A container reporting `Healthy` via its docker `healthcheck:` means the
+process is up *inside* the container; it does not guarantee a client on
+the host can reach the service through its published port.
+`services.<name>.readiness` declares a **host-side reachability contract**
+by endpoint kind.
+
+```yaml
+default_environment:
+  services:
+    db-service:
+      isolation: shared
+      readiness:
+        kind: grpc        # grpc | http | tcp
+```
+
+- **`kind`** — the only field in v1. Vocabulary and their port/path
+  conventions:
+  - **`grpc`** — reachability is a gRPC channel reaching READY. Uses the
+    runner port (`stack.runner_port`) for the runner service, else the
+    service's first published port.
+  - **`http`** — `GET /health` on the service's first published port; a
+    2xx response is reachable.
+  - **`tcp`** — a TCP connect to the service's first published port.
+- **Omission** means the service declares **no explicit readiness
+  contract** — the docker healthcheck remains its only readiness signal.
+- `readiness` is orthogonal to `isolation`, `reset`, and `network_access`;
+  every combination is legal. It deep-merges by name like every other
+  `services.<name>` field — a task-side entry overrides the project-side
+  `kind`, and omitting it inherits the project-side contract.
+
 ## Services and backends — scaffolding
 
 > Per-service isolation, seed-backed reset recipes, and the
@@ -1750,9 +1782,10 @@ for the threat-model treatment.
 
 `default_environment.services.<name>` is the manifest home for
 everything the harness needs to know about a sidecar service.
-Today it holds `isolation` and, for `isolation: "reset"`, a
-`reset.seed` pointer at an entry in `project.assets.seeds`. The
-intended evolution is a **recipe per lifecycle event**:
+Today it holds `isolation` (and, for `isolation: "reset"`, a
+`reset.seed` pointer at an entry in `project.assets.seeds`),
+`network_access`, and `readiness`. The intended evolution is a
+**recipe per lifecycle event**:
 
 ```yaml
 # Illustrative future shape — NOT part of the current schema

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -71,6 +71,25 @@ provisioning them per the manifest's isolation rules. See
 [RUNTIME_BACKENDS.md](RUNTIME_BACKENDS.md) for
 the backend lifecycle.
 
+### Runner readiness contract
+
+The runner is gated for readiness at two independent layers, and they answer
+different questions:
+
+- **Container-internal `HEALTHCHECK`** (`runner.Dockerfile`) opens a gRPC channel
+  to `localhost:50051` *inside the container*. It answers "has the gRPC server
+  bound its port?" and is what `docker compose up --wait` blocks on — but a
+  loopback probe cannot tell whether the port is reachable from outside the
+  container.
+- **Host-side readiness gate** (`PerTrialRuntimeBackend.provision`, per-trial
+  runs) opens a gRPC channel to the runner's *published host port* from the
+  orchestrator process. It answers "can the engine actually invoke this runner?"
+  — the guarantee the container-loopback healthcheck cannot give. The runner is
+  always probed with the `grpc` kind; provisioning fails fast with an actionable
+  `ProvisionError` (naming the resolved `host:port` and the container's listen
+  addresses) rather than surfacing as a downstream client-connect timeout. See
+  [RUNTIME_BACKENDS.md § Readiness gate](RUNTIME_BACKENDS.md#readiness-gate).
+
 ## Runner Image Contents
 
 `runner.Dockerfile` is a multi-stage build on a `python:3.12-slim` base

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -547,15 +547,16 @@ The isolation axis (shared vs per-trial) and the substrate axis (docker compose 
 
 ## Plug-in extension points
 
-The three orchestrator seams — `RuntimeBackend`, `TrialGrader`, and `Conductor` — are each exposed as an `importlib.metadata` entry-point group. A downstream package registers an implementation under a name in its own `pyproject.toml`; the orchestrator discovers it after `pip install`, with no edit to tolokaforge. Each entry point resolves to a **factory callable** `Callable[[<Context>], <Impl>]` — not the raw class — so divergent constructors are adapted behind a per-group context object. tolokaforge's own six built-ins register through the same mechanism.
+Four swappable seams — `RuntimeBackend`, `TrialGrader`, `Conductor`, and `ServiceReadinessProbe` — are each exposed as an `importlib.metadata` entry-point group. A downstream package registers an implementation under a name in its own `pyproject.toml`; the orchestrator discovers it after `pip install`, with no edit to tolokaforge. Each entry point resolves to a **factory callable** — not the raw class — so divergent constructors are adapted behind a factory. The three orchestrator seams pass a per-group frozen-dataclass context (`Callable[[<Context>], <Impl>]`); a readiness probe needs no build dependencies, so its factory is arg-less (`Callable[[], ServiceReadinessProbe]`). tolokaforge's own nine built-ins register through the same mechanism.
 
 | Group | Factory type | Context |
 | --- | --- | --- |
 | `tolokaforge.runtime_backends` | `Callable[[RuntimeBackendBuildContext], RuntimeBackend]` | `runner_address`, `env_manifest`, `run_id`, `seeds`, `log_capture`, `events` |
 | `tolokaforge.trial_graders` | `Callable[[TrialGraderContext], TrialGrader]` | `runtime_backend`, `logger` |
 | `tolokaforge.conductors` | `Callable[[ConductorContext], Conductor]` | per-run deps (adapter, writer, config, agent client, runtime backend, grader, …) |
+| `tolokaforge.service_readiness_probes` | `Callable[[], ServiceReadinessProbe]` | *no context* |
 
-A factory is free to ignore context fields it does not need. The runtime-backend and trial-grader context/factory types are imported from `tolokaforge.core.plugin_registry`; the conductor context is imported from `tolokaforge.core.conductor` (as shown in the conductor example below) since it reuses the pre-existing `ConductorContext` seam. Keep the factory module free of any `tolokaforge.core.orchestrator` import so `.load()` stays independent of the orchestration engine.
+A factory is free to ignore context fields it does not need. The runtime-backend, trial-grader, and readiness-probe context/factory types are imported from `tolokaforge.core.plugin_registry`; the conductor context is imported from `tolokaforge.core.conductor` (as shown in the conductor example below) since it reuses the pre-existing `ConductorContext` seam. Keep the factory module free of any `tolokaforge.core.orchestrator` import so `.load()` stays independent of the orchestration engine.
 
 **Runtime backend** — `mypkg/runtime.py`:
 
@@ -600,6 +601,26 @@ def my_conductor_factory(ctx: ConductorContext) -> "MyConductor":
 [project.entry-points."tolokaforge.conductors"]
 my_conductor = "mypkg.conductor:my_conductor_factory"
 ```
+
+**Service-readiness probe** — `mypkg/readiness.py`. A probe answers, from the calling process, whether a resolved `host:port` is reachable and protocol-ready within a timeout budget, returning a `ReadinessResult`. Register it under a **kind name** (`grpc` / `http` / `tcp`, or a custom kind); the substrate picks it up by kind with no substrate edit. The factory is arg-less — probes carry no build context:
+
+```python
+from tolokaforge.core.service_readiness import ReadinessResult, ResolvedEndpoint
+
+class MyReadinessProbe:
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        ...  # cheap reachability check; ok=True on success, detail set on failure
+
+def my_probe_factory() -> MyReadinessProbe:
+    return MyReadinessProbe()
+```
+
+```toml
+[project.entry-points."tolokaforge.service_readiness_probes"]
+mykind = "mypkg.readiness:my_probe_factory"
+```
+
+tolokaforge ships `grpc`, `http`, and `tcp` built-ins under this group.
 
 **Fail-loud resolution.** Names resolve lazily and are cached per group. Discovery enumerates names and distributions **without importing any target**, which gives the policy two distinct shapes:
 

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -185,17 +185,29 @@ Every step above is a single method call in `tolokaforge/core/per_trial_runtime.
 
 ## Deep-dive — `provision()`
 
-Nine steps, in order. Failure at any step raises `ProvisionError(stage="provision")` and cleans up whatever ran successfully before the raise.
+Ten steps, in order. Failure at any step raises `ProvisionError(stage="provision")` and cleans up whatever ran successfully before the raise.
 
 1. **Guard on manifest presence.** `spec.task.environment_manifest is None` → raise. Tasks without a manifest belong on `SharedStackRuntimeBackend`, not this backend.
 2. **Make a per-trial temp directory.** Path like `/tmp/tolokaforge-<sanitised-trial-id>-<random>/`. The basename is what Docker Compose reads for its auto-generated project name — encoding the trial id here is what gives each concurrent trial its own project.
 3. **Copy the compose context.** Everything in the compose file's parent directory (compose YAML, adjacent bind-mount source files, initial-state fixtures) copies into the temp dir. Bind mounts declared as relative paths resolve inside the copied context; safety validators (ADR-0009) already reject `..` and absolute paths, so the copy is closed and complete.
 4. **Construct `DockerCompose`** with `context=<temp_dir>`, `compose_file_name=<manifest.compose_file.name>`, `pull=False`, `build=False`, `wait=True`.
 5. **`compose.start()`.** Runs `docker compose up -d --wait`. Blocks until every service's compose `healthcheck:` reports healthy. On failure, raise `ProvisionError` and rmtree the temp dir.
-6. **Construct the runner client** — `GrpcRunnerClient(runner_address="<host>:<port>")`. Host + port come from `compose.get_service_host_and_port(manifest.runner_service, manifest.runner_port)`. **The client is not connected here** — `connect()` is deferred to first RPC use (see next section).
-7. **Snapshot endpoints on the handle.** `_resolve_endpoints(...)` looks up `runner_service` at `manifest.runner_port` (required) and, best-effort, the db and rag services. Missing `db-service` leaves `EnvEndpoints.db_url = None`; the runner-side `DBServiceClient` binds to `DB_SERVICE_URL` from its container env and `db_json.py` tools fall back to the same env var, so a missing `db_url` is not a provisioning failure. Runner-missing still raises `ProvisionError`.
-8. **Cache the client** — `self._clients[spec.trial_id] = client`. This is the map every per-trial RPC method reads from.
-9. **Return `_LocalEnvHandle`** carrying the trial_id (public), the compose stack, the runner service name + port, the temp dir, and the endpoints snapshot. All except `trial_id` are backend-private; callers treat the handle as an opaque token.
+6. **Resolve the runner endpoint.** Host + port come from `compose.get_service_host_and_port(manifest.runner_service, manifest.runner_port)`; runner-missing raises `ProvisionError`.
+7. **Run the host-side readiness gate.** Probe the runner endpoint for gRPC channel-readiness, plus every service that declares a `readiness:` spec by that spec's kind on its first published port. A not-ready endpoint raises `ProvisionError(stage="provision")` carrying a `DiagnosticPayload` — see [Readiness gate](#readiness-gate).
+8. **Construct the runner client** — `GrpcRunnerClient(runner_address="<host>:<port>")`. **The client is not connected here** — `connect()` is deferred to first RPC use (see [Lazy runner-client connect](#lazy-runner-client-connect)).
+9. **Snapshot endpoints on the handle** and **cache the client** (`self._clients[spec.trial_id] = client`, the map every per-trial RPC method reads). Endpoint resolution looks up `runner_service` (required) and, best-effort, the db and rag services. Missing `db-service` leaves `EnvEndpoints.db_url = None`; the runner-side `DBServiceClient` binds to `DB_SERVICE_URL` from its container env and `db_json.py` tools fall back to the same env var, so a missing `db_url` is not a provisioning failure.
+10. **Return `_LocalEnvHandle`** carrying the trial_id (public), the compose stack, the runner service name + port, the temp dir, and the endpoints snapshot. All except `trial_id` are backend-private; callers treat the handle as an opaque token.
+
+### Readiness gate
+
+`docker compose up --wait` (step 5) blocks only until each service's *in-container* `healthcheck:` reports healthy — and a container's healthcheck typically probes its own loopback. A service can therefore be Docker-`Healthy` yet unreachable from the orchestrator process on its published host port: it bound `127.0.0.1` only, or bound an IPv6 address the IPv4 published-port DNAT never reaches. The compose `--wait` gate cannot see that gap.
+
+The host-side readiness gate (step 7) closes it. Before the handle is returned, the backend probes each gated endpoint *from the orchestrator process* within the `connect_timeout` budget:
+
+- **The runner substrate is always probed with the `grpc` kind** on its resolved host port — its default client-invocability contract (see [RUNNER.md](RUNNER.md)).
+- **Each service that declares a `readiness:` spec** is additionally probed by that spec's `kind` (`grpc` / `http` / `tcp`) on its first published host port. A declared-readiness service that exposes no resolvable published port fails the gate — the contract cannot be honoured. (Under `no_internet` only the runner joins the egress-capable edge network and gets a host-published port; non-runner services are internal-only, so declaring readiness on them requires `full_internet` or `limited_internet`.)
+
+A not-ready probe raises `ProvisionError(stage="provision")` carrying a `DiagnosticPayload` — the probed `service`/`kind`/`endpoint`, the `ReadinessResult`, and a best-effort docker-side view of where the service *actually* listens (published-port map, container listen addresses from `/proc/net/tcp[6]`, per-network IPs). That converts a downstream 30 s client-connect hang into a fast provisioning failure that names the mechanism. The probe seam is swappable per kind — see [Plug-in extension points](#plug-in-extension-points).
 
 ### Slow-dependency start order
 
@@ -283,7 +295,7 @@ connect" (caller's problem).
 - `_client_for(trial_id)` — invoked by every per-trial RPC method — checks the set; if the trial isn't in it, calls `.connect()` once and adds it. Subsequent calls to the same trial's RPCs skip the connect.
 - `teardown(handle)` and `close()` only invoke `.close()` on clients that were actually connected — closing a never-used client would have nothing to close on the gRPC side.
 
-This means the compose `--wait` gate (which already blocks until every container reports healthy) is the only latency `provision()` adds beyond the compose CLI itself. First RPC call pays the connect cost; subsequent calls hit a warm client.
+The deferred client connect is distinct from the [readiness gate](#readiness-gate): the gate opens a throwaway probe channel to prove the runner's host port is reachable and closes it immediately, adding milliseconds — it does not stand in for, or warm, the per-trial client. So `provision()` adds two bounded costs beyond the compose CLI: the compose `--wait` gate (blocks until every container reports healthy) and the readiness probe (fast reachability check). The first RPC call still pays the client connect cost; subsequent calls hit a warm client.
 
 ## Reporting component status
 
@@ -388,7 +400,8 @@ See [`RESET_RECIPES.md`](RESET_RECIPES.md) for the four seed kinds (`sql_dump`, 
 | `provision` — no manifest | `ProvisionError(stage="provision")` | Nothing to clean |
 | `provision` — compose start fails | `ProvisionError(stage="provision")` wrapping the compose error | Per-service logs captured before teardown (see below); per-trial temp dir removed |
 | `provision` — reset recipe fails | `ProvisionError(stage="reset_recipe")` | Per-service logs captured before teardown (see below); compose stack torn down + temp dir removed |
-| `provision` — runner-client construction (host/port unresolvable) | `ProvisionError(stage="provision")` | Compose stack torn down + temp dir removed |
+| `provision` — runner host/port unresolvable | `ProvisionError(stage="provision")` | Compose stack torn down + temp dir removed |
+| `provision` — readiness gate: a gated endpoint not host-reachable | `ProvisionError(stage="provision")` carrying a `DiagnosticPayload` (probed service/kind/endpoint, `ReadinessResult`, docker-side listen view) | Per-service logs captured before teardown; compose stack torn down + temp dir removed |
 | `provision` — endpoint resolution (missing `db-service`) | Not a failure — `EnvEndpoints.db_url` stays `None`; the runner reads `DB_SERVICE_URL` from its container env | — |
 | `await_ready` | Never raises today (`--wait` gates during provision); reserved for future backends | — |
 | `endpoints` — foreign handle | `TypeError` | — |

--- a/docs/adr/0025-service-readiness-contract.md
+++ b/docs/adr/0025-service-readiness-contract.md
@@ -131,12 +131,6 @@ rather than a stronger container-internal one.
 
 ### Follow-ups
 
-- Code changes required: the provision-time readiness gate +
-  `ProvisionError.diagnostic` land in a later stage of this ticket (#803).
-- Documentation to update: `docs/RUNTIME_BACKENDS.md` § "Plug-in extension
-  points" gains the fourth group row and a worked example (this stage).
-- Tests to add: the provision-gate negative/positive locks land with the gate
-  (later stage of #803).
 - **#805** — `fix(runner)`: bind the gRPC server to explicit IPv4 wildcard
   (`0.0.0.0`) instead of `[::]`. The readiness gate *diagnoses* the #801 class;
   this bind change is what makes an IPv6-only-bound environment actually run.

--- a/docs/adr/0025-service-readiness-contract.md
+++ b/docs/adr/0025-service-readiness-contract.md
@@ -128,6 +128,11 @@ rather than a stronger container-internal one.
   is documented here rather than papered over with an empty context dataclass.
 - A fourth registry group is one more discovery surface to keep in the canonical
   registration snapshot (`test_builtin_plugin_registrations.py`).
+- The HTTP probe path is a v1 convention: `HTTP_HEALTH_PATH = "/health"` is
+  hard-coded rather than configurable. If a real pack ever needs a different
+  path, the escalation is an additive optional `ReadinessSpec.path` field
+  (default `/health`, so existing packs validate unchanged) threaded to the
+  probe — not introduced here to avoid config surface no pack yet needs.
 
 ### Follow-ups
 

--- a/docs/adr/0025-service-readiness-contract.md
+++ b/docs/adr/0025-service-readiness-contract.md
@@ -1,0 +1,153 @@
+# 0025. Service-readiness contract as a fourth entry-point-registry seam
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+A docker `healthcheck:` reporting a container `Healthy` is not the same signal as
+"a client can invoke this service." A container-internal loopback probe can pass
+while the published host port reaches no listener. The runner image
+(`runner.Dockerfile`) probes `localhost:50051` from *inside* the container; on a
+host that binds IPv6-only (`bindv6only=1`) against a `[::]` server bind, the
+loopback probe stays green while the IPv4 published-port DNAT reaches nothing
+from the calling process.
+
+The #801 localization (`docs/plans/2026-08-03-issue-801-runner-host-port-readiness.md`)
+is the empirical evidence: it established that this failure class is real but
+**not reproducible in core on the available platforms** — the `[::]` bind
+collapses to IPv4 where there is no container IPv6 stack, so CI and Mac cannot
+exhibit the wedge. Today `PerTrialRuntimeBackend.provision` trusts
+`docker compose up --wait` and hands off; a caller then hits a 30×1 s connect
+loop against an unreachable endpoint with no diagnostic captured at the failure
+point.
+
+The boundary — *container-healthy* versus *client-invokable* — has no name in
+the codebase. Without one, the class of bug can be reintroduced silently every
+time a new service is added, and every failure surfaces as a downstream timeout
+rather than an actionable diagnostic. This ADR names that boundary as a
+first-class contract.
+
+## Decision Drivers
+
+- **The boundary must be authoritative from the calling process**, not inferred
+  from a container-internal healthcheck that cannot observe host reachability.
+- **Substrate-agnosticism.** The readiness answer depends only on `host:port` +
+  a timeout budget; it must not couple to the docker/compose handle so the same
+  contract serves any endpoint source.
+- **Swappability is real.** gRPC, HTTP, and TCP are three genuinely different
+  readiness checks today, and downstream adapters will want their own — a named
+  second variant exists, so ADR-0011's "introduce a Protocol" test is met.
+- **Reuse the fail-loud registry idiom** rather than inventing a parallel
+  discovery mechanism; the three existing entry-point groups already encode the
+  duplicate/unknown/broken-import policy.
+- **Cheap by construction.** Readiness must cost milliseconds so it can gate
+  every provision without reintroducing a slow loop.
+
+## Considered Options
+
+1. **Probe inline in the backend** — hard-code a gRPC channel-ready check inside
+   `PerTrialRuntimeBackend.provision`.
+2. **A `ServiceReadinessProbe` Protocol behind an entry-point registry** — with
+   built-in `grpc`/`http`/`tcp` probes, an `InMemory*` fixture, and a canonical
+   contract test. **This ADR.**
+3. **Extend `RuntimeBackend.await_ready`** — fold readiness into the existing
+   lifecycle method on the backend Protocol.
+
+## Decision
+
+We adopt **Option 2**: a `@runtime_checkable ServiceReadinessProbe` Protocol
+(`probe(endpoint, *, timeout) -> ReadinessResult`) over frozen-dataclass value
+objects `ResolvedEndpoint` and `ReadinessResult`, three built-in production
+probes (`GrpcReadinessProbe`, `HttpReadinessProbe`, `TcpReadinessProbe`), an
+`InMemoryServiceReadinessProbe` fixture with a call log + failure knobs, and a
+canonical contract test — the full ADR-0011 Pattern-A shape.
+
+The probes are discovered through a **new entry-point group**
+`tolokaforge.service_readiness_probes`, keyed by endpoint kind (`grpc` / `http`
+/ `tcp`), reusing the existing fail-loud `_discover` / `_load` machinery in
+`plugin_registry.py`. This is the **fourth entry-point-registry-backed seam**:
+three registry groups ship today in `pyproject.toml` (`runtime_backends`,
+`trial_graders`, `conductors`); this adds the fourth, validating that the
+registry idiom generalises beyond the orchestrator seams. (The count worth
+stating is the registry-group count, three→four — not a Pattern-A-consumer
+count, since ADR-0011's table already lists ≥6 Pattern-A consumers.) The
+adapter-declared-name work in #800 introduces a related registry-shaped seam by
+the same idiom; it is not yet merged, so this ADR cross-references it by shape
+rather than by number.
+
+Unlike the three orchestrator groups, each of which carries a per-group
+frozen-dataclass context, a readiness probe needs no build dependencies, so its
+factory is arg-less: `ReadinessProbeFactory = Callable[[], ServiceReadinessProbe]`.
+The factory-callable indirection is kept — rather than registering the class
+directly — to match the sibling groups' idiom (uniform arg-less construction, so
+a factory is the faithful match, not a divergent-constructor workaround). No
+`*Context` dataclass is invented for a seam with no deps to pass.
+
+### Readiness is cheap; the per-trial connect stays deferred
+
+Readiness answers *reachable + protocol-ready* in milliseconds — a gRPC channel
+reaching READY, `GET /health` returning 2xx, or a TCP connect completing. It is
+deliberately **not** a full protocol handshake. This is orthogonal to the
+existing deferred per-trial gRPC connect (`per_trial_runtime.py`), which stays
+lazy and unchanged: the runner client's `connect()` is deferred to the first
+per-trial RPC so provisioning latency is not charged the connect cost for a
+trial that never exercises the RPC surface. The readiness gate is a cheap
+host-side reachability check at provision time; the deferred connect is the
+full channel established on first use. Both remain — they answer different
+questions.
+
+### We are not fighting the container loopback healthcheck
+
+The `runner.Dockerfile` loopback `HEALTHCHECK` stays exactly as-is. It answers
+"is the process up inside the container", which is a useful and correct signal.
+The readiness probe is the new *authoritative* signal from the calling process:
+it answers "can I reach and speak to this service from here." The two are
+complementary, not redundant — the whole point is that the loopback check cannot
+observe a host-reachability gap, so a second, host-side signal is required
+rather than a stronger container-internal one.
+
+## Consequences
+
+### Positive
+
+- The container-healthy vs client-invokable boundary is a named, tested
+  contract; the #801 class cannot be reintroduced silently.
+- Readiness is swappable per endpoint kind with no substrate edit — an adapter
+  registers a custom probe under a kind name via entry-point.
+- The registry idiom is shown to generalise beyond the orchestrator seams
+  (three→four groups), reducing the cost of the next registry-backed seam.
+
+### Negative / Trade-offs
+
+- The readiness factory diverges slightly from the three existing groups (arg-less
+  vs context-carrying). The divergence is honest — probes have no build deps — and
+  is documented here rather than papered over with an empty context dataclass.
+- A fourth registry group is one more discovery surface to keep in the canonical
+  registration snapshot (`test_builtin_plugin_registrations.py`).
+
+### Follow-ups
+
+- Code changes required: the provision-time readiness gate +
+  `ProvisionError.diagnostic` land in a later stage of this ticket (#803).
+- Documentation to update: `docs/RUNTIME_BACKENDS.md` § "Plug-in extension
+  points" gains the fourth group row and a worked example (this stage).
+- Tests to add: the provision-gate negative/positive locks land with the gate
+  (later stage of #803).
+- **#805** — `fix(runner)`: bind the gRPC server to explicit IPv4 wildcard
+  (`0.0.0.0`) instead of `[::]`. The readiness gate *diagnoses* the #801 class;
+  this bind change is what makes an IPv6-only-bound environment actually run.
+- **#806** — `feat(runtime)`: multi-service readiness dependency graph
+  (service B waits on service A's readiness). This contract is per-service only.
+
+## Links
+
+- Related ADRs: [0011](0011-seam-and-declaration-conventions.md) (Pattern A),
+  [0007](0007-runtime-backend-protocol.md),
+  [0010](0010-runtime-backend-provisioning-contract.md)
+- Related code: `tolokaforge/core/service_readiness.py`,
+  `tolokaforge/core/plugin_registry.py`
+- External references: #801 (localization), #803 (this ticket), #805, #806

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,11 @@ runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
 in_process = "tolokaforge.core.conductor:in_process_conductor_factory"
 in_memory = "tolokaforge.core.conductor:in_memory_conductor_factory"
 
+[project.entry-points."tolokaforge.service_readiness_probes"]
+grpc = "tolokaforge.core.service_readiness:grpc_readiness_probe_factory"
+http = "tolokaforge.core.service_readiness:http_readiness_probe_factory"
+tcp = "tolokaforge.core.service_readiness:tcp_readiness_probe_factory"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -1,11 +1,12 @@
-"""Built-in entry-point registrations for the three orchestrator seams.
+"""Built-in entry-point registrations for the four swappable seams.
 
 Snapshots the registration table tolokaforge ships in its own ``pyproject.toml``:
-the six built-in names resolve through the fail-loud loader to factories that
-build the right impl, the ``available_*`` listings match the ADR-locked set,
-and the raw ``importlib.metadata`` probe from the acceptance criterion sees the
-runtime-backend names. Canonical tier because it reads *installed* package
-metadata (``uv sync`` / the CI install step registers the entry points).
+the built-in names resolve through the fail-loud loader to factories that build
+the right impl, the ``available_*`` listings match the ADR-locked set, and the
+raw ``importlib.metadata`` probe from the acceptance criterion sees the
+runtime-backend and readiness-probe names. Canonical tier because it reads
+*installed* package metadata (``uv sync`` / the CI install step registers the
+entry points).
 """
 
 from __future__ import annotations
@@ -24,16 +25,24 @@ from tolokaforge.core.conductor import (
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.plugin_registry import (
     RUNTIME_BACKENDS_GROUP,
+    SERVICE_READINESS_PROBES_GROUP,
     RuntimeBackendBuildContext,
     TrialGraderContext,
     available_conductors,
+    available_readiness_probes,
     available_runtime_backends,
     available_trial_graders,
     load_conductor,
+    load_readiness_probe,
     load_runtime_backend,
     load_trial_grader,
 )
 from tolokaforge.core.runtime import InMemoryRuntimeBackend
+from tolokaforge.core.service_readiness import (
+    GrpcReadinessProbe,
+    HttpReadinessProbe,
+    TcpReadinessProbe,
+)
 from tolokaforge.core.shared_stack_runtime import SharedStackRuntimeBackend
 from tolokaforge.core.trial_grader import RunnerRPCTrialGrader
 
@@ -97,12 +106,33 @@ def test_conductor_names_resolve_to_their_class(name: str, expected_cls: type) -
     assert isinstance(conductor, expected_cls)
 
 
+@pytest.mark.parametrize(
+    ("kind", "expected_cls"),
+    [
+        ("grpc", GrpcReadinessProbe),
+        ("http", HttpReadinessProbe),
+        ("tcp", TcpReadinessProbe),
+    ],
+)
+def test_readiness_probe_kinds_resolve_to_their_class(kind: str, expected_cls: type) -> None:
+    probe = load_readiness_probe(kind)()
+    assert isinstance(probe, expected_cls)
+
+
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
     assert available_trial_graders() == ["runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
+    assert available_readiness_probes() == ["grpc", "http", "tcp"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=RUNTIME_BACKENDS_GROUP))
     assert names == ["in_memory", "per_trial", "shared"]
+
+
+def test_raw_entry_point_probe_lists_readiness_probes() -> None:
+    names = sorted(
+        ep.name for ep in importlib.metadata.entry_points(group=SERVICE_READINESS_PROBES_GROUP)
+    )
+    assert names == ["grpc", "http", "tcp"]

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -19,7 +19,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from tolokaforge.core.models import ResetSpec, ServiceSpec
+from tolokaforge.core.models import ReadinessSpec, ResetSpec, ServiceSpec
 from tolokaforge.core.trial import (
     EnvironmentManifest,
     InitialStateRef,
@@ -325,6 +325,45 @@ class TestServiceNetworkAccessContract:
         assert m.services == {}
         assert m.restricted_services == frozenset()
         assert isinstance(m.restricted_services, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# ReadinessSpec — per-service readiness declaration
+# ---------------------------------------------------------------------------
+
+
+class TestServiceReadinessContract:
+    def test_default_readiness_is_none(self) -> None:
+        spec = ServiceSpec(isolation="shared")
+        assert spec.readiness is None
+
+    @pytest.mark.parametrize("kind", ["grpc", "http", "tcp"])
+    def test_readiness_kinds_round_trip(self, kind: str) -> None:
+        spec = ServiceSpec(isolation="shared", readiness=ReadinessSpec(kind=kind))
+        reloaded = ServiceSpec.model_validate_json(spec.model_dump_json())
+        assert reloaded.readiness is not None
+        assert reloaded.readiness.kind == kind
+
+    def test_unknown_readiness_kind_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="kind"):
+            ServiceSpec(isolation="shared", readiness=ReadinessSpec(kind="banana"))
+
+    def test_readiness_spec_forbids_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ReadinessSpec.model_validate({"kind": "grpc", "path": "/ready"})
+
+    def test_service_without_readiness_still_validates(self) -> None:
+        spec = ServiceSpec.model_validate({"isolation": "ephemeral"})
+        assert spec.readiness is None
+
+    @pytest.mark.parametrize("isolation", ["shared", "reset", "ephemeral"])
+    def test_readiness_is_orthogonal_to_isolation(self, isolation: str) -> None:
+        kwargs: dict[str, object] = {"isolation": isolation, "readiness": ReadinessSpec(kind="tcp")}
+        if isolation == "reset":
+            kwargs["reset"] = ResetSpec(seed="baseline")
+        spec = ServiceSpec(**kwargs)  # type: ignore[arg-type]
+        assert spec.readiness is not None
+        assert spec.readiness.kind == "tcp"
 
 
 # ---------------------------------------------------------------------------
@@ -774,11 +813,13 @@ class TestManifestWireShape:
                 "isolation": "reset",
                 "reset": {"seed": "baseline"},
                 "network_access": "default",
+                "readiness": None,
             },
             "default": {
                 "isolation": "shared",
                 "reset": None,
                 "network_access": "default",
+                "readiness": None,
             },
         }
         assert wire["initial_state"] == {"db": {"from_": "./fixtures/seed.sql", "kind": "sql"}}

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -219,6 +219,18 @@ class TestServiceNetworkAccessContract:
                 },
             )
 
+    def test_runner_service_cannot_declare_readiness(self) -> None:
+        with pytest.raises(ValidationError, match="cannot declare a readiness contract"):
+            EnvironmentManifest(
+                compose_file=_fixture("safe_restricted_sibling.yaml"),
+                runner_service="default",
+                services={
+                    "default": ServiceSpec(
+                        isolation="shared", readiness=ReadinessSpec(kind="http")
+                    ),
+                },
+            )
+
     def test_restricted_service_without_compose_networks_is_rejected(self) -> None:
         with pytest.raises(ValidationError, match=r"'db'.*network_access='restricted'"):
             EnvironmentManifest(

--- a/tests/canonical/test_per_trial_runtime_backend.py
+++ b/tests/canonical/test_per_trial_runtime_backend.py
@@ -12,6 +12,7 @@ handle failures per the ADR-0010 contract.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -22,13 +23,43 @@ from tolokaforge.core import per_trial_runtime as per_trial_runtime_module
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend, _LocalEnvHandle
 from tolokaforge.core.runtime import EnvHandle, ProvisionError, RuntimeBackend
+from tolokaforge.core.service_readiness import (
+    DiagnosticPayload,
+    InMemoryServiceReadinessProbe,
+    ReadinessResult,
+    ResolvedEndpoint,
+    ServiceReadinessProbe,
+)
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
-from tolokaforge.runner.models import ResetSpec, ServiceSpec
+from tolokaforge.runner.models import ReadinessSpec, ResetSpec, ServiceSpec
 
 pytestmark = pytest.mark.canonical
 
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "environment_manifest"
+
+
+def _ready_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+    """Readiness-probe loader seam yielding an always-ready in-memory probe, so
+    provision's host-side readiness gate passes without a live listener."""
+    del kind
+    return lambda: InMemoryServiceReadinessProbe(ok=True)
+
+
+class _RecordingLoader:
+    """Readiness-probe loader seam that records the ``kind`` requested per
+    service and hands back an always-ready probe whose own call log captures
+    the endpoint it was probed against."""
+
+    def __init__(self) -> None:
+        self.kinds: list[str] = []
+        self.probes: list[InMemoryServiceReadinessProbe] = []
+
+    def __call__(self, kind: str) -> Callable[[], ServiceReadinessProbe]:
+        self.kinds.append(kind)
+        probe = InMemoryServiceReadinessProbe(ok=True)
+        self.probes.append(probe)
+        return lambda: probe
 
 
 # ---------------------------------------------------------------------------
@@ -101,12 +132,15 @@ class _FakeCompose:
 
 class _FakeContainer:
     def __init__(self, ports: dict[int, int]) -> None:
-        self.Publishers = [_FakePublisher(TargetPort=p) for p in ports]
+        self.Publishers = [
+            _FakePublisher(TargetPort=cp, PublishedPort=hp) for cp, hp in ports.items()
+        ]
 
 
 class _FakePublisher:
-    def __init__(self, TargetPort: int) -> None:  # noqa: N803 — mirrors Testcontainers API
+    def __init__(self, TargetPort: int, PublishedPort: int) -> None:  # noqa: N803
         self.TargetPort = TargetPort
+        self.PublishedPort = PublishedPort
 
 
 class _FakeRunnerClient:
@@ -220,7 +254,7 @@ def patched_backend(monkeypatch: pytest.MonkeyPatch) -> PerTrialRuntimeBackend:
     to record-only fakes. Every test in this file uses this fixture."""
     monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FakeCompose)
     monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
-    return PerTrialRuntimeBackend()
+    return PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
 
 
 def _make_trial_spec(
@@ -363,7 +397,7 @@ class TestProvision:
 
         monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FakeCompose)
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _CountingClient)
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
         backend.provision(spec)
         backend.register_trial(trial_id=spec.trial_id, trial_spec_json="{}")
@@ -397,6 +431,105 @@ class TestProvision:
         assert exc.value.stage == "provision"
         assert exc.value.trial_id == spec.trial_id
 
+    def test_readiness_gate_failure_raises_provision_error_with_diagnostic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A not-ready gated endpoint fails provisioning at the readiness gate
+        with ``stage='provision'`` and a populated :class:`DiagnosticPayload`
+        naming the probed service, kind, resolved endpoint, and probe outcome.
+        No docker: the failing probe is injected through the loader seam, so
+        the docker-introspection fields degrade to empty structures."""
+        monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FakeCompose)
+        monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
+
+        def _failing_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+            del kind
+            return lambda: InMemoryServiceReadinessProbe(ok=False, fail_detail="channel not ready")
+
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_failing_loader)
+        spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
+        with pytest.raises(ProvisionError) as exc:
+            backend.provision(spec)
+        err = exc.value
+        assert err.stage == "provision"
+        assert err.trial_id == spec.trial_id
+        assert "channel not ready" in err.reason
+        assert isinstance(err.diagnostic, DiagnosticPayload)
+        assert err.diagnostic.service == "default"
+        assert err.diagnostic.kind == "grpc"
+        assert err.diagnostic.endpoint == ResolvedEndpoint(host="127.0.0.1", port=50100)
+        assert err.diagnostic.result == ReadinessResult(
+            ok=False, latency_s=0.0, detail="channel not ready"
+        )
+        # No orphan client is cached: the gate runs before the client is built.
+        assert spec.trial_id not in backend._clients
+
+    def test_runner_is_probed_with_grpc_at_resolved_host_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The runner substrate is always probed with the ``grpc`` kind at its
+        resolved host endpoint, regardless of any per-service readiness spec."""
+        monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FakeCompose)
+        monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
+        loader = _RecordingLoader()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=loader)
+        spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
+        backend.provision(spec)
+        assert loader.kinds == ["grpc"]
+        assert loader.probes[0].call_log.calls[0].endpoint == ResolvedEndpoint(
+            host="127.0.0.1", port=50100
+        )
+
+    def test_declared_readiness_service_probed_by_its_kind(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A service that declares a ``readiness`` spec is probed by that spec's
+        kind at its first published host port, alongside the runner's grpc probe."""
+
+        class _WithDbCompose(_FakeCompose):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                super().__init__(*args, **kwargs)
+                self.exposed_services = {"default": {50051: 50100}, "db": {5432: 55432}}
+
+        monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _WithDbCompose)
+        monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
+        loader = _RecordingLoader()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=loader)
+        manifest = EnvironmentManifest(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            services={
+                "db": ServiceSpec(isolation="ephemeral", readiness=ReadinessSpec(kind="tcp"))
+            },
+        )
+        backend.provision(_make_trial_spec(manifest=manifest))
+        assert loader.kinds == ["grpc", "tcp"]
+        assert loader.probes[1].call_log.calls[0].endpoint == ResolvedEndpoint(
+            host="127.0.0.1", port=55432
+        )
+
+    def test_declared_readiness_service_without_published_port_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A declared-readiness service that exposes no resolvable published
+        port cannot have its contract honoured — provisioning fails fast rather
+        than silently skipping the probe."""
+        monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FakeCompose)
+        monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
+        # _FakeCompose exposes "default" + "db-service" but not "db"; the manifest
+        # declares readiness on "db", which resolves to no host port.
+        manifest = EnvironmentManifest(
+            compose_file=_FIXTURES / "safe_two_service.yaml",
+            services={
+                "db": ServiceSpec(isolation="ephemeral", readiness=ReadinessSpec(kind="tcp"))
+            },
+        )
+        with pytest.raises(ProvisionError) as exc:
+            backend.provision(_make_trial_spec(manifest=manifest))
+        assert exc.value.stage == "provision"
+        assert "no resolvable published port" in exc.value.reason
+        assert exc.value.diagnostic is None
+
     def test_compose_start_failure_raises_provision_error(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -407,7 +540,7 @@ class TestProvision:
 
         monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _FailingCompose)
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
         with pytest.raises(ProvisionError) as exc:
             backend.provision(spec)
@@ -554,7 +687,7 @@ class TestEndpoints:
 
         monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _NoDbCompose)
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(compose_file=_FIXTURES / "safe_one_service.yaml")
         handle = backend.provision(spec)
         endpoints = backend.endpoints(handle)
@@ -575,7 +708,7 @@ class TestEndpoints:
 
         monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _WithRagCompose)
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
         handle = backend.provision(spec)
         endpoints = backend.endpoints(handle)
@@ -600,7 +733,7 @@ class TestEndpoints:
 
         monkeypatch.setattr(per_trial_runtime_module, "DockerCompose", _OverrideCompose)
         monkeypatch.setattr(per_trial_runtime_module, "GrpcRunnerClient", _FakeRunnerClient)
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         manifest = EnvironmentManifest(
             compose_file=_FIXTURES / "safe_two_service.yaml",
             runner_port=9000,

--- a/tests/canonical/test_per_trial_runtime_backend_component_logs.py
+++ b/tests/canonical/test_per_trial_runtime_backend_component_logs.py
@@ -14,6 +14,7 @@ leave no routers running because none were constructed on that path.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,7 @@ from tolokaforge.core import per_trial_runtime as per_trial_runtime_module
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend, _LocalEnvHandle
 from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.service_readiness import InMemoryServiceReadinessProbe, ServiceReadinessProbe
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 from tolokaforge.docker.logging import LogRouterError
 from tolokaforge.runner.models import ResetSpec, ServiceSpec
@@ -32,6 +34,13 @@ pytestmark = pytest.mark.canonical
 
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "environment_manifest"
+
+
+def _ready_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+    """Readiness-probe loader seam yielding an always-ready in-memory probe, so
+    provision's host-side readiness gate passes without a live listener."""
+    del kind
+    return lambda: InMemoryServiceReadinessProbe(ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -150,12 +159,15 @@ class _FakeCompose:
 
 class _FakeContainer:
     def __init__(self, ports: dict[int, int]) -> None:
-        self.Publishers = [_FakePublisher(TargetPort=p) for p in ports]
+        self.Publishers = [
+            _FakePublisher(TargetPort=cp, PublishedPort=hp) for cp, hp in ports.items()
+        ]
 
 
 class _FakePublisher:
-    def __init__(self, TargetPort: int) -> None:  # noqa: N803 — mirrors Testcontainers API
+    def __init__(self, TargetPort: int, PublishedPort: int) -> None:  # noqa: N803
         self.TargetPort = TargetPort
+        self.PublishedPort = PublishedPort
 
 
 class _FakeRunnerClient:
@@ -289,7 +301,7 @@ def test_provision_attaches_one_router_per_container(monkeypatch: pytest.MonkeyP
     )
     created = _install_recording_router(monkeypatch)
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec = _make_trial_spec(trial_id="task-1:0", compose_file=_FIXTURES / "safe_two_service.yaml")
     handle = backend.provision(spec)
 
@@ -326,7 +338,7 @@ def test_teardown_stops_routers_before_shutdown_compose(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(per_trial_runtime_module, "shutdown_compose", recording_shutdown)
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
     handle = backend.provision(spec)
     backend.teardown(handle)
@@ -353,7 +365,7 @@ def test_reset_recipe_failure_leaves_no_routers_running(monkeypatch: pytest.Monk
     )
     created = _install_recording_router(monkeypatch)
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     # Named seed absent from registry → reset-recipe stage failure.
     spec = _make_trial_spec(
         compose_file=_FIXTURES / "safe_two_service.yaml",
@@ -388,7 +400,7 @@ def test_concurrent_trials_get_independent_routers(monkeypatch: pytest.MonkeyPat
     )
     created = _install_recording_router(monkeypatch)
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec_a = _make_trial_spec(trial_id="task-1:0", compose_file=_FIXTURES / "safe_two_service.yaml")
     spec_b = _make_trial_spec(trial_id="task-1:1", compose_file=_FIXTURES / "safe_two_service.yaml")
     handle_a = backend.provision(spec_a)
@@ -429,7 +441,7 @@ def test_provision_logs_and_continues_on_router_failure(
     )
     created = _install_recording_router(monkeypatch, fail_for_service="default")
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec = _make_trial_spec(trial_id="task-1:0", compose_file=_FIXTURES / "safe_two_service.yaml")
 
     with caplog.at_level("ERROR"):
@@ -459,7 +471,7 @@ def test_container_without_id_is_skipped(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     created = _install_recording_router(monkeypatch)
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec = _make_trial_spec(trial_id="task-1:0", compose_file=_FIXTURES / "safe_two_service.yaml")
     handle = backend.provision(spec)
 
@@ -487,7 +499,7 @@ def test_teardown_swallows_router_stop_errors(monkeypatch: pytest.MonkeyPatch) -
         lambda _compose: shutdown_calls.append(True),
     )
 
-    backend = PerTrialRuntimeBackend()
+    backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
     spec = _make_trial_spec(compose_file=_FIXTURES / "safe_two_service.yaml")
     handle = backend.provision(spec)
 

--- a/tests/canonical/test_service_readiness_contract.py
+++ b/tests/canonical/test_service_readiness_contract.py
@@ -1,0 +1,196 @@
+"""Contract for the ``ServiceReadinessProbe`` seam and its entry-point registry.
+
+Pins the Protocol method surface + signature, the ``ResolvedEndpoint`` /
+``ReadinessResult`` value shapes, the ``InMemoryServiceReadinessProbe`` call-log
+and failure-knob semantics, and the fail-loud policy of the fourth registry
+group — reusing the loader's ``_clear_discovery_cache`` with injected fake entry
+points so the group's policy is exercised without an installed plug-in.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import inspect
+from typing import get_type_hints
+
+import pytest
+
+from tolokaforge.core import plugin_registry
+from tolokaforge.core.plugin_registry import (
+    SERVICE_READINESS_PROBES_GROUP,
+    DuplicateRegistrationError,
+    UnknownImplementationError,
+    available_readiness_probes,
+    load_readiness_probe,
+)
+from tolokaforge.core.service_readiness import (
+    InMemoryServiceReadinessProbe,
+    ReadinessResult,
+    ResolvedEndpoint,
+    ServiceReadinessProbe,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+class _FakeDist:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeEntryPoint:
+    def __init__(
+        self,
+        name: str,
+        *,
+        factory: object = None,
+        load_error: Exception | None = None,
+        dist: str = "pkg",
+    ) -> None:
+        self.name = name
+        self.dist = _FakeDist(dist)
+        self._factory = factory
+        self._load_error = load_error
+
+    def load(self) -> object:
+        if self._load_error is not None:
+            raise self._load_error
+        return self._factory
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin_registry._clear_discovery_cache()
+    yield
+    plugin_registry._clear_discovery_cache()
+
+
+def _install_entry_points(
+    monkeypatch: pytest.MonkeyPatch, entry_points: list[_FakeEntryPoint]
+) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEntryPoint]:
+        return list(entry_points) if group == SERVICE_READINESS_PROBES_GROUP else []
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+
+
+# --- Protocol + value shapes -------------------------------------------------
+
+
+def test_protocol_is_runtime_checkable_over_the_fixture() -> None:
+    assert isinstance(InMemoryServiceReadinessProbe(), ServiceReadinessProbe)
+
+
+def test_probe_method_signature() -> None:
+    sig = inspect.signature(ServiceReadinessProbe.probe)
+    assert list(sig.parameters) == ["self", "endpoint", "timeout"]
+    assert sig.parameters["timeout"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.return_annotation == "ReadinessResult"
+
+
+def test_resolved_endpoint_field_shape() -> None:
+    assert get_type_hints(ResolvedEndpoint) == {"host": str, "port": int}
+    endpoint = ResolvedEndpoint(host="127.0.0.1", port=50051)
+    with pytest.raises(AttributeError):
+        endpoint.host = "other"  # type: ignore[misc]
+
+
+def test_readiness_result_field_shape() -> None:
+    assert get_type_hints(ReadinessResult) == {
+        "ok": bool,
+        "latency_s": float,
+        "detail": str | None,
+    }
+    result = ReadinessResult(ok=True, latency_s=0.01)
+    assert result.detail is None
+    with pytest.raises(AttributeError):
+        result.ok = False  # type: ignore[misc]
+
+
+# --- InMemoryServiceReadinessProbe semantics ---------------------------------
+
+
+def test_in_memory_probe_records_every_call() -> None:
+    probe = InMemoryServiceReadinessProbe()
+    endpoint = ResolvedEndpoint(host="svc", port=8080)
+
+    probe.probe(endpoint, timeout=2.5)
+
+    assert len(probe.call_log.calls) == 1
+    call = probe.call_log.calls[0]
+    assert call.endpoint == endpoint
+    assert call.timeout == 2.5
+
+
+def test_in_memory_probe_defaults_to_ok() -> None:
+    result = InMemoryServiceReadinessProbe().probe(ResolvedEndpoint("svc", 1), timeout=1.0)
+    assert result == ReadinessResult(ok=True, latency_s=0.0, detail=None)
+
+
+def test_in_memory_probe_ok_shorthand_fails() -> None:
+    result = InMemoryServiceReadinessProbe(ok=False).probe(ResolvedEndpoint("svc", 1), timeout=1.0)
+    assert result.ok is False
+
+
+def test_in_memory_probe_fail_detail_knob() -> None:
+    probe = InMemoryServiceReadinessProbe(fail_detail="unreachable")
+    result = probe.probe(ResolvedEndpoint("svc", 1), timeout=1.0)
+    assert result.ok is False
+    assert result.detail == "unreachable"
+
+
+def test_in_memory_probe_result_knob_takes_precedence() -> None:
+    forced = ReadinessResult(ok=False, latency_s=9.0, detail="forced")
+    probe = InMemoryServiceReadinessProbe(ok=True, result=forced, fail_detail="ignored")
+    assert probe.probe(ResolvedEndpoint("svc", 1), timeout=1.0) is forced
+
+
+# --- Fail-loud registry contract for the fourth group ------------------------
+
+
+def test_unknown_kind_lists_known_kinds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint("grpc", factory=object()), _FakeEntryPoint("http", factory=object())],
+    )
+
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_readiness_probe("missing")
+
+    assert excinfo.value.known == ["grpc", "http"]
+    assert SERVICE_READINESS_PROBES_GROUP in str(excinfo.value)
+
+
+def test_duplicate_kind_fails_naming_both_distributions(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint("grpc", factory=object(), dist="first-pkg"),
+            _FakeEntryPoint("grpc", factory=object(), dist="second-pkg"),
+        ],
+    )
+
+    with pytest.raises(DuplicateRegistrationError) as excinfo:
+        load_readiness_probe("grpc")
+    assert excinfo.value.distributions == ("first-pkg", "second-pkg")
+
+    with pytest.raises(DuplicateRegistrationError):
+        available_readiness_probes()
+
+
+def test_broken_import_propagates_and_spares_healthy_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    good_factory = object()
+    boom = ImportError("missing dependency")
+    _install_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint("tcp", factory=good_factory),
+            _FakeEntryPoint("grpc", load_error=boom),
+        ],
+    )
+
+    assert load_readiness_probe("tcp") is good_factory
+    with pytest.raises(ImportError):
+        load_readiness_probe("grpc")

--- a/tests/integration/docker/test_per_trial_log_capture_integration.py
+++ b/tests/integration/docker/test_per_trial_log_capture_integration.py
@@ -26,6 +26,7 @@ required (the in-memory conductor runs no agent loop).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -48,6 +49,10 @@ from tolokaforge.core.models import (
 from tolokaforge.core.output.artifacts import InMemoryArtifactWriter
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.service_readiness import (
+    InMemoryServiceReadinessProbe,
+    ServiceReadinessProbe,
+)
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 from tolokaforge.runner.models import ResetSpec, ServiceSpec
@@ -91,13 +96,22 @@ def _make_trial_spec(trial_id: str, *, manifest: EnvironmentManifest | None = No
     )
 
 
+def _ready_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+    """Readiness-gate seam yielding an always-ready probe: the fixture runner is
+    an ``nginx`` HTTP stand-in, not a gRPC server, so the production grpc probe
+    would correctly reject it. These tests exercise log capture, not readiness."""
+    del kind
+    return lambda: InMemoryServiceReadinessProbe(ok=True)
+
+
 @pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker not available")
 class TestProvisionFailureLogCapture:
     def test_reset_recipe_failure_captures_service_logs_before_teardown(
         self, tmp_path: Path
     ) -> None:
         backend = PerTrialRuntimeBackend(
-            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False),
+            readiness_probe_loader=_ready_loader,
         )
         spec = _make_trial_spec(trial_id="task-1:0")
 
@@ -138,7 +152,8 @@ class TestSuccessPathCapture:
 
     def test_on_success_false_captures_nothing(self, tmp_path: Path) -> None:
         backend = PerTrialRuntimeBackend(
-            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False),
+            readiness_probe_loader=_ready_loader,
         )
         handle = backend.provision(self._success_spec("task-1:0"))
         try:
@@ -150,7 +165,8 @@ class TestSuccessPathCapture:
 
     def test_on_success_true_captures_logs(self, tmp_path: Path) -> None:
         backend = PerTrialRuntimeBackend(
-            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=True)
+            log_capture=LogCaptureConfig(output_root=tmp_path, tail=200, on_success=True),
+            readiness_probe_loader=_ready_loader,
         )
         handle = backend.provision(self._success_spec("task-1:0"))
         try:
@@ -204,7 +220,9 @@ class TestGradedFailLogCapture:
         self, tmp_path: Path
     ) -> None:
         log_capture = LogCaptureConfig(output_root=tmp_path, tail=200, on_success=False)
-        backend = PerTrialRuntimeBackend(log_capture=log_capture)
+        backend = PerTrialRuntimeBackend(
+            log_capture=log_capture, readiness_probe_loader=_ready_loader
+        )
         # No reset service: the healthy stack comes up and provision succeeds,
         # so the completed-but-red grade is the sole capture trigger.
         spec = _make_trial_spec(

--- a/tests/integration/docker/test_per_trial_runtime_backend_integration.py
+++ b/tests/integration/docker/test_per_trial_runtime_backend_integration.py
@@ -14,6 +14,7 @@ against a real workload (see #143). Unit-level RPC coverage lives in
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -22,9 +23,19 @@ from tests.canonical._factories import make_task_description
 from tests.utils.docker_helpers import is_docker_daemon_available
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend, _LocalEnvHandle
+from tolokaforge.core.service_readiness import InMemoryServiceReadinessProbe, ServiceReadinessProbe
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+def _ready_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+    """Readiness-gate seam yielding an always-ready probe: the fixture runner
+    is an ``nginx`` HTTP stand-in, not a gRPC server, so the production grpc
+    probe would correctly reject it. These tests exercise the compose lifecycle,
+    not runner readiness."""
+    del kind
+    return lambda: InMemoryServiceReadinessProbe(ok=True)
 
 
 _FIXTURE = (
@@ -66,7 +77,7 @@ class TestPerTrialRuntimeBackendLifecycle:
     """
 
     def test_provision_endpoints_teardown_cycle(self) -> None:
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(trial_id="lifecycle:0")
         handle = backend.provision(spec)
         try:
@@ -91,7 +102,7 @@ class TestPerTrialRuntimeBackendLifecycle:
         """Two concurrent trials get different compose projects and
         resolve to different host-side ports for the same container
         port. Proves per-trial isolation."""
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec_a = _make_trial_spec(trial_id="lifecycle:a")
         spec_b = _make_trial_spec(trial_id="lifecycle:b")
         handle_a = backend.provision(spec_a)
@@ -115,7 +126,7 @@ class TestPerTrialRuntimeBackendLifecycle:
         """After teardown, the compose stack's containers and network
         are gone. Verified by observing that a subsequent provision
         with the same trial_id succeeds without collision."""
-        backend = PerTrialRuntimeBackend()
+        backend = PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
         spec = _make_trial_spec(trial_id="lifecycle:cleanup")
         handle_first = backend.provision(spec)
         backend.teardown(handle_first)

--- a/tests/integration/docker/test_service_readiness_gate.py
+++ b/tests/integration/docker/test_service_readiness_gate.py
@@ -1,0 +1,186 @@
+"""Integration locks for ``PerTrialRuntimeBackend``'s provision-time readiness
+gate against a real Docker daemon.
+
+A container that ``docker compose up --wait`` reports ``Healthy`` is not
+necessarily reachable from the host: a service that binds only its container
+loopback passes an in-container healthcheck yet drops the host's published-port
+connection. These tests exercise the shipped gate — the default probe loader,
+no seam injection — so the grpc/http/tcp probe kinds run against real
+containers.
+
+* Positive: a runner speaking h2c on the runner port plus an http-readiness and
+  a tcp-readiness sidecar, all host-reachable, so provision succeeds and every
+  probe kind is exercised. One ``nginx:alpine`` image with ``http2 on`` answers
+  a gRPC channel, ``GET /health``, and a bare TCP connect — no runner image
+  build, no API keys.
+* Negative (#801-class): a runner that binds ``127.0.0.1`` only is Docker
+  ``Healthy`` via its loopback healthcheck but host-unreachable, so provision
+  fails at the gate with a :class:`DiagnosticPayload` naming the loopback
+  listen address that the published port cannot reach.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tests.canonical._factories import make_task_description
+from tests.utils.docker_helpers import is_docker_daemon_available
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.runtime import ProvisionError
+from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, NetworkPolicy, TrialSpec
+from tolokaforge.runner.models import ReadinessSpec, ServiceSpec
+
+pytestmark = [pytest.mark.integration, pytest.mark.docker]
+
+
+_H2C_RUNNER = """\
+server {{
+    http2 on;
+    listen {port};
+    location /health {{ return 200 "ok\\n"; }}
+    location / {{ return 200 "ok\\n"; }}
+}}"""
+
+_LOOPBACK_RUNNER = """\
+server {{
+    http2 on;
+    listen 127.0.0.1:{port};
+    location /health {{ return 200 "ok\\n"; }}
+    location / {{ return 200 "ok\\n"; }}
+}}"""
+
+
+def _nginx_service(config: str, *, listen_probe: str, published_port: int) -> str:
+    """Render an ``nginx:alpine`` compose service that installs ``config`` and
+    health-gates on ``listen_probe`` (the address the in-container healthcheck
+    hits), publishing ``published_port``."""
+    escaped = config.replace("\n", "\\n").replace('"', '\\"')
+    return textwrap.dedent(f"""\
+        image: "nginx:alpine"
+        command:
+          - sh
+          - -c
+          - |
+            printf "{escaped}" > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'
+        ports:
+          - "{published_port}"
+        healthcheck:
+          test: ["CMD", "wget", "-q", "-O", "-", "http://{listen_probe}/health"]
+          interval: 2s
+          timeout: 3s
+          retries: 30
+        """)
+
+
+def _indent_service(name: str, body: str) -> str:
+    inner = textwrap.indent(body.rstrip(), "    ")
+    return f"  {name}:\n{inner}\n"
+
+
+def _positive_compose() -> str:
+    runner = _nginx_service(
+        _H2C_RUNNER.format(port=50051), listen_probe="127.0.0.1:50051", published_port=50051
+    )
+    http_svc = _nginx_service(
+        _H2C_RUNNER.format(port=8080), listen_probe="127.0.0.1:8080", published_port=8080
+    )
+    tcp_svc = _nginx_service(
+        _H2C_RUNNER.format(port=9090), listen_probe="127.0.0.1:9090", published_port=9090
+    )
+    return (
+        "services:\n"
+        + _indent_service("runner", runner)
+        + _indent_service("http_svc", http_svc)
+        + _indent_service("tcp_svc", tcp_svc)
+    )
+
+
+def _loopback_compose() -> str:
+    runner = _nginx_service(
+        _LOOPBACK_RUNNER.format(port=50051), listen_probe="127.0.0.1:50051", published_port=50051
+    )
+    return "services:\n" + _indent_service("runner", runner)
+
+
+def _write_manifest(compose_dir: Path, compose_text: str, **manifest_kwargs) -> EnvironmentManifest:
+    compose_dir.mkdir(parents=True, exist_ok=True)
+    compose_file = compose_dir / "docker-compose.yml"
+    compose_file.write_text(compose_text + "\n")
+    return EnvironmentManifest(
+        compose_file=compose_file, runner_service="runner", **manifest_kwargs
+    )
+
+
+def _make_spec(manifest: EnvironmentManifest, trial_id: str) -> TrialSpec:
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="readiness-gate-integration",
+        task=make_task_description(
+            task_id="readiness-probe",
+            name="readiness-probe",
+            category="general",
+            description="provision-time readiness gate integration lock",
+            environment_manifest=manifest,
+        ),
+        agent_model_config=ModelConfig(name="claude-sonnet-4-6", provider="anthropic"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://placeholder:8000",
+            runner_url="http://placeholder:50051",
+        ),
+    )
+
+
+@pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker daemon not available")
+def test_readiness_gate_passes_for_grpc_http_and_tcp(tmp_path: Path) -> None:
+    """A host-reachable stack passes the gate across all three probe kinds: the
+    runner via the default grpc probe, plus http- and tcp-declared sidecars."""
+    # full_internet: under no_internet, only the runner joins the egress-capable
+    # edge network and gets a host-published port — non-runner services are
+    # internal-only with no host mapping, so a host-side probe of an http/tcp
+    # sidecar is only meaningful when those services are host-published.
+    manifest = _write_manifest(
+        tmp_path / "positive",
+        _positive_compose(),
+        network_policy=NetworkPolicy.FULL_INTERNET,
+        services={
+            "http_svc": ServiceSpec(isolation="ephemeral", readiness=ReadinessSpec(kind="http")),
+            "tcp_svc": ServiceSpec(isolation="ephemeral", readiness=ReadinessSpec(kind="tcp")),
+        },
+    )
+    backend = PerTrialRuntimeBackend(connect_timeout=20.0)
+    handle = backend.provision(_make_spec(manifest, "readiness-positive:0"))
+    try:
+        # Reaching here means the gate accepted grpc + http + tcp; the handle is
+        # only returned once every probe came back ready.
+        assert handle.trial_id == "readiness-positive:0"
+    finally:
+        backend.teardown(handle)
+
+
+@pytest.mark.skipif(not is_docker_daemon_available(), reason="Docker daemon not available")
+def test_readiness_gate_rejects_loopback_only_runner(tmp_path: Path) -> None:
+    """A runner that binds container-loopback only is Docker ``Healthy`` yet
+    host-unreachable — the gate fails provisioning with a diagnostic naming the
+    loopback listen address the published port cannot reach."""
+    manifest = _write_manifest(tmp_path / "negative", _loopback_compose())
+    backend = PerTrialRuntimeBackend(connect_timeout=8.0)
+    with pytest.raises(ProvisionError) as exc:
+        backend.provision(_make_spec(manifest, "readiness-negative:0"))
+
+    err = exc.value
+    assert err.stage == "provision"
+    assert err.diagnostic is not None
+    assert err.diagnostic.service == "runner"
+    assert err.diagnostic.kind == "grpc"
+    assert err.diagnostic.result.ok is False
+    # The published port maps to the container's external interface, but nginx
+    # listens only on 127.0.0.1 inside the container — the diagnostic captures
+    # that loopback listen address, naming the mechanism rather than the symptom.
+    assert err.diagnostic.docker_port_map, "expected a real docker port map"
+    assert any(
+        addr.startswith("127.0.0.1:50051") for addr in err.diagnostic.container_listen_addrs
+    ), f"expected loopback listen address in {err.diagnostic.container_listen_addrs!r}"

--- a/tests/integration/network_policy/_harness.py
+++ b/tests/integration/network_policy/_harness.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import subprocess
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
 
 from testcontainers.compose import DockerCompose
@@ -24,8 +25,25 @@ from testcontainers.compose import DockerCompose
 from tests.canonical._factories import make_task_description
 from tolokaforge.core.compose_materialisation import RUNNER_PORT_DEFAULT
 from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.service_readiness import InMemoryServiceReadinessProbe, ServiceReadinessProbe
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, NetworkPolicy, TrialSpec
 from tolokaforge.runner.models import ServiceSpec
+
+
+def _ready_loader(kind: str) -> Callable[[], ServiceReadinessProbe]:
+    del kind
+    return lambda: InMemoryServiceReadinessProbe(ok=True)
+
+
+def make_backend() -> PerTrialRuntimeBackend:
+    """Real per-trial backend with the readiness gate satisfied by an in-memory
+    probe. The harness runner is an ``nginx`` HTTP stand-in, not a gRPC server,
+    so the production grpc probe would correctly reject it — these tests
+    exercise network topology, not runner readiness, and inject a passing probe
+    through the loader seam."""
+    return PerTrialRuntimeBackend(readiness_probe_loader=_ready_loader)
+
 
 RUNNER_SERVICE = "runner"
 APP_SERVICE = "app"

--- a/tests/integration/network_policy/test_full_internet.py
+++ b/tests/integration/network_policy/test_full_internet.py
@@ -11,7 +11,6 @@ import pytest
 
 from tests.integration.network_policy import _harness
 from tests.utils.docker_helpers import is_docker_daemon_available
-from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.trial import NetworkPolicy
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
@@ -23,7 +22,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.docker]
 )
 def test_full_internet_allows_public_egress(tmp_path) -> None:
     manifest = _harness.write_manifest(tmp_path / "stack", NetworkPolicy.FULL_INTERNET)
-    backend = PerTrialRuntimeBackend()
+    backend = _harness.make_backend()
     handle = backend.provision(_harness.make_spec(manifest, "netpolicy-full-internet:0"))
 
     try:

--- a/tests/integration/network_policy/test_limited_internet.py
+++ b/tests/integration/network_policy/test_limited_internet.py
@@ -16,7 +16,6 @@ import pytest
 
 from tests.integration.network_policy import _harness
 from tests.utils.docker_helpers import is_docker_daemon_available
-from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.trial import NetworkPolicy
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
@@ -49,7 +48,7 @@ def test_limited_internet_allows_only_allowlisted_egress(tmp_path) -> None:
         NetworkPolicy.LIMITED_INTERNET,
         allowlist=[_harness.ALLOWLISTED_HOST],
     )
-    backend = PerTrialRuntimeBackend()
+    backend = _harness.make_backend()
     handle = backend.provision(_harness.make_spec(manifest, "netpolicy-limited-internet:0"))
 
     try:

--- a/tests/integration/network_policy/test_no_internet.py
+++ b/tests/integration/network_policy/test_no_internet.py
@@ -15,7 +15,6 @@ import pytest
 
 from tests.integration.network_policy import _harness
 from tests.utils.docker_helpers import is_docker_daemon_available
-from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.trial import NetworkPolicy
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
@@ -27,7 +26,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.docker]
 )
 def test_no_internet_blocks_egress_but_keeps_runner_reachable(tmp_path) -> None:
     manifest = _harness.write_manifest(tmp_path / "stack", NetworkPolicy.NO_INTERNET)
-    backend = PerTrialRuntimeBackend()
+    backend = _harness.make_backend()
     handle = backend.provision(_harness.make_spec(manifest, "netpolicy-no-internet:0"))
 
     try:

--- a/tests/integration/network_policy/test_partitioning.py
+++ b/tests/integration/network_policy/test_partitioning.py
@@ -24,7 +24,6 @@ import pytest
 
 from tests.integration.network_policy import _harness
 from tests.utils.docker_helpers import is_docker_daemon_available
-from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.trial import NetworkPolicy
 
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
@@ -65,7 +64,7 @@ def _assert_reached(
 )
 def test_restricted_sibling_cannot_reach_runner_under_no_internet(tmp_path) -> None:
     manifest = _harness.write_partitioning_manifest(tmp_path / "stack", NetworkPolicy.NO_INTERNET)
-    backend = PerTrialRuntimeBackend()
+    backend = _harness.make_backend()
     handle = backend.provision(_harness.make_spec(manifest, "netpolicy-partitioning-no-internet:0"))
 
     try:
@@ -111,7 +110,7 @@ def test_restricted_sibling_cannot_reach_runner_under_limited_internet(tmp_path)
         NetworkPolicy.LIMITED_INTERNET,
         allowlist=[_harness.ALLOWLISTED_HOST],
     )
-    backend = PerTrialRuntimeBackend()
+    backend = _harness.make_backend()
     handle = backend.provision(
         _harness.make_spec(manifest, "netpolicy-partitioning-limited-internet:0")
     )

--- a/tests/unit/core/test_service_readiness_probes.py
+++ b/tests/unit/core/test_service_readiness_probes.py
@@ -1,0 +1,123 @@
+"""Built-in readiness probes against real in-process localhost listeners.
+
+Each concrete probe is exercised against a real listener on an ephemeral port
+(a started gRPC server, an ``http.server`` serving ``/health``, a raw socket) —
+no mocks — and then against a free-but-unbound port to lock the failure branch:
+``ok=False`` with a populated ``detail`` inside the timeout budget.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Iterator
+from concurrent import futures
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import grpc
+import pytest
+
+from tolokaforge.core.service_readiness import (
+    GrpcReadinessProbe,
+    HttpReadinessProbe,
+    ResolvedEndpoint,
+    TcpReadinessProbe,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture
+def grpc_endpoint() -> Iterator[ResolvedEndpoint]:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    try:
+        yield ResolvedEndpoint(host="127.0.0.1", port=port)
+    finally:
+        server.stop(grace=None)
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        status = 200 if self.path == "/health" else 404
+        self.send_response(status)
+        self.end_headers()
+
+    def log_message(self, *_args: object) -> None:
+        pass
+
+
+@pytest.fixture
+def http_endpoint() -> Iterator[ResolvedEndpoint]:
+    server = HTTPServer(("127.0.0.1", 0), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield ResolvedEndpoint(host="127.0.0.1", port=server.server_address[1])
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def tcp_endpoint() -> Iterator[ResolvedEndpoint]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    try:
+        yield ResolvedEndpoint(host="127.0.0.1", port=listener.getsockname()[1])
+    finally:
+        listener.close()
+
+
+def test_grpc_probe_ready_against_live_server(grpc_endpoint: ResolvedEndpoint) -> None:
+    result = GrpcReadinessProbe().probe(grpc_endpoint, timeout=5.0)
+    assert result.ok is True
+    assert result.latency_s >= 0.0
+    assert result.detail is None
+
+
+def test_grpc_probe_fails_against_closed_port() -> None:
+    endpoint = ResolvedEndpoint(host="127.0.0.1", port=_free_port())
+    result = GrpcReadinessProbe().probe(endpoint, timeout=1.0)
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.latency_s < 5.0
+
+
+def test_http_probe_ready_against_live_server(http_endpoint: ResolvedEndpoint) -> None:
+    result = HttpReadinessProbe().probe(http_endpoint, timeout=5.0)
+    assert result.ok is True
+    assert result.latency_s >= 0.0
+    assert result.detail is None
+
+
+def test_http_probe_fails_against_closed_port() -> None:
+    endpoint = ResolvedEndpoint(host="127.0.0.1", port=_free_port())
+    result = HttpReadinessProbe().probe(endpoint, timeout=1.0)
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.latency_s < 5.0
+
+
+def test_tcp_probe_ready_against_live_listener(tcp_endpoint: ResolvedEndpoint) -> None:
+    result = TcpReadinessProbe().probe(tcp_endpoint, timeout=5.0)
+    assert result.ok is True
+    assert result.latency_s >= 0.0
+    assert result.detail is None
+
+
+def test_tcp_probe_fails_against_closed_port() -> None:
+    endpoint = ResolvedEndpoint(host="127.0.0.1", port=_free_port())
+    result = TcpReadinessProbe().probe(endpoint, timeout=1.0)
+    assert result.ok is False
+    assert result.detail is not None
+    assert result.latency_s < 5.0

--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -132,6 +132,7 @@ class TestFirstPublishedPort:
     def test_extracts_first_target_port(self) -> None:
         entry = MagicMock()
         entry.TargetPort = 5432
+        entry.PublishedPort = 65432
         container = MagicMock()
         container.Publishers = [entry]
 
@@ -140,14 +141,33 @@ class TestFirstPublishedPort:
     def test_skips_zero_and_non_int_targets(self) -> None:
         zero_entry = MagicMock()
         zero_entry.TargetPort = 0
+        zero_entry.PublishedPort = 60000
         bad_entry = MagicMock()
         bad_entry.TargetPort = "not an int"
+        bad_entry.PublishedPort = 60001
         good_entry = MagicMock()
         good_entry.TargetPort = 8000
+        good_entry.PublishedPort = 68000
         container = MagicMock()
         container.Publishers = [zero_entry, bad_entry, good_entry]
 
         assert first_published_port(container) == 8000
+
+    def test_skips_exposed_but_unpublished_entry(self) -> None:
+        """A Dockerfile-``EXPOSE``d port surfaces as a publisher with
+        ``PublishedPort == 0`` (no host mapping); it must be skipped in favour
+        of the port the compose file actually publishes — otherwise a bare
+        ``image: nginx`` service resolves to its unreachable exposed ``80``."""
+        exposed_only = MagicMock()
+        exposed_only.TargetPort = 80
+        exposed_only.PublishedPort = 0
+        published = MagicMock()
+        published.TargetPort = 50051
+        published.PublishedPort = 57961
+        container = MagicMock()
+        container.Publishers = [exposed_only, published]
+
+        assert first_published_port(container) == 50051
 
     def test_returns_none_when_publishers_absent(self) -> None:
         container = MagicMock(spec=[])  # No Publishers attribute.
@@ -165,6 +185,7 @@ class TestResolveRagUrl:
         container = MagicMock()
         published_entry = MagicMock()
         published_entry.TargetPort = 8080
+        published_entry.PublishedPort = 60080
         container.Publishers = [published_entry]
 
         compose = MagicMock()
@@ -177,7 +198,7 @@ class TestResolveRagUrl:
         """A set ``rag_service`` narrows the scan to that single service
         instead of the ``RAG_SERVICE_CANDIDATES`` convention."""
         container = MagicMock()
-        container.Publishers = [MagicMock(TargetPort=8080)]
+        container.Publishers = [MagicMock(TargetPort=8080, PublishedPort=59090)]
         compose = MagicMock()
         compose.get_container.return_value = container
         compose.get_service_host_and_port.return_value = ("localhost", 59090)
@@ -241,7 +262,7 @@ class TestResolveEnvEndpoints:
             service_name, port
         )
         rag_container = MagicMock()
-        rag_container.Publishers = [MagicMock(TargetPort=8080)]
+        rag_container.Publishers = [MagicMock(TargetPort=8080, PublishedPort=68080)]
         compose.get_container.return_value = rag_container
 
         endpoints = resolve_env_endpoints(compose, "localhost", 60051)

--- a/tests/unit/test_environment_resolve.py
+++ b/tests/unit/test_environment_resolve.py
@@ -16,6 +16,7 @@ import pytest
 from tolokaforge.core.models import (
     EnvironmentManifest,
     EnvironmentPatch,
+    ReadinessSpec,
     ResetSpec,
     ServiceSpec,
     StackPatch,
@@ -442,6 +443,36 @@ class TestServicesMergeAndDefaults:
         assert manifest.services["default"].isolation == "reset"
         assert manifest.services["default"].reset is not None
         assert manifest.services["default"].reset.seed == "baseline"
+
+    def test_task_inherits_project_readiness_when_omitted(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE.parent / "safe_two_service.yaml",
+                runner_service="default",
+            ),
+            services={"db": ServiceSpec(isolation="shared", readiness=ReadinessSpec(kind="grpc"))},
+        )
+        task = EnvironmentPatch(services={"db": ServiceSpec(isolation="shared")})
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["db"].readiness is not None
+        assert manifest.services["db"].readiness.kind == "grpc"
+
+    def test_task_readiness_overrides_project(self) -> None:
+        project = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=ENV_FIXTURE.parent / "safe_two_service.yaml",
+                runner_service="default",
+            ),
+            services={"db": ServiceSpec(isolation="shared", readiness=ReadinessSpec(kind="grpc"))},
+        )
+        task = EnvironmentPatch(
+            services={"db": ServiceSpec(isolation="shared", readiness=ReadinessSpec(kind="http"))},
+        )
+        manifest = resolve(project, task)
+        assert manifest is not None
+        assert manifest.services["db"].readiness is not None
+        assert manifest.services["db"].readiness.kind == "http"
 
     def test_missing_compose_service_defaults_to_ephemeral(self) -> None:
         # safe_two_service.yaml declares `db` and `default`. Only `default`

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import copy
 import logging
 import shutil
+import socket
 import subprocess
 import tempfile
 from collections.abc import Iterable, Mapping
@@ -406,15 +407,167 @@ def resolve_host_port(
 
 
 def first_published_port(container: Any) -> int | None:
-    """Extract the first published container-side port from a
+    """Extract the first *host-published* container-side port from a
     Testcontainers ``ComposeContainer``. Returns ``None`` when nothing
-    is published (or the shape is not what we expect)."""
+    is published (or the shape is not what we expect).
+
+    ``docker compose ps`` lists a Dockerfile ``EXPOSE``d-but-unpublished port
+    as a publisher with ``PublishedPort == 0``; such an entry is skipped so the
+    returned container port is one that actually maps to a host port (a bare
+    ``image: nginx`` service otherwise reports its exposed ``80`` ahead of the
+    port the compose file publishes)."""
     ports = getattr(container, "Publishers", None) or []
     for entry in ports:
         target = getattr(entry, "TargetPort", None)
-        if isinstance(target, int) and target > 0:
+        published = getattr(entry, "PublishedPort", None)
+        if isinstance(target, int) and target > 0 and isinstance(published, int) and published > 0:
             return target
     return None
+
+
+def capture_container_diagnostics(
+    compose: DockerCompose, service_name: str
+) -> tuple[dict[str, str], tuple[str, ...], dict[str, str]]:
+    """Best-effort docker-side view of where ``service_name`` actually listens.
+
+    Returns ``(docker_port_map, container_listen_addrs, per_network_ips)``:
+
+    * ``docker_port_map`` — ``{"<container_port>/<proto>": "<host_ip>:<host_port>"}``
+      from the container's compose publishers.
+    * ``container_listen_addrs`` — human-readable ``host:port`` (IPv6 bracketed)
+      for every LISTEN socket in the container's ``/proc/net/tcp[6]``, so a
+      loopback-only bind is visible next to a wildcard one.
+    * ``per_network_ips`` — ``{network_name: ip}`` from ``docker inspect``.
+
+    Assembled at readiness-gate failure time, against the still-running
+    container, so the ``ProvisionError`` names the mechanism (e.g. a service
+    that listens on ``127.0.0.1`` while its port is published to the host).
+    Never raises: each capture is independently guarded and degrades to an
+    empty structure, mirroring :func:`_fetch_service_logs`. A partial docker
+    failure yields partial diagnostics but never masks the readiness failure
+    behind an introspection error.
+    """
+    try:
+        container = compose.get_container(service_name=service_name)
+    except Exception as exc:  # noqa: BLE001 — service may be gone; diagnostics are best-effort
+        logger.debug(
+            "compose_materialisation: container for %r not resolvable: %s", service_name, exc
+        )
+        return {}, (), {}
+    port_map = _docker_port_map(container)
+    container_id = getattr(container, "ID", None) or ""
+    if not container_id:
+        return port_map, (), {}
+    return port_map, _container_listen_addrs(container_id), _container_network_ips(container_id)
+
+
+def _docker_port_map(container: Any) -> dict[str, str]:
+    """Map ``<container_port>/<proto>`` to ``<host_ip>:<host_port>`` from a
+    container's compose publishers. Empty when nothing is published."""
+    port_map: dict[str, str] = {}
+    for publisher in getattr(container, "Publishers", None) or []:
+        target = getattr(publisher, "TargetPort", None)
+        published = getattr(publisher, "PublishedPort", None)
+        if target is None or published is None:
+            continue
+        proto = getattr(publisher, "Protocol", None) or "tcp"
+        host_ip = getattr(publisher, "URL", None) or "0.0.0.0"  # noqa: S104 — report only
+        port_map[f"{target}/{proto}"] = f"{host_ip}:{published}"
+    return port_map
+
+
+def _container_listen_addrs(container_id: str) -> tuple[str, ...]:
+    """Decode LISTEN sockets from a container's ``/proc/net/tcp`` + ``tcp6``.
+
+    Runs ``docker exec <id> cat /proc/net/tcp /proc/net/tcp6`` and returns the
+    de-duplicated ``host:port`` listen addresses (IPv6 bracketed). Empty tuple
+    on any docker/parse failure — diagnostics are best-effort."""
+    try:
+        result = subprocess.run(
+            ["docker", "exec", container_id, "cat", "/proc/net/tcp", "/proc/net/tcp6"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort; subprocess raises varied types
+        logger.debug(
+            "compose_materialisation: listen-addr capture for %s failed: %s", container_id, exc
+        )
+        return ()
+    return _parse_proc_net_listen(result.stdout)
+
+
+def _parse_proc_net_listen(proc_net_output: str) -> tuple[str, ...]:
+    """Extract LISTEN (state ``0A``) local addresses from ``/proc/net/tcp[6]``
+    text, de-duplicated in first-seen order. The header line is skipped
+    naturally: its 4th column is the string ``local_address``, not ``0A``."""
+    addrs: list[str] = []
+    for line in proc_net_output.splitlines():
+        fields = line.split()
+        if len(fields) < 4 or fields[3] != "0A":
+            continue
+        decoded = _decode_proc_net_endpoint(fields[1])
+        if decoded is not None:
+            addrs.append(decoded)
+    return tuple(dict.fromkeys(addrs))
+
+
+def _decode_proc_net_endpoint(token: str) -> str | None:
+    """Decode one ``<hex_ip>:<hex_port>`` ``/proc/net`` local-address token to
+    ``host:port`` (IPv6 bracketed). ``None`` on a malformed token."""
+    hex_ip, _, hex_port = token.partition(":")
+    if not hex_port:
+        return None
+    try:
+        port = int(hex_port, 16)
+    except ValueError:
+        return None
+    ip = _decode_proc_net_ip(hex_ip)
+    if ip is None:
+        return None
+    return f"[{ip}]:{port}" if ":" in ip else f"{ip}:{port}"
+
+
+def _decode_proc_net_ip(hex_ip: str) -> str | None:
+    """Decode a ``/proc/net/tcp[6]`` hex address to a printable IP. The kernel
+    stores each 32-bit word little-endian, so bytes are reversed per word
+    before :func:`socket.inet_ntop`. ``None`` on an unexpected width."""
+    try:
+        raw = bytes.fromhex(hex_ip)
+    except ValueError:
+        return None
+    if len(raw) == 4:
+        return socket.inet_ntop(socket.AF_INET, raw[::-1])
+    if len(raw) == 16:
+        network_order = b"".join(raw[i : i + 4][::-1] for i in range(0, 16, 4))
+        return socket.inet_ntop(socket.AF_INET6, network_order)
+    return None
+
+
+def _container_network_ips(container_id: str) -> dict[str, str]:
+    """Return ``{network_name: ip}`` for a container via ``docker inspect``.
+    Empty on any docker/parse failure — diagnostics are best-effort."""
+    fmt = "{{range $k,$v := .NetworkSettings.Networks}}{{$k}}={{$v.IPAddress}} {{end}}"
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "-f", fmt, container_id],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort; subprocess raises varied types
+        logger.debug(
+            "compose_materialisation: network-ip capture for %s failed: %s", container_id, exc
+        )
+        return {}
+    ips: dict[str, str] = {}
+    for token in result.stdout.split():
+        name, sep, ip = token.partition("=")
+        if sep and name and ip:
+            ips[name] = ip
+    return ips
 
 
 def resolve_rag_url(

--- a/tolokaforge/core/models.py
+++ b/tolokaforge/core/models.py
@@ -48,6 +48,8 @@ from tolokaforge.runner.models import EnvironmentManifest as EnvironmentManifest
 from tolokaforge.runner.models import EnvironmentPatch as EnvironmentPatch
 from tolokaforge.runner.models import JudgeCustomization as JudgeCustomization
 from tolokaforge.runner.models import LLMJudgeConfig as LLMJudgeConfig
+from tolokaforge.runner.models import ReadinessKind as ReadinessKind
+from tolokaforge.runner.models import ReadinessSpec as ReadinessSpec
 from tolokaforge.runner.models import RecordedToolCall as RecordedToolCall
 from tolokaforge.runner.models import ResetSpec as ResetSpec
 from tolokaforge.runner.models import Rubric as Rubric

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -593,7 +593,7 @@ class PerTrialRuntimeBackend:
             )
         }
         for service_name, service_spec in manifest.services.items():
-            if service_spec.readiness is None or service_name == manifest.runner_service:
+            if service_spec.readiness is None:
                 continue
             endpoint = self._resolve_service_endpoint(compose, service_name)
             if endpoint is None:

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -42,26 +43,31 @@ from tolokaforge.core.compose_materialisation import (
     LogCaptureConfig,
     apply_network_policy_to_compose_file,
     capture_compose_service_logs,
+    capture_container_diagnostics,
     cleanup_partial_materialisation,
     compose_container_to_snapshot,
     copy_compose_context,
+    first_published_port,
     make_project_temp_dir,
     resolve_env_endpoints,
+    resolve_host_port,
     resolve_runner_endpoint,
     shutdown_compose,
     trial_services_dir,
     write_capture_manifest,
 )
 from tolokaforge.core.models import SeedRef
+from tolokaforge.core.plugin_registry import load_readiness_probe
 from tolokaforge.core.run_display_events import ContainerSnapshot, build_component_id
 from tolokaforge.core.runtime import EnvHandle, IsolationMode, ProvisionError
+from tolokaforge.core.service_readiness import DiagnosticPayload, ResolvedEndpoint
 from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient, RunnerClient
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints
 from tolokaforge.docker.logging import LogRouter
 from tolokaforge.runner.models import EnvironmentManifest
 
 if TYPE_CHECKING:
-    from tolokaforge.core.plugin_registry import RuntimeBackendBuildContext
+    from tolokaforge.core.plugin_registry import ReadinessProbeFactory, RuntimeBackendBuildContext
     from tolokaforge.core.trial import TrialSpec
     from tolokaforge.tools.registry import ToolResult
 
@@ -163,15 +169,23 @@ class PerTrialRuntimeBackend:
     and :meth:`capture_service_logs` write ``docker compose logs`` output under
     ``log_capture.output_root/trials/<task>/<idx>/services/`` before teardown."""
 
+    readiness_probe_loader: Callable[[str], ReadinessProbeFactory] = load_readiness_probe
+    """Resolves a readiness-probe ``kind`` to its factory, defaulting to the
+    entry-point registry loader. Production runs use the registered probes;
+    orchestrator-level tests inject a loader returning an
+    :class:`~tolokaforge.core.service_readiness.InMemoryServiceReadinessProbe`
+    so the provision-time readiness gate is exercised without a live listener."""
+
     _clients: dict[str, RunnerClient] = field(default_factory=dict)
     _connected_trials: set[str] = field(default_factory=set)
     """Trial ids whose runner client has passed ``connect()``. Connect
     is deferred until the first per-trial RPC call: the compose stack's
-    ``--wait`` flag has already gated container readiness; connecting
-    the gRPC channel at provision time inflates every trial's
-    provisioning latency by the connect cost even when the trial never
-    exercises the RPC surface. First RPC use triggers connect via
-    :meth:`_client_for`."""
+    ``--wait`` flag has already gated container readiness and the provision
+    readiness gate has already proven the runner's gRPC endpoint reachable
+    (via a throwaway channel), so a persistent client channel at provision
+    time would only inflate every trial's provisioning latency by the connect
+    cost even when the trial never exercises the RPC surface. First RPC use
+    triggers connect via :meth:`_client_for`."""
 
     # ---- Run-level lifecycle ----
 
@@ -288,6 +302,22 @@ class PerTrialRuntimeBackend:
             )
         runner_host, runner_host_port = runner_endpoint
 
+        # Host-side readiness gate: a Docker-Healthy container can still be
+        # unreachable from this process (loopback-only bind, IPv6-only listen).
+        # Probe every gated endpoint now so an unreachable service fails fast
+        # here with a diagnostic naming the mechanism, instead of surfacing as
+        # a downstream client-connect timeout. Failure cleans up like any other
+        # provision-stage failure.
+        try:
+            targets = self._readiness_targets(
+                manifest, compose, runner_host, runner_host_port, spec.trial_id
+            )
+            self._run_readiness_gate(services=targets, compose=compose, trial_id=spec.trial_id)
+        except ProvisionError:
+            self._capture_provision_failure_logs(spec.trial_id, service_names, compose)
+            cleanup_partial_materialisation(compose, temp_dir)
+            raise
+
         # resolve_env_endpoints is best-effort for db_url + rag_url — a task
         # compose file that omits `db-service:8000` gets endpoints with
         # `db_url=None`. The runner-side DBServiceClient reads DB_SERVICE_URL
@@ -321,10 +351,12 @@ class PerTrialRuntimeBackend:
         )
 
     def await_ready(self, handle: EnvHandle) -> None:
-        # ``.start(wait=True)`` in :meth:`provision` already blocks on
-        # docker compose healthchecks. Kept explicit for Protocol shape;
-        # future backends that don't gate readiness in provision slot in
-        # without changing the surface.
+        # No-op: :meth:`provision` already establishes readiness — ``.start(
+        # wait=True)`` blocks on docker compose healthchecks, then the host-side
+        # readiness gate proves each gated endpoint is client-reachable before
+        # the handle is returned. Kept explicit for Protocol shape; future
+        # backends that gate readiness here instead slot in without changing the
+        # surface.
         del handle
 
     def endpoints(self, handle: EnvHandle) -> EnvEndpoints:
@@ -534,6 +566,108 @@ class PerTrialRuntimeBackend:
                         f"(seed {seed_name!r}, kind {seed.kind!r}) failed: {exc}"
                     ),
                 ) from exc
+
+    # ---- Readiness gate ----
+
+    def _readiness_targets(
+        self,
+        manifest: EnvironmentManifest,
+        compose: DockerCompose,
+        runner_host: str,
+        runner_host_port: int,
+        trial_id: str,
+    ) -> dict[str, tuple[str, ResolvedEndpoint]]:
+        """Build the readiness-gate probe map ``service -> (kind, endpoint)``.
+
+        The runner substrate is always probed with the ``grpc`` kind on its
+        resolved host port — its default client-invocability contract. Every
+        service that declares a ``readiness`` spec is additionally probed by
+        that spec's kind on its first published port. A declared-readiness
+        service that exposes no resolvable host port is a provisioning failure:
+        the contract cannot be honoured, so probing cannot be silently skipped.
+        """
+        targets: dict[str, tuple[str, ResolvedEndpoint]] = {
+            manifest.runner_service: (
+                "grpc",
+                ResolvedEndpoint(host=runner_host, port=runner_host_port),
+            )
+        }
+        for service_name, service_spec in manifest.services.items():
+            if service_spec.readiness is None or service_name == manifest.runner_service:
+                continue
+            endpoint = self._resolve_service_endpoint(compose, service_name)
+            if endpoint is None:
+                raise ProvisionError(
+                    trial_id=trial_id,
+                    stage="provision",
+                    reason=(
+                        f"service {service_name!r} declares a "
+                        f"{service_spec.readiness.kind!r} readiness contract but exposes "
+                        "no resolvable published port to probe"
+                    ),
+                )
+            targets[service_name] = (service_spec.readiness.kind, endpoint)
+        return targets
+
+    def _resolve_service_endpoint(
+        self, compose: DockerCompose, service_name: str
+    ) -> ResolvedEndpoint | None:
+        """Resolve a declared-readiness service's host-side endpoint via its
+        first published port. ``None`` when the service is absent from the
+        stack or publishes no port."""
+        try:
+            container = compose.get_container(service_name=service_name)
+        except Exception as exc:  # noqa: BLE001 — service not in stack; treat as unresolvable
+            logger.debug(
+                "PerTrialRuntimeBackend: readiness service %r absent: %s", service_name, exc
+            )
+            return None
+        container_port = first_published_port(container)
+        if container_port is None:
+            return None
+        host, host_port = resolve_host_port(compose, service_name, container_port)
+        if host is None or host_port is None:
+            return None
+        return ResolvedEndpoint(host=host, port=host_port)
+
+    def _run_readiness_gate(
+        self,
+        *,
+        services: dict[str, tuple[str, ResolvedEndpoint]],
+        compose: DockerCompose,
+        trial_id: str,
+    ) -> None:
+        """Probe every gated service; raise :class:`ProvisionError` on the first
+        not-ready result, carrying a :class:`DiagnosticPayload` assembled from
+        the still-running container. The probe opens and closes a throwaway
+        client — it proves reachability, and does not stand in for the deferred
+        per-trial runner-client connect (see :attr:`_connected_trials`)."""
+        for service_name, (kind, endpoint) in services.items():
+            probe = self.readiness_probe_loader(kind)()
+            result = probe.probe(endpoint, timeout=self.connect_timeout)
+            if result.ok:
+                continue
+            port_map, listen_addrs, network_ips = capture_container_diagnostics(
+                compose, service_name
+            )
+            raise ProvisionError(
+                trial_id=trial_id,
+                stage="provision",
+                reason=(
+                    f"service {service_name!r} ({kind}) not ready at "
+                    f"{endpoint.host}:{endpoint.port} within {self.connect_timeout}s: "
+                    f"{result.detail}"
+                ),
+                diagnostic=DiagnosticPayload(
+                    service=service_name,
+                    kind=kind,
+                    endpoint=endpoint,
+                    result=result,
+                    docker_port_map=port_map,
+                    container_listen_addrs=listen_addrs,
+                    per_network_ips=network_ips,
+                ),
+            )
 
     # ---- Internal helpers ----
 

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -641,7 +641,11 @@ class PerTrialRuntimeBackend:
         not-ready result, carrying a :class:`DiagnosticPayload` assembled from
         the still-running container. The probe opens and closes a throwaway
         client — it proves reachability, and does not stand in for the deferred
-        per-trial runner-client connect (see :attr:`_connected_trials`)."""
+        per-trial runner-client connect (see :attr:`_connected_trials`).
+
+        Services are probed in ``services`` insertion order, which is runner-first
+        because :meth:`_readiness_targets` seeds the runner first — intentional, so
+        a broken runner surfaces before budget is spent probing sidecars."""
         for service_name, (kind, endpoint) in services.items():
             probe = self.readiness_probe_loader(kind)()
             result = probe.probe(endpoint, timeout=self.connect_timeout)

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -1,20 +1,24 @@
-"""Fail-loud entry-point registries for the three orchestrator seams.
+"""Fail-loud entry-point registries for the four swappable seams.
 
 External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.runtime.RuntimeBackend`,
-:class:`~tolokaforge.core.trial_grader.TrialGrader`, and
-:class:`~tolokaforge.core.conductor.Conductor` Protocols through
-``importlib.metadata`` entry-point groups — no in-tree edit, no
-monkey-patch. Each entry point resolves to a *factory callable*
-(``Callable[[<Context>], <Impl>]``), mirroring the existing
-:data:`~tolokaforge.core.conductor.ConductorFactory` idiom; the divergent
-impl constructors are adapted to a per-group frozen-dataclass context.
+:class:`~tolokaforge.core.trial_grader.TrialGrader`,
+:class:`~tolokaforge.core.conductor.Conductor`, and
+:class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe` Protocols
+through ``importlib.metadata`` entry-point groups — no in-tree edit, no
+monkey-patch. Each entry point resolves to a *factory callable*, mirroring the
+existing :data:`~tolokaforge.core.conductor.ConductorFactory` idiom. The three
+orchestrator seams adapt divergent impl constructors to a per-group
+frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
+probes need no build dependencies, so their factory is arg-less
+(``Callable[[], ServiceReadinessProbe]``).
 
-The three groups:
+The four groups:
 
 * ``tolokaforge.runtime_backends`` → :data:`RuntimeBackendFactory`
 * ``tolokaforge.trial_graders`` → :data:`TrialGraderFactory`
 * ``tolokaforge.conductors`` → :data:`~tolokaforge.core.conductor.ConductorFactory`
+* ``tolokaforge.service_readiness_probes`` → :data:`ReadinessProbeFactory`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -37,6 +41,7 @@ from typing import TYPE_CHECKING, cast
 from tolokaforge.core.conductor import ConductorFactory
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
 from tolokaforge.core.runtime import RuntimeBackend
+from tolokaforge.core.service_readiness import ServiceReadinessProbe
 from tolokaforge.core.trial_grader import TrialGrader
 
 if TYPE_CHECKING:
@@ -50,6 +55,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ConductorFactory",
     "DuplicateRegistrationError",
+    "ReadinessProbeFactory",
     "RegistryError",
     "RuntimeBackendBuildContext",
     "RuntimeBackendFactory",
@@ -57,9 +63,11 @@ __all__ = [
     "TrialGraderFactory",
     "UnknownImplementationError",
     "available_conductors",
+    "available_readiness_probes",
     "available_runtime_backends",
     "available_trial_graders",
     "load_conductor",
+    "load_readiness_probe",
     "load_runtime_backend",
     "load_trial_grader",
 ]
@@ -67,6 +75,7 @@ __all__ = [
 RUNTIME_BACKENDS_GROUP = "tolokaforge.runtime_backends"
 TRIAL_GRADERS_GROUP = "tolokaforge.trial_graders"
 CONDUCTORS_GROUP = "tolokaforge.conductors"
+SERVICE_READINESS_PROBES_GROUP = "tolokaforge.service_readiness_probes"
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +156,7 @@ class TrialGraderContext:
 
 RuntimeBackendFactory = Callable[[RuntimeBackendBuildContext], RuntimeBackend]
 TrialGraderFactory = Callable[[TrialGraderContext], TrialGrader]
+ReadinessProbeFactory = Callable[[], ServiceReadinessProbe]
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +240,11 @@ def load_conductor(name: str) -> ConductorFactory:
     return cast(ConductorFactory, _load(CONDUCTORS_GROUP, name))
 
 
+def load_readiness_probe(kind: str) -> ReadinessProbeFactory:
+    """Resolve a registered readiness-probe kind to its factory callable."""
+    return cast(ReadinessProbeFactory, _load(SERVICE_READINESS_PROBES_GROUP, kind))
+
+
 def available_runtime_backends() -> list[str]:
     """Sorted names registered in the ``tolokaforge.runtime_backends`` group."""
     return sorted(_discover(RUNTIME_BACKENDS_GROUP))
@@ -243,3 +258,8 @@ def available_trial_graders() -> list[str]:
 def available_conductors() -> list[str]:
     """Sorted names registered in the ``tolokaforge.conductors`` group."""
     return sorted(_discover(CONDUCTORS_GROUP))
+
+
+def available_readiness_probes() -> list[str]:
+    """Sorted kinds registered in the ``tolokaforge.service_readiness_probes`` group."""
+    return sorted(_discover(SERVICE_READINESS_PROBES_GROUP))

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -29,6 +29,7 @@ from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, TrialSp
 
 if TYPE_CHECKING:  # pragma: no cover — type-only imports
     from tolokaforge.core.plugin_registry import RuntimeBackendBuildContext
+    from tolokaforge.core.service_readiness import DiagnosticPayload
     from tolokaforge.tools.registry import ToolResult
 
 __all__ = [
@@ -99,13 +100,25 @@ class ProvisionError(Exception):
     it partially materialised before raising. Callers may call
     :meth:`RuntimeBackend.teardown` again defensively — teardown is
     idempotent.
+
+    ``diagnostic`` carries a structured failure envelope when the readiness
+    gate rejects a service (resolved endpoint, probe outcome, docker-side listen
+    view); it is ``None`` for every other provisioning failure.
     """
 
-    def __init__(self, *, trial_id: str, stage: ProvisionStage, reason: str) -> None:
+    def __init__(
+        self,
+        *,
+        trial_id: str,
+        stage: ProvisionStage,
+        reason: str,
+        diagnostic: DiagnosticPayload | None = None,
+    ) -> None:
         super().__init__(f"[{stage}] trial={trial_id}: {reason}")
         self.trial_id = trial_id
         self.stage = stage
         self.reason = reason
+        self.diagnostic = diagnostic
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/service_readiness.py
+++ b/tolokaforge/core/service_readiness.py
@@ -96,7 +96,9 @@ class HttpReadinessProbe:
         start = time.monotonic()
         url = f"http://{endpoint.host}:{endpoint.port}{HTTP_HEALTH_PATH}"
         try:
-            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            with urllib.request.urlopen(  # noqa: S310 — scheme is the hard-coded http:// health URL, not user input
+                url, timeout=timeout
+            ) as response:
                 status = response.status
             ok = 200 <= status < 300
             detail = None if ok else f"GET {url} returned HTTP {status}"

--- a/tolokaforge/core/service_readiness.py
+++ b/tolokaforge/core/service_readiness.py
@@ -41,6 +41,27 @@ class ReadinessResult:
     detail: str | None = None
 
 
+@dataclass(frozen=True)
+class DiagnosticPayload:
+    """Failure envelope for a readiness-gate probe that came back not-ready.
+
+    Assembled at failure time from the live (not-yet-torn-down) container so the
+    ``ProvisionError`` names the mechanism, not just the symptom: the resolved
+    ``host:port`` the probe hit, the probe outcome, and the docker-side view of
+    where the service actually listens. The docker-introspection fields
+    (``docker_port_map`` / ``container_listen_addrs`` / ``per_network_ips``) are
+    best-effort — empty structures when the docker calls fail, never a raise.
+    """
+
+    service: str
+    kind: str
+    endpoint: ResolvedEndpoint
+    result: ReadinessResult
+    docker_port_map: dict[str, str]
+    container_listen_addrs: tuple[str, ...]
+    per_network_ips: dict[str, str]
+
+
 @runtime_checkable
 class ServiceReadinessProbe(Protocol):
     def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:

--- a/tolokaforge/core/service_readiness.py
+++ b/tolokaforge/core/service_readiness.py
@@ -93,6 +93,9 @@ class HttpReadinessProbe:
     """Ready when ``GET /health`` on the endpoint returns a 2xx within the budget."""
 
     def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        """Redirects are followed by ``urlopen``'s default handlers, so the 2xx
+        check applies to the final response — a ``/health`` that returns 3xx is
+        ready when its redirect target is 2xx."""
         start = time.monotonic()
         url = f"http://{endpoint.host}:{endpoint.port}{HTTP_HEALTH_PATH}"
         try:

--- a/tolokaforge/core/service_readiness.py
+++ b/tolokaforge/core/service_readiness.py
@@ -1,0 +1,168 @@
+"""Service-readiness Protocol seam, built-in probes, and in-memory fixture.
+
+A readiness probe answers one question from the calling process's point of view:
+given a resolved ``host:port`` and a timeout budget, is this service reachable
+and protocol-ready *now*? It is deliberately cheaper than a full protocol
+handshake — a gRPC channel becoming ready, an HTTP ``GET /health`` returning
+2xx, or a TCP connect completing — and it knows nothing about the docker/compose
+substrate that published the endpoint. That substrate-agnosticism is what lets
+the same probe answer readiness whether the endpoint came from compose, a
+remote host, or an in-memory fixture.
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+import grpc
+
+HTTP_HEALTH_PATH = "/health"
+
+
+@dataclass(frozen=True)
+class ResolvedEndpoint:
+    """The caller-process view of where a service is reachable."""
+
+    host: str
+    port: int
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    """Outcome of a single readiness probe: ``detail`` is ``None`` on success."""
+
+    ok: bool
+    latency_s: float
+    detail: str | None = None
+
+
+@runtime_checkable
+class ServiceReadinessProbe(Protocol):
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        """Answer whether ``endpoint`` is reachable and protocol-ready within ``timeout``."""
+        ...
+
+
+class GrpcReadinessProbe:
+    """Ready when a gRPC channel to the endpoint reaches READY within the budget."""
+
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        start = time.monotonic()
+        address = f"{endpoint.host}:{endpoint.port}"
+        channel = grpc.insecure_channel(address)
+        try:
+            grpc.channel_ready_future(channel).result(timeout=timeout)
+            return ReadinessResult(ok=True, latency_s=time.monotonic() - start)
+        except grpc.FutureTimeoutError as exc:
+            return ReadinessResult(
+                ok=False,
+                latency_s=time.monotonic() - start,
+                detail=f"gRPC channel to {address} not ready within {timeout}s: {exc}",
+            )
+        finally:
+            channel.close()
+
+
+class HttpReadinessProbe:
+    """Ready when ``GET /health`` on the endpoint returns a 2xx within the budget."""
+
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        start = time.monotonic()
+        url = f"http://{endpoint.host}:{endpoint.port}{HTTP_HEALTH_PATH}"
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+                status = response.status
+            ok = 200 <= status < 300
+            detail = None if ok else f"GET {url} returned HTTP {status}"
+            return ReadinessResult(ok=ok, latency_s=time.monotonic() - start, detail=detail)
+        except urllib.error.HTTPError as exc:
+            return ReadinessResult(
+                ok=False,
+                latency_s=time.monotonic() - start,
+                detail=f"GET {url} returned HTTP {exc.code}",
+            )
+        except (urllib.error.URLError, OSError) as exc:
+            return ReadinessResult(
+                ok=False,
+                latency_s=time.monotonic() - start,
+                detail=f"GET {url} failed: {exc}",
+            )
+
+
+class TcpReadinessProbe:
+    """Ready when a TCP connect to the endpoint completes within the budget."""
+
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        start = time.monotonic()
+        try:
+            with socket.create_connection((endpoint.host, endpoint.port), timeout=timeout):
+                pass
+            return ReadinessResult(ok=True, latency_s=time.monotonic() - start)
+        except OSError as exc:
+            return ReadinessResult(
+                ok=False,
+                latency_s=time.monotonic() - start,
+                detail=f"TCP connect to {endpoint.host}:{endpoint.port} failed: {exc}",
+            )
+
+
+@dataclass(frozen=True)
+class ReadinessProbeCall:
+    endpoint: ResolvedEndpoint
+    timeout: float
+
+
+@dataclass
+class ReadinessProbeCallLog:
+    """Records every ``(endpoint, timeout)`` a fixture probe was called with."""
+
+    calls: list[ReadinessProbeCall] = field(default_factory=list)
+
+    def record(self, endpoint: ResolvedEndpoint, *, timeout: float) -> None:
+        self.calls.append(ReadinessProbeCall(endpoint=endpoint, timeout=timeout))
+
+
+class InMemoryServiceReadinessProbe:
+    """Deterministic, network-free readiness probe for orchestrator-level tests.
+
+    Precedence of the failure knobs: an explicit ``result`` is returned verbatim;
+    else a non-``None`` ``fail_detail`` yields ``ok=False`` carrying it; else the
+    ``ok`` shorthand decides success.
+    """
+
+    def __init__(
+        self,
+        *,
+        ok: bool = True,
+        result: ReadinessResult | None = None,
+        fail_detail: str | None = None,
+    ) -> None:
+        self.call_log = ReadinessProbeCallLog()
+        self._result = result
+        self._fail_detail = fail_detail
+        self._ok = ok
+
+    def probe(self, endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult:
+        self.call_log.record(endpoint, timeout=timeout)
+        if self._result is not None:
+            return self._result
+        if self._fail_detail is not None:
+            return ReadinessResult(ok=False, latency_s=0.0, detail=self._fail_detail)
+        return ReadinessResult(ok=self._ok, latency_s=0.0)
+
+
+def grpc_readiness_probe_factory() -> GrpcReadinessProbe:
+    return GrpcReadinessProbe()
+
+
+def http_readiness_probe_factory() -> HttpReadinessProbe:
+    return HttpReadinessProbe()
+
+
+def tcp_readiness_probe_factory() -> TcpReadinessProbe:
+    return TcpReadinessProbe()

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -842,6 +842,31 @@ class ResetSpec(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+ReadinessKind = Literal["grpc", "http", "tcp"]
+"""Per-service readiness-probe vocabulary — the endpoint kind the
+provisioner probes for client-side reachability.
+
+* ``grpc`` — probe the gRPC channel on the runner port / first published
+  port until it reaches READY.
+* ``http`` — probe ``GET /health`` on the first published port; 2xx is ready.
+* ``tcp`` — probe a TCP connect to the first published port.
+"""
+
+
+class ReadinessSpec(BaseModel):
+    """Per-service readiness declaration — gates provisioning on client-side
+    reachability of the service's published endpoint.
+
+    Port and path are resolved by convention (see :data:`ReadinessKind`);
+    ``kind`` is the only knob in v1.
+    """
+
+    kind: ReadinessKind
+    """Endpoint kind to probe — see :data:`ReadinessKind`."""
+
+    model_config = {"extra": "forbid"}
+
+
 class ServiceSpec(BaseModel):
     """Per-service manifest entry — the harness's declaration of how a
     compose service is treated between trials.
@@ -863,6 +888,13 @@ class ServiceSpec(BaseModel):
     """Per-service network-access label — see :data:`ServiceNetworkAccess`.
     Orthogonal to :attr:`isolation` and :attr:`reset`; every combination
     is legal."""
+
+    readiness: ReadinessSpec | None = None
+    """Provision-time readiness contract — see :class:`ReadinessSpec`.
+    ``None`` means the service is not gated by an explicit contract (the
+    docker healthcheck is the only readiness signal). Orthogonal to
+    :attr:`isolation`, :attr:`reset`, and :attr:`network_access`; every
+    combination is legal."""
 
     model_config = {"extra": "forbid"}
 

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -1153,6 +1153,19 @@ def _check_runner_not_restricted(
         )
 
 
+def _check_runner_readiness_not_declared(
+    manifest_services: dict[str, ServiceSpec], runner_service: str
+) -> None:
+    spec = manifest_services.get(runner_service)
+    if spec is not None and spec.readiness is not None:
+        raise ValueError(
+            f"EnvironmentManifest.runner_service = {runner_service!r} cannot declare a "
+            f"readiness contract; the runner is always gated by the built-in gRPC "
+            f"readiness probe on its host port. Drop the readiness field from the runner "
+            f"service, or declare it on a non-runner sibling instead."
+        )
+
+
 def _check_restricted_services_have_own_networks(
     compose_services: dict[str, dict[str, Any]],
     manifest_services: dict[str, ServiceSpec],
@@ -1519,6 +1532,7 @@ class EnvironmentManifest(BaseModel):
         _check_initial_state_keys(services, self.initial_state)
         _check_services_keys(services, self.services)
         _check_runner_not_restricted(self.services, self.runner_service)
+        _check_runner_readiness_not_declared(self.services, self.runner_service)
         _check_restricted_services_have_own_networks(services, self.services)
         _check_endpoint_services_declared(services, self.db_service, self.rag_service)
         self._compose_content = content


### PR DESCRIPTION
## Summary

- Names the container-healthy-vs-client-invokable boundary as a first-class `ServiceReadinessProbe` Protocol. A container that is docker-healthy but host-unreachable (loopback-only bind, IPv6-only bind on IPv4-DNAT, etc.) now fails provisioning fast with an actionable `ProvisionError` — instead of a downstream 30 s client-connect timeout with a generic message.
- Ships the **fourth entry-point-registry-backed seam** in the codebase: task packs can declare `services.<name>.readiness: {kind: grpc|http|tcp}` and adapters can register custom probes without touching substrate code.
- Runner gets a gRPC readiness probe by default — existing packs are backwards-compatible; a reachable runner passes the probe in ms.

## Design choices

- **Protocol + entry-point registry + `InMemory*` fixture + canonical contract test**: fourth consumer of the ADR-0011 Pattern-A registry idiom (three groups shipped today; this is the fourth). Validates the shape generalises beyond orchestrator seams.
- **Cheap probes only at provision time**: `channel_ready` / `GET /health` / TCP connect answer "reachable + protocol-ready" in milliseconds. The deferred per-trial gRPC client `connect()` stays lazy and unchanged — reconciled with the existing latency-avoidance rationale in `per_trial_runtime.py`.
- **Diagnostic capture at failure time, not caller responsibility**: `ProvisionError.diagnostic: DiagnosticPayload` is an additive frozen-dataclass field. On any readiness failure, the substrate captures the resolved host:port, docker port map, in-container listen addresses (`/proc/net/tcp[6]`), and per-network container IPs — best-effort, never raises. Zero cost on the happy path.
- **`readiness_probe_loader` backend seam**: `PerTrialRuntimeBackend` gains a dataclass field defaulting to the real registry loader, so real runs get the intended happy-path behaviour unchanged. Fake-runner test harnesses (nginx-as-runner in network_policy, `_FakeCompose` in canonical) inject an `InMemoryServiceReadinessProbe(ok=True)` since they test topology / log-capture / reset — not runner readiness.
- **Runner `readiness:` config rejected at manifest validation, not silently dropped**: user-supplied config fields don't get silently discarded (fail-loud house style). The runner's gRPC contract is fixed; declaring `readiness:` on `runner_service` is now a `ValidationError` with a clear message pointing at the always-gRPC contract.

## Concepts introduced

Three new abstractions the reader will encounter:

- **`ServiceReadinessProbe` Protocol** (`tolokaforge/core/service_readiness.py`): `probe(endpoint: ResolvedEndpoint, *, timeout: float) -> ReadinessResult`. Substrate-agnostic — probes know only host:port + timeout, never the docker/compose handle. Three built-ins registered under `tolokaforge.service_readiness_probes` entry-point group: `grpc`, `http`, `tcp`.
- **Task-pack `readiness` declaration** (`ServiceSpec.readiness: ReadinessSpec | None`): pack authors declare which services get a readiness contract and which kind. Runner gets an implicit gRPC default; other services opt in with `readiness: {kind: <grpc|http|tcp>}`.
- **`DiagnosticPayload` failure envelope** (`ProvisionError.diagnostic`): structured wedge captured at provision-failure time — resolved endpoint, probe result, docker port map, in-container listen addresses, per-network IPs. Consumed by error/logs, not round-tripped as a wire model.

The pattern extension (Protocol + entry-point + `InMemory*` fixture + canonical contract test) is documented in ADR-0025 as the fourth registry-backed seam.

## Plan

The plan below shipped in three commits + one corrective-review commit, as reviewed:

- `b1206e8` — Stage 1: seam + registry + built-in probes + `InMemoryServiceReadinessProbe` fixture + canonical contract test + ADR-0025 + `plugin_registry.py` module docstring + `__all__` rewrite three→four.
- `6612cb0` — Stage 2: `ReadinessSpec(BaseModel, extra="forbid")` + `ServiceSpec.readiness: ReadinessSpec | None = None`. Optional field, backwards-compatible.
- `b14f3e4` — Stage 3: `PerTrialRuntimeBackend._run_readiness_gate` + `readiness_probe_loader` seam + `DiagnosticPayload` + `ProvisionError.diagnostic` + best-effort docker-introspection helper + retrofit of ~4 fake-runner tests to inject `InMemoryServiceReadinessProbe(ok=True)` via the seam + docker-integration positive-3-kind and negative-loopback-only-bind tests.
- `73d2f2e` — Round-1 review corrections: reject runner `readiness:` at manifest validation (fail-loud), tidy ADR-0025 Follow-ups (delete completed bullets), add `noqa: S310` justification, PROJECTS.md current-state fix.

Full staged plan checked into `docs/plans/2026-08-03-issue-803-service-readiness-contract.md` (in-repo per this repo's convention).

## Discovered issues

- **Filed**: [#805](https://github.com/Toloka/tolokaforge/issues/805) (runner `0.0.0.0` bind hardening — the #801 core fix, kept separate); [#806](https://github.com/Toloka/tolokaforge/issues/806) (multi-service readiness dependency graph — file-and-hold, ticket's named non-goal); [#809](https://github.com/Toloka/tolokaforge/issues/809) (pre-existing `multi_service_endpoint_add` seed-digest drift — 5 test failures on `main`, unrelated to this diff, needs `tolokaforge assets stamp`).
- **Fixed in this PR**: `first_published_port` EXPOSE-only-port defect — was returning `PublishedPort==0` for any Dockerfile-`EXPOSE`d-but-unpublished port, breaking declared-service endpoint resolution for bare `image: nginx` services. Now requires `PublishedPort>0`. Locked with a new unit case; adjusted fake publishers + rag mocks that relied on the old behaviour. In-scope per AGENTS.md "broken code found = broken code fixed".

## Test plan

- Provision-time readiness gate blocks on real runner gRPC probe: `pytest -m integration -k readiness` — positive 3-kind (h2c-nginx-runner + `/health`-http + TCP) and negative loopback-only-bind (#801 class) both pass on real docker.
- Canonical negative regression: `pytest -m canonical -k readiness` — `_run_readiness_gate` fails loud with populated `DiagnosticPayload` when the injected probe returns `ok=False`. No docker.
- Runner `readiness:` rejected at manifest validation: `pytest tests/canonical/test_environment_manifest_contract.py::TestServiceNetworkAccessContract::test_runner_service_cannot_declare_readiness` — real Pydantic `ValidationError` with the expected message.
- Existing fake-runner tests unchanged in behaviour: `pytest tests/canonical/test_per_trial_runtime_backend.py` — the retrofit injects an always-ready probe; suite passes.
- Task-pack schema round-trip: `pytest tests/canonical/test_environment_manifest_contract.py -k Readiness` — `ServiceSpec.readiness` accepts `{kind}`, rejects unknown kinds via `extra="forbid"` + `Literal`, and stays `None` by default.

Closes #803
