### PR TITLE
feat(skills): JSONL progress channel for orchestration subagents

### DIFF
--- a/.agents/skills/executing-development-tickets/SKILL.md
+++ b/.agents/skills/executing-development-tickets/SKILL.md
@@ -23,7 +23,7 @@ Main is responsible for: target confirmation, critique-loop mediation, plan appr
 ## Invocation
 
 ```
-/executing-development-tickets <issue-number> [base_branch=<ref>]
+/executing-development-tickets <issue-number> [base_branch=<ref>] [progress_root=<path>]
 ```
 
 or natural language: "execute issue #237", "let's do #244".
@@ -37,20 +37,32 @@ The skill expects the issue to live in `Toloka/tolokaforge`. If a different repo
 
 **Base branch.** Optional context, defaults to `main`. Direct invocations should almost always use the default. `/implement-milestone` passes `base_branch=feat/<milestone-slug>` so per-issue branches stack on the milestone integration branch and per-issue PRs merge into it rather than `main`. When set, it replaces `main` in Step 6 (branch creation) and Step 10 (PR creation). Nothing else changes — the critic, implementer, and reviewer are agnostic to the base branch.
 
+**Progress root.** Optional path to the directory where the per-run events file (`events.jsonl`) is created. Defaults to `~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/` for direct invocations. `/implement-milestone` passes `progress_root=~/.claude/plans/toloka-tolokaforge/progress/milestone-<M>/issue-<N>/` so per-issue events flow into a milestone-scoped tree that the milestone loop tails at a wider scope. Direct users leave it unset.
+
 ## Workflow
 
 ### Step 0 — Progress channel
 
-Before Step 1, set up a JSONL progress channel so main can observe subagent activity in real time. Every subagent this skill launches writes phase-transition lines to a well-known file; main tails that stream via a background bash + `Monitor`.
+Every subagent this skill launches appends phase-transition JSONL lines to a **single aggregate events file** for the run. Main tails that one file via a background bash + `Monitor`, so no glob or directory-watch is involved.
 
-1. Pick a `launch_id` root — `issue-<N>` for a numbered issue, or `adhoc-<UTC-timestamp>` if invoked without an issue number.
-2. Create the progress directory: `mkdir -p ~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/`.
-3. Start the tail as a background bash — `tail -F ~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/*.jsonl 2>/dev/null` — with `run_in_background: true`, and subscribe to it via the `Monitor` tool. Each JSONL line becomes a notification; main can read the stream without polling.
-4. Pass the concrete file path to every subagent as `PROGRESS_FILE=~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/<agent-role>-<UTC-timestamp>.jsonl` in the launch prompt (see per-step prompts below).
+1. Resolve `progress_root`. If the invocation passed one, use it verbatim. Otherwise default to `~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/` (or `adhoc-<UTC-ts>/` when there is no issue number).
+2. Create the events file — touching first guarantees the tail has a real file to follow, sidestepping the empty-directory / glob failure modes:
+   ```bash
+   mkdir -p "$progress_root" && : > "$progress_root/events.jsonl"
+   ```
+3. Start the tail as a **single-file** background bash (no glob, no directory watch) and subscribe with `Monitor`:
+   ```bash
+   tail -n0 -F "$progress_root/events.jsonl"
+   ```
+   Use `run_in_background: true`. Each appended line arrives as a Monitor notification; no polling. Under `/implement-milestone` the milestone loop already runs a wider tail one level up — if `progress_root` was inherited, main skips this step to avoid a duplicate follower.
+4. For every subagent launch in this skill (Steps 3, 4, 7, 8, 9), append two lines to the launch prompt:
+   ```
+   PROGRESS_FILE=<progress_root>/events.jsonl
+   LAUNCH_ID=<main-assigned identifier — see naming scheme below>
+   ```
+   Naming: `architect-issue-<N>` / `critic-issue-<N>[-r<round>]` / `impl-issue-<N>[-s<stage>]` / `reviewer-<lane>-issue-<N>[-r<round>]` / `fix-issue-<N>-r<round>`. The `launch_id` is the JSON join key across every event line for that Agent-tool launch (and its SendMessage continuations in persistent mode).
 
-Progress files are scratch, never committed. They live outside the repo per the same convention as plan and briefing files. The full schema, per-agent phase lists, and reference examples are in the `## Progress protocol` section at the end of this file — read it once, then apply per subagent.
-
-Watchdog behaviour (soft-idle nudge / hard-timeout escalation) is not part of this step yet; it lands in a follow-up change and reads the same stream. For now, the stream exists so main can *see* activity — that alone is enough to distinguish a working agent from a wedged one at a glance.
+Progress files are scratch, never committed. They live outside the repo per the same convention as plan and briefing files. Full schema and per-agent phase lists live in the `## Progress protocol` reference section at the end of this file.
 
 ### Step 1 — Fetch the issue
 
@@ -98,9 +110,10 @@ surfaces need explicit migration (internals refactor cleanly), diagnose by
 running, lock behaviour with tests at the right tier, no compromise, surface
 discovered issues, comment hygiene.
 
-PROGRESS_FILE=<path built by main per Step 0, e.g. ~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/system-architect-planner-<UTC-ts>.jsonl>
+PROGRESS_FILE=<progress_root>/events.jsonl
+LAUNCH_ID=architect-issue-<N>
 Append one JSONL line to $PROGRESS_FILE at each phase transition per your
-charter's Progress reporting section.
+charter's Progress reporting section. Use $LAUNCH_ID as the launch_id field.
 ```
 
 ### Step 3b — Assemble the per-issue briefing pack
@@ -157,9 +170,10 @@ Otherwise, before the user sees the plan, pressure-test it:
    (read-only) the running behaviour. Return your structured verdict block. Do not
    edit the plan — the architect owns it.
 
-   PROGRESS_FILE=<path built by main per Step 0>
+   PROGRESS_FILE=<progress_root>/events.jsonl
+   LAUNCH_ID=critic-issue-<N>[-r<round>]
    Append one JSONL line to $PROGRESS_FILE at each phase transition per your
-   charter's Progress reporting section.
+   charter's Progress reporting section. Use $LAUNCH_ID as the launch_id field.
    ```
 2. **Verdict `APPROVE` / `APPROVE WITH NOTES`** → proceed to Step 5, carrying any 🟡 notes into the user summary.
 3. **Verdict `REVISE`** → `SendMessage` the findings verbatim to the architect. The architect revises the plan and returns per-finding dispositions (fixed / rebutted-with-evidence). `SendMessage` the revision summary + dispositions back to the critic for re-critique.
@@ -211,9 +225,10 @@ The "one stage = one commit" contract, the drift-handling rules, and the correct
    tier the stage names (unit / canonical / integration), exercises real behaviour
    (not mocks), and passes. One stage = one commit. Return your structured report.
 
-   PROGRESS_FILE=<path built by main per Step 0>
+   PROGRESS_FILE=<progress_root>/events.jsonl
+   LAUNCH_ID=impl-issue-<N>-s<stage>
    Append one JSONL line to $PROGRESS_FILE at each phase transition per your
-   charter's Progress reporting section.
+   charter's Progress reporting section. Use $LAUNCH_ID as the launch_id field.
    ```
 2. **Validate the report.** When it returns:
    - Contract matches the stage spec — flag drift in your next user message.
@@ -244,9 +259,10 @@ skill rules within YOUR scope. Plan: <~/.claude/plans/toloka-tolokaforge/...>.
 Briefing: <~/.claude/plans/toloka-tolokaforge/issue-<N>-briefing.md> if present.
 Cover branch + staged + unstaged. Return findings in the standard format.
 
-PROGRESS_FILE=<path built by main per Step 0, one per shard>
+PROGRESS_FILE=<progress_root>/events.jsonl
+LAUNCH_ID=reviewer-<lane>-issue-<N>[-r<round>]
 Append one JSONL line to $PROGRESS_FILE at each phase transition per your
-charter's Progress reporting section.
+charter's Progress reporting section. Use $LAUNCH_ID as the launch_id field.
 ```
 
 When all three return:
@@ -271,9 +287,10 @@ If the reviewer returns 🔴 Blocker or 🟠 Major findings:
 
    <paste reviewer findings verbatim>
 
-   PROGRESS_FILE=<path built by main per Step 0, fix-round scoped>
+   PROGRESS_FILE=<progress_root>/events.jsonl
+   LAUNCH_ID=fix-issue-<N>-r<round>
    Append one JSONL line to $PROGRESS_FILE at each phase transition per your
-   charter's Progress reporting section.
+   charter's Progress reporting section. Use $LAUNCH_ID as the launch_id field.
    ```
 3. Re-launch the three sharded reviewers (`reviewer-correctness`, `reviewer-hygiene`, `reviewer-type-fit`) in parallel on the updated branch, same as Step 8. Merge findings the same way.
 4. Loop until every lane's verdict is `APPROVE` or `APPROVE WITH NITS`. **Cap: 2 fix rounds.** If any lane keeps finding the same Blocker, stop and ask the user — don't grind the implementer.
@@ -359,49 +376,51 @@ Surface to the user:
 
 ## Progress protocol
 
-Every subagent this skill launches writes JSONL progress lines to a per-launch file main opens in Step 0. Main tails the directory via a background `tail -F` + `Monitor`. The stream lets main *see* activity in real time without polling, and is the substrate the watchdog (soft-nudge / hard-timeout) will read in a follow-up change.
+Every subagent this skill launches appends JSONL event lines to one aggregate file per run. Main tails that single file and can see activity in real time without waiting for the subagent to return.
 
-### Path convention
+### Path
 
 ```
-~/.claude/plans/toloka-tolokaforge/progress/<launch_id_root>/<agent-role>-<UTC-timestamp>.jsonl
+<progress_root>/events.jsonl
 ```
 
-- `<launch_id_root>` = `issue-<N>` for a numbered issue, `adhoc-<UTC-ts>` otherwise. Under `/implement-milestone` the root is `milestone-<N>/issue-<K>`.
-- `<agent-role>` = `system-architect-planner`, `plan-critic`, `plan-stage-implementer`, `branch-code-reviewer`, `reviewer-correctness`, `reviewer-hygiene`, `reviewer-type-fit`.
-- `<UTC-timestamp>` = `date -u +%Y%m%dT%H%M%SZ` at launch. Rerunning the same role (fix-loop rounds, corrective launches) yields a distinct file per launch — history is preserved.
-
-Progress files are scratch, never committed, never referenced from PR bodies. They live outside the repo, alongside plan and briefing files.
+`<progress_root>` defaults to `~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/`, or the value passed as the `progress_root` invocation parameter (see Invocation). Under `/implement-milestone` it is `~/.claude/plans/toloka-tolokaforge/progress/milestone-<M>/issue-<N>/`. One file per run; every subagent appends. Scratch, never committed, never referenced from PR bodies.
 
 ### Schema
 
-One JSON object per line, `≤ 300 bytes`, no PII:
+One JSON object per line. Keep lines terse (target ≤ 300 bytes; truncate `detail` if needed). No PII.
 
 ```json
 {"ts":"2026-08-06T12:34:56Z","agent":"plan-stage-implementer","launch_id":"impl-issue-237-s2","phase":"impl","step":"lint_check","detail":"pass","elapsed_s":42,"issue":237,"stage":2}
 ```
 
-Required fields: `ts` (UTC ISO-8601), `agent` (role name), `launch_id` (main-assigned; see below), `phase` (from the per-agent phase list in the charter). Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`, `round`.
+Required fields: `ts` (UTC ISO-8601), `agent` (role name), `launch_id` (from the `LAUNCH_ID=` line in the launch prompt), `phase` (from the per-agent phase list in the charter). Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`, `round`.
 
-Main assigns `launch_id`: for a persistent implementer, `impl-issue-<N>[-s<stage>]`; for shard reviewers, `reviewer-<lane>-issue-<N>[-r<round>]`; for architect/critic, `architect-issue-<N>` / `critic-issue-<N>[-r<round>]`. The `launch_id` is the join key: every line for a single Agent-tool launch (or its SendMessage continuations) carries the same value.
+`launch_id` is the join key — every line for a single Agent-tool launch (and its SendMessage continuations in persistent mode) carries the same value. Main assigns it in the launch prompt per the naming scheme in Step 0.
+
+### Write recipe
+
+Subagents write with `jq -cn` so JSON string values are quote-safe (apostrophes, newlines, and special characters in `detail` do not break the shell):
+
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "plan-stage-implementer" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "impl" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
+```
+
+The leading `[ -n "${PROGRESS_FILE:-}" ]` guard makes progress writes safe under `set -u`: direct-invoke callers without a `PROGRESS_FILE` skip the write silently.
 
 ### When subagents write
 
 Per each agent's `## Progress reporting` section in its charter:
 
-- On start.
-- At each phase transition (phase list is role-specific).
-- Before any tool call expected to exceed 60 s (`phase:"long_call"` + `step:"<tool>"`).
-- On caught error.
+- On start, at each phase transition, and on caught error.
+- Around any span the watchdog would want to time: emit a `long_call` phase before a tool call expected to exceed 60 s and a `long_call_done` after it returns. Similarly for the paired `_start`/`_done` phases (discovery, revision, recritique).
 
 ### Main-side watcher
 
-Main launches at Step 0, once per invocation:
-
-```bash
-tail -F ~/.claude/plans/toloka-tolokaforge/progress/<launch_id_root>/*.jsonl 2>/dev/null
-```
-
-as a background bash (`run_in_background: true`), subscribed via the `Monitor` tool. New JSONL lines arrive as notifications; main reads them opportunistically. Nothing needs to poll.
-
-Watchdog behaviour (soft-idle nudge, hard-timeout `TaskStop`) is not part of this iteration — it lands in a follow-up change and consumes this same stream. For now the observability alone is the win: a wedged agent shows no new lines, and that gap is visible without waiting for a return that never comes.
+Main starts the tail in Step 0 as a background `tail -n0 -F <progress_root>/events.jsonl` subscribed via `Monitor`. New lines arrive as notifications; nothing polls.

--- a/.agents/skills/executing-development-tickets/SKILL.md
+++ b/.agents/skills/executing-development-tickets/SKILL.md
@@ -39,6 +39,19 @@ The skill expects the issue to live in `Toloka/tolokaforge`. If a different repo
 
 ## Workflow
 
+### Step 0 — Progress channel
+
+Before Step 1, set up a JSONL progress channel so main can observe subagent activity in real time. Every subagent this skill launches writes phase-transition lines to a well-known file; main tails that stream via a background bash + `Monitor`.
+
+1. Pick a `launch_id` root — `issue-<N>` for a numbered issue, or `adhoc-<UTC-timestamp>` if invoked without an issue number.
+2. Create the progress directory: `mkdir -p ~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/`.
+3. Start the tail as a background bash — `tail -F ~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/*.jsonl 2>/dev/null` — with `run_in_background: true`, and subscribe to it via the `Monitor` tool. Each JSONL line becomes a notification; main can read the stream without polling.
+4. Pass the concrete file path to every subagent as `PROGRESS_FILE=~/.claude/plans/toloka-tolokaforge/progress/<launch_id>/<agent-role>-<UTC-timestamp>.jsonl` in the launch prompt (see per-step prompts below).
+
+Progress files are scratch, never committed. They live outside the repo per the same convention as plan and briefing files. The full schema, per-agent phase lists, and reference examples are in the `## Progress protocol` section at the end of this file — read it once, then apply per subagent.
+
+Watchdog behaviour (soft-idle nudge / hard-timeout escalation) is not part of this step yet; it lands in a follow-up change and reads the same stream. For now, the stream exists so main can *see* activity — that alone is enough to distinguish a working agent from a wedged one at a glance.
+
 ### Step 1 — Fetch the issue
 
 Use GitHub MCP `issue_read` with `owner=Toloka`, `repo=tolokaforge`, `issue_number=<N>`. Capture title, body, labels.
@@ -84,6 +97,10 @@ Honour your binding principles: interfaces over implementation, compatibility
 surfaces need explicit migration (internals refactor cleanly), diagnose by
 running, lock behaviour with tests at the right tier, no compromise, surface
 discovered issues, comment hygiene.
+
+PROGRESS_FILE=<path built by main per Step 0, e.g. ~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/system-architect-planner-<UTC-ts>.jsonl>
+Append one JSONL line to $PROGRESS_FILE at each phase transition per your
+charter's Progress reporting section.
 ```
 
 ### Step 3b — Assemble the per-issue briefing pack
@@ -139,6 +156,10 @@ Otherwise, before the user sees the plan, pressure-test it:
    Apply your critique dimensions. Verify the plan's claims against the repo and
    (read-only) the running behaviour. Return your structured verdict block. Do not
    edit the plan — the architect owns it.
+
+   PROGRESS_FILE=<path built by main per Step 0>
+   Append one JSONL line to $PROGRESS_FILE at each phase transition per your
+   charter's Progress reporting section.
    ```
 2. **Verdict `APPROVE` / `APPROVE WITH NOTES`** → proceed to Step 5, carrying any 🟡 notes into the user summary.
 3. **Verdict `REVISE`** → `SendMessage` the findings verbatim to the architect. The architect revises the plan and returns per-finding dispositions (fixed / rebutted-with-evidence). `SendMessage` the revision summary + dispositions back to the critic for re-critique.
@@ -189,6 +210,10 @@ The "one stage = one commit" contract, the drift-handling rules, and the correct
    Contract: the stage is not done until the behaviour-locking test exists at the
    tier the stage names (unit / canonical / integration), exercises real behaviour
    (not mocks), and passes. One stage = one commit. Return your structured report.
+
+   PROGRESS_FILE=<path built by main per Step 0>
+   Append one JSONL line to $PROGRESS_FILE at each phase transition per your
+   charter's Progress reporting section.
    ```
 2. **Validate the report.** When it returns:
    - Contract matches the stage spec — flag drift in your next user message.
@@ -218,6 +243,10 @@ Review the current branch vs <base_branch> against AGENTS.md and the code-review
 skill rules within YOUR scope. Plan: <~/.claude/plans/toloka-tolokaforge/...>.
 Briefing: <~/.claude/plans/toloka-tolokaforge/issue-<N>-briefing.md> if present.
 Cover branch + staged + unstaged. Return findings in the standard format.
+
+PROGRESS_FILE=<path built by main per Step 0, one per shard>
+Append one JSONL line to $PROGRESS_FILE at each phase transition per your
+charter's Progress reporting section.
 ```
 
 When all three return:
@@ -241,6 +270,10 @@ If the reviewer returns 🔴 Blocker or 🟠 Major findings:
    commit. Return your structured report.
 
    <paste reviewer findings verbatim>
+
+   PROGRESS_FILE=<path built by main per Step 0, fix-round scoped>
+   Append one JSONL line to $PROGRESS_FILE at each phase transition per your
+   charter's Progress reporting section.
    ```
 3. Re-launch the three sharded reviewers (`reviewer-correctness`, `reviewer-hygiene`, `reviewer-type-fit`) in parallel on the updated branch, same as Step 8. Merge findings the same way.
 4. Loop until every lane's verdict is `APPROVE` or `APPROVE WITH NITS`. **Cap: 2 fix rounds.** If any lane keeps finding the same Blocker, stop and ask the user — don't grind the implementer.
@@ -323,3 +356,52 @@ Surface to the user:
 - **Don't skip Step 5's approval.** The plan needs the user's eyes before main starts mutating the repo — the critic's verdict doesn't replace them.
 - **Don't run this skill for `docs:` / `chore:` issues** that don't need staged implementation. Just edit and commit directly.
 - **Don't dispatch this skill for issues already in progress on a branch.** Continue manually or ask the user.
+
+## Progress protocol
+
+Every subagent this skill launches writes JSONL progress lines to a per-launch file main opens in Step 0. Main tails the directory via a background `tail -F` + `Monitor`. The stream lets main *see* activity in real time without polling, and is the substrate the watchdog (soft-nudge / hard-timeout) will read in a follow-up change.
+
+### Path convention
+
+```
+~/.claude/plans/toloka-tolokaforge/progress/<launch_id_root>/<agent-role>-<UTC-timestamp>.jsonl
+```
+
+- `<launch_id_root>` = `issue-<N>` for a numbered issue, `adhoc-<UTC-ts>` otherwise. Under `/implement-milestone` the root is `milestone-<N>/issue-<K>`.
+- `<agent-role>` = `system-architect-planner`, `plan-critic`, `plan-stage-implementer`, `branch-code-reviewer`, `reviewer-correctness`, `reviewer-hygiene`, `reviewer-type-fit`.
+- `<UTC-timestamp>` = `date -u +%Y%m%dT%H%M%SZ` at launch. Rerunning the same role (fix-loop rounds, corrective launches) yields a distinct file per launch — history is preserved.
+
+Progress files are scratch, never committed, never referenced from PR bodies. They live outside the repo, alongside plan and briefing files.
+
+### Schema
+
+One JSON object per line, `≤ 300 bytes`, no PII:
+
+```json
+{"ts":"2026-08-06T12:34:56Z","agent":"plan-stage-implementer","launch_id":"impl-issue-237-s2","phase":"impl","step":"lint_check","detail":"pass","elapsed_s":42,"issue":237,"stage":2}
+```
+
+Required fields: `ts` (UTC ISO-8601), `agent` (role name), `launch_id` (main-assigned; see below), `phase` (from the per-agent phase list in the charter). Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`, `round`.
+
+Main assigns `launch_id`: for a persistent implementer, `impl-issue-<N>[-s<stage>]`; for shard reviewers, `reviewer-<lane>-issue-<N>[-r<round>]`; for architect/critic, `architect-issue-<N>` / `critic-issue-<N>[-r<round>]`. The `launch_id` is the join key: every line for a single Agent-tool launch (or its SendMessage continuations) carries the same value.
+
+### When subagents write
+
+Per each agent's `## Progress reporting` section in its charter:
+
+- On start.
+- At each phase transition (phase list is role-specific).
+- Before any tool call expected to exceed 60 s (`phase:"long_call"` + `step:"<tool>"`).
+- On caught error.
+
+### Main-side watcher
+
+Main launches at Step 0, once per invocation:
+
+```bash
+tail -F ~/.claude/plans/toloka-tolokaforge/progress/<launch_id_root>/*.jsonl 2>/dev/null
+```
+
+as a background bash (`run_in_background: true`), subscribed via the `Monitor` tool. New JSONL lines arrive as notifications; main reads them opportunistically. Nothing needs to poll.
+
+Watchdog behaviour (soft-idle nudge, hard-timeout `TaskStop`) is not part of this iteration — it lands in a follow-up change and consumes this same stream. For now the observability alone is the win: a wedged agent shows no new lines, and that gap is visible without waiting for a return that never comes.

--- a/.agents/skills/implement-milestone/SKILL.md
+++ b/.agents/skills/implement-milestone/SKILL.md
@@ -41,15 +41,22 @@ Invoking this skill **is** the user's explicit grant to, without re-asking:
 
 ## Step 0 — Progress channel
 
-Before Step 1, set up a milestone-scoped JSONL progress channel so main can observe subagent activity in real time across the whole milestone. Every per-issue sub-skill run inherits it; every subagent writes to it.
+Every per-issue sub-skill run writes its subagent events into a milestone-scoped tree; the milestone loop tails a rollup file so cross-issue activity is visible in one stream.
 
-1. Create the milestone progress root: `mkdir -p ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/`.
-2. Start the tail as a background bash — `tail -F ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/*.jsonl 2>/dev/null` — with `run_in_background: true`, and subscribe to it via the `Monitor` tool. Every subagent line surfaces as a notification without polling.
-3. Pass the milestone-scoped path root to each per-issue sub-skill invocation. The sub-skill's own Step 0 creates a per-issue subdirectory (`milestone-<N>/issue-<K>/`) under it and passes concrete `PROGRESS_FILE=...` paths to each subagent.
+1. Create the milestone events file (touching first guarantees the tail has a real file to follow):
+   ```bash
+   mkdir -p ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/
+   : > ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/rollup.jsonl
+   ```
+2. Start the tail as a **single-file** background bash and subscribe with `Monitor`:
+   ```bash
+   tail -n0 -F ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/rollup.jsonl
+   ```
+   Use `run_in_background: true`. No glob, no directory watch.
+3. For each per-issue sub-skill invocation in Step 3.2, pass `progress_root=~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/issue-<K>/`. The sub-skill creates its own `events.jsonl` under that directory and threads `PROGRESS_FILE=<progress_root>/events.jsonl` into each subagent launch.
+4. After the sub-skill completes for issue K, main appends the issue's event lines into the milestone rollup so the milestone tail surfaces them: `cat <progress_root>/events.jsonl >> ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/rollup.jsonl`. Per-issue files are kept in place as the authoritative per-issue record; the rollup is a stream convenience.
 
-Progress files are scratch, never committed. Schema and per-agent phase lists live in `/executing-development-tickets` §Progress protocol — the same protocol applies here; the milestone loop only adds a wider tail so cross-issue activity is visible in one stream.
-
-Watchdog behaviour (soft-idle nudge / hard-timeout escalation) is not part of this step yet — it lands in a follow-up. For now the stream exists so main can *see* activity, which is enough to distinguish a working agent from a wedged one at a glance across a long milestone run.
+Progress files are scratch, never committed. Schema, write recipe, and per-agent phase lists live in `/executing-development-tickets` §Progress protocol.
 
 ## Step 1 — Intake
 

--- a/.agents/skills/implement-milestone/SKILL.md
+++ b/.agents/skills/implement-milestone/SKILL.md
@@ -39,6 +39,18 @@ Invoking this skill **is** the user's explicit grant to, without re-asking:
 
 **Never granted — always stop and ask:** releases and version tags (`release.yml` / `release-gate.yml` are human-triggered), publishing packages, anything touching provider accounts or API-key budgets beyond normal test runs, force-pushing or committing directly to `main`, deleting the milestone, merging on red or unverified-flaky CI, and — critically — **merging the consolidation PR into `main`**. The consolidation PR is prepared but never auto-merged; the human reviews and merges it.
 
+## Step 0 — Progress channel
+
+Before Step 1, set up a milestone-scoped JSONL progress channel so main can observe subagent activity in real time across the whole milestone. Every per-issue sub-skill run inherits it; every subagent writes to it.
+
+1. Create the milestone progress root: `mkdir -p ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/`.
+2. Start the tail as a background bash — `tail -F ~/.claude/plans/toloka-tolokaforge/progress/milestone-<N>/*.jsonl 2>/dev/null` — with `run_in_background: true`, and subscribe to it via the `Monitor` tool. Every subagent line surfaces as a notification without polling.
+3. Pass the milestone-scoped path root to each per-issue sub-skill invocation. The sub-skill's own Step 0 creates a per-issue subdirectory (`milestone-<N>/issue-<K>/`) under it and passes concrete `PROGRESS_FILE=...` paths to each subagent.
+
+Progress files are scratch, never committed. Schema and per-agent phase lists live in `/executing-development-tickets` §Progress protocol — the same protocol applies here; the milestone loop only adds a wider tail so cross-issue activity is visible in one stream.
+
+Watchdog behaviour (soft-idle nudge / hard-timeout escalation) is not part of this step yet — it lands in a follow-up. For now the stream exists so main can *see* activity, which is enough to distinguish a working agent from a wedged one at a glance across a long milestone run.
+
 ## Step 1 — Intake
 
 1. Resolve the milestone: `gh api 'repos/Toloka/tolokaforge/milestones/<N>'` (the URL's trailing number is the milestone number). List its issues, open and closed: `gh api 'repos/Toloka/tolokaforge/issues?milestone=<N>&state=all&per_page=100'`.

--- a/.claude/agents/branch-code-reviewer.md
+++ b/.claude/agents/branch-code-reviewer.md
@@ -103,27 +103,33 @@ If any box fails → fix it before responding.
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct `/code-review` invocation), skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt when this is a pipeline-mode invocation. Append one JSONL event line to `$PROGRESS_FILE` at each phase transition. Direct `/code-review` invocations set neither — skip writes silently, the guard in the recipe below handles it.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"branch-code-reviewer","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "branch-code-reviewer" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "scan_diff" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round` (fix-loop round). Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`.
 
 **Phases for this agent:**
 
-- `start` — as your first action after reading the launch prompt.
+- `start` — first action after reading the launch prompt.
 - `load_rules` — before reading SKILL.md / AGENTS.md / the briefing pack.
 - `scan_diff` — before opening changed files in full.
-- `verify_findings` — before running probes to confirm each candidate finding.
+- `verify_findings_start` / `verify_findings_done` — around running probes to confirm each candidate finding.
 - `report` — immediately before returning the structured review block.
-- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `long_call_start` / `long_call_done` — around any single tool call you expect to exceed 60 s. Include `step:"<tool>"`.
 - `error` — on any caught exception, with `detail:"<short reason>"`.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Memory
 

--- a/.claude/agents/branch-code-reviewer.md
+++ b/.claude/agents/branch-code-reviewer.md
@@ -101,6 +101,30 @@ If the diff is genuinely clean: **"Reviewed <scope>. No AGENTS.md violations."**
 
 If any box fails → fix it before responding.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct `/code-review` invocation), skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"branch-code-reviewer","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round` (fix-loop round). Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:**
+
+- `start` — as your first action after reading the launch prompt.
+- `load_rules` — before reading SKILL.md / AGENTS.md / the briefing pack.
+- `scan_diff` — before opening changed files in full.
+- `verify_findings` — before running probes to confirm each candidate finding.
+- `report` — immediately before returning the structured review block.
+- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `error` — on any caught exception, with `detail:"<short reason>"`.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Memory
 
 Persistent memory: `~/.claude/agent-memory/branch-code-reviewer/`. Record:

--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -80,6 +80,30 @@ Main re-engages you via SendMessage with the architect's revision and per-findin
 - New findings are allowed only when the revision itself introduces them. No goalpost-moving: a round-3 finding you could have raised in round 1 is your failure — note it as such if it's a genuine 🔴, drop it otherwise.
 - If the same 🔴 survives 3 rounds, stop arguing. Return verdict `DEADLOCK` with a two-sided summary (your position, the architect's rebuttal, what evidence would settle it) so main can put it in front of the user.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt (and in every follow-up SendMessage). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"plan-critic","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:**
+
+- `start` — as your first action after reading the launch prompt.
+- `read_plan` — before opening the plan file.
+- `verify` — before running verification probes against the plan's claims.
+- `verdict` — immediately before returning the structured verdict block.
+- `recritique_start` / `recritique_done` — around each SendMessage-driven re-critique round.
+- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `error` — on any caught exception, with `detail:"<short reason>"`.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Memory
 
 Persistent memory: `~/.claude/agent-memory/plan-critic/`. Record:

--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -82,27 +82,33 @@ Main re-engages you via SendMessage with the architect's revision and per-findin
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt (and in every follow-up SendMessage). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt (and in every follow-up SendMessage). Append one JSONL event line to `$PROGRESS_FILE` at each phase transition so the pipeline can observe your progress instead of waiting for you to return. If either variable is unset (direct or legacy invocation), skip writes silently — the guard in the recipe below handles this.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"plan-critic","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "plan-critic" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "verify" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`.
 
 **Phases for this agent:**
 
-- `start` — as your first action after reading the launch prompt.
+- `start` — first action after reading the launch prompt.
 - `read_plan` — before opening the plan file.
-- `verify` — before running verification probes against the plan's claims.
+- `verify_start` / `verify_done` — around running verification probes against the plan's claims.
 - `verdict` — immediately before returning the structured verdict block.
 - `recritique_start` / `recritique_done` — around each SendMessage-driven re-critique round.
-- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `long_call_start` / `long_call_done` — around any single tool call you expect to exceed 60 s. Include `step:"<tool>"`.
 - `error` — on any caught exception, with `detail:"<short reason>"`.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Memory
 

--- a/.claude/agents/plan-stage-implementer.md
+++ b/.claude/agents/plan-stage-implementer.md
@@ -90,6 +90,35 @@ You are a senior engineer executing one stage of an architect-approved plan. You
 - Prefer MCP servers over ad-hoc bash (Context7 for library docs, GitHub MCP for PR/issue work, dev MCP for tests/lint/format).
 - One stage = one commit. Don't squash, amend, or commit unrelated stages together. Don't push the branch — main handles PR creation after the reviewer signs off.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt (and in every SendMessage for stages 2..N in persistent mode). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"plan-stage-implementer","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent** — write once at the start of each phase you enter (skip any phase your stage does not need):
+
+- `start` — as your first action after reading the launch prompt.
+- `restate` — before restating the stage contract in your own words.
+- `diagnose` — before reproducing / probing the current behaviour.
+- `interface` — before drafting or editing the interface (types, signatures, config schema).
+- `test` — before writing the behaviour-locking test.
+- `impl` — before the production-code edit.
+- `docs` — before updating `docs/*.md` / `AGENTS.md` snippets required by the stage.
+- `verify` — before running lint / format / tests to close the stage.
+- `commit` — before `git commit`.
+- `report` — immediately before returning the structured Stage Report block.
+- `long_call` — before any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`, docker build), with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `error` — on any caught exception, with `detail:"<short reason>"`.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Memory
 
 Persistent memory: `~/.claude/agent-memory/plan-stage-implementer/`. Record:

--- a/.claude/agents/plan-stage-implementer.md
+++ b/.claude/agents/plan-stage-implementer.md
@@ -92,32 +92,38 @@ You are a senior engineer executing one stage of an architect-approved plan. You
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt (and in every SendMessage for stages 2..N in persistent mode). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt (and in every SendMessage for stages 2..N in persistent mode). Append one JSONL event line to `$PROGRESS_FILE` at each phase transition so the pipeline can observe your progress instead of waiting for you to return. If either variable is unset (direct or legacy invocation), skip writes silently — the guard in the recipe below handles this.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"plan-stage-implementer","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "plan-stage-implementer" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "impl" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `stage`.
 
-**Phases for this agent** — write once at the start of each phase you enter (skip any phase your stage does not need):
+**Phases for this agent** — write one line at each phase transition (skip any phase your stage does not need):
 
-- `start` — as your first action after reading the launch prompt.
+- `start` — first action after reading the launch prompt.
 - `restate` — before restating the stage contract in your own words.
 - `diagnose` — before reproducing / probing the current behaviour.
 - `interface` — before drafting or editing the interface (types, signatures, config schema).
 - `test` — before writing the behaviour-locking test.
 - `impl` — before the production-code edit.
 - `docs` — before updating `docs/*.md` / `AGENTS.md` snippets required by the stage.
-- `verify` — before running lint / format / tests to close the stage.
+- `verify_start` / `verify_done` — around running lint / format / tests to close the stage.
 - `commit` — before `git commit`.
 - `report` — immediately before returning the structured Stage Report block.
-- `long_call` — before any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`, docker build), with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `long_call_start` / `long_call_done` — around any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`, docker build). Include `step:"<tool>"`.
 - `error` — on any caught exception, with `detail:"<short reason>"`.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Memory
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -95,27 +95,33 @@ If any box fails → fix it before responding.
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct invocation), skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt when this is a pipeline-mode invocation. Append one JSONL event line to `$PROGRESS_FILE` at each phase transition. Direct invocations set neither — skip writes silently, the guard in the recipe below handles it.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"reviewer-correctness","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "reviewer-correctness" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "scan_diff" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round` (fix-loop round). Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`.
 
 **Phases for this agent:**
 
-- `start` — as your first action after reading the launch prompt.
+- `start` — first action after reading the launch prompt.
 - `load_rules` — before reading SKILL.md / AGENTS.md / the briefing pack.
 - `scan_diff` — before opening changed files in full within your lane.
-- `verify_findings` — before running probes to confirm each candidate finding.
+- `verify_findings_start` / `verify_findings_done` — around running probes to confirm each candidate finding.
 - `report` — immediately before returning the structured review block.
-- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `long_call_start` / `long_call_done` — around any single tool call you expect to exceed 60 s. Include `step:"<tool>"`.
 - `error` — on any caught exception, with `detail:"<short reason>"`.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Memory
 

--- a/.claude/agents/reviewer-correctness.md
+++ b/.claude/agents/reviewer-correctness.md
@@ -93,6 +93,30 @@ If the diff is genuinely clean within your scope: **"Reviewed <scope>. No correc
 
 If any box fails → fix it before responding.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct invocation), skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"reviewer-correctness","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round` (fix-loop round). Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:**
+
+- `start` — as your first action after reading the launch prompt.
+- `load_rules` — before reading SKILL.md / AGENTS.md / the briefing pack.
+- `scan_diff` — before opening changed files in full within your lane.
+- `verify_findings` — before running probes to confirm each candidate finding.
+- `report` — immediately before returning the structured review block.
+- `long_call` — before any single tool call you expect to exceed 60 s, with `step:"<tool>"` so the idle watcher knows work is in flight.
+- `error` — on any caught exception, with `detail:"<short reason>"`.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Memory
 
 Persistent memory: `~/.claude/agent-memory/reviewer-correctness/`. Record:

--- a/.claude/agents/reviewer-hygiene.md
+++ b/.claude/agents/reviewer-hygiene.md
@@ -57,19 +57,25 @@ If the diff is genuinely clean within your scope: **"Reviewed <scope>. No hygien
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided, skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt when this is a pipeline-mode invocation. Append one JSONL event line to `$PROGRESS_FILE` at each phase transition. Direct invocations set neither — skip writes silently.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"reviewer-hygiene","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "reviewer-hygiene" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "scan_diff" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`.
 
-**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings`, `report`, plus `long_call` before any tool call expected to exceed 60 s and `error` on caught exceptions.
+**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings_start`/`_done`, `report`, plus `long_call_start`/`_done` around any tool call expected to exceed 60 s and `error` on caught exceptions.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Behaviour, Self-check, Memory
 

--- a/.claude/agents/reviewer-hygiene.md
+++ b/.claude/agents/reviewer-hygiene.md
@@ -55,6 +55,22 @@ APPROVE | APPROVE WITH NITS | REQUEST CHANGES | BLOCK — <one-sentence justific
 
 If the diff is genuinely clean within your scope: **"Reviewed <scope>. No hygiene / boundary / doc findings."** — and stop. Don't invent findings.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided, skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"reviewer-hygiene","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings`, `report`, plus `long_call` before any tool call expected to exceed 60 s and `error` on caught exceptions.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Behaviour, Self-check, Memory
 
 Same as `reviewer-correctness` — no softening, no fabrication, no scope creep, no duplication of automated checks. Persistent memory at `~/.claude/agent-memory/reviewer-hygiene/`; record recurring doc-drift patterns, comment-hygiene traps, and structure-violation locations that keep regressing.

--- a/.claude/agents/reviewer-type-fit.md
+++ b/.claude/agents/reviewer-type-fit.md
@@ -53,6 +53,22 @@ APPROVE | APPROVE WITH NITS | REQUEST CHANGES | BLOCK — <one-sentence justific
 
 If the diff is genuinely clean within your scope: **"Reviewed <scope>. No type-fit / task-design / docker / MCP findings."** — and stop. Don't invent findings.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided, skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"reviewer-type-fit","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings`, `report`, plus `long_call` before any tool call expected to exceed 60 s and `error` on caught exceptions.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Behaviour, Self-check, Memory
 
 Same as `reviewer-correctness` — no softening, no fabrication, no scope creep, no duplication of automated checks. Persistent memory at `~/.claude/agent-memory/reviewer-type-fit/`; record recurring type-system mismatches, task-pack anti-patterns, and Dockerfile drift worth calibrating against.

--- a/.claude/agents/reviewer-type-fit.md
+++ b/.claude/agents/reviewer-type-fit.md
@@ -55,19 +55,25 @@ If the diff is genuinely clean within your scope: **"Reviewed <scope>. No type-f
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt. Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided, skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt when this is a pipeline-mode invocation. Append one JSONL event line to `$PROGRESS_FILE` at each phase transition. Direct invocations set neither — skip writes silently.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"reviewer-type-fit","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "reviewer-type-fit" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "scan_diff" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with `echo '{...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`, `round`.
 
-**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings`, `report`, plus `long_call` before any tool call expected to exceed 60 s and `error` on caught exceptions.
+**Phases for this agent:** same list as `reviewer-correctness` — `start`, `load_rules`, `scan_diff`, `verify_findings_start`/`_done`, `report`, plus `long_call_start`/`_done` around any tool call expected to exceed 60 s and `error` on caught exceptions.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Behaviour, Self-check, Memory
 

--- a/.claude/agents/system-architect-planner.md
+++ b/.claude/agents/system-architect-planner.md
@@ -125,6 +125,31 @@ Critic findings are not orders: fix the ones that are right; **rebut with eviden
 
 Loop until main confirms approval. Don't preempt: if main says "approved, executing now", just acknowledge and stop. You don't run the execution.
 
+## Progress reporting
+
+Main passes a `PROGRESS_FILE` path in your launch prompt (and in every follow-up SendMessage). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+
+**Schema — one line per event, ≤ 300 bytes, no PII:**
+
+```json
+{"ts":"<ISO-8601 UTC>","agent":"system-architect-planner","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```
+
+Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, and `issue` when the launch prompt names one. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with a single append via Bash: `echo '{"ts":"...", ...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+
+**Phases for this agent:**
+
+- `start` — as your first action after reading the launch prompt.
+- `discovery_start` / `discovery_done` — before and after Phase 1.
+- `plan_drafting` — before your first write to the plan file.
+- `plan_written` — after the plan file is saved.
+- `handoff` — immediately before returning the "Handoff to main" block.
+- `revision_start` / `revision_done` — around each SendMessage-driven revision round (Phase 4).
+- `long_call` — before any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`), with `step:"<tool>"` in the line so the idle watcher knows work is in flight.
+- `error` — on any caught exception, with `detail:"<short reason>"`.
+
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+
 ## Memory
 
 Persistent memory: `~/.claude/agent-memory/system-architect-planner/`. Record:

--- a/.claude/agents/system-architect-planner.md
+++ b/.claude/agents/system-architect-planner.md
@@ -127,28 +127,34 @@ Loop until main confirms approval. Don't preempt: if main says "approved, execut
 
 ## Progress reporting
 
-Main passes a `PROGRESS_FILE` path in your launch prompt (and in every follow-up SendMessage). Append one JSONL line at each phase transition so the pipeline's watchdog can distinguish "still working" from "stuck". If no `PROGRESS_FILE` is provided (direct or legacy invocation), skip these writes silently.
+Main passes `PROGRESS_FILE=<path>` and `LAUNCH_ID=<id>` in your launch prompt (and in every follow-up SendMessage). Append one JSONL event line to `$PROGRESS_FILE` at each phase transition so the pipeline can observe your progress instead of waiting for you to return. If either variable is unset (direct or legacy invocation), skip writes silently — the guard in the recipe below handles this.
 
-**Schema — one line per event, ≤ 300 bytes, no PII:**
+**Write recipe** (quote-safe via `jq`; skip-safe under `set -u`):
 
-```json
-{"ts":"<ISO-8601 UTC>","agent":"system-architect-planner","launch_id":"<from-prompt>","phase":"<name>","step":"<optional>","detail":"<optional>","elapsed_s":<optional int>}
+```bash
+[ -n "${PROGRESS_FILE:-}" ] && jq -cn \
+  --arg ts "$(date -u +%FT%TZ)" \
+  --arg agent "system-architect-planner" \
+  --arg launch_id "$LAUNCH_ID" \
+  --arg phase "plan_drafting" \
+  '{ts:$ts, agent:$agent, launch_id:$launch_id, phase:$phase}' \
+  >> "$PROGRESS_FILE"
 ```
 
-Required: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, and `issue` when the launch prompt names one. Timestamp is UTC ISO-8601 (`date -u +%FT%TZ`). Write with a single append via Bash: `echo '{"ts":"...", ...}' >> "$PROGRESS_FILE"` — one line per call, never overwrite.
+Extend with `--arg step "<value>" --arg detail "<value>" --argjson elapsed_s <int>` as needed. Keep lines terse (target ≤ 300 bytes; truncate `detail` if it would blow past). Required fields: `ts`, `agent`, `launch_id`, `phase`. Optional: `step`, `detail`, `elapsed_s`, `issue`.
 
 **Phases for this agent:**
 
-- `start` — as your first action after reading the launch prompt.
-- `discovery_start` / `discovery_done` — before and after Phase 1.
+- `start` — first action after reading the launch prompt.
+- `discovery_start` / `discovery_done` — around Phase 1.
 - `plan_drafting` — before your first write to the plan file.
 - `plan_written` — after the plan file is saved.
 - `handoff` — immediately before returning the "Handoff to main" block.
 - `revision_start` / `revision_done` — around each SendMessage-driven revision round (Phase 4).
-- `long_call` — before any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`), with `step:"<tool>"` in the line so the idle watcher knows work is in flight.
+- `long_call_start` / `long_call_done` — around any single tool call you expect to exceed 60 s (e.g. a slow `run_tests`). Include `step:"<tool>"`.
 - `error` — on any caught exception, with `detail:"<short reason>"`.
 
-Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed by the watchdog, not a human log.
+Nothing else goes in `$PROGRESS_FILE` — it is machine-parsed, not a human log.
 
 ## Memory
 


### PR DESCRIPTION
## Summary

Adds a per-launch JSONL progress channel so `/executing-development-tickets` and `/implement-milestone` can observe subagent activity in real time instead of waiting until each subagent returns. Every subagent charter gains a "Progress reporting" section with a shared schema (`ts`, `agent`, `launch_id`, `phase`) and a role-specific phase list; both skills gain a Step 0 that creates the progress directory and starts a background `tail -F` + `Monitor` watcher; each subagent-launch prompt template now passes `PROGRESS_FILE=<path>`.

**Observability only — no pipeline behaviour changes.** The pipeline still runs the current full shape (architect → critic ≤3 → implementer → 3 sharded reviewers → fix loop ≤2). The soft-nudge / hard-timeout watchdog logic that consumes this stream lands in a follow-up.

## Design choices

- **Path convention:** `~/.claude/plans/toloka-tolokaforge/progress/<launch_id_root>/<agent-role>-<UTC-ts>.jsonl` — scratch, never committed, same location as plan/briefing files.
- **`PROGRESS_FILE` passed per launch** — main assembles the exact path per subagent invocation and embeds it in the launch prompt. Charters instruct subagents to skip writes silently if `PROGRESS_FILE` is absent, so direct `/code-review` invocations remain unaffected.
- **JSONL schema is minimal on purpose** — `ts`, `agent`, `launch_id`, `phase` required; `step`, `detail`, `elapsed_s`, `issue`, `stage`, `round` optional. One line ≤ 300 bytes, no PII.
- **Role-specific phase lists in each charter** — `system-architect-planner` (discovery / plan_drafting / plan_written / handoff / revision), `plan-critic` (read_plan / verify / verdict / recritique), `plan-stage-implementer` (restate / diagnose / interface / test / impl / docs / verify / commit / report), reviewer trio + monolithic (load_rules / scan_diff / verify_findings / report). Plus `long_call` before any tool call expected to exceed 60 s and `error` on caught exceptions.

## Files changed

- `.agents/skills/executing-development-tickets/SKILL.md` — new Step 0 (progress channel setup); `PROGRESS_FILE=<path>` appended to all 5 subagent-launch prompt templates (architect, critic, implementer, review shards, fix-loop implementer); new `## Progress protocol` reference section.
- `.agents/skills/implement-milestone/SKILL.md` — milestone-scoped Step 0; delegates schema to the sub-skill.
- `.claude/agents/{system-architect-planner,plan-critic,plan-stage-implementer,branch-code-reviewer,reviewer-correctness,reviewer-hygiene,reviewer-type-fit}.md` — each gains a `## Progress reporting` section with schema + phase list.

## Test plan

- [ ] Run `/executing-development-tickets <N>` against a small existing issue. Confirm progress files appear at `~/.claude/plans/toloka-tolokaforge/progress/issue-<N>/`.
- [ ] Confirm each subagent role produces its expected phase transitions in its JSONL file.
- [ ] Confirm `tail -F` + Monitor stream surfaces new lines as notifications during a live run.
- [ ] Confirm direct `/code-review` invocation still works (no `PROGRESS_FILE` in prompt → subagent skips writes silently, no errors).

## Follow-ups

- **PR-B: watchdog** — soft-nudge on stream-idle, hard-timeout `TaskStop` + user escalation. Consumes this stream.
- **PR-C: pre-architect label gate** — `type:docs`/`type:chore`/`size:xs` → skip orchestration entirely.
- **PR-D: architect Complexity Assessment + tier → shape table** — T1/T2/T3 pipeline scaling.
- **PR-E: `/implement-milestone` mirror** for the above.