### PR TITLE
fix(grading): hash-source rule skips a pack whose adapter may supply the source (#911)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -507,12 +507,14 @@ llm_judge:                                 # the judge MODEL is set once per run
 
 A whole-state hash is read only where the flag turns it on: `state_checks.hash`
 carrying an `expected_state_hash` or `golden_actions` under an `enabled` that is not
-truthy is rejected at load, because both substrates test the flag before reading any
-source and the pack would otherwise grade its state without the comparison the author
-wrote. The refusal is addressed at the source the pack declared. Every other
-authoring rule this file's grading block is checked against — tool names, argument
-names, `regex` compilation — is in
-[GRADING.md](GRADING.md#what-is-validated-before-a-run).
+truthy is rejected at load where the task declares `adapter_type: native`, because
+both substrates test the flag before reading any source and the pack would otherwise
+grade its state without the comparison the author wrote. The refusal is addressed at
+the source the pack declared; under any other `adapter_type` the same shape is
+reported unchecked at the same address, because an external adapter may supply the
+source the authored block never names. Every other authoring rule this file's
+grading block is checked against — tool names, argument names, `regex` compilation —
+is in [GRADING.md](GRADING.md#what-is-validated-before-a-run).
 
 The rubric is a structured `Rubric` (per-criterion scoring + a required gate),
 not a free-text blob; a free-text `rubric: "<text>"`, an `output_schema` field,

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -2376,8 +2376,9 @@ Findings come in three classes:
 | `db_probes` beside a non-empty `jsonpaths`, or beside a `hash` block enabled with a source — raised as a config load error before the gate is reached, so it is reported alone | error | `state_checks.db_probes` |
 | a `transcript_rules` block declaring no rule at all — every list empty, both turn bounds absent, and a `tool_expectations` expecting neither tool | error | `transcript_rules` |
 | a `custom_checks` block with no `enabled` key, which the component's own default leaves unrun | error | `custom_checks` |
-| either hash source declared under a `hash.enabled` that is not truthy — written `false`, `0`, `null`, or absent | error, one for the block | `state_checks.hash.<the declared source>`, and `expected_state_hash` where both are declared |
-| a truthy `state_checks.hash.enabled` with neither `expected_state_hash` nor a non-empty `golden_actions` | error | `state_checks.hash.enabled` |
+| either hash source declared under a `hash.enabled` that is not truthy — written `false`, `0`, `null`, or absent — where the task's declared `adapter_type` is `native` | error, one for the block | `state_checks.hash.<the declared source>`, and `expected_state_hash` where both are declared |
+| a truthy `state_checks.hash.enabled` with neither `expected_state_hash` nor a non-empty `golden_actions`, where the task's declared `adapter_type` is `native` | error | `state_checks.hash.enabled` |
+| either flag/source mismatch above, where the task declares any other `adapter_type` — an external adapter may compute the source it compares against from its own fixtures, the way the frozen-core family replays a golden-actions fixture the block never names | unchecked | the address the error would have carried |
 | a truthy `golden_actions` that is not a list of actions, under a truthy `hash.enabled` and whatever else the block declares — the description build raises on the same shape, so a run's pre-flight aborts on it before the gate is reached and only `tolokaforge validate` reports it as a finding | error | `state_checks.hash.golden_actions` |
 | a golden action naming a tool outside the task's declared set, under a truthy `hash.enabled` | error | `state_checks.hash.golden_actions[i].name` |
 | a golden action declaring no usable name — the key absent, `""`, `null`, or a value that is no string — under the same flag | error | as above |
@@ -2405,8 +2406,10 @@ false-reject mode. It is surfaced beside the task all the same — `validate` pr
 it, a run logs it — because a gate that could check nothing must not read as a clean
 bill of health. A task whose tool set the loader cannot resolve, an MCP pack that
 commits no `fixtures/tools.json`, an `args` address below its first segment, a property
-whose schema writes no `type`, a replay world no caller resolved, and a task naming no
-grading source under an adapter that resolves its own all land here.
+whose schema writes no `type`, a replay world no caller resolved, a hash block whose
+flag and source disagree under an external adapter that may supply the source itself,
+and a task naming no grading source under an adapter that resolves its own all land
+here.
 
 **A missing grading source is answered by the adapter the task declares.**
 `get_grading_config` is abstract and the implementations disagree: the native adapter

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -204,8 +204,9 @@ authorable source shapes, and for the two the authoring gate refuses:
   reachable is a directly built config, a bundle recorded before the rule, and — by
   design — every pack another `adapter_type` grades, which the gate reports unchecked
   instead: such an adapter may compute the source itself, the way the frozen-core
-  family replays a golden-actions fixture the authored block never names, so neither
-  substrate reading measured here is the one that pack takes.
+  family replays a golden-actions fixture the authored block never names, so whether
+  either substrate reading measured here is the one that pack takes is not settled
+  here — which is why the gate reports rather than refuses.
 - **`golden_actions` with no world to replay them in** — not proven, and **refused at
   the authoring gate** for the same reason. Core raises `UnbuildableGoldenReplayWorld`
   and the trial is left unscored (below), while the runner has nothing to lack: its

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -196,12 +196,16 @@ authorable source shapes, and for the two the authoring gate refuses:
   runner falls back on refusal semantics and compares the trial against the
   **initial** state where core compares it against the author's literal.
 - **`hash.enabled` with no declared source** — not proven, and **refused at the
-  authoring gate** for that reason. Core produces **no** verdict (below), while the
-  runner runs hash grading anyway for the refusal shape and produces a real binary
-  one. Measured, on a pack with live assertions scoring `0.5` at `weight: 0.6`: core's
-  component is `0.5` on both hash outcomes, the runner's is `0.8` on a match and `0.2`
-  on a divergence. What remains reachable is a directly built config and a bundle
-  recorded before the rule.
+  authoring gate** for that reason where the task declares `adapter_type: native`.
+  Core produces **no** verdict (below), while the runner runs hash grading anyway for
+  the refusal shape and produces a real binary one. Measured, on a pack with live
+  assertions scoring `0.5` at `weight: 0.6`: core's component is `0.5` on both hash
+  outcomes, the runner's is `0.8` on a match and `0.2` on a divergence. What remains
+  reachable is a directly built config, a bundle recorded before the rule, and — by
+  design — every pack another `adapter_type` grades, which the gate reports unchecked
+  instead: such an adapter may compute the source itself, the way the frozen-core
+  family replays a golden-actions fixture the authored block never names, so neither
+  substrate reading measured here is the one that pack takes.
 - **`golden_actions` with no world to replay them in** — not proven, and **refused at
   the authoring gate** for the same reason. Core raises `UnbuildableGoldenReplayWorld`
   and the trial is left unscored (below), while the runner has nothing to lack: its
@@ -974,7 +978,11 @@ a real number in that range — a bool, a numeric string — is rejected on **bo
 substrates rather than coerced into one.
 
 **The flag and a source are declared together, or neither is.** Both halves are
-rejected at load:
+rejected at load where the task declares `adapter_type: native`; under any other
+`adapter_type` the same shapes are reported unchecked at the same address instead,
+because an external adapter may supply the source the authored block never names —
+see the unchecked row in
+[What is validated before a run](#what-is-validated-before-a-run):
 
 - **Either source under a falsy `enabled`** is a comparison that never runs. Both
   substrates test the flag before reading any source, so the pack grades its state

--- a/tests/canonical/test_example_pack_grading_corpus.py
+++ b/tests/canonical/test_example_pack_grading_corpus.py
@@ -28,9 +28,9 @@ Fifteen claims over the packs an author reads as the reference:
    ``examples/`` and ``tests/data/tasks/`` is checked against its own task's tool
    inventory *and* its own effective combine, and produces no error, no advisory and
    nothing unchecked — the measured proof that the gate ships green rather than the
-   claim that it does. The rules that read the block alone are held over the wider
-   93-pack walk too, so a pack outside the two task roots cannot declare a section
-   that asserts nothing.
+   claim that it does. The rules a ``task.yaml`` holder can run without a tool set
+   are held over the wider 93-pack walk too, so a pack outside the two task roots
+   cannot declare a section that asserts nothing.
 6. **``cache_debug`` grades two genuinely alternative diagnostic routes and cannot be
    passed by mutating.** Either comparison its rubric reference names scores in full
    and records itself as the winner; completing neither scores below completing
@@ -104,6 +104,7 @@ from tests.utils.timelines import Turn, build_turn_timeline
 from tests.utils.trace_overrides import override_file
 from tolokaforge.adapters._task_loader import (
     build_tool_inventory,
+    hash_source_layer_under_adapter,
     load_task_yaml,
     replay_world_under_adapter,
 )
@@ -111,6 +112,7 @@ from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.grading.combine import GradingEngine
 from tolokaforge.core.grading.config_validation import (
     AuthoringReport,
+    HashSourceLayer,
     ReplayWorld,
     ToolInventory,
     inspect_grading_authoring,
@@ -496,6 +498,7 @@ def _gate_reports(
     grading: Mapping[str, Any],
     inventory: ToolInventory,
     world: ReplayWorld,
+    hash_sources: HashSourceLayer,
 ) -> tuple[AuthoringReport, AuthoringReport]:
     """A pack's own gate report, and the same pack's under one weight naming nothing.
 
@@ -505,9 +508,11 @@ def _gate_reports(
     gating a whole pack owes that — so a clean sweep would still read clean with those
     two rules never run. The probed report is empty in exactly that case.
 
-    The replay world is the pack's own too, resolved the way the gate's callers resolve
-    it: an unresolvable one would report a skip for every pack replaying golden actions
-    and the ``unchecked`` assertion below would stop saying which rules were skipped.
+    The replay world and the hash layer are the pack's own too, resolved the way the
+    gate's callers resolve each: an unresolvable world would report a skip for every
+    pack replaying golden actions, an unresolvable layer one for every hash block whose
+    flag and source disagree, and the ``unchecked`` assertion below would stop saying
+    which rules were skipped either way.
     """
     combine = _effective_combine(task_yaml, grading)
     probed = combine.model_copy(
@@ -515,9 +520,19 @@ def _gate_reports(
     )
     return (
         inspect_grading_authoring(
-            grading, inventory, replay_world=world, effective_combine=combine
+            grading,
+            inventory,
+            replay_world=world,
+            hash_sources=hash_sources,
+            effective_combine=combine,
         ),
-        inspect_grading_authoring(grading, inventory, replay_world=world, effective_combine=probed),
+        inspect_grading_authoring(
+            grading,
+            inventory,
+            replay_world=world,
+            hash_sources=hash_sources,
+            effective_combine=probed,
+        ),
     )
 
 
@@ -554,7 +569,11 @@ def test_no_shipped_pack_fails_the_authoring_gate() -> None:
             without_an_inventory.append(task.task_id)
             continue
         report, probed = _gate_reports(
-            task_yaml, grading, inventory, replay_world_under_adapter(task, task.adapter_type)
+            task_yaml,
+            grading,
+            inventory,
+            replay_world_under_adapter(task, task.adapter_type),
+            hash_source_layer_under_adapter(task.adapter_type),
         )
         reported = [
             f"{finding.where}: {finding.message}" for finding in report.errors + report.advisories
@@ -601,16 +620,17 @@ def test_no_authored_grading_block_asserts_nothing() -> None:
     :func:`_gated_packs`, so without this the rule's corpus proof stops at the packs
     that happen to live under the two task roots. The inventory is deliberately
     unresolvable: the rules that need a tool set are the gate guard's business above,
-    and what is wanted here is every rule that reads the block alone, over the widest
-    walk in the file.
+    and what is wanted here is every rule a caller holding a ``task.yaml`` can run
+    without one, over the widest walk in the file.
 
     The ``unchecked`` assertion is what stops that from reading as a clean bill of
     health. Every pack reports exactly the one tool-set skip; a rule moved behind
     ``inventory.known`` would show up here as a second skip rather than as a silent
-    loss of coverage. Each pack's real replay world is passed for that assertion's sake:
-    it is the one input besides the block that a caller holding a ``task.yaml`` always
-    has, so leaving it unresolvable would add a second skip to the four packs that
-    replay golden actions and say nothing about any rule.
+    loss of coverage. Each pack's real replay world and real hash layer are passed for
+    that assertion's sake: both are resolved off the ``task.yaml`` every caller here
+    holds, so leaving either unresolvable would add a second skip — to the four packs
+    that replay golden actions, or to any pack whose hash flag and source disagree —
+    and say nothing about any rule.
     """
     findings: dict[str, list[str]] = {}
     unchecked: dict[str, list[str]] = {}
@@ -624,6 +644,7 @@ def test_no_authored_grading_block_asserts_nothing() -> None:
             grading,
             ToolInventory.unresolvable(),
             replay_world=replay_world_under_adapter(task, task.adapter_type),
+            hash_sources=hash_source_layer_under_adapter(task.adapter_type),
         )
         pack = str(task_yaml.relative_to(_REPO))
         if report.errors or report.advisories:

--- a/tests/unit/dx/test_validate_grading_migrations.py
+++ b/tests/unit/dx/test_validate_grading_migrations.py
@@ -570,6 +570,38 @@ def test_validate_passes_an_external_adapters_sourceless_hash_and_reports_it(tmp
     assert result.exit_code == 0
 
 
+def test_validate_refuses_a_native_packs_sourceless_hash_through_the_resolver(tmp_path: Path):
+    """The native mirror of the pass above, through the same layer resolver.
+
+    The direct ``validate_grading_yaml`` locks above hand the rule the resolved layer
+    themselves, so none of them notices ``hash_source_layer_under_adapter`` ceasing to
+    resolve ``native`` — a helper returning unresolvable for every adapter type keeps
+    them green while both gates quietly stop refusing anything. This test dies with
+    that mutation: the pack declares no ``adapter_type``, so the CLI resolves the
+    layer off the native default and the refusal must survive end to end.
+    """
+    task_file = _write_task(
+        tmp_path / "native_hash",
+        """
+        combine:
+          method: weighted
+          weights:
+            state_checks: 1.0
+        state_checks:
+          hash:
+            enabled: true
+            weight: 1.0
+        """,
+    )
+
+    result = CliRunner(mix_stderr=False).invoke(cli, ["validate", "--tasks", str(task_file)])
+
+    out = result.stderr
+    assert "0 valid, 1 invalid" in out
+    assert "declares no expected_state_hash or golden_actions" in out
+    assert result.exit_code != 0
+
+
 @pytest.mark.parametrize("weight", [2.0, -0.1])
 def test_validate_rejects_a_weight_outside_the_unit_interval(tmp_path: Path, weight: float):
     grading = _write_grading(

--- a/tests/unit/dx/test_validate_grading_migrations.py
+++ b/tests/unit/dx/test_validate_grading_migrations.py
@@ -62,7 +62,7 @@ from tolokaforge.core.grading.combine_method import (
     COMBINE_METHODS,
     RETIRED_COMBINE_METHOD_ALIASES,
 )
-from tolokaforge.core.grading.config_validation import ToolInventory
+from tolokaforge.core.grading.config_validation import HashSourceLayer, ToolInventory
 from tolokaforge.core.models import (
     GradingCombineConfig,
     GradingConfig,
@@ -509,7 +509,7 @@ def test_validate_rejects_a_hash_the_flag_stops_anything_from_reading(
 
     grading = _write_grading(tmp_path, {"jsonpaths": _ASSERTIONS, "hash": hash_block})
     with pytest.raises(ValueError, match="the comparison never runs"):
-        validate_grading_yaml(grading, inventory=_UNRESOLVED)
+        validate_grading_yaml(grading, inventory=_UNRESOLVED, hash_sources=HashSourceLayer())
 
 
 def test_validate_rejects_a_flag_with_nothing_to_compare_against(tmp_path: Path):
@@ -528,7 +528,46 @@ def test_validate_rejects_a_flag_with_nothing_to_compare_against(tmp_path: Path)
 
     grading = _write_grading(tmp_path, {"jsonpaths": _ASSERTIONS, "hash": hash_block})
     with pytest.raises(ValueError, match="declares no expected_state_hash or golden_actions"):
-        validate_grading_yaml(grading, inventory=_UNRESOLVED)
+        validate_grading_yaml(grading, inventory=_UNRESOLVED, hash_sources=HashSourceLayer())
+
+
+def test_validate_passes_an_external_adapters_sourceless_hash_and_reports_it(tmp_path: Path):
+    """The shape #911 was filed for, at the surface a pack's author runs.
+
+    The frozen-core adapters compute the hash source from fixtures the authored block
+    never names, so their packs write ``hash: {enabled: true, weight: 1.0}`` and
+    nothing else. Whether that grades is the adapter's to answer, so validate prints
+    the shape beside the task as unchecked rather than refusing the file — the native
+    reading's refusal rejected every frozen pack at v0.15.0.
+    """
+    task_dir = tmp_path / "frozen_hash"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.yaml").write_text(
+        _TASK_YAML.replace(
+            "task_id: rubric_migration_probe",
+            "task_id: frozen_hash_probe\nadapter_type: tlk_mcp_core",
+        )
+    )
+    (task_dir / "grading.yaml").write_text(textwrap.dedent("""
+        combine:
+          method: weighted
+          weights:
+            state_checks: 1.0
+        state_checks:
+          hash:
+            enabled: true
+            weight: 1.0
+        """).strip())
+
+    result = CliRunner(mix_stderr=False).invoke(
+        cli, ["validate", "--tasks", str(task_dir / "task.yaml")]
+    )
+
+    out = result.stderr
+    assert "1 valid, 0 invalid" in out
+    assert "state_checks.hash.enabled not checked" in out
+    assert "an external adapter may compute the source" in out
+    assert result.exit_code == 0
 
 
 @pytest.mark.parametrize("weight", [2.0, -0.1])

--- a/tests/unit/grading/test_grading_authoring_gate.py
+++ b/tests/unit/grading/test_grading_authoring_gate.py
@@ -47,6 +47,7 @@ from tolokaforge.core.grading.config_validation import (
     AuthoringReport,
     CombineLayer,
     Finding,
+    HashSourceLayer,
     ReplayWorld,
     ToolInventory,
     inspect_grading_authoring,
@@ -182,6 +183,14 @@ _NO_INITIAL_STATE = ReplayWorld(initial_state=InitialStateSource.ABSENT, mcp_ser
 _AN_INLINE_INITIAL_STATE = ReplayWorld(initial_state=InitialStateSource.INLINE, mcp_server=True)
 _A_TASK_SUPPLYING_NEITHER = ReplayWorld(initial_state=InitialStateSource.ABSENT, mcp_server=False)
 
+# The two answers a caller can give the hash-source rule. The resolved layer is what both
+# pack gates report for a native task — the authored block is the only place a source can
+# come from — and what every row here means by grading natively. The unresolvable one is
+# the answer for a task an external adapter grades, whose source may live in fixtures the
+# block never names.
+_THE_BLOCK_IS_THE_WHOLE_LAYER = HashSourceLayer()
+_AN_ADAPTER_MAY_SUPPLY_THE_SOURCE = HashSourceLayer.unresolvable()
+
 
 def _quotes(operator: str, name: str) -> dict[str, Any]:
     """A ``present`` over an assistant message whose text reads the bound *name*."""
@@ -197,7 +206,9 @@ class _Rule:
     matcher, and a weight finding beside one would report two defects for one typo.
     ``world`` reads the same way: unresolvable leaves the replay-world rule reporting
     nothing in either finding channel, so only the row that is about the world says
-    what the task supplies.
+    what the task supplies. ``hash_sources`` defaults to the native reading — the
+    authored block is the whole layer — so only the rows about the layer say who else
+    may supply the source.
     """
 
     label: str
@@ -208,6 +219,7 @@ class _Rule:
     message: str
     combine: GradingCombineConfig | None = None
     world: ReplayWorld = ReplayWorld.unresolvable()
+    hash_sources: HashSourceLayer = _THE_BLOCK_IS_THE_WHOLE_LAYER
 
 
 _RULES: tuple[_Rule, ...] = (
@@ -298,6 +310,24 @@ _RULES: tuple[_Rule, ...] = (
         checker="_check_hash_source_declared",
         channel="errors",
         message="Declare expected_state_hash or golden_actions",
+    ),
+    _Rule(
+        label="enabled_hash_whose_source_an_adapter_may_supply",
+        task=_HELPDESK,
+        grading={"state_checks": {"hash": {"enabled": True}}},
+        checker="_check_hash_source_declared",
+        channel="unchecked",
+        message="an external adapter may compute the source",
+        hash_sources=_AN_ADAPTER_MAY_SUPPLY_THE_SOURCE,
+    ),
+    _Rule(
+        label="hash_source_without_the_flag_under_an_unresolved_layer",
+        task=_HELPDESK,
+        grading={"state_checks": {"hash": {"enabled": False, "expected_state_hash": "aaaa"}}},
+        checker="_check_hash_source_declared",
+        channel="unchecked",
+        message="an external adapter may compute the source",
+        hash_sources=_AN_ADAPTER_MAY_SUPPLY_THE_SOURCE,
     ),
     _Rule(
         label="probes_beside_a_source_that_scores_the_same_component",
@@ -418,6 +448,7 @@ def test_each_rule_is_reported_in_its_own_channel_naming_the_fix(rule: _Rule) ->
         _inventory(rule.task),
         effective_combine=rule.combine,
         replay_world=rule.world,
+        hash_sources=rule.hash_sources,
     )
 
     reported = _texts(report, rule.channel)
@@ -461,6 +492,7 @@ def test_every_checker_the_module_declares_is_provoked_by_a_rule(
             _inventory(rule.task),
             effective_combine=rule.combine,
             replay_world=rule.world,
+            hash_sources=rule.hash_sources,
         )
 
     assert answered == declared
@@ -665,7 +697,9 @@ def test_an_unresolvable_inventory_still_runs_the_rules_that_need_no_tools(
 
     with pytest.raises(ValueError) as excinfo:
         validate_grading_yaml(
-            _write_grading(tmp_path, grading), inventory=ToolInventory.unresolvable()
+            _write_grading(tmp_path, grading),
+            inventory=ToolInventory.unresolvable(),
+            hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
         )
 
     message = str(excinfo.value)
@@ -847,7 +881,9 @@ def test_a_truthy_hash_flag_with_no_source_is_refused(enabled: Any) -> None:
     """
     grading = {"state_checks": {"hash": {"enabled": enabled}}}
 
-    report = inspect_grading_authoring(grading, _inventory(_HELPDESK))
+    report = inspect_grading_authoring(
+        grading, _inventory(_HELPDESK), hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER
+    )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.enabled"]
 
@@ -864,7 +900,9 @@ def test_an_enabled_hash_beside_an_empty_jsonpath_list_is_refused() -> None:
     """
     grading = {"state_checks": {"hash": {"enabled": True}, "jsonpaths": []}}
 
-    report = inspect_grading_authoring(grading, _inventory(_HELPDESK))
+    report = inspect_grading_authoring(
+        grading, _inventory(_HELPDESK), hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER
+    )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.enabled"]
 
@@ -879,9 +917,49 @@ def test_an_empty_golden_action_list_is_not_a_hash_source() -> None:
     """
     grading = {"state_checks": {"hash": {"enabled": True, "golden_actions": []}}}
 
-    report = inspect_grading_authoring(grading, _inventory(_HELPDESK))
+    report = inspect_grading_authoring(
+        grading, _inventory(_HELPDESK), hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER
+    )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.enabled"]
+
+
+def test_the_frozen_adapter_convention_is_unchecked_rather_than_refused() -> None:
+    """The shape #911 was filed for: hash on, nothing declared, the adapter supplies it.
+
+    ``enabled: true`` beside only a ``weight`` is the frozen-core adapters' own
+    convention — the source lives in a golden-actions fixture the block never names —
+    so under a layer no caller resolved, the rule reports the shape it cannot check
+    instead of refusing packs that grade fine. The skip is addressed where the native
+    refusal would have been, so an author reading either finds the same key.
+    """
+    grading = {"state_checks": {"hash": {"enabled": True, "weight": 1.0}}}
+
+    report = inspect_grading_authoring(
+        grading, ToolInventory.unresolvable(), hash_sources=_AN_ADAPTER_MAY_SUPPLY_THE_SOURCE
+    )
+
+    assert report.errors == ()
+    assert report.advisories == ()
+    assert [skip.where for skip in report.unchecked if skip.where != "grading"] == [
+        "state_checks.hash.enabled"
+    ]
+
+
+def test_a_block_the_hash_rule_accepts_reports_nothing_on_an_unresolved_layer() -> None:
+    """A clean block is clean on either layer, so the skip names only refusable shapes.
+
+    Reporting every external pack's hash block as unchecked would bury the one skip that
+    means something under one per healthy pack: the rule found nothing to refuse, so
+    there is nothing it failed to check.
+    """
+    grading = {"state_checks": {"hash": {"enabled": True, "expected_state_hash": "aaaa"}}}
+
+    report = inspect_grading_authoring(
+        grading, _inventory(_HELPDESK), hash_sources=_AN_ADAPTER_MAY_SUPPLY_THE_SOURCE
+    )
+
+    assert report == AuthoringReport()
 
 
 def test_golden_actions_alone_are_a_hash_source() -> None:
@@ -985,7 +1063,12 @@ def test_a_golden_action_under_a_disabled_flag_is_refused_at_the_source(
     """
     grading = _golden_actions({"name": "close_widget"}, enabled=False)
 
-    report = inspect_grading_authoring(grading, _inventory(_HELPDESK), replay_world=world)
+    report = inspect_grading_authoring(
+        grading,
+        _inventory(_HELPDESK),
+        replay_world=world,
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
+    )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.golden_actions"]
     assert report.advisories == ()
@@ -1014,7 +1097,10 @@ def test_every_hash_source_under_a_disabled_flag_is_refused_at_its_own_key(key: 
     grading = {"state_checks": {"hash": {"enabled": False, key: _A_TRUTHY_HASH_SOURCE[key]}}}
 
     report = inspect_grading_authoring(
-        grading, _inventory(_HELPDESK), replay_world=_A_BUILDABLE_WORLD
+        grading,
+        _inventory(_HELPDESK),
+        replay_world=_A_BUILDABLE_WORLD,
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
     )
 
     assert [finding.where for finding in report.errors] == [f"state_checks.hash.{key}"]
@@ -1045,7 +1131,10 @@ def test_every_flag_spelling_that_reads_no_source_refuses_the_one_declared(
     grading = {"state_checks": {"hash": {**flag, "golden_actions": [{"name": "write_file"}]}}}
 
     report = inspect_grading_authoring(
-        grading, _inventory(_HELPDESK), replay_world=_A_BUILDABLE_WORLD
+        grading,
+        _inventory(_HELPDESK),
+        replay_world=_A_BUILDABLE_WORLD,
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
     )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.golden_actions"]
@@ -1342,7 +1431,10 @@ def test_a_golden_source_no_replay_can_iterate_under_a_falsy_flag_is_the_flags_f
     grading = {"state_checks": {"hash": {"enabled": False, "golden_actions": "write_file"}}}
 
     report = inspect_grading_authoring(
-        grading, _inventory(_HELPDESK), replay_world=_A_BUILDABLE_WORLD
+        grading,
+        _inventory(_HELPDESK),
+        replay_world=_A_BUILDABLE_WORLD,
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
     )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.golden_actions"]
@@ -1388,7 +1480,10 @@ def test_a_falsy_golden_source_alone_is_a_block_declaring_no_source(golden_actio
     grading = {"state_checks": {"hash": {"enabled": True, "golden_actions": golden_actions}}}
 
     report = inspect_grading_authoring(
-        grading, _inventory(_HELPDESK), replay_world=_A_BUILDABLE_WORLD
+        grading,
+        _inventory(_HELPDESK),
+        replay_world=_A_BUILDABLE_WORLD,
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
     )
 
     assert [finding.where for finding in report.errors] == ["state_checks.hash.enabled"]
@@ -1535,7 +1630,11 @@ def test_every_state_block_that_evaluates_nothing_draws_exactly_one_finding(
     so it draws one finding rather than one per source, addressed at the literal — the
     source core reads first.
     """
-    report = inspect_grading_authoring({"state_checks": state_checks}, _inventory(_HELPDESK))
+    report = inspect_grading_authoring(
+        {"state_checks": state_checks},
+        _inventory(_HELPDESK),
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
+    )
 
     assert [finding.where for finding in report.errors] == [address]
 
@@ -1604,9 +1703,14 @@ def test_the_state_sources_a_probe_may_be_declared_beside(
 
     The inventory is unresolvable and the replay world is left so, which makes every row
     the proof that this rule reads the authored block alone: no tool name, no world, no
-    fold.
+    fold. The hash layer is resolved, because the last three rows are the hash rule's and
+    that rule does read it.
     """
-    report = inspect_grading_authoring(_probes_beside(**beside), ToolInventory.unresolvable())
+    report = inspect_grading_authoring(
+        _probes_beside(**beside),
+        ToolInventory.unresolvable(),
+        hash_sources=_THE_BLOCK_IS_THE_WHOLE_LAYER,
+    )
 
     assert [finding.where for finding in report.errors] == addresses
     assert report.advisories == ()

--- a/tests/unit/test_orchestrator_grading_preflight.py
+++ b/tests/unit/test_orchestrator_grading_preflight.py
@@ -100,6 +100,13 @@ A_GOLDEN_REPLAY = {
     "state_checks": {"hash": {"enabled": True, "golden_actions": [{"name": "http_request"}]}},
 }
 
+# The frozen-core adapter convention #911 was filed for: hash grading on, nothing
+# declared to compare against, the source living in fixtures the block never names.
+AN_ADAPTER_SUPPLIED_HASH = {
+    "combine": {"weights": {"state_checks": 1.0}},
+    "state_checks": {"hash": {"enabled": True, "weight": 1.0}},
+}
+
 _MCP_TOOLS_FIXTURE = [
     {
         "name": "add_note",
@@ -658,6 +665,38 @@ def test_a_gradeless_pack_an_adapter_answers_for_itself_reaches_its_trials(
         ("TASK-NO-GRADING-SOURCE", "grading")
     ]
     assert "'terminal_bench'" in warned[0].reason
+    assert len(conductor.call_log.runs) == 1
+
+
+def test_an_enabled_sourceless_hash_an_adapter_supplies_reaches_its_trials(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A hash source an external adapter computes is not the authored block's to declare.
+
+    The shape #911 was filed for: the frozen-core adapters grade the hash against a
+    golden-actions fixture the authored block never names, so their packs write
+    ``hash: {enabled: true, weight: 1.0}`` and nothing else — and refusing that would
+    reject every pack the adapter grades fine. Both halves are the lock again: the run
+    proceeds, and the shape the gate could not check is logged beside the task rather
+    than passed as a clean bill of health.
+    """
+    root = tmp_path / "pack"
+    _write_builtin_task(root, "TASK-ADAPTER-HASH", AN_ADAPTER_SUPPLIED_HASH)
+    orchestrator, conductor = _orchestrator(root, tmp_path / "results")
+    orchestrator.adapter = _NativeAdapterResolvingToAnExternalType(
+        {"task_packs": [str(root)], "tasks_glob": "**/task.yaml"}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        orchestrator.run()
+
+    warned = {
+        (record.task_id, record.where): record.reason
+        for record in caplog.records
+        if "could not check" in record.getMessage()
+    }
+    reason = warned[("TASK-ADAPTER-HASH", "state_checks.hash.enabled")]
+    assert "an external adapter may compute the source" in reason
     assert len(conductor.call_log.runs) == 1
 
 

--- a/tolokaforge/adapters/_task_loader.py
+++ b/tolokaforge/adapters/_task_loader.py
@@ -67,6 +67,7 @@ from tolokaforge.core.grading.config_validation import (
     UNRESOLVED_COMBINE_REASON,
     AuthoringReport,
     CombineLayer,
+    HashSourceLayer,
     ReplayWorld,
     Skip,
     ToolInventory,
@@ -104,6 +105,7 @@ _PROJECT_SCOPED_DEFAULT_KEYS = frozenset(TaskDefaults.model_fields) - frozenset(
 # Bound once so each signature's default is the value, not a call in the annotation.
 _UNRESOLVED_COMBINE_LAYER = CombineLayer.unresolvable()
 _UNRESOLVED_REPLAY_WORLD = ReplayWorld.unresolvable()
+_UNRESOLVED_HASH_SOURCE_LAYER = HashSourceLayer.unresolvable()
 
 
 _GRADING_BLOCK_SHAPES: dict[str, str] = {
@@ -222,6 +224,7 @@ def validate_grading_yaml(
     *,
     inventory: ToolInventory,
     replay_world: ReplayWorld = _UNRESOLVED_REPLAY_WORLD,
+    hash_sources: HashSourceLayer = _UNRESOLVED_HASH_SOURCE_LAYER,
     combine_layer: CombineLayer = _UNRESOLVED_COMBINE_LAYER,
     fail_on: GradingFindingSeverity = GradingFindingSeverity.ADVISORY,
 ) -> AuthoringReport:
@@ -267,6 +270,11 @@ def validate_grading_yaml(
             A caller that cannot resolve it leaves the default,
             :meth:`ReplayWorld.unresolvable`, which skips the rule reading it into
             ``unchecked`` wherever that rule would have run.
+        hash_sources: What supplies a hash source beneath the authored block. A
+            caller that cannot say which adapter grades the task leaves the default,
+            :meth:`HashSourceLayer.unresolvable`, which moves the hash-source rule's
+            finding into ``unchecked`` where that rule would have refused; the two
+            gates resolve it through :func:`hash_source_layer_under_adapter`.
         combine_layer: What the task's enclosing project supplies beneath its own
             ``combine`` block. A caller that cannot resolve it leaves the default,
             :meth:`CombineLayer.unresolvable`, which skips the two weight rules into
@@ -317,7 +325,11 @@ def validate_grading_yaml(
             combine_layer.project_combine, grading_data.get("combine")
         )
     report = inspect_grading_authoring(
-        grading_data, inventory, replay_world=replay_world, effective_combine=effective_combine
+        grading_data,
+        inventory,
+        replay_world=replay_world,
+        hash_sources=hash_sources,
+        effective_combine=effective_combine,
     )
     if effective_combine is None:
         report = report.with_unchecked(Skip("combine.weights", UNRESOLVED_COMBINE_REASON))
@@ -673,6 +685,26 @@ def replay_world_under_adapter(task: TaskConfig, adapter_type: str) -> ReplayWor
         initial_state=classify_initial_state(task.initial_state.json_db),
         mcp_server=bool(task.tools.agent.get("mcp_server")) if task.tools.agent else False,
     )
+
+
+def hash_source_layer_under_adapter(adapter_type: str) -> HashSourceLayer:
+    """What supplies a hash source beneath a task's authored block, under *adapter_type*.
+
+    The authored ``state_checks.hash`` keys are the native reading's whole layer, so a
+    native task's enabled-but-sourceless block grades nothing and is the gate's to
+    refuse. A task an external adapter owns gets :meth:`HashSourceLayer.unresolvable`
+    for the reason :func:`tool_inventory_under_adapter` gives: the frozen-core adapter
+    family computes the source it compares against from its own fixtures, a reading no
+    surface here resolves, so refusing the bare block would reject packs that grade
+    fine. Letting an adapter *answer* with the source it supplies — so a fixture it
+    lost is refused before the trial is paid for — is the layer's designed extension,
+    deliberately not built here.
+    """
+    from tolokaforge.runner.models import AdapterType
+
+    if adapter_type != AdapterType.NATIVE.value:
+        return HashSourceLayer.unresolvable()
+    return HashSourceLayer()
 
 
 class GradingSourceKind(str, Enum):

--- a/tolokaforge/core/grading/config_validation.py
+++ b/tolokaforge/core/grading/config_validation.py
@@ -175,6 +175,30 @@ class CombineLayer:
 
 
 @dataclass(frozen=True)
+class HashSourceLayer:
+    """What supplies a hash source beneath a task's authored ``state_checks.hash`` block.
+
+    The native reading has nothing beneath the block: the authored keys are the only
+    place a source can come from, so an enabled block declaring none grades nothing —
+    which is what the default construction reports. A caller that cannot say what the
+    grading adapter supplies reports :meth:`unresolvable` — distinct from resolving
+    "nothing beneath", because the two decide opposite things: the second makes the
+    sourceless shape the authoring defect :func:`_check_hash_source_declared` refuses,
+    while the first makes it uncheckable. An external adapter may compute the source it
+    compares against from its own fixtures — the frozen-core family replays a
+    golden-actions fixture the authored block never names — so reading the block as
+    the whole layer there refuses packs that grade fine.
+    """
+
+    known: bool = True
+
+    @classmethod
+    def unresolvable(cls) -> HashSourceLayer:
+        """The layer of a caller that cannot say what the grading adapter supplies."""
+        return cls(known=False)
+
+
+@dataclass(frozen=True)
 class ReplayWorld:
     """What a task gives a golden-action replay to be executed against.
 
@@ -473,8 +497,15 @@ _UNRESOLVED_REPLAY_WORLD_REASON = (
     "world to be built in is not checkable"
 )
 
+_UNRESOLVED_HASH_SOURCE_REASON = (
+    "no caller resolved what the adapter grading this task supplies beneath the authored "
+    "hash block — an external adapter may compute the source it compares against from its "
+    "own fixtures — so whether this block grades as written is not checkable here"
+)
+
 # Bound once so the signature's default is the value, not a call in the annotation.
 _UNRESOLVED_REPLAY_WORLD = ReplayWorld.unresolvable()
+_UNRESOLVED_HASH_SOURCE_LAYER = HashSourceLayer.unresolvable()
 
 
 def inspect_grading_authoring(
@@ -483,6 +514,7 @@ def inspect_grading_authoring(
     *,
     effective_combine: GradingCombineConfig | None = None,
     replay_world: ReplayWorld = _UNRESOLVED_REPLAY_WORLD,
+    hash_sources: HashSourceLayer = _UNRESOLVED_HASH_SOURCE_LAYER,
 ) -> AuthoringReport:
     """Report what a task's tools, its replay world and its fold say about its grading block.
 
@@ -492,9 +524,10 @@ def inspect_grading_authoring(
 
     Every rule that needs the task's tools is skipped into ``unchecked`` when the
     inventory is unresolvable. The rules outside that set still run: regex compilation,
-    the hash-source declaration, the golden source's shape and the state-source
-    exclusivity, which read nothing but the block, and the replay-world rule, which reads
-    the world and skips on its own account.
+    the golden source's shape and the state-source exclusivity, which read nothing but
+    the block, the replay-world rule, which reads the world and skips on its own
+    account, and the hash-source declaration, which skips on the hash layer the same
+    way.
 
     Args:
         grading: The authored block, as written.
@@ -513,6 +546,11 @@ def inspect_grading_authoring(
             The default, :meth:`ReplayWorld.unresolvable`, is the answer for a caller
             holding no ``task.yaml`` — it skips the one rule that reads the world where
             that rule would have run, and fails nothing.
+        hash_sources: What supplies a hash source beneath the authored block. The
+            default, :meth:`HashSourceLayer.unresolvable`, is the answer for a caller
+            that cannot say which adapter grades the task — it moves the hash-source
+            rule's finding to ``unchecked`` where that rule would have refused, and
+            fails nothing.
     """
     constraints = tuple(_trace_constraints(grading))
     sites = tuple(_trace_matcher_sites(constraints))
@@ -521,7 +559,7 @@ def inspect_grading_authoring(
     reports = [
         _check_sections_declare_something(grading),
         _check_regex_compiles(sites, binders, rules.disallow_regex if rules else ()),
-        _check_hash_source_declared(grading),
+        _check_hash_source_declared(grading, hash_sources),
         _check_golden_actions_are_a_list(grading),
         _check_probes_are_the_only_state_source(grading),
         _check_golden_replay_world(grading, replay_world),
@@ -824,7 +862,9 @@ def _check_regex_compiles(
     return AuthoringReport(errors=tuple(finding for finding in findings if finding is not None))
 
 
-def _check_hash_source_declared(grading: Mapping[str, Any]) -> AuthoringReport:
+def _check_hash_source_declared(
+    grading: Mapping[str, Any], hash_sources: HashSourceLayer
+) -> AuthoringReport:
     """The hash check and something to compare against are declared together.
 
     Either half alone grades the state without the comparison the author wrote. A
@@ -852,6 +892,15 @@ def _check_hash_source_declared(grading: Mapping[str, Any]) -> AuthoringReport:
     empty ``golden_actions`` list replays nothing, which is why both substrates
     treat it as no source at all and why such a block is
     :func:`_check_sections_declare_something`'s rather than this rule's.
+
+    Both halves also hold only where the authored block is the whole layer, which is
+    *hash_sources*'s to say: an external adapter may compute the source it compares
+    against from its own fixtures, so under :meth:`HashSourceLayer.unresolvable` the
+    finding either half would have drawn moves to ``unchecked``, addressed where the
+    finding would have been — for the reason the tool rules skip an unresolvable
+    inventory, that refusing a reading the adapter does not use rejects packs that
+    grade fine. A block this rule finds nothing wrong with reports nothing on either
+    layer, so the skip names only the shape a native pack would have been refused for.
     """
     hash_block = _hash_block(grading)
     if hash_block is None:
@@ -859,6 +908,10 @@ def _check_hash_source_declared(grading: Mapping[str, Any]) -> AuthoringReport:
     enabled = hash_block.get("enabled")
     declared = next((key for key in HASH_SOURCE_KEYS if hash_block.get(key)), None)
     if enabled and declared is None:
+        if not hash_sources.known:
+            return AuthoringReport(
+                unchecked=(Skip("state_checks.hash.enabled", _UNRESOLVED_HASH_SOURCE_REASON),)
+            )
         sources = " or ".join(HASH_SOURCE_KEYS)
         return AuthoringReport(
             errors=(
@@ -874,6 +927,10 @@ def _check_hash_source_declared(grading: Mapping[str, Any]) -> AuthoringReport:
         )
     if enabled or declared is None:
         return AuthoringReport()
+    if not hash_sources.known:
+        return AuthoringReport(
+            unchecked=(Skip(f"state_checks.hash.{declared}", _UNRESOLVED_HASH_SOURCE_REASON),)
+        )
     return AuthoringReport(
         errors=(
             Finding(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -15,6 +15,7 @@ from tolokaforge.adapters import BaseAdapter, ensure_registered_adapter, get_ada
 from tolokaforge.adapters._task_loader import (
     GradingSourceKind,
     grading_source_under_adapter,
+    hash_source_layer_under_adapter,
     replay_world_under_adapter,
     tool_inventory_under_adapter,
     validate_grading_yaml,
@@ -1430,6 +1431,7 @@ class Orchestrator:
                 source.path,
                 inventory=tool_inventory_under_adapter(task, task_dir, adapter_type),
                 replay_world=replay_world_under_adapter(task, adapter_type),
+                hash_sources=hash_source_layer_under_adapter(adapter_type),
                 combine_layer=self.adapter.grading_combine_layer(),
                 fail_on=fail_on,
             )

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -1470,6 +1470,7 @@ def validate(tasks: str):
     from tolokaforge.adapters._task_loader import (
         GradingSourceKind,
         grading_source_under_adapter,
+        hash_source_layer_under_adapter,
         replay_world_under_adapter,
         tool_inventory_under_adapter,
         validate_grading_yaml,
@@ -1504,6 +1505,7 @@ def validate(tasks: str):
                         task_config, task_dir, task_config.adapter_type
                     ),
                     replay_world=replay_world_under_adapter(task_config, task_config.adapter_type),
+                    hash_sources=hash_source_layer_under_adapter(task_config.adapter_type),
                     combine_layer=CombineLayer(project_combine),
                 )
                 # Only here, and deliberately not in the pre-run gate: a migration


### PR DESCRIPTION
Closes #911.

## What

`_check_hash_source_declared` refused every frozen-core pack at v0.15.0: their convention is `hash: {enabled: true, weight: 1.0}` with the comparison source living in a golden-actions fixture the authored block never names, and this was the one hash rule that fired whatever the adapter — every `evaluate` shard of the downstream benchmark run aborted before its first trial (e.g. toloka-partners/tolokaforge-tasks run [31127175869](https://github.com/toloka-partners/tolokaforge-tasks/actions/runs/31127175869)). The finding is an **error**, so no `fail_on` setting could waive it.

## How

A new `HashSourceLayer` beside `CombineLayer` / `ReplayWorld`: what supplies a hash source beneath the authored block. Resolved for a native task (the block is the whole layer — the current refusal, verbatim); `unresolvable()` for a task an external adapter grades, which moves the finding either half of the rule would have drawn to the never-fatal `unchecked` channel, addressed where the refusal would have been. Both pack gates (pre-run + `tolokaforge validate`) resolve it through `hash_source_layer_under_adapter`, the same discrimination `tool_inventory_under_adapter` / `replay_world_under_adapter` already make. The skip fires only on the shape a native pack would have been refused for, so healthy external packs stay noise-free.

Letting an adapter *answer* with the source it supplies (so a missing fixture is refused before the trial is paid for) is deliberately out of scope — tracked in toloka-partners/tolokaforge-tools#94.

## Behaviour locks

- gate: the OTS shape under an unresolvable layer is unchecked at `state_checks.hash.enabled`, not refused; a clean block reports nothing on either layer; both `_RULES` rows for the unresolvable layer land in `unchecked`
- orchestrator: an external-adapter pack naming a grading file with the bare enabled hash block reaches its trials, skip logged beside the task
- CLI: `tolokaforge validate` passes the same pack (`1 valid, 0 invalid`) and prints the skip; native sourceless-hash refusals unchanged

## Tests

```
uv run pytest tests/ -m "unit or canonical" --deselect tests/unit/test_persistent_shell_local.py
6864 passed, 1701 deselected in 122.23s
```

(`test_persistent_shell_local.py` fails identically on an untouched `main` checkout in this environment — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)