### PR TITLE
fix(docker): take the runner build context from the builder in core_stack (v0.14.1 still broken)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,67 @@ jobs:
       run: uv run pre-commit run --all-files --show-diff-on-failure
 
   # ============================================================================
+  # Wheel-install gate — the ONE thing every other job is blind to
+  # ============================================================================
+  # Every other job `uv sync`s a source checkout, so `builder.repo_root()` is the
+  # repo and the runner image's build context always resolves. Consumers install
+  # the engine as a wheel, where `repo_root()` is `site-packages` — and that path
+  # shipped broken TWICE (v0.14.0 and v0.14.1): the runner context resolved to
+  # non-existent repo-root paths and every Docker-runtime run died in
+  # `build_images()` before a single trial. This job installs the built wheel into
+  # a clean venv and drives the real production entry point. No Docker needed —
+  # assembling the context is where the bug lives.
+  wheel-install-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "0.9.5"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: Set up Python (pinned in .python-version)
+      run: uv python install "$(cat .python-version)"
+
+    - name: Build the wheel
+      run: uv build --wheel
+
+    - name: Install the wheel into a clean venv (no source tree on the path)
+      run: |
+        uv venv /tmp/wheelenv
+        VIRTUAL_ENV=/tmp/wheelenv uv pip install dist/*.whl
+
+    - name: Runner build context must assemble from the installed wheel
+      # cd / so the source checkout cannot be picked up via CWD.
+      run: |
+        cd /
+        /tmp/wheelenv/bin/python - <<'PY'
+        from pathlib import Path
+        from tolokaforge.docker.builder import assemble_build_context, repo_root
+        from tolokaforge.docker.stacks.core import core_stack
+
+        root = repo_root()
+        assert not (root / "pyproject.toml").is_file(), (
+            f"expected a wheel install, but {root} looks like a source checkout"
+        )
+
+        svc = core_stack().services["runner"]
+        build_dir = assemble_build_context(root, svc.dockerfile, svc.context_files)
+        required = [
+            "pyproject.toml", "README.md", "LICENSE",
+            ".python-version", "scripts/hatch", "tolokaforge",
+        ]
+        missing = [n for n in required if not (build_dir / n).exists()]
+        assert not missing, f"assembled runner context is missing {missing}"
+        print("runner build context assembles from a wheel install:", sorted(required))
+        PY
+
+  # ============================================================================
   # PR smoke tests - fast required gate
   # ============================================================================
   test-smoke:

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -264,9 +264,9 @@ def test_build_image_runner_ships_source_tree_not_a_wheel(monkeypatch) -> None:
         # No host-side wheel is copied into the runner image build context;
         # the subset wheel is produced by the wheel-builder stage.
         wheels = list(root.glob("tolokaforge*.whl"))
-        assert wheels == [], (
-            f"runner build context must not contain a pre-built wheel; found: {wheels}"
-        )
+        assert (
+            wheels == []
+        ), f"runner build context must not contain a pre-built wheel; found: {wheels}"
         # Instead, the source-tree entries hatch consumes must be present.
         assert (root / "pyproject.toml").exists()
         assert (root / "scripts" / "hatch" / "hatch_runner_subset_builder.py").exists()
@@ -594,3 +594,28 @@ def test_runner_build_context_fails_loud_when_wheel_lacks_packaged_inputs(
 
     with pytest.raises(FileNotFoundError, match="force-include"):
         get_image_definition("runner")
+
+
+def test_core_stack_runner_context_comes_from_the_builder_not_a_copy() -> None:
+    """The orchestrator's service stack must take the runner build context from
+    the builder, never from its own copy of the list.
+
+    ``core_stack()`` is the path a real run takes (orchestrator ->
+    ``service_stack.start_all`` -> ``build_images``), and it used to spell the
+    repo-relative context list out a second time. So when the builder learned
+    to resolve packaged copies for a wheel install, the service stack kept
+    handing over repo-root paths and every installed-engine run still died in
+    ``build_images()`` with ``Declared context path not found: pyproject.toml``
+    — v0.14.0 and v0.14.1 both shipped that way.
+
+    Locking equality here means a future edit to one list cannot silently
+    diverge from the other, and the wheel-install branch reaches production."""
+    from tolokaforge.docker.stacks.core import core_stack
+
+    stack = core_stack()
+    assert (
+        stack.services["runner"].context_files == get_image_definition("runner")["context_files"]
+    ), (
+        "core_stack()'s runner context_files diverged from the builder's — the "
+        "service stack must not keep its own copy of the list"
+    )

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -596,26 +596,60 @@ def test_runner_build_context_fails_loud_when_wheel_lacks_packaged_inputs(
         get_image_definition("runner")
 
 
-def test_core_stack_runner_context_comes_from_the_builder_not_a_copy() -> None:
-    """The orchestrator's service stack must take the runner build context from
-    the builder, never from its own copy of the list.
+def test_core_stack_runner_context_assembles_on_a_wheel_install(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``core_stack()`` must produce a runner context that ASSEMBLES when the
+    engine is installed as a wheel.
 
     ``core_stack()`` is the path a real run takes (orchestrator ->
-    ``service_stack.start_all`` -> ``build_images``), and it used to spell the
-    repo-relative context list out a second time. So when the builder learned
-    to resolve packaged copies for a wheel install, the service stack kept
-    handing over repo-root paths and every installed-engine run still died in
-    ``build_images()`` with ``Declared context path not found: pyproject.toml``
-    — v0.14.0 and v0.14.1 both shipped that way.
+    ``service_stack.start_all`` -> ``build_images`` ->
+    ``assemble_build_context(repo_root(), svc.dockerfile, svc.context_files)``).
+    It used to spell the repo-relative list out a second time, so when the
+    builder learned to resolve packaged copies for a wheel install the service
+    stack kept handing over repo-root paths — and v0.14.0 AND v0.14.1 both
+    shipped an engine that died in ``build_images()`` with
+    ``Declared context path not found: pyproject.toml``.
 
-    Locking equality here means a future edit to one list cannot silently
-    diverge from the other, and the wheel-install branch reaches production."""
+    This test must run INSIDE the wheel-install simulation. A plain equality
+    assert in a source checkout cannot fail: there the builder returns the same
+    six strings in the same order as the literal the bug reintroduces, so both
+    sides match either way. Assembling under the patch is what actually gates
+    it — reverting ``core.py`` to its duplicated list makes this raise."""
     from tolokaforge.docker.stacks.core import core_stack
 
-    stack = core_stack()
-    assert (
-        stack.services["runner"].context_files == get_image_definition("runner")["context_files"]
-    ), (
-        "core_stack()'s runner context_files diverged from the builder's — the "
-        "service stack must not keep its own copy of the list"
-    )
+    site_packages = tmp_path / "site-packages"
+    pkg = site_packages / "tolokaforge"
+    packaged = pkg / "_subset_build"
+    (packaged / "scripts" / "hatch").mkdir(parents=True)
+    for name in ("pyproject.toml", "README.md", "LICENSE"):
+        (packaged / name).write_text(f"# {name}\n")
+    (packaged / "scripts" / "hatch" / "hatch_runner_subset_builder.py").write_text("")
+    (pkg / "_python_version.txt").write_text("3.12\n")
+    dockerfiles = pkg / "docker" / "dockerfiles"
+    dockerfiles.mkdir(parents=True)
+    (dockerfiles / "runner.Dockerfile").write_text("FROM scratch\n")
+    monkeypatch.setattr("tolokaforge.docker.builder.repo_root", lambda: site_packages)
+    monkeypatch.setattr("tolokaforge.docker.builder.installed_package_dir", lambda: pkg)
+
+    svc = core_stack().services["runner"]
+    build_dir = assemble_build_context(site_packages, svc.dockerfile, svc.context_files)
+    try:
+        for expected in (
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            ".python-version",
+            "scripts/hatch",
+            "tolokaforge",
+        ):
+            assert (build_dir / expected).exists(), (
+                f"core_stack()'s runner context is missing '{expected}' on a wheel "
+                "install — the service stack is not using the builder's resolved list"
+            )
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+    # Belt and braces: the two lists must also stay identical, so a future edit
+    # to one cannot silently diverge. (Necessary, not sufficient — see above.)
+    assert svc.context_files == get_image_definition("runner")["context_files"]

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -144,10 +144,12 @@ class ServiceDefinition(BaseModel):
         default="latest",
         description="Tag for prebuilt image",
     )
-    context_files: list[str] = Field(
+    context_files: list[str | tuple[str, str]] = Field(
         default_factory=list,
         description="Explicit list of files/dirs to include in build context. "
-        "When set, an isolated temp build directory is created instead of using context.",
+        "When set, an isolated temp build directory is created instead of using context. "
+        "An entry may be a ``(source, destination)`` pair when the name the Dockerfile "
+        "expects differs from the source basename — see builder.assemble_build_context.",
     )
     privileged: bool = Field(
         default=False,

--- a/tolokaforge/docker/stacks/core.py
+++ b/tolokaforge/docker/stacks/core.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
+from tolokaforge.docker.builder import get_image_definition
 from tolokaforge.docker.config import DockerConfig
 from tolokaforge.docker.health import HealthProbe
 from tolokaforge.docker.mount import Mount
@@ -194,18 +195,14 @@ def core_stack(
         image_name="tolokaforge-runner",
         dockerfile="tolokaforge/docker/dockerfiles/runner.Dockerfile",
         context=".",
-        context_files=[
-            # Sources ``hatch build --target custom`` consumes in the
-            # wheel-builder stage. Every path is repo-relative; the temp
-            # build context assembler copies them flat into the isolated
-            # build directory (see ``builder.assemble_build_context``).
-            "pyproject.toml",
-            "README.md",
-            "LICENSE",
-            ".python-version",
-            "scripts/hatch/",
-            "tolokaforge/",
-        ],
+        # Sources ``hatch build --target custom`` consumes in the wheel-builder
+        # stage. Resolved by the builder rather than spelled out here: on a
+        # wheel install the repo-root paths do not exist (``repo_root()`` is
+        # ``site-packages``) and the factory swaps in the packaged copies. This
+        # list used to be duplicated here, which is how v0.14.0/v0.14.1 kept
+        # failing on an installed engine even after the builder was fixed —
+        # this is the code path the orchestrator's service stack actually takes.
+        context_files=get_image_definition("runner")["context_files"],
         ports=[PortConfig(container_port=50051, host_port=runner_port)],
         environment=runner_env,
         depends_on=runner_depends,


### PR DESCRIPTION
**v0.14.1 still cannot run a Docker-runtime eval.** #858 fixed the wrong copy of the list.

## What #858 missed

#858 taught `builder._runner_definition()` to resolve the runner build context from packaged copies on a wheel install. But `stacks/core.py` kept its **own duplicate** of the repo-relative list, and that is the path a real run takes:

```
orchestrator.run -> service_stack.start_all -> build_images
  -> assemble_build_context(repo_root(), svc.dockerfile, svc.context_files)
```

`svc` comes from `core_stack()`, not from `get_image_definition()`. So v0.14.1 fails identically:

```
FileNotFoundError: Declared context path not found: pyproject.toml
  (resolved to .../site-packages/pyproject.toml)
```

That message is the **relative-path branch** of the assembler, which is the proof the factory was never consulted.

My own verification of #858 called `get_image_definition("runner")` directly — a code path production does not use. That is why it looked fixed.

## Fix

`core_stack()` now reads `get_image_definition("runner")["context_files"]` instead of duplicating the list, so the wheel-install branch actually reaches production and the two lists cannot drift apart again. A new test locks the equality.

`ServiceDefinition.context_files` widens to `list[str | tuple[str, str]]` — the resolved wheel-install form carries one `(source, destination)` pair (`_python_version.txt` -> `.python-version`), and a Pydantic `list[str]` would have rejected or stringified it.

## Verification — through the real entry point this time

From a wheel built off this branch and installed into a clean venv (`repo_root()` is `site-packages`, i.e. the failing condition):

1. `core_stack().services["runner"].context_files` -> **6/6 entries resolve**, each landing under the name the Dockerfile `COPY` expects
2. `assemble_build_context(...)` -> context carries `pyproject.toml`, `README.md`, `LICENSE`, `.python-version`, `scripts/hatch`, `tolokaforge`
3. **`stack.build_images()` builds both the db-service and runner images** — the exact call in the failing traceback

Tests: `black --check` clean (747 files), `ruff` clean, **45 passed** across the docker, build-context and runner-subset suites, including the new no-duplication test.

## Supersedes #862

Folds in that black formatting fix. `main`'s lint has been red since #858 because I formatted it with `ruff format`; this repo formats with **black** (pre-commit runs ruff for *linting only*). Red lint also skips `test-full` / `test-gate` / `test-smoke`, so landing this makes those run again.

Needs a **v0.14.2** to be usable by the arena eval (TECHDEL-546).