### PR TITLE
style: black-format test_docker_build_context.py

### DIFF
--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -264,9 +264,9 @@ def test_build_image_runner_ships_source_tree_not_a_wheel(monkeypatch) -> None:
         # No host-side wheel is copied into the runner image build context;
         # the subset wheel is produced by the wheel-builder stage.
         wheels = list(root.glob("tolokaforge*.whl"))
-        assert wheels == [], (
-            f"runner build context must not contain a pre-built wheel; found: {wheels}"
-        )
+        assert (
+            wheels == []
+        ), f"runner build context must not contain a pre-built wheel; found: {wheels}"
         # Instead, the source-tree entries hatch consumes must be present.
         assert (root / "pyproject.toml").exists()
         assert (root / "scripts" / "hatch" / "hatch_runner_subset_builder.py").exists()


### PR DESCRIPTION
`main`'s **lint job is red**, which also skips `test-full` / `test-gate` / `test-smoke`. My fault, from #858.

This repo formats with **black**; `.pre-commit-config.yaml` says ruff is *"linting only, not formatting"*. I formatted #858 with `ruff format`, which rewrote a **pre-existing** assert in `tests/unit/test_docker_build_context.py` into a style black rejects:

```python
# ruff format wants this
assert wheels == [], (
    f"runner build context must not contain a pre-built wheel; found: {wheels}"
)
# black wants this
assert (
    wheels == []
), f"runner build context must not contain a pre-built wheel; found: {wheels}"
```

Running black restores it. One file, formatting only, no behaviour change.

- `black --check .` clean (747 files; it was the only offender)
- `ruff check` clean
- `tests/unit/test_docker_build_context.py` 14 passed