### PR TITLE
feat(skills): pre-flight decisions + educative PR/umbrella templates

### DIFF
--- a/.agents/skills/executing-development-tickets/SKILL.md
+++ b/.agents/skills/executing-development-tickets/SKILL.md
@@ -185,9 +185,11 @@ Otherwise, before the user sees the plan, pressure-test it:
 When the critique loop settles:
 
 1. **Read the plan file yourself.** You're about to execute it — don't relay blind. Look for obvious gaps: a vague contract, a missing behaviour-locking test, an unplanned break of a compatibility surface, a stage that mixes interface and implementation, doc updates not named per stage. If you spot a gap the critic missed, push back via `SendMessage` to the architect *before* showing the plan to the user.
-2. **Surface to the user:** plan file path, stage count, one-paragraph summary, critic verdict + round count (plus any unresolved findings or accepted rebuttals worth knowing), discovery surprises, "Discovered issues" filed, risks. Ask: "Approve, or revise?"
-3. **Revise** → `SendMessage` the architect with the user's feedback. Re-run the critic (one round) only if the revision materially changes contracts or stages. Loop until approved.
-4. **Approve** → continue.
+2. **Surface to the user:** plan file path, stage count, one-paragraph summary, critic verdict + round count (plus any unresolved findings or accepted rebuttals worth knowing), discovery surprises, "Discovered issues" filed, risks.
+3. **Relay the architect's "Decisions needed before implementation" block verbatim.** If the block reads "None — mechanical change." skip this sub-step. Otherwise, present each decision to the user with its default, and ask them to answer or accept-by-silence. Every answered decision becomes an in-band directive the subagents inherit — record the answers in the plan file (append a `## Approved decisions` section) so persistent-mode implementers and fresh-context reviewers see the same authoritative record. **This is the whole point of surfacing decisions up-front: an overnight run that would otherwise stall on the third stage now has the answer bundled in.**
+4. Ask: "Approve, or revise?"
+5. **Revise** → `SendMessage` the architect with the user's feedback (or a decision change). Re-run the critic (one round) only if the revision materially changes contracts or stages. Loop until approved.
+6. **Approve** → continue.
 
 ### Step 6 — Create the branch
 

--- a/.agents/skills/implement-milestone/pr-templates.md
+++ b/.agents/skills/implement-milestone/pr-templates.md
@@ -27,6 +27,13 @@ Discipline shared by both templates (modelled on [Toloka/tolokaforge#121](https:
 ## Concepts introduced
 <One short paragraph naming any new abstraction, contract, policy slot, or vocabulary the reader will encounter. Enough for a future agent scanning stacked PRs to say "ah, this is where FailureKind came from" without opening the diff. If the change is mechanical, write "None — mechanical change." and move on.>
 
+## Concepts glossary (for the PM reader)
+<Three to six bullets. Each: **term** — one sentence on *why this matters at product level*, in language a data-labelling PM without deep runtime knowledge can follow. Complements `Concepts introduced` (which is for future agents scanning the diff); this section is for the PM audience that will read the milestone consolidation without cracking open code. Omit only for pure-mechanical PRs.>
+
+- **<term>** — <why this matters, one sentence>
+- **<term>** — <one sentence>
+- ...
+
 ## Plan
 <the staged plan, pasted from ~/.claude/plans/toloka-tolokaforge/issue-<N>-<short-name>.md — plans have no in-repo home, so the PR body is the plan's durable record>
 
@@ -82,6 +89,9 @@ flowchart LR
 |---|---|
 | <Choice> | <"X because Y — and here is what we deliberately rejected"> |
 | <Choice> | <one row per accepted decision, sourced from each per-issue PR's Design choices section> |
+
+## Concept map
+<One short paragraph tying every new concept this milestone introduced (drawn from the per-issue `Concepts introduced` + `Concepts glossary` sections) to earlier ADRs under `docs/adr/` and, when relevant, to entries in the roadmap release table. The goal: a reader landing here can trace *why now* — this milestone extends decision X (ADR-0Y) to enable roadmap release Z. If no prior work is cited, write "First appearance — no prior ADR linkage." One paragraph, not a graph.>
 
 ## Industry precedents
 <Include only when the milestone was informed by prior art. For each precedent: a link, one sentence of what was borrowed, one sentence of what was deliberately rejected. Reversibility framing — "this choice can be revisited if X changes" — is welcome. Omit the section when N/A rather than filling it with hand-waves.>

--- a/.agents/skills/writing-development-tickets/SKILL.md
+++ b/.agents/skills/writing-development-tickets/SKILL.md
@@ -144,3 +144,54 @@ labels: ["enhancement", "P2"]
 | Epic disguised as ticket | 3+ weeks, 5+ independent deliverables = split it |
 | Stale implementation notes | Endpoint specs from 2 months ago are wrong now |
 | Priority mismatch | P3 ticket for a P0 area = something is wrong |
+
+## Umbrella issue template
+
+An **umbrella issue** is the GitHub-side companion to a milestone. One umbrella per milestone, titled `[umbrella] <milestone-slug> — <name>`. It hosts the milestone's scope, sub-issue list, sequencing constraints, and — after the milestone runs — the merge log that `/implement-milestone` appends to. Feature tickets are children; the umbrella is the parent.
+
+Use this template when creating a new umbrella:
+
+```markdown
+## Problem
+<2–4 sentences. What is broken, missing, or awkward that this milestone exists to fix. Concrete enough that a reader who never worked on the codebase can hold the picture.>
+
+## Product outcome
+<One paragraph. What changes for users (data-labelling teams, adapter authors, or contributors) when this milestone lands. User-facing, not implementation-facing.>
+
+## Key decisions surfaced
+<Enumerate the yes/no or fork-in-the-road choices this milestone forces. One line each with a leaning. These are the decisions a PM must settle before the pipeline runs — they map 1-to-1 with the `## Decisions needed before implementation` block the architect will emit at plan time. Surface them here so the milestone can be scheduled with fewer mid-run stalls.>
+
+- **<Decision label>** — <question>. Leaning: <default>. Impact if reversed: <one line>.
+- ...
+- Or: "None — mechanical execution of a settled design."
+
+## Sub-issues (phases)
+<Group child issues by phase. Each phase is a slice you could ship in a single per-issue pipeline pass. Sequencing constraints go here, not in the individual tickets.>
+
+### Phase 1 — <name>
+- [ ] #<N> <title>
+- [ ] #<N> <title>
+
+### Phase 2 — <name>
+- [ ] #<N> <title>
+
+## Sequencing constraints
+<Bullets. "Phase 2 depends on Phase 1's <specific contract>", "issue #X must land before #Y because …". Explicit — don't rely on issue order.>
+
+## Out of scope
+<Bullets. Anything a reader might reasonably expect to be part of this milestone but isn't. Include a one-line "why not now" for each.>
+
+## Definition of done
+<Bullets. What is true when this milestone is closed. Test-tier evidence where possible (unit / canonical / integration coverage). One clear closure criterion per bullet.>
+
+## Educative hook
+<One sentence. What a reader following the milestone's consolidation PR will *learn* — the concept, pattern, or design principle this milestone teaches. This is the seed the consolidation PR body's `Concept map` will grow into. Skip only if the milestone is purely mechanical.>
+```
+
+**Umbrella-specific rules:**
+
+- Title format: `[umbrella] <milestone-slug> — <name>`. GitHub has no umbrella label; the title convention is the marker.
+- Attach the umbrella issue to the GitHub milestone the same way as any feature ticket.
+- Umbrella body updates during the milestone: `/implement-milestone` appends `#<issue> → PR #<pr> → <sha> — <outcome>` lines as issues merge. That log is load-bearing — treat the umbrella body as a running document, not a static one.
+- Sub-issues are created with the atomic-feature template above. They reference the umbrella (`Part of #<umbrella>`).
+- Priority label is required on the umbrella itself (usually `P1` or `P2`); child priorities can vary.

--- a/.claude/agents/system-architect-planner.md
+++ b/.claude/agents/system-architect-planner.md
@@ -104,6 +104,13 @@ When the plan is written, return a structured handoff:
 - **Discovered issues filed:** #<n>, #<m> (or "None.")
 - **Discovered issues to fix in this PR:** <bullets, or "None.">
 - **Risks / open questions:** <bullets, or "None.">
+
+## Decisions needed before implementation
+<Enumerate every yes/no, contract-shape, or fork-in-the-road choice the plan makes or postpones. One line each, with a default recommendation the user can accept by silence. This block is load-bearing: overnight runs stall when a subagent hits a decision that could have been settled at plan approval. Ask more here, not less.>
+
+- **<Decision label>** — <question, plain-English>. Default: <recommended choice>. Impact if reversed: <one line>.
+- ...
+- If genuinely no decisions: write "None — mechanical change."
 ```
 
 Stop. Do not create the branch. Do not launch other agents. Do not start opening a PR. Main takes it from here — expect it to route your plan through `plan-critic` before the user sees it.


### PR DESCRIPTION
## Summary

Two composable extensions to the ticket-lifecycle skills that surface strategic decisions up-front and add a teaching layer to every milestone.

- **Pre-flight decisions:** architect emits `## Decisions needed before implementation` at plan time; Step 5 relays it to the user; answers become in-band directives so overnight runs stop stalling on questions that could have been settled at approval.
- **Educative narratives:** per-issue PR bodies gain a `Concepts glossary (for the PM reader)`; consolidation PR bodies gain a `Concept map` linking new concepts to prior ADRs + roadmap rows; `writing-development-tickets` gains a full umbrella-issue template (the first one — umbrellas were hand-shaped until now).

## Design choices

- **Two horizons on the same decisions.** The umbrella template's `Key decisions surfaced` section and the architect handoff's `Decisions needed before implementation` block name the same class of choices at two different times — milestone-scoping vs. plan-approval. The umbrella raises them coarsely; the architect refines them. Both feed the user's approval gate.
- **`Concepts glossary` and `Concepts introduced` coexist.** Different audiences: the paragraph-form `Concepts introduced` is for future agents scanning stacked PRs; the new bullet-form glossary is for the PM/reader who will read the milestone consolidation without opening code. No overlap in shape.
- **`Concept map` in the consolidation body links backward.** New concepts get tied to prior ADRs and roadmap rows so a reader lands with the "why now" answered.
- **Umbrella template lands in the writing-development-tickets skill.** That skill already owns feature-ticket authoring; umbrellas belong alongside, not as a new skill.

## Concepts glossary (for the PM reader)

- **Pre-flight decisions** — surfacing every yes/no plan choice at approval time so overnight runs never stop for a question you could have answered at 9am.
- **Concepts glossary** — a 3–6-bullet PM-audience explainer added to every PR body, so milestones teach concepts to the reader who won't crack open the diff.
- **Concept map** — the paragraph in the consolidation PR that ties new concepts to prior ADRs and roadmap rows, making "why now" traceable.
- **Umbrella template** — the first shared shape for umbrella issues; captures problem, product outcome, key decisions, sub-issues by phase, and an educative hook.

## Plan

Not applicable — this is a skills/templates change with no in-repo plan file. The workstream context lives in a personal PM operating-model doc outside this repo.

## Discovered issues

- Filed: none.
- Fixed in this PR: none.

## Test plan

- [ ] Run \`/executing-development-tickets\` on a small issue after merge; confirm the architect handoff includes the new decisions block and Step 5 relays it.
- [ ] Author a new issue via \`/writing-development-tickets\` scoped as an umbrella; confirm the template renders and asks for the educative hook.
- [ ] Merge the next per-issue PR after this lands; confirm the body has the \`Concepts glossary\` section filled with real content, not placeholders.
- [ ] Merge the next consolidation PR; confirm \`Concept map\` cites at least one ADR.