### PR TITLE
feat(automation): let the Slack poller read a header-admission gateway

### DIFF
--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -75,9 +75,17 @@ jobs:
       # A gateway may admit callers by an attribution header rather than by the key alone.
       # The poller reads the catalog through the engine's ProxyConfig, so it sends these
       # exactly like a run does; without them such a gateway answers 403 and every model
-      # would report absent for a transport reason rather than a catalogue one.
-      LLM_PROXY_HEADERS: ${{ vars.LLM_PROXY_HEADERS }}
-      # Values the ${secret:NAME} references inside LLM_PROXY_HEADERS resolve to.
+      # would report as unknown for a transport reason rather than a catalogue one.
+      #
+      # Gated on the base URL because the headers come from a repo VARIABLE while the base
+      # URL is a SECRET: a companion without a base URL is a hard error in the engine, so
+      # an ungated variable would make every poll of a gateway-less deployment log a
+      # configuration failure.
+      LLM_PROXY_HEADERS: >-
+        ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL != '' && vars.LLM_PROXY_HEADERS || '' }}
+      # Values the ${secret:NAME} references inside LLM_PROXY_HEADERS resolve to. Grep both
+      # this list and integrate-model.yml's before adding a third reference: an unresolved
+      # one makes the gateway reject the request.
       LLM_PROXY_SUNDAY_ORDER_ID: ${{ secrets.LLM_PROXY_SUNDAY_ORDER_ID }}
       LLM_PROXY_GATEWAY_RUNNER_KEY: ${{ secrets.LLM_PROXY_GATEWAY_RUNNER_KEY }}
     steps:

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -67,26 +67,19 @@ jobs:
       # Optional comma-separated Slack user-id allowlist. Empty => anyone in the channel may
       # trigger (channel membership is the authz gate; GitHub only ever sees github-actions[bot]).
       ALLOWED_USERS: ${{ vars.ARENA_AUTOMATION_SLACK_ALLOWED_USERS }}
-      # LLM gateway, both optional. Present => the poller reports whether each resolved model
+      # LLM gateway, all optional. Present => the poller reports whether each resolved model
       # is ALSO reachable there, and honours an explicit "via litellm" in the request. Absent
       # => availability is "unknown" and every request integrates over OpenRouter as before.
       LLM_PROXY_BASE_URL: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_BASE_URL }}
       LLM_PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
-      # Headers are deliberately NOT passed here yet. This job reaches the gateway
-      # through ``automation.gateway_catalog``, which reads the two names above from
-      # ``os.environ`` directly and by design (see its comment: routing through
-      # ``DotEnvProvider`` would let a developer's local ``.env`` answer a real poll).
-      # So it would ignore LLM_PROXY_HEADERS, and passing it would be dead config.
-      #
-      # The fix is not to teach that module about one more variable: the gateway
-      # contract already has a model (``ProxyConfig``), and this module reimplements
-      # two thirds of it, which is why it drifts. It should consume a ``ProxyConfig``
-      # built from an env-only ``SecretManager``. Tracked separately, because it needs
-      # an injectable manager on ``resolve_proxy_config``.
-      #
-      # Consequence until then: on a gateway that admits callers by a shared-secret
-      # header, this poll cannot read the catalog, so every model reports as absent
-      # from the gateway for a transport reason rather than a catalogue one.
+      # A gateway may admit callers by an attribution header rather than by the key alone.
+      # The poller reads the catalog through the engine's ProxyConfig, so it sends these
+      # exactly like a run does; without them such a gateway answers 403 and every model
+      # would report absent for a transport reason rather than a catalogue one.
+      LLM_PROXY_HEADERS: ${{ vars.LLM_PROXY_HEADERS }}
+      # Values the ${secret:NAME} references inside LLM_PROXY_HEADERS resolve to.
+      LLM_PROXY_SUNDAY_ORDER_ID: ${{ secrets.LLM_PROXY_SUNDAY_ORDER_ID }}
+      LLM_PROXY_GATEWAY_RUNNER_KEY: ${{ secrets.LLM_PROXY_GATEWAY_RUNNER_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,8 @@ make docker-status       # Show Docker service status
 | `ANTHROPIC_API_KEY` | `claude-review.yml` (the reviewer model) and any integration tests that use Claude. NOT used by `integrate-model.yml` (its resolve/finalize agent runs on OpenRouter via the LiteLLM gateway). |
 | `ARENA_AUTOMATION_OPENROUTER_API_KEY` | `integrate-model.yml` - candidate-model probes/reprobes AND the resolve/finalize agent (routed through the LiteLLM -> OpenRouter gateway) |
 | `ARENA_AUTOMATION_SLACK_BOT_TOKEN` | `integrate-model.yml` + `slack-integrate.yml` (thread notifications and the request poller; both degrade to a no-op without it) |
+| `ARENA_AUTOMATION_LLM_PROXY_BASE_URL` + `_API_KEY` | the optional LLM-gateway route in both workflows (both, or neither). Absent means every request runs over OpenRouter and gateway availability reports as unknown. |
+| whatever `vars.LLM_PROXY_HEADERS` references as `${secret:NAME}` | a gateway that admits callers by an attribution header. Both workflows pass the variable and the referenced secrets; see [`docs/AUTO_INTEGRATION.md`](docs/AUTO_INTEGRATION.md). |
 
 Optional secrets (integration tests auto-skip without them): `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `NOVA_API_KEY`, `TYPESENSE_API_KEY`. CI passes provider keys to test jobs as env vars; runtime code reads them via `SecretManager` (never directly).
 

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -199,6 +199,11 @@ gateway by whichever it finds
 ([`docs/LLM_LAYER.md` § speaking to the gateway](LLM_LAYER.md#speaking-to-the-gateway)), so this
 lookup checks both in that order and a prefixed-only entry *is* evidence.
 
+The two agree except on a catalog carrying **both** names for one model: this lookup reports the
+prefixed one, while the engine refuses to guess and requires `LLM_PROXY_PREFERRED_ROUTE`, because
+the two names can be backed by different upstreams. On such a catalog the reply promises a route
+the run will not take until that variable is set.
+
 The report distinguishes two strengths, because they are not equally trustworthy:
 
 | Reply says | Means |

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -120,6 +120,13 @@ would forward the OpenRouter key to the gateway host):
 | `ARENA_AUTOMATION_LLM_PROXY_BASE_URL` | Gateway base URL, including the path its OpenAI-compatible route lives under (commonly `/v1`). A secret rather than a variable because the hostname is usually internal and this repo is public. |
 | `ARENA_AUTOMATION_LLM_PROXY_API_KEY` | Gateway credential. |
 
+A gateway that admits callers by an **attribution header** rather than by the key alone needs
+`LLM_PROXY_HEADERS` (a variable: a JSON map of header name to value, where a value may be a
+`${secret:NAME}` reference) plus a secret per name it references. Both the integration run and
+the Slack poller pass them, so the poll reads the catalog through the same admission a run uses;
+without them such a gateway answers 403 and every model reports as unknown. See
+[`docs/LLM_LAYER.md` § proxy](LLM_LAYER.md#proxy--routing-calls-through-an-llm-gateway).
+
 ## Labels (the state machine)
 
 `automation:integrate-model` (trigger) -> `automation:integrate-running` (observe) ->
@@ -186,18 +193,17 @@ advisory on purpose: a gateway route may be backed by a *different upstream* for
 name, which is a comparability decision for a human, not a transport detail the automaton should
 take on itself.
 
-The name looked up is the one that actually reaches the gateway: litellm strips exactly one
-provider prefix, so this run's `provider: openrouter` + `name: <slug>` config puts the **bare
-slug** on the wire. An `openrouter/<slug>` (or `openrouter/*`) catalog entry is therefore *not*
-evidence for this run — reaching a prefixed route needs the gateway-named config in
-[`docs/LLM_LAYER.md` § naming a gateway route explicitly](LLM_LAYER.md#naming-a-gateway-route-explicitly),
-which this workflow does not use.
+The names looked up are the ones that actually reach the gateway. The engine resolves a route
+from this same catalog, trying `openrouter/<slug>` and then the bare `<slug>`, and addresses the
+gateway by whichever it finds
+([`docs/LLM_LAYER.md` § speaking to the gateway](LLM_LAYER.md#speaking-to-the-gateway)), so this
+lookup checks both in that order and a prefixed-only entry *is* evidence.
 
 The report distinguishes two strengths, because they are not equally trustworthy:
 
 | Reply says | Means |
 |---|---|
-| `also on the gateway as <route>` | an explicit catalog entry for the bare slug — someone configured this model |
+| `also on the gateway as <route>` | an explicit catalog entry for one of the two names, so someone configured this model |
 | `probably reachable … (matched a passthrough)` | only a wildcard over the slug's own namespace (`x-ai/*`, or a bare `*`) covers it; a live call is the real proof |
 | `not on the gateway` | the catalog was read and does not cover it |
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -672,6 +672,25 @@ board is calibrated on), not looser matching.
 Preset resolution and pricing are unaffected: both key off `ModelConfig.provider` /
 `.name`, not off the wire name.
 
+**Reading the catalog from outside a run.** `resolve_proxy_config()` takes an
+optional `SecretManager`, so a caller that must describe the *deployment's* gateway
+rather than the checkout's can pass an env-only one:
+
+```python
+proxy = resolve_proxy_config(SecretManager([EnvProvider()]))
+served = fetch_gateway_catalog(proxy)
+```
+
+The Slack integration poller does exactly this
+([`automation/gateway_catalog.py`](../tools/automation/src/automation/gateway_catalog.py)).
+Two properties come from it and neither is incidental: the catalog request carries
+the same attribution headers a run sends, so a gateway that admits callers by a
+shared-secret header answers the poll instead of rejecting it; and dropping
+`DotEnvProvider` keeps a developer's local `.env` from answering a production poll,
+which would report availability nobody else can reproduce. Because it is one
+implementation rather than two, an empty answer means "unreadable" on both sides,
+so one gateway state cannot produce two different routing decisions.
+
 ### Which providers can be routed
 
 **Setting `api_base` does not make litellm speak OpenAI to that URL — it makes

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -270,8 +270,16 @@ def _parse_providers(raw: str | None) -> frozenset[str] | None:
     return frozenset(entries)
 
 
-def resolve_proxy_config() -> ProxyConfig | None:
+def resolve_proxy_config(secrets: SecretManager | None = None) -> ProxyConfig | None:
     """Resolve the gateway transport from the environment.
+
+    Parameters
+    ----------
+    secrets
+        Where the variables are read from. Defaults to the process-wide manager,
+        which is what the engine wants. A caller that must read the *deployment's*
+        gateway rather than the checkout's passes an env-only manager: see
+        ``docs/LLM_LAYER.md`` § "Speaking to the gateway".
 
     Returns
     -------
@@ -285,9 +293,10 @@ def resolve_proxy_config() -> ProxyConfig | None:
         When the gateway is enabled but a companion variable is malformed, or
         when companion variables are set while the base URL is missing.
     """
-    from tolokaforge.secrets import get_default
+    if secrets is None:
+        from tolokaforge.secrets import get_default
 
-    secrets = get_default()
+        secrets = get_default()
 
     base_url = (secrets.get_secret(ENV_BASE_URL) or "").strip()
     if not base_url:

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -31,13 +31,14 @@ returns ``unknown`` and the flow is unchanged.
 
 The catalog itself is fetched by the engine (:mod:`tolokaforge.core.llm.gateway_route`)
 through a :class:`~tolokaforge.core.llm.proxy.ProxyConfig`, so the poller and the
-integration run read the same gateway the same way. See ``docs/AUTO_INTEGRATION.md``
-§ "Integration route" for why this module owns no transport of its own.
+integration run read the same gateway the same way. See ``docs/LLM_LAYER.md``
+§ "Speaking to the gateway" for why this module owns no transport of its own.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import os
 import sys
 
 from tolokaforge.core.llm.gateway_route import fetch_gateway_catalog
@@ -85,6 +86,18 @@ class Availability:
 USER_SIMULATOR_SLUG = "anthropic/claude-sonnet-4.6"
 
 
+def _warn(message: str) -> None:
+    """Surface an operator error without failing the poll.
+
+    A misconfigured gateway is not a model problem, but the reply a requester sees says
+    the route could not be confirmed, which points at the model. The annotation is what
+    connects the two.
+    """
+    print(f"[gateway_catalog] {message}", file=sys.stderr)
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::warning title=Gateway configuration unusable::{message}")
+
+
 def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
     """The gateway catalog for THIS deployment, or ``None`` when there is no readable gateway.
 
@@ -98,12 +111,12 @@ def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
     try:
         proxy = resolve_proxy_config(SecretManager([EnvProvider()]))
     except ProxyConfigError as exc:
-        print(f"gateway unusable, availability is unknown: {exc}", file=sys.stderr)
+        _warn(f"gateway unusable, availability is unknown: {exc}")
         return None
     if proxy is None:
         return None
     served = fetch_gateway_catalog(proxy, timeout)
-    # Sorted because resolution against this catalog must be deterministic.
+    # Sorted so the same gateway yields the same resolution and the same log twice over.
     return None if served is None else sorted(served)
 
 

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -28,15 +28,21 @@ it. Nothing here calls the model — availability is a catalog lookup.
 
 Requires no credentials to be useful: with no gateway configured, every lookup
 returns ``unknown`` and the flow is unchanged.
+
+The catalog itself is fetched by the engine (:mod:`tolokaforge.core.llm.gateway_route`)
+through a :class:`~tolokaforge.core.llm.proxy.ProxyConfig`, so the poller and the
+integration run read the same gateway the same way. See ``docs/AUTO_INTEGRATION.md``
+§ "Integration route" for why this module owns no transport of its own.
 """
 
 from __future__ import annotations
 
 import dataclasses
-import json
-import os
-import urllib.error
-import urllib.request
+import sys
+
+from tolokaforge.core.llm.gateway_route import fetch_gateway_catalog
+from tolokaforge.core.llm.proxy import ProxyConfigError, resolve_proxy_config
+from tolokaforge.secrets import EnvProvider, SecretManager
 
 #: Route identifiers accepted in a request and threaded into the integration run.
 ROUTE_OPENROUTER = "openrouter"
@@ -72,44 +78,6 @@ class Availability:
         return self.status in (STATUS_EXACT, STATUS_WILDCARD)
 
 
-def fetch_gateway_catalog(
-    base_url: str | None, api_key: str | None, timeout: int = 15
-) -> list[str] | None:
-    """Route ids the gateway serves, or ``None`` when it cannot be read.
-
-    ``None`` is not an error to propagate: an unconfigured or unreachable gateway
-    must leave the integration flow exactly as it was, so callers treat it as
-    "no information" rather than failing the poll.
-    """
-    if not base_url or not base_url.strip():
-        return None
-    url = base_url.strip().rstrip("/") + "/models"
-    headers = {"Accept": "application/json"}
-    if api_key and api_key.strip():
-        headers["Authorization"] = f"Bearer {api_key.strip()}"
-    try:
-        request = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
-        return None
-    entries = data.get("data")
-    if not isinstance(entries, list):
-        return None
-    return sorted(
-        str(entry["id"]) for entry in entries if isinstance(entry, dict) and entry.get("id")
-    )
-
-
-#: Env names carrying the gateway contract. Read from ``os.environ`` rather than through
-#: ``SecretManager`` (AGENTS.md § Secrets) for one reason that applies to every caller here: this
-#: package is a standalone workspace member without the engine's secrets stack, and the entry
-#: points are CI-only, where the credential arrives through the workflow's ``env:``. Going through
-#: ``DotEnvProvider`` would additionally give a developer's local ``.env`` precedence, which is
-#: how a dev gateway would end up answering a real poll.
-ENV_BASE_URL = "LLM_PROXY_BASE_URL"
-ENV_API_KEY = "LLM_PROXY_API_KEY"
-
 #: The user simulator the wire probes run, from ``integrate-model.yml``. On the gateway route that
 #: workflow's ``.env`` is JOB-WIDE, so the simulator is proxied too and the gateway must serve it
 #: as well - otherwise observe goes infra-dirty in the simulator rather than in the candidate.
@@ -122,8 +90,21 @@ def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
 
     The single owner of the environment read, so every caller sees the same catalog the poll
     does; a hand-run diagnostic that disagreed with the poll would be worse than no diagnostic.
+
+    ``None`` is "no information", never an error to propagate: a notification path must not
+    fail a poll because a gateway is down or misconfigured.
     """
-    return fetch_gateway_catalog(os.environ.get(ENV_BASE_URL), os.environ.get(ENV_API_KEY), timeout)
+    # Env-only: dotenv precedence would let a developer's local .env answer a real poll.
+    try:
+        proxy = resolve_proxy_config(SecretManager([EnvProvider()]))
+    except ProxyConfigError as exc:
+        print(f"gateway unusable, availability is unknown: {exc}", file=sys.stderr)
+        return None
+    if proxy is None:
+        return None
+    served = fetch_gateway_catalog(proxy, timeout)
+    # Sorted because resolution against this catalog must be deterministic.
+    return None if served is None else sorted(served)
 
 
 def lookup(slug: str, catalog: list[str] | None) -> Availability:

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -304,6 +304,9 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
     request, reply in-thread, and write the integration plan to ``out_path``. Always returns 0
     (a poll must never fail the workflow)."""
     plan: list[dict] = []
+    # os.environ rather than SecretManager: this package's entry points are CI-only, where the
+    # token arrives through the workflow's env, and dotenv precedence would let a developer's
+    # local .env drive a real poll. The gateway read keeps the same property (gateway_catalog).
     token = os.environ.get("SLACK_BOT_TOKEN")
     if not token or not channel:
         slack._log("no SLACK_BOT_TOKEN or channel - dry-run no-op")

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -14,9 +14,15 @@ from __future__ import annotations
 import json
 import pathlib
 import re
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 from automation import gateway_catalog, model_resolver, poller, slack
+
+from tolokaforge.core.llm import gateway_route
+from tolokaforge.secrets import DictProvider, SecretManager
+from tolokaforge.secrets import manager as secrets_manager
 
 pytestmark = pytest.mark.unit
 
@@ -70,65 +76,132 @@ class TestLookup:
         assert gateway_catalog.describe(found) == ""
 
 
-class TestFetchDegradesQuietly:
-    def test_no_base_url_returns_none(self) -> None:
-        assert gateway_catalog.fetch_gateway_catalog(None, "sk-x") is None
-        assert gateway_catalog.fetch_gateway_catalog("   ", "sk-x") is None
+ADMISSION_HEADER = "x-github-runner-key"
+ADMISSION_VALUE = "runner-secret"
 
-    def test_unreachable_gateway_returns_none_rather_than_raising(self, monkeypatch) -> None:
-        """A notification path must never break the poll (no real socket: stub the transport)."""
 
-        def fake_urlopen(request, timeout=None):
-            raise gateway_catalog.urllib.error.URLError("boom")
+class _Handler(BaseHTTPRequestHandler):
+    """A gateway that admits callers by an attribution header, like the real deployment."""
 
-        monkeypatch.setattr(gateway_catalog.urllib.request, "urlopen", fake_urlopen)
-        assert gateway_catalog.fetch_gateway_catalog("http://gw.invalid/v1", "sk-x") is None
+    def do_GET(self) -> None:  # noqa: N802
+        SEEN_HEADERS.append({k.lower(): v for k, v in self.headers.items()})
+        if SEEN_HEADERS[-1].get(ADMISSION_HEADER) != ADMISSION_VALUE:
+            body, status = b'{"error":"forbidden"}', 403
+        else:
+            body = json.dumps({"data": [{"id": e} for e in SERVES]}).encode()
+            status = 200
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
-    def test_catalog_is_parsed_and_sorted_from_the_models_route(self, monkeypatch) -> None:
-        seen = {}
+    def log_message(self, *args: object) -> None:
+        pass
 
-        class _Resp:
-            def read(self):
-                return json.dumps(
-                    {"data": [{"id": "x-ai/grok-4.5"}, {"id": "x-ai/*"}, {}, {"id": None}]}
-                ).encode()
 
-            def __enter__(self):
-                return self
+SEEN_HEADERS: list[dict[str, str]] = []
+SERVES: list[str] = []
 
-            def __exit__(self, *a):
-                return False
 
-        def fake_urlopen(request, timeout=None):
-            seen["url"] = request.full_url
-            seen["auth"] = request.headers.get("Authorization")
-            return _Resp()
+@pytest.fixture(scope="module")
+def _server():
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
 
-        monkeypatch.setattr(gateway_catalog.urllib.request, "urlopen", fake_urlopen)
-        assert gateway_catalog.fetch_gateway_catalog("https://gw.invalid/v1/", "sk-x") == [
-            "x-ai/*",
-            "x-ai/grok-4.5",
-        ]
-        assert seen["url"] == "https://gw.invalid/v1/models"
-        assert seen["auth"] == "Bearer sk-x"
 
-    def test_non_list_data_is_no_information_not_an_empty_catalog(self, monkeypatch) -> None:
-        """An empty list would read as 'the gateway serves nothing'; None reads as 'unknown'."""
+@pytest.fixture
+def gateway(_server, monkeypatch):
+    """A configured gateway, with the engine's per-process catalog cache cleared."""
+    SEEN_HEADERS.clear()
+    SERVES[:] = ["x-ai/grok-4.5", "x-ai/*"]
+    gateway_route.clear_catalog_cache()
+    monkeypatch.setenv("LLM_PROXY_BASE_URL", _server)
+    monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-gw")
+    yield _server
+    gateway_route.clear_catalog_cache()
 
-        class _Resp:
-            def read(self):
-                return json.dumps({"data": {"x-ai/grok-4.5": {}}}).encode()
 
-            def __enter__(self):
-                return self
+class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
+    """The poll must reach the same gateway an integration run reaches.
 
-            def __exit__(self, *a):
-                return False
+    It used to send only the key, so a deployment that admits callers by an attribution
+    header answered 403 and every model reported absent for a transport reason. The
+    reply then said "not on the gateway" about a model the gateway serves.
+    """
 
-        monkeypatch.setattr(
-            gateway_catalog.urllib.request, "urlopen", lambda request, timeout=None: _Resp()
+    def test_no_gateway_configured_is_no_information(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
+        monkeypatch.delenv("LLM_PROXY_API_KEY", raising=False)
+        assert gateway_catalog.fetch_configured_catalog() is None
+
+    def test_the_admission_header_rides_along(self, gateway, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": ADMISSION_VALUE})
         )
-        assert gateway_catalog.fetch_gateway_catalog("https://gw.invalid/v1", "sk-x") is None
+        assert gateway_catalog.fetch_configured_catalog() == ["x-ai/*", "x-ai/grok-4.5"]
+        assert SEEN_HEADERS[0]["authorization"] == "Bearer sk-gw"
+
+    def test_a_secret_reference_in_a_header_is_resolved(self, gateway, monkeypatch) -> None:
+        """The workflow passes the value as ``${secret:NAME}``, so an unexpanded
+        reference would reach the gateway verbatim and be rejected."""
+        monkeypatch.setenv("RUNNER_KEY", ADMISSION_VALUE)
+        monkeypatch.setenv(
+            "LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": "${secret:RUNNER_KEY}"})
+        )
+        assert gateway_catalog.fetch_configured_catalog() is not None
+
+    def test_without_the_header_the_catalog_is_unknown_not_empty(
+        self, gateway, monkeypatch
+    ) -> None:
+        """403 is no information. Reporting it as an empty catalog would say
+        "the gateway serves nothing", which downgrades every route with confidence."""
+        monkeypatch.delenv("LLM_PROXY_HEADERS", raising=False)
+        assert gateway_catalog.fetch_configured_catalog() is None
+
+    def test_an_empty_catalog_is_unknown_too(self, gateway, monkeypatch) -> None:
+        """The engine calls an empty answer unreadable; the poller now agrees, so one
+        gateway state cannot produce two different routing decisions."""
+        monkeypatch.setenv(
+            "LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": ADMISSION_VALUE})
+        )
+        SERVES.clear()
+        assert gateway_catalog.fetch_configured_catalog() is None
+
+    def test_an_unreachable_gateway_returns_none_rather_than_raising(self, monkeypatch) -> None:
+        """A notification path must never break the poll."""
+        gateway_route.clear_catalog_cache()
+        monkeypatch.setenv("LLM_PROXY_BASE_URL", "http://127.0.0.1:1/v1")
+        monkeypatch.delenv("LLM_PROXY_API_KEY", raising=False)
+        assert gateway_catalog.fetch_configured_catalog(timeout=2) is None
+
+    def test_a_misconfigured_gateway_is_reported_but_does_not_break_the_poll(
+        self, monkeypatch, capsys
+    ) -> None:
+        """A companion variable without a base URL is an operator error the engine
+        refuses on. Here it must surface without taking the poll down with it."""
+        monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
+        monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-orphan")
+        assert gateway_catalog.fetch_configured_catalog() is None
+        assert "gateway unusable" in capsys.readouterr().err
+
+
+class TestALocalEnvCannotAnswerARealPoll:
+    def test_the_default_manager_is_not_consulted(self, monkeypatch) -> None:
+        """Dotenv precedence would let a developer's gateway answer a production poll,
+        and the reply would record availability nobody can reproduce."""
+        monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
+        monkeypatch.setattr(
+            secrets_manager,
+            "_default_manager",
+            SecretManager([DictProvider({"LLM_PROXY_BASE_URL": "http://dev-gateway.invalid/v1"})]),
+        )
+        gateway_route.clear_catalog_cache()
+        assert gateway_catalog.fetch_configured_catalog() is None
 
 
 class TestRouteDirective:
@@ -251,13 +324,11 @@ class TestPlanRows:
         fetches = {"gateway": 0}
         posted: list[str] = []
 
-        def fake_gateway(base_url, api_key, timeout=15):
+        def fake_gateway(timeout=15):
             fetches["gateway"] += 1
             return gateway
 
         monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
-        monkeypatch.setenv("LLM_PROXY_BASE_URL", "https://gateway.invalid/v1")
-        monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-test")
         monkeypatch.setattr(poller, "_auth_test", lambda token: "B1")
         monkeypatch.setattr(poller, "_already_handled", lambda *a, **k: False)
         monkeypatch.setattr(
@@ -274,7 +345,7 @@ class TestPlanRows:
             lambda channel, text, token, thread_ts=None: (posted.append(text), True)[1],
         )
         monkeypatch.setattr(model_resolver, "fetch_openrouter_catalog", lambda: ["x-ai/grok-4.5"])
-        monkeypatch.setattr(gateway_catalog, "fetch_gateway_catalog", fake_gateway)
+        monkeypatch.setattr(gateway_catalog, "fetch_configured_catalog", fake_gateway)
 
         out = tmp_path / "plan.json"
         assert poller.run("C1", None, str(out)) == 0

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -15,6 +15,7 @@ import json
 import pathlib
 import re
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -80,16 +81,22 @@ ADMISSION_HEADER = "x-github-runner-key"
 ADMISSION_VALUE = "runner-secret"
 
 
+#: Insertion order is deliberately not sorted order: the fetch must sort.
+SERVED = ["x-ai/grok-4.5", "x-ai/*", "azure_ai/cohere-command-a-plus-05-2026", "anthropic/*"]
+
+
 class _Handler(BaseHTTPRequestHandler):
     """A gateway that admits callers by an attribution header, like the real deployment."""
 
     def do_GET(self) -> None:  # noqa: N802
-        SEEN_HEADERS.append({k.lower(): v for k, v in self.headers.items()})
-        if SEEN_HEADERS[-1].get(ADMISSION_HEADER) != ADMISSION_VALUE:
+        self.server.seen.append({k.lower(): v for k, v in self.headers.items()})  # type: ignore[attr-defined]
+        if self.server.hang_s:  # type: ignore[attr-defined]
+            time.sleep(self.server.hang_s)  # type: ignore[attr-defined]
+        if self.server.seen[-1].get(ADMISSION_HEADER) != ADMISSION_VALUE:  # type: ignore[attr-defined]
             body, status = b'{"error":"forbidden"}', 403
         else:
-            body = json.dumps({"data": [{"id": e} for e in SERVES]}).encode()
-            status = 200
+            entries = [{"id": e} for e in self.server.serves]  # type: ignore[attr-defined]
+            body, status = json.dumps({"data": entries}).encode(), 200
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -100,38 +107,42 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
 
-SEEN_HEADERS: list[dict[str, str]] = []
-SERVES: list[str] = []
-
-
 @pytest.fixture(scope="module")
 def _server():
+    """State lives on the server, not in module globals, so no test can inherit another's."""
     server = HTTPServer(("127.0.0.1", 0), _Handler)
     threading.Thread(target=server.serve_forever, daemon=True).start()
     try:
-        yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+        yield server
     finally:
         server.shutdown()
+        server.server_close()
 
 
 @pytest.fixture
 def gateway(_server, monkeypatch):
-    """A configured gateway, with the engine's per-process catalog cache cleared."""
-    SEEN_HEADERS.clear()
-    SERVES[:] = ["x-ai/grok-4.5", "x-ai/*"]
+    """A configured gateway, reset, with the engine's per-process catalog cache cleared."""
+    _server.seen = []
+    _server.serves = list(SERVED)
+    _server.hang_s = 0
     gateway_route.clear_catalog_cache()
-    monkeypatch.setenv("LLM_PROXY_BASE_URL", _server)
+    monkeypatch.setenv("LLM_PROXY_BASE_URL", f"http://127.0.0.1:{_server.server_address[1]}/v1")
     monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-gw")
     yield _server
     gateway_route.clear_catalog_cache()
+
+
+def _admit(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": ADMISSION_VALUE}))
 
 
 class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
     """The poll must reach the same gateway an integration run reaches.
 
     It used to send only the key, so a deployment that admits callers by an attribution
-    header answered 403 and every model reported absent for a transport reason. The
-    reply then said "not on the gateway" about a model the gateway serves.
+    header answered 403. The catalog then read as unreadable, every model reported as
+    unknown for a transport reason rather than a catalogue one, and a gateway-only model
+    could not be resolved at all.
     """
 
     def test_no_gateway_configured_is_no_information(self, monkeypatch) -> None:
@@ -140,11 +151,9 @@ class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
         assert gateway_catalog.fetch_configured_catalog() is None
 
     def test_the_admission_header_rides_along(self, gateway, monkeypatch) -> None:
-        monkeypatch.setenv(
-            "LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": ADMISSION_VALUE})
-        )
-        assert gateway_catalog.fetch_configured_catalog() == ["x-ai/*", "x-ai/grok-4.5"]
-        assert SEEN_HEADERS[0]["authorization"] == "Bearer sk-gw"
+        _admit(monkeypatch)
+        assert gateway_catalog.fetch_configured_catalog() == sorted(SERVED)
+        assert gateway.seen[0]["authorization"] == "Bearer sk-gw"
 
     def test_a_secret_reference_in_a_header_is_resolved(self, gateway, monkeypatch) -> None:
         """The workflow passes the value as ``${secret:NAME}``, so an unexpanded
@@ -166,11 +175,16 @@ class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
     def test_an_empty_catalog_is_unknown_too(self, gateway, monkeypatch) -> None:
         """The engine calls an empty answer unreadable; the poller now agrees, so one
         gateway state cannot produce two different routing decisions."""
-        monkeypatch.setenv(
-            "LLM_PROXY_HEADERS", json.dumps({"X-GitHub-Runner-Key": ADMISSION_VALUE})
-        )
-        SERVES.clear()
+        _admit(monkeypatch)
+        gateway.serves = []
         assert gateway_catalog.fetch_configured_catalog() is None
+
+    def test_a_hanging_gateway_gives_up_on_the_timeout(self, gateway, monkeypatch) -> None:
+        """The poll runs on a schedule against a gateway nobody watches, so the timeout
+        has to reach the socket rather than sit unused in the signature."""
+        _admit(monkeypatch)
+        gateway.hang_s = 2
+        assert gateway_catalog.fetch_configured_catalog(timeout=1) is None
 
     def test_an_unreachable_gateway_returns_none_rather_than_raising(self, monkeypatch) -> None:
         """A notification path must never break the poll."""
@@ -186,22 +200,47 @@ class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
         refuses on. Here it must surface without taking the poll down with it."""
         monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
         monkeypatch.setenv("LLM_PROXY_API_KEY", "sk-orphan")
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
         assert gateway_catalog.fetch_configured_catalog() is None
-        assert "gateway unusable" in capsys.readouterr().err
+        captured = capsys.readouterr()
+        assert "gateway unusable" in captured.err
+        # The reply blames the model ("could not confirm the gateway serves..."), so
+        # without an annotation the real cause is one stderr line in a green job.
+        assert "::warning title=Gateway configuration unusable::" in captured.out
 
 
 class TestALocalEnvCannotAnswerARealPoll:
-    def test_the_default_manager_is_not_consulted(self, monkeypatch) -> None:
+    def test_the_default_manager_is_not_consulted(self, _server, monkeypatch) -> None:
         """Dotenv precedence would let a developer's gateway answer a production poll,
-        and the reply would record availability nobody can reproduce."""
+        and the reply would record availability nobody else can reproduce.
+
+        The default manager is pointed at the REAL test server, so consulting it would
+        succeed loudly. Pointing it at an unreachable host would prove nothing: that
+        returns None as well, which is the answer this test expects.
+        """
+        _server.seen = []
+        _server.serves = list(SERVED)
+        _server.hang_s = 0
+        gateway_route.clear_catalog_cache()
         monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
         monkeypatch.setattr(
             secrets_manager,
             "_default_manager",
-            SecretManager([DictProvider({"LLM_PROXY_BASE_URL": "http://dev-gateway.invalid/v1"})]),
+            SecretManager(
+                [
+                    DictProvider(
+                        {
+                            "LLM_PROXY_BASE_URL": f"http://127.0.0.1:{_server.server_address[1]}/v1",
+                            "LLM_PROXY_HEADERS": json.dumps(
+                                {"X-GitHub-Runner-Key": ADMISSION_VALUE}
+                            ),
+                        }
+                    )
+                ]
+            ),
         )
-        gateway_route.clear_catalog_cache()
         assert gateway_catalog.fetch_configured_catalog() is None
+        assert _server.seen == [], "the gateway was not even asked"
 
 
 class TestRouteDirective:


### PR DESCRIPTION
## The problem

A Slack request for a **gateway-only model** cannot be integrated today. Ask the bot to
integrate `azure_ai/cohere-command-a-plus-05-2026` and the reply is that the model could
not be found, even though the deployment's gateway serves it.

The two-catalog design is not the problem. The poller already asks OpenRouter first and
falls back to the gateway catalog, precisely so a gateway-only model is requestable
(`model_resolver`, `poller.run`). What fails is the second fetch itself:
`automation.gateway_catalog` had its own HTTP client that sent the base URL and the API
key and nothing else. Our deployment admits callers by an attribution header, so that
request is rejected, and from there everything is silent:

```
fetch_configured_catalog() -> None
  -> _gateway_candidates(None, ...) is empty
  -> resolve() returns the primary answer, status "none"
  -> the reply says the model phrase could not be resolved
```

An explicit `via litellm` degrades the same way: the route is "unconfirmed", so it is
downgraded to OpenRouter, which for a gateway-only model is nowhere.

The second failure is quieter. The two fetchers disagreed about an **empty** catalog: the
engine treats it as unreadable and keeps the gateway, the poller treated it as
authoritative and reported everything absent. One gateway state, two routing decisions.

## The change

The poller stops owning a transport. It builds a `ProxyConfig` and calls the engine's
fetcher, so the catalog request carries the same attribution headers a run sends:

```python
proxy = resolve_proxy_config(SecretManager([EnvProvider()]))
served = fetch_gateway_catalog(proxy, timeout)
```

That deletes ~30 lines of duplicated HTTP rather than adding a variable to it. The drift
existed because the gateway contract had two partial owners; adding `LLM_PROXY_HEADERS` to
the second copy would have entrenched it.

`resolve_proxy_config()` gains an optional `SecretManager`, defaulting to today's
process-wide one. The poller passes an **env-only** manager deliberately: dotenv precedence
would let a developer's local `.env` answer a production poll and report availability
nobody else can reproduce. That property was the original reason the poller read
`os.environ` directly, and it is preserved rather than traded away.

Empty-catalog semantics unify as a consequence, not as a separate patch.

`slack-integrate.yml` now passes `LLM_PROXY_HEADERS` and the two secrets its
`${secret:NAME}` references resolve to. The 15-line comment explaining why they were
absent is gone.

## Evidence

**Unit.** Against a local `http.server` that requires the admission header: with it the
catalog is read, without it the result is `None` (unknown) rather than an empty catalog,
and a `${secret:NAME}` reference in a header is resolved rather than sent verbatim. The
env-only property is pinned by a test that puts a base URL in the default manager only and
asserts the poll does not see it.

**Live.** Run against the real gateway through the poller's own entry point:

| lookup | result |
|---|---|
| `azure_ai/cohere-command-a-plus-05-2026` | exact, route `azure_ai/cohere-command-a-plus-05-2026` |
| `anthropic/claude-sonnet-4.6` (user simulator) | exact, route `openrouter/anthropic/claude-sonnet-4.6` |

802 catalog entries, and the replies read "also on the gateway as `<route>`".

**The controlled pair.** On a corporate-VPN host the read succeeds *without* the headers
too, because that gateway also admits by source IP, which is why this gap was invisible
locally. Measured again from the same laptop with the VPN disconnected, so the egress IP is
not allowlisted:

| | catalog |
|---|---|
| with the attribution headers | readable |
| without them | `HTTP 403 Forbidden` |

That is the GitHub-runner situation: an unallowlisted source IP, admitted only by the
shared-secret header. Corroborated by run 30656526064, where this runner took 403s at the
Azure Application Gateway without them.

## Test results

- `tools/automation/tests`: 251 passed
- `tests/unit/llm` proxy + gateway files: 83 passed
- `ruff check` / `ruff format`: clean

Pre-existing and unrelated: three `test_rate_limit_probe_retry` failures that reproduce on
`origin/main`, caused by a local `.env` carrying `LLM_PROXY_*` leaking into those tests.
`test-full` is red on `main` independently of this branch (docker provisioning).

## Scope

Closes the first three deliverables of #948. Not here: wildcard route matching, per-model
route overrides, and any change to the exact-match routing rule.

