### PR TITLE
feat(core): multi-actor architecture — interaction_mode + Actor Protocol + TurnPolicy seam (#868)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -381,6 +381,8 @@ initial_state:
 
 system_prompt: null
 
+interaction_mode: "conversational"   # or "agent_only" — see below
+
 tools:
   agent:
     enabled: ["browser", "read_file", "write_file", "db_query", "search_kb"]
@@ -408,6 +410,25 @@ metadata:
 
 grading: "grading.yaml"
 ```
+
+### `interaction_mode:` — turn-loop shape
+
+Selects whether the trial dispatches a user simulator alongside the agent.
+Two values today, room for future values (e.g. `multi_actor`) as new
+`TurnPolicy` implementations register in the `tolokaforge.turn_policies`
+entry-point group. See [ADR-0028](adr/0028-multi-actor-turn-policy.md).
+
+- **`conversational`** (default) — user simulator dispatched every turn.
+  τ-bench and every existing pack expects this shape; leaving the field
+  unset keeps that behavior byte-for-byte.
+- **`agent_only`** — no user turn dispatched after the initial message.
+  The agent runs to `###STOP###` (routed to `TerminationReason.AGENT_DONE`),
+  `max_turns`, or `episode_timeout_s`. The user simulator is never
+  constructed. Requires a non-empty `initial_user_message` at pack
+  authoring time (fails loud at run-start otherwise — the agent-only
+  route has no simulator to synthesize a bootstrap message). Matches
+  agent-driven eval shapes (code migration, autonomous tool-use) where
+  the task lives entirely in the system prompt.
 
 ## Grading Specification (`grading.yaml`)
 

--- a/docs/PROJECTS.md
+++ b/docs/PROJECTS.md
@@ -186,6 +186,9 @@ task_defaults:
   adapter_type: "native"
   max_turns: 20
   system_prompt: "./shared/system_prompt.md"
+  # interaction_mode: "agent_only"   # optional; leave unset to inherit
+                                     # engine default "conversational".
+                                     # See ADR-0028.
   timeouts:
     trial_seconds: 600
     tool_call_seconds: 60

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -560,7 +560,7 @@ The isolation axis (shared vs per-trial) and the substrate axis (docker compose 
 
 ## Plug-in extension points
 
-Four swappable seams — `RuntimeBackend`, `TrialGrader`, `Conductor`, and `ServiceReadinessProbe` — are each exposed as an `importlib.metadata` entry-point group. A downstream package registers an implementation under a name in its own `pyproject.toml`; the orchestrator discovers it after `pip install`, with no edit to tolokaforge. Each entry point resolves to a **factory callable** — not the raw class — so divergent constructors are adapted behind a factory. The three orchestrator seams pass a per-group frozen-dataclass context (`Callable[[<Context>], <Impl>]`); a readiness probe needs no build dependencies, so its factory is arg-less (`Callable[[], ServiceReadinessProbe]`). tolokaforge's own nine built-ins register through the same mechanism.
+Five swappable seams — `RuntimeBackend`, `TrialGrader`, `Conductor`, `ServiceReadinessProbe`, and `TurnPolicy` — are each exposed as an `importlib.metadata` entry-point group. A downstream package registers an implementation under a name in its own `pyproject.toml`; the orchestrator discovers it after `pip install`, with no edit to tolokaforge. Each entry point resolves to a **factory callable** — not the raw class — so divergent constructors are adapted behind a factory. Four of the seams pass a per-group frozen-dataclass context (`Callable[[<Context>], <Impl>]`); a readiness probe needs no build dependencies, so its factory is arg-less (`Callable[[], ServiceReadinessProbe]`). tolokaforge's own built-ins register through the same mechanism.
 
 | Group | Factory type | Context |
 | --- | --- | --- |
@@ -568,6 +568,7 @@ Four swappable seams — `RuntimeBackend`, `TrialGrader`, `Conductor`, and `Serv
 | `tolokaforge.trial_graders` | `Callable[[TrialGraderContext], TrialGrader]` | `runtime_backend`, `logger` |
 | `tolokaforge.conductors` | `Callable[[ConductorContext], Conductor]` | per-run deps (adapter, writer, config, agent client, runtime backend, grader, …) |
 | `tolokaforge.service_readiness_probes` | `Callable[[], ServiceReadinessProbe]` | *no context* |
+| `tolokaforge.turn_policies` | `Callable[[TurnPolicyContext], TurnPolicy]` | `user_simulator` (the resolved user :class:`Actor`; ``None`` for policies that dispatch no user) |
 
 A factory is free to ignore context fields it does not need. The runtime-backend, trial-grader, and readiness-probe context/factory types are imported from `tolokaforge.core.plugin_registry`; the conductor context is imported from `tolokaforge.core.conductor` (as shown in the conductor example below) since it reuses the pre-existing `ConductorContext` seam. Keep the factory module free of any `tolokaforge.core.orchestrator` import so `.load()` stays independent of the orchestration engine.
 
@@ -634,6 +635,22 @@ mykind = "mypkg.readiness:my_probe_factory"
 ```
 
 tolokaforge ships `grpc`, `http`, and `tcp` built-ins under this group.
+
+**Turn policy** — `mypkg/turn_policy.py`. A turn policy choreographs the loop's turn cycle: `bootstrap` decides how message index 0 is delivered, and `next_actor` picks the actor to speak next (or returns `None` to end the turn cycle for an agent-monologue task). The policy is looked up by `TaskConfig.interaction_mode`, so a policy name in this group is a valid `interaction_mode` value:
+
+```python
+from tolokaforge.core.plugin_registry import TurnPolicyContext
+
+def my_policy_factory(ctx: TurnPolicyContext) -> "MyTurnPolicy":
+    return MyTurnPolicy(user_simulator=ctx.user_simulator)
+```
+
+```toml
+[project.entry-points."tolokaforge.turn_policies"]
+my_shape = "mypkg.turn_policy:my_policy_factory"
+```
+
+tolokaforge ships `conversational` (two-party user-plus-agent) as a built-in under this group.
 
 **Fail-loud resolution.** Names resolve lazily and are cached per group. Discovery enumerates names and distributions **without importing any target**, which gives the policy two distinct shapes:
 

--- a/docs/adr/0028-multi-actor-turn-policy.md
+++ b/docs/adr/0028-multi-actor-turn-policy.md
@@ -1,0 +1,94 @@
+# 0028. Multi-actor turn policy — `interaction_mode` + `Actor` Protocol + `TurnPolicy` seam
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Tolokaforge's turn loop assumes a two-party conversation: user simulator utters, agent responds, tools execute, repeat. That shape came from τ-bench-style customer-service benchmarks where the user is a genuine information source — they hold the reservation ID the agent needs, clarify what they want, end the conversation when their goal is met.
+
+Code-migration and other agent-driven evals are the opposite shape. The task lives in the system prompt + workdir seed. The agent knows when it's done (tests pass), not the user. Upstream reference evals for these benchmarks typically run a single-actor MCP-CLI: the model drives tools directly until it declares done or hits a timeout — no user party at all.
+
+Forcing agent-only tasks through the two-party shape produced a cascade of downstream symptoms in real-MB smoke: context bloat from replayed user replies (82K tokens per call by turn 88), doubled per-turn LLM cost, premature `###STOP###` guessed by the LLM simulator, provider timeouts at high turn counts, stuck-heuristics false-positives on legitimate iterative build/test cycles. Every symptom traces back to the same architectural mismatch — no first-class signal for "does this task have a real user party."
+
+Beyond agent-only, the design must accommodate future actor types: adversarial agents, oracle-in-the-loop, evaluator-as-actor. The design goal is not "add an agent-only escape hatch" but "make the actor count and identity a first-class dimension of a task."
+
+## Decision Drivers
+
+- **Name the actual dimension.** The failing status quo hid the mismatch behind cost/timeout patches; a shape flag surfaces it in `TaskConfig` where authors decide.
+- **Backward compat.** Every existing pack / canonical fixture / τ-bench-style adapter must be byte-for-byte unaffected. Default value carries today's behavior.
+- **Extensibility without core edits.** Future policies (multi-actor, adversarial, oracle) register via entry-point group; the runner has no mode-specific `if` in the loop body.
+- **Reuse the fail-loud registry idiom** and the ADR-0011 Pattern-A discipline (Protocol + value objects + built-in + `InMemory*` fixture + canonical contract test) — five entry-point-registry-backed seams now share one pattern.
+
+## Considered Options
+
+1. **`interaction_mode` flag only, no Protocol** — a single `if` in the runner gates the user-turn dispatch. Rejected: doesn't accommodate future actor types; each new mode becomes another `if` in the loop.
+2. **`TurnPolicy` Protocol + entry-point registry** — mode selects a policy; policies dispatch the turn cycle. **This ADR.**
+3. **Fold user role into system prompt anchor** — deliver `initial_user_message` as a persistent context anchor, no runtime simulator. Rejected: doesn't scale to real multi-turn user tasks.
+4. **Agent yields via continuation token** — single agent, orchestrator re-invokes on `###CONTINUE###`. Rejected: reshapes tolokaforge's turn model too far, doesn't fit conversational adapters.
+
+## Decision
+
+We adopt **Option 2**: a three-layer architecture.
+
+**Layer 1 — `TaskConfig.interaction_mode: Literal["conversational", "agent_only"]`** with default `"conversational"`. Mirrored as `TaskDefaults.interaction_mode: … | None` for project-side deep-merge. Room for future values (e.g. `"multi_actor"`) alongside dedicated policies.
+
+**Layer 2 — `Actor` Protocol** at `tolokaforge/core/actors/actor.py`. `@runtime_checkable`, formalizing the `reply(context, *, observation) -> GenerationResult` contract `UserSimulator` implicitly satisfied since it was written. Minimal: only per-invocation evidence on the Protocol; construction-time deps (`llm_client`, budgets, `rate_limit_probe`) stay on concrete impls. Same discipline as the `Judge` Protocol (ADR-0020) and the `ServiceReadinessProbe` Protocol (ADR-0026).
+
+**Layer 3 — `TurnPolicy` Protocol** at `tolokaforge/core/actors/turn_policy.py`, the choreographer:
+
+```python
+@runtime_checkable
+class TurnPolicy(Protocol):
+    def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision: ...
+    def next_actor(self, state: TurnState) -> ActorTurn | None: ...
+```
+
+Two built-in implementations:
+
+- **`ConversationalTurnPolicy`** — today's behavior. `bootstrap` mirrors the `_seed_first_user_message` short-circuit at `runner.py:508` (non-empty `initial_user_message` → skip simulator; otherwise dispatch the simulator's opening reply). `next_actor` returns `ActorTurn(actor_name="user", ...)` when the last agent turn had no tool calls; `None` otherwise. Byte-for-byte parity with the pre-refactor call graph.
+- **`AgentOnlyTurnPolicy`** — `bootstrap` requires a non-empty `initial_user_message` and fails loud (`ValueError` naming the `task_id` and the mode) if absent — the agent-only route has no simulator to synthesize a bootstrap. `next_actor` returns `None` unconditionally: the agent runs to `###STOP###` (routed to `TerminationReason.AGENT_DONE` via the existing `_AGENT_DONE_MARKERS`), `max_turns`, or `episode_timeout_s`.
+
+Discovered through a **new entry-point group `tolokaforge.turn_policies`** keyed by mode string, reusing the existing fail-loud `_discover` / `_load` machinery in `plugin_registry.py`. This is the **fifth entry-point-registry-backed seam** — the four existing groups (`runtime_backends`, `trial_graders`, `conductors`, `service_readiness_probes`) now share the pattern with a fifth, further validating that the registry idiom generalises.
+
+The factory takes a `TurnPolicyContext(user_simulator: Actor | None)` rather than being arg-less like readiness probes: `ConversationalTurnPolicy` needs an `Actor` to hand back on user-turn dispatch. `AgentOnlyTurnPolicy` ignores it (its `next_actor` never returns an `ActorTurn`).
+
+### Loop wiring: no mode-specific `if` in the loop body
+
+`TrialRunner` at `runner.py:317-318` today wires `should_terminate = self._agent_termination` and `user_turn = self._agent_user_turn` as callables directly into `ToolCallingLoop`. Post-ADR-0028, the runner reads `task.interaction_mode`, resolves `policy = load_turn_policy(mode)(TurnPolicyContext(user_simulator=self.user_simulator))`, and wires policy callables into the loop. The loop body has no knowledge of interaction mode — the policy encapsulates the differences. Adding a future `multi_actor` mode is a new policy registration; the loop stays untouched.
+
+The `Conductor` gates `UserSimulator(...)` construction at `conductor.py:646-668` on `task.interaction_mode == "conversational"`; under `agent_only`, no simulator is constructed and the runner receives `user_simulator=None`.
+
+### Stop protocol reuses the existing marker
+
+`_AGENT_DONE_MARKERS = ("###STOP###",)` at `runner.py:46` already routes agent-emitted `###STOP###` to `TerminationReason.AGENT_DONE`. No new marker is introduced — the same convention serves both modes. In `conversational` mode, user-emitted `###STOP###` still terminates with `TerminationReason.USER_STOP`. In `agent_only` mode, `next_actor` never dispatches the user turn, so agent-`###STOP###` is the only marker-based termination path.
+
+## Consequences
+
+### Positive
+
+- The user-party dimension is a named, tested contract; the class of bugs where agent-only tasks silently paid two-party overhead cannot be reintroduced.
+- Extension surface is registry-level — future actor types (adversary, oracle, evaluator-in-the-loop) register a `TurnPolicy` without editing the runner or loop.
+- The five-seam pattern (runtime backends / trial graders / conductors / service-readiness probes / turn policies) is now a well-established idiom — the next registry-backed seam has near-zero design cost.
+- Agent-driven benchmark adapters (Migration Bench, autonomous tool-use, etc.) opt into `interaction_mode: agent_only` and get MCP-CLI-shaped behavior with no simulator overhead — comparable to their upstream reference evals.
+
+### Negative / Trade-offs
+
+- `TurnPolicyContext` differs from the readiness-probe factory signature (which is arg-less). The divergence is honest — a conversational policy legitimately needs a user simulator to hand back — and documented here rather than papered over with an empty context.
+- Golden snapshots that serialize `TaskConfig.model_dump()` gained one field (`interaction_mode: 'conversational'`). Six goldens regenerated in Stage 5; future canonical fixtures pick up the field automatically via the default.
+- The runner-subset partition now includes `tolokaforge/core/actors` (Stage 5); the module is minimal and stable, so subset growth is bounded.
+
+### Follow-ups
+
+- **`MultiActorTurnPolicy`** for 3+ actor choreography (agent + adversary + oracle, or agent + user + evaluator). The registry accommodates this today; the concrete policy + config shape is a separate design pass.
+- **`tolokaforge.actors` entry-point registry** parallel to `turn_policies` — lets adapters register custom `Actor` implementations by name. Not needed today (MB elides the user actor entirely); worth adding when the first non-built-in actor kind lands.
+- **Reserved actor sub-keys `tools` / `service`** on `ActorSpec` — reserved for future actor types per the M9 canonicalization comment. This ADR does not flip them to strict; that's a separate migration when a concrete actor kind needs them.
+
+## Links
+
+- Related ADRs: [0011](0011-seam-and-declaration-conventions.md) (Pattern A), [0014](0014-trial-grader-protocol.md) (TrialGrader Protocol), [0020](0020-judge-protocol.md) (Judge Protocol), [0026](0026-service-readiness-contract.md) (Service Readiness Contract — same idiom, fourth seam).
+- Related code: `tolokaforge/core/actors/actor.py`, `tolokaforge/core/actors/turn_policy.py`, `tolokaforge/core/runner.py:317-318`, `tolokaforge/core/plugin_registry.py`, `tolokaforge/core/models/task_config.py`.
+- External references: #868 (this ticket), Toloka/tolokaforge#872 (implementation).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,7 @@ only-include = [
     "tolokaforge/runner",
     "tolokaforge/secrets",
     "tolokaforge/tools",
+    "tolokaforge/core/actors",
     "tolokaforge/core/models",
     "tolokaforge/core/llm",
     "tolokaforge/core/grading",
@@ -264,6 +265,7 @@ only-include = [
 exclude = [
     # RUNNER_SUBSET_EXCLUDED_FILES — orchestrator-only files inside an
     # otherwise-included subpackage.
+    "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/replay.py",
     "tolokaforge/core/grading/state_checks.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ http = "tolokaforge.core.service_readiness:http_readiness_probe_factory"
 tcp = "tolokaforge.core.service_readiness:tcp_readiness_probe_factory"
 
 [project.entry-points."tolokaforge.turn_policies"]
+agent_only = "tolokaforge.core.actors.turn_policy:_agent_only_policy_factory"
 conversational = "tolokaforge.core.actors.turn_policy:_conversational_policy_factory"
 
 [tool.hatch.build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ grpc = "tolokaforge.core.service_readiness:grpc_readiness_probe_factory"
 http = "tolokaforge.core.service_readiness:http_readiness_probe_factory"
 tcp = "tolokaforge.core.service_readiness:tcp_readiness_probe_factory"
 
+[project.entry-points."tolokaforge.turn_policies"]
+conversational = "tolokaforge.core.actors.turn_policy:_conversational_policy_factory"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/tests/canonical/snapshots/native_browser_basic/task_config.json
+++ b/tests/canonical/snapshots/native_browser_basic/task_config.json
@@ -28,6 +28,7 @@
     "system_prompt": null
   },
   "initial_user_message": null,
+  "interaction_mode": "conversational",
   "max_turns": null,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/snapshots/native_calc_basic/task_config.json
+++ b/tests/canonical/snapshots/native_calc_basic/task_config.json
@@ -28,6 +28,7 @@
     "system_prompt": null
   },
   "initial_user_message": null,
+  "interaction_mode": "conversational",
   "max_turns": null,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
+++ b/tests/canonical/snapshots/native_example_domain_case_a/task_config.json
@@ -23,6 +23,7 @@
     "system_prompt": null
   },
   "initial_user_message": "Echo 'hello'.",
+  "interaction_mode": "conversational",
   "max_turns": null,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/snapshots/native_shop_orders_02/task_config.json
+++ b/tests/canonical/snapshots/native_shop_orders_02/task_config.json
@@ -23,6 +23,7 @@
     "system_prompt": null
   },
   "initial_user_message": "Hi! I'm customer C-101 (Alex Torres). I'd like to buy 1 \u00d7 Wireless Headphones and 2 \u00d7 USB-C Hub 7-Port. Please check the catalog first so you can confirm availability, then place the order and process my payment.\n",
+  "interaction_mode": "conversational",
   "max_turns": 14,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/snapshots/runner_load_task/tool_use_public_example_01.json
+++ b/tests/canonical/snapshots/runner_load_task/tool_use_public_example_01.json
@@ -30,6 +30,7 @@
     "system_prompt": null
   },
   "initial_user_message": "Use the ticket data to move ticket `T-100` to `in_progress`, assign it to `oncall-platform`, and write a resolution plan to `submissions/tool_use_ticket_plan.md`.",
+  "interaction_mode": "conversational",
   "max_turns": null,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -24,6 +24,7 @@
     "system_prompt": null
   },
   "initial_user_message": "Create a file /tmp/hello.txt containing the text \"Hello, World!\".\n",
+  "interaction_mode": "conversational",
   "max_turns": null,
   "metadata": {
     "complexity": null,

--- a/tests/canonical/test_actor_contract.py
+++ b/tests/canonical/test_actor_contract.py
@@ -1,0 +1,125 @@
+"""Pin the :class:`Actor` Protocol contract — runtime check + round-trip.
+
+Two implementations are checked: :class:`UserSimulator` (the historical
+concrete actor, constructed in scripted mode with a minimal flow) and a
+purpose-built ``_InMemoryActor`` fixture in this file that locks the
+contract's expected value-object shape for future actor kinds (adversary,
+oracle, evaluator).
+
+Layer-2 of the multi-actor design (see plan
+``hazy-doodling-lark.md`` § Layer 2): types-and-tests-only. No runtime
+behaviour changes here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.actors.actor import (
+    Actor,
+    GenerationResult,
+    LLMCallObservation,
+    Message,
+)
+from tolokaforge.core.llm.client import UserSimulator
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.models import MessageRole
+
+pytestmark = pytest.mark.canonical
+
+
+class _InMemoryActor:
+    """Minimal :class:`Actor` for locking the Protocol shape.
+
+    Records every ``reply`` call; returns a scripted :class:`GenerationResult`
+    with empty ``tool_calls`` and zero-usage. No wire I/O, no LLM client.
+    """
+
+    def __init__(self, reply_text: str = "in-memory reply") -> None:
+        self._reply_text = reply_text
+        self.calls: list[tuple[tuple[Message, ...], LLMCallObservation | None]] = []
+
+    def reply(
+        self,
+        context: list[Message],
+        *,
+        observation: LLMCallObservation | None = None,
+    ) -> GenerationResult:
+        self.calls.append((tuple(context), observation))
+        return GenerationResult(
+            text=self._reply_text,
+            tool_calls=[],
+            usage=Usage(),
+            latency_s=0.0,
+        )
+
+
+def _scripted_user_simulator() -> UserSimulator:
+    """Build a scripted :class:`UserSimulator` — no LLM client wired."""
+    return UserSimulator(
+        mode="scripted",
+        scripted_flow=[{"user": "Please complete step one."}],
+    )
+
+
+def _scripted_context() -> list[Message]:
+    """One agent turn to react to — enough to exercise ``reply``."""
+    return [
+        Message(role=MessageRole.ASSISTANT, content="What would you like me to do?"),
+    ]
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; both implementations satisfy
+    it via ``isinstance`` (not just structural type-hint compatibility).
+    """
+
+    def test_user_simulator_passes_isinstance(self) -> None:
+        assert isinstance(_scripted_user_simulator(), Actor)
+
+    def test_in_memory_actor_passes_isinstance(self) -> None:
+        assert isinstance(_InMemoryActor(), Actor)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotAnActor:
+            pass
+
+        assert not isinstance(_NotAnActor(), Actor)
+
+
+class TestReplyRoundTrip:
+    """Given a scripted context, every :class:`Actor` implementation
+    returns a :class:`GenerationResult` whose fields match the shape
+    downstream loop code assumes: ``text`` is a ``str`` (possibly empty),
+    ``tool_calls`` is a ``list``, ``usage`` is a :class:`Usage` instance,
+    ``latency_s`` is a ``float``.
+    """
+
+    def test_user_simulator_reply_shape(self) -> None:
+        result = _scripted_user_simulator().reply(_scripted_context())
+        assert isinstance(result, GenerationResult)
+        assert isinstance(result.text, str)
+        assert result.text
+        assert isinstance(result.tool_calls, list)
+        assert isinstance(result.usage, Usage)
+        assert isinstance(result.latency_s, float)
+
+    def test_in_memory_actor_reply_shape(self) -> None:
+        actor = _InMemoryActor(reply_text="ack")
+        result = actor.reply(_scripted_context())
+        assert isinstance(result, GenerationResult)
+        assert result.text == "ack"
+        assert result.tool_calls == []
+        assert isinstance(result.usage, Usage)
+        assert result.usage.prompt_tokens == 0
+        assert result.usage.completion_tokens == 0
+        assert result.latency_s == 0.0
+
+    def test_in_memory_actor_records_invocation(self) -> None:
+        actor = _InMemoryActor()
+        context = _scripted_context()
+        actor.reply(context, observation=None)
+        assert len(actor.calls) == 1
+        recorded_context, recorded_observation = actor.calls[0]
+        assert recorded_context == tuple(context)
+        assert recorded_observation is None

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tolokaforge.core.actors.turn_policy import ConversationalTurnPolicy
+from tolokaforge.core.actors.turn_policy import AgentOnlyTurnPolicy, ConversationalTurnPolicy
 from tolokaforge.core.conductor import (
     ConductorContext,
     InMemoryConductor,
@@ -126,8 +126,11 @@ def test_readiness_probe_kinds_resolve_to_their_class(kind: str, expected_cls: t
 
 def test_turn_policy_names_resolve_to_their_class() -> None:
     context = TurnPolicyContext(user_simulator=MagicMock())
-    policy = load_turn_policy("conversational")(context)
-    assert isinstance(policy, ConversationalTurnPolicy)
+    conversational = load_turn_policy("conversational")(context)
+    assert isinstance(conversational, ConversationalTurnPolicy)
+
+    agent_only = load_turn_policy("agent_only")(TurnPolicyContext(user_simulator=None))
+    assert isinstance(agent_only, AgentOnlyTurnPolicy)
 
 
 def test_available_listings_match_the_builtin_set() -> None:
@@ -135,7 +138,7 @@ def test_available_listings_match_the_builtin_set() -> None:
     assert available_trial_graders() == ["runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
-    assert available_turn_policies() == ["conversational"]
+    assert available_turn_policies() == ["agent_only", "conversational"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
@@ -152,4 +155,4 @@ def test_raw_entry_point_probe_lists_readiness_probes() -> None:
 
 def test_raw_entry_point_probe_lists_turn_policies() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=TURN_POLICIES_GROUP))
-    assert names == ["conversational"]
+    assert names == ["agent_only", "conversational"]

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tolokaforge.core.actors.turn_policy import ConversationalTurnPolicy
 from tolokaforge.core.conductor import (
     ConductorContext,
     InMemoryConductor,
@@ -26,16 +27,20 @@ from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.plugin_registry import (
     RUNTIME_BACKENDS_GROUP,
     SERVICE_READINESS_PROBES_GROUP,
+    TURN_POLICIES_GROUP,
     RuntimeBackendBuildContext,
     TrialGraderContext,
+    TurnPolicyContext,
     available_conductors,
     available_readiness_probes,
     available_runtime_backends,
     available_trial_graders,
+    available_turn_policies,
     load_conductor,
     load_readiness_probe,
     load_runtime_backend,
     load_trial_grader,
+    load_turn_policy,
 )
 from tolokaforge.core.runtime import InMemoryRuntimeBackend
 from tolokaforge.core.service_readiness import (
@@ -119,11 +124,18 @@ def test_readiness_probe_kinds_resolve_to_their_class(kind: str, expected_cls: t
     assert isinstance(probe, expected_cls)
 
 
+def test_turn_policy_names_resolve_to_their_class() -> None:
+    context = TurnPolicyContext(user_simulator=MagicMock())
+    policy = load_turn_policy("conversational")(context)
+    assert isinstance(policy, ConversationalTurnPolicy)
+
+
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
     assert available_trial_graders() == ["runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
+    assert available_turn_policies() == ["conversational"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
@@ -136,3 +148,8 @@ def test_raw_entry_point_probe_lists_readiness_probes() -> None:
         ep.name for ep in importlib.metadata.entry_points(group=SERVICE_READINESS_PROBES_GROUP)
     )
     assert names == ["grpc", "http", "tcp"]
+
+
+def test_raw_entry_point_probe_lists_turn_policies() -> None:
+    names = sorted(ep.name for ep in importlib.metadata.entry_points(group=TURN_POLICIES_GROUP))
+    assert names == ["conversational"]

--- a/tests/canonical/test_runner_turn_policy_wiring.py
+++ b/tests/canonical/test_runner_turn_policy_wiring.py
@@ -1,0 +1,187 @@
+"""Runner ↔ ``TurnPolicy`` wiring lock (Stage 5 of the multi-actor design).
+
+The runner today constructs a :class:`ToolCallingLoop` whose optional
+``user_turn`` seam is a shim that delegates to
+``policy.next_actor(...)``. Two invariants this file locks:
+
+* Under :class:`~tolokaforge.core.models.task_config.TaskConfig.interaction_mode`
+  ``"conversational"`` (the default), the runner resolves
+  :class:`~tolokaforge.core.actors.turn_policy.ConversationalTurnPolicy`
+  through the ``tolokaforge.turn_policies`` entry-point registry and
+  dispatches the user actor after every tool-call-free agent turn —
+  byte-for-byte the historical two-party shape.
+* Under ``"agent_only"`` the runner resolves
+  :class:`~tolokaforge.core.actors.turn_policy.AgentOnlyTurnPolicy`, and
+  its :meth:`next_actor` returns ``None`` every turn: no user turn is
+  ever dispatched, agent-emitted ``###STOP###`` routes to
+  :attr:`~tolokaforge.core.models.TerminationReason.AGENT_DONE`, and the
+  simulator (if the caller happens to pass one) is never consulted. The
+  conductor passes ``user_simulator=None`` under this mode, so the
+  never-called invariant is the design guarantee agent-monologue tasks
+  rely on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.llm.client import GenerationResult, UserSimulator
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.models import Message, TerminationReason
+from tolokaforge.core.run_display_events import LLMCallObservation
+from tolokaforge.core.runner import TrialRunner
+from tolokaforge.tools.registry import ToolExecutor, ToolRegistry
+
+pytestmark = pytest.mark.canonical
+
+
+class _ScriptedAgent:
+    """Agent generate seam yielding one queued item per turn, repeating the last."""
+
+    def __init__(self, *items: GenerationResult) -> None:
+        self._items = list(items)
+
+    def generate(
+        self,
+        system: str,
+        messages: list[Message],
+        tools: list[dict[str, Any]],
+        tool_choice: str = "auto",
+        observation: LLMCallObservation | None = None,
+    ) -> GenerationResult:
+        return self._items.pop(0) if len(self._items) > 1 else self._items[0]
+
+
+def _agent(text: str) -> GenerationResult:
+    return GenerationResult(
+        text=text, tool_calls=[], usage=Usage(prompt_tokens=10, completion_tokens=5)
+    )
+
+
+def _spy_simulator() -> MagicMock:
+    """Simulator spy that would return ``###STOP###`` if consulted.
+
+    ``reply`` returning a stop-token would end the dialogue with
+    ``USER_STOP``, which is a distinguishable outcome from
+    ``AGENT_DONE`` — so the ``call_count == 0`` invariant is checked
+    against a reply the runner *cannot silently discard*.
+    """
+    sim = MagicMock(spec=UserSimulator)
+    sim.reply.return_value = GenerationResult(text="###STOP###", tool_calls=[], usage=Usage())
+    sim.last_system_prompt = None
+    return sim
+
+
+def test_agent_only_mode_never_invokes_user_simulator() -> None:
+    """The whole trial completes on agent-emitted ``###STOP###`` without a
+    single simulator invocation.
+
+    The scripted agent produces three no-tool-call turns before its
+    ``###STOP###``. Under the conversational shape the loop's
+    ``user_turn`` seam would fire after every one of those turns (three
+    simulator calls) and the seed-turn simulator dispatch would add a
+    fourth; under agent-only the seam is neutralised at every point.
+    """
+    simulator = _spy_simulator()
+    agent = _ScriptedAgent(
+        _agent("Reading the workdir."),
+        _agent("Running the tests."),
+        _agent("All green. ###STOP###"),
+    )
+
+    trajectory = TrialRunner(
+        task_id="agent-only-wiring",
+        trial_index=0,
+        agent_client=agent,
+        user_simulator=simulator,
+        tool_executor=ToolExecutor(ToolRegistry()),
+        tool_schemas=[],
+        max_turns=10,
+        episode_timeout_s=1200,
+        interaction_mode="agent_only",
+    ).run("You are an agent.", "Migrate the crate to Rust.")
+
+    assert simulator.reply.call_count == 0, (
+        "AgentOnlyTurnPolicy dispatched the user simulator; the whole point "
+        "of the mode is that the seam is neutralised for agent-monologue tasks."
+    )
+    assert trajectory.termination_reason is TerminationReason.AGENT_DONE, (
+        "agent-only trial with a ###STOP###-emitting agent must terminate as "
+        f"AGENT_DONE; got {trajectory.termination_reason!r}"
+    )
+
+
+def test_agent_only_mode_accepts_none_user_simulator() -> None:
+    """The conductor passes ``user_simulator=None`` under agent-only; the
+    runner must complete a trial anyway.
+
+    Locks the design guarantee that agent-monologue tasks never
+    construct a simulator: neither the bootstrap nor the turn seam
+    reaches into ``self.user_simulator``.
+    """
+    trajectory = TrialRunner(
+        task_id="agent-only-no-sim",
+        trial_index=0,
+        agent_client=_ScriptedAgent(_agent("Done. ###STOP###")),
+        user_simulator=None,
+        tool_executor=ToolExecutor(ToolRegistry()),
+        tool_schemas=[],
+        max_turns=5,
+        episode_timeout_s=1200,
+        interaction_mode="agent_only",
+    ).run("You are an agent.", "Migrate the crate to Rust.")
+
+    assert trajectory.termination_reason is TerminationReason.AGENT_DONE
+
+
+def test_agent_only_mode_without_initial_message_fails_loud() -> None:
+    """The ``AgentOnlyTurnPolicy.bootstrap`` contract raises when neither
+    an ``initial_user_message`` nor a live simulator can seed turn 0 —
+    surfaced at run-start rather than degraded into a silent empty
+    user turn."""
+    trajectory = TrialRunner(
+        task_id="agent-only-missing-seed",
+        trial_index=0,
+        agent_client=_ScriptedAgent(_agent("unreached")),
+        user_simulator=None,
+        tool_executor=ToolExecutor(ToolRegistry()),
+        tool_schemas=[],
+        max_turns=5,
+        episode_timeout_s=1200,
+        interaction_mode="agent_only",
+    ).run("You are an agent.", "")
+
+    # The runner catches init errors and produces an ERROR trajectory —
+    # the operator sees the ValueError text in the trailing system
+    # message rather than a silent no-op trial.
+    assert trajectory.termination_reason is TerminationReason.ERROR
+    error_surfaced = any("agent_only" in (m.content or "") for m in trajectory.messages)
+    assert error_surfaced, "ValueError text must land in the trajectory system message"
+
+
+def test_conversational_mode_dispatches_user_simulator() -> None:
+    """Byte-for-byte parity check: the default (``conversational``) still
+    routes every tool-call-free agent turn through the user simulator.
+
+    The scripted agent produces one no-tool-call turn; the simulator's
+    ``###STOP###`` closes the dialogue with ``USER_STOP`` — a code path
+    only reachable by an actual simulator dispatch.
+    """
+    simulator = _spy_simulator()
+    trajectory = TrialRunner(
+        task_id="conversational-parity",
+        trial_index=0,
+        agent_client=_ScriptedAgent(_agent("Anything else?")),
+        user_simulator=simulator,
+        tool_executor=ToolExecutor(ToolRegistry()),
+        tool_schemas=[],
+        max_turns=5,
+        episode_timeout_s=1200,
+        interaction_mode="conversational",
+    ).run("You are an agent.", "Please do the task.")
+
+    assert simulator.reply.call_count == 1
+    assert trajectory.termination_reason is TerminationReason.USER_STOP

--- a/tests/canonical/test_turn_policy_contract.py
+++ b/tests/canonical/test_turn_policy_contract.py
@@ -1,8 +1,8 @@
-"""Pin the :class:`TurnPolicy` Protocol contract + :class:`ConversationalTurnPolicy` semantics.
+"""Pin the :class:`TurnPolicy` Protocol contract + built-in policy semantics.
 
-Locks three surfaces that later stages depend on:
+Locks the surfaces later stages depend on:
 
-* the Protocol is ``@runtime_checkable`` and the built-in policy passes
+* the Protocol is ``@runtime_checkable`` and both built-in policies pass
   ``isinstance``;
 * :meth:`ConversationalTurnPolicy.bootstrap` short-circuits to a caller-provided
   ``initial_user_message`` and routes to the simulator otherwise —
@@ -10,7 +10,14 @@ Locks three surfaces that later stages depend on:
   ``runner.py:508`` before the runner starts dispatching through the seam;
 * :meth:`ConversationalTurnPolicy.next_actor` dispatches the user actor only
   when the previous agent turn produced no tool calls — reproducing today's
-  ``_advance_user_turn`` gate at ``loop.py:337-341``.
+  ``_advance_user_turn`` gate at ``loop.py:337-341``;
+* :meth:`AgentOnlyTurnPolicy.bootstrap` accepts a caller-provided seed and
+  fails loud otherwise — the agent-monologue shape has no user simulator to
+  synthesise turn 0 from, so a missing seed is a config error we surface at
+  run-start rather than degrade into an empty user turn;
+* :meth:`AgentOnlyTurnPolicy.next_actor` returns ``None`` unconditionally —
+  the loop never dispatches a user actor in this mode, independent of loop
+  state.
 """
 
 from __future__ import annotations
@@ -24,6 +31,7 @@ from tolokaforge.core.actors.actor import (
 )
 from tolokaforge.core.actors.turn_policy import (
     ActorTurn,
+    AgentOnlyTurnPolicy,
     BootstrapDecision,
     ConversationalTurnPolicy,
     TurnPolicy,
@@ -32,6 +40,7 @@ from tolokaforge.core.actors.turn_policy import (
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.models import MessageRole
 from tolokaforge.core.models.task_config import TaskConfig
+from tolokaforge.core.plugin_registry import TurnPolicyContext
 
 pytestmark = pytest.mark.canonical
 
@@ -150,3 +159,75 @@ class TestNextActor:
         )
 
         assert policy.next_actor(state) is None
+
+
+class TestAgentOnlyProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; ``AgentOnlyTurnPolicy``
+    satisfies it via ``isinstance``, and the factory accepts a context
+    with no user simulator — the whole point of the agent-monologue shape."""
+
+    def test_agent_only_policy_passes_isinstance(self) -> None:
+        assert isinstance(AgentOnlyTurnPolicy(), TurnPolicy)
+
+    def test_factory_ignores_absent_user_simulator(self) -> None:
+        from tolokaforge.core.actors.turn_policy import _agent_only_policy_factory
+
+        policy = _agent_only_policy_factory(TurnPolicyContext(user_simulator=None))
+
+        assert isinstance(policy, AgentOnlyTurnPolicy)
+
+
+class TestAgentOnlyBootstrap:
+    """``bootstrap`` accepts a caller-provided seed and fails loud otherwise.
+
+    Agent-only mode has no user simulator to synthesise turn 0 from, so an
+    empty / missing / whitespace-only ``initial_user_message`` is a config
+    error surfaced at run-start rather than a silent empty-user-turn
+    degrade.
+    """
+
+    def test_returns_provided_message_and_skips_simulator(self) -> None:
+        decision = AgentOnlyTurnPolicy().bootstrap(_task(), "Migrate this crate to Rust.")
+
+        assert decision == BootstrapDecision(
+            first_user_message="Migrate this crate to Rust.",
+            bootstrap_via_simulator=False,
+        )
+
+    def test_none_message_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="agent_only") as excinfo:
+            AgentOnlyTurnPolicy().bootstrap(_task(), None)
+        assert "policy-fixture" in str(excinfo.value)
+
+    def test_empty_message_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="agent_only"):
+            AgentOnlyTurnPolicy().bootstrap(_task(), "")
+
+    def test_whitespace_only_message_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="agent_only"):
+            AgentOnlyTurnPolicy().bootstrap(_task(), "   \n\t ")
+
+
+class TestAgentOnlyNextActor:
+    """``next_actor`` returns ``None`` unconditionally — the mode never
+    dispatches a user turn regardless of what the previous agent turn
+    did.
+    """
+
+    def test_no_tool_calls_returns_none(self) -> None:
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=False,
+            turn_index=1,
+        )
+
+        assert AgentOnlyTurnPolicy().next_actor(state) is None
+
+    def test_tool_call_turn_returns_none(self) -> None:
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=True,
+            turn_index=1,
+        )
+
+        assert AgentOnlyTurnPolicy().next_actor(state) is None

--- a/tests/canonical/test_turn_policy_contract.py
+++ b/tests/canonical/test_turn_policy_contract.py
@@ -1,0 +1,152 @@
+"""Pin the :class:`TurnPolicy` Protocol contract + :class:`ConversationalTurnPolicy` semantics.
+
+Locks three surfaces that later stages depend on:
+
+* the Protocol is ``@runtime_checkable`` and the built-in policy passes
+  ``isinstance``;
+* :meth:`ConversationalTurnPolicy.bootstrap` short-circuits to a caller-provided
+  ``initial_user_message`` and routes to the simulator otherwise —
+  reproducing today's ``_seed_first_user_message`` branch at
+  ``runner.py:508`` before the runner starts dispatching through the seam;
+* :meth:`ConversationalTurnPolicy.next_actor` dispatches the user actor only
+  when the previous agent turn produced no tool calls — reproducing today's
+  ``_advance_user_turn`` gate at ``loop.py:337-341``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.actors.actor import (
+    GenerationResult,
+    LLMCallObservation,
+    Message,
+)
+from tolokaforge.core.actors.turn_policy import (
+    ActorTurn,
+    BootstrapDecision,
+    ConversationalTurnPolicy,
+    TurnPolicy,
+    TurnState,
+)
+from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.models import MessageRole
+from tolokaforge.core.models.task_config import TaskConfig
+
+pytestmark = pytest.mark.canonical
+
+
+class _InMemoryActor:
+    """Scripted stand-in for a real :class:`Actor` implementation.
+
+    Mirrors the fixture used in ``test_actor_contract.py``: no LLM client,
+    empty ``tool_calls``, zero usage. Enough surface for a policy test to
+    check identity of the actor the policy hands back.
+    """
+
+    def __init__(self, reply_text: str = "in-memory reply") -> None:
+        self._reply_text = reply_text
+
+    def reply(
+        self,
+        context: list[Message],
+        *,
+        observation: LLMCallObservation | None = None,
+    ) -> GenerationResult:
+        return GenerationResult(
+            text=self._reply_text,
+            tool_calls=[],
+            usage=Usage(),
+            latency_s=0.0,
+        )
+
+
+def _task() -> TaskConfig:
+    return TaskConfig(task_id="policy-fixture", description="canonical turn-policy test")
+
+
+def _agent_message(text: str = "How can I help?") -> Message:
+    return Message(role=MessageRole.ASSISTANT, content=text)
+
+
+class TestProtocolRuntimeCheck:
+    """The Protocol is ``@runtime_checkable``; ``ConversationalTurnPolicy``
+    satisfies it via ``isinstance`` (not just structural type-hint
+    compatibility)."""
+
+    def test_conversational_policy_passes_isinstance(self) -> None:
+        policy = ConversationalTurnPolicy(user_simulator=_InMemoryActor())
+        assert isinstance(policy, TurnPolicy)
+
+    def test_random_object_does_not_pass_isinstance(self) -> None:
+        class _NotAPolicy:
+            pass
+
+        assert not isinstance(_NotAPolicy(), TurnPolicy)
+
+
+class TestBootstrap:
+    """``bootstrap`` short-circuits to a caller-provided initial message
+    when it carries non-whitespace text, and otherwise flags the runner to
+    dispatch the user simulator."""
+
+    def test_returns_provided_message_and_skips_simulator(self) -> None:
+        policy = ConversationalTurnPolicy(user_simulator=_InMemoryActor())
+
+        decision = policy.bootstrap(_task(), "Please migrate the schema.")
+
+        assert decision == BootstrapDecision(
+            first_user_message="Please migrate the schema.",
+            bootstrap_via_simulator=False,
+        )
+
+    def test_none_message_routes_to_simulator(self) -> None:
+        policy = ConversationalTurnPolicy(user_simulator=_InMemoryActor())
+
+        decision = policy.bootstrap(_task(), None)
+
+        assert decision == BootstrapDecision(
+            first_user_message=None,
+            bootstrap_via_simulator=True,
+        )
+
+    def test_empty_or_whitespace_message_routes_to_simulator(self) -> None:
+        policy = ConversationalTurnPolicy(user_simulator=_InMemoryActor())
+
+        empty = policy.bootstrap(_task(), "")
+        whitespace = policy.bootstrap(_task(), "   \n\t ")
+
+        expected = BootstrapDecision(first_user_message=None, bootstrap_via_simulator=True)
+        assert empty == expected
+        assert whitespace == expected
+
+
+class TestNextActor:
+    """``next_actor`` dispatches the user actor only when the previous
+    agent turn produced no tool calls; tool-call turns keep control on
+    the agent so the tool results feed the next agent generation."""
+
+    def test_no_tool_calls_dispatches_user(self) -> None:
+        simulator = _InMemoryActor()
+        policy = ConversationalTurnPolicy(user_simulator=simulator)
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=False,
+            turn_index=1,
+        )
+
+        turn = policy.next_actor(state)
+
+        assert turn == ActorTurn(actor_name="user", actor=simulator)
+        assert isinstance(turn, ActorTurn)
+        assert turn.actor is simulator
+
+    def test_tool_call_turn_returns_none(self) -> None:
+        policy = ConversationalTurnPolicy(user_simulator=_InMemoryActor())
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=True,
+            turn_index=1,
+        )
+
+        assert policy.next_actor(state) is None

--- a/tests/unit/test_interaction_mode.py
+++ b/tests/unit/test_interaction_mode.py
@@ -1,0 +1,103 @@
+"""Schema-level tests for :attr:`TaskConfig.interaction_mode` and
+:attr:`TaskDefaults.interaction_mode`.
+
+The field selects the trial's turn-loop shape:
+
+- ``conversational`` (default) — user simulator dispatched every turn;
+  the historical / τ-bench shape every existing pack was written for.
+- ``agent_only`` — no user turn after the first message; agent runs to
+  ``###STOP###`` / ``max_turns`` / ``episode_timeout_s``. Backwards-
+  compatible via the default.
+
+These tests pin the schema contract at the model layer. Layer 3 tests
+(``test_turn_policy_contract.py``) exercise the dispatch behavior; Layer
+5 tests (``test_conductor_contract.py``) cover the runner wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models.task_config import TaskConfig, TaskDefaults
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal_task_kwargs(**overrides: object) -> dict[str, object]:
+    """Bare-minimum TaskConfig kwargs; every field under test overrides
+    these defaults."""
+    return {
+        "task_id": "task-1",
+        "description": "test task",
+        **overrides,
+    }
+
+
+class TestInteractionModeDefaults:
+    """The field is backward-compatible: unset means ``conversational``,
+    which is byte-for-byte the shape every existing pack authored today
+    already expects."""
+
+    def test_task_config_default_is_conversational(self) -> None:
+        task = TaskConfig(**_minimal_task_kwargs())
+        assert task.interaction_mode == "conversational"
+
+    def test_task_defaults_default_is_none(self) -> None:
+        """Project-side default is ``None`` (unset) so a task's own
+        ``interaction_mode`` wins on merge without needing to know the
+        engine default."""
+        defaults = TaskDefaults()
+        assert defaults.interaction_mode is None
+
+
+class TestInteractionModeExplicit:
+    def test_task_config_accepts_conversational(self) -> None:
+        task = TaskConfig(**_minimal_task_kwargs(interaction_mode="conversational"))
+        assert task.interaction_mode == "conversational"
+
+    def test_task_config_accepts_agent_only(self) -> None:
+        task = TaskConfig(**_minimal_task_kwargs(interaction_mode="agent_only"))
+        assert task.interaction_mode == "agent_only"
+
+    def test_task_defaults_accepts_agent_only(self) -> None:
+        defaults = TaskDefaults(interaction_mode="agent_only")
+        assert defaults.interaction_mode == "agent_only"
+
+
+class TestInteractionModeRejectsUnknown:
+    """The literal must reject typos and future values that haven't
+    landed yet (e.g. ``multi_actor`` before its policy ships), so a
+    pack referencing an unknown mode fails at load time rather than at
+    turn dispatch when there's no matching :class:`TurnPolicy`."""
+
+    def test_task_config_rejects_typo(self) -> None:
+        with pytest.raises(ValidationError, match="interaction_mode"):
+            TaskConfig(**_minimal_task_kwargs(interaction_mode="conversation"))
+
+    def test_task_config_rejects_future_value_not_yet_registered(self) -> None:
+        """``multi_actor`` is reserved in the design (Layer 3 registry
+        will unlock it) but not yet a valid literal — reject until a
+        matching policy is registered."""
+        with pytest.raises(ValidationError, match="interaction_mode"):
+            TaskConfig(**_minimal_task_kwargs(interaction_mode="multi_actor"))
+
+    def test_task_defaults_rejects_typo(self) -> None:
+        with pytest.raises(ValidationError, match="interaction_mode"):
+            TaskDefaults(interaction_mode="agent-only")
+
+
+class TestModelDumpRoundTrip:
+    """The field must survive ``model_dump`` → ``model_validate`` so
+    engine paths that serialise TaskConfig (canonical fixtures, run
+    reports) preserve the mode."""
+
+    def test_task_config_round_trip_conversational_default(self) -> None:
+        task = TaskConfig(**_minimal_task_kwargs())
+        restored = TaskConfig.model_validate(task.model_dump())
+        assert restored.interaction_mode == "conversational"
+
+    def test_task_config_round_trip_agent_only(self) -> None:
+        task = TaskConfig(**_minimal_task_kwargs(interaction_mode="agent_only"))
+        restored = TaskConfig.model_validate(task.model_dump())
+        assert restored.interaction_mode == "agent_only"

--- a/tests/unit/test_rate_limit_probe_wiring.py
+++ b/tests/unit/test_rate_limit_probe_wiring.py
@@ -945,7 +945,7 @@ class TestSeedMessageRetryLoop:
         runner.user_simulator.reply.side_effect = RuntimeError("Error code: 429")
 
         with pytest.raises(RuntimeError, match="429"):
-            runner._seed_first_user_message("")
+            runner._bootstrap_via_simulator()
 
         assert runner.user_simulator.reply.call_count == 1
 
@@ -957,7 +957,7 @@ class TestSeedMessageRetryLoop:
         runner.user_simulator.reply.side_effect = RuntimeError("Error code: 429")
 
         with pytest.raises(RuntimeError, match="429"):
-            runner._seed_first_user_message("")
+            runner._bootstrap_via_simulator()
 
         assert runner.user_simulator.reply.call_count == 4
 
@@ -973,7 +973,7 @@ class TestSeedMessageRetryLoop:
             runner.user_simulator.reply.side_effect = RuntimeError("upstream 503")
 
             with pytest.raises(RuntimeError, match="503"):
-                runner._seed_first_user_message("")
+                runner._bootstrap_via_simulator()
 
             assert runner.user_simulator.reply.call_count == 1
 

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -40,6 +40,7 @@ RUNNER_SUBSET_PACKAGES: tuple[str, ...] = (
     "tolokaforge/runner",
     "tolokaforge/secrets",
     "tolokaforge/tools",
+    "tolokaforge/core/actors",
     "tolokaforge/core/models",
     "tolokaforge/core/llm",
     "tolokaforge/core/grading",
@@ -112,6 +113,7 @@ shim; before the fix, the subset shipped Python only and a runner image
 booted with an empty pricing table."""
 
 RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
+    "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/replay.py",
     "tolokaforge/core/grading/state_checks.py",
@@ -121,7 +123,16 @@ RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
 )
 """Files that live under a shared-spine subpackage but are orchestrator-only.
 
-Four of them (``core.grading.combine``, ``core.grading.replay``,
+``core.actors.turn_policy`` names the concrete built-in turn policies the
+runner-side ``TrialRunner`` (orchestrator-owned) dispatches on
+``TaskConfig.interaction_mode`` — its imports reach
+``core.plugin_registry`` for :class:`TurnPolicyContext`, which is
+orchestrator-only. The runner container never resolves a policy: the
+orchestrator does that before handing a :class:`TrialRunner` to the
+conductor, and the runner-side wire protocol carries only the resolved
+per-turn artefacts.
+
+Four grading files (``core.grading.combine``, ``core.grading.replay``,
 ``core.grading.state_checks``, ``core.tools.user_tools``) reach
 orchestrator-only siblings (``core.evaluators``, ``core.output.artifacts``,
 ``core.utils.diff``, ``core.env_state``) — including any of these in the

--- a/tolokaforge/core/actors/__init__.py
+++ b/tolokaforge/core/actors/__init__.py
@@ -1,0 +1,8 @@
+"""Actor-level Protocols for the turn loop.
+
+Home of the :class:`~tolokaforge.core.actors.actor.Actor` behavioural
+contract — the per-turn message-producing seam that
+:class:`~tolokaforge.core.llm.client.UserSimulator` satisfies today and
+that future actor kinds (adversary, oracle, evaluator) will plug into
+without re-introducing a two-party assumption in the loop body.
+"""

--- a/tolokaforge/core/actors/__init__.py
+++ b/tolokaforge/core/actors/__init__.py
@@ -1,8 +1,14 @@
 """Actor-level Protocols for the turn loop.
 
-Home of the :class:`~tolokaforge.core.actors.actor.Actor` behavioural
-contract — the per-turn message-producing seam that
-:class:`~tolokaforge.core.llm.client.UserSimulator` satisfies today and
-that future actor kinds (adversary, oracle, evaluator) will plug into
-without re-introducing a two-party assumption in the loop body.
+Home of two sibling seams:
+
+* :class:`~tolokaforge.core.actors.actor.Actor` — the per-turn
+  message-producing contract that
+  :class:`~tolokaforge.core.llm.client.UserSimulator` satisfies and that
+  future actor kinds (adversary, oracle, evaluator) plug into without
+  re-introducing a two-party assumption in the loop body.
+* :class:`~tolokaforge.core.actors.turn_policy.TurnPolicy` — the
+  choreographer of the turn loop, resolved by
+  ``TaskConfig.interaction_mode`` through the
+  ``tolokaforge.turn_policies`` entry-point registry.
 """

--- a/tolokaforge/core/actors/actor.py
+++ b/tolokaforge/core/actors/actor.py
@@ -1,0 +1,72 @@
+"""Actor Protocol — behavioural contract for per-turn message producers.
+
+Formalises the ``reply(context, *, observation) -> GenerationResult`` shape
+that :class:`~tolokaforge.core.llm.client.UserSimulator` has satisfied
+implicitly since it was written (``UserSimulator.reply`` at
+``tolokaforge/core/llm/client.py:2137-2155``).
+
+The Protocol follows the ADR-0026 *Service Readiness Contract* Pattern-A
+shape and mirrors the :class:`~tolokaforge.core.grading.judge.Judge`
+seam:
+
+* ``@runtime_checkable`` so seam wiring can ``isinstance``-check.
+* Minimal surface — one method carrying only per-invocation evidence.
+* No construction-time deps on the Protocol itself; concrete impls own
+  their ``llm_client``, budgets, tool schemas, personas, and so on.
+
+The value objects on the contract are re-exported here so callers of
+:class:`Actor` do not need to reach into ``tolokaforge.core.llm.*``.
+:class:`GenerationResult` is bound lazily via :pep:`562` ``__getattr__``
+because ``tolokaforge.core.llm.client`` imports :class:`Actor` for its
+:class:`~tolokaforge.core.llm.client.UserSimulator` base — an eager
+top-level import would loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from tolokaforge.core.models import Message
+from tolokaforge.core.run_display_events import LLMCallObservation
+
+if TYPE_CHECKING:
+    from tolokaforge.core.llm.client import GenerationResult
+
+__all__ = [
+    "Actor",
+    "GenerationResult",
+    "LLMCallObservation",
+    "Message",
+]
+
+
+@runtime_checkable
+class Actor(Protocol):
+    """Produce one reply given the conversation so far.
+
+    ``context`` is the trial's message history in speaking order.
+    ``observation`` bundles the live event sink plus the call-site
+    identity (``trial_id`` + LLM role) so an LLM-backed actor can fire
+    the LLM-call trio without knowing how the sink is routed; a
+    scripted actor may ignore it.
+
+    The returned :class:`GenerationResult` carries the reply body, any
+    tool calls, a :class:`~tolokaforge.core.llm.usage.Usage` counter
+    (zeroed for scripted actors), and the wall-clock latency.
+    """
+
+    def reply(
+        self,
+        context: list[Message],
+        *,
+        observation: LLMCallObservation | None = None,
+    ) -> GenerationResult: ...
+
+
+def __getattr__(name: str) -> Any:
+    if name == "GenerationResult":
+        from tolokaforge.core.llm.client import GenerationResult
+
+        globals()["GenerationResult"] = GenerationResult
+        return GenerationResult
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tolokaforge/core/actors/turn_policy.py
+++ b/tolokaforge/core/actors/turn_policy.py
@@ -1,0 +1,153 @@
+"""Turn-policy Protocol, value objects, and the built-in conversational policy.
+
+A :class:`TurnPolicy` is the *choreographer* of the turn loop: it owns the two
+decisions the loop body used to hard-code — how message index 0 is delivered
+(:meth:`~TurnPolicy.bootstrap`) and which actor speaks next after each agent
+turn (:meth:`~TurnPolicy.next_actor`, or ``None`` to end the turn cycle).
+Lifting these into a Protocol lets the two-party conversational shape and the
+agent-monologue shape share the same loop body and diverge only at the seam.
+
+The Protocol follows the ADR-0026 *Service Readiness Contract* Pattern-A
+shape and mirrors the sibling :class:`~tolokaforge.core.actors.actor.Actor`
+seam:
+
+* ``@runtime_checkable`` so seam wiring can ``isinstance``-check.
+* Frozen value objects at the boundary (:class:`BootstrapDecision`,
+  :class:`TurnState`, :class:`ActorTurn`) so future actor kinds add fields
+  with defaults without breaking existing policies.
+* No construction-time deps on the Protocol itself; concrete impls own
+  the actors they hand back.
+
+The built-in :class:`ConversationalTurnPolicy` reproduces the two-party
+turn loop the runner has always driven: user simulator provides the seed
+message when the caller does not, and the user is dispatched after each
+agent turn that emits no tool calls. Registered via the
+``tolokaforge.turn_policies`` entry-point group and looked up by
+``TaskConfig.interaction_mode``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from tolokaforge.core.actors.actor import Actor, Message
+
+if TYPE_CHECKING:
+    from tolokaforge.core.models.task_config import TaskConfig
+    from tolokaforge.core.plugin_registry import TurnPolicyContext
+
+__all__ = [
+    "ActorTurn",
+    "BootstrapDecision",
+    "ConversationalTurnPolicy",
+    "TurnPolicy",
+    "TurnState",
+]
+
+
+@dataclass(frozen=True)
+class BootstrapDecision:
+    """How message index 0 should be delivered.
+
+    ``first_user_message`` carries the literal turn-0 user text when the
+    caller supplied it; ``None`` when the runner must consult
+    ``bootstrap_via_simulator`` and dispatch a user simulator to produce it.
+    """
+
+    first_user_message: str | None
+    bootstrap_via_simulator: bool
+
+
+@dataclass(frozen=True)
+class TurnState:
+    """Loop state a policy needs to pick the next actor.
+
+    ``last_agent_had_tool_calls`` drives the conversational policy's
+    user-dispatch decision — a tool-call turn stays with the agent so the
+    tool results feed the next agent generation instead of a synthetic
+    user reply.
+    """
+
+    messages: list[Message]
+    last_agent_had_tool_calls: bool
+    turn_index: int
+
+
+@dataclass(frozen=True)
+class ActorTurn:
+    """The actor the policy hands back for the next turn.
+
+    ``actor_name`` is the seam-friendly key the runner uses for
+    observation identity (e.g. ``"user"``); ``actor`` is the concrete
+    :class:`Actor` instance the runner dispatches.
+    """
+
+    actor_name: str
+    actor: Actor
+
+
+@runtime_checkable
+class TurnPolicy(Protocol):
+    """Choreograph the turn loop.
+
+    :meth:`bootstrap` decides how message index 0 is delivered — a
+    caller-provided literal, a live simulator dispatch, or a synthetic
+    seed. :meth:`next_actor` picks the actor to speak next given the loop
+    state, or returns ``None`` to end the turn cycle (the agent monologue
+    case).
+    """
+
+    def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision:
+        """Return the turn-0 delivery decision for ``task``."""
+        ...
+
+    def next_actor(self, state: TurnState) -> ActorTurn | None:
+        """Return the actor to speak next, or ``None`` to end the turn cycle."""
+        ...
+
+
+class ConversationalTurnPolicy:
+    """Two-party turn loop: user simulator seeds turn 0 and speaks after
+    every tool-call-free agent turn.
+
+    ``bootstrap`` short-circuits to the caller's ``initial_user_message``
+    when it carries non-whitespace text; otherwise routes to the user
+    simulator (``bootstrap_via_simulator=True``). ``next_actor`` returns
+    the user actor when the previous agent turn produced no tool calls,
+    matching the loop's historical ``_advance_user_turn`` gate.
+    """
+
+    def __init__(self, *, user_simulator: Actor) -> None:
+        self._user_simulator = user_simulator
+
+    def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision:
+        if initial_user_message is not None and initial_user_message.strip():
+            return BootstrapDecision(
+                first_user_message=initial_user_message,
+                bootstrap_via_simulator=False,
+            )
+        return BootstrapDecision(
+            first_user_message=None,
+            bootstrap_via_simulator=True,
+        )
+
+    def next_actor(self, state: TurnState) -> ActorTurn | None:
+        if state.last_agent_had_tool_calls:
+            return None
+        return ActorTurn(actor_name="user", actor=self._user_simulator)
+
+
+def _conversational_policy_factory(context: TurnPolicyContext) -> ConversationalTurnPolicy:
+    """Build a :class:`ConversationalTurnPolicy` from a resolved context.
+
+    Fails loud if the runner did not supply a user simulator — the
+    conversational shape cannot function without one, and a silent fallback
+    would just re-hide the mismatch this seam was introduced to make visible.
+    """
+    if context.user_simulator is None:
+        raise ValueError(
+            "ConversationalTurnPolicy requires TurnPolicyContext.user_simulator; "
+            "route agent-monologue tasks through the agent_only policy instead."
+        )
+    return ConversationalTurnPolicy(user_simulator=context.user_simulator)

--- a/tolokaforge/core/actors/turn_policy.py
+++ b/tolokaforge/core/actors/turn_policy.py
@@ -21,9 +21,13 @@ seam:
 The built-in :class:`ConversationalTurnPolicy` reproduces the two-party
 turn loop the runner has always driven: user simulator provides the seed
 message when the caller does not, and the user is dispatched after each
-agent turn that emits no tool calls. Registered via the
-``tolokaforge.turn_policies`` entry-point group and looked up by
-``TaskConfig.interaction_mode``.
+agent turn that emits no tool calls. The sibling
+:class:`AgentOnlyTurnPolicy` covers the agent-monologue shape used by
+migration-bench-style tasks: the caller must supply ``initial_user_message``
+(fail-loud otherwise), and no user turn is ever dispatched — the agent
+runs to ``###STOP###``, ``max_turns``, or ``episode_timeout_s``. Both are
+registered via the ``tolokaforge.turn_policies`` entry-point group and
+looked up by ``TaskConfig.interaction_mode``.
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ActorTurn",
+    "AgentOnlyTurnPolicy",
     "BootstrapDecision",
     "ConversationalTurnPolicy",
     "TurnPolicy",
@@ -151,3 +156,52 @@ def _conversational_policy_factory(context: TurnPolicyContext) -> Conversational
             "route agent-monologue tasks through the agent_only policy instead."
         )
     return ConversationalTurnPolicy(user_simulator=context.user_simulator)
+
+
+class AgentOnlyTurnPolicy:
+    """Agent-monologue turn loop: the caller seeds turn 0, no user turn ever fires.
+
+    ``bootstrap`` returns the caller-supplied ``initial_user_message`` verbatim
+    and raises :class:`ValueError` when it is missing — this shape has no user
+    simulator to synthesise a seed from, so a task authoring
+    ``interaction_mode: agent_only`` without an ``initial_user_message`` is a
+    config error the operator should hear about at run-start, not a silent
+    degrade into an empty-user-turn. ``next_actor`` returns ``None``
+    unconditionally: agent-###STOP###, ``max_turns``, and
+    ``episode_timeout_s`` are the only exits.
+
+    The optional ``user_simulator`` keyword keeps the constructor signature
+    parallel with :class:`ConversationalTurnPolicy` so the runner can hand
+    the same context object to either factory; the policy never dispatches
+    it.
+    """
+
+    def __init__(self, *, user_simulator: Actor | None = None) -> None:
+        del user_simulator
+
+    def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision:
+        if initial_user_message is not None and initial_user_message.strip():
+            return BootstrapDecision(
+                first_user_message=initial_user_message,
+                bootstrap_via_simulator=False,
+            )
+        raise ValueError(
+            f"AgentOnlyTurnPolicy requires initial_user_message for task "
+            f"{task.task_id!r} (interaction_mode='agent_only'); this shape has "
+            f"no user simulator to synthesise a seed from."
+        )
+
+    def next_actor(self, state: TurnState) -> ActorTurn | None:
+        del state
+        return None
+
+
+def _agent_only_policy_factory(context: TurnPolicyContext) -> AgentOnlyTurnPolicy:
+    """Build an :class:`AgentOnlyTurnPolicy` from a resolved context.
+
+    Ignores ``context.user_simulator`` — the agent-monologue shape never
+    dispatches a user actor, and a caller wiring one in is not an error
+    (the runner reuses the same context object across both factories).
+    """
+    del context
+    return AgentOnlyTurnPolicy()

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -643,23 +643,33 @@ class InProcessConductor:
         user_tool_executor = None
         user_tool_schemas: list[dict[str, Any]] = []
 
-        sim = task.resolve_user_simulator()
-        user_llm_config = user_config if sim.mode == "llm" else None
-        # The simulator hits the same provider quota as the agent, so a probe
-        # run has to cover it too — otherwise a simulator 429 kills the trial
-        # the agent-side probe was keeping alive. It gets the shorter
-        # simulator-scoped per-call budget: its throughput is not what the probe
-        # measures, and both budgets are spent inside one uninterruptible turn.
+        # ``interaction_mode='agent_only'`` runs the agent as a monologue —
+        # the turn loop never dispatches a user actor, so constructing a
+        # simulator here would sink the LLM budget its scripted / persona /
+        # backstory carry with it into a component the runner never wakes.
+        # The runner accepts ``user_simulator=None`` under this mode; the
+        # ``AgentOnlyTurnPolicy`` factory ignores ``TurnPolicyContext.user_simulator``.
         rate_limit_probe = self.config.orchestrator.rate_limit_probe
-        user_simulator = UserSimulator(
-            mode=sim.mode,
-            llm_config=user_llm_config,
-            persona=sim.persona,
-            backstory=sim.backstory,
-            scripted_flow=sim.scripted_flow,
-            tool_schemas=user_tool_schemas if user_tool_executor else None,
-            rate_limit_probe=rate_limit_probe.for_simulator(),
-        )
+        user_simulator: UserSimulator | None
+        if task.interaction_mode == "conversational":
+            sim = task.resolve_user_simulator()
+            user_llm_config = user_config if sim.mode == "llm" else None
+            # The simulator hits the same provider quota as the agent, so a probe
+            # run has to cover it too — otherwise a simulator 429 kills the trial
+            # the agent-side probe was keeping alive. It gets the shorter
+            # simulator-scoped per-call budget: its throughput is not what the probe
+            # measures, and both budgets are spent inside one uninterruptible turn.
+            user_simulator = UserSimulator(
+                mode=sim.mode,
+                llm_config=user_llm_config,
+                persona=sim.persona,
+                backstory=sim.backstory,
+                scripted_flow=sim.scripted_flow,
+                tool_schemas=user_tool_schemas if user_tool_executor else None,
+                rate_limit_probe=rate_limit_probe.for_simulator(),
+            )
+        else:
+            user_simulator = None
 
         # Task-scope stuck_heuristics is canonical (populated by the M2
         # loader's per-task merge from ``project.task_defaults``); the
@@ -732,6 +742,7 @@ class InProcessConductor:
             strict=self.strict,
             events=self.events,
             probe_stats=_build_probe_stats(rate_limit_probe),
+            interaction_mode=task.interaction_mode,
         )
 
         # Use initial_user_message if provided (e.g., tool-use style tasks).

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -39,6 +39,7 @@ from tenacity import (
 )
 from tenacity.wait import wait_base
 
+from tolokaforge.core.actors.actor import Actor
 from tolokaforge.core.llm.capabilities import ModelCapabilities
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.llm.prompt_policy import detect_dict_maps
@@ -2105,8 +2106,14 @@ class LLMClient:
         )
 
 
-class UserSimulator:
-    """User simulator for benchmarking."""
+class UserSimulator(Actor):
+    """User simulator for benchmarking.
+
+    Declares :class:`~tolokaforge.core.actors.actor.Actor` conformance so
+    the turn-loop seam can accept any Protocol-satisfying actor kind, not
+    just this concrete simulator. Behaviour is unchanged — the existing
+    :meth:`reply` already matches the Protocol signature.
+    """
 
     def __init__(
         self,

--- a/tolokaforge/core/models/task_config.py
+++ b/tolokaforge/core/models/task_config.py
@@ -31,6 +31,7 @@ __all__ = [
     "GradingDefaults",
     "InitializationAction",
     "InitialStateConfig",
+    "InteractionMode",
     "LLMJudgeDefaults",
     "ProjectConfig",
     "RequiredAction",
@@ -49,6 +50,26 @@ __all__ = [
     "TranscriptRulesConfig",
     "UserSimulatorConfig",
 ]
+
+
+InteractionMode = Literal["conversational", "agent_only"]
+"""Shape of the trial's turn loop — whether a user party participates.
+
+- ``conversational`` (default): user simulator dispatched every turn.
+  Matches τ-bench-style benchmarks where the user is a genuine
+  information source.
+- ``agent_only``: no user turn dispatched after the first message.
+  The agent runs to ``###STOP###`` (routed to
+  :attr:`TerminationReason.AGENT_DONE`), ``max_turns``, or
+  ``episode_timeout_s``. Matches code-migration / agent-driven eval
+  shape where the task lives entirely in the system prompt and the
+  agent decides when it's done. The user simulator is never
+  constructed on this route.
+
+Future values (e.g. ``multi_actor``) will land alongside dedicated
+:class:`TurnPolicy` implementations registered in the
+``tolokaforge.turn_policies`` entry-point group.
+"""
 
 
 class InitializationAction(BaseModel):
@@ -212,6 +233,13 @@ class TaskConfig(BaseModel):
     adapter_type: str = "native"  # Adapter runtime type (native, tlk_mcp_core, tau, …)
     max_turns: int | None = None  # Optional per-task turn cap override
     initial_user_message: str | None = None  # If provided, sent directly as first user message
+    interaction_mode: InteractionMode = "conversational"
+    """Turn-loop shape. ``conversational`` (default) dispatches the user
+    simulator every turn — backward-compatible with every existing pack.
+    ``agent_only`` skips user-turn dispatch entirely; the agent runs to
+    ``###STOP###`` / ``max_turns`` / ``episode_timeout_s``. Selects a
+    concrete :class:`TurnPolicy` via the ``tolokaforge.turn_policies``
+    entry-point registry (see ADR-0027)."""
     initial_state: InitialStateConfig = Field(default_factory=InitialStateConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     actors: dict[str, ActorSpec] | None = None
@@ -499,6 +527,12 @@ class TaskDefaults(BaseModel):
 
     adapter_type: str | None = None
     max_turns: int | None = Field(default=None, ge=1)
+    interaction_mode: InteractionMode | None = None
+    """Project-side default for :attr:`TaskConfig.interaction_mode`.
+    ``None`` leaves the engine default (``conversational``) in effect;
+    a task's own ``interaction_mode`` overrides. Enables a project to
+    declare "every task under me is agent_only" once instead of per
+    task.yaml."""
     system_prompt: str | None = None
     actors: dict[str, ActorSpec] | None = None
     """Named actor map inherited by every task. ``actors.user`` configures

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -1,24 +1,26 @@
-"""Fail-loud entry-point registries for the four swappable seams.
+"""Fail-loud entry-point registries for the five swappable seams.
 
 External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.runtime.RuntimeBackend`,
 :class:`~tolokaforge.core.trial_grader.TrialGrader`,
-:class:`~tolokaforge.core.conductor.Conductor`, and
-:class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe` Protocols
+:class:`~tolokaforge.core.conductor.Conductor`,
+:class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe`, and
+:class:`~tolokaforge.core.actors.turn_policy.TurnPolicy` Protocols
 through ``importlib.metadata`` entry-point groups — no in-tree edit, no
 monkey-patch. Each entry point resolves to a *factory callable*, mirroring the
-existing :data:`~tolokaforge.core.conductor.ConductorFactory` idiom. The three
-orchestrator seams adapt divergent impl constructors to a per-group
-frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
-probes need no build dependencies, so their factory is arg-less
+existing :data:`~tolokaforge.core.conductor.ConductorFactory` idiom. Four of
+the seams adapt divergent impl constructors to a per-group frozen-dataclass
+context (``Callable[[<Context>], <Impl>]``); the readiness probes need no
+build dependencies, so their factory is arg-less
 (``Callable[[], ServiceReadinessProbe]``).
 
-The four groups:
+The five groups:
 
 * ``tolokaforge.runtime_backends`` → :data:`RuntimeBackendFactory`
 * ``tolokaforge.trial_graders`` → :data:`TrialGraderFactory`
 * ``tolokaforge.conductors`` → :data:`~tolokaforge.core.conductor.ConductorFactory`
 * ``tolokaforge.service_readiness_probes`` → :data:`ReadinessProbeFactory`
+* ``tolokaforge.turn_policies`` → :data:`TurnPolicyFactory`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -38,6 +40,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
+from tolokaforge.core.actors.turn_policy import TurnPolicy
 from tolokaforge.core.conductor import ConductorFactory
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
 from tolokaforge.core.runtime import RuntimeBackend
@@ -47,6 +50,7 @@ from tolokaforge.core.trial_grader import TrialGrader
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
 
+    from tolokaforge.core.actors.actor import Actor
     from tolokaforge.core.compose_materialisation import LogCaptureConfig
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import SeedRef
@@ -61,21 +65,26 @@ __all__ = [
     "RuntimeBackendFactory",
     "TrialGraderContext",
     "TrialGraderFactory",
+    "TurnPolicyContext",
+    "TurnPolicyFactory",
     "UnknownImplementationError",
     "available_conductors",
     "available_readiness_probes",
     "available_runtime_backends",
     "available_trial_graders",
+    "available_turn_policies",
     "load_conductor",
     "load_readiness_probe",
     "load_runtime_backend",
     "load_trial_grader",
+    "load_turn_policy",
 ]
 
 RUNTIME_BACKENDS_GROUP = "tolokaforge.runtime_backends"
 TRIAL_GRADERS_GROUP = "tolokaforge.trial_graders"
 CONDUCTORS_GROUP = "tolokaforge.conductors"
 SERVICE_READINESS_PROBES_GROUP = "tolokaforge.service_readiness_probes"
+TURN_POLICIES_GROUP = "tolokaforge.turn_policies"
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +168,22 @@ class TrialGraderContext:
     logger: StructuredLogger
 
 
+@dataclass(frozen=True)
+class TurnPolicyContext:
+    """Dependencies a turn-policy factory receives from the runner.
+
+    ``user_simulator`` is ``None`` for policies that dispatch no user actor
+    (the agent-monologue case); the conversational factory refuses that
+    combination loudly rather than papering over it with a scripted stub.
+    """
+
+    user_simulator: Actor | None = None
+
+
 RuntimeBackendFactory = Callable[[RuntimeBackendBuildContext], RuntimeBackend]
 TrialGraderFactory = Callable[[TrialGraderContext], TrialGrader]
 ReadinessProbeFactory = Callable[[], ServiceReadinessProbe]
+TurnPolicyFactory = Callable[[TurnPolicyContext], TurnPolicy]
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +272,11 @@ def load_readiness_probe(kind: str) -> ReadinessProbeFactory:
     return cast(ReadinessProbeFactory, _load(SERVICE_READINESS_PROBES_GROUP, kind))
 
 
+def load_turn_policy(name: str) -> TurnPolicyFactory:
+    """Resolve a registered turn-policy name to its factory callable."""
+    return cast(TurnPolicyFactory, _load(TURN_POLICIES_GROUP, name))
+
+
 def available_runtime_backends() -> list[str]:
     """Sorted names registered in the ``tolokaforge.runtime_backends`` group."""
     return sorted(_discover(RUNTIME_BACKENDS_GROUP))
@@ -268,3 +295,8 @@ def available_conductors() -> list[str]:
 def available_readiness_probes() -> list[str]:
     """Sorted kinds registered in the ``tolokaforge.service_readiness_probes`` group."""
     return sorted(_discover(SERVICE_READINESS_PROBES_GROUP))
+
+
+def available_turn_policies() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.turn_policies`` group."""
+    return sorted(_discover(TURN_POLICIES_GROUP))

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -4,6 +4,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+from tolokaforge.core.actors.actor import Actor
+from tolokaforge.core.actors.turn_policy import TurnPolicy, TurnState
 from tolokaforge.core.llm import GenerationResult, LLMClient, UserSimulator
 from tolokaforge.core.logging import StructuredLogger, init_trial_logger
 from tolokaforge.core.logging_context import trial_id_scope
@@ -27,6 +29,7 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
 )
+from tolokaforge.core.models.task_config import InteractionMode, TaskConfig
 from tolokaforge.core.rate_limiter import GlobalRateLimiter
 from tolokaforge.core.run_display_events import (
     _NULL_EVENTS,
@@ -111,7 +114,7 @@ class TrialRunner:
         task_id: str,
         trial_index: int,
         agent_client: LLMClient,
-        user_simulator: UserSimulator,
+        user_simulator: UserSimulator | None,
         tool_executor: ToolExecutor,
         tool_schemas: list[dict[str, Any]],
         max_turns: int = 50,
@@ -124,6 +127,7 @@ class TrialRunner:
         strict: bool = False,
         events: RunDisplayEvents = _NULL_EVENTS,
         probe_stats: RateLimitProbeStats | None = None,
+        interaction_mode: InteractionMode = "conversational",
     ):
         self.task_id = task_id
         self.trial_index = trial_index
@@ -139,6 +143,7 @@ class TrialRunner:
         self.request_limiter = request_limiter
         self.verbose = verbose
         self.strict = strict
+        self.interaction_mode = interaction_mode
         self._events = events
         # Non-``None`` only under rate-limit probe mode. Shared by the agent and
         # user observations so both roles' 429s land in one per-trial total, and
@@ -299,7 +304,23 @@ class TrialRunner:
             )
 
             try:
-                self._seed_first_user_message(initial_user_message)
+                # Deferred import: the plugin registry pulls the conductor
+                # protocol, which pulls this runner module — an eager top-level
+                # import would loop.
+                from tolokaforge.core.plugin_registry import (
+                    TurnPolicyContext,
+                    load_turn_policy,
+                )
+
+                policy = load_turn_policy(self.interaction_mode)(
+                    TurnPolicyContext(user_simulator=self.user_simulator)
+                )
+                task_config = TaskConfig(
+                    task_id=self.task_id,
+                    description="",
+                    interaction_mode=self.interaction_mode,
+                )
+                self._seed_first_user_message(task_config, policy, initial_user_message)
 
                 outcome = ToolCallingLoop(
                     llm_client=self.agent_client,
@@ -315,7 +336,7 @@ class TrialRunner:
                         trial_id=trial_id,
                     ),
                     should_terminate=self._agent_termination,
-                    user_turn=self._agent_user_turn,
+                    user_turn=lambda messages: self._policy_user_turn(policy, messages),
                     recorder=self.tool_call_recorder,
                     request_limiter=self.request_limiter,
                     normalize_tool_arguments=self._normalize_tool_arguments,
@@ -491,70 +512,39 @@ class TrialRunner:
         folded = text.casefold()
         return any(marker.casefold() in folded for marker in _AGENT_DONE_MARKERS)
 
-    def _seed_first_user_message(self, initial_user_message: str) -> None:
+    def _seed_first_user_message(
+        self,
+        task_config: TaskConfig,
+        policy: TurnPolicy,
+        initial_user_message: str,
+    ) -> None:
         """Determine and append the first user message before the loop runs.
 
-        If ``initial_user_message`` is provided, use it directly (tool-use / Tau
-        style). Otherwise generate it via the user simulator (legacy behaviour),
-        retrying on rate limits — and *only* on rate limits: any other error is
-        re-raised on the first attempt. The task instruction lives in the
-        simulator's backstory and is NOT sent to the agent.
+        Delegates to ``policy.bootstrap(...)``: a policy may short-circuit to a
+        caller-provided literal (tool-use / Tau style, agent-monologue seed),
+        route to a user simulator to synthesise turn 0 (today's default
+        conversational path), or raise :class:`ValueError` when a required seed
+        is missing (agent-only with no ``initial_user_message``).
 
-        This runs before the loop, so no episode-timeout check can interrupt it
-        mid-flight, but its wall time is *consumed from* the episode budget
-        rather than added to it: ``run()`` sets ``self.start_time`` before
-        calling this and hands that same ``start_time`` to the loop.
+        The simulator invocation retries on rate limits — and *only* on rate
+        limits: any other error is re-raised on the first attempt. This runs
+        before the loop, so no episode-timeout check can interrupt it mid-flight,
+        but its wall time is *consumed from* the episode budget rather than
+        added to it: ``run()`` sets ``self.start_time`` before calling this and
+        hands that same ``start_time`` to the loop.
         """
-        if initial_user_message.strip():
-            first_user_text = initial_user_message
+        seed = initial_user_message if initial_user_message.strip() else None
+        decision = policy.bootstrap(task_config, seed)
+
+        if decision.first_user_message is not None:
+            first_user_text = decision.first_user_message
             self.logger.debug("Using provided initial_user_message directly")
+        elif decision.bootstrap_via_simulator:
+            first_user_text = self._bootstrap_via_simulator()
         else:
-            greeting_context = [
-                Message(
-                    role=MessageRole.ASSISTANT,
-                    content="Hi! How can I help you today?",
-                    ts=datetime.now(tz=timezone.utc),
-                )
-            ]
-            first_user_result = None
-            # Probe mode collapses this to one attempt. This loop only ever
-            # retries 429s (see the ``is_rate_limit and`` guard below), and under
-            # probe mode the simulator's own client already polls 429s at a fixed
-            # interval for up to its per-call budget — strictly more tolerant
-            # than 4 attempts of 2/4/8 s backoff — so the outer attempts are
-            # redundant. Dropping them also keeps this step's worst case at one
-            # simulator budget instead of ``init_attempts`` of them, which is
-            # what makes the budget invariant alone sufficient to bound the trial
-            # under its ``max(300, episode_s * 2)`` queue lease. Non-429 errors
-            # are unaffected: they were never retried here, and the client's own
-            # five-attempt exponential path still covers them under probe mode.
-            init_attempts = 1 if self._rate_limit_probe_active else 4
-            for attempt in range(1, init_attempts + 1):
-                try:
-                    first_user_result = self.user_simulator.reply(
-                        greeting_context, observation=self._user_observation
-                    )
-                    break
-                except Exception as exc:
-                    is_rate_limit = self._is_rate_limit_error(exc)
-                    if is_rate_limit and attempt < init_attempts:
-                        wait_s = min(2**attempt, 12)
-                        self.logger.warning(
-                            "Initial user generation rate-limited; retrying",
-                            attempt=attempt,
-                            max_attempts=init_attempts,
-                            wait_s=wait_s,
-                            error=str(exc),
-                        )
-                        time.sleep(wait_s)
-                        continue
-                    raise
-
-            if first_user_result is None:
-                raise RuntimeError("Failed to generate initial user message")
-
-            first_user_text = first_user_result.text
-            self.logger.debug("User simulator generated first message")
+            raise RuntimeError(
+                "BootstrapDecision must supply first_user_message or bootstrap_via_simulator=True"
+            )
 
         self.messages.append(
             Message(
@@ -563,6 +553,59 @@ class TrialRunner:
                 ts=datetime.now(tz=timezone.utc),
             )
         )
+
+    def _bootstrap_via_simulator(self) -> str:
+        """Synthesise turn 0 by dispatching the user simulator against a canned
+        agent greeting. Retries on rate limits only.
+
+        Probe mode collapses this to one attempt. The retry loop only ever
+        catches 429s (see the ``is_rate_limit`` guard below), and under probe
+        mode the simulator's own client already polls 429s at a fixed interval
+        for up to its per-call budget — strictly more tolerant than 4 attempts
+        of 2/4/8 s backoff — so the outer attempts are redundant. Dropping
+        them also keeps this step's worst case at one simulator budget instead
+        of ``init_attempts`` of them, which is what makes the budget invariant
+        alone sufficient to bound the trial under its
+        ``max(300, episode_s * 2)`` queue lease. Non-429 errors are unaffected:
+        they were never retried here, and the client's own five-attempt
+        exponential path still covers them under probe mode.
+        """
+        if self.user_simulator is None:
+            raise RuntimeError(
+                "bootstrap_via_simulator requires a user simulator; the conductor "
+                "must construct one for interaction_mode='conversational'."
+            )
+        greeting_context = [
+            Message(
+                role=MessageRole.ASSISTANT,
+                content="Hi! How can I help you today?",
+                ts=datetime.now(tz=timezone.utc),
+            )
+        ]
+        init_attempts = 1 if self._rate_limit_probe_active else 4
+        for attempt in range(1, init_attempts + 1):
+            try:
+                first_user_result = self.user_simulator.reply(
+                    greeting_context, observation=self._user_observation
+                )
+                self.logger.debug("User simulator generated first message")
+                return first_user_result.text
+            except Exception as exc:
+                is_rate_limit = self._is_rate_limit_error(exc)
+                if is_rate_limit and attempt < init_attempts:
+                    wait_s = min(2**attempt, 12)
+                    self.logger.warning(
+                        "Initial user generation rate-limited; retrying",
+                        attempt=attempt,
+                        max_attempts=init_attempts,
+                        wait_s=wait_s,
+                        error=str(exc),
+                    )
+                    time.sleep(wait_s)
+                    continue
+                raise
+
+        raise RuntimeError("Failed to generate initial user message")
 
     def _agent_termination(
         self, result: GenerationResult, turn: int, messages: list[Message]
@@ -592,8 +635,34 @@ class TrialRunner:
 
         return None
 
-    def _agent_user_turn(self, messages: list[Message]) -> UserTurnResult:
-        """Agent user turn: simulator reply, ``###STOP###`` detection, user tools.
+    def _policy_user_turn(self, policy: TurnPolicy, messages: list[Message]) -> UserTurnResult:
+        """Route the loop's optional user turn through ``policy.next_actor``.
+
+        The loop invokes this shim only when the just-completed agent turn
+        produced no tool calls (``loop.py``'s ``_advance_user_turn`` gate), so
+        the :class:`TurnState` handed to the policy sets
+        ``last_agent_had_tool_calls=False``. ``turn_index`` is the count of
+        assistant messages so far — the next actor the policy hands back is the
+        speaker of turn ``turn_index + 1``.
+
+        A :class:`~tolokaforge.core.actors.turn_policy.ConversationalTurnPolicy`
+        returns the user actor here (byte-for-byte the historical dispatch);
+        :class:`~tolokaforge.core.actors.turn_policy.AgentOnlyTurnPolicy` returns
+        ``None`` and the shim returns an empty :class:`UserTurnResult` — the
+        loop appends nothing and advances to the next agent turn.
+        """
+        state = TurnState(
+            messages=messages,
+            last_agent_had_tool_calls=False,
+            turn_index=sum(1 for m in messages if m.role == MessageRole.ASSISTANT),
+        )
+        actor_turn = policy.next_actor(state)
+        if actor_turn is None:
+            return UserTurnResult()
+        return self._dispatch_user_actor(actor_turn.actor, messages)
+
+    def _dispatch_user_actor(self, actor: Actor, messages: list[Message]) -> UserTurnResult:
+        """Run one user actor turn: reply, ``###STOP###`` detection, user tools.
 
         Embeds user tool-call results in the user message text (Anthropic does
         not support ``tool_use`` from the USER role) while preserving the
@@ -619,7 +688,7 @@ class TrialRunner:
                 )
             )
 
-        user_result = self.user_simulator.reply(messages, observation=self._user_observation)
+        user_result = actor.reply(messages, observation=self._user_observation)
 
         if "###STOP###" in user_result.text:
             pre_stop_text, _, _ = user_result.text.partition("###STOP###")


### PR DESCRIPTION
## Summary

Tolokaforge's turn loop today assumes a two-party conversation: user simulator utters, agent responds, tools execute, repeat. That shape came from τ-bench-style customer-service benchmarks where the user is a genuine information source. Migration Bench and every code-migration / agent-driven eval is the opposite shape — the task lives in the system prompt + workdir seed; the agent knows when it's done (tests pass); there is no "user" whose replies advance the task.

This PR introduces a first-class multi-actor architecture that:
- Adds ``TaskConfig.interaction_mode: Literal["conversational", "agent_only"]`` with default ``"conversational"`` (backward-compatible).
- Formalizes the ``Actor`` Protocol (the contract ``UserSimulator`` implicitly satisfied since it was written).
- Introduces a ``TurnPolicy`` seam that encapsulates turn-cycle choreography, with two built-ins (\`ConversationalTurnPolicy\`, \`AgentOnlyTurnPolicy\`) and a plugin-registry entry-point group ``tolokaforge.turn_policies`` for future policies.
- Migrates ``TrialRunner`` to dispatch via the resolved policy — no mode-specific ``if`` in the loop body, the policy encapsulates the differences.
- Preserves byte-for-byte behavior in ``conversational`` mode. Every existing pack / canonical fixture / τ-bench-style adapter is unaffected.

## Design choices

- **First-class shape flag over a "silent simulator" hack** — names the actual dimension (is there a real user party) rather than hiding it behind cost/timeout patches. Future values (e.g. \`multi_actor\`) land alongside dedicated \`TurnPolicy\` implementations registered in the same entry-point group.
- **\`@runtime_checkable\` Protocol over inheritance** — matches the ADR-0011 Pattern-A / ADR-0026 (Service Readiness Contract) / \`Judge\` Protocol precedent. Concrete impls carry construction-time deps (\`llm_client\`, budgets, etc.); the Protocol carries only per-invocation evidence.
- **\`TurnPolicy\` as choreographer** — encapsulates mode-specific dispatch so the loop body stays mode-agnostic. Entry-point registry unlocks future adapter-registered policies without core changes. \`AgentOnlyTurnPolicy.next_actor(...)\` returns \`None\` unconditionally — the agent monologues to \`###STOP###\`, \`max_turns\`, or \`episode_timeout_s\`.
- **Reuse existing \`TerminationReason.AGENT_DONE\`** and \`_AGENT_DONE_MARKERS = ("###STOP###",)\` — agent-emitted \`###STOP###\` already routes correctly; no enum or marker change needed.
- **Reuse \`initial_user_message\` short-circuit** at \`runner.py:508\` — \`AgentOnlyTurnPolicy.bootstrap\` delegates through the existing path; no simulator construction on the agent-only route.
- **\`AgentOnlyTurnPolicy.bootstrap\` fails loud** if \`initial_user_message\` is missing — the agent-only route has no simulator to synthesize a bootstrap message, so a task authoring \`interaction_mode: agent_only\` without an initial message is a config error the operator should hear at run-start, not silently degrade into "agent sees empty user turn".

## Six-stage staged landing

Each stage is one commit with a behavior-locking test at the correct tier.

1. \`285017a\` **\`interaction_mode\` schema field** on \`TaskConfig\` + \`TaskDefaults\`. 10 unit tests lock defaults, explicit values, unknown-value rejection, model-dump round-trip.
2. \`a749533\` **\`Actor\` Protocol + \`UserSimulator\` conformance**. Types + canonical contract test. Zero behavior change.
3. \`784eb69\` **\`TurnPolicy\` Protocol + \`ConversationalTurnPolicy\`** built-in + \`tolokaforge.turn_policies\` entry-point registry group.
4. \`b01604b\` **\`AgentOnlyTurnPolicy\`** built-in. \`next_actor\` returns \`None\` unconditionally; \`bootstrap\` fails loud without \`initial_user_message\`.
5. \`6c450ce\` **Runner ↔ turn-policy wiring**. \`TrialRunner\` resolves policy via registry; \`Conductor\` gates \`UserSimulator\` construction on \`interaction_mode == "conversational"\`. Runner-subset partition updated so \`tolokaforge.core.actors\` is available to the runner container. Six golden snapshots regenerated to carry the new \`interaction_mode\` field.

## Test plan
- [x] 10 unit tests for the schema field.
- [x] 6 canonical tests for the \`Actor\` Protocol contract.
- [x] 15 canonical tests for the \`TurnPolicy\` Protocol + both built-in policies.
- [x] 4 canonical tests locking the runner ↔ policy wiring (byte-for-byte parity in conversational mode + agent-only mode never invokes simulator + fail-loud on missing initial message).
- [x] Full unit lane: 4488 passed, 2 pre-existing digest failures unrelated to actors work.
- [x] Full canonical lane: 995 passed, 3 pre-existing digest failures on the same \`multi_service_endpoint_add\` seed drift.
- [x] Runner subset install smoke: 7/7 passed.
- [ ] CI green.
- [ ] Downstream verification: MB adapter (private repo, separate PR) regenerates a pack with \`interaction_mode: agent_only\`, runs end-to-end without user-simulator overhead, reaches /grade endpoint, produces a comparable score to the upstream benchmark's own eval path.

## Discovered follow-ups (out of scope)

- **\`MultiActorTurnPolicy\`** for 3+ actor choreography (adversary, oracle, evaluator-in-the-loop) — the registry accommodates this; the concrete policy + config shape is a separate design pass.
- **\`tolokaforge.actors\` entry-point registry** (parallel to \`turn_policies\`) for custom actor kinds — worth adding when the first non-built-in actor kind lands.
- **\`ADR-0027-multi-actor-turn-policy.md\`** — the ADR listed in the plan hasn't been written yet. Best landed as a docs-only follow-up so it can describe the merged design in one place.
- **Pre-existing pristine-source digest mismatch** on \`examples/native/multi_service_endpoint_add/assets/source\` — 5 failing tests independent of this PR (reproduce on \`main\`). Needs \`tolokaforge assets stamp\` re-run or source restore.

Closes #868