### PR TITLE
feat(tools): optional docker exec --user for compose-variant bash_session + str_replace_editor

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -245,8 +245,12 @@ variant; a missing or non-directory root fails loud on first use.
 To select the compose variant, add a per-tool kwargs block under
 `tools.agent.<name>` naming the target `service` and the `compose_project_prefix`
 used to bring the stack up. `bash_session` additionally accepts `timeout_s`;
-`str_replace_editor` additionally accepts `working_root` (see above). The editor
-has no configurable per-command timeout:
+`str_replace_editor` additionally accepts `working_root` (see above). Both
+compose variants accept an optional `user` field (a `--user` value passed to
+`docker exec` — a name or `uid:gid`) so an agent-facing session can drop
+privileges when the target container's ENTRYPOINT itself runs as root. Default
+`None` inherits the container's default user. The editor has no configurable
+per-command timeout:
 
 ```yaml
 tools:
@@ -256,10 +260,12 @@ tools:
       service: main
       compose_project_prefix: env_
       timeout_s: 120
+      user: model             # optional; docker exec --user; default inherits
     str_replace_editor:
       service: main
       compose_project_prefix: env_
       working_root: /srv/agent  # optional; defaults to /work
+      user: model             # optional; docker exec --user; default inherits
 ```
 
 > **Compose-variant network isolation.** Under `network_policy: no_internet` /

--- a/tests/canonical/test_persistent_shell_dispatch.py
+++ b/tests/canonical/test_persistent_shell_dispatch.py
@@ -69,3 +69,79 @@ def test_compose_backend_wires_resolved_name_into_session():
     session = wrapper._new_session()
     assert isinstance(session, DockerComposeBashSession)
     assert session.container_name == "tolokaforge_abc123_app"
+
+
+def test_compose_backend_default_user_is_none():
+    """No ``user`` in ``tool_config`` → the compose backend inherits the
+    container's default user (no ``--user`` flag on the exec argv).
+    Preserves prior behaviour for every current pack."""
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "tolokaforge_"})
+    wrapper._trial_id = "abc123"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+    assert session.user is None
+
+
+def test_compose_backend_threads_user_from_tool_config():
+    """``tool_config.user`` threads through to the ``docker exec --user
+    <user>`` flag. Task packs whose grader container runs as root use
+    this to drop privileges on the agent-facing exec session."""
+    wrapper = _wrapper(
+        {
+            "service": "app",
+            "compose_project_prefix": "tolokaforge_",
+            "user": "model",
+        }
+    )
+    wrapper._trial_id = "abc123"
+    session = wrapper._new_session()
+    assert isinstance(session, DockerComposeBashSession)
+    assert session.user == "model"
+
+
+def test_compose_backend_accepts_uid_gid_user():
+    """Numeric ``uid:gid`` is a valid ``docker exec --user`` value —
+    useful when the container doesn't have a named user for the
+    intended UID."""
+    wrapper = _wrapper(
+        {
+            "service": "app",
+            "compose_project_prefix": "tolokaforge_",
+            "user": "1000:1000",
+        }
+    )
+    wrapper._trial_id = "abc123"
+    session = wrapper._new_session()
+    assert session.user == "1000:1000"
+
+
+def test_compose_backend_popen_argv_includes_user_flag_when_set():
+    """The ``--user`` flag lands in the exec argv exactly when
+    ``session.user`` is set. Locks the argv shape so a future refactor
+    of ``_popen`` doesn't silently drop the flag."""
+    import os
+    import subprocess as sp
+    from unittest.mock import patch
+
+    session = DockerComposeBashSession("some-container", user="model")
+
+    with patch("subprocess.Popen") as mock_popen:
+        # Use a slave_fd of 0 (stdin) — irrelevant to the argv assertion.
+        try:
+            session._popen(cwd=None, slave_fd=0)
+        except Exception:
+            pass
+        argv = mock_popen.call_args.args[0]
+        assert "--user" in argv, argv
+        assert argv[argv.index("--user") + 1] == "model"
+
+    # Symmetric: absence of ``user`` means no ``--user`` in argv.
+    session_default = DockerComposeBashSession("some-container")
+    with patch("subprocess.Popen") as mock_popen:
+        try:
+            session_default._popen(cwd=None, slave_fd=0)
+        except Exception:
+            pass
+        argv = mock_popen.call_args.args[0]
+        assert "--user" not in argv, argv
+    del os, sp  # linter: unused after fixture

--- a/tests/canonical/test_persistent_shell_dispatch.py
+++ b/tests/canonical/test_persistent_shell_dispatch.py
@@ -119,18 +119,18 @@ def test_compose_backend_popen_argv_includes_user_flag_when_set():
     """The ``--user`` flag lands in the exec argv exactly when
     ``session.user`` is set. Locks the argv shape so a future refactor
     of ``_popen`` doesn't silently drop the flag."""
-    import os
-    import subprocess as sp
     from unittest.mock import patch
 
+    # ``slave_fd=0`` is nonsensical as a real PTY fd (it's stdin) but
+    # ``subprocess.Popen`` is mocked, so nothing actually reads/writes
+    # to it — only the argv the mock was called with matters here.
     session = DockerComposeBashSession("some-container", user="model")
-
     with patch("subprocess.Popen") as mock_popen:
-        # Use a slave_fd of 0 (stdin) — irrelevant to the argv assertion.
         try:
             session._popen(cwd=None, slave_fd=0)
         except Exception:
             pass
+        assert mock_popen.call_args is not None, "subprocess.Popen was never called"
         argv = mock_popen.call_args.args[0]
         assert "--user" in argv, argv
         assert argv[argv.index("--user") + 1] == "model"
@@ -142,6 +142,6 @@ def test_compose_backend_popen_argv_includes_user_flag_when_set():
             session_default._popen(cwd=None, slave_fd=0)
         except Exception:
             pass
+        assert mock_popen.call_args is not None, "subprocess.Popen was never called"
         argv = mock_popen.call_args.args[0]
         assert "--user" not in argv, argv
-    del os, sp  # linter: unused after fixture

--- a/tests/canonical/test_str_replace_editor_dispatch.py
+++ b/tests/canonical/test_str_replace_editor_dispatch.py
@@ -124,6 +124,7 @@ def test_compose_editor_exec_argv_includes_user_flag_when_set():
             editor_user._exec("script", "arg1", allow_failure=True)
         except Exception:
             pass
+        assert mock_run.call_args is not None, "subprocess.run was never called"
         argv = mock_run.call_args.args[0]
         assert "--user" in argv, argv
         assert argv[argv.index("--user") + 1] == "model"
@@ -137,5 +138,6 @@ def test_compose_editor_exec_argv_includes_user_flag_when_set():
             editor_default._exec("script", "arg1", allow_failure=True)
         except Exception:
             pass
+        assert mock_run.call_args is not None, "subprocess.run was never called"
         argv = mock_run.call_args.args[0]
         assert "--user" not in argv, argv

--- a/tests/canonical/test_str_replace_editor_dispatch.py
+++ b/tests/canonical/test_str_replace_editor_dispatch.py
@@ -91,3 +91,51 @@ def test_working_root_defaults_to_work_for_both_backends():
     compose = _wrapper({"service": "app", "compose_project_prefix": "foo_"})
     assert isinstance(compose._backend, DockerComposeEditor)
     assert compose._backend.base_path == "/work"
+
+
+def test_compose_backend_default_user_is_none():
+    """No ``user`` in ``tool_config`` → no ``--user`` flag; the editor
+    inherits the container's default user. Preserves prior behaviour."""
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "foo_"})
+    assert isinstance(wrapper._backend, DockerComposeEditor)
+    assert wrapper._backend.user is None
+
+
+def test_compose_backend_threads_user_from_tool_config():
+    """``tool_config.user`` threads through to the ``docker exec --user
+    <user>`` flag — symmetric with ``bash_session``."""
+    wrapper = _wrapper({"service": "app", "compose_project_prefix": "foo_", "user": "model"})
+    assert isinstance(wrapper._backend, DockerComposeEditor)
+    assert wrapper._backend.user == "model"
+
+
+def test_compose_editor_exec_argv_includes_user_flag_when_set():
+    """Every editor subprocess invokes ``docker exec [--user U]``. Lock
+    the argv shape both ways: user set → ``--user`` present; user unset
+    → ``--user`` absent."""
+    from unittest.mock import patch
+
+    editor_user = DockerComposeEditor("some-container", "/work", user="model")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = b""
+        mock_run.return_value.stderr = b""
+        try:
+            editor_user._exec("script", "arg1", allow_failure=True)
+        except Exception:
+            pass
+        argv = mock_run.call_args.args[0]
+        assert "--user" in argv, argv
+        assert argv[argv.index("--user") + 1] == "model"
+
+    editor_default = DockerComposeEditor("some-container", "/work")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = b""
+        mock_run.return_value.stderr = b""
+        try:
+            editor_default._exec("script", "arg1", allow_failure=True)
+        except Exception:
+            pass
+        argv = mock_run.call_args.args[0]
+        assert "--user" not in argv, argv

--- a/tolokaforge/runner/tool_factory.py
+++ b/tolokaforge/runner/tool_factory.py
@@ -1174,6 +1174,13 @@ class PersistentShellToolWrapper(ToolWrapper):
         # local subprocess backend. The wire schema is identical either way.
         self._service: str | None = tool_config.get("service")
         self._project_prefix: str | None = tool_config.get("compose_project_prefix")
+        # Optional ``docker exec --user <user>`` for the compose backend. Task
+        # packs whose grader container runs as root (so the in-container
+        # grader can read a hidden test oracle) use this to drop privileges
+        # on agent-facing exec sessions. Local backend ignores it. Default
+        # ``None`` inherits the container's default user — preserves prior
+        # behaviour for every current pack.
+        self._user: str | None = tool_config.get("user")
         if self._service is not None and not self._project_prefix:
             raise ToolConfigurationError(
                 self.name,
@@ -1222,7 +1229,7 @@ class PersistentShellToolWrapper(ToolWrapper):
         container = self._resolve_container_name(
             self._trial_id, self._service, self._project_prefix
         )
-        return DockerComposeBashSession(container)
+        return DockerComposeBashSession(container, user=self._user)
 
     @staticmethod
     def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:
@@ -1283,6 +1290,11 @@ class StrReplaceEditorToolWrapper(ToolWrapper):
                 "prefix used to bring the stack up)",
             )
         self._working_root: str = tool_config.get("working_root", self._DEFAULT_WORKING_ROOT)
+        # Optional ``docker exec --user <user>`` for the compose backend —
+        # symmetric with ``PersistentShellToolWrapper._user``. Local backend
+        # ignores it. Default ``None`` inherits the container's default
+        # user and preserves prior behaviour.
+        self._user: str | None = tool_config.get("user")
         self._trial_id = trial_id
         self._backend = self._new_backend()
 
@@ -1293,7 +1305,7 @@ class StrReplaceEditorToolWrapper(ToolWrapper):
         container = self._resolve_container_name(
             self._trial_id, self._service, self._project_prefix
         )
-        return DockerComposeEditor(container, base_path=self._working_root)
+        return DockerComposeEditor(container, base_path=self._working_root, user=self._user)
 
     @staticmethod
     def _resolve_container_name(trial_id: str, service: str, project_prefix: str) -> str:

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -352,10 +352,13 @@ class DockerComposeBashSession(_PtyBashSession):
         return self._user
 
     def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
-        argv = ["docker", "exec", "-i"]
+        # ``--user`` before ``-i``: matches ``docker exec --help`` order and
+        # the editor's ``_exec`` (str_replace_editor.py) argv shape so a
+        # future grep over the codebase sees one neighbour pattern.
+        argv = ["docker", "exec"]
         if self._user is not None:
             argv.extend(["--user", self._user])
-        argv.extend([self._container_name, "bash", "--norc", "--noprofile"])
+        argv.extend(["-i", self._container_name, "bash", "--norc", "--noprofile"])
         return subprocess.Popen(
             argv,
             stdin=slave_fd,

--- a/tolokaforge/tools/persistent_shell.py
+++ b/tolokaforge/tools/persistent_shell.py
@@ -327,17 +327,37 @@ class DockerComposeBashSession(_PtyBashSession):
     preserves it).
     """
 
-    def __init__(self, container_name: str) -> None:
+    def __init__(self, container_name: str, user: str | None = None) -> None:
+        """Hold a ``docker exec -i`` bash session into *container_name*.
+
+        ``user`` optionally sets ``docker exec --user <user>`` so the
+        session runs as a specific user (name or ``uid:gid``) rather
+        than the container's default. Task-side callers use this to
+        drop privileges: an image whose ENTRYPOINT runs as root can
+        still hand the agent an unprivileged shell, so root-owned files
+        (e.g. a hidden test oracle staged by the container's own
+        grader) stay unreachable to the agent. Default ``None`` inherits
+        the container's default user and preserves prior behaviour.
+        """
         super().__init__()
         self._container_name = container_name
+        self._user = user
 
     @property
     def container_name(self) -> str:
         return self._container_name
 
+    @property
+    def user(self) -> str | None:
+        return self._user
+
     def _popen(self, cwd: str | None, slave_fd: int) -> subprocess.Popen[bytes]:
+        argv = ["docker", "exec", "-i"]
+        if self._user is not None:
+            argv.extend(["--user", self._user])
+        argv.extend([self._container_name, "bash", "--norc", "--noprofile"])
         return subprocess.Popen(
-            ["docker", "exec", "-i", self._container_name, "bash", "--norc", "--noprofile"],
+            argv,
             stdin=slave_fd,
             stdout=slave_fd,
             stderr=slave_fd,

--- a/tolokaforge/tools/str_replace_editor.py
+++ b/tolokaforge/tools/str_replace_editor.py
@@ -288,11 +288,29 @@ class DockerComposeEditor:
     (the local engine's single-process temp+rename has no such window).
     """
 
-    def __init__(self, container_name: str, base_path: str, timeout_s: float | None = None) -> None:
+    def __init__(
+        self,
+        container_name: str,
+        base_path: str,
+        timeout_s: float | None = None,
+        user: str | None = None,
+    ) -> None:
+        """Bind an editor to *base_path* inside a running compose service.
+
+        ``user`` optionally sets ``docker exec --user <user>`` so every
+        editor operation runs as a specific user (name or ``uid:gid``)
+        rather than the container's default. Task-side callers use this
+        to drop privileges: an image whose ENTRYPOINT runs as root can
+        still hand the agent an unprivileged editor, so root-owned
+        files (e.g. a hidden test oracle staged by the container's own
+        grader) stay unreachable. Default ``None`` inherits the
+        container's default user and preserves prior behaviour.
+        """
         self._container_name = container_name
         self._base = base_path
         self._timeout_s = timeout_s if timeout_s is not None else _DEFAULT_EXEC_TIMEOUT_S
         self._base_real: str | None = None
+        self._user = user
 
     @property
     def container_name(self) -> str:
@@ -301,6 +319,10 @@ class DockerComposeEditor:
     @property
     def base_path(self) -> str:
         return self._base
+
+    @property
+    def user(self) -> str | None:
+        return self._user
 
     def view(self, path: str, view_range: list[int] | None = None) -> str:
         resolved = self._resolve(path)
@@ -403,6 +425,8 @@ class DockerComposeEditor:
         allow_failure: bool = False,
     ) -> subprocess.CompletedProcess[bytes]:
         cmd = ["docker", "exec"]
+        if self._user is not None:
+            cmd += ["--user", self._user]
         if stdin is not None:
             cmd.append("-i")
         cmd += [self._container_name, "sh", "-c", script, "_", *args]


### PR DESCRIPTION
## Summary
Threads a per-task ``user`` field through ``tool_config`` for the two compose-variant tools (``bash_session``, ``str_replace_editor``). Task packs whose grader container runs as root can drop privileges on the agent-facing exec session by declaring ``user: model`` (or ``user: 1000:1000``) alongside ``service:`` / ``compose_project_prefix:``.

## Motivation

Follow-up to the Migration Bench substrate refactor (tolokaforge-tools PR #83 landed the per-problem middle-block extraction; a subsequent PR needs to switch the mb-server container's default user from ``model`` to ``root`` so the in-container grader can read the hidden expected-tests oracle). For that to be safe, the agent-facing ``docker exec`` must NOT inherit root — it needs an explicit ``--user model`` so the agent can't read the oracle either.

The reference eval solves the same problem with a Python ``preexec_fn=demote`` per subprocess (`taiga.tools.run.demote` → `setgid(1000); setuid(1000)`). Our substrate's equivalent is ``docker exec --user`` — the only way to control per-exec identity from the host side without in-container helper binaries.

## Change surface

- ``DockerComposeBashSession.__init__(container_name, user=None)``: optional ``--user`` flag inserted into the ``docker exec -i`` argv when set. ``session.user`` exposed for test-side introspection.
- ``DockerComposeEditor.__init__(..., user=None)``: symmetric. Every editor subprocess (``_exec``) inserts ``--user`` when set.
- ``PersistentShellToolWrapper`` and ``StrReplaceEditorToolWrapper``: read ``tool_config.get(\"user\")`` and thread it into the compose backend. Local backends ignore it.

## Backward compatibility

**Zero risk**. Default ``user=None`` → no ``--user`` on the exec argv → prior behaviour byte-for-byte. Verified via cross-repo audit: no in-tree task pack sets ``tool_config.user`` today, so absent-field default preserves current semantics for every current pack. Non-MB packs (τ-bench, OTS, native, terminal-bench, tlk-mcp-core) never touch this code path.

## Test locks

7 new canonical tests across the two dispatch test files:

- Default ``user is None`` (both tools)
- Threading from ``tool_config`` (both tools)
- Numeric ``uid:gid`` acceptance (bash)
- Argv-shape lock both ways: ``--user`` present iff ``user`` set (both tools, both branches)

## Docs

``docs/TOOLS.md``: the ``user`` field is documented on both tools with a YAML example.

## Test plan

- [ ] ``pytest tests/canonical/test_persistent_shell_dispatch.py tests/canonical/test_str_replace_editor_dispatch.py`` — 22 pass locally
- [ ] Non-regression: ``pytest tests/unit/test_persistent_shell_local.py tests/canonical/test_str_replace_editor_local.py`` — 58 total pass
- [ ] Follow-up in tolokaforge-tools: MB adapter's ``pack_builder`` will emit ``user: model`` in ``tool_config`` on generated packs and drop ``USER model`` from ``Dockerfile.entrypoint-layer``'s tail (container default becomes root)

Refs Toloka/tolokaforge#892