### PR TITLE
test(grading): a listed numeric-string field folds alike on both substrates, measured

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -275,8 +275,8 @@ on the wire: forcing the runner's fold to a constant weight, and replacing it wi
 plain product of the two scores, each turn every cell red. No cell there lists a
 `numeric_string_fields` entry; that key is proven by its own differential, below.
 Nor does the canonical suite prove this test *passes*: it resolves the nodeid and stops
-there. The job that runs on every pull request is `test-smoke`, whose one pytest step
-is `tests/unit/ tests/canonical/` and which has no integration step at all; `test-gate`
+there. The job that runs on every pull request is `test-smoke`, whose repo-suite pytest
+step is `tests/unit/ tests/canonical/` and which has no integration step at all; `test-gate`
 is the job that runs `tests/integration/`, and it is triggered by the `ready-to-merge`
 label — so the canonical tier gates every pull request, and this tier's output is
 quoted from a local run until that label lands.

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -56,9 +56,12 @@ author-facing key is one `GradingKey` entry declaring three axes:
   `DIFFERENTIAL_CANONICAL`: a satisfying/violating pair moves both substrates'
   scores in-process. `DIFFERENTIAL_INTEGRATION`: the differential needs real
   services, and `enforcing_test` names the test function that runs it as a pytest
-  nodeid — `<module path>::<test function>`, resolved by the canonical suite
-  against the module's own AST so naming a file that merely contains a test is
-  rejected. `FIELD_RESOLUTION_ONLY`: only "the field exists and resolves" is proven.
+  nodeid — `<module path>::<test function>`. `enforcing_test` is required at that
+  tier and permitted at any, and the canonical suite resolves it wherever it is
+  present, against the module's own AST, so naming a file that merely contains a
+  test is rejected; on a canonically proven entry it records where the same claim
+  was additionally observed in production rather than carrying the enforcement.
+  `FIELD_RESOLUTION_ONLY`: only "the field exists and resolves" is proven.
 
 `trace_checks` is the one component where parity is structural rather than
 maintained: both substrates call the same `evaluate_trace_checks` over the same
@@ -294,6 +297,17 @@ nothing because the key is read once per grade on both substrates whatever the b
 documents separately — booleans never folding to ints, leading-zero ids never
 equating — carry their own unit coverage, which this matrix does not extend. A folding
 field nested under a differently named record key at greater depth is outside both.
+
+The same pair is also observed on the production path, in
+[`tests/integration/test_docker_grading_hash_composition.py`](../tests/integration/test_docker_grading_hash_composition.py):
+one representation difference — a golden action rewriting `"130.00"` as `"130.0"` — under
+the empty list, `["amount"]` and `["quantity"]`, graded over real gRPC against the
+containerised db-service. Those cells declare one state source and no `hash.weight`, so
+the wire's `state_checks` component is the hash verdict itself and reading it needs no
+arithmetic. That is what the row's `enforcing_test` names. It adds the one
+thing no in-process test can speak for — that the *deployed* db-service parses and honours
+the `numeric_string_fields` query parameter the runner sends it — and it is falsifiable by
+configuration only, because a source patch does not reach a container.
 
 **A service-free differential reaches that evaluator.** `_drive_hash_family`
 ([`tests/canonical/test_grading_substrate_parity.py`](../tests/canonical/test_grading_substrate_parity.py))

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -269,12 +269,31 @@ and required to differ between the two weights.
 **What that proves and what it does not.** The runner's own golden-replay verdict
 reaches the shared composer, and the author's `weight` reaches the fold — measured
 on the wire: forcing the runner's fold to a constant weight, and replacing it with a
-plain product of the two scores, each turn every cell red. What it does not prove is
-`state_checks.numeric_string_fields`, which stays `FIELD_RESOLUTION_ONLY` (#687) —
-the folding pair is claimed to be honored identically on both substrates and no test
-drives it through the runner's hash evaluator. Nor does the canonical suite prove
-this test *passes*: it resolves the nodeid and stops there, and `test-gate` does not
-fire on a pull request (#700), so this tier is run locally and its output quoted.
+plain product of the two scores, each turn every cell red. No cell there lists a
+`numeric_string_fields` entry; that key is proven by its own differential, below.
+Nor does the canonical suite prove this test *passes*: it resolves the nodeid and stops
+there. The job that runs on every pull request is `test-smoke`, whose one pytest step
+is `tests/unit/ tests/canonical/` and which has no integration step at all; `test-gate`
+is the job that runs `tests/integration/`, and it is triggered by the `ready-to-merge`
+label — so the canonical tier gates every pull request, and this tier's output is
+quoted from a local run until that label lands.
+
+**`numeric_string_fields` folds by name, on both substrates.** A six-cell matrix in the
+parity suite declares one money field at `"130.00"` and grades a trial that left it at
+`"130.0"` — the same amount written another way — or at `"131.0"`, under three field
+lists: the empty list, `["amount"]`, and `["quantity"]`, a different field the same
+record declares. Exactly one cell scores `1.0`, and both substrates answer every cell
+alike — the runner through `RegisterTrial` → a mutation on the trial's own db-service →
+`GradeTrial`, core through `GradingEngine.grade_trajectory`, neither arm reading what
+the other computed. The `["quantity"]` cells are what make it a differential rather
+than a smoke test: a build that folded whenever the author wrote a *non-empty* list
+answers every other cell correctly. The boundary is one table, one record depth, one
+declared field and one hash source — `expect_initial_state`, which costs the claim
+nothing because the key is read once per grade on both substrates whatever the basis.
+`canonicalize_numbers: false` and the guards [`hash.py`](../tolokaforge/core/hash.py)
+documents separately — booleans never folding to ints, leading-zero ids never
+equating — carry their own unit coverage, which this matrix does not extend. A folding
+field nested under a differently named record key at greater depth is outside both.
 
 **A service-free differential reaches that evaluator.** `_drive_hash_family`
 ([`tests/canonical/test_grading_substrate_parity.py`](../tests/canonical/test_grading_substrate_parity.py))
@@ -284,7 +303,7 @@ runner's evaluator runs against a real database with no service to stand up. Not
 load-bearing is mocked there: the db-service app is the real one and only the HTTP
 transport is a `TestClient`. The hash family's `DIFFERENTIAL_INTEGRATION` rows therefore
 name the tier each entry was measured at rather than the strongest tier reachable for
-it, and #687 owns re-measuring them against that path.
+it, and #1018 owns re-measuring them against that path.
 
 **Coverage and enforcement are orthogonal on purpose**, which is what lets a true
 coverage claim carry weak enforcement. `state_checks.hash.golden_actions` is the
@@ -318,6 +337,15 @@ on a citation:
 - `state_checks.hash.weight` — the sweep still spans two weights strictly inside
   `(0, 1)`, the weights at which a fold that merely *selects* the dominant source is
   distinguishable from one that mixes them.
+- `state_checks.numeric_string_fields` — the folding matrix still pairs a
+  representation difference against a genuine one, under the empty list beside two
+  lists of one name each: the field that differs, and another field the record
+  declares. Equal length is what the second list is for — drop it and a build reading
+  the list's *length* rather than the names it holds answers every remaining cell
+  correctly. This is also the one entry here whose clause resolves its differential's
+  own nodeid through the same parse the `enforcing_test` claims use, so deleting or
+  renaming the function that runs the matrix fails the enumeration instead of leaving
+  it unchanged; the other entries keep the weaker guarantee stated above.
 - `combine.method` — the method differential's hand-written answer table still
   covers every declared method, with a distinct score each, so an implementation
   returning one aggregation for all three cannot satisfy it. See

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,7 +170,8 @@ Compare output against committed golden snapshots in `snapshots/`.
   `grading.yaml` key is unaccounted for, claims a substrate that does not evaluate
   it, addresses a position below a claimed field by something other than an element
   path — the manifest's one mechanism for that — no longer survives adapter
-  translation, or names a `runner_field` the runtime ledger cannot resolve. Fix the
+  translation, names a `runner_field` the runtime ledger cannot resolve, or stopped
+  folding a listed numeric-string field by name on one of the two substrates. Fix the
   manifest entry in
   `tolokaforge/core/grading/key_manifest.py` or the drift it exposed; widening a
   frozen exemption set in the test module is the deliberate last resort.

--- a/tests/README.md
+++ b/tests/README.md
@@ -360,10 +360,12 @@ testcontainer fixtures pin, so retag after building:
 
 Some suites in this tier are the `enforcing_test` a grading-key manifest entry
 names — `test_docker_grading_hash_composition.py` for the `state_checks.hash`
-family, `test_helpdesk_workflow_end_to_end.py` for `state_checks.db_probes`,
+family and for `state_checks.numeric_string_fields`,
+`test_helpdesk_workflow_end_to_end.py` for `state_checks.db_probes`,
 `test_rubric_judge_live.py` for `llm_judge`. `test_grading_substrate_parity.py`
-resolves each nodeid without importing it, so renaming one of those test functions
-fails the canonical tier naming the manifest entry.
+resolves each nodeid without importing it — every entry carrying one, whatever its
+enforcement tier — so renaming one of those test functions fails the canonical tier
+naming the manifest entry.
 
 Two members of this tier are **Docker-free and keyless** (they need only the `uv`
 CLI): `test_plugin_discovery.py` and `test_external_harness_e2e.py`. Both install

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -13,8 +13,9 @@ component that took a verdict:
 2. the exemption sets are frozen here — in the test module, never beside the
    manifest data they guard — so widening one is a reviewable edit, every entry
    matching lock 3's predicate names both evaluators and owns a fixture, and every
-   ``DIFFERENTIAL_INTEGRATION`` claim's ``enforcing_test`` nodeid resolves to a test
-   function pytest would collect;
+   entry carrying an ``enforcing_test`` — at any tier, since a canonically proven
+   claim may still record where it was observed in production — has that nodeid
+   resolve to a test function pytest would collect;
 3. every key claiming both substrates at ``DIFFERENTIAL_CANONICAL`` demonstrably
    moves both substrates' component scores, through each substrate's real
    production evaluator and its real combine;
@@ -1160,7 +1161,7 @@ def test_exemption_sets_are_frozen_and_classified(test_data_dir):
     )
 
     for item in GRADING_KEYS:
-        if item.enforcement is Enforcement.DIFFERENTIAL_INTEGRATION:
+        if item.enforcing_test:
             _assert_enforcing_test_is_collectable(item)
         for evaluator in (item.core_evaluator, item.runner_evaluator):
             if evaluator is None:

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -1,10 +1,11 @@
 """Substrate-parity guard rail for the grading key manifest.
 
-Eighteen locks. Locks 1-15 are over :mod:`tolokaforge.core.grading.key_manifest`:
+Nineteen locks. Locks 1-15 are over :mod:`tolokaforge.core.grading.key_manifest`:
 what each grading key is, which substrate scores it, and whether the two agree.
-Locks 16-18 are over what a grade *does* and *says*, which the manifest does not
-describe — the proposition a hash source compares against, and what
-``Grade.reasons`` carries for a component that took a verdict:
+Locks 16-19 are over what a grade *does* and *says*, which the manifest does not
+describe — the proposition a hash source compares against, what the hash reads a
+record's numeric-looking strings as, and what ``Grade.reasons`` carries for a
+component that took a verdict:
 
 1. every field either substrate's grading config declares is claimed by exactly
    one manifest entry, and every claimed field resolves; a position below a claimed
@@ -32,8 +33,10 @@ describe — the proposition a hash source compares against, and what
    inside it — which is what makes lock 6's canonical-tier hash inputs the only
    values that path yields rather than a stand-in for it;
 8. every ``DIFFERENTIAL_CANONICAL`` claim lock 3's predicate cannot reach is
-   enumerated here, and the two tables those claims rest on — lock 6's weight sweep
-   and lock 9's method answers — stay substantive;
+   enumerated here, and the tables those claims rest on — lock 6's weight sweep,
+   lock 9's method answers, lock 19's folding matrix — stay substantive; lock 19's
+   own nodeid is resolved besides, so that one differential cannot be deleted or
+   renamed with the set unchanged;
 9. both substrates aggregate one split pair of deterministic components by the
    author's ``combine.method``, each method pinned to a score written out here;
 10. both substrates score one ``trace_checks`` pack to the same component through
@@ -74,13 +77,19 @@ describe — the proposition a hash source compares against, and what
     enumerates the registry and the renderer enumerates by hand, so this is what
     holds the second list to the first — and the row names the marker rather than
     asking whether the grade said anything, because a component whose branch went or
-    whose marker was renamed leaves the grade just as full either way.
+    whose marker was renamed leaves the grade just as full either way;
+19. a record field's numeric-looking string folds on both substrates when — and only
+    when — ``state_checks.numeric_string_fields`` names that field: a matrix pairing a
+    representation difference against a genuine one, under the empty list, the list
+    naming the field that differs and a list of the same length naming another
+    declared field, so a build reading the list's length rather than the names it
+    holds fails one row alone.
 
 The exemption sets and the differential fixtures are the enforcement mechanism:
 adding a grading key to one substrate only cannot pass this suite without an
 explicit, reviewable edit to one of the frozen constants below.
 
-Locks 3, 6, 7, 9, 10, 11, 15, 16, 17 and 18 drive a real trial, and each reads it
+Locks 3, 6, 7, 9, 10, 11, 15, 16, 17, 18 and 19 drive a real trial, and each reads it
 through one fixture loader, so what a ``grading_parity`` pack can express bounds what
 they can prove — for locks 15 and 18 that bound covers the keys their driver tables
 send to a parity pack, the hash family, the probes and the judge being driven from
@@ -238,6 +247,7 @@ whatever the ledger recorded for the keys that feed it.
 _HASH_FAMILY_ROOT = "state_checks.hash"
 _EXPECT_INITIAL_STATE_KEY = "state_checks.hash.expect_initial_state"
 _GOLDEN_ACTIONS_KEY = "state_checks.hash.golden_actions"
+_NUMERIC_STRING_FIELDS_KEY = "state_checks.numeric_string_fields"
 
 # The one in-repo pack that both declares golden actions and gives them a world to be
 # replayed in — a JSON initial-state file and an ``mcp_server`` whose tools they call.
@@ -300,6 +310,7 @@ _NON_DIFFERENTIAL_SCORED_KEYS = frozenset(
 _CANONICAL_DIFFERENTIALS_OUTSIDE_LOCK_3 = frozenset(
     {
         "state_checks.hash.weight",
+        "state_checks.numeric_string_fields",
         "combine.method",
         "combine.weights",
         "trace_checks",
@@ -509,23 +520,23 @@ def _differential_entries() -> tuple[GradingKey, ...]:
     )
 
 
-def _assert_enforcing_test_is_collectable(item: GradingKey) -> None:
-    """The named integration test exists as a function pytest would collect.
+def _assert_nodeid_is_collectable(label: str, nodeid: str) -> None:
+    """The nodeid names a module-level function pytest would collect.
 
     Resolved by parsing the module, never by importing it: the integration tier
     pulls testcontainers and a docker daemon, neither of which the canonical tier
     has. That is also the limit of what this can prove — the nodeid resolves and is
-    collectable; whether it *passes* is what running the integration tier answers.
+    collectable; whether it *passes* is what running that tier answers.
     """
-    module_path, separator, function_name = item.enforcing_test.partition("::")
+    module_path, separator, function_name = nodeid.partition("::")
     assert separator, (
-        f"{item.author_key}: enforcing_test {item.enforcing_test!r} is a module path, not a "
-        "pytest nodeid, so it names no test function"
+        f"{label} {nodeid!r} is a module path, not a pytest nodeid, so it names a file that "
+        "may hold no test function at all"
     )
     module_file = _REPO_ROOT / module_path
     assert module_file.is_file(), (
-        f"{item.author_key}: enforcing_test module {module_path!r} does not exist on disk, "
-        "so nothing proves the integration differential"
+        f"{label} names module {module_path!r}, which does not exist on disk, so nothing "
+        "proves the differential"
     )
     declared = {
         node.name
@@ -534,13 +545,18 @@ def _assert_enforcing_test_is_collectable(item: GradingKey) -> None:
     }
     collectable = sorted(name for name in declared if name.startswith("test_"))
     assert function_name in declared, (
-        f"{item.author_key}: enforcing_test names {function_name!r}, which {module_path} does "
-        f"not declare at module level. It declares {collectable}"
+        f"{label} names {function_name!r}, which {module_path} does not declare at module "
+        f"level. It declares {collectable}"
     )
     assert function_name.startswith("test_"), (
-        f"{item.author_key}: enforcing_test names {function_name!r}, which pytest does not "
-        "collect as a test"
+        f"{label} names {function_name!r}, which pytest does not collect as a test — the nodeid "
+        "resolves to a function no run of that module would execute"
     )
+
+
+def _assert_enforcing_test_is_collectable(item: GradingKey) -> None:
+    """The integration test the entry names exists as a function pytest would collect."""
+    _assert_nodeid_is_collectable(f"{item.author_key}: enforcing_test", item.enforcing_test)
 
 
 def _split_dotted(path: str) -> tuple[Any, list[str]]:
@@ -1872,6 +1888,50 @@ def test_the_hash_verdict_is_binary_on_both_substrates(test_data_dir):
 # --------------------------------------------------------------------------
 
 
+def _assert_the_folding_matrix_discriminates() -> None:
+    """The property lock 19's differential rests on, read off its matrix.
+
+    Folding is per-field, so the rows have to differ in the places that make that
+    question askable: a representation difference a fold may collapse beside a genuine
+    difference it must refuse, and two field lists of one name each — the field that
+    differs, and another the record declares.
+    """
+    record = _FOLDING_INITIAL_ORDERS["orders"][0]
+    assert {_FOLDING_FIELD, _FOLDING_CONTROL_FIELD} <= set(record), (
+        f"the folding record {record} does not declare both {_FOLDING_FIELD!r} and "
+        f"{_FOLDING_CONTROL_FIELD!r}, so a row listing the second names a field no state "
+        "carries and the per-field rule is never asked a question"
+    )
+
+    amounts = {cell.final_amount for cell in _NUMERIC_STRING_FOLDING_MATRIX}
+    assert len(amounts) == 2 and _FOLDING_DECLARED_AMOUNT not in amounts, (
+        f"the matrix leaves the trial's {_FOLDING_FIELD} at {sorted(amounts)} against a declared "
+        f"{_FOLDING_DECLARED_AMOUNT!r}. It needs exactly two, neither the declared string itself, "
+        "or there is no representation difference for a fold to collapse"
+    )
+    folds = {amount for amount in amounts if float(amount) == float(_FOLDING_DECLARED_AMOUNT)}
+    assert len(folds) == 1, (
+        f"{sorted(folds)} of the matrix's amounts are numerically equal to "
+        f"{_FOLDING_DECLARED_AMOUNT!r}, not one. With none there is nothing a fold may collapse; "
+        "with both there is no genuine difference a fold must refuse"
+    )
+
+    listed = {cell.numeric_string_fields for cell in _NUMERIC_STRING_FOLDING_MATRIX}
+    assert listed == {(), (_FOLDING_FIELD,), (_FOLDING_CONTROL_FIELD,)}, (
+        f"the matrix's field lists are {sorted(listed)}, not the empty list beside two lists of "
+        f"one name each — {_FOLDING_FIELD!r}, which differs, and {_FOLDING_CONTROL_FIELD!r}, "
+        "which does not. Drop the second and a build folding whenever the list is non-empty "
+        "answers every remaining row correctly"
+    )
+
+    matched = [cell for cell in _NUMERIC_STRING_FOLDING_MATRIX if cell.state_checks == 1.0]
+    assert matched == [_FoldingCell((_FOLDING_FIELD,), next(iter(folds)), 1.0)], (
+        f"the matrix expects a match on {matched}, not on the one row pairing the listed "
+        "differing field with the amount that is the declared one written another way. Every "
+        "other row is a refusal, so a table agreeing everywhere proves no discrimination"
+    )
+
+
 def test_canonical_differentials_outside_lock_3_are_enumerated_and_substantive():
     """Lock 3 selects ``kind: SCORED_CHECK``, so ``CONFIG_INPUT`` and ``AGGREGATION`` escape it.
 
@@ -1880,10 +1940,17 @@ def test_canonical_differentials_outside_lock_3_are_enumerated_and_substantive()
     names asserted nothing. So this asserts the property each escaped claim depends
     on instead: that lock 6's sweep still spans the weights where a fold rule is
     distinguishable at all, that lock 9's answer table still spans the declared
-    combine methods with one distinct score each, and that lock 14's weight maps still
+    combine methods with one distinct score each, that lock 14's weight maps still
     span the pair a membership rule is distinguishable over while its zero-share table
-    still answers ``all``/``any`` differently from ``weighted``. Membership alone
-    enforces nothing: a differential deleted wholesale leaves the escaped set unchanged.
+    still answers ``all``/``any`` differently from ``weighted``, and that lock 19's
+    folding matrix still pairs a representation difference against a genuine one under
+    field lists that differ by name rather than by length. Membership alone enforces
+    nothing: a differential deleted wholesale leaves the escaped set unchanged.
+
+    Lock 19 is the one entry here that does not rest on membership: its nodeid is
+    resolved through the same parse the ``enforcing_test`` claims use, so deleting or
+    renaming the function that runs its matrix fails this test. The other entries keep
+    the weaker guarantee.
     """
     reached = {item.author_key for item in _differential_entries()}
     escaped = {
@@ -1944,6 +2011,11 @@ def test_canonical_differentials_outside_lock_3_are_enumerated_and_substantive()
     }, (
         "_ZERO_WEIGHT_VERDICTS pins the same verdicts under all/any as under weighted, so the "
         "zero-total-weight rule scoped to every method would satisfy the whole table"
+    )
+
+    _assert_the_folding_matrix_discriminates()
+    _assert_nodeid_is_collectable(
+        f"{_NUMERIC_STRING_FIELDS_KEY}: its differential", _FOLDING_DIFFERENTIAL_NODEID
     )
 
 
@@ -4156,6 +4228,202 @@ def test_every_registered_component_narrates_itself_in_a_real_grade(
         f"{author_key} scored its component and the grade never named it: no "
         f"{marker!r} in {reasons!r}"
     )
+
+
+# --------------------------------------------------------------------------
+# 19. Both substrates fold a listed numeric-string field alike
+# --------------------------------------------------------------------------
+
+_FOLDING_TASK_ID = "parity_numeric_string_folding"
+_FOLDING_FIELD = "amount"
+_FOLDING_CONTROL_FIELD = "quantity"
+_FOLDING_DECLARED_AMOUNT = "130.00"
+
+#: The record the folding task seeds. Its money field is the one a row may list, its
+#: quantity the declared field a row may list *instead* — same list length, different
+#: name, so a build reading the list's length rather than the names it holds cannot
+#: tell the two rows apart.
+_FOLDING_INITIAL_ORDERS: dict[str, Any] = {
+    "orders": [{"order_id": "O1", "amount": _FOLDING_DECLARED_AMOUNT, "quantity": "2"}]
+}
+
+
+@dataclass(frozen=True)
+class _FoldingCell:
+    """One row: what the pack listed, what the trial left, what both substrates owe."""
+
+    numeric_string_fields: tuple[str, ...]
+    final_amount: str
+    state_checks: float
+
+
+#: ``"130.0"`` is the declared amount written another way; ``"131.0"`` is a different
+#: amount. Folding is representational, so only the first can collapse, and only for a
+#: row that named the field it sits under.
+_NUMERIC_STRING_FOLDING_MATRIX: tuple[_FoldingCell, ...] = (
+    _FoldingCell((), "130.0", 0.0),
+    _FoldingCell((), "131.0", 0.0),
+    _FoldingCell((_FOLDING_FIELD,), "130.0", 1.0),
+    _FoldingCell((_FOLDING_FIELD,), "131.0", 0.0),
+    _FoldingCell((_FOLDING_CONTROL_FIELD,), "130.0", 0.0),
+    _FoldingCell((_FOLDING_CONTROL_FIELD,), "131.0", 0.0),
+)
+
+_FOLDING_DIFFERENTIAL_NODEID = (
+    "tests/canonical/test_grading_substrate_parity.py"
+    "::test_both_substrates_fold_a_listed_numeric_string_field_alike"
+)
+"""The differential the matrix above exists for, named so lock 8 can resolve it.
+
+Membership in :data:`_CANONICAL_DIFFERENTIALS_OUTSIDE_LOCK_3` says the claim needs a
+differential in this module; this says which function it is, and lock 8 holds the
+module to declaring it.
+"""
+
+#: What the runner's ``Grade.reasons`` carries for each verdict the matrix pins. Read
+#: beside the component so a row scoring 0.0 is a hash verdict rather than a component
+#: that took no verdict at all and left the wire's default behind.
+_FOLDING_HASH_SENTENCE = {1.0: "State: hash match", 0.0: "State mismatch"}
+
+
+def _folding_label(cell: _FoldingCell) -> str:
+    """One row's inputs as a name — never the verdict it is asserted against."""
+    listed = "_".join(cell.numeric_string_fields) or "nothing"
+    return f"{listed}_listed_{cell.final_amount.replace('.', '_')}"
+
+
+def _folding_task(numeric_string_fields: tuple[str, ...]) -> dict[str, Any]:
+    """The folding task as the runner takes it, listing ``numeric_string_fields``."""
+    return {
+        "task_id": _FOLDING_TASK_ID,
+        "name": "Numeric string folding",
+        "category": "test",
+        "description": "A trial whose money field ends in another representation",
+        "adapter_type": "native",
+        "system_prompt": "You are a test assistant.",
+        "initial_state": {
+            "tables": _FOLDING_INITIAL_ORDERS,
+            "schemas": [
+                {
+                    "table_name": "orders",
+                    "fields": {"order_id": "string", "amount": "string", "quantity": "string"},
+                    "primary_key": "order_id",
+                }
+            ],
+        },
+        "agent_tools": [],
+        "user_tools": [],
+        "grading": {
+            "combine_method": "weighted",
+            "weights": {"state_checks": 1.0},
+            "pass_threshold": 0.5,
+            "state_checks": {
+                "hash_enabled": True,
+                "expect_initial_state": True,
+                "numeric_string_fields": list(numeric_string_fields),
+            },
+        },
+    }
+
+
+def _folding_core_grading(numeric_string_fields: tuple[str, ...]) -> dict[str, Any]:
+    """The same declaration as core takes it, in the authored block's own naming."""
+    return {
+        "combine": {"method": "weighted", "weights": {"state_checks": 1.0}, "pass_threshold": 0.5},
+        "state_checks": {
+            "hash": {"enabled": True, "expect_initial_state": True},
+            "numeric_string_fields": list(numeric_string_fields),
+        },
+    }
+
+
+def _folding_final_orders(final_amount: str) -> dict[str, Any]:
+    """The trial's database with its money field rewritten and nothing else moved."""
+    return {"orders": [{**_FOLDING_INITIAL_ORDERS["orders"][0], "amount": final_amount}]}
+
+
+def _drive_numeric_string_folding(
+    servicer: RunnerServiceImpl, context: Any, *, trial_id: str, cell: _FoldingCell
+) -> pb2.GradeTrialResponse:
+    """Grade a trial whose money field ends in ``cell.final_amount``.
+
+    The mutation crosses the trial's own db-service and the evaluator hashes both
+    sides back through it, so what the fold reads is the record that service stored
+    rather than a mapping this module handed a hasher.
+    """
+    task_description = runner_models.TaskDescription.model_validate(
+        _folding_task(cell.numeric_string_fields)
+    )
+    _register_pack(servicer, context, task_description, trial_id)
+    servicer._run_async(
+        servicer.db_client.mutate(
+            trial_id,
+            "orders",
+            [
+                {
+                    "op": "upsert",
+                    "record": _folding_final_orders(cell.final_amount)["orders"][0],
+                    "key": "order_id",
+                }
+            ],
+        )
+    )
+    return _grade_registered_trial(servicer, context, trial_id, _HASH_TRANSCRIPT)
+
+
+def _core_numeric_string_folding_verdict(cell: _FoldingCell) -> float:
+    """Core's ``state_checks`` for the same row, built from the row and nothing else."""
+    grade = GradingEngine(
+        core_models.GradingConfig(**_folding_core_grading(cell.numeric_string_fields)),
+        task_initial_state=core_models.InitialStateConfig(json_db=_FOLDING_INITIAL_ORDERS),
+    ).grade_trajectory(
+        _messageless_trajectory(_FOLDING_TASK_ID),
+        {"db": _folding_final_orders(cell.final_amount)},
+    )
+    return grade.components.state_checks
+
+
+@pytest.mark.parametrize(
+    "cell",
+    tuple(pytest.param(cell, id=_folding_label(cell)) for cell in _NUMERIC_STRING_FOLDING_MATRIX),
+)
+def test_both_substrates_fold_a_listed_numeric_string_field_alike(
+    cell, runner_service, mock_grpc_context
+):
+    """``state_checks.numeric_string_fields``'s ``BOTH_SCORE_PARITY`` claim.
+
+    The declared hash source is ``expect_initial_state``, because the key is read once
+    per grade before the runner picks a basis and in every one of core's three
+    branches — so the source costs the claim nothing, and it is the one both substrates
+    can drive in process with no golden world to replay an action in.
+
+    Each arm reaches the trial's final state its own way and neither reads what the
+    other computed: the runner mutates its own db-service and grades over its real
+    handlers, core hashes the row's final mapping against the task's declared initial
+    state in its own algebra. Six cells of agreement are therefore six measurements
+    rather than one taken twice.
+
+    What the matrix cannot express: one table, one record depth, one declared field and
+    one hash source. ``canonicalize_numbers=False`` and the guards ``hash.py`` documents
+    separately — booleans never folding to ints, leading-zero ids never equating — carry
+    their own unit coverage in ``tests/unit/grading/test_hash.py``, which this does not
+    extend. A folding field nested under a differently named record key at greater depth
+    is outside both.
+    """
+    response = _drive_numeric_string_folding(
+        runner_service,
+        mock_grpc_context,
+        trial_id=_ledger_trial_id(_folding_label(cell), _NUMERIC_STRING_FIELDS_KEY),
+        cell=cell,
+    )
+
+    assert response.success is True, response.error
+    assert response.grade.components.state_checks == pytest.approx(cell.state_checks)
+    assert _FOLDING_HASH_SENTENCE[cell.state_checks] in response.grade.reasons, (
+        f"the runner scored {cell.state_checks} for {_folding_label(cell)} without its "
+        f"grade naming the hash verdict that score restates: {response.grade.reasons!r}"
+    )
+    assert _core_numeric_string_folding_verdict(cell) == pytest.approx(cell.state_checks)
 
 
 # --------------------------------------------------------------------------

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -1896,7 +1896,43 @@ def _assert_the_folding_matrix_discriminates() -> None:
     question askable: a representation difference a fold may collapse beside a genuine
     difference it must refuse, and two field lists of one name each — the field that
     differs, and another the record declares.
+
+    The differential is then bound to *this* matrix, because the clauses below and the
+    rows lock 19 actually drives are otherwise two lists nothing holds together: slicing
+    the parametrisation would drop the control rows while every clause here still read
+    the whole constant. What that binding reaches is the decorator naming the constant
+    whole; a helper filtering rows at call time would still escape it.
     """
+    module_path, _, function_name = _FOLDING_DIFFERENTIAL_NODEID.partition("::")
+    differential = next(
+        (
+            node
+            for node in ast.parse((_REPO_ROOT / module_path).read_text()).body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ),
+        None,
+    )
+    assert differential is not None, (
+        f"{module_path} declares no module-level {function_name!r}, so the matrix below "
+        "is asserted over and driven by nothing"
+    )
+    parametrisation = [
+        node for decorator in differential.decorator_list for node in ast.walk(decorator)
+    ]
+    assert any(
+        isinstance(node, ast.Name) and node.id == _FOLDING_MATRIX_NAME for node in parametrisation
+    ), (
+        f"{function_name} is not parametrised over {_FOLDING_MATRIX_NAME}, so the rows this "
+        "test asserts the discrimination of and the rows that differential drives are two "
+        "separate lists"
+    )
+    assert not any(isinstance(node, ast.Subscript) for node in parametrisation), (
+        f"{function_name}'s parametrisation subscripts its source, so it can drive a subset "
+        f"of {_FOLDING_MATRIX_NAME} while every clause here still reads the whole constant. "
+        "Dropping the control rows that way reopens the per-field question in silence"
+    )
+
     record = _FOLDING_INITIAL_ORDERS["orders"][0]
     assert {_FOLDING_FIELD, _FOLDING_CONTROL_FIELD} <= set(record), (
         f"the folding record {record} does not declare both {_FOLDING_FIELD!r} and "
@@ -1949,9 +1985,10 @@ def test_canonical_differentials_outside_lock_3_are_enumerated_and_substantive()
     nothing: a differential deleted wholesale leaves the escaped set unchanged.
 
     Lock 19 is the one entry here that does not rest on membership: its nodeid is
-    resolved through the same parse the ``enforcing_test`` claims use, so deleting or
-    renaming the function that runs its matrix fails this test. The other entries keep
-    the weaker guarantee.
+    resolved through the same parse the ``enforcing_test`` claims use, and its
+    parametrisation is read out of the same AST, so deleting the function, renaming it,
+    or pointing it at a *subset* of the matrix asserted here all fail this test. The
+    other entries keep the weaker guarantee.
     """
     reached = {item.author_key for item in _differential_entries()}
     escaped = {
@@ -2014,10 +2051,10 @@ def test_canonical_differentials_outside_lock_3_are_enumerated_and_substantive()
         "zero-total-weight rule scoped to every method would satisfy the whole table"
     )
 
-    _assert_the_folding_matrix_discriminates()
     _assert_nodeid_is_collectable(
         f"{_NUMERIC_STRING_FIELDS_KEY}: its differential", _FOLDING_DIFFERENTIAL_NODEID
     )
+    _assert_the_folding_matrix_discriminates()
 
 
 # --------------------------------------------------------------------------
@@ -4269,6 +4306,9 @@ _NUMERIC_STRING_FOLDING_MATRIX: tuple[_FoldingCell, ...] = (
     _FoldingCell((_FOLDING_CONTROL_FIELD,), "130.0", 0.0),
     _FoldingCell((_FOLDING_CONTROL_FIELD,), "131.0", 0.0),
 )
+
+_FOLDING_MATRIX_NAME = "_NUMERIC_STRING_FOLDING_MATRIX"
+"""The matrix constant's own name, so lock 8 can read it out of the differential's AST."""
 
 _FOLDING_DIFFERENTIAL_NODEID = (
     "tests/canonical/test_grading_substrate_parity.py"

--- a/tests/data/tool_artifacts/hash_composition_tools/order_amount.py
+++ b/tests/data/tool_artifacts/hash_composition_tools/order_amount.py
@@ -1,0 +1,32 @@
+"""A tau-style tool the runner replays as a golden action.
+
+Shipped into the runner container as a ``TaskDescription.tool_artifacts`` entry by
+``tests/integration/test_docker_grading_hash_composition.py``, which is the only
+consumer. Reconstructed as ``InvocationStyle.TAU_SYNC``, so its mutation reaches
+the trial's own db-service namespace through the runner's trial-scoped proxy.
+
+``amount`` is written as the string the caller passed, never coerced to a number:
+what the folding cells compare is two representations of one amount, and a tool
+that parsed them would erase the difference before the hash ever saw it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class SetOrderAmount:
+    """Set one order's ``amount`` in a tau-style state dict."""
+
+    @staticmethod
+    def invoke(data: dict[str, Any], order_id: str, amount: str) -> str:
+        rows = data["orders"]
+        if not any(row["id"] == order_id for row in rows):
+            raise ValueError(f"no order {order_id!r} among {[row['id'] for row in rows]}")
+        # A new list of new records rather than an in-place edit: the runner's tau
+        # wrapper detects mutations by diffing the state dict it read against the
+        # one the tool leaves behind, and the two share their nested objects.
+        data["orders"] = [
+            {**row, "amount": amount} if row["id"] == order_id else row for row in rows
+        ]
+        return f"order {order_id} amount set to {amount}"

--- a/tests/integration/test_docker_grading_hash_composition.py
+++ b/tests/integration/test_docker_grading_hash_composition.py
@@ -1,12 +1,14 @@
 """The runner folds its own hash verdict with its JSONPath score, over real services.
 
-``tests/canonical/test_grading_substrate_parity.py`` drives the same fold at the
-canonical tier, but it *hands* the runner's composer a hash score: the runner's hash
-evaluator replays golden actions against db-service over HTTP, so no in-process
-differential can reach it, and mocking the DB client on the one test whose job is to
-detect substrate drift would defeat that test (#687). This suite closes the gap on the
-production path — ``RegisterTrial`` over real gRPC, golden replay against the real
-db-service, and the ``state_checks`` component read back off the wire — with no LLM.
+``tests/canonical/test_grading_substrate_parity.py`` reaches the runner's hash
+evaluator in process, against an in-process ``json_db_service``. What it cannot reach
+is *this* discrimination: its replayed golden action mutates no database, so the golden
+world it leaves is the reset initial state and the verdict is a match either way —
+``_drive_hash_family``'s own docstring calls that a hollow evaluation, and re-measuring
+the golden-replay basis canonically is #1018. This suite is where a matching final state
+is told apart from a diverging one, on the production path — ``RegisterTrial`` over real
+gRPC, golden replay against the real db-service, and the ``state_checks`` component read
+back off the wire — with no LLM.
 
 Across the four fold cells the trial's database is the registered ``initial_state``:
 nothing runs an agent, so the only thing that moves between cells is what the golden
@@ -31,6 +33,12 @@ The four cells are ``0.625`` and ``0.8`` for a matching hash at weights ``0.25``
 ``0.6``, and ``0.375`` and ``0.2`` for a diverging one. A rule that multiplied the two
 sources rather than blending them returns ``0.5``, ``0.5``, ``0.0``, ``0.0`` — no cell
 agrees, so every cell discriminates.
+
+Three folding cells sit beside them on a task of their own — their own ``task_id``,
+schema and single tool — so the cells above are driven byte-identically by a builder
+this file no longer shares. They ask a different question of the same wire: whether the
+*deployed* db-service honours the ``numeric_string_fields`` query parameter the runner
+sends it.
 """
 
 from __future__ import annotations
@@ -173,6 +181,107 @@ def _task_description(
                     }
                 ],
                 "jsonpath_checks": _JSONPATH_CHECKS,
+            },
+        },
+    }
+
+
+_FOLDING_TASK_ID = "hash_composition_folding_wire"
+_FOLDING_TOOL_ARTIFACT_PATH = "hash_composition_tools/order_amount.py"
+_FOLDING_TOOL_SOURCE = (
+    Path(__file__).resolve().parents[1] / "data" / "tool_artifacts" / _FOLDING_TOOL_ARTIFACT_PATH
+)
+
+# Not a suffix of anything the folding task registers, and nothing registered is a
+# suffix of it, so the runner's ``…_<name>`` golden-action rescue rule stays inert here.
+_FOLDING_TOOL_NAME = "set_order_amount"
+
+# The amount the folding task seeds, and the amount its golden action replays: one
+# value, two representations. The trial runs no agent, so its database still holds the
+# first at grade time and the whole difference between the two hashed states is a
+# trailing zero.
+_DECLARED_AMOUNT = "130.00"
+_REPLAYED_AMOUNT = "130.0"
+
+_FOLDING_FIELD = "amount"
+
+# A second numeric-looking string field the same record declares, which the golden
+# replay never touches. Listing it is a request to fold something that does not differ.
+_FOLDING_CONTROL_FIELD = "quantity"
+
+
+def _folding_tool_artifacts() -> dict[str, str]:
+    """The amount-writing tool, base64'd onto the wire field the runner extracts."""
+    encoded = base64.b64encode(_FOLDING_TOOL_SOURCE.read_bytes()).decode()
+    return {_FOLDING_TOOL_ARTIFACT_PATH: encoded}
+
+
+def _folding_task_description(numeric_string_fields: tuple[str, ...]) -> dict[str, Any]:
+    """A hash-graded trial whose golden action rewrites one amount's representation.
+
+    No JSONPath check and no ``hash_weight``: the hash is the only source scoring
+    ``state_checks``, so the wire's component *is* the verdict. Declaring a weight here
+    would be inert and the grade would say so — the weight is consulted only when a hash
+    verdict and a non-empty ``state_checks.jsonpaths`` are both scored.
+    """
+    return {
+        "task_id": _FOLDING_TASK_ID,
+        "name": "Numeric string folding over gRPC",
+        "category": "test",
+        "description": "Grade a representation difference against the folding list an author wrote",
+        "adapter_type": "native",
+        "system_prompt": "You are a test assistant.",
+        "initial_state": {
+            "tables": {"orders": [{"id": _ORDER_ID, "amount": _DECLARED_AMOUNT, "quantity": "2"}]},
+            "schemas": [
+                {
+                    "table_name": "orders",
+                    "fields": {"id": "string", "amount": "string", "quantity": "string"},
+                    "primary_key": "id",
+                }
+            ],
+            "unstable_fields": [],
+        },
+        "agent_tools": [
+            {
+                "name": _FOLDING_TOOL_NAME,
+                "description": "Set an order's amount",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "order_id": {"type": "string"},
+                        "amount": {"type": "string"},
+                    },
+                    "required": ["order_id", "amount"],
+                    "additionalProperties": False,
+                },
+                "category": "write",
+                "source": {
+                    "toolset": "hash_composition_tools",
+                    "module_path": "order_amount",
+                    "class_name": "SetOrderAmount",
+                    "invocation_style": "tau_sync",
+                },
+            }
+        ],
+        "user_tools": [],
+        "tool_artifacts": _folding_tool_artifacts(),
+        "grading": {
+            "combine_method": "weighted",
+            "weights": {"state_checks": 1.0},
+            "pass_threshold": 0.99,
+            "state_checks": {
+                "hash_enabled": True,
+                "numeric_string_fields": list(numeric_string_fields),
+                "golden_actions": [
+                    {
+                        "tool_name": _FOLDING_TOOL_NAME,
+                        "arguments": {
+                            "order_id": _ORDER_ID,
+                            "amount": _REPLAYED_AMOUNT,
+                        },
+                    }
+                ],
             },
         },
     }
@@ -385,3 +494,76 @@ def test_the_two_weights_score_the_same_trial_differently(graded_cells) -> None:
             f"the runner scored {case} identically at weights {interior}: {components}. "
             "The author's state_checks.hash.weight does not reach the fold"
         )
+
+
+@pytest.mark.parametrize(
+    ("numeric_string_fields", "hash_score"),
+    [
+        pytest.param((), 0.0, id="nothing_listed"),
+        pytest.param((_FOLDING_FIELD,), 1.0, id="amount_listed"),
+        pytest.param((_FOLDING_CONTROL_FIELD,), 0.0, id="quantity_listed"),
+    ],
+)
+def test_the_deployed_db_service_folds_a_listed_numeric_string_field(
+    numeric_string_fields: tuple[str, ...],
+    hash_score: float,
+    runner_client: GrpcRunnerClient,
+) -> None:
+    """One representation difference, three field lists, graded over real services.
+
+    The golden action rewrites ``130.00`` as ``130.0``, so the two hashed states differ
+    in a trailing zero and nothing else. Listing ``amount`` collapses that difference;
+    listing ``quantity`` — a field the same record declares and the replay never
+    touches — does not, which is the cell that separates a runner reading the list *by
+    name* from one folding whenever the author wrote a non-empty list.
+
+    These cells declare one state source and no weight, which is why this module's
+    argument that only an interior weight discriminates does not reach them. That
+    argument is about the **fold**: at ``0.0`` and ``1.0`` a rule merely selecting the
+    dominant source reproduces the blend, so the cells above need an interior weight to
+    tell a blend from a selection. These cells prove the fold's **input** instead, where
+    a second source would add only arithmetic this test would have to restate. The
+    reasons string is read beside the component regardless, so the verdict is observed
+    rather than inferred from a number two sources could have produced.
+
+    What these cells cannot express: the runner and db-service containers execute the
+    code baked into their images, so **a source patch does not reach them**. The
+    canonical differential's falsifiers — dropping the query parameter, folding
+    unconditionally, keying the fold off the list's length — have no counterpart here
+    short of rebuilding an image. What is falsifiable here is configuration: point the
+    matching cell's list at ``quantity``, or give the empty cell ``amount``, and it
+    reds. What that buys over the canonical tier is the one thing no in-process test can
+    speak for — that the *deployed* db-service parses and honours the
+    ``numeric_string_fields`` query parameter the runner sends it.
+    """
+    listed = "_".join(numeric_string_fields) or "none"
+    trial_id = f"{_FOLDING_TASK_ID}_{listed}:0"
+    task = _folding_task_description(numeric_string_fields)
+    registered = runner_client.register_trial(
+        trial_id=trial_id, trial_spec_json=_trial_spec_json(trial_id, task)
+    )
+    assert registered["success"] is True, registered["error"]
+
+    try:
+        result = runner_client.grade_trial(trial_id=trial_id)
+    finally:
+        runner_client.cleanup_trial(trial_id=trial_id)
+
+    assert result["success"] is True, result["error"]
+    grade = result["grade"]
+    reasons = grade["reasons"]
+
+    assert "GOLDEN REPLAY ERRORS" not in reasons, (
+        "the golden replay did not run whole, so the amount the hash compared against is "
+        f"not the one the action wrote and this cell measures nothing (#734): {reasons!r}"
+    )
+    if hash_score == 1.0:
+        assert "State: hash match" in reasons, reasons
+    else:
+        assert "State: hash match" not in reasons, reasons
+
+    component = grade["components"]["state_checks"]
+    assert component == pytest.approx(hash_score), (
+        f"with {list(numeric_string_fields)} declared, the runner scored {_DECLARED_AMOUNT!r} "
+        f"against a replayed {_REPLAYED_AMOUNT!r} as {component}, not {hash_score}"
+    )

--- a/tolokaforge/core/grading/key_manifest.py
+++ b/tolokaforge/core/grading/key_manifest.py
@@ -456,12 +456,11 @@ GRADING_KEYS: tuple[GradingKey, ...] = (
         author_key="state_checks.numeric_string_fields",
         kind=KeyKind.CONFIG_INPUT,
         coverage=SubstrateCoverage.BOTH_SCORE_PARITY,
-        enforcement=Enforcement.FIELD_RESOLUTION_ONLY,
+        enforcement=Enforcement.DIFFERENTIAL_CANONICAL,
         core_field="StateChecksConfig.numeric_string_fields",
         runner_field="RunnerStateChecksConfig.numeric_string_fields",
         core_evaluator="tolokaforge.core.hash.compute_stable_hash",
         runner_evaluator=RUNNER_HASH_EVALUATOR,
-        tracking_issue=687,
     ),
     GradingKey(
         author_key="state_checks.id_fields",

--- a/tolokaforge/core/grading/key_manifest.py
+++ b/tolokaforge/core/grading/key_manifest.py
@@ -106,7 +106,10 @@ class GradingKey:
 
     ``enforcing_test`` is a pytest nodeid — ``<module path>::<test function>`` —
     so the claim names the function that runs the differential rather than a file
-    that merely contains one.
+    that merely contains one. It is required at ``DIFFERENTIAL_INTEGRATION`` and
+    permitted at any tier, and it is resolved wherever it is present: on an entry
+    proven canonically it records where the same claim was additionally observed in
+    production, which is a pointer rather than the enforcement.
     """
 
     author_key: str
@@ -187,6 +190,18 @@ A matching and a diverging final state, at two weights strictly inside ``(0, 1)`
 it alone covers is the transport the verdict crosses: a real ``GradeTrial`` over gRPC
 against a real db-service, where the canonical differentials drive the servicer and its
 db-service in process.
+"""
+
+_NUMERIC_STRING_FOLDING_WIRE_TEST = (
+    "tests/integration/test_docker_grading_hash_composition.py"
+    "::test_the_deployed_db_service_folds_a_listed_numeric_string_field"
+)
+"""Where the per-field folding claim was additionally observed in production.
+
+One representation difference under three field lists, graded over real gRPC against
+the containerised db-service. The enforcement itself is canonical — this records that
+the deployed service honours the query parameter the runner sends it, which no
+in-process differential can speak for.
 """
 
 _HASH_SOURCE_SHAPE_REASON = (
@@ -461,6 +476,7 @@ GRADING_KEYS: tuple[GradingKey, ...] = (
         runner_field="RunnerStateChecksConfig.numeric_string_fields",
         core_evaluator="tolokaforge.core.hash.compute_stable_hash",
         runner_evaluator=RUNNER_HASH_EVALUATOR,
+        enforcing_test=_NUMERIC_STRING_FOLDING_WIRE_TEST,
     ),
     GradingKey(
         author_key="state_checks.id_fields",


### PR DESCRIPTION
Closes #687.

`docs/GRADING.md` promises `state_checks.numeric_string_fields` is "honored identically on both grading substrates". Nothing drove it. The key sat in the manifest as `FIELD_RESOLUTION_ONLY` — the guard proved the field resolves on both config models, not that either substrate scores it.

## What lands

**A six-cell differential, both substrates, per row.** A money field declared `"130.00"` and left at `"130.0"` or `"131.0"`, under `[]` / `["amount"]` / `["quantity"]`, graded through the runner's real `RegisterTrial → db_client.mutate → GradeTrial` and through core's `GradingEngine.grade_trajectory`. Exactly the `["amount"] × "130.0"` cell scores `1.0`; every other cell scores `0.0` on both.

The `["quantity"]` rows are the point. Under an implementation that folds every numeric string whenever the list is non-empty, five of six rows still agree with the truth — that row is the only red. A matrix without it is a smoke test.

**Three of the same cells over the wire**, against the deployed db-service, as a production-path observation.

## Why the tier is canonical, not integration

#687's third acceptance criterion asks the manifest row to move to `DIFFERENTIAL_INTEGRATION`. It ships **`DIFFERENTIAL_CANONICAL`**, because `Enforcement`'s own docstring defines the tiers by what the differential *requires* — and this one requires no services. The `runner_service` fixture is a real `RunnerServiceImpl` over a real `DBServiceClient` whose transport is a `TestClient` around the *real* `json_db_service` app; only the HTTP transport is substituted.

The evidence is a result, not a code reading: the `["amount"]`/`"130.0"` cell returns `1.0`, which can only happen if the parameter crossed a real query string and was parsed server-side. Review confirmed it by falsification — dropping `params` from the `/state/hash` GET reds that cell.

Declaring an integration tier for a service-free proof would state something false about the evidence, which is the defect #1018 was filed for. The row carries an `enforcing_test` naming the wire test as a production-path observation, with the canonical lock as the enforcement, and the field's docstring says which is which.

## What makes the guards guards

**The enforcement is anchored, not cited.** `_assert_enforcing_test_is_collectable`'s body is extracted so lock 8 resolves the differential's **own** nodeid: deleting or renaming it now reds. Before, the row's only machine-checked pointer named a test that was explicitly not its enforcement, and the enforcement itself could be deleted with the suite green.

**And the differential is bound to the matrix it asserts over.** Review found the anchor bound the function's *name* and the matrix's *contents* but not the wiring: slicing the parametrize to `[:4]` dropped both `["quantity"]` cells, reopened the escape hatch, and left both clauses green — demonstrated on the pre-fix code before the fix was written. Lock 8 now reads the decorator from the AST it already parses and asserts the matrix is named whole, with a second falsifier covering the indirection a real decoupling would take (`_DRIVEN_CELLS = MATRIX[:4]`), which a subscript check alone would miss. The residual limit is stated: a helper filtering rows at call time still escapes.

## Corrections made along the way

The plan prescribed `hash_weight: 1.0` on the wire cells. Every grade came back carrying `INERT_HASH_WEIGHT_REASON` — the weight is consulted only when a hash verdict and a non-empty `state_checks.jsonpaths` are both scored, so with no JSONPath check it is never read, and `state_checks` equals the verdict because the hash is the *only* scored source. The key was dropped rather than documented: writing a harness-declared-inert value into every cell of a suite whose subject is that declared keys are read would have been the wrong lesson.

Two doc claims were narrowed rather than repeated. The integration module cited #687 as its reason to exist and asserted "no in-process differential can reach it" — already false at HEAD; what canonical cannot reach is *this discrimination*, because the replayed action mutates no database (#1018). And nested-depth folding under a differently named record key turns out to be covered **nowhere**, where the plan had grouped it with cases that do carry unit coverage.

## A note on method

Every falsifier here fired on exactly the predicted rows — F1 and F1b on the runner assert, F2 on the *core* assert, which is the evidence the two arms are independent rather than one value read twice.

Two runs did not, at first, and the reason is worth recording: the patch script aborted on its anchor assertion while pytest ran against the unpatched tree, reporting **green**. That is indistinguishable from "the falsifier does not fire" unless you check the patch landed. A green and a zero are both claims about the world, and both need a positive control — the same failure, whatever produced it.

## Validation

Canonical **1242 passed / 7970 deselected** (1236 at base). Integration **10 passed** (7 at base), with the original seven keeping their ids, verdicts and order — a real confirmation now that the folding cells no longer share a builder with them. No image build fired; both `:latest` tags were present throughout. No LLM, no key, no spend.

## Follow-ups filed

#1018 (the hash family's integration rows are not re-measured against the service-free path), #1019 (`docs/GRADING.md` restates every key's manifest axes in prose tied to `GRADING_KEYS` by nothing), #1021 (eight of nine canonical-differential entries can still have their differential deleted with the suite green — this branch closed the ninth).
