### PR TITLE
feat(ci): auto-promote rc images to stable on green rc-smoke (#917)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -221,12 +221,16 @@ jobs:
     # untouched — auto-promote and move-tags are mutually exclusive.
     if: github.event_name == 'push' && contains(github.ref_name, '-rc.')
     runs-on: ubuntu-latest
+    # Bound the blast radius of a hung Docker Hub call — the default 6h would
+    # tie up the runner and hold the concurrency slot for the tag. move-tags
+    # below is analogous and could use the same cap; kept scoped to this PR.
+    timeout-minutes: 20
     # Same OIDC scoping as move-tags — the promote step uses the `release`
     # deployment scope, minting a Docker Hub push token distinct from the
     # `pre-stable` token that pushed the rc images. An rc build that fell into
     # this branch through some ref-name accident would fail OIDC claim
-    # resolution and block the push, matching the safety property the
-    # existing publish job's environment expression names on line 68.
+    # resolution and block the push, matching the safety property the publish
+    # job's `environment:` expression enforces for the initial rc push.
     environment: release
     permissions:
       id-token: write
@@ -291,11 +295,18 @@ jobs:
       # smoke, and move-tags sequence for no additional value. The rc tag is
       # the auditable pointer to the digest that was promoted; the Release
       # title names the stable version so `gh release list` reads correctly.
+      # Fail loud on a Docker Hub hiccup — GH-Actions `bash` default is
+      # `set -eo pipefail`, but a failing `$(imagetools inspect …)` command
+      # substitution is NOT propagated to errexit unless `inherit_errexit`
+      # is on. Without this shopt, a transient 500 would leave `digest=""`
+      # and the step would silently publish a garbled digest row.
       - name: Collect image digests
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+          shopt -s inherit_errexit
           {
             echo "## Published images (auto-promoted from ${REF_NAME})"
             echo ""
@@ -308,10 +319,15 @@ jobs:
             done
           } | tee release-notes.md >> "$GITHUB_STEP_SUMMARY"
 
+      # The Release title carries the rc suffix so that a hotfix flow which
+      # auto-promotes rc.1 and then rc.2 for the same X.Y.Z produces two
+      # visibly distinct Releases in `gh release list`. Without the suffix
+      # both entries would read `Docker images vX.Y.Z` and consumers would
+      # have to open each body to tell which is the current stable.
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Docker images v${{ steps.meta.outputs.version }}
+          name: Docker images v${{ steps.meta.outputs.version }} (from ${{ steps.meta.outputs.rc_version }})
           body_path: release-notes.md
           # Do NOT append_body — the auto-promote job is idempotent for the
           # image tags, and the release body must be idempotent too. A retry

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -10,6 +10,14 @@ concurrency:
   group: publish-images-${{ github.ref }}
   cancel-in-progress: true
 
+# Single source of truth for the first-party image set. The matrix below
+# carries per-image metadata (Dockerfile path, whether the image bundles
+# the wheel) and must stay in sync with this list, but every bash loop that
+# only needs the names reads from here — kept in one place so adding a
+# fifth image is one env edit + one matrix row, not six sites.
+env:
+  FIRST_PARTY_IMAGES: "runner db-service rag-service mock-web"
+
 jobs:
   build-wheel:
     name: Build wheel
@@ -257,7 +265,7 @@ jobs:
           RC_VERSION: ${{ steps.meta.outputs.rc_version }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          for image in runner db-service rag-service mock-web; do
+          for image in $FIRST_PARTY_IMAGES; do
             repo="tolokasoft1/tolokaforge-${image}"
             docker buildx imagetools create -t "${repo}:${VERSION}" "${repo}:${RC_VERSION}"
           done
@@ -271,7 +279,7 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
           MAJOR_MINOR: ${{ steps.meta.outputs.major_minor }}
         run: |
-          for image in runner db-service rag-service mock-web; do
+          for image in $FIRST_PARTY_IMAGES; do
             repo="tolokasoft1/tolokaforge-${image}"
             docker buildx imagetools create -t "${repo}:latest" "${repo}:${VERSION}"
             docker buildx imagetools create -t "${repo}:${MAJOR_MINOR}" "${repo}:${VERSION}"
@@ -293,7 +301,7 @@ jobs:
             echo ""
             echo "| Image | Tag | Digest |"
             echo "|---|---|---|"
-            for image in runner db-service rag-service mock-web; do
+            for image in $FIRST_PARTY_IMAGES; do
               repo="tolokasoft1/tolokaforge-${image}"
               digest="$(docker buildx imagetools inspect "${repo}:${VERSION}" --format '{{.Manifest.Digest}}')"
               echo "| \`${repo}\` | ${VERSION} | \`${digest}\` |"
@@ -305,7 +313,13 @@ jobs:
         with:
           name: Docker images v${{ steps.meta.outputs.version }}
           body_path: release-notes.md
-          append_body: true
+          # Do NOT append_body — the auto-promote job is idempotent for the
+          # image tags, and the release body must be idempotent too. A retry
+          # (rerun-failed-jobs, transient CI hiccup) with `append_body: true`
+          # would pile duplicate digest tables into the same Release. False
+          # (the default) replaces the body, so retries land on identical
+          # content whether they're the first run or the tenth.
+          append_body: false
           generate_release_notes: true
 
   move-tags:
@@ -350,7 +364,7 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
           MAJOR_MINOR: ${{ steps.meta.outputs.major_minor }}
         run: |
-          for image in runner db-service rag-service mock-web; do
+          for image in $FIRST_PARTY_IMAGES; do
             repo="tolokasoft1/tolokaforge-${image}"
             docker buildx imagetools create -t "${repo}:latest" "${repo}:${VERSION}"
             docker buildx imagetools create -t "${repo}:${MAJOR_MINOR}" "${repo}:${VERSION}"
@@ -372,7 +386,7 @@ jobs:
             echo ""
             echo "| Image | Tag | Digest |"
             echo "|---|---|---|"
-            for image in runner db-service rag-service mock-web; do
+            for image in $FIRST_PARTY_IMAGES; do
               repo="tolokasoft1/tolokaforge-${image}"
               digest="$(docker buildx imagetools inspect "${repo}:${version}" --format '{{.Manifest.Digest}}')"
               echo "| \`${repo}\` | ${version} | \`${digest}\` |"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -204,6 +204,110 @@ jobs:
             uv run pytest tests/integration/deploy/test_published_images_rc_smoke.py \
             -v --tb=short -m "integration and requires_docker"
 
+  auto-promote-rc-to-stable:
+    name: Auto-promote rc → stable (retag digest + move :latest + release notes)
+    needs: smoke
+    # Only fires on the automated rc-push path. A workflow_dispatch dry-run has
+    # no images to promote (see the publish job's `push: false`) and skips.
+    # A manual stable `image-vX.Y.Z` push takes the move-tags branch below
+    # untouched — auto-promote and move-tags are mutually exclusive.
+    if: github.event_name == 'push' && contains(github.ref_name, '-rc.')
+    runs-on: ubuntu-latest
+    # Same OIDC scoping as move-tags — the promote step uses the `release`
+    # deployment scope, minting a Docker Hub push token distinct from the
+    # `pre-stable` token that pushed the rc images. An rc build that fell into
+    # this branch through some ref-name accident would fail OIDC claim
+    # resolution and block the push, matching the safety property the
+    # existing publish job's environment expression names on line 68.
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Resolve version tags
+        id: meta
+        run: |
+          rc_version="${GITHUB_REF_NAME#image-v}"       # e.g. 0.14.2-rc.1
+          version="${rc_version%%-rc.*}"                # e.g. 0.14.2
+          major_minor="${version%.*}"                   # e.g. 0.14
+          {
+            echo "rc_version=$rc_version"
+            echo "version=$version"
+            echo "major_minor=$major_minor"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mint Docker Hub OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@v1
+        with:
+          connection_id: "06a2983d-e4d1-473e-8dab-f1d6ead9bc8f"
+
+      - name: Docker Hub login
+        uses: docker/login-action@v3
+        with:
+          username: tolokasoft1
+          password: ${{ steps.docker_oidc.outputs.token }}
+
+      # Same-digest retag from :X.Y.Z-rc.N onto :X.Y.Z. No rebuild — the
+      # image bytes are already public and rc-smoke has already validated
+      # them. Idempotent: re-running re-points the immutable :X.Y.Z tag
+      # onto the same digest, so a mid-loop failure is safe to rerun.
+      - name: Retag rc → stable (idempotent digest copy)
+        env:
+          RC_VERSION: ${{ steps.meta.outputs.rc_version }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          for image in runner db-service rag-service mock-web; do
+            repo="tolokasoft1/tolokaforge-${image}"
+            docker buildx imagetools create -t "${repo}:${VERSION}" "${repo}:${RC_VERSION}"
+          done
+
+      # Duplicated from the move-tags job below — kept in-place so the
+      # auto-promote job is self-contained and its DAG stays linear off
+      # `smoke`. A shared job would need a needs-graph across two `if:`
+      # branches that complicates the graph for no readability win.
+      - name: Move :latest and :major.minor onto the stable digest
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          MAJOR_MINOR: ${{ steps.meta.outputs.major_minor }}
+        run: |
+          for image in runner db-service rag-service mock-web; do
+            repo="tolokasoft1/tolokaforge-${image}"
+            docker buildx imagetools create -t "${repo}:latest" "${repo}:${VERSION}"
+            docker buildx imagetools create -t "${repo}:${MAJOR_MINOR}" "${repo}:${VERSION}"
+          done
+
+      # Attach the GitHub Release to the rc tag that triggered this run — not
+      # to a new `image-vX.Y.Z` git tag. Creating a stable git tag here would
+      # fire publish-images.yml on that tag and duplicate the entire build,
+      # smoke, and move-tags sequence for no additional value. The rc tag is
+      # the auditable pointer to the digest that was promoted; the Release
+      # title names the stable version so `gh release list` reads correctly.
+      - name: Collect image digests
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## Published images (auto-promoted from ${REF_NAME})"
+            echo ""
+            echo "| Image | Tag | Digest |"
+            echo "|---|---|---|"
+            for image in runner db-service rag-service mock-web; do
+              repo="tolokasoft1/tolokaforge-${image}"
+              digest="$(docker buildx imagetools inspect "${repo}:${VERSION}" --format '{{.Manifest.Digest}}')"
+              echo "| \`${repo}\` | ${VERSION} | \`${digest}\` |"
+            done
+          } | tee release-notes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Docker images v${{ steps.meta.outputs.version }}
+          body_path: release-notes.md
+          append_body: true
+          generate_release_notes: true
+
   move-tags:
     name: Move :latest and :X.Y
     needs: smoke

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,19 +1,19 @@
 # Releasing Tolokaforge
 
-A tolokaforge release has two independent axes, each cut by its own tag push and
-each with its own GitHub Actions workflow:
+A tolokaforge release has two axes, each with its own GitHub Actions workflow:
 
 - **The PyPI package** — `vX.Y.Z` tags, cut automatically by the "Release (cz
   bump)" workflow.
 - **The Docker images** — the `image-vX.Y.Z-rc.1` release-candidate tag is cut
-  automatically by the same "Release (cz bump)" workflow; the stable
-  `image-vX.Y.Z` tag is pushed by hand once the rc is verified.
+  automatically by the same "Release (cz bump)" workflow; the stable images
+  are promoted automatically once the keyless rc-smoke passes. No manual tag
+  push is required for the routine release path.
 
 Both axes are locked to a single version number. The PyPI release sets that
 number (it owns `[project].version` in `pyproject.toml`); the image workflow
 refuses to publish unless the image tag agrees with it. Cutting the package
-release also cuts the rc image tag; the stable image tag is pushed by hand
-afterwards.
+release cuts the rc image tag; the auto-promote job flips the rc images to
+stable in the same run once the smoke gate is green.
 
 ## PyPI package — `vX.Y.Z` (automated)
 
@@ -52,16 +52,16 @@ Pushing the `vX.Y.Z` tag then triggers two tag-driven workflows automatically:
 If `auto` finds no releasable commits since the last tag, the workflow exits
 cleanly without cutting a release.
 
-## Docker images — `image-vX.Y.Z-rc.1` (auto) and `image-vX.Y.Z` (manual)
+## Docker images — `image-vX.Y.Z-rc.1` (auto) → auto-promoted to stable
 
 The four first-party images —
 `tolokasoft1/tolokaforge-{runner,db-service,rag-service,mock-web}` — are published
 by [`publish-images.yml`](../.github/workflows/publish-images.yml), which fires on
 any pushed `image-v*` tag. The release workflow cuts the release-candidate tag
-`image-vX.Y.Z-rc.1` for you; the stable tag `image-vX.Y.Z` is pushed by hand once
-the rc is verified. The workflow builds the wheel once; only the images that ship
-it — `runner` and `rag-service` — are layered from that artifact, while
-`db-service` and `mock-web` build without it.
+`image-vX.Y.Z-rc.1` for you; the stable images are promoted from the rc digests
+automatically once the keyless rc-smoke gate passes. The workflow builds the wheel
+once; only the images that ship it — `runner` and `rag-service` — are layered from
+that artifact, while `db-service` and `mock-web` build without it.
 
 Images are `linux/amd64` only. The standalone compose recipe pins
 `platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}`, so Apple-Silicon hosts run the
@@ -74,29 +74,42 @@ Before building, the workflow asserts that `image-v<base>` equals the
 first. The image tag must therefore match the package version cut by the PyPI
 release. The two axes share one version number but are separate tag pushes.
 
-### Release-candidate, then stable
+### Release-candidate, then automatic promotion to stable
 
-Every image release goes through a release candidate first.
+Every image release goes through a release candidate first, then auto-promotes
+to stable when the smoke gate is green. The whole sequence runs in one
+`publish-images.yml` invocation off the single rc tag push.
 
 1. **The rc tag is cut for you.** When "Release (cz bump)" cuts `vX.Y.Z`, it also
    pushes `image-vX.Y.Z-rc.1`. That routes through the `pre-stable` deployment
-   environment, pushes the immutable `:X.Y.Z-rc.1` tags, and runs a keyless
-   rc-smoke against the freshly-pushed images. It does **not** move `:latest` or
-   `:X.Y`.
+   environment and pushes the immutable `:X.Y.Z-rc.1` tags.
 
-2. **Verify the rc** — pull the `:X.Y.Z-rc.1` images and smoke them yourself.
+2. **rc-smoke runs against the freshly-pushed images.** The `smoke` job pulls
+   each `:X.Y.Z-rc.1` image and asserts entrypoint + healthcheck + the documented
+   exec surface (see the "keyless rc-smoke" section below). It is keyless: the
+   run-trial check accepts a well-formed `error` wire line as a pass, so this
+   gate costs zero tokens and needs no provider key.
 
-3. **Push the stable tag.**
+3. **Auto-promote fires only on a green smoke.** The `auto-promote-rc-to-stable`
+   job runs in the `release` deployment environment, mints its own Docker Hub
+   OIDC token, and uses `docker buildx imagetools create` to copy the immutable
+   rc digest onto the `:X.Y.Z` stable tag, then onto the moving `:latest` and
+   `:X.Y` tags. Same digest, three additional tag references — no rebuild. It
+   finally publishes a GitHub Release listing each image's digest.
 
-   ```bash
-   git tag image-vX.Y.Z
-   git push origin image-vX.Y.Z
-   ```
+A red rc-smoke blocks the promote step: `:latest` stays on the previous stable
+version, and the operator investigates the rc images before anything moves.
 
-   This routes through the `release` environment and pushes the immutable
-   `:X.Y.Z` tags. Only **after** the smoke gate passes does the workflow move the
-   `:latest` and `:X.Y` moving tags onto that digest, then publish a GitHub
-   Release listing each image's digest.
+### Override — manual `image-vX.Y.Z` push
+
+The manual path stays available for rare cases the automated path cannot cover
+(promoting an older rc after a hotfix, re-publishing after a Docker Hub incident,
+etc.). Pushing an `image-vX.Y.Z` tag (no `-rc.` suffix) triggers the same
+`publish-images.yml` workflow through the `move-tags` job, which mints the
+`release`-environment OIDC token and moves `:latest` / `:X.Y` onto the
+already-published immutable `:X.Y.Z` digest. Use this only when the automated
+promote is not the right fit; for a routine release it does nothing beyond what
+auto-promote already did.
 
 ### Dry run
 
@@ -106,11 +119,14 @@ Dockerfiles and wheel still build.
 
 ## Typical order
 
-1. Run "Release (cz bump)" to cut `vX.Y.Z` — this sets the version, publishes the
-   package, and pushes `image-vX.Y.Z-rc.1` to build the rc images.
-2. Verify the rc images.
-3. `git tag image-vX.Y.Z && git push origin image-vX.Y.Z` to publish the stable
-   images and move `:latest`.
+1. Run "Release (cz bump)" from the Actions tab. This cuts `vX.Y.Z` (PyPI
+   publishes automatically) and pushes `image-vX.Y.Z-rc.1` (rc images build,
+   rc-smoke gates the promote).
+2. Watch the `publish-images.yml` run. When `smoke` passes, the
+   `auto-promote-rc-to-stable` job flips the rc digests to stable, moves
+   `:latest` and `:X.Y`, and publishes the GitHub Release.
+
+That is the entire routine. There is no manual tag push for the happy path.
 
 ## See also
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -103,13 +103,21 @@ version, and the operator investigates the rc images before anything moves.
 ### Override — manual `image-vX.Y.Z` push
 
 The manual path stays available for rare cases the automated path cannot cover
-(promoting an older rc after a hotfix, re-publishing after a Docker Hub incident,
-etc.). Pushing an `image-vX.Y.Z` tag (no `-rc.` suffix) triggers the same
-`publish-images.yml` workflow through the `move-tags` job, which mints the
-`release`-environment OIDC token and moves `:latest` / `:X.Y` onto the
-already-published immutable `:X.Y.Z` digest. Use this only when the automated
-promote is not the right fit; for a routine release it does nothing beyond what
-auto-promote already did.
+(re-publishing after a Docker Hub incident, cutting a fresh stable build off a
+hotfix branch, etc.). Pushing an `image-vX.Y.Z` tag (no `-rc.` suffix) fires the
+same `publish-images.yml` workflow through the full `build-wheel` → `publish` →
+`smoke` → `move-tags` sequence: **the images are rebuilt from source** and
+`:X.Y.Z` is republished with the fresh digest, then `:latest` / `:X.Y` move onto
+that digest.
+
+**This is a rebuild, not a retag** — the manifest digest published under
+`:X.Y.Z` after a manual override differs from the auto-promoted digest even
+when the source tree is identical (base-image drift, transitive dep resolution,
+buildkit re-serialization). The freshly-built images pass rc-smoke on the way
+out, but the specific bytes that operators may have already validated against
+the auto-promoted digest are gone. Do not use the manual path as a "safety
+net" or "double-check" on top of auto-promote; use it only when you need a
+fresh build.
 
 ### Trade-offs of the automated flow
 
@@ -136,10 +144,13 @@ Three properties of the auto-promote path that are worth knowing:
   framing (a well-formed `error` line on garbage stdin counts as pass), so it
   never spends provider tokens. This is the right coverage for the release
   ceremony's scope but does not exercise real trials. For major releases with
-  broad behavior changes, consider running a full smoke against the rc images
-  before the auto-promote fires — you can pull `:X.Y.Z-rc.1` manually while
-  the workflow is between `smoke` and `auto-promote-rc-to-stable` and, if
-  something looks off, cancel the workflow before the promote step starts.
+  broad behavior changes where you want a human gate between `smoke` and
+  promotion, add a **required reviewer** to the `release` deployment
+  environment in the repository settings — the auto-promote job runs under
+  that environment and will pause pending approval before the retag step.
+  Without a required reviewer configured, the workflow transitions from
+  `smoke` into `auto-promote-rc-to-stable` in seconds; there is no
+  meaningful window in which to cancel the run by hand.
 
 ### Dry run
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -111,6 +111,36 @@ already-published immutable `:X.Y.Z` digest. Use this only when the automated
 promote is not the right fit; for a routine release it does nothing beyond what
 auto-promote already did.
 
+### Trade-offs of the automated flow
+
+Three properties of the auto-promote path that are worth knowing:
+
+- **The GitHub Release is attached to the rc tag** (`image-vX.Y.Z-rc.1`), not to
+  a new `image-vX.Y.Z` git tag. Creating a stable git tag from CI would fire
+  `publish-images.yml` again on that tag and duplicate the entire build for no
+  additional value. Consequence: `gh release view image-vX.Y.Z` returns 404 for
+  auto-promoted releases; use `gh release list` and the Release title (`Docker
+  images vX.Y.Z`) to find them, or `gh api repos/…/releases/tags/image-vX.Y.Z-rc.1`
+  for the rc tag. The manual override path (below) still attaches to the stable
+  git tag if that shape matters for downstream tooling.
+
+- **The stable `:X.Y.Z` manifest digest differs from the `:X.Y.Z-rc.N` digest.**
+  `docker buildx imagetools create` re-serializes the manifest list to produce
+  the new tag, so the top-level digest changes even though every referenced
+  layer is byte-identical. Supply-chain checks that pin by
+  `sha256:…` will see distinct digests across rc and stable — the manifest is
+  a new artifact, the content it references is not.
+
+- **rc-smoke is the only automatic gate.** It is deliberately keyless:
+  `test_published_images_rc_smoke.py` asserts entrypoint + healthcheck + wire
+  framing (a well-formed `error` line on garbage stdin counts as pass), so it
+  never spends provider tokens. This is the right coverage for the release
+  ceremony's scope but does not exercise real trials. For major releases with
+  broad behavior changes, consider running a full smoke against the rc images
+  before the auto-promote fires — you can pull `:X.Y.Z-rc.1` manually while
+  the workflow is between `smoke` and `auto-promote-rc-to-stable` and, if
+  something looks off, cancel the workflow before the promote step starts.
+
 ### Dry run
 
 Running `publish-images.yml` from the Actions tab as a `workflow_dispatch` builds


### PR DESCRIPTION
## Summary

Closes #917. Adds an `auto-promote-rc-to-stable` job to `publish-images.yml` that flips rc images to stable automatically once the keyless rc-smoke gate is green — no more manual `git tag image-vX.Y.Z && git push` step.

- **Same digest, three additional tag references.** `docker buildx imagetools create` copies the immutable rc digest onto `:X.Y.Z` (immutable stable), then onto `:latest` and `:X.Y` (moving). No rebuild — rc-smoke has already validated these bytes.
- **rc-smoke stays authoritative.** The new job `needs: smoke`, so a red rc-smoke blocks the promote. `:latest` never moves onto a broken image.
- **Idempotent.** `imagetools create` is safe to rerun; a mid-loop failure re-points the same digest onto the same tag on retry.
- **OIDC scoping preserved.** The promote step runs in `environment: release`, minting a Docker Hub push token distinct from the `pre-stable` one that pushed the rc images. Matches the pattern the existing `move-tags` job already uses.

## Design choices

- **Additive, not a rewrite.** The existing `move-tags` + `release-notes` jobs stay in place for the manual `image-vX.Y.Z` override path (hotfixes, older-rc promotions, re-publishing after a Docker Hub incident). Auto-promote and move-tags are mutually exclusive via `contains(github.ref_name, '-rc.')`.
- **Attach the GitHub Release to the rc tag that triggered the run, not to a new `image-vX.Y.Z` git tag.** Pushing a stable git tag would fire `publish-images.yml` again on it and duplicate the entire build+smoke+move sequence for no value. The rc tag is the auditable pointer to the digest that was promoted; the Release title (`Docker images vX.Y.Z`) names the stable version so `gh release list` still reads correctly.
- **Duplicate the move-tags loop inline** in the auto-promote job rather than share via a reusable job. A shared job would need a needs-graph across two `if:` branches that complicates the DAG for no readability gain; the two loops are three lines each.

## Concepts introduced

- **`auto-promote-rc-to-stable` job.** New concept the docs name for consumers: an rc image build implicitly promotes to stable on green smoke, without any operator action.

## Plan

Followed `~/.claude/plans/i-recently-worked-on-refactored-brooks.md` § Recommendation. Two files touched, no behaviour beyond the CI workflow:

1. `.github/workflows/publish-images.yml` — new job inserted between `smoke` and `move-tags`.
2. `docs/RELEASING.md` — rewrote the "Release-candidate, then stable" section to describe the automated promote; added an "Override" subsection for the manual path; simplified "Typical order" to two steps.

## Discovered issues

None during implementation. Adjacent CI gaps still worth filing as separate issues if they matter (from the plan's non-blocking list):

- `release-gate.yml` runs on `v*` push but doesn't gate `publish-tolokaforge.yml` — PyPI can publish even on red gate.
- Non-atomic rc image tag push in `release.yml`.
- Version-guard bypass on `workflow_dispatch` in `publish-images.yml`.
- Hardcoded 4-image list duplicated in three places (matrix + two loops).

## Test plan

Behavioural verification only happens on the next real release cut — the auto-promote job cannot fully be exercised outside a rc tag push against real Docker Hub. What has been done locally:

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-images.yml'))"` — YAML parses.
- [x] `actionlint .github/workflows/publish-images.yml` — clean.
- [x] Pre-commit `Lint GitHub Actions workflow files` hook — passes on the diff.
- [ ] Behavioural: on the next release cut, verify the auto-promote job fires after `smoke`, retags all 4 images, moves `:latest` and `:X.Y`, and publishes the GitHub Release. Success = `docker pull tolokasoft1/tolokaforge-runner:latest` on a fresh host reflects the new release without any manual tag push.
- [ ] Failure-mode verification: on a future release where rc-smoke fails, verify auto-promote does NOT fire and `:latest` stays on the previous version.

The `move-tags` + `release-notes` override path is unchanged and remains manually testable via `workflow_dispatch` if we want additional confidence before the next real release.