### PR TITLE
chore(adr): renumber service-readiness ADR 0025 → 0026

### DIFF
--- a/docs/adr/0026-service-readiness-contract.md
+++ b/docs/adr/0026-service-readiness-contract.md
@@ -1,4 +1,4 @@
-# 0025. Service-readiness contract as a fourth entry-point-registry seam
+# 0026. Service-readiness contract as a fourth entry-point-registry seam
 
 - **Status:** Accepted
 - **Date:** 2026-08-03


### PR DESCRIPTION
## Summary

Two ADRs shipped with number 0025 in quick succession — #813's `0025-runner-wheel-split.md` merged first, then #817 added `0025-service-readiness-contract.md`. This PR renames the service-readiness ADR to `0026` so numbers are unique. The runner-wheel-split ADR keeps 0025 (landed first).

The number-contention was flagged as a known risk in #803's plan; the resolution is a scoped rename rather than mutating history.

## Design choices

- **Rename, not renumber-other-ADR**: the runner-wheel-split ADR (0025) landed first, so it retains its number. The service-readiness ADR moves.
- **Title line updated to match filename**: `# 0025. …` → `# 0026. …`. No other content change.
- **No cross-references to update**: `grep` for `0025-service-readiness` and `ADR-0025` across `*.md` + `*.py` returned zero hits outside the file itself.

## Concepts introduced

None — mechanical rename.

## Test plan

- N/A (docs-only, no code paths touched).

Closes nothing (housekeeping follow-up to #817).