### PR TITLE
feat(docker): multi-stage runner.Dockerfile builds and installs the runner-subset wheel

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -155,8 +155,13 @@ section of [`pyproject.toml`](../pyproject.toml) declares the subset build
 target; the custom builder at
 [`scripts/hatch/hatch_runner_subset_builder.py`](../scripts/hatch/hatch_runner_subset_builder.py)
 renames the distribution to `tolokaforge-runner-subset`, replaces the base
-wheel's dependency list with the runner-runtime deps, and strips console-script
-/ entry-point tables.
+wheel's dependency list with the runner-runtime deps, and binds the
+subset-native CLI shim
+([ADR-0026](adr/0026-subset-native-cli-shim.md)) — `tolokaforge =
+tolokaforge.runner._cli:main` — as the subset wheel's sole `[console_scripts]`
+entry. The base wheel's other entry-point tables (runtime backends,
+trial-grader factories, conductors) still point at orchestrator-only modules
+and are deliberately stripped from the subset.
 
 ```bash
 uv run hatch build --target custom
@@ -191,6 +196,31 @@ wheel is a Docker-only artifact and is never uploaded to PyPI.
   `netpolicy_constants.py`, `pricing.py`, `run_display_events.py`, `trial.py`
   — the shared-spine files at the root of `core/` the runner closure reaches
   directly.
+
+**Data files in the subset:**
+
+- `tolokaforge/core/data/pricing.json`, `tolokaforge/core/data/model_presets.yaml`
+  — non-Python payloads `tolokaforge.core.pricing` and
+  `tolokaforge.core.llm.presets` read at import time via
+  `importlib.resources`. Shipped as `RUNNER_SUBSET_DATA_FILES` inside
+  `_runner_subset.py`; without them the runner image would boot with an
+  empty pricing table (cost telemetry silently zero) and the preset
+  registry would raise on first grading-model resolution.
+- `tolokaforge/_python_version.txt` — the pinned Python minor version;
+  landed via a `force-include` remap of the repo-root `.python-version`
+  dotfile, mirroring the base wheel's identical remap.
+
+**Subset-native CLI shim ([ADR-0026](adr/0026-subset-native-cli-shim.md)):**
+
+- `tolokaforge/runner/_cli.py` — the module bound as the subset wheel's
+  `tolokaforge` console script. Preserves the ADR-0024 committed exec
+  surface (`tolokaforge --version` / `tolokaforge run-trial`) inside the
+  slim image without dragging `tolokaforge/_entry.py` or `dx/cli/*`
+  (base-wheel only) into the subset. The shim's `run-trial` orchestrates
+  in-process against the local runner gRPC service and cannot exercise
+  adapter-specific setup — see
+  [STANDALONE_RUNNER.md § Command surface of the published runner image](STANDALONE_RUNNER.md#command-surface-of-the-published-runner-image)
+  for the narrower semantics.
 
 **Excluded — orchestrator-only files under a subpackage otherwise in the subset:**
 

--- a/docs/STANDALONE_RUNNER.md
+++ b/docs/STANDALONE_RUNNER.md
@@ -155,12 +155,40 @@ programmatic `docker exec` against a running container:
   on stdout. It is hidden from interactive `tolokaforge --help` **by design** —
   a machine-facing wire protocol, documented here for programmatic use, not
   surfaced in the human command list.
-- `tolokaforge --version` — prints the installed `tolokaforge` package version;
+- `tolokaforge --version` — prints the installed subset wheel's version;
   a stable version probe for a running container.
 
 A `tolokaforge config-dump` command does **not** exist and is not part of the
 committed surface; it is reserved and tracked as
 [#626](https://github.com/Toloka/tolokaforge/issues/626).
+
+**Subset-native CLI shim ([ADR-0026](adr/0026-subset-native-cli-shim.md)).**
+Inside the published runner image, `tolokaforge` binds to a subset-native shim
+(`tolokaforge.runner._cli:main`), *not* the base wheel's
+`tolokaforge._entry:main`. The two ADR-0024 subcommands above are preserved
+verbatim; other operator ergonomics differ from a base-wheel install:
+
+- **`tolokaforge --version`** reports the subset wheel's version. In a
+  release build the subset wheel and the base wheel are cut from the same
+  commit and carry the same version literal, so external consumers see no
+  drift; the substring the rc-smoke gate asserts against (the tagged base
+  version) matches.
+- **`tolokaforge run-trial`** is *narrower* than the base wheel's
+  `run-trial`. The subset-native driver orchestrates in-process against the
+  local runner gRPC service on `localhost:50051`; it **cannot** spin up
+  compose stacks, switch backends, or exercise adapter-specific setup —
+  the adapter machinery (`tolokaforge.adapters.*`, `tolokaforge.core.run_trial`,
+  runtime-backend factories) is base-wheel-only per [ADR-0025](adr/0025-runner-wheel-split.md).
+  A `start` envelope whose task shape needs adapter processing surfaces as
+  a well-formed `{"v":1,"type":"error","error_type":"ProvisionError",…}`
+  wire response, naming the base wheel's
+  `tolokaforge.core.run_trial.run_trial(…)` or the runner service's raw
+  `RegisterTrial` gRPC as the right entry.
+- **No other CLI subcommands** are available inside the image. Commands
+  that live under the base wheel's `tolokaforge/dx/cli/*` — `tolokaforge run`,
+  `tolokaforge adapter`, `tolokaforge docker …` — are not part of the
+  runner image and produce a click "No such command" error. Drive those
+  from a host-side base-wheel install.
 
 ## Quickstart
 

--- a/docs/adr/0026-subset-native-cli-shim.md
+++ b/docs/adr/0026-subset-native-cli-shim.md
@@ -1,0 +1,125 @@
+# 0026. Subset-native CLI shim — bridging the ADR-0024 exec surface and the ADR-0025 partition
+
+- **Status:** Proposed
+- **Date:** 2026-08-04
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+M15 execution surfaced a contradiction between two Accepted ADRs. [ADR-0024 § "Documented docker exec subcommands"](0024-container-command-surface.md#documented-docker-exec-subcommands) commits **`tolokaforge --version`** and **`tolokaforge run-trial`** as `docker exec` entry points on the published runner image; the keyless rc-smoke test suite gates promotion on both. [ADR-0025 § "The module partition"](0025-runner-wheel-split.md#the-module-partition) places `tolokaforge/_entry.py` (the console-script shim) and all of `tolokaforge/dx/` (the Click command tree) in "Not in the runner subset (base wheel only)". The runner-subset build target added in [PR #828](https://github.com/Toloka/tolokaforge/pull/828) further omits `[project.scripts]` from the subset wheel entirely, because there is no CLI entrypoint code in the subset to bind them to.
+
+Result: the runner image built from the subset wheel installs cleanly but `docker exec tolokaforge-runner tolokaforge --version` fails with `executable file not found in $PATH`. The gRPC contract on `:50051` and the healthcheck are preserved, but the two committed exec subcommands from ADR-0024 vanish.
+
+The static AST closure from `_entry.py` + `dx/cli/main.py` + `dx/cli/run_trial_command.py` reaches 77 additional first-party files (all of `adapters/`, all of `dx/`, `core/orchestrator.py`, `core/run_trial.py`, `core/plugin_registry.py`, `core/output/`, `core/compose_materialisation.py`, `core/shared_stack_runtime.py`, `core/per_trial_runtime.py`, `docker/`, `core/evaluators/`). Extending the subset to swallow that closure would erase the point of the subset.
+
+## Decision Drivers
+
+- **Preserve the ADR-0024 committed contract without gutting the ADR-0025 partition.** Both ADRs remain valid as-written; this ADR adds the bridging surface between them.
+- **The gRPC contract on `:50051` is the runner container's primary operator surface** ([ADR-0022 § Surface 1](0022-runtime-independence.md#surface-1--entry-point-protocol-registries-536) and the runner's proto). The exec subcommands are a **secondary** surface — a convenience for external harnesses that prefer stdin/stdout wire-driven trials to a raw gRPC client. Preserving both surfaces in the subset means providing a subset-native CLI that talks to the local gRPC service, not shipping the orchestrator's in-process trial runner.
+- **`--version` is a light diagnostic**; `run-trial` is a wire-protocol subprocess (ADR-0022 § Surface 3). Both can be satisfied by a small subset-native module without touching the orchestrator or the adapters.
+- **Reversibility.** If the subset CLI shim turns out to be more maintenance than it's worth, ADR-0025's partition can be broadened later, or ADR-0024's exec surface narrowed. Neither is easier if we don't first ship the honest fix now.
+
+## Considered Options
+
+1. **Subset-native CLI shim (this ADR).** Add `tolokaforge/runner/_cli.py` inside the runner subset. `--version` reads the subset wheel's own installed version via `importlib.metadata`. `run-trial` reads the [ADR-0022 § Surface 3](0022-runtime-independence.md#surface-3--tolokaforge-run-trial-subprocess-wire-format-538) JSON-Lines `start` envelope on stdin and drives a single trial by orchestrating in-process against the **local runner service on `localhost:50051`** — using components already in the runner subset (`core.llm.client`, `core.loop.ToolCallingLoop`, `runner_pb2_grpc`) rather than the orchestrator's task-driven-backend-selection machinery. The subset builder emits `[project.scripts]` `tolokaforge = tolokaforge.runner._cli:main`.
+2. **Amend ADR-0024** to narrow the runner image's committed exec surface to remove `tolokaforge --version` and `tolokaforge run-trial`. Retire the corresponding rc-smoke tests. Cheapest, but breaks the operator contract for anyone driving trials via `docker exec run-trial`.
+3. **Extend ADR-0025's partition to swallow the CLI closure.** Bring `_entry.py` + adapters + dx + orchestrator + run_trial + friends into the subset. Roughly restores the base wheel; erases the milestone's slim-image goal.
+4. **Shim-as-stub.** Add a subset-native `_cli.py` where `--version` works but `run-trial` only emits a well-formed `error` envelope on any input. Preserves the rc-smoke's error-path assertion but breaks the operator use case genuinely — a hollow contract preservation.
+
+## Decision
+
+We adopt **Option 1** — the subset-native CLI shim that actually drives trials against the local runner service.
+
+### The shim
+
+A new module **`tolokaforge/runner/_cli.py`** lands in the runner subset. It exposes a `main()` function bound to the subset wheel's `[project.scripts]` entry `tolokaforge = tolokaforge.runner._cli:main`. Two subcommands, matching the ADR-0024 committed surface verbatim:
+
+- **`tolokaforge --version`.** Prints the installed subset-wheel version resolved via `importlib.metadata.version("tolokaforge-runner-subset")`. When invoked inside the runner image, the reported version identifies the subset build; when invoked (hypothetically) outside the image where the subset wheel is not installed, the metadata lookup fails loudly — no silent misreport.
+- **`tolokaforge run-trial`.** Implements ADR-0022 § Surface 3 verbatim: JSON-Lines on stdin/stdout, `"v":1`, one `start` message then EOF, one `result` or `error` envelope out, standard exit codes and SIGTERM handling. Internally it:
+  1. Parses the `start` envelope into `TaskConfig` + `models` (post-#818 shared spine).
+  2. Constructs an LLM client via `core.llm.client` (in the subset).
+  3. Constructs a `ToolCallingLoop` from `core.loop` (in the subset).
+  4. Instantiates a gRPC client against `localhost:50051` (the local runner service — `runner_pb2_grpc` in the subset) and wires it as the loop's tool executor and grader.
+  5. Drives the loop through the trial, calls `GradeTrial`, assembles a `TrialResult`.
+  6. Writes the JSON-Lines `result` envelope on stdout, exits 0.
+
+The shim is **thin by design.** It reuses the runner subset's existing gRPC client machinery, `ToolCallingLoop`, and LLM abstractions. It does **not** import from `tolokaforge/_entry.py`, `dx/cli/*`, `adapters/*`, or `core/orchestrator.py`. The subset partition (`RUNNER_SUBSET_PACKAGES` + `LOOSE_FILES` + `EXCLUDED_FILES`) grows by exactly one file: the shim itself.
+
+### What ADR-0024 keeps promising
+
+Every element of [ADR-0024 § "Documented docker exec subcommands"](0024-container-command-surface.md#documented-docker-exec-subcommands) is preserved by the shim:
+
+- `tolokaforge --version` returns a version string (now the subset wheel's version, which tracks the base wheel's version in locked-step within a release — no consumer-visible drift).
+- `tolokaforge run-trial` accepts a JSON-Lines `start` envelope on stdin, emits `result` or `error` on stdout, honours SIGTERM, exits with documented codes. The **wire format is bit-for-bit ADR-0022 § Surface 3.**
+- `tolokaforge run-trial` remains `hidden=True` in interactive `--help` (a machine protocol, deliberately). The shim's Click / argparse tree honours the hidden convention.
+
+### What ADR-0025 keeps promising
+
+The partition remains as ADR-0025 § "The module partition" wrote it:
+
+- `tolokaforge/_entry.py` and `tolokaforge/dx/*` stay **base-wheel only**. Not in the subset.
+- The subset's runtime graph still passes the negative import-boundary invariant test.
+- The `RUNNER_SUBSET_PACKAGES` deliverable from [#820](https://github.com/Toloka/tolokaforge/issues/820) gains one file (`tolokaforge/runner/_cli.py`) via `RUNNER_SUBSET_LOOSE_FILES`; the packages list is otherwise unchanged.
+
+Options 2, 3, and 4 are rejected:
+
+- **Option 2** breaks the operator contract for real users of `docker exec run-trial`. That surface exists precisely because JSON-Lines is easier than protobuf-aware gRPC for language-agnostic and shell-driven harnesses; amending it away costs those users a real capability.
+- **Option 3** brings the CLI closure's 77 files into the subset. The subset would be within ~10% of the base wheel by file count; the M15 slim-image goal evaporates.
+- **Option 4** satisfies the letter of the rc-smoke by making `run-trial` always error. It preserves nothing an operator actually needs. Do not ship a contract we've already hollowed out.
+
+## Consequences
+
+### Positive
+
+- ADR-0024's committed exec surface is preserved on the subset image with no observable change to operators or the rc-smoke.
+- ADR-0025's partition stands as written; the "slim runner image" goal is preserved (the subset gains one file, not 77).
+- The runner-image consumer gets a **more honest** CLI: `run-trial` inside the subset now clearly routes through the *local* runner service via gRPC, rather than reconstructing an orchestrator in-container. That matches what the runner image actually IS.
+- Third-party harnesses driving trials via `docker exec tolokaforge-runner tolokaforge run-trial` continue to work.
+
+### Negative / Trade-offs
+
+- **A small chunk of new code lands in the runner subset.** `_cli.py` will grow to include ADR-0022 § Surface 3 wire framing, an LLM-loop driver, and gRPC client wiring. Bounded (single file, no new dependencies) but non-trivial.
+- **Trial-execution semantics inside `docker exec run-trial` are *narrower* than the base wheel's `tolokaforge run-trial`.** The subset shim orchestrates in-process against the local gRPC runner; it cannot spin up compose stacks, cannot switch backends, cannot exercise adapter-specific setup. Documented in `docs/STANDALONE_RUNNER.md`. For any operator today driving a trial that touches those surfaces via `docker exec run-trial`, this is a regression — but the runner container never had the machinery for those things anyway, so any pre-M15 `docker exec run-trial` invocation that "worked" was accidentally using in-container orchestrator scaffolding that was neither documented nor guaranteed.
+- **The subset wheel now declares a `[project.scripts]` entry.** The base wheel already has `tolokaforge = tolokaforge._entry:main`; the subset wheel declares `tolokaforge = tolokaforge.runner._cli:main`. Installing both wheels in one Python environment would collide on the console script — but M15's whole point is that they never install in the same environment (the subset is Docker-only; the base wheel is PyPI-only for users).
+
+### Follow-ups
+
+**Code changes required (all in one PR, `feat/822-dockerfile-subset-v2`):**
+
+- Add `tolokaforge/runner/_cli.py` per the § Decision above.
+- Update `scripts/hatch/hatch_runner_subset_builder.py` to emit `[project.scripts]` `tolokaforge = tolokaforge.runner._cli:main` in the subset wheel's metadata.
+- Update `tolokaforge/core/_runner_subset.py` to include `tolokaforge/runner/_cli.py` in `RUNNER_SUBSET_LOOSE_FILES` (or `PACKAGES` if `_cli.py` grows into a small subpackage — implementer's judgment).
+- Multi-stage `tolokaforge/docker/dockerfiles/runner.Dockerfile` per the original #822 scope, installing the subset wheel from the builder stage.
+- Extend `tests/canonical/test_runner_subset_partition.py` with subset-CLI structural assertions (the shim exists; `[project.scripts]` binds it; the shim does NOT import from `dx/`, `adapters/`, or `core.orchestrator`).
+- Fold in [#830](https://github.com/Toloka/tolokaforge/issues/830)'s data-files omission (`pricing.json`, `model_presets.yaml`) since the subset builder is being rebuilt.
+
+**Documentation to update:**
+
+- `docs/STANDALONE_RUNNER.md` — document the subset-native CLI shim's `run-trial` semantics (routes to local gRPC; not equivalent to base-wheel `tolokaforge run-trial`).
+- `docs/RUNNER.md` — cross-reference this ADR from the "Runner subset" section.
+- `docs/ROADMAP.md` — no change until release event.
+
+**Tests to add:**
+
+- Structural canonical tests as listed above.
+- Integration test: `docker exec tolokaforge-runner tolokaforge --version` returns the subset wheel's version.
+- Integration test: `docker exec tolokaforge-runner tolokaforge run-trial < a-real-start-envelope.jsonl` returns a well-formed `result` envelope for a bundled mock-graded example.
+- Existing rc-smoke tests (`test_runner_version_matches_tag`, `test_runner_run_trial_speaks_wire`) must continue to pass unchanged.
+
+## Links
+
+- Related ADRs:
+  - [ADR-0022 § Surface 3](0022-runtime-independence.md#surface-3--tolokaforge-run-trial-subprocess-wire-format-538) — the wire the subset shim honours.
+  - [ADR-0023](0023-runner-image-internals.md) — image internals uncommitted; the subset shim IS the kind of internal change this ADR reserved room for.
+  - [ADR-0024 § "Documented docker exec subcommands"](0024-container-command-surface.md#documented-docker-exec-subcommands) — the committed surface the shim preserves.
+  - [ADR-0025 § "The module partition"](0025-runner-wheel-split.md#the-module-partition) — the partition the shim respects; the shim adds one file to the subset via `RUNNER_SUBSET_LOOSE_FILES`.
+- Related code:
+  - [`tolokaforge/runner/_cli.py`](../../tolokaforge/runner/_cli.py) — new file, lands with the implementation PR.
+  - [`scripts/hatch/hatch_runner_subset_builder.py`](../../scripts/hatch/hatch_runner_subset_builder.py) — updated to emit `[project.scripts]` in the subset.
+  - [`tolokaforge/docker/dockerfiles/runner.Dockerfile`](../../tolokaforge/docker/dockerfiles/runner.Dockerfile) — multi-stage subset install.
+- Related issues:
+  - [GH #822](https://github.com/Toloka/tolokaforge/issues/822) — the Dockerfile rewire ticket this ADR unblocks.
+  - [GH #830](https://github.com/Toloka/tolokaforge/issues/830) — data-files omission, folded into the same PR.
+  - [GH #622](https://github.com/Toloka/tolokaforge/issues/622) — M15 umbrella.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,13 @@ only-include = [
     "tolokaforge/core/pricing.py",
     "tolokaforge/core/run_display_events.py",
     "tolokaforge/core/trial.py",
+    # RUNNER_SUBSET_DATA_FILES — non-Python assets runtime code reads at
+    # import time. Ship them into the subset wheel so the runner image's
+    # pricing / preset tables are non-empty (GitHub #830). The
+    # ``.python-version`` dotfile lands via the ``force-include`` table
+    # below (source path differs from destination path).
+    "tolokaforge/core/data/pricing.json",
+    "tolokaforge/core/data/model_presets.yaml",
 ]
 exclude = [
     # RUNNER_SUBSET_EXCLUDED_FILES — orchestrator-only files inside an
@@ -225,6 +232,14 @@ exclude = [
     "tolokaforge/core/llm/fallback_client.py",
     "tolokaforge/tools/user_tools.py",
 ]
+
+# Force-include the repo-root ``.python-version`` dotfile into the subset
+# wheel as ``tolokaforge/_python_version.txt`` — mirrors the base wheel's
+# ``[tool.hatch.build.targets.wheel.force-include]`` block so the pinned
+# Python version is discoverable via ``importlib.resources`` from either
+# wheel variant.
+[tool.hatch.build.targets.custom.force-include]
+".python-version" = "tolokaforge/_python_version.txt"
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,6 +435,7 @@ dev = [
     "mcp>=0.1.0",
     "build>=1.0.0",
     "commitizen>=4.0.0",
+    "hatch>=1.12.0",
     "psycopg[binary]>=3.2.0",
     "tolokaforge-adapter-terminal-bench",
     "dev-mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,7 +435,12 @@ dev = [
     "mcp>=0.1.0",
     "build>=1.0.0",
     "commitizen>=4.0.0",
-    "hatch>=1.12.0",
+    # ``hatchling`` is our PEP 517 build backend (see ``[build-system].requires``);
+    # the canonical subset-wheel tests drive it directly via
+    # ``python -m hatchling build -t custom`` — pinning it in the dev group keeps
+    # it in the ``uv sync --dev`` closure so those tests do not depend on the
+    # ephemeral build-backend install being present.
+    "hatchling>=1.31.0",
     "psycopg[binary]>=3.2.0",
     "tolokaforge-adapter-terminal-bench",
     "dev-mcp",

--- a/scripts/hatch/hatch_runner_subset_builder.py
+++ b/scripts/hatch/hatch_runner_subset_builder.py
@@ -21,10 +21,15 @@ Every override in this module exists so the subset wheel:
   the base wheel's ``[project.optional-dependencies].runner`` group
   (which the runner image used to install behind
   ``pip install tolokaforge[runner]``);
-- carries no console-script or entry-point tables — those routes
-  (``Orchestrator``, backend factories, trial-grader factories) point at
-  modules the subset does not include, so exposing them here would
-  create dangling references. The base wheel keeps them intact.
+- declares one console-script entry — ``tolokaforge = tolokaforge.runner._cli:main`` —
+  binding the subset-native CLI shim (ADR-0026) that preserves the ADR-0024
+  ``docker exec`` surface (``tolokaforge --version`` / ``tolokaforge run-trial``)
+  inside the slim image. The base wheel's ``tolokaforge = tolokaforge._entry:main``
+  is deliberately not carried through: ``tolokaforge._entry`` / ``dx/cli/*`` are
+  base-wheel only, so a subset wheel that exposed them would create a dangling
+  reference. Other entry-point tables (runtime backends, trial-grader
+  factories, conductors) still point at orchestrator-only modules and stay
+  base-wheel only.
 
 The subset wheel is a Docker-only build artifact. It is not — and
 per ``docs/adr/0025-runner-wheel-split.md`` never will be — published to
@@ -47,6 +52,13 @@ if TYPE_CHECKING:
 # ``tolokaforge.core.models``, ...); only the pip-level distribution
 # identifier differs.
 SUBSET_DISTRIBUTION_NAME = "tolokaforge-runner-subset"
+
+# The subset-native CLI shim's ``[project.scripts]`` binding — literally the
+# entry-point table pip writes into ``site-packages/…-dist-info/entry_points.txt``
+# for the subset wheel. Kept as a module constant so ``pip show``,
+# ``importlib.metadata.entry_points``, and the canonical drift-lock test all
+# read the same string. See ADR-0026 for the shim.
+SUBSET_ENTRY_POINTS: str = "[console_scripts]\ntolokaforge = tolokaforge.runner._cli:main\n"
 
 
 # Runtime dependencies the runner container needs.
@@ -115,7 +127,12 @@ class RunnerSubsetBuilder(WheelBuilder):
         return self.project_id
 
     def construct_entry_points_file(self) -> str:  # type: ignore[override]
-        return ""
+        """Emit the subset wheel's ``entry_points.txt``.
+
+        The single ``[console_scripts]`` entry binds the subset-native CLI
+        shim so pip registers a ``tolokaforge`` console script inside the
+        runner image. See ADR-0026 for the full rationale."""
+        return SUBSET_ENTRY_POINTS
 
     def write_project_metadata(
         self,

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -494,13 +494,20 @@ def _find_subset_wheel() -> Path | None:
 @pytest.fixture(scope="module")
 def subset_wheel_path() -> Path:
     """Path to the subset wheel — build one on demand if the ``dist/`` copy
-    is stale or absent."""
+    is stale or absent.
+
+    Invokes the hatchling PEP 517 build backend directly via
+    ``python -m hatchling build -t custom``. Equivalent to
+    ``hatch build --target custom`` but drives hatchling straight from the
+    active interpreter, so it has no dependency on the ``hatch`` CLI being
+    installed or on hatch's ``default`` environment being resolvable — both
+    of which fail cleanly in a uv-managed venv where only ``hatchling``
+    (the build backend, listed in ``[dependency-groups] dev``) is present."""
     existing = _find_subset_wheel()
     if existing is not None:
         return existing
-    # Build the subset wheel — mirrors ``uv run hatch build --target custom``.
     build_result = subprocess.run(
-        ["uv", "run", "hatch", "build", "--target", "custom"],
+        [sys.executable, "-m", "hatchling", "build", "-t", "custom"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -39,11 +39,13 @@ import ast
 import json
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from tolokaforge.core._runner_subset import (
+    RUNNER_SUBSET_DATA_FILES,
     RUNNER_SUBSET_EXCLUDED_FILES,
     RUNNER_SUBSET_LOOSE_FILES,
     RUNNER_SUBSET_PACKAGES,
@@ -80,6 +82,13 @@ LAZY_LOADABLE_SUBSET_MODULES: frozenset[str] = frozenset(
         # any runtime path. Shipping it inside the subset lets the follow-up
         # build script and image-side introspection consume it verbatim.
         "tolokaforge/core/_runner_subset.py",
+        # Subset-native CLI shim (ADR-0026). Not reached by the runner boot
+        # closure — the shim is invoked via ``docker exec tolokaforge …`` on
+        # a running container after boot, so its imports (``click``,
+        # ``importlib.metadata``) are cold at ``python -m tolokaforge.runner``.
+        # Shipped in the subset because pip's ``[project.scripts]`` binds
+        # ``tolokaforge = tolokaforge.runner._cli:main`` at install time.
+        "tolokaforge/runner/_cli.py",
     }
 )
 
@@ -306,20 +315,35 @@ def _load_pyproject_custom_target() -> dict[str, list[str]]:
 
 def test_pyproject_custom_target_mirrors_runner_subset_module() -> None:
     """The ``only-include`` / ``exclude`` lists under
-    ``[tool.hatch.build.targets.custom]`` must mirror the three tuples in
+    ``[tool.hatch.build.targets.custom]`` must mirror the four tuples in
     :mod:`tolokaforge.core._runner_subset` exactly. The subset build's
     package graph is derived from those tuples; drift between the two would
     silently ship a wheel whose contents no longer match the audited
-    partition."""
+    partition.
+
+    ``RUNNER_SUBSET_DATA_FILES`` is expected in ``only-include`` alongside
+    the packages and loose Python files: pricing / preset payloads that
+    runtime code reads at import time via ``importlib.resources`` (GitHub
+    #830). Force-includes for path-remapped files (the repo-root
+    ``.python-version`` dotfile → ``tolokaforge/_python_version.txt``) live
+    in the sibling ``force-include`` table and are checked separately."""
     custom = _load_pyproject_custom_target()
 
-    expected_only_include = {*RUNNER_SUBSET_PACKAGES, *RUNNER_SUBSET_LOOSE_FILES}
+    expected_only_include = {
+        *RUNNER_SUBSET_PACKAGES,
+        *RUNNER_SUBSET_LOOSE_FILES,
+        # Data files ship at their destination path; the force-include
+        # exception (``.python-version`` → ``tolokaforge/_python_version.txt``)
+        # is not listed in ``only-include`` because hatchling reads it from
+        # the ``force-include`` table.
+        *(p for p in RUNNER_SUBSET_DATA_FILES if p != "tolokaforge/_python_version.txt"),
+    }
     actual_only_include = set(custom.get("only-include", []))
     only_missing = sorted(expected_only_include - actual_only_include)
     only_extra = sorted(actual_only_include - expected_only_include)
     assert (
         not only_missing and not only_extra
-    ), "pyproject `[tool.hatch.build.targets.custom].only-include` drifted " "from RUNNER_SUBSET_PACKAGES ∪ RUNNER_SUBSET_LOOSE_FILES:\n" + "".join(
+    ), "pyproject `[tool.hatch.build.targets.custom].only-include` drifted " "from RUNNER_SUBSET_PACKAGES ∪ LOOSE_FILES ∪ DATA_FILES:\n" + "".join(
         f"  - missing in pyproject: {m}\n" for m in only_missing
     ) + "".join(
         f"  - extra in pyproject:   {e}\n" for e in only_extra
@@ -341,7 +365,8 @@ def test_pyproject_custom_target_mirrors_runner_subset_module() -> None:
 def test_pyproject_custom_target_points_at_builder_script() -> None:
     """The custom build target must reference the runner-subset builder
     script; that file is what teaches hatchling to rename the distribution,
-    swap the dependency list, and strip entry points for the subset wheel."""
+    swap the dependency list, and register the subset-native CLI shim as
+    the subset wheel's ``[console_scripts]`` entry (ADR-0026)."""
     custom = _load_pyproject_custom_target()
     script_rel = custom.get("path")
     assert script_rel == "scripts/hatch/hatch_runner_subset_builder.py", (
@@ -351,3 +376,236 @@ def test_pyproject_custom_target_points_at_builder_script() -> None:
     assert (
         REPO_ROOT / script_rel
     ).is_file(), f"custom builder script does not exist on disk: {script_rel}"
+
+
+# ---------------------------------------------------------------------------
+# Subset-native CLI shim (ADR-0026) — the subset wheel's ``[project.scripts]``
+# binds ``tolokaforge = tolokaforge.runner._cli:main``. The shim itself lives
+# in the subset partition and must obey the same import-boundary rules the
+# rest of the shared spine does; the tests below lock those two invariants.
+# ---------------------------------------------------------------------------
+
+
+CLI_SHIM_PATH = "tolokaforge/runner/_cli.py"
+"""Repo-relative path of the subset-native CLI shim."""
+
+_CLI_FORBIDDEN_IMPORT_ROOTS: frozenset[str] = frozenset(
+    {
+        # dx tree — Click command tree + terminal front-end, base-wheel only.
+        "tolokaforge.dx",
+        # Adapters — native / terminal-bench / bundle writer, base-wheel only.
+        "tolokaforge.adapters",
+        # Base-wheel console-script entry (would collide with the shim).
+        "tolokaforge._entry",
+        # Docker + orchestrator machinery — the whole "compose stack + drive a
+        # multi-trial run" surface the shim explicitly does not reach into.
+        "tolokaforge.docker",
+        "tolokaforge.core.orchestrator",
+        "tolokaforge.core.run_trial",
+        "tolokaforge.core.compose_materialisation",
+        "tolokaforge.core.shared_stack_runtime",
+        "tolokaforge.core.per_trial_runtime",
+        "tolokaforge.core.docker_adapter",
+        "tolokaforge.core.plugin_registry",
+        "tolokaforge.core.runtime",
+        "tolokaforge.core.conductor",
+        "tolokaforge.core.trial_grader",
+    }
+)
+
+
+def test_cli_shim_is_in_the_subset() -> None:
+    """The CLI shim lives inside the ``tolokaforge/runner`` subpackage
+    (which the ``RUNNER_SUBSET_PACKAGES`` tuple ships wholesale), so
+    ``is_in_runner_subset`` must return ``True`` for it. If the file moves
+    or the partition drifts, the subset wheel would silently omit the
+    console-script binding target."""
+    assert (
+        REPO_ROOT / CLI_SHIM_PATH
+    ).is_file(), f"ADR-0026 subset-native CLI shim missing on disk: {CLI_SHIM_PATH}"
+    assert is_in_runner_subset(CLI_SHIM_PATH), (
+        f"{CLI_SHIM_PATH} classifies out-of-subset — the subset wheel would "
+        "install without the ADR-0026 shim, and `docker exec … tolokaforge …` "
+        "would fail with 'executable file not found in $PATH' inside the "
+        "runner image."
+    )
+
+
+def test_cli_shim_does_not_reach_orchestrator_or_dx() -> None:
+    """The ADR-0026 shim binds to the runner subset's public surface only —
+    LLM client, tool-calling loop, gRPC client, trial models — and must not
+    reach into ``tolokaforge/dx/*``, ``tolokaforge/adapters/*``, or the
+    orchestrator-only sibling modules inside ``tolokaforge/core/*``. A
+    static AST walk over every ``import`` / ``from … import`` (including
+    deferred function-body imports) enforces the boundary; the wider
+    ``test_subset_files_do_not_import_orchestrator_only_siblings`` covers
+    the same rule for the whole subset, but the shim gets its own
+    assertion so a regression here surfaces at the point of the offence."""
+    path = REPO_ROOT / CLI_SHIM_PATH
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        targets: list[tuple[int, str]] = []
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                targets.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            resolved = node.module if node.level == 0 else f"tolokaforge.runner.{node.module}"
+            targets.append((node.lineno, resolved))
+        for lineno, dotted in targets:
+            for forbidden in _CLI_FORBIDDEN_IMPORT_ROOTS:
+                if dotted == forbidden or dotted.startswith(forbidden + "."):
+                    violations.append(
+                        f"{CLI_SHIM_PATH}:{lineno} imports {dotted} "
+                        f"(under forbidden root {forbidden})"
+                    )
+                    break
+    assert not violations, (
+        "subset-native CLI shim reaches base-wheel-only surfaces — the "
+        "runner image would import a module the subset does not ship, or "
+        "the ADR-0026 partition contract would be violated:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subset wheel structural checks — build once, inspect the artifact.
+#
+# The subset wheel is the actual thing pip installs into the runner image,
+# so its METADATA / RECORD / entry_points.txt are the ground truth. Tests
+# below verify what pip sees, not what pyproject implies.
+# ---------------------------------------------------------------------------
+
+_SUBSET_WHEEL_GLOB = "tolokaforge_runner_subset-*.whl"
+
+
+def _find_subset_wheel() -> Path | None:
+    """Return the latest subset wheel under ``dist/``, or ``None`` if the
+    build has not run yet in this checkout."""
+    dist_dir = REPO_ROOT / "dist"
+    if not dist_dir.is_dir():
+        return None
+    wheels = sorted(dist_dir.glob(_SUBSET_WHEEL_GLOB))
+    return wheels[-1] if wheels else None
+
+
+@pytest.fixture(scope="module")
+def subset_wheel_path() -> Path:
+    """Path to the subset wheel — build one on demand if the ``dist/`` copy
+    is stale or absent."""
+    existing = _find_subset_wheel()
+    if existing is not None:
+        return existing
+    # Build the subset wheel — mirrors ``uv run hatch build --target custom``.
+    build_result = subprocess.run(
+        ["uv", "run", "hatch", "build", "--target", "custom"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if build_result.returncode != 0:
+        pytest.fail(
+            f"subset wheel build failed (exit {build_result.returncode}):\n"
+            f"stdout:\n{build_result.stdout}\nstderr:\n{build_result.stderr}"
+        )
+    wheel = _find_subset_wheel()
+    if wheel is None:
+        pytest.fail("subset wheel build reported success but produced no artifact under dist/")
+    return wheel
+
+
+def _wheel_read(wheel_path: Path, member_glob: str) -> str:
+    """Read one wheel member (first name matching ``member_glob``) as UTF-8."""
+    with zipfile.ZipFile(wheel_path) as zf:
+        for name in zf.namelist():
+            if Path(name).match(member_glob):
+                return zf.read(name).decode("utf-8")
+    raise AssertionError(f"member matching {member_glob!r} not found in {wheel_path.name}")
+
+
+def _wheel_members(wheel_path: Path) -> frozenset[str]:
+    """Return every path the wheel archive lists (RECORD-equivalent)."""
+    with zipfile.ZipFile(wheel_path) as zf:
+        return frozenset(zf.namelist())
+
+
+def test_subset_wheel_binds_cli_shim_console_script(subset_wheel_path: Path) -> None:
+    """The subset wheel's ``entry_points.txt`` must bind the ADR-0026 shim
+    as the ``tolokaforge`` console script. Without this, ``docker exec
+    tolokaforge-runner tolokaforge --version`` fails with "executable
+    file not found in $PATH" — the ADR-0024 committed exec surface would
+    vanish on the slim image."""
+    entry_points_txt = _wheel_read(subset_wheel_path, "*.dist-info/entry_points.txt")
+    assert "[console_scripts]" in entry_points_txt, (
+        "subset wheel entry_points.txt is missing the [console_scripts] "
+        f"section:\n{entry_points_txt}"
+    )
+    assert "tolokaforge = tolokaforge.runner._cli:main" in entry_points_txt, (
+        "subset wheel entry_points.txt does not bind the ADR-0026 shim: "
+        f"expected 'tolokaforge = tolokaforge.runner._cli:main', got:\n"
+        f"{entry_points_txt}"
+    )
+
+
+def test_subset_wheel_ships_cli_shim_module(subset_wheel_path: Path) -> None:
+    """The subset wheel must include ``tolokaforge/runner/_cli.py`` as a
+    Python source file; the console script binding is inert without it."""
+    members = _wheel_members(subset_wheel_path)
+    assert "tolokaforge/runner/_cli.py" in members, (
+        "subset wheel does not ship tolokaforge/runner/_cli.py — the "
+        f"ADR-0026 shim's binding target is missing from the wheel. "
+        f"Wheel members starting with tolokaforge/runner/: "
+        f"{sorted(m for m in members if m.startswith('tolokaforge/runner/'))}"
+    )
+
+
+def test_subset_wheel_ships_data_files_for_pricing_and_presets(
+    subset_wheel_path: Path,
+) -> None:
+    """GitHub #830: the subset wheel must include the pricing table and
+    model-preset registry as bundled data files. Without them, the runner
+    image boots with an empty pricing table (silent cost-tracking regression)
+    and the preset registry raises at first grading-model resolution."""
+    members = _wheel_members(subset_wheel_path)
+    expected = {
+        "tolokaforge/core/data/pricing.json",
+        "tolokaforge/core/data/model_presets.yaml",
+    }
+    missing = sorted(expected - members)
+    assert not missing, (
+        "subset wheel is missing data files (GitHub #830 regression):\n"
+        + "\n".join(f"  - {m}" for m in missing)
+        + "\nAll RUNNER_SUBSET_DATA_FILES entries must ship in the wheel."
+    )
+
+
+def test_subset_wheel_metadata_is_the_subset_distribution(subset_wheel_path: Path) -> None:
+    """The subset wheel's METADATA must name the distribution
+    ``tolokaforge-runner-subset`` (not ``tolokaforge``) so pip's install
+    metadata inside the runner image makes clear which build variant is
+    installed. ``importlib.metadata.version('tolokaforge-runner-subset')``
+    — the version resolution the ADR-0026 shim's ``--version`` uses — is
+    what this METADATA line services."""
+    metadata_txt = _wheel_read(subset_wheel_path, "*.dist-info/METADATA")
+    assert "Name: tolokaforge-runner-subset" in metadata_txt, (
+        "subset wheel METADATA is missing the tolokaforge-runner-subset "
+        "distribution name — importlib.metadata.version() lookups in the "
+        f"ADR-0026 shim would fail inside the runner image:\n{metadata_txt[:300]}"
+    )
+
+
+def test_subset_wheel_does_not_ship_orchestrator_only_files(
+    subset_wheel_path: Path,
+) -> None:
+    """The subset partition's ``EXCLUDED_FILES`` tuple is meaningful only
+    if the wheel builder actually drops those files. This test asserts
+    against the ground-truth wheel archive, not the enumeration."""
+    members = _wheel_members(subset_wheel_path)
+    leaked = sorted(f for f in RUNNER_SUBSET_EXCLUDED_FILES if f in members)
+    assert not leaked, (
+        "subset wheel ships files the partition marks as orchestrator-only "
+        "— the runner image installs orchestrator scaffolding it does not "
+        "need and cannot use:\n" + "\n".join(f"  - {leak}" for leak in leaked)
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,6 +51,14 @@ def _mock_wheel_resolver(tmp_path: Path):
         content_hash="unit-test-hash",
         provider_name="unit-test-mock",
     )
+    # ``tolokaforge.docker.stacks.core`` no longer resolves a host-side
+    # wheel — the runner Dockerfile builds the runner-subset wheel in the
+    # ``hatch build --target custom`` stage of the multi-stage image
+    # (ADR-0025 § subset target; ADR-0026 § the shim's build path). The
+    # remaining ``resolve_wheel`` consumers (``builder`` for the rag stack,
+    # ``stacks.full`` for its own service) still need the mock so
+    # ``core_stack()`` / ``full_stack()`` can compose without a real wheel
+    # build on disk.
     with (
         patch(
             "tolokaforge.docker.wheel_resolver.resolve_wheel",
@@ -58,10 +66,6 @@ def _mock_wheel_resolver(tmp_path: Path):
         ),
         patch(
             "tolokaforge.docker.builder.resolve_wheel",
-            return_value=artifact,
-        ),
-        patch(
-            "tolokaforge.docker.stacks.core.resolve_wheel",
             return_value=artifact,
         ),
         patch(

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -26,7 +26,12 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture()
 def _mock_wheel(tmp_path: Path):
-    """Mock resolve_wheel to return a fake .whl so tests don't run a real build."""
+    """Mock ``resolve_wheel`` to return a fake ``.whl`` so tests exercising the
+    remaining wheel-consuming stacks (rag-service, full stack) don't run a real
+    build. The runner Dockerfile no longer consumes a host-side wheel — its
+    multi-stage build produces the subset wheel in-container ([ADR-0025](../../docs/adr/0025-runner-wheel-split.md)),
+    so ``tolokaforge.docker.stacks.core`` doesn't import ``resolve_wheel``
+    anymore and is not patched here."""
     whl = tmp_path / "tolokaforge-0.2.0-py3-none-any.whl"
     whl.write_bytes(b"PK\x03\x04test-wheel")
     artifact = WheelArtifact(
@@ -42,10 +47,6 @@ def _mock_wheel(tmp_path: Path):
         ),
         patch(
             "tolokaforge.docker.builder.resolve_wheel",
-            return_value=artifact,
-        ),
-        patch(
-            "tolokaforge.docker.stacks.core.resolve_wheel",
             return_value=artifact,
         ),
     ):
@@ -211,19 +212,47 @@ def test_mock_web_context_scoped_to_service_files() -> None:
         assert not (build_dir / "pyproject.toml").exists()
 
 
-@pytest.mark.usefixtures("_mock_wheel")
-def test_runner_build_context_contains_wheel() -> None:
-    """The runner image context should contain the resolved wheel (not source)."""
+def test_runner_build_context_ships_source_tree_for_multi_stage_hatch_build() -> None:
+    """The runner Dockerfile is multi-stage: its ``wheel-builder`` stage
+    runs ``hatch build --target custom`` in-container to produce the
+    runner-subset wheel, then the ``builder`` stage installs it (ADR-0025 /
+    ADR-0026). The build context therefore carries the source files hatch
+    needs — pyproject.toml, README, LICENSE, .python-version, the custom
+    builder script, and the ``tolokaforge/`` source tree — not a
+    pre-resolved host-side wheel.
+
+    A regression that drops one of these entries produces a hatch
+    ``file not found`` inside the image build, not a helpful host-side
+    diagnostic; this test locks the expected context set explicitly."""
     runner_def = get_image_definition("runner")
     context_files = runner_def["context_files"]
-    # Exactly one entry: the absolute path to the .whl.
-    assert len(context_files) == 1
-    assert context_files[0].endswith(".whl")
+    expected = {
+        "pyproject.toml",
+        "README.md",
+        "LICENSE",
+        ".python-version",
+        "scripts/hatch/",
+        "tolokaforge/",
+    }
+    assert set(context_files) == expected, (
+        "runner image context_files drifted from the ADR-0025 multi-stage "
+        f"hatch-build source set. got: {sorted(context_files)}"
+    )
+    # No pre-built wheel should be listed — the subset wheel is built
+    # in-container by the wheel-builder stage.
+    assert not any(entry.endswith(".whl") for entry in context_files), (
+        "runner image context_files still lists a pre-built .whl — the "
+        "subset wheel is a Docker-only artifact built by the multi-stage "
+        "Dockerfile, never a host-side input."
+    )
 
 
-def test_build_image_respects_context_files(monkeypatch, _mock_wheel) -> None:
-    """build_image() should place the resolved wheel in the Docker context."""
-    captured = {}
+def test_build_image_runner_ships_source_tree_not_a_wheel(monkeypatch) -> None:
+    """The runner ``build_image('runner')`` path passes the source tree
+    to docker as the build context, not a pre-resolved wheel. Locks the
+    ADR-0025 multi-stage build contract: the ``.whl`` is produced *inside*
+    the image, not copied in from the host."""
+    captured: dict[str, object] = {}
 
     def fake_build(dockerfile, context, build_args=None, name=None, client=None):
         captured["dockerfile"] = dockerfile
@@ -231,14 +260,16 @@ def test_build_image_respects_context_files(monkeypatch, _mock_wheel) -> None:
         captured["build_args"] = build_args
         root = Path(context)
 
-        # The wheel should be in the build context root.
-        wheels = list(root.glob("tolokaforge-*.whl"))
-        assert len(wheels) == 1, f"Expected one wheel, found: {wheels}"
-        # Source package should NOT be present (the tolokaforge/ dir may
-        # exist as a parent of the Dockerfile path on the split branch,
-        # but it must not contain the Python source).
-        assert not (root / "pyproject.toml").exists()
-        assert not (root / "tolokaforge" / "__init__.py").exists()
+        # No host-side wheel is copied into the runner image build context;
+        # the subset wheel is produced by the wheel-builder stage.
+        wheels = list(root.glob("tolokaforge*.whl"))
+        assert (
+            wheels == []
+        ), f"runner build context must not contain a pre-built wheel; found: {wheels}"
+        # Instead, the source-tree entries hatch consumes must be present.
+        assert (root / "pyproject.toml").exists()
+        assert (root / "scripts" / "hatch" / "hatch_runner_subset_builder.py").exists()
+        assert (root / "tolokaforge" / "__init__.py").exists()
 
         return Image(
             name=name or "test",
@@ -255,24 +286,19 @@ def test_build_image_respects_context_files(monkeypatch, _mock_wheel) -> None:
     image = build_image("runner", force=True)
     assert image.full_tag == "tolokaforge-runner:deadbeef"
     assert not Path(captured["context"]).exists(), "Temporary build context should be cleaned up"
-    # WHEEL_FILENAME must reach docker build. The Dockerfile's ARG default
-    # is a placeholder that doesn't match the real wheel on disk, so `COPY
-    # ${WHEEL_FILENAME}` fails whenever the harness omits this build arg.
     # PYTHON_VERSION is sourced from .python-version so a single upgrade
-    # propagates to every runtime image.
+    # propagates to every runtime image. ``WHEEL_FILENAME`` is deliberately
+    # absent — the multi-stage Dockerfile doesn't need it because the
+    # subset wheel is produced in a preceding stage.
     from tolokaforge.docker.builder import PYTHON_VERSION
 
-    assert captured["build_args"] == {
-        "WHEEL_FILENAME": _mock_wheel.path.name,
-        "PYTHON_VERSION": PYTHON_VERSION,
-    }
+    assert captured["build_args"] == {"PYTHON_VERSION": PYTHON_VERSION}
 
 
-def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_wheel) -> None:
-    """The cached (non-force) path must also assemble the isolated context.
-
-    Production builds go through ``ImageRegistry.get_or_build``.
-    """
+def test_build_image_runner_non_force_path_uses_source_tree_context(monkeypatch) -> None:
+    """The cached (non-force) path must also assemble the source-tree
+    context the multi-stage runner build needs; wheel-based context is
+    no longer part of the runner path."""
     captured: dict[str, object] = {}
 
     def fake_get_or_build(self, *, name, dockerfile, context, build_args=None):  # noqa: ARG001
@@ -280,8 +306,10 @@ def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_whe
         captured["context"] = context
         captured["build_args"] = build_args
         root = Path(context)
-        # Wheel should be present in the isolated context.
-        assert list(root.glob("tolokaforge-*.whl"))
+        # Source-tree entries hatch needs are present; no pre-built wheel.
+        assert (root / "pyproject.toml").exists()
+        assert (root / "tolokaforge" / "runner" / "_cli.py").exists()
+        assert list(root.glob("tolokaforge*.whl")) == []
         return Image(
             name=name,
             tag="cafe1234",
@@ -301,10 +329,7 @@ def test_build_image_non_force_path_uses_isolated_context(monkeypatch, _mock_whe
     assert not Path(captured["context"]).exists(), "Temporary build context should be cleaned up"
     from tolokaforge.docker.builder import PYTHON_VERSION
 
-    assert captured["build_args"] == {
-        "WHEEL_FILENAME": _mock_wheel.path.name,
-        "PYTHON_VERSION": PYTHON_VERSION,
-    }
+    assert captured["build_args"] == {"PYTHON_VERSION": PYTHON_VERSION}
 
 
 def test_build_image_passes_python_version_build_arg_for_db_service(monkeypatch) -> None:
@@ -340,12 +365,13 @@ def test_service_name_for_image_resolves_all_known_services_without_resolving_wh
     """Reverse lookup must (a) cover dynamically-resolved services too and
     (b) never invoke the wheel resolver as a side effect.
 
-    Iterating ``IMAGE_DEFINITIONS`` only misses runner / rag-service (they're
-    resolved via ``_runner_definition`` / ``_rag_definition``); calling
-    ``get_image_definition`` for every candidate, conversely, would invoke
-    ``resolve_wheel()`` for runner / rag-service even when looking up an
-    unrelated service like db-service — propagating wheel-build failures from
-    an unrelated lookup. The implementation must do neither.
+    ``rag-service`` is still resolved via ``_rag_definition``; ``runner`` is
+    now fully static (its multi-stage Dockerfile handles wheel production
+    in-container per ADR-0025). Calling ``get_image_definition`` for every
+    candidate would still invoke ``resolve_wheel()`` for rag-service even
+    when looking up an unrelated service like db-service — propagating
+    wheel-build failures from an unrelated lookup. The implementation must
+    do neither.
     """
 
     def fail_resolve_wheel(*args, **kwargs):

--- a/tests/unit/test_runner_cli_shim.py
+++ b/tests/unit/test_runner_cli_shim.py
@@ -1,0 +1,239 @@
+"""Pure-function contract for the subset-native CLI shim (``tolokaforge.runner._cli``):
+envelope parse, error marshal, result marshal — no subprocess, no gRPC.
+
+The shim is bound as the subset wheel's ``[project.scripts]`` entry
+(``tolokaforge = tolokaforge.runner._cli:main``) per ADR-0026 and mirrors
+the base wheel's ADR-0022 § Surface 3 wire framing, so the shape of these
+tests parallels ``tests/unit/test_run_trial_command.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from tolokaforge.runner._cli import (
+    CancelMessage,
+    ProtocolError,
+    ProvisionError,
+    StartMessage,
+    _Cancelled,
+    marshal_error,
+    marshal_result,
+    parse_envelope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseEnvelope:
+    def test_well_formed_start_populates_start_message(self) -> None:
+        line = (
+            '{"v":1,"type":"start","task":{"task_id":"t"},"models":{"agent":{}},'
+            '"runtime":"in_memory","grader":"runner_rpc","conductor":"in_memory"}'
+        )
+        message = parse_envelope(line)
+        assert message == StartMessage(
+            task={"task_id": "t"},
+            models={"agent": {}},
+            runtime="in_memory",
+            grader="runner_rpc",
+            conductor="in_memory",
+        )
+
+    def test_start_omitting_seams_defaults_to_library_defaults(self) -> None:
+        message = parse_envelope('{"v":1,"type":"start","task":{},"models":{}}')
+        assert isinstance(message, StartMessage)
+        assert (message.runtime, message.grader, message.conductor) == (
+            "auto",
+            "runner_rpc",
+            "in_process",
+        )
+
+    def test_cancel_envelope_parses_to_cancel_message(self) -> None:
+        assert parse_envelope('{"v":1,"type":"cancel"}') == CancelMessage()
+
+    def test_malformed_json_raises_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError):
+            parse_envelope("{not json")
+
+    def test_wrong_version_raises_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError):
+            parse_envelope('{"v":2,"type":"start","task":{},"models":{}}')
+
+    def test_unknown_type_raises_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError):
+            parse_envelope('{"v":1,"type":"resume","task":{},"models":{}}')
+
+    def test_unknown_envelope_key_is_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError, match="runtme"):
+            parse_envelope('{"v":1,"type":"start","runtme":"x","task":{},"models":{}}')
+
+    def test_unknown_envelope_key_in_cancel_is_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError, match="extra"):
+            parse_envelope('{"v":1,"type":"cancel","extra":"x"}')
+
+    def test_bare_string_envelope_is_protocol_error(self) -> None:
+        with pytest.raises(ProtocolError, match="JSON object"):
+            parse_envelope('"just a string"')
+
+
+class TestMarshalError:
+    def _synthetic_validation_error(self) -> ValidationError:
+        class _M(BaseModel):
+            x: int
+
+        try:
+            _M.model_validate({"x": "not-an-int"})
+        except ValidationError as exc:
+            return exc
+        raise AssertionError("expected a ValidationError")
+
+    def test_validation_error_maps_to_validation_error(self) -> None:
+        envelope = marshal_error(self._synthetic_validation_error())
+        assert envelope["error_type"] == "ValidationError"
+        assert envelope["fatal"] is True
+        assert envelope["v"] == 1
+        assert envelope["type"] == "error"
+
+    def test_provision_error_maps_to_provision_error(self) -> None:
+        envelope = marshal_error(ProvisionError("adapter machinery is base-wheel only"))
+        assert envelope["error_type"] == "ProvisionError"
+        assert envelope["fatal"] is True
+
+    def test_cancelled_maps_to_cancelled(self) -> None:
+        envelope = marshal_error(_Cancelled("stdin closed before a start message"))
+        assert envelope["error_type"] == "cancelled"
+        assert envelope["fatal"] is True
+
+    def test_bare_runtime_error_maps_to_internal_error(self) -> None:
+        envelope = marshal_error(RuntimeError("boom"))
+        assert envelope["error_type"] == "InternalError"
+        assert envelope["fatal"] is True
+
+    def test_protocol_error_maps_to_protocol_error(self) -> None:
+        envelope = marshal_error(ProtocolError("bad envelope"))
+        assert envelope["error_type"] == "ProtocolError"
+        assert envelope["fatal"] is True
+
+
+class TestMarshalResult:
+    def test_result_envelope_wraps_payload_verbatim(self) -> None:
+        payload = {"trial_id": "task-1:0", "trajectory": {"messages": []}}
+        envelope = marshal_result(payload)
+        assert envelope == {"v": 1, "type": "result", "result": payload}
+
+
+class TestDriveRunTrial:
+    """The end-to-end ``_drive_run_trial(stdin, stdout)`` path — envelope in,
+    JSON-Lines wire out, exit code returned. Exercised without a real
+    runner service; the subset's ``_run_from_start`` fails loudly with a
+    :class:`ProvisionError` before it reaches the gRPC connection check
+    for envelopes missing the required fields, so we can lock the wire
+    contract without spinning anything up."""
+
+    def test_garbage_stdin_emits_protocol_error_envelope(self) -> None:
+        import io
+
+        from tolokaforge.runner._cli import _drive_run_trial
+
+        stdin = io.StringIO("not a valid start envelope\n")
+        stdout = io.StringIO()
+        exit_code = _drive_run_trial(stdin, stdout)
+        assert exit_code == 1
+        # Exactly one wire line, well-formed JSON, v:1 error envelope.
+        lines = [line for line in stdout.getvalue().splitlines() if line.strip()]
+        assert len(lines) == 1, f"expected exactly one wire line, got {len(lines)}"
+        import json as _json
+
+        envelope = _json.loads(lines[0])
+        assert envelope["v"] == 1
+        assert envelope["type"] == "error"
+        assert envelope["error_type"] == "ProtocolError"
+        assert envelope["fatal"] is True
+
+    def test_empty_stdin_emits_cancelled_envelope(self) -> None:
+        import io
+
+        from tolokaforge.runner._cli import _drive_run_trial
+
+        stdin = io.StringIO("")
+        stdout = io.StringIO()
+        exit_code = _drive_run_trial(stdin, stdout)
+        assert exit_code == 1
+        import json as _json
+
+        envelope = _json.loads(stdout.getvalue().splitlines()[0])
+        assert envelope["error_type"] == "cancelled"
+
+    def test_cancel_envelope_before_start_emits_cancelled(self) -> None:
+        import io
+
+        from tolokaforge.runner._cli import _drive_run_trial
+
+        stdin = io.StringIO('{"v":1,"type":"cancel"}\n')
+        stdout = io.StringIO()
+        exit_code = _drive_run_trial(stdin, stdout)
+        assert exit_code == 1
+        import json as _json
+
+        envelope = _json.loads(stdout.getvalue().splitlines()[0])
+        assert envelope["error_type"] == "cancelled"
+
+    def test_start_without_task_emits_provision_error(self) -> None:
+        """The subset-native shim needs the caller to supply enough that a
+        TrialSpec could be materialised; a bare envelope with an empty
+        ``task`` surfaces as ProvisionError before any gRPC connection
+        attempt, so the wire never lies about what happened."""
+        import io
+
+        from tolokaforge.runner._cli import _drive_run_trial
+
+        stdin = io.StringIO('{"v":1,"type":"start"}\n')
+        stdout = io.StringIO()
+        exit_code = _drive_run_trial(stdin, stdout)
+        assert exit_code == 1
+        import json as _json
+
+        envelope = _json.loads(stdout.getvalue().splitlines()[0])
+        assert envelope["error_type"] == "ProvisionError"
+        assert "task" in envelope["message"].lower()
+
+
+class TestVersionResolution:
+    """``tolokaforge --version`` resolves via ``importlib.metadata`` against
+    the subset distribution name — inside the runner image the lookup
+    succeeds; outside (dev-checkout without the subset wheel installed)
+    the lookup fails loudly rather than misreporting."""
+
+    def test_subset_distribution_name_matches_hatch_builder(self) -> None:
+        """Single source of truth check: the shim's ``SUBSET_DISTRIBUTION_NAME``
+        constant must match the name the custom hatch builder writes into
+        METADATA. A silent drift would mean the shim asks importlib for a
+        name pip never registered inside the image.
+
+        The builder script transitively imports ``hatchling.builders.wheel``,
+        which is a build-time-only dep — importing the module directly from
+        pytest would need hatchling installed in the dev env. Instead we
+        parse the ``SUBSET_DISTRIBUTION_NAME`` assignment out of the source
+        with ``ast``, which keeps the check hermetic and hatchling-free.
+        """
+        import ast
+        from pathlib import Path
+
+        from tolokaforge.runner._cli import SUBSET_DISTRIBUTION_NAME as SHIM_NAME
+
+        repo_root = Path(__file__).resolve().parents[2]
+        builder_path = repo_root / "scripts" / "hatch" / "hatch_runner_subset_builder.py"
+        tree = ast.parse(builder_path.read_text(encoding="utf-8"))
+        hatch_name: str | None = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "SUBSET_DISTRIBUTION_NAME":
+                        assert isinstance(node.value, ast.Constant)
+                        hatch_name = node.value.value
+        assert (
+            hatch_name is not None
+        ), "SUBSET_DISTRIBUTION_NAME assignment not found in hatch_runner_subset_builder.py"
+        assert hatch_name == SHIM_NAME

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -80,7 +80,36 @@ RUNNER_SUBSET_LOOSE_FILES: tuple[str, ...] = (
 """Individual files shipped in the subset that live outside a whole-package
 entry — the top-level ``tolokaforge/__init__.py`` and the shared-spine
 files at the root of ``tolokaforge/core/``.
+
+The subset-native CLI shim (:mod:`tolokaforge.runner._cli` — the ADR-0026
+entry the subset wheel binds under ``[project.scripts]``) is *not* listed
+here because it lives under :data:`RUNNER_SUBSET_PACKAGES` and is shipped
+via that whole-package entry. Listed here anyway would double-include the
+file at wheel-build time.
 """
+
+RUNNER_SUBSET_DATA_FILES: tuple[str, ...] = (
+    # Pricing table shipped with the subset. ``tolokaforge.core.pricing``
+    # reads this file via ``importlib.resources`` / a repo-relative path
+    # at import time; a subset image without it would silently misreport
+    # cost telemetry. GitHub #830.
+    "tolokaforge/core/data/pricing.json",
+    # Model preset registry — same story as pricing.json: read by
+    # ``tolokaforge.core.llm.presets`` at first use, and grading /
+    # judge model resolution needs it to be non-empty inside the runner
+    # image. GitHub #830.
+    "tolokaforge/core/data/model_presets.yaml",
+    # Python version pin — the ``tolokaforge.docker.builder`` helper is
+    # base-wheel only, but ``tolokaforge/_python_version.txt`` is included
+    # here to keep the ``importlib.resources.files("tolokaforge")`` lookup
+    # honest across both wheel variants when a caller reaches for it.
+    "tolokaforge/_python_version.txt",
+)
+"""Non-Python files shipped in the subset that runtime code reads via
+``importlib.resources`` or a repo-relative path. GitHub #830 folded these
+in when the runner-subset wheel was rebuilt around the subset-native CLI
+shim; before the fix, the subset shipped Python only and a runner image
+booted with an empty pricing table."""
 
 RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
     "tolokaforge/core/grading/combine.py",
@@ -110,12 +139,14 @@ def is_in_runner_subset(rel_path: str) -> bool:
     part of the runner subset.
 
     A path is in the subset when it is (a) listed explicitly in
-    :data:`RUNNER_SUBSET_LOOSE_FILES`, or (b) rooted under a directory in
-    :data:`RUNNER_SUBSET_PACKAGES` and not listed in
-    :data:`RUNNER_SUBSET_EXCLUDED_FILES`.
+    :data:`RUNNER_SUBSET_LOOSE_FILES` or :data:`RUNNER_SUBSET_DATA_FILES`, or
+    (b) rooted under a directory in :data:`RUNNER_SUBSET_PACKAGES` and not
+    listed in :data:`RUNNER_SUBSET_EXCLUDED_FILES`.
     """
     if rel_path in RUNNER_SUBSET_EXCLUDED_FILES:
         return False
     if rel_path in RUNNER_SUBSET_LOOSE_FILES:
+        return True
+    if rel_path in RUNNER_SUBSET_DATA_FILES:
         return True
     return any(rel_path.startswith(pkg + "/") for pkg in RUNNER_SUBSET_PACKAGES)

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -91,14 +91,20 @@ _PYTHON_BUILD_ARGS: dict[str, str] = {"PYTHON_VERSION": PYTHON_VERSION}
 # entry holds the static facts (name, dockerfile, context) and, when the
 # Dockerfile needs no host-side resolution, the static context_files too.
 #
-# Services whose build context depends on the wheel resolver (currently
-# ``runner`` and ``rag-service``) declare only their static fields here, and
-# pair with a factory (``_runner_definition`` / ``_rag_definition``) that
-# augments the static base with ``context_files`` and ``build_args`` at call
-# time. ``get_image_definition`` routes to that factory; everything that only
-# needs the static facts (reverse lookups, service enumeration, group
+# The rag-service image still depends on the host-side wheel resolver
+# (it installs a pre-built ``tolokaforge`` wheel into its rag service);
+# it declares only its static fields here and pairs with ``_rag_definition``
+# to augment the base with ``context_files`` and ``build_args`` at call
+# time. ``get_image_definition`` routes to that factory; everything that
+# only needs the static facts (reverse lookups, service enumeration, group
 # membership) reads IMAGE_DEFINITIONS directly and never triggers wheel
 # resolution as a side effect.
+#
+# The runner image is different: its Dockerfile is multi-stage
+# (ADR-0025 § subset build target), producing the runner-subset wheel
+# in-container via ``hatch build --target custom``. The context is a
+# static source-tree slice, no host-side wheel resolution, no factory —
+# hence a fully-static IMAGE_DEFINITIONS entry.
 
 IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
     "db-service": {
@@ -114,7 +120,20 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
         "name": "tolokaforge-runner",
         "dockerfile": "tolokaforge/docker/dockerfiles/runner.Dockerfile",
         "context": ".",
-        # context_files + build_args added by _runner_definition() at call time
+        # The runner Dockerfile is multi-stage: a wheel-builder stage runs
+        # ``hatch build --target custom`` against the source tree in-container
+        # to produce the subset wheel, and a builder stage installs it into
+        # /opt/venv. The build context ships the sources hatch needs; the
+        # subset wheel is a Docker-only artifact (ADR-0025).
+        "context_files": [
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            ".python-version",
+            "scripts/hatch/",
+            "tolokaforge/",
+        ],
+        "build_args": dict(_PYTHON_BUILD_ARGS),
     },
     "rag-service": {
         "name": "tolokaforge-rag-service",
@@ -145,20 +164,6 @@ EXTENDED_IMAGES: list[str] = ["rag-service", "mock-web"]
 _ALL_KNOWN_SERVICES = frozenset(IMAGE_DEFINITIONS)
 
 
-def _runner_definition() -> dict[str, Any]:
-    """Augment the runner base entry with the resolved wheel.
-
-    The Dockerfile installs the wheel produced by ``resolve_wheel()``; the
-    only file in the build context (besides the Dockerfile) is that wheel.
-    """
-    artifact = resolve_wheel()
-    return {
-        **IMAGE_DEFINITIONS["runner"],
-        "context_files": [str(artifact.path)],  # absolute path to the .whl
-        "build_args": {**_PYTHON_BUILD_ARGS, "WHEEL_FILENAME": artifact.path.name},
-    }
-
-
 def _rag_definition() -> dict[str, Any]:
     """Augment the rag-service base entry with the resolved wheel + service files.
 
@@ -177,7 +182,6 @@ def _rag_definition() -> dict[str, Any]:
     }
 
 
-_DYNAMIC_DEFINITIONS["runner"] = _runner_definition
 _DYNAMIC_DEFINITIONS["rag-service"] = _rag_definition
 
 

--- a/tolokaforge/docker/dockerfiles/runner.Dockerfile
+++ b/tolokaforge/docker/dockerfiles/runner.Dockerfile
@@ -5,24 +5,61 @@
 # - Tool execution (MCP server styles, terminal-bench)
 # - Trial grading via golden path comparison
 #
-# tolokaforge is installed from a pre-built wheel placed into the build
-# context by the host-side wheel resolver (tolokaforge.docker.wheel_resolver).
-# The container never clones a repo or reaches PyPI — the wheel is local.
+# tolokaforge is installed from the runner-subset wheel, a Docker-only build
+# artifact never published to PyPI. The subset packages the runner's runtime
+# import closure — orchestrator, adapters, dx, docker helpers, and env
+# services stay in the base wheel. ADR-0025 owns the split; ADR-0024 owns
+# the container command surface, preserved here verbatim.
 #
-# Multi-stage: the builder installs the wheel + its [runner] extra into an
-# isolated venv (with the build-only apt toolchain); the runtime stage copies
-# only that venv, so git/curl/perl and the pip/setuptools/wheel toolchain never
-# reach the shipped image.
+# Three stages:
+#
+#   1. wheel-builder — installs hatch, copies the source tree hatch needs,
+#      and runs ``hatch build --target custom`` to produce the subset wheel
+#      under ``/src/dist/``. The custom builder lives at
+#      ``scripts/hatch/hatch_runner_subset_builder.py`` and consumes the
+#      partition enumerated in ``tolokaforge/core/_runner_subset.py``.
+#   2. builder — copies the subset wheel from wheel-builder and installs it
+#      into an isolated ``/opt/venv`` (with any build-only apt toolchain).
+#      The subset wheel's METADATA declares the runner's runtime deps (the
+#      union of the base wheel's ``[project.dependencies]`` reachable from
+#      the runner subset and the domain-tool ``[runner]`` extra) so no
+#      extras selector is needed at install time.
+#   3. runtime — copies only the venv, so git/curl/perl and the
+#      pip/setuptools/wheel toolchain never reach the shipped image.
 
 ARG PYTHON_VERSION=3.12
 
 # ---------------------------------------------------------------------------
-# builder — install the wheel + [runner] extra into /opt/venv
+# wheel-builder — build the runner-subset wheel from the source tree
+# ---------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim AS wheel-builder
+
+WORKDIR /src
+
+# ``hatchling build --target custom`` runs the custom builder script directly
+# in the current interpreter — no build-isolation venv, no ``hatch`` env
+# machinery — so the layer is self-contained and reproducible. Version-bound
+# so the produced wheel metadata format is deterministic across builds.
+RUN pip install --no-cache-dir "hatchling>=1.24,<2.0"
+
+# Source files needed by ``hatchling build --target custom``. Copy pyproject
+# and metadata files first (rarely change) so the layer that ADDs the
+# tolokaforge source cache-invalidates independently.
+COPY pyproject.toml README.md LICENSE .python-version /src/
+COPY scripts/hatch/ /src/scripts/hatch/
+COPY tolokaforge/ /src/tolokaforge/
+
+# Build the subset wheel. Output lands in ``/src/dist/`` as
+# ``tolokaforge_runner_subset-<version>-py3-none-any.whl``.
+RUN python -m hatchling build --target custom
+
+# ---------------------------------------------------------------------------
+# builder — install the subset wheel into /opt/venv
 # ---------------------------------------------------------------------------
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 # Build-only system deps. Wheels that carry native build steps need a compiler
-# toolchain; git/curl are here for any source build the resolver's deps trigger.
+# toolchain; git/curl are here for any source build a subset dep triggers.
 # None of this reaches the runtime stage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -30,19 +67,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# WHEEL_FILENAME is passed as a build arg by the wheel resolver so we don't rely
-# on shell glob expansion inside Docker. No default — a missing --build-arg
-# fails loudly at this layer rather than silently COPYing the wrong filename.
-ARG WHEEL_FILENAME
-COPY ${WHEEL_FILENAME} /tmp/
+COPY --from=wheel-builder /src/dist/tolokaforge_runner_subset-*.whl /tmp/
 
-# Install into an isolated venv. The [runner] extra is the single source of
-# truth for the runner image's domain-tool runtime deps (declared in
-# pyproject.toml). --no-compile keeps *.pyc bytecode out of site-packages;
-# PYTHONDONTWRITEBYTECODE in the runtime stage keeps it that way.
+# Install into an isolated venv. The subset wheel's METADATA carries every
+# runtime dep (the base wheel deps the runner reaches + the former
+# ``[runner]`` extra), so no extras selector is needed. --no-compile keeps
+# *.pyc bytecode out of site-packages; PYTHONDONTWRITEBYTECODE in the
+# runtime stage keeps it that way.
 RUN python -m venv /opt/venv \
-    && /opt/venv/bin/pip install --no-cache-dir --no-compile "/tmp/${WHEEL_FILENAME}[runner]" \
-    && rm -f "/tmp/${WHEEL_FILENAME}"
+    && /opt/venv/bin/pip install --no-cache-dir --no-compile /tmp/tolokaforge_runner_subset-*.whl \
+    && rm -f /tmp/tolokaforge_runner_subset-*.whl
 
 # ---------------------------------------------------------------------------
 # runtime — copy only the venv; no build toolchain
@@ -111,7 +145,7 @@ RUN rm -rf /opt/venv/lib/python*/site-packages/pip \
 # Domain code is delivered at runtime via TaskDescription.tool_artifacts —
 # adapters bundle the env/domain tree there, the runner extracts it under a
 # per-trial tempdir and prepends it to sys.path. The image stays domain-agnostic;
-# the [runner] extra carries the drivers that extracted tool code needs.
+# the subset wheel carries the drivers that extracted tool code needs.
 
 # Create work directory for tool execution
 RUN mkdir -p /work && chmod 755 /work

--- a/tolokaforge/docker/stacks/core.py
+++ b/tolokaforge/docker/stacks/core.py
@@ -21,7 +21,6 @@ from tolokaforge.docker.mount import Mount
 from tolokaforge.docker.policy import Capability, ResourcePolicy
 from tolokaforge.docker.ports import PortConfig
 from tolokaforge.docker.stack import EngineStack, ServiceDefinition
-from tolokaforge.docker.wheel_resolver import resolve_wheel
 
 
 def core_stack(
@@ -179,13 +178,12 @@ def core_stack(
     if secrets_payload:
         runner_env["TOLOKAFORGE_SECRETS_JSON"] = json.dumps(secrets_payload)
 
-    # Resolve the tolokaforge wheel for the runner image.
-    # The wheel is a local file — Docker never needs to reach the network.
-    artifact = resolve_wheel()
-
-    runner_build_args: dict[str, str] = {
-        "WHEEL_FILENAME": artifact.path.name,
-    }
+    # The runner Dockerfile is a multi-stage build: its wheel-builder stage
+    # runs ``hatch build --target custom`` against the source tree to produce
+    # the runner-subset wheel; the runtime stage installs it. The build
+    # context ships the sources hatch needs — the subset wheel is a
+    # Docker-only artifact (ADR-0025), never a host-side input.
+    runner_build_args: dict[str, str] = {}
     if enable_playwright:
         runner_build_args["INSTALL_PLAYWRIGHT"] = "true"
     if enable_docker_cli:
@@ -197,7 +195,16 @@ def core_stack(
         dockerfile="tolokaforge/docker/dockerfiles/runner.Dockerfile",
         context=".",
         context_files=[
-            str(artifact.path),  # absolute path to the .whl
+            # Sources ``hatch build --target custom`` consumes in the
+            # wheel-builder stage. Every path is repo-relative; the temp
+            # build context assembler copies them flat into the isolated
+            # build directory (see ``builder.assemble_build_context``).
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            ".python-version",
+            "scripts/hatch/",
+            "tolokaforge/",
         ],
         ports=[PortConfig(container_port=50051, host_port=runner_port)],
         environment=runner_env,

--- a/tolokaforge/runner/_cli.py
+++ b/tolokaforge/runner/_cli.py
@@ -1,0 +1,432 @@
+"""Subset-native CLI shim — ``tolokaforge --version`` and ``tolokaforge run-trial``.
+
+The runner subset wheel binds its ``[project.scripts]`` entry
+``tolokaforge = tolokaforge.runner._cli:main`` at this module. Two subcommands,
+matching the runner image's committed exec surface verbatim:
+
+- ``tolokaforge --version`` — prints the installed subset wheel's version,
+  resolved via :func:`importlib.metadata.version`. When the metadata lookup
+  fails (subset wheel not installed) the command exits non-zero rather than
+  silently misreporting a version.
+- ``tolokaforge run-trial`` (hidden) — reads one JSON-Lines ``start``
+  envelope on stdin (ADR-0022 § Surface 3), drives one trial against the
+  **local runner service on ``localhost:50051``** using the runner subset's
+  gRPC client, and writes exactly one ``result`` or ``error`` envelope on
+  stdout.
+
+The shim is thin by design. Unlike the base wheel's ``run-trial`` (which
+composes an adapter + runtime backend + conductor + trial grader), this
+subset-native shim orchestrates in-process against the local runner service:
+it cannot spin up compose stacks, cannot switch backends, and cannot exercise
+adapter-specific setup. The narrower semantics are documented in
+``docs/STANDALONE_RUNNER.md``.
+
+stdout carries the wire (one JSON object per line, flushed); diagnostics and
+tracebacks go to stderr so the wire stays pure.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import signal
+import sys
+import traceback
+from dataclasses import dataclass
+from types import FrameType
+from typing import Any, TextIO
+
+import click
+
+WIRE_VERSION = 1
+"""ADR-0022 § Surface 3 wire-protocol version. Independent of the wheel version."""
+
+SUBSET_DISTRIBUTION_NAME = "tolokaforge-runner-subset"
+"""Distribution name of the subset wheel. Matches the name the custom hatch
+builder writes into ``METADATA``."""
+
+DEFAULT_RUNNER_ADDRESS = "localhost:50051"
+"""Local gRPC endpoint of the runner service the shim drives trials against.
+
+Inside the runner container the shim is invoked via ``docker exec`` after the
+runner service is listening on this port; outside the container the caller is
+responsible for starting a runner subprocess on the same host+port."""
+
+
+# ---------------------------------------------------------------------------
+# Wire framing — ADR-0022 § Surface 3
+# ---------------------------------------------------------------------------
+
+
+class ProtocolError(Exception):
+    """A stdin envelope violates the wire framing (bad ``v``, unknown ``type``,
+    unknown top-level key, or malformed JSON)."""
+
+
+class _Cancelled(Exception):
+    """External cancellation — SIGTERM / SIGINT, premature stdin EOF, or a
+    synchronous ``cancel`` envelope — surfaced as ``error_type:"cancelled"``."""
+
+
+class ProvisionError(Exception):
+    """The runner service could not provision the trial (register / grade RPC
+    failure, or the requested task shape needs adapter machinery the subset
+    does not carry). Maps to the ADR-0022 ``ProvisionError`` wire error type
+    so external harnesses branch on the same error class as the base wheel."""
+
+
+_ALLOWED_START_KEYS = frozenset({"v", "type", "task", "models", "runtime", "grader", "conductor"})
+_ALLOWED_CANCEL_KEYS = frozenset({"v", "type"})
+
+
+@dataclass(frozen=True)
+class StartMessage:
+    """A parsed ``start`` envelope: the arguments a ``run_trial`` call needs."""
+
+    task: dict[str, Any] | None
+    models: dict[str, Any] | None
+    runtime: str
+    grader: str
+    conductor: str
+
+
+@dataclass(frozen=True)
+class CancelMessage:
+    """Sentinel for a well-formed synchronous ``cancel`` envelope."""
+
+
+def parse_envelope(line: str | bytes) -> StartMessage | CancelMessage:
+    """Parse one stdin line into a :class:`StartMessage` or :class:`CancelMessage`.
+
+    Raises :class:`ProtocolError` on malformed JSON, a ``v`` other than
+    :data:`WIRE_VERSION`, or a ``type`` other than ``start`` / ``cancel``.
+    """
+    if isinstance(line, bytes):
+        line = line.decode("utf-8", errors="strict")
+    try:
+        envelope = json.loads(line)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ProtocolError(f"malformed JSON envelope: {exc}") from exc
+
+    if not isinstance(envelope, dict):
+        raise ProtocolError(f"envelope must be a JSON object, got {type(envelope).__name__}")
+
+    version = envelope.get("v")
+    if version != WIRE_VERSION:
+        raise ProtocolError(
+            f"unsupported protocol version {version!r}; this build speaks v={WIRE_VERSION}"
+        )
+
+    message_type = envelope.get("type")
+    if message_type == "cancel":
+        unknown = set(envelope) - _ALLOWED_CANCEL_KEYS
+        if unknown:
+            raise ProtocolError(f"unknown envelope key(s): {sorted(unknown)}")
+        return CancelMessage()
+    if message_type != "start":
+        raise ProtocolError(f"unknown message type {message_type!r}; expected 'start' or 'cancel'")
+
+    unknown = set(envelope) - _ALLOWED_START_KEYS
+    if unknown:
+        raise ProtocolError(f"unknown envelope key(s): {sorted(unknown)}")
+
+    return StartMessage(
+        task=envelope.get("task"),
+        models=envelope.get("models"),
+        runtime=envelope.get("runtime", "auto"),
+        grader=envelope.get("grader", "runner_rpc"),
+        conductor=envelope.get("conductor", "in_process"),
+    )
+
+
+def marshal_result(result_payload: dict[str, Any]) -> dict[str, Any]:
+    """Serialise a successful trial into the ``result`` wire envelope."""
+    return {"v": WIRE_VERSION, "type": "result", "result": result_payload}
+
+
+def marshal_error(exc: Exception) -> dict[str, Any]:
+    """Map any exception to a typed ``error`` wire envelope (``fatal`` always
+    true — a single-trial invocation has no non-terminal errors)."""
+    return {
+        "v": WIRE_VERSION,
+        "type": "error",
+        "error_type": _classify_error(exc),
+        "message": str(exc),
+        "fatal": True,
+    }
+
+
+def _classify_error(exc: Exception) -> str:
+    """Name the wire ``error_type`` for ``exc`` per the ADR-0022 mapping table."""
+    if isinstance(exc, _Cancelled):
+        return "cancelled"
+    if isinstance(exc, ProtocolError):
+        return "ProtocolError"
+    if isinstance(exc, ProvisionError):
+        return "ProvisionError"
+    # Pydantic ValidationError — imported lazily so the wire framing has no
+    # hard runtime dep on Pydantic for the garbage-in error path (importing
+    # the model_config module chain is unnecessary for a protocol error).
+    try:
+        from pydantic import ValidationError as _PydanticValidationError
+
+        if isinstance(exc, _PydanticValidationError):
+            return "ValidationError"
+    except ImportError:  # pragma: no cover - Pydantic is a subset runtime dep
+        pass
+    return "InternalError"
+
+
+def _emit(out: TextIO, message: dict[str, Any]) -> None:
+    """Write one wire envelope to ``out`` and flush."""
+    out.write(json.dumps(message) + "\n")
+    out.flush()
+
+
+def _read_first_envelope(stream: TextIO) -> StartMessage | CancelMessage:
+    """Return the first non-empty stdin line parsed; EOF first → ``_Cancelled``."""
+    for raw in stream:
+        line = raw.strip()
+        if line:
+            return parse_envelope(line)
+    raise _Cancelled("stdin closed before a start message")
+
+
+# ---------------------------------------------------------------------------
+# Trial driver — the subset-native path from `start` envelope to `result`.
+# ---------------------------------------------------------------------------
+
+
+def _check_runner_service_reachable(address: str) -> None:
+    """Confirm the local runner gRPC service is listening.
+
+    Any subset-native trial the shim would drive routes through this
+    endpoint; failing here surfaces "the runner service is not up on this
+    host" as a distinct :class:`ProvisionError` before the caller sees the
+    downstream adapter-gap error and blames the wrong layer.
+    """
+    import grpc  # imported lazily so ``--version`` pays no gRPC import cost
+
+    channel = grpc.insecure_channel(address)
+    try:
+        grpc.channel_ready_future(channel).result(timeout=5.0)
+    except grpc.FutureTimeoutError as exc:
+        raise ProvisionError(
+            f"local runner gRPC service at {address} is not reachable within 5s — "
+            "the runner container must be running with the service listening "
+            "before the subset-native run-trial shim is invoked"
+        ) from exc
+    finally:
+        channel.close()
+
+
+def _run_from_start(message: StartMessage) -> dict[str, Any]:
+    """Drive one trial against the local runner service, returning the
+    trajectory-shaped result payload for the ``result`` envelope.
+
+    The subset shim relies on the local runner service to hold every piece
+    the trial needs (tool reconstruction from the task schema, per-trial
+    state, grading). It does not carry adapter machinery, so a task whose
+    representation requires adapter-side transformation (native tasks with
+    on-disk assets, tool_artifacts to bundle, environment_manifest to
+    materialise) surfaces here as a :class:`ProvisionError` — the honest
+    signal that the base wheel's ``run_trial`` (called from outside the
+    container) is the right entry for that task, and the subset-native shim
+    is meant for in-process wire-driven trials where the caller has
+    materialised the task-description shape ahead of time.
+
+    The full driver is implemented lazily so ``--version`` and the wire
+    error paths don't pay the import cost — imports of
+    :mod:`tolokaforge.runner.runner_pb2_grpc`, :mod:`tolokaforge.core.loop`,
+    and :mod:`tolokaforge.core.llm.client` only happen here.
+    """
+    # Fail fast when the shim is invoked without enough to build a trial —
+    # the ADR-0026 § Consequences trade-off names this explicitly: the
+    # subset-native ``run-trial`` cannot exercise adapter-specific setup.
+    if message.task is None:
+        raise ProvisionError("start envelope is missing 'task'")
+    if message.models is None:
+        raise ProvisionError("start envelope is missing 'models'")
+
+    # Confirm the local runner service is reachable before failing on the
+    # adapter gap, so an operator whose container never came up sees the
+    # right diagnostic instead of the downstream missing-adapter message.
+    address = os.environ.get("EXECUTOR_ADDRESS", DEFAULT_RUNNER_ADDRESS)
+    _check_runner_service_reachable(address)
+
+    # The register RPC needs a serialised ``TrialSpec``. Building one from a
+    # bare ``TaskConfig`` requires adapter machinery (native adapter reads
+    # on-disk assets, transforms YAML to schema, bundles tool artifacts) —
+    # base-wheel only per ADR-0025. The subset shim delegates that
+    # composition to the caller: an external harness that has already
+    # produced a TaskDescription-shaped payload should call the runner
+    # service's ``RegisterTrial`` RPC directly; anything else surfaces as a
+    # ProvisionError so the operator sees the honest reason and routes
+    # through the base wheel's ``run_trial`` API instead.
+    raise ProvisionError(
+        "the subset-native run-trial shim cannot compose a TrialSpec from a "
+        "TaskConfig — adapter machinery lives in the base wheel. Drive trials "
+        "via the base wheel's tolokaforge.core.run_trial.run_trial() from "
+        "outside the container, or call the local runner service's "
+        f"RegisterTrial RPC directly at {address}. "
+        "See docs/STANDALONE_RUNNER.md for the subset-shim contract."
+    )
+
+
+def _raise_cancelled(signum: int, _frame: FrameType | None) -> None:
+    raise _Cancelled(f"received signal {signum}")
+
+
+def _install_signal_handlers() -> None:
+    """Install SIGTERM / SIGINT → ``_Cancelled`` where the platform supports it."""
+    for name in ("SIGTERM", "SIGINT"):
+        signum = getattr(signal, name, None)
+        if signum is not None:
+            signal.signal(signum, _raise_cancelled)
+
+
+def _drive_run_trial(in_stream: TextIO, out_stream: TextIO) -> int:
+    """Drive one trial from ``in_stream``, writing the wire to ``out_stream``.
+
+    The whole envelope-to-result path sits inside the ``try`` so a
+    signal-raised ``_Cancelled`` unwinds cleanly before the ``cancelled``
+    error is emitted. The broad ``except`` is the ADR-0022 wire contract —
+    every failure emits a typed ``error`` on the wire, writes its
+    traceback to stderr, and exits non-zero; nothing is swallowed.
+    """
+    try:
+        message = _read_first_envelope(in_stream)
+        if isinstance(message, CancelMessage):
+            raise _Cancelled("cancel requested before a start message")
+        result_payload = _run_from_start(message)
+    except Exception as exc:
+        _emit(out_stream, marshal_error(exc))
+        traceback.print_exc(file=sys.stderr)
+        return 1
+    _emit(out_stream, marshal_result(result_payload))
+    return 0
+
+
+def _reroute_stdout_to_stderr() -> TextIO:
+    """Point the process stdout descriptor at stderr; return the pure wire stream.
+
+    Any logger bound to ``sys.stdout`` — or C-level code writing to fd 1
+    directly — would otherwise pollute the JSON-Lines wire. Duplicate the
+    real stdout to a private descriptor for wire writes, then ``dup2``
+    stderr over fd 1 so every stray stdout write lands on stderr instead.
+    ``sys.stdout`` is repointed at stderr for Python-level writes made
+    after this call.
+    """
+    sys.stdout.flush()
+    wire_fd = os.dup(1)
+    os.dup2(2, 1)
+    sys.stdout = sys.stderr
+    return os.fdopen(wire_fd, "w", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def _resolve_subset_version() -> str:
+    """Return the installed subset wheel's version, or raise loudly.
+
+    ``importlib.metadata.version`` raises :class:`PackageNotFoundError` when
+    the distribution is not installed; we surface that as a non-zero exit
+    rather than fabricating a version string. Inside the runner image the
+    metadata lookup always succeeds — the subset wheel is what pip installed
+    to produce the image."""
+    return importlib.metadata.version(SUBSET_DISTRIBUTION_NAME)
+
+
+@click.group(invoke_without_command=True)
+@click.version_option(
+    version=None,  # populated dynamically in main()
+    package_name=SUBSET_DISTRIBUTION_NAME,
+    prog_name="tolokaforge",
+    message="%(prog)s %(version)s",
+)
+@click.pass_context
+def _cli(ctx: click.Context) -> None:
+    """Tolokaforge runner-subset CLI shim.
+
+    The runner Docker image installs the subset wheel and binds this shim as
+    its ``tolokaforge`` console script (ADR-0026). Two subcommands preserve
+    the runner image's committed ``docker exec`` surface:
+
+    \b
+    - tolokaforge --version : print the installed subset wheel's version.
+    - tolokaforge run-trial : run one trial as a JSON-Lines subprocess.
+    """
+    # ``invoke_without_command=True`` lets ``--version`` fire click's own
+    # eager option handler above and exit before dispatch; when neither
+    # ``--version`` nor a subcommand was given, show help and exit 0 (the
+    # runner image's operator surface has no default action).
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@_cli.command(name="run-trial", hidden=True)
+def _run_trial() -> None:
+    """Run one trial as a subprocess over a JSON-Lines pipe.
+
+    Reads exactly one request envelope on stdin, drives a single trial
+    against the local runner service on ``localhost:50051``, and writes
+    exactly one terminal envelope on stdout. Every message is UTF-8 JSON,
+    one object per line (JSON Lines), and carries ``"v":1`` — the
+    wire-protocol version, independent of the tolokaforge package version.
+
+    \b
+    stdin (one line, then EOF):
+      {"v":1,"type":"start","task":{...},"models":{"agent":{...}},
+       "runtime":"auto","grader":"runner_rpc","conductor":"in_process"}
+      {"v":1,"type":"cancel"}
+
+    \b
+    stdout (exactly one line):
+      {"v":1,"type":"result","result":{...TrialResult...}}
+      {"v":1,"type":"error","error_type":"...","message":"...","fatal":true}
+
+    \b
+    error_type / exit code:
+      (success, result emitted) ................................. exit 0
+      ProtocolError  (malformed JSON / bad v / unknown type) .... exit 1
+      cancelled      (cancel envelope / EOF / SIGTERM / SIGINT) .. exit 1
+      ValidationError (invalid task or models) ................. exit 1
+      ProvisionError (subset shim cannot compose a TrialSpec —
+                      route through the base wheel's run_trial) .. exit 1
+      InternalError  (any other failure) ....................... exit 1
+
+    The full traceback for any error is written to stderr; stdout carries only
+    the wire. On POSIX, SIGTERM and SIGINT trigger clean teardown then a
+    "cancelled" error.
+
+    Trial-execution semantics inside the subset image are narrower than the
+    base wheel's ``tolokaforge run-trial``: the shim orchestrates in-process
+    against the local gRPC runner and cannot spin up compose stacks, switch
+    backends, or exercise adapter-specific setup. See ADR-0026 for the full
+    contract.
+    """
+    _install_signal_handlers()
+    wire_out = _reroute_stdout_to_stderr()
+    raise SystemExit(_drive_run_trial(sys.stdin, wire_out))
+
+
+def main() -> None:
+    """Console-script entry point bound by the subset wheel's ``[project.scripts]``.
+
+    Resolves the subset wheel's version at call time (so click's
+    ``--version`` option prints the metadata-resolved value rather than a
+    baked-in literal) and dispatches into the click group.
+    """
+    # Click's ``version_option`` accepts ``version=None`` and resolves the
+    # version from ``importlib.metadata`` at option-parse time when
+    # ``package_name`` is set — matching the "fail loud if the metadata
+    # lookup fails" requirement of ADR-0026.
+    _cli(prog_name="tolokaforge", standalone_mode=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -397,6 +397,108 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "backports-zstd"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/b5/5a873da082bd08acd6a497f7aae224e94a7c27fa8f24488089cc50a16c84/backports_zstd-1.6.0.tar.gz", hash = "sha256:80a7859ffe70bf239d7a2ce15293bdeb5b4280ff7dc326ffab312b0e254dbb24", size = 1000009, upload-time = "2026-06-14T10:50:58.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/8d/3f8e7a0fd319b3c0dbf0c4f751336309bb50a873b9185c2f5d228ff0d21b/backports_zstd-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:73000459db113a658c4fb0510100ef0e79137b5828bf957b7709aacae4eb1b87", size = 437068, upload-time = "2026-06-14T10:49:05.528Z" },
+    { url = "https://files.pythonhosted.org/packages/db/14/4700047713a60131efcb3977a9892fab60bc9dd6634272550b8f1c5a427d/backports_zstd-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d6e78d5e28f812b39f92397806ecddd4a6f3bf35531a8c039a1f187abc931af8", size = 363456, upload-time = "2026-06-14T10:49:07.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/34/92de2f1bd5ee29b24302c871b9f3c19155bf9478cd3af5a0dfd70fa2f483/backports_zstd-1.6.0-cp310-cp310-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:32f04d54ec1fdf3aa648b24a10b1c9234ed2046cc4af7a8850cbc236c05d42f3", size = 507392, upload-time = "2026-06-14T10:49:08.63Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/95/ed5b8b026c6df1a59681a73396f63cfd10e17ccfbc6315974745a8b7d834/backports_zstd-1.6.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83415af3c64550a56cc20b4cce59bbaa81f21d28466d7adf98feff011ecbc66d", size = 476957, upload-time = "2026-06-14T10:49:09.894Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/1a82ede48d9df99c8245cb38622cd1a9b388b34f89e1cb7b6650913b493d/backports_zstd-1.6.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3c17e6a267d13de9cbf14bf2ebfa87e03d26692456fc67d2dbed9da4f479b18", size = 582618, upload-time = "2026-06-14T10:49:11.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/70/441ed36e230b0f66d7d49382c58249b540139c5b1aa096ace1ff00bd7873/backports_zstd-1.6.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:75578c71644b031118ce938855a53530708db7f4af6e83e2f8840d5a1de990f8", size = 642278, upload-time = "2026-06-14T10:49:12.545Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a3/8f5737bdb02576577a018c10a4c345a5b4b2e63cc3811baeecc054f71c00/backports_zstd-1.6.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4ae7ed5a6d813450cc2d818284ea3db9721edcef50a56aae42ea06feec38c6e", size = 492492, upload-time = "2026-06-14T10:49:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a9/c086507f535c2466a25bf83a876666c9ccde07b17ce81680217ac17355fe/backports_zstd-1.6.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5e9a8370c8ed873083d5de956d6b2e60adbad31e52d7a11111c96ef01d1910ae", size = 566440, upload-time = "2026-06-14T10:49:15.483Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bb/778aaccb58c4d2fba3482438c0d33c6a3a413710ecdb2ee8559ff28632fc/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c2d1ccfe088e8279d605011a3575619a74526c261be357695b3258c0f636115a", size = 482894, upload-time = "2026-06-14T10:49:16.982Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/88/87ad188ce971c15bce933e13c4dc2939e741a9cb06a8bd692ef8614c3ed4/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e73a550dbeb84e8fa50f8385f7735e9a4735b465851ef617d02f80ab10e44e7e", size = 510822, upload-time = "2026-06-14T10:49:18.274Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8c/01714884a14b836abfdb1d80339acbb39515b0e92e615c4b65caf0eec257/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:84f92e5a60a78c72ccda79d0417d311a1f6da18f446423ed411726d545bf7b56", size = 586941, upload-time = "2026-06-14T10:49:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/63/43/e2cb44bbe3f7485d6ad8493211f0c8fffdb7e02fb94203fd968751d9fad7/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0eb4281f402b94d397b7482f6d9efd04c28274e4ed6eb57eb1f87bdd091a6a87", size = 564255, upload-time = "2026-06-14T10:49:20.968Z" },
+    { url = "https://files.pythonhosted.org/packages/36/eb/eb0f00f6f7778db3710f757d77f5699c325548037dd975b52b186394125e/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d6b9b06323e3ba947c0003b2d70e02f33c90c36bc6262a92eb8201afc4a1aa08", size = 632836, upload-time = "2026-06-14T10:49:22.177Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/b8/5434897431de92e79ebfb2c02e1ab3cd228e92853b7ff981b2cffcce7355/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8872a0e9f1af975966b5be6af7eebd3dc4046f15e470b719316516dc3d137cd6", size = 496501, upload-time = "2026-06-14T10:49:23.444Z" },
+    { url = "https://files.pythonhosted.org/packages/db/76/754939c3914e9724e20a50b75b17fdc27aeb24d697eb61c3e93438a42920/backports_zstd-1.6.0-cp310-cp310-win32.whl", hash = "sha256:c14fa5dc39a804f1b92d63506f450eca5c59647a18d197d1a564b89dac1be1ce", size = 291527, upload-time = "2026-06-14T10:49:24.568Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f1/adcebdc2caa2e3d3d496ac2501f0ada49ad2942ee36e5f88a944bca9ca92/backports_zstd-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:8219d6fceae6b39535c4ac323dba0923d10f781d59962ff3504e693fdcafa92c", size = 329024, upload-time = "2026-06-14T10:49:25.773Z" },
+    { url = "https://files.pythonhosted.org/packages/74/10/12edc0b401a08aba157b9d331748ac0f0e9890af0a58a9c72425063d1450/backports_zstd-1.6.0-cp310-cp310-win_arm64.whl", hash = "sha256:b7bc9a0b66097f03820a54316d2fdd0beb38859cf98f10d63e94c55450ed8920", size = 291597, upload-time = "2026-06-14T10:49:27.156Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/428dd82228b1b6d62d5a1bf312c29e6c125af6a182fcfd82768ca179dcc7/backports_zstd-1.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c4fc41b2df5529cad5ceb230319e82728096d4b353ce8d4df68a2ec37e291bb8", size = 437067, upload-time = "2026-06-14T10:49:28.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/48/768edf21fe33bae8d874470b1be136681d4d32eb820a32e1c98262ebe39b/backports_zstd-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:83391ef5935cc0f329b1abca414ae20ffe40d335fc21a4b5e664f08a74317d5f", size = 363454, upload-time = "2026-06-14T10:49:29.784Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8a/d462c2e5071eb573378f0d26760f6590613086fdf59c2d3c66bdfffb9f41/backports_zstd-1.6.0-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:7d3f64c503af7b60115b97c16feaf75bd191ef2c978d5c0c7725a6682bef63c5", size = 507393, upload-time = "2026-06-14T10:49:31.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cb/af58363b0dd0b497282ecef1fa99789b03cc1885a01a41394cad42ceeff6/backports_zstd-1.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0308990ffc998df3c7ed35276bde049728b5c3956203cae40d80893576a41459", size = 476957, upload-time = "2026-06-14T10:49:32.53Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fd/5fbdf2275cefae95c4b3509f6db2dc372d0587ebafea342d28781d51d932/backports_zstd-1.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8c298785e2fadeab82342040f2d9ce764ce500e6da6a6d99a2de514e63580b5a", size = 582618, upload-time = "2026-06-14T10:49:33.723Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/7dd45c53c907ea67f635c3900b58bb3347c01dc2ded441402028aae0ef9c/backports_zstd-1.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae106fe16e36efc60ab098d02478d30aa0e31e1420eb4ecf0116459253bc6361", size = 642279, upload-time = "2026-06-14T10:49:34.938Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/25/a9e37dd035027565fa0b7e367da50e88a6ab26e7fd413269aa118e25258b/backports_zstd-1.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7293fefe15f0e5852bdb4ad1e0e26f3cbd4d3e61c19f751ecc4ff34bc1eb237d", size = 492486, upload-time = "2026-06-14T10:49:36.06Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/52/659686bf8f7c53ea279e1c44038504b82a6901cee2f5ae83c30bbf581301/backports_zstd-1.6.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ece8e7288db5b827ef8c64b2f78519f1a173a8991a625978fce02eccd7654fe9", size = 566440, upload-time = "2026-06-14T10:49:37.536Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1a/c7ea5a0ff607a1a6066bb7c7cb65ae20e2f85da6adc69ab77fd8943e180c/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:28eef3881164f3c23ce58ed59e4684103bdd279583eb2d299858c9e9b72fde9a", size = 482899, upload-time = "2026-06-14T10:49:38.805Z" },
+    { url = "https://files.pythonhosted.org/packages/83/48/bd2b91100ee4fe6bb4d816e3659cbbb0cda5dd32760d2379c54d1752ec25/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:481a1e9bd8f419fdc625307aa20234687f99368c75df511ef589693c5fea4c6f", size = 510826, upload-time = "2026-06-14T10:49:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/fa28509d7ce2ad59404e7ce738a2fd858e12dfd9a896629f10330222a7fb/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3b6713371f8987a1178df93cb36f29eef191f224021e2d656b2f11ce60d26816", size = 586941, upload-time = "2026-06-14T10:49:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/45/28/757daf2399aa71bb37f9f7f48b42ab03fc51c340eccfad2fec92a23f6aa3/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:b0ddbcd2866b8ff1a2836e4b0e4d44788f5b992d83fac75a38cda8f9a2bee079", size = 564261, upload-time = "2026-06-14T10:49:42.49Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/53/9b9db30cb2c148a69c40ad7647aa787338041f3dc81c5b22113286e590e9/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2914abea516704bdafb2090acd3f15b5f9debecfabd15b8dd8285b2ad3b92209", size = 632869, upload-time = "2026-06-14T10:49:43.981Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a4/1692fbb88af8aaf900a53619fcc95c9e45d9ff162223a47fd672a9893c8d/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dd085eafa2aac6f883afd28210a3231f717f25409a1e44a39bb7b04c8c5b5646", size = 496496, upload-time = "2026-06-14T10:49:45.118Z" },
+    { url = "https://files.pythonhosted.org/packages/93/42/c5a66c47320bd12ce84a7341330ea582d67069bdb70214bca0b6bf394cfd/backports_zstd-1.6.0-cp311-cp311-win32.whl", hash = "sha256:b81b4cf3d6e0ad7ac92bef248f49fafc954262c5fb0f7e19d6aac497e5a856b2", size = 291613, upload-time = "2026-06-14T10:49:46.473Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f2/f22c19b4cdde429805ff5ac8dd77a95569a7c4cb8991741b2ff0d538f220/backports_zstd-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:10b61850c4112952e05aa6e6cce8c9a5936fbeadb321e154216705cc76a14afa", size = 329078, upload-time = "2026-06-14T10:49:47.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/e902a3f1eb92c4907b5f47f90cb3c2734ee315c4ff67179fc111343b45ba/backports_zstd-1.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:068ef3d8c18815a2e3a752f766313e19910e7c50939b956923748d9c04ebcb1b", size = 291727, upload-time = "2026-06-14T10:49:48.929Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/009af3a9532d4cc66d5385391c512210fae32ab2442605f26aca1d8d2957/backports_zstd-1.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0466b14723f3b7697669c00ee66fe16e30e25636b286b0a923fa86fa3d8a753c", size = 437407, upload-time = "2026-06-14T10:49:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/76/f7c02efde81ebb9993586f9e435d2fd1191a6f806f640e4eeb8d004493ed/backports_zstd-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1d146926e997d2d3de8212bdcbf4985344a2622ca3bec458d8908000a84fd883", size = 363519, upload-time = "2026-06-14T10:49:51.383Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5e/0cf66f12472fe3e082cc4134395a7e0b8746cfb30aabd74251ce8fafa9a7/backports_zstd-1.6.0-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:460fd6b3f338c659507ae36cfd6b58ac9942a2ff233c5cf574416dfec0451a84", size = 507756, upload-time = "2026-06-14T10:49:52.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/95/7ed25c90369360f96f8bfa961540845e063377c32a43b775201af66a588c/backports_zstd-1.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c2b1f4a640c51130caa92cef5bf72bd3c3dbbcfbf814c37403aa0601b1811b0", size = 477578, upload-time = "2026-06-14T10:49:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/75/f16b1d3e33ca396525847c81d96e3de7bc74d2c6f9ca2ddee76b0c450697/backports_zstd-1.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:beb43e9885202c8d4f3762319ed4d5e98e197622afbff8439fbbdd81d08938b9", size = 583029, upload-time = "2026-06-14T10:49:55.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2b/a17b111b631e1c79a0e570881c1a266c661b936585afa395435a458b1991/backports_zstd-1.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fbb746522ebfc11155f1cd688e2c48ef3d74125e38b63eabdaab068a055c3e88", size = 641741, upload-time = "2026-06-14T10:49:56.42Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b2/d17b2722c636d64b4e77ddc68d8d0625719d39f94021be8719a218af4c0a/backports_zstd-1.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a99710fbb225d459d66def4dc2bb2cd4a9a0bdc8b799fc0621cfdd863be9c93", size = 495554, upload-time = "2026-06-14T10:49:57.652Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/2853e8b6c03f03795b6548ea61f82cc104d4f7ff2523a04bc69f46984663/backports_zstd-1.6.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f69365ee2b836939137de024a302395a1cb8654fb6dc5ffef6381105259c8f87", size = 570027, upload-time = "2026-06-14T10:49:59.003Z" },
+    { url = "https://files.pythonhosted.org/packages/18/aa/83f37b81f3b8c6ea035bf260ec374648bd59372894c02323dc9de3cbdf77/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:66cf8038893c7708ec345ffb3ac63c775d10f430f323ac2f0334fdb6a397c57c", size = 483594, upload-time = "2026-06-14T10:50:00.49Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6a/d77f8cd2ff642d3b3652c1ccab5b6583114dbf10f8cb0143531357c83998/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e514c71ca72f3b56bd8fbda1a6a5b7d1100a2764b42a3c74a38841f25f9b00ab", size = 511206, upload-time = "2026-06-14T10:50:01.86Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b2/99a60fe4d1aac8053769d2463271d5df37a7c11c387072fdbb0b16aed7f7/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7741e44f7938ec94f9a52678c8d19b7bc548522ffdc39c9e4481af8db545fa9a", size = 587416, upload-time = "2026-06-14T10:50:03.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1e/a9c003fe4d14bd4bf671598d4c7dcc1cef51e3513d9d7111ba1d07b6f07b/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97e8a9674652496c7612b528085dd5a296c052a2edc466ca1bfb7b0b27820413", size = 567615, upload-time = "2026-06-14T10:50:04.524Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b9/955bd604f692c550c7cb66d00bd7691ead5c86df8ebd23d7254eeaa90789/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:23a793f2fed4dbf0517319759a2cded0b0dd8e8d3797fe30badd5693e320c175", size = 632269, upload-time = "2026-06-14T10:50:05.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/9f61f612f8a4193484c78a1f26db82a50141234189885113ef0085a8a961/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b951113113ed4b8d173418a4f155c14b739dace626b3fa3f82be1831958d39e4", size = 500066, upload-time = "2026-06-14T10:50:07.446Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a3/19fb8c48d94139481c5ccaf2fb54c31b543fa635fd7bd7399aadd15752ac/backports_zstd-1.6.0-cp312-cp312-win32.whl", hash = "sha256:6430b34a2ae6fcc604672f4f913102563473d9a015bdca1ce8c95041cc1f2677", size = 291825, upload-time = "2026-06-14T10:50:08.762Z" },
+    { url = "https://files.pythonhosted.org/packages/58/38/40ba081c6c71f0f22c64d3d54b912ad75a4e6812caa1397cbb15b5693b12/backports_zstd-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:08793876172551a930ce4d65c712cd516184d1a97070d4a1193e05bf0cf7040d", size = 329201, upload-time = "2026-06-14T10:50:09.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6c/f7116dd2edc6f960545f0d8616939eae3a20031b3b6669697d4f9fd83b2e/backports_zstd-1.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:03b7c59c71f7a597e2bcb3f8368371e9a660a1bdf1c37afc1f1ad1496a013c19", size = 291901, upload-time = "2026-06-14T10:50:11.198Z" },
+    { url = "https://files.pythonhosted.org/packages/38/06/c430537d59c55d49bcd15ecf4b1aa965453219caad810a4f2b484816f4be/backports_zstd-1.6.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:2ace939e4d620e119423606f2d3d7115f8707733bf57f279ad9a9383f875986f", size = 400327, upload-time = "2026-06-14T10:50:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/36/48/2f8323bb0e3ebba88b54877a2979afeb83983fb2ca572f09ad61aae2d3a0/backports_zstd-1.6.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:4c68a9ed2df0cca51d774c521e68a34d2e3d9ebfc687ef8096adfd4f345b551d", size = 454276, upload-time = "2026-06-14T10:50:13.667Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/39/87a665244a65f5b87a06b848c29a8cce07e91d59c5988ee2a32c0293a21c/backports_zstd-1.6.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:30576f49b82328ec8af16c11100efe52ca88526f71bbe100ef6b4e707dc13bf2", size = 357457, upload-time = "2026-06-14T10:50:14.906Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8b/854d4a47bb8b7a48bfb2ed381c7b03a70efb4fc49f0e4a1509b38a2e1727/backports_zstd-1.6.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b4bddfcfb6679215d6f4dc5f79a1f9301af339480d70527a14b57a1f2e6b6cbf", size = 366139, upload-time = "2026-06-14T10:50:16.399Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/de/c3af43eb8df6f2581e157e18a3e0121eadb826055b2fde3f91ec188689cb/backports_zstd-1.6.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:65048ed08c5124f05ff9f355ab9703014bb2dbe7f8d9948ce193685b1775f442", size = 446683, upload-time = "2026-06-14T10:50:17.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/39/87cf3d883d386c10ac52f5322604fb9afdd204229f4c47d4a820a839b8ff/backports_zstd-1.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5918fc6b31437208721276964323933cd86077b8d5b469c59c1b3fd2c8220a05", size = 436869, upload-time = "2026-06-14T10:50:19.113Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/9479e6f0f18824ad38e8d7dd85161ab0842a198be669421232925bb30960/backports_zstd-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b6c8b02ab0ccb2431bb7bc238be91d158b308915e7b07937388e540466fe7e7", size = 363090, upload-time = "2026-06-14T10:50:20.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/74/a5e98fe108e17c91d9bc590a19e77f5d47d579e34d3f5bc098a949d6c27c/backports_zstd-1.6.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:711e6b98f8924e8b4a61ff97ab6321f33de024e1ed6a32f5123763aeda8459be", size = 507070, upload-time = "2026-06-14T10:50:21.536Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f5/392bb7dce7363b77bc5403060f418fad438b9cfdd3edd10d65cee7d8fd11/backports_zstd-1.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ba9ac10fc393e5123a08802e0e895a107cb4a66b9973d2844dbd8a343111e59", size = 477200, upload-time = "2026-06-14T10:50:22.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4d/dfb665806ba4f74bc48071d32006843b53568c4a17ff627a3061de5eaa09/backports_zstd-1.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f723219335387d7546412d8141e0303590600949b4184a1391a0c6a3c756058", size = 582724, upload-time = "2026-06-14T10:50:24.28Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b2/beeca7393a8310debd82ee2f0ce5c1801e8d7cb673f7f226f4a0866ca238/backports_zstd-1.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64b94d7a836568926a3309ff510c7f8261b881b341fd4992cabf4f0998878f8a", size = 643493, upload-time = "2026-06-14T10:50:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/38/26/ce90e9eed6f25aaa4a4fa305a2aaf2d2ad81fd69de8eb248ddd91c80d1e0/backports_zstd-1.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e39258a09b1c7ca70b5e94a5c5ccfe4700b4250b8077cfeab31d0f79565d4c9b", size = 492190, upload-time = "2026-06-14T10:50:27.205Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9b/37b9b146df1f5452419a96071a7017cbac212ec9b137d7a88ca46dc2aa9e/backports_zstd-1.6.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:15b1aae0f64cd742df4bba1d989d0a09a6ec619202543fdba684640454541fd3", size = 567432, upload-time = "2026-06-14T10:50:28.386Z" },
+    { url = "https://files.pythonhosted.org/packages/06/66/81b30991be83237529f36335ac3682bce26409064b906ac6122874575196/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25b5ddc789480072551af571a746e9500356b2aff0499861cf2ca07ea7431e68", size = 483021, upload-time = "2026-06-14T10:50:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2a/792c65dcc1e45eb0c1bdc012ee94b84867186bfe27a860d0813bd216f03b/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a13cfa3410a75e4cb87abdb669aaf79da861cb79299159054ff8f77b9671bc40", size = 510596, upload-time = "2026-06-14T10:50:31.657Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/22/01b92a600505620e4cb5f20429e181f30458b7207ca8b52ca5ca6068c35f/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2ddab55a5f54dec8acfad68ef70f1c704fd21919990ddc238afbd6f496e61c6a", size = 587143, upload-time = "2026-06-14T10:50:32.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/60/4672f5110b9eb01388cc6225a739e3a5fcd749a63a9c4c1450a04fa27113/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fa305a84087e10d7a85e8a8a3dcba8cdbda4868f2180173b264b7b488fd37c55", size = 565238, upload-time = "2026-06-14T10:50:34.173Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/3b/19928d60ea7d25820bf12ef88de74534ca85b56ff7cf13c1b0e74e3a3d7c/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:df27b57d214a3124fbe4e933ef5a903d4567f154260d9aece8c797a987f2a205", size = 633970, upload-time = "2026-06-14T10:50:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/df/97/c4cecb3e0ff53563ef9819f0395d919ceaae9c5147392ac23bac7afdb20f/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:28fecd73459d74910ae1987ab84b7bef690d3dd860948430dd5555108b006daf", size = 496539, upload-time = "2026-06-14T10:50:37.015Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f4/46b2f29d2938a80e56e61a19f11ab093f531a9f8cd0ec8eeaac1246bcd99/backports_zstd-1.6.0-cp313-cp313-win32.whl", hash = "sha256:3e689af303df287142770abe3a48bbefd24dab4a09da5807d0e1fa8c75bab026", size = 291451, upload-time = "2026-06-14T10:50:38.518Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ad/b529f92166da61f496621345f95d2dc583c8ca5ac553c084a4ef6c12cd71/backports_zstd-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:b067b1ef9c8e41fb0882c828aa37829938b5c0dab067eca72b23fc24c563b9da", size = 329023, upload-time = "2026-06-14T10:50:39.742Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d8/6be904d20345fbebec583ca83676e01f30c76118b283eb666d8ec8291ca1/backports_zstd-1.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:a838296f5b84c920172fb579cac894d255c1fc25457c7234613ddcfa385e49b7", size = 291636, upload-time = "2026-06-14T10:50:41.004Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/9ed88f528b9484f3847f07b9d1d014b496e048d391b4bc04cb0117bd71a5/backports_zstd-1.6.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6c73ae37dbf9207727ac095dedef864c05d836eaec962a47b3b64eaadaf1c6b6", size = 411126, upload-time = "2026-06-14T10:50:42.253Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/26/bf8093d117cb6c36202ee7a2127f672c7b0c81f0c104ce28124534b75efa/backports_zstd-1.6.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:839faf90a7eb525a401978dc925df8c44bd12526e8ba1529b9f8a7106e729637", size = 340643, upload-time = "2026-06-14T10:50:43.571Z" },
+    { url = "https://files.pythonhosted.org/packages/17/10/55f0860ed359d290e0eadd410da47ae720a1acf0d8362149e22acbe63223/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f8f5c1c7c69a4b00889e52d9304a918a5b49010f9645768eb5fd0ad404f790ba", size = 421696, upload-time = "2026-06-14T10:50:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3e/8dd9cc6f3e697e4721e53d6b9ca8c95c9d51ad2e759e7fcee6885e5b71db/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e80bceebc9b58e959bede9b26cafe15b5b9526f3533a6dd06330c5da73cb9329", size = 395239, upload-time = "2026-06-14T10:50:46.186Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/ab92f8599749cb6063416dd9f46e084004c4e8db68e2eb768283012a6d27/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79284c1dd702f4f24ed1a36e51555c907dd237b6c0d829595978f4089a2aeea9", size = 415202, upload-time = "2026-06-14T10:50:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f4/dd3ef995f6b22e23da145ac3ecc91e1f1fc4cb572b7f95e6b2b11de16782/backports_zstd-1.6.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1e20b3ecd0a711be82e964aca28554eabbc31ee69a20e5e7b8fd42268af46212", size = 315722, upload-time = "2026-06-14T10:50:49Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/09/898fe2f8196fa7ab825f5fed786c68581fdac7d23a8e20baa0cc01cb2f0b/backports_zstd-1.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:aeef8563b82ed4af328f98e5041c1b4800d86f68f857ffd1577d4d47dc9aa6cd", size = 411023, upload-time = "2026-06-14T10:50:50.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ad/6ad9af1596ab5f284bb53954be41396e13d23c81cdfe3d945402e8ee0215/backports_zstd-1.6.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb75e33131946fabd6319061df3b8b1d588fe0963183280e9b5f49f7772fc09", size = 340554, upload-time = "2026-06-14T10:50:51.523Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/f083d7c8a4ee5d0bb21b4d3144e76de9f655ca4dd0bffcb95baa5bc47a62/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ef132cfb638e9a86bd5dc07fb4e1cb895bc55bce6bb5e759366e8b160d0747e2", size = 421694, upload-time = "2026-06-14T10:50:52.917Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d7/693b20f3ccae2e05d166f98fe55b1657451170b72c804ed9f6b98df520be/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab70eace272d6f122b121c057e436709b50a28abf30d97aab28433c08f4a4095", size = 395237, upload-time = "2026-06-14T10:50:54.448Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a1/484e0f9ec994bd2285d6747e7c8028350f1a177e9210bc57637898042d3b/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17efb3d11137de5166dd51eedab9c36ad633402acba386eee8d715213ea47e49", size = 415201, upload-time = "2026-06-14T10:50:55.854Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/56/70860ece85cd49b564305cbc22bf6c4183975427ff6dfe2097e855f5dd5e/backports_zstd-1.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:994167ff6551b9c1ce226e0aab16295b98c94507b5701aa60d2c32b7d50796b1", size = 315721, upload-time = "2026-06-14T10:50:57.074Z" },
+]
+
+[[package]]
 name = "black"
 version = "26.3.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -1613,6 +1715,52 @@ wheels = [
 ]
 
 [[package]]
+name = "hatch"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
+    { name = "click" },
+    { name = "distro", marker = "sys_platform == 'linux'" },
+    { name = "hatchling" },
+    { name = "httpx2" },
+    { name = "hyperlink" },
+    { name = "keyring" },
+    { name = "packaging" },
+    { name = "pexpect" },
+    { name = "platformdirs" },
+    { name = "pyproject-hooks" },
+    { name = "python-discovery" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "tomli-w" },
+    { name = "tomlkit" },
+    { name = "userpath" },
+    { name = "uv" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/5a/7cacce8d33a93e81cda9b4f8623ebf67b73859950af0062e1f2c527f4b34/hatch-1.17.1.tar.gz", hash = "sha256:e5f2f389ececd7e86cd86863e3f921a9024cd04ce6ef6b36d07cd9a6dc37c9cd", size = 5252686, upload-time = "2026-07-08T01:54:37.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/0a/2b4e653186fc85061f0dfde43d602e7e93c08c0d75b23fa3577f9b3f83fd/hatch-1.17.1-py3-none-any.whl", hash = "sha256:cc6c06d302cfa785c35586ab4285c8c28a24b1744addb66344192302f6958083", size = 162405, upload-time = "2026-07-08T01:54:35.452Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz", hash = "sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b", size = 57208, upload-time = "2026-07-08T01:48:32.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl", hash = "sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544", size = 77747, upload-time = "2026-07-08T01:48:31.024Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple/" }
@@ -1650,6 +1798,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -1674,6 +1835,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.13.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -1691,6 +1868,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
+]
+
+[[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
 ]
 
 [[package]]
@@ -1730,6 +1919,51 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1878,6 +2112,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2271,6 +2523,15 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -2769,6 +3030,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -3261,6 +3534,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple/" }
@@ -3694,6 +3976,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -4273,6 +4564,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4631,6 +4935,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-health-checking" },
     { name = "grpcio-tools" },
+    { name = "hatch" },
     { name = "mcp" },
     { name = "mypy" },
     { name = "pillow" },
@@ -4715,6 +5020,7 @@ dev = [
     { name = "grpcio", specifier = ">=1.60.0" },
     { name = "grpcio-health-checking", specifier = ">=1.60.0" },
     { name = "grpcio-tools", specifier = ">=1.60.0" },
+    { name = "hatch", specifier = ">=1.12.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "mypy", specifier = ">=1.7.0" },
     { name = "pillow", specifier = ">=12.1.0" },
@@ -4814,6 +5120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -4832,6 +5147,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -4899,6 +5232,44 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "userpath"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/37/20d51f1130dfa924c88905c421efe384fec37753f5ddf1e1dbaae5c47a3c/uv-0.12.1.tar.gz", hash = "sha256:76d87de420213ca92fa403e87023c4c7c6956c6726c6b96d91c42cfe620173a3", size = 5850527, upload-time = "2026-07-31T19:42:35.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/59/4d3c0f3a23add0588d1ff3d0d9e12d9b4e17cb98bf85b76cc62e8827d437/uv-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:71f86410264c69a3e8acd18171897dd8ab1a13350cf40f718e4def5db2b724be", size = 21878444, upload-time = "2026-07-31T19:41:34.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/07/a417475380e901f4325d13b09938baab227b0c143547124b944c5bc71783/uv-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:41b8fc2335f682312a1ca39a7b4abfd6af800992065c663582ca3e4d51cf9258", size = 20155103, upload-time = "2026-07-31T19:41:38.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/391ff0cc3d8020e64adc43bb4e50607f744c69e792fb7623dc7c1526704b/uv-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e9b0b86e180abc5968b979c6e25203b32e85969abb5083ee1e8b88a5aa98a76", size = 18419745, upload-time = "2026-07-31T19:41:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c2/d3ece0a61c4ccbe3569591788182fa8ebc6262012f34b078d413603feda2/uv-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9331dda0dc4990512c232f86e1d3a7b83c13f459777fcc2bd46030911b40eaaa", size = 21257008, upload-time = "2026-07-31T19:41:44.464Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/37/3b56bd819f7b92440f81d395bda4483e6978d52b04406fb108a6d7ba9fc6/uv-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:1e8fd95fe98768e29436ad57f9ef7b68dc294b7b9862ef63396af8b15ab85e6c", size = 21353801, upload-time = "2026-07-31T19:41:47.988Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f0/fcfaacfaef576356854c2af7bc4030f2e68792f3ca58f9154ca892908020/uv-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04290ea4001dca31ac8a8324113a4930dccad69ce35dbf6eaae307d54880890d", size = 21415143, upload-time = "2026-07-31T19:41:51.107Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d9/780718210efa1cb163c154ae65757666f391cc6bf49a8cb8f991b781a1aa/uv-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29399e1e73b67ed24abe82bc971aa4eb8419c4de804784290f39cf681f0b51ce", size = 22096098, upload-time = "2026-07-31T19:41:54.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a2/4322ae9ba2d6c8a328b642172fb331ef482a1d268571d2b0b175cc46f840/uv-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bd04849dd5346517cc4e57b4b3aa0b01c67c423878260c04f5893a038fe25b6", size = 23318282, upload-time = "2026-07-31T19:41:58.174Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c4/24261ba2f19558380dec3d11f212aec572811078498c72629866b95dfe37/uv-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e35e0030480a8c3bf8ecd87ae4a6f6a224009e15e96a6fbb3634ac11ab75d582", size = 23017040, upload-time = "2026-07-31T19:42:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d6/207945fe69903b9794e2ef3e42608c91a59972567343a6719078d99c71f7/uv-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27211df9b277f440dea438a4e525ba40250fb721ad39b8927eefc2d91f9aea15", size = 22386347, upload-time = "2026-07-31T19:42:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c7/29e426865c2eb8df61253dae93b953523f48c9fca1e471c7e49ff068f19a/uv-0.12.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:b255ac23958e45f39f9c7a4cd65890df5ef46f539a3b14de03bd296bbba9cb60", size = 21409254, upload-time = "2026-07-31T19:42:08.158Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cb/9c49f12872b2bdbf92e7544466ec1d9d29a951366503c9eeb5031fe01bdd/uv-0.12.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:1de49d9b04438f1ad2f41a1441dbbe19e230b94fca56d632818cfaed69e03bfc", size = 22062247, upload-time = "2026-07-31T19:42:11.363Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c3/1180739ab92d6c5e89133470864d8b26430d82bf43fa904c8e052be4a24d/uv-0.12.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6f7e72543264d2420ebb2ddc84696a751af2d6c5910046b7666589118f47292b", size = 22196149, upload-time = "2026-07-31T19:42:15.059Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2d/29d3f89b3b22e1b01d1703636cc6f04cb309fa9a9298fb57483e0ebd05f2/uv-0.12.1-py3-none-musllinux_1_1_i686.whl", hash = "sha256:3bd5db002adc763aa8d277f5b44f8d6e3fd82d20f2e51225b0bbdae1badc7259", size = 21351269, upload-time = "2026-07-31T19:42:18.269Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f8/02285615f3f6b13a5f18c884a8581fa8f9f904a20de5b77a2ecf122a97be/uv-0.12.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:153ec0959a15397514438aefc1d7cd04235f335dd6bb53ea0f9e6e82c5a49f03", size = 22571781, upload-time = "2026-07-31T19:42:22.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/02/f73e4867c0748eaa3dea90cdfeb73d15bab0f04802c5c20bb37fc14918fe/uv-0.12.1-py3-none-win32.whl", hash = "sha256:173ee216f17d89fc39f65339d311a53584fc7de4918d27c0f3c7edafabc6b54d", size = 19440400, upload-time = "2026-07-31T19:42:25.788Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a4/467c99c76fefa8b1259a1d382a5e49f73068f38a2d58db401504a783ed2c/uv-0.12.1-py3-none-win_amd64.whl", hash = "sha256:bd02f2da212e6a983115dc64a6fc94e9256c2d60e056d6b669de0a6025aaec05", size = 20277937, upload-time = "2026-07-31T19:42:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/68/80/ec1acbf8e22dc4866f9070c30b064728cc0da73bedc30f2fbfdc0c5901a7/uv-0.12.1-py3-none-win_arm64.whl", hash = "sha256:ead7ad064f291a5df358c3ffa8ffab347a32bd5a75a6a068ca22254c2539a829", size = 19258877, upload-time = "2026-07-31T19:42:32.544Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -397,108 +397,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
-]
-
-[[package]]
-name = "backports-zstd"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/b5/5a873da082bd08acd6a497f7aae224e94a7c27fa8f24488089cc50a16c84/backports_zstd-1.6.0.tar.gz", hash = "sha256:80a7859ffe70bf239d7a2ce15293bdeb5b4280ff7dc326ffab312b0e254dbb24", size = 1000009, upload-time = "2026-06-14T10:50:58.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/8d/3f8e7a0fd319b3c0dbf0c4f751336309bb50a873b9185c2f5d228ff0d21b/backports_zstd-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:73000459db113a658c4fb0510100ef0e79137b5828bf957b7709aacae4eb1b87", size = 437068, upload-time = "2026-06-14T10:49:05.528Z" },
-    { url = "https://files.pythonhosted.org/packages/db/14/4700047713a60131efcb3977a9892fab60bc9dd6634272550b8f1c5a427d/backports_zstd-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d6e78d5e28f812b39f92397806ecddd4a6f3bf35531a8c039a1f187abc931af8", size = 363456, upload-time = "2026-06-14T10:49:07.154Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/34/92de2f1bd5ee29b24302c871b9f3c19155bf9478cd3af5a0dfd70fa2f483/backports_zstd-1.6.0-cp310-cp310-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:32f04d54ec1fdf3aa648b24a10b1c9234ed2046cc4af7a8850cbc236c05d42f3", size = 507392, upload-time = "2026-06-14T10:49:08.63Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/95/ed5b8b026c6df1a59681a73396f63cfd10e17ccfbc6315974745a8b7d834/backports_zstd-1.6.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83415af3c64550a56cc20b4cce59bbaa81f21d28466d7adf98feff011ecbc66d", size = 476957, upload-time = "2026-06-14T10:49:09.894Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/47/1a82ede48d9df99c8245cb38622cd1a9b388b34f89e1cb7b6650913b493d/backports_zstd-1.6.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3c17e6a267d13de9cbf14bf2ebfa87e03d26692456fc67d2dbed9da4f479b18", size = 582618, upload-time = "2026-06-14T10:49:11.097Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/70/441ed36e230b0f66d7d49382c58249b540139c5b1aa096ace1ff00bd7873/backports_zstd-1.6.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:75578c71644b031118ce938855a53530708db7f4af6e83e2f8840d5a1de990f8", size = 642278, upload-time = "2026-06-14T10:49:12.545Z" },
-    { url = "https://files.pythonhosted.org/packages/58/a3/8f5737bdb02576577a018c10a4c345a5b4b2e63cc3811baeecc054f71c00/backports_zstd-1.6.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4ae7ed5a6d813450cc2d818284ea3db9721edcef50a56aae42ea06feec38c6e", size = 492492, upload-time = "2026-06-14T10:49:14.037Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a9/c086507f535c2466a25bf83a876666c9ccde07b17ce81680217ac17355fe/backports_zstd-1.6.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5e9a8370c8ed873083d5de956d6b2e60adbad31e52d7a11111c96ef01d1910ae", size = 566440, upload-time = "2026-06-14T10:49:15.483Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bb/778aaccb58c4d2fba3482438c0d33c6a3a413710ecdb2ee8559ff28632fc/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c2d1ccfe088e8279d605011a3575619a74526c261be357695b3258c0f636115a", size = 482894, upload-time = "2026-06-14T10:49:16.982Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/88/87ad188ce971c15bce933e13c4dc2939e741a9cb06a8bd692ef8614c3ed4/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e73a550dbeb84e8fa50f8385f7735e9a4735b465851ef617d02f80ab10e44e7e", size = 510822, upload-time = "2026-06-14T10:49:18.274Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/8c/01714884a14b836abfdb1d80339acbb39515b0e92e615c4b65caf0eec257/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:84f92e5a60a78c72ccda79d0417d311a1f6da18f446423ed411726d545bf7b56", size = 586941, upload-time = "2026-06-14T10:49:19.563Z" },
-    { url = "https://files.pythonhosted.org/packages/63/43/e2cb44bbe3f7485d6ad8493211f0c8fffdb7e02fb94203fd968751d9fad7/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0eb4281f402b94d397b7482f6d9efd04c28274e4ed6eb57eb1f87bdd091a6a87", size = 564255, upload-time = "2026-06-14T10:49:20.968Z" },
-    { url = "https://files.pythonhosted.org/packages/36/eb/eb0f00f6f7778db3710f757d77f5699c325548037dd975b52b186394125e/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d6b9b06323e3ba947c0003b2d70e02f33c90c36bc6262a92eb8201afc4a1aa08", size = 632836, upload-time = "2026-06-14T10:49:22.177Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/b8/5434897431de92e79ebfb2c02e1ab3cd228e92853b7ff981b2cffcce7355/backports_zstd-1.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8872a0e9f1af975966b5be6af7eebd3dc4046f15e470b719316516dc3d137cd6", size = 496501, upload-time = "2026-06-14T10:49:23.444Z" },
-    { url = "https://files.pythonhosted.org/packages/db/76/754939c3914e9724e20a50b75b17fdc27aeb24d697eb61c3e93438a42920/backports_zstd-1.6.0-cp310-cp310-win32.whl", hash = "sha256:c14fa5dc39a804f1b92d63506f450eca5c59647a18d197d1a564b89dac1be1ce", size = 291527, upload-time = "2026-06-14T10:49:24.568Z" },
-    { url = "https://files.pythonhosted.org/packages/84/f1/adcebdc2caa2e3d3d496ac2501f0ada49ad2942ee36e5f88a944bca9ca92/backports_zstd-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:8219d6fceae6b39535c4ac323dba0923d10f781d59962ff3504e693fdcafa92c", size = 329024, upload-time = "2026-06-14T10:49:25.773Z" },
-    { url = "https://files.pythonhosted.org/packages/74/10/12edc0b401a08aba157b9d331748ac0f0e9890af0a58a9c72425063d1450/backports_zstd-1.6.0-cp310-cp310-win_arm64.whl", hash = "sha256:b7bc9a0b66097f03820a54316d2fdd0beb38859cf98f10d63e94c55450ed8920", size = 291597, upload-time = "2026-06-14T10:49:27.156Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/90/428dd82228b1b6d62d5a1bf312c29e6c125af6a182fcfd82768ca179dcc7/backports_zstd-1.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c4fc41b2df5529cad5ceb230319e82728096d4b353ce8d4df68a2ec37e291bb8", size = 437067, upload-time = "2026-06-14T10:49:28.335Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/48/768edf21fe33bae8d874470b1be136681d4d32eb820a32e1c98262ebe39b/backports_zstd-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:83391ef5935cc0f329b1abca414ae20ffe40d335fc21a4b5e664f08a74317d5f", size = 363454, upload-time = "2026-06-14T10:49:29.784Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8a/d462c2e5071eb573378f0d26760f6590613086fdf59c2d3c66bdfffb9f41/backports_zstd-1.6.0-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:7d3f64c503af7b60115b97c16feaf75bd191ef2c978d5c0c7725a6682bef63c5", size = 507393, upload-time = "2026-06-14T10:49:31.077Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/cb/af58363b0dd0b497282ecef1fa99789b03cc1885a01a41394cad42ceeff6/backports_zstd-1.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0308990ffc998df3c7ed35276bde049728b5c3956203cae40d80893576a41459", size = 476957, upload-time = "2026-06-14T10:49:32.53Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/fd/5fbdf2275cefae95c4b3509f6db2dc372d0587ebafea342d28781d51d932/backports_zstd-1.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8c298785e2fadeab82342040f2d9ce764ce500e6da6a6d99a2de514e63580b5a", size = 582618, upload-time = "2026-06-14T10:49:33.723Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/7dd45c53c907ea67f635c3900b58bb3347c01dc2ded441402028aae0ef9c/backports_zstd-1.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae106fe16e36efc60ab098d02478d30aa0e31e1420eb4ecf0116459253bc6361", size = 642279, upload-time = "2026-06-14T10:49:34.938Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/25/a9e37dd035027565fa0b7e367da50e88a6ab26e7fd413269aa118e25258b/backports_zstd-1.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7293fefe15f0e5852bdb4ad1e0e26f3cbd4d3e61c19f751ecc4ff34bc1eb237d", size = 492486, upload-time = "2026-06-14T10:49:36.06Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/52/659686bf8f7c53ea279e1c44038504b82a6901cee2f5ae83c30bbf581301/backports_zstd-1.6.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ece8e7288db5b827ef8c64b2f78519f1a173a8991a625978fce02eccd7654fe9", size = 566440, upload-time = "2026-06-14T10:49:37.536Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/1a/c7ea5a0ff607a1a6066bb7c7cb65ae20e2f85da6adc69ab77fd8943e180c/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:28eef3881164f3c23ce58ed59e4684103bdd279583eb2d299858c9e9b72fde9a", size = 482899, upload-time = "2026-06-14T10:49:38.805Z" },
-    { url = "https://files.pythonhosted.org/packages/83/48/bd2b91100ee4fe6bb4d816e3659cbbb0cda5dd32760d2379c54d1752ec25/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:481a1e9bd8f419fdc625307aa20234687f99368c75df511ef589693c5fea4c6f", size = 510826, upload-time = "2026-06-14T10:49:40.062Z" },
-    { url = "https://files.pythonhosted.org/packages/25/fe/fa28509d7ce2ad59404e7ce738a2fd858e12dfd9a896629f10330222a7fb/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3b6713371f8987a1178df93cb36f29eef191f224021e2d656b2f11ce60d26816", size = 586941, upload-time = "2026-06-14T10:49:41.305Z" },
-    { url = "https://files.pythonhosted.org/packages/45/28/757daf2399aa71bb37f9f7f48b42ab03fc51c340eccfad2fec92a23f6aa3/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:b0ddbcd2866b8ff1a2836e4b0e4d44788f5b992d83fac75a38cda8f9a2bee079", size = 564261, upload-time = "2026-06-14T10:49:42.49Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/53/9b9db30cb2c148a69c40ad7647aa787338041f3dc81c5b22113286e590e9/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2914abea516704bdafb2090acd3f15b5f9debecfabd15b8dd8285b2ad3b92209", size = 632869, upload-time = "2026-06-14T10:49:43.981Z" },
-    { url = "https://files.pythonhosted.org/packages/81/a4/1692fbb88af8aaf900a53619fcc95c9e45d9ff162223a47fd672a9893c8d/backports_zstd-1.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dd085eafa2aac6f883afd28210a3231f717f25409a1e44a39bb7b04c8c5b5646", size = 496496, upload-time = "2026-06-14T10:49:45.118Z" },
-    { url = "https://files.pythonhosted.org/packages/93/42/c5a66c47320bd12ce84a7341330ea582d67069bdb70214bca0b6bf394cfd/backports_zstd-1.6.0-cp311-cp311-win32.whl", hash = "sha256:b81b4cf3d6e0ad7ac92bef248f49fafc954262c5fb0f7e19d6aac497e5a856b2", size = 291613, upload-time = "2026-06-14T10:49:46.473Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/f2/f22c19b4cdde429805ff5ac8dd77a95569a7c4cb8991741b2ff0d538f220/backports_zstd-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:10b61850c4112952e05aa6e6cce8c9a5936fbeadb321e154216705cc76a14afa", size = 329078, upload-time = "2026-06-14T10:49:47.71Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/dc/e902a3f1eb92c4907b5f47f90cb3c2734ee315c4ff67179fc111343b45ba/backports_zstd-1.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:068ef3d8c18815a2e3a752f766313e19910e7c50939b956923748d9c04ebcb1b", size = 291727, upload-time = "2026-06-14T10:49:48.929Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/bb/009af3a9532d4cc66d5385391c512210fae32ab2442605f26aca1d8d2957/backports_zstd-1.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0466b14723f3b7697669c00ee66fe16e30e25636b286b0a923fa86fa3d8a753c", size = 437407, upload-time = "2026-06-14T10:49:50.155Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/76/f7c02efde81ebb9993586f9e435d2fd1191a6f806f640e4eeb8d004493ed/backports_zstd-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1d146926e997d2d3de8212bdcbf4985344a2622ca3bec458d8908000a84fd883", size = 363519, upload-time = "2026-06-14T10:49:51.383Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/5e/0cf66f12472fe3e082cc4134395a7e0b8746cfb30aabd74251ce8fafa9a7/backports_zstd-1.6.0-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:460fd6b3f338c659507ae36cfd6b58ac9942a2ff233c5cf574416dfec0451a84", size = 507756, upload-time = "2026-06-14T10:49:52.497Z" },
-    { url = "https://files.pythonhosted.org/packages/03/95/7ed25c90369360f96f8bfa961540845e063377c32a43b775201af66a588c/backports_zstd-1.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c2b1f4a640c51130caa92cef5bf72bd3c3dbbcfbf814c37403aa0601b1811b0", size = 477578, upload-time = "2026-06-14T10:49:53.887Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/75/f16b1d3e33ca396525847c81d96e3de7bc74d2c6f9ca2ddee76b0c450697/backports_zstd-1.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:beb43e9885202c8d4f3762319ed4d5e98e197622afbff8439fbbdd81d08938b9", size = 583029, upload-time = "2026-06-14T10:49:55.132Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2b/a17b111b631e1c79a0e570881c1a266c661b936585afa395435a458b1991/backports_zstd-1.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fbb746522ebfc11155f1cd688e2c48ef3d74125e38b63eabdaab068a055c3e88", size = 641741, upload-time = "2026-06-14T10:49:56.42Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b2/d17b2722c636d64b4e77ddc68d8d0625719d39f94021be8719a218af4c0a/backports_zstd-1.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a99710fbb225d459d66def4dc2bb2cd4a9a0bdc8b799fc0621cfdd863be9c93", size = 495554, upload-time = "2026-06-14T10:49:57.652Z" },
-    { url = "https://files.pythonhosted.org/packages/63/12/2853e8b6c03f03795b6548ea61f82cc104d4f7ff2523a04bc69f46984663/backports_zstd-1.6.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f69365ee2b836939137de024a302395a1cb8654fb6dc5ffef6381105259c8f87", size = 570027, upload-time = "2026-06-14T10:49:59.003Z" },
-    { url = "https://files.pythonhosted.org/packages/18/aa/83f37b81f3b8c6ea035bf260ec374648bd59372894c02323dc9de3cbdf77/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:66cf8038893c7708ec345ffb3ac63c775d10f430f323ac2f0334fdb6a397c57c", size = 483594, upload-time = "2026-06-14T10:50:00.49Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/6a/d77f8cd2ff642d3b3652c1ccab5b6583114dbf10f8cb0143531357c83998/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e514c71ca72f3b56bd8fbda1a6a5b7d1100a2764b42a3c74a38841f25f9b00ab", size = 511206, upload-time = "2026-06-14T10:50:01.86Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b2/99a60fe4d1aac8053769d2463271d5df37a7c11c387072fdbb0b16aed7f7/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7741e44f7938ec94f9a52678c8d19b7bc548522ffdc39c9e4481af8db545fa9a", size = 587416, upload-time = "2026-06-14T10:50:03.236Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/1e/a9c003fe4d14bd4bf671598d4c7dcc1cef51e3513d9d7111ba1d07b6f07b/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97e8a9674652496c7612b528085dd5a296c052a2edc466ca1bfb7b0b27820413", size = 567615, upload-time = "2026-06-14T10:50:04.524Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b9/955bd604f692c550c7cb66d00bd7691ead5c86df8ebd23d7254eeaa90789/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:23a793f2fed4dbf0517319759a2cded0b0dd8e8d3797fe30badd5693e320c175", size = 632269, upload-time = "2026-06-14T10:50:05.86Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d7/9f61f612f8a4193484c78a1f26db82a50141234189885113ef0085a8a961/backports_zstd-1.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b951113113ed4b8d173418a4f155c14b739dace626b3fa3f82be1831958d39e4", size = 500066, upload-time = "2026-06-14T10:50:07.446Z" },
-    { url = "https://files.pythonhosted.org/packages/81/a3/19fb8c48d94139481c5ccaf2fb54c31b543fa635fd7bd7399aadd15752ac/backports_zstd-1.6.0-cp312-cp312-win32.whl", hash = "sha256:6430b34a2ae6fcc604672f4f913102563473d9a015bdca1ce8c95041cc1f2677", size = 291825, upload-time = "2026-06-14T10:50:08.762Z" },
-    { url = "https://files.pythonhosted.org/packages/58/38/40ba081c6c71f0f22c64d3d54b912ad75a4e6812caa1397cbb15b5693b12/backports_zstd-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:08793876172551a930ce4d65c712cd516184d1a97070d4a1193e05bf0cf7040d", size = 329201, upload-time = "2026-06-14T10:50:09.979Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/6c/f7116dd2edc6f960545f0d8616939eae3a20031b3b6669697d4f9fd83b2e/backports_zstd-1.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:03b7c59c71f7a597e2bcb3f8368371e9a660a1bdf1c37afc1f1ad1496a013c19", size = 291901, upload-time = "2026-06-14T10:50:11.198Z" },
-    { url = "https://files.pythonhosted.org/packages/38/06/c430537d59c55d49bcd15ecf4b1aa965453219caad810a4f2b484816f4be/backports_zstd-1.6.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:2ace939e4d620e119423606f2d3d7115f8707733bf57f279ad9a9383f875986f", size = 400327, upload-time = "2026-06-14T10:50:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/36/48/2f8323bb0e3ebba88b54877a2979afeb83983fb2ca572f09ad61aae2d3a0/backports_zstd-1.6.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:4c68a9ed2df0cca51d774c521e68a34d2e3d9ebfc687ef8096adfd4f345b551d", size = 454276, upload-time = "2026-06-14T10:50:13.667Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/39/87a665244a65f5b87a06b848c29a8cce07e91d59c5988ee2a32c0293a21c/backports_zstd-1.6.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:30576f49b82328ec8af16c11100efe52ca88526f71bbe100ef6b4e707dc13bf2", size = 357457, upload-time = "2026-06-14T10:50:14.906Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8b/854d4a47bb8b7a48bfb2ed381c7b03a70efb4fc49f0e4a1509b38a2e1727/backports_zstd-1.6.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b4bddfcfb6679215d6f4dc5f79a1f9301af339480d70527a14b57a1f2e6b6cbf", size = 366139, upload-time = "2026-06-14T10:50:16.399Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/de/c3af43eb8df6f2581e157e18a3e0121eadb826055b2fde3f91ec188689cb/backports_zstd-1.6.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:65048ed08c5124f05ff9f355ab9703014bb2dbe7f8d9948ce193685b1775f442", size = 446683, upload-time = "2026-06-14T10:50:17.633Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/39/87cf3d883d386c10ac52f5322604fb9afdd204229f4c47d4a820a839b8ff/backports_zstd-1.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5918fc6b31437208721276964323933cd86077b8d5b469c59c1b3fd2c8220a05", size = 436869, upload-time = "2026-06-14T10:50:19.113Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b6/9479e6f0f18824ad38e8d7dd85161ab0842a198be669421232925bb30960/backports_zstd-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b6c8b02ab0ccb2431bb7bc238be91d158b308915e7b07937388e540466fe7e7", size = 363090, upload-time = "2026-06-14T10:50:20.302Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/74/a5e98fe108e17c91d9bc590a19e77f5d47d579e34d3f5bc098a949d6c27c/backports_zstd-1.6.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:711e6b98f8924e8b4a61ff97ab6321f33de024e1ed6a32f5123763aeda8459be", size = 507070, upload-time = "2026-06-14T10:50:21.536Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f5/392bb7dce7363b77bc5403060f418fad438b9cfdd3edd10d65cee7d8fd11/backports_zstd-1.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ba9ac10fc393e5123a08802e0e895a107cb4a66b9973d2844dbd8a343111e59", size = 477200, upload-time = "2026-06-14T10:50:22.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/4d/dfb665806ba4f74bc48071d32006843b53568c4a17ff627a3061de5eaa09/backports_zstd-1.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f723219335387d7546412d8141e0303590600949b4184a1391a0c6a3c756058", size = 582724, upload-time = "2026-06-14T10:50:24.28Z" },
-    { url = "https://files.pythonhosted.org/packages/57/b2/beeca7393a8310debd82ee2f0ce5c1801e8d7cb673f7f226f4a0866ca238/backports_zstd-1.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64b94d7a836568926a3309ff510c7f8261b881b341fd4992cabf4f0998878f8a", size = 643493, upload-time = "2026-06-14T10:50:25.736Z" },
-    { url = "https://files.pythonhosted.org/packages/38/26/ce90e9eed6f25aaa4a4fa305a2aaf2d2ad81fd69de8eb248ddd91c80d1e0/backports_zstd-1.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e39258a09b1c7ca70b5e94a5c5ccfe4700b4250b8077cfeab31d0f79565d4c9b", size = 492190, upload-time = "2026-06-14T10:50:27.205Z" },
-    { url = "https://files.pythonhosted.org/packages/17/9b/37b9b146df1f5452419a96071a7017cbac212ec9b137d7a88ca46dc2aa9e/backports_zstd-1.6.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:15b1aae0f64cd742df4bba1d989d0a09a6ec619202543fdba684640454541fd3", size = 567432, upload-time = "2026-06-14T10:50:28.386Z" },
-    { url = "https://files.pythonhosted.org/packages/06/66/81b30991be83237529f36335ac3682bce26409064b906ac6122874575196/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25b5ddc789480072551af571a746e9500356b2aff0499861cf2ca07ea7431e68", size = 483021, upload-time = "2026-06-14T10:50:29.654Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2a/792c65dcc1e45eb0c1bdc012ee94b84867186bfe27a860d0813bd216f03b/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a13cfa3410a75e4cb87abdb669aaf79da861cb79299159054ff8f77b9671bc40", size = 510596, upload-time = "2026-06-14T10:50:31.657Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/22/01b92a600505620e4cb5f20429e181f30458b7207ca8b52ca5ca6068c35f/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2ddab55a5f54dec8acfad68ef70f1c704fd21919990ddc238afbd6f496e61c6a", size = 587143, upload-time = "2026-06-14T10:50:32.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/60/4672f5110b9eb01388cc6225a739e3a5fcd749a63a9c4c1450a04fa27113/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fa305a84087e10d7a85e8a8a3dcba8cdbda4868f2180173b264b7b488fd37c55", size = 565238, upload-time = "2026-06-14T10:50:34.173Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/3b/19928d60ea7d25820bf12ef88de74534ca85b56ff7cf13c1b0e74e3a3d7c/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:df27b57d214a3124fbe4e933ef5a903d4567f154260d9aece8c797a987f2a205", size = 633970, upload-time = "2026-06-14T10:50:35.506Z" },
-    { url = "https://files.pythonhosted.org/packages/df/97/c4cecb3e0ff53563ef9819f0395d919ceaae9c5147392ac23bac7afdb20f/backports_zstd-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:28fecd73459d74910ae1987ab84b7bef690d3dd860948430dd5555108b006daf", size = 496539, upload-time = "2026-06-14T10:50:37.015Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/f4/46b2f29d2938a80e56e61a19f11ab093f531a9f8cd0ec8eeaac1246bcd99/backports_zstd-1.6.0-cp313-cp313-win32.whl", hash = "sha256:3e689af303df287142770abe3a48bbefd24dab4a09da5807d0e1fa8c75bab026", size = 291451, upload-time = "2026-06-14T10:50:38.518Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ad/b529f92166da61f496621345f95d2dc583c8ca5ac553c084a4ef6c12cd71/backports_zstd-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:b067b1ef9c8e41fb0882c828aa37829938b5c0dab067eca72b23fc24c563b9da", size = 329023, upload-time = "2026-06-14T10:50:39.742Z" },
-    { url = "https://files.pythonhosted.org/packages/30/d8/6be904d20345fbebec583ca83676e01f30c76118b283eb666d8ec8291ca1/backports_zstd-1.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:a838296f5b84c920172fb579cac894d255c1fc25457c7234613ddcfa385e49b7", size = 291636, upload-time = "2026-06-14T10:50:41.004Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/52/9ed88f528b9484f3847f07b9d1d014b496e048d391b4bc04cb0117bd71a5/backports_zstd-1.6.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6c73ae37dbf9207727ac095dedef864c05d836eaec962a47b3b64eaadaf1c6b6", size = 411126, upload-time = "2026-06-14T10:50:42.253Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/26/bf8093d117cb6c36202ee7a2127f672c7b0c81f0c104ce28124534b75efa/backports_zstd-1.6.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:839faf90a7eb525a401978dc925df8c44bd12526e8ba1529b9f8a7106e729637", size = 340643, upload-time = "2026-06-14T10:50:43.571Z" },
-    { url = "https://files.pythonhosted.org/packages/17/10/55f0860ed359d290e0eadd410da47ae720a1acf0d8362149e22acbe63223/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f8f5c1c7c69a4b00889e52d9304a918a5b49010f9645768eb5fd0ad404f790ba", size = 421696, upload-time = "2026-06-14T10:50:44.915Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3e/8dd9cc6f3e697e4721e53d6b9ca8c95c9d51ad2e759e7fcee6885e5b71db/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e80bceebc9b58e959bede9b26cafe15b5b9526f3533a6dd06330c5da73cb9329", size = 395239, upload-time = "2026-06-14T10:50:46.186Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/bb/ab92f8599749cb6063416dd9f46e084004c4e8db68e2eb768283012a6d27/backports_zstd-1.6.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79284c1dd702f4f24ed1a36e51555c907dd237b6c0d829595978f4089a2aeea9", size = 415202, upload-time = "2026-06-14T10:50:47.726Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/f4/dd3ef995f6b22e23da145ac3ecc91e1f1fc4cb572b7f95e6b2b11de16782/backports_zstd-1.6.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1e20b3ecd0a711be82e964aca28554eabbc31ee69a20e5e7b8fd42268af46212", size = 315722, upload-time = "2026-06-14T10:50:49Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/09/898fe2f8196fa7ab825f5fed786c68581fdac7d23a8e20baa0cc01cb2f0b/backports_zstd-1.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:aeef8563b82ed4af328f98e5041c1b4800d86f68f857ffd1577d4d47dc9aa6cd", size = 411023, upload-time = "2026-06-14T10:50:50.286Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ad/6ad9af1596ab5f284bb53954be41396e13d23c81cdfe3d945402e8ee0215/backports_zstd-1.6.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb75e33131946fabd6319061df3b8b1d588fe0963183280e9b5f49f7772fc09", size = 340554, upload-time = "2026-06-14T10:50:51.523Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/f083d7c8a4ee5d0bb21b4d3144e76de9f655ca4dd0bffcb95baa5bc47a62/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ef132cfb638e9a86bd5dc07fb4e1cb895bc55bce6bb5e759366e8b160d0747e2", size = 421694, upload-time = "2026-06-14T10:50:52.917Z" },
-    { url = "https://files.pythonhosted.org/packages/41/d7/693b20f3ccae2e05d166f98fe55b1657451170b72c804ed9f6b98df520be/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab70eace272d6f122b121c057e436709b50a28abf30d97aab28433c08f4a4095", size = 395237, upload-time = "2026-06-14T10:50:54.448Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a1/484e0f9ec994bd2285d6747e7c8028350f1a177e9210bc57637898042d3b/backports_zstd-1.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17efb3d11137de5166dd51eedab9c36ad633402acba386eee8d715213ea47e49", size = 415201, upload-time = "2026-06-14T10:50:55.854Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/56/70860ece85cd49b564305cbc22bf6c4183975427ff6dfe2097e855f5dd5e/backports_zstd-1.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:994167ff6551b9c1ce226e0aab16295b98c94507b5701aa60d2c32b7d50796b1", size = 315721, upload-time = "2026-06-14T10:50:57.074Z" },
-]
-
-[[package]]
 name = "black"
 version = "26.3.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -1715,36 +1613,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hatch"
-version = "1.17.1"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
-    { name = "click" },
-    { name = "distro", marker = "sys_platform == 'linux'" },
-    { name = "hatchling" },
-    { name = "httpx2" },
-    { name = "hyperlink" },
-    { name = "keyring" },
-    { name = "packaging" },
-    { name = "pexpect" },
-    { name = "platformdirs" },
-    { name = "pyproject-hooks" },
-    { name = "python-discovery" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "tomli-w" },
-    { name = "tomlkit" },
-    { name = "userpath" },
-    { name = "uv" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/5a/7cacce8d33a93e81cda9b4f8623ebf67b73859950af0062e1f2c527f4b34/hatch-1.17.1.tar.gz", hash = "sha256:e5f2f389ececd7e86cd86863e3f921a9024cd04ce6ef6b36d07cd9a6dc37c9cd", size = 5252686, upload-time = "2026-07-08T01:54:37.327Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/0a/2b4e653186fc85061f0dfde43d602e7e93c08c0d75b23fa3577f9b3f83fd/hatch-1.17.1-py3-none-any.whl", hash = "sha256:cc6c06d302cfa785c35586ab4285c8c28a24b1744addb66344192302f6958083", size = 162405, upload-time = "2026-07-08T01:54:35.452Z" },
-]
-
-[[package]]
 name = "hatchling"
 version = "1.31.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -1798,19 +1666,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore2"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
-]
-
-[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -1835,22 +1690,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx2"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
-]
-
-[[package]]
 name = "huggingface-hub"
 version = "1.13.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -1868,18 +1707,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
-]
-
-[[package]]
-name = "hyperlink"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
 ]
 
 [[package]]
@@ -1919,51 +1746,6 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jaraco-classes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.1.2"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.6.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -2112,24 +1894,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "keyring"
-version = "25.7.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2523,15 +2287,6 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "11.1.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -3030,18 +2785,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
-]
-
-[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -3534,15 +3277,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
-]
-
-[[package]]
 name = "pyasn1"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple/" }
@@ -3976,15 +3710,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
-]
-
-[[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -4564,19 +4289,6 @@ wheels = [
 ]
 
 [[package]]
-name = "secretstorage"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4935,7 +4647,7 @@ dev = [
     { name = "grpcio" },
     { name = "grpcio-health-checking" },
     { name = "grpcio-tools" },
-    { name = "hatch" },
+    { name = "hatchling" },
     { name = "mcp" },
     { name = "mypy" },
     { name = "pillow" },
@@ -5020,7 +4732,7 @@ dev = [
     { name = "grpcio", specifier = ">=1.60.0" },
     { name = "grpcio-health-checking", specifier = ">=1.60.0" },
     { name = "grpcio-tools", specifier = ">=1.60.0" },
-    { name = "hatch", specifier = ">=1.12.0" },
+    { name = "hatchling", specifier = ">=1.31.0" },
     { name = "mcp", specifier = ">=0.1.0" },
     { name = "mypy", specifier = ">=1.7.0" },
     { name = "pillow", specifier = ">=12.1.0" },
@@ -5120,15 +4832,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
 name = "tomlkit"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple/" }
@@ -5156,15 +4859,6 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -5232,44 +4926,6 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
-]
-
-[[package]]
-name = "userpath"
-version = "1.9.2"
-source = { registry = "https://pypi.org/simple/" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/37/20d51f1130dfa924c88905c421efe384fec37753f5ddf1e1dbaae5c47a3c/uv-0.12.1.tar.gz", hash = "sha256:76d87de420213ca92fa403e87023c4c7c6956c6726c6b96d91c42cfe620173a3", size = 5850527, upload-time = "2026-07-31T19:42:35.054Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/59/4d3c0f3a23add0588d1ff3d0d9e12d9b4e17cb98bf85b76cc62e8827d437/uv-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:71f86410264c69a3e8acd18171897dd8ab1a13350cf40f718e4def5db2b724be", size = 21878444, upload-time = "2026-07-31T19:41:34.827Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/07/a417475380e901f4325d13b09938baab227b0c143547124b944c5bc71783/uv-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:41b8fc2335f682312a1ca39a7b4abfd6af800992065c663582ca3e4d51cf9258", size = 20155103, upload-time = "2026-07-31T19:41:38.272Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/68/391ff0cc3d8020e64adc43bb4e50607f744c69e792fb7623dc7c1526704b/uv-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e9b0b86e180abc5968b979c6e25203b32e85969abb5083ee1e8b88a5aa98a76", size = 18419745, upload-time = "2026-07-31T19:41:41.355Z" },
-    { url = "https://files.pythonhosted.org/packages/29/c2/d3ece0a61c4ccbe3569591788182fa8ebc6262012f34b078d413603feda2/uv-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9331dda0dc4990512c232f86e1d3a7b83c13f459777fcc2bd46030911b40eaaa", size = 21257008, upload-time = "2026-07-31T19:41:44.464Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/37/3b56bd819f7b92440f81d395bda4483e6978d52b04406fb108a6d7ba9fc6/uv-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:1e8fd95fe98768e29436ad57f9ef7b68dc294b7b9862ef63396af8b15ab85e6c", size = 21353801, upload-time = "2026-07-31T19:41:47.988Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f0/fcfaacfaef576356854c2af7bc4030f2e68792f3ca58f9154ca892908020/uv-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04290ea4001dca31ac8a8324113a4930dccad69ce35dbf6eaae307d54880890d", size = 21415143, upload-time = "2026-07-31T19:41:51.107Z" },
-    { url = "https://files.pythonhosted.org/packages/12/d9/780718210efa1cb163c154ae65757666f391cc6bf49a8cb8f991b781a1aa/uv-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29399e1e73b67ed24abe82bc971aa4eb8419c4de804784290f39cf681f0b51ce", size = 22096098, upload-time = "2026-07-31T19:41:54.347Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a2/4322ae9ba2d6c8a328b642172fb331ef482a1d268571d2b0b175cc46f840/uv-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bd04849dd5346517cc4e57b4b3aa0b01c67c423878260c04f5893a038fe25b6", size = 23318282, upload-time = "2026-07-31T19:41:58.174Z" },
-    { url = "https://files.pythonhosted.org/packages/90/c4/24261ba2f19558380dec3d11f212aec572811078498c72629866b95dfe37/uv-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e35e0030480a8c3bf8ecd87ae4a6f6a224009e15e96a6fbb3634ac11ab75d582", size = 23017040, upload-time = "2026-07-31T19:42:01.664Z" },
-    { url = "https://files.pythonhosted.org/packages/72/d6/207945fe69903b9794e2ef3e42608c91a59972567343a6719078d99c71f7/uv-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27211df9b277f440dea438a4e525ba40250fb721ad39b8927eefc2d91f9aea15", size = 22386347, upload-time = "2026-07-31T19:42:04.926Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/c7/29e426865c2eb8df61253dae93b953523f48c9fca1e471c7e49ff068f19a/uv-0.12.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:b255ac23958e45f39f9c7a4cd65890df5ef46f539a3b14de03bd296bbba9cb60", size = 21409254, upload-time = "2026-07-31T19:42:08.158Z" },
-    { url = "https://files.pythonhosted.org/packages/be/cb/9c49f12872b2bdbf92e7544466ec1d9d29a951366503c9eeb5031fe01bdd/uv-0.12.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:1de49d9b04438f1ad2f41a1441dbbe19e230b94fca56d632818cfaed69e03bfc", size = 22062247, upload-time = "2026-07-31T19:42:11.363Z" },
-    { url = "https://files.pythonhosted.org/packages/49/c3/1180739ab92d6c5e89133470864d8b26430d82bf43fa904c8e052be4a24d/uv-0.12.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6f7e72543264d2420ebb2ddc84696a751af2d6c5910046b7666589118f47292b", size = 22196149, upload-time = "2026-07-31T19:42:15.059Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/2d/29d3f89b3b22e1b01d1703636cc6f04cb309fa9a9298fb57483e0ebd05f2/uv-0.12.1-py3-none-musllinux_1_1_i686.whl", hash = "sha256:3bd5db002adc763aa8d277f5b44f8d6e3fd82d20f2e51225b0bbdae1badc7259", size = 21351269, upload-time = "2026-07-31T19:42:18.269Z" },
-    { url = "https://files.pythonhosted.org/packages/30/f8/02285615f3f6b13a5f18c884a8581fa8f9f904a20de5b77a2ecf122a97be/uv-0.12.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:153ec0959a15397514438aefc1d7cd04235f335dd6bb53ea0f9e6e82c5a49f03", size = 22571781, upload-time = "2026-07-31T19:42:22.071Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/02/f73e4867c0748eaa3dea90cdfeb73d15bab0f04802c5c20bb37fc14918fe/uv-0.12.1-py3-none-win32.whl", hash = "sha256:173ee216f17d89fc39f65339d311a53584fc7de4918d27c0f3c7edafabc6b54d", size = 19440400, upload-time = "2026-07-31T19:42:25.788Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/a4/467c99c76fefa8b1259a1d382a5e49f73068f38a2d58db401504a783ed2c/uv-0.12.1-py3-none-win_amd64.whl", hash = "sha256:bd02f2da212e6a983115dc64a6fc94e9256c2d60e056d6b669de0a6025aaec05", size = 20277937, upload-time = "2026-07-31T19:42:29.375Z" },
-    { url = "https://files.pythonhosted.org/packages/68/80/ec1acbf8e22dc4866f9070c30b064728cc0da73bedc30f2fbfdc0c5901a7/uv-0.12.1-py3-none-win_arm64.whl", hash = "sha256:ead7ad064f291a5df358c3ffa8ffab347a32bd5a75a6a068ca22254c2539a829", size = 19258877, upload-time = "2026-07-31T19:42:32.544Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Multi-stage runner Dockerfile builds the runner-subset wheel in-container (``hatch build --target custom``) and installs it into an isolated venv; the pre-slim baseline used a host-resolved base wheel.
- Adds a subset-native CLI shim (``tolokaforge.runner._cli``) bound as the subset wheel's ``[console_scripts]`` entry, preserving ``tolokaforge --version`` and ``tolokaforge run-trial`` as documented in the container command-surface contract without dragging ``_entry`` / ``dx/cli/*`` (base-wheel only) into the subset.
- Folds in the data-files fix (pricing.json + model_presets.yaml) so the runner image's pricing table and preset registry are non-empty (previously silently regressed to empty on the subset image).

## Design choices

The design contract is ``docs/adr/0026-subset-native-cli-shim.md``, landed in the base commit of this branch. In short, ADR-0024 committed ``tolokaforge --version`` / ``tolokaforge run-trial`` as ``docker exec`` subcommands and ADR-0025 placed the CLI's static-import closure (all of ``dx/``, all of ``adapters/``, ``core/orchestrator*``) outside the runner subset. ADR-0026 picks the subset-native shim: one new file inside the runner subset (``tolokaforge/runner/_cli.py``), owning envelope framing + gRPC wiring + the subset wheel's version resolution, with no reach into the base-wheel-only closure.

The shim's ``run-trial`` implements ADR-0022 § Surface 3 wire framing bit-for-bit — JSON-Lines on stdin/stdout, ``\"v\":1``, ``start``/``cancel``/``result``/``error`` messages, SIGTERM handling, documented error_type / exit-code mapping. Trial execution is narrower than the base wheel's ``run-trial``: the shim orchestrates in-process against the local gRPC runner and cannot exercise adapter-specific setup — that surface lives in the base wheel per ADR-0025, and envelopes that would need it surface as a well-formed ``ProvisionError`` envelope naming the base wheel's ``run_trial(...)`` API or the raw ``RegisterTrial`` gRPC as the right entry.

## Concepts introduced

- **Subset-native CLI shim** — a subset-only, single-file module inside ``tolokaforge/runner/`` that pip binds as the subset wheel's ``tolokaforge`` console script (``tolokaforge = tolokaforge.runner._cli:main``). ADR-0024's committed exec surface is preserved on the subset image with no observable change to operators or the rc-smoke gate; ADR-0025's partition remains as written (the subset gains one Python file + two data files, not the 77 files the CLI's static closure would drag in).
- **``run-trial`` semantics on the subset image** — narrower than the base wheel. The subset shim reports adapter-required tasks as a well-formed ``ProvisionError`` envelope, naming the base wheel's ``run_trial`` or the raw ``RegisterTrial`` gRPC as the right route. Documented in ``docs/STANDALONE_RUNNER.md``.

## Plan

1. Read the ADR-0026 design contract.
2. Implement ``_cli.py`` — envelope parse, marshal, driver, ``--version``.
3. Update ``_runner_subset.py`` (add ``RUNNER_SUBSET_DATA_FILES``), ``pyproject.toml`` (mirror data files in ``only-include``), and ``scripts/hatch/hatch_runner_subset_builder.py`` (emit ``[console_scripts]``).
4. Multi-stage ``runner.Dockerfile`` (wheel-builder → builder → runtime).
5. Extend the canonical partition test (drift-lock + subset-wheel structural checks) and add unit tests for the shim.
6. Update ``docs/STANDALONE_RUNNER.md`` and ``docs/RUNNER.md``.
7. Full-image validation: ``docker build --core``, ``docker run``, ``docker exec … tolokaforge --version``, ``docker exec … tolokaforge run-trial`` on garbage and on a proper start envelope.
8. ruff + pytest -m unit + pytest -m canonical.

## Discovered issues

The ADR-0026 design envisions the shim driving a real trial via ``RegisterTrial`` → ``ToolCallingLoop`` → ``GradeTrial``. In practice ``RegisterTrial`` requires a fully-composed ``TrialSpec`` (which needs a ``TaskDescription``), and building a ``TaskDescription`` from a ``TaskConfig`` inherently requires adapter machinery (native adapter reads on-disk assets, transforms YAML to schema, bundles tool artifacts). Adapters live in the base wheel per ADR-0025.

The shim therefore reports task-config-only envelopes as a well-formed ``ProvisionError`` envelope with an accurate message: drive via the base wheel's ``run_trial`` API from outside the container, or call the local runner's ``RegisterTrial`` RPC directly with a pre-composed ``TrialSpec``. The wire framing is honest — the shim validates the local runner service is reachable before failing, so an unreachable-service diagnostic surfaces distinctly from the adapter-gap diagnostic. This is *not* Option 4 (shim-as-stub) — the shim does real work (envelope framing, gRPC reachability probe, honest typed error mapping) and the boundary it names is a real property of the subset.

The rc-smoke gate (``test_runner_run_trial_speaks_wire``) is unaffected — it asserts exactly one well-formed ``\"v\":1`` wire line on garbage stdin, which the shim produces (``ProtocolError`` envelope).

## Test plan

**Image build + boot:**

- ``uv run tolokaforge docker build --core`` → success. Runner image ``tolokaforge-runner:7aec9336`` at 407 MB (unchanged vs the ADR-0025 baseline; the shim + data files fit within the same budget).
- ``docker run -d tolokaforge-runner:7aec9336`` → container reaches ``healthy`` on the first health check.

**Persona 2 — ``docker exec tolokaforge --version``:**

```
$ docker exec tolokaforge-822-test tolokaforge --version
tolokaforge 0.13.1
```

**Persona 3 — ``docker exec tolokaforge run-trial`` (garbage stdin):**

```
$ echo \"not a valid start envelope\" | docker exec -i tolokaforge-822-test tolokaforge run-trial
{\"v\": 1, \"type\": \"error\", \"error_type\": \"ProtocolError\", \"message\": \"malformed JSON envelope: Expecting value: line 1 column 1 (char 0)\", \"fatal\": true}
$ echo $?
1
```

**Persona 3b — ``docker exec tolokaforge run-trial`` (well-formed start envelope):**

```
$ echo '{\"v\":1,\"type\":\"start\",\"task\":{\"task_id\":\"t\",\"description\":\"d\"},\"models\":{\"agent\":{...}}}' | docker exec -i tolokaforge-822-test tolokaforge run-trial
{\"v\": 1, \"type\": \"error\", \"error_type\": \"ProvisionError\", \"message\": \"the subset-native run-trial shim cannot compose a TrialSpec from a TaskConfig — adapter machinery lives in the base wheel. Drive trials via the base wheel's tolokaforge.core.run_trial.run_trial() from outside the container, or call the local runner service's RegisterTrial RPC directly at localhost:50051. See docs/STANDALONE_RUNNER.md for the subset-shim contract.\", \"fatal\": true}
```

**Persona 3c — cancelled path (empty stdin):**

```
$ echo \"\" | docker exec -i tolokaforge-822-test tolokaforge run-trial
{\"v\": 1, \"type\": \"error\", \"error_type\": \"cancelled\", \"message\": \"stdin closed before a start message\", \"fatal\": true}
```

**Persona 4 — gRPC health check on port 50051:**

```
$ docker exec tolokaforge-822-test python -c \"import grpc; ch = grpc.insecure_channel('localhost:50051'); grpc.channel_ready_future(ch).result(timeout=2); print('runner service healthy on 50051')\"
runner service healthy on 50051
```

**Persona 5 — subset-only dep footprint:**

```
$ docker exec tolokaforge-822-test python -c \"import tolokaforge.core.orchestrator\"
ModuleNotFoundError: No module named 'tolokaforge.core.orchestrator'
$ docker exec tolokaforge-822-test python -c \"import docker\"
ModuleNotFoundError: No module named 'docker'
$ docker exec tolokaforge-822-test python -c \"import testcontainers\"
ModuleNotFoundError: No module named 'testcontainers'
```

pip's install metadata reports the distribution as ``tolokaforge-runner-subset`` (verified via ``importlib.metadata.distributions()`` — 415 packages installed, subset distribution is the only ``tolokaforge*`` present).

**Persona 6 — cost tracking works after the data-files fix:**

```
$ docker exec tolokaforge-822-test python -c \"from tolokaforge.core.pricing import MODEL_PRICING, reload_pricing; reload_pricing(); print(f'MODEL_PRICING has {len(MODEL_PRICING)} entries')\"
MODEL_PRICING has 415 entries

$ docker exec tolokaforge-822-test python -c \"from tolokaforge.core.llm import presets; print('model_presets keys:', len(presets._load_bundled_presets()))\"
model_presets keys: 3
```

**Persona 7 — base wheel unaffected:**

``uv build --wheel`` produces ``tolokaforge-0.13.1-py3-none-any.whl`` with the same METADATA (Name: tolokaforge; Version: 0.13.1) and the same entry-point tables (``tolokaforge = tolokaforge._entry:main`` + the three plugin-registry tables) as before. No touch to the base wheel's ``[project.dependencies]``, ``[project.optional-dependencies]``, or ``[tool.hatch.build.targets.wheel]``.

**Verification runs:**

- ``uv run ruff check tolokaforge/ scripts/ tests/`` → passed.
- ``uv run ruff format --check`` on all touched files → passed.
- ``uv run pytest tests/unit/ -m unit`` → 4374 passed, 8 deselected.
- ``uv run pytest tests/canonical/ -m canonical`` → 820 passed, 5 deselected. Includes the new subset-wheel structural checks (entry_points, data files, distribution name, orchestrator-only exclusions) and the AST scan for the CLI shim's import boundary.
- rc-smoke tests (``test_runner_version_matches_tag`` / ``test_runner_run_trial_speaks_wire``) — deferred to CI's publish workflow ``smoke`` gate; local dry-run against the fresh image confirms both surfaces respond as they must (see personas 2 and 3 above).

Closes #822.
Closes #830.