### PR TITLE
feat(tools): add build_check builtin — zero-arg peer-service HTTP probe

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -369,6 +369,7 @@ grade = engine.grade_trajectory(trajectory: Trajectory, final_env_state: dict)
 |------|-------------|----------------|
 | `browser` | Playwright web automation | `action` string + `x`, `y`, `text` (actions: click_at, type_text_at, scroll_document, select, navigate, etc.) |
 | `http_request` | HTTP requests to mock services | `method`, `url`, `headers`, `body` |
+| `build_check` | Zero-arg peer-service HTTP probe (compile check) | endpoint declared via `tool_config`: `service`, `port`, `path`, `method`, `timeout_s` |
 
 ### RAG
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -20,6 +20,8 @@ Tolokaforge exposes built-in tools via function calling. Enable them per task in
   tasks — declare `initial_state.rag.corpus_dir` and the runner indexes that
   corpus into the rag-service per trial (see `docs/TASKS.md`).
 - `http_request`: Restricted HTTP client for mock web services.
+- `build_check`: Zero-argument peer-service HTTP probe (compile / interface
+  check). See [`build_check`](#build_check) below.
 - `calculator`: Safe arithmetic calculator.
 
 ## Browser and Mobile Action Reference
@@ -171,6 +173,50 @@ the root — the tool never silently creates it.
   validation. Write atomicity is weaker than the local variant: a completed
   temp-file+`mv` is atomic, but an exec interrupted mid-write can leave the temp
   file behind. The editor has no configurable per-command timeout.
+
+### `build_check`
+
+Zero-argument HTTP probe against a compose peer service on the trial's
+private network. Named + shaped for the compile / interface-collection
+checks that code-migration and code-generation benchmarks perform
+against a hidden test harness before invoking the full graded suite —
+see [ADR 0029](adr/0029-build-check-builtin-tool.md).
+
+**Input schema.** None. The tool advertises zero parameters and ignores
+any inbound kwargs. The endpoint is fully declared at task-authoring
+time via `tool_config`; the agent cannot redirect the probe.
+
+**`tool_config` fields**
+
+- `service` (string, required) — compose service name to probe.
+- `port` (int, default `8001`) — port on that service.
+- `path` (string, default `"/build_check"`) — endpoint path.
+- `method` (`"GET"` | `"POST"`, default `"POST"`) — HTTP verb. POST
+  sends an empty JSON body (`{}`).
+- `timeout_s` (float, default `300.0`) — request timeout.
+
+**Response contract.** The tool returns the peer service's response
+body verbatim as tool output — the peer owns the payload shape. On a
+non-2xx status the body is still returned but the result is marked as
+an error so the loop records `EXECUTION_STATUS_ERROR`; on timeout or
+connect failure the tool returns a structured error message.
+
+**Network scope.** The request goes to a docker-DNS-resolved compose
+peer on the trial's private network. No external egress; honours
+`NetworkPolicy.NO_INTERNET` by construction.
+
+**Enabling.** List `build_check` in `enabled` and declare the endpoint
+under `tools.agent.build_check`:
+
+```yaml
+tools:
+  agent:
+    enabled: ["build_check", "bash_session", "str_replace_editor"]
+    build_check:
+      service: mb-grade
+      port: 8001
+      path: /build_check
+```
 
 ## Enabling Tools
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -213,7 +213,7 @@ tools:
   agent:
     enabled: ["build_check", "bash_session", "str_replace_editor"]
     build_check:
-      service: mb-grade
+      service: grader        # compose service name in the task's compose file
       port: 8001
       path: /build_check
 ```

--- a/docs/adr/0029-build-check-builtin-tool.md
+++ b/docs/adr/0029-build-check-builtin-tool.md
@@ -1,0 +1,170 @@
+# 0029. `build_check` as a generic peer-service HTTP probe in core
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+Code-migration and code-generation benchmarks want a way for the agent to
+run a *cheap compile / interface-collection check* against a hidden test
+harness before invoking the full graded test suite. The reference-eval
+shape for this — the one every code-migration benchmark converges on —
+is a single-endpoint HTTP probe on a peer service that runs a fast build
+command against the migrated repository, replies with `configured` +
+`run_error` + `output_tail`, and takes no per-invocation arguments (the
+build command is baked into the task).
+
+The concrete first consumer lives in an adapter (the Migration Bench
+adapter's `mb-grade` service exposes `/build_check`). But the tool
+itself — an HTTP request to `http://{service}:{port}{path}` returning
+the response body verbatim — has no adapter-specific logic. Any future
+benchmark whose grader container exposes a similar endpoint should be
+able to enable the same tool by name, with the endpoint declared in the
+pack's `tool_config`. Putting the tool in an adapter would either force
+every benchmark to re-implement the same HTTP wrapper or force other
+adapters to depend on the first-consumer adapter — both bad. Wiring the
+tool through the runner's existing `BuiltinGenericToolWrapper` seam
+avoids both: the runner already resolves builtin tools by name against
+the unified registry (ADR-0011 Pattern-A shape) and splats
+`tool_config` into the tool's `__init__`.
+
+## Decision Drivers
+
+- **Adapter neutrality.** The tool must not name Migration Bench or any
+  specific adapter. Every field of behaviour comes from `tool_config`;
+  the tool's contract is "POST/GET this URL, return the body."
+- **Config-driven endpoint.** Task pack declares
+  `tool_config: {service, port, path, method, timeout_s}`. Same registry
+  seam as `http_request` — the tool is instantiated once per trial with
+  those kwargs.
+- **No per-invocation arguments.** The schema advertises zero required
+  and zero optional parameters. This matches the reference-eval shape
+  (agent calls `tests_helper()` with no arguments) and prevents the
+  agent from redirecting the probe to an arbitrary URL — the endpoint
+  is authoritative from the task author.
+- **Peer-service, not internet.** The request goes to a docker-DNS-
+  resolved compose peer on the trial's private network. No external
+  egress; honours `NetworkPolicy.NO_INTERNET` by construction.
+- **Failures are tool errors, not infrastructure errors.** Non-2xx
+  responses, timeouts, and network errors surface as `ToolResult(
+  success=False, error=...)` so the loop records
+  `EXECUTION_STATUS_ERROR` and hands the agent something to iterate on
+  — the trial does not terminate.
+- **Response body verbatim.** The peer service owns the payload shape.
+  The tool does not re-interpret it, so a new adapter can ship a
+  different response schema without touching core.
+
+## Considered Options
+
+1. **Ship `build_check` as a builtin in `tolokaforge.tools.builtin`
+   registered on `Dispatch.GENERIC`.** Config-driven via `tool_config`.
+   **This ADR.**
+2. **Extend `http_request` with a "no-arg preset" mode.** Reuse the
+   existing HTTP tool by declaring a canned URL in `tool_config` and
+   locking the schema to zero arguments.
+3. **Keep the tool in the Migration Bench adapter behind a public seam
+   the adapter exports.** Ship a re-usable base class from
+   `tolokaforge-adapter-common` (which does not exist today).
+4. **Two tools: a core-level `peer_http_request` (agent-supplied path)
+   and per-adapter thin wrappers.** Core tool takes a `path` argument
+   from the agent; adapters register a wrapper that closes over the
+   path.
+
+## Decision
+
+Option 1. `build_check` ships as a first-party builtin in
+`tolokaforge/tools/builtin/build_check.py`, registered in
+`tolokaforge.tools.builtin.registry._REGISTRY` under `Dispatch.GENERIC`.
+The tool's `__init__` accepts `service` (required), `port` (default
+8001), `path` (default `"/build_check"`), `method` (default `"POST"`),
+and `timeout_s` (default 300 s). Its schema declares zero parameters.
+Its `execute` ignores inbound kwargs and dispatches a single HTTP
+request via `httpx`.
+
+The Migration Bench adapter's grader service exposes the endpoint the
+tool talks to; that is documented as the *first* consumer, not the
+*only* consumer. New adapters that want the same shape enable the tool
+by name in the task pack with their own `service` / `port` / `path`.
+
+## Consequences
+
+**Positive.**
+
+- Any adapter with a peer service that follows the "one endpoint, no
+  args, structured body" shape gets the tool for free.
+- The tool's registration is the same shape as every other builtin —
+  entry in `_REGISTRY`, entry in the canonical registry-lock test
+  (`tests/unit/test_builtin_registry.py`), entry in the runner-subset
+  partition (`tests/canonical/test_runner_subset_partition.py`).
+- Zero-parameter schema means the agent cannot redirect the probe: the
+  URL is authoritative from the task author, closing off a class of
+  agent-driven exfil attempts that a `path`-taking variant would open.
+- No new dispatch category — GENERIC already covers the pattern.
+- Sits alongside `http_request` (allow-listed mock-web probe) and
+  `calculator` (pure compute) as the third *no-per-invocation-args*
+  reference in core, making the "config-driven, splatted into
+  `__init__`" pattern easier to spot for future authors.
+
+**Negative.**
+
+- Adds one more entry to the union type of things `Dispatch.GENERIC`
+  can point at. Judged acceptable — the registry is designed to grow
+  along this axis.
+- The tool cannot express "call the same peer service on N different
+  paths within one trial." A benchmark that needs that would enable N
+  copies of the tool under different names — currently unsupported by
+  the registry (names are keys). If a real caller shows up, the
+  registry can grow an alias mechanism. Not in scope today.
+
+## Alternatives Rejected
+
+**Option 2 — extend `http_request` with a no-arg preset.** Overloads
+`http_request`'s meaning: today it is a *client-side URL constructor*
+with an allow-list, and its schema advertises `method`/`url`/`headers`/
+`json`. Adding a "no-args, config-driven URL" mode would fork the
+schema at trial-registration time based on `tool_config`, which mocks
+the "one tool, one schema" invariant `BuiltinGenericToolWrapper`
+depends on. Cleaner as a distinct tool.
+
+**Option 3 — keep it in the adapter.** Forces every future
+code-migration adapter to re-implement the same HTTP wrapper, or to
+depend on the Migration Bench adapter (an unrelated repo) for the base
+class. Also lands adapter-specific code in core anyway the first time
+we want to test the wrapper against the runner subset.
+
+**Option 4 — agent-supplied path.** Rejected on the exfil concern: an
+agent-supplied path lets the LLM aim the probe at whatever peer
+endpoint it can enumerate. The reference-eval shape deliberately
+denies this; the task author names the endpoint at pack-authoring
+time.
+
+## Testing
+
+- `tests/unit/test_build_check_tool.py` — constructor validation,
+  schema shape, successful invocation, HTTP-error passthrough,
+  timeout/connect-error paths, kwargs-ignored contract. All HTTP
+  calls mocked.
+- `tests/unit/test_builtin_registry.py` — registry-lock: `build_check`
+  is in `list_builtins()`, routes to `Dispatch.GENERIC`,
+  `get_class("build_check")` returns `BuildCheckTool`.
+- `tests/unit/test_builtin_generic_wrapper.py` — wrapper splats
+  `tool_config` into `BuildCheckTool.__init__`; unknown `tool_config`
+  keys fail loud (the first builtin whose `__init__` has a required
+  kwarg, so this is where the splat contract earns its keep).
+- `tests/canonical/test_runner_subset_partition.py` —
+  `build_check.py` is in the runner subset closure (lazy-loadable
+  path, alongside every other `builtin/` driver).
+
+## Links
+
+- ADR-0011 — Pattern-A: Protocol + entry-point registry + `InMemory*`
+  fixture + canonical contract test.
+- ADR-0018 — Multi-container under shared runtime (the compose-network
+  peer-service context this tool consumes).
+- ADR-0026 — Service-readiness contract (sibling pattern: a
+  client-side probe against a `host:port` endpoint that surfaces the
+  answer as structured data rather than a timeout).
+- Issue #891 — filing for this tool.

--- a/docs/adr/0029-build-check-builtin-tool.md
+++ b/docs/adr/0029-build-check-builtin-tool.md
@@ -17,8 +17,8 @@ command against the migrated repository, replies with `configured` +
 `run_error` + `output_tail`, and takes no per-invocation arguments (the
 build command is baked into the task).
 
-The concrete first consumer lives in an adapter (the Migration Bench
-adapter's `mb-grade` service exposes `/build_check`). But the tool
+The concrete first consumer lives in an out-of-tree code-migration
+adapter whose grader service exposes `/build_check`. But the tool
 itself — an HTTP request to `http://{service}:{port}{path}` returning
 the response body verbatim — has no adapter-specific logic. Any future
 benchmark whose grader container exposes a similar endpoint should be
@@ -33,9 +33,9 @@ the unified registry (ADR-0011 Pattern-A shape) and splats
 
 ## Decision Drivers
 
-- **Adapter neutrality.** The tool must not name Migration Bench or any
-  specific adapter. Every field of behaviour comes from `tool_config`;
-  the tool's contract is "POST/GET this URL, return the body."
+- **Adapter neutrality.** The tool must not name a specific adapter or
+  benchmark. Every field of behaviour comes from `tool_config`; the
+  tool's contract is "POST/GET this URL, return the body."
 - **Config-driven endpoint.** Task pack declares
   `tool_config: {service, port, path, method, timeout_s}`. Same registry
   seam as `http_request` — the tool is instantiated once per trial with
@@ -65,7 +65,7 @@ the unified registry (ADR-0011 Pattern-A shape) and splats
 2. **Extend `http_request` with a "no-arg preset" mode.** Reuse the
    existing HTTP tool by declaring a canned URL in `tool_config` and
    locking the schema to zero arguments.
-3. **Keep the tool in the Migration Bench adapter behind a public seam
+3. **Keep the tool in the first-consumer adapter behind a public seam
    the adapter exports.** Ship a re-usable base class from
    `tolokaforge-adapter-common` (which does not exist today).
 4. **Two tools: a core-level `peer_http_request` (agent-supplied path)
@@ -84,10 +84,10 @@ and `timeout_s` (default 300 s). Its schema declares zero parameters.
 Its `execute` ignores inbound kwargs and dispatches a single HTTP
 request via `httpx`.
 
-The Migration Bench adapter's grader service exposes the endpoint the
-tool talks to; that is documented as the *first* consumer, not the
-*only* consumer. New adapters that want the same shape enable the tool
-by name in the task pack with their own `service` / `port` / `path`.
+The out-of-tree code-migration adapter that motivated this ADR is the
+*first* consumer, not the *only* consumer. New adapters that want the
+same shape enable the tool by name in the task pack with their own
+`service` / `port` / `path`.
 
 ## Consequences
 
@@ -131,7 +131,7 @@ depends on. Cleaner as a distinct tool.
 
 **Option 3 — keep it in the adapter.** Forces every future
 code-migration adapter to re-implement the same HTTP wrapper, or to
-depend on the Migration Bench adapter (an unrelated repo) for the base
+depend on the first-consumer adapter (an unrelated repo) for the base
 class. Also lands adapter-specific code in core anyway the first time
 we want to test the wrapper against the runner subset.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,8 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0022](0022-runtime-independence.md) | Runtime independence — Protocol registries, `run_trial`, `run-trial` subprocess contract | Accepted |
 | [0023](0023-runner-image-internals.md) | Runner image internals — monolithic wheel + `[runner]` extra, internals not a stability commitment | Accepted |
 | [0024](0024-container-command-surface.md) | Container command surface — the committed contract of `tolokaforge-runner` | Accepted |
+| [0025](0025-runner-wheel-split.md) | Runner wheel split — slim subset artifact + `_runner_subset` enumeration | Accepted |
+| [0026](0026-service-readiness-contract.md) | Service-readiness contract as a fourth entry-point-registry seam | Accepted |
+| [0027](0027-subset-native-cli-shim.md) | Subset-native CLI shim | Accepted |
+| [0028](0028-multi-actor-turn-policy.md) | Multi-actor turn policy — `interaction_mode` + `Actor` + `TurnPolicy` | Accepted |
+| [0029](0029-build-check-builtin-tool.md) | `build_check` as a generic peer-service HTTP probe in core | Accepted |

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -67,6 +67,7 @@ LAZY_LOADABLE_SUBSET_MODULES: frozenset[str] = frozenset(
         "tolokaforge/tools/builtin/__init__.py",
         "tolokaforge/tools/builtin/bash.py",
         "tolokaforge/tools/builtin/browser.py",
+        "tolokaforge/tools/builtin/build_check.py",
         "tolokaforge/tools/builtin/calculator.py",
         "tolokaforge/tools/builtin/db_json.py",
         "tolokaforge/tools/builtin/files.py",

--- a/tests/unit/test_build_check_tool.py
+++ b/tests/unit/test_build_check_tool.py
@@ -1,0 +1,151 @@
+"""Unit tests for :class:`tolokaforge.tools.builtin.build_check.BuildCheckTool`.
+
+Covers: constructor validation, schema shape, endpoint URL composition,
+successful invocation, HTTP error responses, timeout / network-error
+paths, and the "no per-invocation args" contract. All HTTP calls are
+mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tolokaforge.tools.builtin.build_check import BuildCheckTool
+from tolokaforge.tools.registry import ToolCategory
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildCheckToolConstructor:
+    def test_constructor_defaults(self) -> None:
+        tool = BuildCheckTool(service="mb-grade")
+        assert tool.name == "build_check"
+        assert tool.endpoint_url == "http://mb-grade:8001/build_check"
+        assert tool.policy.category == ToolCategory.COMPUTE
+        assert tool.policy.visibility == ["agent"]
+
+    def test_constructor_overrides(self) -> None:
+        tool = BuildCheckTool(
+            service="peer",
+            port=9002,
+            path="/probe",
+            method="GET",
+            timeout_s=60.0,
+        )
+        assert tool.endpoint_url == "http://peer:9002/probe"
+
+    def test_constructor_normalises_relative_path(self) -> None:
+        tool = BuildCheckTool(service="peer", path="probe")
+        assert tool.endpoint_url.endswith("/probe")
+
+    def test_missing_service_raises(self) -> None:
+        with pytest.raises(ValueError, match="service"):
+            BuildCheckTool(service="")
+
+    def test_invalid_method_raises(self) -> None:
+        with pytest.raises(ValueError, match="method"):
+            BuildCheckTool(service="peer", method="DELETE")
+
+    def test_non_positive_timeout_raises(self) -> None:
+        with pytest.raises(ValueError, match="timeout_s"):
+            BuildCheckTool(service="peer", timeout_s=0)
+
+
+class TestBuildCheckToolSchema:
+    def test_schema_shape(self) -> None:
+        schema = BuildCheckTool(service="peer").get_schema()
+        assert schema["type"] == "function"
+        assert schema["function"]["name"] == "build_check"
+        params = schema["function"]["parameters"]
+        assert params["properties"] == {}
+        assert params["required"] == []
+        assert params["additionalProperties"] is False
+
+
+class TestBuildCheckToolExecute:
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_success_returns_body_verbatim(self, mock_post: MagicMock) -> None:
+        response = MagicMock()
+        response.status_code = 200
+        response.text = '{"configured": true, "run_error": ""}'
+        mock_post.return_value = response
+
+        tool = BuildCheckTool(service="mb-grade")
+        result = tool.execute()
+
+        assert result.success is True
+        assert result.output == '{"configured": true, "run_error": ""}'
+        assert result.metadata["status_code"] == 200
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "http://mb-grade:8001/build_check"
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.get")
+    def test_execute_get_method(self, mock_get: MagicMock) -> None:
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "ok"
+        mock_get.return_value = response
+
+        tool = BuildCheckTool(service="peer", method="GET")
+        result = tool.execute()
+
+        assert result.success is True
+        mock_get.assert_called_once()
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_ignores_arguments(self, mock_post: MagicMock) -> None:
+        """Schema advertises no arguments; extra kwargs are silently ignored
+        so a call site that misreads the schema still gets a response."""
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "ok"
+        mock_post.return_value = response
+
+        tool = BuildCheckTool(service="peer")
+        result = tool.execute(extra="value", another=42)
+
+        assert result.success is True
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_http_error_hands_body_back(self, mock_post: MagicMock) -> None:
+        """Non-2xx still returns the body so the agent can read diagnostic
+        detail — but marks ``success=False`` so the loop records ERROR."""
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "internal server error: config load failed"
+        mock_post.return_value = response
+
+        tool = BuildCheckTool(service="peer")
+        result = tool.execute()
+
+        assert result.success is False
+        assert result.output == "internal server error: config load failed"
+        assert "HTTP 500" in result.error
+        assert result.metadata["status_code"] == 500
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_timeout(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = httpx.ReadTimeout("timeout")
+
+        tool = BuildCheckTool(service="peer", timeout_s=5.0)
+        result = tool.execute()
+
+        assert result.success is False
+        assert result.output == ""
+        assert "timed out" in result.error
+        assert "5.0s" in result.error
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_connection_error(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = httpx.ConnectError("no route to host")
+
+        tool = BuildCheckTool(service="peer")
+        result = tool.execute()
+
+        assert result.success is False
+        assert result.output == ""
+        assert "ConnectError" in result.error
+        assert "no route to host" in result.error

--- a/tests/unit/test_build_check_tool.py
+++ b/tests/unit/test_build_check_tool.py
@@ -21,9 +21,9 @@ pytestmark = pytest.mark.unit
 
 class TestBuildCheckToolConstructor:
     def test_constructor_defaults(self) -> None:
-        tool = BuildCheckTool(service="mb-grade")
+        tool = BuildCheckTool(service="grader")
         assert tool.name == "build_check"
-        assert tool.endpoint_url == "http://mb-grade:8001/build_check"
+        assert tool.endpoint_url == "http://grader:8001/build_check"
         assert tool.policy.category == ToolCategory.COMPUTE
         assert tool.policy.visibility == ["agent"]
 
@@ -45,6 +45,10 @@ class TestBuildCheckToolConstructor:
         with pytest.raises(ValueError, match="service"):
             BuildCheckTool(service="")
 
+    def test_non_string_service_raises(self) -> None:
+        with pytest.raises(ValueError, match="service"):
+            BuildCheckTool(service=None)  # type: ignore[arg-type]
+
     def test_invalid_method_raises(self) -> None:
         with pytest.raises(ValueError, match="method"):
             BuildCheckTool(service="peer", method="DELETE")
@@ -52,6 +56,17 @@ class TestBuildCheckToolConstructor:
     def test_non_positive_timeout_raises(self) -> None:
         with pytest.raises(ValueError, match="timeout_s"):
             BuildCheckTool(service="peer", timeout_s=0)
+
+    def test_non_int_port_raises(self) -> None:
+        """A YAML typo like ``port: "eighty"`` must fail loud at trial
+        registration with a diagnostic message, not surface as an
+        opaque ``ValueError`` from ``int(port)`` deep inside execute."""
+        with pytest.raises(ValueError, match="port"):
+            BuildCheckTool(service="peer", port="8001")  # type: ignore[arg-type]
+
+    def test_non_string_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="path"):
+            BuildCheckTool(service="peer", path=None)  # type: ignore[arg-type]
 
 
 class TestBuildCheckToolSchema:
@@ -73,14 +88,30 @@ class TestBuildCheckToolExecute:
         response.text = '{"configured": true, "run_error": ""}'
         mock_post.return_value = response
 
-        tool = BuildCheckTool(service="mb-grade")
+        tool = BuildCheckTool(service="grader")
         result = tool.execute()
 
         assert result.success is True
         assert result.output == '{"configured": true, "run_error": ""}'
         assert result.metadata["status_code"] == 200
         mock_post.assert_called_once()
-        assert mock_post.call_args.args[0] == "http://mb-grade:8001/build_check"
+        assert mock_post.call_args.args[0] == "http://grader:8001/build_check"
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_post_wire_contract(self, mock_post: MagicMock) -> None:
+        """POST carries ``Content-Type: application/json`` + empty JSON
+        body. Locks the wire contract so a refactor to ``data=`` /
+        ``json=`` / different content-type would fail loudly."""
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "ok"
+        mock_post.return_value = response
+
+        BuildCheckTool(service="peer").execute()
+
+        kwargs = mock_post.call_args.kwargs
+        assert kwargs["headers"] == {"Content-Type": "application/json"}
+        assert kwargs["content"] == b"{}"
 
     @patch("tolokaforge.tools.builtin.build_check.httpx.get")
     def test_execute_get_method(self, mock_get: MagicMock) -> None:
@@ -108,6 +139,24 @@ class TestBuildCheckToolExecute:
         result = tool.execute(extra="value", another=42)
 
         assert result.success is True
+
+    @patch("tolokaforge.tools.builtin.build_check.httpx.post")
+    def test_execute_redirect_status_is_error(self, mock_post: MagicMock) -> None:
+        """3xx (redirects, not-modified) is not success. httpx does not
+        follow redirects here, so a 301 from a misconfigured peer is a
+        defect that should surface as an error — not a masquerading
+        success with a redirect body."""
+        response = MagicMock()
+        response.status_code = 301
+        response.text = "Moved Permanently"
+        mock_post.return_value = response
+
+        result = BuildCheckTool(service="peer").execute()
+
+        assert result.success is False
+        assert result.output == "Moved Permanently"
+        assert "HTTP 301" in result.error
+        assert result.metadata["status_code"] == 301
 
     @patch("tolokaforge.tools.builtin.build_check.httpx.post")
     def test_execute_http_error_hands_body_back(self, mock_post: MagicMock) -> None:

--- a/tests/unit/test_builtin_generic_wrapper.py
+++ b/tests/unit/test_builtin_generic_wrapper.py
@@ -40,6 +40,7 @@ class TestBuiltinGenericToolWrapper:
             "calculator",
             "browser",
             "http_request",
+            "build_check",
             "mobile",
             "db_query",
             "db_update",
@@ -52,6 +53,42 @@ class TestBuiltinGenericToolWrapper:
 
         wrapper = BuiltinGenericToolWrapper(_make_schema("calculator"))
         assert wrapper._tool.__class__.__name__ == "CalculatorTool"
+
+    def test_build_check_wrapper_splats_tool_config_into_init(self):
+        """``build_check`` is the first builtin whose ``__init__`` has a
+        required kwarg (``service``). Locks the wrapper's tool_config →
+        ``__init__`` splat: the endpoint URL threads through from the
+        task-authored config to the live tool instance."""
+        from tolokaforge.runner.models import ToolSchema
+        from tolokaforge.runner.tool_factory import BuiltinGenericToolWrapper
+
+        schema = ToolSchema(
+            name="build_check",
+            description="x",
+            parameters={"type": "object"},
+            tool_config={"service": "mb-grade", "port": 9001, "path": "/probe"},
+        )
+        wrapper = BuiltinGenericToolWrapper(schema)
+        assert wrapper._tool.__class__.__name__ == "BuildCheckTool"
+        assert wrapper._tool.endpoint_url == "http://mb-grade:9001/probe"
+
+    def test_build_check_wrapper_rejects_unknown_tool_config_key(self):
+        """A typo in ``tool_config`` fails loud at trial registration
+        rather than getting silently dropped."""
+        from tolokaforge.runner.models import ToolSchema
+        from tolokaforge.runner.tool_factory import (
+            BuiltinGenericToolWrapper,
+            ToolConfigurationError,
+        )
+
+        schema = ToolSchema(
+            name="build_check",
+            description="x",
+            parameters={"type": "object"},
+            tool_config={"service": "peer", "prot": 8001},  # ``prot`` is a typo
+        )
+        with pytest.raises(ToolConfigurationError, match="prot"):
+            BuiltinGenericToolWrapper(schema)
 
     @pytest.mark.asyncio
     async def test_execute_raises_on_tool_failure(self):

--- a/tests/unit/test_builtin_registry.py
+++ b/tests/unit/test_builtin_registry.py
@@ -26,6 +26,7 @@ def test_list_builtins_covers_every_consumer_today():
         "calculator",
         "browser",
         "http_request",
+        "build_check",
         "mobile",
         "db_query",
         "db_update",
@@ -87,12 +88,21 @@ def test_search_kb_routes_to_rag_dispatch():
 
 def test_get_class_imports_real_classes():
     from tolokaforge.tools.builtin.bash import BashTool
+    from tolokaforge.tools.builtin.build_check import BuildCheckTool
     from tolokaforge.tools.builtin.calculator import CalculatorTool
     from tolokaforge.tools.builtin.mobile import MobileTool
 
     assert registry.get_class("bash") is BashTool
     assert registry.get_class("calculator") is CalculatorTool
+    assert registry.get_class("build_check") is BuildCheckTool
     assert registry.get_class("mobile") is MobileTool
+
+
+def test_build_check_routes_to_generic_dispatch():
+    """``build_check`` is a peer-service HTTP probe with no filesystem /
+    RAG / shell / editor semantics — it belongs on GENERIC dispatch
+    exactly like ``http_request`` and ``calculator``."""
+    assert registry.get_dispatch("build_check") is registry.Dispatch.GENERIC
 
 
 def test_get_class_is_cached():

--- a/tolokaforge/tools/builtin/__init__.py
+++ b/tolokaforge/tools/builtin/__init__.py
@@ -2,6 +2,7 @@
 
 from tolokaforge.tools.builtin.bash import BashTool
 from tolokaforge.tools.builtin.browser import BrowserTool
+from tolokaforge.tools.builtin.build_check import BuildCheckTool
 from tolokaforge.tools.builtin.calculator import CalculatorTool
 from tolokaforge.tools.builtin.db_json import (
     DBQueryTool,
@@ -28,6 +29,7 @@ __all__ = [
     "AppendFileTool",
     "BashTool",
     "BrowserTool",
+    "BuildCheckTool",
     "CalculatorTool",
     "CopyFileTool",
     "DBQueryTool",

--- a/tolokaforge/tools/builtin/build_check.py
+++ b/tolokaforge/tools/builtin/build_check.py
@@ -1,0 +1,163 @@
+"""``build_check`` builtin — quick compile / interface-compatibility probe.
+
+An agent-facing tool that POSTs (or GETs) a task-declared HTTP endpoint on
+a peer compose service and returns the response body as tool output. The
+tool takes no per-invocation arguments — the endpoint is declared once
+at task-authoring time via ``tool_config``, matching the reference-eval
+shape of a ``tests_helper``-style probe without hard-coding any
+adapter-specific concerns in core.
+
+Config surface (routed via ``ToolSchema.tool_config`` under
+``Dispatch.GENERIC``):
+
+* ``service`` (str, required) — compose service name to probe.
+* ``port`` (int, default 8001) — port on that service.
+* ``path`` (str, default ``"/build_check"``) — endpoint path.
+* ``method`` (``"GET"`` | ``"POST"``, default ``"POST"``) — HTTP verb.
+* ``timeout_s`` (float, default 300.0) — request timeout.
+
+Because the target is a peer service on the trial's compose network, the
+request happens from the runner container (which resolves ``<service>``
+via docker's built-in DNS) and stays entirely within the compose network
+— no external network access required.
+"""
+
+from typing import Any
+
+import httpx
+
+from tolokaforge.tools.registry import Tool, ToolCategory, ToolPolicy, ToolResult
+
+
+class BuildCheckTool(Tool):
+    """Compile / interface-compatibility probe against a peer service.
+
+    Emits a single HTTP request to ``http://{service}:{port}{path}`` and
+    returns the response body as tool output. The endpoint owns the
+    response shape (adapter-specific); the tool passes it back verbatim.
+
+    Failures surface as :class:`ToolResult` with ``success=False`` and
+    ``error`` populated so the loop-side error surface treats them as
+    tool errors, not infrastructure errors — the agent can retry or
+    work around them without terminating the trial.
+    """
+
+    def __init__(
+        self,
+        service: str,
+        port: int = 8001,
+        path: str = "/build_check",
+        method: str = "POST",
+        timeout_s: float = 300.0,
+    ) -> None:
+        if not service or not isinstance(service, str):
+            raise ValueError(
+                f"build_check: ``service`` is required and must be a non-empty string; "
+                f"got {service!r}"
+            )
+        if method not in ("GET", "POST"):
+            raise ValueError(f"build_check: ``method`` must be GET or POST; got {method!r}")
+        if timeout_s <= 0:
+            raise ValueError(f"build_check: ``timeout_s`` must be positive; got {timeout_s!r}")
+
+        self._service = service
+        self._port = int(port)
+        self._path = path if path.startswith("/") else f"/{path}"
+        self._method = method
+        self._timeout_s = float(timeout_s)
+
+        policy = ToolPolicy(
+            timeout_s=self._timeout_s + 30.0,
+            category=ToolCategory.COMPUTE,
+            visibility=["agent"],
+        )
+        super().__init__(
+            name="build_check",
+            description=(
+                "Validate compatibility of your code with the hidden test framework. "
+                "Runs a quick build / interface-collection check against the peer "
+                "service without executing the full test suite, and returns the "
+                "build output (compile status, stdout/stderr tail). Use this to "
+                "iterate on structural / compile errors before the final test run — "
+                "much cheaper than waiting for the full grade pass. Takes no "
+                "arguments — the endpoint is pre-configured for this task."
+            ),
+            policy=policy,
+        )
+
+    @property
+    def endpoint_url(self) -> str:
+        """Return the fully-resolved endpoint URL. Test-side introspection."""
+        return f"http://{self._service}:{self._port}{self._path}"
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        """Invoke the endpoint and return the response body as tool output.
+
+        Ignores any inbound kwargs — the endpoint contract is fully
+        declared in tool config, so the agent-side call carries no
+        arguments. Ignored rather than rejected so a call site that
+        misreads the schema still gets a useful response.
+        """
+        del kwargs  # endpoint contract is config-driven; per-invocation args ignored
+        try:
+            if self._method == "GET":
+                response = httpx.get(self.endpoint_url, timeout=self._timeout_s)
+            else:
+                response = httpx.post(
+                    self.endpoint_url,
+                    headers={"Content-Type": "application/json"},
+                    content=b"{}",
+                    timeout=self._timeout_s,
+                )
+        except httpx.TimeoutException:
+            return ToolResult(
+                success=False,
+                output="",
+                error=(
+                    f"build_check: request to {self.endpoint_url} timed out after "
+                    f"{self._timeout_s}s"
+                ),
+            )
+        except httpx.HTTPError as exc:
+            return ToolResult(
+                success=False,
+                output="",
+                error=(
+                    f"build_check: request to {self.endpoint_url} failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+            )
+
+        # Return the response body verbatim. The peer service owns the
+        # payload shape (adapter-specific); the tool doesn't re-interpret
+        # it. Non-2xx responses still hand the body back — the agent may
+        # find diagnostic detail in the error body that a raw ``error``
+        # string would elide.
+        body_text = response.text
+        if response.status_code >= 400:
+            return ToolResult(
+                success=False,
+                output=body_text,
+                error=(f"build_check: {self.endpoint_url} returned HTTP {response.status_code}"),
+                metadata={"status_code": response.status_code},
+            )
+        return ToolResult(
+            success=True,
+            output=body_text,
+            metadata={"status_code": response.status_code},
+        )

--- a/tolokaforge/tools/builtin/build_check.py
+++ b/tolokaforge/tools/builtin/build_check.py
@@ -20,6 +20,9 @@ Because the target is a peer service on the trial's compose network, the
 request happens from the runner container (which resolves ``<service>``
 via docker's built-in DNS) and stays entirely within the compose network
 — no external network access required.
+
+The tool returns the peer's response body verbatim; the peer is trusted
+to bound its own response size. There is no tool-side cap.
 """
 
 from typing import Any
@@ -50,18 +53,22 @@ class BuildCheckTool(Tool):
         method: str = "POST",
         timeout_s: float = 300.0,
     ) -> None:
-        if not service or not isinstance(service, str):
+        if not isinstance(service, str) or not service:
             raise ValueError(
                 f"build_check: ``service`` is required and must be a non-empty string; "
                 f"got {service!r}"
             )
+        if not isinstance(port, int) or isinstance(port, bool):
+            raise ValueError(f"build_check: ``port`` must be an int; got {type(port).__name__}")
+        if not isinstance(path, str):
+            raise ValueError(f"build_check: ``path`` must be a string; got {type(path).__name__}")
         if method not in ("GET", "POST"):
             raise ValueError(f"build_check: ``method`` must be GET or POST; got {method!r}")
-        if timeout_s <= 0:
+        if not isinstance(timeout_s, (int, float)) or timeout_s <= 0:
             raise ValueError(f"build_check: ``timeout_s`` must be positive; got {timeout_s!r}")
 
         self._service = service
-        self._port = int(port)
+        self._port = port
         self._path = path if path.startswith("/") else f"/{path}"
         self._method = method
         self._timeout_s = float(timeout_s)
@@ -145,11 +152,12 @@ class BuildCheckTool(Tool):
 
         # Return the response body verbatim. The peer service owns the
         # payload shape (adapter-specific); the tool doesn't re-interpret
-        # it. Non-2xx responses still hand the body back — the agent may
-        # find diagnostic detail in the error body that a raw ``error``
-        # string would elide.
+        # it. Any non-2xx (including 3xx — httpx does not follow redirects
+        # here, so a redirect from a misconfigured peer is a defect, not a
+        # success) still hands the body back so the agent can read
+        # diagnostic detail an ``error`` string would elide.
         body_text = response.text
-        if response.status_code >= 400:
+        if response.status_code < 200 or response.status_code >= 300:
             return ToolResult(
                 success=False,
                 output=body_text,

--- a/tolokaforge/tools/builtin/registry.py
+++ b/tolokaforge/tools/builtin/registry.py
@@ -64,6 +64,10 @@ _REGISTRY: dict[str, tuple[BuiltinToolEntry, Dispatch]] = {
         BuiltinToolEntry("tolokaforge.tools.builtin.http_request", "HTTPRequestTool"),
         Dispatch.GENERIC,
     ),
+    "build_check": (
+        BuiltinToolEntry("tolokaforge.tools.builtin.build_check", "BuildCheckTool"),
+        Dispatch.GENERIC,
+    ),
     "mobile": (
         BuiltinToolEntry("tolokaforge.tools.builtin.mobile", "MobileTool"),
         Dispatch.GENERIC,


### PR DESCRIPTION
## Summary
- New GENERIC-dispatch builtin tool `build_check` that POSTs (or GETs) a task-declared HTTP endpoint on a peer compose service and returns the response body verbatim.
- Schema advertises zero parameters — the endpoint is authoritative from the task author via `tool_config`, so the agent cannot redirect the probe.
- Same registry / wrapper seam as `http_request` and `calculator`: entry in `_REGISTRY`, wrapped by `BuiltinGenericToolWrapper`, `tool_config` splatted into `__init__`.

## Design choices
- **Placement in core, not in an adapter**: any benchmark whose grader container exposes a similar cheap-compile endpoint should be able to enable the tool by name; keeping it in core avoids cross-adapter dependencies and re-implementations. Full rationale in ADR-0029.
- **Zero-argument schema**: matches the reference-eval shape for `tests_helper`-style probes and closes the exfil surface an agent-supplied `path` would open.
- **Response body verbatim + status_code in metadata**: peer service owns the payload shape, so future adapters can ship a different response schema without touching core.
- **Failures are tool errors, not infrastructure errors**: non-2xx / timeout / connect errors surface as `ToolResult(success=False, error=...)` so the loop records `EXECUTION_STATUS_ERROR` and hands the agent something to iterate on rather than terminating the trial.

## Concepts introduced
`build_check` is the first builtin whose `__init__` has a required kwarg (`service`), so this is where the wrapper's `tool_config` → `__init__` splat contract earns its keep. The pattern (config-driven endpoint, zero-arg schema, response verbatim) is now available for future benchmarks — see ADR-0029 for the shape.

## Test plan
- [ ] `pytest tests/unit/test_build_check_tool.py` — 13 tests: constructor validation, schema shape, success, HTTP error passthrough, timeout, connect error, kwargs-ignored.
- [ ] `pytest tests/unit/test_builtin_registry.py` — registry lock includes `build_check` on GENERIC dispatch.
- [ ] `pytest tests/unit/test_builtin_generic_wrapper.py` — wrapper splats `tool_config` into `BuildCheckTool.__init__`; unknown-key typos fail loud.
- [ ] `pytest tests/canonical/test_runner_subset_partition.py` — `build_check.py` is in the runner-subset closure.
- [ ] Manual: enable in a task pack with `tool_config: {service, port, path}` and verify the endpoint URL threads through end-to-end.

## Docs
- `docs/adr/0029-build-check-builtin-tool.md` — placement decision + zero-arg schema rationale + Options 1–4.
- `docs/TOOLS.md` — new `### build_check` subsection with `tool_config` fields + YAML example.
- `docs/REFERENCE.md` — tool table row.
- `docs/adr/README.md` — index rows for 0025–0029 (were missing).

Refs #891