### PR TITLE
fix(automation): auto-integration reliability + self-referential cap gate (absorbs #852)

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -702,6 +702,14 @@ jobs:
             echo "::error::cert does not reconcile with the observe baseline - refusing to commit"
             exit 1
           fi
+          # Any NEWLY registered policy class must be referenced by the overlay and covered by
+          # a unit test (docs/ADD_NEW_MODEL.md step 5). The fix-loop's success signal is the live
+          # reprobe, so a missing unit test is otherwise invisible. set -e safe; exit 1 ->
+          # needs-human. Reads the STAGED presets.py diff, so it must run after `git add`.
+          if ! uv run automation check-new-classes --overlay observation/resolve/overlay.yaml; then
+            echo "::error::a new policy class is untested or unreferenced - refusing to commit"
+            exit 1
+          fi
           # Verify EXACTLY the staged tree (what we are about to commit), not the workspace.
           # `stash --keep-index` drops everything not staged so the worktree == the future
           # commit; then gate on: (1) it imports; (2) no-regression - the resolved policy must

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -405,8 +405,8 @@ jobs:
 
       - name: Post observation summary on the PR
         # Gated on parse success (not bare always()): before parse there is no candidate and no
-        # observation/ dir, so on the fork-reject / checkout-failed paths this used to post a
-        # junk "ran for ``" comment. A parse-fail posts its own comment above.
+        # observation/ dir, so on the fork-reject / checkout-failed paths this would post a junk
+        # "ran for ``" comment. A parse-fail posts its own comment above.
         if: always() && steps.parse.outcome == 'success'
         # CANDIDATE_NAME is PR-title-derived (attacker-controllable); reference only via env.
         env:
@@ -432,10 +432,10 @@ jobs:
         env:
           CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
         run: |
-          # One tested command owns the verdict (the old inline python -c silently ignored
-          # api_timeout and could not tell "wire never ran" from "wire clean"). Missing or
-          # unreadable findings.json prints its own dirty token, so all not-clean paths share
-          # this branch and the needs-human message carries the exact reason.
+          # One tested command owns the verdict (an inline check here cannot be unit-tested
+          # and drifts from the infra-key set). Missing or unreadable findings.json prints its
+          # own dirty token, so all not-clean paths share this branch and the needs-human
+          # message carries the exact reason.
           GATE="$(uv run automation observe-gate observation/findings.json || echo 'dirty: observe-gate crashed')"
           echo "observe gate: $GATE"
           if [ "$GATE" = "clean" ]; then
@@ -585,10 +585,17 @@ jobs:
               claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
               --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
+            # Archive whatever this iteration produced, IMMEDIATELY: a later guard may
+            # `continue` past a partial attempt (overlay written, decision missing after a
+            # turn-limit stall) and the next iteration's rm would erase it - yet the next
+            # agent (a fresh context) must see every axis already tried, and the needs-human
+            # artifacts must carry it. A file not produced is simply not archived.
+            cp observation/resolve/overlay.yaml "observation/resolve/overlay_iter${i}.yaml" 2>/dev/null || true
+            cp observation/resolve/decision.json "observation/resolve/decision_iter${i}.json" 2>/dev/null || true
             # Agent-requested escalation: if it lacks the data to produce a CORRECT policy (a
             # data-bound quirk whose scope needs real-domain evidence the observe never surfaced),
             # it sets `needs_human: true` in decision.json. Break immediately - no wasted
-            # iterations, no fabricated fix. Checked before the overlay guard: escalation needs
+            # iterations, no fabricated fix. Checked before the stall guards: escalation needs
             # only decision.json (the agent need not write an overlay it does not believe in).
             NEEDS_HUMAN="$(uv run python -c "import json,sys; print('yes' if json.load(open(sys.argv[1])).get('needs_human') else 'no')" observation/resolve/decision.json 2>/dev/null || echo no)"
             if [ "$NEEDS_HUMAN" = "yes" ]; then
@@ -598,30 +605,32 @@ jobs:
               echo "needs_human_reason=$REASON" >> "$GITHUB_OUTPUT"
               echo "::endgroup::"; break
             fi
-            if [ ! -f observation/resolve/overlay.yaml ] || [ ! -f observation/resolve/decision.json ]; then
-              echo "::warning::iteration $i produced no overlay/decision (agent stalled or hit max-turns)"
-              printf -- '- Iter %s: no overlay produced (agent stalled / hit its turn limit / an upstream error via the OpenRouter gateway)\n' "$i" >> observation/resolve/loop_summary.md
+            if [ ! -f observation/resolve/decision.json ]; then
+              echo "::warning::iteration $i produced no decision (agent stalled or hit max-turns)"
+              printf -- '- Iter %s: no decision produced (agent stalled / hit its turn limit / an upstream error via the OpenRouter gateway)\n' "$i" >> observation/resolve/loop_summary.md
               echo "::endgroup::"
-              # Back off before the next attempt: a no-overlay iteration usually means the agent
+              # Back off before the next attempt: a no-decision iteration usually means the agent
               # exhausted its turns, often because its calls through the LiteLLM -> OpenRouter gateway
               # hit a transient error / rate limit. A short, growing sleep (capped 90s) lets that
               # window pass; it fires ONLY on this failure path, so a converging run is never slowed.
               if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
               continue
             fi
-            # Archive this iteration's attempt BEFORE the next iteration's rm deletes it: the
-            # prompt tells the agent to try "a materially DIFFERENT axis than last time", and
-            # each iteration is a fresh context - without these files it cannot know what it
-            # already tried (last_reprobe.json records results, not the overlay that produced
-            # them). Also what the needs-human artifacts point a human at.
-            cp observation/resolve/overlay.yaml "observation/resolve/overlay_iter${i}.yaml" || true
-            cp observation/resolve/decision.json "observation/resolve/decision_iter${i}.json" || true
             # Reprobe ONLY the agent's fix-targets (single-line python-c, no indentation
-            # to break). All-ceiling decisions name none -> nothing to prove, skip reprobe.
+            # to break). All-ceiling decisions name none -> nothing to prove, skip reprobe -
+            # and need no overlay either (an honest all-ceiling has no policy to write; the
+            # integration is then cert + pricing only, on the default preset).
             TARGETS="$(uv run python -c "import json,sys; print(','.join(json.load(open(sys.argv[1])).get('fix_targets',[])))" observation/resolve/decision.json 2>/dev/null || echo '')"
             if [ -z "$TARGETS" ]; then
               echo "iteration $i: decision named no fix-targets (all-ceiling) -> NO_TARGETS"
               VERDICT=NO_TARGETS
+            elif [ ! -f observation/resolve/overlay.yaml ]; then
+              # Fix-targets named but no policy written: a mid-attempt stall, not a verdict.
+              echo "::warning::iteration $i named fix-targets but produced no overlay (stalled mid-attempt)"
+              printf -- '- Iter %s: decision named fix-targets but no overlay was produced (stalled mid-attempt / turn limit)\n' "$i" >> observation/resolve/loop_summary.md
+              echo "::endgroup::"
+              if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
+              continue
             else
               # Workflow runs the reprobe (agent never does). Only the fix-targets, K reps
               # each, as a flat (probe x rep) pool at RESOLVE_CAP_PARALLEL width. Fast.
@@ -906,17 +915,20 @@ jobs:
         env:
           CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
         run: |
-          # A failure with no handled needs-human path (checkout / uv sync / docker build died
-          # before the gate could run) would leave the PR wearing `integrate-running` forever -
-          # a dead run displayed as live. Flip the label first; idempotent on the handled paths
-          # (they already set needs-human), and independent of the Slack dedup below.
+          # The marker doubles as the label sentinel: every handled path sets its terminal
+          # label BEFORE touching the marker, so marker-present means the labels are already
+          # correct and this step must not touch them - a post-finalize failure (e.g. the
+          # artifact upload) would otherwise stamp needs-human onto an integrate-done PR.
+          if [ -f "$RUNNER_TEMP/slack_terminal_sent" ]; then
+            echo "terminal state already handled -> no catch-all label/ping"; exit 0
+          fi
+          # Unhandled failure (checkout / uv sync / docker build died before any handler):
+          # without this the PR wears `automation:integrate-running` forever - a dead run
+          # displayed as live.
           gh pr edit "$PR" -R "$REPO" \
             --remove-label 'automation:integrate-running' \
             --remove-label 'automation:resolve-running' \
             --add-label 'automation:integrate-needs-human' || true
-          if [ -f "$RUNNER_TEMP/slack_terminal_sent" ]; then
-            echo "terminal Slack already sent -> no catch-all ping"; exit 0
-          fi
           uv run automation slack reply \
             --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
             --icon pipeline_error --text 'Pipeline error: unexpected failure, PR left mid-state' \

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -624,6 +624,7 @@ jobs:
             if [ -z "$TARGETS" ]; then
               echo "iteration $i: decision named no fix-targets (all-ceiling) -> NO_TARGETS"
               VERDICT=NO_TARGETS
+              SUMMARY_LINE="all-ceiling decision (empty fix-targets), verdict = NO_TARGETS"
             elif [ ! -f observation/resolve/overlay.yaml ]; then
               # Fix-targets named but no policy written: a mid-attempt stall, not a verdict.
               echo "::warning::iteration $i named fix-targets but produced no overlay (stalled mid-attempt)"
@@ -644,9 +645,10 @@ jobs:
               # Are all fix-targets green under the overlay? (helper script, not inline
               # python, so YAML indentation cannot break it.)
               VERDICT="$(uv run automation greencheck observation/resolve/decision.json observation/resolve/reprobe_$i/findings.json 2>/dev/null || echo PARSE_FAIL)"
+              SUMMARY_LINE="fix produced, reprobe verdict = $VERDICT"
             fi
             echo "iteration $i verdict: $VERDICT"
-            printf -- '- Iter %s: fix produced, reprobe verdict = %s\n' "$i" "$VERDICT" >> observation/resolve/loop_summary.md
+            printf -- '- Iter %s: %s\n' "$i" "$SUMMARY_LINE" >> observation/resolve/loop_summary.md
             echo "::endgroup::"
             # Converge when every fix-target is green, OR the agent proved there is nothing
             # to fix (all failures are genuine ceilings -> finalize writes them as unsupported).

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -389,11 +389,16 @@ jobs:
           PY
 
       - name: Aggregate deterministic findings (report-only)
+        id: findings
         run: |
           uv run automation observe-findings observation \
             --out observation/findings.json \
             --summary-out observation/summary.md \
             --run-url "$RUN_URL"
+          # Hash the evidence BEFORE any agent runs. Step outputs live outside the
+          # workspace, so the finalize gate can require the findings it judges to be
+          # byte-identical to what observe actually measured.
+          echo "sha=$(sha256sum observation/findings.json | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload observation bundle (artifact for debugging / re-runs)
         uses: actions/upload-artifact@v4
@@ -585,6 +590,13 @@ jobs:
               claude -p "$(cat /tmp/compose_$i.md)" --model "$AGENT_MODEL" \
               --allowedTools "Bash,Read,Edit,Write" --dangerously-skip-permissions \
               --max-turns "${RESOLVE_MAX_TURNS}" --verbose || true
+            # The compose agent just ran with unrestricted Bash in this workspace; the loop's
+            # own verdict tooling (reprobe / greencheck under tools/automation) must be
+            # pristine when it judges the attempt - an edit there would otherwise run HERE
+            # and then be stash-popped back at finalize without ever appearing in the PR.
+            # Restores index AND worktree from HEAD; committed (PR-visible) changes remain
+            # the human review's job.
+            git restore --source=HEAD --staged --worktree tools/automation
             # Agent-requested escalation: if it lacks the data to produce a CORRECT policy (a
             # data-bound quirk whose scope needs real-domain evidence the observe never surfaced),
             # it sets `needs_human: true` in decision.json. Break immediately - no wasted
@@ -679,15 +691,31 @@ jobs:
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
           AUTO_MERGE_ENABLED: ${{ vars.ARENA_AUTOMATION_AUTO_MERGE_ENABLED }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.head_ref }}
+          FINDINGS_SHA: ${{ steps.findings.outputs.sha }}
         run: |
           set -euo pipefail
+          # Agent-tamper hardening. Both agents above ran with unrestricted Bash in this
+          # workspace BEFORE these gates, and an unstaged edit under tools/automation would
+          # run here and then be stash-popped back without ever appearing in the PR. Re-pin
+          # the gate code to HEAD (index + worktree), and require the observe evidence the
+          # gates judge against to be byte-identical to what the aggregation step hashed
+          # before any agent ran. Committed (PR-visible) tampering remains the review's job.
+          git restore --source=HEAD --staged --worktree tools/automation
+          ACTUAL_SHA="$(sha256sum observation/findings.json | cut -d' ' -f1)"
+          if [ "$ACTUAL_SHA" != "$FINDINGS_SHA" ]; then
+            echo "::error::observation/findings.json differs from the observe-time evidence (hash mismatch) - refusing to finalize"
+            exit 1
+          fi
           # Deterministic commit + report (the agent only wrote files). Stage the WHOLE engine
           # LLM package, not a fixed file list: a code-CREATE can write a new adapter class in ANY
           # module (reasoning_codec / schema_sanitizer / prompt_policy / content_policy /
           # cache_policy), and a narrow list silently drops the new file while committing its
-          # wiring -> a build-breaking dangling import. Plus the cert + preset.
+          # wiring -> a build-breaking dangling import. Plus the cert + preset - and the unit
+          # tests under tests/unit/llm/ that the class gate requires: the gate reads the INDEX,
+          # so a test it credits but this list dropped would pass the gate and then vanish
+          # from the commit.
           git add tolokaforge/core/llm tolokaforge/core/data/model_presets.yaml \
-            tolokaforge/core/data/pricing.json tests/integration/llm/ 2>/dev/null || true
+            tolokaforge/core/data/pricing.json tests/integration/llm/ tests/unit/llm/ 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "::error::finalize produced no file changes"; exit 1
           fi

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -404,7 +404,10 @@ jobs:
           retention-days: 30
 
       - name: Post observation summary on the PR
-        if: always()
+        # Gated on parse success (not bare always()): before parse there is no candidate and no
+        # observation/ dir, so on the fork-reject / checkout-failed paths this used to post a
+        # junk "ran for ``" comment. A parse-fail posts its own comment above.
+        if: always() && steps.parse.outcome == 'success'
         # CANDIDATE_NAME is PR-title-derived (attacker-controllable); reference only via env.
         env:
           CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
@@ -419,26 +422,23 @@ jobs:
       # -------------------------------------------------------------- GATE
       - name: Cleanliness gate (clean observe chains to resolve)
         id: gate
-        if: always()
-        # A clean observe (capability suite actually ran AND no infra contamination) proceeds to
+        # A clean observe (per `automation observe-gate`: capability suite ran, wire probes ran,
+        # and no rate-limit / API-error / API-timeout / status-error contamination) proceeds to
         # the in-job resolve steps below. Infra-dirty / did-not-run goes to a human (re-run),
         # never resolve. Sets a step output the resolve steps gate on (no cross-workflow label).
+        # Gated on parse success: before parse there is no candidate to gate (a parse-fail
+        # already labelled + notified); the catch-all below owns the label on pre-parse crashes.
+        if: always() && steps.parse.outcome == 'success'
         env:
           CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
         run: |
-          if [ ! -f observation/findings.json ]; then
-            gh pr edit "$PR" -R "$REPO" --remove-label 'automation:integrate-running' \
-              --add-label 'automation:integrate-needs-human' || true
-            echo "clean=no" >> "$GITHUB_OUTPUT"
-            uv run automation slack reply \
-              --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
-              --icon needs_human --text 'Needs human: observe did not run to completion (no findings.json - infra failure or crash before aggregation)' \
-              --pr-url "$PR_URL" --run-url "$RUN_URL" || true
-            touch "$RUNNER_TEMP/slack_terminal_sent" || true
-            echo "no findings.json -> needs human"; exit 0
-          fi
-          CLEAN="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); i=f.get("wire",{}).get("infra",{}); print("dirty" if (not f.get("capability_ran")) or any(i.get(k,0) for k in ("rate_limit","api_error","status_error")) else "clean")')"
-          if [ "$CLEAN" = "clean" ]; then
+          # One tested command owns the verdict (the old inline python -c silently ignored
+          # api_timeout and could not tell "wire never ran" from "wire clean"). Missing or
+          # unreadable findings.json prints its own dirty token, so all not-clean paths share
+          # this branch and the needs-human message carries the exact reason.
+          GATE="$(uv run automation observe-gate observation/findings.json || echo 'dirty: observe-gate crashed')"
+          echo "observe gate: $GATE"
+          if [ "$GATE" = "clean" ]; then
             gh pr edit "$PR" -R "$REPO" --remove-label 'automation:integrate-running' \
               --add-label 'automation:resolve-running' || true
             echo "clean=yes" >> "$GITHUB_OUTPUT"
@@ -452,10 +452,10 @@ jobs:
             echo "clean=no" >> "$GITHUB_OUTPUT"
             uv run automation slack reply \
               --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
-              --icon needs_human --text 'Needs human: observe infra-dirty (rate-limit / API error / capability suite did not run)' \
+              --icon needs_human --text "Needs human: observe not clean (${GATE}) - re-run needed" \
               --pr-url "$PR_URL" --run-url "$RUN_URL" || true
             touch "$RUNNER_TEMP/slack_terminal_sent" || true
-            echo "observe infra-dirty or did-not-run -> needs human"
+            echo "observe not clean (${GATE}) -> needs human"
           fi
 
       # -------------------------------------------------------------- RESOLVE (clean only)
@@ -609,6 +609,13 @@ jobs:
               if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
               continue
             fi
+            # Archive this iteration's attempt BEFORE the next iteration's rm deletes it: the
+            # prompt tells the agent to try "a materially DIFFERENT axis than last time", and
+            # each iteration is a fresh context - without these files it cannot know what it
+            # already tried (last_reprobe.json records results, not the overlay that produced
+            # them). Also what the needs-human artifacts point a human at.
+            cp observation/resolve/overlay.yaml "observation/resolve/overlay_iter${i}.yaml" || true
+            cp observation/resolve/decision.json "observation/resolve/decision_iter${i}.json" || true
             # Reprobe ONLY the agent's fix-targets (single-line python-c, no indentation
             # to break). All-ceiling decisions name none -> nothing to prove, skip reprobe.
             TARGETS="$(uv run python -c "import json,sys; print(','.join(json.load(open(sys.argv[1])).get('fix_targets',[])))" observation/resolve/decision.json 2>/dev/null || echo '')"
@@ -637,6 +644,35 @@ jobs:
             if [ "$VERDICT" = "CONVERGED" ] || [ "$VERDICT" = "NO_TARGETS" ]; then CONVERGED=yes; break; fi
           done
           echo "converged=$CONVERGED" >> "$GITHUB_OUTPUT"
+
+      - name: Final wire verification (evidence-only, RESOLVE_WIRE_K reps)
+        # The fix loop reprobes CAPABILITY probes only (--skip-wire), so a fix whose live
+        # evidence was the WIRE (a tool-arg rejection with no failing capability probe - the
+        # NO_TARGETS convergence) would otherwise ship with no post-fix measurement at all.
+        # Re-run exactly the baseline's rejecting wire tasks under the converged overlay; the
+        # finalize step below posts the fresh stats on the PR. EVIDENCE for the human gate,
+        # never a convergence gate: a still-rejecting wire task can be a genuine model miss
+        # (a ceiling, not a blocker), so this step never fails the run.
+        if: steps.gate.outputs.clean == 'yes' && steps.loop.outputs.converged == 'yes'
+        env:
+          GH_TOKEN: ""
+          TF_PROVIDER: ${{ steps.parse.outputs.provider }}
+          TF_NAME: ${{ steps.parse.outputs.name }}
+        run: |
+          set -uo pipefail
+          REJECTIONS="$(uv run python -c 'import json; print(json.load(open("observation/findings.json"))["wire"]["tool_arg_rejections"]["total"])' 2>/dev/null || echo 0)"
+          if [ "${REJECTIONS:-0}" = "0" ]; then
+            echo "baseline wire had no tool-arg rejections -> nothing to verify"; exit 0
+          fi
+          if [ ! -f observation/resolve/overlay.yaml ]; then
+            echo "no overlay (all-ceiling convergence without a policy) -> nothing to verify the wire under"; exit 0
+          fi
+          uv run automation reprobe \
+            --baseline observation/findings.json --overlay observation/resolve/overlay.yaml \
+            --provider "$TF_PROVIDER" --name "$TF_NAME" \
+            --out observation/resolve/wire_verify --wire-only \
+            --wire-k "${RESOLVE_WIRE_K}" --workers "${WORKERS}" \
+            || echo "::warning::final wire verification failed to run - the PR carries no post-fix wire evidence"
 
       - name: Finalize - compose the integration (agent writes preset + cert)
         # AGENT step, scoped: empty GH_TOKEN so the --dangerously-skip-permissions agent cannot
@@ -737,6 +773,15 @@ jobs:
             RECORD_URL="$(gh pr comment "$PR" -R "$REPO" --body-file observation/resolve/pr_comment.md || true)"
           fi
           [ -f observation/resolve/pr_body.md ] && gh pr edit "$PR" -R "$REPO" --body-file observation/resolve/pr_body.md || true
+          # Post-fix wire evidence (written by the wire-verification step; absent when the
+          # baseline wire was clean or convergence shipped no overlay). Prefixed so the
+          # comment cannot be misread as a fresh observe. Evidence-only, informs the human
+          # gate; a genuine wire miss is a ceiling, not a merge blocker.
+          if [ -f observation/resolve/wire_verify/summary.md ]; then
+            { printf '%s\n\n' '### Final wire verification - the baseline-rejecting wire tasks, re-run under the resolved policy (evidence-only)'; \
+              cat observation/resolve/wire_verify/summary.md; } \
+              | gh pr comment "$PR" -R "$REPO" --body-file - || true
+          fi
           # Data-scope review gate: an array-under-free-form-object recovery is DATA-BOUND - its
           # scope depends on domain data the observe may not fully surface, so even a converged,
           # gate-passing fix needs a broader HUMAN check before merge. Route it to needs-human
@@ -839,6 +884,19 @@ jobs:
             --pr-comment "$CURL" --pr-url "$PR_URL" --run-url "$RUN_URL" || true
           touch "$RUNNER_TEMP/slack_terminal_sent" || true
 
+      - name: Upload resolve bundle (per-iteration overlays/decisions + reprobe + wire evidence)
+        # The observation bundle uploads BEFORE the gate, so nothing the resolve steps produce
+        # would reach the run artifacts without this - yet the needs-human comments point the
+        # human exactly there ("latest overlay + reprobe are in the run artifacts"). A distinct
+        # name because v4 artifacts are immutable (the observe upload cannot be appended to).
+        uses: actions/upload-artifact@v4
+        if: always() && steps.gate.outputs.clean == 'yes'
+        with:
+          name: integration-resolve-pr${{ github.event.pull_request.number || inputs.pr }}
+          path: observation/resolve/
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Slack notify - unexpected failure (catch-all)
         # Last line of defence: an unexpected step failure (checkout done, but e.g. uv sync,
         # docker build, or a gate/step crash) that left the PR mid-state with no explicit handler
@@ -848,6 +906,14 @@ jobs:
         env:
           CANDIDATE_NAME: ${{ steps.parse.outputs.name }}
         run: |
+          # A failure with no handled needs-human path (checkout / uv sync / docker build died
+          # before the gate could run) would leave the PR wearing `integrate-running` forever -
+          # a dead run displayed as live. Flip the label first; idempotent on the handled paths
+          # (they already set needs-human), and independent of the Slack dedup below.
+          gh pr edit "$PR" -R "$REPO" \
+            --remove-label 'automation:integrate-running' \
+            --remove-label 'automation:resolve-running' \
+            --add-label 'automation:integrate-needs-human' || true
           if [ -f "$RUNNER_TEMP/slack_terminal_sent" ]; then
             echo "terminal Slack already sent -> no catch-all ping"; exit 0
           fi

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -166,6 +166,15 @@ jobs:
           # The finalize step re-supplies an explicit token only for its own git push.
           persist-credentials: false
 
+      - name: Pin the checked-out head commit
+        # Captured BEFORE any agent step runs, as a step output (outside the workspace).
+        # The tamper restores and the finalize gate must reference an immovable commit id:
+        # symbolic HEAD can be moved by a local `git commit` from an agent, which would
+        # turn "re-pin to HEAD" into "re-pin to the tampered commit". Not GITHUB_SHA - on
+        # the workflow_dispatch path that is the base-ref sha, not the checked-out head.
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: astral-sh/setup-uv@v7
         with:
           version: "0.9.5"
@@ -552,6 +561,7 @@ jobs:
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
         run: |
           set -uo pipefail
           mkdir -p observation/resolve
@@ -594,9 +604,9 @@ jobs:
             # own verdict tooling (reprobe / greencheck under tools/automation) must be
             # pristine when it judges the attempt - an edit there would otherwise run HERE
             # and then be stash-popped back at finalize without ever appearing in the PR.
-            # Restores index AND worktree from HEAD; committed (PR-visible) changes remain
-            # the human review's job.
-            git restore --source=HEAD --staged --worktree tools/automation
+            # Restores index AND worktree from the CHECKOUT-TIME commit (HEAD_SHA, pinned
+            # before any agent ran - symbolic HEAD could be moved by a local agent commit).
+            git restore --source="$HEAD_SHA" --staged --worktree tools/automation
             # Archive whatever this iteration produced, IMMEDIATELY: a later guard may
             # `continue` past a partial attempt (overlay written, decision missing after a
             # turn-limit stall) and the next iteration's rm would erase it - yet the next
@@ -628,12 +638,25 @@ jobs:
               if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
               continue
             fi
-            # Reprobe ONLY the agent's fix-targets (single-line python-c, no indentation
-            # to break). All-ceiling decisions name none -> nothing to prove, skip reprobe -
+            # ONE tested command parses the decision (automation decision-targets): a
+            # malformed decision.json - the agent died mid-write, or deviated from the
+            # schema - is a STALL to retry, never an all-ceiling verdict. An inline
+            # `|| echo ''` extraction converted exactly that parse failure into
+            # NO_TARGETS and CONVERGED a run in which nobody ever judged the ceilings.
+            # (The NEEDS_HUMAN read above tolerates the same corruption by design: an
+            # unparsable file cannot carry a trustworthy escalation, and it lands here.)
+            DECISION="$(uv run automation decision-targets observation/resolve/decision.json || echo PARSE_FAIL)"
+            if [ "$DECISION" = "PARSE_FAIL" ]; then
+              echo "::warning::iteration $i wrote a malformed decision.json (stalled mid-write / schema deviation)"
+              printf -- '- Iter %s: no decision could be parsed (malformed decision.json - stalled mid-write / schema deviation)\n' "$i" >> observation/resolve/loop_summary.md
+              echo "::endgroup::"
+              if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
+              continue
+            fi
+            # All-ceiling decisions name no fix-targets -> nothing to prove, skip reprobe -
             # and need no overlay either (an honest all-ceiling has no policy to write; the
             # integration is then cert + pricing only, on the default preset).
-            TARGETS="$(uv run python -c "import json,sys; print(','.join(json.load(open(sys.argv[1])).get('fix_targets',[])))" observation/resolve/decision.json 2>/dev/null || echo '')"
-            if [ -z "$TARGETS" ]; then
+            if [ "$DECISION" = "NO_TARGETS" ]; then
               echo "iteration $i: decision named no fix-targets (all-ceiling) -> NO_TARGETS"
               VERDICT=NO_TARGETS
               SUMMARY_LINE="all-ceiling decision (empty fix-targets), verdict = NO_TARGETS"
@@ -645,6 +668,7 @@ jobs:
               if [ "$i" -lt "$MAX_ITER" ]; then sleep $(( i * 15 > 90 ? 90 : i * 15 )); fi
               continue
             else
+              TARGETS="${DECISION#TARGETS:}"
               # Workflow runs the reprobe (agent never does). Only the fix-targets, K reps
               # each, as a flat (probe x rep) pool at RESOLVE_CAP_PARALLEL width. Fast.
               uv run automation reprobe \
@@ -677,12 +701,23 @@ jobs:
         # never a convergence gate: a still-rejecting wire task can be a genuine model miss
         # (a ceiling, not a blocker), so this step never fails the run.
         if: steps.gate.outputs.clean == 'yes' && steps.loop.outputs.converged == 'yes'
+        id: wireverify
         env:
           GH_TOKEN: ""
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
+          FINDINGS_SHA: ${{ steps.findings.outputs.sha }}
         run: |
           set -uo pipefail
+          # The loop agents ran before this step, and the baseline it re-runs is only
+          # evidence if it is the one observe measured - check the aggregation-time hash
+          # HERE too (finalize checks it again for its own gates). A mismatch is a loud
+          # stop, not a skip: it routes the run to needs-human via the finalize skip.
+          ACTUAL_SHA="$(sha256sum observation/findings.json | cut -d' ' -f1)"
+          if [ "$ACTUAL_SHA" != "$FINDINGS_SHA" ]; then
+            echo "::error::observation/findings.json differs from the observe-time evidence - refusing to run the wire verification"
+            exit 1
+          fi
           REJECTIONS="$(uv run python -c 'import json; print(json.load(open("observation/findings.json"))["wire"]["tool_arg_rejections"]["total"])' 2>/dev/null || echo 0)"
           if [ "${REJECTIONS:-0}" = "0" ]; then
             echo "baseline wire had no tool-arg rejections -> nothing to verify"; exit 0
@@ -696,6 +731,12 @@ jobs:
             --out observation/resolve/wire_verify --wire-only \
             --wire-k "${RESOLVE_WIRE_K}" --workers "${WORKERS}" \
             || echo "::warning::final wire verification failed to run - the PR carries no post-fix wire evidence"
+          # Seal the evidence: the finalize compose agent runs between this step and the
+          # posting, so finalize publishes the summary ONLY byte-identical to this hash
+          # (a step output, outside the workspace).
+          if [ -f observation/resolve/wire_verify/summary.md ]; then
+            echo "summary_sha=$(sha256sum observation/resolve/wire_verify/summary.md | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Finalize - compose the integration (agent writes preset + cert)
         # AGENT step, scoped: empty GH_TOKEN so the --dangerously-skip-permissions agent cannot
@@ -739,15 +780,23 @@ jobs:
           AUTO_MERGE_ENABLED: ${{ vars.ARENA_AUTOMATION_AUTO_MERGE_ENABLED }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.head_ref }}
           FINDINGS_SHA: ${{ steps.findings.outputs.sha }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
+          WIRE_SUMMARY_SHA: ${{ steps.wireverify.outputs.summary_sha }}
         run: |
           set -euo pipefail
           # Agent-tamper hardening. Both agents above ran with unrestricted Bash in this
           # workspace BEFORE these gates, and an unstaged edit under tools/automation would
-          # run here and then be stash-popped back without ever appearing in the PR. Re-pin
-          # the gate code to HEAD (index + worktree), and require the observe evidence the
-          # gates judge against to be byte-identical to what the aggregation step hashed
-          # before any agent ran. Committed (PR-visible) tampering remains the review's job.
-          git restore --source=HEAD --staged --worktree tools/automation
+          # run here and then be stash-popped back without ever appearing in the PR. Refuse
+          # a moved HEAD (a local agent commit would otherwise become both the restore
+          # source and a published ancestor), re-pin the gate code to the CHECKOUT-TIME
+          # commit (index + worktree), and require the observe evidence the gates judge
+          # against to be byte-identical to what the aggregation step hashed before any
+          # agent ran. Committed-on-the-branch (PR-visible) changes remain the review's job.
+          if [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
+            echo "::error::HEAD moved since checkout (a local commit during the agent steps) - refusing to finalize"
+            exit 1
+          fi
+          git restore --source="$HEAD_SHA" --staged --worktree tools/automation
           ACTUAL_SHA="$(sha256sum observation/findings.json | cut -d' ' -f1)"
           if [ "$ACTUAL_SHA" != "$FINDINGS_SHA" ]; then
             echo "::error::observation/findings.json differs from the observe-time evidence (hash mismatch) - refusing to finalize"
@@ -821,12 +870,22 @@ jobs:
           fi
           [ -f observation/resolve/pr_body.md ] && gh pr edit "$PR" -R "$REPO" --body-file observation/resolve/pr_body.md || true
           # Post-fix wire evidence (written by the wire-verification step; absent when the
-          # baseline wire was clean or convergence shipped no overlay). Prefixed so the
-          # comment cannot be misread as a fresh observe. Evidence-only, informs the human
-          # gate; a genuine wire miss is a ceiling, not a merge blocker.
-          if [ -f observation/resolve/wire_verify/summary.md ]; then
+          # baseline wire was clean or convergence shipped no overlay). Published ONLY
+          # byte-identical to what that step sealed in its summary_sha output: the finalize
+          # compose agent ran in between, and a comment presented as a deterministic re-run
+          # must not be forgeable by it. Planted, altered or deleted evidence is fatal
+          # (needs-human); a genuine wire miss inside the VERIFIED summary stays a ceiling,
+          # not a merge blocker.
+          WIRE_SUMMARY=observation/resolve/wire_verify/summary.md
+          if [ -f "$WIRE_SUMMARY" ] || [ -n "${WIRE_SUMMARY_SHA:-}" ]; then
+            ACTUAL_WIRE_SHA=""
+            [ -f "$WIRE_SUMMARY" ] && ACTUAL_WIRE_SHA="$(sha256sum "$WIRE_SUMMARY" | cut -d' ' -f1)"
+            if [ "$ACTUAL_WIRE_SHA" != "${WIRE_SUMMARY_SHA:-}" ]; then
+              echo "::error::wire verification evidence changed after the verification step wrote it - refusing to publish"
+              exit 1
+            fi
             { printf '%s\n\n' '### Final wire verification - the baseline-rejecting wire tasks, re-run under the resolved policy (evidence-only)'; \
-              cat observation/resolve/wire_verify/summary.md; } \
+              cat "$WIRE_SUMMARY"; } \
               | gh pr comment "$PR" -R "$REPO" --body-file - || true
           fi
           # Data-scope review gate: an array-under-free-form-object recovery is DATA-BOUND - its

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -128,13 +128,23 @@ jobs:
           # logs a warning and returns non-zero so the caller continues to the next model.
           bootstrap () {
             SLUG="$1"; REQUESTER="$2"; TS="$3"
-            # EXACT open-PR check (grep -Fx, not the fuzzy `--search in:title`): the fuzzy form
-            # would let "integrate: x-ai/grok-4.5" match an open "integrate: x-ai/grok-4" (skip)
-            # or miss on `/`.`-tokenization (duplicate). -F makes SLUG a literal, not a pattern.
-            EXISTING="$(gh pr list -R "$REPO" --state open --json title --jq '.[].title' 2>/dev/null \
-              | grep -Fxc "integrate: $SLUG" || true)"
-            if [ "${EXISTING:-0}" != "0" ]; then
-              echo "open integration PR already exists for '$SLUG' -> skip"; return 0
+            BOOT_PR_URL=""
+            # EXACT open-PR check (jq string equality, not the fuzzy `--search in:title`): the
+            # fuzzy form would let "integrate: x-ai/grok-4.5" match an open "integrate: x-ai/grok-4"
+            # (skip) or miss on `/`.`-tokenization (duplicate). SLUG is catalog-resolved and
+            # charset-guarded upstream, so splicing it into the jq program is safe.
+            EXISTING_URL="$(gh pr list -R "$REPO" --state open --json title,url \
+              --jq ".[] | select(.title == \"integrate: ${SLUG}\") | .url" 2>/dev/null | head -1)"
+            if [ -n "$EXISTING_URL" ]; then
+              echo "open integration PR already exists for '$SLUG' -> skip (${EXISTING_URL})"
+              # Not silent: the poll-step reply just confirmed this model to the requester, so a
+              # bare skip leaves them waiting on a run that will never start (the reply is the
+              # dedup marker - re-requesting cannot revive an orphaned PR either, it lands here
+              # again). Point at the existing PR and at the label, which is the designed
+              # re-trigger when the earlier dispatch died after PR creation.
+              uv run automation slack post-thread --channel "$SLACK_CHANNEL" --thread-ts "$TS" \
+                --icon pr_exists --text "An integration PR is already open for ${SLUG}: <${EXISTING_URL}|its status lives there>. I am not starting a second run. If that PR shows no activity (no automation label, no run), a maintainer can re-trigger it by adding the automation:integrate-model label to it." || true
+              return 0
             fi
             SAFE="$(printf '%s' "$SLUG" | tr '/ ' '--' | tr -cd 'A-Za-z0-9._-')"
             BRANCH="automation/slack-integrate/${SAFE}-${RUN_ID}"
@@ -146,6 +156,10 @@ jobs:
             PR_URL="$(gh pr create -R "$REPO" --draft --base "$BASE_REF" --head "$BRANCH" \
               --title "integrate: ${SLUG}" \
               --body "Auto-opened from a Slack request by <@${REQUESTER}> (message ts ${TS}). The poller resolved the model deterministically (OpenRouter catalog first, then the LLM gateway's); this draft PR is the human review gate. The integration engine runs via workflow_dispatch on this PR." )" || return 1
+            # From here the PR exists: remember it so the failure reply below can say "start it
+            # via the label" instead of the re-request advice, which the exact-title skip above
+            # would turn into a silent dead end.
+            BOOT_PR_URL="$PR_URL"
             PR_NUM="$(printf '%s' "$PR_URL" | grep -oE '[0-9]+$')"
             [ -n "$PR_NUM" ] || { echo "could not parse PR number from '$PR_URL'"; return 1; }
             echo "opened PR #${PR_NUM} for ${SLUG} (${PR_URL})"
@@ -172,10 +186,17 @@ jobs:
             if ! bootstrap "$SLUG" "$REQUESTER" "$TS"; then
               echo "::warning title=Integration bootstrap failed::could not start integration for ${SLUG} (see log); continuing"
               # Not silent: the poll-step reply already said this model was starting, so tell the
-              # requester in-thread that it did NOT, and to re-request (the reply marker means it
-              # will not auto-retry).
-              uv run automation slack post-thread --channel "$SLACK_CHANNEL" --thread-ts "$TS" \
-                --icon dispatch_failed --text "I could not start the integration for ${SLUG} (a transient error opening the PR or dispatching). Please re-request it by tagging me with that model again." || true
+              # requester in-thread that it did NOT - and tell them the recovery that actually
+              # works. Re-requesting only helps while NO PR exists; once the PR was opened (the
+              # dispatch died after `gh pr create`), a re-request hits the exact-title skip, so
+              # the label on that PR is the re-trigger.
+              if [ -n "${BOOT_PR_URL:-}" ]; then
+                uv run automation slack post-thread --channel "$SLACK_CHANNEL" --thread-ts "$TS" \
+                  --icon dispatch_failed --text "I opened <${BOOT_PR_URL}|the integration PR> for ${SLUG} but could not start the engine on it (the dispatch failed). Re-requesting here will NOT restart it - a maintainer can start it by adding the automation:integrate-model label to that PR." || true
+              else
+                uv run automation slack post-thread --channel "$SLACK_CHANNEL" --thread-ts "$TS" \
+                  --icon dispatch_failed --text "I could not start the integration for ${SLUG} (a transient error before the PR existed). Please re-request it by tagging me with that model again." || true
+              fi
               FAIL=1
             fi
           done

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -117,10 +117,15 @@ bundle uploads separately, before the gate, as `integration-observation-pr<N>`).
   `model_presets.yaml` (by key in a value position, or by name), and mentioned by a unit test under
   `tests/unit/llm/` as staged in the INDEX - the finalize commit stages that directory, so the
   test the gate credits is the test that ships. Before any of these gates run, the workflow
-  re-pins `tools/automation/` to HEAD and requires `observation/findings.json` to hash-match the
-  value captured at aggregation time - the resolve/finalize agents run earlier, with Bash, in the
-  same workspace, and must not be able to weaken the gates or the evidence without it showing in
-  the PR diff.
+  refuses a moved HEAD and re-pins `tools/automation/` to the CHECKOUT-TIME commit (a step
+  output captured before any agent ran - symbolic HEAD could be moved by a local agent commit),
+  and requires `observation/findings.json` to hash-match the value captured at aggregation time,
+  both at the wire-verification step and at finalize; the wire-verification summary is published
+  only byte-identical to the hash that step sealed. The resolve/finalize agents run earlier, with
+  Bash, in the same workspace, and must not be able to weaken the gates or the evidence without
+  it showing in the PR diff. On the same fail-closed principle, a malformed `decision.json`
+  (`automation decision-targets` prints `PARSE_FAIL`) is a stall to retry, never the all-ceiling
+  `NO_TARGETS` convergence.
   Only then does it commit to the PR branch, comment the record, and label
   `automation:integrate-done`. A broken / over-reaching / divergent fix (or a cert that does not
   reconcile) fails verification here and goes to `automation:integrate-needs-human`. Never

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -5,7 +5,8 @@ quirks, propose and PROVE a policy fix (or classify a genuine ceiling), and land
 capability cert on the PR for human review. A SINGLE GitHub Actions workflow
 (`.github/workflows/integrate-model.yml`) runs OBSERVE and, on a clean observe, RESOLVE in the
 SAME run - one job, not two workflows, because a `GITHUB_TOKEN` label add cannot trigger a
-second workflow. It NEVER merges: the draft PR is the human review gate.
+second workflow. By default it never merges - the draft PR is the human review gate; the only
+exception is the explicit auto-merge opt-in (see the AUTO-MERGE note under "Notes").
 
 ## Trigger
 
@@ -37,9 +38,10 @@ flowchart TD
     I --> J{"all fix-targets green? (or none -> NO_TARGETS)"}
     J -- "no, iter < MAX_ITER (refine)" --> G
     J -- "no, iter = MAX_ITER" --> H
-    J -- "yes / all-ceiling (converged)" --> K["finalize agent (Opus): fold preset + write cert + PR report"]
+    J -- "yes / all-ceiling (converged)" --> W["workflow: final wire verification under the overlay (evidence-only)"]
+    W --> K["finalize agent (Opus): fold preset + write cert + PR report"]
     K --> L["workflow: commit to PR branch + comment + automation:integrate-done"]
-    L --> M["human review gate: draft PR, NEVER auto-merge"]
+    L --> M["human review gate: draft PR (auto-merge only via the explicit opt-in)"]
 ```
 
 ## Stage 1 - Observe
@@ -48,11 +50,16 @@ Deterministic detection on the DEFAULT (raw) preset. Runs the capability integra
 shape variants (report-only, K repeats) and the NON-SCORING wire-probe task-pack, then
 `automation observe-findings` emits `findings.json` (raw pass counts + the
 tool-arg rejections that graded metrics are blind to). Posts a summary comment. A `gate` step
-then decides:
+then decides, via the tested `automation observe-gate` command:
 
-- Clean (capability suite ran AND no infra contamination) -> the resolve steps below run in the
-  SAME job (label flips to `automation:resolve-running`).
-- Infra-dirty / did-not-run -> `automation:integrate-needs-human` (re-run needed); resolve skipped.
+- Clean (capability suite ran, wire probes ran, and no rate-limit / API-error / API-timeout /
+  status-error contamination) -> the resolve steps below run in the SAME job (label flips to
+  `automation:resolve-running`). `max_turns` and `stuck` deliberately do NOT dirty the gate:
+  both can be genuine model behaviour (the four-bucket taxonomy), so they are resolve-agent
+  data, not contamination.
+- Not clean (infra-dirty, a suite that never ran, or a missing `findings.json`) ->
+  `automation:integrate-needs-human` with the exact reason in the notification (re-run needed);
+  resolve skipped.
 
 ## Stage 2 - Resolve (same workflow, `if: gate.clean == 'yes'`)
 
@@ -73,7 +80,21 @@ breaks IMMEDIATELY to `automation:integrate-needs-human` with the agent's reason
 iterations, no fabricated fix. (Distinct from `data_scope_review`, which commits a fix the agent
 DID produce and routes it for a post-hoc human scope-check.)
 
-- Converged -> a finalize agent (`prompts/resolve_finalize.md`) folds the preset into
+Each iteration's `overlay.yaml` + `decision.json` are archived as
+`overlay_iter<N>.yaml` / `decision_iter<N>.json` before the next iteration deletes them: the
+compose agent starts every iteration with a fresh context, so these files are how it knows
+which axes it already tried (the prompt's "materially different axis" rule is judged against
+them), and they are what the needs-human artifacts hand a human. Everything under
+`observation/resolve/` uploads as the `integration-resolve-pr<N>` run artifact (the observe
+bundle uploads separately, before the gate, as `integration-observation-pr<N>`).
+
+- Converged -> first, when the observe wire had tool-arg rejections and an overlay exists, the
+  workflow re-runs exactly those wire tasks under the proven overlay
+  (`automation reprobe --wire-only`, `RESOLVE_WIRE_K` reps) and posts the fresh wire stats as a
+  PR comment. EVIDENCE for the human gate, never a convergence gate: the fix loop reprobes
+  capability probes only (`--skip-wire`), so this pass is the only post-fix measurement a
+  wire-evidenced fix gets - and a still-rejecting wire task can be a genuine model miss (a
+  ceiling, not a blocker). Then a finalize agent (`prompts/resolve_finalize.md`) folds the preset into
   `model_presets.yaml` and writes the cert into `registry.py`. Before committing, the workflow
   VERIFIES the staged tree (what it is about to commit, via `git stash --keep-index`): it must
   import, must not turn any already-valid tool-call arg invalid (`test_policy_no_regression`, the
@@ -85,7 +106,8 @@ DID produce and routes it for a post-hoc human scope-check.)
   free-form cert's under-declaration and false-pessimism.
   Only then does it commit to the PR branch, comment the record, and label
   `automation:integrate-done`. A broken / over-reaching / divergent fix (or a cert that does not
-  reconcile) fails verification here and goes to `automation:integrate-needs-human`. NEVER merges.
+  reconcile) fails verification here and goes to `automation:integrate-needs-human`. Never
+  merges by default (auto-merge is the explicit opt-in; see the AUTO-MERGE note).
 - Not converged within `MAX_ITER` (or staged verification failed) -> `automation:integrate-needs-human`.
 
 ## Auth
@@ -109,7 +131,7 @@ Both the AGENT and the CANDIDATE run on the OpenRouter budget (`ARENA_AUTOMATION
 | `RESOLVE_AGENT_OR_MODEL` | openrouter/anthropic/claude-opus-4.8 | the OpenRouter model the LiteLLM gateway routes the agent to |
 | `RESOLVE_CAPABILITY_K` | 5 | resolve per-iteration capability reprobe (cheap inner loop) |
 | `RESOLVE_CAP_PARALLEL` | 10 | resolve reprobe width (flat probe x rep pool; keep >= `RESOLVE_CAPABILITY_K`, <= ~16 for the rate limit) |
-| `RESOLVE_WIRE_K` | 10 | reserved for the final wire-verification pass (not yet wired) |
+| `RESOLVE_WIRE_K` | 10 | final wire-verification reps (evidence-only; runs on convergence when the observe wire had rejections and an overlay exists) |
 | `ARENA_AUTOMATION_AUTO_MERGE_ENABLED` | (unset = off) | When `true` (case-insensitive), squash-merge the integration PR on a clean success. Never merges a `test/*` de-integration branch; a data-scope needs-human path never merges; any merge error (branch protection, draft, perms, conflict) leaves the PR open. `false` / missing / error => nothing merges. |
 
 Two **secrets** gate the optional gateway route (both, or neither — a base URL without a key
@@ -340,14 +362,20 @@ sub-agent); the resolve prompts drive the fix loop. `index.yaml` is the machine-
 
 - `automation observe-findings` - deterministic raw-stat facts emitter (no banding,
   no verdict; interpretation is the agent's job).
+- `automation observe-gate` - the tested cleanliness verdict over `findings.json`: prints
+  `clean` (resolve may run) or `dirty: <reason>`; the reason surfaces verbatim in the
+  needs-human notification. Requires BOTH suites to have run and gates on
+  rate_limit / api_error / api_timeout / status_error (not max_turns / stuck, which can be
+  genuine model behaviour).
 - `automation run-probes` - flat (node x rep) parallel runner for the observe
   capability + variant steps: collects the candidate's nodes once, then runs each node x rep as
   its own single-node pytest at `OBSERVE_CAP_PARALLEL` width (so nodes AND repeats parallelize,
   not `W` long serial reps - the fix for a slow reasoning model spending hours on the variants).
 - `automation reprobe` - targeted re-probe under a policy overlay; re-runs ONLY the
   named `--targets` (the agent's fix-targets), or all failed probes if none given, as a flat
-  (probe x rep) pool parallelized at `--cap-parallel`; capability-only inner loop, plus a final
-  wire pass on failed wire tasks.
+  (probe x rep) pool parallelized at `--cap-parallel`. `--skip-wire` is the capability-only
+  inner loop; `--wire-only` is the final wire-verification pass (no capability probes, only the
+  baseline's rejecting wire tasks).
 - `automation greencheck` - fix-target convergence check.
 - `automation ensure-pricing` - best-effort, run before observe: if the candidate's
   litellm name is missing from `pricing.json`, fetch its OpenRouter pricing and insert one key

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -81,8 +81,21 @@ DID produce and routes it for a post-hoc human scope-check.)
   round-trips against the tool's Pydantic schema (`test_policy_array_recovery`). The cert itself is
   reconciled against the observe baseline (`automation reconcile-cert`, run before the stash so
   `findings.json` is still present): every probed capability must be declared (no silent auto-skip),
-  and no capability the baseline shows passing (>= 0.9) may be `known_unsupported` - catching the
-  free-form cert's under-declaration and false-pessimism.
+  no capability the baseline shows passing (>= 0.9) may be `known_unsupported` - catching the
+  free-form cert's under-declaration and false-pessimism - and a PAYLOAD-ONLY capability
+  (`thinking_replay_roundtrip` / `unsigned_thinking_replay`, whose probes mock the provider turn
+  and assert only our own outgoing payload) may be `required` only on a MEASURED passing native
+  baseline: promotion off a failing or absent baseline is SELF-REFERENTIAL and hard-fails, and any
+  other `required` with no probe result warns as UNBACKED. A newly registered policy class must
+  additionally be wired and covered (`automation check-new-classes`, an AST set-diff of the STAGED
+  `presets.py` registry against HEAD): referenced from the overlay or the staged
+  `model_presets.yaml` (by key in a value position, or by name), and mentioned by a unit test under
+  `tests/unit/llm/` as staged in the INDEX - the finalize commit stages that directory, so the
+  test the gate credits is the test that ships. Before any of these gates run, the workflow
+  re-pins `tools/automation/` to HEAD and requires `observation/findings.json` to hash-match the
+  value captured at aggregation time - the resolve/finalize agents run earlier, with Bash, in the
+  same workspace, and must not be able to weaken the gates or the evidence without it showing in
+  the PR diff.
   Only then does it commit to the PR branch, comment the record, and label
   `automation:integrate-done`. A broken / over-reaching / divergent fix (or a cert that does not
   reconcile) fails verification here and goes to `automation:integrate-needs-human`. NEVER merges.
@@ -355,9 +368,17 @@ sub-agent); the resolve prompts drive the fix loop. `index.yaml` is the machine-
   auto-merge price gate.
 - `automation reconcile-cert` - reconciles the finalized cert against the observe
   `findings.json`: fails if any probed capability is undeclared, if a capability the baseline shows
-  passing (>= 0.9) is marked `known_unsupported`, or if any CORE capability (e.g.
-  `cost_usd_populated`) is `known_unsupported` (a laundered pricing gap). Runs in the finalize gate
+  passing (>= 0.9) is marked `known_unsupported`, if any CORE capability (e.g.
+  `cost_usd_populated`) is `known_unsupported` (a laundered pricing gap), or if a PAYLOAD-ONLY
+  capability is `required` against a failing or absent native baseline (SELF-REFERENTIAL); any
+  other `required` with no probe result warns as UNBACKED. Runs in the finalize gate
   before the stash.
+- `automation check-new-classes` - finalize gate for newly registered policy classes: an AST
+  set-diff of the STAGED `presets.py` registry against HEAD (so quoting, wrapping, moves and
+  binding style cannot hide or fake an addition), requiring each new binding's class to be
+  mentioned by a unit test under `tests/unit/llm/` as staged in the INDEX and referenced from the
+  overlay or the staged `model_presets.yaml`. Fails loud on any git/parse error - a guard that
+  cannot see the registry must not skip.
 - `automation slack` - Slack thread notifier (`ensure-root` / `reply` / `post-thread`
   subcommands); dry-run no-op without a token. See "Slack notifications" above. `post-thread`
   posts a plain threaded reply under an arbitrary message ts (the poller's per-request

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -78,7 +78,10 @@ a correct policy from the observe data (a data-bound quirk whose correct scope n
 evidence the observe never surfaced), it sets `needs_human: true` in `decision.json` and the loop
 breaks IMMEDIATELY to `automation:integrate-needs-human` with the agent's reason - no wasted
 iterations, no fabricated fix. (Distinct from `data_scope_review`, which commits a fix the agent
-DID produce and routes it for a post-hoc human scope-check.)
+DID produce and routes it for a post-hoc human scope-check.) On the all-ceiling path the overlay
+itself is OPTIONAL: an honest all-ceiling decision (`fix_targets` empty, `needs_human` false)
+converges as `NO_TARGETS` without one, and the integration lands as cert + pricing on the
+default preset.
 
 Each iteration's `overlay.yaml` + `decision.json` are archived as
 `overlay_iter<N>.yaml` / `decision_iter<N>.json` before the next iteration deletes them: the
@@ -90,11 +93,12 @@ bundle uploads separately, before the gate, as `integration-observation-pr<N>`).
 
 - Converged -> first, when the observe wire had tool-arg rejections and an overlay exists, the
   workflow re-runs exactly those wire tasks under the proven overlay
-  (`automation reprobe --wire-only`, `RESOLVE_WIRE_K` reps) and posts the fresh wire stats as a
-  PR comment. EVIDENCE for the human gate, never a convergence gate: the fix loop reprobes
-  capability probes only (`--skip-wire`), so this pass is the only post-fix measurement a
-  wire-evidenced fix gets - and a still-rejecting wire task can be a genuine model miss (a
-  ceiling, not a blocker). Then a finalize agent (`prompts/resolve_finalize.md`) folds the preset into
+  (`automation reprobe --wire-only`, `RESOLVE_WIRE_K` reps); the finalize step posts the fresh
+  wire stats on the PR after its commit lands (a failed finalize leaves them in the
+  `integration-resolve-pr<N>` artifact instead). EVIDENCE for the human gate, never a
+  convergence gate: the fix loop reprobes capability probes only (`--skip-wire`), so this pass
+  is the only post-fix measurement a wire-evidenced fix gets - and a still-rejecting wire task
+  can be a genuine model miss (a ceiling, not a blocker). Then a finalize agent (`prompts/resolve_finalize.md`) folds the preset into
   `model_presets.yaml` and writes the cert into `registry.py`. Before committing, the workflow
   VERIFIES the staged tree (what it is about to commit, via `git stash --keep-index`): it must
   import, must not turn any already-valid tool-call arg invalid (`test_policy_no_regression`, the

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -16,7 +16,10 @@ measured observe baseline in these ways this gate catches:
      an overlay can make it green BY CONSTRUCTION; a green reprobe is therefore not
      evidence about the model.
   5. UNBACKED - a capability is ``required`` with no probe result at all, so nothing
-     measured supports it (warning: a probe can legitimately fail to collect).
+     measured supports it (warning: a probe can legitimately fail to collect). For a
+     PAYLOAD-ONLY capability this is a hard SELF-REFERENTIAL violation instead: the
+     only admissible promotion evidence is a measured passing native baseline, so
+     "nothing measured" cannot stay a warning there.
 
 Checks 1-3 are SYMMETRIC-BY-DESIGN gaps this module originally shipped with: it
 guarded against under-crediting a model but not against over-crediting one. Check 4
@@ -130,10 +133,21 @@ def reconcile(
             "missing-pricing gap)."
         )
     for cap in sorted(required - set(probed)):
-        warnings.append(
-            f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
-            "nothing measured supports it. Confirm the probe collected, or demote it."
-        )
+        if cap in payload_only:
+            # For a payload-only cap the ONLY admissible evidence is a measured passing
+            # native baseline (its probe mocks the provider turn, so a post-overlay green
+            # proves nothing). "No probe result at all" therefore cannot stay a warning:
+            # it would let an all-unparseable-junit run promote the cap unbacked.
+            violations.append(
+                f"SELF-REFERENTIAL: `{cap}` is `required` with NO probe result in the "
+                "baseline. A payload-only capability may be promoted only on a MEASURED "
+                "passing native baseline - re-run observe or demote it."
+            )
+        else:
+            warnings.append(
+                f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
+                "nothing measured supports it. Confirm the probe collected, or demote it."
+            )
     for cap, rate in sorted(probed.items()):
         if cap not in declared:
             violations.append(

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -1,7 +1,7 @@
 """Reconcile a candidate ``ModelCertificate`` against the observe ``findings.json``.
 
 The resolve agent's certificate is free-form reasoning; it can diverge from the
-measured observe baseline in three ways this gate catches:
+measured observe baseline in these ways this gate catches:
 
   1. COMPLETENESS - a capability that WAS probed is left undeclared (neither
      ``required`` nor ``known_unsupported``); it would silently auto-skip.
@@ -10,6 +10,18 @@ measured observe baseline in three ways this gate catches:
   3. CORE-UNSUPPORTED - a CORE capability (e.g. ``cost_usd_populated``) is marked
      ``known_unsupported`` - which would launder a missing-pricing gap into a fake
      ceiling.
+  4. SELF-REFERENTIAL - a PAYLOAD-ONLY capability (see
+     ``PAYLOAD_ONLY_CAPABILITIES``) is ``required`` against a FAILING baseline. Its
+     probe asserts our own outgoing request body with the provider turn mocked, so
+     an overlay can make it green BY CONSTRUCTION; a green reprobe is therefore not
+     evidence about the model.
+  5. UNBACKED - a capability is ``required`` with no probe result at all, so nothing
+     measured supports it (warning: a probe can legitimately fail to collect).
+
+Checks 1-3 are SYMMETRIC-BY-DESIGN gaps this module originally shipped with: it
+guarded against under-crediting a model but not against over-crediting one. Check 4
+closes the over-crediting side for the one probe class where "the reprobe went green"
+cannot mean what it appears to mean.
 
 A capability in ``[SOFT_PASS, HARD_PASS)`` marked ``known_unsupported`` is WARNED,
 not failed. Baseline pass_rate is the MIN across a capability's parametrised probes,
@@ -27,6 +39,28 @@ import sys
 
 HARD_PASS = 0.9
 SOFT_PASS = 0.8
+
+# Capabilities whose probe observes OUR OWN outgoing request payload rather than the
+# provider's behaviour: both replay tests fire turn 1 live, then MOCK turn 2 and
+# assert on the captured ``messages`` kwarg. Writing a codec that emits the expected
+# shape satisfies them by construction, so a fix-loop reprobe going green proves the
+# agent wrote the payload it set out to write - nothing about the model.
+#
+# Consequence for the cert: these may be promoted to ``required`` ONLY on a passing
+# NATIVE baseline (the model already round-trips without our overlay). Promotion off
+# a failing baseline is a self-referential claim and hard-fails.
+#
+# (Real miss: deepseek-v4-flash-0731, PR #846. ``unsigned_thinking_replay`` was 0/15
+# native; a new reasoning codec took the reprobe to 5/5 and the cap shipped
+# ``required``. A live A/B afterwards measured turn-2 ``prompt_tokens`` 523 vs 523
+# with and without the replay payload: the route accepts the field and silently
+# ignores it. The cert claimed a model property the evidence could not support.)
+PAYLOAD_ONLY_CAPABILITIES = frozenset(
+    {
+        "thinking_replay_roundtrip",
+        "unsigned_thinking_replay",
+    }
+)
 
 # Mirror of tests/canonical/test_capability_registry.py::_CORE_CAPABILITIES - the
 # capabilities every model MUST support. A core cap can NEVER be ``known_unsupported``
@@ -83,6 +117,7 @@ def reconcile(
     core: frozenset[str] = frozenset(),
     hard: float = HARD_PASS,
     soft: float = SOFT_PASS,
+    payload_only: frozenset[str] = PAYLOAD_ONLY_CAPABILITIES,
 ) -> tuple[list[str], list[str]]:
     """Return ``(violations, warnings)``. Pure - unit-tested without the registry."""
     declared = required | known_unsupported
@@ -94,11 +129,25 @@ def reconcile(
             "can never be `known_unsupported` (e.g. cost_usd_populated as a ceiling hides a "
             "missing-pricing gap)."
         )
+    for cap in sorted(required - set(probed)):
+        warnings.append(
+            f"UNBACKED: `{cap}` is `required` but has no probe result in the baseline - "
+            "nothing measured supports it. Confirm the probe collected, or demote it."
+        )
     for cap, rate in sorted(probed.items()):
         if cap not in declared:
             violations.append(
                 f"UNDECLARED: `{cap}` was probed (baseline {rate:.2f}) but is neither "
                 "`required` nor `known_unsupported` - it will silently auto-skip."
+            )
+        elif cap in required and cap in payload_only and rate < hard:
+            violations.append(
+                f"SELF-REFERENTIAL: `{cap}` is `required` but the NATIVE baseline fails "
+                f"{rate:.2f} (< {hard:.2f}). This probe asserts our own outgoing request "
+                "payload with the provider turn MOCKED, so an overlay satisfies it by "
+                "construction and a green reprobe says nothing about the model. Promote it "
+                "only on a passing native baseline; otherwise keep it `known_unsupported` "
+                "(the policy may still ship - only the cert claim is refused)."
             )
         elif cap in known_unsupported and rate >= hard:
             violations.append(

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -2,156 +2,303 @@
 
 Every policy class the resolve agent writes has to be registered in a
 ``_POLICY_REGISTRIES`` slot (``tolokaforge/core/llm/presets.py``) to be referenceable
-from a preset, so the staged diff of that file is a complete, deterministic index of
-what the integration added. This gate reads it and requires two things per new class:
+from a preset, so the registry is a complete, deterministic index of what the
+integration added. This gate compares the STAGED registry against HEAD and requires
+two things per newly added binding:
 
-  1. A unit test under ``tests/unit/llm/`` mentions the class by name. ``docs/ADD_NEW_MODEL.md``
-     step 5 already mandates this ("add a unit-test fixture ... so the codec round-trip is
-     unit-testable without burning provider spend"), but nothing enforced it: the fix-loop's
-     success signal is the live reprobe, so a missing unit test was invisible.
-  2. The class is actually referenced from the overlay. An unreferenced new class is dead
-     public API - the agent solved the probe some other way and left the class behind.
+  1. A unit test under ``tests/unit/llm/`` - read from the INDEX, i.e. the tree the
+     finalize commit will actually ship - mentions the bound class by name.
+     ``docs/ADD_NEW_MODEL.md`` step 5 already mandates this ("add a unit-test fixture
+     ... so the codec round-trip is unit-testable without burning provider spend"),
+     but nothing enforced it: the fix-loop's success signal is the live reprobe, so a
+     missing unit test was invisible. The mention is name-level (word-boundary), not
+     an executed test - the reviewer still checks the test is real.
+  2. The class is actually referenced - by registry key in a VALUE position of the
+     overlay or of the staged ``model_presets.yaml``, or by class name in either. An
+     unreferenced new class is dead public API: the agent solved the probe some other
+     way and left the class behind.
 
-Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer* sees
-the class's real input/output shape. Both defects this gate targets shipped together in
-PR #846 (a new reasoning codec with no unit test, whose behaviour a shipped codec already
-covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in :mod:`automation.cert`).
+Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer*
+sees the class's real input/output shape. Both defects this gate targets shipped
+together in PR #846 (a new reasoning codec with no unit test, whose behaviour a
+shipped codec already covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in
+:mod:`automation.cert`).
 
-``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers below are
-unit-tested without touching git.
+The registry comparison is an AST set-diff, not a diff-text regex: quoting style,
+trailing commas, wrapped lines, dotted values, instance bindings and factory names
+cannot hide a binding, and a moved or reordered line never reads as new. Covered
+registration shapes (module top level): a dict-literal assignment to a slot registry,
+``_SLOT["key"] = Value``, and ``_SLOT.update({...})``. This is a guard, so it FAILS
+LOUD: any git error, an unparsable staged registry, or a registry in which no
+``_POLICY_REGISTRIES`` slot can be found exits 1 (needs-human) instead of skipping.
+
+``run`` returns an exit code (1 on any violation or read failure, 0 otherwise); the
+pure helpers below are unit-tested without git, and ``run`` itself against throwaway
+git repos.
 """
 
 from __future__ import annotations
 
+import ast
 import pathlib
 import re
 import subprocess
+from typing import NamedTuple
 
 REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
+PRESETS_FILE = "tolokaforge/core/data/model_presets.yaml"
 DEFAULT_TESTS_DIR = "tests/unit/llm"
 
-# One added binding line, e.g. ``+    "json_coerce": JsonCoerceResponse,``. The leading
-# ``[A-Z]`` is what separates a CLASS binding from a registry-slot line (the
-# ``_POLICY_REGISTRIES`` values are underscore-prefixed), so slot lines never register as
-# new classes. Single source of truth for the line shape - every reader below goes through
-# :func:`added_bindings`.
-_REGISTRY_BINDING = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
-_DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
+# The repo root anchored to THIS file (tools/automation/src/automation/classgate.py),
+# like cert._load_cert - never the caller's CWD, which silently empties every git
+# answer from a subdirectory and turns the gate into a no-op.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 
 
-def added_bindings(diff_text: str) -> list[tuple[str, str]]:
-    """``(registry_key, ClassName)`` for every binding this diff ADDS to the registry file.
+class Binding(NamedTuple):
+    """One registry entry: which slot registry, under which key, bound to what."""
 
-    Scoped to added lines inside that file's hunks, so a class merely *defined* elsewhere
-    in the diff (or a registry line that only moved) is not reported. Order is source
-    order, so failure messages read deterministically. A class bound under several keys
-    yields one pair per key.
+    registry: str
+    key: str
+    value: str
+
+
+def _expr_repr(node: ast.expr) -> str:
+    """A stable identifier rendering for a binding value.
+
+    ``Name`` -> ``Cls``; ``Attribute`` -> ``pkg.Cls``; ``Call`` -> ``Cls()`` (an
+    instance or factory binding still names what was bound); anything else falls back
+    to ``ast.dump`` so an exotic shape still produces a DISTINCT, diffable binding
+    (detected as new -> gated) rather than vanishing.
     """
-    bindings: list[tuple[str, str]] = []
-    in_registry_file = False
-    for line in diff_text.splitlines():
-        header = _DIFF_FILE_HEADER.match(line)
-        if header:
-            in_registry_file = header.group(1) == REGISTRY_FILE
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_expr_repr(node.value)}.{node.attr}"
+    if isinstance(node, ast.Call):
+        return f"{_expr_repr(node.func)}()"
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    return ast.dump(node)
+
+
+def _key_repr(node: ast.expr) -> str:
+    """Registry keys are string constants; anything else renders via ``_expr_repr``
+    so a computed key still surfaces as a (necessarily unreferenced) new binding."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return _expr_repr(node)
+
+
+def _assign_target(node: ast.stmt) -> str | None:
+    """The single ``Name`` target of an ``Assign``/``AnnAssign``, else ``None``."""
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+        target = node.targets[0]
+        return target.id if isinstance(target, ast.Name) else None
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _dict_bindings(registry: str, node: ast.Dict) -> set[Binding]:
+    return {
+        Binding(registry, _key_repr(key), _expr_repr(value))
+        for key, value in zip(node.keys, node.values)
+        if key is not None  # a ``**spread`` entry has no literal key to gate on
+    }
+
+
+def registry_bindings(source: str) -> set[Binding]:
+    """Every registry binding in a ``presets.py`` source, as a set.
+
+    Slot registries are discovered from the ``_POLICY_REGISTRIES`` index itself (its
+    dict values name the per-slot dicts, or carry inline dicts), so a brand-new slot
+    the agent wires in is covered too. Raises on an unparsable source or when no slot
+    can be found - a guard that cannot see the registry must fail loud, never skip.
+    """
+    tree = ast.parse(source)
+    slot_vars: set[str] = set()
+    bindings: set[Binding] = set()
+    for node in tree.body:
+        if _assign_target(node) != "_POLICY_REGISTRIES":
             continue
-        if not in_registry_file:
-            continue
-        match = _REGISTRY_BINDING.match(line)
-        if match:
-            pair = (match.group(1), match.group(2))
-            if pair not in bindings:
-                bindings.append(pair)
+        index = node.value
+        if not isinstance(index, ast.Dict):
+            raise ValueError("_POLICY_REGISTRIES is not a dict literal - the gate cannot read it")
+        for key, value in zip(index.keys, index.values):
+            if isinstance(value, ast.Name):
+                slot_vars.add(value.id)
+            elif isinstance(value, ast.Dict):
+                bindings |= _dict_bindings(_key_repr(key) if key else "?", value)
+    if not slot_vars and not bindings:
+        raise ValueError(
+            f"no _POLICY_REGISTRIES slots found in {REGISTRY_FILE} - the gate cannot "
+            "see the registry"
+        )
+    for node in tree.body:
+        target = _assign_target(node)
+        if target in slot_vars and isinstance(getattr(node, "value", None), ast.Dict):
+            bindings |= _dict_bindings(target, node.value)
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(sub := node.targets[0], ast.Subscript)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id in slot_vars
+        ):
+            bindings.add(Binding(sub.value.id, _key_repr(sub.slice), _expr_repr(node.value)))
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(call := node.value, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "update"
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id in slot_vars
+            and call.args
+            and isinstance(call.args[0], ast.Dict)
+        ):
+            bindings |= _dict_bindings(call.func.value.id, call.args[0])
     return bindings
 
 
-def added_registry_classes(diff_text: str) -> list[str]:
-    """Distinct class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff."""
-    seen: list[str] = []
-    for _key, name in added_bindings(diff_text):
-        if name not in seen:
-            seen.append(name)
-    return seen
+def added_bindings(staged_source: str, head_source: str) -> list[Binding]:
+    """Bindings present in the staged registry but not in HEAD's, sorted.
 
-
-def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
-    """New classes named by neither the overlay nor a preset entry in the diff.
-
-    An overlay references a class through its registry KEY, not its name, so match on
-    either: the class name appearing in the diff's preset YAML hunks, or ANY of the keys
-    it was bound to appearing in the overlay (a class bound under several keys is
-    referenced if the overlay uses any one of them). Keeping this permissive is deliberate
-    - the gate is here to catch a class nobody wired up at all, not to police style.
+    A set diff, so a binding that merely moved (the agent alphabetized a dict while
+    inserting its entry) is not reported - only genuinely new (registry, key, value)
+    triples are.
     """
-    keys_by_class = _registry_keys(diff_text)
-    return [
+    return sorted(registry_bindings(staged_source) - registry_bindings(head_source))
+
+
+def bound_name(value_repr: str) -> str:
+    """``codecs.BrandNewCodec()`` -> ``BrandNewCodec``: the identifier a test must name."""
+    return value_repr.removesuffix("()").rsplit(".", 1)[-1]
+
+
+def untested(names: list[str], test_blob: str) -> list[str]:
+    """Names no unit-test source mentions as a whole word.
+
+    Word-boundary, not substring: an existing mention of ``MinimaxM3TagRecoveryResponse``
+    must not vouch for a new ``TagRecoveryResponse``.
+    """
+    return [name for name in names if not re.search(rf"\b{re.escape(name)}\b", test_blob)]
+
+
+def _key_referenced(key: str, text: str) -> bool:
+    """A registry key counts as referenced only in a YAML VALUE position
+    (``slot: key`` / ``slot: "key"``), not as a raw substring - a short family key
+    like ``qwen`` must not be satisfied by a ``match:`` glob that merely contains it."""
+    return re.search(rf""":\s*['"]?{re.escape(key)}\b""", text) is not None
+
+
+def unreferenced(bindings: list[Binding], overlay_text: str, presets_text: str) -> list[str]:
+    """Bound names that neither the overlay nor the staged preset file references.
+
+    A reference is any of that name's registry keys in a value position, or the name
+    itself as a whole word, in either source. Keeping this permissive is deliberate -
+    the gate catches a class nobody wired up at all, not style.
+    """
+    keys_by_name: dict[str, set[str]] = {}
+    for binding in bindings:
+        keys_by_name.setdefault(bound_name(binding.value), set()).add(binding.key)
+    combined = (overlay_text, presets_text)
+    return sorted(
         name
-        for name in classes
-        if name not in overlay_text
-        and not any(key in overlay_text for key in keys_by_class.get(name, ()))
-    ]
-
-
-def _registry_keys(diff_text: str) -> dict[str, tuple[str, ...]]:
-    """``{ClassName: (registry_key, ...)}`` for bindings added in the registry file."""
-    keys: dict[str, tuple[str, ...]] = {}
-    for key, name in added_bindings(diff_text):
-        keys[name] = (*keys.get(name, ()), key)
-    return keys
-
-
-def untested(classes: list[str], test_blob: str) -> list[str]:
-    """New classes no unit-test source mentions by name."""
-    return [name for name in classes if name not in test_blob]
-
-
-def read_tests(tests_dir: str = DEFAULT_TESTS_DIR) -> str:
-    """Concatenate every unit-test source under ``tests_dir`` (missing dir -> empty)."""
-    root = pathlib.Path(tests_dir)
-    if not root.is_dir():
-        return ""
-    return "\n".join(path.read_text(errors="replace") for path in sorted(root.rglob("test_*.py")))
-
-
-def _staged_diff() -> str:
-    proc = subprocess.run(
-        ["git", "diff", "--cached", "--unified=0", "--", REGISTRY_FILE],
-        capture_output=True,
-        text=True,
-        check=False,
+        for name, keys in keys_by_name.items()
+        if not any(_key_referenced(key, text) for key in keys for text in combined)
+        and not any(re.search(rf"\b{re.escape(name)}\b", text) for text in combined)
     )
+
+
+def _git(args: list[str], root: pathlib.Path) -> str:
+    """Run git anchored at ``root``; any failure raises with git's own stderr.
+
+    A guard must fail loud: swallowing a nonzero exit here is how "not a git repo"
+    or a wrong CWD used to read as "no new policy class registered".
+    """
+    proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=root, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}"
+        )
     return proc.stdout
 
 
-def run(overlay_path: str | None = None, tests_dir: str = DEFAULT_TESTS_DIR) -> int:
-    """Gate the STAGED diff. Returns 1 on any violation (finalize routes that to
-    needs-human), 0 otherwise. No new class -> nothing to check -> 0."""
-    diff_text = _staged_diff()
-    classes = added_registry_classes(diff_text)
-    if not classes:
-        print("classgate: OK (no new policy class registered)")
-        return 0
+def _git_optional(args: list[str], root: pathlib.Path) -> str:
+    """Like ``_git`` but a path absent from the requested tree reads as empty - used
+    only for reference SOURCES (a missing preset file just means no reference can
+    come from it), never for the registry the gate exists to judge."""
+    try:
+        return _git(args, root)
+    except RuntimeError as exc:
+        message = str(exc)
+        if "does not exist" in message or "but not in" in message:
+            return ""
+        raise
+
+
+def read_index_tests(root: pathlib.Path, tests_dir: str = DEFAULT_TESTS_DIR) -> str:
+    """Concatenate every ``test_*.py`` under ``tests_dir`` as staged in the INDEX.
+
+    The index is the tree the finalize commit ships. A worktree-only test file (never
+    ``git add``-ed) deliberately does not count: it would satisfy the gate and then
+    vanish from the commit - the exact false assurance this gate exists to prevent.
+    """
+    listed = _git(["ls-files", "--cached", "--", tests_dir], root)
+    sources = []
+    for path in sorted(line for line in listed.splitlines() if line):
+        name = pathlib.PurePosixPath(path).name
+        if name.startswith("test_") and name.endswith(".py"):
+            sources.append(_git(["show", f":{path}"], root))
+    return "\n".join(sources)
+
+
+def run(
+    overlay_path: str | None = None,
+    tests_dir: str = DEFAULT_TESTS_DIR,
+    root: str | None = None,
+) -> int:
+    """Gate the STAGED registry against HEAD. Returns 1 on any violation or read
+    failure (finalize routes both to needs-human), 0 otherwise. No new binding ->
+    nothing to check -> 0."""
+    repo = pathlib.Path(root).resolve() if root else REPO_ROOT
+    try:
+        staged = _git(["show", f":{REGISTRY_FILE}"], repo)
+        head = _git(["show", f"HEAD:{REGISTRY_FILE}"], repo)
+        added = added_bindings(staged, head)
+        if not added:
+            print("classgate: OK (no new policy class registered)")
+            return 0
+        test_blob = read_index_tests(repo, tests_dir)
+        presets_text = _git_optional(["show", f":{PRESETS_FILE}"], repo)
+    except Exception as exc:  # fail loud - a guard must never silently pass
+        print(f"::error::classgate could not read the staged tree: {exc}")
+        return 1
 
     overlay_text = ""
     if overlay_path and pathlib.Path(overlay_path).is_file():
         overlay_text = pathlib.Path(overlay_path).read_text(errors="replace")
 
+    names = sorted({bound_name(binding.value) for binding in added})
     violations = [
-        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no unit test under "
-        f"{tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test (with a "
-        "captured real-response fixture) for a new policy class - the live reprobe does not "
-        "substitute for one."
-        for name in untested(classes, read_tests(tests_dir))
+        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no STAGED unit test "
+        f"under {tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test "
+        "(prefer a captured real-response fixture) for a new policy class - the live reprobe "
+        "does not substitute for one, and a test left unstaged would not ship."
+        for name in untested(names, test_blob)
     ]
     violations += [
         f"UNREFERENCED-CLASS: `{name}` is registered in {REGISTRY_FILE} but neither the "
-        "overlay nor a preset entry references it - dead public API. Wire it up or drop it."
-        for name in unreferenced(classes, overlay_text, diff_text)
+        f"overlay nor the staged {PRESETS_FILE} references it (by key in a value position, "
+        "or by name) - dead public API. Wire it up or drop it."
+        for name in unreferenced(added, overlay_text, presets_text)
     ]
 
     for violation in violations:
         print(f"::error::classgate: {violation}")
     if violations:
-        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(classes)} new class(es))")
+        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(names)} new class(es))")
         return 1
-    print(f"classgate: OK ({len(classes)} new class(es) tested and referenced)")
+    print(f"classgate: OK ({len(names)} new class(es) tested and referenced)")
     return 0

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -30,19 +30,24 @@ import subprocess
 REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
 DEFAULT_TESTS_DIR = "tests/unit/llm"
 
-# ``"json_coerce": JsonCoerceResponse,`` inside a _POLICY_REGISTRIES slot.
-_REGISTRY_BINDING = re.compile(r'^\+\s*"[A-Za-z0-9_]+"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+# One added binding line, e.g. ``+    "json_coerce": JsonCoerceResponse,``. The leading
+# ``[A-Z]`` is what separates a CLASS binding from a registry-slot line (the
+# ``_POLICY_REGISTRIES`` values are underscore-prefixed), so slot lines never register as
+# new classes. Single source of truth for the line shape - every reader below goes through
+# :func:`added_bindings`.
+_REGISTRY_BINDING = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
 _DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
 
 
-def added_registry_classes(diff_text: str) -> list[str]:
-    """Class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff.
+def added_bindings(diff_text: str) -> list[tuple[str, str]]:
+    """``(registry_key, ClassName)`` for every binding this diff ADDS to the registry file.
 
-    Scoped to added lines inside the registry file's hunks, so a class merely *defined*
-    elsewhere in the diff (or a registry line that only moved) is not reported. Order is
-    deduplicated-stable so the failure message reads deterministically.
+    Scoped to added lines inside that file's hunks, so a class merely *defined* elsewhere
+    in the diff (or a registry line that only moved) is not reported. Order is source
+    order, so failure messages read deterministically. A class bound under several keys
+    yields one pair per key.
     """
-    found: list[str] = []
+    bindings: list[tuple[str, str]] = []
     in_registry_file = False
     for line in diff_text.splitlines():
         header = _DIFF_FILE_HEADER.match(line)
@@ -52,43 +57,45 @@ def added_registry_classes(diff_text: str) -> list[str]:
         if not in_registry_file:
             continue
         match = _REGISTRY_BINDING.match(line)
-        if match and match.group(1) not in found:
-            found.append(match.group(1))
-    return found
+        if match:
+            pair = (match.group(1), match.group(2))
+            if pair not in bindings:
+                bindings.append(pair)
+    return bindings
+
+
+def added_registry_classes(diff_text: str) -> list[str]:
+    """Distinct class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff."""
+    seen: list[str] = []
+    for _key, name in added_bindings(diff_text):
+        if name not in seen:
+            seen.append(name)
+    return seen
 
 
 def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
     """New classes named by neither the overlay nor a preset entry in the diff.
 
     An overlay references a class through its registry KEY, not its name, so match on
-    either: the class name appearing in the diff's preset YAML hunks, or the registry key
-    it was bound to appearing in the overlay. Keeping this permissive is deliberate - the
-    gate is here to catch a class nobody wired up at all, not to police style.
+    either: the class name appearing in the diff's preset YAML hunks, or ANY of the keys
+    it was bound to appearing in the overlay (a class bound under several keys is
+    referenced if the overlay uses any one of them). Keeping this permissive is deliberate
+    - the gate is here to catch a class nobody wired up at all, not to police style.
     """
     keys_by_class = _registry_keys(diff_text)
-    missing = []
-    for name in classes:
-        key = keys_by_class.get(name, "")
-        referenced = name in overlay_text or (key and key in overlay_text)
-        if not referenced:
-            missing.append(name)
-    return missing
+    return [
+        name
+        for name in classes
+        if name not in overlay_text
+        and not any(key in overlay_text for key in keys_by_class.get(name, ()))
+    ]
 
 
-def _registry_keys(diff_text: str) -> dict[str, str]:
-    """``{ClassName: registry_key}`` for bindings added in the registry file."""
-    keys: dict[str, str] = {}
-    in_registry_file = False
-    pattern = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
-    for line in diff_text.splitlines():
-        header = _DIFF_FILE_HEADER.match(line)
-        if header:
-            in_registry_file = header.group(1) == REGISTRY_FILE
-            continue
-        if in_registry_file:
-            match = pattern.match(line)
-            if match:
-                keys.setdefault(match.group(2), match.group(1))
+def _registry_keys(diff_text: str) -> dict[str, tuple[str, ...]]:
+    """``{ClassName: (registry_key, ...)}`` for bindings added in the registry file."""
+    keys: dict[str, tuple[str, ...]] = {}
+    for key, name in added_bindings(diff_text):
+        keys[name] = (*keys.get(name, ()), key)
     return keys
 
 

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -1,0 +1,150 @@
+"""Finalize gate: a new engine policy class must ship a unit test.
+
+Every policy class the resolve agent writes has to be registered in a
+``_POLICY_REGISTRIES`` slot (``tolokaforge/core/llm/presets.py``) to be referenceable
+from a preset, so the staged diff of that file is a complete, deterministic index of
+what the integration added. This gate reads it and requires two things per new class:
+
+  1. A unit test under ``tests/unit/llm/`` mentions the class by name. ``docs/ADD_NEW_MODEL.md``
+     step 5 already mandates this ("add a unit-test fixture ... so the codec round-trip is
+     unit-testable without burning provider spend"), but nothing enforced it: the fix-loop's
+     success signal is the live reprobe, so a missing unit test was invisible.
+  2. The class is actually referenced from the overlay. An unreferenced new class is dead
+     public API - the agent solved the probe some other way and left the class behind.
+
+Why this matters beyond hygiene: a unit test is the cheapest place where a *reviewer* sees
+the class's real input/output shape. Both defects this gate targets shipped together in
+PR #846 (a new reasoning codec with no unit test, whose behaviour a shipped codec already
+covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in :mod:`automation.cert`).
+
+``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers below are
+unit-tested without touching git.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+REGISTRY_FILE = "tolokaforge/core/llm/presets.py"
+DEFAULT_TESTS_DIR = "tests/unit/llm"
+
+# ``"json_coerce": JsonCoerceResponse,`` inside a _POLICY_REGISTRIES slot.
+_REGISTRY_BINDING = re.compile(r'^\+\s*"[A-Za-z0-9_]+"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+_DIFF_FILE_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
+
+
+def added_registry_classes(diff_text: str) -> list[str]:
+    """Class names newly bound into a ``_POLICY_REGISTRIES`` slot by this diff.
+
+    Scoped to added lines inside the registry file's hunks, so a class merely *defined*
+    elsewhere in the diff (or a registry line that only moved) is not reported. Order is
+    deduplicated-stable so the failure message reads deterministically.
+    """
+    found: list[str] = []
+    in_registry_file = False
+    for line in diff_text.splitlines():
+        header = _DIFF_FILE_HEADER.match(line)
+        if header:
+            in_registry_file = header.group(1) == REGISTRY_FILE
+            continue
+        if not in_registry_file:
+            continue
+        match = _REGISTRY_BINDING.match(line)
+        if match and match.group(1) not in found:
+            found.append(match.group(1))
+    return found
+
+
+def unreferenced(classes: list[str], overlay_text: str, diff_text: str) -> list[str]:
+    """New classes named by neither the overlay nor a preset entry in the diff.
+
+    An overlay references a class through its registry KEY, not its name, so match on
+    either: the class name appearing in the diff's preset YAML hunks, or the registry key
+    it was bound to appearing in the overlay. Keeping this permissive is deliberate - the
+    gate is here to catch a class nobody wired up at all, not to police style.
+    """
+    keys_by_class = _registry_keys(diff_text)
+    missing = []
+    for name in classes:
+        key = keys_by_class.get(name, "")
+        referenced = name in overlay_text or (key and key in overlay_text)
+        if not referenced:
+            missing.append(name)
+    return missing
+
+
+def _registry_keys(diff_text: str) -> dict[str, str]:
+    """``{ClassName: registry_key}`` for bindings added in the registry file."""
+    keys: dict[str, str] = {}
+    in_registry_file = False
+    pattern = re.compile(r'^\+\s*"([A-Za-z0-9_]+)"\s*:\s*([A-Z][A-Za-z0-9_]*)\s*,')
+    for line in diff_text.splitlines():
+        header = _DIFF_FILE_HEADER.match(line)
+        if header:
+            in_registry_file = header.group(1) == REGISTRY_FILE
+            continue
+        if in_registry_file:
+            match = pattern.match(line)
+            if match:
+                keys.setdefault(match.group(2), match.group(1))
+    return keys
+
+
+def untested(classes: list[str], test_blob: str) -> list[str]:
+    """New classes no unit-test source mentions by name."""
+    return [name for name in classes if name not in test_blob]
+
+
+def read_tests(tests_dir: str = DEFAULT_TESTS_DIR) -> str:
+    """Concatenate every unit-test source under ``tests_dir`` (missing dir -> empty)."""
+    root = pathlib.Path(tests_dir)
+    if not root.is_dir():
+        return ""
+    return "\n".join(path.read_text(errors="replace") for path in sorted(root.rglob("test_*.py")))
+
+
+def _staged_diff() -> str:
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--", REGISTRY_FILE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout
+
+
+def run(overlay_path: str | None = None, tests_dir: str = DEFAULT_TESTS_DIR) -> int:
+    """Gate the STAGED diff. Returns 1 on any violation (finalize routes that to
+    needs-human), 0 otherwise. No new class -> nothing to check -> 0."""
+    diff_text = _staged_diff()
+    classes = added_registry_classes(diff_text)
+    if not classes:
+        print("classgate: OK (no new policy class registered)")
+        return 0
+
+    overlay_text = ""
+    if overlay_path and pathlib.Path(overlay_path).is_file():
+        overlay_text = pathlib.Path(overlay_path).read_text(errors="replace")
+
+    violations = [
+        f"UNTESTED-CLASS: `{name}` is registered in {REGISTRY_FILE} but no unit test under "
+        f"{tests_dir}/ mentions it. docs/ADD_NEW_MODEL.md step 5 requires a unit test (with a "
+        "captured real-response fixture) for a new policy class - the live reprobe does not "
+        "substitute for one."
+        for name in untested(classes, read_tests(tests_dir))
+    ]
+    violations += [
+        f"UNREFERENCED-CLASS: `{name}` is registered in {REGISTRY_FILE} but neither the "
+        "overlay nor a preset entry references it - dead public API. Wire it up or drop it."
+        for name in unreferenced(classes, overlay_text, diff_text)
+    ]
+
+    for violation in violations:
+        print(f"::error::classgate: {violation}")
+    if violations:
+        print(f"classgate: FAIL ({len(violations)} violation(s) over {len(classes)} new class(es))")
+        return 1
+    print(f"classgate: OK ({len(classes)} new class(es) tested and referenced)")
+    return 0

--- a/tools/automation/src/automation/classgate.py
+++ b/tools/automation/src/automation/classgate.py
@@ -26,11 +26,15 @@ shipped codec already covered - see ``PAYLOAD_ONLY_CAPABILITIES`` in
 
 The registry comparison is an AST set-diff, not a diff-text regex: quoting style,
 trailing commas, wrapped lines, dotted values, instance bindings and factory names
-cannot hide a binding, and a moved or reordered line never reads as new. Covered
-registration shapes (module top level): a dict-literal assignment to a slot registry,
-``_SLOT["key"] = Value``, and ``_SLOT.update({...})``. This is a guard, so it FAILS
-LOUD: any git error, an unparsable staged registry, or a registry in which no
-``_POLICY_REGISTRIES`` slot can be found exits 1 (needs-human) instead of skipping.
+cannot hide a binding, and a moved or reordered line never reads as new. Registration
+shapes are collected over the whole tree (``if``/``try`` nesting included):
+dict-literal (re)assignment, ``_SLOT["key"] = Value``, ``_SLOT |= {...}``,
+``_SLOT.update({...})`` / ``_SLOT.update(k=V)``, and ``_SLOT.setdefault("k", V)``.
+This is a guard, so it FAILS LOUD instead of skipping: any git error, an unparsable
+staged registry, a registry with no discoverable ``_POLICY_REGISTRIES`` slot, and any
+slot-registry mutation the gate cannot model (a non-dict reassignment, another
+AugAssign shape, ``update(**splat)``, an unrecognized method call) all exit 1
+(needs-human).
 
 ``run`` returns an exit code (1 on any violation or read failure, 0 otherwise); the
 pure helpers below are unit-tested without git, and ``run`` itself against throwaway
@@ -108,13 +112,25 @@ def _dict_bindings(registry: str, node: ast.Dict) -> set[Binding]:
     }
 
 
+# Slot-var method calls that only READ (the real presets.py resolves policies via
+# ``_X.get(...)`` and passes the dicts as function arguments). Any OTHER method call
+# on a slot registry is an un-modelable mutation and fails the gate loud.
+_READ_ONLY_METHODS = frozenset({"get", "items", "keys", "values", "copy"})
+
+
 def registry_bindings(source: str) -> set[Binding]:
     """Every registry binding in a ``presets.py`` source, as a set.
 
     Slot registries are discovered from the ``_POLICY_REGISTRIES`` index itself (its
     dict values name the per-slot dicts, or carry inline dicts), so a brand-new slot
-    the agent wires in is covered too. Raises on an unparsable source or when no slot
-    can be found - a guard that cannot see the registry must fail loud, never skip.
+    the agent wires in is covered too. Mutations are collected over the WHOLE tree
+    (``if``/``try`` nesting cannot hide a registration) in every modelable shape:
+    dict-literal (re)assignment, ``_SLOT["k"] = V``, ``_SLOT |= {...}``,
+    ``_SLOT.update({...})`` / ``_SLOT.update(k=V)``, ``_SLOT.setdefault("k", V)``.
+    Anything else that could mutate a slot registry - a non-dict reassignment, another
+    AugAssign shape, ``update(**splat)``, an unrecognized method call - RAISES, as do an
+    unparsable source and a registry with no discoverable slot: a guard that cannot
+    model what it sees must fail loud, never skip.
     """
     tree = ast.parse(source)
     slot_vars: set[str] = set()
@@ -135,10 +151,17 @@ def registry_bindings(source: str) -> set[Binding]:
             f"no _POLICY_REGISTRIES slots found in {REGISTRY_FILE} - the gate cannot "
             "see the registry"
         )
-    for node in tree.body:
-        target = _assign_target(node)
-        if target in slot_vars and isinstance(getattr(node, "value", None), ast.Dict):
-            bindings |= _dict_bindings(target, node.value)
+    for node in ast.walk(tree):
+        target = _assign_target(node) if isinstance(node, (ast.Assign, ast.AnnAssign)) else None
+        if target in slot_vars:
+            value = getattr(node, "value", None)
+            if isinstance(value, ast.Dict):
+                bindings |= _dict_bindings(target, value)
+            elif value is not None:
+                raise ValueError(
+                    f"unmodelable reassignment of registry {target} (not a dict literal)"
+                )
+            continue
         if (
             isinstance(node, ast.Assign)
             and len(node.targets) == 1
@@ -147,17 +170,46 @@ def registry_bindings(source: str) -> set[Binding]:
             and sub.value.id in slot_vars
         ):
             bindings.add(Binding(sub.value.id, _key_repr(sub.slice), _expr_repr(node.value)))
-        if (
-            isinstance(node, ast.Expr)
-            and isinstance(call := node.value, ast.Call)
-            and isinstance(call.func, ast.Attribute)
-            and call.func.attr == "update"
-            and isinstance(call.func.value, ast.Name)
-            and call.func.value.id in slot_vars
-            and call.args
-            and isinstance(call.args[0], ast.Dict)
+        elif isinstance(node, ast.AugAssign):
+            if isinstance(node.target, ast.Name) and node.target.id in slot_vars:
+                if isinstance(node.op, ast.BitOr) and isinstance(node.value, ast.Dict):
+                    bindings |= _dict_bindings(node.target.id, node.value)
+                else:
+                    raise ValueError(
+                        f"unmodelable augmented assignment to registry {node.target.id}"
+                    )
+            elif (
+                isinstance(node.target, ast.Subscript)
+                and isinstance(node.target.value, ast.Name)
+                and node.target.value.id in slot_vars
+            ):
+                raise ValueError(
+                    f"unmodelable augmented item assignment on registry {node.target.value.id}"
+                )
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and (slot := node.func.value.id) in slot_vars
         ):
-            bindings |= _dict_bindings(call.func.value.id, call.args[0])
+            method = node.func.attr
+            if method == "update":
+                for keyword in node.keywords:
+                    if keyword.arg is None:  # **splat hides its keys from the gate
+                        raise ValueError(f"unmodelable update(**...) on registry {slot}")
+                    bindings.add(Binding(slot, keyword.arg, _expr_repr(keyword.value)))
+                if node.args:
+                    if len(node.args) == 1 and isinstance(node.args[0], ast.Dict):
+                        bindings |= _dict_bindings(slot, node.args[0])
+                    else:
+                        raise ValueError(f"unmodelable update(...) argument on registry {slot}")
+            elif method == "setdefault":
+                if len(node.args) == 2:
+                    bindings.add(Binding(slot, _key_repr(node.args[0]), _expr_repr(node.args[1])))
+                else:
+                    raise ValueError(f"unmodelable setdefault(...) on registry {slot}")
+            elif method not in _READ_ONLY_METHODS:
+                raise ValueError(f"unmodelable method call .{method}() on registry {slot}")
     return bindings
 
 

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -79,6 +79,16 @@ def greencheck_cmd(
     raise typer.Exit(greencheck.run(decision, reprobe_findings))
 
 
+@app.command("decision-targets")
+def decision_targets_cmd(
+    decision: str = typer.Argument(..., help="path to the compose step's decision.json"),
+) -> None:
+    """Print the decision's target token: PARSE_FAIL (malformed -> stall, never a verdict),
+    NO_TARGETS (a well-formed empty fix_targets = the all-ceiling convergence), or
+    TARGETS:<comma-joined>. Always exits 0; the workflow branches on stdout."""
+    raise typer.Exit(greencheck.run_decision_targets(decision))
+
+
 @app.command("run-probes")
 def run_probes(
     k_expr: str = typer.Option(..., "--k-expr", help="the pytest -k selection for the candidate"),

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -103,11 +103,17 @@ def reprobe_cmd(
     skip_wire: bool = typer.Option(
         False, "--skip-wire", help="capability-only (the agent's inner loop)"
     ),
+    wire_only: bool = typer.Option(
+        False,
+        "--wire-only",
+        help="NO capability probes; re-run only the baseline's rejecting wire tasks "
+        "(the final wire-verification pass after the fix loop converges)",
+    ),
     run_url: str | None = typer.Option(None, "--run-url"),
 ) -> None:
     """Re-run only the failed probes under a policy overlay and emit findings (RESOLVE)."""
-    raise typer.Exit(
-        reprobe.run(
+    try:
+        code = reprobe.run(
             baseline=baseline,
             overlay=overlay,
             provider=provider,
@@ -120,9 +126,23 @@ def reprobe_cmd(
             cap_parallel=cap_parallel,
             targets=targets,
             skip_wire=skip_wire,
+            wire_only=wire_only,
             run_url=run_url,
         )
-    )
+    except ValueError as exc:  # conflicting flags - refuse loudly, never guess
+        raise typer.BadParameter(str(exc)) from exc
+    raise typer.Exit(code)
+
+
+@app.command("observe-gate")
+def observe_gate(
+    findings: str = typer.Argument(..., help="path to the observe findings.json"),
+) -> None:
+    """Print the observe cleanliness token: `clean` (resolve may run) or `dirty: <reason>`.
+
+    Always exits 0 - the workflow branches on stdout, and a missing/unreadable findings file
+    prints a dirty token rather than raising (observe crashed before aggregation)."""
+    raise typer.Exit(observe.gate(findings))
 
 
 @app.command("observe-findings")

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -112,8 +112,15 @@ def reprobe_cmd(
     run_url: str | None = typer.Option(None, "--run-url"),
 ) -> None:
     """Re-run only the failed probes under a policy overlay and emit findings (RESOLVE)."""
+    # Pre-check ONLY the flag combination: a conflict is a usage error (exit 2, no
+    # traceback), while anything run() itself raises - e.g. an unreadable baseline
+    # file - is a real failure that must traceback loudly, not read as a CLI mistake.
     try:
-        code = reprobe.run(
+        reprobe.validate_selection_flags(targets, wire_only, skip_wire)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    raise typer.Exit(
+        reprobe.run(
             baseline=baseline,
             overlay=overlay,
             provider=provider,
@@ -129,9 +136,7 @@ def reprobe_cmd(
             wire_only=wire_only,
             run_url=run_url,
         )
-    except ValueError as exc:  # conflicting flags - refuse loudly, never guess
-        raise typer.BadParameter(str(exc)) from exc
-    raise typer.Exit(code)
+    )
 
 
 @app.command("observe-gate")

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -11,6 +11,7 @@ import typer
 
 from automation import (
     cert,
+    classgate,
     gateway_catalog,
     greencheck,
     model_resolver,
@@ -46,6 +47,17 @@ def reconcile_cert(
 ) -> None:
     """Reconcile the staged ModelCertificate against the observe baseline (finalize gate)."""
     raise typer.Exit(cert.run(model_id, findings))
+
+
+@app.command("check-new-classes")
+def check_new_classes(
+    overlay: str | None = typer.Option(
+        None, "--overlay", help="path to the resolve overlay.yaml (for the reference check)"
+    ),
+    tests_dir: str = typer.Option(classgate.DEFAULT_TESTS_DIR, "--tests-dir"),
+) -> None:
+    """Require a unit test + an overlay reference for every newly registered policy class."""
+    raise typer.Exit(classgate.run(overlay_path=overlay, tests_dir=tests_dir))
 
 
 @app.command("ensure-pricing")

--- a/tools/automation/src/automation/greencheck.py
+++ b/tools/automation/src/automation/greencheck.py
@@ -1,4 +1,4 @@
-"""Green-check for the resolve fix-loop.
+"""Green-check + decision parsing for the resolve fix-loop.
 
 Reads the compose step's ``decision.json`` (its ``fix_targets``) plus a reprobe
 ``findings.json``, and prints one token the workflow branches on:
@@ -8,8 +8,16 @@ Reads the compose step's ``decision.json`` (its ``fix_targets``) plus a reprobe
 * ``NO_TARGETS`` - the decision named no fix-targets (nothing to prove).
 * ``PARSE_FAIL`` - a file was missing/unreadable.
 
-The token-computing logic is :func:`evaluate` (pure, unit-tested); ``run`` loads the
-two files, prints the token, and always exits 0 - the caller reads stdout.
+``decision_targets`` is the loop's OTHER stdout-token seam: it parses the decision's
+``fix_targets`` up front, so that a malformed ``decision.json`` (the agent died
+mid-write, or deviated from the schema) reads as ``PARSE_FAIL`` - a stall to retry -
+and never as the empty-targets ``NO_TARGETS``, which is the all-ceiling CONVERGENCE
+verdict. An inline ``|| echo ''`` extraction cannot tell those apart, and the
+difference is an integration shipping with every failure recorded as a ceiling
+nobody actually judged.
+
+The token-computing logic is pure and unit-tested; the ``run*`` wrappers load files,
+print the token, and always exit 0 - the caller reads stdout.
 """
 
 from __future__ import annotations
@@ -20,6 +28,41 @@ import json
 def _load(path: str) -> dict:
     with open(path) as handle:
         return json.load(handle)
+
+
+def decision_targets(decision: dict) -> str:
+    """The loop's target token for one decision: ``PARSE_FAIL`` / ``NO_TARGETS`` /
+    ``TARGETS:<comma-joined>``.
+
+    Fail-closed: ``fix_targets`` missing, not a list, or containing anything but
+    non-empty comma-free strings is ``PARSE_FAIL`` (a comma would corrupt the joined
+    form; junit probe ids never contain one). Only a well-formed EMPTY list is the
+    all-ceiling ``NO_TARGETS``.
+    """
+    targets = decision.get("fix_targets")
+    if not isinstance(targets, list):
+        return "PARSE_FAIL"
+    cleaned = []
+    for target in targets:
+        if not isinstance(target, str) or not target.strip() or "," in target:
+            return "PARSE_FAIL"
+        cleaned.append(target.strip())
+    return "NO_TARGETS" if not cleaned else "TARGETS:" + ",".join(cleaned)
+
+
+def run_decision_targets(decision_path: str) -> int:
+    """Load ``decision.json``, print the target token, exit 0 (the caller reads
+    stdout). Missing/unreadable/non-object files print ``PARSE_FAIL``."""
+    try:
+        decision = _load(decision_path)
+    except (OSError, ValueError):
+        print("PARSE_FAIL")
+        return 0
+    if not isinstance(decision, dict):
+        print("PARSE_FAIL")
+        return 0
+    print(decision_targets(decision))
+    return 0
 
 
 def evaluate(decision: dict, reprobe: dict) -> str:

--- a/tools/automation/src/automation/icons.py
+++ b/tools/automation/src/automation/icons.py
@@ -64,7 +64,7 @@ DEFAULT_ICONS: dict[str, str] = {
     "request_ambiguous": ":warning:",
     "request_unresolved": ":x:",
     # A model whose integration PR is already open: the poller starts no second run and the
-    # reply points at the existing PR (previously a silent log-only skip).
+    # reply points at the existing PR instead.
     "pr_exists": ":information_source:",
     # A `via <route>` directive that could not be honoured.
     "route_downgraded": ":warning:",

--- a/tools/automation/src/automation/icons.py
+++ b/tools/automation/src/automation/icons.py
@@ -63,6 +63,9 @@ DEFAULT_ICONS: dict[str, str] = {
     "request_resolved": ":white_check_mark:",
     "request_ambiguous": ":warning:",
     "request_unresolved": ":x:",
+    # A model whose integration PR is already open: the poller starts no second run and the
+    # reply points at the existing PR (previously a silent log-only skip).
+    "pr_exists": ":information_source:",
     # A `via <route>` directive that could not be honoured.
     "route_downgraded": ":warning:",
 }

--- a/tools/automation/src/automation/observe.py
+++ b/tools/automation/src/automation/observe.py
@@ -317,9 +317,10 @@ GATE_INFRA_KEYS = ("rate_limit", "api_error", "api_timeout", "status_error")
 def evaluate_gate(findings: dict[str, Any]) -> tuple[bool, str]:
     """Observe cleanliness gate: may a clean observe chain into resolve?
 
-    Pure and unit-tested (the workflow used to inline this as a ``python -c`` one-liner,
-    which silently missed ``api_timeout`` and could not require the wire probes to have
-    run at all). Returns ``(clean, reason)``; ``reason`` is empty when clean.
+    Lives here rather than inline in the workflow because an inline check cannot be
+    unit-tested and silently drifts from :data:`GATE_INFRA_KEYS`. Both suites must have
+    RUN (the wire step is ``|| true``-guarded in the workflow, so a startup crash shows
+    up only as 0 trials). Returns ``(clean, reason)``; ``reason`` is empty when clean.
     """
     if not findings.get("capability_ran"):
         return False, "capability suite did not run (0 probes)"

--- a/tools/automation/src/automation/observe.py
+++ b/tools/automation/src/automation/observe.py
@@ -301,6 +301,50 @@ def build_findings(obs_dir: Path) -> dict[str, Any]:
     }
 
 
+# The wire termination reasons that make an observe run untrustworthy. max_turns and stuck are
+# deliberately NOT here: both can be genuine model behaviour (see the four-bucket taxonomy in
+# prompts/_shared_context.md), so they are data for the resolve agent, not contamination.
+GATE_INFRA_KEYS = ("rate_limit", "api_error", "api_timeout", "status_error")
+
+
+def evaluate_gate(findings: dict[str, Any]) -> tuple[bool, str]:
+    """Observe cleanliness gate: may a clean observe chain into resolve?
+
+    Pure and unit-tested (the workflow used to inline this as a ``python -c`` one-liner,
+    which silently missed ``api_timeout`` and could not require the wire probes to have
+    run at all). Returns ``(clean, reason)``; ``reason`` is empty when clean.
+    """
+    if not findings.get("capability_ran"):
+        return False, "capability suite did not run (0 probes)"
+    wire = findings.get("wire") or {}
+    if not wire.get("trials"):
+        return False, "wire probes did not run (0 trials)"
+    infra = wire.get("infra") or {}
+    contaminated = {key: infra.get(key, 0) for key in GATE_INFRA_KEYS if infra.get(key, 0)}
+    if contaminated:
+        detail = ", ".join(f"{key}={count}" for key, count in sorted(contaminated.items()))
+        return False, f"wire infra contamination ({detail})"
+    return True, ""
+
+
+def gate(findings_path: str) -> int:
+    """Print the observe gate token and return 0 (the workflow branches on stdout).
+
+    ``clean`` when resolve may run; ``dirty: <reason>`` otherwise, the reason surfacing
+    verbatim in the needs-human notification. A missing/unreadable findings file is dirty
+    (the observe crashed before aggregation), never an exception - the gate must always
+    hand the workflow a token it can route on.
+    """
+    try:
+        findings = json.loads(Path(findings_path).read_text())
+    except (OSError, ValueError) as exc:
+        print(f"dirty: findings unreadable - observe crashed before aggregation ({exc})")
+        return 0
+    clean, reason = evaluate_gate(findings)
+    print("clean" if clean else f"dirty: {reason}")
+    return 0
+
+
 def render_summary(findings: dict[str, Any], run_url: str | None = None) -> str:
     """Render a short human-readable markdown summary of the raw stats."""
     cap = findings.get("capability", {})

--- a/tools/automation/src/automation/observe.py
+++ b/tools/automation/src/automation/observe.py
@@ -278,7 +278,10 @@ def build_findings(obs_dir: Path) -> dict[str, Any]:
         " failure_attribution.json and metrics.tool_success_rate do NOT reflect"
         " tool-argument rejections; wire.tool_arg_rejections is the faithful signal.",
     ]
-    if not capability_ran:
+    # For the observe stage, 0 capability probes is an infra failure worth flagging; on a
+    # reprobe artifact a missing capability section can be the deliberate wire-only pass,
+    # so the note would mislabel it.
+    if not capability_ran and manifest.get("stage", "observe") == "observe":
         notes.insert(
             0,
             "capability suite did NOT execute (0 probes ran - report absent or every"
@@ -287,7 +290,11 @@ def build_findings(obs_dir: Path) -> dict[str, Any]:
         )
     return {
         "schema_version": SCHEMA_VERSION,
-        "stage": "observe",
+        # The reprobe stage writes its own manifest (stage=reprobe) before calling this;
+        # carrying it through keeps the artifact self-describing and lets the summary
+        # renderer tell a deliberate wire-only pass from an observe whose capability
+        # suite failed to run.
+        "stage": manifest.get("stage", "observe"),
         "candidate": manifest.get("candidate", {}),
         "preset": manifest.get("preset", "default"),
         # The single yes/no the deterministic layer commits to. Everything else is
@@ -353,15 +360,27 @@ def render_summary(findings: dict[str, Any], run_url: str | None = None) -> str:
     rej = wire.get("tool_arg_rejections", {})
     candidate = (findings.get("candidate") or {}).get("name", "?")
     preset = findings.get("preset", "default")
+    stage = findings.get("stage", "observe")
 
-    if not findings.get("capability_ran", True):
+    # A reprobe artifact with no capability section is the deliberate wire-only pass, not a
+    # capability suite that failed to run - its verdict is the wire result.
+    wire_only = stage == "reprobe" and not cap.get("report_present")
+    if wire_only:
+        if wire.get("trials"):
+            verdict = (
+                f"wire-only pass: {rej.get('rejecting_trials', 0)}/{wire.get('trials', 0)} "
+                "trials with a tool-arg rejection"
+            )
+        else:
+            verdict = "wire-only pass produced no trials (the wire run failed to start)"
+    elif not findings.get("capability_ran", True):
         verdict = "capability suite did NOT run (0 probes) - infra failure, not a pass"
     elif findings.get("all_passed"):
         verdict = "all probes passed"
     else:
         verdict = "failures present"
     lines = [
-        f"### Auto-integration observe: `{candidate}` on the `{preset}` preset",
+        f"### Auto-integration {stage}: `{candidate}` on the `{preset}` preset",
         "",
         f"**{verdict}** (raw stats only; the agent analyzes the errors).",
         "",

--- a/tools/automation/src/automation/observe.py
+++ b/tools/automation/src/automation/observe.py
@@ -412,10 +412,11 @@ def render_summary(findings: dict[str, Any], run_url: str | None = None) -> str:
         rate_str = f", {rate} of trials" if rate is not None else ""
         lines.append(f"  - `{task}` / `{shape['tool']}` rejected{rate_str}")
     infra = wire.get("infra", {})
-    lines.append(
-        f"- Infra: rate_limit={infra.get('rate_limit', 0)}, "
-        f"max_turns={infra.get('max_turns', 0)}, stuck={infra.get('stuck', 0)}."
-    )
+    # Every gate key plus the model-attributable pair: the PR-visible summary must show
+    # the same counters the gate dirties on, or an api_timeout needs-human reads as
+    # "all-zero infra" here and the reason only ever appears in Slack.
+    infra_keys = (*GATE_INFRA_KEYS, "max_turns", "stuck")
+    lines.append("- Infra: " + ", ".join(f"{key}={infra.get(key, 0)}" for key in infra_keys) + ".")
     lines.append("")
     tail = "Full artifact (capability reports + trajectories + `findings.json`) for the next step."
     if run_url:

--- a/tools/automation/src/automation/prompts/resolve_agent.md
+++ b/tools/automation/src/automation/prompts/resolve_agent.md
@@ -16,6 +16,10 @@ and pushes the whole integration to needs-human.
   probes + wire tool-arg rejections).
 - `{{OBS_DIR}}/resolve/last_reprobe.json` - the PREVIOUS iteration's reprobe result (absent on
   iteration 1). On a later iteration, read it to see which fix-targets are STILL red and adjust.
+- `{{OBS_DIR}}/resolve/overlay_iter<N>.yaml` + `decision_iter<N>.json` - YOUR OWN earlier
+  attempts, archived per iteration (absent on iteration 1). Read the most recent one before
+  composing: "a materially DIFFERENT axis" below is judged against what these files actually
+  tried, not against memory - each iteration starts with a fresh context.
 - Candidate: provider=`{{PROVIDER}}`, name=`{{NAME}}`, model_id=`{{MODEL_ID}}`.
   Iteration `{{ITER}}` of `{{MAX_ITER}}`.
 - Engine: presets in `tolokaforge/core/data/model_presets.yaml`; adapter classes registered in

--- a/tools/automation/src/automation/prompts/resolve_agent.md
+++ b/tools/automation/src/automation/prompts/resolve_agent.md
@@ -84,10 +84,24 @@ and pushes the whole integration to needs-human.
      An unbounded tree-walk forces `data_scope_review: true`. The docstring MUST state the exact
      firing condition and depth; it is reviewed against the code, so an understated scope is a
      defect, not politeness.
-   - Before creating a class or registry key, grep `response_policy.py` + `schema_sanitizer.py`
-     (this branch AND main) for an existing class/key covering the same quirk - a sibling
-     integration may have just landed one. NEVER rebind an existing registry key to different
+   - Before creating a class or registry key, grep the WHOLE policy surface (this branch AND
+     main) for an existing class/key covering the same quirk - a sibling integration may have
+     just landed one. That means every module behind `_POLICY_REGISTRIES`, not just the two
+     obvious ones: `response_policy.py`, `schema_sanitizer.py`, `reasoning_codec.py`,
+     `content_policy.py`, `prompt_policy.py`, `cache_policy.py`. Also read `model_presets.yaml`
+     for a sibling preset that already solved your fix-target by RE-POINTING an axis at a
+     shipped class - a one-line preset change always beats a new class. A newly registered
+     class must be referenced by your overlay AND covered by a unit test under
+     `tests/unit/llm/` (docs/ADD_NEW_MODEL.md step 5); the deterministic `check-new-classes`
+     gate fails the integration otherwise. NEVER rebind an existing registry key to different
      semantics; if your mechanism differs, use a new, model-line-specific name.
+     (Real miss: deepseek-v4-flash-0731 PR #846 wrote a new reasoning codec for
+     `unsigned_thinking_replay`, having grepped only the two modules named above. The shipped
+     `gemini` codec already covered that route - verified live - and `qwen3.8-max` had solved
+     the IDENTICAL fix-target days earlier with exactly that one-line
+     `reasoning_codec: gemini` swap. The new class also round-tripped LESS faithfully: it
+     rebuilt the envelope from the flat summary, dropping the provider's own `format` and
+     `index` that the shipped codec preserves.)
 4. Write `{{OBS_DIR}}/resolve/decision.json`:
    ```
    {"fix_targets": ["<exact junit probe names from findings.json that the overlay should turn green>"],
@@ -133,10 +147,23 @@ and pushes the whole integration to needs-human.
    `needs_human` is true you may leave `fix_targets` empty and skip writing `overlay.yaml`.
 
    `required` must be EVIDENCE-BACKED, never optimistic. List a capability as `required` ONLY if
-   it passed NATIVELY in `findings.json` OR the reprobe shows it green under your overlay. Do NOT
-   promote a capability to `required` on a mechanism that cannot support it: e.g. a summary-only
-   (OpenAI-style) `reasoning_codec` carries no signed thinking blocks, so `THINKING_EMITS_BLOCKS`
-   and the `*_THINKING_REPLAY` caps stay `known_unsupported` under it; a `passthrough` schema that
+   it passed NATIVELY in `findings.json` OR the reprobe shows it green under your overlay.
+
+   EXCEPTION - PAYLOAD-ONLY probes (`thinking_replay_roundtrip`, `unsigned_thinking_replay`):
+   these fire turn 1 live and then MOCK the provider turn, asserting only OUR OWN outgoing
+   request body. A codec that emits the expected shape satisfies them BY CONSTRUCTION, so a
+   green reprobe proves you wrote the payload you meant to write and says NOTHING about the
+   model. Promote either one to `required` ONLY on a passing NATIVE baseline. Off a failing
+   native baseline they stay `known_unsupported` even when your overlay turns them green - the
+   deterministic `cert_reconcile` gate FAILS the integration otherwise (SELF-REFERENTIAL). You
+   may still ship the policy; only the cert claim is refused. (Real miss: deepseek-v4-flash-0731
+   PR #846 promoted `unsigned_thinking_replay` off an 0/15 native baseline via a new codec; a
+   live A/B afterwards measured turn-2 `prompt_tokens` 523 vs 523 with and without the replay
+   payload - that route accepts the field and silently ignores it.)
+
+   Do NOT otherwise promote a capability to `required` on a mechanism that cannot support it:
+   e.g. a summary-only (OpenAI-style) `reasoning_codec` carries no SIGNED thinking blocks, so
+   `THINKING_REPLAY_ROUNDTRIP` stays `known_unsupported` under it; a `passthrough` schema that
    only cleared a weak-assertion probe (no 500, args parse) is NOT evidence the emitted VALUE is
    correct. When the mechanism does not clearly support it or the evidence is a weak probe, prefer
    `known_unsupported` (an honest floor) over a `required` that inflates the leaderboard score -

--- a/tools/automation/src/automation/prompts/resolve_agent.md
+++ b/tools/automation/src/automation/prompts/resolve_agent.md
@@ -61,7 +61,11 @@ and pushes the whole integration to needs-human.
    entry whose `match` globs match THIS model only, composing the needed reusable axes
    (schema_sanitizer / prompt_policy / response_policy / reasoning_codec / content_policy /
    cache_policy / params). Reuse shipped classes; that single model-specific entry IS the
-   composite when several axes are needed. Validate it:
+   composite when several axes are needed. EXCEPTION - all-ceiling: when EVERY failure is a
+   genuine ceiling (`fix_targets` empty, `needs_human` false), there is no policy to write -
+   skip `overlay.yaml` entirely; the loop converges on your `decision.json` alone (NO_TARGETS)
+   and the integration lands as cert + pricing on the default preset. Never write a no-op
+   overlay just to have one. Otherwise, validate it:
    `uv run python -c "from tolokaforge.core.llm.presets import validate_overlay_file as v; v('{{OBS_DIR}}/resolve/overlay.yaml')"`
 3. If NO shipped class covers a fix-target, write a NEW small reusable adapter class in the
    right module (e.g. a response policy in `response_policy.py`), register it in the matching

--- a/tools/automation/src/automation/prompts/resolve_finalize.md
+++ b/tools/automation/src/automation/prompts/resolve_finalize.md
@@ -1,14 +1,19 @@
 # Resolve finalize: land the proven policy as the integration
 
-The fix loop CONVERGED: `{{OBS_DIR}}/resolve/overlay.yaml` is proven (the last reprobe went
-green on every fix-target). Land it as the model's integration ON THIS BRANCH. Do NOT commit,
+The fix loop CONVERGED: either `{{OBS_DIR}}/resolve/overlay.yaml` is proven (the last reprobe
+went green on every fix-target), or the decision is all-ceiling (`NO_TARGETS`: empty
+fix_targets, no overlay, nothing to prove - the integration is cert + pricing only). Land it
+as the model's integration ON THIS BRANCH. Do NOT commit,
 push, or comment - the WORKFLOW does that after you. Write files only, then stop. This is a
 normal synchronous Claude Code run; nothing to await.
 
 ## Inputs
-- `{{OBS_DIR}}/resolve/overlay.yaml` - the proven preset (one model-specific entry).
+- `{{OBS_DIR}}/resolve/overlay.yaml` - the proven preset (one model-specific entry; ABSENT on
+  an all-ceiling convergence).
 - `{{OBS_DIR}}/resolve/decision.json` - `fix_targets`, `ceilings` (known_unsupported), `required`.
-- `{{OBS_DIR}}/resolve/last_reprobe.json` - the final reprobe evidence (per-probe passed/runs).
+- `{{OBS_DIR}}/resolve/last_reprobe.json` - the final reprobe evidence (per-probe passed/runs;
+  absent when no reprobe ran, e.g. an all-ceiling convergence - findings.json is then the
+  only evidence).
 - `{{OBS_DIR}}/findings.json` - the observe baseline (before -> after comparison).
 - Candidate: provider=`{{PROVIDER}}`, name=`{{NAME}}`, model_id=`{{MODEL_ID}}`, PR #`{{PR}}`.
 

--- a/tools/automation/src/automation/prompts/resolve_finalize.md
+++ b/tools/automation/src/automation/prompts/resolve_finalize.md
@@ -16,7 +16,9 @@ normal synchronous Claude Code run; nothing to await.
 1. Fold the overlay preset into `tolokaforge/core/data/model_presets.yaml`: add ONE new entry
    under `presets:` with the overlay's `match` + axes. Leave every other preset untouched (do
    NOT broaden a shared glob). If the compose step wrote a new adapter class, it is already in
-   the engine + `_POLICY_REGISTRIES` + `__init__.py`; leave it.
+   the engine + `_POLICY_REGISTRIES` + `__init__.py`; leave it. If `overlay.yaml` is ABSENT
+   (an all-ceiling convergence: every failure was a genuine limit, no policy needed), skip this
+   step - the integration is then cert + pricing only, and the model runs on the default preset.
 2. Add the candidate cert to `tests/integration/llm/registry.py`: an `MC(...)` entry in `_ALL`
    with `model_id="{{MODEL_ID}}"`, provider/name, `env_key="OPENROUTER_API_KEY"`,
    `required=frozenset({...})` from decision.json `required`, and

--- a/tools/automation/src/automation/reprobe.py
+++ b/tools/automation/src/automation/reprobe.py
@@ -53,6 +53,21 @@ def failed_wire_tasks(findings: dict[str, Any]) -> list[str]:
     return sorted((by_task or {}).keys())
 
 
+def validate_selection_flags(targets: str | None, wire_only: bool, skip_wire: bool) -> None:
+    """Reject conflicting selection flags; raises ``ValueError`` naming the conflict.
+
+    One rule, two callers: the CLI pre-checks so a flag conflict is a usage error (exit 2,
+    no traceback), and :func:`select_reprobe_targets` enforces it for library callers.
+    """
+    if wire_only and skip_wire:
+        raise ValueError("--wire-only and --skip-wire are mutually exclusive")
+    if wire_only and targets:
+        raise ValueError(
+            "--wire-only re-runs the baseline's rejecting wire tasks; --targets selects "
+            "capability probes - pass one or the other"
+        )
+
+
 def select_reprobe_targets(
     baseline: dict[str, Any],
     targets: str | None,
@@ -66,13 +81,7 @@ def select_reprobe_targets(
     this pass a fix whose only live evidence was the wire would ship unmeasured).
     Conflicting flags raise instead of guessing.
     """
-    if wire_only and skip_wire:
-        raise ValueError("--wire-only and --skip-wire are mutually exclusive")
-    if wire_only and targets:
-        raise ValueError(
-            "--wire-only re-runs the baseline's rejecting wire tasks; --targets selects "
-            "capability probes - pass one or the other"
-        )
+    validate_selection_flags(targets, wire_only, skip_wire)
     if wire_only:
         return [], failed_wire_tasks(baseline)
     if targets:

--- a/tools/automation/src/automation/reprobe.py
+++ b/tools/automation/src/automation/reprobe.py
@@ -53,6 +53,35 @@ def failed_wire_tasks(findings: dict[str, Any]) -> list[str]:
     return sorted((by_task or {}).keys())
 
 
+def select_reprobe_targets(
+    baseline: dict[str, Any],
+    targets: str | None,
+    wire_only: bool,
+    skip_wire: bool,
+) -> tuple[list[str], list[str]]:
+    """The ``(probes, wire_tasks)`` a reprobe run should re-run. Pure, fail-fast.
+
+    ``wire_only`` is the final wire-verification pass: NO capability probes, only the
+    baseline's rejecting wire tasks (the fix loop iterates with ``skip_wire``, so without
+    this pass a fix whose only live evidence was the wire would ship unmeasured).
+    Conflicting flags raise instead of guessing.
+    """
+    if wire_only and skip_wire:
+        raise ValueError("--wire-only and --skip-wire are mutually exclusive")
+    if wire_only and targets:
+        raise ValueError(
+            "--wire-only re-runs the baseline's rejecting wire tasks; --targets selects "
+            "capability probes - pass one or the other"
+        )
+    if wire_only:
+        return [], failed_wire_tasks(baseline)
+    if targets:
+        probes = [t.strip() for t in targets.split(",") if t.strip()]
+    else:
+        probes = failed_probes(baseline.get("capability")) + failed_probes(baseline.get("variants"))
+    return probes, ([] if skip_wire else failed_wire_tasks(baseline))
+
+
 def k_group(probe_name: str) -> str:
     """Turn a junit probe name ``func[param]`` into a precise ``-k`` group.
 
@@ -187,6 +216,7 @@ def run(
     cap_parallel: int = 10,
     targets: str | None = None,
     skip_wire: bool = False,
+    wire_only: bool = False,
     run_url: str | None = None,
 ) -> int:
     """Re-run only the failed probes under a policy overlay and emit findings. Returns 0."""
@@ -198,15 +228,10 @@ def run(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Which probes to reprobe: the agent's fix_targets if given (skips the slow, un-fixable
-    # ceiling probes), else ALL failed probes from the baseline (capability + variants).
-    if targets:
-        probes = [t.strip() for t in targets.split(",") if t.strip()]
-    else:
-        probes = failed_probes(baseline_findings.get("capability")) + failed_probes(
-            baseline_findings.get("variants")
-        )
+    # ceiling probes), else ALL failed probes from the baseline (capability + variants) -
+    # or, for the final wire-verification pass, no probes and only the rejecting wire tasks.
+    probes, wire_tasks = select_reprobe_targets(baseline_findings, targets, wire_only, skip_wire)
     n_var = sum(1 for p in probes if p.startswith("test_variant"))
-    wire_tasks = [] if skip_wire else failed_wire_tasks(baseline_findings)
     print(
         f"re-probe targets: {len(probes) - n_var} capability, {n_var} variant, "
         f"{len(wire_tasks)} wire task(s) under overlay {overlay} "

--- a/tools/automation/src/automation/resolve_report.py
+++ b/tools/automation/src/automation/resolve_report.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 
 import typer
 
@@ -105,6 +106,29 @@ def _load_decision(path: pathlib.Path) -> dict | None:
         return None
 
 
+def latest_decision(resolve_dir: pathlib.Path) -> dict | None:
+    """The agent's most recent decision, surviving a stalled final iteration.
+
+    ``decision.json`` is rm'd at the top of every loop iteration, so when the LAST
+    iteration stalls (no overlay, no decision) the live file is gone and the report
+    would say nothing about what the agent last tried. The workflow archives each
+    produced attempt as ``decision_iter<N>.json``; fall back to the highest N.
+    """
+    live = _load_decision(resolve_dir / "decision.json")
+    if live is not None:
+        return live
+
+    def iter_no(path: pathlib.Path) -> int:
+        match = re.search(r"decision_iter(\d+)", path.stem)
+        return int(match.group(1)) if match else -1
+
+    for path in sorted(resolve_dir.glob("decision_iter*.json"), key=iter_no, reverse=True):
+        archived = _load_decision(path)
+        if archived is not None:
+            return archived
+    return None
+
+
 def run(resolve_dir: str, max_iter: int) -> int:
     d = pathlib.Path(resolve_dir)
     summary = ""
@@ -114,7 +138,7 @@ def run(resolve_dir: str, max_iter: int) -> int:
             summary = sp.read_text()
         except OSError:
             summary = ""
-    decision = _load_decision(d / "decision.json")
+    decision = latest_decision(d)
     print(build_report(summary, decision, max_iter))
     return 0
 

--- a/tools/automation/src/automation/resolve_report.py
+++ b/tools/automation/src/automation/resolve_report.py
@@ -23,6 +23,19 @@ import re
 import typer
 
 
+def has_converged(summary_text: str) -> bool:
+    """True when the loop reached a terminal CONVERGED / NO_TARGETS verdict.
+
+    The needs-human step also fires when the loop CONVERGED but finalize then failed
+    its gates (reconcile-cert, class gate, staged verification, push) - a report headed
+    "why the loop did not converge" would point the human at the wrong layer there.
+    """
+    return any(
+        "verdict = CONVERGED" in line or "verdict = NO_TARGETS" in line
+        for line in summary_text.splitlines()
+    )
+
+
 def counts(summary_text: str) -> tuple[int, int, int]:
     """(total, no_overlay, red) iteration counts from the appended summary lines.
 
@@ -86,14 +99,25 @@ def build_report(summary_text: str, decision: dict | None, max_iter: int) -> str
     """Markdown block: header + per-iteration list + diagnosis + the agent's last decision."""
     total, no_overlay, red = counts(summary_text)
     body = summary_text.strip() or "- (no per-iteration outcome was recorded)"
+    if has_converged(summary_text):
+        header = f"### The resolve loop CONVERGED, but finalize failed its gates (ran {total}/{max_iter} iterations)"
+        diagnosis = (
+            "The fix loop reached a terminal verdict (see the last iteration below); the "
+            "failure is in the FINALIZE layer - the compose/verify gates (cert reconcile, "
+            "class gate, evidence hash, staged verification) or the commit/push. Inspect "
+            "the finalize step log; the loop itself does not need a re-run."
+        )
+    else:
+        header = f"### Why the resolve loop did not converge (ran {total}/{max_iter} iterations)"
+        diagnosis = diagnose(total, no_overlay, red, max_iter)
     out = [
-        f"### Why the resolve loop did not converge (ran {total}/{max_iter} iterations)",
+        header,
         "",
         "**Per-iteration outcome:**",
         "",
         body,
         "",
-        f"**Diagnosis.** {diagnose(total, no_overlay, red, max_iter)}",
+        f"**Diagnosis.** {diagnosis}",
     ]
     if decision:
         targets = decision.get("fix_targets") or []

--- a/tools/automation/src/automation/resolve_report.py
+++ b/tools/automation/src/automation/resolve_report.py
@@ -24,14 +24,19 @@ import typer
 
 
 def counts(summary_text: str) -> tuple[int, int, int]:
-    """(total, no_overlay, red) iteration counts from the appended summary lines."""
+    """(total, no_overlay, red) iteration counts from the appended summary lines.
+
+    A stalled iteration is logged as "no decision produced" (nothing at all) or "no
+    overlay was produced" (a decision that named fix-targets but no policy); both are
+    the same stalled class for the diagnosis.
+    """
     total = no_overlay = red = 0
     for line in summary_text.splitlines():
         if "Iter " not in line:
             continue
         total += 1
         low = line.lower()
-        if "no overlay" in low:
+        if "no overlay" in low or "no decision" in low:
             no_overlay += 1
         elif "red" in low:
             red += 1

--- a/tools/automation/src/automation/resolve_report.py
+++ b/tools/automation/src/automation/resolve_report.py
@@ -52,9 +52,10 @@ def diagnose(total: int, no_overlay: int, red: int, max_iter: int) -> str:
         )
     if no_overlay == total:
         return (
-            f"The agent produced NO overlay in any of the {total} iteration(s): it stalled or "
-            "exhausted its per-iteration turn budget every time. That is almost always an "
-            "upstream THROTTLE or error on the agent's model calls, which now route through the "
+            f"The agent produced no usable attempt in any of the {total} iteration(s) (no "
+            "decision, or fix-targets without an overlay): it stalled or exhausted its "
+            "per-iteration turn budget every time. That is almost always an "
+            "upstream THROTTLE or error on the agent's model calls, which route through the "
             "LiteLLM -> OpenRouter gateway (HTTP 429 / gateway down / bad model slug) - not a model "
             "or observe problem, since observe was clean and there was never a candidate fix to "
             "verify. Check the gateway startup + OpenRouter status in the run log; re-running when "

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -200,23 +200,45 @@ def test_unbacked_required_capability_warns():
     assert any("UNBACKED" in w and "never_probed_cap" in w for w in warnings)
 
 
+def test_payload_only_cap_required_with_no_probe_result_is_a_violation():
+    """An all-unparseable-junit run must not smuggle a payload-only cap to `required`
+    through the soft UNBACKED path: with no measurement there is by definition no
+    passing native baseline, which is the only admissible promotion evidence."""
+    violations, warnings = cert.reconcile(
+        required={"unsigned_thinking_replay"},
+        known_unsupported=set(),
+        probed={},
+    )
+    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations)
+    assert not any("unsigned_thinking_replay" in w for w in warnings)
+
+
 def test_payload_only_set_matches_the_probes_that_mock_the_provider():
     """Drift guard, keyed on a STRUCTURAL fact rather than prose.
 
     A probe can only assert our own outgoing payload by stubbing the transport, and the
-    single seam for that is ``tolokaforge.core.llm.client.completion`` - the one and only
-    patch target anywhere in the live capability suite. So "patches that symbol" is
-    exactly "does not observe the provider". If a third replay-style probe lands it
-    belongs in the set; if one of these starts making a real second call, it must come
-    out.
+    single seam for that is ``client.completion`` - so "stubs that seam" is exactly
+    "does not observe the provider". The match covers the seam's patch SPELLINGS, not
+    one literal: the dotted string (``patch("tolokaforge.core.llm.client.completion")``
+    / ``monkeypatch.setattr("tolokaforge...")``) plus the object forms
+    (``patch.object(client, "completion")`` / ``monkeypatch.setattr(client,
+    "completion", ...)``) - a replay-style probe written in any of them must land in
+    the set, and keying on one literal would let the guard pass vacuously for the
+    others. If one of these probes starts making a real second call, it must come out.
     """
     import pathlib
+    import re
 
+    provider_mock = re.compile(
+        r"tolokaforge\.core\.llm\.client\.completion"
+        r"""|patch\.object\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
+        r"""|setattr\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
+    )
     root = pathlib.Path(cert.__file__).resolve().parents[4] / "tests" / "integration" / "llm"
     mocked = {
         path.stem[len("test_") :]
         for path in root.glob("test_*.py")
-        if "tolokaforge.core.llm.client.completion" in path.read_text()
+        if provider_mock.search(path.read_text())
     }
     assert mocked == cert.PAYLOAD_ONLY_CAPABILITIES, cert.PAYLOAD_ONLY_CAPABILITIES ^ mocked
 

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -120,6 +120,107 @@ def test_core_capability_can_never_be_known_unsupported():
     assert not any("CORE-UNSUPPORTED" in v for v in v2)
 
 
+def _deepseek_0731_probed():
+    """The real PR #846 observe baseline (abridged): unsigned replay 0/15 NATIVE."""
+    return {
+        "basic_completion": 1.0,
+        "dict_map_tool_call": 1.0,
+        "thinking_emits_blocks": 1.0,
+        "implicit_prompt_caching": 1.0,
+        "unsigned_thinking_replay": 0.0,
+        "thinking_replay_roundtrip": 0.0,
+        "prompt_caching": 0.0,
+    }
+
+
+def test_self_referential_promotion_is_a_violation():
+    """PR #846 shipped `unsigned_thinking_replay` as required off an 0/15 native baseline.
+
+    The reprobe went 5/5, but that probe mocks the provider turn and asserts our own
+    outgoing payload, so a new codec satisfies it by construction.
+    """
+    violations, _ = cert.reconcile(
+        required={
+            "basic_completion",
+            "dict_map_tool_call",
+            "thinking_emits_blocks",
+            "implicit_prompt_caching",
+            "unsigned_thinking_replay",
+        },
+        known_unsupported={"thinking_replay_roundtrip", "prompt_caching"},
+        probed=_deepseek_0731_probed(),
+    )
+    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations), (
+        violations
+    )
+    # The honest posture for the same baseline reconciles clean.
+    ok, _ = cert.reconcile(
+        required={
+            "basic_completion",
+            "dict_map_tool_call",
+            "thinking_emits_blocks",
+            "implicit_prompt_caching",
+        },
+        known_unsupported={
+            "unsigned_thinking_replay",
+            "thinking_replay_roundtrip",
+            "prompt_caching",
+        },
+        probed=_deepseek_0731_probed(),
+    )
+    assert ok == []
+
+
+def test_payload_only_cap_required_on_a_passing_native_baseline_is_fine():
+    """A model that round-trips WITHOUT our overlay has genuinely earned the cap."""
+    violations, _ = cert.reconcile(
+        required={"unsigned_thinking_replay"},
+        known_unsupported=set(),
+        probed={"unsigned_thinking_replay": 1.0},
+    )
+    assert violations == []
+
+
+def test_non_payload_cap_promoted_off_a_failing_baseline_is_allowed():
+    """A real formatting fix legitimately turns a red probe green - not this gate's business."""
+    violations, _ = cert.reconcile(
+        required={"dict_map_tool_call"},
+        known_unsupported=set(),
+        probed={"dict_map_tool_call": 0.0},
+    )
+    assert violations == []
+
+
+def test_unbacked_required_capability_warns():
+    _, warnings = cert.reconcile(
+        required={"basic_completion", "never_probed_cap"},
+        known_unsupported=set(),
+        probed={"basic_completion": 1.0},
+    )
+    assert any("UNBACKED" in w and "never_probed_cap" in w for w in warnings)
+
+
+def test_payload_only_set_matches_the_probes_that_mock_the_provider():
+    """Drift guard, keyed on a STRUCTURAL fact rather than prose.
+
+    A probe can only assert our own outgoing payload by stubbing the transport, and the
+    single seam for that is ``tolokaforge.core.llm.client.completion`` - the one and only
+    patch target anywhere in the live capability suite. So "patches that symbol" is
+    exactly "does not observe the provider". If a third replay-style probe lands it
+    belongs in the set; if one of these starts making a real second call, it must come
+    out.
+    """
+    import pathlib
+
+    root = pathlib.Path(cert.__file__).resolve().parents[4] / "tests" / "integration" / "llm"
+    mocked = {
+        path.stem[len("test_") :]
+        for path in root.glob("test_*.py")
+        if "tolokaforge.core.llm.client.completion" in path.read_text()
+    }
+    assert mocked == cert.PAYLOAD_ONLY_CAPABILITIES, cert.PAYLOAD_ONLY_CAPABILITIES ^ mocked
+
+
 def test_core_capabilities_mirror_canon():
     # Guard against drift: the hardcoded set MUST equal the canonical one (7 caps incl.
     # progress_after_success) - a missing entry would reopen the laundering loophole.

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -218,19 +218,21 @@ def test_payload_only_set_matches_the_probes_that_mock_the_provider():
 
     A probe can only assert our own outgoing payload by stubbing the transport, and the
     single seam for that is ``client.completion`` - so "stubs that seam" is exactly
-    "does not observe the provider". The match covers the seam's patch SPELLINGS, not
-    one literal: the dotted string (``patch("tolokaforge.core.llm.client.completion")``
-    / ``monkeypatch.setattr("tolokaforge...")``) plus the object forms
+    "does not observe the provider". The match covers the seam's known patch SPELLINGS:
+    any quoted dotted path ending in ``.completion`` (the canonical
+    ``patch("tolokaforge.core.llm.client.completion")`` and the use-site form
+    ``patch("tests....test_x.completion")`` alike) plus the object forms
     (``patch.object(client, "completion")`` / ``monkeypatch.setattr(client,
-    "completion", ...)``) - a replay-style probe written in any of them must land in
-    the set, and keying on one literal would let the guard pass vacuously for the
-    others. If one of these probes starts making a real second call, it must come out.
+    "completion", ...)``) - keying on one literal would let the guard pass vacuously
+    for the others. A genuinely novel indirection (aliasing the function under another
+    name before stubbing it) is still invisible here and stays a review concern. If one
+    of these probes starts making a real second call, it must come out of the set.
     """
     import pathlib
     import re
 
     provider_mock = re.compile(
-        r"tolokaforge\.core\.llm\.client\.completion"
+        r"""['"][A-Za-z0-9_.]+\.completion['"]"""
         r"""|patch\.object\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
         r"""|setattr\(\s*(?:\w+\.)*client\s*,\s*['"]completion['"]"""
     )

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -150,9 +150,9 @@ def test_self_referential_promotion_is_a_violation():
         known_unsupported={"thinking_replay_roundtrip", "prompt_caching"},
         probed=_deepseek_0731_probed(),
     )
-    assert any("SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations), (
-        violations
-    )
+    assert any(
+        "SELF-REFERENTIAL" in v and "unsigned_thinking_replay" in v for v in violations
+    ), violations
     # The honest posture for the same baseline reconciles clean.
     ok, _ = cert.reconcile(
         required={

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -3,158 +3,312 @@
 The scenario mirrors the real deepseek-v4-flash-0731 PR #846, which registered
 ``OpenAISummaryReplayReasoningCodec`` with no unit test anywhere - the exact defect
 ``docs/ADD_NEW_MODEL.md`` step 5 forbids and nothing enforced.
+
+The pure helpers are exercised on source strings; ``run`` is exercised end to end on
+throwaway git repositories, because the defects it guards against live exactly in the
+git seam (index vs worktree, CWD, error handling) that a monkeypatched shim cannot see.
 """
 
 from __future__ import annotations
 
+import subprocess
+
 import automation.classgate as classgate
 import pytest
+from automation.classgate import Binding
 
 pytestmark = pytest.mark.unit
 
-# Trimmed to the shape ``git diff --cached --unified=0`` emits for the registry file.
-PR846_DIFF = """\
-diff --git a/tolokaforge/core/llm/presets.py b/tolokaforge/core/llm/presets.py
---- a/tolokaforge/core/llm/presets.py
-+++ b/tolokaforge/core/llm/presets.py
-@@ -112,0 +113 @@
-+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,
-"""
+BASE_PRESETS = """\
+_REASONING_CODECS = {
+    "openai": OpenAIReasoningCodec,
+}
 
-OTHER_FILE_DIFF = """\
-diff --git a/tolokaforge/core/llm/response_policy.py b/tolokaforge/core/llm/response_policy.py
---- a/tolokaforge/core/llm/response_policy.py
-+++ b/tolokaforge/core/llm/response_policy.py
-@@ -10,0 +11 @@
-+class SomeHelper:
-+    "not a registry binding"
+_RESPONSE_POLICIES = {
+    "standard": StandardResponse,
+}
+
+_POLICY_REGISTRIES = {
+    "reasoning_codec": _REASONING_CODECS,
+    "response_policy": _RESPONSE_POLICIES,
+}
 """
 
 
-class TestAddedRegistryClasses:
-    def test_finds_the_new_codec_binding(self):
-        assert classgate.added_registry_classes(PR846_DIFF) == ["OpenAISummaryReplayReasoningCodec"]
+def _with_binding(line: str) -> str:
+    """BASE_PRESETS with one extra line inside ``_REASONING_CODECS``."""
+    return BASE_PRESETS.replace(
+        '    "openai": OpenAIReasoningCodec,\n',
+        f'    "openai": OpenAIReasoningCodec,\n    {line}\n',
+    )
 
-    def test_ignores_added_lines_in_other_files(self):
-        """A class DEFINED elsewhere is not a registration - only presets.py counts."""
-        assert classgate.added_registry_classes(OTHER_FILE_DIFF) == []
 
-    def test_ignores_removed_and_context_lines(self):
-        diff = PR846_DIFF.replace(
-            '+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,',
-            '-    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,\n'
-            '     "openai": OpenAIReasoningCodec,',
+class TestRegistryBindings:
+    def test_reads_the_baseline_bindings(self):
+        assert classgate.registry_bindings(BASE_PRESETS) == {
+            Binding("_REASONING_CODECS", "openai", "OpenAIReasoningCodec"),
+            Binding("_RESPONSE_POLICIES", "standard", "StandardResponse"),
+        }
+
+    @pytest.mark.parametrize(
+        ("line", "expected_value"),
+        [
+            # Every spelling the old diff-text regex silently missed - each one was a
+            # fail-open evasion; the AST cannot be fooled by surface syntax.
+            ("'new_codec': BrandNewCodec,", "BrandNewCodec"),  # single quotes
+            ('"new_codec": BrandNewCodec', "BrandNewCodec"),  # no trailing comma
+            ('"new_codec": codecs.BrandNewCodec,', "codecs.BrandNewCodec"),  # dotted
+            ('"new_codec": BrandNewCodec(),', "BrandNewCodec()"),  # instance
+            ('"new_codec": make_brand_new_codec,', "make_brand_new_codec"),  # factory
+        ],
+    )
+    def test_binding_shape_variants_are_all_seen(self, line: str, expected_value: str):
+        bindings = classgate.registry_bindings(_with_binding(line))
+        assert Binding("_REASONING_CODECS", "new_codec", expected_value) in bindings
+
+    def test_value_wrapped_onto_the_next_line_is_seen(self):
+        source = BASE_PRESETS.replace(
+            '    "openai": OpenAIReasoningCodec,\n',
+            '    "openai": OpenAIReasoningCodec,\n    "new_codec":\n        BrandNewCodec,\n',
         )
-        assert classgate.added_registry_classes(diff) == []
+        assert Binding("_REASONING_CODECS", "new_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
 
-    def test_deduplicates_repeated_bindings(self):
-        diff = PR846_DIFF + '+    "alias": OpenAISummaryReplayReasoningCodec,\n'
-        assert classgate.added_registry_classes(diff) == ["OpenAISummaryReplayReasoningCodec"]
+    def test_subscript_assignment_is_seen(self):
+        source = BASE_PRESETS + '_REASONING_CODECS["late_codec"] = BrandNewCodec\n'
+        assert Binding("_REASONING_CODECS", "late_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
 
-    def test_empty_diff_is_empty(self):
-        assert classgate.added_registry_classes("") == []
+    def test_update_call_is_seen(self):
+        source = BASE_PRESETS + '_REASONING_CODECS.update({"late_codec": BrandNewCodec})\n'
+        assert Binding("_REASONING_CODECS", "late_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
+
+    def test_inline_slot_dict_in_the_index_is_seen(self):
+        source = (
+            'X = 1\n_POLICY_REGISTRIES = {\n    "reasoning_codec": {"inline": InlineCodec},\n}\n'
+        )
+        assert classgate.registry_bindings(source) == {
+            Binding("reasoning_codec", "inline", "InlineCodec")
+        }
+
+    def test_non_slot_dicts_are_ignored(self):
+        source = BASE_PRESETS + '_DEFAULT_PRESET_DATA = {"default": DefaultThing}\n'
+        assert not any(
+            binding.registry == "_DEFAULT_PRESET_DATA"
+            for binding in classgate.registry_bindings(source)
+        )
+
+    def test_missing_registry_index_fails_loud(self):
+        with pytest.raises(ValueError, match="no _POLICY_REGISTRIES slots"):
+            classgate.registry_bindings("_REASONING_CODECS = {'a': A}\n")
+
+    def test_unparsable_source_raises(self):
+        with pytest.raises(SyntaxError):
+            classgate.registry_bindings("this is not python {")
+
+
+class TestAddedBindings:
+    def test_a_new_binding_is_reported(self):
+        staged = _with_binding('"new_codec": BrandNewCodec,')
+        assert classgate.added_bindings(staged, BASE_PRESETS) == [
+            Binding("_REASONING_CODECS", "new_codec", "BrandNewCodec")
+        ]
+
+    def test_moved_and_reordered_lines_are_not_new(self):
+        """Alphabetizing a dict while inserting nothing must not hard-fail the gate on
+        pre-existing classes (set semantics, not line semantics)."""
+        reordered = BASE_PRESETS.replace(
+            '_POLICY_REGISTRIES = {\n    "reasoning_codec": _REASONING_CODECS,\n'
+            '    "response_policy": _RESPONSE_POLICIES,\n}\n',
+            '_POLICY_REGISTRIES = {\n    "response_policy": _RESPONSE_POLICIES,\n'
+            '    "reasoning_codec": _REASONING_CODECS,\n}\n',
+        )
+        assert classgate.added_bindings(reordered, BASE_PRESETS) == []
+
+    def test_rebinding_an_existing_key_is_reported(self):
+        staged = BASE_PRESETS.replace("OpenAIReasoningCodec", "ReplacementCodec")
+        assert classgate.added_bindings(staged, BASE_PRESETS) == [
+            Binding("_REASONING_CODECS", "openai", "ReplacementCodec")
+        ]
+
+
+class TestBoundName:
+    @pytest.mark.parametrize(
+        ("value", "name"),
+        [
+            ("BrandNewCodec", "BrandNewCodec"),
+            ("codecs.BrandNewCodec", "BrandNewCodec"),
+            ("BrandNewCodec()", "BrandNewCodec"),
+            ("make_brand_new_codec", "make_brand_new_codec"),
+        ],
+    )
+    def test_names_the_identifier_a_test_must_mention(self, value: str, name: str):
+        assert classgate.bound_name(value) == name
 
 
 class TestUntested:
     def test_flags_a_class_no_test_mentions(self):
-        assert classgate.untested(
-            ["OpenAISummaryReplayReasoningCodec"], "def test_something(): pass"
-        ) == ["OpenAISummaryReplayReasoningCodec"]
+        assert classgate.untested(["BrandNewCodec"], "def test_something(): pass") == [
+            "BrandNewCodec"
+        ]
 
     def test_accepts_a_class_a_test_mentions(self):
-        blob = "from x import OpenAISummaryReplayReasoningCodec\ndef test_it(): ..."
-        assert classgate.untested(["OpenAISummaryReplayReasoningCodec"], blob) == []
+        blob = "from x import BrandNewCodec\ndef test_it(): ..."
+        assert classgate.untested(["BrandNewCodec"], blob) == []
+
+    def test_substring_of_an_existing_mention_does_not_vouch(self):
+        """`MinimaxM3TagRecoveryResponse` in an existing test must not satisfy a NEW
+        `TagRecoveryResponse` - word-boundary, not substring."""
+        blob = "from y import MinimaxM3TagRecoveryResponse\ndef test_m3(): ..."
+        assert classgate.untested(["TagRecoveryResponse"], blob) == ["TagRecoveryResponse"]
 
 
 class TestUnreferenced:
-    def test_flags_a_class_the_overlay_never_uses(self):
-        assert classgate.unreferenced(
-            ["OpenAISummaryReplayReasoningCodec"], "presets:\n  x:\n    match: ['a']\n", PR846_DIFF
-        ) == ["OpenAISummaryReplayReasoningCodec"]
+    BINDINGS = [Binding("_REASONING_CODECS", "openai_summary_replay", "BrandNewCodec")]
 
-    def test_registry_key_in_the_overlay_counts_as_a_reference(self):
-        """Overlays reference a class by its registry KEY, not its class name."""
+    def test_flags_a_class_nothing_references(self):
+        overlay = "presets:\n  x:\n    match: ['a']\n"
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == ["BrandNewCodec"]
+
+    def test_registry_key_in_a_value_position_counts(self):
         overlay = "presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"
-        assert (
-            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
-        )
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-    def test_class_name_in_the_overlay_also_counts(self):
-        overlay = "# uses OpenAISummaryReplayReasoningCodec\n"
-        assert (
-            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
-        )
+    def test_quoted_value_position_counts(self):
+        overlay = 'presets:\n  x:\n    reasoning_codec: "openai_summary_replay"\n'
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-    def test_any_of_several_keys_counts_as_a_reference(self):
-        """A class bound under two keys is referenced if the overlay uses EITHER one."""
-        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
-        for key in ("openai_summary_replay", "second_alias"):
-            overlay = f"presets:\n  x:\n    reasoning_codec: {key}\n"
-            assert (
-                classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, diff) == []
-            ), key
+    def test_key_inside_a_match_glob_does_not_count(self):
+        """A short family key must not be auto-referenced by a slug that merely
+        contains it - `qwen` in `match: ["qwen/qwen3.8-max"]` is not a reference."""
+        bindings = [Binding("_RESPONSE_POLICIES", "qwen", "QwenRecovery")]
+        overlay = 'presets:\n  x:\n    match: ["qwen/qwen3.8-max"]\n'
+        assert classgate.unreferenced(bindings, overlay, "") == ["QwenRecovery"]
 
+    def test_class_name_mention_counts(self):
+        overlay = "# uses BrandNewCodec\n"
+        assert classgate.unreferenced(self.BINDINGS, overlay, "") == []
 
-class TestAddedBindings:
-    def test_returns_key_class_pairs(self):
-        assert classgate.added_bindings(PR846_DIFF) == [
-            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec")
-        ]
+    def test_staged_preset_file_reference_counts(self):
+        presets = "presets:\n  folded:\n    reasoning_codec: openai_summary_replay\n"
+        assert classgate.unreferenced(self.BINDINGS, "", presets) == []
 
-    def test_keeps_every_key_for_a_multiply_bound_class(self):
-        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
-        assert classgate.added_bindings(diff) == [
-            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec"),
-            ("second_alias", "OpenAISummaryReplayReasoningCodec"),
-        ]
-
-    def test_ignores_underscore_prefixed_registry_slot_lines(self):
-        """``_POLICY_REGISTRIES`` slot values are underscore-prefixed, not classes."""
-        diff = (
-            "+++ b/tolokaforge/core/llm/presets.py\n" '+    "reasoning_codec": _REASONING_CODECS,\n'
-        )
-        assert classgate.added_bindings(diff) == []
+    def test_any_of_several_keys_counts(self):
+        bindings = self.BINDINGS + [Binding("_REASONING_CODECS", "second_alias", "BrandNewCodec")]
+        overlay = "presets:\n  x:\n    reasoning_codec: second_alias\n"
+        assert classgate.unreferenced(bindings, overlay, "") == []
 
 
-class TestReadTests:
-    def test_missing_dir_is_empty_not_an_error(self):
-        assert classgate.read_tests("does/not/exist") == ""
+# --- run(): end to end on throwaway git repos -----------------------------------
 
-    def test_concatenates_test_sources(self, tmp_path):
-        (tmp_path / "test_a.py").write_text("MarkerClassA")
-        (tmp_path / "helper.py").write_text("MarkerNotATest")
-        blob = classgate.read_tests(str(tmp_path))
-        assert "MarkerClassA" in blob
-        assert "MarkerNotATest" not in blob
+
+def _git(repo, *args) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+NEW_BINDING_PRESETS = BASE_PRESETS.replace(
+    '    "openai": OpenAIReasoningCodec,\n',
+    '    "openai": OpenAIReasoningCodec,\n    "openai_summary_replay": BrandNewCodec,\n',
+)
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A committed baseline repo shaped like the paths the gate reads."""
+    root = tmp_path / "repo"
+    (root / "tolokaforge/core/llm").mkdir(parents=True)
+    (root / "tolokaforge/core/data").mkdir(parents=True)
+    (root / "tests/unit/llm").mkdir(parents=True)
+    (root / "tolokaforge/core/llm/presets.py").write_text(BASE_PRESETS)
+    (root / "tolokaforge/core/data/model_presets.yaml").write_text("presets: {}\n")
+    _git(root, "init", "-q")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base")
+    return root
+
+
+def _stage_new_binding(root) -> None:
+    (root / "tolokaforge/core/llm/presets.py").write_text(NEW_BINDING_PRESETS)
+    _git(root, "add", "tolokaforge/core/llm/presets.py")
+
+
+def _overlay(tmp_path, text="presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"):
+    path = tmp_path / "overlay.yaml"
+    path.write_text(text)
+    return str(path)
 
 
 class TestRun:
-    def test_no_new_class_passes(self, monkeypatch):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: OTHER_FILE_DIFF)
-        assert classgate.run() == 0
+    def test_no_new_binding_passes(self, repo):
+        assert classgate.run(root=str(repo)) == 0
 
-    def test_pr846_shape_fails_on_the_missing_unit_test(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        overlay = tmp_path / "overlay.yaml"
-        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
-        empty_tests = tmp_path / "tests"
-        empty_tests.mkdir()
-        assert classgate.run(overlay_path=str(overlay), tests_dir=str(empty_tests)) == 1
+    def test_staged_test_and_overlay_reference_pass(self, repo, tmp_path):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
 
-    def test_passes_once_a_unit_test_covers_the_class(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        overlay = tmp_path / "overlay.yaml"
-        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
-        tests = tmp_path / "tests"
-        tests.mkdir()
-        (tests / "test_codec.py").write_text(
-            "from y import OpenAISummaryReplayReasoningCodec\ndef test_c(): ..."
+    def test_worktree_only_test_does_not_count(self, repo, tmp_path, capsys):
+        """The finalize commit ships the INDEX. A test that exists only in the worktree
+        would satisfy a worktree-reading gate and then vanish from the commit - the
+        false assurance the gate exists to prevent - so it must NOT count."""
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")  # never added
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 1
+        assert "UNTESTED-CLASS" in capsys.readouterr().out
+
+    def test_unreferenced_class_fails_without_any_reference(self, repo, tmp_path, capsys):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        assert classgate.run(overlay_path=None, root=str(repo)) == 1
+        assert "UNREFERENCED-CLASS" in capsys.readouterr().out
+
+    def test_staged_model_presets_reference_passes_without_an_overlay(self, repo):
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        (repo / "tolokaforge/core/data/model_presets.yaml").write_text(
+            "presets:\n  folded:\n    reasoning_codec: openai_summary_replay\n"
         )
-        assert classgate.run(overlay_path=str(overlay), tests_dir=str(tests)) == 0
+        _git(repo, "add", "tolokaforge/core/data/model_presets.yaml")
+        assert classgate.run(overlay_path=None, root=str(repo)) == 0
 
-    def test_missing_overlay_still_flags_the_unreferenced_class(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
-        tests = tmp_path / "tests"
-        tests.mkdir()
-        (tests / "test_codec.py").write_text("OpenAISummaryReplayReasoningCodec")
-        assert classgate.run(overlay_path=None, tests_dir=str(tests)) == 1
+    def test_cwd_does_not_matter(self, repo, tmp_path, monkeypatch):
+        """The old gate read git from the caller's CWD: from a subdirectory every git
+        answer silently emptied and the gate no-opped. The root is now anchored."""
+        _stage_new_binding(repo)
+        (repo / "tests/unit/llm/test_codec.py").write_text("BrandNewCodec\n")
+        _git(repo, "add", "tests/unit/llm/test_codec.py")
+        monkeypatch.chdir(repo / "tests")
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
+        monkeypatch.chdir(tmp_path)  # unrelated dir
+        assert classgate.run(overlay_path=_overlay(tmp_path), root=str(repo)) == 0
+
+    def test_non_git_root_fails_loud_not_open(self, tmp_path, capsys):
+        """git exiting 128 used to read as "no new policy class registered" (rc=0).
+        A guard must fail loud, never skip."""
+        outside = tmp_path / "not-a-repo"
+        outside.mkdir()
+        assert classgate.run(root=str(outside)) == 1
+        assert "could not read the staged tree" in capsys.readouterr().out
+
+    def test_reordered_registry_does_not_false_positive(self, repo, tmp_path):
+        """A move is a -/+ pair in diff text; the set diff must not report it."""
+        reordered = BASE_PRESETS.replace(
+            '_REASONING_CODECS = {\n    "openai": OpenAIReasoningCodec,\n}\n',
+            '_REASONING_CODECS = {\n\n    "openai": OpenAIReasoningCodec,\n}\n',
+        )
+        (repo / "tolokaforge/core/llm/presets.py").write_text(reordered)
+        _git(repo, "add", "tolokaforge/core/llm/presets.py")
+        assert classgate.run(root=str(repo)) == 0

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -102,6 +102,56 @@ class TestRegistryBindings:
             for binding in classgate.registry_bindings(source)
         )
 
+    @pytest.mark.parametrize(
+        ("statement", "key"),
+        [
+            ('_REASONING_CODECS |= {"late_codec": BrandNewCodec}', "late_codec"),
+            ("_REASONING_CODECS.update(late_codec=BrandNewCodec)", "late_codec"),
+            ('_REASONING_CODECS.setdefault("late_codec", BrandNewCodec)', "late_codec"),
+        ],
+        ids=["augassign-or", "update-kwargs", "setdefault"],
+    )
+    def test_further_mutation_shapes_are_seen(self, statement: str, key: str):
+        source = BASE_PRESETS + statement + "\n"
+        assert Binding("_REASONING_CODECS", key, "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
+
+    def test_registration_nested_in_a_conditional_is_seen(self):
+        source = BASE_PRESETS + 'if True:\n    _REASONING_CODECS["late_codec"] = BrandNewCodec\n'
+        assert Binding("_REASONING_CODECS", "late_codec", "BrandNewCodec") in (
+            classgate.registry_bindings(source)
+        )
+
+    @pytest.mark.parametrize(
+        "statement",
+        [
+            "_REASONING_CODECS = dict(late_codec=BrandNewCodec)",  # non-dict-literal reassign
+            "_REASONING_CODECS += extra",  # AugAssign shape the gate cannot model
+            "_REASONING_CODECS.update(**extra)",  # a splat hides its keys
+            "_REASONING_CODECS.update(make_extra())",  # non-dict positional
+            '_REASONING_CODECS.setdefault("late_codec")',  # no value bound
+            '_REASONING_CODECS.pop("openai")',  # unrecognized mutation
+        ],
+        ids=["dict-call", "augassign-add", "splat", "call-arg", "setdefault-1", "pop"],
+    )
+    def test_unmodelable_mutations_fail_loud_not_open(self, statement: str):
+        with pytest.raises(ValueError, match="unmodelable"):
+            classgate.registry_bindings(BASE_PRESETS + statement + "\n")
+
+    def test_read_only_uses_are_not_mutations(self):
+        source = BASE_PRESETS + 'x = _REASONING_CODECS.get("openai")\nresolve(_REASONING_CODECS)\n'
+        assert classgate.registry_bindings(source) == classgate.registry_bindings(BASE_PRESETS)
+
+    def test_the_real_registry_file_parses_without_raising(self):
+        # Pins the fail-loud net against false positives on the engine's actual
+        # presets.py (its .get() resolution calls and argument-position passes must
+        # stay recognized as reads).
+        source = (classgate.REPO_ROOT / classgate.REGISTRY_FILE).read_text()
+        bindings = classgate.registry_bindings(source)
+        assert len(bindings) >= 20
+        assert len({binding.registry for binding in bindings}) == 6
+
     def test_missing_registry_index_fails_loud(self):
         with pytest.raises(ValueError, match="no _POLICY_REGISTRIES slots"):
             classgate.registry_bindings("_REASONING_CODECS = {'a': A}\n")

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -1,0 +1,130 @@
+"""Unit tests for ``automation.classgate``.
+
+The scenario mirrors the real deepseek-v4-flash-0731 PR #846, which registered
+``OpenAISummaryReplayReasoningCodec`` with no unit test anywhere - the exact defect
+``docs/ADD_NEW_MODEL.md`` step 5 forbids and nothing enforced.
+"""
+
+from __future__ import annotations
+
+import automation.classgate as classgate
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Trimmed to the shape ``git diff --cached --unified=0`` emits for the registry file.
+PR846_DIFF = """\
+diff --git a/tolokaforge/core/llm/presets.py b/tolokaforge/core/llm/presets.py
+--- a/tolokaforge/core/llm/presets.py
++++ b/tolokaforge/core/llm/presets.py
+@@ -112,0 +113 @@
++    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,
+"""
+
+OTHER_FILE_DIFF = """\
+diff --git a/tolokaforge/core/llm/response_policy.py b/tolokaforge/core/llm/response_policy.py
+--- a/tolokaforge/core/llm/response_policy.py
++++ b/tolokaforge/core/llm/response_policy.py
+@@ -10,0 +11 @@
++class SomeHelper:
++    "not a registry binding"
+"""
+
+
+class TestAddedRegistryClasses:
+    def test_finds_the_new_codec_binding(self):
+        assert classgate.added_registry_classes(PR846_DIFF) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_ignores_added_lines_in_other_files(self):
+        """A class DEFINED elsewhere is not a registration - only presets.py counts."""
+        assert classgate.added_registry_classes(OTHER_FILE_DIFF) == []
+
+    def test_ignores_removed_and_context_lines(self):
+        diff = PR846_DIFF.replace(
+            '+    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,',
+            '-    "openai_summary_replay": OpenAISummaryReplayReasoningCodec,\n'
+            '     "openai": OpenAIReasoningCodec,',
+        )
+        assert classgate.added_registry_classes(diff) == []
+
+    def test_deduplicates_repeated_bindings(self):
+        diff = PR846_DIFF + '+    "alias": OpenAISummaryReplayReasoningCodec,\n'
+        assert classgate.added_registry_classes(diff) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_empty_diff_is_empty(self):
+        assert classgate.added_registry_classes("") == []
+
+
+class TestUntested:
+    def test_flags_a_class_no_test_mentions(self):
+        assert classgate.untested(
+            ["OpenAISummaryReplayReasoningCodec"], "def test_something(): pass"
+        ) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_accepts_a_class_a_test_mentions(self):
+        blob = "from x import OpenAISummaryReplayReasoningCodec\ndef test_it(): ..."
+        assert classgate.untested(["OpenAISummaryReplayReasoningCodec"], blob) == []
+
+
+class TestUnreferenced:
+    def test_flags_a_class_the_overlay_never_uses(self):
+        assert classgate.unreferenced(
+            ["OpenAISummaryReplayReasoningCodec"], "presets:\n  x:\n    match: ['a']\n", PR846_DIFF
+        ) == ["OpenAISummaryReplayReasoningCodec"]
+
+    def test_registry_key_in_the_overlay_counts_as_a_reference(self):
+        """Overlays reference a class by its registry KEY, not its class name."""
+        overlay = "presets:\n  x:\n    reasoning_codec: openai_summary_replay\n"
+        assert (
+            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
+        )
+
+    def test_class_name_in_the_overlay_also_counts(self):
+        overlay = "# uses OpenAISummaryReplayReasoningCodec\n"
+        assert (
+            classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
+        )
+
+
+class TestReadTests:
+    def test_missing_dir_is_empty_not_an_error(self):
+        assert classgate.read_tests("does/not/exist") == ""
+
+    def test_concatenates_test_sources(self, tmp_path):
+        (tmp_path / "test_a.py").write_text("MarkerClassA")
+        (tmp_path / "helper.py").write_text("MarkerNotATest")
+        blob = classgate.read_tests(str(tmp_path))
+        assert "MarkerClassA" in blob
+        assert "MarkerNotATest" not in blob
+
+
+class TestRun:
+    def test_no_new_class_passes(self, monkeypatch):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: OTHER_FILE_DIFF)
+        assert classgate.run() == 0
+
+    def test_pr846_shape_fails_on_the_missing_unit_test(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        overlay = tmp_path / "overlay.yaml"
+        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
+        empty_tests = tmp_path / "tests"
+        empty_tests.mkdir()
+        assert classgate.run(overlay_path=str(overlay), tests_dir=str(empty_tests)) == 1
+
+    def test_passes_once_a_unit_test_covers_the_class(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        overlay = tmp_path / "overlay.yaml"
+        overlay.write_text("presets:\n  x:\n    reasoning_codec: openai_summary_replay\n")
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_codec.py").write_text(
+            "from y import OpenAISummaryReplayReasoningCodec\ndef test_c(): ..."
+        )
+        assert classgate.run(overlay_path=str(overlay), tests_dir=str(tests)) == 0
+
+    def test_missing_overlay_still_flags_the_unreferenced_class(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(classgate, "_staged_diff", lambda: PR846_DIFF)
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test_codec.py").write_text("OpenAISummaryReplayReasoningCodec")
+        assert classgate.run(overlay_path=None, tests_dir=str(tests)) == 1

--- a/tools/automation/tests/test_classgate.py
+++ b/tools/automation/tests/test_classgate.py
@@ -85,6 +85,36 @@ class TestUnreferenced:
             classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, PR846_DIFF) == []
         )
 
+    def test_any_of_several_keys_counts_as_a_reference(self):
+        """A class bound under two keys is referenced if the overlay uses EITHER one."""
+        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
+        for key in ("openai_summary_replay", "second_alias"):
+            overlay = f"presets:\n  x:\n    reasoning_codec: {key}\n"
+            assert (
+                classgate.unreferenced(["OpenAISummaryReplayReasoningCodec"], overlay, diff) == []
+            ), key
+
+
+class TestAddedBindings:
+    def test_returns_key_class_pairs(self):
+        assert classgate.added_bindings(PR846_DIFF) == [
+            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec")
+        ]
+
+    def test_keeps_every_key_for_a_multiply_bound_class(self):
+        diff = PR846_DIFF + '+    "second_alias": OpenAISummaryReplayReasoningCodec,\n'
+        assert classgate.added_bindings(diff) == [
+            ("openai_summary_replay", "OpenAISummaryReplayReasoningCodec"),
+            ("second_alias", "OpenAISummaryReplayReasoningCodec"),
+        ]
+
+    def test_ignores_underscore_prefixed_registry_slot_lines(self):
+        """``_POLICY_REGISTRIES`` slot values are underscore-prefixed, not classes."""
+        diff = (
+            "+++ b/tolokaforge/core/llm/presets.py\n" '+    "reasoning_codec": _REASONING_CODECS,\n'
+        )
+        assert classgate.added_bindings(diff) == []
+
 
 class TestReadTests:
     def test_missing_dir_is_empty_not_an_error(self):

--- a/tools/automation/tests/test_greencheck.py
+++ b/tools/automation/tests/test_greencheck.py
@@ -74,3 +74,50 @@ def test_red_list_is_sorted_and_capped_at_eight():
     reds = token[len("RED:") :].split(";")
     assert reds == sorted(targets)[:8]
     assert len(reds) == 8
+
+
+class TestDecisionTargets:
+    """PARSE_FAIL vs NO_TARGETS is the loop's convergence boundary: a malformed decision
+    must be a stall to retry, never the all-ceiling verdict nobody actually made."""
+
+    def test_named_targets_join(self):
+        decision = {"fix_targets": [" test_a[x] ", "test_b[y]"]}
+        assert greencheck.decision_targets(decision) == "TARGETS:test_a[x],test_b[y]"
+
+    def test_well_formed_empty_list_is_the_all_ceiling_verdict(self):
+        assert greencheck.decision_targets({"fix_targets": []}) == "NO_TARGETS"
+
+    @pytest.mark.parametrize(
+        "decision",
+        [
+            {},  # fix_targets missing entirely (schema deviation)
+            {"fix_targets": None},
+            {"fix_targets": "test_a[x]"},  # string, not a list
+            {"fix_targets": [42]},  # non-string element
+            {"fix_targets": [""]},  # empty element
+            {"fix_targets": ["a,b"]},  # a comma would corrupt the joined form
+        ],
+        ids=["missing", "null", "string", "non-str", "empty-str", "comma"],
+    )
+    def test_malformed_shapes_are_parse_fail_not_no_targets(self, decision):
+        assert greencheck.decision_targets(decision) == "PARSE_FAIL"
+
+    def test_run_prints_parse_fail_for_truncated_json(self, tmp_path, capsys):
+        path = tmp_path / "decision.json"
+        path.write_text('{"fix_targets": ["test_a[x]"')  # died mid-write
+        assert greencheck.run_decision_targets(str(path)) == 0
+        assert capsys.readouterr().out.strip() == "PARSE_FAIL"
+
+    def test_run_prints_parse_fail_for_a_non_object_document(self, tmp_path, capsys):
+        path = tmp_path / "decision.json"
+        path.write_text('["not", "an", "object"]')
+        assert greencheck.run_decision_targets(str(path)) == 0
+        assert capsys.readouterr().out.strip() == "PARSE_FAIL"
+
+    def test_run_prints_the_token_for_a_valid_decision(self, tmp_path, capsys):
+        import json
+
+        path = tmp_path / "decision.json"
+        path.write_text(json.dumps({"fix_targets": ["test_a[x]"]}))
+        assert greencheck.run_decision_targets(str(path)) == 0
+        assert capsys.readouterr().out.strip() == "TARGETS:test_a[x]"

--- a/tools/automation/tests/test_observe.py
+++ b/tools/automation/tests/test_observe.py
@@ -94,6 +94,36 @@ def test_render_summary_shows_verdict_and_failing_probe():
     assert "`test_b`: 1/2 passed" in summary
 
 
+def test_render_summary_wire_only_reprobe_verdict_is_the_wire_result():
+    # The final wire-verification artifact has NO capability section by design; its
+    # summary must lead with the wire result, not "capability suite did NOT run -
+    # infra failure" (which is the right verdict only for an observe artifact).
+    findings = {
+        "stage": "reprobe",
+        "candidate": {"name": "vendor/m"},
+        "preset": "overlay",
+        "capability_ran": False,
+        "all_passed": False,
+        "capability": {"report_present": False},
+        "variants": {"report_present": False},
+        "wire": {
+            "trials": 40,
+            "tool_call_count": 120,
+            "tool_arg_rejections": {
+                "rejecting_trials": 3,
+                "trial_rate": 0.075,
+                "by_task_trial_rate": {},
+            },
+            "rejected_examples": [],
+            "infra": {},
+        },
+    }
+    summary = observe.render_summary(findings)
+    assert "### Auto-integration reprobe:" in summary
+    assert "wire-only pass: 3/40 trials with a tool-arg rejection" in summary
+    assert "infra failure" not in summary
+
+
 def _gate_findings(**overrides):
     """A clean-observe findings skeleton the gate tests mutate per case."""
     findings = {

--- a/tools/automation/tests/test_observe.py
+++ b/tools/automation/tests/test_observe.py
@@ -124,6 +124,43 @@ def test_render_summary_wire_only_reprobe_verdict_is_the_wire_result():
     assert "infra failure" not in summary
 
 
+def test_build_findings_carries_reprobe_stage_into_wire_only_summary(tmp_path):
+    # End to end through the real artifact shape: a wire_verify-style out dir (reprobe
+    # manifest, no capability junit, one wire trajectory) must yield stage=reprobe, no
+    # infra-failure note, and a wire-only summary verdict. Pins the manifest -> findings
+    # -> summary path so re-hardcoding stage in build_findings cannot pass the suite.
+    import json
+
+    import yaml
+
+    (tmp_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "stage": "reprobe",
+                "candidate": {"name": "vendor/m"},
+                "preset": "overlay",
+            }
+        )
+    )
+    trial = tmp_path / "wire_probes_1" / "trials" / "task_w" / "1"
+    trial.mkdir(parents=True)
+    (trial / "trajectory.yaml").write_text(
+        yaml.safe_dump({"task_id": "task_w", "status": "completed", "messages": []})
+    )
+
+    findings = observe.build_findings(tmp_path)
+    assert findings["stage"] == "reprobe"
+    assert findings["capability_ran"] is False
+    assert not any("did NOT execute" in note for note in findings["notes"])
+    assert findings["wire"]["trials"] == 1
+
+    summary = observe.render_summary(findings)
+    assert "### Auto-integration reprobe:" in summary
+    assert "wire-only pass: 0/1 trials with a tool-arg rejection" in summary
+    assert "infra failure" not in summary
+
+
 def _gate_findings(**overrides):
     """A clean-observe findings skeleton the gate tests mutate per case."""
     findings = {
@@ -158,7 +195,7 @@ def test_gate_dirty_when_capability_did_not_run():
 
 def test_gate_dirty_when_wire_never_ran():
     # The wire step is `|| true`-guarded in the workflow: a run that failed at startup
-    # produces 0 trials and used to read as clean (no rejections, all-zero infra).
+    # produces 0 trials and would otherwise read as clean (no rejections, all-zero infra).
     clean, reason = observe.evaluate_gate(_gate_findings(wire={"trials": 0, "infra": {}}))
     assert clean is False
     assert "wire probes did not run" in reason
@@ -166,8 +203,8 @@ def test_gate_dirty_when_wire_never_ran():
 
 @pytest.mark.parametrize("key", sorted(observe.GATE_INFRA_KEYS))
 def test_gate_dirty_on_each_infra_key(key):
-    # api_timeout is the regression case: observe.py counted it, the old inline
-    # workflow gate never read it, so an all-timeout wire run chained into resolve.
+    # Every key is pinned individually so a gate that drops one (an all-timeout wire
+    # run chaining into resolve) cannot pass the suite.
     findings = _gate_findings()
     findings["wire"]["infra"][key] = 3
     clean, reason = observe.evaluate_gate(findings)
@@ -189,6 +226,13 @@ def test_gate_cli_prints_dirty_token_for_missing_file(tmp_path, capsys):
     assert observe.gate(str(tmp_path / "absent.json")) == 0
     out = capsys.readouterr().out
     assert out.startswith("dirty: findings unreadable")
+
+
+def test_gate_cli_prints_dirty_token_for_malformed_json(tmp_path, capsys):
+    path = tmp_path / "findings.json"
+    path.write_text("{truncated")
+    assert observe.gate(str(path)) == 0
+    assert capsys.readouterr().out.startswith("dirty: findings unreadable")
 
 
 def test_gate_cli_prints_clean_token(tmp_path, capsys):

--- a/tools/automation/tests/test_observe.py
+++ b/tools/automation/tests/test_observe.py
@@ -124,6 +124,34 @@ def test_render_summary_wire_only_reprobe_verdict_is_the_wire_result():
     assert "infra failure" not in summary
 
 
+def test_render_summary_wire_only_reprobe_with_no_trials_says_the_run_failed():
+    # Unreachable from the workflow (the rejections>0 guard implies wire tasks exist), but
+    # a wire run that crashes at startup - or a manual CLI invocation - lands here and must
+    # not read as a wire-clean pass.
+    findings = {
+        "stage": "reprobe",
+        "candidate": {"name": "vendor/m"},
+        "preset": "overlay",
+        "capability_ran": False,
+        "all_passed": False,
+        "capability": {"report_present": False},
+        "variants": {"report_present": False},
+        "wire": {
+            "trials": 0,
+            "tool_call_count": 0,
+            "tool_arg_rejections": {
+                "rejecting_trials": 0,
+                "trial_rate": 0,
+                "by_task_trial_rate": {},
+            },
+            "rejected_examples": [],
+            "infra": {},
+        },
+    }
+    summary = observe.render_summary(findings)
+    assert "wire-only pass produced no trials" in summary
+
+
 def test_build_findings_carries_reprobe_stage_into_wire_only_summary(tmp_path):
     # End to end through the real artifact shape: a wire_verify-style out dir (reprobe
     # manifest, no capability junit, one wire trajectory) must yield stage=reprobe, no

--- a/tools/automation/tests/test_observe.py
+++ b/tools/automation/tests/test_observe.py
@@ -92,3 +92,79 @@ def test_render_summary_shows_verdict_and_failing_probe():
     assert "failures present" in summary
     assert "`vendor/m`" in summary
     assert "`test_b`: 1/2 passed" in summary
+
+
+def _gate_findings(**overrides):
+    """A clean-observe findings skeleton the gate tests mutate per case."""
+    findings = {
+        "capability_ran": True,
+        "wire": {
+            "trials": 40,
+            "infra": {
+                "rate_limit": 0,
+                "status_error": 0,
+                "max_turns": 0,
+                "stuck": 0,
+                "api_error": 0,
+                "api_timeout": 0,
+            },
+        },
+    }
+    findings.update(overrides)
+    return findings
+
+
+def test_gate_clean_when_both_suites_ran_and_infra_zero():
+    clean, reason = observe.evaluate_gate(_gate_findings())
+    assert clean is True
+    assert reason == ""
+
+
+def test_gate_dirty_when_capability_did_not_run():
+    clean, reason = observe.evaluate_gate(_gate_findings(capability_ran=False))
+    assert clean is False
+    assert "capability suite did not run" in reason
+
+
+def test_gate_dirty_when_wire_never_ran():
+    # The wire step is `|| true`-guarded in the workflow: a run that failed at startup
+    # produces 0 trials and used to read as clean (no rejections, all-zero infra).
+    clean, reason = observe.evaluate_gate(_gate_findings(wire={"trials": 0, "infra": {}}))
+    assert clean is False
+    assert "wire probes did not run" in reason
+
+
+@pytest.mark.parametrize("key", sorted(observe.GATE_INFRA_KEYS))
+def test_gate_dirty_on_each_infra_key(key):
+    # api_timeout is the regression case: observe.py counted it, the old inline
+    # workflow gate never read it, so an all-timeout wire run chained into resolve.
+    findings = _gate_findings()
+    findings["wire"]["infra"][key] = 3
+    clean, reason = observe.evaluate_gate(findings)
+    assert clean is False
+    assert f"{key}=3" in reason
+
+
+@pytest.mark.parametrize("key", ["max_turns", "stuck"])
+def test_gate_ignores_model_attributable_terminations(key):
+    # max_turns / stuck can be genuine model behaviour (four-bucket taxonomy) - they are
+    # resolve-agent data, not contamination, and must not block the chain into resolve.
+    findings = _gate_findings()
+    findings["wire"]["infra"][key] = 7
+    clean, _reason = observe.evaluate_gate(findings)
+    assert clean is True
+
+
+def test_gate_cli_prints_dirty_token_for_missing_file(tmp_path, capsys):
+    assert observe.gate(str(tmp_path / "absent.json")) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("dirty: findings unreadable")
+
+
+def test_gate_cli_prints_clean_token(tmp_path, capsys):
+    import json
+
+    path = tmp_path / "findings.json"
+    path.write_text(json.dumps(_gate_findings()))
+    assert observe.gate(str(path)) == 0
+    assert capsys.readouterr().out.strip() == "clean"

--- a/tools/automation/tests/test_observe.py
+++ b/tools/automation/tests/test_observe.py
@@ -124,6 +124,37 @@ def test_render_summary_wire_only_reprobe_verdict_is_the_wire_result():
     assert "infra failure" not in summary
 
 
+def test_render_summary_infra_line_shows_every_gate_key():
+    # The PR-visible summary must show the same counters the gate dirties on: an
+    # all-timeout observe used to render an all-zero infra line while the gate marked
+    # the PR needs-human for api_timeout, leaving Slack as the only place with the reason.
+    findings = {
+        "candidate": {"name": "vendor/m"},
+        "preset": "default",
+        "capability_ran": True,
+        "all_passed": False,
+        "capability": {"report_present": False},
+        "variants": {"report_present": False},
+        "wire": {
+            "trials": 40,
+            "tool_call_count": 0,
+            "tool_arg_rejections": {
+                "rejecting_trials": 0,
+                "trial_rate": 0,
+                "by_task_trial_rate": {},
+            },
+            "rejected_examples": [],
+            "infra": {"api_timeout": 40, "api_error": 2, "status_error": 1},
+        },
+    }
+    summary = observe.render_summary(findings)
+    assert "api_timeout=40" in summary
+    assert "api_error=2" in summary
+    assert "status_error=1" in summary
+    assert "rate_limit=0" in summary
+    assert "max_turns=0" in summary and "stuck=0" in summary
+
+
 def test_render_summary_wire_only_reprobe_with_no_trials_says_the_run_failed():
     # Unreachable from the workflow (the rejections>0 guard implies wire tasks exist), but
     # a wire run that crashes at startup - or a manual CLI invocation - lands here and must

--- a/tools/automation/tests/test_reprobe.py
+++ b/tools/automation/tests/test_reprobe.py
@@ -48,3 +48,39 @@ def test_failed_wire_tasks_sorted_from_by_task():
 def test_failed_wire_tasks_tolerates_missing():
     assert reprobe.failed_wire_tasks({}) == []
     assert reprobe.failed_wire_tasks({"wire": {}}) == []
+
+
+_BASELINE = {
+    "capability": {"per_probe": [{"probe": "test_cap[x]", "passed": 1, "runs": 5}]},
+    "variants": {"per_probe": [{"probe": "test_variant_v[y]", "passed": 0, "runs": 5}]},
+    "wire": {"tool_arg_rejections": {"by_task": {"task_w": 4}}},
+}
+
+
+def test_select_targets_default_is_all_failed_plus_wire():
+    probes, wire = reprobe.select_reprobe_targets(_BASELINE, None, wire_only=False, skip_wire=False)
+    assert probes == ["test_cap[x]", "test_variant_v[y]"]
+    assert wire == ["task_w"]
+
+
+def test_select_targets_explicit_targets_and_skip_wire():
+    probes, wire = reprobe.select_reprobe_targets(
+        _BASELINE, "test_cap[x], test_other[z]", wire_only=False, skip_wire=True
+    )
+    assert probes == ["test_cap[x]", "test_other[z]"]
+    assert wire == []
+
+
+def test_select_targets_wire_only_selects_no_probes():
+    # The final wire-verification pass: the fix loop iterates with --skip-wire, so this is
+    # the only place a wire-evidenced fix gets a post-fix measurement.
+    probes, wire = reprobe.select_reprobe_targets(_BASELINE, None, wire_only=True, skip_wire=False)
+    assert probes == []
+    assert wire == ["task_w"]
+
+
+def test_select_targets_conflicting_flags_raise():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        reprobe.select_reprobe_targets(_BASELINE, None, wire_only=True, skip_wire=True)
+    with pytest.raises(ValueError, match="pass one or the other"):
+        reprobe.select_reprobe_targets(_BASELINE, "test_cap[x]", wire_only=True, skip_wire=False)

--- a/tools/automation/tests/test_resolve_report.py
+++ b/tools/automation/tests/test_resolve_report.py
@@ -62,6 +62,32 @@ class TestDiagnose:
         assert "did not run" in rr.diagnose(0, 0, 0, 8)
 
 
+class TestHasConverged:
+    def test_converged_and_no_targets_lines_are_terminal(self):
+        assert rr.has_converged("- Iter 3: fix produced, reprobe verdict = CONVERGED\n")
+        assert rr.has_converged(NO_TARGETS_LINE)
+
+    def test_stalls_and_reds_are_not(self):
+        assert not rr.has_converged(STALLED_ALL)
+        assert not rr.has_converged(ALL_RED)
+
+
+class TestConvergedButFinalizeFailed:
+    def test_header_and_diagnosis_point_at_the_finalize_layer(self):
+        # The needs-human step also fires when the loop CONVERGED but a finalize gate
+        # rejected the result; "why the loop did not converge" would send the human to
+        # the wrong layer.
+        summary = ALL_RED + "- Iter 3: fix produced, reprobe verdict = CONVERGED\n"
+        out = rr.build_report(summary, None, 8)
+        assert "CONVERGED, but finalize failed its gates" in out
+        assert "did not converge" not in out
+        assert "finalize step log" in out
+
+    def test_non_converged_report_is_unchanged(self):
+        out = rr.build_report(ALL_RED, None, 8)
+        assert "Why the resolve loop did not converge" in out
+
+
 class TestLatestDecision:
     def test_live_decision_wins(self, tmp_path):
         import json

--- a/tools/automation/tests/test_resolve_report.py
+++ b/tools/automation/tests/test_resolve_report.py
@@ -8,9 +8,9 @@ import pytest
 pytestmark = pytest.mark.unit
 
 STALLED_ALL = """\
-- Iter 1: no overlay produced (agent stalled or hit its turn limit / throttled)
-- Iter 2: no overlay produced (agent stalled or hit its turn limit / throttled)
-- Iter 3: no overlay produced (agent stalled or hit its turn limit / throttled)
+- Iter 1: no decision produced (agent stalled or hit its turn limit / throttled)
+- Iter 2: no overlay was produced (stalled mid-attempt / turn limit)
+- Iter 3: no decision produced (agent stalled or hit its turn limit / throttled)
 """
 
 MIXED = """\
@@ -90,7 +90,7 @@ class TestBuildReport:
         out = rr.build_report(STALLED_ALL, None, 8)
         assert "did not converge (ran 3/8 iterations)" in out
         assert "Per-iteration outcome:" in out
-        assert "Iter 1: no overlay" in out
+        assert "Iter 1: no decision" in out
         assert "Diagnosis." in out
 
     def test_includes_agent_decision_when_present(self):

--- a/tools/automation/tests/test_resolve_report.py
+++ b/tools/automation/tests/test_resolve_report.py
@@ -24,6 +24,9 @@ ALL_RED = """\
 - Iter 2: fix produced, reprobe verdict = RED:dict_map
 """
 
+# The overlay-less all-ceiling convergence line: neither a stall nor a red.
+NO_TARGETS_LINE = "- Iter 1: all-ceiling decision (empty fix-targets), verdict = NO_TARGETS\n"
+
 
 class TestCounts:
     def test_all_stalled(self):
@@ -38,11 +41,14 @@ class TestCounts:
     def test_empty(self):
         assert rr.counts("") == (0, 0, 0)
 
+    def test_no_targets_line_is_neither_stall_nor_red(self):
+        assert rr.counts(NO_TARGETS_LINE) == (1, 0, 0)
+
 
 class TestDiagnose:
-    def test_all_stalled_points_at_anthropic_throttle(self):
+    def test_all_stalled_points_at_gateway_throttle(self):
         msg = rr.diagnose(3, 3, 0, 8)
-        assert "NO overlay" in msg and "THROTTLE" in msg.upper()
+        assert "no usable attempt" in msg and "THROTTLE" in msg.upper()
 
     def test_mixed_mentions_both(self):
         msg = rr.diagnose(3, 1, 2, 8)

--- a/tools/automation/tests/test_resolve_report.py
+++ b/tools/automation/tests/test_resolve_report.py
@@ -56,6 +56,35 @@ class TestDiagnose:
         assert "did not run" in rr.diagnose(0, 0, 0, 8)
 
 
+class TestLatestDecision:
+    def test_live_decision_wins(self, tmp_path):
+        import json
+
+        (tmp_path / "decision.json").write_text(json.dumps({"notes": "live"}))
+        (tmp_path / "decision_iter3.json").write_text(json.dumps({"notes": "archived"}))
+        assert rr.latest_decision(tmp_path) == {"notes": "live"}
+
+    def test_falls_back_to_highest_archived_iteration(self, tmp_path):
+        # decision.json is rm'd at the top of every iteration, so a stalled FINAL
+        # iteration leaves only the archives; numeric order, not lexicographic
+        # (iter10 > iter2).
+        import json
+
+        (tmp_path / "decision_iter2.json").write_text(json.dumps({"notes": "iter2"}))
+        (tmp_path / "decision_iter10.json").write_text(json.dumps({"notes": "iter10"}))
+        assert rr.latest_decision(tmp_path) == {"notes": "iter10"}
+
+    def test_unreadable_archive_falls_through_to_older(self, tmp_path):
+        import json
+
+        (tmp_path / "decision_iter1.json").write_text(json.dumps({"notes": "iter1"}))
+        (tmp_path / "decision_iter2.json").write_text("{not json")
+        assert rr.latest_decision(tmp_path) == {"notes": "iter1"}
+
+    def test_nothing_anywhere_is_none(self, tmp_path):
+        assert rr.latest_decision(tmp_path) is None
+
+
 class TestBuildReport:
     def test_includes_header_summary_diagnosis(self):
         out = rr.build_report(STALLED_ALL, None, 8)


### PR DESCRIPTION
## What this is

A reliability/observability review of the agent-based model auto-integration flow (`integrate-model.yml` + `slack-integrate.yml` + `tools/automation`), done at the agentic-workflow level: how the deterministic loop and the per-iteration Claude agents divide the work, how well the flow covers new-model addition, and where it can silently lose signal. Draft PR: every finding below is either fixed here or explicitly listed as out of scope.

**Scope update: this PR now also carries the whole of #852** (closed in favour of one consolidated review). The merge commit `24fbe85` brings in the self-referential cap gate work plus the fixes for its 9 adversarial-review findings - see "Absorbed from #852" below.

## Fixes in this PR

**1. The observe cleanliness gate had two blind spots** (`automation observe-gate`, new + tested)

- `observe.py` counts `api_timeout` as wire infra precisely so that "a wire run that died on provider 5xx/timeouts on every trial" cannot read as clean, but the workflow's inline `python -c` gate only checked `rate_limit` / `api_error` / `status_error`. An all-timeout observe chained into resolve as "clean".
- The wire-probe step is `|| true`-guarded, so a wire run that failed at startup produced 0 trials, zero rejections, all-zero infra, and read as clean. There was a `capability_ran` check but no wire equivalent. This is not hypothetical: while the #557 `RuntimeBackendBuildContext` regression was live (2026-07-24 to its fix), every wire step crashed silently and observes scored green on "Wire (0 trials, 0 tool calls)" - e.g. PR #614 (opus-5) reached integrate-done with a vacuous wire dimension. The underlying TypeError is fixed on main; this gate check is the regression-proofing so that class of failure reads as needs-human instead of clean.

The verdict now lives in `automation observe-gate` (unit-tested, same stdout-token pattern as `greencheck`), and the exact dirty reason travels into the needs-human Slack/PR notification instead of a generic "infra-dirty" text. `max_turns` / `stuck` deliberately stay non-gating: per the four-bucket taxonomy they can be genuine model behaviour, so they are resolve-agent data, not contamination.

**2. The resolve loop erased its own memory between iterations**

`resolve_agent.md` instructs the iteration-N agent to try "a materially DIFFERENT axis than last time" and to never resubmit the same overlay, but the loop `rm -f`s `overlay.yaml` + `decision.json` at the top of every iteration and each `claude -p` starts with a fresh context. `last_reprobe.json` records results, not the overlay that produced them, so the agent literally could not know which axes it had already tried; convergence on hard quirks relied on luck. Each attempt is now archived as `overlay_iter<N>.yaml` / `decision_iter<N>.json` and the prompt's Inputs section points at them.

**3. Resolve evidence never reached the run artifacts**

The only `upload-artifact` step runs before the gate, so overlays, decisions, reprobe findings (and now the wire verification) were never uploaded, while the needs-human comments tell the human "latest overlay + reprobe are in the run artifacts". A second end-of-job upload (`integration-resolve-pr<N>`, `if: always()` on the clean path) makes that claim true.

**4. The documented final wire pass existed only as a reserved variable** (`reprobe --wire-only`)

`RESOLVE_WIRE_K` was documented as "reserved for the final wire-verification pass (not yet wired)". Consequence: the fix loop reprobes capability probes only (`--skip-wire`), so a fix whose only live evidence was the wire (tool-arg rejections with no failing capability probe = the `NO_TARGETS` convergence) shipped with no post-fix measurement at all. On convergence, when the observe wire had rejections and an overlay exists, the workflow now re-runs exactly those wire tasks under the proven overlay and posts the fresh stats as a PR comment. Evidence-only by design, never a convergence gate: a still-rejecting wire task can be a genuine model miss, which is a ceiling, not a blocker, and gating on it would deadlock legitimate integrations.

**5. Needs-human hygiene on early-failure paths**

- The summary + gate steps ran under bare `always()`: a fork-reject / checkout-fail posted a junk "Observation stage ran for \`\`" comment, and a parse-fail double-pinged Slack (its own needs-human plus the gate's "observe did not run"). Both steps now require `steps.parse.outcome == 'success'`.
- A crash before the gate (checkout / uv sync / docker build) left the PR wearing `automation:integrate-running` forever. The catch-all now flips it to `automation:integrate-needs-human` (idempotent on the handled paths).

**6. The Slack poller's exact-title skip was a silent dead end**

The poll-step reply (which is also the dedup marker) confirms the model to the requester; if `bootstrap()` then finds an open `integrate: <slug>` PR it skipped without a word. Worse: the advertised recovery for a failed dispatch was "re-request by tagging me again", but once the PR exists a re-request lands in that same silent skip, so an orphaned PR (created, never dispatched) could not be revived from Slack at all. The skip now replies in-thread with the existing PR link and names the actual re-trigger (the `automation:integrate-model` label), and the dispatch-failed reply distinguishes PR-created-but-not-started from failed-before-the-PR.

**7. Docs drift**

`AUTO_INTEGRATION.md` said "It NEVER merges" in the intro, the mermaid flow, and the Stage-2 bullet, contradicting the `ARENA_AUTOMATION_AUTO_MERGE_ENABLED` opt-in documented lower in the same file. All three now qualified; the new gate/wire/artifact behaviour is documented.

## Assessment of what is already strong (no change needed)

- Determinism split: the workflow owns loop control, reprobe and git; the agents only reason and write files. Escalation (`needs_human`), all-ceiling (`NO_TARGETS`), data-scope review, and the staged-tree verification (import + anti-over-reach + recovery oracle + `reconcile-cert`) are well-designed convergence guards.
- Security posture: `persist-credentials: false`, empty `GH_TOKEN` for both `--dangerously-skip-permissions` agent steps, env-only handling of the attacker-controllable PR title, charset-guarded slugs, pinned litellm gateway with a fail-fast smoke.
- New-model coverage on the OpenRouter path is genuinely end-to-end: pricing (pre-observe + finalize + auto-merge price gate), preset overlay (or a new adapter class), cert with reconciliation, live capability evidence quoted on the PR. This matches steps 1-4 of `docs/ADD_NEW_MODEL.md`.

## Absorbed from #852 (the self-referential cap gate, plus its review-finding fixes)

The original #852 work, now here:

- `cert.py`: SELF-REFERENTIAL violation - a `PAYLOAD_ONLY_CAPABILITIES` cap (`thinking_replay_roundtrip`, `unsigned_thinking_replay`; their probes mock the provider turn and assert our own outgoing payload) declared `required` against a failing NATIVE baseline hard-fails, since a post-overlay green proves nothing about the model (the PR #846 miss). UNBACKED warning for any other `required` with no probe result.
- `classgate.py` + `automation check-new-classes`: a newly registered policy class must be referenced and covered by a unit test (the other half of the PR #846 miss).
- `resolve_agent.md`: payload-only promotion rules + code-shape grep discipline.

Plus the fixes for the 9 findings of its adversarial review (commits `d50af55`, `ee819e2`, `d750856`):

1. The gate-demanded unit test never got committed: `git add` now stages `tests/unit/llm/`, and the gate reads test sources from the INDEX - the test it credits is the test that ships.
2. `classgate` failed open on git failure and on any CWD but the repo root: root anchored to `__file__`, `cwd=root`, nonzero git exit fails the gate; tests run against throwaway git repos.
3. + 4. The diff-text binding regex failed open on quoting/comma/wrapping/dotted/instance/factory shapes and reported moved lines as new: replaced by an AST set-diff of the staged vs HEAD registry.
5. Substring matching under-enforced both checks: word-boundary class names; keys count only in a YAML value position.
6. The mock drift guard keyed on one literal patch string: now matches `patch.object` / `setattr` spellings too.
7. The gates read agent-writable inputs in the same workspace the agents run in: `tools/automation` is re-pinned to HEAD after every compose invocation and before the finalize gates, and finalize refuses to run against a `findings.json` that no longer hash-matches the aggregation-time value (a step output, outside the workspace).
8. Docs enumerate the actual finalize gate set.
9. The claimed preset-entry reference check is now implemented (staged `model_presets.yaml` is really read).

Design note also applied: a payload-only cap `required` with NO probe result is a hard violation (previously a soft UNBACKED warning - the all-unparseable-junit loophole). Follow-up-sized and deliberately not here: policing registry-key REBINDS beyond set-diff visibility, and executing (rather than name-matching) the gated unit test.

## Known gaps left out of scope (deliberately)
- **Non-OpenRouter providers** (ADD_NEW_MODEL step 6): the flow is OpenRouter-first with a gateway-only fallback; a provider like `azure_ai/...` still needs manual work (see the in-flight `integrate/cohere-ff` branch). Known and documented; automating it is a separate feature.
- **Smoke eval (ADD_NEW_MODEL step 4a)** lives in the tasks repo by design; the wire probes are a non-scoring mini-proxy, not a replacement.
- **Docker image build cache**: observe rebuilds the core runner image every run on a cold runner; a buildx/GHA cache would shave minutes but touches the CLI-driven build path.
- **Poller auto-redispatch**: the existing-PR reply could go further and re-dispatch a bot-opened PR that carries no automation label. Left out because a freshly-dispatched-but-queued run is indistinguishable from a wedged one without an age heuristic; the label is the designed manual re-trigger.

## Independent post-merge review (third round, fresh reviewer)

After the #852 merge, an independent Fable review walked the consolidated diff end to end (its "checked and clean" list covers the full merged workflow ordering, the classgate AST logic against the real registry, the REPO_ROOT anchoring under the actual `uv run` editable install, and every PR-body claim). 0 blockers; its 3 majors, 3 minors and 1 nit are all applied in `881591d`:

- **Malformed `decision.json` can no longer converge as all-ceiling**: the new tested `automation decision-targets` token makes a parse failure a stall to retry, never the `NO_TARGETS` verdict (previously an inline `|| echo ''` shipped every failure as a ceiling nobody judged).
- **The tamper restores pin to the checkout-time commit sha**, captured as a step output before any agent runs, and finalize refuses a moved HEAD - a local `git commit` by an agent can no longer become both the restore source and a published ancestor.
- **The wire-verification evidence joins the integrity net**: the wire step verifies the findings hash before running and seals its summary's hash as a step output; finalize publishes the summary only byte-identical (planted/altered/deleted evidence is fatal).
- Minors: the PR-posted observe summary's Infra line shows every gate key; `resolve-report` distinguishes converged-but-finalize-failed from no-convergence; `classgate` models `|=` / `update(kwargs)` / `setdefault` / nested registrations and fails loud on any mutation shape it cannot model. Nit: the payload-only drift guard also matches the use-site patch spelling.

## Second pass + adversarial review

A second self-review plus an independent Fable 5 review round produced further fixes, all applied. The reviewer's re-verification confirmed every finding resolved with no new functional defects; the remaining nit-level prose/coverage residuals (all-ceiling loop-summary wording, stalled-diagnosis phrasing, finalize-prompt input hedges, the zero-trials verdict test) are closed in the last commit:

- The wire-only verification summary led with "capability suite did NOT run - infra failure" (right for observe, wrong as the opening line of the wire-evidence comment). The reprobe stage now travels manifest -> findings -> summary, and a wire-only pass gets a wire verdict.
- The catch-all label flip sits below the terminal-marker check, so a post-finalize failure (e.g. the artifact upload) cannot stamp needs-human onto an integrate-done PR.
- Per-iteration archives happen immediately after the agent invocation, so partial attempts (overlay without decision after a turn-limit stall) are preserved too.
- All-ceiling convergence no longer requires a no-op overlay: the stall guard is decision-only, empty `fix_targets` converges as `NO_TARGETS` with or without an overlay, and `resolve_agent.md` says so explicitly. `resolve-report` counts both stall shapes and falls back to the archived `decision_iter<N>.json` when the final iteration stalls.
- `reprobe` flag conflicts are a usage error; an unreadable baseline tracebacks instead of masquerading as a CLI mistake.
- Docs state that the wire evidence is posted by the finalize step after its commit (artifact-only on a failed finalize).

## Tests

- `tools/automation/tests`: 342 passed (union of both branches + the post-merge review round; 24 new here, the #852 gate suite incl. its finding-fix tests, and the decision-targets / converged-report / classgate-mutation / infra-line pins: gate verdicts incl. the api_timeout regression case and the model-attributable exclusions, wire-only selection + conflicting-flag fail-fast, manifest -> findings -> summary end-to-end pin, malformed-JSON gate token, archived-decision fallback, stall-line counting).
- `ruff check` + `ruff format` clean; both workflows YAML-parse; full `tests/canonical` suite green (895 passed).
- CLI smokes: `observe-gate` clean/dirty/missing-file tokens, `reprobe --wire-only` end to end on an empty baseline, conflicting flags rejected with a clear message.
