### PR TITLE
fix(grading): set RequiredAction extra=forbid to catch typos at load time

### DIFF
--- a/tolokaforge/core/models/task_config.py
+++ b/tolokaforge/core/models/task_config.py
@@ -337,7 +337,7 @@ class TaskConfig(BaseModel):
 class RequiredAction(BaseModel):
     """Required tool call that must appear in trajectory"""
 
-    model_config = {"extra": "ignore"}
+    model_config = {"extra": "forbid"}
 
     action_id: str  # unique identifier for this action
     requestor: Literal["assistant", "user"]  # who should make the call


### PR DESCRIPTION
## Problem

`RequiredAction` uses `extra="ignore"`, so a typo in a key (e.g. `compare_arg` instead of `compare_args`) is silently accepted and changes matching semantics without any error.

Every other grading config block uses `extra="forbid"` for exactly this reason - the docs say so explicitly (GRADING.md, tool_expectations):
> `extra="forbid"` on the block means a misspelled key (`required_toolz`) fails at load rather than grading as an empty list.

## Fix

Change `RequiredAction`'s `extra` setting from `"ignore"` to `"forbid"`.

## Testing

- Existing tests pass: 1943 unit tests + 248 canonical grading tests, including the golden trajectory grading canon
- The reproduction from the issue (a `compare_arg` typo inside `required_actions`) now raises a `ValidationError` (`extra_forbidden` at `transcript_rules.required_actions.0.compare_arg`) at load time instead of silently resolving `compare_args` to `None`
- A scan of all yaml fixtures in `tests/` and `examples/` found no `required_actions` element carrying unknown keys, so no recorded bundle is broken by the stricter setting

Fixes #900