### PR TITLE
fix(grading): a contradictory hash verdict is unrepresentable

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -332,16 +332,23 @@ because the hash verdict either substrate produces is `0.0` or `1.0`, never a
 fraction, so the value handed in is one the runner's own path would yield; the same
 lock asserts core's evaluator returns exactly those two for the fixture's two states.
 
-**That premise is audited, within a stated limit.** The suite reads the source of
-every function the manifest names as a hash-verdict producer — derived from the hash
-family's declared evaluators and asserted as set equality against a frozen set, so a
-fourth producer forces a reviewable edit rather than landing with the audit green.
-Each one must choose its score between literals rather than computing it, and every
-`return` must carry that score somewhere the audit reads. What it cannot see is a
-producer reached only *through* one of those functions: the audit follows declared
-evaluators, not call graphs. So a partial hash score cannot land inside an audited
-producer without the sweep's premise being re-examined, and a new producer cannot be
-declared without one.
+**That premise is guarded, within a stated limit.** The producers the manifest names
+split by the shape their verdict leaves in. Core's `check_hash` and
+`check_hash_against_golden_replay` hand theirs on as a bare float in a tuple, so the
+suite reads their sources: each must choose its score between literals rather than
+computing it, and every `return` must carry that score somewhere the audit reads. The
+runner's `_execute_hash_grading` returns its verdict inside `HashGradingResult`, whose
+`hash_score` is derived from the boolean `hash_match` — a non-binary or contradictory
+verdict is unrepresentable, so that producer's source needs no audit; the suite proves
+the derivation over both `hash_match` values, that constructing the model with an
+explicit `hash_score` is refused, and that the producer's declared return type keeps
+its verdict inside the model. The producer set is derived from the hash family's
+declared evaluators and asserted as set equality against the union of the two frozen
+partitions, so a fourth producer forces a reviewable edit rather than landing with the
+guard green. What the source audit cannot see is a producer reached only *through* one
+of the functions it reads: it follows declared evaluators, not call graphs. So a
+partial hash score cannot land inside a guarded producer without the sweep's premise
+being re-examined, and a new producer cannot be declared without one.
 
 ### Score-parity keys outside the hash family
 

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -22,9 +22,11 @@ Fifteen locks over :mod:`tolokaforge.core.grading.key_manifest`:
 6. both substrates fold a hash verdict and a JSONPath score into one
    ``state_checks`` component by the author's weight, pinned cell by cell to
    arithmetic this module computes for itself;
-7. the hash verdict either substrate can produce is binary, which is what makes
-   lock 6's canonical-tier hash inputs the only values that path yields rather
-   than a stand-in for it;
+7. the hash verdict either substrate can produce is binary — source-audited for
+   the producers whose verdict leaves as a bare float in a tuple, and a type
+   invariant of ``HashGradingResult`` for the producer whose verdict leaves
+   inside it — which is what makes lock 6's canonical-tier hash inputs the only
+   values that path yields rather than a stand-in for it;
 8. every ``DIFFERENTIAL_CANONICAL`` claim lock 3's predicate cannot reach is
    enumerated here, and the two tables those claims rest on — lock 6's weight sweep
    and lock 9's method answers — stay substantive;
@@ -78,11 +80,11 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from types import MappingProxyType, UnionType
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 import pytest
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from tests.utils.combine_method_verdicts import (
     COMBINE_METHOD_COMPONENTS,
@@ -95,7 +97,7 @@ from tolokaforge.core import models as core_models
 from tolokaforge.core.grading.combine import GradingEngine
 from tolokaforge.core.grading.combine_method import COMBINE_METHODS
 from tolokaforge.core.grading.combine_weights import MissingComponentWeight
-from tolokaforge.core.grading.golden_replay import resolve_initial_state
+from tolokaforge.core.grading.golden_replay import GoldenReplayRecord, resolve_initial_state
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
 from tolokaforge.core.grading.key_manifest import (
     GRADING_KEYS,
@@ -216,13 +218,22 @@ _GOLDEN_ACTIONS_KEY = "state_checks.hash.golden_actions"
 _GOLDEN_REPLAY_PACK = "shop_orders_02"
 
 # Every function that can hand a hash verdict to the shared composer, as
-# (repo-relative module, function name). Asserted as set equality against the
-# hash family's declared evaluators, so a fourth producer forces an edit here
-# instead of landing with lock 7 green and lock 6's binariness premise false.
-_HASH_VERDICT_PRODUCERS = frozenset(
+# (repo-relative module, function name), partitioned by the shape the verdict
+# leaves in. Tuple-verdict producers hand it on as a bare float in a tuple, so
+# lock 7 audits their sources; the model-verdict producer returns it inside
+# ``HashGradingResult``, which derives the score from ``hash_match``, so lock 7
+# proves that invariant instead of reading its source. The union is asserted as
+# set equality against the hash family's declared evaluators, so a fourth
+# producer forces an edit here instead of landing with lock 7 green and lock
+# 6's binariness premise false.
+_TUPLE_VERDICT_PRODUCERS = frozenset(
     {
         ("tolokaforge/core/grading/state_checks.py", "check_hash"),
         ("tolokaforge/core/grading/state_checks.py", "check_hash_against_golden_replay"),
+    }
+)
+_MODEL_VERDICT_PRODUCERS = frozenset(
+    {
         ("tolokaforge/runner/service.py", "_execute_hash_grading"),
     }
 )
@@ -533,19 +544,23 @@ def _evaluator_source(evaluator: str) -> tuple[str, str]:
     return str(Path(module.__file__).resolve().relative_to(_REPO_ROOT)), attributes[-1]
 
 
-def _declared_hash_verdict_producers() -> frozenset[tuple[str, str]]:
+def _declared_hash_verdict_producers() -> dict[tuple[str, str], Any]:
     """Every evaluator the manifest names for a *scored* member of the hash family.
+
+    Keyed by source location — what the frozen producer partitions pin — with the
+    resolved callable as the value, so lock 7's model-verdict clause reads the
+    declared return type off the same walk its gate reads the set from.
 
     ``state_checks.hash.weight`` is ``CONFIG_INPUT`` — it names the composer that
     consumes a verdict, not a function that produces one — so the ``SCORED_CHECK``
     filter is what keeps the fold itself out of the audit.
     """
-    return frozenset(
-        _evaluator_source(evaluator)
+    return {
+        _evaluator_source(evaluator): _import_dotted(evaluator)
         for author_key in family_author_keys(_HASH_FAMILY_ROOT)
         for evaluator in (entry(author_key).core_evaluator, entry(author_key).runner_evaluator)
         if evaluator is not None and entry(author_key).kind is KeyKind.SCORED_CHECK
-    )
+    }
 
 
 # --------------------------------------------------------------------------
@@ -1667,21 +1682,19 @@ def _verdict_constants(expression: ast.expr) -> frozenset[float] | None:
 def _verdict_expression(node: ast.AST) -> ast.expr | None:
     """The expression ``node`` puts in the hash-score position, or ``None``.
 
-    Three shapes carry a verdict out of a producer: the first element of a returned
-    tuple (the ``(score, reason)`` pair both core producers return), a ``hash_score``
-    keyword argument (the runner returns its verdict inside a model), and an
-    assignment to ``hash_score``, which the other two then hand on.
+    Two shapes carry a verdict out of a tuple-verdict producer: the first element
+    of a returned tuple (the ``(score, reason, …)`` pair both audited producers
+    return) and an assignment to ``hash_score``, which a later return then hands on.
     """
     if isinstance(node, ast.Return) and isinstance(node.value, ast.Tuple):
         return node.value.elts[0]
-    named = isinstance(node, ast.keyword) and node.arg == _HASH_SCORE_NAME
     assigned = (
         isinstance(node, ast.Assign)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
         and node.targets[0].id == _HASH_SCORE_NAME
     )
-    return node.value if named or assigned else None
+    return node.value if assigned else None
 
 
 def _sole_function(module_path: str, function_name: str) -> ast.AST:
@@ -1709,7 +1722,7 @@ def _reachable_hash_verdicts(module_path: str, function_name: str) -> frozenset[
     Fails when a score position holds a computed expression rather than a choice
     between literals: a derived partial verdict would make lock 6's ``0.0``/``1.0``
     runner inputs a stand-in for values that path never yields. Fails too when the
-    producer leaves by a ``return`` whose verdict sits outside the three positions
+    producer leaves by a ``return`` whose verdict sits outside the two positions
     :func:`_verdict_expression` reads — otherwise a refactor to ``return result``
     routes the verdict past the audit while the literals it left behind keep the
     binariness assertion green.
@@ -1735,36 +1748,79 @@ def _reachable_hash_verdicts(module_path: str, function_name: str) -> frozenset[
     assert not unaudited, (
         f"{module_path}::{function_name} returns at lines {unaudited} without putting a "
         "verdict in a position this audit reads — the first element of a returned tuple, "
-        f"an assignment to {_HASH_SCORE_NAME}, or a {_HASH_SCORE_NAME}= keyword. The "
-        "literals it leaves behind would keep the binariness assertion green while the "
-        "verdict it actually returns went unread"
+        f"or an assignment to {_HASH_SCORE_NAME}. The literals it leaves behind would "
+        "keep the binariness assertion green while the verdict it actually returns "
+        "went unread"
     )
     return frozenset(constants)
 
 
-def test_the_hash_verdict_is_binary_on_both_substrates(test_data_dir):
-    """Read from the source, because neither remaining producer is callable here.
+def _minimal_hash_result(**score_fields: Any) -> runner_models.HashGradingResult:
+    """A ``HashGradingResult`` carrying only what lock 7's model clause varies."""
+    return runner_models.HashGradingResult(
+        basis=runner_models.HashComparisonBasis.UNDECLARED_INITIAL_STATE,
+        golden_replay=GoldenReplayRecord(authored=0),
+        **score_fields,
+    )
 
-    The runner's hash evaluator drives db-service over HTTP and core's golden-replay
-    producer needs a task's MCP server, so a canonical-tier call reaches neither.
-    What is callable is ``check_hash``, which core's ``expect_initial_state`` branch
-    reaches by hashing the pack's declared initial state; the composition fixture's
-    two cases are graded through it against a digest computed here the way that
-    branch computes it — which pins the two values lock 6 hands the runner as the
-    ones core's own evaluator returns for the same states.
+
+def test_the_hash_verdict_is_binary_on_both_substrates(test_data_dir):
+    """Each producer is held to binariness by the shape its verdict leaves in.
+
+    The two core producers hand their verdict on as a bare float in a tuple, and
+    core's golden-replay producer needs a task's MCP server, so their sources are
+    read: each must choose its score between literals, and every ``return`` must
+    carry it somewhere the audit reads. The runner's producer returns its verdict
+    inside ``HashGradingResult``, which derives ``hash_score`` from ``hash_match``
+    — so instead of reading that function's source, the lock proves the derivation
+    by exhaustion over the model's one free bit, that supplying a score at
+    construction is refused, and that the producer's declared return type keeps
+    the verdict inside the model.
+
+    What is callable is ``check_hash``, which core's ``expect_initial_state``
+    branch reaches by hashing the pack's declared initial state; the composition
+    fixture's two cases are graded through it against a digest computed here the
+    way that branch computes it — which pins the two values lock 6 hands the
+    runner as the ones core's own evaluator returns for the same states.
     """
     producers = _declared_hash_verdict_producers()
-    assert producers == _HASH_VERDICT_PRODUCERS, (
+    assert frozenset(producers) == _TUPLE_VERDICT_PRODUCERS | _MODEL_VERDICT_PRODUCERS, (
         "the set of functions the manifest names as hash-verdict producers changed. Every "
-        "one is audited below, and lock 6 hands the runner's fold a 0.0/1.0 verdict on the "
-        "strength of that audit — so widening this set is an edit a reviewer sees"
+        "one is guarded below — tuple-verdict producers by source audit, the model-verdict "
+        "producer by the model's own derivation — and lock 6 hands the runner's fold a "
+        "0.0/1.0 verdict on the strength of that guard, so widening either partition is an "
+        "edit a reviewer sees"
     )
-    for module_path, function_name in sorted(producers):
+    for module_path, function_name in sorted(_TUPLE_VERDICT_PRODUCERS):
         reachable = _reachable_hash_verdicts(module_path, function_name)
         assert reachable == _BINARY_HASH_VERDICT, (
             f"{module_path}::{function_name} can produce hash scores {sorted(reachable)}, "
             f"not {sorted(_BINARY_HASH_VERDICT)}"
         )
+
+    for module_path, function_name in sorted(_MODEL_VERDICT_PRODUCERS):
+        declared_return = get_type_hints(producers[(module_path, function_name)]).get("return")
+        assert declared_return is runner_models.HashGradingResult, (
+            f"{module_path}::{function_name} declares return type {declared_return!r}, not "
+            "HashGradingResult — its verdict would leave outside the model whose derivation "
+            "is the whole of what holds this producer to a binary verdict"
+        )
+    for match in (True, False):
+        derived = _minimal_hash_result(hash_match=match).hash_score
+        assert derived == (1.0 if match else 0.0), (
+            f"HashGradingResult(hash_match={match}) derives hash_score {derived}, so the "
+            "score no longer restates the verdict bit"
+        )
+    assert {
+        _minimal_hash_result(hash_match=match).hash_score for match in (True, False)
+    } == _BINARY_HASH_VERDICT, (
+        "exhausting hash_match yields hash scores outside "
+        f"{sorted(_BINARY_HASH_VERDICT)}, so the model-verdict producer's path can hand "
+        "the fold a value lock 6 never drives"
+    )
+    for match, score in ((True, 0.0), (True, 1.0), (False, 0.37)):
+        with pytest.raises(ValidationError, match=_HASH_SCORE_NAME):
+            _minimal_hash_result(hash_match=match, hash_score=score)
 
     pack = _pack_dir(test_data_dir, _COMPOSITION_KEY)
     task_id = _task_id_for(_COMPOSITION_KEY)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -3277,7 +3277,6 @@ class HashGradingResult(BaseModel):
     """Result of hash-based grading."""
 
     hash_match: bool
-    hash_score: float
     basis: HashComparisonBasis
     """Which state the verdict was reached against, and which declaration selected it.
 
@@ -3295,3 +3294,8 @@ class HashGradingResult(BaseModel):
     """
 
     model_config = {"extra": "forbid"}
+
+    @property
+    def hash_score(self) -> float:
+        """Derived from ``hash_match``, so a non-binary or contradictory verdict cannot exist."""
+        return 1.0 if self.hash_match else 0.0

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -2337,9 +2337,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 compare against and the fields whose numeric-looking strings fold
 
         Returns:
-            HashGradingResult with hash_match, hash_score, the basis the comparison was
-            run against, an optional state_diff, and the record of how much of the
-            golden path ran
+            HashGradingResult with hash_match (the model derives hash_score from it),
+            the basis the comparison was run against, an optional state_diff, and the
+            record of how much of the golden path ran
 
         Raises:
             UnresolvableGoldenAction: an action names no tool registered for the trial,
@@ -2486,7 +2486,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
 
         # 8. Compare hashes
         hash_match = trial_hash == golden_hash
-        hash_score = 1.0 if hash_match else 0.0
 
         # 9. If mismatch, compute state diff
         state_diff: StateDiff | None = None
@@ -2510,7 +2509,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
 
         return HashGradingResult(
             hash_match=hash_match,
-            hash_score=hash_score,
             basis=basis,
             state_diff=state_diff,
             golden_replay=GoldenReplayRecord(


### PR DESCRIPTION
## Summary
- A contradictory or non-binary hash verdict is now unrepresentable: `HashGradingResult.hash_score` stops being a stored field and becomes a read-only property derived from `hash_match` (`1.0`/`0.0`); supplying a score at construction raises.
- Parity lock 7 states the guard partition as a contract: the two core producers whose verdict leaves as a bare tuple stay source-audited; the runner producer whose verdict leaves inside the model is guarded by the model itself (routing + derivation-by-exhaustion + refusal locks), with the manifest set-equality gate preserved over the union.
- The issue's first deliverable (a behavioural test for `check_hash_against_golden_replay`) was found already satisfied at a cheaper tier than the issue thought possible — `tests/unit/test_golden_replay.py` drives it over two real in-repo packs in-process — and this PR records that verification rather than rebuilding it.

## Design choices
- **Derivation over the issue's literal validator**: a `model_validator` is bypassable via `model_construct`/`model_copy(update=)` and stores one bit twice; a getter-only property makes the contradictory state unrepresentable everywhere (probed: `model_construct` sneaks are dropped on read, `model_copy` sneaks lose to the class descriptor and never leak into a dump). The issue's own stated end — "the model would refuse to represent the state" — achieved more completely.
- **The two core producers keep bare-tuple verdicts**: their values are in-process, consumed immediately by the combine, and exhaustively AST-audited; promoting them to validated models is the type-system misfit the repo's own table warns against. The audit is the right guard for a verdict that leaves as a bare float; the model invariant is the right guard for one that leaves inside a model — and lock 7 now says which guard covers which producer.
- **One commit by necessity, not preference**: removing the score position from `_execute_hash_grading` reds the pre-existing AST audit, so the model change and the lock-7 restructure cannot be separated (measured before planning the stage).

## Concepts introduced
None — mechanical strengthening of an existing guard. The lock-7 partition (`_TUPLE_VERDICT_PRODUCERS` / `_MODEL_VERDICT_PRODUCERS`) is new vocabulary inside the parity suite only.

## Plan
# Plan: The hash verdict's binariness becomes a type invariant

Issue: #742
Branch: fix/742-hash-binariness-guards

## Context

#742 claims two gaps in the guard over the hash verdict's binariness. Re-measured at
`feat/940-hash-source-adapter-hook` (`d2ee0f2c`), one premise has rotted and one holds:

- **Rotted — "`check_hash_against_golden_replay` has no behavioural test."** It now has a
  substantial unit-tier suite: `tests/unit/test_golden_replay.py` drives it over two real
  in-repo packs (`tests/data/tasks/shop_orders_02`, and a tau-style pack for the
  string-payload population), covering the matching verdict (`1.0`), the diverging verdict
  (`0.0` with a diff), every `UnresolvableGoldenAction` refusal shape, and the annotated
  partial-replay verdicts. Engine-level `GoldenReplayError` paths are driven in
  `tests/unit/grading/test_state_checks_composition.py`. The issue's assumption that this
  needed an MCP server subprocess (hence integration tier) was defeated by loading the
  pack's server module in-process — the tests are at a *cheaper* tier than the issue asked
  for. Verified green at this tree. **Nothing to build for deliverable 1**; the PR body
  records the verification.
- **Holds — a contradictory `HashGradingResult` is constructible.** Measured at this tree:
  `HashGradingResult(hash_match=True, hash_score=0.0, ...)` and `hash_score=0.37` are both
  accepted (`tolokaforge/runner/models.py:3276`).

Supporting facts, all measured:

- `HashGradingResult` has exactly one production construction site —
  `RunnerServiceImpl._execute_hash_grading`, `tolokaforge/runner/service.py:2511` — which
  computes `hash_score = 1.0 if hash_match else 0.0` (line 2489). No test constructs the
  model directly; no code calls `model_dump()`/`model_construct()`/`model_copy()` on it;
  it never crosses a serialisation boundary (consumers read `.hash_match`, `.hash_score`,
  `.state_diff`, `.golden_replay`, `.basis` in-process: `service.py:1530-1533`, `1734`).
- The parity module's lock 7 (`tests/canonical/test_grading_substrate_parity.py:1745`)
  source-audits three producers via AST (`_HASH_VERDICT_PRODUCERS`, line 222): core's
  `check_hash` and `check_hash_against_golden_replay` (both return the verdict as the
  first element of a bare tuple) and the runner's `_execute_hash_grading` (returns the
  verdict inside `HashGradingResult`). The set is asserted equal to the manifest's
  declared hash-family evaluators, so a fourth producer forces a reviewable edit.
- Related issues have moved: **#734 is closed** (its fix is what the unit suite above
  locks); **#816** (open) owns whether a partial-world verdict should exist at all;
  **#687** (open) is narrowed to the `numeric_string_fields` folding pair; the
  `DIFFERENTIAL_INTEGRATION` enforcing test
  `tests/integration/test_docker_grading_hash_composition.py` exists and covers both
  verdict directions plus the refusal and raised paths.

What remains of #742 is deliverable 2 (refuse the contradictory result) and deliverable 3
(state the relationship between that refusal and the source audit — "say which, rather
than leaving two overlapping guards with no stated relationship").

## Goal

The runner's hash verdict becomes impossible to misstate, not merely audited:

1. `HashGradingResult` cannot represent a non-binary or contradictory verdict. The issue
   asked for a validator; this plan goes one step stronger and **derives** `hash_score`
   from `hash_match` — `hash_match: bool` stays the single verdict bit, `hash_score` stays
   readable as an attribute (`1.0`/`0.0`) but is no longer a stored field, and supplying
   it at construction is refused (`extra="forbid"` does this for free). Rationale for
   derivation over a validator: a `model_validator` is bypassable via `model_construct`
   and `model_copy(update=...)` and stores one bit twice; a derived attribute makes the
   contradictory state unrepresentable everywhere, which is the issue's own stated end
   ("the model would refuse to represent the state the audit is looking for").
2. Lock 7 states the guard partition as a contract: producers whose verdict leaves as a
   **bare float in a tuple** (core's `check_hash`, `check_hash_against_golden_replay`)
   remain source-audited exactly as today; the producer whose verdict leaves **inside
   `HashGradingResult`** (`_execute_hash_grading`) is guarded by the model itself, and
   lock 7 proves that guard instead of reading that function's source. The set-equality
   gate against the manifest's declared evaluators is preserved over the union, so a new
   producer still cannot land without a reviewable edit.

## Non-goals

- No change to the *semantics* of any verdict: which trials score `1.0` vs `0.0` moves
  nowhere on either substrate. Partial-world admissibility stays with #816.
- No new integration test and no change to
  `test_docker_grading_hash_composition.py` — #687's residue
  (`numeric_string_fields` folding pair) stays with #687.
- No typed-result conversion for the two core producers. Considered and rejected: their
  verdicts are in-process values consumed immediately by the combine, the AST audit
  covers every branch of them exhaustively, and promoting in-process tuples to validated
  models is the type-system misfit AGENTS.md's table warns against. The audit is the
  right guard for a verdict that leaves as a bare float; the model invariant is the right
  guard for one that leaves inside a model.
- No change to `RunnerGradeComponents.hash_score` (the `-1.0` "not evaluated" sentinel is
  a different contract — a component slot, not a producer's verdict).

## Stages

### Stage 1: A contradictory hash verdict is unrepresentable, and lock 7 says so

- **Contract:**
  - `HashGradingResult` (`tolokaforge/runner/models.py`): `hash_match: bool` remains a
    required field; `hash_score` ceases to be a field and becomes a read-only derived
    attribute returning `1.0` if `hash_match` else `0.0`. Constructing with a
    `hash_score=` argument raises (`extra="forbid"` — pydantic `ValidationError`). All
    other fields (`basis`, `state_diff`, `golden_replay`) and all attribute reads
    (`result.hash_score`, `result.hash_match`, …) are unchanged for consumers.
  - `RunnerServiceImpl._execute_hash_grading` (`tolokaforge/runner/service.py`): return
    type stays `HashGradingResult`; it stops computing a score (delete the
    `hash_score = 1.0 if hash_match else 0.0` line and the `hash_score=` kwarg). Its
    docstring's "Returns" text describes the result as carrying `hash_match` and the
    derived score. Observable behaviour of `GradeTrial` is byte-identical.
  - Lock 7 (`tests/canonical/test_grading_substrate_parity.py`): `_HASH_VERDICT_PRODUCERS`
    splits into two frozen constants — tuple-verdict producers (the two core functions,
    AST-audited exactly as today) and model-verdict producers (`_execute_hash_grading`).
    The gate becomes: manifest-declared producers `==` union of the two sets. For each
    model-verdict producer the lock asserts (a) its declared return type is
    `HashGradingResult` (so a refactor that routes the verdict around the model fails the
    lock), (b) `HashGradingResult(hash_match=m, ...).hash_score == (1.0 if m else 0.0)`
    for **both** values of `m` — binariness by exhaustion over the model's one free bit —
    and (c) constructing with an explicit `hash_score` is refused, including the
    contradictory pair the issue measured (`hash_match=True, hash_score=0.0`). The
    module docstring's lock-7 line and the lock's own docstring describe the partition as
    the current state (no "previously audited" history).
- **Behaviour to lock** (all canonical tier, inside the restructured lock 7):
  - derivation: both `hash_match` values map to exactly `{1.0, 0.0}`;
  - refusal: `HashGradingResult(hash_match=True, hash_score=0.0, ...)` raises
    `ValidationError`;
  - routing: `_execute_hash_grading`'s verdict leaves as `HashGradingResult`;
  - the frozen-set gate still equals the manifest's declared hash-family evaluators.
  - **Falsifiers, one per assertion:** re-adding a stored `hash_score` field (with any
    default) fails the refusal lock; deriving anything but the two literals fails the
    exhaustion lock; changing `_execute_hash_grading` to return a bare tuple fails the
    routing lock; declaring a fourth producer in the manifest fails the set gate. The
    existing unit suite (`test_golden_replay.py`) independently fails if the producer's
    results stop carrying correct verdicts, since it reads `result.hash_score` off real
    `_execute_hash_grading` calls.
- **Compatibility:** internal only. The model never serialises, has one production
  construction site (updated in this stage), and no direct test constructions exist.
  No task-contract, config-schema, CLI, or published-API surface moves.
- **Deliverable:** a repo where `python -c "HashGradingResult(hash_match=True,
  hash_score=0.0, ...)"` cannot run, lock 7 partitions its producers with the reason in
  its docstrings, and `docs/GRADING.md` describes the partition as the only state.
- **Validation:**
  - `uv run pytest tests/canonical/ -m canonical` (parity module included) — green.
  - `uv run pytest tests/unit/test_golden_replay.py tests/unit/grading/ -m unit` — green.
  - Full unit lane green modulo the known 8 env-sensitive
    `test_persistent_shell_local.py` failures (pre-existing baseline, do not touch).
  - End-to-end on the changed production path: the local Docker images were pruned, so
    first remove any stale `:latest` tags if present (`docker rmi
    tolokaforge-runner:latest tolokaforge-db-service:latest tolokaforge-rag-service:latest
    || true`), then `scripts/with_env.sh uv run pytest
    tests/integration/test_docker_grading_hash_composition.py -v -m integration` — the
    testcontainer fixtures (`tests/utils/containers.py::_check_image_available`)
    auto-build missing images from the tree's Dockerfiles, so with no stale tag the run
    is guaranteed to exercise this stage's code (this is the concrete answer to #740's
    "resolve the image from the tree" for this suite). Budget for the image build on
    first run.
  - `mcp__dev__format_check` / `lint_check` scoped to touched files; `black --check` on
    them too (both formatters must pass).
- **Doc updates:** `docs/GRADING.md` — rewrite the "That premise is audited, within a
  stated limit" paragraph (§ Substrate Parity, ~line 335) so it states the partition as
  the current fact: the two core producers' sources are audited (choose-between-literals,
  every return carries the score somewhere the audit reads, set-equality against the
  manifest); the runner's verdict is a type invariant of `HashGradingResult` — a
  non-binary or contradictory verdict is unrepresentable, so its producer's source needs
  no audit. Keep the stated limit (the audit follows declared evaluators, not call
  graphs). No before/after narration anywhere; `rg`-check that no other doc or comment
  still claims all three producers are source-audited (`rg -n "source of\s*every function"
  docs/ tests/`, plus `rg -n "hash_score" docs/`).

## Discovered issues

- **Fix in this PR:** none beyond the issue's own scope.
- **Filed as issues:** none. Everything discovered was already tracked: deliverable 1 was
  satisfied by the milestone-28 unit suite (this plan's PR body records the verification
  so #742 can close on the remaining deliverables); partial-world verdict admissibility
  is #816; the `numeric_string_fields` folding residue is #687.

## Risks / open questions

- **Pydantic property on a `BaseModel`:** a plain `@property` on a pydantic v2 model is
  supported and excluded from `model_dump()`. Nothing dumps `HashGradingResult`
  (measured), so the disappearance of `hash_score` from dumps is unobservable today; the
  routing lock plus `extra="forbid"` make any future divergence loud rather than silent.
- **Derivation vs the issue's literal ask (a validator):** the issue's end goal is that
  the model "refuse to represent" the contradictory state; derivation achieves that
  strictly more thoroughly than a validator (no `model_construct`/`model_copy(update=)`
  bypass, no doubly-stored bit). If review prefers the literal validator, the stage
  degrades gracefully — same locks, weaker mechanism — but the plan's position is
  derivation.
- **Single-stage plan:** the model change and the lock-7 restructure cannot be separate
  commits — removing the score positions from `_execute_hash_grading` fails the current
  AST audit's "return carries no verdict" assertion, so the invariant and the lock that
  states it must land together. One stage, one commit, one claim.
- **Integration validation cost:** the image rebuild after the prune is the slow step
  (runner + db-service + rag-service images; the runner fixture depends on all three).
  It is validation of an unchanged observable contract, not a new lock — if the rebuild
  proves impractical, the canonical parity drives (`_runner_state_checks_hash_verdict`
  registers and grades real trials through `_execute_hash_grading` in-process) already
  exercise the changed producer, and the wire test can run in the milestone's next
  integration pass instead. Stated so main can decide; default is to run it.

## Discovered issues
- Filed: none — everything adjacent was already tracked (#816 partial-world admissibility, #687 `numeric_string_fields` folding residue).
- Premise correction recorded: the issue's "no behavioural test" claim rotted between filing and execution; `tests/unit/test_golden_replay.py` (47 tests) covers matching/diverging verdicts, every refusal shape, and the annotated partial-replay verdicts, with engine-level `GoldenReplayError` paths in `tests/unit/grading/test_state_checks_composition.py`.

## Test plan
- Canonical: 1191 passed (`tests/canonical/ -m canonical`; identical collection on base and branch).
- Unit: 5951 passed / 8 pre-existing env-sensitive failures in `test_persistent_shell_local.py` (red on main too).
- Integration (ran, not deferred): `tests/integration/test_docker_grading_hash_composition.py` — 7 passed, with image freshness proven: the fixture rebuilt the runner image from the edited tree (distinct content tag from the pre-edit build), so the wire run exercised the changed producer.
- Falsifiers driven for every lock clause (stored-field re-add, fill-in-validator variant, non-binary derivation, bare-tuple routing, fourth-producer manifest edit) — each reds exactly its own clause; the fill-in-validator variant was independently re-driven during review.

Closes #742
