### PR TITLE
fix(core): the TypeSense Docker rewrite drops the description cache

### DIFF
--- a/tests/unit/test_orchestrator_typesense_cache_invalidation.py
+++ b/tests/unit/test_orchestrator_typesense_cache_invalidation.py
@@ -14,6 +14,13 @@ The lock sits on the two private seams the regression lives between —
 (the rewrite) — because the end-to-end surface needs a Docker daemon the unit
 lane does not have. The orchestrator is real; only the Docker SDK boundary and
 the adapter are stand-ins.
+
+One contract this file assumes rather than proves: the mcp_core adapters read
+``params["typesense"]`` at ``to_task_description`` time, not at construction
+time (their construction-time snapshot serves host-side indexing only). No
+in-repo adapter exercises that read, so an adapter that started snapshotting
+would regress to #925 with these tests still green — that end of the contract
+belongs to the external adapters' own suites.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_orchestrator_typesense_cache_invalidation.py
+++ b/tests/unit/test_orchestrator_typesense_cache_invalidation.py
@@ -1,0 +1,177 @@
+"""A description cached before the TypeSense Docker rewrite must not reach a trial.
+
+The pre-run grading gate resolves every selected task through the run-scoped
+description cache before the Docker stack exists, so each cached ``SearchConfig``
+carries the host-side TypeSense address. After the stack starts,
+``_connect_typesense_to_runner_network`` rewrites the adapter's TypeSense params
+to the Docker-network alias — and inside the runner container the host-side
+address points at the runner itself, so a trial served the stale description has
+every ``search_policy`` call die with "Search service is not available" (#925).
+The rewrite therefore drops the cache, and this file locks that.
+
+The lock sits on the two private seams the regression lives between —
+``_task_description`` (the cache) and ``_connect_typesense_to_runner_network``
+(the rewrite) — because the end-to-end surface needs a Docker daemon the unit
+lane does not have. The orchestrator is real; only the Docker SDK boundary and
+the adapter are stand-ins.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.conductor import InMemoryConductor
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+    TypeSenseConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+from tolokaforge.core.runtime import InMemoryRuntimeBackend
+from tolokaforge.runner.models import SearchConfig, TaskDescription
+
+pytestmark = pytest.mark.unit
+
+HOST_SIDE = {"enabled": True, "mode": "local", "host": "127.0.0.1", "port": 8108, "api_key": "k"}
+
+
+class _KbAdapter:
+    """An adapter that answers with whatever TypeSense params it currently holds.
+
+    The frozen mcp_core adapter reads ``params["typesense"]`` into each
+    description's ``SearchConfig`` the same way; what matters here is only that
+    the address in the description is the address in the params at build time.
+    """
+
+    def __init__(self, params: dict[str, Any]) -> None:
+        self.params = params
+        self.builds = 0
+
+    def to_task_description(self, task_id: str) -> TaskDescription:
+        self.builds += 1
+        ts = self.params.get("typesense") or {}
+        port = ts.get("port")
+        return TaskDescription(
+            task_id=task_id,
+            name=task_id,
+            category="unit",
+            description="",
+            adapter_type="native",
+            system_prompt="",
+            search=SearchConfig(
+                enabled=False,
+                domain_name="unit_domain",
+                host=ts.get("host"),
+                port=port if isinstance(port, int) else None,
+                api_key=ts.get("api_key"),
+            ),
+        )
+
+
+class _TypesenseServer:
+    """The started-server handle the rewrite reads the container from."""
+
+    def __init__(self) -> None:
+        container = types.SimpleNamespace(container_id="ts-container-id")
+        self._stack = types.SimpleNamespace(_containers={"typesense": container})
+
+
+class _ServiceStack:
+    """The core stack handle the rewrite reads the runner network from."""
+
+    def __init__(self) -> None:
+        net = types.SimpleNamespace(network_id="net-id", name="runner-net")
+        self._networks = {"runner-net": net}
+
+
+class _DockerNetwork:
+    def __init__(self) -> None:
+        self.connected: list[tuple[str, tuple[str, ...]]] = []
+
+    def connect(self, container: Any, aliases: list[str] | None = None) -> None:
+        self.connected.append((container.name, tuple(aliases or ())))
+
+
+def _docker_module(network: _DockerNetwork) -> types.SimpleNamespace:
+    client = types.SimpleNamespace(
+        containers=types.SimpleNamespace(
+            get=lambda cid: types.SimpleNamespace(id=cid, name="tolokaforge-typesense")
+        ),
+        networks=types.SimpleNamespace(get=lambda _nid: network),
+    )
+    return types.SimpleNamespace(from_env=lambda: client)
+
+
+def _orchestrator(tmp_path: Path) -> Orchestrator:
+    return Orchestrator(
+        RunConfig(
+            models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+            orchestrator=OrchestratorConfig(
+                workers=1,
+                repeats=1,
+                auto_start_services=False,
+                shuffle_trials=False,
+                typesense=TypeSenseConfig(**HOST_SIDE),
+            ),
+            evaluation=EvaluationConfig(
+                output_dir=str(tmp_path / "results"), projects=[str(tmp_path)]
+            ),
+        ),
+        deps=OrchestratorDeps(
+            runtime_backend=InMemoryRuntimeBackend(),
+            conductor_factory=lambda _ctx: InMemoryConductor(),
+        ),
+    )
+
+
+def test_a_pre_stack_description_is_rebuilt_with_the_docker_address(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate's cache warm-up must not pin the host-side address on the trial."""
+    network = _DockerNetwork()
+    monkeypatch.setitem(sys.modules, "docker", _docker_module(network))
+
+    orchestrator = _orchestrator(tmp_path)
+    orchestrator.adapter = _KbAdapter({"typesense": dict(HOST_SIDE)})
+    orchestrator._typesense_server = _TypesenseServer()
+
+    # The pre-run grading gate resolves the task first — stack not started yet.
+    before = orchestrator._task_description("TASK-KB")
+    assert before.search.host == "127.0.0.1"
+
+    orchestrator._connect_typesense_to_runner_network(_ServiceStack())
+
+    # The rewrite really ran, against the real method's docker calls...
+    assert network.connected == [("tolokaforge-typesense", ("typesense",))]
+
+    # ...and the trial-facing resolve now rebuilds with the Docker alias
+    # instead of serving the stale host-side copy back.
+    after = orchestrator._task_description("TASK-KB")
+    assert after.search.host == "typesense"
+    assert after.search.port == 8108
+
+
+def test_descriptions_cache_again_once_rebuilt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One rewrite costs one rebuild per task — the cache is dropped, not disabled."""
+    monkeypatch.setitem(sys.modules, "docker", _docker_module(_DockerNetwork()))
+
+    orchestrator = _orchestrator(tmp_path)
+    adapter = _KbAdapter({"typesense": dict(HOST_SIDE)})
+    orchestrator.adapter = adapter
+    orchestrator._typesense_server = _TypesenseServer()
+
+    orchestrator._task_description("TASK-KB")
+    orchestrator._connect_typesense_to_runner_network(_ServiceStack())
+    orchestrator._task_description("TASK-KB")
+    orchestrator._task_description("TASK-KB")
+
+    assert adapter.builds == 2

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1279,6 +1279,12 @@ class Orchestrator:
                 # (typesense:8108) into SearchConfig rather than host-side ones.
                 if self.adapter and hasattr(self.adapter, "params"):
                     self.adapter.params["typesense"] = resolved_config
+                    # Descriptions resolved before this rewrite — the pre-run
+                    # grading gate resolves every selected task — carry the
+                    # host-side address, which inside the runner container is
+                    # the runner itself (#925). Drop them so trials rebuild
+                    # against the rewritten params.
+                    self._task_desc_cache.clear()
                     self.logger.debug(
                         "Propagated TypeSense Docker config to adapter",
                         host="typesense",

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -439,7 +439,10 @@ class Orchestrator:
         # task_id. ``adapter.to_task_description()`` reads the system
         # prompt, tool schemas, fixtures, and base64-bundles the task_dir
         # — repeating that K times for ``repeats=K`` trials of the same
-        # task is wasted work. Populated lazily by ``_build_trial_spec``.
+        # task is wasted work. Populated by whichever resolver runs first
+        # (the pre-run grading gate, backend selection, or trial-spec
+        # building) and dropped when the TypeSense Docker rewrite makes
+        # every cached SearchConfig address stale (#925).
         self._task_desc_cache: dict[str, TaskDescription] = {}
         # Run-wide trial ordering: ``(task_id, trial_index) → total_index``
         # (0..total-1). Populated by :meth:`_build_pending_trials` and
@@ -679,11 +682,15 @@ class Orchestrator:
         return conductor
 
     def _task_description(self, task_id: str) -> TaskDescription:
-        """The task's wire-format description, resolved once per run.
+        """The task's wire-format description, resolved once per adapter configuration.
 
         The registration check runs on the build, so every description in the
         cache has had its declared backend verified against the host registry —
         writing the cache around this method would skip it.
+
+        "Once per adapter configuration", not "once per run": the TypeSense
+        Docker rewrite invalidates the cache, so descriptions resolved before
+        the stack starts are rebuilt against the rewritten params (#925).
         """
         if self.adapter is None:
             raise RuntimeError("Task descriptions cannot be resolved before the adapter is loaded.")


### PR DESCRIPTION
Fixes #925.

## What broke

Since v0.16.0, every `search_policy` call in a full_stack Docker run fails with `Search service is not available` (326 failures across all 4 shards of [tolokaforge-tasks run 31150454474](https://github.com/toloka-partners/tolokaforge-tasks/actions/runs/31150454474); agents document the outage in case notes and escalate, so KB scores are corrupted while CI reports green).

The pre-run grading gate (#890) resolves every selected task through `_task_description()` at the top of `run()` — before the Docker stack exists — so the run-scoped `_task_desc_cache` fills with descriptions whose `SearchConfig` carries the **host-side** TypeSense address. When `_connect_typesense_to_runner_network` later rewrites `adapter.params["typesense"]` to the Docker alias (`typesense:8108`), that rewrite only affects future description builds — and the warm cache guarantees there are none. Trials ship `host=127.0.0.1` into the runner container, where that address is the runner itself: mcp_core registers no usable client, `get_typesense_for_domain` returns `None`, and the frozen pack's `search_policy` raises on every call.

## The fix

One hunk: the rewrite clears `_task_desc_cache` right after propagating the Docker address to the adapter params, so trial-facing resolves rebuild against the rewritten values. The gate keeps resolving through the cache (its registration-check-on-build contract is why the cache exists); the cost of the invalidation is one extra description build per task per run.

## Behaviour locks

`tests/unit/test_orchestrator_typesense_cache_invalidation.py`, driving a real `Orchestrator` through the real `_connect_typesense_to_runner_network` (only the Docker SDK boundary and the adapter are stand-ins):

- a description resolved before the stack starts is re-resolved with the Docker alias afterwards — **fails on current main** (`127.0.0.1` is served back from the cache), passes with the fix;
- the cache is dropped, not disabled: one rewrite costs exactly one rebuild per task.

## Verification

- `pytest tests/unit -k orchestrator`: 233 passed
- full unit lane: 5771 passed; the only failures are the 8 `test_persistent_shell_local.py` cases that fail identically on untouched main in this devcontainer (environmental)
- canonical lane: 1101 passed
- `ruff check` clean on touched files; `ruff format` drift in `orchestrator.py` is pre-existing (lines ~206, fails the check on baseline too — AGENTS.md gotcha #3); `black --check` clean

## Rollout

Ship as v0.16.1, then re-pin `tolokaforge-tasks` `dev/ots` (same flow as the #911/v0.16.0 cycle). Follow-ups filed separately: #926 (runner fails loud when a declared search plane is unusable), #927 (stack-level TypeSense address instead of per-task SearchConfig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CajmZnqsPoV4MC8E96UuEf