### PR TITLE
feat(llm): address the gateway in its own dialect and by its own route name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,5 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # litellm transport sends an OpenAI-envelope request. Widen this only if your
 # gateway also serves the other provider's native route (see docs).
 # LLM_PROXY_PROVIDERS=openrouter,openai
+# Namespace that wins when the gateway serves one model under several names:
+# LLM_PROXY_PREFERRED_ROUTE=openrouter/

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -190,7 +190,7 @@ The name looked up is the one that actually reaches the gateway: litellm strips 
 provider prefix, so this run's `provider: openrouter` + `name: <slug>` config puts the **bare
 slug** on the wire. An `openrouter/<slug>` (or `openrouter/*`) catalog entry is therefore *not*
 evidence for this run — reaching a prefixed route needs the gateway-named config in
-[`docs/LLM_LAYER.md` § the model name must be the gateway's route name](LLM_LAYER.md#the-model-name-must-be-the-gateways-route-name),
+[`docs/LLM_LAYER.md` § naming a gateway route explicitly](LLM_LAYER.md#naming-a-gateway-route-explicitly),
 which this workflow does not use.
 
 The report distinguishes two strengths, because they are not equally trustworthy:

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -564,6 +564,24 @@ different upstreams, which is a serving-path choice rather than a transport deta
 `LLM_PROXY_PREFERRED_ROUTE` names the namespace that wins; without it the resolver
 raises rather than guessing.
 
+**Hard requirement on the gateway: route names must mirror upstream names.** The
+resolver derives exactly two candidates and does no fuzzy matching, so a route named
+as an arbitrary alias (`sonnet-4.6`, `team-default`, or a separator variant like
+`claude-sonnet-4-6` for a config that says `4.6`) is invisible to it. The model then
+resolves as "not served" and the call goes to the provider directly, with only a
+per-client warning. On a gateway-only model that direct call fails; on any other it
+runs unattributed. If a deployment cannot rename such a route, the exact-name entry
+has to be added alongside the alias.
+
+Wildcard entries (`openrouter/*`, `anthropic/*`) are deliberately **not** accepted as
+evidence: a wildcard says the gateway will forward the request, not that the model
+exists behind it. Measured on a live gateway, `anthropic/*` accepted a name that its
+Bedrock backing then rejected as invalid, while the very same wildcard also "covered"
+a nonexistent model. If routing every model through the gateway ever becomes the
+goal, the extension point is a *namespace-matched* wildcard (accept `openrouter/*`
+only for `provider: openrouter` configs, where the fallback is the same upstream the
+board is calibrated on), not looser matching.
+
 Preset resolution and pricing are unaffected: both key off `ModelConfig.provider` /
 `.name`, not off the wire name.
 
@@ -593,23 +611,25 @@ next to its own hardcoded base URL; a gateway replaces the base URL but not the
 rewrite, so litellm would get a provider-less model string and raise
 `BadRequestError` before sending anything.
 
-### The model name must be the gateway's route name
+### Naming a gateway route explicitly
 
-Enabling the gateway is **not** a drop-in for existing run configs. litellm
-strips exactly one provider prefix before sending, so `provider: openrouter` +
-`name: anthropic/claude-opus-4.7` puts `anthropic/claude-opus-4.7` on the wire.
-A gateway resolves that against *its own* model table, which need not mean what
-the provider would mean by it.
+Route resolution (above) makes existing run configs work through the gateway
+unchanged, so this section is the **manual override**: pinning a config directly to
+one specific gateway route, either because the catalog is unreadable from the
+running host or because a deployment needs a route the resolver's two candidates
+cannot derive (an alias, see the hard requirement above).
 
-Observed on a real LiteLLM proxy: that name matched the gateway's catch-all
-`anthropic/*` route, which is backed by **Bedrock**, so the request was served
-by a different upstream than the config asked for. It failed loudly there only
-because that particular Bedrock model rejects `temperature=0.0`; a
-closer-matching route would have silently evaluated a different serving path.
-For a leaderboard that is a comparability break, not a transport detail.
+The cautionary tale that motivates being explicit at all: before route resolution
+existed, `provider: openrouter` + `name: anthropic/claude-opus-4.7` put the bare
+`anthropic/claude-opus-4.7` on the wire (litellm strips one prefix), and on a real
+LiteLLM proxy that matched the catch-all `anthropic/*` route, backed by **Bedrock**,
+a different upstream than the config asked for. It failed loudly there only
+because that particular Bedrock model rejects `temperature=0.0`; a closer-matching
+route would have silently evaluated a different serving path. For a leaderboard that
+is a comparability break, not a transport detail.
 
-So name the model the way the gateway names it, and pick the provider so that
-litellm's prefix strip leaves that name intact:
+To pin a route by hand, name the model the way the gateway names it, and pick the
+provider so that litellm's prefix strip leaves that name intact:
 
 ```yaml
 # Gateway route "openrouter/anthropic/claude-opus-4.7"
@@ -637,10 +657,13 @@ couplings described below:
   `extra_body.reasoning`. That is correct for an OpenAI-shaped gateway endpoint,
   but verify it for reasoning models before trusting a run.
 
-**This was a transport swap and nothing else until the gateway route resolution above; routed calls now also carry the gateway's dialect and its route name.** `_build_kwargs` sets `api_base`,
-`api_key`, and `extra_headers`; the litellm model string keeps its original
-`<provider>/<name>` shape. Two distinct couplings hang off model naming, and
-only the second is to that formatted string:
+What `_build_kwargs` does differs by path. **On a resolved route** it rewrites
+`model` to the gateway's route name, forces `custom_llm_provider="openai"`, and
+drops OpenRouter-only body fields (`extra_body.provider`). **On the
+unrouted / unreadable-catalog path** it sets only `api_base`, `api_key` and
+`extra_headers`; the model string keeps its `<provider>/<name>` shape, and
+OpenRouter's headers and provider pin still apply. Two distinct couplings hang off
+model naming, and only the second is to the formatted string:
 
 - Preset `match:` globs resolve off `ModelConfig.name` and the `providers:`
   overlay off `ModelConfig.provider` (see [`presets`](#presets)). Re-prefixing
@@ -653,10 +676,11 @@ only the second is to that formatted string:
   verbatim. A second prefix guarantees a pricing-table miss, degrading
   `cost_source` to `"unknown"` and tripping `Capability.COST_USD_POPULATED`.
 
-Because the provider string is untouched, provider-specific request shaping
-still applies on top of the gateway: OpenRouter's `HTTP-Referer` / `X-Title`
-headers and its `extra_body.provider` upstream pinning both survive. On a
-header-name collision the gateway's configured header wins, since that is
+`ModelConfig.provider` is untouched either way, so OpenRouter's
+`HTTP-Referer` / `X-Title` headers still apply on top of the gateway; the
+`extra_body.provider` upstream pin applies only on the unrouted path (a resolved
+route drops it, since a non-OpenRouter upstream rejects it as an unknown field).
+On a header-name collision the gateway's configured header wins, since that is
 explicit operator configuration and the other is an engine default.
 
 ### Verifying a gateway from CI

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -450,8 +450,9 @@ posting to a route the gateway does not serve.
 | `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. A value may reference a secret as `${secret:NAME}`, see below. |
 | `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
 | `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
+| `LLM_PROXY_PREFERRED_ROUTE` | Namespace that wins when the gateway serves one model under several names, e.g. `openrouter/`. Without it an ambiguous lookup raises rather than guessing a serving path. |
 
-All five resolve through `SecretManager`, so `.env`, the process environment,
+All six resolve through `SecretManager`, so `.env`, the process environment,
 and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
 A malformed value raises `ProxyConfigError` at the first `LLMClient`
 construction rather than running a whole evaluation with unattributed spend. Setting
@@ -522,6 +523,49 @@ host→container boundary if it is enumerable, which for the environment means i
 every `.env` key unconditionally, so putting referenced names in `.env` is the way
 to make in-container resolution work if that is ever needed.
 
+
+### Speaking to the gateway
+
+A gateway is an OpenAI-compatible endpoint, so routed calls speak that dialect
+(`custom_llm_provider="openai"`) and address the gateway by **its** route name,
+resolved from `GET {base}/models` at client construction and cached per base URL.
+
+Both halves are load-bearing, and each replaces a measured failure.
+
+**The dialect.** litellm's OpenRouter transformation unconditionally adds
+`usage: {"include": true}` to the body to get cost data back. That field is an
+OpenRouter extension. Forwarded by the gateway to any other upstream it is rejected
+(`usage: Extra inputs are not permitted` from both Anthropic and Bedrock), so every
+call to a non-OpenRouter-backed route failed. The dialect also decides prefix
+handling: the OpenRouter transport strips one leading `openrouter/`, the OpenAI one
+does not.
+
+**The name.** Those two effects are coupled, so the name that arrives depends on the
+dialect, and the gateway's name for a model is not derivable from the engine's model
+string. It is whichever of `<provider>/<name>` or `<name>` the catalog contains:
+
+| engine model string | gateway route |
+|---|---|
+| `openrouter/azure_ai/cohere-command-a-plus-05-2026` | `azure_ai/cohere-command-a-plus-05-2026` |
+| `openrouter/anthropic/claude-sonnet-4.6` | `openrouter/anthropic/claude-sonnet-4.6` |
+
+Three outcomes, deliberately different:
+
+* **Catalog names the model** → route through the gateway under that name.
+* **Catalog answers and omits it** → the gateway does not serve this model, so the
+  call goes to the provider directly. This is what lets one run mix a gateway-only
+  candidate with a simulator the gateway does not carry.
+* **Catalog unreadable** (or empty) → keep the gateway and send the untranslated
+  name. Unreadable is not absence: silently leaving the gateway is the
+  unattributed-spend outcome this transport exists to prevent.
+
+When the catalog serves a model under several names, they can be backed by
+different upstreams, which is a serving-path choice rather than a transport detail.
+`LLM_PROXY_PREFERRED_ROUTE` names the namespace that wins; without it the resolver
+raises rather than guessing.
+
+Preset resolution and pricing are unaffected: both key off `ModelConfig.provider` /
+`.name`, not off the wire name.
 
 ### Which providers can be routed
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -637,7 +637,7 @@ couplings described below:
   `extra_body.reasoning`. That is correct for an OpenAI-shaped gateway endpoint,
   but verify it for reasoning models before trusting a run.
 
-**This is a transport swap and nothing else.** `_build_kwargs` sets `api_base`,
+**This was a transport swap and nothing else until the gateway route resolution above; routed calls now also carry the gateway's dialect and its route name.** `_build_kwargs` sets `api_base`,
 `api_key`, and `extra_headers`; the litellm model string keeps its original
 `<provider>/<name>` shape. Two distinct couplings hang off model naming, and
 only the second is to that formatted string:

--- a/tests/unit/llm/conftest.py
+++ b/tests/unit/llm/conftest.py
@@ -1,7 +1,34 @@
 """LLM-layer unit-test fixtures.
 
 The overlay fixtures (``overlay_isolation``, ``write_overlay``) live in the
-top-level ``tests/conftest.py`` so integration tests can use them too. This
-file is intentionally empty — kept so pytest still treats this directory as
-a fixture-source root.
+top-level ``tests/conftest.py`` so integration tests can use them too.
 """
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from tolokaforge.core.llm import gateway_route
+
+
+@pytest.fixture(autouse=True)
+def _no_gateway_catalog_network(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep the gateway catalog off the wire for every LLM unit test.
+
+    Building an ``LLMClient`` with ``LLM_PROXY_BASE_URL`` set fetches the catalog, so
+    without this a unit test does live DNS and HTTP against whatever host it configured
+    and can block for the fetch timeout. It also made those tests *network-dependent*:
+    they passed only while the fake host failed to answer, and would have flipped behind
+    a captive portal or a proxy that answers 200.
+
+    The default stands in for an unreadable catalog, which is the branch that keeps the
+    gateway and leaves the model string alone, so existing expectations are unchanged.
+    A test that cares about a resolved route patches
+    ``tolokaforge.core.llm.client.fetch_gateway_catalog`` itself.
+    """
+    gateway_route.clear_catalog_cache()
+    monkeypatch.setattr("tolokaforge.core.llm.client.fetch_gateway_catalog", lambda *_a, **_k: None)
+    yield
+    gateway_route.clear_catalog_cache()

--- a/tests/unit/llm/test_gateway_catalog_fetch.py
+++ b/tests/unit/llm/test_gateway_catalog_fetch.py
@@ -67,6 +67,7 @@ def gateway(_server: str) -> Iterator[str]:
 
 
 def _config(base: str, **kw: object) -> ProxyConfig:
+    # kwargs are per-test ProxyConfig fields; typing them precisely here buys nothing.
     return ProxyConfig(base_url=base, **kw)  # type: ignore[arg-type]
 
 
@@ -120,33 +121,47 @@ class TestCacheSemantics:
         assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
         assert len(HITS) == 1
 
-    def test_an_empty_answer_is_not_cached(self, gateway: str) -> None:
+    def test_an_empty_answer_is_not_cached(
+        self, gateway: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The bug this file was written for: an empty answer is called transient in
         the design, so caching it pinned a whole process on the degraded path."""
+        monkeypatch.setattr(gateway_route, "CATALOG_RETRY_COOLDOWN_S", 0.0)
         RESPONSES.append((200, json.dumps({"data": []})))
         RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
         assert fetch_gateway_catalog(_config(gateway)) is None
         assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
 
-    def test_a_failure_is_not_cached(self, gateway: str) -> None:
+    def test_a_failure_is_not_cached(self, gateway: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not cached, only cooled down; with the cooldown at zero the next call retries."""
+        monkeypatch.setattr(gateway_route, "CATALOG_RETRY_COOLDOWN_S", 0.0)
         RESPONSES.append((500, "boom"))
         RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
         assert fetch_gateway_catalog(_config(gateway)) is None
         assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
 
-    def test_repeated_failure_stops_retrying(self, gateway: str) -> None:
+    def test_a_failure_starts_a_cooldown(self, gateway: str) -> None:
         """A gateway that HANGS would otherwise cost the timeout on every client
-        construction for the whole run."""
-        for _ in range(gateway_route.MAX_CATALOG_ATTEMPTS):
-            RESPONSES.append((500, "boom"))
-            assert fetch_gateway_catalog(_config(gateway)) is None
+        construction. Within the cooldown no request is made at all."""
+        RESPONSES.append((500, "boom"))
+        assert fetch_gateway_catalog(_config(gateway)) is None
         before = len(HITS)
         assert fetch_gateway_catalog(_config(gateway)) is None
-        assert len(HITS) == before, "gave up, so no further request"
+        assert len(HITS) == before, "inside the cooldown, so no further request"
 
-    def test_a_success_resets_the_failure_count(self, gateway: str) -> None:
+    def test_the_cooldown_expires_so_a_long_run_recovers(
+        self, gateway: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reason this is a cooldown and not a hard attempt cap: constructions
+        cluster at run start, so a cap would burn out during warmup with no way back."""
         RESPONSES.append((500, "boom"))
         assert fetch_gateway_catalog(_config(gateway)) is None
+        monkeypatch.setattr(gateway_route, "CATALOG_RETRY_COOLDOWN_S", 0.0)
+        gateway_route._RETRY_AFTER.clear()
         RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
         assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
-        assert gateway_route._FAILURES.get(_config(gateway).base_url, 0) == 0
+
+    def test_a_success_clears_the_cooldown(self, gateway: str) -> None:
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+        assert _config(gateway).base_url not in gateway_route._RETRY_AFTER

--- a/tests/unit/llm/test_gateway_catalog_fetch.py
+++ b/tests/unit/llm/test_gateway_catalog_fetch.py
@@ -1,0 +1,152 @@
+"""The fetch half of gateway routing, against a real local endpoint.
+
+The resolver and the client wiring are pinned elsewhere; both patch this function
+out, so without this file the HTTP handling, the auth and attribution headers, the
+empty-answer mapping and the cache semantics are unpinned. A caching bug shipped
+through exactly that gap once.
+
+A local ``http.server`` rather than a mocked ``urlopen``: the point is to exercise
+the request this code really sends.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tolokaforge.core.llm import gateway_route
+from tolokaforge.core.llm.gateway_route import clear_catalog_cache, fetch_gateway_catalog
+from tolokaforge.core.llm.proxy import ProxyConfig
+
+pytestmark = pytest.mark.unit
+
+SEEN_HEADERS: list[dict[str, str]] = []
+RESPONSES: list[tuple[int, str]] = []
+HITS: list[str] = []
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        HITS.append(self.path)
+        SEEN_HEADERS.append({k.lower(): v for k, v in self.headers.items()})
+        status, body = RESPONSES.pop(0) if RESPONSES else (200, json.dumps({"data": []}))
+        payload = body.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args: object) -> None:
+        pass
+
+
+@pytest.fixture(scope="module")
+def _server() -> Iterator[str]:
+    """One server for the file: shutdown() costs a poll interval each time."""
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def gateway(_server: str) -> Iterator[str]:
+    SEEN_HEADERS.clear()
+    RESPONSES.clear()
+    HITS.clear()
+    clear_catalog_cache()
+    yield _server
+    clear_catalog_cache()
+
+
+def _config(base: str, **kw: object) -> ProxyConfig:
+    return ProxyConfig(base_url=base, **kw)  # type: ignore[arg-type]
+
+
+class TestTheRequest:
+    def test_it_asks_the_models_endpoint_and_returns_the_ids(self, gateway: str) -> None:
+        RESPONSES.append(
+            (200, json.dumps({"data": [{"id": "azure_ai/m"}, {"id": "openrouter/n"}]}))
+        )
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"azure_ai/m", "openrouter/n"})
+        assert HITS == ["/v1/models"]
+
+    def test_the_gateway_key_and_headers_ride_along(self, gateway: str) -> None:
+        """The catalog must be fetched through the same admission the calls use, or a
+        header-admission gateway answers 403 and every model reads as absent."""
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        fetch_gateway_catalog(_config(gateway, api_key="sk-gw", headers={"X-Admission": "tok"}))
+        assert SEEN_HEADERS[0]["authorization"] == "Bearer sk-gw"
+        assert SEEN_HEADERS[0]["x-admission"] == "tok"
+
+    def test_entries_without_an_id_are_skipped(self, gateway: str) -> None:
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}, {}, {"id": ""}, "junk"]})))
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+
+
+class TestUnreadableAnswers:
+    @pytest.mark.parametrize(
+        ("status", "body", "case"),
+        [
+            (200, json.dumps({"data": []}), "empty list"),
+            (200, json.dumps({"data": {}}), "data is not a list"),
+            (200, "not json", "malformed body"),
+            (403, json.dumps({"error": "forbidden"}), "rejected"),
+            (500, "boom", "server error"),
+        ],
+    )
+    def test_every_unreadable_shape_maps_to_none(
+        self, gateway: str, status: int, body: str, case: str
+    ) -> None:
+        RESPONSES.append((status, body))
+        assert fetch_gateway_catalog(_config(gateway)) is None, case
+
+    def test_an_unreachable_host_maps_to_none_rather_than_raising(self) -> None:
+        clear_catalog_cache()
+        assert fetch_gateway_catalog(_config("http://127.0.0.1:1/v1"), timeout=2) is None
+
+
+class TestCacheSemantics:
+    def test_a_successful_read_is_cached(self, gateway: str) -> None:
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+        assert len(HITS) == 1
+
+    def test_an_empty_answer_is_not_cached(self, gateway: str) -> None:
+        """The bug this file was written for: an empty answer is called transient in
+        the design, so caching it pinned a whole process on the degraded path."""
+        RESPONSES.append((200, json.dumps({"data": []})))
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        assert fetch_gateway_catalog(_config(gateway)) is None
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+
+    def test_a_failure_is_not_cached(self, gateway: str) -> None:
+        RESPONSES.append((500, "boom"))
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        assert fetch_gateway_catalog(_config(gateway)) is None
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+
+    def test_repeated_failure_stops_retrying(self, gateway: str) -> None:
+        """A gateway that HANGS would otherwise cost the timeout on every client
+        construction for the whole run."""
+        for _ in range(gateway_route.MAX_CATALOG_ATTEMPTS):
+            RESPONSES.append((500, "boom"))
+            assert fetch_gateway_catalog(_config(gateway)) is None
+        before = len(HITS)
+        assert fetch_gateway_catalog(_config(gateway)) is None
+        assert len(HITS) == before, "gave up, so no further request"
+
+    def test_a_success_resets_the_failure_count(self, gateway: str) -> None:
+        RESPONSES.append((500, "boom"))
+        assert fetch_gateway_catalog(_config(gateway)) is None
+        RESPONSES.append((200, json.dumps({"data": [{"id": "m"}]})))
+        assert fetch_gateway_catalog(_config(gateway)) == frozenset({"m"})
+        assert gateway_route._FAILURES.get(_config(gateway).base_url, 0) == 0

--- a/tests/unit/llm/test_gateway_route.py
+++ b/tests/unit/llm/test_gateway_route.py
@@ -1,0 +1,106 @@
+"""Which name a model answers to on the gateway, and what happens when it does not.
+
+The rules pinned here were each derived from a live failure; see
+``docs/LLM_LAYER.md`` § "Speaking to the gateway".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.llm.gateway_route import (
+    GatewayRouteError,
+    resolve_gateway_route,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestRouteName:
+    def test_the_bare_name_wins_when_the_gateway_serves_the_upstream_itself(self) -> None:
+        """A gateway-only model: the engine prefix is not part of its route name."""
+        catalog = frozenset({"azure_ai/cohere-command-a-plus-05-2026"})
+        assert (
+            resolve_gateway_route("openrouter/azure_ai/cohere-command-a-plus-05-2026", catalog)
+            == "azure_ai/cohere-command-a-plus-05-2026"
+        )
+
+    def test_the_full_string_wins_when_the_gateway_proxies_the_provider(self) -> None:
+        """A model reached through the gateway's own OpenRouter route keeps the prefix."""
+        catalog = frozenset({"openrouter/anthropic/claude-sonnet-4.6"})
+        assert (
+            resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", catalog)
+            == "openrouter/anthropic/claude-sonnet-4.6"
+        )
+
+    def test_a_model_the_gateway_does_not_serve_returns_none(self) -> None:
+        assert (
+            resolve_gateway_route("openrouter/anthropic/claude-opus-4.8", frozenset({"x/y"}))
+            is None
+        )
+
+    def test_an_unreadable_catalog_disables_routing_rather_than_failing(self) -> None:
+        """``None`` is "no information": an unreachable gateway must not fail a run."""
+        assert resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", None) is None
+
+    def test_a_provider_less_model_string_has_one_candidate(self) -> None:
+        assert resolve_gateway_route("solo", frozenset({"solo"})) == "solo"
+
+
+class TestAmbiguityIsRefused:
+    """Two names for one model can be two different upstreams, so guessing is refused."""
+
+    both = frozenset({"openrouter/anthropic/claude-sonnet-4.6", "anthropic/claude-sonnet-4.6"})
+
+    def test_two_matches_without_a_preference_raise(self) -> None:
+        with pytest.raises(GatewayRouteError) as excinfo:
+            resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", self.both)
+        message = str(excinfo.value)
+        assert "LLM_PROXY_PREFERRED_ROUTE" in message
+        for name in self.both:
+            assert name in message
+
+    @pytest.mark.parametrize(
+        ("preference", "expected"),
+        [
+            ("openrouter/", "openrouter/anthropic/claude-sonnet-4.6"),
+            ("anthropic/", "anthropic/claude-sonnet-4.6"),
+        ],
+    )
+    def test_the_preference_picks_one(self, preference: str, expected: str) -> None:
+        assert (
+            resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", self.both, preference)
+            == expected
+        )
+
+    def test_a_preference_matching_neither_still_raises(self) -> None:
+        """Silently ignoring the preference would pick a serving path nobody asked for."""
+        with pytest.raises(GatewayRouteError):
+            resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", self.both, "gemini/")
+
+    def test_a_preference_is_ignored_when_there_is_nothing_to_disambiguate(self) -> None:
+        catalog = frozenset({"azure_ai/cohere-command-a-plus-05-2026"})
+        assert (
+            resolve_gateway_route(
+                "openrouter/azure_ai/cohere-command-a-plus-05-2026", catalog, "gemini/"
+            )
+            == "azure_ai/cohere-command-a-plus-05-2026"
+        )
+
+
+class TestUnreadableIsNotAbsent:
+    """An unreadable catalog must not silently take the run off the gateway.
+
+    Leaving the gateway is the unattributed-spend outcome the transport exists to
+    prevent, so a catalog that cannot be read keeps the gateway and the untranslated
+    name; only a catalog that *answers* and omits the model sends it direct. The
+    client owns that split; this pins the resolver half of it.
+    """
+
+    def test_no_catalog_and_no_match_are_both_none_at_this_layer(self) -> None:
+        assert resolve_gateway_route("openrouter/x/y", None) is None
+        assert resolve_gateway_route("openrouter/x/y", frozenset({"other"})) is None
+
+    def test_an_empty_catalog_is_treated_as_no_information(self) -> None:
+        """A gateway that answers with zero models is broken, not authoritative."""
+        assert resolve_gateway_route("openrouter/x/y", frozenset()) is None

--- a/tests/unit/llm/test_gateway_routing_applied.py
+++ b/tests/unit/llm/test_gateway_routing_applied.py
@@ -141,3 +141,50 @@ class TestModelConfigIsUntouched:
         assert client.model_name == FULL
         assert client.config.name == MODEL
         assert client.config.provider == "openrouter"
+
+
+class TestOpenRouterOnlyBodyFieldsAreDropped:
+    def test_the_provider_pin_does_not_ride_to_the_gateway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same class as the usage extension: a non-OpenRouter upstream rejects it."""
+        from tolokaforge.core.models import OpenRouterConfig
+
+        secrets_manager._default_manager = SecretManager(
+            [
+                DictProvider(
+                    {
+                        "OPENROUTER_API_KEY": "sk-or",
+                        "LLM_PROXY_BASE_URL": GATEWAY,
+                        "LLM_PROXY_API_KEY": "sk-gw",
+                    }
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            "tolokaforge.core.llm.client.fetch_gateway_catalog", lambda *_a, **_k: frozenset({FULL})
+        )
+        config = ModelConfig(
+            provider="openrouter",
+            name=MODEL,
+            openrouter=OpenRouterConfig(provider_order=["anthropic"]),
+        )
+        kwargs = _kwargs(LLMClient(config))
+        assert "provider" not in kwargs.get("extra_body", {})
+        assert kwargs["custom_llm_provider"] == "openai"
+
+    def test_it_still_rides_when_the_call_is_not_routed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tolokaforge.core.models import OpenRouterConfig
+
+        secrets_manager._default_manager = SecretManager(
+            [DictProvider({"OPENROUTER_API_KEY": "sk"})]
+        )
+        config = ModelConfig(
+            provider="openrouter",
+            name=MODEL,
+            openrouter=OpenRouterConfig(provider_order=["anthropic"]),
+        )
+        kwargs = _kwargs(LLMClient(config))
+        assert kwargs["extra_body"]["provider"]["order"] == ["anthropic"]

--- a/tests/unit/llm/test_gateway_routing_applied.py
+++ b/tests/unit/llm/test_gateway_routing_applied.py
@@ -17,7 +17,6 @@ from typing import Any
 
 import pytest
 
-from tolokaforge.core.llm import gateway_route
 from tolokaforge.core.llm.client import LLMClient
 from tolokaforge.core.models import Message, MessageRole, ModelConfig
 from tolokaforge.secrets import DictProvider, SecretManager
@@ -32,13 +31,13 @@ FULL = f"openrouter/{MODEL}"
 
 @pytest.fixture(autouse=True)
 def _isolate() -> Iterator[None]:
+    """The directory conftest already clears the catalog cache; this restores the
+    secrets singleton and os.environ, which client construction mutates."""
     original_manager = secrets_manager._default_manager
     original_env = dict(os.environ)
-    gateway_route.clear_catalog_cache()
     try:
         yield
     finally:
-        gateway_route.clear_catalog_cache()
         secrets_manager._default_manager = original_manager
         os.environ.clear()
         os.environ.update(original_env)
@@ -59,7 +58,7 @@ def _client(
             )
         ]
     )
-    monkeypatch.setattr(gateway_route, "fetch_gateway_catalog", lambda *_a, **_k: catalog)
+    # client.py imports the name, so only its binding is live.
     monkeypatch.setattr(
         "tolokaforge.core.llm.client.fetch_gateway_catalog", lambda *_a, **_k: catalog
     )

--- a/tests/unit/llm/test_gateway_routing_applied.py
+++ b/tests/unit/llm/test_gateway_routing_applied.py
@@ -1,0 +1,143 @@
+"""The client half of gateway routing: what actually reaches litellm.
+
+The resolver is pinned in test_gateway_route.py. This pins the wiring, because a
+resolver that returns the right answer into a call site that ignores it is a feature
+that does not exist. Each test here fails if the payload in ``_build_kwargs`` or the
+constructor's three-outcome split is removed.
+
+The catalog fetch is monkeypatched throughout: unit tests do no network I/O, and the
+module-level cache is cleared so ordering cannot leak a catalog between tests.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.llm import gateway_route
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.models import Message, MessageRole, ModelConfig
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import manager as secrets_manager
+
+pytestmark = pytest.mark.unit
+
+GATEWAY = "https://gateway.example.com"
+MODEL = "anthropic/claude-sonnet-4.6"
+FULL = f"openrouter/{MODEL}"
+
+
+@pytest.fixture(autouse=True)
+def _isolate() -> Iterator[None]:
+    original_manager = secrets_manager._default_manager
+    original_env = dict(os.environ)
+    gateway_route.clear_catalog_cache()
+    try:
+        yield
+    finally:
+        gateway_route.clear_catalog_cache()
+        secrets_manager._default_manager = original_manager
+        os.environ.clear()
+        os.environ.update(original_env)
+
+
+def _client(
+    catalog: frozenset[str] | None, monkeypatch: pytest.MonkeyPatch, **extra: str
+) -> LLMClient:
+    secrets_manager._default_manager = SecretManager(
+        [
+            DictProvider(
+                {
+                    "OPENROUTER_API_KEY": "sk-or",
+                    "LLM_PROXY_BASE_URL": GATEWAY,
+                    "LLM_PROXY_API_KEY": "sk-gw",
+                    **extra,
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(gateway_route, "fetch_gateway_catalog", lambda *_a, **_k: catalog)
+    monkeypatch.setattr(
+        "tolokaforge.core.llm.client.fetch_gateway_catalog", lambda *_a, **_k: catalog
+    )
+    return LLMClient(ModelConfig(provider="openrouter", name=MODEL))
+
+
+def _kwargs(client: LLMClient) -> dict[str, Any]:
+    return client._build_kwargs(
+        system="s",
+        messages=[Message(role=MessageRole.USER, content="x")],
+        tools=None,
+        tool_choice=None,
+        temperature=None,
+        seed=None,
+        reasoning=None,
+        top_p=None,
+        max_tokens=None,
+    )
+
+
+class TestCatalogNamesTheModel:
+    def test_the_gateway_route_name_replaces_the_model_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        kwargs = _kwargs(_client(frozenset({FULL}), monkeypatch))
+        assert kwargs["model"] == FULL
+        assert kwargs["api_base"] == GATEWAY
+
+    def test_the_bare_name_is_used_when_that_is_what_the_gateway_serves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        kwargs = _kwargs(_client(frozenset({MODEL}), monkeypatch))
+        assert kwargs["model"] == MODEL
+
+    def test_the_dialect_becomes_the_gateways_own(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without this litellm adds OpenRouter's ``usage`` extension, which every
+        other upstream rejects."""
+        assert _kwargs(_client(frozenset({FULL}), monkeypatch))["custom_llm_provider"] == "openai"
+
+
+class TestCatalogAnswersAndOmits:
+    def test_the_call_goes_to_the_provider_directly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A gateway that does not serve the model must not intercept it."""
+        client = _client(frozenset({"some/other-model"}), monkeypatch)
+        kwargs = _kwargs(client)
+        assert client._proxy is None
+        assert "api_base" not in kwargs
+        assert kwargs["model"] == FULL
+
+
+class TestCatalogUnreadable:
+    @pytest.mark.parametrize("catalog", [None], ids=["unreadable"])
+    def test_the_gateway_is_kept_with_the_untranslated_name(
+        self, catalog: frozenset[str] | None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unreadable is not absence: leaving the gateway on a blip is the
+        unattributed-spend outcome this transport exists to prevent."""
+        client = _client(catalog, monkeypatch)
+        kwargs = _kwargs(client)
+        assert client._proxy is not None
+        assert kwargs["api_base"] == GATEWAY
+        assert kwargs["model"] == FULL
+        assert kwargs.get("custom_llm_provider") != "openai"
+
+
+class TestPreferenceReachesTheClient:
+    def test_the_preferred_namespace_picks_the_route(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        both = frozenset({FULL, MODEL})
+        kwargs = _kwargs(_client(both, monkeypatch, LLM_PROXY_PREFERRED_ROUTE="openrouter/"))
+        assert kwargs["model"] == FULL
+
+
+class TestModelConfigIsUntouched:
+    def test_rewriting_the_wire_name_does_not_move_presets_or_pricing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both key off ModelConfig, so the wire rename must not reach them."""
+        client = _client(frozenset({MODEL}), monkeypatch)
+        assert client.model_name == FULL
+        assert client.config.name == MODEL
+        assert client.config.provider == "openrouter"

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -191,6 +191,7 @@ class TestProxyConfigValidation:
             "LLM_PROXY_HEADERS",
             "LLM_PROXY_REQUEST_ID_HEADER",
             "LLM_PROXY_PROVIDERS",
+            "LLM_PROXY_PREFERRED_ROUTE",
         ],
     )
     def test_companion_without_base_url_raises(self, install_secrets, orphan: str) -> None:

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -4,10 +4,11 @@ Covers the two halves of the feature:
 
 * :mod:`tolokaforge.core.llm.proxy` — resolving and validating the env
   contract.
-* :class:`~tolokaforge.core.llm.client.LLMClient` — applying it as a *transport
-  swap only*, which is the load-bearing invariant: the litellm model string
-  must keep its ``<provider>/<name>`` shape so preset resolution and pricing
-  normalisation stay untouched.
+* :class:`~tolokaforge.core.llm.client.LLMClient` — applying it, on the branch
+  where the gateway catalog is unreadable so the model string is left alone. The
+  route-resolving branches live in test_gateway_routing_applied.py. What preset
+  resolution and pricing key off either way is ``ModelConfig``, never the wire
+  name.
 """
 
 from __future__ import annotations
@@ -336,7 +337,11 @@ class TestHeaderSecretRefs:
 
 
 class TestClientAppliesProxy:
-    """``LLMClient`` treats the gateway as a transport swap and nothing more."""
+    """``LLMClient`` applying the gateway, with the catalog unreadable.
+
+    The autouse fixture in conftest.py stubs the catalog fetch to ``None``, so these
+    pin the degraded branch rather than a general invariant.
+    """
 
     def test_kwargs_carry_base_url_and_key(self, install_secrets) -> None:
         install_secrets(
@@ -349,12 +354,19 @@ class TestClientAppliesProxy:
         assert kwargs["api_base"] == "https://gateway.example.com"
         assert kwargs["api_key"] == "sk-gateway"
 
-    def test_model_string_is_unchanged(self, install_secrets) -> None:
-        """The invariant that keeps presets and pricing working."""
+    def test_an_unreadable_catalog_leaves_the_model_string_alone(self, install_secrets) -> None:
+        """Pins the unreadable-catalog branch, not a general invariant.
+
+        A readable catalog naming the model DOES rewrite this to the gateway's route
+        name; that path is covered in test_gateway_routing_applied.py. What presets and
+        pricing actually key off is ``ModelConfig``, asserted below.
+        """
         install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
         config = ModelConfig(provider="openrouter", name="anthropic/claude-opus-4.7")
         kwargs = _build_kwargs(config)
         assert kwargs["model"] == "openrouter/anthropic/claude-opus-4.7"
+        assert config.provider == "openrouter"
+        assert config.name == "anthropic/claude-opus-4.7"
 
     def test_configured_headers_reach_the_request(self, install_secrets) -> None:
         install_secrets(

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -41,6 +41,7 @@ from tenacity.wait import wait_base
 
 from tolokaforge.core.actors.actor import Actor
 from tolokaforge.core.llm.capabilities import ModelCapabilities
+from tolokaforge.core.llm.gateway_route import fetch_gateway_catalog, resolve_gateway_route
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.llm.prompt_policy import detect_dict_maps
 from tolokaforge.core.llm.proxy import UNROUTABLE_PROVIDERS, resolve_proxy_config
@@ -664,6 +665,32 @@ class LLMClient:
                     provider=self.provider,
                 )
             self._proxy = None
+
+        # A gateway that does not serve this model must not intercept it: fall back
+        # to the direct provider rather than post a name it cannot route.
+        # docs/LLM_LAYER.md § Speaking to the gateway.
+        self._gateway_route: str | None = None
+        if self._proxy is not None:
+            catalog = fetch_gateway_catalog(self._proxy)
+            if catalog is None:
+                # Unreadable is NOT "absent": silently leaving the gateway would be
+                # the unattributed-spend outcome this transport exists to prevent.
+                self.logger.warning(
+                    "Gateway catalog unreadable; routing on the untranslated name",
+                    base_url=self._proxy.base_url,
+                    model=self.model_name,
+                )
+            else:
+                self._gateway_route = resolve_gateway_route(
+                    self.model_name, catalog, self._proxy.preferred_route
+                )
+                if self._gateway_route is None:
+                    self.logger.warning(
+                        "Gateway does not serve this model; calling the provider directly",
+                        base_url=self._proxy.base_url,
+                        model=self.model_name,
+                    )
+                    self._proxy = None
 
         self._openrouter_headers = (
             self._configure_openrouter_headers() if self.provider.startswith("openrouter") else {}
@@ -1740,9 +1767,13 @@ class LLMClient:
                 }
 
         if self._proxy is not None:
-            # Transport swap only. ``model`` keeps its ``<provider>/<name>``
-            # shape so preset resolution and pricing normalisation are
-            # untouched — see the module docstring in ``llm/proxy.py``.
+            # The gateway is an OpenAI-compatible endpoint, so speak that dialect
+            # and address it by ITS route name. docs/LLM_LAYER.md § Speaking to the
+            # gateway has the failure modes this replaces.
+            route = self._gateway_route
+            if route is not None:
+                kwargs["model"] = route
+                kwargs["custom_llm_provider"] = "openai"
             kwargs["api_base"] = self._proxy.base_url
             if self._proxy.api_key:
                 kwargs["api_key"] = self._proxy.api_key

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1774,6 +1774,13 @@ class LLMClient:
             if route is not None:
                 kwargs["model"] = route
                 kwargs["custom_llm_provider"] = "openai"
+                # Same class as the usage extension the dialect switch removes: an
+                # OpenRouter-only body field a non-OpenRouter upstream rejects.
+                extra_body = kwargs.get("extra_body")
+                if isinstance(extra_body, dict):
+                    extra_body.pop("provider", None)
+                    if not extra_body:
+                        kwargs.pop("extra_body")
             kwargs["api_base"] = self._proxy.base_url
             if self._proxy.api_key:
                 kwargs["api_key"] = self._proxy.api_key

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1948,7 +1948,9 @@ class LLMClient:
                     if not kwargs["model"].startswith("openai/"):
                         kwargs["model"] = f"openai/{kwargs['model']}"
 
-                elif "/" in self.config.provider:
+                elif self._gateway_route is None and "/" in self.config.provider:
+                    # Not when routed: _build_kwargs already set the gateway's dialect
+                    # and overwriting it here reverts the name AND the body shape.
                     base_provider = self.config.provider.split("/")[0]
                     kwargs["custom_llm_provider"] = base_provider
 

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -681,6 +681,8 @@ class LLMClient:
                     model=self.model_name,
                 )
             else:
+                # A readable catalog is never empty here: the fetch maps an empty
+                # answer to None, so resolver-None below can only mean "omitted".
                 self._gateway_route = resolve_gateway_route(
                     self.model_name, catalog, self._proxy.preferred_route
                 )

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import http.client
 import json
 import logging
+import time
 import urllib.error
 import urllib.request
 from typing import TYPE_CHECKING
@@ -30,12 +31,14 @@ logger = logging.getLogger(__name__)
 #: caching it would keep a whole run degraded after one blip.
 _CATALOG_CACHE: dict[str, frozenset[str]] = {}
 
-#: Consecutive failures per base URL, so a gateway that HANGS costs the timeout a
-#: bounded number of times instead of once per client construction for a whole run.
-_FAILURES: dict[str, int] = {}
+#: When a base URL may be retried again, so a gateway that HANGS costs the timeout
+#: occasionally rather than on every client construction. Time-based rather than a
+#: hard cap: constructions cluster at run start, so a cap would burn every attempt
+#: during warmup and pin a long run on the degraded path with no way back.
+_RETRY_AFTER: dict[str, float] = {}
 
-#: Give up for the process after this many consecutive failures.
-MAX_CATALOG_ATTEMPTS = 3
+#: How long to stop asking after a failure.
+CATALOG_RETRY_COOLDOWN_S = 60.0
 
 
 class GatewayRouteError(Exception):
@@ -45,7 +48,7 @@ class GatewayRouteError(Exception):
 def clear_catalog_cache() -> None:
     """Drop the cached catalogs and the failure counters. For tests."""
     _CATALOG_CACHE.clear()
-    _FAILURES.clear()
+    _RETRY_AFTER.clear()
 
 
 def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[str] | None:
@@ -60,7 +63,7 @@ def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[st
     cached = _CATALOG_CACHE.get(key)
     if cached is not None:
         return cached
-    if _FAILURES.get(key, 0) >= MAX_CATALOG_ATTEMPTS:
+    if time.monotonic() < _RETRY_AFTER.get(key, 0.0):
         return None
 
     url = proxy.base_url.rstrip("/") + "/models"
@@ -87,11 +90,11 @@ def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[st
         ValueError,
         OSError,
     ) as exc:
-        _FAILURES[key] = _FAILURES.get(key, 0) + 1
+        _RETRY_AFTER[key] = time.monotonic() + CATALOG_RETRY_COOLDOWN_S
         logger.warning("Gateway catalog unreadable at %s: %s", url, exc)
         return None
 
-    _FAILURES.pop(key, None)
+    _RETRY_AFTER.pop(key, None)
     _CATALOG_CACHE[key] = served
     return served
 

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -25,10 +25,17 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-#: Successful reads only, cached per base URL: a catalog changes when an operator
-#: edits the gateway, not within a run, while a failure is transient and caching it
-#: would keep a whole run on the degraded path after one blip.
-_CATALOG_CACHE: dict[str, frozenset[str] | None] = {}
+#: Successful, non-empty reads only, keyed by base URL: a catalog changes when an
+#: operator edits the gateway, not within a run, while a failure is transient and
+#: caching it would keep a whole run degraded after one blip.
+_CATALOG_CACHE: dict[str, frozenset[str]] = {}
+
+#: Consecutive failures per base URL, so a gateway that HANGS costs the timeout a
+#: bounded number of times instead of once per client construction for a whole run.
+_FAILURES: dict[str, int] = {}
+
+#: Give up for the process after this many consecutive failures.
+MAX_CATALOG_ATTEMPTS = 3
 
 
 class GatewayRouteError(Exception):
@@ -36,19 +43,25 @@ class GatewayRouteError(Exception):
 
 
 def clear_catalog_cache() -> None:
-    """Drop the cached catalogs. For tests and long-lived processes."""
+    """Drop the cached catalogs and the failure counters. For tests."""
     _CATALOG_CACHE.clear()
+    _FAILURES.clear()
 
 
 def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[str] | None:
     """Route ids the gateway serves, or ``None`` when the catalog cannot be read.
 
-    ``None`` is "no information", never an error to propagate: an unreadable catalog
-    must leave routing exactly as it was rather than fail a run.
+    ``None`` is "no information", never an error to propagate: the caller keeps the
+    gateway and skips rewriting rather than failing a run. An **empty** answer counts
+    as unreadable, since a gateway that serves nothing is broken rather than
+    authoritative.
     """
     key = proxy.base_url
-    if key in _CATALOG_CACHE:
-        return _CATALOG_CACHE[key]
+    cached = _CATALOG_CACHE.get(key)
+    if cached is not None:
+        return cached
+    if _FAILURES.get(key, 0) >= MAX_CATALOG_ATTEMPTS:
+        return None
 
     url = proxy.base_url.rstrip("/") + "/models"
     headers = {"Accept": "application/json", **proxy.request_headers()}
@@ -65,7 +78,8 @@ def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[st
         # An empty catalog is a broken answer, not an authoritative "serves nothing":
         # treating it as authoritative would take the run off the gateway.
         served = frozenset(str(e["id"]) for e in entries if isinstance(e, dict) and e.get("id"))
-        catalog: frozenset[str] | None = served if served else None
+        if not served:
+            raise ValueError("the catalog is empty")
     except (
         urllib.error.URLError,
         http.client.HTTPException,
@@ -73,11 +87,13 @@ def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[st
         ValueError,
         OSError,
     ) as exc:
+        _FAILURES[key] = _FAILURES.get(key, 0) + 1
         logger.warning("Gateway catalog unreadable at %s: %s", url, exc)
         return None
 
-    _CATALOG_CACHE[key] = catalog
-    return catalog
+    _FAILURES.pop(key, None)
+    _CATALOG_CACHE[key] = served
+    return served
 
 
 def _candidates(model_string: str) -> list[str]:
@@ -87,7 +103,7 @@ def _candidates(model_string: str) -> list[str]:
     proxies that provider) or the bare ``<name>`` (the gateway serves the upstream
     itself under the name's own namespace).
     """
-    head, _, tail = model_string.partition("/")
+    _, _, tail = model_string.partition("/")
     return [model_string] if not tail else [model_string, tail]
 
 
@@ -100,7 +116,9 @@ def resolve_gateway_route(
 
     Args:
         model_string: The engine's litellm model string, ``<provider>/<name>``.
-        catalog: Route ids from :func:`fetch_gateway_catalog`; ``None`` disables routing.
+        catalog: Route ids from :func:`fetch_gateway_catalog`. ``None`` means the
+            catalog could not be read, which the caller treats as "keep the gateway,
+            skip rewriting" rather than as "not served".
         preferred_prefix: Namespace that wins when the gateway serves the model under
             more than one name.
 

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -1,0 +1,121 @@
+"""Which name does a model answer to on the gateway, and does it answer at all.
+
+See ``docs/LLM_LAYER.md`` § "Speaking to the gateway" for why the gateway needs its
+own model name and its own dialect, and what goes wrong without them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tolokaforge.core.llm.proxy import ProxyConfig
+
+__all__ = [
+    "GatewayRouteError",
+    "resolve_gateway_route",
+    "fetch_gateway_catalog",
+    "clear_catalog_cache",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Cached per base URL. A catalog changes when an operator edits the gateway, not
+#: within a run, and a run builds one client per role per trial.
+_CATALOG_CACHE: dict[str, frozenset[str] | None] = {}
+
+
+class GatewayRouteError(Exception):
+    """The gateway serves this model under more than one name and none was chosen."""
+
+
+def clear_catalog_cache() -> None:
+    """Drop the cached catalogs. For tests and long-lived processes."""
+    _CATALOG_CACHE.clear()
+
+
+def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[str] | None:
+    """Route ids the gateway serves, or ``None`` when the catalog cannot be read.
+
+    ``None`` is "no information", never an error to propagate: an unreadable catalog
+    must leave routing exactly as it was rather than fail a run.
+    """
+    key = proxy.base_url
+    if key in _CATALOG_CACHE:
+        return _CATALOG_CACHE[key]
+
+    url = proxy.base_url.rstrip("/") + "/models"
+    headers = {"Accept": "application/json", **proxy.request_headers()}
+    if proxy.api_key:
+        headers["Authorization"] = f"Bearer {proxy.api_key}"
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - operator-supplied gateway URL
+            urllib.request.Request(url, headers=headers), timeout=timeout
+        ) as response:
+            payload = json.load(response)
+        entries = payload.get("data")
+        if not isinstance(entries, list):
+            raise ValueError(f"expected a data list, got {type(entries).__name__}")
+        catalog: frozenset[str] | None = frozenset(
+            str(e["id"]) for e in entries if isinstance(e, dict) and e.get("id")
+        )
+    except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError, OSError) as exc:
+        logger.warning("Gateway catalog unreadable at %s: %s", url, exc)
+        catalog = None
+
+    _CATALOG_CACHE[key] = catalog
+    return catalog
+
+
+def _candidates(model_string: str) -> list[str]:
+    """The names this model could answer to on the gateway, most specific first.
+
+    A gateway entry is either the engine's full ``<provider>/<name>`` (the gateway
+    proxies that provider) or the bare ``<name>`` (the gateway serves the upstream
+    itself under the name's own namespace).
+    """
+    head, _, tail = model_string.partition("/")
+    return [model_string] if not tail else [model_string, tail]
+
+
+def resolve_gateway_route(
+    model_string: str,
+    catalog: frozenset[str] | None,
+    preferred_prefix: str | None = None,
+) -> str | None:
+    """Return the gateway's name for ``model_string``, or ``None`` if it serves none.
+
+    Args:
+        model_string: The engine's litellm model string, ``<provider>/<name>``.
+        catalog: Route ids from :func:`fetch_gateway_catalog`; ``None`` disables routing.
+        preferred_prefix: Namespace that wins when the gateway serves the model under
+            more than one name.
+
+    Raises:
+        GatewayRouteError: Several names match and ``preferred_prefix`` picks none of
+            them. Guessing is refused: the names can be backed by different upstreams,
+            which changes the serving path rather than the transport.
+    """
+    if not catalog:
+        return None
+
+    hits = [c for c in _candidates(model_string) if c in catalog]
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+
+    if preferred_prefix:
+        for hit in hits:
+            if hit.startswith(preferred_prefix):
+                return hit
+    raise GatewayRouteError(
+        f"the gateway serves {model_string!r} under {len(hits)} names ({', '.join(hits)}) "
+        f"and no preference picks one. They can be backed by different upstreams, so "
+        f"this is a serving-path choice rather than a transport detail: set "
+        f"LLM_PROXY_PREFERRED_ROUTE to the namespace you want."
+    )

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -6,6 +6,7 @@ own model name and its own dialect, and what goes wrong without them.
 
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import urllib.error
@@ -24,8 +25,9 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-#: Cached per base URL. A catalog changes when an operator edits the gateway, not
-#: within a run, and a run builds one client per role per trial.
+#: Successful reads only, cached per base URL: a catalog changes when an operator
+#: edits the gateway, not within a run, while a failure is transient and caching it
+#: would keep a whole run on the degraded path after one blip.
 _CATALOG_CACHE: dict[str, frozenset[str] | None] = {}
 
 
@@ -60,12 +62,19 @@ def fetch_gateway_catalog(proxy: ProxyConfig, timeout: int = 15) -> frozenset[st
         entries = payload.get("data")
         if not isinstance(entries, list):
             raise ValueError(f"expected a data list, got {type(entries).__name__}")
-        catalog: frozenset[str] | None = frozenset(
-            str(e["id"]) for e in entries if isinstance(e, dict) and e.get("id")
-        )
-    except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError, OSError) as exc:
+        # An empty catalog is a broken answer, not an authoritative "serves nothing":
+        # treating it as authoritative would take the run off the gateway.
+        served = frozenset(str(e["id"]) for e in entries if isinstance(e, dict) and e.get("id"))
+        catalog: frozenset[str] | None = served if served else None
+    except (
+        urllib.error.URLError,
+        http.client.HTTPException,
+        TimeoutError,
+        ValueError,
+        OSError,
+    ) as exc:
         logger.warning("Gateway catalog unreadable at %s: %s", url, exc)
-        catalog = None
+        return None
 
     _CATALOG_CACHE[key] = catalog
     return catalog

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -119,6 +119,7 @@ ENV_API_KEY = "LLM_PROXY_API_KEY"
 ENV_HEADERS = "LLM_PROXY_HEADERS"
 ENV_REQUEST_ID_HEADER = "LLM_PROXY_REQUEST_ID_HEADER"
 ENV_PROVIDERS = "LLM_PROXY_PROVIDERS"
+ENV_PREFERRED_ROUTE = "LLM_PROXY_PREFERRED_ROUTE"
 
 #: Providers routed when ``LLM_PROXY_PROVIDERS`` is unset.
 #:
@@ -179,6 +180,7 @@ class ProxyConfig:
     headers: dict[str, str] = field(default_factory=dict)
     request_id_header: str | None = None
     providers: frozenset[str] | None = None
+    preferred_route: str | None = None
 
     def applies_to(self, provider: str) -> bool:
         """Return whether ``provider`` should be routed through the gateway.
@@ -300,7 +302,13 @@ def resolve_proxy_config() -> ProxyConfig | None:
         # direct provider access.
         orphans = sorted(
             name
-            for name in (ENV_API_KEY, ENV_HEADERS, ENV_REQUEST_ID_HEADER, ENV_PROVIDERS)
+            for name in (
+                ENV_API_KEY,
+                ENV_HEADERS,
+                ENV_REQUEST_ID_HEADER,
+                ENV_PROVIDERS,
+                ENV_PREFERRED_ROUTE,
+            )
             if (secrets.get_secret(name) or "").strip()
         )
         if orphans:
@@ -317,4 +325,5 @@ def resolve_proxy_config() -> ProxyConfig | None:
         headers=_parse_headers(secrets.get_secret(ENV_HEADERS), secrets),
         request_id_header=(secrets.get_secret(ENV_REQUEST_ID_HEADER) or "").strip() or None,
         providers=_parse_providers(secrets.get_secret(ENV_PROVIDERS)),
+        preferred_route=(secrets.get_secret(ENV_PREFERRED_ROUTE) or "").strip() or None,
     )

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -82,10 +82,10 @@ serves this provider's native route" — true for a LiteLLM proxy's
 :data:`UNROUTABLE_PROVIDERS` cannot be opted in at all and are rejected
 loudly, because no gateway can serve them (see that constant).
 
-Routed calls now DO force the OpenAI envelope, because that is the gateway's own
+Routed calls force the OpenAI envelope, because that is the gateway's own
 protocol; see ``docs/LLM_LAYER.md`` § "Speaking to the gateway". Widening
 ``LLM_PROXY_PROVIDERS`` to a provider whose gateway route is a native passthrough
-rather than an OpenAI-compatible one is therefore still not supported.
+rather than an OpenAI-compatible one is not supported.
 
 The model name on the wire
 --------------------------

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -82,24 +82,20 @@ serves this provider's native route" — true for a LiteLLM proxy's
 :data:`UNROUTABLE_PROVIDERS` cannot be opted in at all and are rejected
 loudly, because no gateway can serve them (see that constant).
 
-Widening the default to *every* provider would need this module to force the
-OpenAI envelope (``custom_llm_provider="openai"`` on routed calls, as the Nova
-path already does) rather than only swapping the base URL. That is a larger
-change than a transport swap — it collides with the ``custom_llm_provider`` the
-OpenRouter branch sets — and is deliberately not attempted here.
+Routed calls now DO force the OpenAI envelope, because that is the gateway's own
+protocol; see ``docs/LLM_LAYER.md`` § "Speaking to the gateway". Widening
+``LLM_PROXY_PROVIDERS`` to a provider whose gateway route is a native passthrough
+rather than an OpenAI-compatible one is therefore still not supported.
 
-Why the model name is left alone
---------------------------------
+The model name on the wire
+--------------------------
 
-:meth:`LLMClient._build_kwargs` applies this transport by setting ``api_base``
-and ``api_key`` only. The litellm model string keeps its original
-``<provider>/<name>`` shape. Only one thing depends on that string:
-:func:`tolokaforge.core.pricing.normalize_model_name` keys off it, and it
-returns any second-prefixed name verbatim, guaranteeing a pricing-table miss
-that degrades ``cost_source`` to ``"unknown"``. Presets are *not* coupled to it
-— ``build_capabilities`` resolves off ``ModelConfig.name`` / ``.provider``
-directly — but renaming *those* to gateway-specific values does drop the
-matched preset and the ``providers:`` overlay. See ``docs/LLM_LAYER.md`` § proxy.
+Routed calls are addressed by the gateway's route name, resolved from its catalog
+(:mod:`tolokaforge.core.llm.gateway_route`). ``ModelConfig.provider`` / ``.name`` are
+untouched, so preset resolution and
+:func:`tolokaforge.core.pricing.normalize_model_name` are unaffected: both key off
+the config, not off the wire name. See ``docs/LLM_LAYER.md`` § "Speaking to the
+gateway" for the three catalog outcomes.
 """
 
 from __future__ import annotations

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -14,14 +14,12 @@ a transport detail. The automaton surfaces the option; a human picks it.
 Which name reaches the gateway
 ------------------------------
 
-The name that reaches the gateway is **not** the engine's litellm model string.
-litellm strips exactly one provider prefix, so the integration's ``provider:
-openrouter`` + ``name: x-ai/grok-4.5`` sends the bare ``x-ai/grok-4.5`` — an
-``openrouter/x-ai/grok-4.5`` entry is a route this run cannot reach without the
-gateway-named config in ``docs/LLM_LAYER.md`` § "The model name must be the
-gateway's route name". So the lookup is keyed on the bare slug, and the wildcard
-that counts is one covering the slug's own namespace (``x-ai/*``), not
-``openrouter/*``.
+The engine resolves the gateway's route name from this same catalog and addresses
+the gateway by it, trying ``openrouter/<slug>`` and then the bare ``<slug>``
+(``tolokaforge.core.llm.gateway_route``). So both shapes are reachable and this
+lookup checks both, in the same order. The wildcard that counts is still one
+covering the slug's own namespace (``x-ai/*``), because a wildcard says the
+gateway will forward the request, not that the model exists behind it.
 
 An exact entry and a wildcard are **not** equally strong evidence, so they are
 reported separately: an exact entry means someone configured this model; a
@@ -131,20 +129,18 @@ def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
 def lookup(slug: str, catalog: list[str] | None) -> Availability:
     """Classify how (or whether) ``slug`` is reachable on the gateway.
 
-    The name checked is the one that actually reaches the gateway. litellm strips
-    exactly one provider prefix, so the integration's ``provider: openrouter`` +
-    ``name: <slug>`` config puts the BARE ``<slug>`` on the wire -- an
-    ``openrouter/<slug>`` catalog entry is NOT evidence for this run. Reaching a
-    prefixed route needs the gateway-named config in ``docs/LLM_LAYER.md`` under
-    "The model name must be the gateway's route name", which the integration
-    workflow does not use.
+    Both names the engine can reach are checked, in its order: the prefixed
+    ``openrouter/<slug>`` first, then the bare ``<slug>``. The engine resolves the
+    route name from this same catalog and addresses the gateway by it, so a
+    prefixed-only entry IS reachable. See ``tolokaforge.core.llm.gateway_route``.
     """
     if catalog is None:
         return Availability(slug=slug, status=STATUS_UNKNOWN)
 
     entries = set(catalog)
-    if slug in entries:
-        return Availability(slug=slug, status=STATUS_EXACT, route=slug)
+    for candidate in (f"openrouter/{slug}", slug):
+        if candidate in entries:
+            return Availability(slug=slug, status=STATUS_EXACT, route=candidate)
     namespace = slug.split("/", 1)[0]
     if f"{namespace}/*" in entries or "*" in entries:
         return Availability(slug=slug, status=STATUS_WILDCARD, route=slug)

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -29,11 +29,19 @@ _CATALOG = [
 
 
 class TestLookup:
-    def test_prefixed_entry_is_not_evidence_for_this_run(self) -> None:
-        """litellm strips `openrouter/`, so the run asks for the BARE slug (LLM_LAYER.md)."""
+    def test_a_prefixed_entry_is_reachable_and_reported_with_its_route(self) -> None:
+        """The engine resolves the route name from this catalog and addresses the
+        gateway by it, so a prefixed-only entry IS reachable. Reporting it absent was
+        the bug that made the poller disagree with the engine."""
         found = gateway_catalog.lookup("anthropic/claude-opus-4.7", _CATALOG)
-        assert found.status == gateway_catalog.STATUS_ABSENT
-        assert not found.reachable
+        assert found.status == gateway_catalog.STATUS_EXACT
+        assert found.route == "openrouter/anthropic/claude-opus-4.7"
+        assert found.reachable
+
+    def test_the_prefixed_entry_wins_over_the_bare_one(self) -> None:
+        """Same order the engine tries, so the two never disagree."""
+        catalog = ["openrouter/a/b", "a/b"]
+        assert gateway_catalog.lookup("a/b", catalog).route == "openrouter/a/b"
 
     def test_bare_slug_entry_is_the_exact_match(self) -> None:
         found = gateway_catalog.lookup("azure_ai/cohere-command-a-plus-05-2026", _CATALOG)


### PR DESCRIPTION
## The problem

An evaluation run cannot use a gateway for the models the gateway actually serves. Two independent defects, both measured against a live LiteLLM proxy:

**1. The gateway is addressed in the wrong dialect.** litellm's OpenRouter transformation unconditionally adds `usage: {"include": true}` to the request body ("ALWAYS add usage parameter to get cost data from OpenRouter", `openrouter/chat/transformation.py`). That is an OpenRouter extension. A gateway forwards it to whatever upstream backs the route, and every non-OpenRouter upstream rejects it:

```
anthropic-direct/claude-sonnet-4-6   usage: Extra inputs are not permitted   (Anthropic)
anthropic/claude-sonnet-4-6          usage: Extra inputs are not permitted   (Bedrock)
```

**2. The gateway is addressed by the wrong name.** The gateway's route name is not the engine's model string, and is not derivable from it. Worse, the two defects are coupled: the OpenRouter transport strips one leading `openrouter/` and the OpenAI transport does not, so *changing the dialect changes the name that arrives*. Measured, same model, same gateway:

| dialect | name on the wire | result |
|---|---|---|
| `openrouter` | `anthropic/claude-sonnet-4.6` | `model identifier is invalid` |
| `openai` | `openrouter/anthropic/claude-sonnet-4.6` | works |

and in the opposite direction for a gateway-only model:

| dialect | name on the wire | result |
|---|---|---|
| `openrouter` | `azure_ai/cohere-command-a-plus-05-2026` | works |
| `openai` | `openrouter/azure_ai/cohere-command-a-plus-05-2026` | `is not a valid model ID` |

So neither dialect is right for both, and no fixed name rule works either.

### What this cost, concretely

A real auto-integration run over the `litellm` route ([31172961198](https://github.com/Toloka/tolokaforge/actions/runs/31172961198)) went `needs-human: observe infra-dirty` with **95 API errors and 948 `model identifier is invalid`** in the wire probes. The candidate reached the gateway; the user simulator alongside it did not, because its name is only valid under the other dialect. `integrate-model.yml`'s own comment records the constraint that produced this: *"the gateway must serve BOTH models"*.

This is also the deferred work `proxy.py`'s module docstring already names:

> Widening the default to *every* provider would need this module to force the OpenAI envelope (`custom_llm_provider="openai"` on routed calls, as the Nova path already does) rather than only swapping the base URL. That is a larger change than a transport swap [...] and is deliberately not attempted here.

## The fix

A gateway is an OpenAI-compatible endpoint, so routed calls speak that dialect and address the gateway by **its** route name, resolved from `GET {base}/models` at client construction and cached per base URL.

The route name is whichever of `<provider>/<name>` or `<name>` the catalog contains. That is deterministic, needs no fuzzy matching, and covers both shapes above.

Three outcomes, deliberately different:

| catalog says | what happens |
|---|---|
| names the model | route through the gateway under that name, OpenAI dialect |
| answers and omits it | the gateway does not serve it, so call the provider directly |
| unreadable, or an empty answer | keep the gateway, send the untranslated name; a failure starts a 60s cooldown so a hanging catalog is not re-fetched per construction |

The third row is the one worth arguing about. **Unreadable is not absence.** Treating a network blip as "not on the gateway" would silently take a run off the gateway, which is precisely the unattributed-spend outcome this transport exists to prevent. Only a catalog that answers *with something* is authoritative: an empty `data` list is a broken answer (a key without model-list permission, a gateway mid-reload), not a claim that the gateway serves nothing.

Three revisions of this branch got parts of that wrong and were caught rather than shipped: the first disabled the gateway on an unreadable catalog (eight existing tests failed); the second still left it on an *empty* one; the third mapped an empty answer correctly but then negative-cached it, pinning the whole process on the degraded path after one blip. All three are now pinned by tests, the last one against a real local endpoint.

The second row is what makes a mixed run possible at all: a gateway-only candidate and a simulator the gateway does not carry can now run side by side, each on the transport that serves it. That removes the "gateway must serve BOTH models" constraint.

### Ambiguity is refused, not guessed

When the catalog serves one model under several names, those names can be backed by *different upstreams*. Picking one silently would change the serving path, which is a leaderboard-comparability decision rather than a transport detail, and `gateway_catalog.py` already argues this in its own docstring. `LLM_PROXY_PREFERRED_ROUTE` names the namespace that wins; without it the resolver raises and says so.

A documented hard requirement comes with the deterministic rule: **gateway route names must mirror upstream names.** An aliased route (`sonnet-4.6`, `team-default`) is invisible to the two derived candidates, resolves as "not served", and the call quietly goes direct. The docs record that, and record the extension point if everything should ever route through the gateway: a namespace-matched wildcard (accept `openrouter/*` only for `provider: openrouter` configs, where the fallback is the same upstream the board is calibrated on), not looser matching.

## Verification

End to end against the live gateway, all three cases, on this branch:

```
candidate (gateway-only)   gateway=yes          route=azure_ai/cohere-command-a-plus-05-2026
   -> SUCCESS 126 in / 52 out
simulator (on both)        gateway=yes          route=openrouter/anthropic/claude-sonnet-4.6
   -> SUCCESS 15 in / 4 out
not on gateway             gateway=NO (direct)  route=None
   -> SUCCESS 20 in / 4 out
```

The middle line is the 948-error case from the failed run, now working.

```
$ pytest tests/unit/llm/test_gateway_route.py \
         tests/unit/llm/test_gateway_routing_applied.py \
         tests/unit/llm/test_gateway_catalog_fetch.py \
         tests/unit/llm/test_llm_proxy.py \
         tests/canonical/test_llm_gateway_envelope_contract.py -q   86 passed
$ ruff check tolokaforge/ tests/                                    All checks passed!
$ black --check tolokaforge tests                                   clean

$ pytest tests/unit tests/canonical -q
47 failed, 6889 passed, 10 errors
```

**Those 47 are pre-existing on this `main`, not from this branch.** Zero of them are in
`gateway_route`, `test_llm_proxy` or the envelope contract. Checked rather than assumed:
the three largest failing files run on a clean `origin/main` checkout, with none of this
applied, give `31 failed, 42 passed`.

### The wiring is tested, not just the resolver

A resolver returning the right answer into a call site that ignores it is a feature that does not exist, so both halves are mutation-checked. Disabling the route rewrite plus the dialect switch fails 2 tests; never dropping the proxy when the catalog omits the model fails 1. Both of those mutations passed the whole suite before `test_gateway_routing_applied.py` existed.

The unit suite does no network I/O for the wiring: an autouse fixture in `tests/unit/llm/conftest.py` stubs the fetch and clears the cache for the whole LLM lane. Without it, every proxy-configured client construction really attempted a GET, and the suite was green only because that fetch failed.

The fetch itself is tested separately and for real, against a local `http.server`: request shape, the gateway key and admission headers riding along, every unreadable shape (empty list, wrong type, malformed body, 403, 500, unreachable host), and all three cache branches. A gateway that hangs is bounded to three attempts per base URL rather than costing the timeout on every client construction.

## Not in this PR

**The Slack poller now agrees with the engine about reachability** (its `lookup()` mirrors the engine's candidate order, so prefixed-only entries no longer report `absent`), but it still cannot read a header-admission gateway: it reads only the base URL and key from `os.environ` (by design, so a local `.env` cannot answer a real poll) and ignores `LLM_PROXY_HEADERS`. The full unification, one fetcher consuming a `ProxyConfig` with identical empty-catalog semantics everywhere, is tracked in #948.

**Pricing on gateway routes.** `normalize_model_name` keys off the engine's model string, which is unchanged, so pricing behaves exactly as before this PR. A gateway route whose name is absent from the pricing table still degrades `cost_source` to `unknown`, as it did before.

