### PR TITLE
fix(llm): admit the parameters an operator declares, when litellm's map cannot

### DIFF
--- a/docs/ADD_NEW_MODEL.md
+++ b/docs/ADD_NEW_MODEL.md
@@ -88,7 +88,7 @@ don't need to cut a new wheel. Put the same preset entry in a separate YAML
 file and point the engine at it:
 
 ```yaml
-# my_overlay.yaml — same schema as model_presets.yaml
+# my_overlay.yaml — the model_presets.yaml schema, plus `litellm_models:`
 presets:
   my_provider_new_model:
     match: ["my-provider/new-model*"]
@@ -117,6 +117,12 @@ overlay path and the offending key):
   `match:` globs let you shadow a bundled preset.
 - Same-named overlay presets replace the bundled entry (logged at INFO so the
   swap is visible).
+- A `litellm_models:` entry needs a non-empty `evidence` and at least one
+  capability set true, its key must be a full `<provider>/<model>` litellm id,
+  and unknown keys are rejected. That block is how a model litellm's own map
+  does not carry gets its parameters admitted - without it the provider
+  refuses `tools` before the request is sent. See
+  [`docs/LLM_LAYER.md`](LLM_LAYER.md#when-litellm-has-never-heard-of-the-model).
 
 For distributed runs, the overlay path passed to `tolokaforge prepare` is
 persisted into the run queue's state file. Subsequent `tolokaforge worker`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -348,7 +348,24 @@ Set the overlay path two ways; precedence is **CLI flag > config field**:
      presets_file: ./overlay.yaml   # relative to the working directory
    ```
 
-The overlay file uses the same schema as `model_presets.yaml`. Overlay
+The overlay file uses the schema of `model_presets.yaml` (`default:`,
+`presets:`, `providers:`) plus one block the bundled file has no use for:
+
+```yaml
+litellm_models:                    # models litellm's own map does not carry
+  meta/muse-spark-1.2:
+    supports_function_calling: true
+    supports_reasoning: true       # needed when the config sets models.agent.reasoning
+    evidence: "2026-08-10, litellm 1.96.0: no entry, so meta refused tools
+      before sending; admitting them returns a correct tool call."
+```
+
+Each entry declares what a model accepts on the wire, with the observation
+behind it, and admits exactly the parameters its flags name for that model's
+calls. Nothing else changes, and nothing is written into litellm's global
+map. See [`docs/LLM_LAYER.md`](LLM_LAYER.md#when-litellm-has-never-heard-of-the-model).
+
+Overlay
 presets are prepended to the iteration order so first-match-wins lets you
 shadow a bundled preset. Same-named overlay presets *replace* the bundled
 entry (logged at INFO so the replacement is visible). Policy-name strings

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -23,6 +23,7 @@ for the design rationale and the canonical litellm surface.
 | [`response_policy.py`](../tolokaforge/core/llm/response_policy.py) | Tool-call argument post-processing |
 | [`capabilities.py`](../tolokaforge/core/llm/capabilities.py) | `ModelCapabilities` frozen dataclass |
 | [`presets.py`](../tolokaforge/core/llm/presets.py) | YAML preset loader → `ModelCapabilities`. Also implements the **operator-overridable preset overlay** (`--presets-file`, `engine.presets_file`) so new model registrations don't require an engine release — see [ADR 0002](adr/0002-external-model-registry.md) and [`docs/CONFIG.md` § Preset overlay file](CONFIG.md#preset-overlay-file-no-engine-release-required). |
+| [`litellm_params.py`](../tolokaforge/core/llm/litellm_params.py) | Turns overlay-declared capabilities into litellm's `allowed_openai_params`, so a vendor-native provider does not refuse `tools` for a model its map lacks — see [§ When litellm has never heard of the model](#when-litellm-has-never-heard-of-the-model) |
 | [`proxy.py`](../tolokaforge/core/llm/proxy.py) | Optional LLM-gateway transport (`ProxyConfig`), e.g. a LiteLLM proxy; configured entirely by env |
 | [`client.py`](../tolokaforge/core/llm/client.py) | `LLMClient`, `GenerationResult`, `UserSimulator` |
 
@@ -419,6 +420,92 @@ unchanged — litellm's native `_remove_additional_properties` only runs for
 Vertex AI, hosted vLLM, and WatsonX. Our `StrictSchema` and `DictMapHints`
 policies in `tolokaforge/core/llm/` handle **all** GPT-5 tool-schema
 adaptation independently of litellm, so this gap is transparent to callers.
+
+## When litellm has never heard of the model
+
+litellm decides which OpenAI parameters a provider may be sent by looking the
+model up in its own map. For most providers that decision is generic, but a
+**vendor-native** provider answers from the entry alone. A model the map does
+not carry is therefore read as supporting NO parameters, and the request is
+refused inside our process, before anything is sent:
+
+```
+litellm.UnsupportedParamsError: meta does not support parameters:
+['tools', 'tool_choice'], for model=muse-spark-1.2
+```
+
+Measured 2026-08-10 across litellm versions with an identical request: 1.83.14
+passes the tools through, 1.93.0 and 1.96.0 refuse them. The strictness arrived
+in a patch release, so a routine dependency bump can turn a working
+vendor-native model into one that cannot make a single tool call — and the
+error names the provider rather than the missing data, so it reads as "this
+vendor does not do tool calls".
+
+It says nothing about the model. The identical request driven through litellm's
+`openai` transport against the same `api_base` returns a correct tool call —
+the gap is upstream DATA, and the fix is to supply the entry rather than to
+wait on someone else's release.
+
+litellm's own answer to this is `allowed_openai_params`, a per-call kwarg
+naming the parameters to admit past the map gating for that one request; its
+error message says so. `litellm_params.py` turns an operator's declaration into
+that list, and it ships with **no list of models**. A model missing from a
+third-party map is not a fact about an engine release, and a list in the wheel
+would tie every future gap to the release cadence — the argument
+[ADR 0002](adr/0002-external-model-registry.md) already
+made for preset data. So the entries are operator data, declared in the same
+preset overlay (`--presets-file` / `RunConfig.engine.presets_file`):
+
+```yaml
+litellm_models:
+  meta/muse-spark-1.2:
+    supports_function_calling: true
+    supports_reasoning: true       # the config sets models.agent.reasoning
+    evidence: "2026-08-10, litellm 1.96.0: no entry, so meta refused tools
+      before sending; the same request through litellm's openai transport
+      against api.meta.ai returned a correct tool call."
+```
+
+The key is the litellm model id, because that is the lookup litellm performs.
+An entry **declares**; it does not copy. Only the parameters its flags name are
+admitted, so a capability nothing observed is never asserted on the model's
+behalf.
+
+Two rules keep it honest:
+
+- **The flags are an allow-list.** A parameter stays refused until someone
+  declares the capability with evidence, and extending the map is a decision
+  about what we are willing to assert. `supports_reasoning` is on it because a
+  config that sets `models.agent.reasoning` sends `reasoning_effort`, which
+  litellm refuses for an unmapped model exactly as it refuses `tools`.
+- **Nothing is written into litellm's global map.** The kwarg is per call, so
+  our own price can never end up labelled `cost_source="litellm"` (the label
+  meaning provider-authoritative), no entry of ours can outlive the day
+  upstream ships a richer one, and there is no process-global mutation to
+  synchronise across the trial thread pool. Once upstream carries the model,
+  the allow-list is a harmless no-op.
+
+An undeclared capability is **refused**, not dropped: the allow-list only ever
+ADDS to what litellm already permits, so a config that sets
+`models.agent.reasoning` against an entry that does not declare
+`supports_reasoning` fails per call rather than quietly running without it. An
+entry has to cover what its config asks for.
+
+Validation is at overlay load and is louder than the preset blocks beside it: a
+preset that fails to apply changes how a request is shaped, while a dropped
+entry here decides whether a request is sent at all.
+
+Three things that look like fixes and are not:
+
+- **`drop_params: true`** silences the error by stripping `tools`, turning
+  every tool-use trial into a no-tool trial. The eval then measures a
+  configuration mistake and reports it as model capability.
+- **A preset `params:` block** cannot reach this. They validate against a
+  closed set introspected from `GenerationParams.__init__`, and the refusal
+  happens upstream of every policy slot.
+- **`extra_body`** passes ungated, so smuggling a refused parameter through it
+  works — and a provider that silently ignores the key is then invisible,
+  which is the same failure wearing a different hat.
 
 ## `proxy` — routing calls through an LLM gateway
 

--- a/tests/unit/llm/test_litellm_params.py
+++ b/tests/unit/llm/test_litellm_params.py
@@ -1,0 +1,294 @@
+"""A model missing from litellm's map is refused its parameters before sending."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import litellm
+import pytest
+import yaml
+
+from tolokaforge.core.llm.litellm_params import (
+    DECLARABLE_FLAGS,
+    FLAG_PARAMS,
+    allowed_openai_params,
+)
+from tolokaforge.core.llm.presets import litellm_model_entries, set_overlay_path
+
+pytestmark = pytest.mark.unit
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {"name": "f", "parameters": {"type": "object", "properties": {}}},
+    }
+]
+
+#: An id litellm will never carry, so the contract tests below fail only for
+#: the reason they name. Keying them on a real model made them go red the day
+#: upstream shipped it - reporting a broken contract when the good thing
+#: happened. The gating is identical for any id the map lacks.
+MID = "meta/tolokaforge-canary-not-a-real-model"
+NAME = "tolokaforge-canary-not-a-real-model"
+EVIDENCE = "2026-08-10, litellm 1.96.0: no entry, so meta refused tools before sending"
+
+
+@pytest.fixture()
+def overlay(tmp_path: Path):
+    """Install a `litellm_models:` overlay, the way an operator would."""
+
+    def _install(entries: dict) -> Path:
+        path = tmp_path / "overlay.yaml"
+        path.write_text(yaml.safe_dump({"litellm_models": entries}))
+        set_overlay_path(str(path))
+        return path
+
+    yield _install
+    set_overlay_path(None)
+
+
+def _entry(**overrides) -> dict:
+    return {"supports_function_calling": True, "evidence": EVIDENCE, **overrides}
+
+
+def _params(allowed: list[str] | None = None, **kwargs) -> list[str] | None:
+    """What litellm would put on the wire, or None when it refuses the call."""
+    extra = {"allowed_openai_params": allowed} if allowed else {}
+    try:
+        return sorted(
+            litellm.utils.get_optional_params(
+                model=NAME,
+                custom_llm_provider="meta",
+                tools=TOOLS,
+                tool_choice="auto",
+                **extra,
+                **kwargs,
+            )
+        )
+    except litellm.UnsupportedParamsError:
+        return None
+
+
+class TestTheCanonicalContract:
+    """What the installed litellm must keep doing for this design to hold.
+
+    The premise of the whole feature is that litellm patch releases change
+    parameter gating, so the escape hatch it offers is pinned here rather than
+    assumed. Measured across 1.83.14 / 1.93.0 / 1.96.0.
+    """
+
+    def test_an_unmapped_model_is_refused_its_tools(self):
+        assert MID not in litellm.model_cost
+        assert _params() is None
+
+    def test_and_admitted_when_the_call_names_them(self):
+        assert "tools" in (_params(["tools", "tool_choice"]) or [])
+
+    def test_the_allow_list_only_ever_adds(self):
+        """The property the declaration rests on: it cannot loosen anything."""
+        assert _params(["tools", "tool_choice"], reasoning_effort="high") is None
+        assert "reasoning_effort" in (
+            _params(["tools", "tool_choice", "reasoning_effort"], reasoning_effort="high") or []
+        )
+
+    def test_completion_threads_the_kwarg_end_to_end(self):
+        """get_optional_params accepting it is not enough; the call must too."""
+        response = litellm.completion(
+            model=MID,
+            messages=[{"role": "user", "content": "hi"}],
+            tools=TOOLS,
+            tool_choice="auto",
+            mock_response="ok",
+            api_key="unused",
+            allowed_openai_params=["tools", "tool_choice"],
+        )
+        assert response.choices[0].message.content == "ok"
+
+    def test_without_it_the_same_call_is_refused(self):
+        with pytest.raises(litellm.UnsupportedParamsError):
+            litellm.completion(
+                model=MID,
+                messages=[{"role": "user", "content": "hi"}],
+                tools=TOOLS,
+                tool_choice="auto",
+                mock_response="ok",
+                api_key="unused",
+            )
+
+
+class TestWhatAnEntryAdmits:
+    def test_a_declared_flag_admits_its_parameters(self, overlay):
+        overlay({MID: _entry()})
+        assert allowed_openai_params(MID) == ["tools", "tool_choice"]
+
+    def test_reasoning_is_admitted_only_when_declared(self, overlay):
+        overlay({MID: _entry()})
+        assert "reasoning_effort" not in allowed_openai_params(MID)
+        overlay({MID: _entry(supports_reasoning=True)})
+        assert "reasoning_effort" in allowed_openai_params(MID)
+
+    def test_a_flag_declared_false_admits_nothing(self, overlay):
+        overlay({MID: _entry(supports_function_calling=False, supports_reasoning=True)})
+        assert allowed_openai_params(MID) == ["reasoning_effort"]
+
+    def test_every_declarable_flag_admits_a_parameter_we_actually_send(self):
+        """A flag admitting something the engine never sends is a dead knob.
+
+        `tool_choice` only ever ships alongside `tools`, and
+        `parallel_tool_calls` is never set, so a flag for either would validate
+        cleanly and leave the run refused on the parameter it needed.
+        """
+        sent_somewhere = {"tools", "tool_choice", "reasoning_effort"}
+        for flag in DECLARABLE_FLAGS:
+            assert FLAG_PARAMS[flag], f"{flag} admits nothing"
+            assert set(FLAG_PARAMS[flag]) <= sent_somewhere, f"{flag} admits an unsent parameter"
+
+
+class TestTheEngineShipsNoList:
+    """The capability is in the wheel; which models need it is operator data."""
+
+    def test_no_overlay_means_nothing_is_admitted(self):
+        set_overlay_path(None)
+        assert litellm_model_entries() == {}
+        assert allowed_openai_params(MID) == []
+
+    def test_a_model_no_overlay_mentions_is_left_alone(self, overlay):
+        overlay({MID: _entry()})
+        assert allowed_openai_params("openrouter/deepseek/deepseek-v4-flash") == []
+
+    def test_nothing_is_written_into_litellms_map(self, overlay):
+        """No global mutation: no clobbering upstream, no cost relabelling."""
+        before = dict(litellm.model_cost)
+        overlay({MID: _entry(supports_reasoning=True)})
+        allowed_openai_params(MID)
+        assert litellm.model_cost == before
+        assert MID not in litellm.model_cost
+
+
+class TestAModelIdThatCarriesNoVendor:
+    """The Nova path sends litellm a BARE name, with no `<provider>/` prefix."""
+
+    def test_the_entry_is_found_via_the_provider(self, overlay):
+        overlay({"nova/some-nova-model": _entry()})
+        assert allowed_openai_params("some-nova-model", "nova") == ["tools", "tool_choice"]
+
+    def test_without_a_provider_a_bare_id_matches_nothing(self, overlay):
+        overlay({"nova/some-nova-model": _entry()})
+        assert allowed_openai_params("some-nova-model") == []
+
+
+class TestOverlayValidation:
+    """Louder than the preset blocks around it: a dropped entry here does not
+    change how a request is shaped, it decides whether one is sent at all."""
+
+    @pytest.mark.parametrize(
+        "entry, expected",
+        [
+            ({"supports_function_calling": True}, "evidence"),
+            ({"supports_function_calling": True, "evidence": "  "}, "evidence"),
+            ({"evidence": EVIDENCE, "like": "meta/muse-spark-1.1"}, "unknown keys"),
+            ({"evidence": EVIDENCE, "input": 1.25}, "unknown keys"),
+            ({"evidence": EVIDENCE, "supports_function_calling": "yes"}, "true or false"),
+            ({"evidence": EVIDENCE}, "declares nothing"),
+            ({"evidence": EVIDENCE, "supports_function_calling": False}, "declares nothing"),
+        ],
+    )
+    def test_a_malformed_entry_fails_the_load(self, overlay, entry, expected):
+        overlay({MID: entry})
+        with pytest.raises(ValueError, match=expected):
+            litellm_model_entries()
+
+    @pytest.mark.parametrize("model_id", ["/some-model", "meta/", "/", "meta"])
+    def test_a_key_that_is_not_a_litellm_model_id_fails(self, overlay, model_id):
+        """The key IS the lookup, so a bare or half-bare name matches nothing."""
+        overlay({model_id: _entry()})
+        with pytest.raises(ValueError, match="provider./.model"):
+            litellm_model_entries()
+
+    def test_a_non_mapping_block_fails(self, tmp_path: Path):
+        path = tmp_path / "overlay.yaml"
+        path.write_text(yaml.safe_dump({"litellm_models": [MID]}))
+        set_overlay_path(str(path))
+        try:
+            with pytest.raises(ValueError, match="must be a mapping"):
+                litellm_model_entries()
+        finally:
+            set_overlay_path(None)
+
+
+class TestCaseIsNotAWayToMiss:
+    """One case rule on both sides of the lookup.
+
+    The validator accepts any case, and the lookup lowercases the vendor. If
+    only one of them did, a capitalised `Meta/...` in the YAML would validate,
+    load, and then match nothing - producing the one report nobody can act on:
+    the overlay is installed and the model still refuses its tools.
+    """
+
+    @pytest.mark.parametrize(
+        "declared, asked",
+        [
+            ("Meta/muse-spark-1.2", "meta/muse-spark-1.2"),
+            ("meta/muse-spark-1.2", "Meta/muse-spark-1.2"),
+            ("META/muse-spark-1.2", "meta/muse-spark-1.2"),
+        ],
+    )
+    def test_the_vendor_case_does_not_decide_whether_it_matches(self, overlay, declared, asked):
+        overlay({declared: _entry()})
+        assert allowed_openai_params(asked) == ["tools", "tool_choice"]
+
+    def test_and_on_the_bare_name_path_too(self, overlay):
+        overlay({"Nova/some-nova-model": _entry()})
+        assert allowed_openai_params("some-nova-model", "NOVA") == ["tools", "tool_choice"]
+
+    def test_the_model_name_keeps_its_own_case(self, overlay):
+        """Only the vendor is normalised: litellm's ids are lowercase, model
+        names are the vendor's business."""
+        overlay({"meta/Muse-Spark-1.2": _entry()})
+        assert allowed_openai_params("meta/Muse-Spark-1.2") == ["tools", "tool_choice"]
+        assert allowed_openai_params("meta/muse-spark-1.2") == []
+
+
+class TestTheClientActuallyAttachesIt:
+    """The one line that connects the declaration to a request.
+
+    Everything else here tests the list or tests litellm; without this, the
+    whole feature could compute a list nobody reads and the suite would stay
+    green while every declared model was still refused its tools.
+    """
+
+    def _kwargs(self, provider: str, name: str) -> dict:
+        from tolokaforge.core.llm.client import LLMClient
+        from tolokaforge.core.models.run_config import ModelConfig
+
+        client = LLMClient(ModelConfig(provider=provider, name=name))
+        return client._build_kwargs(
+            system="You are a test.",
+            messages=[],
+            tools=TOOLS,
+            tool_choice="auto",
+            temperature=None,
+            seed=None,
+            reasoning=None,
+            top_p=None,
+            max_tokens=None,
+        )
+
+    def test_a_declared_model_carries_the_allow_list(self, overlay):
+        overlay({MID: _entry()})
+        assert self._kwargs("meta", NAME)["allowed_openai_params"] == ["tools", "tool_choice"]
+
+    def test_a_model_litellm_knows_carries_no_kwarg_at_all(self, overlay):
+        """Absent, not empty: an empty list is still a claim about the call."""
+        overlay({MID: _entry()})
+        assert "allowed_openai_params" not in self._kwargs(
+            "openrouter", "deepseek/deepseek-v4-flash"
+        )
+
+    def test_what_is_declared_is_what_is_attached(self, overlay):
+        overlay({MID: _entry(supports_reasoning=True)})
+        assert self._kwargs("meta", NAME)["allowed_openai_params"] == [
+            "tools",
+            "tool_choice",
+            "reasoning_effort",
+        ]

--- a/tests/unit/llm/test_preset_overlay_validation.py
+++ b/tests/unit/llm/test_preset_overlay_validation.py
@@ -60,7 +60,7 @@ class TestOverlayLoadErrors:
         path = tmp_path / "empty.yaml"
         path.write_text("")
         data = _load_overlay_file(str(path))
-        assert data == {"default": {}, "presets": {}, "providers": {}}
+        assert data == {"default": {}, "presets": {}, "providers": {}, "litellm_models": {}}
 
     def test_unknown_top_level_key_rejected(self, tmp_path: Path) -> None:
         path = tmp_path / "typo.yaml"

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -295,3 +295,92 @@ class TestValidationResult:
             ]
         )
         assert r.ok
+
+
+class TestPreflightConsultsTheOverlay:
+    """`config validate` loads the `litellm_models:` block, so it has to use it.
+
+    Otherwise the command that schema-validates the declaration turns around
+    and reports the model unable to call functions, while the run works. The
+    test drives the real CLI: an earlier version of this passed by calling
+    `set_overlay_path` itself, which is exactly the step the CLI was missing.
+    """
+
+    def _tree(self, tmp_path, *, declared: bool, provider: str = "meta"):
+        import yaml
+
+        overlay = tmp_path / "overlay.yaml"
+        entry = {"evidence": "2026-08-10, litellm 1.96.0: measured"}
+        if declared:
+            entry["supports_function_calling"] = True
+        else:
+            entry["supports_reasoning"] = True
+        overlay.write_text(yaml.safe_dump({"litellm_models": {"meta/muse-spark-1.2": entry}}))
+
+        config = tmp_path / "run.yaml"
+        config.write_text(
+            yaml.safe_dump(
+                {
+                    "evaluation": {
+                        "tasks_glob": "tasks/**/task.yaml",
+                        "output_dir": "output",
+                        "harness_adapter": {"type": "frozen_mcp_core"},
+                    },
+                    "orchestrator": {"workers": 1, "repeats": 1},
+                    "models": {
+                        "agent": {"provider": provider, "name": "muse-spark-1.2"},
+                        "user": {"provider": "openrouter", "name": "anthropic/claude-sonnet-4.6"},
+                    },
+                    "engine": {"presets_file": str(overlay)},
+                }
+            )
+        )
+        return config
+
+    def _validate(self, config):
+        from click.testing import CliRunner
+
+        from tolokaforge.dx.cli.main import cli
+
+        return CliRunner().invoke(cli, ["config", "validate", "--config", str(config)])
+
+    def test_a_declared_model_is_not_reported_unable(self, tmp_path):
+        result = self._validate(self._tree(tmp_path, declared=True))
+        assert "does not appear to support function calling" not in result.output
+
+    @pytest.mark.parametrize("provider", ["meta", "Meta", "META"])
+    def test_the_preflight_lookup_is_case_symmetric_like_the_run(self, provider, tmp_path):
+        """Asserted on the lookup, not on the CLI output.
+
+        A capitalised provider makes litellm raise, so the wrapper answers
+        `None` and no issue is emitted whatever the overlay says - a CLI-level
+        case test would pass without the symmetry existing.
+        """
+        import yaml
+
+        from tolokaforge.core import config_validator as cv
+        from tolokaforge.core.llm.presets import set_overlay_path
+
+        overlay = tmp_path / "overlay.yaml"
+        overlay.write_text(
+            yaml.safe_dump(
+                {
+                    "litellm_models": {
+                        "meta/muse-spark-1.2": {
+                            "supports_function_calling": True,
+                            "evidence": "2026-08-10, litellm 1.96.0: measured",
+                        }
+                    }
+                }
+            )
+        )
+        set_overlay_path(str(overlay))
+        try:
+            assert cv._declared_function_calling("muse-spark-1.2", provider) is True
+        finally:
+            set_overlay_path(None)
+
+    def test_and_one_the_overlay_does_not_declare_still_is(self, tmp_path):
+        """The check still fails closed - the overlay is not a blanket pass."""
+        result = self._validate(self._tree(tmp_path, declared=False))
+        assert "does not appear to support function calling" in result.output

--- a/tolokaforge/core/config_validator.py
+++ b/tolokaforge/core/config_validator.py
@@ -123,6 +123,23 @@ def _model_supports_reasoning(model_name: str) -> bool | None:
     return None  # unknown – let the caller decide
 
 
+def _declared_function_calling(name: str, provider: str) -> bool:
+    """Whether an operator overlay admits tool calls for this model.
+
+    Asked through the same function the RUN asks, so the preflight cannot
+    disagree with it about which entry applies - a second lookup here would
+    have its own idea of how to build the key.
+    """
+    from tolokaforge.core.llm.litellm_params import allowed_openai_params
+
+    try:
+        return "tools" in allowed_openai_params(name, provider)
+    except (OSError, ValueError):
+        # A broken overlay has its own, louder error path at load; this check
+        # must not turn it into a confusing function-calling verdict.
+        return False
+
+
 def _model_supports_function_calling(model_name: str) -> bool | None:
     """Best-effort check via LiteLLM, returns None on failure."""
     try:
@@ -259,6 +276,17 @@ def _validate_model(
     if role == "agent" and provider:
         litellm_name = f"{provider}/{name}" if not name.startswith(f"{provider}/") else name
         fc_support = _model_supports_function_calling(litellm_name)
+        if fc_support is not True and _declared_function_calling(name, provider):
+            # An overlay entry answers the same question litellm's map cannot,
+            # and this command already loads and schema-validates that block.
+            # Reporting the model unable to call functions while the run works
+            # is a preflight that contradicts the thing it is checking.
+            #
+            # `is not True` rather than `is False`: today an unmapped model
+            # reads False, but the premise of this whole feature is that
+            # litellm's answers move between patch releases, and a future
+            # `None` would quietly stop consulting the declaration.
+            fc_support = True
         if fc_support is False:
             # For OpenRouter, LiteLLM may not recognise the model (future /
             # niche models).  Downgrade to WARNING so we don't block runs for

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -41,6 +41,7 @@ from tenacity.wait import wait_base
 
 from tolokaforge.core.actors.actor import Actor
 from tolokaforge.core.llm.capabilities import ModelCapabilities
+from tolokaforge.core.llm.litellm_params import allowed_openai_params
 from tolokaforge.core.llm.presets import build_capabilities
 from tolokaforge.core.llm.prompt_policy import detect_dict_maps
 from tolokaforge.core.llm.proxy import UNROUTABLE_PROVIDERS, resolve_proxy_config
@@ -625,6 +626,9 @@ class LLMClient:
     ):
         self.config = config
         self.model_name = self._format_model_name()
+        # Parameters an overlay admits for a model litellm's map does not carry.
+        # Empty for every model it does: the kwarg is then omitted entirely.
+        self.allowed_openai_params = allowed_openai_params(self.model_name, self.config.provider)
         self.capabilities = build_capabilities(
             self.config.name,
             self.config.provider,
@@ -1698,6 +1702,12 @@ class LLMClient:
         because it needs ``NOVA_API_KEY`` read fresh per attempt.
         """
         kwargs: dict[str, Any] = {"model": self.model_name}
+        if self.allowed_openai_params:
+            # litellm's own escape hatch for a model its map does not carry: the
+            # named parameters are admitted past the gating for this call, and
+            # stripped before the request body is built. Anything NOT named is
+            # still refused, so the declaration stays the boundary.
+            kwargs["allowed_openai_params"] = list(self.allowed_openai_params)
 
         # Adapt model-specific parameters (temperature, seed, reasoning)
         kwargs = self.capabilities.params_policy.adapt(

--- a/tolokaforge/core/llm/litellm_params.py
+++ b/tolokaforge/core/llm/litellm_params.py
@@ -1,0 +1,140 @@
+"""Admitting the parameters a model accepts, when litellm's map has never heard of it.
+
+See ``docs/LLM_LAYER.md`` § "When litellm has never heard of the model" for the
+measured version behaviour and for the fixes that look right and are not.
+
+litellm decides which OpenAI parameters a provider may be sent by looking the
+model up in its own map. For most providers that decision is generic, but a
+vendor-native one narrows it by the entry: measured on 1.96.0, the `meta` route
+admits 32 parameters for a model the map carries and 26 for one it does not,
+and the six it withholds are exactly ``function_call``, ``functions``,
+``parallel_tool_calls``, ``reasoning_effort``, ``tool_choice`` and ``tools``.
+Temperature, max_tokens, top_p, seed and the rest pass untouched - which is why
+the error names only the tool parameters, and why it is rejected before any
+request leaves the process::
+
+    litellm.UnsupportedParamsError: meta does not support parameters:
+    ['tools', 'tool_choice'], for model=muse-spark-1.2
+
+That is a gap in litellm's data, not a statement about the model - the same
+model returns a correct tool call once the parameters are admitted.
+
+litellm's own answer to this is ``allowed_openai_params``, a per-call kwarg
+naming the parameters to admit past the map gating for that one request; its
+error message says so. This module turns an operator's declaration into that
+list. It carries no list of models: a model missing from a third-party map is
+not a fact about this engine release, and pinning one here would tie every
+future gap to the release cadence - the same argument ADR 0002 made for preset
+data. So entries are operator data, declared in the preset overlay
+(``--presets-file`` / ``RunConfig.engine.presets_file``)::
+
+    litellm_models:
+      meta/muse-spark-1.2:
+        supports_function_calling: true
+        supports_reasoning: true      # the config sets models.agent.reasoning
+        evidence: "2026-08-10, litellm 1.96.0: no entry, so meta refused tools
+          before sending; admitting them returns a correct tool call."
+
+An entry DECLARES; it does not copy. Only the parameters its flags name are
+admitted, so a capability nothing observed is never asserted on the model's
+behalf, and an undeclared parameter is still refused loudly - the allow-list
+only ever ADDS to what litellm already permits.
+
+Nothing is written into litellm's global model map. That keeps three problems
+from existing: a price of ours cannot end up labelled ``cost_source="litellm"``
+(provider-authoritative) when it is our own table, an entry cannot survive to
+overwrite the richer upstream row once litellm ships one, and there is no
+process-global mutation to synchronise across the trial thread pool. When
+upstream does ship the entry, the allow-list becomes a harmless no-op.
+
+Never reach for ``drop_params`` to silence the error this fixes: that strips
+``tools`` and turns every tool-use trial into a no-tool trial, which reads as a
+capability result rather than a configuration one. Nor ``extra_body``, which
+passes ungated: a provider silently ignoring a key smuggled through it is
+invisible, which is the same failure wearing a different hat.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Models whose evidence line has been logged. A client is built per trial per
+#: role, so without this a 4000-trial eval repeats the same sentence thousands
+#: of times. Nothing reads it but the logger.
+_LOGGED: set[str] = set()
+
+__all__ = ["DECLARABLE_FLAGS", "FLAG_PARAMS", "allowed_openai_params"]
+
+
+#: Declared capability -> the OpenAI parameters it admits. Every flag here
+#: admits something this engine actually sends: `tool_choice` is only ever set
+#: alongside `tools`, and `parallel_tool_calls` is never set at all, so flags
+#: for those would validate cleanly, admit a parameter no request carries, and
+#: leave the run refused on the one it needed. Extending this map is a decision
+#: about what we are willing to assert, and about what we actually send.
+#:
+#: ``supports_reasoning`` is here because a config that sets
+#: ``models.agent.reasoning`` sends ``reasoning_effort``, which litellm refuses
+#: for an unmapped model exactly as it refuses ``tools``.
+FLAG_PARAMS: dict[str, tuple[str, ...]] = {
+    "supports_function_calling": ("tools", "tool_choice"),
+    "supports_reasoning": ("reasoning_effort",),
+}
+
+#: The flags an overlay entry may set, in declaration order.
+DECLARABLE_FLAGS: tuple[str, ...] = tuple(FLAG_PARAMS)
+
+
+def _entry_key(model_id: str, provider: str) -> str:
+    """The overlay key for a model id litellm will be asked about.
+
+    Overlay keys are always ``<provider>/<model>`` - one shape to validate and
+    one to document - but the id litellm resolves is not always: the Nova path
+    sends a bare name. Composing the key from the provider keeps a config whose
+    model id carries no vendor reachable from the overlay.
+
+    The vendor is lowercased on both sides of this lookup (see
+    ``presets._validate_litellm_models``), so a config and an overlay that
+    disagree on the case of ``Meta`` still meet. A validator that accepted what
+    the lookup could not find would produce the one report nobody can act on:
+    the overlay is loaded and the model still refuses tools.
+    """
+    if "/" in model_id:
+        vendor, _, name = model_id.partition("/")
+        return f"{vendor.lower()}/{name}"
+    vendor = (provider or "").strip().lower()
+    return f"{vendor}/{model_id}" if vendor else model_id
+
+
+def allowed_openai_params(model_id: str, provider: str = "") -> list[str]:
+    """Parameters an overlay entry admits for *model_id*, for litellm's kwarg.
+
+    Empty when no entry declares this model, which is every model litellm
+    already knows - the kwarg is then omitted and nothing about the request
+    changes.
+
+    *model_id* is the string litellm resolves (``_format_model_name``);
+    *provider* names the vendor for the ids that do not carry one.
+    """
+    from tolokaforge.core.llm.presets import litellm_model_entries
+
+    entry = litellm_model_entries().get(_entry_key(model_id, provider))
+    if not entry:
+        return []
+
+    params: list[str] = []
+    for flag, names in FLAG_PARAMS.items():
+        if not entry.get(flag):
+            continue
+        params.extend(name for name in names if name not in params)
+    if params and model_id not in _LOGGED:
+        _LOGGED.add(model_id)
+        logger.info(
+            "Admitting %s for %s, which litellm's map does not carry. %s",
+            ", ".join(params),
+            model_id,
+            entry.get("evidence"),
+        )
+    return params

--- a/tolokaforge/core/llm/presets.py
+++ b/tolokaforge/core/llm/presets.py
@@ -30,6 +30,7 @@ from tolokaforge.core.llm.content_policy import (
     OpenAIContent,
     ToolContentPolicy,
 )
+from tolokaforge.core.llm.litellm_params import DECLARABLE_FLAGS
 from tolokaforge.core.llm.params_policy import GenerationParams
 from tolokaforge.core.llm.prompt_policy import (
     DictMapHints,
@@ -70,6 +71,7 @@ __all__ = [
     "get_overlay_path",
     "resolve_overlay_path",
     "validate_overlay_file",
+    "litellm_model_entries",
 ]
 
 
@@ -138,7 +140,12 @@ _POLICY_REGISTRIES: dict[str, dict[str, type[Any]]] = {
 }
 
 
-_DEFAULT_PRESET_DATA: dict[str, Any] = {"default": {}, "presets": {}, "providers": {}}
+_DEFAULT_PRESET_DATA: dict[str, Any] = {
+    "default": {},
+    "presets": {},
+    "providers": {},
+    "litellm_models": {},
+}
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +164,15 @@ _DEFAULT_PRESET_DATA: dict[str, Any] = {"default": {}, "presets": {}, "providers
 # ``tolokaforge.adapters``.
 
 #: Top-level keys allowed in an overlay (and the bundled file).
-_OVERLAY_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"default", "presets", "providers"})
+_OVERLAY_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {"default", "presets", "providers", "litellm_models"}
+)
+
+#: Keys one ``litellm_models:`` entry may carry: the wire capabilities it
+#: DECLARES (``litellm_params.DECLARABLE_FLAGS``) plus the ``evidence`` for them.
+#: No prices - a registered price would relabel our own table as
+#: provider-authoritative; see ``litellm_params`` for why.
+_LITELLM_MODEL_KEYS: frozenset[str] = frozenset({"evidence", *DECLARABLE_FLAGS})
 
 #: Valid ``params:`` block keys — introspected from ``GenerationParams.__init__``
 #: so adding a new kwarg to ``GenerationParams`` automatically extends overlay
@@ -278,6 +293,79 @@ def validate_overlay_file(path: str) -> None:
     _load_overlay_file(path)
 
 
+def _lower_vendor_keys(block: dict[str, Any]) -> dict[str, Any]:
+    """Store entries under a lowercased vendor, which is what the lookup builds.
+
+    litellm's own ids are lowercase, and the alternative - rejecting
+    ``Meta/...`` at load - fails a file that says exactly what it means.
+    """
+    lowered: dict[str, Any] = {}
+    for model_id, entry in block.items():
+        vendor, _, name = str(model_id).partition("/")
+        lowered[f"{vendor.lower()}/{name}"] = entry
+    return lowered
+
+
+def _validate_litellm_models(block: Any, path: str) -> None:
+    """Validate a ``litellm_models:`` block. Loud on anything malformed.
+
+    Louder than the preset blocks around it on purpose: a preset that fails to
+    apply changes how a request is shaped, while an entry here changes whether
+    the request is sent at all, and a silently-dropped one reappears as
+    "this provider does not support tool calls". Runs at overlay load, which is
+    the CLI boundary, so a bad entry fails before the orchestrator exists and
+    before anything has been spent.
+    """
+    if not isinstance(block, dict):
+        raise ValueError(
+            f"Preset overlay {path!r}: litellm_models must be a mapping of "
+            f"'<provider>/<model>' to an entry, got {type(block).__name__}."
+        )
+    for model_id, entry in block.items():
+        where = f"litellm_models[{model_id!r}]"
+        vendor, _, name = model_id.partition("/") if isinstance(model_id, str) else ("", "", "")
+        if not vendor or not name:
+            raise ValueError(
+                f"Preset overlay {path!r}: {where} must be a litellm model id of the "
+                "form '<provider>/<model>' - that is the key litellm looks up, and "
+                "half of one matches nothing."
+            )
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Preset overlay {path!r}: {where} must be a mapping, got {type(entry).__name__}."
+            )
+        unknown = set(entry) - _LITELLM_MODEL_KEYS
+        if unknown:
+            raise ValueError(
+                f"Preset overlay {path!r}: {where} has unknown keys {sorted(unknown)}. "
+                f"Allowed: {sorted(_LITELLM_MODEL_KEYS)}. Capability flags are an "
+                "allow-list on purpose: an entry states what we are willing to "
+                "assert about a model, not everything litellm can hold."
+            )
+        evidence = entry.get("evidence")
+        if not isinstance(evidence, str) or not evidence.strip():
+            raise ValueError(
+                f"Preset overlay {path!r}: {where} needs a non-empty 'evidence'. "
+                "The entry asserts what a model accepts on the wire, so it has to "
+                "say what was observed and when, or nobody can re-check it."
+            )
+        declared = [flag for flag in DECLARABLE_FLAGS if flag in entry]
+        for flag in declared:
+            if not isinstance(entry[flag], bool):
+                raise ValueError(
+                    f"Preset overlay {path!r}: {where}.{flag} must be true or false, "
+                    f"got {entry[flag]!r}."
+                )
+        if not any(entry[flag] for flag in declared):
+            raise ValueError(
+                f"Preset overlay {path!r}: {where} declares nothing. An entry exists "
+                f"to state a capability litellm's map is missing, so one of "
+                f"{list(DECLARABLE_FLAGS)} must be true - otherwise the model is "
+                "left exactly as unusable as it was, and the file reads as though "
+                "it had been fixed."
+            )
+
+
 def _validate_overlay(data: dict[str, Any], path: str) -> None:
     """Host-boundary validation for an overlay's contents.
 
@@ -298,6 +386,8 @@ def _validate_overlay(data: dict[str, Any], path: str) -> None:
             f"Preset overlay {path!r} has unknown top-level keys: "
             f"{sorted(unknown_top)}. Allowed: {sorted(_OVERLAY_TOP_LEVEL_KEYS)}."
         )
+
+    _validate_litellm_models(data.get("litellm_models") or {}, path)
 
     def _check_block(block: dict[str, Any], where: str) -> None:
         if not isinstance(block, dict):
@@ -354,6 +444,7 @@ def _merge_overlay(
       at INFO so the operator can confirm it took effect.
     - ``providers:`` shallow merge per provider key; overlay wins; nested
       ``params`` merges deeply.
+    - ``litellm_models:`` shallow merge per model id; overlay wins.
     """
     merged: dict[str, Any] = {}
 
@@ -405,6 +496,15 @@ def _merge_overlay(
         new_providers[name] = merged_p
     merged["providers"] = new_providers
 
+    # litellm_models — per-model-id, overlay wins. Nothing is bundled today, so
+    # in practice this is the overlay's own block.
+    merged["litellm_models"] = _lower_vendor_keys(
+        {
+            **(bundled.get("litellm_models") or {}),
+            **(overlay.get("litellm_models") or {}),
+        }
+    )
+
     return merged
 
 
@@ -426,6 +526,17 @@ def _load_presets() -> dict[str, Any]:
     overlay = _load_overlay_file(_OVERLAY_PATH)
     _CACHED_PRESETS = _merge_overlay(bundled, overlay, _OVERLAY_PATH)
     return _CACHED_PRESETS
+
+
+def litellm_model_entries() -> dict[str, dict[str, Any]]:
+    """Operator-supplied entries for models litellm's own map does not carry.
+
+    Empty unless an overlay declares them - the engine ships no list of its
+    own, because a model missing from a third-party map is not a fact about
+    this release. See ``litellm_params.allowed_openai_params`` for what is done
+    with them, and ``docs/LLM_LAYER.md`` for why they exist at all.
+    """
+    return dict(_load_presets().get("litellm_models") or {})
 
 
 def _iter_preset_matches(

--- a/tolokaforge/dx/cli/config.py
+++ b/tolokaforge/dx/cli/config.py
@@ -14,6 +14,7 @@ import click
 from tolokaforge.core.config_validator import Severity, validate_run_config
 from tolokaforge.core.llm.presets import (
     resolve_overlay_path,
+    set_overlay_path,
     validate_overlay_file,
 )
 from tolokaforge.core.project_loader import load_effective_run_config
@@ -100,6 +101,12 @@ def validate(config_path: str, strict: bool, presets_file: str | None) -> None:
             else None
         )
         resolved_overlay = resolve_overlay_path(cli_value=presets_file, config_value=config_overlay)
+        # INSTALLED, not merely read: the checks below ask what the overlay
+        # declares (a model litellm's own map does not carry is declared there),
+        # and validating the file without installing it reported such a model
+        # unable to call functions while the run worked. Set unconditionally so
+        # one config in a glob cannot inherit the previous config's overlay.
+        set_overlay_path(resolved_overlay or None)
         if resolved_overlay:
             try:
                 validate_overlay_file(resolved_overlay)


### PR DESCRIPTION
## The problem

litellm decides which OpenAI parameters a provider may be sent by looking the model up in its own map, and a **vendor-native** provider answers from that entry alone. A model the map does not carry is read as supporting NO parameters, so `tools` is refused inside our process, before a request is ever sent:

```
litellm.UnsupportedParamsError: meta does not support parameters: ['tools', 'tool_choice'], for model=muse-spark-1.2
```

Measured 2026-08-10, identical request, three litellm versions:

| litellm | `tools` on the `meta` route |
|---|---|
| 1.83.14 | passes |
| 1.93.0 | refused |
| 1.96.0 | refused |

The strictness arrived in a patch release. A routine dependency bump can therefore turn a working vendor-native model into one that cannot make a single tool call, and the error names the provider rather than the missing data, so it reads as "this vendor does not do tool calls".

It is not about the model: the identical request returns a correct tool call once the parameters are admitted. The gap is upstream DATA.

## The change

litellm's own answer is `allowed_openai_params`, a per-call kwarg naming the parameters to admit past the map gating for that one request; its error message says so. This turns an operator's declaration into that list.

`litellm_params.py` carries **no list of models**. A model missing from a third-party map is not a fact about an engine release, and a list in the wheel would tie every future gap to the release cadence — the argument [ADR 0002](docs/adr/0002-external-model-registry.md) already made for preset data, which [ADR-0030](docs/adr/0030-tolokaforge-models-split.md) carries further. So entries are operator data, in the same preset overlay:

```yaml
litellm_models:
  meta/muse-spark-1.2:
    supports_function_calling: true
    supports_reasoning: true       # the config sets models.agent.reasoning
    evidence: "2026-08-10, litellm 1.96.0: no entry, so meta refused tools before
      sending; admitting them returns a correct tool call."
```

`LLMClient.__init__` computes the list once; `_build_kwargs` attaches it when non-empty, so for every model litellm already knows the kwarg is absent and nothing about the request changes.

An entry **declares**; it does not copy. Only the parameters its flags name are admitted, and the allow-list only ever ADDS to what litellm already permits — so an undeclared parameter is still refused loudly, and the declaration is the boundary in both directions. `supports_reasoning` is declarable because a config that sets `models.agent.reasoning` sends `reasoning_effort`, which litellm refuses for an unmapped model exactly as it refuses `tools`; an entry has to cover what its config asks for.

**Nothing is written into litellm's global map.** That keeps three problems from existing rather than solving them: our own price cannot end up labelled `cost_source="litellm"` (the label meaning provider-authoritative), no entry of ours can outlive the day upstream ships a richer one, and there is no process-global mutation to synchronise across the trial thread pool. Once upstream carries the model, the allow-list is a no-op.

Entries are validated at overlay load, which is the CLI boundary, so a malformed one fails before the orchestrator exists rather than as a run of failed trials. Validation is louder than the preset blocks beside it, deliberately: a preset that fails to apply changes how a request is shaped, while a dropped entry here decides whether a request is sent at all.

`config validate` consults the overlay too. It loads and schema-validates the block already, and without this it reported the model unable to call functions while the run worked — a preflight contradicting the thing it checks.

Overlay keys are always `<provider>/<model>`, and the vendor segment is lowercased on both sides of the lookup, so a config and an overlay that disagree about the case of `Meta` still meet. The lookup composes that key from the provider when a config's model id carries no vendor, which keeps the Nova path reachable.

## Verification

- **`TestTheCanonicalContract`** pins what the installed litellm must keep doing, since the premise here is that its patch releases change parameter gating: an unmapped model is refused, naming the parameters admits them, an undeclared name is still refused, and `completion` threads the kwarg end to end (with its paired refusal test). Note `inspect.signature(litellm.completion)` does not list the kwarg on any tested version — it is absorbed by `**kwargs`, so only an actual call proves it.
- The rest of `test_litellm_params.py` covers what an entry admits, that nothing is written into litellm's map, the bare-name path, vendor-case symmetry, and every validation failure.
- `test_config_validator.py` covers the preflight, parametrised over litellm answering `False` and `None`.
- Full engine unit suite: 5866 passed. One pre-existing failure in `test_docker_build_context.py`, which fails identically on `main`.
- `ruff` and `black` clean.

Docs: `docs/LLM_LAYER.md` § "When litellm has never heard of the model".

## Two things that look like fixes and are not

- `drop_params: true` silences the error by stripping `tools`, turning every tool-use trial into a no-tool trial. The eval then measures a configuration mistake and reports it as model capability.
- `extra_body` passes ungated, so a refused parameter can be smuggled through it — and a provider that silently ignores the key is then invisible, which is the same failure wearing a different hat.

A preset `params:` block cannot reach this either: they validate against a closed set introspected from `GenerationParams.__init__`, and the refusal happens upstream of every policy slot.

## What review changed

The first draft mutated `litellm.model_cost`: a model list in the wheel, capability flags cloned from a "witness" sibling, and prices. Review took it apart, and all of it is gone:

- Cloning laundered one observed fact into fifteen. `supports_reasoning` travelled, and litellm then put `reasoning_effort` on the wire for a model nobody had measured for it.
- The price guard failed open: cost keys were overridden but not stripped, so a model absent from our table inherited the sibling's prices.
- The stand-down path stored upstream's dict as if it were ours, so the second client construction registered over the richer upstream row.
- A hardcoded list defeats the seam it sits beside.

The per-call kwarg deletes that whole class of problem — registration, both ledgers, the lock, the stand-down branch, and the test fixture that restored five kinds of hidden litellm global state through a private API — while keeping the schema, the evidence requirement, the allow-list and the validation unchanged.