### PR TITLE
fix(actors): AgentOnlyTurnPolicy signals AGENT_DONE on text-only turn (#876)

### DIFF
--- a/docs/adr/0028-multi-actor-turn-policy.md
+++ b/docs/adr/0028-multi-actor-turn-policy.md
@@ -44,7 +44,7 @@ We adopt **Option 2**: a three-layer architecture.
 @runtime_checkable
 class TurnPolicy(Protocol):
     def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision: ...
-    def next_actor(self, state: TurnState) -> ActorTurn | None: ...
+    def next_actor(self, state: TurnState) -> ActorTurn | TerminationDecision | None: ...
 ```
 
 Two built-in implementations:
@@ -64,7 +64,22 @@ The `Conductor` gates `UserSimulator(...)` construction at `conductor.py:646-668
 
 ### Stop protocol reuses the existing marker
 
-`_AGENT_DONE_MARKERS = ("###STOP###",)` at `runner.py:46` already routes agent-emitted `###STOP###` to `TerminationReason.AGENT_DONE`. No new marker is introduced — the same convention serves both modes. In `conversational` mode, user-emitted `###STOP###` still terminates with `TerminationReason.USER_STOP`. In `agent_only` mode, `next_actor` never dispatches the user turn, so agent-`###STOP###` is the only marker-based termination path.
+`_AGENT_DONE_MARKERS = ("###STOP###",)` at `runner.py:46` already routes agent-emitted `###STOP###` to `TerminationReason.AGENT_DONE`. No new marker is introduced — the same convention serves both modes. In `conversational` mode, user-emitted `###STOP###` still terminates with `TerminationReason.USER_STOP`.
+
+### Termination signalling from the policy (refined for #876)
+
+`next_actor` returns one of three things:
+
+- **`ActorTurn`** — dispatch this actor's `reply`. The historical two-party path.
+- **`TerminationDecision`** — end the trial with the given reason. `AgentOnlyTurnPolicy` takes this branch: the loop dispatches `next_actor` only when the just-completed agent turn produced no tool calls, and under agent-only that condition is definitional (no user party exists, no more tool actions coming). The trial is done, and the loop must terminate rather than retry the agent against a context ending in `role: assistant` — Anthropic's `opus-4-6` rejects that as an unsupported prefill, and semantically the agent falling silent IS the completion signal.
+- **`None`** — no actor speaks this iteration, loop advances to the next agent turn. Reserved for future policies that may want to skip a turn without terminating; not exercised by either built-in today.
+
+This means `agent_only` has three termination paths, all routed to `TerminationReason.AGENT_DONE`:
+1. Agent emits `###STOP###` — explicit signal.
+2. Agent emits text-only (no tool calls, no `###STOP###`) — implicit completion via `next_actor`'s `TerminationDecision` return.
+3. Loop-level bounds: `max_turns` or `episode_timeout_s`.
+
+Path 2 matches Claude Code / MCP-CLI shape: a text-only assistant turn is the natural last turn of an autonomous tool-driven run. The Anthropic API constraint just makes it structural.
 
 ## Consequences
 
@@ -91,4 +106,4 @@ The `Conductor` gates `UserSimulator(...)` construction at `conductor.py:646-668
 
 - Related ADRs: [0011](0011-seam-and-declaration-conventions.md) (Pattern A), [0014](0014-trial-grader-protocol.md) (TrialGrader Protocol), [0020](0020-judge-protocol.md) (Judge Protocol), [0026](0026-service-readiness-contract.md) (Service Readiness Contract — same idiom, fourth seam).
 - Related code: `tolokaforge/core/actors/actor.py`, `tolokaforge/core/actors/turn_policy.py`, `tolokaforge/core/runner.py:317-318`, `tolokaforge/core/plugin_registry.py`, `tolokaforge/core/models/task_config.py`.
-- External references: #868 (this ticket), Toloka/tolokaforge#872 (implementation).
+- External references: #868 (this ticket), Toloka/tolokaforge#872 (initial implementation), #876 (termination-signalling refinement for the agent-only text-only case).

--- a/tests/canonical/test_runner_turn_policy_wiring.py
+++ b/tests/canonical/test_runner_turn_policy_wiring.py
@@ -137,6 +137,58 @@ def test_agent_only_mode_accepts_none_user_simulator() -> None:
     assert trajectory.termination_reason is TerminationReason.AGENT_DONE
 
 
+def test_agent_only_mode_text_only_completion_terminates_as_agent_done() -> None:
+    """Regression lock for #876 at the runner-wiring level.
+
+    The real-MB smoke that surfaced #876 died on this exact shape: the
+    agent finished the migration and emitted a text-only completion
+    summary (no ``###STOP###``, no tool calls). Under the pre-fix
+    implementation the runner shim returned an empty ``UserTurnResult``
+    and the loop retried the agent — sending a request ending in
+    ``role: assistant`` which Anthropic's ``opus-4-6`` rejects as
+    unsupported prefill, so the trial went to ``status=error`` and
+    ``/grade`` was skipped entirely.
+
+    Post-fix, ``AgentOnlyTurnPolicy.next_actor`` returns a
+    :class:`TerminationDecision` with ``reason=AGENT_DONE``. The runner
+    shim propagates it via ``UserTurnResult(termination=...)`` and the
+    loop honors it. The trial completes with ``AGENT_DONE`` and the
+    downstream grading path fires as it would for an explicit
+    ``###STOP###``. This test locks that end-to-end wiring, not just
+    the policy's return value (which is unit-tested separately in
+    ``test_turn_policy_contract.py``).
+    """
+    simulator = _spy_simulator()  # never invoked
+    agent = _ScriptedAgent(
+        _agent(
+            "The migration is complete. All tests pass. "
+            "Migrated 20 subcommands to Go."
+            # Deliberately no ``###STOP###`` — matches the real-MB failure shape.
+        )
+    )
+
+    trajectory = TrialRunner(
+        task_id="agent-only-text-only-completion",
+        trial_index=0,
+        agent_client=agent,
+        user_simulator=simulator,
+        tool_executor=ToolExecutor(ToolRegistry()),
+        tool_schemas=[],
+        max_turns=10,
+        episode_timeout_s=1200,
+        interaction_mode="agent_only",
+    ).run("You are a migration agent.", "Migrate the crate to Rust.")
+
+    assert simulator.reply.call_count == 0, (
+        "AgentOnlyTurnPolicy must not dispatch the simulator even on the "
+        "text-only-completion branch."
+    )
+    assert trajectory.termination_reason is TerminationReason.AGENT_DONE, (
+        f"text-only agent completion under agent_only must route to AGENT_DONE; "
+        f"got {trajectory.termination_reason!r} (pre-#876 shape would have been ERROR)."
+    )
+
+
 def test_agent_only_mode_without_initial_message_fails_loud() -> None:
     """The ``AgentOnlyTurnPolicy.bootstrap`` contract raises when neither
     an ``initial_user_message`` nor a live simulator can seed turn 0 —

--- a/tests/canonical/test_turn_policy_contract.py
+++ b/tests/canonical/test_turn_policy_contract.py
@@ -38,8 +38,10 @@ from tolokaforge.core.actors.turn_policy import (
     TurnState,
 )
 from tolokaforge.core.llm.usage import Usage
+from tolokaforge.core.loop import TerminationDecision
 from tolokaforge.core.models import MessageRole
 from tolokaforge.core.models.task_config import TaskConfig
+from tolokaforge.core.models.trajectory import TerminationReason, TrialStatus
 from tolokaforge.core.plugin_registry import TurnPolicyContext
 
 pytestmark = pytest.mark.canonical
@@ -209,25 +211,72 @@ class TestAgentOnlyBootstrap:
 
 
 class TestAgentOnlyNextActor:
-    """``next_actor`` returns ``None`` unconditionally — the mode never
-    dispatches a user turn regardless of what the previous agent turn
-    did.
+    """``next_actor`` returns a :class:`TerminationDecision` — the mode
+    never dispatches a user turn, and (per #876) a text-only agent turn
+    signals implicit completion so the loop must terminate rather than
+    silently retry the agent against a context ending in
+    ``role: assistant`` (which Anthropic's ``opus-4-6`` rejects as
+    prefill).
     """
 
-    def test_no_tool_calls_returns_none(self) -> None:
+    def test_no_tool_calls_returns_agent_done_termination(self) -> None:
         state = TurnState(
             messages=[_agent_message()],
             last_agent_had_tool_calls=False,
             turn_index=1,
         )
 
-        assert AgentOnlyTurnPolicy().next_actor(state) is None
+        decision = AgentOnlyTurnPolicy().next_actor(state)
 
-    def test_tool_call_turn_returns_none(self) -> None:
+        assert isinstance(decision, TerminationDecision)
+        assert decision.reason == TerminationReason.AGENT_DONE
+        assert decision.status == TrialStatus.COMPLETED
+        assert "agent_only" in decision.system_message
+
+    def test_tool_call_turn_also_returns_termination(self) -> None:
+        """The loop today only calls ``next_actor`` after a tool-call-free
+        agent turn, but the policy stays consistent regardless of state:
+        agent-only never dispatches a user, so any invocation of
+        ``next_actor`` means the trial is done."""
         state = TurnState(
             messages=[_agent_message()],
             last_agent_had_tool_calls=True,
             turn_index=1,
         )
 
-        assert AgentOnlyTurnPolicy().next_actor(state) is None
+        decision = AgentOnlyTurnPolicy().next_actor(state)
+
+        assert isinstance(decision, TerminationDecision)
+        assert decision.reason == TerminationReason.AGENT_DONE
+
+
+class TestConversationalNeverReturnsTermination:
+    """Regression lock for the conversational path (per #876): the
+    two-party shape must never surface a :class:`TerminationDecision`
+    from ``next_actor`` — the user simulator always dispatches, and the
+    loop keeps its historical byte-for-byte behavior. Guards against a
+    future refactor that would silently converge the two policies."""
+
+    def test_conversational_never_returns_termination_on_no_tool_calls(self) -> None:
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=False,
+            turn_index=1,
+        )
+
+        decision = ConversationalTurnPolicy(user_simulator=_InMemoryActor()).next_actor(state)
+
+        assert not isinstance(decision, TerminationDecision)
+        # Actually returns an ActorTurn — pinned by the sibling test above.
+
+    def test_conversational_never_returns_termination_on_tool_call_turn(self) -> None:
+        state = TurnState(
+            messages=[_agent_message()],
+            last_agent_had_tool_calls=True,
+            turn_index=1,
+        )
+
+        decision = ConversationalTurnPolicy(user_simulator=_InMemoryActor()).next_actor(state)
+
+        assert not isinstance(decision, TerminationDecision)
+        # Actually returns None — pinned by the sibling test above.

--- a/tests/canonical/test_turn_policy_contract.py
+++ b/tests/canonical/test_turn_policy_contract.py
@@ -234,10 +234,15 @@ class TestAgentOnlyNextActor:
         assert "agent_only" in decision.system_message
 
     def test_tool_call_turn_also_returns_termination(self) -> None:
-        """The loop today only calls ``next_actor`` after a tool-call-free
-        agent turn, but the policy stays consistent regardless of state:
-        agent-only never dispatches a user, so any invocation of
-        ``next_actor`` means the trial is done."""
+        """Invariant lock: policy is stateless on ``last_agent_had_tool_calls``.
+
+        The runner today gates ``next_actor`` at ``loop.py:337-341`` to fire
+        only after a tool-call-free agent turn, so this test exercises a
+        state combination the standard wiring never produces. Preserved
+        for two reasons: (1) direct callers (future policy compositions,
+        tests) can still hit ``next_actor`` on any state and must see a
+        consistent decision; (2) forward-compatibility if the loop's
+        dispatch gate is ever generalised."""
         state = TurnState(
             messages=[_agent_message()],
             last_agent_had_tool_calls=True,

--- a/tolokaforge/core/actors/turn_policy.py
+++ b/tolokaforge/core/actors/turn_policy.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from tolokaforge.core.actors.actor import Actor, Message
+from tolokaforge.core.loop import TerminationDecision
+from tolokaforge.core.models.trajectory import TerminationReason, TrialStatus
 
 if TYPE_CHECKING:
     from tolokaforge.core.models.task_config import TaskConfig
@@ -98,17 +100,32 @@ class TurnPolicy(Protocol):
 
     :meth:`bootstrap` decides how message index 0 is delivered — a
     caller-provided literal, a live simulator dispatch, or a synthetic
-    seed. :meth:`next_actor` picks the actor to speak next given the loop
-    state, or returns ``None`` to end the turn cycle (the agent monologue
-    case).
+    seed. :meth:`next_actor` picks who speaks next given the loop state,
+    with three possible outcomes:
+
+    * :class:`ActorTurn` — dispatch this actor's ``reply`` and append
+      the resulting message. The historical two-party path.
+    * :class:`TerminationDecision` — end the trial with the given reason.
+      Used by the agent-monologue shape when the agent falls silent
+      (no tool calls, no explicit ``###STOP###``): the API-level
+      constraint that a conversation must end with a ``user`` message
+      makes a follow-up agent turn illegal on some providers
+      (Anthropic ``opus-4-6`` rejects the prefill), and — as importantly
+      — an agent that emits neither a tool call nor a stop signal has
+      no further action to take. Terminating here matches the natural
+      MCP-CLI shape where a text-only assistant turn is the last turn.
+    * ``None`` — no actor speaks this iteration; the loop advances to
+      the next agent turn. Reserved for future policy variants that
+      may want to skip a turn without terminating; not exercised by
+      either built-in today.
     """
 
     def bootstrap(self, task: TaskConfig, initial_user_message: str | None) -> BootstrapDecision:
         """Return the turn-0 delivery decision for ``task``."""
         ...
 
-    def next_actor(self, state: TurnState) -> ActorTurn | None:
-        """Return the actor to speak next, or ``None`` to end the turn cycle."""
+    def next_actor(self, state: TurnState) -> ActorTurn | TerminationDecision | None:
+        """Return the next-actor decision — dispatch, terminate, or skip."""
         ...
 
 
@@ -137,7 +154,7 @@ class ConversationalTurnPolicy:
             bootstrap_via_simulator=True,
         )
 
-    def next_actor(self, state: TurnState) -> ActorTurn | None:
+    def next_actor(self, state: TurnState) -> ActorTurn | TerminationDecision | None:
         if state.last_agent_had_tool_calls:
             return None
         return ActorTurn(actor_name="user", actor=self._user_simulator)
@@ -166,9 +183,22 @@ class AgentOnlyTurnPolicy:
     simulator to synthesise a seed from, so a task authoring
     ``interaction_mode: agent_only`` without an ``initial_user_message`` is a
     config error the operator should hear about at run-start, not a silent
-    degrade into an empty-user-turn. ``next_actor`` returns ``None``
-    unconditionally: agent-###STOP###, ``max_turns``, and
-    ``episode_timeout_s`` are the only exits.
+    degrade into an empty-user-turn.
+
+    ``next_actor`` returns a :class:`TerminationDecision` with reason
+    :attr:`TerminationReason.AGENT_DONE`. The loop dispatches this method
+    only when the just-completed agent turn produced no tool calls, and
+    under agent-only that condition is definitional: the agent has no
+    more actions to take and there is no user party that could ask for
+    more. Terminating here matches the MCP-CLI shape (a text-only
+    assistant turn is the last turn) AND resolves the Anthropic API-level
+    constraint that a conversation must end with a ``user`` message —
+    letting the loop retry the agent would produce a request ending in
+    ``role: assistant`` which the ``opus-4-6`` model rejects as prefill.
+    Agent-``###STOP###``, ``max_turns``, and ``episode_timeout_s``
+    remain as complementary termination paths that also route to
+    :attr:`TerminationReason.AGENT_DONE` (``###STOP###``) or their own
+    reasons.
 
     The optional ``user_simulator`` keyword keeps the constructor signature
     parallel with :class:`ConversationalTurnPolicy` so the runner can hand
@@ -191,9 +221,17 @@ class AgentOnlyTurnPolicy:
             f"no user simulator to synthesise a seed from."
         )
 
-    def next_actor(self, state: TurnState) -> ActorTurn | None:
+    def next_actor(self, state: TurnState) -> ActorTurn | TerminationDecision | None:
         del state
-        return None
+        return TerminationDecision(
+            reason=TerminationReason.AGENT_DONE,
+            system_message=(
+                "Agent emitted a text-only turn (no tool calls, no ###STOP###) "
+                "under interaction_mode=agent_only. Treating as implicit completion; "
+                "no user party exists to advance the conversation."
+            ),
+            status=TrialStatus.COMPLETED,
+        )
 
 
 def _agent_only_policy_factory(context: TurnPolicyContext) -> AgentOnlyTurnPolicy:

--- a/tolokaforge/core/actors/turn_policy.py
+++ b/tolokaforge/core/actors/turn_policy.py
@@ -155,6 +155,12 @@ class ConversationalTurnPolicy:
         )
 
     def next_actor(self, state: TurnState) -> ActorTurn | TerminationDecision | None:
+        # Defensive: today's runner gate at ``loop.py:337-341`` calls
+        # ``next_actor`` only after a tool-call-free agent turn, so this
+        # branch is unreachable via the standard wiring. Preserved for
+        # direct callers (tests, future policy compositions) and as a
+        # forward-compatibility hedge in case the loop's dispatch gate
+        # is generalised later.
         if state.last_agent_had_tool_calls:
             return None
         return ActorTurn(actor_name="user", actor=self._user_simulator)
@@ -228,7 +234,7 @@ class AgentOnlyTurnPolicy:
             system_message=(
                 "Agent emitted a text-only turn (no tool calls, no ###STOP###) "
                 "under interaction_mode=agent_only. Treating as implicit completion; "
-                "no user party exists to advance the conversation."
+                "the agent_only policy dispatches no user actor."
             ),
             status=TrialStatus.COMPLETED,
         )

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -645,21 +645,32 @@ class TrialRunner:
         assistant messages so far — the next actor the policy hands back is the
         speaker of turn ``turn_index + 1``.
 
-        A :class:`~tolokaforge.core.actors.turn_policy.ConversationalTurnPolicy`
-        returns the user actor here (byte-for-byte the historical dispatch);
-        :class:`~tolokaforge.core.actors.turn_policy.AgentOnlyTurnPolicy` returns
-        ``None`` and the shim returns an empty :class:`UserTurnResult` — the
-        loop appends nothing and advances to the next agent turn.
+        Three possible policy outcomes:
+
+        * :class:`ActorTurn` — dispatch the actor (the historical path).
+          :class:`~tolokaforge.core.actors.turn_policy.ConversationalTurnPolicy`
+          takes this branch byte-for-byte identically to today.
+        * :class:`TerminationDecision` — surface it as
+          ``UserTurnResult(termination=...)``. The loop honors it and stops.
+          :class:`~tolokaforge.core.actors.turn_policy.AgentOnlyTurnPolicy`
+          takes this branch: agent has no more actions and no user party
+          exists to advance the conversation, so the trial is done.
+        * ``None`` — reserved for future policies that want to skip a
+          turn without terminating; returns an empty
+          :class:`UserTurnResult` and the loop advances to the next agent
+          turn. Not exercised by either built-in.
         """
         state = TurnState(
             messages=messages,
             last_agent_had_tool_calls=False,
             turn_index=sum(1 for m in messages if m.role == MessageRole.ASSISTANT),
         )
-        actor_turn = policy.next_actor(state)
-        if actor_turn is None:
+        decision = policy.next_actor(state)
+        if decision is None:
             return UserTurnResult()
-        return self._dispatch_user_actor(actor_turn.actor, messages)
+        if isinstance(decision, TerminationDecision):
+            return UserTurnResult(termination=decision)
+        return self._dispatch_user_actor(decision.actor, messages)
 
     def _dispatch_user_actor(self, actor: Actor, messages: list[Message]) -> UserTurnResult:
         """Run one user actor turn: reply, ``###STOP###`` detection, user tools.


### PR DESCRIPTION
## Summary

Follow-up bug from #868, surfaced in real-MB smoke immediately after #872 merged. Under \`interaction_mode: agent_only\`, when the agent naturally completes a task by emitting a text-only summary (no tool calls, no explicit \`###STOP###\`), the trial fails with:

\`\`\`
Anthropic API: This model does not support assistant message prefill.
The conversation must end with a user message.
\`\`\`

Both celery-rust and celery-go smoke trials died this way after the agent had done meaningful migration work — the agent finished, reported completion in prose, and the loop tried to retry against a context ending in \`role: assistant\`. \`opus-4-6\` rejects that as an unsupported prefill request, the trial goes to \`status=error\`, and \`/grade\` is skipped entirely. Real completion evidence lost.

## Fix

Widen \`TurnPolicy.next_actor\` return type from \`ActorTurn | None\` to \`ActorTurn | TerminationDecision | None\`. \`AgentOnlyTurnPolicy.next_actor\` now returns a \`TerminationDecision(reason=AGENT_DONE, status=COMPLETED)\` — the agent falling silent IS the completion signal, matching Claude Code / MCP-CLI shape and satisfying the Anthropic API's structural rule. The runner's \`_policy_user_turn\` shim propagates the decision to the loop as \`UserTurnResult(termination=...)\`; the loop honors it and stops.

## Blast radius: zero for conversational tasks

- \`ConversationalTurnPolicy.next_actor\` unchanged in behavior. Return type widening is additive; it still returns \`ActorTurn(user)\` when \`last_agent_had_tool_calls=False\` (byte-for-byte the historical dispatch) and \`None\` otherwise.
- Every existing conversational path (τ-bench, tool-use, browser, native, multi-service) physically cannot hit the new terminate branch — the user simulator always dispatches between agent turns, so the loop's context never ends with \`role: assistant\`.
- Two new regression-lock tests (\`TestConversationalNeverReturnsTermination\`) pin that conversational must never surface a \`TerminationDecision\` from \`next_actor\` — guards against a future refactor silently converging the two policies.

## Documentation

ADR-0028 extended with a new **"Termination signalling from the policy"** subsection documenting the three-valued \`next_actor\` return contract (\`ActorTurn\` / \`TerminationDecision\` / \`None\`) and the three termination paths \`agent_only\` now has:

1. Explicit \`###STOP###\` from the agent.
2. Implicit completion via text-only turn (this fix).
3. Loop-level bounds (\`max_turns\` / \`episode_timeout_s\`).

## Test plan
- [x] 77 tests pass across turn-policy contract + actor contract + runner turn-policy wiring + runner logic lanes (including 2 new \`TestConversationalNeverReturnsTermination\` regression locks and the updated \`TestAgentOnlyNextActor\` asserting the new termination-decision return).
- [x] Existing conversational tests unchanged and green.
- [ ] CI green.
- [ ] Downstream verification: rerun the real-MB smoke against celery-rust + celery-go; both trials should now reach \`/grade\` and produce real \`custom_checks_details[0]\` scores (evidence recovery after the API-rejection loss).

Closes #876