### PR TITLE
test(parity): lock 15 drives every ledger key's recording site through a real GradeTrial

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -82,9 +82,12 @@ key that claims both substrates at `DIFFERENTIAL_CANONICAL` must move both
 substrates' component scores against
 [`tests/data/grading_parity/`](../tests/data/grading_parity/) fixtures; every key
 both substrates declare must survive adapter translation non-default; and every key
-the runtime ledger checks must resolve to a field on the runner config **and** be
-claimed by one of the ledger's recording sites, so a key no site records fails the
-suite instead of failing every `GradeTrial` that carries it.
+the runtime ledger checks must resolve to a field on the runner config, be declared
+in `accountable_author_keys()`, **and** have its recording site driven — a real
+`RegisterTrial → ExecuteTool → GradeTrial` per key, with the outcome the ledger
+reports asserted to be the one the manifest implies. A key whose site is deleted,
+downgraded to a skip, or filed as `EVALUATED` over an evaluation that never ran
+fails the suite instead of failing every `GradeTrial` that carries it.
 
 ### The runtime ledger
 

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -105,6 +105,17 @@ manifest declares `CORE_ONLY` that nonetheless arrives populated fails the same
 way, quoting that entry's `reason` — unless a recording site claims it as a
 standing skip, per **Every skip is recorded, not silent** below.
 
+Every one of those recording sites is *driven*, per key, by the canonical suite —
+the hash family, the db probes and the judge included. For each ledger key naming a
+runner field, a real `RegisterTrial → ExecuteTool → GradeTrial` populates the key,
+lets its evaluator run, and the outcome the ledger reports is asserted to be the one
+the manifest implies. Two external services are substituted and nothing else: the
+judge's model provider, and the postgres a db probe queries, whose DSN resolves only
+inside the task's docker network. Neither stands in for a recording site, an
+evaluator's decision, the audit or the combine. A key the manifest enforces at the
+integration tier for its **score** is still driven here for its **recording site**;
+the two are orthogonal.
+
 Three properties keep the ledger from rejecting configs that grade correctly:
 
 - **It covers `kind: SCORED_CHECK` only.** `CONFIG_INPUT` keys (`id_fields`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -144,6 +144,13 @@ Compare output against committed golden snapshots in `snapshots/`.
   ledger cannot resolve. Fix the manifest entry in
   `tolokaforge/core/grading/key_manifest.py` or the drift it exposed; widening a
   frozen exemption set in the test module is the deliberate last resort.
+  A **lock 15** failure is narrower: one ledger key's recording site was deleted,
+  downgraded to a skip, filed `EVALUATED` for an evaluation that did not run, or its
+  driver stopped populating the key. The failing row names the key — fix the
+  evaluate-or-skip site in `_grade_trial_async` (or the evaluator it calls) rather
+  than the assertion. A key missing from the lock's driver table fails
+  `test_every_ledger_key_names_a_driver_that_can_populate_it` instead, which means a
+  new ledger key arrived with no way to drive it: add a driver, never drop the row.
 - Trace timeline substrate parity (`test_trace_timeline_substrate_parity.py`) — one
   scripted tool-call sequence driven through each substrate's real recording path
   must build the same events. A failure means one substrate's recording drifted,

--- a/tests/README.md
+++ b/tests/README.md
@@ -146,9 +146,11 @@ Compare output against committed golden snapshots in `snapshots/`.
   frozen exemption set in the test module is the deliberate last resort.
   A **lock 15** failure is narrower: one ledger key's recording site was deleted,
   downgraded to a skip, filed `EVALUATED` for an evaluation that did not run, or its
-  driver stopped populating the key. The failing row names the key — fix the
-  evaluate-or-skip site in `_grade_trial_async` (or the evaluator it calls) rather
-  than the assertion. A key missing from the lock's driver table fails
+  driver stopped populating the key. The sweep covers **every** ledger key naming a
+  runner field — the hash family, the db probes and the judge included, not a subset
+  — so the failing row names the key. Fix the evaluate-or-skip site in
+  `_grade_trial_async` (or the evaluator it calls) rather than the assertion. A key
+  missing from the lock's driver table fails
   `test_every_ledger_key_names_a_driver_that_can_populate_it` instead, which means a
   new ledger key arrived with no way to drive it: add a driver, never drop the row.
 - Trace timeline substrate parity (`test_trace_timeline_substrate_parity.py`) — one

--- a/tests/README.md
+++ b/tests/README.md
@@ -207,6 +207,10 @@ authorable — wall time is not compared across substrates, so a pinned value wo
 be one nothing reads. Any other key fails the load naming itself, because a
 fixture key the loader ignores expresses less than its author wrote.
 
+A pack whose key reads DB state declares its rows in `task.yaml`'s `initial_state`,
+not only in the case's `state:` — the runner provisions a trial's DB service from
+`initial_state`, and lock 15 grades every pack through `RegisterTrial`.
+
 The pack directory is the author key with its dots replaced by underscores, so a
 leaf key inside a list field gets its own pack:
 `trace_checks.constraints.absent_before` is

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -1,6 +1,6 @@
 """Substrate-parity guard rail for the grading key manifest.
 
-Thirteen locks over :mod:`tolokaforge.core.grading.key_manifest`:
+Fifteen locks over :mod:`tolokaforge.core.grading.key_manifest`:
 
 1. every field either substrate's grading config declares is claimed by exactly
    one manifest entry, and every claimed field resolves;
@@ -14,9 +14,10 @@ Thirteen locks over :mod:`tolokaforge.core.grading.key_manifest`:
    production evaluator and its real combine;
 4. every key both substrates declare survives adapter translation;
 5. every ledger key's ``runner_field`` resolves to a place in the runner
-   ``GradingConfig`` dump *and* some recording site in the grading path claims
-   it, so a malformed or unclaimed entry fails here rather than at grade time in
-   production;
+   ``GradingConfig`` dump *and* is declared in ``accountable_author_keys()``, the
+   per-key human claim that a recording site files it, so a malformed or
+   undeclared entry fails here rather than at grade time in production — lock 15
+   is what drives the site itself;
 6. both substrates fold a hash verdict and a JSONPath score into one
    ``state_checks`` component by the author's weight, pinned cell by cell to
    arithmetic this module computes for itself;
@@ -41,7 +42,16 @@ Thirteen locks over :mod:`tolokaforge.core.grading.key_manifest`:
 13. a state source that declares nothing leaves ``state_checks`` unscored on both
     substrates, and the one asymmetry the rule permits — a probe-only pack, which
     only the runner can read, and which is the whole of what a pack declaring a probe
-    may be — is asserted against the manifest's own claim rather than assumed.
+    may be — is asserted against the manifest's own claim rather than assumed;
+14. every scored component a pack produces declares a share of ``combine.weights``
+    on both substrates, and a fold with no share to read decides rather than
+    defaulting to one;
+15. every ledger key's recording site is *driven*: a real
+    ``RegisterTrial → ExecuteTool → GradeTrial`` populates the key, lets its
+    evaluator run, and the outcome the ledger reports is the one the manifest
+    implies. Editing a declaration cannot satisfy it — deleting a recording site,
+    downgrading it to a skip, filing ``EVALUATED`` over an evaluation that never
+    ran, or driving a config that never populated the key each fail it.
 
 The exemption sets and the differential fixtures are the enforcement mechanism:
 adding a grading key to one substrate only cannot pass this suite without an
@@ -61,6 +71,7 @@ import re
 import shutil
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from types import MappingProxyType, UnionType
 from typing import Any, Union, get_args, get_origin
@@ -104,6 +115,7 @@ from tolokaforge.core.models import (
 from tolokaforge.runner import grading as runner_grading
 from tolokaforge.runner import models as runner_models
 from tolokaforge.runner import runner_pb2 as pb2
+from tolokaforge.runner import service as runner_service_module
 from tolokaforge.runner.grading import (
     combine_grade_components,
     evaluate_db_probes,
@@ -112,11 +124,20 @@ from tolokaforge.runner.grading import (
     resolve_state_checks_component,
 )
 from tolokaforge.runner.grading_ledger import (
+    CORE_ONLY_HASH_SKIP,
     LEDGER_KEYS,
     accountable_author_keys,
+    populated_ledger_keys,
     runner_dump_path,
+    skip_note,
+    skip_note_prefix,
 )
-from tolokaforge.runner.models import TRACE_CONSTRAINT_KINDS, TraceConstraintExpr
+from tolokaforge.runner.models import (
+    TRACE_CONSTRAINT_KINDS,
+    KeyAccounting,
+    KeyAccountingRecord,
+    TraceConstraintExpr,
+)
 from tolokaforge.runner.service import (
     RunnerServiceImpl,
     TrialContextRuntime,
@@ -1190,7 +1211,7 @@ def test_adapter_translation_carries_every_runner_key(test_data_dir):
 
 
 # --------------------------------------------------------------------------
-# 5. Every ledger key resolves in the runner config dump and has a recording site
+# 5. Every ledger key resolves in the runner config dump and declares a site
 # --------------------------------------------------------------------------
 
 _LEDGER_PROBE_TRACE_CHECKS = runner_models.TraceChecksConfig(
@@ -1240,10 +1261,12 @@ def test_every_ledger_key_resolves_in_the_runner_config_dump():
             "the ledger would never see the key as populated"
         )
         assert item.author_key in accountable, (
-            f"{item.author_key} reaches the runner but no recording site in the grading "
-            "path claims it, so every task populating it would fail GradeTrial. Add an "
-            "evaluate-or-skip site in _grade_trial_async (or the evaluator it calls) and "
-            "list the key in grading_ledger.accountable_author_keys"
+            f"{item.author_key} reaches the runner but nobody has declared a recording "
+            "site for it in grading_ledger.accountable_author_keys, so every task "
+            "populating it would fail GradeTrial. Add an evaluate-or-skip site in "
+            "_grade_trial_async (or the evaluator it calls) and list the key there. "
+            "This asserts the declaration only; lock 15 is what drives the site and "
+            "reads the outcome it filed"
         )
 
 
@@ -2676,6 +2699,300 @@ def test_a_config_scoring_nothing_passes_only_when_it_asked_for_nothing(weights,
         return
     assert named in core.reasons, core.reasons
     assert named in (runner.reason or ""), runner.reason
+
+
+# --------------------------------------------------------------------------
+# 15. Every ledger key's recording site is driven through a real GradeTrial
+# --------------------------------------------------------------------------
+
+
+class _Driver(str, Enum):
+    """How lock 15 gets one ledger key populated with its evaluator able to run."""
+
+    PARITY_PACK = "parity_pack"
+    HASH_FAMILY = "hash_family"
+    DB_PROBES = "db_probes"
+    LLM_JUDGE = "llm_judge"
+
+
+_LEDGER_KEY_DRIVERS: Mapping[str, _Driver] = MappingProxyType(
+    {
+        "custom_checks": _Driver.PARITY_PACK,
+        "state_checks.jsonpaths": _Driver.PARITY_PACK,
+        "transcript_rules.must_contain": _Driver.PARITY_PACK,
+        "transcript_rules.disallow_regex": _Driver.PARITY_PACK,
+        "transcript_rules.max_turns": _Driver.PARITY_PACK,
+        "transcript_rules.min_assistant_turns": _Driver.PARITY_PACK,
+        "transcript_rules.tool_expectations": _Driver.PARITY_PACK,
+        "transcript_rules.required_actions": _Driver.PARITY_PACK,
+        "transcript_rules.communicate_info": _Driver.PARITY_PACK,
+        "trace_checks.constraints": _Driver.PARITY_PACK,
+        "trace_checks.alternatives": _Driver.PARITY_PACK,
+        "trace_checks.constraints.present": _Driver.PARITY_PACK,
+        "trace_checks.constraints.absent": _Driver.PARITY_PACK,
+        "trace_checks.constraints.count": _Driver.PARITY_PACK,
+        "trace_checks.constraints.before": _Driver.PARITY_PACK,
+        "trace_checks.constraints.immediately_before": _Driver.PARITY_PACK,
+        "trace_checks.constraints.absent_before": _Driver.PARITY_PACK,
+        "trace_checks.constraints.absent_between": _Driver.PARITY_PACK,
+        "trace_checks.constraints.all_of": _Driver.PARITY_PACK,
+        "trace_checks.constraints.any_of": _Driver.PARITY_PACK,
+        "trace_checks.constraints.negate": _Driver.PARITY_PACK,
+        "state_checks.hash.enabled": _Driver.HASH_FAMILY,
+        "state_checks.hash.golden_actions": _Driver.HASH_FAMILY,
+        "state_checks.hash.expected_state_hash": _Driver.HASH_FAMILY,
+        "state_checks.db_probes": _Driver.DB_PROBES,
+        "llm_judge": _Driver.LLM_JUDGE,
+    }
+)
+"""Which driver can populate each ledger key and let its evaluator run.
+
+Written out per key, like ``accountable_author_keys()`` and for the same reason:
+comprehended from :data:`LEDGER_KEYS` the totality assertion below would compare
+that set against itself, and a key nothing can drive would join the sweep as a row
+that silently proves nothing.
+"""
+
+_LEDGER_SITE_KEYS = tuple(item.author_key for item in LEDGER_KEYS if item.runner_field is not None)
+
+_UNSCORED_COMPONENT = -1.0
+"""What ``GradeComponents`` carries for a component the runner did not score.
+
+Every component evaluator in ``tolokaforge/runner/grading.py`` returns it when
+handed nothing to evaluate, so a slot holding it means no evaluation happened
+whatever the ledger recorded for the keys that feed it.
+"""
+
+
+def test_every_ledger_key_names_a_driver_that_can_populate_it():
+    """A ledger key absent from the table would drop out of the sweep, not fail it."""
+    undriven = sorted(set(_LEDGER_SITE_KEYS) - set(_LEDGER_KEY_DRIVERS))
+    stale = sorted(set(_LEDGER_KEY_DRIVERS) - set(_LEDGER_SITE_KEYS))
+
+    assert not undriven and not stale, (
+        f"the lock-15 driver table names no driver for {undriven or 'nothing'} and "
+        f"names {stale or 'nothing'} that is not a ledger key with a runner_field. "
+        "Every ledger key needs a driver here, or its recording site is unverified"
+    )
+
+
+def _assert_the_site_reported(
+    author_key: str,
+    grading_config: runner_models.RunnerGradingConfig,
+    response: pb2.GradeTrialResponse,
+) -> None:
+    """Assert the runner reported ``author_key`` the way the manifest implies.
+
+    ``grading_config`` is the config the runner *graded* — read off the registered
+    trial, not the test's own copy, because the spec round-trips through JSON and
+    the two are siblings.
+
+    The manifest decides which outcome to expect and the ledger supplies the text,
+    so neither this module nor a task author can spell an expectation production
+    never emits.
+    """
+    item = entry(author_key)
+
+    assert author_key in populated_ledger_keys(grading_config), (
+        f"{author_key}: the config the runner graded does not populate the key, so "
+        "the audit never visited it and every claim below would hold over a config "
+        "that asked for nothing"
+    )
+    assert response.success is True, (
+        f"{author_key}: GradeTrial failed, which is what the audit does when no "
+        f"recording site filed the key — {response.error}"
+    )
+
+    if item.coverage is SubstrateCoverage.CORE_ONLY:
+        expected = skip_note(author_key, CORE_ONLY_HASH_SKIP)
+        assert expected in response.grade.reasons, (
+            f"{author_key} is CORE_ONLY, so its recording site must file the standing "
+            f"skip and the grade must say so. Expected {expected!r} in "
+            f"{response.grade.reasons!r}"
+        )
+        return
+
+    assert item.runner_evaluator is not None, (
+        f"{author_key}: the manifest gives it neither a runner evaluator nor CORE_ONLY "
+        "coverage, so this lock cannot say what its recording site should have filed"
+    )
+    assert skip_note_prefix(author_key) not in response.grade.reasons, (
+        f"{author_key} declares the runner evaluator {item.runner_evaluator}, so its "
+        "recording site must file EVALUATED — the grade instead carries a skip note "
+        f"for it: {response.grade.reasons!r}"
+    )
+    component = author_key.split(".")[0]
+    assert getattr(response.grade.components, component) != _UNSCORED_COMPONENT, (
+        f"{author_key} was recorded as evaluated, but the {component} component it "
+        "feeds is the unscored sentinel — the site filed an evaluation that did not "
+        "happen"
+    )
+
+
+def _drive_parity_pack(
+    author_key: str,
+    test_data_dir: Path,
+    servicer: RunnerServiceImpl,
+    context: Any,
+    *,
+    label: str,
+) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
+    """Grade the key's own pack, and hand back the config the runner actually graded.
+
+    ``label`` separates one caller's trial from another's. The DB service keeps a
+    trial's rows for the whole session, so two calls naming the same trial collide
+    at ``RegisterTrial`` rather than grading.
+    """
+    task_id = _task_id_for(author_key)
+    task_description = _parity_adapter(test_data_dir).to_task_description(task_id)
+    case = _load_case(_pack_dir(test_data_dir, author_key), "satisfying")
+    trial_id = f"ledger_site_{label}_{task_id}:0"
+    response = _grade_pack_through_the_runner(servicer, context, task_description, case, trial_id)
+    return servicer.trials[trial_id].grading_config, response
+
+
+def _sweep_params() -> list[Any]:
+    """One row per ledger key, the not-yet-driven ones marked ``xfail(strict=True)``.
+
+    Strict is what makes the marks self-removing: the row that starts passing when
+    its driver lands fails until the mark goes with it.
+    """
+    params = []
+    for author_key in _LEDGER_SITE_KEYS:
+        driver = _LEDGER_KEY_DRIVERS.get(author_key)
+        marks = (
+            ()
+            if driver is _Driver.PARITY_PACK
+            else (
+                pytest.mark.xfail(
+                    strict=True,
+                    reason=f"the {driver.value if driver else 'missing'} driver is not built yet",
+                ),
+            )
+        )
+        params.append(pytest.param(author_key, id=author_key, marks=marks))
+    return params
+
+
+@pytest.mark.parametrize("author_key", _sweep_params())
+def test_every_ledger_keys_recording_site_is_driven(
+    author_key, test_data_dir, runner_service, mock_grpc_context
+):
+    """Drive a real ``GradeTrial`` per ledger key and read what its site filed.
+
+    Editing ``accountable_author_keys()`` cannot satisfy this: the key has to be
+    populated on a config the runner registered, its evaluator has to run, and the
+    outcome the ledger reports has to be the one the manifest implies.
+    """
+    driver = _LEDGER_KEY_DRIVERS[author_key]
+    assert driver is _Driver.PARITY_PACK, (
+        f"{author_key} is driven by {driver.value}, which is not built yet — its "
+        "recording site is declared but never driven"
+    )
+
+    grading_config, response = _drive_parity_pack(
+        author_key, test_data_dir, runner_service, mock_grpc_context, label="sweep"
+    )
+
+    _assert_the_site_reported(author_key, grading_config, response)
+
+
+# Fault injections. Without them lock 15 is a gate nobody has seen fail, so each
+# drives a real trial through a broken runner and asserts the helper rejects it.
+
+_INJECTION_JSONPATHS = "state_checks.jsonpaths"
+_INJECTION_TRACE = "trace_checks.constraints.all_of"
+_INJECTION_TRANSCRIPT = "transcript_rules.must_contain"
+
+
+def test_the_site_lock_rejects_a_config_that_populated_nothing(
+    test_data_dir, runner_service, mock_grpc_context
+):
+    """Claim 1: a real grade beside a config that never asked for the key."""
+    _, response = _drive_parity_pack(
+        _INJECTION_JSONPATHS, test_data_dir, runner_service, mock_grpc_context, label="unpopulated"
+    )
+
+    with pytest.raises(AssertionError, match="does not populate the key"):
+        _assert_the_site_reported(
+            _INJECTION_JSONPATHS, runner_models.RunnerGradingConfig(), response
+        )
+
+
+def test_the_site_lock_rejects_a_site_that_filed_a_skip_where_it_evaluated(
+    test_data_dir, runner_service, mock_grpc_context, monkeypatch
+):
+    """Claim 3: a recording site downgraded to a skip while its evaluator still ran.
+
+    Patching the module-level ``EVALUATED`` stands in for the class of defect rather
+    than reproducing one site's edit: every inline site reads this global, so the
+    downgrade lands on all of them at once. The targeted single-line edit is the
+    reviewer differential quoted in this stage's report.
+    """
+    monkeypatch.setattr(
+        runner_service_module,
+        "EVALUATED",
+        KeyAccountingRecord(outcome=KeyAccounting.SKIPPED, detail="downgraded by injection"),
+    )
+
+    grading_config, response = _drive_parity_pack(
+        _INJECTION_JSONPATHS, test_data_dir, runner_service, mock_grpc_context, label="downgraded"
+    )
+
+    assert response.success is True, response.error
+    with pytest.raises(AssertionError, match="must file EVALUATED"):
+        _assert_the_site_reported(_INJECTION_JSONPATHS, grading_config, response)
+
+
+@pytest.mark.parametrize(
+    ("evaluator_name", "author_key"),
+    [
+        ("evaluate_trace_checks", _INJECTION_TRACE),
+        ("evaluate_transcript_rules", _INJECTION_TRANSCRIPT),
+    ],
+)
+def test_the_site_lock_rejects_an_evaluator_that_stopped_accounting(
+    evaluator_name, author_key, test_data_dir, runner_service, mock_grpc_context, monkeypatch
+):
+    """Claim 2: the evaluator still scores, but records no key — the audit fails the RPC."""
+    real = getattr(runner_service_module, evaluator_name)
+
+    def drifted(*args: Any, **kwargs: Any) -> Any:
+        return real(*args, **kwargs).model_copy(update={"accounted_keys": {}})
+
+    monkeypatch.setattr(runner_service_module, evaluator_name, drifted)
+
+    grading_config, response = _drive_parity_pack(
+        author_key, test_data_dir, runner_service, mock_grpc_context, label="unaccounted"
+    )
+
+    assert response.success is False, "the audit was meant to fail the RPC"
+    with pytest.raises(AssertionError, match="GradeTrial failed"):
+        _assert_the_site_reported(author_key, grading_config, response)
+
+
+def test_the_site_lock_rejects_an_evaluated_record_over_an_evaluation_that_did_not_run(
+    test_data_dir, runner_service, mock_grpc_context, monkeypatch
+):
+    """Claim 4: real accounting filed EVALUATED while the component stayed unscored."""
+    real = runner_service_module.evaluate_transcript_rules
+
+    def hollow(*args: Any, **kwargs: Any) -> Any:
+        return real(*args, **kwargs).model_copy(update={"score": _UNSCORED_COMPONENT})
+
+    monkeypatch.setattr(runner_service_module, "evaluate_transcript_rules", hollow)
+
+    grading_config, response = _drive_parity_pack(
+        _INJECTION_TRANSCRIPT, test_data_dir, runner_service, mock_grpc_context, label="hollow"
+    )
+
+    assert response.success is True, response.error
+    assert skip_note_prefix(_INJECTION_TRANSCRIPT) not in response.grade.reasons, (
+        "the key must still be recorded as evaluated, or claim 3 would fire here "
+        "and claim 4 would go unmeasured"
+    )
+    with pytest.raises(AssertionError, match="unscored sentinel"):
+        _assert_the_site_reported(_INJECTION_TRANSCRIPT, grading_config, response)
 
 
 # --------------------------------------------------------------------------

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -91,6 +91,7 @@ from tolokaforge.core import models as core_models
 from tolokaforge.core.grading.combine import GradingEngine
 from tolokaforge.core.grading.combine_method import COMBINE_METHODS
 from tolokaforge.core.grading.combine_weights import MissingComponentWeight
+from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
 from tolokaforge.core.grading.key_manifest import (
     GRADING_KEYS,
     Enforcement,
@@ -126,6 +127,8 @@ from tolokaforge.runner.grading import (
 from tolokaforge.runner.grading_ledger import (
     CORE_ONLY_HASH_SKIP,
     LEDGER_KEYS,
+    LLM_JUDGE_KEY,
+    NO_JUDGE_MESSAGES_SKIP,
     accountable_author_keys,
     populated_ledger_keys,
     runner_dump_path,
@@ -1825,21 +1828,40 @@ def _register_pack(
     context: Any,
     task_description: runner_models.TaskDescription,
     trial_id: str,
+    *,
+    judge_model_config: core_models.ModelConfig | None = None,
 ) -> None:
     """Put ``task_description`` on the runner through its own ``RegisterTrial``.
 
     The spec round-trips through JSON, so the runner grades the config it rebuilt
     rather than the caller's object — which is why a caller that needs the graded
     config reads it back off ``servicer.trials[trial_id]``.
+
+    ``judge_model_config`` rides the spec for a task declaring an ``llm_judge``
+    rubric, which ``_grade_llm_judge`` refuses to grade without.
     """
     registered = servicer.RegisterTrial(
         register_request(
-            trial_spec_json(task_description.model_dump(mode="json"), trial_id=trial_id),
+            trial_spec_json(
+                task_description.model_dump(mode="json"),
+                trial_id=trial_id,
+                judge_model_config=judge_model_config,
+            ),
             trial_id=trial_id,
         ),
         context,
     )
     assert registered.success is True, registered.error
+
+
+def _grade_registered_trial(
+    servicer: RunnerServiceImpl, context: Any, trial_id: str, llm_messages_json: str
+) -> pb2.GradeTrialResponse:
+    """``GradeTrial`` on an already-registered trial, response unasserted."""
+    return servicer.GradeTrial(
+        pb2.GradeTrialRequest(trial_id=trial_id, llm_messages_json=llm_messages_json),
+        context,
+    )
 
 
 def _grade_pack_through_the_runner(
@@ -1859,12 +1881,7 @@ def _grade_pack_through_the_runner(
     """
     _register_pack(servicer, context, task_description, trial_id)
     _replay_authored_calls(servicer, context, trial_id, case)
-    return servicer.GradeTrial(
-        pb2.GradeTrialRequest(
-            trial_id=trial_id, llm_messages_json=json.dumps(case.runner_messages)
-        ),
-        context,
-    )
+    return _grade_registered_trial(servicer, context, trial_id, json.dumps(case.runner_messages))
 
 
 def _runner_trace_checks_grade(
@@ -2829,72 +2846,277 @@ def _assert_the_site_reported(
     )
 
 
+def _ledger_trial_id(label: str, author_key: str) -> str:
+    """A trial id unique to one caller and one key.
+
+    The DB service keeps a trial's rows for the whole session, so two tests naming
+    the same trial collide at ``RegisterTrial`` instead of grading. Sibling keys
+    sharing a driver — the three hash-family members — still need one trial each.
+    """
+    return f"ledger_site_{label}_{_task_id_for(author_key)}:0"
+
+
 def _drive_parity_pack(
     author_key: str,
     test_data_dir: Path,
     servicer: RunnerServiceImpl,
     context: Any,
     *,
-    label: str,
+    trial_id: str,
 ) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
-    """Grade the key's own pack, and hand back the config the runner actually graded.
-
-    ``label`` separates one caller's trial from another's. The DB service keeps a
-    trial's rows for the whole session, so two calls naming the same trial collide
-    at ``RegisterTrial`` rather than grading.
-    """
-    task_id = _task_id_for(author_key)
-    task_description = _parity_adapter(test_data_dir).to_task_description(task_id)
+    """Grade the key's own pack, and hand back the config the runner actually graded."""
+    task_description = _parity_adapter(test_data_dir).to_task_description(_task_id_for(author_key))
     case = _load_case(_pack_dir(test_data_dir, author_key), "satisfying")
-    trial_id = f"ledger_site_{label}_{task_id}:0"
     response = _grade_pack_through_the_runner(servicer, context, task_description, case, trial_id)
     return servicer.trials[trial_id].grading_config, response
 
 
-def _sweep_params() -> list[Any]:
-    """One row per ledger key, the not-yet-driven ones marked ``xfail(strict=True)``.
+_HASH_DRIVER_TOOL = "ship_order"
 
-    Strict is what makes the marks self-removing: the row that starts passing when
-    its driver lands fails until the mark goes with it.
+_HASH_DRIVER_TASK: dict[str, Any] = {
+    "task_id": "ledger_hash_family",
+    "name": "Ledger hash family",
+    "category": "test",
+    "description": "A hash-graded trial, for the hash family's recording site",
+    "adapter_type": "native",
+    "system_prompt": "You are a test assistant.",
+    "initial_state": {
+        "tables": {"orders": [{"order_id": "O1", "status": "pending"}]},
+        "schemas": [
+            {
+                "table_name": "orders",
+                "fields": {"order_id": "string", "status": "string"},
+                "primary_key": "order_id",
+            }
+        ],
+    },
+    # The golden action resolves against the trial's registered callables rather
+    # than against declared tool sources, so the tool is bound after registration
+    # and declaring it here would only ask the runner to reconstruct it.
+    "agent_tools": [],
+    "user_tools": [],
+    "grading": {
+        "combine_method": "weighted",
+        "weights": {"state_checks": 1.0},
+        "pass_threshold": 0.5,
+        "state_checks": {
+            "hash_enabled": True,
+            "golden_actions": [{"tool_name": _HASH_DRIVER_TOOL, "arguments": {"order_id": "O1"}}],
+            "expected_hash": "deadbeef",
+        },
+    },
+}
+
+_JUDGE_DRIVER_TASK: dict[str, Any] = {
+    "task_id": "ledger_llm_judge",
+    "name": "Ledger llm judge",
+    "category": "test",
+    "description": "A rubric-graded trial, for the judge's recording site",
+    "adapter_type": "native",
+    "system_prompt": "You are a test assistant.",
+    "initial_state": {},
+    "agent_tools": [],
+    "user_tools": [],
+    "grading": {
+        "combine_method": "weighted",
+        "weights": {"llm_judge": 1.0},
+        "pass_threshold": 0.5,
+        "llm_judge": {
+            "rubric": {
+                "criteria": [
+                    {
+                        "id": "explained",
+                        "description": "the agent explained the outcome",
+                        "kind": "binary",
+                        "weight": 1.0,
+                    }
+                ]
+            }
+        },
+    },
+}
+
+_JUDGE_TRANSCRIPT = json.dumps(
+    [{"role": "assistant", "content": "I shipped order O1, so the request is complete."}]
+)
+_PROBE_TRANSCRIPT = json.dumps([{"role": "assistant", "content": "Corrective action recorded."}])
+_HASH_TRANSCRIPT = json.dumps([{"role": "assistant", "content": "Order O1 is shipped."}])
+
+#: Rows standing in for the postgres the pack's probe queries. The DSN resolves only
+#: inside the task's docker network, which is why the manifest enforces this key's
+#: *score* at the integration tier — orthogonal to whether its *recording site* can be
+#: driven here, which is what lock 15 asks.
+_PROBE_ROWS = [{"reason_code": "CAPA-01", "status": "open"}]
+
+
+class _StubJudge:
+    """Stands in for the model provider at the seam ``service.LLMJudge`` names.
+
+    What it replaces is an external LLM call, not a recording site, an evaluator's
+    decision, the audit or the combine — all of those stay real on this path.
     """
-    params = []
-    for author_key in _LEDGER_SITE_KEYS:
-        driver = _LEDGER_KEY_DRIVERS.get(author_key)
-        marks = (
-            ()
-            if driver is _Driver.PARITY_PACK
-            else (
-                pytest.mark.xfail(
-                    strict=True,
-                    reason=f"the {driver.value if driver else 'missing'} driver is not built yet",
-                ),
-            )
+
+    def __init__(self, model_config: Any, **_kwargs: Any) -> None:
+        self.model_config = model_config
+
+    def run(self, **_kwargs: Any) -> JudgeResult:
+        return JudgeResult(
+            status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
         )
-        params.append(pytest.param(author_key, id=author_key, marks=marks))
-    return params
 
 
-@pytest.mark.parametrize("author_key", _sweep_params())
+async def _shipped(arguments: dict[str, Any]) -> str:
+    return json.dumps({"order_id": arguments["order_id"], "status": "shipped"})
+
+
+def _drive_hash_family(
+    servicer: RunnerServiceImpl, context: Any, *, trial_id: str
+) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
+    """Grade a hash-enabled trial whose one golden action names a registered tool.
+
+    Asserts the replay ran whole. ``hash_family_accounting(EVALUATED)`` is recorded
+    whenever ``_execute_hash_grading`` returns — including when every golden action
+    failed to take effect, which still grades ``success=True`` with
+    ``state_checks == 1.0``. All four of lock 15's claims hold on that hollow
+    evaluation, so without this guard claim 4 would mean nothing for the hash family.
+    """
+    task_description = runner_models.TaskDescription.model_validate(_HASH_DRIVER_TASK)
+    _register_pack(servicer, context, task_description, trial_id)
+    servicer.trials[trial_id].agent_tools[_HASH_DRIVER_TOOL] = _shipped
+
+    response = _grade_registered_trial(servicer, context, trial_id, _HASH_TRANSCRIPT)
+
+    assert "GOLDEN REPLAY ERRORS" not in response.grade.reasons, (
+        "the golden replay did not run whole, so the hash verdict was computed "
+        f"against a partial golden world and evaluating it proves nothing: "
+        f"{response.grade.reasons!r}"
+    )
+    return servicer.trials[trial_id].grading_config, response
+
+
+def _drive_db_probes(
+    test_data_dir: Path,
+    servicer: RunnerServiceImpl,
+    context: Any,
+    monkeypatch: Any,
+    *,
+    trial_id: str,
+) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
+    """Grade the ``db_probe_grading`` pack with the probe's postgres substituted.
+
+    ``_fetch_probe_rows`` is the seam lock 13 already reads this pack through. The
+    probe's own ``expect`` assertions, the fold that reads the score, the recording
+    site and the audit are all the real ones.
+    """
+
+    async def _rows(_dsn: str, _query: str) -> list[dict[str, Any]]:
+        return _PROBE_ROWS
+
+    monkeypatch.setattr(runner_grading, "_fetch_probe_rows", _rows)
+    task_description = _adapter_for(test_data_dir, _TASKS_GLOB).to_task_description(_PROBE_PACK)
+    _register_pack(servicer, context, task_description, trial_id)
+
+    response = _grade_registered_trial(servicer, context, trial_id, _PROBE_TRANSCRIPT)
+    return servicer.trials[trial_id].grading_config, response
+
+
+def _drive_llm_judge(
+    servicer: RunnerServiceImpl,
+    context: Any,
+    monkeypatch: Any,
+    *,
+    trial_id: str,
+    transcript: str = _JUDGE_TRANSCRIPT,
+) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
+    """Grade a rubric-configured trial with the model provider substituted.
+
+    The spec carries a judge ``ModelConfig``: ``_grade_llm_judge`` raises before it
+    ever constructs the judge without one, so the row would otherwise red on claim 2
+    for a reason with nothing to do with the recording site.
+    """
+    monkeypatch.setattr(runner_service_module, "LLMJudge", _StubJudge)
+    task_description = runner_models.TaskDescription.model_validate(_JUDGE_DRIVER_TASK)
+    _register_pack(
+        servicer,
+        context,
+        task_description,
+        trial_id,
+        judge_model_config=core_models.ModelConfig(name="test-judge", provider="test"),
+    )
+
+    response = _grade_registered_trial(servicer, context, trial_id, transcript)
+    return servicer.trials[trial_id].grading_config, response
+
+
+def _drive_the_key(
+    author_key: str,
+    test_data_dir: Path,
+    servicer: RunnerServiceImpl,
+    context: Any,
+    monkeypatch: Any,
+    *,
+    label: str,
+) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
+    """Whichever driver the table names for ``author_key``."""
+    driver = _LEDGER_KEY_DRIVERS[author_key]
+    trial_id = _ledger_trial_id(label, author_key)
+    if driver is _Driver.PARITY_PACK:
+        return _drive_parity_pack(author_key, test_data_dir, servicer, context, trial_id=trial_id)
+    if driver is _Driver.HASH_FAMILY:
+        return _drive_hash_family(servicer, context, trial_id=trial_id)
+    if driver is _Driver.DB_PROBES:
+        return _drive_db_probes(test_data_dir, servicer, context, monkeypatch, trial_id=trial_id)
+    if driver is _Driver.LLM_JUDGE:
+        return _drive_llm_judge(servicer, context, monkeypatch, trial_id=trial_id)
+    raise AssertionError(f"{author_key}: the {driver.value} driver has no implementation")
+
+
+@pytest.mark.parametrize("author_key", _LEDGER_SITE_KEYS)
 def test_every_ledger_keys_recording_site_is_driven(
-    author_key, test_data_dir, runner_service, mock_grpc_context
+    author_key, test_data_dir, runner_service, mock_grpc_context, monkeypatch
 ):
     """Drive a real ``GradeTrial`` per ledger key and read what its site filed.
 
     Editing ``accountable_author_keys()`` cannot satisfy this: the key has to be
     populated on a config the runner registered, its evaluator has to run, and the
     outcome the ledger reports has to be the one the manifest implies.
-    """
-    driver = _LEDGER_KEY_DRIVERS[author_key]
-    assert driver is _Driver.PARITY_PACK, (
-        f"{author_key} is driven by {driver.value}, which is not built yet — its "
-        "recording site is declared but never driven"
-    )
 
-    grading_config, response = _drive_parity_pack(
-        author_key, test_data_dir, runner_service, mock_grpc_context, label="sweep"
+    Two rows substitute an external service — the probe's postgres and the judge's
+    model provider — and nothing else. A key the manifest enforces at the
+    *integration* tier for its **score** is still canonically drivable for its
+    **recording site**; the two are orthogonal, and conflating them is what would
+    leave a residue here.
+    """
+    grading_config, response = _drive_the_key(
+        author_key, test_data_dir, runner_service, mock_grpc_context, monkeypatch, label="sweep"
     )
 
     _assert_the_site_reported(author_key, grading_config, response)
+
+
+def test_a_judge_with_no_transcript_messages_records_its_skip(
+    runner_service, mock_grpc_context, monkeypatch
+):
+    """The judge's other branch, kept beside the sweep rather than in it.
+
+    Every sweep row carries one manifest-derived expectation; this trial populates
+    ``llm_judge`` and legitimately skips it, which is the one shape that expectation
+    cannot describe. Its note is what tells a task author the rubric scored nothing.
+    """
+    grading_config, response = _drive_llm_judge(
+        runner_service,
+        mock_grpc_context,
+        monkeypatch,
+        trial_id=_ledger_trial_id("skip", LLM_JUDGE_KEY),
+        transcript="",
+    )
+
+    assert response.success is True, response.error
+    assert LLM_JUDGE_KEY in populated_ledger_keys(grading_config)
+    assert skip_note(LLM_JUDGE_KEY, NO_JUDGE_MESSAGES_SKIP) in response.grade.reasons, (
+        "a judge-configured trial with no transcript to judge must say so on the "
+        f"grade: {response.grade.reasons!r}"
+    )
 
 
 # Fault injections. Without them lock 15 is a gate nobody has seen fail, so each
@@ -2910,7 +3132,11 @@ def test_the_site_lock_rejects_a_config_that_populated_nothing(
 ):
     """Claim 1: a real grade beside a config that never asked for the key."""
     _, response = _drive_parity_pack(
-        _INJECTION_JSONPATHS, test_data_dir, runner_service, mock_grpc_context, label="unpopulated"
+        _INJECTION_JSONPATHS,
+        test_data_dir,
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id("unpopulated", _INJECTION_JSONPATHS),
     )
 
     with pytest.raises(AssertionError, match="does not populate the key"):
@@ -2936,7 +3162,11 @@ def test_the_site_lock_rejects_a_site_that_filed_a_skip_where_it_evaluated(
     )
 
     grading_config, response = _drive_parity_pack(
-        _INJECTION_JSONPATHS, test_data_dir, runner_service, mock_grpc_context, label="downgraded"
+        _INJECTION_JSONPATHS,
+        test_data_dir,
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id("downgraded", _INJECTION_JSONPATHS),
     )
 
     assert response.success is True, response.error
@@ -2963,7 +3193,11 @@ def test_the_site_lock_rejects_an_evaluator_that_stopped_accounting(
     monkeypatch.setattr(runner_service_module, evaluator_name, drifted)
 
     grading_config, response = _drive_parity_pack(
-        author_key, test_data_dir, runner_service, mock_grpc_context, label="unaccounted"
+        author_key,
+        test_data_dir,
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id("unaccounted", author_key),
     )
 
     assert response.success is False, "the audit was meant to fail the RPC"
@@ -2983,7 +3217,11 @@ def test_the_site_lock_rejects_an_evaluated_record_over_an_evaluation_that_did_n
     monkeypatch.setattr(runner_service_module, "evaluate_transcript_rules", hollow)
 
     grading_config, response = _drive_parity_pack(
-        _INJECTION_TRANSCRIPT, test_data_dir, runner_service, mock_grpc_context, label="hollow"
+        _INJECTION_TRANSCRIPT,
+        test_data_dir,
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id("hollow", _INJECTION_TRANSCRIPT),
     )
 
     assert response.success is True, response.error
@@ -2993,6 +3231,30 @@ def test_the_site_lock_rejects_an_evaluated_record_over_an_evaluation_that_did_n
     )
     with pytest.raises(AssertionError, match="unscored sentinel"):
         _assert_the_site_reported(_INJECTION_TRANSCRIPT, grading_config, response)
+
+
+def test_the_site_lock_rejects_hash_accounting_that_files_nothing(
+    runner_service, mock_grpc_context, monkeypatch
+):
+    """Claim 2 for the mechanism the hash family alone uses.
+
+    The whole family reaches the ledger through one ``hash_family_accounting`` call,
+    so that call returning nothing is how this family's recording site disappears.
+    The assertion is on lock 15's own helper: the mutation also breaks a dozen unit
+    tests elsewhere, and a lock that relied on those going red would not be reading
+    its own claim.
+    """
+    monkeypatch.setattr(runner_service_module, "hash_family_accounting", lambda outcome: {})
+
+    grading_config, response = _drive_hash_family(
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id("unaccounted_hash", "state_checks.hash.enabled"),
+    )
+
+    assert response.success is False, "the audit was meant to fail the RPC"
+    with pytest.raises(AssertionError, match="GradeTrial failed"):
+        _assert_the_site_reported("state_checks.hash.enabled", grading_config, response)
 
 
 # --------------------------------------------------------------------------

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -1797,14 +1797,18 @@ def _replay_authored_calls(
         assert executed.status == pb2.EXECUTION_STATUS_SUCCESS, executed.error_message
 
 
-def _runner_trace_checks_grade(
+def _register_pack(
     servicer: RunnerServiceImpl,
-    task_description: runner_models.TaskDescription,
-    case: _TrialCase,
-    trial_id: str,
     context: Any,
-) -> pb2.Grade:
-    """The runner's own ``GradeTrial`` verdict on ``case``, over real gRPC handlers."""
+    task_description: runner_models.TaskDescription,
+    trial_id: str,
+) -> None:
+    """Put ``task_description`` on the runner through its own ``RegisterTrial``.
+
+    The spec round-trips through JSON, so the runner grades the config it rebuilt
+    rather than the caller's object — which is why a caller that needs the graded
+    config reads it back off ``servicer.trials[trial_id]``.
+    """
     registered = servicer.RegisterTrial(
         register_request(
             trial_spec_json(task_description.model_dump(mode="json"), trial_id=trial_id),
@@ -1813,13 +1817,42 @@ def _runner_trace_checks_grade(
         context,
     )
     assert registered.success is True, registered.error
+
+
+def _grade_pack_through_the_runner(
+    servicer: RunnerServiceImpl,
+    context: Any,
+    task_description: runner_models.TaskDescription,
+    case: _TrialCase,
+    trial_id: str,
+) -> pb2.GradeTrialResponse:
+    """Register the task, replay ``case``'s calls, grade — the runner's whole path.
+
+    The ``GradeTrialResponse`` comes back unasserted. A caller may be reading the
+    RPC's own verdict — a failed audit is an outcome, not a fixture error — so
+    asserting ``success`` here would consume the very fact it was called for.
+    Registration is asserted, because a trial that never registered is a broken
+    fixture whichever outcome the caller wants.
+    """
+    _register_pack(servicer, context, task_description, trial_id)
     _replay_authored_calls(servicer, context, trial_id, case)
-    response = servicer.GradeTrial(
+    return servicer.GradeTrial(
         pb2.GradeTrialRequest(
             trial_id=trial_id, llm_messages_json=json.dumps(case.runner_messages)
         ),
         context,
     )
+
+
+def _runner_trace_checks_grade(
+    servicer: RunnerServiceImpl,
+    task_description: runner_models.TaskDescription,
+    case: _TrialCase,
+    trial_id: str,
+    context: Any,
+) -> pb2.Grade:
+    """The runner's own ``GradeTrial`` verdict on ``case``, over real gRPC handlers."""
+    response = _grade_pack_through_the_runner(servicer, context, task_description, case, trial_id)
     assert response.success is True, response.error
     return response.grade
 
@@ -2066,14 +2099,7 @@ def _runner_undecided_grade(
     a hand-written counterpart could describe a trial the runner did not have, and
     then the two substrates would be graded on two different trials.
     """
-    registered = servicer.RegisterTrial(
-        register_request(
-            trial_spec_json(task_description.model_dump(mode="json"), trial_id=trial_id),
-            trial_id=trial_id,
-        ),
-        context,
-    )
-    assert registered.success is True, registered.error
+    _register_pack(servicer, context, task_description, trial_id)
 
     lookup = _execute_declared_call(servicer, context, trial_id, _UNDECIDED_LOOKUP, succeeds=True)
     assert lookup.status == pb2.EXECUTION_STATUS_SUCCESS, lookup.error_message
@@ -2176,6 +2202,52 @@ def test_an_undecided_verdict_crosses_the_wire_as_the_fact_it_is(
     )
     assert (core_unrecorded.passed, core_unrecorded.undecided) == (False, True)
     assert (core_failed.passed, core_failed.undecided) == (False, False)
+
+
+# --------------------------------------------------------------------------
+# The runner's own registration path reaches the DB-reading packs
+# --------------------------------------------------------------------------
+
+_STATE_READING_PACKS = (
+    ("state_checks_jsonpaths", "state_checks"),
+    ("custom_checks", "custom_checks"),
+)
+
+
+@pytest.mark.parametrize(("task_id", "component"), _STATE_READING_PACKS)
+def test_a_state_reading_pack_grades_through_the_runners_own_registration(
+    task_id, component, test_data_dir, runner_service, mock_grpc_context
+):
+    """Both DB-reading parity packs are reachable through ``RegisterTrial`` and score.
+
+    Every other parity pack grades off the transcript, so these two are the only
+    ones whose runner path depends on the trial's DB service having been
+    provisioned — and ``RegisterTrial`` provisions it from ``initial_state``, not
+    from the trial fixture's ``state:``.
+
+    Only the satisfying case is asserted. The rows come from ``initial_state``, so
+    the violating case replays its messages against those same rows and scores
+    identically; discriminating the two is lock 3's claim, made over the trial
+    fixture's state. What is claimed here is reachability of the runner's own path.
+    """
+    adapter = _parity_adapter(test_data_dir)
+    task_description = adapter.to_task_description(task_id)
+    case = _load_case(test_data_dir / "grading_parity" / task_id, "satisfying")
+
+    response = _grade_pack_through_the_runner(
+        runner_service,
+        mock_grpc_context,
+        task_description,
+        case,
+        f"reachability_{task_id}:0",
+    )
+
+    assert response.success is True, response.error
+    assert getattr(response.grade.components, component) == pytest.approx(1.0), (
+        f"{task_id} reached GradeTrial but scored {component} at "
+        f"{getattr(response.grade.components, component)}: the runner graded against "
+        "a database RegisterTrial did not provision from initial_state"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -57,8 +57,11 @@ The exemption sets and the differential fixtures are the enforcement mechanism:
 adding a grading key to one substrate only cannot pass this suite without an
 explicit, reviewable edit to one of the frozen constants below.
 
-Locks 3, 6, 7, 9, 10 and 11 drive a real trial, and each reads it through one fixture
-loader, so what a ``grading_parity`` pack can express bounds what they can prove.
+Locks 3, 6, 7, 9, 10, 11 and 15 drive a real trial, and each reads it through one
+fixture loader, so what a ``grading_parity`` pack can express bounds what they can
+prove — for lock 15 that bound covers the keys its driver table sends to a parity
+pack, the hash family, the probes and the judge being driven from tasks written out
+in this module instead.
 That loader's contract — a tool call belongs to the message that requested it, and
 carries that call's own result text — is locked at the end of this module.
 """
@@ -2821,6 +2824,11 @@ def _assert_the_site_reported(
     )
 
     if item.coverage is SubstrateCoverage.CORE_ONLY:
+        assert author_key in family_author_keys(_HASH_FAMILY_ROOT), (
+            f"{author_key} is CORE_ONLY but outside the hash family, and "
+            "CORE_ONLY_HASH_SKIP is the only standing-skip record this helper "
+            "knows. Map coverage to the record its site files, per key"
+        )
         expected = skip_note(author_key, CORE_ONLY_HASH_SKIP)
         assert expected in response.grade.reasons, (
             f"{author_key} is CORE_ONLY, so its recording site must file the standing "
@@ -3120,7 +3128,8 @@ def test_a_judge_with_no_transcript_messages_records_its_skip(
 
 
 # Fault injections. Without them lock 15 is a gate nobody has seen fail, so each
-# drives a real trial through a broken runner and asserts the helper rejects it.
+# asserts the helper rejects a trial the runner graded — five through a broken
+# runner, one through a config that never asked for the key.
 
 _INJECTION_JSONPATHS = "state_checks.jsonpaths"
 _INJECTION_TRACE = "trace_checks.constraints.all_of"
@@ -3152,8 +3161,7 @@ def test_the_site_lock_rejects_a_site_that_filed_a_skip_where_it_evaluated(
 
     Patching the module-level ``EVALUATED`` stands in for the class of defect rather
     than reproducing one site's edit: every inline site reads this global, so the
-    downgrade lands on all of them at once. The targeted single-line edit is the
-    reviewer differential quoted in this stage's report.
+    downgrade lands on all of them at once.
     """
     monkeypatch.setattr(
         runner_service_module,

--- a/tests/data/grading_parity/custom_checks/task.yaml
+++ b/tests/data/grading_parity/custom_checks/task.yaml
@@ -5,8 +5,15 @@ description: |
   Substrate-parity differential fixture. The grading.yaml declares exactly one
   author key so a violating trial can only be discriminated by that key.
 
+# RegisterTrial provisions the trial's DB service only when initial_state carries
+# tables, and checks.py reads `ctx.final_state.data["orders"]`, so grading this pack
+# through the runner's own handlers needs the rows declared here rather than only on
+# the trial.
 initial_state:
-  json_db: null
+  json_db:
+    orders:
+      - id: O1
+        status: shipped
 
 tools:
   agent:

--- a/tests/data/grading_parity/state_checks_jsonpaths/task.yaml
+++ b/tests/data/grading_parity/state_checks_jsonpaths/task.yaml
@@ -5,8 +5,14 @@ description: |
   Substrate-parity differential fixture. The grading.yaml declares exactly one
   author key so a violating trial can only be discriminated by that key.
 
+# RegisterTrial provisions the trial's DB service only when initial_state carries
+# tables, and this pack's jsonpath reads `$.db.orders`, so grading it through the
+# runner's own handlers needs the rows declared here rather than only on the trial.
 initial_state:
-  json_db: null
+  json_db:
+    orders:
+      - id: O1
+        status: shipped
 
 tools:
   agent:

--- a/tests/unit/grading/test_grading_ledger.py
+++ b/tests/unit/grading/test_grading_ledger.py
@@ -33,8 +33,14 @@ from tolokaforge.core.models import ToolCall
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.grading_ledger import (
     CORE_ONLY_HASH_SKIP,
+    CUSTOM_CHECKS_DISABLED_SKIP,
+    DB_PROBES_KEY,
     EVALUATED,
     HASH_DISABLED_SKIP,
+    JSONPATHS_KEY,
+    LEDGER_KEYS,
+    MIN_ASSISTANT_TURNS_KEY,
+    NO_TIMELINE_EVENTS_SKIP,
     TRACE_ALTERNATIVES_KEY,
     TRACE_CONSTRAINT_KEY_BY_KIND,
     TRACE_CONSTRAINTS_KEY,
@@ -42,8 +48,11 @@ from tolokaforge.runner.grading_ledger import (
     accountable_author_keys,
     audit_accounted_keys,
     hash_family_accounting,
+    populated_ledger_keys,
     reject_hash_members_read_by_another_evaluator,
     runner_dump_path,
+    skip_note,
+    skip_note_prefix,
 )
 from tolokaforge.runner.models import (
     TRACE_CONSTRAINT_KINDS,
@@ -195,6 +204,14 @@ def test_config_inputs_are_outside_the_ledger_by_kind():
 
 
 def test_a_recorded_skip_becomes_a_visible_note_not_an_error():
+    """The note is also exactly ``skip_note``'s rendering of the same record.
+
+    The canonical guard rail decides a key was skipped by matching ``skip_note``'s
+    output against ``grade.reasons``. An audit that rendered its own sentence
+    would leave every such match silently unsatisfiable, so the second equality
+    is what stops the two spellings from drifting apart while the first keeps the
+    text itself pinned.
+    """
     config = RunnerGradingConfig(state_checks=RunnerStateChecksConfig(expected_hash="deadbeef"))
 
     audit = audit_accounted_keys(
@@ -204,6 +221,9 @@ def test_a_recorded_skip_becomes_a_visible_note_not_an_error():
     assert audit.error is None
     assert audit.skip_notes == (
         "state_checks.hash.expected_state_hash skipped: hash grading not enabled",
+    )
+    assert audit.skip_notes == (
+        skip_note("state_checks.hash.expected_state_hash", HASH_DISABLED_SKIP),
     )
 
 
@@ -537,7 +557,7 @@ def test_a_constraint_whose_binder_selected_nothing_accounts_its_nested_kinds_as
 
         assert audit.error is None, policy
         assert set(audit.skip_notes) == {
-            f"{TRACE_CONSTRAINT_KEY_BY_KIND[kind]} skipped: {UNBOUND_BINDING_SKIP.detail}"
+            skip_note(TRACE_CONSTRAINT_KEY_BY_KIND[kind], UNBOUND_BINDING_SKIP)
             for kind in ("before", "present")
         }, policy
         assert accounted[TRACE_CONSTRAINT_KEY_BY_KIND["before"]] == UNBOUND_BINDING_SKIP, policy
@@ -631,7 +651,7 @@ def test_a_binder_whose_value_the_trial_never_recorded_accounts_its_nested_kinds
     assert timeline.records_present is False
     assert audit.error is None
     assert set(audit.skip_notes) == {
-        f"{TRACE_CONSTRAINT_KEY_BY_KIND[kind]} skipped: {UNBOUND_BINDING_SKIP.detail}"
+        skip_note(TRACE_CONSTRAINT_KEY_BY_KIND[kind], UNBOUND_BINDING_SKIP)
         for kind in ("present", "absent")
     }
     assert result.accounted_keys[TRACE_CONSTRAINT_KEY_BY_KIND["present"]] == UNBOUND_BINDING_SKIP
@@ -640,6 +660,86 @@ def test_a_binder_whose_value_the_trial_never_recorded_accounts_its_nested_kinds
     assert result.constraints[0].kind is TraceConstraintKind.ALL_OF
     assert result.constraints[0].passed is False
     assert "cannot be decided" in result.constraints[0].message
+
+
+# --------------------------------------------------------------------------
+# The predicates the canonical guard rail reads
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "record",
+    [HASH_DISABLED_SKIP, CUSTOM_CHECKS_DISABLED_SKIP],
+    ids=["hash_disabled", "custom_checks_disabled"],
+)
+def test_a_skip_note_starts_with_its_key_prefix_whatever_the_detail(record):
+    """A caller expecting a key to be *evaluated* asserts the prefix is absent.
+
+    It knows the key and cannot know what detail a hypothetical skip would carry,
+    so the prefix is the whole needle it has. Both halves are needed: a prefix
+    that were not literally how the note starts would let that assertion pass
+    over a key that was in fact skipped, and one that did not name the key would
+    make it fail over a sibling key's skip.
+    """
+    assert skip_note(JSONPATHS_KEY, record).startswith(skip_note_prefix(JSONPATHS_KEY))
+    assert not skip_note(DB_PROBES_KEY, record).startswith(skip_note_prefix(JSONPATHS_KEY))
+
+
+def test_an_evaluated_record_has_no_skip_note_to_render():
+    """Rendering one would let a caller match a sentence the audit never emits."""
+    with pytest.raises(ValueError, match="an EVALUATED record has no skip note"):
+        skip_note(JSONPATHS_KEY, EVALUATED)
+
+
+_PARTIALLY_POPULATED_KEYS = frozenset(
+    {
+        "custom_checks",
+        "state_checks.hash.expected_state_hash",
+        "state_checks.jsonpaths",
+        "trace_checks.constraints",
+        "trace_checks.constraints.all_of",
+        "trace_checks.constraints.before",
+        "trace_checks.constraints.count",
+        "transcript_rules.must_contain",
+    }
+)
+
+
+def _partially_populated_config() -> RunnerGradingConfig:
+    """A config populating :data:`_PARTIALLY_POPULATED_KEYS` and no other ledger key."""
+    return RunnerGradingConfig(
+        state_checks=RunnerStateChecksConfig(
+            jsonpath_checks=[_JSONPATH_CHECK], expected_hash="deadbeef"
+        ),
+        transcript_rules=RunnerTranscriptRulesConfig(must_contain=["shipped"]),
+        trace_checks=TraceChecksConfig(**_NESTED_TRACE_BLOCK),
+        custom_checks={"enabled": True, "file": "checks.py", "interface_version": "1.0"},
+    )
+
+
+def test_populated_ledger_keys_agrees_with_the_audit_on_what_is_populated():
+    """Two answers to "did this config populate the key" must not diverge.
+
+    The canonical guard rail asserts that a driver populated the key it claims to
+    drive; on a predicate that had drifted from the one the audit visits keys by,
+    it would vouch for a key the audit never looked at. Starving the audit of
+    records makes it name every key it visited, which is the only observation of
+    its own predicate it exposes.
+
+    ``state_checks.hash`` is absent because it names no ``runner_field``:
+    resolving one raises, so the comprehension over :data:`LEDGER_KEYS` written
+    without the audit's guard would fail on every call rather than return a set.
+    """
+    config = _partially_populated_config()
+
+    populated = populated_ledger_keys(config)
+    starved = audit_accounted_keys(config, {})
+
+    assert populated == _PARTIALLY_POPULATED_KEYS
+    assert "state_checks.hash" not in populated
+    domain = frozenset(item.author_key for item in LEDGER_KEYS if item.runner_field is not None)
+    assert frozenset(key for key in domain if f"{key} (" in starved.error) == populated
+    assert domain - populated, "the config must leave ledger keys unpopulated to discriminate"
 
 
 # --------------------------------------------------------------------------
@@ -818,7 +918,7 @@ def test_degenerate_trial_still_grades_a_declared_activity_floor(runner_service,
     # The blanket skip sweeps the whole subtree by key prefix, so the floor is the one
     # member that must be carved out of it. Left in, the reasons would say the floor
     # drove the verdict *and* was never evaluated.
-    assert "transcript_rules.min_assistant_turns skipped" not in response.grade.reasons
+    assert skip_note_prefix(MIN_ASSISTANT_TURNS_KEY) not in response.grade.reasons
     assert (
         "transcript_rules.must_contain skipped: the trial's timeline carries no events"
         in response.grade.reasons
@@ -989,13 +1089,10 @@ def test_a_degenerate_trial_leaves_trace_checks_unscored(runner_service, mock_gr
     # The skip is asserted together with the unscored component: a component the
     # runner silently declined to score is as opaque to the task author as one it
     # never accounted for.
+    assert skip_note(TRACE_CONSTRAINTS_KEY, NO_TIMELINE_EVENTS_SKIP) in response.grade.reasons
     assert (
-        f"{TRACE_CONSTRAINTS_KEY} skipped: the trial's timeline carries no events"
+        skip_note(TRACE_CONSTRAINT_KEY_BY_KIND["all_of"], NO_TIMELINE_EVENTS_SKIP)
         in response.grade.reasons
-    )
-    assert (
-        f"{TRACE_CONSTRAINT_KEY_BY_KIND['all_of']} skipped: the trial's timeline carries no "
-        "events" in response.grade.reasons
     )
 
 

--- a/tests/utils/runner_requests.py
+++ b/tests/utils/runner_requests.py
@@ -16,18 +16,28 @@ from tolokaforge.runner.models import TaskDescription
 from tolokaforge.runner.protocol import ENGINE_PROTOCOL_VERSION
 
 
-def trial_spec_json(task_dict: dict[str, Any], trial_id: str = "test:0") -> str:
+def trial_spec_json(
+    task_dict: dict[str, Any],
+    trial_id: str = "test:0",
+    judge_model_config: ModelConfig | None = None,
+) -> str:
     """Build a valid ``TrialSpec`` JSON wrapping ``task_dict``.
 
     The runner-side ``RegisterTrial`` handler validates the full ``TrialSpec``
     (not just ``spec.task``), so tests must construct a complete spec rather
     than a minimal ``{"task": ...}`` wrapper.
+
+    A complete spec for a task declaring an ``llm_judge`` rubric includes the
+    judge model: ``_grade_llm_judge`` raises before constructing the judge when
+    the spec carries none. Every other task leaves ``judge_model_config`` unset,
+    which is what the runner expects.
     """
     return TrialSpec(
         trial_id=trial_id,
         run_id="test_run",
         task=TaskDescription.model_validate(task_dict),
         agent_model_config=ModelConfig(name="test-model", provider="test"),
+        judge_model_config=judge_model_config,
         env_endpoints=EnvEndpoints(
             db_url="http://db.test:8000",
             runner_url="http://runner.test:50051",

--- a/tolokaforge/runner/grading_ledger.py
+++ b/tolokaforge/runner/grading_ledger.py
@@ -150,6 +150,32 @@ class LedgerAudit:
     skip_notes: tuple[str, ...]
 
 
+def skip_note_prefix(author_key: str) -> str:
+    """How every skip note for ``author_key`` starts, whatever the detail.
+
+    A caller asserting a key was *not* skipped has no hypothetical detail to
+    match on, so it matches this instead: the prefix is the whole format the
+    audit renders, and single-sourcing it is what stops a test from spelling a
+    sentence production never emits.
+    """
+    return f"{author_key} skipped: "
+
+
+def skip_note(author_key: str, record: KeyAccountingRecord) -> str:
+    """The sentence ``grade.reasons`` carries for ``author_key``'s recorded skip.
+
+    Raises ``ValueError`` on an ``EVALUATED`` record: an evaluated key produces
+    no note at all, and rendering one would let a caller assert against text the
+    audit never emits.
+    """
+    if record.outcome is KeyAccounting.EVALUATED:
+        raise ValueError(
+            f"{author_key}: an EVALUATED record has no skip note — the audit renders "
+            "a note only for a populated key that was skipped"
+        )
+    return f"{skip_note_prefix(author_key)}{record.detail}"
+
+
 def hash_family_accounting(runner_outcome: KeyAccountingRecord) -> dict[str, KeyAccountingRecord]:
     """The whole ``state_checks.hash`` family's accounting for one component phase.
 
@@ -267,7 +293,7 @@ def audit_accounted_keys(
         if record is None:
             unaccounted.append(_unaccounted_detail(item))
         elif record.outcome is not KeyAccounting.EVALUATED:
-            skip_notes.append(f"{item.author_key} skipped: {record.detail}")
+            skip_notes.append(skip_note(item.author_key, record))
     error = None
     if unaccounted:
         error = (
@@ -275,6 +301,22 @@ def audit_accounted_keys(
             f"recorded a skip for: {'; '.join(unaccounted)}"
         )
     return LedgerAudit(error=error, skip_notes=tuple(skip_notes))
+
+
+def populated_ledger_keys(grading_config: RunnerGradingConfig) -> frozenset[str]:
+    """The ledger keys ``grading_config`` populates, by the audit's own predicate.
+
+    Restricted to keys naming a ``runner_field``, as the audit's loop is: the
+    ``state_checks.hash`` family root names none, and resolving it raises. So the
+    domain is the 26 keys a recording site can be driven for, and a caller
+    reading this set is reading the same fact the audit acted on.
+    """
+    dumped = grading_config.model_dump(exclude_defaults=True)
+    return frozenset(
+        item.author_key
+        for item in LEDGER_KEYS
+        if item.runner_field is not None and _populated(dumped, item)
+    )
 
 
 def _populated(dumped: dict[str, Any], item: GradingKey) -> bool:

--- a/tolokaforge/runner/grading_ledger.py
+++ b/tolokaforge/runner/grading_ledger.py
@@ -207,19 +207,23 @@ def transcript_rules_author_keys() -> tuple[str, ...]:
 
 
 def accountable_author_keys() -> frozenset[str]:
-    """Every author key some recording site in the grading path can record.
+    """The per-key human declaration that a recording site files each author key.
 
-    Lock 5 of ``tests/canonical/test_grading_substrate_parity.py`` asserts every
-    ledger key with a ``runner_field`` is in here, so a manifest entry no site
-    claims fails the canonical suite rather than failing ``GradeTrial`` in
-    production for every task that populates it.
+    A declaration, not evidence. Lock 15 of
+    ``tests/canonical/test_grading_substrate_parity.py`` drives every ledger key's
+    site through a real ``GradeTrial`` and reads the outcome it filed; what this
+    set adds is the claim a person made, key by key, independent of whether anyone
+    could build a driver for it. If a driver is ever narrowed or removed, the
+    declaration is what survives. Lock 5 reads it, and a key missing from here
+    fails the canonical suite rather than failing ``GradeTrial`` in production for
+    every task that populates it.
 
-    Every member is therefore named per site, or derived from a hand-written
-    mapping that same site is handed — the two hash-family tuples, and the
-    per-kind trace-constraint keys. Comprehending any member from
-    :data:`LEDGER_KEYS` would make lock 5 compare that set against itself: a
-    tautological assertion is worse than a missing one, because the next reader
-    trusts its message and stops looking.
+    Its sole consumer is that canonical suite — no runtime path calls it. Every
+    member is named per site, or derived from a hand-written mapping that same
+    site is handed — the two hash-family tuples, and the per-kind trace-constraint
+    keys. Comprehending any member from :data:`LEDGER_KEYS` would make lock 5
+    compare that set against itself: a tautological assertion is worse than a
+    missing one, because the next reader trusts its message and stops looking.
     """
     return frozenset(
         {

--- a/tolokaforge/runner/grading_ledger.py
+++ b/tolokaforge/runner/grading_ledger.py
@@ -218,12 +218,13 @@ def accountable_author_keys() -> frozenset[str]:
     fails the canonical suite rather than failing ``GradeTrial`` in production for
     every task that populates it.
 
-    Its sole consumer is that canonical suite — no runtime path calls it. Every
-    member is named per site, or derived from a hand-written mapping that same
-    site is handed — the two hash-family tuples, and the per-kind trace-constraint
-    keys. Comprehending any member from :data:`LEDGER_KEYS` would make lock 5
-    compare that set against itself: a tautological assertion is worse than a
-    missing one, because the next reader trusts its message and stops looking.
+    No runtime path calls it: its only callers are that canonical lock and the
+    ledger's own unit tests. Every member is named per site, or derived from a
+    hand-written mapping that same site is handed — the two hash-family tuples,
+    and the per-kind trace-constraint keys. Comprehending any member from
+    :data:`LEDGER_KEYS` would make lock 5 compare that set against itself: a
+    tautological assertion is worse than a missing one, because the next reader
+    trusts its message and stops looking.
     """
     return frozenset(
         {
@@ -287,12 +288,9 @@ def audit_accounted_keys(
     ``disallowed_tools: []`` is indistinguishable from unset, and an empty check
     has nothing to evaluate either way.
     """
-    dumped = grading_config.model_dump(exclude_defaults=True)
     unaccounted: list[str] = []
     skip_notes: list[str] = []
-    for item in LEDGER_KEYS:
-        if item.runner_field is None or not _populated(dumped, item):
-            continue
+    for item in _populated_items(grading_config):
         record = accounted_keys.get(item.author_key)
         if record is None:
             unaccounted.append(_unaccounted_detail(item))
@@ -312,14 +310,21 @@ def populated_ledger_keys(grading_config: RunnerGradingConfig) -> frozenset[str]
 
     Restricted to keys naming a ``runner_field``, as the audit's loop is: the
     ``state_checks.hash`` family root names none, and resolving it raises. So the
-    domain is the 26 keys a recording site can be driven for, and a caller
+    domain is the ledger keys a recording site can be driven for, and a caller
     reading this set is reading the same fact the audit acted on.
+
+    No runtime path calls it: its only callers are lock 15 of
+    ``tests/canonical/test_grading_substrate_parity.py`` and the ledger's own unit
+    tests.
     """
+    return frozenset(item.author_key for item in _populated_items(grading_config))
+
+
+def _populated_items(grading_config: RunnerGradingConfig) -> tuple[GradingKey, ...]:
+    """Every ledger key the config populates — the one predicate both readers visit."""
     dumped = grading_config.model_dump(exclude_defaults=True)
-    return frozenset(
-        item.author_key
-        for item in LEDGER_KEYS
-        if item.runner_field is not None and _populated(dumped, item)
+    return tuple(
+        item for item in LEDGER_KEYS if item.runner_field is not None and _populated(dumped, item)
     )
 
 


### PR DESCRIPTION
## Summary

- Parity lock 5 proved only that a *declaration* exists for each ledger key; deleting a real recording site from `service.py` left the whole canonical suite green (measured — the 7th instance of milestone 28's presence-vs-validity defect shape, sitting inside the guard rail built to catch the other six). A new **lock 15** drives every one of the 26 ledger keys with a `runner_field` through the runner's real `RegisterTrial → ExecuteTool → GradeTrial` and asserts, per key, that the recording site filed the outcome the manifest implies.
- The issue's accepted residue is **closed rather than documented**: the hash family runs in-process against the real JSON DB service, and `db_probes` / `llm_judge` are driven through external-service seams the tree already treats as seams (`runner_grading._fetch_probe_rows`, `service.LLMJudge`) — the recording sites, evaluators, audit, and combine all stay real.
- Deleting a site, downgrading its outcome to a skip, filing `EVALUATED` for an evaluation that did not run, or driving a config that never populated the key each go red — six committed fault injections plus four production differentials, every one reproduced independently by the review round.

## Design choices

- **The lock asserts reported outcomes, not RPC success**: downgrading a site to a `SKIPPED` record leaves every suite green today (measured) — "the RPC succeeded" is too weak, so claim 3 matches `skip_note_prefix(key)` in `grade.reasons`.
- **The skip-note format is single-sourced** (`skip_note_prefix` / `skip_note` / `populated_ledger_keys`, shared with the audit via one `_populated_items` predicate) because a test that can spell the format independently of production can pass while production drifts.
- **`accountable_author_keys()` is kept, not deleted**: it is the only assertion that a *human* declared a site per key, independent of driver buildability — if lock 15's driver table is ever narrowed, the declaration is what remains. Its docstring now states its only callers are tests.
- **The driver table is hand-written and asserted total by set-equality** against the ledger's own key list — comprehending it from `LEDGER_KEYS` would compare a set against itself, the exact tautology the issue forbids.
- **The judge skip branch is a named test beside the sweep**, so every sweep row carries one manifest-derived expectation with no per-row exceptions.
- **The hash driver asserts `GOLDEN REPLAY ERRORS` is absent**: `EVALUATED` is recorded even when every golden action failed to take effect (measured), so without the guard all four claims pass on a hollow evaluation.

## Concepts introduced

**Recording-site differentials**: the parity suite's enforcement vocabulary gains a fourth kind of claim — not "the key resolves", "the key is declared", or "the substrates agree on the score", but "driving this key through a real trial makes its recording site file the manifest-implied outcome". A key being integration-enforced for its *score* is orthogonal to its recording site being canonically drivable; conflating the two is what left the residue undocumented before this PR.

## Plan

# Plan: parity lock 5 verifies a recording site, not a declaration

Issue: #711
Branch: `fix/711-ledger-call-sites`
Base: `feat/trace-checks-tail` (cut from `main` at `9d3be7c6`, v0.15.0)

> **Revision 1 (2026-08-06)** — folds critic round 1
> (`~/.claude/plans/toloka-tolokaforge/issue-711-critique-round1.md`). The new lock is **15**,
> not 14 (the slot was occupied). Stage 1 exports three helpers instead of one. The per-key
> assertion gained a **populated** claim, so the claims renumbered 1–4 (old 1→2, 2→3, 3→4).
> Every measurement in Context is unchanged; the critic re-ran all of them and they
> reproduced.
>
> **Revision 2 (2026-08-06)** — folds critic round 2
> (`~/.claude/plans/toloka-tolokaforge/issue-711-critique-round2.md`). Three bounded fixes,
> all re-verified against the tree: the `llm_judge` driver needs `judge_model_config` on its
> `TrialSpec` (and the plan now makes the shared-helper call rather than leaving it to the
> implementer); `populated_ledger_keys` must skip the one ledger key with no `runner_field`;
> and the graded config claim 1 reads comes from the **registered trial**, not the test's own
> `task_description`. No stage was added, removed or reordered.

## Context

Lock 5 of the substrate-parity guard rail
(`tests/canonical/test_grading_substrate_parity.py:1218`) asserts that every ledger key
with a `runner_field` appears in `accountable_author_keys()` — itself a hand-maintained
frozenset (`tolokaforge/runner/grading_ledger.py:183-217`). It therefore proves a
*declaration* exists, not a *recording site*.

**Re-measured on 2026-08-06 against this tree**, patch-and-restore, all three findings
reproduced from a clean `git status`:

1. **The issue's headline claim holds, and is wider than stated.** Deleting the
   `accounted_keys[CUSTOM_CHECKS_KEY] = …` block from `tolokaforge/runner/service.py:1625`
   leaves the *entire* canonical parity module green — all 70 tests, including lock 5 and
   lock 3's own `custom_checks` differential (lock 3 calls `_grade_custom_checks` directly
   and never enters `_grade_trial_async`). Only the two runtime cases in
   `tests/unit/grading/test_grading_ledger.py` fail, both with the production audit error.

2. **A second hole nothing catches at all.** *Downgrading* a recording site rather than
   deleting it — replacing `accounted_keys[JSONPATHS_KEY] = EVALUATED`
   (`service.py:1515`) with a `SKIPPED` record — leaves the whole ledger unit module *and*
   the whole canonical parity module green (103 passed here; the critic reproduced it over a
   wider selection, 1561 passed). Every task then carries
   `state_checks.jsonpaths skipped: …` in `grade.reasons` for a key that was in fact scored.
   "The RPC succeeded" is therefore too weak an assertion: the lock has to be about the
   *reported outcome*, not merely about the site's existence.

3. **Two recording sites are guarded by declaration alone, today.** Deleting both
   `accounted_keys[LLM_JUDGE_KEY] = NO_JUDGE_MESSAGES_SKIP` (`service.py:1612`) and
   `accounted_keys[DB_PROBES_KEY] = EVALUATED` (`service.py:1530`) leaves `tests/unit` +
   `tests/canonical` byte-identical to baseline — 8 failed / 6855 passed either way (the
   8 are pre-existing `test_persistent_shell_local.py` environment failures, unrelated).
   By contrast the hash-family and judge `EVALUATED` sites *are* covered incidentally:
   deleting them breaks 17+ tests across `test_runner_pipeline.py`,
   `test_state_checks_composition.py` and `test_runner_judge_kb_gate.py`.

The issue's suggested scoping — "the hash family and `db_probes` are not canonical-tier
provable without a mock AGENTS.md Rule 5 forbids, so a residue stays declaration-guarded"
— **does not hold against the current tree**. Measured: hash grading runs fully in-process
on the `runner_service` fixture (real in-process JSON DB service, no docker); `db_probes`
is already driven at canonical tier through the `runner_grading._fetch_probe_rows` seam
(`test_grading_substrate_parity.py:2353`); the LLM judge is already driven at unit tier by
substituting `tolokaforge.runner.service.LLMJudge` (`tests/unit/test_runner_judge_kb_gate.py:511`).
Both substitutions replace an *external service* at a seam this repo already treats as one,
outside the subject under test. So the residue can be closed rather than documented.

### Why the sweep lives in the parity module, not in `test_grading_ledger.py`

`tests/unit/grading/test_grading_ledger.py` already drives a real
`RegisterTrial → GradeTrial` per key on the `runner_service` fixture, over a `_task_dict`
(`:92-120`) that already carries `initial_state.tables` and `schemas` — which is exactly
what Stage 2's two fixture edits add to the parity packs. So "extend that module instead"
is the obvious cheaper route and the reviewer will ask for it. Three reasons it is the
wrong home, written down here so nobody has to re-derive them:

- **`_task_dict` is a hand-written runner config; a parity pack is an authored
  `grading.yaml`.** The pack path runs `NativeAdapter.to_task_description`, so a key that
  reaches the runner only because a test wrote the runner field directly cannot pass —
  translation is part of the path under test. `_task_dict` skips it entirely.
- **The pack path replays the trial's tool calls through the runner's own `ExecuteTool`**
  (`_replay_authored_calls`, `test_grading_substrate_parity.py:1770`), so `GradeTrial` reads
  a tool record the runner wrote rather than one the test handed it. Every
  `transcript_rules` and `trace_checks` key is evaluated against that record.
- **The totality claim belongs beside lock 5.** The sweep's load-bearing property is that
  it is parameterised over `LEDGER_KEYS` and that its driver table is asserted set-equal to
  them. That claim is meaningless unless it sits next to the manifest-derived locks that
  share the invariant — and lock 5, whose overstatement this issue is about, is the one it
  narrows. Splitting them across tiers is how the next reader reads lock 5's message and
  stops looking.

The cost is real and acknowledged: two shared-fixture edits (Stage 2, measured
regression-free at 3211 passed) and roughly 200 lines added to a 2760-line module, which is
why #897 was filed rather than buried.

## Goal

Every ledger recording site is verified by driving it. For each of the 26 keys in
`LEDGER_KEYS` that names a `runner_field`, a real `GradeTrial` — over the runner's own
`RegisterTrial` → `ExecuteTool` → `GradeTrial` handlers — is driven with that key
populated and its evaluator able to run, and the outcome the ledger reports for that key
is asserted to be the one the manifest implies. Editing a frozenset cannot satisfy it;
deleting a call site, downgrading its outcome, recording an outcome without evaluating, or
driving a config that never populated the key in the first place all fail it, each with its
own committed falsifier.

## Non-goals

- Deriving `accountable_author_keys()` from `LEDGER_KEYS`. The issue rules it out and the
  reasoning in its docstring still holds: a comprehension would make lock 5 compare a set
  against itself.
- Changing any evaluator, any score, or the audit's semantics. This is a guard-rail change;
  `tolokaforge/runner/service.py`'s grading logic is not touched.
- Adding an accounting dump to the gRPC surface. The reported outcome is already
  observable — `grade.reasons` carries a skip note for every populated key recorded as
  skipped, and a failed RPC names every key recorded as nothing. See Risks.
- Renumbering or restating any existing lock. Lock 14 (`combine.weights`) keeps its number;
  this plan only adds its missing docstring entry.
- Fixing the two reporting defects found while measuring (#895, #896) or splitting the
  2760-line parity module (#897).

## Stages

### Stage 1: the ledger exports the three predicates its guard rail reads

- **Contract:** `tolokaforge/runner/grading_ledger.py` exports three names. Each exists
  because the canonical lock must read a fact the audit already computes, and must not be
  able to spell it differently.

  ```
  skip_note_prefix(author_key: str) -> str
      # f"{author_key} skipped: " — what a note for this key starts with,
      # independent of any detail. This is what an "expected EVALUATED" row asserts
      # is absent: it does not know, and must not know, what detail a hypothetical
      # skip would carry.

  skip_note(author_key: str, record: KeyAccountingRecord) -> str
      # skip_note_prefix(author_key) + record.detail — the sentence a task author
      # reads. Raises ValueError on an EVALUATED record: there is no note for a key
      # that was evaluated, and returning one would let a caller assert against a
      # sentence production never emits.

  populated_ledger_keys(grading_config: RunnerGradingConfig) -> frozenset[str]
      # every ledger key *that names a runner_field* which the config populates,
      # by the same predicate the audit applies (grading_ledger.py:263-264,
      # `_populated` over one model_dump(exclude_defaults=True)).
  ```

  **The `runner_field` guard is load-bearing, not a detail.** `LEDGER_KEYS` has 27 entries and
  only 26 name a `runner_field`; the odd one is the `state_checks.hash` family root, and
  `_populated` on it raises `ValueError: state_checks.hash: has no runner_field to resolve`
  through `runner_dump_path` (`grading_ledger.py:227-228`). Written as the obvious
  comprehension over `LEDGER_KEYS` the function would raise on *every* call. The audit avoids
  this with the guard at `grading_ledger.py:264`; the new function carries the same guard, which
  also makes its domain identical to the sweep's parameterisation and Stage 1's lock (d)
  well-defined.

  `audit_accounted_keys` builds `LedgerAudit.skip_notes` through `skip_note`, and
  `populated_ledger_keys` shares the private `_populated` helper with it rather than
  re-implementing the walk. The audit keeps its single dump and its existing loop — it
  needs the `GradingKey` object for `_unaccounted_detail`, so routing it through the new
  frozenset would cost a lookup and buy nothing. **The rendered text does not change**, so
  no grade string moves.

- **Behaviour to lock:** *unit*, `tests/unit/grading/test_grading_ledger.py` —
  (a) `audit_accounted_keys` over a populated key with a skip record returns exactly
  `skip_note(key, record)`, so the two cannot drift; (b) `skip_note(key, record)` starts
  with `skip_note_prefix(key)`; (c) `skip_note` on an `EVALUATED` record raises;
  (d) `populated_ledger_keys` agrees with the audit on a config populating some keys and
  not others — the audit reports an error naming exactly the keys the frozenset contains
  when handed no records at all. Falsifiers: change the format in either place → (a) red;
  change either predicate's notion of populated → (d) red.
- **Compatibility:** internal only. `tolokaforge.runner.grading_ledger` is not part of the
  published Python API (`docs/API.md` does not name it) and the runner is not a
  user-authored surface. No task contract, task-pack format, run-config field or CLI flag
  moves. No migration needed.
- **Deliverable:** three exported names; `audit_accounted_keys` and every test that
  currently re-spells the format read them instead. `rg '" skipped: "'` and
  `rg 'skipped: ' tests/` come back with no hand-spelled instance of the format outside the
  helpers' own tests — the six existing assertions in `test_grading_ledger.py` that pin
  *rendered detail text* (e.g. `"… skipped: hash grading not enabled"`) are assertions about
  a detail, not about the format, and stay as they are.
- **Validation:** `mcp__dev__run_tests` marker `unit` path `tests/unit/grading/`; marker
  `canonical` path `tests/canonical/test_grading_substrate_parity.py`. Reviewer checks that
  no rendered grade string changed.
- **Doc updates:** none. `docs/GRADING.md` and `docs/GRPC_PROTOCOL.md` describe the note's
  text and condition, both unchanged.

### Stage 2: the parity packs grade through the runner's real registration path

- **Contract:** a driver in `tests/canonical/test_grading_substrate_parity.py`:

  ```
  _grade_pack_through_the_runner(
      servicer, context, task_description, case, trial_id
  ) -> pb2.GradeTrialResponse
  ```

  registers the task, replays the case's authored calls through `ExecuteTool` (reusing
  `_replay_authored_calls`), and returns the raw `GradeTrialResponse` — **not** an asserted
  `grade`. Lock 10's `_runner_trace_checks_grade` asserts `success is True` before
  returning, which the new lock cannot do: a failed audit is one of the outcomes it reads.
  `_runner_trace_checks_grade` is re-expressed on top of the new driver in this stage;
  there is no second registration path.

  **The driver's signature does not change in Stage 3.** Stage 3's assertion helper needs the
  graded `RunnerGradingConfig`, and it reads it off the **registered trial** —
  `servicer.trials[trial_id].grading_config`, the property at `service.py:390` returning the
  registered `TaskDescription.grading`, which is the object `_grade_trial_async` grades
  (`service.py:1401`). It must **not** read the test's own `task_description.grading`: those
  are siblings, because `trial_spec_json` round-trips the task through JSON and `RegisterTrial`
  rebuilds it. Claim 1 asserted against the test's copy would be a statement about the pack —
  which lock 3 already makes — rather than about the config the runner graded, which is the
  whole point of claim 1.

  Fixture prerequisite: `tests/data/grading_parity/state_checks_jsonpaths/task.yaml` and
  `tests/data/grading_parity/custom_checks/task.yaml` declare a DB-backed `initial_state`
  (`json_db: {orders: [{id: O1, status: shipped}]}`) instead of `json_db: null`. Both packs
  grade against DB state, and `RegisterTrial` provisions the DB service only when
  `initial_state` carries tables (`service.py:847-859`) — so today `state_checks_jsonpaths`
  fails `GradeTrial` with `Grading error: TrialNotFoundError` and `custom_checks` scores
  `0.0` off an empty database. The trial-level `state:` in each `trial.yaml` is untouched
  and still feeds locks 3 and 13, which hand it to the substrates directly.

- **Behaviour to lock:** *canonical*, in the parity module — both state-reading packs grade
  their **satisfying** case through the real handlers: `state_checks_jsonpaths` scores
  `components.state_checks == 1.0`, `custom_checks` scores
  `components.custom_checks == 1.0`. Falsifier: revert either `task.yaml` → the first
  raises `TrialNotFoundError`, the second scores `0.0`. Both measured.

  The lock asserts the satisfying case only, and says why in the assertion message: the DB
  is provisioned from `initial_state`, so the violating case's messages replay against the
  same rows and score identically. Discrimination is lock 3's claim, over the fixture state;
  this stage's claim is reachability of the runner's own path.

- **Compatibility:** internal only — test fixtures and a test helper.
- **Deliverable:** the driver, the two fixture edits, the two reachability assertions, and
  `_runner_trace_checks_grade` rebuilt on the driver.
- **Validation:** `marker=canonical path=tests/canonical` plus `marker=unit` over
  `tests/unit/grading`, `tests/unit/adapters`, `tests/unit/dx`. [Corrected at Stage 2
  landing: the "3211 passed" annotation was stale — the true baseline at `9d3be7c6` is
  3206 (2113 unit + 1093 canonical), measured in a throwaway worktree; the branch after
  Stages 1+2 is 3212, delta of 6 = 4 Stage-1 unit locks + 2 Stage-2 canonical rows.]
  Reviewer checks that locks
  3, 4 and 13 read the same fixture values as before — the fixture edit adds a field none of
  them reads.
- **Doc updates:** none yet; the lock the docs describe arrives in Stage 3.

### Stage 3: lock 15 — every ledger key's recording site is driven

> The module's numbered locks already run to **14** (`combine.weights`,
> `test_grading_substrate_parity.py:2406`), which the module docstring never gained an entry
> for — it still says "Thirteen locks" and enumerates 1–13. The new lock is **15**, and this
> stage also closes that pre-existing docstring gap. No existing lock is renumbered (#897).

- **Contract:** a fifteenth lock in
  `tests/canonical/test_grading_substrate_parity.py`, parameterised over
  `[item.author_key for item in LEDGER_KEYS if item.runner_field is not None]` (26 keys
  today), resting on two named pieces:

  1. **A driver table**, a module-level frozen mapping from author key to the driver that
     can populate it and let its evaluator run. Asserted as **set equality** against the
     parameterised key list, so a ledger key with no driver fails here naming the key —
     never silently drops out of the sweep. Four drivers:

     | Driver | Keys | How it populates |
     |---|---|---|
     | `parity_pack` | 21 — `custom_checks`, `state_checks.jsonpaths`, 7 × `transcript_rules.*`, 12 × `trace_checks.*` | the key's own `tests/data/grading_parity/<task_id>/` pack, via Stage 2's driver on the satisfying case |
     | `hash_family` | 3 — `state_checks.hash.enabled`, `.golden_actions`, `.expected_state_hash` | a task with `hash_enabled: true`, one golden action naming a registered tool, and a populated `expected_hash` |
     | `db_probes` | 1 — `state_checks.db_probes` | the `db_probe_grading` pack, with `runner_grading._fetch_probe_rows` substituted — the same seam lock 13 uses at `test_grading_substrate_parity.py:2353` |
     | `llm_judge` | 1 — `llm_judge` | a judge-configured task whose `TrialSpec` carries `judge_model_config`, with `tolokaforge.runner.service.LLMJudge` substituted (see Stage 4 — substituting the class alone is not enough) |

     Stage 4 adds the last three; this stage lands `parity_pack` and the totality
     assertion, with the other three keys' drivers registered as `pytest.xfail(strict=True)`
     rows so the table is total from the start and Stage 4's arrival is what turns them
     green. (If the implementer finds `xfail` obscures the message, splitting the table's
     assertion across the two stages is acceptable — the invariant that matters is that no
     ledger key is ever absent from the table.)

  2. **A per-key assertion helper**,
     `_assert_the_site_reported(author_key, grading_config, response)`, called by the sweep
     and by the fault-injection cases. It takes the **graded `RunnerGradingConfig`** — read off
     the registered trial per Stage 2, never the test's own copy — as well as the response,
     because the first claim is about the input. Four claims, each with a falsifier committed
     below:

     - **Claim 1 — the driver populated the key.**
       `author_key in populated_ledger_keys(grading_config)`. The audit visits only
       populated keys (`grading_ledger.py:263-264`), so for a key the driver's config never
       populates there is no note to find and claim 3 — an *absence* assertion — is
       satisfied trivially. Claim 4 does not rescue it either: the seven
       `transcript_rules.*` keys all map to the `transcript_rules` component and the twelve
       `trace_checks.*` keys all map to `trace_checks`, so one sibling scoring the slot
       makes claim 4 green for the whole family. Without claim 1 the lock would read as "26
       recording sites driven" while proving less. The 21 `parity_pack` rows do have an
       external guarantee — lock 3 asserts each pack declares its key and nothing else
       (`test_grading_substrate_parity.py:1053-1057`) — but that is a *different test*, so
       relying on it leaves lock 15 not self-contained; and Stage 4's three bespoke configs
       have no such guarantee at all.
     - **Claim 2 — the site exists.** `response.success is True`. A key no site records
       fails the audit, and the RPC names it.
     - **Claim 3 — the site filed the outcome the manifest implies.** The manifest decides
       *which* expectation applies; the expected **text** comes from the ledger:
       - the manifest names a `runner_evaluator` ⇒ the key was evaluated ⇒
         `skip_note_prefix(author_key)` does **not** appear in `grade.reasons`;
       - the manifest declares `SubstrateCoverage.CORE_ONLY` (only
         `state_checks.hash.expected_state_hash`) ⇒ a standing skip is expected ⇒
         `skip_note(author_key, CORE_ONLY_HASH_SKIP)` **does** appear.

       The expected string is the ledger's record detail, **not** the manifest entry's
       `reason` — `entry("state_checks.hash.expected_state_hash").reason` is a 35-word
       paragraph, while the note carries `CORE_ONLY_HASH_SKIP.detail`,
       `"core-only — no runner path reads it (#693)"` (`grading_ledger.py:59-61`).
     - **Claim 4 — the `EVALUATED` sits at a real evaluation.** For keys expected
       `EVALUATED`, the key's component (`author_key.split(".")[0]` → the
       `pb2.GradeComponents` slot, confirmed to name a real field for all 26 keys) is scored
       rather than left at the `-1.0` unscored sentinel. For the 12
       `trace_checks.constraints.<kind>` keys this is meaningful per kind because lock 3
       already asserts each kind's pack authors that kind and no other at top level
       (`test_grading_substrate_parity.py:1060-1068`), so the block being scored is that
       kind being scored.

- **Behaviour to lock:** *canonical*. The sweep, plus **five fault-injection cases** in the
  same module, each asserting `_assert_the_site_reported` raises `AssertionError` naming the
  key. Without these the lock is a gate that has never been shown to fail:

  | # | Injection | Seam | Claim falsified |
  |---|---|---|---|
  | 1 | a config that populates nothing | `RunnerGradingConfig()` handed to the helper beside a real response | claim 1 |
  | 2 | an inline site downgraded | `monkeypatch.setattr(service, "EVALUATED", <SKIPPED record>)` | claim 3 on `state_checks.jsonpaths` |
  | 3 | evaluator stops decomposing | `service.evaluate_trace_checks` returns its real result with `accounted_keys={}` | claim 2 on `trace_checks.constraints.all_of` |
  | 4 | transcript accounting dropped | `service.evaluate_transcript_rules` likewise | claim 2 on `transcript_rules.must_contain` |
  | 5 | recorded without evaluating | `service.evaluate_transcript_rules` returns its real accounting with `score=-1.0` | claim 4 on `transcript_rules.must_contain` |

  Injections 3 and 4 reuse the technique already in
  `test_grading_ledger.py::test_grade_trial_fails_loud_when_an_evaluator_stops_decomposing_a_key`.

  **Injection 2 is a stand-in, and its assertion message must say so.** Patching
  `service.EVALUATED` swaps the module global that *every* inline site reads — jsonpaths,
  db probes, the judge's `EVALUATED`, and the argument handed to `hash_family_accounting` —
  so it is not the single-line edit at `service.py:1515` that was measured green. It
  reproduces the *class* (a site that files a weaker outcome than it should). The targeted
  one-line edit stays where it belongs, in this stage's reviewer differential below.

- **Compatibility:** internal only.
- **Deliverable:** lock 15, its driver table, its assertion helper, its five injections; and
  **lock 5 narrowed to what it proves** — the `accountable_author_keys()` half of
  `test_every_ledger_key_resolves_in_the_runner_config_dump` keeps its assertion but its
  message stops claiming a site exists and points at lock 15 for that.
  `accountable_author_keys()`'s docstring is rewritten to say it is the per-key human
  declaration that lock 5 reads, that lock 15 drives the sites, and that its sole consumer
  is the canonical suite (see Risk 2).
- **Validation:** `marker=canonical path=tests/canonical/test_grading_substrate_parity.py`;
  then the manual differential the reviewer will repeat — delete
  `accounted_keys[CUSTOM_CHECKS_KEY] = …` from `service.py`, confirm lock 15's
  `custom_checks` row goes red, restore; and separately downgrade the single line at
  `service.py:1515` to a `SKIPPED` record, confirm the `state_checks.jsonpaths` row goes red
  on claim 3, restore. The implementer quotes both outputs in the stage report.
- **Doc updates:**
  - The parity module docstring: "Thirteen locks" → "Fifteen locks"; item 5 rewritten to
    claim resolution and declaration only; **item 14 added for `combine.weights`**, closing
    the gap that lock's landing left; item 15 added, stating that every ledger key's
    recording site is driven through a real `GradeTrial`.
  - `docs/GRADING.md` lines 84-86: the sentence "every key the runtime ledger checks must
    resolve to a field on the runner config **and** be claimed by one of the ledger's
    recording sites" is rewritten to describe the current state as the only state — the key
    resolves, is declared, **and** its recording site is driven per key through a real
    `GradeTrial`. No "previously"/"now" phrasing.
  - `tests/README.md` § Canonical Tests, the `test_grading_substrate_parity.py` bullet:
    add what a lock-15 failure means (a recording site was deleted, downgraded to a skip,
    files `EVALUATED` for an evaluation that did not run, or a driver stopped populating its
    key) and how to fix it.

### Stage 4: the residue is closed — hash family, db probes, judge

- **Contract:** the three remaining drivers from Stage 3's table are implemented, and their
  keys join the sweep under the same four claims:
  - `hash_family` — a task registering one tool, `state_checks.hash_enabled: true`, one
    `golden_actions` entry naming that tool, and a populated `expected_hash`. Drives
    `_execute_hash_grading` in-process against the `runner_service` fixture's real JSON DB
    service; the critic built and ran this driver, so its feasibility is measured rather
    than assumed (there was no in-tree precedent — `test_state_checks_composition.py:1035`
    drives `hash_enabled: true` only with `golden_actions: []`, and
    `test_golden_replay.py:550` calls `_execute_hash_grading` directly rather than through
    `GradeTrial`).

    **The driver additionally asserts `"GOLDEN REPLAY ERRORS"` is absent from
    `grade.reasons`.** `hash_family_accounting(EVALUATED)` is recorded whenever
    `_execute_hash_grading` returns, *including* when every golden action failed to take
    effect — measured: a hash task graded `success=True` with
    `components.state_checks == 1.0` while `reasons` carried
    `GOLDEN REPLAY ERRORS: 1 of 1 golden actions did not take effect`. All four claims go
    green on that hollow evaluation, so claim 4 needs this guard to mean anything for the
    hash family. The prefix is a declared contract rather than a phrasing choice
    (`golden_replay.py:321`, #599) and six existing tests already assert on it — e.g.
    `tests/integration/test_docker_grading_hash_composition.py:251` asserts exactly this
    absence — so spelling it here reads a contract rather than duplicating a format.
  - `db_probes` — the `db_probe_grading` pack (loaded through the `tasks/**` glob, as lock
    4's `_TRANSLATION_PACK_GLOBS` already does), with `_fetch_probe_rows` substituted at
    the seam lock 13 uses.
  - `llm_judge` — a judge-configured task with `service.LLMJudge` substituted, a non-empty
    `llm_messages_json`, **and `judge_model_config` on the registered `TrialSpec`**.

    Substituting the class is not sufficient, and the precedent does not say it is.
    `_grade_llm_judge` raises before it ever constructs the judge unless the spec carries a
    judge `ModelConfig` (`service.py:1921-1926`) — measured with `trial_spec_json` as it stands
    today, the RPC returns `Grading error: ValueError: Trial judge_eval:0 has an llm_judge
    rubric but no judge ModelConfig on its TrialSpec (judge_model_config is None)`, so the sweep
    row would red on claim 2 for a reason with nothing to do with the recording site. The seam
    use at `tests/unit/test_runner_judge_kb_gate.py:511` calls `_grade_llm_judge` **directly**
    with a hand-built context, bypassing `TrialSpec` — it establishes that the class can be
    substituted, not that the seam is reachable through a real `GradeTrial`. With
    `judge_model_config=ModelConfig(name="test-judge", provider="test")` on the spec the driver
    works: measured `success=True`, `components.llm_judge == 1.0`,
    `reasons == 'Judge: score=1.00 (ok)'`, no skip note.

    **Decision — `tests/utils/runner_requests.py::trial_spec_json` gains an optional
    `judge_model_config: ModelConfig | None = None` parameter**, defaulting to `None` and
    forwarded onto the `TrialSpec` (the field already exists, `tolokaforge/core/trial.py:103`).
    The judge driver does **not** hand-build its own spec. Rationale: the helper's own docstring
    says it exists because "the runner-side `RegisterTrial` handler validates the full
    `TrialSpec`, so tests must construct a complete spec rather than a minimal wrapper" — a
    complete spec for a judge-configured trial includes the judge model, and the helper being
    unable to express it is the gap, not a reason to route around it. The default keeps all 50
    existing call sites across 20 test modules byte-identical, and hand-building would add a
    21st spec-construction path inside the module #897 already flags as oversized. The
    parameter mirrors the helper's existing
    `agent_model_config=ModelConfig(name="test-model", provider="test")`.

  Each substitution replaces a service outside the subject under test — a model provider
  and a postgres the DSN for which resolves only inside the task's docker network. Neither
  stands in for a recording site, an evaluator's decision, the audit, or the combine. The
  assertion message for each states this, so the next reader does not have to re-derive
  whether the lock is testing a mock.

  The judge's **skip** branch is a separate named test beside the sweep, not a sweep row:
  the same judge-configured task with an empty `llm_messages_json` must put
  `skip_note(LLM_JUDGE_KEY, NO_JUDGE_MESSAGES_SKIP)` in `grade.reasons`. Keeping it out of
  the sweep is what lets every sweep row carry one manifest-derived expectation instead of a
  per-row exception.

- **Behaviour to lock:** *canonical*, three more sweep rows plus the judge skip test, plus a
  **sixth fault injection** for the mechanism this stage introduces:
  `monkeypatch.setattr(service, "hash_family_accounting", lambda outcome: {})` → claim 2
  fires on `state_checks.hash.enabled`. Measured: that mutation is the one that breaks 13+
  existing unit tests, so the injection must assert lock 15's own helper raises rather than
  relying on the suite going red elsewhere.
- **Compatibility:** internal only. The one change reaching outside this stage's own code is
  the optional `judge_model_config` parameter on `tests/utils/runner_requests.py::trial_spec_json`,
  a test utility shared by 20 test modules. It defaults to `None`, which is what those modules
  already get, so no existing spec changes shape. `TrialSpec` itself is untouched — the field
  has been declared since `tolokaforge/core/trial.py:103`; the helper simply could not set it.
- **Deliverable:** every one of the 26 ledger keys with a `runner_field` is driven; the
  driver table has no `xfail` rows left; `trial_spec_json` carries its optional
  `judge_model_config` with every existing call site unchanged (`rg 'trial_spec_json\('`
  shows 50 sites, none of which move); `_NON_DIFFERENTIAL_SCORED_KEYS` and the manifest's
  `enforcement` tiers are untouched — a key being *integration*-enforced for its **score**
  is orthogonal to its **recording site** being canonically drivable, and the assertion
  message says so, because that conflation is what the issue's suggested scoping rested on.
- **Validation:** full `marker=canonical`; `marker=unit path=tests/unit` (which covers every
  `trial_spec_json` caller outside the integration tier, so an inert default is demonstrated
  rather than asserted); `marker=integration` is **not** required — no driver here needs a
  service the other tiers lack. Then the differential: delete
  `accounted_keys[DB_PROBES_KEY] = EVALUATED` and confirm lock 15's `state_checks.db_probes`
  sweep row reds; separately delete `accounted_keys[LLM_JUDGE_KEY] = NO_JUDGE_MESSAGES_SKIP`
  and confirm the judge **skip** test reds — it is a named test beside the sweep, not a sweep
  row, so naming the wrong one would look like a pass. Both deletions are measured green across
  the whole unit+canonical suite today. Quoted in the stage report.
- **Doc updates:**
  - `docs/GRADING.md` § The runtime ledger: state that every recording site — including the
    hash family, the db probes and the judge — is driven per key by the canonical suite,
    and that the two seams substituted are the model provider and the probe's postgres.
  - `tests/README.md`: the lock-15 bullet from Stage 3 amended to say the sweep covers every
    ledger key rather than a subset.

## Discovered issues

- **Fix in this PR:** none. Every defect found while measuring is outside the guard rail's
  contract and needs its own behaviour lock. The one exception is cosmetic and in scope by
  necessity: the parity module docstring's missing item 14, which Stage 3 adds because it
  cannot add item 15 without it.
- **Filed as issues:**
  - **#895** (bug, P2, milestone 28) — `build_grade_reasons` omits `custom_checks`, so a
    custom-checks-only pack reports `"No grading components evaluated"` while
    `components.custom_checks == 1.0` decided `binary_pass`. Measured through the real
    `GradeTrial`. Same "the grade lies about its own derivation" family as this issue.
  - **#896** (bug, P3, milestone 28) — a pack declaring `state_checks.jsonpaths` with a
    `path:` on a task with no `initial_state` fails `GradeTrial` with
    `Grading error: TrialNotFoundError: Trial 'x' not found`, naming neither the key nor the
    missing DB. This is the error Stage 2's fixture edit removes for the parity pack; the
    authoring shape survives in production.
  - **#897** (chore, P3) — `test_grading_substrate_parity.py` is 2760 lines against
    AGENTS.md § Code Standards rule 3, and this plan adds roughly 200 more. Names the
    natural seam (promote the fixture loader to `tests/utils/`) and rules out renumbering
    the locks.

## Risks / open questions

1. **Claim 3 reads `grade.reasons`, a human-facing string.** Stage 1 single-sources the
   needle through `skip_note_prefix` / `skip_note` so the test cannot spell the format
   independently of production, which is the mitigation. The alternative — putting the
   per-key accounting on `GradeTrialResponse` — is a proto/compat-surface change that would
   need a product justification of its own (arguably a good one: a `grade.yaml` reader
   currently cannot tell "this key was read" from "this key is not mentioned").
   **Recommendation:** keep the lock on the observable that exists; if the user wants the
   accounting on the wire, that is its own ticket, and I will file it on request rather than
   fold it in here.

2. **`accountable_author_keys()` survives, and it has no production consumer.** Measured:
   the only references in the tree are its definition (`grading_ledger.py:183`),
   `test_grading_substrate_parity.py:116,1231` and `test_grading_ledger.py:42,313`. So
   keeping it means `tolokaforge/runner/` carries a hand-maintained frozenset read only by
   two test modules, which a hygiene reviewer will raise — that is the fact the decision
   rests on, and it is stated here rather than left for the reviewer to discover.

   **Decision: keep it.** Not because "it fails earlier with better advice" — that is a weak
   reason to keep a guard. The real reason is that it is the only assertion that a *human*
   claimed a recording site exists for each key, independent of whether anyone could build a
   driver for it. If lock 15's driver table is ever narrowed — a key moved to `xfail`, a
   driver deleted as flaky — the declaration is what remains. The rewritten docstring must
   say plainly that its sole consumer is the canonical suite, so nobody hunts for a runtime
   caller.

3. **The `llm_judge` and `db_probes` drivers substitute an external service.** Both use a
   seam already in the tree for exactly this purpose, and the substituted thing is outside
   the subject (the subject is `_grade_trial_async`'s bookkeeping). The reviewer will
   nonetheless read `monkeypatch.setattr` in a canonical test against AGENTS.md rule 5, so
   the assertion messages must carry the reasoning. If the user would rather these two keys
   stay outside the sweep, Stage 4 shrinks to the hash family alone and the plan states a
   two-key residue instead of none — the rest of the plan is unaffected.

4. **The measured baseline carries 8 unrelated failures.** `tests/unit/test_persistent_shell_local.py`
   fails 8 tests on this machine on a clean tree, before and after every mutation in this
   plan. Stage validation must compare against that baseline rather than against zero, or
   an implementer will chase them.

5. **Stage 3 lands three `xfail(strict=True)` rows that Stage 4 removes.** They exist so the
   driver table is total from its first commit — a table that is only asserted total at the
   end can be partial in between without anything noticing. If the critic prefers, the
   totality assertion can be deferred to Stage 4 and the two stages merged; the invariant to
   preserve is that no ledger key is ever silently absent from the sweep.

## Discovered issues

- Filed during planning: #895 (`build_grade_reasons` omits `custom_checks` — a custom-checks-only pack reports "No grading components evaluated" while scoring 1.0; reconfirmed live through the real `GradeTrial` by this PR's Stage 2 test), #896 (a jsonpaths pack with no `initial_state` fails `GradeTrial` with an unaddressed `TrialNotFoundError`), #897 (split the 2760-line parity module; do not renumber locks).
- Fixed in this PR: the duplicated 7-line register-and-assert block (`_register_pack`); the module docstring's missing item 14 for the pre-existing `combine.weights` lock.
- Review nits deliberately not taken: driver-table author-key literals → exported constants (a wrong literal already fails loudly at the totality test); a production-side named constant for the `-1.0` unscored sentinel (out of this branch's scope).

## Test plan

- `pytest tests/canonical/test_grading_substrate_parity.py -m canonical` — 106 passed, 0 xfail: the 26-row sweep, the totality lock, 6 fault injections, 2 reachability rows.
- `pytest tests/unit -m unit` — 5753 passed / 8 failed, byte-identical to the base-branch baseline (the 8 are the known env-sensitive `test_persistent_shell_local.py` set, red on `main` too).
- Post-merge spot-check: delete `accounted_keys[CUSTOM_CHECKS_KEY]` from `service.py` → lock 15's `custom_checks` row reds naming the key; restore. Downgrade `service.py`'s jsonpaths `EVALUATED` to a skip → the `state_checks.jsonpaths` row reds on the skip-note claim; restore.

Closes #711
