### PR TITLE
docs(grading): a hash comparison hashes both sides on one substrate

### DIFF
--- a/docs/DB_SERVICE_API.md
+++ b/docs/DB_SERVICE_API.md
@@ -34,7 +34,7 @@ the Docker architecture's trial isolation and grading requirements.
 1. **Trial Isolation** — Each trial has isolated state, schemas, and snapshots
 2. **Schema-Aware** — Stores table schemas for validation and type inference
 3. **Unstable Field Filtering** — Explicit field exclusion for deterministic hashing
-4. **Tau/TlkMcpCore Compatible** — Hash algorithm matches existing implementations
+4. **Single-Substrate Digests** — state hashes are `compute_stable_hash` output ([Get Stable Hash](#4-get-stable-hash)); a digest never crosses substrates
 5. **Snapshot/Restore** — Supports golden path execution during grading
 
 ---

--- a/docs/DB_SERVICE_API.md
+++ b/docs/DB_SERVICE_API.md
@@ -226,37 +226,21 @@ Get SHA-256 hash of the stable state. This is the primary endpoint for grading c
 
 #### Hash Computation Algorithm
 
-The hash is computed to match the existing Tau/TlkMcpCore implementation:
+The hash is the runner substrate's persisted digest, computed by
+[`tolokaforge/core/hash.py::compute_stable_hash`](../tolokaforge/core/hash.py) —
+the implementation of record: unstable-field filtering, datetime conversion,
+number canonicalization (numeric types always, numeric-looking strings per the
+task's `numeric_string_fields` opt-in), then compact sorted JSON and SHA-256.
+Every consumer of db-service digests — ETags, snapshot hashes, and the
+`ResetTrialResponse.state_hash` / `GetStateResponse.stable_hash` wire fields —
+compares only against output of that same function
+([`TASK_DESCRIPTION_SCHEMA.md` § Stable State Hash](TASK_DESCRIPTION_SCHEMA.md#stable-state-hash)).
 
-```python
-def compute_stable_hash(state: Dict, unstable_fields: List[UnstableFieldSpec]) -> str:
-    # 1. Deep copy state
-    stable_state = copy.deepcopy(state)
-    
-    # 2. Remove unstable fields from each table
-    for spec in unstable_fields:
-        table = stable_state.get(spec.table_name, [])
-        for record in table:
-            if spec.field_name in record:
-                del record[spec.field_name]
-    
-    # 3. Convert datetime objects to ISO strings
-    stable_state = convert_datetime_to_str(stable_state)
-    
-    # 4. Serialize with sorted keys and compact separators
-    json_str = json.dumps(stable_state, sort_keys=True, separators=(",", ":"))
-    
-    # 5. Compute SHA-256
-    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-```
-
-**CRITICAL:** The hash algorithm must match the canonical algorithm defined in [`TASK_DESCRIPTION_SCHEMA.md`](TASK_DESCRIPTION_SCHEMA.md#canonical-hash-algorithm) and [`calculate_database_hash()`](../contrib/mcp_core/src/mcp_core/utils/validation.py:74) from mcp_core:
-- `sort_keys=True` for deterministic key ordering
-- `separators=(",", ":")` for compact JSON (no spaces) — NOT default `(", ", ": ")`
-- `encode("utf-8")` — explicit UTF-8 encoding
-- SHA-256 hexdigest
-
-**WARNING:** Using different separators or serialization methods (e.g., `str(tuple)`) will cause hash mismatches and grading failures.
+Core grading hashes state in a different algebra by design (`state_digest` in
+[`tolokaforge/core/grading/state_checks.py`](../tolokaforge/core/grading/state_checks.py)):
+the two agree on which states are equal and label every state differently, so a
+hash comparison computes both sides on one substrate and a digest never crosses
+substrates — see [`GRADING.md` § Substrate Parity](GRADING.md#substrate-parity).
 
 ---
 
@@ -624,33 +608,10 @@ def convert_datetime_to_str(data: Any) -> Any:
 
 ## Hash Computation Algorithm
 
-The hash must be compatible with existing Tau/TlkMcpCore implementations:
-
-```python
-def compute_stable_hash(trial: TrialState) -> str:
-    """
-    Compute SHA-256 hash of stable state.
-    
-    MUST match mcp_core.utils.validation.calculate_database_hash()
-    """
-    # Get stable state (unstable fields filtered)
-    stable_state = get_stable_state(trial)
-    
-    # Serialize with deterministic settings
-    # - sort_keys=True: deterministic key ordering
-    # - separators=(",", ":"): compact JSON, no spaces
-    json_str = json.dumps(stable_state, sort_keys=True, separators=(",", ":"))
-    
-    # SHA-256 with UTF-8 encoding
-    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-```
-
-### Compatibility Notes
-
-1. **Key Ordering**: `sort_keys=True` ensures deterministic ordering regardless of Python dict insertion order
-2. **Compact JSON**: `separators=(",", ":")` removes whitespace for consistent hashing
-3. **UTF-8 Encoding**: Explicit UTF-8 encoding before hashing
-4. **Datetime Handling**: All datetime objects converted to ISO 8601 strings before serialization
+The service hashes stable state with
+[`tolokaforge/core/hash.py::compute_stable_hash`](../tolokaforge/core/hash.py) —
+see [Get Stable Hash](#4-get-stable-hash) for the algorithm, its scope, and the
+substrate invariant.
 
 ---
 

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -235,6 +235,23 @@ The rows say *signal* parity rather than *score* parity because of the two shape
 gate refuses: they survive in bundles recorded before the rule, and there each substrate
 takes a different component.
 
+**One comparison, one substrate.** Every hash comparison in the system computes both
+sides on one substrate: core hashes both operands with `state_digest`
+(`consistent_hash(to_hashable(...))`,
+[`state_checks.py`](../tolokaforge/core/grading/state_checks.py)), the runner hashes
+both with [`compute_stable_hash`](../tolokaforge/core/hash.py). The two algebras share
+the folding promise — `numeric_string_fields` behaves identically on both — and nothing
+else: they label every state differently, so digests never cross substrates and are
+never authored, which is why a hash source names a state rather than a digest. The two
+functions are deliberately not unified: `compute_stable_hash` backs persisted digests —
+db-service ETags, snapshot hashes, and the `ResetTrialResponse.state_hash` /
+`GetStateResponse.stable_hash` wire fields — and core's algebra reproduces the digests
+recorded bundles carry, so changing either function invalidates digests that already
+exist, while nothing needs a digest to travel between substrates.
+[`tests/canonical/test_expected_state_hash_is_not_portable.py`](../tests/canonical/test_expected_state_hash_is_not_portable.py)
+locks all three facts: same equivalence relation, a different label on every state, and
+no wire route for a digest to cross.
+
 The golden-actions differential runs over real gRPC and a real db-service, in
 [`tests/integration/test_docker_grading_hash_composition.py`](../tests/integration/test_docker_grading_hash_composition.py):
 a matching and a diverging final state against the same golden replay, at two weights

--- a/docs/GRPC_PROTOCOL.md
+++ b/docs/GRPC_PROTOCOL.md
@@ -781,16 +781,17 @@ def grade_trial(trial_id: str, llm_messages: list[dict]) -> Grade:
     )
 ```
 
-**CRITICAL: Hash Algorithm Compatibility**
+**CRITICAL: Hash Substrate Discipline**
 
-The `db_service.get_stable_hash()` call MUST use the canonical hash algorithm defined in [`TASK_DESCRIPTION_SCHEMA.md`](TASK_DESCRIPTION_SCHEMA.md#canonical-hash-algorithm):
-
-```python
-json_str = json.dumps(stable_state, sort_keys=True, separators=(",", ":"), default=str)
-return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-```
-
-All components (DB Service, adapters, grading engine) MUST use this exact algorithm for hash comparison to work correctly.
+`db_service.get_stable_hash()` and every comparison against its output MUST stay
+within the runner substrate's persisted-digest algorithm —
+`tolokaforge/core/hash.py::compute_stable_hash`, defined in
+[`TASK_DESCRIPTION_SCHEMA.md` § Stable State Hash](TASK_DESCRIPTION_SCHEMA.md#stable-state-hash).
+That scope is db-service and the consumers of its digests, nothing wider. The
+grading engine's core substrate hashes state in a different algebra by design:
+the two agree on which states are equal and label every state differently, so a
+hash comparison computes both sides on one substrate and a digest never crosses
+substrates — see [`GRADING.md` § Substrate Parity](GRADING.md#substrate-parity).
 
 ### Component scores on the wire
 

--- a/docs/TASK_DESCRIPTION_SCHEMA.md
+++ b/docs/TASK_DESCRIPTION_SCHEMA.md
@@ -20,7 +20,7 @@ Host (Loader)                    Runner Container (Runtime)         DB Service C
 3. **Adapter-Agnostic** — single schema supports Native, Tau, and TlkMcpCore
 4. **Unstable Fields as Data** — field stability metadata is explicit, not Python annotations
 5. **Reconstructable** — `ToolSource` provides enough info to reconstruct tools at runtime
-6. **Canonical Hash Algorithm** — all components use identical JSON-based SHA-256 hashing
+6. **Single-Substrate Hash Comparisons** — a state-hash comparison computes both sides within one substrate's algorithm; a digest never crosses substrates ([Stable State Hash](#stable-state-hash))
 
 ---
 
@@ -718,43 +718,27 @@ POST   /restore/{name}        ← restore from snapshot (for golden path executi
 
 ---
 
-## Canonical Hash Algorithm
+## Stable State Hash
 
-**CRITICAL:** All components MUST use the identical hash algorithm for grading to work correctly.
+This section defines the **runner substrate's** persisted-digest algorithm — what
+db-service's `/state/hash` endpoint, ETags, snapshot hashes and the
+`ResetTrialResponse.state_hash` / `GetStateResponse.stable_hash` wire fields all
+compute. The implementation of record is
+[`tolokaforge/core/hash.py::compute_stable_hash`](../tolokaforge/core/hash.py):
+unstable-field filtering, datetime conversion, number canonicalization (numeric
+types always, numeric-looking strings per the task's `numeric_string_fields`
+opt-in), then compact sorted JSON and SHA-256. Every consumer of that substrate's
+digests computes and compares them with that function — and only consumers of that
+substrate's digests are bound by it.
 
-```python
-import hashlib
-import json
-from typing import Any, Dict
-
-def compute_stable_hash(state: Dict[str, Any]) -> str:
-    """
-    Compute canonical hash of stable state.
-    
-    This algorithm MUST be used by:
-    - DB Service /state/hash endpoint
-    - TlkMcpCore adapter grading
-    - Tau adapter grading
-    - Any other component computing state hashes
-    
-    Algorithm:
-    1. JSON serialize with sort_keys=True, separators=(",", ":")
-    2. UTF-8 encode
-    3. SHA-256 hexdigest
-    
-    IMPORTANT: Do NOT use str(tuple) or other serialization methods!
-    """
-    json_str = json.dumps(state, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-```
-
-**Key Requirements:**
-- `sort_keys=True` — deterministic key ordering
-- `separators=(",", ":")` — compact JSON, no spaces (NOT default `(", ", ": ")`)
-- `encode("utf-8")` — explicit UTF-8 encoding
-- `default=str` — handle datetime and other non-JSON types
-
-**Reference Implementation:** [`mcp_core.utils.validation.calculate_database_hash()`](../contrib/mcp_core/src/mcp_core/utils/validation.py)
+Core grading's digest is a different algebra by design — `state_digest`
+(`consistent_hash(to_hashable(...))`) in
+[`tolokaforge/core/grading/state_checks.py`](../tolokaforge/core/grading/state_checks.py).
+The two agree on which states are equal (the `numeric_string_fields` folding
+promise holds identically on both) and label every state differently, so a
+state-hash comparison computes both sides within one substrate and a digest never
+crosses substrates — see
+[`GRADING.md` § Substrate Parity](GRADING.md#substrate-parity).
 
 ---
 

--- a/tests/canonical/test_expected_state_hash_is_not_portable.py
+++ b/tests/canonical/test_expected_state_hash_is_not_portable.py
@@ -15,9 +15,11 @@ that literal is a core-algebra digest, so routing it to the runner's evaluator w
 ``0.0`` on the state core scores ``1.0``. The fourth pins that there is no longer a wire
 field to route it through.
 
-See #915 for unifying the two hash functions, which is not in reach here:
-``compute_stable_hash`` also backs db-service ETags, snapshot hashes and
-``ResetTrialResponse.state_hash``.
+The two functions are deliberately separate (#915). ``compute_stable_hash`` backs
+persisted digests — db-service ETags, snapshot hashes, ``ResetTrialResponse.state_hash``
+— and core's algebra reproduces the digests recorded bundles carry, so unifying in
+either direction invalidates digests that already exist; and with no wire field left to
+carry one across, nothing needs the portability unification would buy.
 """
 
 from __future__ import annotations

--- a/tolokaforge/core/grading/state_checks.py
+++ b/tolokaforge/core/grading/state_checks.py
@@ -81,7 +81,16 @@ def to_hashable(
 
 
 def consistent_hash(value: Hashable) -> str:
-    """Compute consistent SHA256 hash (tau-bench compatible)"""
+    """Compute consistent SHA256 hash (tau-bench compatible).
+
+    This is the CORE substrate's digest algebra: SHA-256 over ``str`` of the
+    :func:`to_hashable` tuple tree. The runner's is
+    :func:`tolokaforge.core.hash.compute_stable_hash` — same equivalence
+    relation (both fold through ``canonical_number``), different label for
+    every state — so a digest this function produced is comparable only
+    against another one it produced, and never crosses to the runner
+    substrate (``tests/canonical/test_expected_state_hash_is_not_portable.py``).
+    """
     return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
 
 
@@ -93,6 +102,12 @@ def state_digest(state: dict[str, Any], *, numeric_string_fields: list[str] | No
     same rule :meth:`StateChecker.check_hash` hashes the trial's state by. Two spellings
     of this expression would let one side fold a numeric-looking string the other did
     not, and the verdict would read as an agent failure.
+
+    The rule reaches across the substrate boundary too: this is core's algebra, the
+    runner's is :func:`tolokaforge.core.hash.compute_stable_hash`, and the two label
+    every state differently while agreeing on which states are equal — so a
+    comparison computes both sides on one substrate, and a digest never crosses to
+    the other.
     """
     string_fields = frozenset(numeric_string_fields) if numeric_string_fields else None
     return consistent_hash(to_hashable(state, string_fields))

--- a/tolokaforge/core/hash.py
+++ b/tolokaforge/core/hash.py
@@ -8,8 +8,20 @@ so it intentionally diverges from that byte-for-byte output. Numeric-looking
 STRINGS ("130.00" == "130.0") fold only for the per-field opt-in set
 ``numeric_string_fields`` — see :func:`compute_stable_hash`.
 
-All hash computations across the codebase should use compute_stable_hash()
-to ensure consistent results.
+:func:`compute_stable_hash` is the RUNNER substrate's digest: db-service state
+hashes, ETags (:func:`compute_etag`), snapshot hashes, and the
+``ResetTrialResponse.state_hash`` / ``GetStateResponse.stable_hash`` wire
+fields. Core grading's digest is a different algebra —
+``state_digest`` (``consistent_hash(to_hashable(...))``) in
+``tolokaforge/core/grading/state_checks.py``. The two agree on which states are
+equal (both fold through :func:`canonical_number`) and disagree on every label,
+so a hash comparison hashes both sides with one function, on one substrate,
+and a digest never crosses substrates. The two algebras stay separate
+deliberately: this module's digests are persisted and core's reproduce the
+digests recorded bundles carry, so changing either function invalidates
+digests that already exist — while nothing needs a digest to travel between
+substrates. Locked by
+``tests/canonical/test_expected_state_hash_is_not_portable.py``.
 """
 
 import hashlib
@@ -269,6 +281,16 @@ def compute_stable_hash(
     mcp_core.utils.validation.calculate_database_hash() for identical state
     dictionaries. The default (True) additionally folds numerically-equal
     representations, intentionally diverging from that byte-for-byte output.
+
+    This is the runner substrate's digest, and it is frozen: its output is
+    persisted — db-service ETags (:func:`compute_etag`), snapshot hashes, and
+    the ``ResetTrialResponse.state_hash`` / ``GetStateResponse.stable_hash``
+    wire fields — so a serialisation change invalidates every digest already
+    stored. Core grading's ``state_digest``
+    (``tolokaforge/core/grading/state_checks.py``) is a different algebra over
+    the same equivalence relation: a comparison hashes both sides with one
+    function, and a digest never crosses substrates
+    (``tests/canonical/test_expected_state_hash_is_not_portable.py``).
 
     Algorithm:
     1. Filter out unstable fields (if specified)


### PR DESCRIPTION
## Summary
- The cross-substrate hash invariant is now stated at every surface an implementer meets before writing a hash comparison: **a hash comparison hashes both sides on the same substrate, and a digest never crosses substrates.** The two grading substrates agree on the state-equivalence relation (including the `numeric_string_fields` folding promise) but label every equivalence class differently, so no state hash is portable between them.
- The tree previously taught the *opposite* in five places, in escalating strength — from `core/hash.py`'s "all hash computations should use compute_stable_hash()" docstring up to `docs/TASK_DESCRIPTION_SCHEMA.md`'s "**CRITICAL:** All components MUST use the identical hash algorithm" with stale pre-folding pseudocode binding every grading path to one algorithm. All copies are gone, replaced by the invariant and pointers to one implementation of record.
- The unification decision is recorded: **the two algebras stay separate.** `compute_stable_hash` backs persisted digests (ETags, snapshots, `ResetTrialResponse.state_hash` / `GetStateResponse.stable_hash`), so changing it invalidates every persisted digest; core's algebra reproduces recorded-bundle literals; and after the retirement of `expected_state_hash`, nothing needs digest portability.

## Design choices
- **Prose-only closure of a bug-labelled issue, deliberately**: the issue's behavioural deliverable — a canonical test pinning agree-on-relation / disagree-on-digest — already shipped inside the `expected_state_hash` retirement as `tests/canonical/test_expected_state_hash_is_not_portable.py` (15 tests, both falsifiers live: unifying one serialisation reds the disagreement lock, diverging the folding reds the agreement lock). This PR records that verification and resolves the module docstring's forward reference into the decision.
- **One algorithm description of record, pointers everywhere else**: the stale pseudocode copies (pre-folding shape, describing neither substrate's current algorithm) are replaced by pointers to `compute_stable_hash` — duplicated algorithm prose is the reason the docs went stale in the first place.
- **Scope re-binding rather than deletion for normative MUSTs**: `GRPC_PROTOCOL.md`'s hash-compatibility MUST now binds `db_service.get_stable_hash()` and comparisons against its output only.

## Concepts introduced
None — the PR names an invariant that already governed the tree implicitly and records a decision. No behaviour, schema, wire field, or API moves; not one byte of any digest changes.

## Plan
# Plan: The two hash algebras are named where an implementer meets them

Issue: #915
Branch: fix/915-hash-algebra-invariant

> **Revision 1** (critic round 1). The anti-invariant survives as a normative MUST in
> `docs/TASK_DESCRIPTION_SCHEMA.md` § Canonical Hash Algorithm (plus Design Principle 6),
> cross-referenced as a MUST from `docs/GRPC_PROTOCOL.md` — verified verbatim at the
> current tree. Folded into Stage 1's surface list per main's ruling, with a
> concept-level sweep added to Validation so a paraphrase of the universality claim
> cannot survive the stage green. Measurement baseline note: this plan's measurements
> were taken at `47733013`; the integration branch has since moved (#742 merged,
> `9a50e473`) — main pins the implementer to current HEAD, and every section is re-read
> as it stands at dispatch, never patched against this plan's line anchors.

## Context

#915 records that the two grading substrates hash the same state to different digests:
core's `state_digest` (`consistent_hash(to_hashable(...))`,
`tolokaforge/core/grading/state_checks.py:83-98`) and the runner's db-service
`compute_stable_hash` (`tolokaforge/core/hash.py:258`) induce the same equivalence
relation but label every state differently. Re-measured at the current tree
(`fix/742-hash-binariness-guards`, `47733013`): every number in the issue reproduces
exactly — the example state hashes to `83da7795…` (core) vs `c51d50ab…` (runner), the
recorded `tau_retail_mini` bundle literal `1c0b0362…` is core's digest of its recorded
state while the runner's is `eb3b282d…`, and the folding table (numeric types always,
numeric-looking strings per opt-in) agrees across both substrates in all four cells.

Two of the issue's premises have moved since it was filed, both in this milestone:

- **`GradeTrialRequest.precomputed_expected_hash` no longer exists.** #693 deleted the
  field (`reserved 3;` in `tolokaforge/runner/runner.proto:202`), retired
  `expected_state_hash` behind a migration message, and made `expect_initial_state` the
  replacement in which each substrate computes *both* sides of its comparison itself. No
  path in the tree moves a digest between substrates, and the wire route for one is
  locked shut.
- **The issue's first deliverable is already built.** #693 shipped
  `tests/canonical/test_expected_state_hash_is_not_portable.py` — 15 canonical tests,
  verified green at this tree — pinning precisely the fact #915 asks to pin:
  `test_both_substrates_induce_the_same_equivalence_relation` asserts each substrate's
  folding verdict against a pinned truth column over all four opt-in shapes, and
  `test_the_two_substrates_label_the_same_state_differently` asserts the digests differ
  on three labelled states. The falsifiers hold in both directions: patching either
  function to the other's serialisation reds the disagreement lock; patching the folding
  rules apart reds the agreement lock; re-declaring the wire field reds the descriptor
  locks. Nothing to build for deliverable 1 — the PR body records the verification.

What remains is deliverables 2 and 3, and they are prose with live defects at their
centre — the anti-invariant is in the tree twice, in escalating strength:

- The `tolokaforge/core/hash.py` module docstring closes with "All hash computations
  across the codebase should use compute_stable_hash() to ensure consistent results" —
  false: core grading deliberately does not.
- `docs/TASK_DESCRIPTION_SCHEMA.md` § Canonical Hash Algorithm (~line 721) states it
  with more force: "**CRITICAL:** All components MUST use the identical hash algorithm
  for grading to work correctly", pseudocode whose docstring names both adapter-family
  grading paths and "Any other component computing state hashes" as required users of
  one algorithm, and "IMPORTANT: Do NOT use str(tuple) or other serialization methods!"
  — which condemns core's actual `consistent_hash` (`sha256(str(value))`,
  `state_checks.py:83-85`) by name of technique. Design Principle 6 (~line 23) repeats
  the claim, and `docs/GRPC_PROTOCOL.md` (~line 784-793) cross-references it as a MUST
  binding "All components (DB Service, adapters, grading engine)". The section is stale
  on a second axis too: its pseudocode is the pre-folding shape — no number
  canonicalization step — so it describes neither substrate's current algorithm.

An implementer taking any of these at their word would "unify" one substrate's algebra
onto the other — the exact mistake the canonical locks exist to catch, invited by the
tree's own prose. This is the issue's closing observation ("the next such path is
written on the assumption that a state hash is a state hash") sitting in the tree as
normative instruction.

## Goal

The invariant is stated, as current fact, at every surface an implementer reaches before
writing a hash comparison — and the unification decision is recorded:

1. **The invariant:** a hash comparison hashes both sides with one function, on one
   substrate; a digest never crosses substrates and is never persisted as a comparison
   operand. The two functions share the equivalence relation (both fold through
   `canonical_number`) and share nothing about the label.
2. **The decision:** the two algebras stay separate, deliberately. `compute_stable_hash`
   backs persisted digests — db-service ETags (`compute_etag`), snapshot hashes, and the
   `ResetTrialResponse.state_hash` / `GetStateResponse.stable_hash` wire fields — and
   core's algebra reproduces the digests in recorded bundles, so changing either function
   invalidates digests that already exist; and since #693 removed every crossing route,
   no consumer needs portability. Unification would pay a real migration for a property
   nothing uses.

## Non-goals

- No change to either hash function's behaviour — not one byte of any digest moves.
- No new tests. The canonical lock module exists and is green; this PR's prose points at
  it rather than duplicating it.
- #687 (runner-side `numeric_string_fields` folding differential), #836
  (`compute_golden_hash` dead contract method), #815 (golden-action name namespaces) —
  all stay where they are tracked.
- No purge of `#915` citations already in `docs/GRADING.md` (lines ~210, ~2817): they
  cite the issue as provenance for a fact, match the doc's citation convention, and will
  point at a closed issue carrying the decision record.

## Stages

### Stage 1: State the invariant at its surfaces and record the decision

- **Contract:** documentation-and-docstring only; no runtime behaviour, schema, CLI, or
  API change anywhere. The surfaces and what each must say when the stage is done:
  - `tolokaforge/core/hash.py` **module docstring** — the false universality sentence
    ("All hash computations across the codebase should use compute_stable_hash()…") is
    gone. In its place, the module states its actual scope: this is the **runner
    substrate's** digest — db-service state hashes, ETags (`compute_etag`), snapshot
    hashes, and the reset/state wire fields — while core grading's digest is
    `state_digest` in `tolokaforge/core/grading/state_checks.py`; the two functions
    agree on which states are equal (both fold through this module's
    `canonical_number`) and disagree on every digest, so a comparison hashes both sides
    with one function and a digest never crosses substrates.
  - `compute_stable_hash` **docstring** — gains the invariant plus the reason the
    function is frozen: its digests are persisted (ETags, snapshots, wire fields), so a
    serialisation change invalidates every digest already stored. Points at the
    canonical lock module by path.
  - `tolokaforge/core/grading/state_checks.py` — `consistent_hash` and `state_digest`
    docstrings state the mirror image: this is **core's** algebra; the runner's is
    `compute_stable_hash`; same equivalence relation, different labels; a digest this
    function produced is comparable only against another one it produced. `state_digest`
    already carries the within-core both-sides rule — the addition extends it across the
    substrate boundary; no existing sentence is contradicted.
  - `docs/GRADING.md` § Substrate Parity — one normative paragraph beside the hash
    family's source-shape bullets (the `expect_initial_state` bullet at ~line 205
    already states the two-algebras fact as a consequence): every hash comparison in the
    system computes both sides on one substrate; the two algebras share the folding
    promise (`numeric_string_fields` behaves identically) and nothing else; digests
    never cross and are never authored — which is why hash sources name states rather
    than digests — and the two functions are deliberately not unified, because
    `compute_stable_hash`'s digests are persisted and core's reproduce recorded bundles,
    so either change invalidates existing digests while no consumer needs portability.
    Names `tests/canonical/test_expected_state_hash_is_not_portable.py` as the lock.
    Written as the only state — no "previously", no "decision history".
  - `tests/canonical/test_expected_state_hash_is_not_portable.py` **module docstring** —
    the closing sentence "See #915 for unifying the two hash functions, which is not in
    reach here…" currently defers an open question; it becomes the answer: the two are
    deliberately separate, digests never cross, and unification is refused because
    persisted digests (ETags, snapshots, wire fields, recorded bundles) would all
    invalidate. Test bodies untouched.
  - `docs/TASK_DESCRIPTION_SCHEMA.md` **§ Canonical Hash Algorithm** (~line 721) —
    rewritten as current fact. The section defines the **runner substrate's**
    persisted-digest algorithm — what db-service's `/state/hash` endpoint, ETags,
    snapshot hashes and the reset/state wire fields all compute — and its scope claim
    shrinks to exactly that: the MUST binds every consumer of *that substrate's
    digests*, not "all components". The pseudocode is corrected to the current
    `compute_stable_hash` shape (unstable-field filtering, datetime conversion, number
    canonicalization — default-on for numeric types, per-field opt-in for
    numeric-looking strings — then compact sorted JSON, SHA-256) or replaced by a
    pointer to `tolokaforge/core/hash.py` as the implementation of record, whichever
    reads cleaner; either way the "Do NOT use str(tuple)" admonition is replaced by the
    invariant: core grading's digest is a different algebra by design, the two agree on
    the equivalence relation only, and a comparison hashes both sides on one substrate
    — with a pointer to `docs/GRADING.md` § Substrate Parity. **Design Principle 6**
    (~line 23) is rewritten to state the actual principle: state-hash comparisons are
    computed within one substrate's algorithm; digests never cross. Naming stays at the
    level the section already uses (in-repo adapter and module names only — no new
    external names introduced).
  - `docs/GRPC_PROTOCOL.md` **"CRITICAL: Hash Algorithm Compatibility"** block
    (~line 784-793) — the MUST re-scoped to what is true: `db_service.get_stable_hash()`
    and every comparison against its output use the canonical persisted-digest
    algorithm; the "All components (DB Service, adapters, grading engine) MUST use this
    exact algorithm" sentence is replaced by the invariant + the § Substrate Parity
    pointer, since the grading engine's core substrate demonstrably does not and must
    not be told to.
- **Behaviour to lock:** none new — the lock already exists at canonical tier
  (15 tests in the module above, green at `47733013`). The stage's claims map onto its
  assertions: "same equivalence relation" is
  `test_both_substrates_induce_the_same_equivalence_relation` (falsifier: patch either
  function's folding and it reds), "different labels" is
  `test_the_two_substrates_label_the_same_state_differently` (falsifier: patch either
  function to the other's serialisation and it reds), "no crossing route" is the two
  descriptor tests (falsifier: re-declare the wire field or un-reserve number 3).
  Every normative sentence the stage writes is backed by one of those assertions or
  describes call sites verifiable by `rg` (`compute_etag`, the proto fields).
- **Compatibility:** internal only. Docstrings and docs; no compatibility surface moves.
- **Deliverable:** a tree where reading either hash function tells an implementer the
  other exists, why the digests differ, and that the difference is a decision with a
  lock — and where no docstring invites migrating one substrate onto the other's
  algebra. #915 closes on this PR with the decision paragraph in the PR body.
- **Validation:**
  - `uv run pytest tests/canonical/test_expected_state_hash_is_not_portable.py tests/canonical/test_grading_substrate_parity.py -q` — green (docstring edits cannot move behaviour; this proves it).
  - `uv run pytest tests/unit/grading/ -q -m unit` — green.
  - `rg -n "All hash computations" tolokaforge docs` — no hits.
  - `rg -n "not in reach here" tests/` — no hits.
  - **Concept-level sweep, not just the exact words:**
    `rg -in "identical hash|canonical hash algorithm|MUST use.*hash|same hash algorithm" docs tolokaforge tests`
    — every surviving hit reviewed and either scoped to one substrate or already
    stating the invariant. Known-acceptable residue: `compute_etag`'s docstring
    ("using the canonical hash algorithm", `tolokaforge/core/hash.py:342`) is an
    intra-substrate claim — it aliases `compute_stable_hash` — and stays; a hit
    claiming cross-substrate universality is a stage failure, whatever its phrasing.
  - `mcp__dev__format_check` / `lint_check` scoped to the three touched Python files;
    `black --check` on them too (both formatters must pass; 68-file ruff drift baseline
    is not ours to touch).
- **Doc updates:** `docs/GRADING.md` as specified above — the doc edit *is* the stage,
  not an appendix to it.

## Discovered issues

- **Fix in this PR:** the false universality sentence in `tolokaforge/core/hash.py`'s
  module docstring — it is deliverable 2's own surface, not a side find.
- **Filed as issues:** #957 — the dev MCP `run_tests` tool silently ignores an unknown
  argument (`paths` for `path`) and runs the full 8,847-test suite instead of refusing;
  observed during this discovery, fail-fast violation in `tools/dev-mcp`.

## Risks / open questions

- **A prose-only PR closing a `bug`-labelled issue.** Deliberate: the behavioural half
  of #915 was consumed by #693 (route removed + canonical lock), verified green here.
  If the critic or user wants a redundant assertion added anyway, the natural home is
  one more labelled state in `_LABELLED_STATES` — but the plan's position is that the
  existing locks are sufficient and duplication adds review surface, not safety.
- **Milestone concurrency.** The stage touches `docs/GRADING.md` (§ Substrate Parity,
  ~line 205 region) and the canonical module's docstring — both edited by #742/#693 on
  this integration branch, which has already moved past this plan's measurement commit
  (`47733013` → `9a50e473`, #742 merged). Main pins the implementer to current HEAD;
  every cited section and line anchor is re-read as it stands at dispatch, never
  patched against this plan's excerpts.
- **Issue-closure mechanics.** Deliverable 3 asks for the decision "recorded"; the
  durable record is `docs/GRADING.md` + the two module docstrings, and the PR body
  carries the same paragraph so #915's closure event contains it. Main owns posting it.

---
**Main-authored execution note (post-Stage-1, ratified as justified drift):** the implementer found `docs/DB_SERVICE_API.md` carrying TWO sibling copies of the defect outside this plan's surface list — §4 "Hash Computation Algorithm" (stale pre-folding pseudocode + "must match the canonical algorithm", plus an inbound anchor to the renamed section) and a second full `## Hash Computation Algorithm` section (~:609, "MUST match mcp_core…", named-adapter compatibility claims). Both escaped the plan's sweep regexes but meet its stated failure criterion. Fixed in the same commit (`30e765d4`): both replaced with pointers to `compute_stable_hash` + the invariant. Also: § Canonical Hash Algorithm was renamed § Stable State Hash (the heading itself matched the sweep pattern); both inbound anchors updated; `rg canonical-hash-algorithm` clean. Residue line anchor moved hash.py:342→:364 (docstrings above grew).

## Discovered issues
- Filed: #957 (dev MCP `run_tests` silently ignores an unknown argument and runs the full suite — found during planning).
- Fixed in this PR beyond the planned surface list (justified drift, plan-recorded): `docs/DB_SERVICE_API.md` carried three further copies of the false universality claim — two full "Hash Computation Algorithm" sections and a Design Principles bullet — all replaced with the invariant and pointers.

## Test plan
- `tests/canonical/test_expected_state_hash_is_not_portable.py`: 15 passed (assertions untouched; docstring resolves the #915 forward reference into the recorded decision).
- `tests/canonical/test_grading_substrate_parity.py`: 110 passed. `tests/unit/grading/ -m unit`: 1503 passed.
- Concept-level sweep (positive-controlled before the edits against all five offending lines): after, the only survivor is `compute_etag`'s intra-substrate wording — the plan's one declared-acceptable residue.
- Every `.py` hunk verified docstring-only during review; zero behaviour bytes moved.

Closes #915
