### PR TITLE
fix(tests): every parity fixture declares the tools its grading names

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -243,6 +243,20 @@ A pack whose key reads DB state declares its rows in `task.yaml`'s `initial_stat
 not only in the case's `state:` — the runner provisions a trial's DB service from
 `initial_state`, and lock 15 grades every pack through `RegisterTrial`.
 
+A parity pack's `tools.agent.enabled` names every tool its grading block and its
+trials do: the authoring gate refuses a matcher or a `tool_expectations` entry
+naming a tool no actor can call, and a declaration short of the timeline describes
+a trial the task could not have run. The schemas come from the pack's own
+`mcp_server.py` through the `fixtures/tools.json` it commits beside it — a JSON
+list of `{name, description, parameters}` covering *every* enabled tool, including
+`write_file`, because one server sources all of an MCP-bearing task's tools. Each
+`parameters` object declares as `properties`, under `additionalProperties: false`,
+every argument name that pack's matchers address and its timeline sends, which is
+what puts the gate's argument checks at error tier rather than leaving them
+unchecked. Nothing starts these servers — both parity suites substitute a call's
+recorded result before any `ExecuteTool` — so a script's bodies echo their
+arguments, and it exists to define the tools whose schemas the pack ships.
+
 The pack directory is the author key with its dots replaced by underscores, so a
 leaf key inside a list field gets its own pack:
 `trace_checks.constraints.absent_before` is

--- a/tests/README.md
+++ b/tests/README.md
@@ -156,6 +156,15 @@ Compare output against committed golden snapshots in `snapshots/`.
 - Grading pipeline results
 - Custom checks with real project data (food_delivery_2)
 - Golden-set hash grading verification
+- Authoring-gate corpus (`test_example_pack_grading_corpus.py`) — every pack under
+  `examples/` and `tests/data/tasks/` faces the whole gate against its own tool
+  inventory and effective combine, and
+  `test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate` holds the 48
+  authored packs outside those roots — `grading_parity`, `transcript_parity`,
+  `tests/data/projects` and `tests/data/migration_packs` — to the same gate. A new
+  parity fixture whose grading names a tool its `task.yaml` never declares fails
+  there, before anyone runs `validate`. Every pack in that walk carries a positive
+  control, so the sweep cannot read clean by having stopped running.
 - Grading substrate parity (`test_grading_substrate_parity.py`) — a failure means a
   `grading.yaml` key is unaccounted for, claims a substrate that does not evaluate
   it, addresses a position below a claimed field by something other than an element

--- a/tests/README.md
+++ b/tests/README.md
@@ -163,8 +163,9 @@ Compare output against committed golden snapshots in `snapshots/`.
   authored packs outside those roots — `grading_parity`, `transcript_parity`,
   `tests/data/projects` and `tests/data/migration_packs` — to the same gate. A new
   parity fixture whose grading names a tool its `task.yaml` never declares fails
-  there, before anyone runs `validate`. Every pack in that walk carries a positive
-  control, so the sweep cannot read clean by having stopped running.
+  there, before anyone runs `validate`. Every pack in that walk carries both of the
+  walk's positive controls — a tool no actor can call and a weight naming no
+  component — so the sweep cannot read clean by having stopped running.
 - Grading substrate parity (`test_grading_substrate_parity.py`) — a failure means a
   `grading.yaml` key is unaccounted for, claims a substrate that does not evaluate
   it, addresses a position below a claimed field by something other than an element
@@ -221,9 +222,11 @@ Compare output against committed golden snapshots in `snapshots/`.
   to cross-referencing each other, so neither spelling can be documented alone.
 
 Every substrate-parity pack lives in `tests/data/grading_parity/<task_id>/` and
-authors a `task.yaml` and a `grading.yaml`. A pack that drives a differential adds
-a `trial.yaml` holding one named case per trial it grades — conventionally
-`satisfying` and `violating` — in the one shape its loader reads:
+authors a `task.yaml` and a `grading.yaml`, and — where its grading or its trials
+name a tool — an `mcp_server.py` with the `fixtures/tools.json` described below. A
+pack that drives a differential adds a `trial.yaml` holding one named case per
+trial it grades — conventionally `satisfying` and `violating` — in the one shape
+its loader reads:
 
 ```yaml
 satisfying:
@@ -264,7 +267,7 @@ every argument name that pack's matchers address and its timeline sends, which i
 what puts the gate's argument checks at error tier rather than leaving them
 unchecked. Nothing starts these servers — both parity suites substitute a call's
 recorded result before any `ExecuteTool` — so a script's bodies echo their
-arguments, and it exists to define the tools whose schemas the pack ships.
+arguments: the script exists to define the tools whose schemas the pack ships.
 
 The pack directory is the author key with its dots replaced by underscores, so a
 leaf key inside a list field gets its own pack:

--- a/tests/canonical/test_example_pack_grading_corpus.py
+++ b/tests/canonical/test_example_pack_grading_corpus.py
@@ -28,9 +28,12 @@ Fifteen claims over the packs an author reads as the reference:
    ``examples/`` and ``tests/data/tasks/`` is checked against its own task's tool
    inventory *and* its own effective combine, and produces no error, no advisory and
    nothing unchecked — the measured proof that the gate ships green rather than the
-   claim that it does. The rules a ``task.yaml`` holder can run without a tool set
-   are held over the wider 107-pack walk too, so a pack outside the two task roots
-   cannot declare a section that asserts nothing.
+   claim that it does. The 48 authored packs outside those two roots — the two parity
+   roots, the recorded projects and the migration fixtures — face the same whole gate
+   against their own inventories, so a fixture naming a tool its task never declares
+   is refused before anyone runs ``validate``. The rules a ``task.yaml`` holder can
+   run without a tool set are held over the wider 107-pack walk on top of that, so no
+   pack anywhere can declare a section that asserts nothing.
 6. **``cache_debug`` grades two genuinely alternative diagnostic routes and cannot be
    passed by mutating.** Either comparison its rubric reference names scores in full
    and records itself as the winner; completing neither scores below completing
@@ -88,6 +91,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -645,11 +649,13 @@ def test_no_shipped_pack_fails_the_authoring_gate() -> None:
 def test_no_authored_grading_block_asserts_nothing() -> None:
     """Rule 1 over all 107 authored packs, which is 48 more than the gate walk reaches.
 
-    ``tests/data/grading_parity``, ``tests/data/transcript_parity`` and
-    ``tests/data/projects`` sit outside
+    ``tests/data/grading_parity``, ``tests/data/transcript_parity``,
+    ``tests/data/projects`` and ``tests/data/migration_packs`` sit outside
     :func:`_gated_packs`, so without this the rule's corpus proof stops at the packs
     that happen to live under the two task roots. The inventory is deliberately
-    unresolvable: the rules that need a tool set are the gate guard's business above,
+    unresolvable: the rules that need a tool set are the two gate guards' business —
+    the one above for the task roots, and
+    :func:`test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate` for these —
     and what is wanted here is every rule a caller holding a ``task.yaml`` can run
     without one, over the widest walk in the file.
 
@@ -700,8 +706,9 @@ def test_no_authored_grading_block_asserts_nothing() -> None:
     )
 
 
-# The address the golden-action name rule reports under, and a name no pack declares,
-# injected into every pack's hash block as the positive control.
+# The address the golden-action name rule reports under, and a name no pack declares.
+# The name is every tool-set control's sentinel: injected into a hash block here, and
+# written over a matcher or a tool_expectations entry by the whole-gate guard.
 _GOLDEN_ACTION_ADDRESS = "state_checks.hash.golden_actions["
 _A_TOOL_NO_ACTOR_CAN_CALL = "a_tool_no_actor_can_call"
 
@@ -709,11 +716,11 @@ _A_TOOL_NO_ACTOR_CAN_CALL = "a_tool_no_actor_can_call"
 def _golden_action_findings(report: AuthoringReport) -> list[str]:
     """Only what the golden-action name rule reported, out of the whole gate's report.
 
-    Scoped to one rule because this walk is 46 packs wider than
-    :func:`_gated_packs`, and the extra packs are wire-parity fixtures that name tools
-    no actor is given on purpose — over the whole report the guard below would be red on
-    21 of them for reasons that are not this rule's. Widening the gate walk itself is a
-    corpus measurement of its own.
+    Scoped to one rule because the guard below is a single-rule instrument: it pairs its
+    walk with a control provoking this rule and nothing else, so a finding another rule
+    reported would leave the sweep saying nothing about whether this one still fires.
+    The whole gate over the packs beyond :func:`_gated_packs` is
+    :func:`test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate`'s business.
     """
     return [
         f"{finding.where}: {finding.message}"
@@ -794,6 +801,181 @@ def test_no_authored_golden_action_names_a_tool_no_actor_can_call() -> None:
     )
 
 
+# The authored packs the gate walk does not reach: the two parity roots, the recorded
+# projects and the migration fixtures. Pinned so a walk that stopped finding them fails
+# rather than passing over the empty set, and computed as a difference so a fifth root
+# is covered the day someone adds one.
+_PACKS_OUTSIDE_THE_GATE_WALK = 48
+
+# The two addresses a name no actor can call is reported under, one per producer.
+_UNCALLABLE_TOOL_ADDRESSES = ("trace_checks.", "transcript_rules.tool_expectations.")
+
+
+def _packs_outside_the_gate_walk() -> list[Path]:
+    """Every authored pack :func:`_gated_packs` does not reach."""
+    gated = {task_yaml for task_yaml, _ in _gated_packs()}
+    return [task_yaml for task_yaml in _authored_packs() if task_yaml not in gated]
+
+
+def _findings_naming_the_uncallable_tool(report: AuthoringReport) -> list[str]:
+    """Only what the control provoked, filtered on the sentinel in the message.
+
+    On the name rather than on an address, because the control reaches its packs by two
+    branches reporting under different addresses: an address constant answers for one
+    branch and passes over the other half of the walk. The name also keeps the filter
+    honest should a pack ever carry a finding of its own at the injected address, which
+    an address constant would read as the control firing. Both producers quote the
+    offending tool, so one predicate reads both branches.
+    """
+    return [
+        f"{finding.where}: {finding.message}"
+        for finding in report.errors + report.advisories
+        if _A_TOOL_NO_ACTOR_CAN_CALL in finding.message
+    ]
+
+
+def _retargeting_one_tool_named(grading: Any) -> bool:
+    """Point the first tool-naming site in *grading* at a tool no actor can call.
+
+    In place and depth-first, so the site is the first one an author reads. Returns
+    whether the block held one at all: half the walk authors neither a matcher nor a
+    ``tool_expectations`` entry, and those packs need the other branch.
+    """
+    if isinstance(grading, dict):
+        tool = grading.get("tool")
+        if isinstance(tool, dict):
+            if isinstance(tool.get("equals"), str):
+                tool["equals"] = _A_TOOL_NO_ACTOR_CAN_CALL
+                return True
+            for key in ("in_", "in"):
+                named = tool.get(key)
+                if isinstance(named, list) and named and isinstance(named[0], str):
+                    named[0] = _A_TOOL_NO_ACTOR_CAN_CALL
+                    return True
+        expectations = grading.get("tool_expectations")
+        if isinstance(expectations, dict):
+            for key in ("required_tools", "disallowed_tools"):
+                named = expectations.get(key)
+                if isinstance(named, list) and named and isinstance(named[0], str):
+                    named[0] = _A_TOOL_NO_ACTOR_CAN_CALL
+                    return True
+        return any(_retargeting_one_tool_named(value) for value in grading.values())
+    if isinstance(grading, list):
+        return any(_retargeting_one_tool_named(value) for value in grading)
+    return False
+
+
+def _naming_a_tool_no_actor_can_call_where_the_pack_looks(
+    grading: Mapping[str, Any],
+) -> dict[str, Any]:
+    """*grading* with one tool no actor can call, wherever this pack can hold one.
+
+    A pack carrying a matcher or a ``tool_expectations`` entry has that site retargeted,
+    which is what puts the trace rule under the control. The 23 carrying neither have a
+    ``disallowed_tools`` entry injected instead — beside whatever the block already
+    declares, the way :func:`_naming_a_tool_no_actor_can_call` injects a golden action.
+    Mutating alone would leave half the walk with no control at all.
+    """
+    retargeted = deepcopy(dict(grading))
+    if _retargeting_one_tool_named(retargeted):
+        return retargeted
+    rules = {**(grading.get("transcript_rules") or {})}
+    expectations = {**(rules.get("tool_expectations") or {})}
+    expectations["disallowed_tools"] = [
+        *(expectations.get("disallowed_tools") or []),
+        _A_TOOL_NO_ACTOR_CAN_CALL,
+    ]
+    rules["tool_expectations"] = expectations
+    return {**grading, "transcript_rules": rules}
+
+
+def test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate() -> None:
+    """The parity roots and their neighbours face every rule, not only the block-only ones.
+
+    :func:`_gated_packs` stops at the two task roots, which leaves the 48 packs under
+    ``grading_parity``, ``transcript_parity``, ``tests/data/projects`` and
+    ``tests/data/migration_packs`` reached only by guards scoped to a single rule
+    apiece. Here each faces the whole gate, against **its own** inventory, replay world,
+    hash layer and seeded tables, built the way ``tolokaforge validate``'s caller builds
+    them — so a fixture whose grading names a tool its task never declares is refused
+    here, before anyone runs ``validate`` and before a trial is paid for.
+
+    The residue is asserted empty rather than pinned to whatever comes back: every one of
+    these packs declares the schemas of the arguments it addresses, so a skip appearing
+    here is a fixture that stopped doing so.
+
+    The control is defined for every pack by whichever of its two branches that pack can
+    carry, because the 23 authoring neither a matcher nor a ``tool_expectations`` entry
+    would otherwise sit inside a walk that proves nothing about them.
+    """
+    findings: dict[str, list[str]] = {}
+    advisories: dict[str, list[str]] = {}
+    unchecked: dict[str, list[str]] = {}
+    unprobed: list[str] = []
+    misaddressed: list[str] = []
+    packs = _packs_outside_the_gate_walk()
+
+    for task_yaml in packs:
+        task, task_dir = load_task_yaml(task_yaml)
+        assert task.grading is not None
+        grading = yaml.safe_load((task_dir / task.grading).read_text()) or {}
+        inventory = build_tool_inventory(task, task_dir)
+        world = replay_world_under_adapter(task, task.adapter_type)
+        layer = hash_source_layer_under_adapter(task, task_dir, task.adapter_type)
+        tables = seeded_tables_under_adapter(task, task_dir, task.adapter_type)
+        pack = str(task_yaml.relative_to(_REPO))
+
+        report = inspect_grading_authoring(
+            grading, inventory, replay_world=world, hash_sources=layer, seeded_tables=tables
+        )
+        if report.errors:
+            findings[pack] = [f"{f.where}: {f.message}" for f in report.errors]
+        if report.advisories:
+            advisories[pack] = [f"{f.where}: {f.message}" for f in report.advisories]
+        if report.unchecked:
+            unchecked[pack] = [f"{skip.where}: {skip.reason}" for skip in report.unchecked]
+
+        probed = inspect_grading_authoring(
+            _naming_a_tool_no_actor_can_call_where_the_pack_looks(grading),
+            inventory,
+            replay_world=world,
+            hash_sources=layer,
+            seeded_tables=tables,
+        )
+        reported = _findings_naming_the_uncallable_tool(probed)
+        if not reported:
+            unprobed.append(pack)
+        misaddressed += [
+            where for where in reported if not where.startswith(_UNCALLABLE_TOOL_ADDRESSES)
+        ]
+
+    assert len(packs) == _PACKS_OUTSIDE_THE_GATE_WALK, (
+        f"the guard inspected {len(packs)} packs, not {_PACKS_OUTSIDE_THE_GATE_WALK}. A "
+        "corpus proof over a subset says nothing about the packs it skipped"
+    )
+    assert findings == {}, (
+        "these packs cannot be graded as written: the gate refuses the block against the "
+        "tool set the pack's own task declares, so every trial they grade is paid for "
+        "and lost"
+    )
+    assert advisories == {}, (
+        "the gate reported a probable defect in these packs, and a corpus that ships one "
+        "teaches the shape it reports"
+    )
+    assert unchecked == {}, (
+        "the gate could not check a rule for these packs — an addressed argument whose "
+        "schema no longer resolves — so the sweep above passed over what it reports on"
+    )
+    assert unprobed == [], (
+        "the gate did not refuse a tool no actor can call for these packs, so the rule "
+        "never ran here and the clean sweep above proves nothing about them"
+    )
+    assert misaddressed == [], (
+        "a control finding quoted the sentinel from an address neither the trace rule "
+        f"nor the tool-expectation rule owns: {misaddressed}"
+    )
+
+
 # The address the replay-world rule reports the whole block under, distinct from the
 # per-action ``…[i].name`` the name rule uses, so scoping to one is scoping to one rule.
 _GOLDEN_REPLAY_WORLD_ADDRESS = "state_checks.hash.golden_actions"
@@ -802,8 +984,8 @@ _GOLDEN_REPLAY_WORLD_ADDRESS = "state_checks.hash.golden_actions"
 def _replay_world_findings(report: AuthoringReport) -> list[str]:
     """Only what the replay-world rule reported, out of the whole gate's report.
 
-    Scoped for the reason :func:`_golden_action_findings` gives: this walk reaches 46
-    packs the gate walk does not, and they name tools no actor is given on purpose.
+    Scoped for the reason :func:`_golden_action_findings` gives: one rule, one control,
+    so the sweep answers for the rule its control provokes.
     """
     return [
         f"{finding.where}: {finding.message}"
@@ -837,8 +1019,8 @@ def test_no_authored_pack_gives_its_golden_replay_no_world_to_be_built_in() -> N
     Over all 107 authored packs, each against **its own** replay world resolved the way
     the gate's callers resolve it, because the facts the rule reads live in ``task.yaml``
     rather than in the block. The tool inventory is deliberately unresolvable: this rule
-    reads no tool, and the packs outside the two task roots name tools no actor is given
-    on purpose.
+    reads no tool, so resolving one would decide nothing here and would couple this
+    sweep to a rule its control does not provoke.
 
     Every pack is checked a second time with its MCP server module withheld and a golden
     action injected, which has to be refused — without that control a rule that stopped
@@ -908,8 +1090,8 @@ _PACKS_DECLARING_A_FOLD_SCORED_STATE_SOURCE = 26
 def _probe_exclusivity_findings(report: AuthoringReport) -> list[str]:
     """Only what the state-source exclusivity rule reported, out of the whole report.
 
-    Scoped for the reason :func:`_golden_action_findings` gives: this walk reaches 46
-    packs the gate walk does not, and they name tools no actor is given on purpose.
+    Scoped for the reason :func:`_golden_action_findings` gives: one rule, one control,
+    so the sweep answers for the rule its control provokes.
     """
     return [
         f"{finding.where}: {finding.message}"
@@ -967,8 +1149,9 @@ def test_no_authored_pack_declares_a_probe_beside_another_state_source() -> None
     that stopped declaring hash and JSONPath sources could not leave the positive arm
     vacuous.
 
-    The tool inventory is deliberately unresolvable: this rule reads no tool, and the
-    packs outside the two task roots name tools no actor is given on purpose.
+    The tool inventory is deliberately unresolvable: this rule reads no tool, so
+    resolving one would decide nothing here and would couple this sweep to a rule its
+    control does not provoke.
     """
     findings: dict[str, list[str]] = {}
     unprobed: list[str] = []

--- a/tests/canonical/test_example_pack_grading_corpus.py
+++ b/tests/canonical/test_example_pack_grading_corpus.py
@@ -30,8 +30,11 @@ Fifteen claims over the packs an author reads as the reference:
    nothing unchecked — the measured proof that the gate ships green rather than the
    claim that it does. The 48 authored packs outside those two roots — the two parity
    roots, the recorded projects and the migration fixtures — face the same whole gate
-   against their own inventories, so a fixture naming a tool its task never declares
-   is refused before anyone runs ``validate``. The rules a ``task.yaml`` holder can
+   through the same call site, against their own inventories and their own effective
+   combines, so a fixture naming a tool its task never declares, or weighting a
+   component it never configures, is refused before anyone runs ``validate``. Every
+   schema those packs resolve closes its argument set, which is what keeps the
+   argument rules refusing rather than advising. The rules a ``task.yaml`` holder can
    run without a tool set are held over the wider 107-pack walk on top of that, so no
    pack anywhere can declare a section that asserts nothing.
 6. **``cache_debug`` grades two genuinely alternative diagnostic routes and cannot be
@@ -115,6 +118,7 @@ from tolokaforge.adapters._task_loader import (
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.grading.combine import GradingEngine
 from tolokaforge.core.grading.config_validation import (
+    ArgumentSchema,
     AuthoringReport,
     HashSourceLayer,
     ReplayWorld,
@@ -708,7 +712,8 @@ def test_no_authored_grading_block_asserts_nothing() -> None:
 
 # The address the golden-action name rule reports under, and a name no pack declares.
 # The name is every tool-set control's sentinel: injected into a hash block here, and
-# written over a matcher or a tool_expectations entry by the whole-gate guard.
+# written over a matcher or a tool_expectations entry — or injected as one where the
+# pack authors neither — by the whole-gate guard.
 _GOLDEN_ACTION_ADDRESS = "state_checks.hash.golden_actions["
 _A_TOOL_NO_ACTOR_CAN_CALL = "a_tool_no_actor_can_call"
 
@@ -847,11 +852,10 @@ def _retargeting_one_tool_named(grading: Any) -> bool:
             if isinstance(tool.get("equals"), str):
                 tool["equals"] = _A_TOOL_NO_ACTOR_CAN_CALL
                 return True
-            for key in ("in_", "in"):
-                named = tool.get(key)
-                if isinstance(named, list) and named and isinstance(named[0], str):
-                    named[0] = _A_TOOL_NO_ACTOR_CAN_CALL
-                    return True
+            named = tool.get("in_")
+            if isinstance(named, list) and named and isinstance(named[0], str):
+                named[0] = _A_TOOL_NO_ACTOR_CAN_CALL
+                return True
         expectations = grading.get("tool_expectations")
         if isinstance(expectations, dict):
             for key in ("required_tools", "disallowed_tools"):
@@ -895,23 +899,40 @@ def test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate() -> None:
     :func:`_gated_packs` stops at the two task roots, which leaves the 48 packs under
     ``grading_parity``, ``transcript_parity``, ``tests/data/projects`` and
     ``tests/data/migration_packs`` reached only by guards scoped to a single rule
-    apiece. Here each faces the whole gate, against **its own** inventory, replay world,
-    hash layer and seeded tables, built the way ``tolokaforge validate``'s caller builds
-    them — so a fixture whose grading names a tool its task never declares is refused
-    here, before anyone runs ``validate`` and before a trial is paid for.
+    apiece. Here each faces the whole gate through :func:`_gate_reports` — the same
+    instrument the gated walk runs, over the half of the corpus that walk does not
+    reach — against **its own** inventory, replay world, hash layer, seeded tables and
+    effective combine, built the way ``tolokaforge validate``'s caller builds them. So a
+    fixture whose grading names a tool its task never declares is refused here, before
+    anyone runs ``validate`` and before a trial is paid for.
 
     The residue is asserted empty rather than pinned to whatever comes back: every one of
     these packs declares the schemas of the arguments it addresses, so a skip appearing
     here is a fixture that stopped doing so.
 
-    The control is defined for every pack by whichever of its two branches that pack can
-    carry, because the 23 authoring neither a matcher nor a ``tool_expectations`` entry
-    would otherwise sit inside a walk that proves nothing about them.
+    Closure is asserted beside the residue because ``fixtures/tools.json`` is a cache: a
+    pack whose committed file goes missing has it regenerated from the pack's own server,
+    and the servers never emit ``additionalProperties``. The regenerated schema checks
+    the same argument names at advisory tier instead of refusing them, which moves
+    nothing in a report whose addressed arguments are all present — so neither the sweep
+    nor the residue can see that happen, and this list can. A tool whose schema does not
+    resolve read-only at all is a different state and stays legitimate here.
+
+    Two controls, because the sweep answers for two families of rule. Every pack is
+    checked again with a tool no actor can call, written wherever that pack can hold
+    one — the 23 authoring neither a matcher nor a ``tool_expectations`` entry would
+    otherwise sit inside a walk that proves nothing about them — and again with a weight
+    naming no component, which :func:`_gate_reports` supplies from the same resolved
+    combine: hand the gate no combine and the two weight rules are absent from the
+    report entirely, so a sweep that stopped resolving the layer would go on reading
+    clean over rules that never ran.
     """
     findings: dict[str, list[str]] = {}
     advisories: dict[str, list[str]] = {}
     unchecked: dict[str, list[str]] = {}
-    unprobed: list[str] = []
+    opened: list[str] = []
+    unprobed_tools: list[str] = []
+    unprobed_weights: list[str] = []
     misaddressed: list[str] = []
     packs = _packs_outside_the_gate_walk()
 
@@ -925,15 +946,22 @@ def test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate() -> None:
         tables = seeded_tables_under_adapter(task, task_dir, task.adapter_type)
         pack = str(task_yaml.relative_to(_REPO))
 
-        report = inspect_grading_authoring(
-            grading, inventory, replay_world=world, hash_sources=layer, seeded_tables=tables
-        )
+        report, weighted = _gate_reports(task_yaml, grading, inventory, world, layer, tables)
         if report.errors:
             findings[pack] = [f"{f.where}: {f.message}" for f in report.errors]
         if report.advisories:
             advisories[pack] = [f"{f.where}: {f.message}" for f in report.advisories]
         if report.unchecked:
             unchecked[pack] = [f"{skip.where}: {skip.reason}" for skip in report.unchecked]
+        opened += [
+            f"{pack}:{tool}"
+            for tool in sorted(inventory.declared)
+            if inventory.strictness(tool) is ArgumentSchema.OPEN
+        ]
+        if [finding.where for finding in weighted.errors] != [
+            f"combine.weights.{_A_WEIGHT_NAMING_NO_COMPONENT}"
+        ]:
+            unprobed_weights.append(pack)
 
         probed = inspect_grading_authoring(
             _naming_a_tool_no_actor_can_call_where_the_pack_looks(grading),
@@ -944,9 +972,11 @@ def test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate() -> None:
         )
         reported = _findings_naming_the_uncallable_tool(probed)
         if not reported:
-            unprobed.append(pack)
+            unprobed_tools.append(pack)
         misaddressed += [
-            where for where in reported if not where.startswith(_UNCALLABLE_TOOL_ADDRESSES)
+            reported_finding
+            for reported_finding in reported
+            if not reported_finding.startswith(_UNCALLABLE_TOOL_ADDRESSES)
         ]
 
     assert len(packs) == _PACKS_OUTSIDE_THE_GATE_WALK, (
@@ -966,9 +996,17 @@ def test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate() -> None:
         "the gate could not check a rule for these packs — an addressed argument whose "
         "schema no longer resolves — so the sweep above passed over what it reports on"
     )
-    assert unprobed == [], (
+    assert opened == [], (
+        "a schema in this walk stopped closing its argument set, so an argument the "
+        "gate would refuse is now only advised about and the sweep above reads green"
+    )
+    assert unprobed_tools == [], (
         "the gate did not refuse a tool no actor can call for these packs, so the rule "
         "never ran here and the clean sweep above proves nothing about them"
+    )
+    assert unprobed_weights == [], (
+        "the gate did not refuse a weight naming no component for these packs, so the "
+        "weight rules never ran here and the clean sweep above proves nothing about them"
     )
     assert misaddressed == [], (
         "a control finding quoted the sentinel from an address neither the trace rule "

--- a/tests/data/grading_parity/all_keys/fixtures/tools.json
+++ b/tests/data/grading_parity/all_keys/fixtures/tools.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "write_file",
+    "description": "Write content to a file",
+    "parameters": {
+      "properties": {
+        "path": {
+          "description": "Path to the file to write",
+          "title": "Path",
+          "type": "string"
+        },
+        "content": {
+          "description": "Content to write to the file",
+          "title": "Content",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "content"
+      ],
+      "title": "write_fileArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "close_widget",
+    "description": "Close a widget, ending work on it.",
+    "parameters": {
+      "properties": {
+        "widget_id": {
+          "description": "Widget identifier, e.g. 'W1'",
+          "title": "Widget Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "widget_id"
+      ],
+      "title": "close_widgetArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "delete_widget",
+    "description": "Delete a widget.",
+    "parameters": {
+      "properties": {
+        "widget_id": {
+          "description": "Widget identifier, e.g. 'W1'",
+          "title": "Widget Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "widget_id"
+      ],
+      "title": "delete_widgetArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "notify_customer",
+    "description": "Send the customer a message.",
+    "parameters": {
+      "properties": {
+        "widget_id": {
+          "description": "Widget identifier, e.g. 'W1'",
+          "title": "Widget Id",
+          "type": "string"
+        },
+        "message": {
+          "description": "Text sent to the customer",
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "widget_id",
+        "message"
+      ],
+      "title": "notify_customerArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/all_keys/mcp_server.py
+++ b/tests/data/grading_parity/all_keys/mcp_server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""MCP server for the all_keys parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "all-keys")
+
+
+@registry.tool("Write content to a file")
+def write_file(
+    data: dict,
+    path: Annotated[str, Field(description="Path to the file to write")],
+    content: Annotated[str, Field(description="Content to write to the file")],
+) -> dict:
+    return {"path": path, "content": content}
+
+
+@registry.tool("Close a widget, ending work on it.")
+def close_widget(
+    data: dict,
+    widget_id: Annotated[str, Field(description="Widget identifier, e.g. 'W1'")],
+) -> dict:
+    return {"widget_id": widget_id}
+
+
+@registry.tool("Delete a widget.")
+def delete_widget(
+    data: dict,
+    widget_id: Annotated[str, Field(description="Widget identifier, e.g. 'W1'")],
+) -> dict:
+    return {"widget_id": widget_id}
+
+
+@registry.tool("Send the customer a message.")
+def notify_customer(
+    data: dict,
+    widget_id: Annotated[str, Field(description="Widget identifier, e.g. 'W1'")],
+    message: Annotated[str, Field(description="Text sent to the customer")],
+) -> dict:
+    return {"widget_id": widget_id, "message": message}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/all_keys/task.yaml
+++ b/tests/data/grading_parity/all_keys/task.yaml
@@ -16,8 +16,12 @@ initial_state:
 
 tools:
   agent:
+    mcp_server: mcp_server.py
     enabled:
       - write_file
+      - close_widget
+      - delete_widget
+      - notify_customer
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_alternatives/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_alternatives/fixtures/tools.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "read_ledger",
+    "description": "Read the ledger entries held for an account.",
+    "parameters": {
+      "properties": {
+        "account_id": {
+          "description": "Account identifier, e.g. 'ACC-88'",
+          "title": "Account Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "account_id"
+      ],
+      "title": "read_ledgerArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "recompute_ledger_total",
+    "description": "Recompute an account's ledger total from its entries.",
+    "parameters": {
+      "properties": {
+        "account_id": {
+          "description": "Account identifier, e.g. 'ACC-88'",
+          "title": "Account Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "account_id"
+      ],
+      "title": "recompute_ledger_totalArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "fetch_statement",
+    "description": "Fetch an account's most recent statement.",
+    "parameters": {
+      "properties": {
+        "account_id": {
+          "description": "Account identifier, e.g. 'ACC-88'",
+          "title": "Account Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "account_id"
+      ],
+      "title": "fetch_statementArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "read_closing_balance",
+    "description": "Read the closing balance off a statement.",
+    "parameters": {
+      "properties": {
+        "account_id": {
+          "description": "Account identifier, e.g. 'ACC-88'",
+          "title": "Account Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "account_id"
+      ],
+      "title": "read_closing_balanceArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_alternatives/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_alternatives/mcp_server.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_alternatives parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-alternatives")
+
+
+@registry.tool("Read the ledger entries held for an account.")
+def read_ledger(
+    data: dict,
+    account_id: Annotated[str, Field(description="Account identifier, e.g. 'ACC-88'")],
+) -> dict:
+    return {"account_id": account_id}
+
+
+@registry.tool("Recompute an account's ledger total from its entries.")
+def recompute_ledger_total(
+    data: dict,
+    account_id: Annotated[str, Field(description="Account identifier, e.g. 'ACC-88'")],
+) -> dict:
+    return {"account_id": account_id}
+
+
+@registry.tool("Fetch an account's most recent statement.")
+def fetch_statement(
+    data: dict,
+    account_id: Annotated[str, Field(description="Account identifier, e.g. 'ACC-88'")],
+) -> dict:
+    return {"account_id": account_id}
+
+
+@registry.tool("Read the closing balance off a statement.")
+def read_closing_balance(
+    data: dict,
+    account_id: Annotated[str, Field(description="Account identifier, e.g. 'ACC-88'")],
+) -> dict:
+    return {"account_id": account_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_alternatives/task.yaml
+++ b/tests/data/grading_parity/trace_checks_alternatives/task.yaml
@@ -10,7 +10,12 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - read_ledger
+      - recompute_ledger_total
+      - fetch_statement
+      - read_closing_balance
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "servicenow_csm_update_case",
+    "description": "Update a customer service case, recording how it was resolved.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "u_resolution_code": {
+          "description": "Resolution code written on the case",
+          "title": "U Resolution Code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "u_resolution_code"
+      ],
+      "title": "servicenow_csm_update_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints")
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+@registry.tool("Update a customer service case, recording how it was resolved.")
+def servicenow_csm_update_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    u_resolution_code: Annotated[str, Field(description="Resolution code written on the case")],
+) -> dict:
+    return {"case_id": case_id, "u_resolution_code": u_resolution_code}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_get_payment
+      - servicenow_csm_update_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_absent/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_absent/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "billing_api_refund_payment",
+    "description": "Refund a payment in full.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_refund_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "customer_api_delete_account",
+    "description": "Delete a customer account and everything filed under it.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "customer_api_delete_accountArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_absent/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_absent/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_absent parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-absent")
+
+
+@registry.tool("Refund a payment in full.")
+def billing_api_refund_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+@registry.tool("Delete a customer account and everything filed under it.")
+def customer_api_delete_account(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_absent/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_absent/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_refund_payment
+      - customer_api_delete_account
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_absent_before/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_before/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "search_policy",
+    "description": "Search the policy library.",
+    "parameters": {
+      "properties": {
+        "query": {
+          "description": "Text to search the policy library for",
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "search_policyArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "servicenow_csm_update_case",
+    "description": "Update a customer service case, recording how it was resolved.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "u_resolution_code": {
+          "description": "Resolution code written on the case",
+          "title": "U Resolution Code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "u_resolution_code"
+      ],
+      "title": "servicenow_csm_update_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_absent_before/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_before/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_absent_before parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-absent-before")
+
+
+@registry.tool("Search the policy library.")
+def search_policy(
+    data: dict,
+    query: Annotated[str, Field(description="Text to search the policy library for")],
+) -> dict:
+    return {"query": query}
+
+
+@registry.tool("Update a customer service case, recording how it was resolved.")
+def servicenow_csm_update_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    u_resolution_code: Annotated[str, Field(description="Resolution code written on the case")],
+) -> dict:
+    return {"case_id": case_id, "u_resolution_code": u_resolution_code}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_absent_before/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_before/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - search_policy
+      - servicenow_csm_update_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_absent_between/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_between/fixtures/tools.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "open_case",
+    "description": "Open a case for a piece of work.",
+    "parameters": {
+      "properties": {
+        "subject": {
+          "description": "One-line summary the case is opened under",
+          "title": "Subject",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "open_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "close_case",
+    "description": "Close a case, ending work on it.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id"
+      ],
+      "title": "close_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "notify_customer",
+    "description": "Send the customer a message.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "template": {
+          "description": "Identifier of the message template to send",
+          "title": "Template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "template"
+      ],
+      "title": "notify_customerArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_absent_between/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_between/mcp_server.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_absent_between parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-absent-between")
+
+
+@registry.tool("Open a case for a piece of work.")
+def open_case(
+    data: dict,
+    subject: Annotated[str, Field(description="One-line summary the case is opened under")],
+) -> dict:
+    return {"subject": subject}
+
+
+@registry.tool("Close a case, ending work on it.")
+def close_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+) -> dict:
+    return {"case_id": case_id}
+
+
+@registry.tool("Send the customer a message.")
+def notify_customer(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    template: Annotated[str, Field(description="Identifier of the message template to send")],
+) -> dict:
+    return {"case_id": case_id, "template": template}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_absent_between/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_absent_between/task.yaml
@@ -10,7 +10,11 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - open_case
+      - close_case
+      - notify_customer
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_all_of/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_all_of/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "write_report",
+    "description": "Write up a case in full.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "body": {
+          "description": "Text of the report",
+          "title": "Body",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "body"
+      ],
+      "title": "write_reportArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "close_case",
+    "description": "Close a case, ending work on it.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id"
+      ],
+      "title": "close_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_all_of/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_all_of/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_all_of parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-all-of")
+
+
+@registry.tool("Write up a case in full.")
+def write_report(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    body: Annotated[str, Field(description="Text of the report")],
+) -> dict:
+    return {"case_id": case_id, "body": body}
+
+
+@registry.tool("Close a case, ending work on it.")
+def close_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+) -> dict:
+    return {"case_id": case_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_all_of/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_all_of/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - write_report
+      - close_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_any_of/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_any_of/fixtures/tools.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "search_policy",
+    "description": "Search the policy library.",
+    "parameters": {
+      "properties": {
+        "query": {
+          "description": "Text to search the policy library for",
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "search_policyArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "escalate_to_human",
+    "description": "Hand a case to a human agent.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the case is being escalated",
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "reason"
+      ],
+      "title": "escalate_to_humanArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "resolve_case",
+    "description": "Resolve a case, recording the outcome.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "resolution": {
+          "description": "How the case was resolved",
+          "title": "Resolution",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "resolution"
+      ],
+      "title": "resolve_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_any_of/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_any_of/mcp_server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_any_of parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-any-of")
+
+
+@registry.tool("Search the policy library.")
+def search_policy(
+    data: dict,
+    query: Annotated[str, Field(description="Text to search the policy library for")],
+) -> dict:
+    return {"query": query}
+
+
+@registry.tool("Hand a case to a human agent.")
+def escalate_to_human(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    reason: Annotated[str, Field(description="Why the case is being escalated")],
+) -> dict:
+    return {"case_id": case_id, "reason": reason}
+
+
+@registry.tool("Resolve a case, recording the outcome.")
+def resolve_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    resolution: Annotated[str, Field(description="How the case was resolved")],
+) -> dict:
+    return {"case_id": case_id, "resolution": resolution}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_any_of/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_any_of/task.yaml
@@ -10,7 +10,11 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - search_policy
+      - escalate_to_human
+      - resolve_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_before/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_before/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "servicenow_csm_update_case",
+    "description": "Update a customer service case, recording how it was resolved.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "u_resolution_code": {
+          "description": "Resolution code written on the case",
+          "title": "U Resolution Code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "u_resolution_code"
+      ],
+      "title": "servicenow_csm_update_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_before/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_before/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_before parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-before")
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+@registry.tool("Update a customer service case, recording how it was resolved.")
+def servicenow_csm_update_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    u_resolution_code: Annotated[str, Field(description="Resolution code written on the case")],
+) -> dict:
+    return {"case_id": case_id, "u_resolution_code": u_resolution_code}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_before/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_before/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_get_payment
+      - servicenow_csm_update_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_count/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_count/fixtures/tools.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_count/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_count/mcp_server.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_count parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-count")
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_count/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_count/task.yaml
@@ -10,7 +10,9 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_get_payment
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_immediately_before/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_immediately_before/fixtures/tools.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "order_api_get_order",
+    "description": "Fetch an order by its identifier.",
+    "parameters": {
+      "properties": {
+        "order_id": {
+          "description": "Order identifier, e.g. 'O-001'",
+          "title": "Order Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "order_id"
+      ],
+      "title": "order_api_get_orderArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "search_policy",
+    "description": "Search the policy library.",
+    "parameters": {
+      "properties": {
+        "query": {
+          "description": "Text to search the policy library for",
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "search_policyArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "create_case",
+    "description": "Open a case for a piece of work.",
+    "parameters": {
+      "properties": {
+        "subject": {
+          "description": "One-line summary the case is opened under",
+          "title": "Subject",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "create_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_immediately_before/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_immediately_before/mcp_server.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_immediately_before parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-immediately-before")
+
+
+@registry.tool("Fetch an order by its identifier.")
+def order_api_get_order(
+    data: dict,
+    order_id: Annotated[str, Field(description="Order identifier, e.g. 'O-001'")],
+) -> dict:
+    return {"order_id": order_id}
+
+
+@registry.tool("Search the policy library.")
+def search_policy(
+    data: dict,
+    query: Annotated[str, Field(description="Text to search the policy library for")],
+) -> dict:
+    return {"query": query}
+
+
+@registry.tool("Open a case for a piece of work.")
+def create_case(
+    data: dict,
+    subject: Annotated[str, Field(description="One-line summary the case is opened under")],
+) -> dict:
+    return {"subject": subject}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_immediately_before/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_immediately_before/task.yaml
@@ -10,7 +10,11 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - order_api_get_order
+      - search_policy
+      - create_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_negate/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_negate/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "billing_api_refund_payment",
+    "description": "Refund a payment in full.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_refund_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_negate/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_negate/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_negate parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-negate")
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+@registry.tool("Refund a payment in full.")
+def billing_api_refund_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_negate/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_negate/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_get_payment
+      - billing_api_refund_payment
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_on_missing/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_on_missing/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "verify_identity",
+    "description": "Verify that the caller is who they say they are.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "verify_identityArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "disclose_balance",
+    "description": "Read a customer's balance out to them.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "disclose_balanceArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_on_missing/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_on_missing/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_on_missing parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-on-missing")
+
+
+@registry.tool("Verify that the caller is who they say they are.")
+def verify_identity(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+@registry.tool("Read a customer's balance out to them.")
+def disclose_balance(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_on_missing/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_on_missing/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - verify_identity
+      - disclose_balance
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_present/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_present/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "search_policy",
+    "description": "Search the policy library.",
+    "parameters": {
+      "properties": {
+        "query": {
+          "description": "Text to search the policy library for",
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "search_policyArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_present/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_present/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_present parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-present")
+
+
+@registry.tool("Search the policy library.")
+def search_policy(
+    data: dict,
+    query: Annotated[str, Field(description="Text to search the policy library for")],
+) -> dict:
+    return {"query": query}
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_present/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_present/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - search_policy
+      - billing_api_get_payment
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_severity/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_severity/fixtures/tools.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "read_audit_log",
+    "description": "Read the audit log kept for a table.",
+    "parameters": {
+      "properties": {
+        "table": {
+          "description": "Name of the table to act on",
+          "title": "Table",
+          "type": "string"
+        }
+      },
+      "required": [
+        "table"
+      ],
+      "title": "read_audit_logArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "verify_checksum",
+    "description": "Verify a table's checksum against the one on record.",
+    "parameters": {
+      "properties": {
+        "table": {
+          "description": "Name of the table to act on",
+          "title": "Table",
+          "type": "string"
+        }
+      },
+      "required": [
+        "table"
+      ],
+      "title": "verify_checksumArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "delete_row",
+    "description": "Delete one row from a table.",
+    "parameters": {
+      "properties": {
+        "table": {
+          "description": "Name of the table to act on",
+          "title": "Table",
+          "type": "string"
+        },
+        "row_id": {
+          "description": "Row identifier within the table",
+          "title": "Row Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "table",
+        "row_id"
+      ],
+      "title": "delete_rowArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_severity/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_severity/mcp_server.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_severity parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-severity")
+
+
+@registry.tool("Read the audit log kept for a table.")
+def read_audit_log(
+    data: dict,
+    table: Annotated[str, Field(description="Name of the table to act on")],
+) -> dict:
+    return {"table": table}
+
+
+@registry.tool("Verify a table's checksum against the one on record.")
+def verify_checksum(
+    data: dict,
+    table: Annotated[str, Field(description="Name of the table to act on")],
+) -> dict:
+    return {"table": table}
+
+
+@registry.tool("Delete one row from a table.")
+def delete_row(
+    data: dict,
+    table: Annotated[str, Field(description="Name of the table to act on")],
+    row_id: Annotated[str, Field(description="Row identifier within the table")],
+) -> dict:
+    return {"table": table, "row_id": row_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_severity/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_severity/task.yaml
@@ -10,7 +10,11 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - read_audit_log
+      - verify_checksum
+      - delete_row
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_weight/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_weight/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "verify_identity",
+    "description": "Verify that the caller is who they say they are.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "verify_identityArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "log_contact_note",
+    "description": "File a note about a contact on the customer record.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        },
+        "note": {
+          "description": "Text of the note kept on the contact record",
+          "title": "Note",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id",
+        "note"
+      ],
+      "title": "log_contact_noteArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_weight/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_weight/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_weight parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-weight")
+
+
+@registry.tool("Verify that the caller is who they say they are.")
+def verify_identity(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+@registry.tool("File a note about a contact on the customer record.")
+def log_contact_note(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+    note: Annotated[str, Field(description="Text of the note kept on the contact record")],
+) -> dict:
+    return {"customer_id": customer_id, "note": note}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_weight/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_weight/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - verify_identity
+      - log_contact_note
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_constraints_within/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_constraints_within/fixtures/tools.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "order_api_get_order",
+    "description": "Fetch an order by its identifier.",
+    "parameters": {
+      "properties": {
+        "order_id": {
+          "description": "Order identifier, e.g. 'O-001'",
+          "title": "Order Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "order_id"
+      ],
+      "title": "order_api_get_orderArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "create_case",
+    "description": "Open a case for a piece of work.",
+    "parameters": {
+      "properties": {
+        "subject": {
+          "description": "One-line summary the case is opened under",
+          "title": "Subject",
+          "type": "string"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "create_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "send_email",
+    "description": "Send the customer an email.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "template": {
+          "description": "Identifier of the message template to send",
+          "title": "Template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "template"
+      ],
+      "title": "send_emailArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_constraints_within/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_constraints_within/mcp_server.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_constraints_within parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-constraints-within")
+
+
+@registry.tool("Fetch an order by its identifier.")
+def order_api_get_order(
+    data: dict,
+    order_id: Annotated[str, Field(description="Order identifier, e.g. 'O-001'")],
+) -> dict:
+    return {"order_id": order_id}
+
+
+@registry.tool("Open a case for a piece of work.")
+def create_case(
+    data: dict,
+    subject: Annotated[str, Field(description="One-line summary the case is opened under")],
+) -> dict:
+    return {"subject": subject}
+
+
+@registry.tool("Send the customer an email.")
+def send_email(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    template: Annotated[str, Field(description="Identifier of the message template to send")],
+) -> dict:
+    return {"case_id": case_id, "template": template}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_constraints_within/task.yaml
+++ b/tests/data/grading_parity/trace_checks_constraints_within/task.yaml
@@ -10,7 +10,11 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - order_api_get_order
+      - create_case
+      - send_email
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_gate/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_gate/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "read_meter",
+    "description": "Read a meter's current value.",
+    "parameters": {
+      "properties": {
+        "meter_id": {
+          "description": "Meter identifier, e.g. 'M-7'",
+          "title": "Meter Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "meter_id"
+      ],
+      "title": "read_meterArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "reset_meter",
+    "description": "Reset a meter to zero.",
+    "parameters": {
+      "properties": {
+        "meter_id": {
+          "description": "Meter identifier, e.g. 'M-7'",
+          "title": "Meter Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "meter_id"
+      ],
+      "title": "reset_meterArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_gate/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_gate/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_gate parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-gate")
+
+
+@registry.tool("Read a meter's current value.")
+def read_meter(
+    data: dict,
+    meter_id: Annotated[str, Field(description="Meter identifier, e.g. 'M-7'")],
+) -> dict:
+    return {"meter_id": meter_id}
+
+
+@registry.tool("Reset a meter to zero.")
+def reset_meter(
+    data: dict,
+    meter_id: Annotated[str, Field(description="Meter identifier, e.g. 'M-7'")],
+) -> dict:
+    return {"meter_id": meter_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_gate/task.yaml
+++ b/tests/data/grading_parity/trace_checks_gate/task.yaml
@@ -10,7 +10,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - read_meter
+      - reset_meter
   user:
     enabled: []
 

--- a/tests/data/grading_parity/trace_checks_undecided/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_undecided/fixtures/tools.json
@@ -27,6 +27,12 @@
           "description": "Case identifier, e.g. 'CS-1042'",
           "title": "Case Id",
           "type": "string"
+        },
+        "u_resolution_code": {
+          "default": "",
+          "description": "Resolution code written on the case",
+          "title": "U Resolution Code",
+          "type": "string"
         }
       },
       "required": [

--- a/tests/data/grading_parity/trace_checks_undecided/fixtures/tools.json
+++ b/tests/data/grading_parity/trace_checks_undecided/fixtures/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "billing_api_get_payment",
+    "description": "Fetch a payment record by its identifier.",
+    "parameters": {
+      "properties": {
+        "payment_id": {
+          "description": "Payment identifier, e.g. 'PAY-664306'",
+          "title": "Payment Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payment_id"
+      ],
+      "title": "billing_api_get_paymentArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "servicenow_csm_update_case",
+    "description": "Update a customer service case, recording how it was resolved.",
+    "parameters": {
+      "properties": {
+        "case_id": {
+          "description": "Case identifier, e.g. 'CS-1042'",
+          "title": "Case Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id"
+      ],
+      "title": "servicenow_csm_update_caseArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/trace_checks_undecided/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_undecided/mcp_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""MCP server for the trace_checks_undecided parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "trace-checks-undecided")
+
+
+@registry.tool("Fetch a payment record by its identifier.")
+def billing_api_get_payment(
+    data: dict,
+    payment_id: Annotated[str, Field(description="Payment identifier, e.g. 'PAY-664306'")],
+) -> dict:
+    return {"payment_id": payment_id}
+
+
+@registry.tool("Update a customer service case, recording how it was resolved.")
+def servicenow_csm_update_case(
+    data: dict,
+    case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+) -> dict:
+    return {"case_id": case_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/trace_checks_undecided/mcp_server.py
+++ b/tests/data/grading_parity/trace_checks_undecided/mcp_server.py
@@ -27,8 +27,11 @@ def billing_api_get_payment(
 def servicenow_csm_update_case(
     data: dict,
     case_id: Annotated[str, Field(description="Case identifier, e.g. 'CS-1042'")],
+    u_resolution_code: Annotated[
+        str, Field(description="Resolution code written on the case")
+    ] = "",
 ) -> dict:
-    return {"case_id": case_id}
+    return {"case_id": case_id, "u_resolution_code": u_resolution_code}
 
 
 if __name__ == "__main__":

--- a/tests/data/grading_parity/trace_checks_undecided/task.yaml
+++ b/tests/data/grading_parity/trace_checks_undecided/task.yaml
@@ -12,7 +12,10 @@ initial_state:
 
 tools:
   agent:
-    enabled: []
+    mcp_server: mcp_server.py
+    enabled:
+      - billing_api_get_payment
+      - servicenow_csm_update_case
   user:
     enabled: []
 

--- a/tests/data/grading_parity/transcript_rules_tool_expectations/fixtures/tools.json
+++ b/tests/data/grading_parity/transcript_rules_tool_expectations/fixtures/tools.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "write_file",
+    "description": "Write content to a file",
+    "parameters": {
+      "properties": {
+        "path": {
+          "description": "Path to the file to write",
+          "title": "Path",
+          "type": "string"
+        },
+        "content": {
+          "description": "Content to write to the file",
+          "title": "Content",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "content"
+      ],
+      "title": "write_fileArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "cancel_order",
+    "description": "Cancel an order that has not shipped.",
+    "parameters": {
+      "properties": {
+        "order_id": {
+          "description": "Order identifier, e.g. 'O-001'",
+          "title": "Order Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "order_id"
+      ],
+      "title": "cancel_orderArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "delete_customer",
+    "description": "Delete a customer record.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "delete_customerArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/grading_parity/transcript_rules_tool_expectations/mcp_server.py
+++ b/tests/data/grading_parity/transcript_rules_tool_expectations/mcp_server.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""MCP server for the transcript_rules_tool_expectations parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "transcript-rules-tool-expectations")
+
+
+@registry.tool("Write content to a file")
+def write_file(
+    data: dict,
+    path: Annotated[str, Field(description="Path to the file to write")],
+    content: Annotated[str, Field(description="Content to write to the file")],
+) -> dict:
+    return {"path": path, "content": content}
+
+
+@registry.tool("Cancel an order that has not shipped.")
+def cancel_order(
+    data: dict,
+    order_id: Annotated[str, Field(description="Order identifier, e.g. 'O-001'")],
+) -> dict:
+    return {"order_id": order_id}
+
+
+@registry.tool("Delete a customer record.")
+def delete_customer(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/grading_parity/transcript_rules_tool_expectations/task.yaml
+++ b/tests/data/grading_parity/transcript_rules_tool_expectations/task.yaml
@@ -10,8 +10,11 @@ initial_state:
 
 tools:
   agent:
+    mcp_server: mcp_server.py
     enabled:
       - write_file
+      - cancel_order
+      - delete_customer
   user:
     enabled: []
 

--- a/tests/data/transcript_parity/disallowed_tools_one/fixtures/tools.json
+++ b/tests/data/transcript_parity/disallowed_tools_one/fixtures/tools.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "write_file",
+    "description": "Write content to a file",
+    "parameters": {
+      "properties": {
+        "path": {
+          "description": "Path to the file to write",
+          "title": "Path",
+          "type": "string"
+        },
+        "content": {
+          "description": "Content to write to the file",
+          "title": "Content",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "content"
+      ],
+      "title": "write_fileArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "delete_customer",
+    "description": "Delete a customer record.",
+    "parameters": {
+      "properties": {
+        "customer_id": {
+          "description": "Customer identifier, e.g. 'C-101'",
+          "title": "Customer Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "customer_id"
+      ],
+      "title": "delete_customerArguments",
+      "type": "object",
+      "additionalProperties": false
+    }
+  }
+]

--- a/tests/data/transcript_parity/disallowed_tools_one/mcp_server.py
+++ b/tests/data/transcript_parity/disallowed_tools_one/mcp_server.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""MCP server for the disallowed_tools_one parity fixture.
+
+Supplies the schemas of the tools this pack's grading and trials name. The
+substrate-parity suites replay recorded results, so nothing here is ever
+dispatched; each body echoes what it was handed rather than modelling a domain.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from tolokaforge.core.tools_interface import create_server
+
+mcp, registry, TOOLS = create_server(__file__, "disallowed-tools-one")
+
+
+@registry.tool("Write content to a file")
+def write_file(
+    data: dict,
+    path: Annotated[str, Field(description="Path to the file to write")],
+    content: Annotated[str, Field(description="Content to write to the file")],
+) -> dict:
+    return {"path": path, "content": content}
+
+
+@registry.tool("Delete a customer record.")
+def delete_customer(
+    data: dict,
+    customer_id: Annotated[str, Field(description="Customer identifier, e.g. 'C-101'")],
+) -> dict:
+    return {"customer_id": customer_id}
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/data/transcript_parity/disallowed_tools_one/task.yaml
+++ b/tests/data/transcript_parity/disallowed_tools_one/task.yaml
@@ -12,8 +12,10 @@ initial_state:
 
 tools:
   agent:
+    mcp_server: mcp_server.py
     enabled:
       - write_file
+      - delete_customer
   user:
     enabled: []
 


### PR DESCRIPTION
## Summary
- Every substrate-parity fixture is now a **truthful task**: its `tools.agent.enabled` declares the tools its matchers, `tool_expectations` and recorded timeline actually name, backed by a per-fixture `mcp_server.py` and a committed `fixtures/tools.json` so the schemas resolve read-only. 21 packs move from 46 authoring-gate errors to zero — and, because the schemas are closed, their argument checks run at **error** tier rather than being advised about.
- A new canonical guard holds the **48 authored packs that the existing gate walk does not reach** (`grading_parity` 32, `transcript_parity` 12, `projects` 2, `migration_packs` 2 — computed as a difference, never listed) to the whole authoring gate, with a positive control on every pack. A new parity fixture naming an undeclared tool now reds here, before anyone runs `validate`.
- Zero verdict movement, enforced mechanically: the fixture stage's diff is confined to `tests/data/` and `tests/README.md`, and the parity suites' pinned verdicts are unreachable from the change because the harness overrides `trial.agent_tools` before every `ExecuteTool`.

## Design choices
- **Truthful tasks over a gate exemption.** The issue offered "declare the tools" or "exempt parity fixtures". Declaring alone is a dead end at this tree — measured: it passes the gate but hard-fails `RegisterTrial` with `ToolConfigurationError` for every parity pack the suites register, and only passes `validate` through a genuine validation gap (filed as #978). Giving each fixture a real server and committed schemas is what makes the declaration resolvable; `RegisterTrial` reconstruction was driven end to end with `subprocess.Popen` instrumented — every tool reconstructs, **zero servers start**.
- **Schemas derived from each live server, then closed by hand.** Names, types and descriptions are the server's own answer (verified: zero drift across all 21). `additionalProperties: false` is merged on because it is true of a signature-backed tool and is what the builtin registry already emits — and it is what buys error tier over advisory.
- **The control filters on the sentinel in the message, not on an address.** Measured: sentinel findings land under *both* families (27 `transcript_rules`, 21 `trace_checks`), so an address constant would have covered half the walk — swapping it back reds `unprobed`.
- **Two positive controls, not one.** 23 of the 48 packs carry no matcher or `tool_expectations` entry to mutate, so the tool control injects one where a pack authors neither; the weight control comes free from reusing the gated walk's own `_gate_reports` call site.

## Concepts introduced
None in the product. The guard adds `_packs_outside_the_gate_walk()` (a computed difference) and reuses the module's existing `_A_TOOL_NO_ACTOR_CAN_CALL` sentinel rather than declaring a second one.

## Plan
# Plan: Parity fixtures declare the tools their grading names

Issue: #767
Branch: fix/767-parity-fixture-tools
Revision: 3 (critic round 2 — multiline pre-controlled prose sweep, walk corrected to 48 with its fourth root, sentinel-message control filter)

## Context

The authoring gate refuses a grading block naming a tool outside the task's declared set. Every trace-checks differential fixture under `tests/data/grading_parity/` declares `tools.agent.enabled: []` (or `["write_file"]`) while its matchers and `tool_expectations` name the business tools its recorded timeline really calls — so the packs are behaviourally right and formally ungradeable. Measured at this tree (branch `fix/717-failed-result-text-parity` @ `7c2578d4`): **20 of 32 grading_parity packs invalid, 46 errors** (grown from the issue's 16/35 — milestone 28 added fixtures: `absent_between`, `severity`, `undecided`, `immediately_before`, and #975 among others), plus the same defect once in the sibling root: `tests/data/transcript_parity/disallowed_tools_one` (1 error; 21 red packs total, the exact count `test_example_pack_grading_corpus.py` cites — across five docstrings — as its reason for scoping its corpus guards down to single rules). All findings are **error-class** — the native inventory resolves, so the post-#940 unchecked routing does not apply.

## Goal

Every in-repo parity fixture is a truthful task: its `tools.agent.enabled` declares every tool its grading block and trial timeline name, the declared schemas resolve read-only, and the runner's `RegisterTrial` can reconstruct every declared tool. `tolokaforge validate` over both parity roots exits 0 with zero findings, a canonical corpus guard holds the parity roots to the **full** authoring gate from now on (so a new fixture naming an undeclared tool is caught in CI), and no differential verdict moves.

## Non-goals

- No change to the authoring gate, the tool inventory, the native adapter, the runner, or any other harness code. This is a fixtures + tests + docs change only.
- No gate exemption vocabulary. Rejected shape — see "Design decision" below.
- No fix for the declared-but-unconstructible-tool validation gap this planning discovered; that is #978.
- No widening of `_gated_packs` / merging of the corpus walks beyond the one new guard; restructuring the corpus module is not this PR.
- The four recorded `output/trials/**/task.yaml` artifacts under `tests/data/projects/` stay red under a raw `validate` glob — they are recorded wire objects, not authored packs, and the corpus walk already excludes them.

## Design decision (why declare, not exempt)

Three shapes were measured on a probe copy of `trace_checks_constraints`:

1. **Names only** (`enabled: [billing_api_get_payment, …]`, no source): passes the gate (args checks degrade to `unchecked`), but `ToolFactory.reconstruct_tools` — which `RegisterTrial` calls fail-fast — raises `ToolConfigurationError: Tool has no source configuration` for every source-less non-builtin name. Both parity suites drive their packs through the real `RegisterTrial`, so this shape breaks them outright. It also only passes validate through the gap now filed as #978. Dead end.
2. **Names + `mcp_server` ref + committed `fixtures/tools.json`**: gate fully green with `args` addresses *checked* (schemas resolve read-only via `_load_rich_tool_schemas`); the wire carries real `MCP_SERVER`-sourced `ToolSchema`s with real properties; `reconstruct_tools` builds `MCPServerToolWrapper`s lazily — registration succeeds, the server is never started, and the parity harness's timeline replay (which overrides `trial.agent_tools[name]` before `ExecuteTool`) is untouched. Verified end-to-end on the probe.
3. **A gate exemption the fixtures declare**: new authoring vocabulary (the milestone's posture disfavors it), makes the gate blind exactly where the parity corpus lives, and inverts deliverable 2 — a new fixture would *declare its way past* the check rather than be caught by it. Rejected.

Also rejected: parking the names in `tools.user.enabled` (the union clears the gate and `NativeAdapter.to_task_description` never emits user tools, so nothing breaks — but the recorded calls are agent calls under #975's executor semantics, so it is a lie that survives only until native reads `user.enabled`).

Shape 2 is the plan. The fixtures' timelines really call these tools; declaring them with a resolvable source is the honest description, and it upgrades the gate's coverage of the fixtures (args addresses move from unfindable to checked).

## Stages

### Stage 1: Every parity fixture declares its tools with a resolvable source

- **Contract:** For each of the 21 red packs — the 20 `tests/data/grading_parity/` packs `tolokaforge validate` names at this tree (`all_keys`, `trace_checks_alternatives`, `trace_checks_constraints` and the 14 red `trace_checks_constraints_*` siblings, `trace_checks_gate`, `trace_checks_undecided`, `transcript_rules_tool_expectations`) plus `tests/data/transcript_parity/disallowed_tools_one`. **`trace_checks_constraints_bind` is green and stays untouched** — its matchers name `read_file` / `write_file`, which it already declares, and it is the one `constraints_*` sibling the red set excludes. The command output is authoritative: implement against the packs `validate` names, not against a name pattern:
  - `task.yaml` `tools.agent.enabled` lists every tool name the pack's `grading.yaml` matchers, `tool_expectations`, and `trial.yaml` timeline reference (superset check: the gate enforces grading↔declared; the timeline names are the same set by construction of these fixtures).
  - `task.yaml` gains `tools.agent.mcp_server` pointing at a per-fixture server script, and the fixture commits `fixtures/tools.json` — a JSON **list** of `{name, description, parameters}` entries (the shape `_load_rich_tool_schemas` reads) — covering *every* enabled tool, including `write_file` where a pack mixes it in (`all_keys`, `disallowed_tools_one`): an `mcp_server`-bearing native task sources **all** its enabled tools from the server, which is the platform's existing semantics, not a new rule.
  - Each committed `parameters` schema declares (as `properties`, with `additionalProperties: false`) every argument name the pack's matchers address (`args:` keys, `bind.values[*].field`) and its timeline sends — so the gate's argument checks run at error tier and pass, with **zero** `unchecked` residue for these packs.
  - The server scripts follow the established minimal in-repo mcp-server fixture pattern and define the tools `fixtures/tools.json` lists; nothing in the suites starts them (the parity harness substitutes its recorded outputs before any `ExecuteTool`), but the script must not be an empty lie.
  - Per-fixture files are the recommended layout (a parity pack is a self-describing single-key instrument); the shared-domain `_shared/domain.yaml` layout is loader-supported but shifts the effective task dir and couples 21 independent instruments — the implementer may only choose it if per-fixture files prove genuinely unworkable, and must then re-verify the corpus pack counts and path resolution.
- **Behaviour to lock (this stage's own validation; the canonical lock is Stage 2):**
  - `tolokaforge validate --tasks "tests/data/grading_parity/**/task.yaml"` and `--tasks "tests/data/transcript_parity/**/task.yaml"` both exit 0, zero errors/advisories, zero `unchecked` lines.
  - Zero-verdict-movement: the full canonical suite (1199 tests green at baseline) and `uv run pytest tests/ -m unit` pass **without editing any score, verdict, or wire expectation** — the diff outside `tests/data/` and `tests/README.md` must be empty in this stage. If any existing lock reds, that is a discovery to bring back, not a snapshot to regenerate.
- **Compatibility:** internal only — test fixtures and their docs; no compatibility surface moves. (`all_keys`' `initial_state.json_db` stays the inline mapping, so it remains the corpus's world-that-cannot-be-built control; its `hash_weight: 0.75` translation lock reads `grading`, not tools.)
- **Deliverable:** 21 fixtures each carrying a truthful `enabled` list, an `mcp_server` script, and a committed `fixtures/tools.json`; both parity globs validate clean; canonical + unit suites green unchanged.
- **Validation:** the two `validate` commands above; `mcp__dev__run_tests` over `tests/canonical` and `tests/unit`; falsifier — revert any one fixture's `task.yaml` hunk and the grading_parity `validate` command must exit 1 naming that pack.
- **Doc updates:** `tests/README.md` § substrate-parity pack anatomy: state as current fact that a parity pack declares every tool its grading and trials name, with `mcp_server` + `fixtures/tools.json` supplying the schemas — written as the only state, no change narration.

### Stage 2: The parity roots are held to the full gate, and a new bad fixture is caught

- **Contract:** a new canonical guard in `tests/canonical/test_example_pack_grading_corpus.py` covering exactly the authored packs `_authored_packs()` reaches that `_gated_packs()` does not — **48 packs** at this tree (computed, never hand-listed): `grading_parity` 32, `transcript_parity` 12, `tests/data/projects` 2 (`order_modify_with_checks`, `order_six_items_golden`), `tests/data/migration_packs` 2 (`notes_duplicate_check_narrowed`, `notes_duplicate_check_policy_narrowed`). The fourth root is named here because the walk reaches it whether or not anyone remembers it exists; the guard must keep computing the difference so a fifth root is covered on arrival:
  - runs `inspect_grading_authoring` with each pack's **own** `build_tool_inventory`, replay world, hash-source layer, and seeded tables, built the way `validate`'s caller builds them;
  - asserts zero errors and zero advisories across the walk;
  - asserts the `unchecked` residue equals a pinned constant. Measured over the true 48-pack walk today: exactly **3** `.args` skips (`all_keys`, `trace_checks_constraints`, `trace_checks_constraints_before`), every one of them in a pack Stage 1 fixes — and the four non-parity members (2 under `tests/data/projects`, 2 under `tests/data/migration_packs`) report **no** findings and **no** residue today. So the post-Stage-1 pin is expected to be **empty**, and the implementer asserts emptiness rather than transcribing whatever comes back; a non-empty residue is a Stage 1 defect to report, not a constant to widen;
  - positive control, per the file's own injection pattern, defined for **every** pack in the walk: 23 of the 48 carry neither a matcher nor a `tool_expectations` entry to mutate (measured over the 48-pack walk: the `state_checks_*`, `must_contain_*`, `disallow_regex_*`, `custom_checks`, `combine_method`, `required_actions_*` and most `transcript_parity` packs; both `migration_packs` members do carry sites), so a mutation-only control would silently cover half the walk. Where a pack has a site, mutate one to name `_A_TOOL_NO_ACTOR_CAN_CALL`; where it has none, **inject** `transcript_rules.tool_expectations.disallowed_tools: [_A_TOOL_NO_ACTOR_CAN_CALL]` — into the pack's existing `transcript_rules` block where it has one, else adding the block — exactly as `_naming_a_tool_no_actor_can_call` injects a golden action into all 107.
    Each probed report is filtered on **the sentinel in the finding's message** (`_A_TOOL_NO_ACTOR_CAN_CALL in finding.message`), not on an address constant. Both producers quote the offending name in their message (`_check_tool_expectation_names`, `config_validation.py:897-913`, and the matcher rule), so one predicate covers both the mutation branch — which reports under the `trace_checks.….match.tool` family — and the injection branch under `transcript_rules.tool_expectations.*`, where an address constant would cover only half the walk. It is also self-sufficient against a pack's *own* pre-existing undeclared name at that address (3 packs today: `all_keys`, `transcript_rules_tool_expectations`, `disallowed_tools_one` — all declared after Stage 1), which an address filter would confuse with the control firing. Keep the address prefix as a secondary assertion to match the file's `_*_findings` style.
  This guard is deliverable 2's lock: a NEW parity fixture naming an undeclared tool lands inside this walk and reds the zero-findings assertion; one whose declared set drifts from its schemas reds the pinned-unchecked assertion.
- **Behaviour to lock:** the guard itself (canonical tier), plus its control arm. Falsifier: reintroduce Stage 1's defect in any one fixture — the guard must red with that pack's address before `validate` is ever run.
- **Compatibility:** internal only.
- **Deliverable:** the guard, plus **every** docstring in the corpus module carrying the now-false tools-no-actor / red-on-21 justification, rewritten to state the actual current reason for the single-rule scoping (each guard is a single-rule instrument with its own control; full-gate coverage of these roots lives in the new guard) — as present-state fact, no history narration. Five sites at this tree, verified: `_golden_action_findings` (:712-715, the "red on 21 of them" sentence), `_replay_world_findings` (:806), `test_no_authored_pack_gives_its_golden_replay_no_world_to_be_built_in` (:840), `_probe_exclusivity_findings` (:912), and `test_no_authored_pack_declares_a_probe_beside_another_state_source` (:971) — plus `test_no_authored_grading_block_asserts_nothing`, whose deliberately-unresolvable-inventory rationale is still true and needs only its "on purpose" clause corrected. The stage's own check is a sweep, not the line list — and the sweep must be **multiline and shown to fire before any edit**, because site five wraps between "given" and "on purpose" and a single-line pattern misses exactly the site that made this deliverable necessary:

  ```
  rg -U "no actor is given\s+on purpose|red on 21|46 packs" tests/canonical/test_example_pack_grading_corpus.py
  ```

  Run it **first** and confirm it reports 5 sites (a sweep that has never been seen to fire is not a check — the single-line form returns 4 and reads clean with :840-841 stale); rewrite; run it again and require zero hits. Then run the same multiline pattern across `tests/` and `docs/` to catch any surviving twin. `46 packs` is in the pattern because :712 says the walk is "46 packs wider" when the computed difference is 48 — a freshly written docstring shipping a false number is the exact defect this deliverable exists to remove, and :646 in the same file already says 48. Any pinned pack-count constants are re-derived (`_AUTHORED_PACK_COUNT` stays 107: Stage 1 adds no `task.yaml`).
- **Validation:** `mcp__dev__run_tests` over `tests/canonical`; run the falsifier above once and revert.
- **Doc updates:** `tests/README.md` § canonical tests: one line naming the parity-roots gate guard beside the other corpus guards. `docs/GRADING.md` needs nothing — the gate's behaviour did not change.

## Discovered issues

- **Fix in this PR:** `tests/data/transcript_parity/disallowed_tools_one` — the identical defect one root over (1 error, same fix shape, and the corpus guard in Stage 2 walks both roots, so leaving it red is not an option).
- **Filed as issues:** #978 — a native task declaring an enabled tool that is neither builtin nor `mcp_server`-backed passes `validate` and then dies at `RegisterTrial`, per trial, fail-fast (found by probing shape 1; the gate's callers can answer constructibility read-only).

## Risks / open questions

- **Enumerating verdict movement:** analysis says none — the evaluators read the trial timeline, not the declared set; the parity harness overrides `trial.agent_tools` before `ExecuteTool`; the only wire movement is `agent_tools` entries and the `tool_artifacts` bundle (`needs_bundle` flips on with `mcp_server`), which no current lock pins for these packs. The Stage 1 hard rule (no assertion edits outside `tests/data/` + `tests/README.md`) converts this claim into a mechanical check; if it fails, the stage stops and reports.
- **`all_keys` sources `write_file` from the mcp server after this change** (established semantics for mcp-bearing tasks: one server sources all enabled tools). Its runner-side execution is override-driven in the parity suite, so nothing behavioural moves, but the reviewer should see this named rather than discover it.
- **Schema authorship is load-bearing:** with resolvable schemas the args checks go from unfindable to error-tier, so a `tools.json` that omits an addressed argument makes its pack *newly* red. Stage 1's zero-`unchecked`/zero-error validate criterion catches this per pack.
- The count drift (issue's 16/35 → today's 20/46 + 1) is fixture growth during milestone 28, not a gate regression; the plan targets the measured set by name, so further drift before implementation would surface as a Stage 1 validate failure, not silent under-coverage.

---
**Main-authored execution note (post-Stage-1, ratified):** 21 packs converted exactly as planned (20 grading_parity + transcript_parity/disallowed_tools_one); `trace_checks_constraints_bind` untouched and still green. Schemas DERIVED from each live server via `_fetch_mcp_tool_schemas` (names/types/descriptions are the server's own answer) minus the two `_tolokaforge_*_state_` internals, with `additionalProperties: false` hand-merged — FastMCP never emits it, the builtin registry does, and Control B measured what it buys (error tier, not advisory). Zero-residue is MEASURED not assumed: the implementer noticed baseline silence proved nothing (validate's unchecked loop only runs on the ✓ path) and drove two controls — A: withholding a tools.json produces the predicted "no schema resolved … arguments are not checkable" skip; B: dropping an addressed argument from a closed schema produces an error. Falsifier driven (revert one task.yaml hunk → exit 1 naming that pack, restored byte-identical via cmp). Nothing removed from any `enabled` list (unforced movement avoided); `all_keys` keeps its inline json_db so it remains the world-that-cannot-be-built control; `trace_checks_undecided` declares the lookup its harness-table timeline sends. Mechanical zero-movement check passed (`git show --name-only | grep -v "^tests/"` empty). Counts: canonical 1199 unchanged, unit 6051/8 identical env set, both parity roots validate clean with zero unchecked. Stage 2 clarification from measurement: post-Stage-1 residue over both roots is `{}` — assert emptiness, do not transcribe a constant.

---
**Main-authored execution note (post-Stage-2, ratified):** guard `test_the_packs_outside_the_gate_walk_are_held_to_the_whole_gate` computes the difference (authored 107 − gated 59 = 48; roots grading_parity 32 / transcript_parity 12 / projects 2 / migration_packs 2) and asserts count + errors {} + advisories {} + unchecked {} (emptiness, as measured) + unprobed [] + misaddressed []. Control: 25 mutation / 23 injection branches (matching the plan's measured census), filtered on the sentinel in the message. The address-filter question is settled by measurement: sentinel findings land under BOTH families (transcript_rules 27, trace_checks 21) — an address constant covers half the walk, and swapping the filter for one reds `unprobed` (falsifier-driven). Five-falsifier matrix, each biting a distinct assertion (Stage-1 defect → findings; neutered control → unprobed; withheld tools.json → unchecked; single-address filter → unprobed; open schema missing an addressed arg → advisories). Sweep run FIRST and seen to fire (5 sites; the single-line form matched 4, missing the wrapped :840-841 — the trap held exactly). THREE extra stale sites found and fixed beyond the five (a root list omitting migration_packs, a comment describing one control as if it were both, a module-header claim that the wider walk gets only tool-set-free rules). TWO plan-text corrections by measurement: the plan's "sixth site" does not exist as described (that docstring carries no "on purpose" clause — its real defect was the incomplete root list), and the plan's three-pack filter rationale was falsified by Stage 1 (those packs now declare their tools) — the implementer rewrote it as the conditional property it is rather than shipping a fresh false claim into the de-staling file. Canonical 1200 (1199 + the guard).

---
**Main-authored execution note (post-fix-round, ratified):** review found two substantive gaps the branch's own theme predicted. (1) The guard omitted `effective_combine`, so two weight rules never ran for any of the 48 packs and `unchecked == {}` was structurally blind — the gate produced nothing to see (the sibling guard's docstring documents this exact trap). Fixed by the stronger route: the sweep now runs through `_gate_reports`, the gated walk's own call site, which resolves each pack's combine AND hands back the weight-naming-nothing control (new `unprobed_weights == []`); the tool-sentinel probe stays a separate call because a combine buys it nothing. Measured: weight control fires 48/48 with the fix, 0/48 without. (2) The `additionalProperties: false` error tier was UNLOCKED and the loader's own regeneration path removes it (`_load_rich_tool_schemas` rewrites a missing tools.json from the live server; FastMCP never emits the key) — with every addressed argument present, CLOSED and OPEN produce identical empty reports, so the downgrade was invisible. Fixed by asserting the strictness the GATE computes: `opened == []` over `inventory.strictness(...)` (75 CLOSED / 0 OPEN / 50 UNKNOWN — UNKNOWN from FOUR packs, both projects and both migration_packs, correcting the review's "two"). F2 is the proof: with the key stripped, findings/advisories/unchecked all PASS and only `opened` reds. Ratified deviation: `u_resolution_code` declared OPTIONAL on trace_checks_undecided, not required as its siblings have it — that pack's harness call sends `case_id` alone, so requiring it would describe a call the fixture never makes (the same class of lie the PR removes). Also dropped an unreachable `"in"` operator arm (`ValuePredicate` declares `in_` with no alias under extra="forbid"; census confirms both 0). Counts: canonical 1200, corpus module 67, both parity roots validate clean.

## Discovered issues
- Filed: **#978** (a declared-but-unconstructible tool passes `validate` and dies per-trial at `RegisterTrial` — the gap that made the issue's simpler shape look viable), **#980** (a committed `fixtures/tools.json` can drift from its server with no guard outside `examples/`), **#981** (`tolokaforge validate` writes its whole report to stderr, so piping stdout reads as a clean sweep), **#982** (a unit module cites 94 authored packs where the corpus is 107), **#984** (the loader regenerates a missing schema cache *without* `additionalProperties`, silently downgrading argument checks to advisory — the defect this PR's new strictness assertion catches for the parity walk).
- Fixed in this PR beyond the planned surface: eight stale-justification sites in the corpus module (five named by the plan, three found by the sweep), including a root list omitting `migration_packs` and a comment describing one of two controls as if it were both.

## Test plan
- Both parity roots validate clean: `grading_parity` 32/0, `transcript_parity` 12/0, zero `unchecked` lines — measured directly over the walk, not inferred from silence (validate only prints unchecked lines on the `✓` path, so a red pack's silence proves nothing; two controls were driven to show the channel fires).
- Canonical 1200, corpus module 67, unit 6051 with the 8 known env failures unchanged. `RegisterTrial` driven for four converted packs: reconstruction succeeds, no subprocess spawned.
- Nine falsifiers across the three commits, each biting a distinct assertion — including the two that matter most: the pre-fix call site reds `unprobed_weights` on all 48 (the weight rules were silently not running), and a stripped `additionalProperties` reds `opened` while `findings`/`advisories`/`unchecked` all pass (the tier downgrade is invisible to every other assertion).
- Post-merge: a new parity fixture naming a tool its task does not declare reds the whole-gate guard.

Closes #767
