### PR TITLE
chore(core): partition audit for the runner subset (#820)

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -138,6 +138,64 @@ and rejecting each `ExecuteTool` would reach the agent as an ordinary tool failu
 so it would retry until its turn budget was gone and report a completed trial
 scoring near zero, with the skew visible only inside the transcript.
 
+### Runner subset — what the runner image ships
+
+The published PyPI wheel carries every `tolokaforge/**` file; the runner Docker
+image installs a Docker-only *subset* build of that same tree so the image
+contains only code the runner actually runs
+([ADR-0025](adr/0025-runner-wheel-split.md) § "The module partition"). The
+canonical enumeration lives in
+[`tolokaforge/core/_runner_subset.py`](../tolokaforge/core/_runner_subset.py) —
+consumed verbatim by the hatch build target and locked against the runner
+container's actual runtime import closure by
+[`tests/canonical/test_runner_subset_partition.py`](../tests/canonical/test_runner_subset_partition.py).
+
+**Whole subpackages in the subset:**
+
+| Path | Rationale |
+|---|---|
+| `tolokaforge/runner/` | The runner service, gRPC glue, DB / RAG clients, tool factory, runner-side grading. |
+| `tolokaforge/secrets/` | Single-abstraction secret manager reconstructed from `TOLOKAFORGE_SECRETS_JSON`. |
+| `tolokaforge/tools/` | Tool registry + built-in tool drivers the tool factory dispatches by name at `RegisterTrial`. (One file excluded — see below.) |
+| `tolokaforge/core/models/` | Wire types the gRPC surface serialises. |
+| `tolokaforge/core/llm/` | LLM client + policies; the runner runs LLM-as-judge in-container. (One file excluded — see below.) |
+| `tolokaforge/core/grading/` | Grading substrate — check runner, checks helpers, judge, key manifest, state composition, state diff, trace timeline, transcript wire. (Four files excluded — see below.) |
+
+**Loose files in the subset:**
+
+- `tolokaforge/__init__.py` — package init; lazy `__getattr__` symbols that
+  resolve to orchestrator modules (`Orchestrator`, metrics, run queue) are
+  present but raise `AttributeError` on the slim image, and the runner never
+  reads them.
+- `tolokaforge/core/__init__.py`, `tolokaforge/core/_runner_subset.py` —
+  the subset's own audit artifact and the `core/` package init.
+- `tolokaforge/core/deprecations.py`, `hash.py`, `logging.py`, `loop.py`,
+  `netpolicy_constants.py`, `pricing.py`, `run_display_events.py`, `trial.py`
+  — the shared-spine files at the root of `core/` the runner closure reaches
+  directly.
+
+**Excluded — orchestrator-only files under a subpackage otherwise in the subset:**
+
+| Path | Excluded because |
+|---|---|
+| `tolokaforge/core/grading/combine.py` | Imports `core.evaluators.*` (orchestrator-only). |
+| `tolokaforge/core/grading/replay.py` | Imports `core.output.artifacts` (orchestrator-only). |
+| `tolokaforge/core/grading/state_checks.py` | Imports `core.utils.diff` (orchestrator-only). |
+| `tolokaforge/core/grading/transcript.py` | Consumed only by orchestrator-side code paths. |
+| `tolokaforge/core/llm/fallback_client.py` | Consumed only by `dx/cli/main.py`. |
+| `tolokaforge/tools/user_tools.py` | Imports `core.env_state` (orchestrator-only). |
+
+**Not in the subset:** everything at the `tolokaforge/core/` root not listed above
+(the `Orchestrator` class, dry-run, output writer, config validator, compose
+materialisation, engine run state, backend capabilities, the `RuntimeBackend` /
+`Conductor` / `TrialGrader` Protocol definitions and their factories, the
+`run_trial` library entry, run queue, resume, project loader, plugin registry,
+metrics, budgets, and the remaining utility modules); `tolokaforge/core/evaluators/`;
+`tolokaforge/core/output/`; `tolokaforge/core/search/`; `tolokaforge/core/utils/`;
+`tolokaforge/core/schema/`; `tolokaforge/adapters/`; `tolokaforge/dx/`;
+`tolokaforge/docker/`; `tolokaforge/env/`; `tolokaforge/runtime/`;
+`tolokaforge/_entry.py`.
+
 ## Tool Lifecycle
 
 Some tools own per-trial resources — a compose stack, a long-lived

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -1,0 +1,289 @@
+"""Runner subset partition lock (ADR-0025 § "The module partition").
+
+:mod:`tolokaforge.core._runner_subset` names the exact set of first-party
+files the runner subset build target ships. This test freezes that
+partition against the actual runner container's runtime import closure so
+drift in either direction fails CI:
+
+1. **Positive lock (closure ⊆ subset).** Every first-party module the runner
+   container's boot path reaches (walking imports from
+   :mod:`tolokaforge.runner.__main__` + :mod:`tolokaforge.runner.service`)
+   must be classified in-subset. Adding a runner import that would need a
+   module the subset omits fails here — otherwise it fails at container
+   start, silently in the artifact and loudly in production.
+
+2. **Negative lock (subset ⊆ closure ∪ lazy-loadable).** Every file the
+   subset ships must either be reached by that same closure or be a lazy /
+   entry-point-loadable module the runner reconstructs from a task schema
+   at ``RegisterTrial`` (the ``tolokaforge.tools.builtin.*`` drivers and the
+   two persistent-shell / str-replace-editor wrappers dispatched through
+   :mod:`tolokaforge.tools.builtin.registry`). A subset entry that fits
+   neither is dead weight in the image.
+
+3. **Cross-import invariant.** No file classified in the subset may import
+   a file classified out of the subset. A shared-spine module that reaches
+   an orchestrator-only sibling would either fail at import inside the
+   runner container or force the sibling into the subset — either way the
+   partition is wrong. The static AST walk catches this at any nesting
+   depth (module-level or deferred function-body).
+
+The subset closure runs in a clean subprocess for the same reason as
+:mod:`tests.canonical.test_runner_import_boundary`: the pytest process has
+already imported much of the tree, so an in-process footprint proves
+nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core._runner_subset import (
+    RUNNER_SUBSET_EXCLUDED_FILES,
+    RUNNER_SUBSET_LOOSE_FILES,
+    RUNNER_SUBSET_PACKAGES,
+    is_in_runner_subset,
+)
+
+pytestmark = pytest.mark.canonical
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOLOKAFORGE_ROOT = REPO_ROOT / "tolokaforge"
+
+# Lazy / dispatch-loaded modules the runner reaches from a live
+# ``RegisterTrial``, not from boot. Present in the subset because the runner
+# reconstructs them from a task schema at runtime; absent from the
+# boot-time closure because no boot-side import statement names them.
+LAZY_LOADABLE_SUBSET_MODULES: frozenset[str] = frozenset(
+    {
+        "tolokaforge/tools/__init__.py",
+        "tolokaforge/tools/builtin/__init__.py",
+        "tolokaforge/tools/builtin/bash.py",
+        "tolokaforge/tools/builtin/browser.py",
+        "tolokaforge/tools/builtin/calculator.py",
+        "tolokaforge/tools/builtin/db_json.py",
+        "tolokaforge/tools/builtin/files.py",
+        "tolokaforge/tools/builtin/http_request.py",
+        "tolokaforge/tools/builtin/mobile.py",
+        "tolokaforge/tools/builtin/rag_search.py",
+        "tolokaforge/tools/builtin/registry.py",
+        # ``runner.proto`` is a source-level protobuf definition, not a
+        # Python module — the compiled ``runner_pb2*.py`` files carry its
+        # runtime surface. Kept in the subset for repro / regeneration.
+        "tolokaforge/runner/runner.proto",
+        # Audit / documentation artifact — imported by this test but not by
+        # any runtime path. Shipping it inside the subset lets the follow-up
+        # build script and image-side introspection consume it verbatim.
+        "tolokaforge/core/_runner_subset.py",
+    }
+)
+
+
+_CLOSURE_PROBE = r"""
+import builtins
+import json
+import sys
+
+edges = {}
+real_import = builtins.__import__
+
+
+def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+    parent = (globals or {}).get("__name__")
+    before = set(sys.modules)
+    module = real_import(name, globals, locals, fromlist, level)
+    for new_module in set(sys.modules) - before:
+        edges.setdefault(new_module, parent)
+    return module
+
+
+builtins.__import__ = tracking_import
+import tolokaforge.runner.__main__  # noqa: F401
+import tolokaforge.runner.service  # noqa: F401
+builtins.__import__ = real_import
+
+first_party = sorted(m for m in sys.modules if m.split(".")[0] == "tolokaforge")
+json.dump(first_party, sys.stdout)
+"""
+
+
+@pytest.fixture(scope="module")
+def runner_boot_closure() -> frozenset[str]:
+    """Set of first-party modules imported by ``python -m tolokaforge.runner``."""
+    result = subprocess.run(
+        [sys.executable, "-c", _CLOSURE_PROBE],
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"runner boot closure probe failed (exit {result.returncode}):\n{result.stderr}"
+    return frozenset(json.loads(result.stdout))
+
+
+def _module_to_path(module_name: str) -> str:
+    """Repo-relative POSIX path for *module_name* — package ``__init__`` for a
+    package, ``<leaf>.py`` for a module."""
+    rel = module_name.replace(".", "/")
+    pkg_init = TOLOKAFORGE_ROOT.parent / rel / "__init__.py"
+    if pkg_init.is_file():
+        return f"{rel}/__init__.py"
+    return f"{rel}.py"
+
+
+def _enumerate_subset_files() -> frozenset[str]:
+    """All ``.py`` (and ``.proto``) files the subset covers, per the current
+    classification in :mod:`tolokaforge.core._runner_subset`."""
+    files: set[str] = set()
+    for pkg in RUNNER_SUBSET_PACKAGES:
+        pkg_dir = REPO_ROOT / pkg
+        for path in pkg_dir.rglob("*"):
+            if "__pycache__" in path.parts:
+                continue
+            if not path.is_file():
+                continue
+            if path.suffix not in {".py", ".proto"}:
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in RUNNER_SUBSET_EXCLUDED_FILES:
+                continue
+            files.add(rel)
+    files.update(RUNNER_SUBSET_LOOSE_FILES)
+    return frozenset(files)
+
+
+def test_declared_loose_files_exist() -> None:
+    """Every path in the loose-files tuple must exist on disk."""
+    missing = [p for p in RUNNER_SUBSET_LOOSE_FILES if not (REPO_ROOT / p).is_file()]
+    assert not missing, "RUNNER_SUBSET_LOOSE_FILES names paths that no longer exist:\n" + "\n".join(
+        f"  - {m}" for m in missing
+    )
+
+
+def test_runner_boot_closure_is_covered_by_subset(runner_boot_closure: frozenset[str]) -> None:
+    """Every module reached by ``python -m tolokaforge.runner`` must map to a
+    file the subset ships."""
+    missing: list[str] = []
+    for module in sorted(runner_boot_closure):
+        rel = _module_to_path(module)
+        if not is_in_runner_subset(rel):
+            missing.append(f"{module} -> {rel}")
+    assert not missing, (
+        "runner boot closure reaches files the subset would omit — the "
+        "runner container would fail at import inside the slim image:\n"
+        + "\n".join(f"  - {m}" for m in missing)
+    )
+
+
+def test_subset_files_are_reachable(runner_boot_closure: frozenset[str]) -> None:
+    """Every file shipped in the subset is either reached at boot or a
+    dispatch-loaded driver the runner reconstructs from task schemas."""
+    boot_files = {_module_to_path(m) for m in runner_boot_closure}
+    subset_files = _enumerate_subset_files()
+    dead: list[str] = []
+    for rel in sorted(subset_files):
+        if rel in boot_files:
+            continue
+        if rel in LAZY_LOADABLE_SUBSET_MODULES:
+            continue
+        dead.append(rel)
+    assert not dead, (
+        "subset ships files that neither the runner boot closure nor the "
+        "lazy-loadable dispatch surface reaches — dead weight in the "
+        "runner image:\n" + "\n".join(f"  - {d}" for d in dead)
+    )
+
+
+def _resolve_import_from(node: ast.ImportFrom, package: str) -> str | None:
+    if node.level == 0:
+        return node.module
+    bits = package.rsplit(".", node.level - 1)
+    if len(bits) < node.level:
+        return None
+    base = bits[0]
+    return f"{base}.{node.module}" if node.module else base
+
+
+def _module_qualname(path: Path) -> tuple[str, bool]:
+    parts = list(path.relative_to(REPO_ROOT).with_suffix("").parts)
+    is_package = parts[-1] == "__init__"
+    if is_package:
+        parts = parts[:-1]
+    return ".".join(parts), is_package
+
+
+def _target_to_path(dotted: str) -> str | None:
+    """Repo-relative path for a dotted first-party import target, or None if
+    the target names a file we cannot classify (external package, missing
+    module, plain namespace)."""
+    if not (dotted == "tolokaforge" or dotted.startswith("tolokaforge.")):
+        return None
+    rel = dotted.replace(".", "/")
+    pkg_init = REPO_ROOT / rel / "__init__.py"
+    if pkg_init.is_file():
+        return f"{rel}/__init__.py"
+    module_file = REPO_ROOT / f"{rel}.py"
+    if module_file.is_file():
+        return f"{rel}.py"
+    return None
+
+
+def test_subset_files_do_not_import_orchestrator_only_siblings() -> None:
+    """A shared-spine file that reached an orchestrator-only sibling would
+    force that sibling into the subset (or crash inside the slim image).
+    Static AST walk covers every ``import`` / ``from … import`` at any
+    nesting depth, including deferred function-body imports."""
+    subset_files = _enumerate_subset_files()
+    violations: list[str] = []
+    for rel in sorted(subset_files):
+        path = REPO_ROOT / rel
+        if path.suffix != ".py":
+            continue
+        module_name, is_package = _module_qualname(path)
+        package = module_name if is_package else module_name.rpartition(".")[0]
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:  # pragma: no cover - would fail the ruff gate first
+            violations.append(f"{rel}: parse error {exc}")
+            continue
+        for node in ast.walk(tree):
+            targets: list[tuple[int, str]] = []
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    targets.append((node.lineno, alias.name))
+            elif isinstance(node, ast.ImportFrom):
+                resolved = _resolve_import_from(node, package)
+                if resolved is None:
+                    continue
+                targets.append((node.lineno, resolved))
+                for alias in node.names:
+                    targets.append((node.lineno, f"{resolved}.{alias.name}"))
+            for lineno, dotted in targets:
+                target_path = _target_to_path(dotted)
+                if target_path is None:
+                    continue
+                if target_path == rel:
+                    continue
+                if is_in_runner_subset(target_path):
+                    continue
+                violations.append(f"{rel}:{lineno} imports {dotted} -> {target_path}")
+    assert not violations, (
+        "subset files reach orchestrator-only siblings — the partition is "
+        "inconsistent:\n" + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+def test_declared_excluded_files_exist() -> None:
+    """Every path in the excluded-files tuple must exist on disk — otherwise
+    the exclusion is stale and hides that a real file drifted."""
+    missing = [p for p in RUNNER_SUBSET_EXCLUDED_FILES if not (REPO_ROOT / p).is_file()]
+    assert (
+        not missing
+    ), "RUNNER_SUBSET_EXCLUDED_FILES names paths that no longer exist:\n" + "\n".join(
+        f"  - {m}" for m in missing
+    )

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -1,0 +1,116 @@
+"""Runner subset partition — the machine-readable enumeration ADR-0025 asks for.
+
+The runner Docker image installs a subset build target rather than the full
+``tolokaforge`` wheel: this module names exactly which first-party files that
+subset covers. The base wheel published to PyPI carries every file; the subset
+is a Docker-only artifact built from these same sources.
+
+The partition is derived from the runner container's actual runtime import
+closure — the modules ``python -m tolokaforge.runner`` reaches from
+:mod:`tolokaforge.runner.__main__` + :mod:`tolokaforge.runner.service`, plus
+the lazily-loaded builtin-tool drivers the runner reconstructs from task
+schemas at ``RegisterTrial``. Anything the closure never reaches at any point
+in the runner's lifecycle stays base-wheel-only.
+
+``core/`` mixes shared spine (models, LLM, grading substrate, protocols,
+utility modules the closure needs) with orchestrator-only code (the
+``Orchestrator`` class, dry-run, output writer, compose materialisation,
+engine run state, backend factories, run-trial library entry). Rather than
+reorganize the directory this ticket enumerates at file level: subpackages
+whose contents are all shared-spine are named whole; subpackages with a mix
+are named whole with the orchestrator-only files listed in
+:data:`RUNNER_SUBSET_EXCLUDED_FILES`; individual files that live outside a
+whole-package entry (the mixed root of ``core/`` and the top-level
+``tolokaforge/__init__.py``) are named in :data:`RUNNER_SUBSET_LOOSE_FILES`.
+
+The follow-up ticket that adds the hatch build target consumes these tuples
+verbatim; the canonical test :mod:`tests.canonical.test_runner_subset_partition`
+locks them against the actual runtime closure and rejects drift in either
+direction.
+"""
+
+from __future__ import annotations
+
+RUNNER_SUBSET_PACKAGES: tuple[str, ...] = (
+    "tolokaforge/runner",
+    "tolokaforge/secrets",
+    "tolokaforge/tools",
+    "tolokaforge/core/models",
+    "tolokaforge/core/llm",
+    "tolokaforge/core/grading",
+)
+"""Subpackage directories shipped in the runner subset.
+
+Every ``.py`` under these paths is in the subset unless listed in
+:data:`RUNNER_SUBSET_EXCLUDED_FILES`. Directory paths use forward slashes
+so the value round-trips into a POSIX-style hatch enumeration unchanged on
+any host platform.
+"""
+
+RUNNER_SUBSET_LOOSE_FILES: tuple[str, ...] = (
+    # Top-level package init — reached because every ``tolokaforge.*`` import
+    # traverses it. Ships a lazy ``__getattr__`` that resolves orchestrator
+    # symbols (``Orchestrator``, metrics, run queue) via ``importlib`` — those
+    # symbols raise ``AttributeError`` on the slim image because their target
+    # modules are base-wheel-only. The runner never reads them.
+    "tolokaforge/__init__.py",
+    # Shared-spine files at the root of ``tolokaforge/core/``. Everything
+    # else at the core root — the orchestrator, dry-run, config validator,
+    # compose materialisation, engine run state, backend capabilities,
+    # runtime / conductor / trial-grader protocol definitions, the
+    # ``run_trial`` library entry, run queue, resume, project loader,
+    # plugin registry, metrics, budgets, and the remaining utility modules
+    # — is orchestrator-only.
+    "tolokaforge/core/__init__.py",
+    "tolokaforge/core/_runner_subset.py",
+    "tolokaforge/core/deprecations.py",
+    "tolokaforge/core/hash.py",
+    "tolokaforge/core/logging.py",
+    "tolokaforge/core/loop.py",
+    "tolokaforge/core/netpolicy_constants.py",
+    "tolokaforge/core/pricing.py",
+    "tolokaforge/core/run_display_events.py",
+    "tolokaforge/core/trial.py",
+)
+"""Individual files shipped in the subset that live outside a whole-package
+entry — the top-level ``tolokaforge/__init__.py`` and the shared-spine
+files at the root of ``tolokaforge/core/``.
+"""
+
+RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
+    "tolokaforge/core/grading/combine.py",
+    "tolokaforge/core/grading/replay.py",
+    "tolokaforge/core/grading/state_checks.py",
+    "tolokaforge/core/grading/transcript.py",
+    "tolokaforge/core/llm/fallback_client.py",
+    "tolokaforge/tools/user_tools.py",
+)
+"""Files that live under a shared-spine subpackage but are orchestrator-only.
+
+Four of them (``core.grading.combine``, ``core.grading.replay``,
+``core.grading.state_checks``, ``core.tools.user_tools``) reach
+orchestrator-only siblings (``core.evaluators``, ``core.output.artifacts``,
+``core.utils.diff``, ``core.env_state``) — including any of these in the
+subset would drag those orchestrator-only surfaces along with them, or
+fail at import time inside the runner container. Two (``core.grading
+.transcript``, ``core.llm.fallback_client``) have only shared-spine
+imports but are consumed exclusively by orchestrator-side code and would
+ship as dead weight. The runner container's runtime closure reaches none
+of them.
+"""
+
+
+def is_in_runner_subset(rel_path: str) -> bool:
+    """Return True if *rel_path* (a POSIX-slash repo-relative ``.py`` path) is
+    part of the runner subset.
+
+    A path is in the subset when it is (a) listed explicitly in
+    :data:`RUNNER_SUBSET_LOOSE_FILES`, or (b) rooted under a directory in
+    :data:`RUNNER_SUBSET_PACKAGES` and not listed in
+    :data:`RUNNER_SUBSET_EXCLUDED_FILES`.
+    """
+    if rel_path in RUNNER_SUBSET_EXCLUDED_FILES:
+        return False
+    if rel_path in RUNNER_SUBSET_LOOSE_FILES:
+        return True
+    return any(rel_path.startswith(pkg + "/") for pkg in RUNNER_SUBSET_PACKAGES)


### PR DESCRIPTION
## Summary

- Walks the runner container's actual runtime import closure (starting from `tolokaforge.runner.__main__` + `tolokaforge.runner.service`) and freezes the resulting per-file classification the follow-up hatch build target consumes.
- No file moves: the shared-spine set is expressible as three whole subpackages, one whole extra subpackage with six file exclusions, and eleven loose files at the top of `tolokaforge/` and the root of `tolokaforge/core/`.
- Adds a canonical test that regenerates the boot closure in a clean subprocess and rejects any drift between it and the declared partition, plus a static AST check that no subset file imports an orchestrator-only sibling.
- Documents the partition in `docs/RUNNER.md` so #821's implementer can lift the tuples verbatim into `pyproject.toml`.

Closes #820.

## Design choices

**File-level enumeration over reorganisation.** ADR-0025 § "The module partition" leaves the choice between reorganising `core/` and file-level enumeration to this ticket. The ticket body explicitly prefers file-level when the list is manageable. The shared-spine set fits inside three whole subpackages (`core/models`, `core/llm`, `core/grading` with six exclusions), the top-level package init, and nine loose files under the `core/` root — 11 loose entries in total. Moving any of those to a `core/spine/` subpackage would rewire 45+ importers across `core/`, `runtime/reset_recipes/`, `dx/`, `adapters/`, and would collide with the ongoing terminal-dx work on `feat/terminal-dx`. Reorganisation stays deferrable to a future ticket if the file-level list ever grows unwieldy.

**One canonical module, three tuples.** The classification lives in `tolokaforge/core/_runner_subset.py` (the underscore prefix marks it internal). It exports:

- `RUNNER_SUBSET_PACKAGES` — whole subpackage directories: `tolokaforge/runner`, `tolokaforge/secrets`, `tolokaforge/tools`, `tolokaforge/core/models`, `tolokaforge/core/llm`, `tolokaforge/core/grading`.
- `RUNNER_SUBSET_LOOSE_FILES` — `tolokaforge/__init__.py`, `tolokaforge/core/__init__.py`, `tolokaforge/core/_runner_subset.py`, and the shared-spine files at the root of `core/`: `deprecations`, `hash`, `logging`, `loop`, `netpolicy_constants`, `pricing`, `run_display_events`, `trial`.
- `RUNNER_SUBSET_EXCLUDED_FILES` — six orchestrator-only leaves under an otherwise-shared subpackage: `core/grading/{combine,replay,state_checks,transcript}.py`, `core/llm/fallback_client.py`, `tools/user_tools.py`.

A small `is_in_runner_subset(rel_path)` helper composes the three so the follow-up build config and the canonical test consume one source of truth.

**Runner boot closure is the source of truth, not the ADR's aspirational list.** ADR-0025 named `runtime.py` / `conductor.py` / `trial_grader.py` / `evaluators/*` as belonging to the subset — but a live closure walk from the container's actual boot path (`python -m tolokaforge.runner`) shows the runner never reaches those Protocol modules at runtime; they are consumed by the orchestrator side that composes concrete instances. This ticket's job is exactly to reconcile the ADR's guess with what the code actually does. The audit's outcome: those Protocol modules stay base-wheel-only.

## Concepts introduced

- **`RUNNER_SUBSET_PACKAGES` / `RUNNER_SUBSET_LOOSE_FILES` / `RUNNER_SUBSET_EXCLUDED_FILES`** — the machine-readable enumeration the next ticket drops into a hatch build target. Directory paths use POSIX slashes so the values round-trip into `pyproject.toml` unchanged on any host platform.
- **Positive partition-lock test** — extends the existing negative import-boundary invariant (`test_runner_import_boundary.py` proves the runner does not reach forbidden surfaces) with a positive check: every module the runner does reach must be in-subset, and every file the subset ships must be reachable at boot or through the lazy builtin-tool dispatch (`LAZY_LOADABLE_SUBSET_MODULES`).
- **Cross-import invariant** — a static AST walk asserts no subset file imports an orchestrator-only sibling. Deferred function-body imports are included.

## Plan

1. Read ADR-0025 § "The module partition", the existing `test_runner_import_boundary.py`, and enumerate `tolokaforge/core/`. Done.
2. Compute the runner's runtime import closure via a clean-subprocess `builtins.__import__` tracker. Done.
3. Cross-check against the ADR's shared-spine list. Done — deltas are Protocol modules (`runtime`, `conductor`, `trial_grader`) and `evaluators/*` which the runner does not actually reach at runtime.
4. Decide: reorganise vs file-level. File-level (11 loose entries, 6 exclusions) is cleanly expressible. Done.
5. Static AST cross-import scan of the shared-spine set. Done — the four subpackage-relative violations (`combine`, `replay`, `state_checks` in `grading/`, and `user_tools`) resolve by classifying those specific files as orchestrator-only, not by moving anything.
6. Deliver the module, the canonical test, and the docs. Done.
7. Verify lint / unit / canonical / existing boundary tests. Done — see below.

## Discovered issues

None. The partition is naturally clean once `user_tools.py`, the four `grading/` leaves, and `fallback_client.py` are excluded. The remaining shared-spine set has no cross-imports to orchestrator-only surfaces.

## Test plan

- [x] `uv run ruff check tolokaforge tests scripts tools` — passes.
- [x] `uv run ruff format --check tolokaforge/core/_runner_subset.py tests/canonical/test_runner_subset_partition.py` — new files format cleanly.
- [x] `uv run pytest -m canonical tests/canonical/test_runner_subset_partition.py` — 5/5 pass.
- [x] `uv run pytest -m canonical tests/canonical/test_runner_import_boundary.py` — 7/7 pass (unchanged; existing invariant continues to hold).
- [x] `uv run pytest -m canonical tests/` — 819/819 pass.
- [x] `uv run pytest -m unit tests/` — 4359/4359 pass.
- [x] No file moves, so no dry-run integration test needed for reorganisation.