### PR TITLE
feat(community): issue/PR/discussion templates, CoC, GOVERNANCE, roadmap link

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,29 @@
+title: "[discussion] <topic>"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Discussions are for design ideas, "what if" questions, tradeoffs, or general chat. If you have a concrete bug or feature request, file an issue instead — they're tracked separately.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you thinking about? Set the stage in a paragraph or two.
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What you'd like to discuss
+      description: The specific question, tradeoff, or idea you'd like input on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art / related links
+      description: Optional. Papers, tools, other projects, or tolokaforge docs / issues that are relevant.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: A tolokaforge behaviour that doesn't match what the docs or tests promise.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. A minimal reproduction is worth more than a long description — the shorter your repro, the faster this gets fixed.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you observe? Paste the error output or unexpected behaviour verbatim.
+      placeholder: |
+        Ran `tolokaforge run examples/native/tool_use` and got:
+        ```
+        <paste output>
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What should have happened instead — and where in the docs or a test you'd expect that behaviour to be pinned.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: |
+        The smallest sequence of commands (or the smallest task pack) that reliably shows the bug.
+        Prefer bundled examples under `examples/` when possible.
+      placeholder: |
+        1. `make install-dev`
+        2. `make docker-up`
+        3. `tolokaforge run examples/native/tool_use`
+        4. Observe the error above.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: tolokaforge version
+      description: Output of `tolokaforge --version` (or the commit SHA if you're on a source checkout).
+      placeholder: "0.15.0 or a4d4344a"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.11.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - macOS
+        - Linux
+        - Windows (WSL2)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Docker state, LLM provider, task pack details, or anything else you think matters.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion
+    url: https://github.com/Toloka/tolokaforge/discussions
+    about: Design ideas, "what if" questions, tradeoffs, or general chat — anything that isn't a concrete bug or feature request.
+  - name: Documentation
+    url: https://github.com/Toloka/tolokaforge#documentation
+    about: Setup, task authoring, grading, runner, adapters — most questions have an answer in the docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: A capability tolokaforge should have but doesn't yet.
+title: "feat: <short description>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests that describe the *problem* land faster than ones that describe the solution. Tell us what you're trying to do, we'll help figure out the right shape.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that tolokaforge doesn't let you do today? Include the concrete workflow, not the abstraction.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: |
+        Optional. If you have a concrete API / CLI / config shape in mind, describe it. Otherwise leave this blank — a good "problem" section is enough.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you've tried
+      description: What did you try before filing? Even "nothing yet" is a useful answer.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: |
+        Is this a small addition to an existing surface, a new surface, or a rethink of an existing one? If you know it touches a compatibility surface (task contracts, run-config schemas, CLI, published API), flag it here.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Related links, prior art, why-now, or how urgent this is for you.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,34 @@
+name: Question / help
+description: A question about how tolokaforge works or how to use it.
+title: "q: <short summary>"
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome. Before filing, please check:
+        - [The README](../../README.md) — install, quick start, examples.
+        - [The docs index](../../README.md#documentation) — architecture, task authoring, grading, runner, adapters.
+        - Existing issues (Search → filter to Closed to see resolved ones).
+
+        If your question is more of a discussion (design ideas, "what if", tradeoffs), open a [Discussion](../../discussions) instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to understand or accomplish?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you've already tried / read
+      description: Which docs, commands, or examples did you look at first? What did you learn from them?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Your use case, environment, task pack, or anything that helps us answer well.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Please write the PR body in the format described in
+`.agents/skills/implement-milestone/pr-templates.md` (the canonical templates
+maintainers and agents both use). The template below is a fallback if you
+don't have that file handy.
+-->
+
+## Summary
+- <what user-visible thing changes>
+
+## Design choices
+- **<decision>**: <"X because Y" — one line each>
+
+## Concepts introduced
+<One short paragraph on any new abstraction or contract, or "None — mechanical change.">
+
+## Concepts glossary (for the PM reader)
+<3–6 bullets. **term** — one sentence on why this matters at product level. Skip only for pure-mechanical PRs.>
+
+## Test plan
+- <what to verify post-merge>
+
+Closes #<issue> <!-- required for feature/bug PRs; omit for pure docs/chore -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our pledge
+
+We — everyone who participates in the tolokaforge community — pledge to make participation a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Standards
+
+Examples of behaviour that contribute to a positive environment:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility, apologising to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information — such as a physical or email address — without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour can be reported to the project maintainers at the address listed in `GOVERNANCE.md`. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — GitHub issues, pull requests, discussions, and any external channel officially linked from the repository — and also applies when an individual is officially representing the community in public spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at [contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,44 @@
+# Governance
+
+tolokaforge is an open-source project sponsored by [Toloka](https://toloka.ai/). This document describes how decisions are made, who is responsible for what, and how to get involved.
+
+## Roles
+
+**Maintainer.** Reviews and merges PRs, triages issues, cuts releases, and shepherds the roadmap. The active maintainer is listed under the repository's [About](https://github.com/Toloka/tolokaforge) sidebar (currently Ciro Gamboa on the Toloka team).
+
+**Contributor.** Anyone who has had a PR merged. Contributors are credited in release notes and on the [GitHub contributors page](https://github.com/Toloka/tolokaforge/graphs/contributors).
+
+**Sponsor.** Toloka provides engineering time, hosting for the arena / release infrastructure, and product direction. Sponsor-driven priorities are visible in the public roadmap at [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+## Decision-making
+
+Most decisions happen in the open on issues and PRs.
+
+- **Small changes** (bug fixes, docs, small features) — reviewed and merged by the maintainer on their normal cadence.
+- **Compatibility-surface changes** (task contracts, task-pack formats, run-config schemas, CLI surface, published Python API) — need a design discussion first. Open a [Discussion](https://github.com/Toloka/tolokaforge/discussions) or file an umbrella issue. See `AGENTS.md` §Core Rule 5 for the migration expectations.
+- **Architectural changes** — captured in an ADR under [`docs/adr/`](docs/adr/) before implementation lands. Existing ADRs are the template.
+
+The maintainer has the final say on merges. When a decision is contested, the maintainer explains the reasoning in the issue or PR thread and links to the ADR when applicable.
+
+## Contribution ladder
+
+Progression is by contribution, not by tenure:
+
+1. **First-time contributor** — file an issue, open a small PR, ask a question. All welcome.
+2. **Regular contributor** — several merged PRs, engaged in reviews. Ping the maintainer if you'd like triage rights.
+3. **Triager** — can label and close issues, cannot merge. Granted on ask after regular contribution.
+4. **Maintainer** — merge rights and release rights. Added when the workload justifies it and the maintainer has confidence in your judgement on the compatibility-surface rules.
+
+## Release cadence
+
+Releases follow semantic versioning and are cut on demand — usually every 2–4 weeks — after a set of related milestones lands. The current release table and per-release ADR links are in [`docs/ROADMAP.md`](docs/ROADMAP.md). Release mechanics are in [`docs/RELEASING.md`](docs/RELEASING.md).
+
+## Reporting
+
+- **Bugs, features, questions:** GitHub issues (templates auto-load).
+- **Design discussion:** GitHub Discussions.
+- **Code of Conduct issues:** contact the maintainer directly via the email listed on their GitHub profile, or via a private security-advisory report at [github.com/Toloka/tolokaforge/security/advisories/new](https://github.com/Toloka/tolokaforge/security/advisories/new).
+
+## Security
+
+Security vulnerabilities should NOT be reported in public issues. Use the private [security advisory](https://github.com/Toloka/tolokaforge/security/advisories/new) form on GitHub, or contact the maintainer directly.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ examples/             # Reference task layouts with runnable run_config.yaml
 └── terminal_bench/   # `terminal_bench` adapter (Docker compose)
 ```
 
+## Roadmap
+
+The release-versioned architecture arc and per-release ADR links are in [docs/ROADMAP.md](docs/ROADMAP.md). Governance and the contribution ladder are in [GOVERNANCE.md](GOVERNANCE.md).
+
 ## Documentation
 
 | Topic | Link |


### PR DESCRIPTION
## Summary

Community-facing surface additions so outside contributors have structured entry points and can find the roadmap. All additive except the README, which gains a small Roadmap section above the existing Documentation table.

## Design choices

- **Issue templates in YAML forms**, not free-text Markdown. Forms produce more consistent field content and integrate cleanly with the auto-triage workflow we'll add later.
- **A thin PR template** points contributors at the canonical templates in \`.agents/skills/implement-milestone/pr-templates.md\`. The thin template is a fallback for contributors without agent tooling; maintainers use the fuller ones.
- **Governance doc is intentionally light.** Names maintainer + sponsor + contribution ladder + decision rules; defers most policy detail to existing docs (AGENTS.md for engineering rules, docs/ROADMAP.md for scope, docs/adr/ for decisions).
- **CoC is Contributor Covenant 2.1 unchanged.** Most-referenced OSS standard; no reason to fork wording.

## Concepts glossary (for the PM reader)

- **Issue templates (forms)** — structured entry points that make bug reports and feature requests easier to triage; the auto-triage skill I'll wire up later reads these fields.
- **PR template** — a thin fallback for contributors who aren't running the agent tooling; agents themselves use the fuller templates in \`.agents/skills/\`.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, the standard OSS baseline. Enforcement points at maintainer + private security advisory.
- **GOVERNANCE.md** — the "who decides what and how you level up" doc. Currently light; can grow if the community does.
- **Roadmap link in README** — closes a gap outside readers hit: they land on the README and can't find the release-versioned architecture arc.

## Files added

- \`.github/ISSUE_TEMPLATE/{bug_report,feature_request,question}.yml\`
- \`.github/ISSUE_TEMPLATE/config.yml\` (disables blank issues, adds contact links)
- \`.github/PULL_REQUEST_TEMPLATE.md\`
- \`.github/DISCUSSION_TEMPLATE/general.yml\`
- \`CODE_OF_CONDUCT.md\`
- \`GOVERNANCE.md\`

## Files modified

- \`README.md\` — new "Roadmap" section (2 lines) above the Documentation table.

## Test plan

- [ ] After merge, open a new issue on GitHub — confirm one of the three templates renders and the blank-issue link is gone.
- [ ] Open a new discussion — confirm the discussion template loads.
- [ ] Open a new PR — confirm the thin template renders.
- [ ] Follow the CODE_OF_CONDUCT and GOVERNANCE links from the README — confirm they render on the repo landing page.