### PR TITLE
ci(models): scaffold tolokaforge-models PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-tolokaforge-models.yml
+++ b/.github/workflows/publish-tolokaforge-models.yml
@@ -1,0 +1,133 @@
+name: Publish tolokaforge-models to PyPI
+
+on:
+  push:
+    tags:
+      - "models-v*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+concurrency:
+  group: publish-tolokaforge-models-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install "$(cat .python-version)"
+
+      - name: Build package
+        working-directory: tolokaforge_models
+        run: uv build
+
+      - name: Verify package contents
+        working-directory: tolokaforge_models
+        run: |
+          echo "=== Built artifacts ==="
+          ls -lh dist/
+          echo ""
+          echo "=== Wheel contents ==="
+          uv run python -c "
+          import zipfile, sys
+          for f in __import__('pathlib').Path('dist').glob('*.whl'):
+              print(f'--- {f.name} ---')
+              with zipfile.ZipFile(f) as zf:
+                  for name in sorted(zf.namelist()):
+                      print(f'  {name}')
+          "
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tolokaforge-models-dist
+          path: tolokaforge_models/dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tolokaforge-models-dist
+          path: dist/
+
+      - name: List downloaded files
+        run: find dist/ -type f
+
+      - name: Publish to TestPyPI
+        run: uv publish dist/* --publish-url https://test.pypi.org/legacy/ --trusted-publishing always
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/models-v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tolokaforge-models-dist
+          path: dist/
+
+      - name: List downloaded files
+        run: find dist/ -type f
+
+      - name: Publish to PyPI
+        run: uv publish dist/* --trusted-publishing always
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/models-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tolokaforge-models-dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
Registers the `publish-tolokaforge-models.yml` workflow on `main` so it can be triggered via `workflow_dispatch` (which GitHub only recognises for workflows that exist on the default branch).

The workflow itself is dormant on `main` — nothing publishes yet. Trigger conditions:
- `push: tags: models-v*` — no such tags exist and none will until the models wheel lands (via #938 / #645 milestone).
- `workflow_dispatch` — manual trigger only, choosing between `testpypi` and `pypi`.

## Why merge to main now

Milestone 29 needs a fast dry-run against TestPyPI to validate the OIDC Trusted-Publisher setup for the new `tolokaforge-models` PyPI project before the #938 cutover PR merges. Without the workflow file on `main`, `gh workflow run` returns 404 and the dry-run is blocked.

Post-merge:
\`\`\`
gh workflow run publish-tolokaforge-models.yml --ref feat/938-tolokaforge-models-cutover -f target=testpypi
\`\`\`

## Notes

- Uses the same `release` / `testpypi` GitHub environments as `publish-tolokaforge.yml`, so Trusted-Publisher config on PyPI is expected to name those environments for the `tolokaforge-models` project.
- The build step `cd`s into `tolokaforge_models/` — that directory does not exist on `main` yet (lands in #938). A manual `workflow_dispatch` triggered before #938 merges will fail at the `uv build` step with a legible \"No such file or directory\". That is exactly the failure mode we want to observe before touching real PyPI: dry-run against TestPyPI from the `feat/938-...` branch, which has `tolokaforge_models/` populated.