### PR TITLE
fix(runner-client): accept degraded runner status + introduce HealthLevel/HealthReport pattern (#801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Fix
+
+- **runner-client**: `GrpcRunnerClient.health_check` now accepts both `healthy` and `degraded` runner statuses (per `docs/GRPC_PROTOCOL.md` § HealthCheck) as reachable-for-connect purposes. The prior strict `status == "healthy"` check made every trial pack without a `db-service` fail the 30-attempt connect loop even though the runner's `HealthCheck` RPC was successfully answering. Only `unhealthy` and `RpcError` remain as fail states (#801)
+
 ### Feat
 
 - **runtime**: task packs may declare `services.<name>.readiness: {kind: grpc|http|tcp}`, an optional per-service client-reachability contract (default: none — the docker healthcheck stays the only readiness signal). Every existing pack validates unchanged (#803)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project are documented in this file.
 
 ### Feat
 
+- **core**: new `tolokaforge.core.health` module — reusable pattern for ordered health hierarchies. `HealthLevel` (an `IntEnum` with `UNHEALTHY < DEGRADED < HEALTHY`) + `HealthReport` (a frozen dataclass wrapping the level with `is_reachable()` / `is_fully_operational()` semantic predicates) + `HealthReport.from_status()` (single-source-of-truth mapping from protocol status strings, with unknowns mapping fail-loud to `UNHEALTHY`). `GrpcRunnerClient.health_report()` is the new primary API; `health_check()` becomes a backwards-compat facade over `health_report().is_reachable()`. The pattern replaces stringly-typed status comparisons with domain predicates on the wrapper — the mapping from protocol state to "can I use this service?" lives once, not scattered across call sites
+
+### Feat
+
 - **runtime**: task packs may declare `services.<name>.readiness: {kind: grpc|http|tcp}`, an optional per-service client-reachability contract (default: none — the docker healthcheck stays the only readiness signal). Every existing pack validates unchanged (#803)
 - **runtime**: `PerTrialRuntimeBackend.provision` gates on host-side readiness before returning — the runner is always probed for gRPC channel-readiness on its published host port, and any service declaring `readiness:` is probed by its kind. A container that is Docker-healthy but host-unreachable (loopback-only or IPv6-only bind) now fails fast with a `ProvisionError` whose `diagnostic` names the resolved endpoint, probe outcome, and the container's actual listen addresses, instead of a downstream 30 s client-connect timeout (#803)
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,98 @@
+"""Contract tests for the ordered health hierarchy pattern.
+
+Pins :class:`~tolokaforge.core.health.HealthLevel`'s ordering,
+:class:`~tolokaforge.core.health.HealthReport`'s semantic predicates, and
+:meth:`HealthReport.from_status`'s parse behaviour. The pattern is
+designed to be reused across service-status responses in the codebase;
+this file locks the reference implementation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.health import HealthLevel, HealthReport
+
+pytestmark = pytest.mark.unit
+
+
+class TestHealthLevelOrdering:
+    """The enum is ordered: comparisons express intent."""
+
+    def test_level_hierarchy_is_ascending(self) -> None:
+        """``UNHEALTHY < DEGRADED < HEALTHY`` — order is load-bearing."""
+        assert HealthLevel.UNHEALTHY < HealthLevel.DEGRADED
+        assert HealthLevel.DEGRADED < HealthLevel.HEALTHY
+
+    def test_at_least_reachable_reads_as_ge_degraded(self) -> None:
+        """The intent 'at least reachable for RPCs' is written as
+        ``level >= DEGRADED`` in call sites — verify that reads correctly."""
+        assert HealthLevel.DEGRADED >= HealthLevel.DEGRADED
+        assert HealthLevel.HEALTHY >= HealthLevel.DEGRADED
+        assert not (HealthLevel.UNHEALTHY >= HealthLevel.DEGRADED)
+
+
+class TestHealthReportPredicates:
+    """The domain decision (is this service usable?) lives on the wrapper."""
+
+    def test_is_reachable_true_for_healthy(self) -> None:
+        assert HealthReport(level=HealthLevel.HEALTHY).is_reachable() is True
+
+    def test_is_reachable_true_for_degraded(self) -> None:
+        """Degraded means the service's own gRPC surface is up — a
+        downstream dependency is the service's own concern to surface,
+        not a reason for the client to reject reachability."""
+        assert HealthReport(level=HealthLevel.DEGRADED).is_reachable() is True
+
+    def test_is_reachable_false_for_unhealthy(self) -> None:
+        assert HealthReport(level=HealthLevel.UNHEALTHY).is_reachable() is False
+
+    def test_is_fully_operational_true_only_for_healthy(self) -> None:
+        """Callers that genuinely need the whole stack (e.g. a grading
+        run that will hit the DB service through the runner) ask this
+        stricter question."""
+        assert HealthReport(level=HealthLevel.HEALTHY).is_fully_operational() is True
+        assert HealthReport(level=HealthLevel.DEGRADED).is_fully_operational() is False
+        assert HealthReport(level=HealthLevel.UNHEALTHY).is_fully_operational() is False
+
+
+class TestHealthReportFromStatus:
+    """Protocol-string → HealthLevel mapping lives in one place."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected_level"),
+        [
+            ("healthy", HealthLevel.HEALTHY),
+            ("degraded", HealthLevel.DEGRADED),
+            ("unhealthy", HealthLevel.UNHEALTHY),
+        ],
+    )
+    def test_known_status_maps_to_expected_level(
+        self, status: str, expected_level: HealthLevel
+    ) -> None:
+        """Three-state protocol vocabulary from ``docs/GRPC_PROTOCOL.md``
+        § HealthCheck maps directly."""
+        report = HealthReport.from_status(status)
+        assert report.level == expected_level
+
+    def test_unknown_status_maps_to_unhealthy(self) -> None:
+        """A future protocol addition or a typo hits UNHEALTHY, not silent
+        accept — fail-loud on drift. The client sees an unknown state and
+        treats it as 'don't use this service' until the client is updated
+        to understand the new state."""
+        report = HealthReport.from_status("warming_up")
+        assert report.level == HealthLevel.UNHEALTHY
+
+    def test_carries_version_and_detail_metadata(self) -> None:
+        """Context fields don't affect the domain decision but are
+        preserved for logging / display."""
+        report = HealthReport.from_status("degraded", version="1.2.3", detail="db unreachable")
+        assert report.version == "1.2.3"
+        assert report.detail == "db unreachable"
+        # Predicates are unaffected by context.
+        assert report.is_reachable() is True
+
+    def test_empty_status_maps_to_unhealthy(self) -> None:
+        """Empty string is neither known nor an intentional protocol
+        value — treated as unknown/UNHEALTHY."""
+        assert HealthReport.from_status("").level == HealthLevel.UNHEALTHY

--- a/tests/unit/test_shared_stack_runtime_connect_idempotency.py
+++ b/tests/unit/test_shared_stack_runtime_connect_idempotency.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tolokaforge.core.health import HealthLevel
 from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient, SharedStackRuntimeBackend
 
 pytestmark = pytest.mark.unit
@@ -88,49 +89,72 @@ class TestRunnerClientConnectIdempotency:
         assert health_check_calls == 2
 
 
-class TestGrpcRunnerClientHealthCheckAcceptsDegraded:
-    """``GrpcRunnerClient.health_check`` accepts both ``healthy`` and
-    ``degraded`` from the runner's ``HealthCheckResponse``.
+class TestGrpcRunnerClientHealthReport:
+    """``GrpcRunnerClient.health_report`` is the primary API — returns a
+    semantic :class:`~tolokaforge.core.health.HealthReport` derived from
+    the runner's ``HealthCheckResponse``. Callers ask domain questions
+    via the report's predicates instead of comparing the raw protocol
+    status string.
 
-    The runner's ``HealthCheck`` RPC reports three status values per
-    ``docs/GRPC_PROTOCOL.md`` § HealthCheck: ``healthy``, ``degraded``,
-    ``unhealthy``. ``degraded`` means the runner's own gRPC surface is up
-    and answering but a downstream service (DB, RAG) is unavailable. That
-    is the runner's concern to surface via its own per-service warnings —
-    it is NOT a signal the client should reject the runner itself for the
-    purpose of a connect-time reachability probe. Only ``unhealthy`` or an
-    ``RpcError`` are "the runner is dead" states.
-
-    This test pins that semantics against a regression where an earlier
-    strict ``status == "healthy"`` check made a downstream-less trial pack
-    (a common shape: MB adapter smoke has no ``db-service`` in its per-trial
-    compose) fail the 30-attempt connect loop even though the runner's
+    ``health_check`` is now a backwards-compat facade over
+    ``health_report().is_reachable()``. The prior strict
+    ``status == "healthy"`` check made every downstream-less trial pack
+    (MB adapter smoke shape: no ``db-service`` in the per-trial compose)
+    fail the 30-attempt connect loop even though the runner's
     ``HealthCheck`` RPC was successfully responding with ``degraded``.
+    This test class pins the new semantics — both the primary API and
+    the facade — against that regression.
     """
 
-    def _client_with_status(self, status: str, monkeypatch: pytest.MonkeyPatch) -> GrpcRunnerClient:
+    def _client_with_status(self, status: str) -> GrpcRunnerClient:
         client = GrpcRunnerClient(runner_address="sentinel:50051")
         stub = MagicMock()
         response = MagicMock()
         response.status = status
+        response.version = "1.0.0"
         stub.HealthCheck.return_value = response
         client.stub = stub
         return client
 
-    def test_healthy_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        client = self._client_with_status("healthy", monkeypatch)
-        assert client.health_check() is True
+    # --- Primary API: health_report() returns a HealthReport ---
 
-    def test_degraded_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The whole point of this test class — degraded runners are still
-        callable, so health_check must return True."""
-        client = self._client_with_status("degraded", monkeypatch)
-        assert client.health_check() is True
+    def test_health_report_maps_healthy_to_healthy_level(self) -> None:
+        report = self._client_with_status("healthy").health_report()
+        assert report.level == HealthLevel.HEALTHY
+        assert report.is_reachable() is True
+        assert report.is_fully_operational() is True
 
-    def test_unhealthy_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The runner explicitly signalling unhealthy is a real fail."""
-        client = self._client_with_status("unhealthy", monkeypatch)
-        assert client.health_check() is False
+    def test_health_report_maps_degraded_to_degraded_level(self) -> None:
+        """Whole point: degraded is reachable-but-not-fully-operational.
+        The two predicates on the wrapper distinguish these cases; the
+        client no longer collapses them via a string compare."""
+        report = self._client_with_status("degraded").health_report()
+        assert report.level == HealthLevel.DEGRADED
+        assert report.is_reachable() is True
+        assert report.is_fully_operational() is False
+
+    def test_health_report_maps_unhealthy_to_unhealthy_level(self) -> None:
+        report = self._client_with_status("unhealthy").health_report()
+        assert report.level == HealthLevel.UNHEALTHY
+        assert report.is_reachable() is False
+        assert report.is_fully_operational() is False
+
+    def test_health_report_carries_version(self) -> None:
+        """Context field is preserved on the wrapper for logging /
+        display — not part of the domain decision."""
+        report = self._client_with_status("healthy").health_report()
+        assert report.version == "1.0.0"
+
+    # --- Backwards-compat facade: health_check() delegates ---
+
+    def test_health_check_facade_returns_true_for_healthy(self) -> None:
+        assert self._client_with_status("healthy").health_check() is True
+
+    def test_health_check_facade_returns_true_for_degraded(self) -> None:
+        assert self._client_with_status("degraded").health_check() is True
+
+    def test_health_check_facade_returns_false_for_unhealthy(self) -> None:
+        assert self._client_with_status("unhealthy").health_check() is False
 
 
 class TestSharedStackRuntimeBackendConnectDelegates:

--- a/tests/unit/test_shared_stack_runtime_connect_idempotency.py
+++ b/tests/unit/test_shared_stack_runtime_connect_idempotency.py
@@ -88,6 +88,51 @@ class TestRunnerClientConnectIdempotency:
         assert health_check_calls == 2
 
 
+class TestGrpcRunnerClientHealthCheckAcceptsDegraded:
+    """``GrpcRunnerClient.health_check`` accepts both ``healthy`` and
+    ``degraded`` from the runner's ``HealthCheckResponse``.
+
+    The runner's ``HealthCheck`` RPC reports three status values per
+    ``docs/GRPC_PROTOCOL.md`` § HealthCheck: ``healthy``, ``degraded``,
+    ``unhealthy``. ``degraded`` means the runner's own gRPC surface is up
+    and answering but a downstream service (DB, RAG) is unavailable. That
+    is the runner's concern to surface via its own per-service warnings —
+    it is NOT a signal the client should reject the runner itself for the
+    purpose of a connect-time reachability probe. Only ``unhealthy`` or an
+    ``RpcError`` are "the runner is dead" states.
+
+    This test pins that semantics against a regression where an earlier
+    strict ``status == "healthy"`` check made a downstream-less trial pack
+    (a common shape: MB adapter smoke has no ``db-service`` in its per-trial
+    compose) fail the 30-attempt connect loop even though the runner's
+    ``HealthCheck`` RPC was successfully responding with ``degraded``.
+    """
+
+    def _client_with_status(self, status: str, monkeypatch: pytest.MonkeyPatch) -> GrpcRunnerClient:
+        client = GrpcRunnerClient(runner_address="sentinel:50051")
+        stub = MagicMock()
+        response = MagicMock()
+        response.status = status
+        stub.HealthCheck.return_value = response
+        client.stub = stub
+        return client
+
+    def test_healthy_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = self._client_with_status("healthy", monkeypatch)
+        assert client.health_check() is True
+
+    def test_degraded_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The whole point of this test class — degraded runners are still
+        callable, so health_check must return True."""
+        client = self._client_with_status("degraded", monkeypatch)
+        assert client.health_check() is True
+
+    def test_unhealthy_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The runner explicitly signalling unhealthy is a real fail."""
+        client = self._client_with_status("unhealthy", monkeypatch)
+        assert client.health_check() is False
+
+
 class TestSharedStackRuntimeBackendConnectDelegates:
     """``SharedStackRuntimeBackend.connect`` is a one-line wrapper that delegates to
     ``RunnerClient.connect``. The Protocol's idempotency promise rides on

--- a/tolokaforge/core/health.py
+++ b/tolokaforge/core/health.py
@@ -1,0 +1,105 @@
+"""Ordered health hierarchy for service-status responses.
+
+Encapsulates the pattern: bounded state enum + ordered levels + semantic
+predicates on a wrapper. Consumers ask domain questions
+(``is_reachable``, ``is_fully_operational``) instead of string equality
+against raw status values.
+
+The runner's ``HealthCheck`` RPC (``docs/GRPC_PROTOCOL.md`` § HealthCheck)
+is the reference use — its ``HealthCheckResponse.status`` values map to
+:class:`HealthLevel` via :meth:`HealthReport.from_status`. The mapping
+lives once, here, instead of scattered across every caller.
+
+Extending the pattern: any service response with a ``status`` string that
+carries an ordered health hierarchy should adopt this shape. Callers that
+ask "is the service usable?" get a named predicate; callers that ask
+"is everything fully up?" get a different named predicate; the domain
+decision lives on the wrapper, not in each call site.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class HealthLevel(IntEnum):
+    """Ordered health hierarchy. Higher = more capable.
+
+    Comparisons express intent: ``level >= DEGRADED`` reads as "at least
+    reachable for RPCs"; ``level == HEALTHY`` reads as "fully operational,
+    all downstreams up". Ordering is load-bearing — callers rely on
+    ``>=`` / ``==`` for their semantic checks, so a future addition to
+    the enum must be inserted at the correct rank.
+    """
+
+    UNHEALTHY = 0
+    DEGRADED = 1
+    HEALTHY = 2
+
+
+# Mapping from runner's protocol status strings to HealthLevel.
+# See docs/GRPC_PROTOCOL.md § HealthCheck for the authoritative status
+# vocabulary. Unknown strings map to UNHEALTHY at the from_status site.
+_STATUS_TO_LEVEL: dict[str, HealthLevel] = {
+    "healthy": HealthLevel.HEALTHY,
+    "degraded": HealthLevel.DEGRADED,
+    "unhealthy": HealthLevel.UNHEALTHY,
+}
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    """Semantic wrapper for a service HealthCheck response.
+
+    ``level`` is the ordered classification; other fields carry context
+    but do not participate in the domain decision. Callers should invoke
+    the predicate methods (:meth:`is_reachable`, :meth:`is_fully_operational`)
+    rather than reading ``level`` directly, so the mapping from state to
+    domain question lives in one place.
+    """
+
+    level: HealthLevel
+    version: str = ""
+    detail: str | None = None
+
+    def is_reachable(self) -> bool:
+        """Can I invoke RPCs on this service now?
+
+        True for ``HEALTHY`` and ``DEGRADED`` — both states mean the
+        service's gRPC surface is up and answering. ``DEGRADED`` reports
+        a downstream is unavailable, which is the service's own concern
+        to surface via per-dependency warnings, not a signal callers
+        should reject the service itself for connect-time reachability.
+        """
+        return self.level >= HealthLevel.DEGRADED
+
+    def is_fully_operational(self) -> bool:
+        """Are all downstream dependencies also up? True only for ``HEALTHY``.
+
+        Use this when a caller genuinely needs the service AND its
+        downstream stack — e.g. a grading run that will invoke the DB
+        service through the runner. For connect-time reachability, prefer
+        :meth:`is_reachable`.
+        """
+        return self.level == HealthLevel.HEALTHY
+
+    @classmethod
+    def from_status(
+        cls,
+        status: str,
+        version: str = "",
+        detail: str | None = None,
+    ) -> HealthReport:
+        """Parse a raw protocol status string into a :class:`HealthReport`.
+
+        Unknown status values map to ``UNHEALTHY`` (fail-loud on protocol
+        drift — an unknown state is treated as "don't use this service"
+        rather than silently accepting it as reachable). Callers that
+        need to distinguish "runner reported unhealthy" from "runner
+        reported an unknown state" should inspect the original status
+        string themselves; the HealthReport interface deliberately hides
+        that distinction so predicates stay simple.
+        """
+        level = _STATUS_TO_LEVEL.get(status, HealthLevel.UNHEALTHY)
+        return cls(level=level, version=version, detail=detail)

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -43,6 +43,7 @@ from tolokaforge.core.compose_materialisation import (
     shutdown_compose,
     write_capture_manifest,
 )
+from tolokaforge.core.health import HealthLevel, HealthReport
 from tolokaforge.core.models import SeedRef
 from tolokaforge.core.run_display_events import (
     _NULL_EVENTS,
@@ -774,40 +775,55 @@ class GrpcRunnerClient:
             logger.error(f"gRPC error in cleanup_trial: {e}")
             return {"success": False, "error": f"gRPC error: {str(e)}"}
 
-    def health_check(self) -> bool:
-        """Check if Runner service is healthy
+    def health_report(self) -> HealthReport:
+        """Query the runner's HealthCheck RPC and return a semantic
+        :class:`~tolokaforge.core.health.HealthReport`.
 
-        Returns:
-            True if service is healthy
+        Primary API. Callers should ask domain questions via
+        :meth:`~tolokaforge.core.health.HealthReport.is_reachable` /
+        :meth:`~tolokaforge.core.health.HealthReport.is_fully_operational`
+        rather than inspecting the raw protocol status string. The mapping
+        from protocol strings (``healthy`` / ``degraded`` / ``unhealthy``,
+        per ``docs/GRPC_PROTOCOL.md`` § HealthCheck) to
+        :class:`~tolokaforge.core.health.HealthLevel` lives once in
+        :meth:`HealthReport.from_status`; unknown status strings map to
+        ``UNHEALTHY`` (fail-loud on protocol drift).
 
-        A failed probe logs at ``ERROR`` — the record's real level, so
-        ``-v`` inspection, external log processors, and post-mortem
-        artifacts see it correctly. The log record is tagged with
-        ``extra={"component_id": ...}``; ``_LogSink`` recognises that tag
-        and routes the record into the component's tail widget instead of
-        ``print_above``-ing over the Rich panel. Visualisation stays
-        compact; signal is preserved.
+        A failed probe (``RpcError``) returns a ``HealthReport`` at
+        ``UNHEALTHY`` carrying the exception message in ``detail`` and
+        logs at ``ERROR`` — the record's real level, so ``-v`` inspection,
+        external log processors, and post-mortem artifacts see it. The
+        log record is tagged with ``extra={"component_id": ...}``;
+        ``_LogSink`` recognises that tag and routes the record into the
+        component's tail widget instead of ``print_above``-ing over the
+        Rich panel. Visualisation stays compact; signal is preserved.
         """
         if not self.stub:
             self.connect()
 
         try:
             response = self.stub.HealthCheck(runner_pb2.HealthCheckRequest())
-            # The protocol (docs/GRPC_PROTOCOL.md § HealthCheck) defines three
-            # status values: ``healthy``, ``degraded``, ``unhealthy``. Both
-            # ``healthy`` and ``degraded`` mean the runner's own gRPC surface
-            # is up and answering — degraded reports a downstream (DB / RAG)
-            # is unreachable, which is the runner's concern to surface via its
-            # own per-service warnings, not a signal the client should reject
-            # the runner itself. Only ``unhealthy`` or an ``RpcError`` are the
-            # runner is dead states.
-            return response.status in ("healthy", "degraded")
+            return HealthReport.from_status(
+                status=response.status,
+                version=response.version,
+            )
         except grpc.RpcError as e:
             logger.error(
                 f"Health check failed: {e}",
                 extra={"component_id": build_component_id("engine", "grpc.client", "runner")},
             )
-            return False
+            return HealthReport(level=HealthLevel.UNHEALTHY, detail=str(e))
+
+    def health_check(self) -> bool:
+        """Backwards-compat facade — True iff the runner is reachable for RPCs.
+
+        Delegates to :meth:`health_report` and applies
+        :meth:`~tolokaforge.core.health.HealthReport.is_reachable`. New
+        callers should prefer :meth:`health_report` directly and use
+        the semantic predicates, so the domain decision lives on the
+        response wrapper rather than at each call site.
+        """
+        return self.health_report().is_reachable()
 
     def health_check_detailed(self) -> dict:
         """Get detailed health check information

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -793,7 +793,15 @@ class GrpcRunnerClient:
 
         try:
             response = self.stub.HealthCheck(runner_pb2.HealthCheckRequest())
-            return response.status == "healthy"
+            # The protocol (docs/GRPC_PROTOCOL.md § HealthCheck) defines three
+            # status values: ``healthy``, ``degraded``, ``unhealthy``. Both
+            # ``healthy`` and ``degraded`` mean the runner's own gRPC surface
+            # is up and answering — degraded reports a downstream (DB / RAG)
+            # is unreachable, which is the runner's concern to surface via its
+            # own per-service warnings, not a signal the client should reject
+            # the runner itself. Only ``unhealthy`` or an ``RpcError`` are the
+            # runner is dead states.
+            return response.status in ("healthy", "degraded")
         except grpc.RpcError as e:
             logger.error(
                 f"Health check failed: {e}",


### PR DESCRIPTION
## Summary

- **#801 root-cause fix**: `GrpcRunnerClient` no longer rejects `degraded` runners as unreachable. The prior strict `status == "healthy"` check made every trial pack without a `db-service` fail the 30-attempt connect loop even though the runner's `HealthCheck` RPC was successfully answering with `degraded` (a downstream state, not a runner-is-dead state).
- **Reusable pattern folded in**: introduces `tolokaforge/core/health.py` with `HealthLevel` (an ordered `IntEnum`: `UNHEALTHY < DEGRADED < HEALTHY`) and `HealthReport` (a frozen dataclass with `is_reachable()` / `is_fully_operational()` semantic predicates). `GrpcRunnerClient.health_report()` is the new primary API; `health_check()` becomes a backwards-compat facade over `health_report().is_reachable()`. Consumers ask the domain question directly instead of comparing raw protocol strings.

## Design choices

- **Ordered enum + semantic predicates on a wrapper**: replaces stringly-typed status comparisons with a bounded state hierarchy where comparisons express intent (`level >= DEGRADED` reads as "at least reachable"; `level == HEALTHY` reads as "fully operational"). The mapping from protocol strings to the domain question lives once in `HealthReport.from_status()`, not scattered across every call site.
- **Unknown status maps fail-loud to `UNHEALTHY`**: future protocol additions or typos are treated as "don't use this service" until the client is updated to understand the new state. Explicit include over permissive exclude — safer against protocol drift.
- **Backwards-compat facade**: `health_check() -> bool` still works. Existing callers keep working without change; new callers should prefer `health_report()` for the semantic predicates. Zero migration cost.

## Concepts introduced

Two new domain types: `HealthLevel` (ordered `IntEnum`) and `HealthReport` (predicate wrapper). Together they encode a **reusable pattern**: any status-carrying response with an ordered hierarchy should adopt the shape — bounded state at the type layer, order-preserving encoding, semantic predicates on a wrapper. Future adopters flagged in the module docstring: `ReadinessResult` (from #817), `ExecutionStatus` / `JudgeStatus` proto enums, trial-state / run-state / container-state fields anywhere in the codebase.

## Diagnostic evidence of #801's actual root cause

Ran the MB adapter smoke config against a `deepmerge` pack (no `db-service` in its compose stack). Probed the live runner container mid-run:

- Runner's `/proc/net/tcp`: `0.0.0.0:50051` LISTEN (IPv4, container has no IPv6 stack — matches earlier localization).
- Docker port map: `50051/tcp -> 0.0.0.0:<host_port>`, published cleanly.
- `nc -zv localhost <host_port>` from host: succeeded.
- Direct `HealthCheck` RPC call from host to the same published port (via a small Python probe using `runner_pb2_grpc.RunnerServiceStub`): returned `status: "degraded", version: "1.0.0", available_adapters: "native"` in ~1 ms.
- Runner log: `Runner server started, listening on [::]:50051` + `Server started but DB Service connectivity is degraded`.

The runner was up. It was answering. The client's strict `status == "healthy"` comparison was the only thing preventing the connect from succeeding.

## Test plan

- `pytest tests/unit/test_health.py -v` — 12 tests locking the pattern: `HealthLevel` ordering, `HealthReport` predicates for all three levels, `from_status` parse behaviour for known + unknown + empty + metadata-carrying inputs.
- `pytest tests/unit/test_shared_stack_runtime_connect_idempotency.py -v` — 11 tests total: 3 pre-existing idempotency tests + 4 `health_report()` primary-API tests + 3 `health_check()` facade delegation tests + 1 `SharedStackRuntimeBackend` delegation.
- Post-merge: the MB adapter smoke run (this session's discovery workload) should provision cleanly and drive the agent through to grading.

Closes #801