### PR TITLE
fix(docker): resolve the runner build context on a wheel install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,23 @@ packages = ["tolokaforge"]
 # absent from ``site-packages``.
 [tool.hatch.build.targets.wheel.force-include]
 ".python-version" = "tolokaforge/_python_version.txt"
+# Runner-image build inputs. The runner Dockerfile builds the subset wheel
+# in-container with ``hatchling build --target custom`` (ADR-0025), so its
+# build context needs this pyproject, the metadata files pyproject
+# references, and the custom builder script. On a wheel install the repo
+# root is ``site-packages`` and none of these are there, which broke every
+# Docker-runtime run on 0.14.0. Ship packaged copies so
+# ``builder._runner_definition()`` can assemble the same context from an
+# installed package. Same source-of-truth shape as the ``.python-version``
+# copy above: repo-root file authoritative, packaged copy is its artifact.
+# ``.python-version`` is NOT repeated here: the entry above already ships it
+# as ``tolokaforge/_python_version.txt`` (one force-include key per source),
+# and ``_runner_definition()`` re-lands that copy in the context under its
+# original dotfile name via a (source, destination) context entry.
+"pyproject.toml" = "tolokaforge/_subset_build/pyproject.toml"
+"README.md" = "tolokaforge/_subset_build/README.md"
+"LICENSE" = "tolokaforge/_subset_build/LICENSE"
+"scripts/hatch" = "tolokaforge/_subset_build/scripts/hatch"
 
 [tool.hatch.build.targets.sdist]
 

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from tolokaforge.docker.builder import (
+    assemble_build_context,
     build_image,
     get_image_definition,
     service_name_for_image,
@@ -263,9 +264,9 @@ def test_build_image_runner_ships_source_tree_not_a_wheel(monkeypatch) -> None:
         # No host-side wheel is copied into the runner image build context;
         # the subset wheel is produced by the wheel-builder stage.
         wheels = list(root.glob("tolokaforge*.whl"))
-        assert (
-            wheels == []
-        ), f"runner build context must not contain a pre-built wheel; found: {wheels}"
+        assert wheels == [], (
+            f"runner build context must not contain a pre-built wheel; found: {wheels}"
+        )
         # Instead, the source-tree entries hatch consumes must be present.
         assert (root / "pyproject.toml").exists()
         assert (root / "scripts" / "hatch" / "hatch_runner_subset_builder.py").exists()
@@ -517,3 +518,79 @@ def test_build_and_prepare_builds_images_and_networks_without_starting_container
     # container-lifecycle side of the stack stayed untouched.
     stack.stop_all()  # would raise if containers had been created via the patched Container.create.
     stack.destroy(remove_networks=False)
+
+
+def test_runner_build_context_resolves_from_installed_wheel(tmp_path: Path, monkeypatch) -> None:
+    """On a wheel install the runner context must resolve to the PACKAGED
+    copies, not the repo-root paths.
+
+    ``repo_root()`` is ``Path(__file__).parents[2]``, which is
+    ``site-packages`` once tolokaforge is installed as a wheel — so
+    ``pyproject.toml`` / ``README.md`` / ``LICENSE`` / ``scripts/hatch`` are
+    simply not there. 0.14.0 shipped the repo-relative set unconditionally,
+    so every Docker-runtime run died in ``build_images()`` with
+    ``FileNotFoundError: Declared context path not found: pyproject.toml``
+    before a single trial executed — invisible to CI, which
+    only ever builds from a source checkout.
+
+    This locks the wheel-install branch: entries are absolute paths into the
+    packaged ``_subset_build`` dir, and they land in the assembled context
+    under exactly the names the Dockerfile ``COPY`` lines expect."""
+    site_packages = tmp_path / "site-packages"
+    pkg = site_packages / "tolokaforge"
+    packaged = pkg / "_subset_build"
+    (packaged / "scripts" / "hatch").mkdir(parents=True)
+    for name in ("pyproject.toml", "README.md", "LICENSE"):
+        (packaged / name).write_text(f"# {name}\n")
+    (packaged / "scripts" / "hatch" / "hatch_runner_subset_builder.py").write_text("")
+    (pkg / "_python_version.txt").write_text("3.12\n")
+    # The base wheel ships the Dockerfiles inside the package, so
+    # ``assemble_build_context`` still finds the runner Dockerfile under
+    # ``repo_root``/``site-packages``.
+    dockerfiles = pkg / "docker" / "dockerfiles"
+    dockerfiles.mkdir(parents=True)
+    (dockerfiles / "runner.Dockerfile").write_text("FROM scratch\n")
+    # A wheel install has no repo-root pyproject.toml — that is the trigger.
+    monkeypatch.setattr("tolokaforge.docker.builder.repo_root", lambda: site_packages)
+    monkeypatch.setattr("tolokaforge.docker.builder.installed_package_dir", lambda: pkg)
+
+    runner_def = get_image_definition("runner")
+    entries = runner_def["context_files"]
+
+    for entry in entries:
+        src = Path(entry[0] if isinstance(entry, tuple) else entry)
+        assert src.is_absolute(), f"wheel-install entry must be absolute: {entry}"
+        assert src.exists(), f"wheel-install entry does not exist: {entry}"
+
+    build_dir = assemble_build_context(site_packages, runner_def["dockerfile"], entries)
+    try:
+        for expected in (
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            ".python-version",
+            "scripts/hatch",
+            "tolokaforge",
+        ):
+            assert (build_dir / expected).exists(), (
+                f"assembled runner context is missing '{expected}', which the "
+                "runner Dockerfile COPYs for its hatchling build stage"
+            )
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+
+def test_runner_build_context_fails_loud_when_wheel_lacks_packaged_inputs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A wheel built from a pyproject without the force-include entries must
+    fail with an actionable message naming the missing paths, not with a bare
+    ``FileNotFoundError`` from deep inside the context copy."""
+    site_packages = tmp_path / "site-packages"
+    pkg = site_packages / "tolokaforge"
+    pkg.mkdir(parents=True)
+    monkeypatch.setattr("tolokaforge.docker.builder.repo_root", lambda: site_packages)
+    monkeypatch.setattr("tolokaforge.docker.builder.installed_package_dir", lambda: pkg)
+
+    with pytest.raises(FileNotFoundError, match="force-include"):
+        get_image_definition("runner")

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import shutil
 import tempfile
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from importlib import resources
 from pathlib import Path
@@ -83,6 +83,24 @@ PYTHON_VERSION = _pinned_python_version()
 _PYTHON_BUILD_ARGS: dict[str, str] = {"PYTHON_VERSION": PYTHON_VERSION}
 
 
+#: Build-context entries the runner Dockerfile's ``hatchling build`` stage
+#: needs, as repo-relative source-checkout paths. ``_runner_definition()``
+#: maps each to a packaged copy when the repo root is not available.
+_RUNNER_SOURCE_CONTEXT_FILES: list[str] = [
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+    ".python-version",
+    "scripts/hatch/",
+    "tolokaforge/",
+]
+
+#: Where the base wheel's ``force-include`` table lands the repo-root files
+#: above, relative to the installed ``tolokaforge`` package. Keys are the
+#: build-context names the Dockerfile ``COPY`` lines expect.
+_PACKAGED_SUBSET_BUILD_DIR = "_subset_build"
+
+
 # =============================================================================
 # Image Definitions — Single Source of Truth
 # =============================================================================
@@ -102,9 +120,11 @@ _PYTHON_BUILD_ARGS: dict[str, str] = {"PYTHON_VERSION": PYTHON_VERSION}
 #
 # The runner image is different: its Dockerfile is multi-stage
 # (ADR-0025 § subset build target), producing the runner-subset wheel
-# in-container via ``hatch build --target custom``. The context is a
-# static source-tree slice, no host-side wheel resolution, no factory —
-# hence a fully-static IMAGE_DEFINITIONS entry.
+# in-container via ``hatch build --target custom``. Its context is a source-
+# tree slice rather than a resolved wheel, so it needs no host-side wheel
+# resolution — but it DOES pair with ``_runner_definition()``, which picks
+# between the repo-root paths (source checkout) and the packaged copies
+# (wheel install, where the repo root is ``site-packages``).
 
 IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
     "db-service": {
@@ -125,14 +145,12 @@ IMAGE_DEFINITIONS: dict[str, dict[str, Any]] = {
         # to produce the subset wheel, and a builder stage installs it into
         # /opt/venv. The build context ships the sources hatch needs; the
         # subset wheel is a Docker-only artifact (ADR-0025).
-        "context_files": [
-            "pyproject.toml",
-            "README.md",
-            "LICENSE",
-            ".python-version",
-            "scripts/hatch/",
-            "tolokaforge/",
-        ],
+        #
+        # These entries are the *source-checkout* paths. On a wheel install
+        # the repo-root files are absent from ``site-packages``, so
+        # ``_runner_definition()`` swaps in the packaged copies — see that
+        # factory and ``docs/adr/0025-runner-wheel-split.md``.
+        "context_files": _RUNNER_SOURCE_CONTEXT_FILES,
         "build_args": dict(_PYTHON_BUILD_ARGS),
     },
     "rag-service": {
@@ -183,6 +201,79 @@ def _rag_definition() -> dict[str, Any]:
 
 
 _DYNAMIC_DEFINITIONS["rag-service"] = _rag_definition
+
+
+def installed_package_dir() -> Path:
+    """Directory of the installed ``tolokaforge`` package (its source root)."""
+    return Path(__file__).resolve().parents[1]
+
+
+def packaged_subset_build_dir() -> Path:
+    """Directory holding the packaged copies of the runner's build inputs.
+
+    The base wheel's ``force-include`` table copies the repo-root files the
+    runner Dockerfile needs into ``tolokaforge/_subset_build/``. Same shape
+    as the ``.python-version`` -> ``tolokaforge/_python_version.txt`` copy
+    that :func:`_pinned_python_version` reads: the repo-root file stays the
+    single source of truth at write time, the packaged copy is a build
+    artifact of it.
+    """
+    return installed_package_dir() / _PACKAGED_SUBSET_BUILD_DIR
+
+
+def _runner_definition() -> dict[str, Any]:
+    """Resolve the runner build context for source-checkout OR wheel install.
+
+    The Dockerfile's ``hatchling build --target custom`` stage needs the
+    pyproject (which carries the ``[tool.hatch.build.targets.custom]``
+    table), the metadata files that pyproject references, the custom builder
+    script, and the ``tolokaforge`` sources. In a source checkout those sit
+    at the repo root. Installed as a wheel they do NOT: ``repo_root()`` is
+    ``site-packages``, so the repo-relative entries resolve to paths that do
+    not exist and the build dies before any trial runs.
+
+    Absolute context entries are copied flat into the build dir, so the
+    packaged copies land under exactly the names the ``COPY`` lines expect.
+    """
+    if (repo_root() / "pyproject.toml").is_file():
+        # Source checkout / editable install — repo-relative entries work.
+        return dict(IMAGE_DEFINITIONS["runner"])
+
+    packaged = packaged_subset_build_dir()
+    pkg_dir = installed_package_dir()
+    # Flat-copied absolutes land under their own basename, which is already
+    # the name each COPY line expects. ``.python-version`` is the exception:
+    # it ships as ``_python_version.txt`` (one force-include key per source),
+    # so it needs an explicit destination.
+    entries: list[Any] = [
+        packaged / "pyproject.toml",
+        packaged / "README.md",
+        packaged / "LICENSE",
+        packaged / "scripts",  # dir -> build_dir/scripts (holds hatch/)
+        pkg_dir,  # dir -> build_dir/tolokaforge
+        (pkg_dir / "_python_version.txt", ".python-version"),
+    ]
+    missing = [
+        str(e[0] if isinstance(e, tuple) else e)
+        for e in entries
+        if not (e[0] if isinstance(e, tuple) else e).exists()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "Runner build context is incomplete for a wheel install. The base "
+            "wheel must force-include the runner's subset-build inputs into "
+            f"'tolokaforge/{_PACKAGED_SUBSET_BUILD_DIR}/' — missing: "
+            f"{missing}. Rebuild the wheel from a pyproject that carries the "
+            "[tool.hatch.build.targets.wheel.force-include] entries, or run "
+            "from a source checkout."
+        )
+    return {
+        **IMAGE_DEFINITIONS["runner"],
+        "context_files": [(str(e[0]), e[1]) if isinstance(e, tuple) else str(e) for e in entries],
+    }
+
+
+_DYNAMIC_DEFINITIONS["runner"] = _runner_definition
 
 
 def get_image_definition(service_name: str) -> dict[str, Any]:
@@ -374,7 +465,7 @@ def expected_image_ref(service_name: str) -> str:
 def assemble_build_context(
     repo_root: Path,
     dockerfile: str,
-    context_files: list[str],
+    context_files: Sequence[str | tuple[str, str]],
 ) -> Path:
     """Create a temporary build directory with only the declared files.
 
@@ -385,7 +476,10 @@ def assemble_build_context(
     Args:
         repo_root: Repository root directory.
         dockerfile: Path to Dockerfile (relative to repo_root).
-        context_files: List of file/directory paths to include (relative to repo_root).
+        context_files: File/directory paths to include. Each entry is
+            either a path (relative to repo_root, or absolute -> copied
+            flat under its basename) or a ``(source, destination)`` pair
+            when the context name must differ from the source basename.
 
     Returns:
         Path to temporary build directory. The caller owns the directory and
@@ -405,7 +499,25 @@ def assemble_build_context(
     # Copy declared context files.
     # Paths may be relative (resolved against repo_root) or absolute
     # (e.g. a wheel from the wheel-cache — copied flat into build_dir).
+    # An entry may also be a ``(source, destination)`` pair when the name the
+    # Dockerfile expects differs from the source basename — used by
+    # ``_runner_definition()`` to land the packaged ``_python_version.txt``
+    # back under its repo-root dotfile name.
     for entry in context_files:
+        if isinstance(entry, tuple):
+            src_spec, dest_rel = entry
+            src = Path(src_spec)
+            if not src.is_absolute():
+                src = repo_root / src
+            if not src.is_file():
+                shutil.rmtree(build_dir, ignore_errors=True)
+                raise FileNotFoundError(
+                    f"Declared context path not found: {src_spec} -> {dest_rel}"
+                )
+            dst = build_dir / dest_rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            continue
         entry_path = Path(entry)
         if entry_path.is_absolute():
             # Absolute path: copy the file flat into the build dir root.


### PR DESCRIPTION
**v0.14.0 cannot run a Docker-runtime eval at all.** Every run dies in `build_images()` before a single trial executes:

```
FileNotFoundError: Declared context path not found: pyproject.toml
  (resolved to .../site-packages/pyproject.toml)
```

## Cause

The runner wheel split (#847, ADR-0025) moved the subset-wheel build in-container: the image now runs `hatchling build --target custom`, so its build context became a **source-tree slice** instead of a host-resolved wheel:

```python
"context_files": ["pyproject.toml", "README.md", "LICENSE", ".python-version", "scripts/hatch/", "tolokaforge/"]
```

Those are repo-relative, and `repo_root()` is `Path(__file__).parents[2]` — which is **`site-packages`** once tolokaforge is installed as a wheel. Only `tolokaforge/` is there; the other four are not.

Before #847 the runner context was a single `resolve_wheel()` artifact, which worked in both install modes.

## Why CI didn't catch it

CI only ever builds from a **source checkout**, where all six paths exist. The failure is specific to the **installed-package** path — which is exactly how every arena eval runs the engine (installed from a release tag, driving the Docker runtime). Same blind spot that let the `runner.models` `Runner*` rename through in the same release.

## Fix

Follows the pattern `_pinned_python_version()` already established for this exact class of problem — its docstring says the two-branch shape "only exists to cover the wheel-install case where the repo-root dotfile is not available in `site-packages`".

- **pyproject** force-includes `pyproject.toml` / `README.md` / `LICENSE` / `scripts/hatch` into `tolokaforge/_subset_build/`. `.python-version` is *not* repeated (one force-include key per source) — it already ships as `tolokaforge/_python_version.txt`.
- **`_runner_definition()`** picks the branch: repo-relative entries for a source checkout, absolute packaged paths otherwise. Absolute entries are copied flat into the context, so they land under the exact names the Dockerfile `COPY` lines expect.
- `.python-version` needs a rename on the way in, so **`assemble_build_context` now also accepts a `(source, destination)` entry**.
- A wheel built without the force-included inputs **fails loud naming the missing paths**, rather than surfacing a bare `FileNotFoundError` from inside the copy loop.

The repo-root files stay the single source of truth at write time; the packaged copies are build artifacts of them.

## Verification

Not just unit tests — the real path, end to end:

1. built the wheel → confirmed all four inputs land under `tolokaforge/_subset_build/`
2. installed it into a **clean venv** → `repo_root()` is `site-packages`, `pyproject.toml` absent (reproduces the bug)
3. `get_image_definition("runner")` → all 6 entries resolve to existing absolute paths
4. `assemble_build_context(...)` → context contains `pyproject.toml`, `README.md`, `LICENSE`, `.python-version`, `scripts/hatch`, `tolokaforge`
5. **`docker build` of the runner image from that context succeeds**
6. inside the built image: `tolokaforge.runner` imports, `build_capabilities("qwen/qwen3.8-max")` resolves to `GeminiReasoningCodec`, pricing table populated
7. source-checkout mode still returns the original repo-relative entries (dev path unchanged)

Tests: 2 new regression tests (wheel-install resolution + loud-fail on an incomplete wheel). `tests/unit/test_docker_build_context.py` 14 passed, `tests/canonical/test_runner_subset_partition.py` (the drift-lock guard) 14 passed. ruff clean.

## Out of scope, but worth knowing

- The subset wheel installs as distribution **`tolokaforge-runner-subset`**, so `tolokaforge.__version__` *inside the runner image* reports `0.0.0+unknown` (`_pkg_version("tolokaforge")` raises `PackageNotFoundError`). Inherent to ADR-0025, not introduced here — but it means the runner container has no engine-version provenance of its own.
- `tests/canonical/test_runner_subset_install_smoke.py` cannot run locally against uv 0.11.x because of the repo's `required-version = ">=0.9.5,<0.10"` pin.
- `main` CI has been red on 7 docker/runtime integration tests all day, with a **byte-identical failing set before and after** #847 and the v0.14.0 release — pre-existing, unrelated to this change.

Found while starting the Qwen3.8 Max arena eval (TECHDEL-546) on v0.14.0. The companion adapter-side fix for the same release's `Runner*` rename is toloka-partners/tolokaforge-tools#72.