### PR TITLE
feat(build): add runner-subset hatch build target (#821)

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -150,6 +150,24 @@ consumed verbatim by the hatch build target and locked against the runner
 container's actual runtime import closure by
 [`tests/canonical/test_runner_subset_partition.py`](../tests/canonical/test_runner_subset_partition.py).
 
+**Building the subset wheel.** The `[tool.hatch.build.targets.custom]`
+section of [`pyproject.toml`](../pyproject.toml) declares the subset build
+target; the custom builder at
+[`scripts/hatch/hatch_runner_subset_builder.py`](../scripts/hatch/hatch_runner_subset_builder.py)
+renames the distribution to `tolokaforge-runner-subset`, replaces the base
+wheel's dependency list with the runner-runtime deps, and strips console-script
+/ entry-point tables.
+
+```bash
+uv run hatch build --target custom
+# → dist/tolokaforge_runner_subset-<version>-py3-none-any.whl
+```
+
+The base `tolokaforge` wheel — `hatch build --target wheel` /
+`uv build --wheel` — is unchanged, still published to PyPI, and still installs
+via `pip install tolokaforge` / `pip install tolokaforge[runner]`. The subset
+wheel is a Docker-only artifact and is never uploaded to PyPI.
+
 **Whole subpackages in the subset:**
 
 | Path | Rationale |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,60 @@ packages = ["tolokaforge"]
 
 [tool.hatch.build.targets.sdist]
 
+# =============================================================================
+# Runner-subset wheel — Docker-only build artifact, NEVER published to PyPI.
+# =============================================================================
+#
+# ``hatch build --target custom`` (equivalently
+# ``uv run hatch build --target custom``) produces
+# ``dist/tolokaforge_runner_subset-<version>-py3-none-any.whl`` — a slimmed
+# variant of the base wheel that contains only the Python files the runner
+# container's runtime graph reaches. The runner Docker image installs this
+# wheel; pip cannot pull it from PyPI. See
+# ``docs/adr/0025-runner-wheel-split.md``.
+#
+# ``tolokaforge/core/_runner_subset.py`` is the single source of truth for
+# the partition. The ``only-include`` / ``exclude`` lists below mirror its
+# three tuples verbatim; the canonical drift-lock test in
+# ``tests/canonical/test_runner_subset_partition.py`` fails CI if the two
+# ever disagree.
+#
+# The base wheel — ``[tool.hatch.build.targets.wheel]`` above — and its
+# PyPI-facing metadata are unchanged.
+[tool.hatch.build.targets.custom]
+path = "scripts/hatch/hatch_runner_subset_builder.py"
+only-include = [
+    # RUNNER_SUBSET_PACKAGES — whole subpackages in the subset.
+    "tolokaforge/runner",
+    "tolokaforge/secrets",
+    "tolokaforge/tools",
+    "tolokaforge/core/models",
+    "tolokaforge/core/llm",
+    "tolokaforge/core/grading",
+    # RUNNER_SUBSET_LOOSE_FILES — shared-spine files outside a whole package.
+    "tolokaforge/__init__.py",
+    "tolokaforge/core/__init__.py",
+    "tolokaforge/core/_runner_subset.py",
+    "tolokaforge/core/deprecations.py",
+    "tolokaforge/core/hash.py",
+    "tolokaforge/core/logging.py",
+    "tolokaforge/core/loop.py",
+    "tolokaforge/core/netpolicy_constants.py",
+    "tolokaforge/core/pricing.py",
+    "tolokaforge/core/run_display_events.py",
+    "tolokaforge/core/trial.py",
+]
+exclude = [
+    # RUNNER_SUBSET_EXCLUDED_FILES — orchestrator-only files inside an
+    # otherwise-included subpackage.
+    "tolokaforge/core/grading/combine.py",
+    "tolokaforge/core/grading/replay.py",
+    "tolokaforge/core/grading/state_checks.py",
+    "tolokaforge/core/grading/transcript.py",
+    "tolokaforge/core/llm/fallback_client.py",
+    "tolokaforge/tools/user_tools.py",
+]
+
 [tool.black]
 line-length = 100
 target-version = ['py310']

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,8 @@ Utility scripts for developing with Tolokaforge.
     ├── with_env.sh                            # Load .env + run a command
     ├── with_profile.sh                        # Load profile (no .env) + run a command
     ├── generate_task_pack_compose_override.py  # Generate Docker compose overrides for task packs
+    ├── hatch/
+    │   └── hatch_runner_subset_builder.py     # Custom hatchling builder for the runner-subset wheel (Docker-only; hatch build --target custom)
     ├── setup/
     │   ├── cbm-onboard.sh                     # codebase-memory-mcp + Claude Code hooks into ~/.claude/ (make cbm-onboard)
     │   ├── cbm-offboard.sh                    # Reverse of cbm-onboard (make cbm-offboard)

--- a/scripts/hatch/hatch_runner_subset_builder.py
+++ b/scripts/hatch/hatch_runner_subset_builder.py
@@ -1,0 +1,168 @@
+"""Custom hatchling builder producing the runner-subset wheel.
+
+Wired from ``pyproject.toml`` under ``[tool.hatch.build.targets.custom]``.
+Invoked with ``hatch build --target custom`` (equivalently
+``uv run hatch build --target custom``); the result is a wheel named
+``tolokaforge_runner_subset-<version>-py3-none-any.whl`` under ``dist/``.
+
+The set of Python files the subset ships is enumerated in
+``tolokaforge/core/_runner_subset.py`` and consumed by the ``only-include``
+/ ``exclude`` lists in ``[tool.hatch.build.targets.custom]``. The
+canonical test ``tests/canonical/test_runner_subset_partition.py`` fails
+CI if pyproject and the enumeration module ever disagree.
+
+Every override in this module exists so the subset wheel:
+
+- is named ``tolokaforge-runner-subset`` (not ``tolokaforge``) — pip's
+  install metadata inside the runner Docker image makes clear which
+  build variant is installed;
+- declares only the dependencies the runner runtime graph needs — the
+  base wheel's ``[project].dependencies`` reachable from the subset, plus
+  the base wheel's ``[project.optional-dependencies].runner`` group
+  (which the runner image used to install behind
+  ``pip install tolokaforge[runner]``);
+- carries no console-script or entry-point tables — those routes
+  (``Orchestrator``, backend factories, trial-grader factories) point at
+  modules the subset does not include, so exposing them here would
+  create dangling references. The base wheel keeps them intact.
+
+The subset wheel is a Docker-only build artifact. It is not — and
+per ``docs/adr/0025-runner-wheel-split.md`` never will be — published to
+PyPI. The published surface remains one ``tolokaforge`` wheel.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from hatchling.builders.wheel import WheelBuilder
+
+if TYPE_CHECKING:
+    from hatchling.builders.wheel import RecordFile, WheelArchive
+
+
+# Distribution name for the subset wheel. Import paths inside
+# ``site-packages/`` are unchanged (``tolokaforge.runner``,
+# ``tolokaforge.core.models``, ...); only the pip-level distribution
+# identifier differs.
+SUBSET_DISTRIBUTION_NAME = "tolokaforge-runner-subset"
+
+
+# Runtime dependencies the runner container needs.
+#
+# Union of:
+#   - the base wheel's ``[project.dependencies]`` — every entry the runner
+#     subset's import graph reaches at runtime;
+#   - the base wheel's ``[project.optional-dependencies].runner`` — the
+#     domain-tool runtime deps (fastapi/uvicorn/sqlalchemy/asyncpg/...)
+#     the runner image previously pulled via ``tolokaforge[runner]``.
+#
+# ``docker`` and ``testcontainers`` are intentionally omitted: they are
+# reached only from orchestrator-side runtime backends
+# (``per_trial_runtime``, ``shared_stack_runtime``, ``docker_adapter``)
+# which live in the base wheel and are not shipped inside the subset.
+SUBSET_DEPENDENCIES: tuple[str, ...] = (
+    # Reachable from the runner subset (subset of ``[project.dependencies]``).
+    "litellm>=1.83.14,!=1.92.0,<2.0.0",
+    "pydantic>=2.0.0",
+    "pydantic[email]>=2.0.0",
+    "jsonschema>=4.20.0",
+    "pyyaml>=6.0.1",
+    "python-dotenv>=1.0.0",
+    "click>=8.1.0,<8.2",
+    "jsonpath-ng>=1.6.0",
+    "httpx>=0.25.0",
+    "tenacity>=8.2.0",
+    "jinja2>=3.1.0",
+    "loguru>=0.7.0",
+    "docstring_parser>=0.16",
+    "deepdiff>=6.0.0",
+    "toml>=0.10.0",
+    "addict>=2.4.0",
+    "starlette>=0.52.1",
+    "typesense>=2.0.0",
+    "structlog>=24.0.0",
+    "grpcio>=1.60.0",
+    "grpcio-health-checking>=1.60.0",
+    "mcp>=0.1.0",
+    # Domain-tool runtime deps (formerly ``[project.optional-dependencies].runner``).
+    "asyncpg>=0.29.0",
+    "psycopg2-binary>=2.9.0",
+    "alembic>=1.13.0",
+    "python-jose>=3.3.0",
+    "fastapi>=0.108.0",
+    "uvicorn>=0.25.0",
+    "sqlalchemy>=2.0.48",
+    "odata-query>=0.10.0",
+)
+
+
+class RunnerSubsetBuilder(WheelBuilder):
+    """WheelBuilder subclass producing the runner-subset Docker-only wheel."""
+
+    PLUGIN_NAME = "custom"
+
+    @property
+    def project_id(self) -> str:
+        return (
+            f"{self.normalize_file_name_component(SUBSET_DISTRIBUTION_NAME)}"
+            f"-{self.metadata.version}"
+        )
+
+    @property
+    def artifact_project_id(self) -> str:
+        return self.project_id
+
+    def construct_entry_points_file(self) -> str:  # type: ignore[override]
+        return ""
+
+    def write_project_metadata(
+        self,
+        archive: WheelArchive,
+        records: RecordFile,
+        extra_dependencies: Sequence[str] = (),
+    ) -> None:
+        record = archive.write_metadata(
+            "METADATA", self._construct_subset_metadata_file(extra_dependencies)
+        )
+        records.write(record)
+
+    def _construct_subset_metadata_file(self, extra_dependencies: Sequence[str]) -> str:
+        core: Any = self.metadata.core
+        parts: list[str] = ["Metadata-Version: 2.3"]
+        parts.append(f"Name: {SUBSET_DISTRIBUTION_NAME}")
+        parts.append(f"Version: {self.metadata.version}")
+        base_summary = core.description or ""
+        parts.append(
+            "Summary: Tolokaforge runner-subset wheel — Docker-only build "
+            "artifact, not published to PyPI"
+            + (f" (base project summary: {base_summary})" if base_summary else "")
+        )
+        if core.urls:
+            for label, url in core.urls.items():
+                parts.append(f"Project-URL: {label}, {url}")
+        if core.requires_python:
+            parts.append(f"Requires-Python: {core.requires_python}")
+        if core.license_expression:
+            parts.append(f"License: {core.license_expression}")
+        elif core.license:
+            for i, license_line in enumerate(core.license.splitlines()):
+                prefix = "License: " if i == 0 else "         "
+                parts.append(f"{prefix}{license_line}")
+        for dep in SUBSET_DEPENDENCIES:
+            parts.append(f"Requires-Dist: {dep}")
+        for dep in extra_dependencies:
+            parts.append(f"Requires-Dist: {dep}")
+        return "\n".join(parts) + "\n"
+
+
+def get_builder() -> type[RunnerSubsetBuilder]:
+    """Plugin-loader entry point.
+
+    ``hatchling.plugin.utils.load_plugin_from_script`` finds every
+    ``BuilderInterface`` subclass in this file — including ``WheelBuilder``
+    itself, which is imported for subclassing. Returning
+    ``RunnerSubsetBuilder`` explicitly disambiguates the selection.
+    """
+    return RunnerSubsetBuilder

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -287,3 +287,67 @@ def test_declared_excluded_files_exist() -> None:
     ), "RUNNER_SUBSET_EXCLUDED_FILES names paths that no longer exist:\n" + "\n".join(
         f"  - {m}" for m in missing
     )
+
+
+def _load_pyproject_custom_target() -> dict[str, list[str]]:
+    """Read ``[tool.hatch.build.targets.custom]`` from ``pyproject.toml``.
+
+    Uses ``tomllib`` on 3.11+, ``tomli`` on 3.10 (already a transitive dev
+    dependency)."""
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # Python 3.10 branch
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+        data = tomllib.load(f)
+    return data["tool"]["hatch"]["build"]["targets"]["custom"]
+
+
+def test_pyproject_custom_target_mirrors_runner_subset_module() -> None:
+    """The ``only-include`` / ``exclude`` lists under
+    ``[tool.hatch.build.targets.custom]`` must mirror the three tuples in
+    :mod:`tolokaforge.core._runner_subset` exactly. The subset build's
+    package graph is derived from those tuples; drift between the two would
+    silently ship a wheel whose contents no longer match the audited
+    partition."""
+    custom = _load_pyproject_custom_target()
+
+    expected_only_include = {*RUNNER_SUBSET_PACKAGES, *RUNNER_SUBSET_LOOSE_FILES}
+    actual_only_include = set(custom.get("only-include", []))
+    only_missing = sorted(expected_only_include - actual_only_include)
+    only_extra = sorted(actual_only_include - expected_only_include)
+    assert (
+        not only_missing and not only_extra
+    ), "pyproject `[tool.hatch.build.targets.custom].only-include` drifted " "from RUNNER_SUBSET_PACKAGES ∪ RUNNER_SUBSET_LOOSE_FILES:\n" + "".join(
+        f"  - missing in pyproject: {m}\n" for m in only_missing
+    ) + "".join(
+        f"  - extra in pyproject:   {e}\n" for e in only_extra
+    )
+
+    expected_exclude = set(RUNNER_SUBSET_EXCLUDED_FILES)
+    actual_exclude = set(custom.get("exclude", []))
+    exclude_missing = sorted(expected_exclude - actual_exclude)
+    exclude_extra = sorted(actual_exclude - expected_exclude)
+    assert (
+        not exclude_missing and not exclude_extra
+    ), "pyproject `[tool.hatch.build.targets.custom].exclude` drifted from " "RUNNER_SUBSET_EXCLUDED_FILES:\n" + "".join(
+        f"  - missing in pyproject: {m}\n" for m in exclude_missing
+    ) + "".join(
+        f"  - extra in pyproject:   {e}\n" for e in exclude_extra
+    )
+
+
+def test_pyproject_custom_target_points_at_builder_script() -> None:
+    """The custom build target must reference the runner-subset builder
+    script; that file is what teaches hatchling to rename the distribution,
+    swap the dependency list, and strip entry points for the subset wheel."""
+    custom = _load_pyproject_custom_target()
+    script_rel = custom.get("path")
+    assert script_rel == "scripts/hatch/hatch_runner_subset_builder.py", (
+        "[tool.hatch.build.targets.custom].path must point at "
+        "scripts/hatch/hatch_runner_subset_builder.py; got: " + repr(script_rel)
+    )
+    assert (
+        REPO_ROOT / script_rel
+    ).is_file(), f"custom builder script does not exist on disk: {script_rel}"

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -23,10 +23,15 @@ are named whole with the orchestrator-only files listed in
 whole-package entry (the mixed root of ``core/`` and the top-level
 ``tolokaforge/__init__.py``) are named in :data:`RUNNER_SUBSET_LOOSE_FILES`.
 
-The follow-up ticket that adds the hatch build target consumes these tuples
-verbatim; the canonical test :mod:`tests.canonical.test_runner_subset_partition`
-locks them against the actual runtime closure and rejects drift in either
-direction.
+The runner-subset hatch build target consumes these tuples verbatim: the
+``only-include`` / ``exclude`` lists under ``[tool.hatch.build.targets.custom]``
+in ``pyproject.toml`` mirror them, and the custom builder script at
+``scripts/hatch/hatch_runner_subset_builder.py`` produces the
+``tolokaforge_runner_subset-<version>-py3-none-any.whl`` artifact from that
+enumeration. The canonical test
+:mod:`tests.canonical.test_runner_subset_partition` locks the enumeration
+against the actual runtime closure — and against the pyproject mirror — and
+rejects drift in either direction.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Adds a second hatch build target — `[tool.hatch.build.targets.custom]` in `pyproject.toml` — that produces `dist/tolokaforge_runner_subset-<version>-py3-none-any.whl`, a slimmed variant of the base wheel containing only the Python files the runner container's runtime graph reaches.
- The subset wheel is a Docker-only build artifact — never published to PyPI. The published surface remains one `tolokaforge` wheel; base-wheel PyPI-facing metadata is unchanged.
- Custom builder at `scripts/hatch/hatch_runner_subset_builder.py` renames the distribution to `tolokaforge-runner-subset`, replaces the base wheel's dependency list with the runner-runtime deps, and strips console-script / entry-point tables.
- Closes #821.

## Design choices

**Target name — `custom`.** Hatchling's built-in `wheel` target only supports one config block; `custom` is the built-in extension point for a wheel variant produced by a user-supplied builder script. The CLI invocation is `hatch build --target custom` — documented in `docs/RUNNER.md`. Renaming to `runner-subset` would require registering a full plugin package (extra dev overhead) rather than a repo-local script.

**Distribution name — `tolokaforge-runner-subset`.** Distinct from `tolokaforge` so `pip show` and `pip list` inside the runner image make clear which build variant is installed. Import paths inside `site-packages/` are unchanged (`tolokaforge.runner`, `tolokaforge.core.models`, ...) — only the pip-level distribution identifier differs. Filename becomes `tolokaforge_runner_subset-<version>-py3-none-any.whl`, distinct from the base wheel's `tolokaforge-<version>-py3-none-any.whl`.

**Dependency declaration.** The subset's `Requires-Dist` list is the union of the base wheel's `[project.dependencies]` reachable from the subset's import graph plus the base wheel's `[project.optional-dependencies].runner` group. `docker` and `testcontainers` are intentionally omitted — they are reached only from orchestrator-side runtime backends (`per_trial_runtime`, `shared_stack_runtime`, `docker_adapter`) which live in the base wheel and are not shipped inside the subset.

**Drift-lock — explicit duplication + a canonical test.** The `only-include` / `exclude` lists in `[tool.hatch.build.targets.custom]` mirror the three tuples in `tolokaforge/core/_runner_subset.py` verbatim. A new canonical test (`test_pyproject_custom_target_mirrors_runner_subset_module`) parses `pyproject.toml` and fails CI if the two ever disagree. This trades a tiny duplication for the ability to read the subset partition directly out of TOML without executing Python at build-configuration time.

**Location — `scripts/hatch/`.** AGENTS.md forbids scripts at the repo root; `scripts/build/` conflicts with the `build/` gitignore pattern. `scripts/hatch/` is the descriptive resting place for hatchling-specific build helpers, listed in `scripts/README.md`.

## Concepts introduced

- **The runner-subset wheel as a second, Docker-only build artifact.** Same source tree, same commit, same version string; different file selection, different dependency list, different distribution name. Reversible by removing `[tool.hatch.build.targets.custom]` and the builder script.
- **Custom hatchling builder script as a `[tool.hatch.build.targets.custom].path` reference.** Overrides `WheelBuilder` methods to swap distribution name, METADATA content, and entry-point emission — without mutating shared `ProjectMetadata` state (so building both wheels in the same `hatch build --target wheel --target custom` invocation is safe).

## Plan

1. Author `scripts/hatch/hatch_runner_subset_builder.py` — `RunnerSubsetBuilder(WheelBuilder)` with `project_id` / `artifact_project_id` overrides, `construct_entry_points_file() -> ""`, and a hand-constructed METADATA that drops optional-dependencies and entry points.
2. Add `[tool.hatch.build.targets.custom]` to `pyproject.toml` — `path` at the builder script, `only-include` = `RUNNER_SUBSET_PACKAGES` ∪ `RUNNER_SUBSET_LOOSE_FILES`, `exclude` = `RUNNER_SUBSET_EXCLUDED_FILES`.
3. Bidirectional cross-reference in `tolokaforge/core/_runner_subset.py`'s docstring and the "Runner subset" section of `docs/RUNNER.md`.
4. Two new canonical tests in `tests/canonical/test_runner_subset_partition.py` — drift-lock (pyproject ↔ enumeration module) and builder-script-path lock.
5. Validate with an actual build + install + import cycle in a clean venv.

## Discovered issues

**Pre-existing protobuf drift (out of scope for this ticket).** A fresh `pip install` from PyPI resolves `protobuf==6.33.6` even though `tolokaforge/runner/runner_pb2.py` was generated by protoc 7.35.1 and requires runtime `>=7.35.1`. Reproduces on both the base wheel and the subset wheel — the base wheel install worked in this validation because `protobuf>=7.35.1` was pinned manually. `grpcio`'s dep spec does not carry a floor tight enough to prevent this. Not introduced by #821; belongs to a separate ticket in the runner-runtime family (likely follow-up after #822).

## Test plan

- [x] `uv run ruff check tolokaforge tests scripts` — clean.
- [x] `uv run ruff format --check` — subset touch files clean (60 pre-existing drift files unrelated to this branch, per AGENTS.md gotcha #3).
- [x] `uv run pytest -m unit tests/` — 4359 passed, 2430 deselected.
- [x] `uv run pytest -m canonical tests/` — 821 passed, 5968 deselected. The two new drift-lock tests + the five existing partition tests all green.

**Real-scenario validation** (executed in this branch's terminal):

- [x] `hatch build --target custom` → `dist/tolokaforge_runner_subset-0.13.1-py3-none-any.whl` (423 KB, 87 files vs. base wheel's 894 KB / 205 files — ~47%).
- [x] `uv build --wheel` → `dist/tolokaforge-0.13.1-py3-none-any.whl` (894 KB, 205 files). METADATA `Name: tolokaforge`, all classifiers / deps / extras / entry-points intact — base wheel unchanged.
- [x] `python -m venv /tmp/scratch_venv && /tmp/scratch_venv/bin/pip install dist/tolokaforge_runner_subset-0.13.1-py3-none-any.whl 'protobuf>=7.35.1'` succeeds. `pip show tolokaforge-runner-subset` reports the runner-runtime deps as `Requires:` — `addict, alembic, asyncpg, click, deepdiff, docstring_parser, fastapi, grpcio, grpcio-health-checking, httpx, jinja2, jsonpath-ng, jsonschema, litellm, loguru, mcp, odata-query, psycopg2-binary, pydantic, python-dotenv, python-jose, pyyaml, sqlalchemy, starlette, structlog, tenacity, toml, typesense, uvicorn`.
- [x] Positive imports in the scratch venv: `tolokaforge.runner`, `tolokaforge.secrets`, `tolokaforge.tools`, `tolokaforge.core.models`, `tolokaforge.core.llm`, `tolokaforge.core.grading` — all succeed.
- [x] Negative imports in the scratch venv: `tolokaforge.core.orchestrator`, `tolokaforge.adapters`, `tolokaforge.dx`, `tolokaforge.docker`, `tolokaforge.env` — all raise `ModuleNotFoundError` as expected.
- [x] Base wheel install still works: fresh venv install of `dist/tolokaforge-0.13.1-py3-none-any.whl` succeeds; `from tolokaforge._entry import main` loads.

Closes #821.