### PR TITLE
fix(automation): gate self-referential capability claims and untested classes

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -702,6 +702,14 @@ jobs:
             echo "::error::cert does not reconcile with the observe baseline - refusing to commit"
             exit 1
           fi
+          # Any NEWLY registered policy class must be referenced by the overlay and covered by
+          # a unit test (docs/ADD_NEW_MODEL.md step 5). The fix-loop's success signal is the live
+          # reprobe, so a missing unit test is otherwise invisible. set -e safe; exit 1 ->
+          # needs-human. Reads the STAGED presets.py diff, so it must run after `git add`.
+          if ! uv run automation check-new-classes --overlay observation/resolve/overlay.yaml; then
+            echo "::error::a new policy class is untested or unreferenced - refusing to commit"
+            exit 1
+          fi
           # Verify EXACTLY the staged tree (what we are about to commit), not the workspace.
           # `stash --keep-index` drops everything not staged so the worktree == the future
           # commit; then gate on: (1) it imports; (2) no-regression - the resolved policy must

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -389,11 +389,16 @@ jobs:
           PY
 
       - name: Aggregate deterministic findings (report-only)
+        id: findings
         run: |
           uv run automation observe-findings observation \
             --out observation/findings.json \
             --summary-out observation/summary.md \
             --run-url "$RUN_URL"
+          # Hash the evidence BEFORE any agent runs. Step outputs live outside the
+          # workspace, so the finalize gate can require the findings it judges to be
+          # byte-identical to what observe actually measured.
+          echo "sha=$(sha256sum observation/findings.json | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload observation bundle (artifact for debugging / re-runs)
         uses: actions/upload-artifact@v4
@@ -585,6 +590,13 @@ jobs:
               claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
               --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
+            # The compose agent just ran with unrestricted Bash in this workspace; the loop's
+            # own verdict tooling (reprobe / greencheck under tools/automation) must be
+            # pristine when it judges the attempt - an edit there would otherwise run HERE
+            # and then be stash-popped back at finalize without ever appearing in the PR.
+            # Restores index AND worktree from HEAD; committed (PR-visible) changes remain
+            # the human review's job.
+            git restore --source=HEAD --staged --worktree tools/automation
             # Agent-requested escalation: if it lacks the data to produce a CORRECT policy (a
             # data-bound quirk whose scope needs real-domain evidence the observe never surfaced),
             # it sets `needs_human: true` in decision.json. Break immediately - no wasted
@@ -679,15 +691,31 @@ jobs:
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
           AUTO_MERGE_ENABLED: ${{ vars.ARENA_AUTOMATION_AUTO_MERGE_ENABLED }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.head_ref }}
+          FINDINGS_SHA: ${{ steps.findings.outputs.sha }}
         run: |
           set -euo pipefail
+          # Agent-tamper hardening. Both agents above ran with unrestricted Bash in this
+          # workspace BEFORE these gates, and an unstaged edit under tools/automation would
+          # run here and then be stash-popped back without ever appearing in the PR. Re-pin
+          # the gate code to HEAD (index + worktree), and require the observe evidence the
+          # gates judge against to be byte-identical to what the aggregation step hashed
+          # before any agent ran. Committed (PR-visible) tampering remains the review's job.
+          git restore --source=HEAD --staged --worktree tools/automation
+          ACTUAL_SHA="$(sha256sum observation/findings.json | cut -d' ' -f1)"
+          if [ "$ACTUAL_SHA" != "$FINDINGS_SHA" ]; then
+            echo "::error::observation/findings.json differs from the observe-time evidence (hash mismatch) - refusing to finalize"
+            exit 1
+          fi
           # Deterministic commit + report (the agent only wrote files). Stage the WHOLE engine
           # LLM package, not a fixed file list: a code-CREATE can write a new adapter class in ANY
           # module (reasoning_codec / schema_sanitizer / prompt_policy / content_policy /
           # cache_policy), and a narrow list silently drops the new file while committing its
-          # wiring -> a build-breaking dangling import. Plus the cert + preset.
+          # wiring -> a build-breaking dangling import. Plus the cert + preset - and the unit
+          # tests under tests/unit/llm/ that the class gate requires: the gate reads the INDEX,
+          # so a test it credits but this list dropped would pass the gate and then vanish
+          # from the commit.
           git add tolokaforge/core/llm tolokaforge/core/data/model_presets.yaml \
-            tolokaforge/core/data/pricing.json tests/integration/llm/ 2>/dev/null || true
+            tolokaforge/core/data/pricing.json tests/integration/llm/ tests/unit/llm/ 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "::error::finalize produced no file changes"; exit 1
           fi

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -81,8 +81,21 @@ DID produce and routes it for a post-hoc human scope-check.)
   round-trips against the tool's Pydantic schema (`test_policy_array_recovery`). The cert itself is
   reconciled against the observe baseline (`automation reconcile-cert`, run before the stash so
   `findings.json` is still present): every probed capability must be declared (no silent auto-skip),
-  and no capability the baseline shows passing (>= 0.9) may be `known_unsupported` - catching the
-  free-form cert's under-declaration and false-pessimism.
+  no capability the baseline shows passing (>= 0.9) may be `known_unsupported` - catching the
+  free-form cert's under-declaration and false-pessimism - and a PAYLOAD-ONLY capability
+  (`thinking_replay_roundtrip` / `unsigned_thinking_replay`, whose probes mock the provider turn
+  and assert only our own outgoing payload) may be `required` only on a MEASURED passing native
+  baseline: promotion off a failing or absent baseline is SELF-REFERENTIAL and hard-fails, and any
+  other `required` with no probe result warns as UNBACKED. A newly registered policy class must
+  additionally be wired and covered (`automation check-new-classes`, an AST set-diff of the STAGED
+  `presets.py` registry against HEAD): referenced from the overlay or the staged
+  `model_presets.yaml` (by key in a value position, or by name), and mentioned by a unit test under
+  `tests/unit/llm/` as staged in the INDEX - the finalize commit stages that directory, so the
+  test the gate credits is the test that ships. Before any of these gates run, the workflow
+  re-pins `tools/automation/` to HEAD and requires `observation/findings.json` to hash-match the
+  value captured at aggregation time - the resolve/finalize agents run earlier, with Bash, in the
+  same workspace, and must not be able to weaken the gates or the evidence without it showing in
+  the PR diff.
   Only then does it commit to the PR branch, comment the record, and label
   `automation:integrate-done`. A broken / over-reaching / divergent fix (or a cert that does not
   reconcile) fails verification here and goes to `automation:integrate-needs-human`. NEVER merges.
@@ -355,9 +368,17 @@ sub-agent); the resolve prompts drive the fix loop. `index.yaml` is the machine-
   auto-merge price gate.
 - `automation reconcile-cert` - reconciles the finalized cert against the observe
   `findings.json`: fails if any probed capability is undeclared, if a capability the baseline shows
-  passing (>= 0.9) is marked `known_unsupported`, or if any CORE capability (e.g.
-  `cost_usd_populated`) is `known_unsupported` (a laundered pricing gap). Runs in the finalize gate
+  passing (>= 0.9) is marked `known_unsupported`, if any CORE capability (e.g.
+  `cost_usd_populated`) is `known_unsupported` (a laundered pricing gap), or if a PAYLOAD-ONLY
+  capability is `required` against a failing or absent native baseline (SELF-REFERENTIAL); any
+  other `required` with no probe result warns as UNBACKED. Runs in the finalize gate
   before the stash.
+- `automation check-new-classes` - finalize gate for newly registered policy classes: an AST
+  set-diff of the STAGED `presets.py` registry against HEAD (so quoting, wrapping, moves and
+  binding style cannot hide or fake an addition), requiring each new binding's class to be
+  mentioned by a unit test under `tests/unit/llm/` as staged in the INDEX and referenced from the
+  overlay or the staged `model_presets.yaml`. Fails loud on any git/parse error - a guard that
+  cannot see the registry must not skip.
 - `automation slack` - Slack thread notifier (`ensure-root` / `reply` / `post-thread`
   subcommands); dry-run no-op without a token. See "Slack notifications" above. `post-thread`
   posts a plain threaded reply under an arbitrary message ts (the poller's per-request

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -16,7 +16,10 @@ measured observe baseline in these ways this gate catches:
      an overlay can make it green BY CONSTRUCTION; a green reprobe is therefore not
      evidence about the model.
   5. UNBACKED - a capability is ``required`` with no probe result at all, so nothing
-     measured supports it (warning: a probe can legitimately fail to collect).
+     measured supports it (warning: a probe can legitimately fail to collect). For a
+     PAYLOAD-ONLY capability this is a hard SELF-REFERENTIAL violation instead: the
+     only admissible promotion evidence is a measured passing native baseline, so
+     "nothing measured" cannot stay a warning there.
 
 Checks 1-3 are SYMMETRIC-BY-DESIGN gaps this module originally shipped with: it
 guarded against under-crediting a model but not against over-crediting one. Check 4
@@ -130,10 +133,21 @@ def reconcile(
             "missing-pricing gap)."
         )
     for cap in sorted(required - set(probed)):
-        warnings.append(
-            f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
-            "nothing measured supports it. Confirm the probe collected, or demote it."
-        )
+        if cap in payload_only:
+            # For a payload-only cap the ONLY admissible evidence is a measured passing
+            # native baseline (its probe mocks the provider turn, so a post-overlay green
+            # proves nothing). "No probe result at all" therefore cannot stay a warning:
+            # it would let an all-unparseable-junit run promote the cap unbacked.
+            violations.append(
+                f"SELF-REFERENTIAL: `{cap}` is `required` with NO probe result in the "
+                "baseline. A payload-only capability may be promoted only on a MEASURED "
+                "passing native baseline - re-run observe or demote it."
+            )
+        else:
+            warnings.append(
+                f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
+                "nothing measured supports it. Confirm the probe collected, or demote it."
+            )
     for cap, rate in sorted(probed.items()):
         if cap not in declared:
             violations.append(

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -1,7 +1,7 @@
 """Reconcile a candidate ``ModelCertificate`` against the observe ``findings.json``.
 
 The resolve agent's certificate is free-form reasoning; it can diverge from the
-measured observe baseline in three ways this gate catches:
+measured observe baseline in these ways this gate catches:
 
   1. COMPLETENESS - a capability that WAS probed is left undeclared (neither
      ``required`` nor ``known_unsupported``); it would silently auto-skip.
@@ -10,6 +10,18 @@ measured observe baseline in three ways this gate catches:
   3. CORE-UNSUPPORTED - a CORE capability (e.g. ``cost_usd_populated``) is marked
      ``known_unsupported`` - which would launder a missing-pricing gap into a fake
      ceiling.
+  4. SELF-REFERENTIAL - a PAYLOAD-ONLY capability (see
+     ``PAYLOAD_ONLY_CAPABILITIES``) is ``required`` against a FAILING baseline. Its
+     probe asserts our own outgoing request body with the provider turn mocked, so
+     an overlay can make it green BY CONSTRUCTION; a green reprobe is therefore not
+     evidence about the model.
+  5. UNBACKED - a capability is ``required`` with no probe result at all, so nothing
+     measured supports it (warning: a probe can legitimately fail to collect).
+
+Checks 1-3 are SYMMETRIC-BY-DESIGN gaps this module originally shipped with: it
+guarded against under-crediting a model but not against over-crediting one. Check 4
+closes the over-crediting side for the one probe class where "the reprobe went green"
+cannot mean what it appears to mean.
 
 A capability in ``[SOFT_PASS, HARD_PASS)`` marked ``known_unsupported`` is WARNED,
 not failed. Baseline pass_rate is the MIN across a capability's parametrised probes,
@@ -27,6 +39,28 @@ import sys
 
 HARD_PASS = 0.9
 SOFT_PASS = 0.8
+
+# Capabilities whose probe observes OUR OWN outgoing request payload rather than the
+# provider's behaviour: both replay tests fire turn 1 live, then MOCK turn 2 and
+# assert on the captured ``messages`` kwarg. Writing a codec that emits the expected
+# shape satisfies them by construction, so a fix-loop reprobe going green proves the
+# agent wrote the payload it set out to write - nothing about the model.
+#
+# Consequence for the cert: these may be promoted to ``required`` ONLY on a passing
+# NATIVE baseline (the model already round-trips without our overlay). Promotion off
+# a failing baseline is a self-referential claim and hard-fails.
+#
+# (Real miss: deepseek-v4-flash-0731, PR #846. ``unsigned_thinking_replay`` was 0/15
+# native; a new reasoning codec took the reprobe to 5/5 and the cap shipped
+# ``required``. A live A/B afterwards measured turn-2 ``prompt_tokens`` 523 vs 523
+# with and without the replay payload: the route accepts the field and silently
+# ignores it. The cert claimed a model property the evidence could not support.)
+PAYLOAD_ONLY_CAPABILITIES = frozenset(
+    {
+        "thinking_replay_roundtrip",
+        "unsigned_thinking_replay",
+    }
+)
 
 # Mirror of tests/canonical/test_capability_registry.py::_CORE_CAPABILITIES - the
 # capabilities every model MUST support. A core cap can NEVER be ``known_unsupported``
@@ -83,6 +117,7 @@ def reconcile(
     core: frozenset[str] = frozenset(),
     hard: float = HARD_PASS,
     soft: float = SOFT_PASS,
+    payload_only: frozenset[str] = PAYLOAD_ONLY_CAPABILITIES,
 ) -> tuple[list[str], list[str]]:
     """Return ``(violations, warnings)``. Pure - unit-tested without the registry."""
     declared = required | known_unsupported
@@ -94,11 +129,25 @@ def reconcile(
             "can never be `known_unsupported` (e.g. cost_usd_populated as a ceiling hides a "
             "missing-pricing gap)."
         )
+    for cap in sorted(required - set(probed)):
+        warnings.append(
+            f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
+            "nothing measured supports it. Confirm the probe collected, or demote it."
+        )
     for cap, rate in sorted(probed.items()):
         if cap not in declared:
             violations.append(
                 f"UNDECLARED: `{cap}` was probed (baseline {rate:.2f}) but is neither "
                 "`required` nor `known_unsupported` - it will silently auto-skip."
+            )
+        elif cap in required and cap in payload_only and rate < hard:
+            violations.append(
+                f"SELF-REFERENTIAL: `{cap}` is `required` but the NATIVE baseline fails "
+                f"{rate:.2f} (< {hard:.2f}). This probe asserts our own outgoing request "
+                "payload with the provider turn MOCKED, so an overlay satisfies it by "
+                "construction and a green reprobe says nothing about the model. Promote it "
+                "only on a passing native baseline; otherwise keep it `known_unsupported` "
+                "(the policy may still ship - only the cert claim is refused)."
             )
         elif cap in known_unsupported and rate >= hard:
             violations.append(

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -2,156 +2,303 @@
 
 Every policy class the resolve agent writes has to be registered in a
 ``_POLICY_REGISTRIES`` slot (``tolokaforge/core/llm/presets.py``) to be referenceable
-from a preset, so the staged diff of that file is a complete, deterministic index of
-what the integration added. This gate reads it and requires two things per new class:
+from a preset, so the registry is a complete, deterministic index of what the
+integration added. This gate compares the STAGED registry against HEAD and requires
+two things per newly added binding:
 
-  1. A unit test under ``tests/unit/llm/`` mentions the class by name. ``docs/ADD_NEW_MODEL.md``
-     step 5 already mandates this ("add a unit-test fixture ... so the codec round-trip is
-     unit-testable without burning provider spend"), but nothing enforced it: the fix-loop's
-     success signal is the live reprobe, so a missing unit test was invisible.
-  2. The class is actually referenced from the overlay. An unreferenced new class is dead
-     public API - the agent solved the probe some other way and left the class behind.
+  1. A unit test under ``tests/unit/llm/`` - read from the INDEX, i.e. the tree the
+     finalize commit will actually ship - mentions the bound class by name.
+     ``docs/ADD_NEW_MODEL.md`` step 5 already mandates this ("add a unit-test fixture
+     ... so the codec round-trip is unit-testable without burning provider spend"),
+     but nothing enforced it: the fix-loop's success signal is the live reprobe, so a
+     missing unit test was invisible. The mention is name-level (word-boundary), not
+     an executed test - the reviewer still checks the test is real.
+  2. The class is actually referenced - by registry key in a VALUE position of the
+     overlay or of the staged ``model_presets.yaml``, or by class name in either. An
+     unreferenced new class is dead public API: the agent solved the probe some other
+     way and left the class behind.
 
-Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer* sees
-the class's real input/output shape. Both defects this gate targets shipped together in
-PR #846 (a new reasoning codec with no unit test, whose behaviour a shipped codec already
-covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in :mod:`automation.cert`).
+Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer*
+sees the class's real input/output shape. Both defects this gate targets shipped
+together in PR #846 (a new reasoning codec with no unit test, whose behaviour a
+shipped codec already covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in
+:mod:`automation.cert`).
 
-``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers below are
-unit-tested without touching git.
+The registry comparison is an AST set-diff, not a diff-text regex: quoting style,
+trailing commas, wrapped lines, dotted values, instance bindings and factory names
+cannot hide a binding, and a moved or reordered line never reads as new. Covered
+registration shapes (module top level): a dict-literal assignment to a slot registry,
+``_SLOT["key"] = Value``, and ``_SLOT.update({...})``. This is a guard, so it FAILS
+LOUD: any git error, an unparsable staged registry, or a registry in which no
+``_POLICY_REGISTRIES`` slot can be found exits 1 (needs-human) instead of skipping.
+
+``run`` returns an exit code (1 on any violation or read failure, 0 otherwise); the
+pure helpers below are unit-tested without git, and ``run`` itself against throwaway
+git repos.
 """
 
 from __future__ import annotations
 
+import ast
 import pathlib
 import re
 import subprocess
+from typing import NamedTuple
 
 REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
+PRESETS_FILE = "tolokaforge/core/data/model_presets.yaml"
 DEFAULT_TESTS_DIR = "tests/unit/llm"
 
-# One added binding line, e.g. ``+    "json_coerce": JsonCoerceResponse,``. The leading
-# ``[A-Z]`` is what separates a CLASS binding from a registry-slot line (the
-# ``_POLICY_REGISTRIES`` values are underscore-prefixed), so slot lines never register as
-# new classes. Single source of truth for the line shape - every reader below goes through
-# :func:`added_bindings`.
-_REGISTRY_BINDING = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
-_DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
+# The repo root anchored to THIS file (tools/automation/src/automation/classgate.py),
+# like cert._load_cert - never the caller's CWD, which silently empties every git
+# answer from a subdirectory and turns the gate into a no-op.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 
 
-def added_bindings(diff_text: str) -> list[tuple[str, str]]:
-    """``(registry_key, ClassName)`` for every binding this diff ADDS to the registry file.
+class Binding(NamedTuple):
+    """One registry entry: which slot registry, under which key, bound to what."""
 
-    Scoped to added lines inside that file's hunks, so a class merely *defined* elsewhere
-    in the diff (or a registry line that only moved) is not reported. Order is source
-    order, so failure messages read deterministically. A class bound under several keys
-    yields one pair per key.
+    registry: str
+    key: str
+    value: str
+
+
+def _expr_repr(node: ast.expr) -> str:
+    """A stable identifier rendering for a binding value.
+
+    ``Name`` -> ``Cls``; ``Attribute`` -> ``pkg.Cls``; ``Call`` -> ``Cls()`` (an
+    instance or factory binding still names what was bound); anything else falls back
+    to ``ast.dump`` so an exotic shape still produces a DISTINCT, diffable binding
+    (detected as new -> gated) rather than vanishing.
     """
-    bindings: list[tuple[str, str]] = []
-    in_registry_file = False
-    for line in diff_text.splitlines():
-        header = _DIFF_FILE_HEADER.match(line)
-        if header:
-            in_registry_file = header.group(1) == REGISTRY_FILE
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_expr_repr(node.value)}.{node.attr}"
+    if isinstance(node, ast.Call):
+        return f"{_expr_repr(node.func)}()"
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    return ast.dump(node)
+
+
+def _key_repr(node: ast.expr) -> str:
+    """Registry keys are string constants; anything else renders via ``_expr_repr``
+    so a computed key still surfaces as a (necessarily unreferenced) new binding."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return _expr_repr(node)
+
+
+def _assign_target(node: ast.stmt) -> str | None:
+    """The single ``Name`` target of an ``Assign``/``AnnAssign``, else ``None``."""
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+        target = node.targets[0]
+        return target.id if isinstance(target, ast.Name) else None
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _dict_bindings(registry: str, node: ast.Dict) -> set[Binding]:
+    return {
+        Binding(registry, _key_repr(key), _expr_repr(value))
+        for key, value in zip(node.keys, node.values)
+        if key is not None  # a ``**spread`` entry has no literal key to gate on
+    }
+
+
+def registry_bindings(source: str) -> set[Binding]:
+    """Every registry binding in a ``presets.py`` source, as a set.
+
+    Slot registries are discovered from the ``_POLICY_REGISTRIES`` index itself (its
+    dict values name the per-slot dicts, or carry inline dicts), so a brand-new slot
+    the agent wires in is covered too. Raises on an unparsable source or when no slot
+    can be found - a guard that cannot see the registry must fail loud, never skip.
+    """
+    tree = ast.parse(source)
+    slot_vars: set[str] = set()
+    bindings: set[Binding] = set()
+    for node in tree.body:
+        if _assign_target(node) != "_POLICY_REGISTRIES":
             continue
-        if not in_registry_file:
-            continue
-        match = _REGISTRY_BINDING.match(line)
-        if match:
-            pair = (match.group(1), match.group(2))
-            if pair not in bindings:
-                bindings.append(pair)
+        index = node.value
+        if not isinstance(index, ast.Dict):
+            raise ValueError("_POLICY_REGISTRIES is not a dict literal - the gate cannot read it")
+        for key, value in zip(index.keys, index.values):
+            if isinstance(value, ast.Name):
+                slot_vars.add(value.id)
+            elif isinstance(value, ast.Dict):
+                bindings |= _dict_bindings(_key_repr(key) if key else "?", value)
+    if not slot_vars and not bindings:
+        raise ValueError(
+            f"no _POLICY_REGISTRIES slots found in {REGISTRY_FILE} - the gate cannot "
+            "see the registry"
+        )
+    for node in tree.body:
+        target = _assign_target(node)
+        if target in slot_vars and isinstance(getattr(node, "value", None), ast.Dict):
+            bindings |= _dict_bindings(target, node.value)
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(sub := node.targets[0], ast.Subscript)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id in slot_vars
+        ):
+            bindings.add(Binding(sub.value.id, _key_repr(sub.slice), _expr_repr(node.value)))
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(call := node.value, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "update"
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id in slot_vars
+            and call.args
+            and isinstance(call.args[0], ast.Dict)
+        ):
+            bindings |= _dict_bindings(call.func.value.id, call.args[0])
     return bindings
 
 
-def added_registry_classes(diff_text: str) -> list[str]:
-    """Distinct class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff."""
-    seen: list[str] = []
-    for _key, name in added_bindings(diff_text):
-        if name not in seen:
-            seen.append(name)
-    return seen
+def added_bindings(staged_source: str, head_source: str) -> list[Binding]:
+    """Bindings present in the staged registry but not in HEAD's, sorted.
 
-
-def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
-    """New classes named by neither the overlay nor a preset entry in the diff.
-
-    An overlay references a class through its registry KEY, not its name, so match on
-    either: the class name appearing in the diff's preset YAML hunks, or ANY of the keys
-    it was bound to appearing in the overlay (a class bound under several keys is
-    referenced if the overlay uses any one of them). Keeping this permissive is deliberate
-    - the gate is here to catch a class nobody wired up at all, not to police style.
+    A set diff, so a binding that merely moved (the agent alphabetized a dict while
+    inserting its entry) is not reported - only genuinely new (registry, key, value)
+    triples are.
     """
-    keys_by_class = _registry_keys(diff_text)
-    return [
+    return sorted(registry_bindings(staged_source) - registry_bindings(head_source))
+
+
+def bound_name(value_repr: str) -> str:
+    """``codecs.BrandNewCodec()`` -> ``BrandNewCodec``: the identifier a test must name."""
+    return value_repr.removesuffix("()").rsplit(".", 1)[-1]
+
+
+def untested(names: list[str], test_blob: str) -> list[str]:
+    """Names no unit-test source mentions as a whole word.
+
+    Word-boundary, not substring: an existing mention of ``MinimaxM3TagRecoveryResponse``
+    must not vouch for a new ``TagRecoveryResponse``.
+    """
+    return [name for name in names if not re.search(rf"\b{re.escape(name)}\b", test_blob)]
+
+
+def _key_referenced(key: str, text: str) -> bool:
+    """A registry key counts as referenced only in a YAML VALUE position
+    (``slot: key`` / ``slot: "key"``), not as a raw substring - a short family key
+    like ``qwen`` must not be satisfied by a ``match:`` glob that merely contains it."""
+    return re.search(rf""":\s*['"]?{re.escape(key)}\b""", text) is not None
+
+
+def unreferenced(bindings: list[Binding], overlay_text: str, presets_text: str) -> list[str]:
+    """Bound names that neither the overlay nor the staged preset file references.
+
+    A reference is any of that name's registry keys in a value position, or the name
+    itself as a whole word, in either source. Keeping this permissive is deliberate -
+    the gate catches a class nobody wired up at all, not style.
+    """
+    keys_by_name: dict[str, set[str]] = {}
+    for binding in bindings:
+        keys_by_name.setdefault(bound_name(binding.value), set()).add(binding.key)
+    combined = (overlay_text, presets_text)
+    return sorted(
         name
-        for name in classes
-        if name not in overlay_text
-        and not any(key in overlay_text for key in keys_by_class.get(name, ()))
-    ]
-
-
-def _registry_keys(diff_text: str) -> dict[str, tuple[str, ...]]:
-    """``{ClassName: (registry_key, ...)}`` for bindings added in the registry file."""
-    keys: dict[str, tuple[str, ...]] = {}
-    for key, name in added_bindings(diff_text):
-        keys[name] = (*keys.get(name, ()), key)
-    return keys
-
-
-def untested(classes: list[str], test_blob: str) -> list[str]:
-    """New classes no unit-test source mentions by name."""
-    return [name for name in classes if name not in test_blob]
-
-
-def read_tests(tests_dir: str = DEFAULT_TESTS_DIR) -> str:
-    """Concatenate every unit-test source under ``tests_dir`` (missing dir -> empty)."""
-    root = pathlib.Path(tests_dir)
-    if not root.is_dir():
-        return ""
-    return "\n".join(path.read_text(errors="replace") for path in sorted(root.rglob("test_*.py")))
-
-
-def _staged_diff() -> str:
-    proc = subprocess.run(
-        ["git", "diff", "--cached", "--unified=0", "--", REGISTRY_FILE],
-        capture_output=True,
-        text=True,
-        check=False,
+        for name, keys in keys_by_name.items()
+        if not any(_key_referenced(key, text) for key in keys for text in combined)
+        and not any(re.search(rf"\b{re.escape(name)}\b", text) for text in combined)
     )
+
+
+def _git(args: list[str], root: pathlib.Path) -> str:
+    """Run git anchored at ``root``; any failure raises with git's own stderr.
+
+    A guard must fail loud: swallowing a nonzero exit here is how "not a git repo"
+    or a wrong CWD used to read as "no new policy class registered".
+    """
+    proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=root, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}"
+        )
     return proc.stdout
 
 
-def run(overlay_path: str | None = None, tests_dir: str = DEFAULT_TESTS_DIR) -> int:
-    """Gate the STAGED diff. Returns 1 on any violation (finalize routes that to
-    needs-human), 0 otherwise. No new class -> nothing to check -> 0."""
-    diff_text = _staged_diff()
-    classes = added_registry_classes(diff_text)
-    if not classes:
-        print("classgate: OK (no new policy class registered)")
-        return 0
+def _git_optional(args: list[str], root: pathlib.Path) -> str:
+    """Like ``_git`` but a path absent from the requested tree reads as empty - used
+    only for reference SOURCES (a missing preset file just means no reference can
+    come from it), never for the registry the gate exists to judge."""
+    try:
+        return _git(args, root)
+    except RuntimeError as exc:
+        message = str(exc)
+        if "does not exist" in message or "but not in" in message:
+            return ""
+        raise
+
+
+def read_index_tests(root: pathlib.Path, tests_dir: str = DEFAULT_TESTS_DIR) -> str:
+    """Concatenate every ``test_*.py`` under ``tests_dir`` as staged in the INDEX.
+
+    The index is the tree the finalize commit ships. A worktree-only test file (never
+    ``git add``-ed) deliberately does not count: it would satisfy the gate and then
+    vanish from the commit - the exact false assurance this gate exists to prevent.
+    """
+    listed = _git(["ls-files", "--cached", "--", tests_dir], root)
+    sources = []
+    for path in sorted(line for line in listed.splitlines() if line):
+        name = pathlib.PurePosixPath(path).name
+        if name.startswith("test_") and name.endswith(".py"):
+            sources.append(_git(["show", f":{path}"], root))
+    return "\n".join(sources)
+
+
+def run(
+    overlay_path: str | None = None,
+    tests_dir: str = DEFAULT_TESTS_DIR,
+    root: str | None = None,
+) -> int:
+    """Gate the STAGED registry against HEAD. Returns 1 on any violation or read
+    failure (finalize routes both to needs-human), 0 otherwise. No new binding ->
+    nothing to check -> 0."""
+    repo = pathlib.Path(root).resolve() if root else REPO_ROOT
+    try:
+        staged = _git(["show", f":{REGISTRY_FILE}"], repo)
+        head = _git(["show", f"HEAD:{REGISTRY_FILE}"], repo)
+        added = added_bindings(staged, head)
+        if not added:
+            print("classgate: OK (no new policy class registered)")
+            return 0
+        test_blob = read_index_tests(repo, tests_dir)
+        presets_text = _git_optional(["show", f":{PRESETS_FILE}"], repo)
+    except Exception as exc:  # fail loud - a guard must never silently pass
+        print(f"::error::classgate could not read the staged tree: {exc}")
+        return 1
 
     overlay_text = ""
     if overlay_path and pathlib.Path(overlay_path).is_file():
         overlay_text = pathlib.Path(overlay_path).read_text(errors="replace")
 
+    names = sorted({bound_name(binding.value) for binding in added})
     violations = [
-        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no unit test under "
-        f"{tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test (with a "
-        "captured real-response fixture) for a new policy class - the live reprobe does not "
-        "substitute for one."
-        for name in untested(classes, read_tests(tests_dir))
+        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no STAGED unit test "
+        f"under {tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test "
+        "(prefer a captured real-response fixture) for a new policy class - the live reprobe "
+        "does not substitute for one, and a test left unstaged would not ship."
+        for name in untested(names, test_blob)
     ]
     violations += [
         f"UNREFERENCED-CLASS: `{name}` is registered in {REGISTRY_FILE} but neither the "
-        "overlay nor a preset entry references it - dead public API. Wire it up or drop it."
-        for name in unreferenced(classes, overlay_text, diff_text)
+        f"overlay nor the staged {PRESETS_FILE} references it (by key in a value position, "
+        "or by name) - dead public API. Wire it up or drop it."
+        for name in unreferenced(added, overlay_text, presets_text)
     ]
 
     for violation in violations:
         print(f"::error::classgate: {violation}")
     if violations:
-        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(classes)} new class(es))")
+        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(names)} new class(es))")
         return 1
-    print(f"classgate: OK ({len(classes)} new class(es) tested and referenced)")
+    print(f"classgate: OK ({len(names)} new class(es) tested and referenced)")
     return 0

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -30,19 +30,24 @@ import subprocess
 REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
 DEFAULT_TESTS_DIR = "tests/unit/llm"
 
-# ``"json_coerce": JsonCoerceResponse,`` inside a _POLICY_REGISTRIES slot.
-_REGISTRY_BINDING = re.compile(r'^\+\s*"[A-Za-z0-9_]+"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+# One added binding line, e.g. ``+    "json_coerce": JsonCoerceResponse,``. The leading
+# ``[A-Z]`` is what separates a CLASS binding from a registry-slot line (the
+# ``_POLICY_REGISTRIES`` values are underscore-prefixed), so slot lines never register as
+# new classes. Single source of truth for the line shape - every reader below goes through
+# :func:`added_bindings`.
+_REGISTRY_BINDING = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
 _DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
 
 
-def added_registry_classes(diff_text: str) -> list[str]:
-    """Class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff.
+def added_bindings(diff_text: str) -> list[tuple[str, str]]:
+    """``(registry_key, ClassName)`` for every binding this diff ADDS to the registry file.
 
-    Scoped to added lines inside the registry file's hunks, so a class merely *defined*
-    elsewhere in the diff (or a registry line that only moved) is not reported. Order is
-    deduplicated-stable so the failure message reads deterministically.
+    Scoped to added lines inside that file's hunks, so a class merely *defined* elsewhere
+    in the diff (or a registry line that only moved) is not reported. Order is source
+    order, so failure messages read deterministically. A class bound under several keys
+    yields one pair per key.
     """
-    found: list[str] = []
+    bindings: list[tuple[str, str]] = []
     in_registry_file = False
     for line in diff_text.splitlines():
         header = _DIFF_FILE_HEADER.match(line)
@@ -52,43 +57,45 @@ def added_registry_classes(diff_text: str) -> list[str]:
         if not in_registry_file:
             continue
         match = _REGISTRY_BINDING.match(line)
-        if match and match.group(1) not in found:
-            found.append(match.group(1))
-    return found
+        if match:
+            pair = (match.group(1), match.group(2))
+            if pair not in bindings:
+                bindings.append(pair)
+    return bindings
+
+
+def added_registry_classes(diff_text: str) -> list[str]:
+    """Distinct class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff."""
+    seen: list[str] = []
+    for _key, name in added_bindings(diff_text):
+        if name not in seen:
+            seen.append(name)
+    return seen
 
 
 def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
     """New classes named by neither the overlay nor a preset entry in the diff.
 
     An overlay references a class through its registry KEY, not its name, so match on
-    either: the class name appearing in the diff's preset YAML hunks, or the registry key
-    it was bound to appearing in the overlay. Keeping this permissive is deliberate - the
-    gate is here to catch a class nobody wired up at all, not to police style.
+    either: the class name appearing in the diff's preset YAML hunks, or ANY of the keys
+    it was bound to appearing in the overlay (a class bound under several keys is
+    referenced if the overlay uses any one of them). Keeping this permissive is deliberate
+    - the gate is here to catch a class nobody wired up at all, not to police style.
     """
     keys_by_class = _registry_keys(diff_text)
-    missing = []
-    for name in classes:
-        key = keys_by_class.get(name, "")
-        referenced = name in overlay_text or (key and key in overlay_text)
-        if not referenced:
-            missing.append(name)
-    return missing
+    return [
+        name
+        for name in classes
+        if name not in overlay_text
+        and not any(key in overlay_text for key in keys_by_class.get(name, ()))
+    ]
 
 
-def _registry_keys(diff_text: str) -> dict[str, str]:
-    """``{ClassName: registry_key}`` for bindings added in the registry file."""
-    keys: dict[str, str] = {}
-    in_registry_file = False
-    pattern = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
-    for line in diff_text.splitlines():
-        header = _DIFF_FILE_HEADER.match(line)
-        if header:
-            in_registry_file = header.group(1) == REGISTRY_FILE
-            continue
-        if in_registry_file:
-            match = pattern.match(line)
-            if match:
-                keys.setdefault(match.group(2), match.group(1))
+def _registry_keys(diff_text: str) -> dict[str, tuple[str, ...]]:
+    """``{ClassName: (registry_key, ...)}`` for bindings added in the registry file."""
+    keys: dict[str, tuple[str, ...]] = {}
+    for key, name in added_bindings(diff_text):
+        keys[name] = (*keys.get(name, ()), key)
     return keys
 
 

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -1,0 +1,150 @@
+"""Finalize gate: a new engine policy class must ship a unit test.
+
+Every policy class the resolve agent writes has to be registered in a
+``_POLICY_REGISTRIES`` slot (``tolokaforge/core/llm/presets.py``) to be referenceable
+from a preset, so the staged diff of that file is a complete, deterministic index of
+what the integration added. This gate reads it and requires two things per new class:
+
+  1. A unit test under ``tests/unit/llm/`` mentions the class by name. ``docs/ADD_NEW_MODEL.md``
+     step 5 already mandates this ("add a unit-test fixture ... so the codec round-trip is
+     unit-testable without burning provider spend"), but nothing enforced it: the fix-loop's
+     success signal is the live reprobe, so a missing unit test was invisible.
+  2. The class is actually referenced from the overlay. An unreferenced new class is dead
+     public API - the agent solved the probe some other way and left the class behind.
+
+Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer* sees
+the class's real input/output shape. Both defects this gate targets shipped together in
+PR #846 (a new reasoning codec with no unit test, whose behaviour a shipped codec already
+covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in :mod:`automation.cert`).
+
+``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers below are
+unit-tested without touching git.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
+DEFAULT_TESTS_DIR = "tests/unit/llm"
+
+# ``"json_coerce": JsonCoerceResponse,`` inside a _POLICY_REGISTRIES slot.
+_REGISTRY_BINDING = re.compile(r'^\+\s*"[A-Za-z0-9_]+"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+_DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
+
+
+def added_registry_classes(diff_text: str) -> list[str]:
+    """Class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff.
+
+    Scoped to added lines inside the registry file's hunks, so a class merely *defined*
+    elsewhere in the diff (or a registry line that only moved) is not reported. Order is
+    deduplicated-stable so the failure message reads deterministically.
+    """
+    found: list[str] = []
+    in_registry_file = False
+    for line in diff_text.splitlines():
+        header = _DIFF_FILE_HEADER.match(line)
+        if header:
+            in_registry_file = header.group(1) == REGISTRY_FILE
+            continue
+        if not in_registry_file:
+            continue
+        match = _REGISTRY_BINDING.match(line)
+        if match and match.group(1) not in found:
+            found.append(match.group(1))
+    return found
+
+
+def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
+    """New classes named by neither the overlay nor a preset entry in the diff.
+
+    An overlay references a class through its registry KEY, not its name, so match on
+    either: the class name appearing in the diff's preset YAML hunks, or the registry key
+    it was bound to appearing in the overlay. Keeping this permissive is deliberate - the
+    gate is here to catch a class nobody wired up at all, not to police style.
+    """
+    keys_by_class = _registry_keys(diff_text)
+    missing = []
+    for name in classes:
+        key = keys_by_class.get(name, "")
+        referenced = name in overlay_text or (key and key in overlay_text)
+        if not referenced:
+            missing.append(name)
+    return missing
+
+
+def _registry_keys(diff_text: str) -> dict[str, str]:
+    """``{ClassName: registry_key}`` for bindings added in the registry file."""
+    keys: dict[str, str] = {}
+    in_registry_file = False
+    pattern = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+    for line in diff_text.splitlines():
+        header = _DIFF_FILE_HEADER.match(line)
+        if header:
+            in_registry_file = header.group(1) == REGISTRY_FILE
+            continue
+        if in_registry_file:
+            match = pattern.match(line)
+            if match:
+                keys.setdefault(match.group(2), match.group(1))
+    return keys
+
+
+def untested(classes: list[str], test_blob: str) -> list[str]:
+    """New classes no unit-test source mentions by name."""
+    return [name for name in classes if name not in test_blob]
+
+
+def read_tests(tests_dir: str = DEFAULT_TESTS_DIR) -> str:
+    """Concatenate every unit-test source under ``tests_dir`` (missing dir -> empty)."""
+    root = pathlib.Path(tests_dir)
+    if not root.is_dir():
+        return ""
+    return "\n".join(path.read_text(errors="replace") for path in sorted(root.rglob("test_*.py")))
+
+
+def _staged_diff() -> str:
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--", REGISTRY_FILE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout
+
+
+def run(overlay_path: str | None = None, tests_dir: str = DEFAULT_TESTS_DIR) -> int:
+    """Gate the STAGED diff. Returns 1 on any violation (finalize routes that to
+    needs-human), 0 otherwise. No new class -> nothing to check -> 0."""
+    diff_text = _staged_diff()
+    classes = added_registry_classes(diff_text)
+    if not classes:
+        print("classgate: OK (no new policy class registered)")
+        return 0
+
+    overlay_text = ""
+    if overlay_path and pathlib.Path(overlay_path).is_file():
+        overlay_text = pathlib.Path(overlay_path).read_text(errors="replace")
+
+    violations = [
+        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no unit test under "
+        f"{tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test (with a "
+        "captured real-response fixture) for a new policy class - the live reprobe does not "
+        "substitute for one."
+        for name in untested(classes, read_tests(tests_dir))
+    ]
+    violations += [
+        f"UNREFERENCED-CLASS: `{name}` is registered in {REGISTRY_FILE} but neither the "
+        "overlay nor a preset entry references it - dead public API. Wire it up or drop it."
+        for name in unreferenced(classes, overlay_text, diff_text)
+    ]
+
+    for violation in violations:
+        print(f"::error::classgate: {violation}")
+    if violations:
+        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(classes)} new class(es))")
+        return 1
+    print(f"classgate: OK ({len(classes)} new class(es) tested and referenced)")
+    return 0

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -11,6 +11,7 @@ import typer
 
 from automation import (
     cert,
+    classgate,
     gateway_catalog,
     greencheck,
     model_resolver,
@@ -46,6 +47,17 @@ def reconcile_cert(
 ) -> None:
     """Reconcile the staged ModelCertificate against the observe baseline (finalize gate)."""
     raise typer.Exit(cert.run(model_id, findings))
+
+
+@app.command("check-new-classes")
+def check_new_classes(
+    overlay: str | None = typer.Option(
+        None, "--overlay", help="path to the resolve overlay.yaml (for the reference check)"
+    ),
+    tests_dir: str = typer.Option(classgate.DEFAULT_TESTS_DIR, "--tests-dir"),
+) -> None:
+    """Require a unit test + an overlay reference for every newly registered policy class."""
+    raise typer.Exit(classgate.run(overlay_path=overlay, tests_dir=tests_dir))
 
 
 @app.command("ensure-pricing")

--- a/tools/automation/src/automation/prompts/resolve_agent.md
+++ b/tools/automation/src/automation/prompts/resolve_agent.md
@@ -84,10 +84,24 @@ and pushes the whole integration to needs-human.
      An unbounded tree-walk forces `data_scope_review: true`. The docstring MUST state the exact
      firing condition and depth; it is reviewed against the code, so an understated scope is a
      defect, not politeness.
-   - Before creating a class or registry key, grep `response_policy.py` + `schema_sanitizer.py`
-     (this branch AND main) for an existing class/key covering the same quirk - a sibling
-     integration may have just landed one. NEVER rebind an existing registry key to different
+   - Before creating a class or registry key, grep the WHOLE policy surface (this branch AND
+     main) for an existing class/key covering the same quirk - a sibling integration may have
+     just landed one. That means every module behind `_POLICY_REGISTRIES`, not just the two
+     obvious ones: `response_policy.py`, `schema_sanitizer.py`, `reasoning_codec.py`,
+     `content_policy.py`, `prompt_policy.py`, `cache_policy.py`. Also read `model_presets.yaml`
+     for a sibling preset that already solved your fix-target by RE-POINTING an axis at a
+     shipped class - a one-line preset change always beats a new class. A newly registered
+     class must be referenced by your overlay AND covered by a unit test under
+     `tests/unit/llm/` (docs/ADD_NEW_MODEL.md step 5); the deterministic `check-new-classes`
+     gate fails the integration otherwise. NEVER rebind an existing registry key to different
      semantics; if your mechanism differs, use a new, model-line-specific name.
+     (Real miss: deepseek-v4-flash-0731 PR #846 wrote a new reasoning codec for
+     `unsigned_thinking_replay`, having grepped only the two modules named above. The shipped
+     `gemini` codec already covered that route - verified live - and `qwen3.8-max` had solved
+     the IDENTICAL fix-target days earlier with exactly that one-line
+     `reasoning_codec: gemini` swap. The new class also round-tripped LESS faithfully: it
+     rebuilt the envelope from the flat summary, dropping the provider's own `format` and
+     `index` that the shipped codec preserves.)
 4. Write `{{OBS_DIR}}/resolve/decision.json`:
    ```
    {"fix_targets": ["<exact junit probe names from findings.json that the overlay should turn green>"],
@@ -133,10 +147,23 @@ and pushes the whole integration to needs-human.
    `needs_human` is true you may leave `fix_targets` empty and skip writing `overlay.yaml`.
 
    `required` must be EVIDENCE-BACKED, never optimistic. List a capability as `required` ONLY if
-   it passed NATIVELY in `findings.json` OR the reprobe shows it green under your overlay. Do NOT
-   promote a capability to `required` on a mechanism that cannot support it: e.g. a summary-only
-   (OpenAI-style) `reasoning_codec` carries no signed thinking blocks, so `THINKING_EMITS_BLOCKS`
-   and the `*_THINKING_REPLAY` caps stay `known_unsupported` under it; a `passthrough` schema that
+   it passed NATIVELY in `findings.json` OR the reprobe shows it green under your overlay.
+
+   EXCEPTION - PAYLOAD-ONLY probes (`thinking_replay_roundtrip`, `unsigned_thinking_replay`):
+   these fire turn 1 live and then MOCK the provider turn, asserting only OUR OWN outgoing
+   request body. A codec that emits the expected shape satisfies them BY CONSTRUCTION, so a
+   green reprobe proves you wrote the payload you meant to write and says NOTHING about the
+   model. Promote either one to `required` ONLY on a passing NATIVE baseline. Off a failing
+   native baseline they stay `known_unsupported` even when your overlay turns them green - the
+   deterministic `cert_reconcile` gate FAILS the integration otherwise (SELF-REFERENTIAL). You
+   may still ship the policy; only the cert claim is refused. (Real miss: deepseek-v4-flash-0731
+   PR #846 promoted `unsigned_thinking_replay` off an 0/15 native baseline via a new codec; a
+   live A/B afterwards measured turn-2 `prompt_tokens` 523 vs 523 with and without the replay
+   payload - that route accepts the field and silently ignores it.)
+
+   Do NOT otherwise promote a capability to `required` on a mechanism that cannot support it:
+   e.g. a summary-only (OpenAI-style) `reasoning_codec` carries no SIGNED thinking blocks, so
+   `THINKING_REPLAY_ROUNDTRIP` stays `known_unsupported` under it; a `passthrough` schema that
    only cleared a weak-assertion probe (no 500, args parse) is NOT evidence the emitted VALUE is
    correct. When the mechanism does not clearly support it or the evidence is a weak probe, prefer
    `known_unsupported` (an honest floor) over a `required` that inflates the leaderboard score -

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -200,23 +200,45 @@ def test_unbacked_required_capability_warns():
     assert any("UNBACKED" in w and "never_probed_cap" in w for w in warnings)
 
 
+def test_payload_only_cap_required_with_no_probe_result_is_a_violation():
+    """An all-unparseable-junit run must not smuggle a payload-only cap to `required`
+    through the soft UNBACKED path: with no measurement there is by definition no
+    passing native baseline, which is the only admissible promotion evidence."""
+    violations, warnings = cert.reconcile(
+        required={"unsigned_thinking_replay"},
+        known_unsupported=set(),
+        probed={},
+    )
+    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations)
+    assert not any("unsigned_thinking_replay" in w for w in warnings)
+
+
 def test_payload_only_set_matches_the_probes_that_mock_the_provider():
     """Drift guard, keyed on a STRUCTURAL fact rather than prose.
 
     A probe can only assert our own outgoing payload by stubbing the transport, and the
-    single seam for that is ``tolokaforge.core.llm.client.completion`` - the one and only
-    patch target anywhere in the live capability suite. So "patches that symbol" is
-    exactly "does not observe the provider". If a third replay-style probe lands it
-    belongs in the set; if one of these starts making a real second call, it must come
-    out.
+    single seam for that is ``client.completion`` - so "stubs that seam" is exactly
+    "does not observe the provider". The match covers the seam's patch SPELLINGS, not
+    one literal: the dotted string (``patch("tolokaforge.core.llm.client.completion")``
+    / ``monkeypatch.setattr("tolokaforge...")``) plus the object forms
+    (``patch.object(client, "completion")`` / ``monkeypatch.setattr(client,
+    "completion", ...)``) - a replay-style probe written in any of them must land in
+    the set, and keying on one literal would let the guard pass vacuously for the
+    others. If one of these probes starts making a real second call, it must come out.
     """
     import pathlib
+    import re
 
+    provider_mock = re.compile(
+        r"tolokaforge\.core\.llm\.client\.completion"
+        r"""|patch\.object\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
+        r"""|setattr\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
+    )
     root = pathlib.Path(cert.__file__).resolve().parents[4] / "tests" / "integration" / "llm"
     mocked = {
         path.stem[len("test_") :]
         for path in root.glob("test_*.py")
-        if "tolokaforge.core.llm.client.completion" in path.read_text()
+        if provider_mock.search(path.read_text())
     }
     assert mocked == cert.PAYLOAD_ONLY_CAPABILITIES, cert.PAYLOAD_ONLY_CAPABILITIES ^ mocked
 

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -120,6 +120,107 @@ def test_core_capability_can_never_be_known_unsupported():
     assert not any("CORE-UNSUPPORTED" in v for v in v2)
 
 
+def _deepseek_0731_probed():
+    """The real PR #846 observe baseline (abridged): unsigned replay 0/15 NATIVE."""
+    return {
+        "basic_completion": 1.0,
+        "dict_map_tool_call": 1.0,
+        "thinking_emits_blocks": 1.0,
+        "implicit_prompt_caching": 1.0,
+        "unsigned_thinking_replay": 0.0,
+        "thinking_replay_roundtrip": 0.0,
+        "prompt_caching": 0.0,
+    }
+
+
+def test_self_referential_promotion_is_a_violation():
+    """PR #846 shipped `unsigned_thinking_replay` as required off an 0/15 native baseline.
+
+    The reprobe went 5/5, but that probe mocks the provider turn and asserts our own
+    outgoing payload, so a new codec satisfies it by construction.
+    """
+    violations, _ = cert.reconcile(
+        required={
+            "basic_completion",
+            "dict_map_tool_call",
+            "thinking_emits_blocks",
+            "implicit_prompt_caching",
+            "unsigned_thinking_replay",
+        },
+        known_unsupported={"thinking_replay_roundtrip", "prompt_caching"},
+        probed=_deepseek_0731_probed(),
+    )
+    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations), (
+        violations
+    )
+    # The honest posture for the same baseline reconciles clean.
+    ok, _ = cert.reconcile(
+        required={
+            "basic_completion",
+            "dict_map_tool_call",
+            "thinking_emits_blocks",
+            "implicit_prompt_caching",
+        },
+        known_unsupported={
+            "unsigned_thinking_replay",
+            "thinking_replay_roundtrip",
+            "prompt_caching",
+        },
+        probed=_deepseek_0731_probed(),
+    )
+    assert ok == []
+
+
+def test_payload_only_cap_required_on_a_passing_native_baseline_is_fine():
+    """A model that round-trips WITHOUT our overlay has genuinely earned the cap."""
+    violations, _ = cert.reconcile(
+        required={"unsigned_thinking_replay"},
+        known_unsupported=set(),
+        probed={"unsigned_thinking_replay": 1.0},
+    )
+    assert violations == []
+
+
+def test_non_payload_cap_promoted_off_a_failing_baseline_is_allowed():
+    """A real formatting fix legitimately turns a red probe green - not this gate's business."""
+    violations, _ = cert.reconcile(
+        required={"dict_map_tool_call"},
+        known_unsupported=set(),
+        probed={"dict_map_tool_call": 0.0},
+    )
+    assert violations == []
+
+
+def test_unbacked_required_capability_warns():
+    _, warnings = cert.reconcile(
+        required={"basic_completion", "never_probed_cap"},
+        known_unsupported=set(),
+        probed={"basic_completion": 1.0},
+    )
+    assert any("UNBACKED" in w and "never_probed_cap" in w for w in warnings)
+
+
+def test_payload_only_set_matches_the_probes_that_mock_the_provider():
+    """Drift guard, keyed on a STRUCTURAL fact rather than prose.
+
+    A probe can only assert our own outgoing payload by stubbing the transport, and the
+    single seam for that is ``tolokaforge.core.llm.client.completion`` - the one and only
+    patch target anywhere in the live capability suite. So "patches that symbol" is
+    exactly "does not observe the provider". If a third replay-style probe lands it
+    belongs in the set; if one of these starts making a real second call, it must come
+    out.
+    """
+    import pathlib
+
+    root = pathlib.Path(cert.__file__).resolve().parents[4] / "tests" / "integration" / "llm"
+    mocked = {
+        path.stem[len("test_") :]
+        for path in root.glob("test_*.py")
+        if "tolokaforge.core.llm.client.completion" in path.read_text()
+    }
+    assert mocked == cert.PAYLOAD_ONLY_CAPABILITIES, cert.PAYLOAD_ONLY_CAPABILITIES ^ mocked
+
+
 def test_core_capabilities_mirror_canon():
     # Guard against drift: the hardcoded set MUST equal the canonical one (7 caps incl.
     # progress_after_success) - a missing entry would reopen the laundering loophole.

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -150,9 +150,9 @@ def test_self_referential_promotion_is_a_violation():
         known_unsupported={"thinking_replay_roundtrip", "prompt_caching"},
         probed=_deepseek_0731_probed(),
     )
-    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations), (
-        violations
-    )
+    assert any(
+        "SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations
+    ), violations
     # The honest posture for the same baseline reconciles clean.
     ok, _ = cert.reconcile(
         required={

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -3,158 +3,312 @@
 The scenario mirrors the real deepseek-v4-flash-0731 PR #846, which registered
 ``OpenAISummaryReplayReasoningCodec`` with no unit test anywhere - the exact defect
 ``docs/ADD_NEW_MODEL.md`` step 5 forbids and nothing enforced.
+
+The pure helpers are exercised on source strings; ``run`` is exercised end to end on
+throwaway git repositories, because the defects it guards against live exactly in the
+git seam (index vs worktree, CWD, error handling) that a monkeypatched shim cannot see.
 """
 
 from __future__ import annotations
 
+import subprocess
+
 import automation.classgate as classgate
 import pytest
+from automation.classgate import Binding
 
 pytestmark = pytest.mark.unit
 
-# Trimmed to the shape ``git diff --cached --unified=0`` emits for the registry file.
-PR846_DIFF = """\
-diff --git a/tolokaforge/core/llm/presets.py b/tolokaforge/core/llm/presets.py
---- a/tolokaforge/core/llm/presets.py
-+++ b/tolokaforge/core/llm/presets.py
-@@ -112,0 +113 @@
-+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,
-"""
+BASE_PRESETS = """\
+_REASONING_CODECS = {
+    "openai": OpenAIReasoningCodec,
+}
 
-OTHER_FILE_DIFF = """\
-diff --git a/tolokaforge/core/llm/response_policy.py b/tolokaforge/core/llm/response_policy.py
---- a/tolokaforge/core/llm/response_policy.py
-+++ b/tolokaforge/core/llm/response_policy.py
-@@ -10,0 +11 @@
-+class SomeHelper:
-+    "not a registry binding"
+_RESPONSE_POLICIES = {
+    "standard": StandardResponse,
+}
+
+_POLICY_REGISTRIES = {
+    "reasoning_codec": _REASONING_CODECS,
+    "response_policy": _RESPONSE_POLICIES,
+}
 """
 
 
-class TestAddedRegistryClasses:
-    def test_finds_the_new_codec_binding(self):
-        assert classgate.added_registry_classes(PR846_DIFF) == ["OpenAISummaryReplayReasoningCodec"]
+def _with_binding(line: str) -> str:
+    """BASE_PRESETS with one extra line inside ``_REASONING_CODECS``."""
+    return BASE_PRESETS.replace(
+        '    "openai": OpenAIReasoningCodec,\n',
+        f'    "openai": OpenAIReasoningCodec,\n    {line}\n',
+    )
 
-    def test_ignores_added_lines_in_other_files(self):
-        """A class DEFINED elsewhere is not a registration - only presets.py counts."""
-        assert classgate.added_registry_classes(OTHER_FILE_DIFF) == []
 
-    def test_ignores_removed_and_context_lines(self):
-        diff = PR846_DIFF.replace(
-            '+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,',
-            '-    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,\n'
-            '     "openai": OpenAIReasoningCodec,',
+class TestRegistryBindings:
+    def test_reads_the_baseline_bindings(self):
+        assert classgate.registry_bindings(BASE_PRESETS) == {
+            Binding("_REASONING_CODECS", "openai", "OpenAIReasoningCodec"),
+            Binding("_RESPONSE_POLICIES", "standard", "StandardResponse"),
+        }
+
+    @pytest.mark.parametrize(
+        ("line", "expected_value"),
+        [
+            # Every spelling the old diff-text regex silently missed - each one was a
+            # fail-open evasion; the AST cannot be fooled by surface syntax.
+            ("'new_codec': BrandNewCodec,", "BrandNewCodec"),  # single quotes
+            ('"new_codec": BrandNewCodec', "BrandNewCodec"),  # no trailing comma
+            ('"new_codec": codecs.BrandNewCodec,', "codecs.BrandNewCodec"),  # dotted
+            ('"new_codec": BrandNewCodec(),', "BrandNewCodec()"),  # instance
+            ('"new_codec": make_brand_new_codec,', "make_brand_new_codec"),  # factory
+        ],
+    )
+    def test_binding_shape_variants_are_all_seen(self, line: str, expected_value: str):
+        bindings = classgate.registry_bindings(_with_binding(line))
+        assert Binding("_REASONING_CODECS", "new_codec", expected_value) in bindings
+
+    def test_value_wrapped_onto_the_next_line_is_seen(self):
+        source = BASE_PRESETS.replace(
+            '    "openai": OpenAIReasoningCodec,\n',
+            '    "openai": OpenAIReasoningCodec,\n    "new_codec":\n        BrandNewCodec,\n',
         )
-        assert classgate.added_registry_classes(diff) == []
+        assert Binding("_REASONING_CODECS", "new_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
 
-    def test_deduplicates_repeated_bindings(self):
-        diff = PR846_DIFF + '+    "alias": OpenAISummaryReplayReasoningCodec,\n'
-        assert classgate.added_registry_classes(diff) == ["OpenAISummaryReplayReasoningCodec"]
+    def test_subscript_assignment_is_seen(self):
+        source = BASE_PRESETS + '_REASONING_CODECS["late_codec"] = BrandNewCodec\n'
+        assert Binding("_REASONING_CODECS", "late_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
 
-    def test_empty_diff_is_empty(self):
-        assert classgate.added_registry_classes("") == []
+    def test_update_call_is_seen(self):
+        source = BASE_PRESETS + '_REASONING_CODECS.update({"late_codec": BrandNewCodec})\n'
+        assert Binding("_REASONING_CODECS", "late_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
+
+    def test_inline_slot_dict_in_the_index_is_seen(self):
+        source = (
+            'X = 1\n_POLICY_REGISTRIES = {\n    "reasoning_codec": {"inline": InlineCodec},\n}\n'
+        )
+        assert classgate.registry_bindings(source) == {
+            Binding("reasoning_codec", "inline", "InlineCodec")
+        }
+
+    def test_non_slot_dicts_are_ignored(self):
+        source = BASE_PRESETS + '_DEFAULT_PRESET_DATA = {"default": DefaultThing}\n'
+        assert not any(
+            binding.registry == "_DEFAULT_PRESET_DATA"
+            for binding in classgate.registry_bindings(source)
+        )
+
+    def test_missing_registry_index_fails_loud(self):
+        with pytest.raises(ValueError, match="no _POLICY_REGISTRIES slots"):
+            classgate.registry_bindings("_REASONING_CODECS = {'a': A}\n")
+
+    def test_unparsable_source_raises(self):
+        with pytest.raises(SyntaxError):
+            classgate.registry_bindings("this is not python {")
+
+
+class TestAddedBindings:
+    def test_a_new_binding_is_reported(self):
+        staged = _with_binding('"new_codec": BrandNewCodec,')
+        assert classgate.added_bindings(staged, BASE_PRESETS) == [
+            Binding("_REASONING_CODECS", "new_codec", "BrandNewCodec")
+        ]
+
+    def test_moved_and_reordered_lines_are_not_new(self):
+        """Alphabetizing a dict while inserting nothing must not hard-fail the gate on
+        pre-existing classes (set semantics, not line semantics)."""
+        reordered = BASE_PRESETS.replace(
+            '_POLICY_REGISTRIES = {\n    "reasoning_codec": _REASONING_CODECS,\n'
+            '    "response_policy": _RESPONSE_POLICIES,\n}\n',
+            '_POLICY_REGISTRIES = {\n    "response_policy": _RESPONSE_POLICIES,\n'
+            '    "reasoning_codec": _REASONING_CODECS,\n}\n',
+        )
+        assert classgate.added_bindings(reordered, BASE_PRESETS) == []
+
+    def test_rebinding_an_existing_key_is_reported(self):
+        staged = BASE_PRESETS.replace("OpenAIReasoningCodec", "ReplacementCodec")
+        assert classgate.added_bindings(staged, BASE_PRESETS) == [
+            Binding("_REASONING_CODECS", "openai", "ReplacementCodec")
+        ]
+
+
+class TestBoundName:
+    @pytest.mark.parametrize(
+        ("value", "name"),
+        [
+            ("BrandNewCodec", "BrandNewCodec"),
+            ("codecs.BrandNewCodec", "BrandNewCodec"),
+            ("BrandNewCodec()", "BrandNewCodec"),
+            ("make_brand_new_codec", "make_brand_new_codec"),
+        ],
+    )
+    def test_names_the_identifier_a_test_must_mention(self, value: str, name: str):
+        assert classgate.bound_name(value) == name
 
 
 class TestUntested:
     def test_flags_a_class_no_test_mentions(self):
-        assert classgate.untested(
-            ["OpenAISummaryReplayReasoningCodec"], "def test_something(): pass"
-        ) == ["OpenAISummaryReplayReasoningCodec"]
+        assert classgate.untested(["BrandNewCodec"], "def test_something(): pass") == [
+            "BrandNewCodec"
+        ]
 
     def test_accepts_a_class_a_test_mentions(self):
-        blob = "from x import OpenAISummaryReplayReasoningCodec\ndef test_it(): ..."
-        assert classgate.untested(["OpenAISummaryReplayReasoningCodec"], blob) == []
+        blob = "from x import BrandNewCodec\ndef test_it(): ..."
+        assert classgate.untested(["BrandNewCodec"], blob) == []
+
+    def test_substring_of_an_existing_mention_does_not_vouch(self):
+        """`MinimaxM3TagRecoveryResponse` in an existing test must not satisfy a NEW
+        `TagRecoveryResponse` - word-boundary, not substring."""
+        blob = "from y import MinimaxM3TagRecoveryResponse\ndef test_m3(): ..."
+        assert classgate.untested(["TagRecoveryResponse"], blob) == ["TagRecoveryResponse"]
 
 
 class TestUnreferenced:
-    def test_flags_a_class_the_overlay_never_uses(self):
-        assert classgate.unreferenced(
-            ["OpenAISummaryReplayReasoningCodec"], "presets:\n  x:\n    match: ['a']\n", PR846_DIFF
-        ) == ["OpenAISummaryReplayReasoningCodec"]
+    BINDINGS = [Binding("_REASONING_CODECS", "openai_summary_replay", "BrandNewCodec")]
 
-    def test_registry_key_in_the_overlay_counts_as_a_reference(self):
-        """Overlays reference a class by its registry KEY, not its class name."""
+    def test_flags_a_class_nothing_references(self):
+        overlay = "presets:\n  x:\n    match: ['a']\n"
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == ["BrandNewCodec"]
+
+    def test_registry_key_in_a_value_position_counts(self):
         overlay = "presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"
-        assert (
-            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
-        )
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-    def test_class_name_in_the_overlay_also_counts(self):
-        overlay = "# uses OpenAISummaryReplayReasoningCodec\n"
-        assert (
-            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
-        )
+    def test_quoted_value_position_counts(self):
+        overlay = 'presets:\n  x:\n    reasoning_codec: "openai_summary_replay"\n'
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-    def test_any_of_several_keys_counts_as_a_reference(self):
-        """A class bound under two keys is referenced if the overlay uses EITHER one."""
-        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
-        for key in ("openai_summary_replay", "second_alias"):
-            overlay = f"presets:\n  x:\n    reasoning_codec: {key}\n"
-            assert (
-                classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, diff) == []
-            ), key
+    def test_key_inside_a_match_glob_does_not_count(self):
+        """A short family key must not be auto-referenced by a slug that merely
+        contains it - `qwen` in `match: ["qwen/qwen3.8-max"]` is not a reference."""
+        bindings = [Binding("_RESPONSE_POLICIES", "qwen", "QwenRecovery")]
+        overlay = 'presets:\n  x:\n    match: ["qwen/qwen3.8-max"]\n'
+        assert classgate.unreferenced(bindings, overlay, "") == ["QwenRecovery"]
 
+    def test_class_name_mention_counts(self):
+        overlay = "# uses BrandNewCodec\n"
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-class TestAddedBindings:
-    def test_returns_key_class_pairs(self):
-        assert classgate.added_bindings(PR846_DIFF) == [
-            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec")
-        ]
+    def test_staged_preset_file_reference_counts(self):
+        presets = "presets:\n  folded:\n    reasoning_codec: openai_summary_replay\n"
+        assert classgate.unreferenced(self.BINDINGS, "", presets) == []
 
-    def test_keeps_every_key_for_a_multiply_bound_class(self):
-        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
-        assert classgate.added_bindings(diff) == [
-            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec"),
-            ("second_alias", "OpenAISummaryReplayReasoningCodec"),
-        ]
-
-    def test_ignores_underscore_prefixed_registry_slot_lines(self):
-        """``_POLICY_REGISTRIES`` slot values are underscore-prefixed, not classes."""
-        diff = (
-            "+++ b/tolokaforge/core/llm/presets.py\n" '+    "reasoning_codec": _REASONING_CODECS,\n'
-        )
-        assert classgate.added_bindings(diff) == []
+    def test_any_of_several_keys_counts(self):
+        bindings = self.BINDINGS + [Binding("_REASONING_CODECS", "second_alias", "BrandNewCodec")]
+        overlay = "presets:\n  x:\n    reasoning_codec: second_alias\n"
+        assert classgate.unreferenced(bindings, overlay, "") == []
 
 
-class TestReadTests:
-    def test_missing_dir_is_empty_not_an_error(self):
-        assert classgate.read_tests("does/not/exist") == ""
+# --- run(): end to end on throwaway git repos -----------------------------------
 
-    def test_concatenates_test_sources(self, tmp_path):
-        (tmp_path / "test_a.py").write_text("MarkerClassA")
-        (tmp_path / "helper.py").write_text("MarkerNotATest")
-        blob = classgate.read_tests(str(tmp_path))
-        assert "MarkerClassA" in blob
-        assert "MarkerNotATest" not in blob
+
+def _git(repo, *args) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+NEW_BINDING_PRESETS = BASE_PRESETS.replace(
+    '    "openai": OpenAIReasoningCodec,\n',
+    '    "openai": OpenAIReasoningCodec,\n    "openai_summary_replay": BrandNewCodec,\n',
+)
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A committed baseline repo shaped like the paths the gate reads."""
+    root = tmp_path / "repo"
+    (root / "tolokaforge/core/llm").mkdir(parents=True)
+    (root / "tolokaforge/core/data").mkdir(parents=True)
+    (root / "tests/unit/llm").mkdir(parents=True)
+    (root / "tolokaforge/core/llm/presets.py").write_text(BASE_PRESETS)
+    (root / "tolokaforge/core/data/model_presets.yaml").write_text("presets: {}\n")
+    _git(root, "init", "-q")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base")
+    return root
+
+
+def _stage_new_binding(root) -> None:
+    (root / "tolokaforge/core/llm/presets.py").write_text(NEW_BINDING_PRESETS)
+    _git(root, "add", "tolokaforge/core/llm/presets.py")
+
+
+def _overlay(tmp_path, text="presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"):
+    path = tmp_path / "overlay.yaml"
+    path.write_text(text)
+    return str(path)
 
 
 class TestRun:
-    def test_no_new_class_passes(self, monkeypatch):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: OTHER_FILE_DIFF)
-        assert classgate.run() == 0
+    def test_no_new_binding_passes(self, repo):
+        assert classgate.run(root=str(repo)) == 0
 
-    def test_pr846_shape_fails_on_the_missing_unit_test(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        overlay = tmp_path / "overlay.yaml"
-        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
-        empty_tests = tmp_path / "tests"
-        empty_tests.mkdir()
-        assert classgate.run(overlay_path=str(overlay), tests_dir=str(empty_tests)) == 1
+    def test_staged_test_and_overlay_reference_pass(self, repo, tmp_path):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
 
-    def test_passes_once_a_unit_test_covers_the_class(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        overlay = tmp_path / "overlay.yaml"
-        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
-        tests = tmp_path / "tests"
-        tests.mkdir()
-        (tests / "test_codec.py").write_text(
-            "from y import OpenAISummaryReplayReasoningCodec\ndef test_c(): ..."
+    def test_worktree_only_test_does_not_count(self, repo, tmp_path, capsys):
+        """The finalize commit ships the INDEX. A test that exists only in the worktree
+        would satisfy a worktree-reading gate and then vanish from the commit - the
+        false assurance the gate exists to prevent - so it must NOT count."""
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")  # never added
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 1
+        assert "UNTESTED-CLASS" in capsys.readouterr().out
+
+    def test_unreferenced_class_fails_without_any_reference(self, repo, tmp_path, capsys):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        assert classgate.run(overlay_path=None, root=str(repo)) == 1
+        assert "UNREFERENCED-CLASS" in capsys.readouterr().out
+
+    def test_staged_model_presets_reference_passes_without_an_overlay(self, repo):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        (repo / "tolokaforge/core/data/model_presets.yaml").write_text(
+            "presets:\n  folded:\n    reasoning_codec: openai_summary_replay\n"
         )
-        assert classgate.run(overlay_path=str(overlay), tests_dir=str(tests)) == 0
+        _git(repo, "add", "tolokaforge/core/data/model_presets.yaml")
+        assert classgate.run(overlay_path=None, root=str(repo)) == 0
 
-    def test_missing_overlay_still_flags_the_unreferenced_class(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        tests = tmp_path / "tests"
-        tests.mkdir()
-        (tests / "test_codec.py").write_text("OpenAISummaryReplayReasoningCodec")
-        assert classgate.run(overlay_path=None, tests_dir=str(tests)) == 1
+    def test_cwd_does_not_matter(self, repo, tmp_path, monkeypatch):
+        """The old gate read git from the caller's CWD: from a subdirectory every git
+        answer silently emptied and the gate no-opped. The root is now anchored."""
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        monkeypatch.chdir(repo / "tests")
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
+        monkeypatch.chdir(tmp_path)  # unrelated dir
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
+
+    def test_non_git_root_fails_loud_not_open(self, tmp_path, capsys):
+        """git exiting 128 used to read as "no new policy class registered" (rc=0).
+        A guard must fail loud, never skip."""
+        outside = tmp_path / "not-a-repo"
+        outside.mkdir()
+        assert classgate.run(root=str(outside)) == 1
+        assert "could not read the staged tree" in capsys.readouterr().out
+
+    def test_reordered_registry_does_not_false_positive(self, repo, tmp_path):
+        """A move is a -/+ pair in diff text; the set diff must not report it."""
+        reordered = BASE_PRESETS.replace(
+            '_REASONING_CODECS = {\n    "openai": OpenAIReasoningCodec,\n}\n',
+            '_REASONING_CODECS = {\n\n    "openai": OpenAIReasoningCodec,\n}\n',
+        )
+        (repo / "tolokaforge/core/llm/presets.py").write_text(reordered)
+        _git(repo, "add", "tolokaforge/core/llm/presets.py")
+        assert classgate.run(root=str(repo)) == 0

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -1,0 +1,130 @@
+"""Unit tests for ``automation.classgate``.
+
+The scenario mirrors the real deepseek-v4-flash-0731 PR #846, which registered
+``OpenAISummaryReplayReasoningCodec`` with no unit test anywhere - the exact defect
+``docs/ADD_NEW_MODEL.md`` step 5 forbids and nothing enforced.
+"""
+
+from __future__ import annotations
+
+import automation.classgate as classgate
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Trimmed to the shape ``git diff --cached --unified=0`` emits for the registry file.
+PR846_DIFF = """\
+diff --git a/tolokaforge/core/llm/presets.py b/tolokaforge/core/llm/presets.py
+--- a/tolokaforge/core/llm/presets.py
++++ b/tolokaforge/core/llm/presets.py
+@@ -112,0 +113 @@
++    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,
+"""
+
+OTHER_FILE_DIFF = """\
+diff --git a/tolokaforge/core/llm/response_policy.py b/tolokaforge/core/llm/response_policy.py
+--- a/tolokaforge/core/llm/response_policy.py
++++ b/tolokaforge/core/llm/response_policy.py
+@@ -10,0 +11 @@
++class SomeHelper:
++    "not a registry binding"
+"""
+
+
+class TestAddedRegistryClasses:
+    def test_finds_the_new_codec_binding(self):
+        assert classgate.added_registry_classes(PR846_DIFF) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_ignores_added_lines_in_other_files(self):
+        """A class DEFINED elsewhere is not a registration - only presets.py counts."""
+        assert classgate.added_registry_classes(OTHER_FILE_DIFF) == []
+
+    def test_ignores_removed_and_context_lines(self):
+        diff = PR846_DIFF.replace(
+            '+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,',
+            '-    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,\n'
+            '     "openai": OpenAIReasoningCodec,',
+        )
+        assert classgate.added_registry_classes(diff) == []
+
+    def test_deduplicates_repeated_bindings(self):
+        diff = PR846_DIFF + '+    "alias": OpenAISummaryReplayReasoningCodec,\n'
+        assert classgate.added_registry_classes(diff) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_empty_diff_is_empty(self):
+        assert classgate.added_registry_classes("") == []
+
+
+class TestUntested:
+    def test_flags_a_class_no_test_mentions(self):
+        assert classgate.untested(
+            ["OpenAISummaryReplayReasoningCodec"], "def test_something(): pass"
+        ) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_accepts_a_class_a_test_mentions(self):
+        blob = "from x import OpenAISummaryReplayReasoningCodec\ndef test_it(): ..."
+        assert classgate.untested(["OpenAISummaryReplayReasoningCodec"], blob) == []
+
+
+class TestUnreferenced:
+    def test_flags_a_class_the_overlay_never_uses(self):
+        assert classgate.unreferenced(
+            ["OpenAISummaryReplayReasoningCodec"], "presets:\n  x:\n    match: ['a']\n", PR846_DIFF
+        ) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_registry_key_in_the_overlay_counts_as_a_reference(self):
+        """Overlays reference a class by its registry KEY, not its class name."""
+        overlay = "presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"
+        assert (
+            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
+        )
+
+    def test_class_name_in_the_overlay_also_counts(self):
+        overlay = "# uses OpenAISummaryReplayReasoningCodec\n"
+        assert (
+            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
+        )
+
+
+class TestReadTests:
+    def test_missing_dir_is_empty_not_an_error(self):
+        assert classgate.read_tests("does/not/exist") == ""
+
+    def test_concatenates_test_sources(self, tmp_path):
+        (tmp_path / "test_a.py").write_text("MarkerClassA")
+        (tmp_path / "helper.py").write_text("MarkerNotATest")
+        blob = classgate.read_tests(str(tmp_path))
+        assert "MarkerClassA" in blob
+        assert "MarkerNotATest" not in blob
+
+
+class TestRun:
+    def test_no_new_class_passes(self, monkeypatch):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: OTHER_FILE_DIFF)
+        assert classgate.run() == 0
+
+    def test_pr846_shape_fails_on_the_missing_unit_test(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        overlay = tmp_path / "overlay.yaml"
+        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
+        empty_tests = tmp_path / "tests"
+        empty_tests.mkdir()
+        assert classgate.run(overlay_path=str(overlay), tests_dir=str(empty_tests)) == 1
+
+    def test_passes_once_a_unit_test_covers_the_class(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        overlay = tmp_path / "overlay.yaml"
+        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_codec.py").write_text(
+            "from y import OpenAISummaryReplayReasoningCodec\ndef test_c(): ..."
+        )
+        assert classgate.run(overlay_path=str(overlay), tests_dir=str(tests)) == 0
+
+    def test_missing_overlay_still_flags_the_unreferenced_class(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_codec.py").write_text("OpenAISummaryReplayReasoningCodec")
+        assert classgate.run(overlay_path=None, tests_dir=str(tests)) == 1

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -85,6 +85,36 @@ class TestUnreferenced:
             classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
         )
 
+    def test_any_of_several_keys_counts_as_a_reference(self):
+        """A class bound under two keys is referenced if the overlay uses EITHER one."""
+        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
+        for key in ("openai_summary_replay", "second_alias"):
+            overlay = f"presets:\n  x:\n    reasoning_codec: {key}\n"
+            assert (
+                classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, diff) == []
+            ), key
+
+
+class TestAddedBindings:
+    def test_returns_key_class_pairs(self):
+        assert classgate.added_bindings(PR846_DIFF) == [
+            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec")
+        ]
+
+    def test_keeps_every_key_for_a_multiply_bound_class(self):
+        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
+        assert classgate.added_bindings(diff) == [
+            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec"),
+            ("second_alias", "OpenAISummaryReplayReasoningCodec"),
+        ]
+
+    def test_ignores_underscore_prefixed_registry_slot_lines(self):
+        """``_POLICY_REGISTRIES`` slot values are underscore-prefixed, not classes."""
+        diff = (
+            "+++ b/tolokaforge/core/llm/presets.py\n" '+    "reasoning_codec": _REASONING_CODECS,\n'
+        )
+        assert classgate.added_bindings(diff) == []
+
 
 class TestReadTests:
     def test_missing_dir_is_empty_not_an_error(self):


### PR DESCRIPTION
## Why

The auto-resolve fix-loop's only success signal is "the reprobe went green". For most probes that is a real provider measurement. For the two replay probes it is not: `test_thinking_replay_roundtrip` and `test_unsigned_thinking_replay` fire turn 1 live, then **mock the provider turn** and assert only our own outgoing request body. A codec that emits the expected shape satisfies them **by construction**, so the loop cannot distinguish "I fixed the model's behaviour" from "I wrote the payload I set out to write".

`deepseek/deepseek-v4-flash-0731` (#846) walked straight into that gap. It shipped a new reasoning codec, took `unsigned_thinking_replay` from 0/15 to 5/5, and certified the capability `required`. A live A/B afterwards, on the same conversation with and without the replay payload:

| | turn-2 `prompt_tokens` |
|---|---|
| with `reasoning_details` on the wire (2.8 kB, ~668 reasoning tokens) | 523 |
| without | 523 |

The route accepts the field and silently ignores it. Nothing in the pipeline could have caught that, and the prose rule that came closest lost to the competing "OR the reprobe shows it green" clause in the same paragraph.

## What this adds

**`cert_reconcile` was asymmetric by construction.** It guarded against *under*-crediting a model (false-pessimism, undeclared, core-unsupported) with no check on the over-crediting side.

- **SELF-REFERENTIAL** (violation) — a payload-only capability declared `required` against a failing **native** baseline. The policy may still ship; only the cert claim is refused.
- **UNBACKED** (warning) — `required` with no probe result at all.

`PAYLOAD_ONLY_CAPABILITIES` is drift-guarded against a *structural* fact rather than prose: the set must equal the probes that patch `tolokaforge.core.llm.client.completion` — the only transport seam, and the only patch target, in the live capability suite.

**New `automation.classgate`** (finalize gate, `automation check-new-classes`): every newly registered policy class must be referenced by the overlay **and** covered by a unit test under `tests/unit/llm/`. `docs/ADD_NEW_MODEL.md` step 5 already mandated the test; nothing enforced it, because the fix-loop's success signal never looks there.

## Prompt fixes for the two upstream causes

1. The payload-only rule is now stated at **probe level** and names the deterministic gate, instead of generalising about mechanisms. The old phrasing was both **evadable** (write a codec that is no longer "summary-only") and **wrong** (`THINKING_EMITS_BLOCKS` does pass live on such a codec).
2. The "grep before you write a class" rule listed only `response_policy.py` and `schema_sanitizer.py` — which is exactly why `reasoning_codec.py` went unsearched. It now covers every module behind `_POLICY_REGISTRIES` plus `model_presets.yaml`.

That second omission cost a redundant class. The shipped `gemini` codec already satisfies unsigned replay on that route (verified live), and `qwen3.8-max` had solved the **identical** fix-target days earlier with a one-line `reasoning_codec: gemini` swap. The new class also round-tripped *less* faithfully: it rebuilds the envelope from the flat summary, dropping the provider's own `format` and `index` that the shipped codec preserves.

## Verification

- `tools/automation` suite: **267 passed** (28 in the two touched files, incl. the real #846 and mimo baselines as fixtures).
- End-to-end: staging the real #846 registry line makes `classgate` fail with `UNTESTED-CLASS` + `UNREFERENCED-CLASS`.
- `ruff check` + `ruff format --check` clean; workflow YAML parses.
- Both new gates are additive and fail closed to `needs-human`; no existing integration path changes when a candidate adds no class and claims no payload-only capability.

## Note

This does not attempt to fix #846 itself. Given the finding above, the better resolution there is to drop the new codec and use `reasoning_codec: gemini`; that is a separate change.