### PR TITLE
fix(orchestrator): allow per-trial runs with heterogeneous compose files

### DIFF
--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -33,12 +33,23 @@ pytestmark = pytest.mark.unit
 _FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
 
 
-def _run_config(runtime: str = "shared") -> RunConfig:
+def _run_config(runtime: str | None = "shared") -> RunConfig:
+    """Build a minimal :class:`RunConfig`. ``runtime`` defaults to
+    ``"shared"`` so existing tests exercise the shared-stack heterogeneity
+    check; pass ``runtime="per_trial"`` for the operator-override branch
+    or ``runtime=None`` for the task-driven signal branch (which
+    requires a stub adapter on the orchestrator).
+    """
+    orchestrator_kwargs: dict[str, Any] = {
+        "workers": 1,
+        "repeats": 1,
+        "auto_start_services": False,
+    }
+    if runtime is not None:
+        orchestrator_kwargs["runtime"] = runtime
     return RunConfig(
         models={"agent": ModelConfig(provider="openai", name="gpt-4")},
-        orchestrator=OrchestratorConfig(
-            workers=1, repeats=1, auto_start_services=False, runtime=runtime
-        ),
+        orchestrator=OrchestratorConfig(**orchestrator_kwargs),
         evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
     )
 
@@ -211,6 +222,36 @@ class TestPerTrialRuntimeReturnsNone:
         orch.tasks = [_task("t1", m1), _task("t2", m2)]
         with pytest.raises(RuntimeError, match="different environment_manifest.compose_file"):
             orch._extract_run_env_manifest()
+
+    def test_task_driven_per_trial_signal_short_circuits(self) -> None:
+        """When the operator drops the deprecated ``orchestrator.runtime``
+        override and per-trial selection derives from
+        ``manifest.requires_per_trial`` via
+        :meth:`_select_backend_from_tasks`, the short-circuit must still
+        fire — otherwise the shared-stack heterogeneity check would run
+        on a per-trial run.
+
+        Uses a stub adapter to drive the task-driven branch (``override
+        is None + adapter is not None``); this is the path exercised
+        once the deprecation lands and consumers migrate off the
+        operator override.
+        """
+        m1 = _patch("safe_one_service.yaml")
+        m2 = _patch("safe_two_service.yaml")
+        # override=None → task-driven selection
+        orch = Orchestrator(_run_config(runtime=None))
+        orch.tasks = [_task("t1", m1), _task("t2", m2)]
+        # Stub adapter: to_task_description returns a manifest whose
+        # ``requires_per_trial`` is True, driving _select_backend_from_tasks
+        # to return "per_trial".
+        adapter = MagicMock()
+        per_trial_manifest = MagicMock()
+        per_trial_manifest.requires_per_trial = True
+        task_desc = MagicMock()
+        task_desc.environment_manifest = per_trial_manifest
+        adapter.to_task_description.return_value = task_desc
+        orch.adapter = adapter
+        assert orch._extract_run_env_manifest() is None
 
 
 class TestServicesDeclarationsPreserved:

--- a/tests/unit/test_orchestrator_extract_run_env_manifest.py
+++ b/tests/unit/test_orchestrator_extract_run_env_manifest.py
@@ -33,10 +33,12 @@ pytestmark = pytest.mark.unit
 _FIXTURES = Path(__file__).parent.parent / "canonical" / "fixtures" / "environment_manifest"
 
 
-def _run_config() -> RunConfig:
+def _run_config(runtime: str = "shared") -> RunConfig:
     return RunConfig(
         models={"agent": ModelConfig(provider="openai", name="gpt-4")},
-        orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+        orchestrator=OrchestratorConfig(
+            workers=1, repeats=1, auto_start_services=False, runtime=runtime
+        ),
         evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
     )
 
@@ -161,6 +163,54 @@ class TestRunWorkerGuard:
         # single ``if`` in run_worker; here we just pin the helper's
         # non-None contract that the guard depends on.
         assert orch._extract_run_env_manifest() is not None
+
+
+class TestPerTrialRuntimeReturnsNone:
+    """Under ``runtime: per_trial`` the backend resolves
+    ``task.environment_manifest`` independently per trial — a run-level
+    shared manifest doesn't apply. The helper must short-circuit to
+    ``None`` and NOT enforce the shared-stack single-compose-file
+    constraint that only applies to ``SharedStackRuntimeBackend``.
+
+    Regression lock: the MB adapter emits one pack per problem, each
+    with its own problem-specific compose. A three-problem per-trial
+    smoke run declares three distinct ``compose_file`` values — before
+    this gate the run failed at ``_extract_run_env_manifest`` before
+    Docker was even touched.
+    """
+
+    def test_heterogeneous_compose_files_allowed_under_per_trial(self) -> None:
+        m1 = _patch("safe_one_service.yaml")
+        m2 = _patch("safe_two_service.yaml")
+        orch = Orchestrator(_run_config(runtime="per_trial"))
+        orch.tasks = [_task("t1", m1), _task("t2", m2)]
+        assert orch._extract_run_env_manifest() is None
+
+    def test_mixed_declared_and_undeclared_allowed_under_per_trial(self) -> None:
+        m = _patch("safe_two_service.yaml")
+        orch = Orchestrator(_run_config(runtime="per_trial"))
+        orch.tasks = [_task("with", m), _task("without", None)]
+        assert orch._extract_run_env_manifest() is None
+
+    def test_consistent_manifests_also_return_none_under_per_trial(self) -> None:
+        """Even when tasks happen to share one compose file, per-trial
+        doesn't consume a run-level manifest — the backend resolves the
+        task's own manifest per trial. Return None to keep the call
+        sites consistent (``run_env_manifest is None`` under per-trial)."""
+        p = _patch("safe_two_service.yaml")
+        orch = Orchestrator(_run_config(runtime="per_trial"))
+        orch.tasks = [_task("t1", p), _task("t2", p)]
+        assert orch._extract_run_env_manifest() is None
+
+    def test_shared_runtime_still_enforces_heterogeneity_check(self) -> None:
+        """Ensure the per-trial short-circuit does not silently loosen
+        the shared-runtime invariant."""
+        m1 = _patch("safe_one_service.yaml")
+        m2 = _patch("safe_two_service.yaml")
+        orch = Orchestrator(_run_config(runtime="shared"))
+        orch.tasks = [_task("t1", m1), _task("t2", m2)]
+        with pytest.raises(RuntimeError, match="different environment_manifest.compose_file"):
+            orch._extract_run_env_manifest()
 
 
 class TestServicesDeclarationsPreserved:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -796,6 +796,19 @@ class Orchestrator:
         adapter emits one pack per problem, each with its own
         problem-specific compose). Return ``None`` — per-trial doesn't
         consume a run-level shared manifest.
+
+        Two call sites read this return value:
+
+        - :meth:`run` (the main run entry point): uses the manifest to
+          decide shared-stack materialisation and endpoint logging. Under
+          per-trial the ``None`` return routes through the task-scoped
+          resolution path.
+        - :meth:`run_worker` (distributed worker mode): raises when the
+          return is non-``None`` because a worker joining an env-manifest
+          run would connect to the parent's testcontainers-allocated
+          address, which isn't propagated. Under per-trial the guard is
+          skipped — workers materialise their own per-trial stacks and
+          never depend on a parent-allocated address.
         """
         from tolokaforge.core.project_loader import resolve
 
@@ -1535,7 +1548,11 @@ class Orchestrator:
                     self.logger.info("Creating service stack (db-service + runner)")
                     stack_factory = core_stack
                 service_stack = stack_factory(**core_stack_kwargs)
-                per_trial_mode = self.config.orchestrator.runtime == "per_trial"
+                # Route through the effective-choice helper so both the
+                # operator override and the task-driven per-trial signal
+                # produce the same task-declared-stack decision (see
+                # sibling guard at the endpoint-logging site below).
+                per_trial_mode = self._resolve_effective_runtime_choice() == "per_trial"
                 # In per_trial mode OR shared+env_manifest mode the built-in engine
                 # containers go unused — the task-declared compose stack owns the
                 # runner + db-service. The engine images still need to be BUILT so
@@ -1632,7 +1649,14 @@ class Orchestrator:
         from tolokaforge.core.shared_stack_runtime import _build_env_endpoints
 
         env_endpoints = _build_env_endpoints(runner_address)
-        if self.config.orchestrator.runtime == "per_trial" or run_env_manifest is not None:
+        # Route through ``_resolve_effective_runtime_choice`` so the guard
+        # covers both the operator override AND the task-driven per-trial
+        # signal. The direct ``config.orchestrator.runtime`` string check
+        # would miss the task-driven case now that
+        # ``_extract_run_env_manifest`` returns ``None`` for it — the
+        # ``else`` branch below would then log phantom default endpoints
+        # that never reach a trial spec, defeating this guard's intent.
+        if self._resolve_effective_runtime_choice() == "per_trial" or run_env_manifest is not None:
             # Per-trial backend resolves fresh endpoints per trial via
             # ``endpoints(handle)``. Shared+env_manifest resolves them once
             # at connect time from the materialised stack. In both cases the

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -782,14 +782,37 @@ class Orchestrator:
         :class:`EnvironmentManifest`, then dedupes by compose-file
         identity.
 
-        The run's tasks must be consistent: either every task in the run
-        declares the same ``environment_manifest.compose_file`` or none do.
-        Mixed runs (some tasks with, some without; or different compose
-        files across tasks) fail loud — a single ``SharedStackRuntimeBackend``
-        can only materialise one substrate per run, and a mixed declaration
-        signals an ambiguous operator intent.
+        For a **shared** runtime, the run's tasks must be consistent:
+        either every task in the run declares the same
+        ``environment_manifest.compose_file`` or none do. Mixed runs
+        (some tasks with, some without; or different compose files
+        across tasks) fail loud — a single ``SharedStackRuntimeBackend``
+        can only materialise one substrate per run, and a mixed
+        declaration signals an ambiguous operator intent.
+
+        For **per_trial** runtime this constraint does not apply — the
+        backend resolves ``task.environment_manifest`` independently per
+        trial. Heterogeneous compose files are legitimate (e.g. the MB
+        adapter emits one pack per problem, each with its own
+        problem-specific compose). Return ``None`` — per-trial doesn't
+        consume a run-level shared manifest.
         """
         from tolokaforge.core.project_loader import resolve
+
+        # Per-trial short-circuit — resolves via the same signal
+        # ``_construct_runtime_backend`` uses to pick the backend, so the
+        # two decisions stay in lock-step. Both the operator override
+        # ``orchestrator.runtime`` and the task-driven per-trial signal
+        # suppress the shared-stack heterogeneity check. Inlined rather
+        # than routed through ``_resolve_effective_runtime_choice`` so
+        # the override path works when the adapter isn't loaded yet
+        # (unit-test seams).
+        override = self.config.orchestrator.runtime
+        if override == "per_trial":
+            return None
+        if override is None and self.adapter is not None:
+            if self._select_backend_from_tasks() == "per_trial":
+                return None
 
         project_env = self.project.default_environment if self.project is not None else None
         manifests_by_compose: dict[str, EnvironmentManifest] = {}


### PR DESCRIPTION
## Summary
- \`_extract_run_env_manifest\` was rejecting per-trial runs whose tasks declare distinct \`environment.compose.yaml\` files, even though \`PerTrialRuntimeBackend\` materialises one substrate per trial and has no shared-stack invariant to enforce.
- Fix: short-circuit the helper to \`None\` when the effective runtime choice is \`per_trial\` (either via the deprecated \`orchestrator.runtime\` override or via the task-driven signal from \`_select_backend_from_tasks\`).
- Shared-runtime heterogeneity check unchanged; new unit test locks that it still fires under \`runtime=shared\`.

## Design choices
- **Inline the resolution rather than route through \`_resolve_effective_runtime_choice\`**: the override path must work when the adapter isn't loaded yet (unit-test seams that set \`orchestrator.runtime\` directly and skip adapter construction). \`_select_backend_from_tasks\` requires the adapter; the inlined form gates on it explicitly.
- **Return \`None\` even for consistent-manifest per-trial runs**: keeps the two downstream call sites (\`_construct_runtime_backend\` env_manifest arg, \`run_worker\` guard) consistent — under per-trial they read \`None\` and route via task-scoped resolution instead of the shared-stack path.

## Reproducing the bug
A 3-problem per-trial run with distinct compose files raises before Docker is touched:
\`\`\`
RuntimeError: Run has tasks declaring different environment_manifest.compose_file
values: [...three paths...]. A single SharedStackRuntimeBackend materialises one
substrate for the whole run. Split into separate runs or converge on one compose file.
\`\`\`
(Runtime backend logged as \`PerTrialRuntimeBackend\` at run start; the raise came from the shared-stack check firing regardless.)

## Test plan
- [x] \`tests/unit/test_orchestrator_extract_run_env_manifest.py\` — 4 new tests under \`TestPerTrialRuntimeReturnsNone\` (heterogeneous compose files allowed, mixed declared/undeclared allowed, consistent manifests also return None under per-trial, shared runtime still enforces heterogeneity). All 15 tests in the file pass.
- [ ] CI green.
- [ ] Downstream verification: 3-problem MB smoke completes end-to-end after this lands (evidence for TECHDEL-500 closure gated on this).