### PR TITLE
feat(automation): integrate a model only the gateway serves

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -52,6 +52,14 @@ on:
         options:
           - openrouter
           - litellm
+      pricing:
+        description: >-
+          "<input>,<output>" USD per million tokens, for a model OpenRouter does not carry (a
+          gateway-only route). Nothing can fetch such a price, and COST_USD_POPULATED is a CORE
+          capability that can never be declared unsupported, so without this the run cannot
+          finish clean. Leave empty for an OpenRouter model: the price is fetched.
+        required: false
+        default: ""
 
 # Optional workspace restyling: a JSON map from icon ROLE to the emoji the
 # workspace uploaded, e.g. {"observe_started":":tf-observe-started:"}. Keyed on
@@ -280,8 +288,39 @@ jobs:
         # tops it up, and the auto-merge price gate is the backstop).
         env:
           TF_NAME: ${{ steps.parse.outputs.name }}
+          DECLARED: ${{ inputs.pricing }}
         run: |
-          uv run automation ensure-pricing --name "$TF_NAME" || true
+          if [ -n "$DECLARED" ]; then
+            IN="${DECLARED%%,*}"; OUT="${DECLARED##*,}"
+            if [ "$IN" = "$DECLARED" ] || [ -z "$IN" ] || [ -z "$OUT" ]; then
+              echo "::error title=pricing input malformed::expected \"<input>,<output>\", got '$DECLARED'"
+              exit 1
+            fi
+            uv run automation ensure-pricing --name "$TF_NAME" --input-usd "$IN" --output-usd "$OUT"
+          else
+            uv run automation ensure-pricing --name "$TF_NAME" || true
+          fi
+
+      - name: Open the capability gate a curated certificate declares
+        # Re-onboarding a model that already has a certificate reuses THAT certificate
+        # (registry._candidate_from_env), so the run inherits its env_key rather than the
+        # synthesised OPENROUTER_API_KEY one. A gateway-only model's gate names the deployment
+        # that serves the route, which no workflow sets, so every probe would skip and the
+        # cleanliness gate would read "capability suite did not run". Only on the gateway
+        # route: that route is chosen deliberately, and it is the claim the gate encodes.
+        env:
+          MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          ROUTE: ${{ inputs.route || 'openrouter' }}
+          OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+        run: |
+          GATE="$(uv run automation cert-env-gate --model-id "$MODEL_ID")"
+          if [ -z "$GATE" ]; then echo "no certificate gate to open"; exit 0; fi
+          if [ "$ROUTE" = "litellm" ]; then
+            echo "$GATE=1" >> "$GITHUB_ENV"
+            echo "opened the capability gate $GATE for the gateway route"
+          else
+            echo "::warning title=Capability suite will skip::the certificate for $MODEL_ID gates on $GATE, which is unset on the $ROUTE route; its live probes will skip and observe will read as not-run"
+          fi
 
       # ---------------------------------------------------------------- OBSERVE
       - name: Capability integration probes (report-only, CAPABILITY_K repeats)
@@ -654,12 +693,23 @@ jobs:
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          ROUTE: ${{ inputs.route || 'openrouter' }}
         run: |
           set -euo pipefail
           P=tools/automation/src/automation/prompts
+          # A gateway-only model has no OpenRouter key to gate on, so its certificate names the
+          # deployment that serves the route instead. Derived rather than agent-invented, so the
+          # "Open the capability gate" step can find it again on a re-onboarding.
+          if [ "$ROUTE" = "litellm" ]; then
+            CERT_ENV_KEY="TF_$(printf '%s' "$MODEL_ID" | tr 'a-z.-' 'A-Z__' | tr -cd 'A-Z0-9_')_GATEWAY_LIVE"
+          else
+            CERT_ENV_KEY=OPENROUTER_API_KEY
+          fi
+          echo "certificate gate for this run: $CERT_ENV_KEY"
           fill () {
             sed -e "s|{{OBS_DIR}}|observation|g" -e "s|{{PROVIDER}}|${TF_PROVIDER}|g" \
-              -e "s|{{NAME}}|${TF_NAME}|g" -e "s|{{MODEL_ID}}|${MODEL_ID}|g" -e "s|{{PR}}|${PR}|g" "$1"
+              -e "s|{{NAME}}|${TF_NAME}|g" -e "s|{{MODEL_ID}}|${MODEL_ID}|g" -e "s|{{PR}}|${PR}|g" \
+              -e "s|{{CERT_ENV_KEY}}|${CERT_ENV_KEY}|g" "$1"
           }
           fill "$P/resolve_finalize.md" > /tmp/finalize.md
           # `|| true`: if the agent hits --max-turns it exits non-zero; do not abort - the commit

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -248,6 +248,32 @@ GOTCHA: `schedule` and `workflow_dispatch` only activate once this file is on th
 (a brand-new workflow on a feature branch is not yet registered). Before then, exercise the poller
 by TEMPORARILY adding a `push:` trigger on the feature branch (remove it before merge).
 
+### Integrating a model only the gateway serves
+
+Two things do not follow from the route alone, and both would surface late.
+
+**Pricing.** `ensure-pricing` resolves a price by exact id against the OpenRouter catalog, so a
+gateway-only id never matches, and nothing else can fetch one. `COST_USD_POPULATED` is a CORE
+capability that can never be a `known_unsupported` ceiling, so the run cannot finish clean
+without a price. Supply it at dispatch as the `pricing` input, `"<input>,<output>"` in USD per
+million tokens; it is written verbatim. Nothing invents a price: without the input the miss is
+reported and left for a human.
+
+**The certificate gate.** A certificate's `env_key` names what must be set before its live
+probes run; absent, they skip. The first onboarding of a model has no certificate, so the
+registry synthesises one gated on the provider key the run already supplies. A **re-onboarding**
+reuses the curated certificate instead, and a gateway-only model's gate names the deployment that
+serves the route, which no workflow sets. Every probe would then skip and the cleanliness gate
+would read "capability suite did not run", which is a transport fact wearing a capability mask.
+
+So the run opens that gate itself: `automation cert-env-gate --model-id <slug>` reports the
+variable a curated certificate declares and the workflow sets it, but only on the gateway route,
+because that route is the claim the gate encodes. On the OpenRouter route an unset gate is a
+warning instead, since nothing there can vouch for it.
+
+New certificates the finalize agent writes get a derived gate name on the gateway route
+(`TF_<MODEL_ID>_GATEWAY_LIVE`) rather than an invented one, so a later re-onboarding finds it.
+
 ## Slack notifications (optional)
 
 One Slack thread per integration PR: a root the pipeline posts once

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -17,11 +17,16 @@ so a hard false-pessimism flag requires EVERY parameter to pass.
 
 ``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers
 below are unit-tested without importing the engine registry.
+
+:func:`env_gate` answers a different question for the same registry: which variable
+gates a curated certificate's live probes. See ``docs/AUTO_INTEGRATION.md``
+§ "Integrating a model only the gateway serves".
 """
 
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import sys
 
@@ -133,6 +138,27 @@ def _load_cert(model_id: str) -> tuple[set[str], set[str], list[str]]:
                 cap_values,
             )
     raise SystemExit(f"cert_reconcile: model_id {model_id!r} not found in ALL_MODELS")
+
+
+def env_gate(model_id: str) -> int:
+    """Print the variable gating ``model_id``'s live probes, if it needs opening.
+
+    Prints nothing when no certificate names one, when the certificate is the
+    synthesised candidate (whose gate is the provider key the run already sets),
+    or when the variable already carries a value. Exit code is 0 either way: a
+    model with no curated certificate is the normal case, not a failure.
+    """
+    try:
+        sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[4]))
+        from tests.integration.llm.registry import ALL_MODELS
+    except Exception as exc:  # fail loud - a silent empty answer reads as "no gate"
+        print(f"::error::cert_env_gate could not import the registry: {exc}")
+        return 1
+    for mc in ALL_MODELS:
+        if mc.model_id == model_id and mc.env_key and not os.environ.get(mc.env_key):
+            print(mc.env_key)
+            break
+    return 0
 
 
 def run(model_id: str, findings_path: str) -> int:

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -53,9 +53,26 @@ def ensure_pricing(
     name: str = typer.Option(..., "--name", help="litellm model name, e.g. xiaomi/mimo-v2.5-pro"),
     pricing_file: str = typer.Option(pricing.DEFAULT_PRICING_FILE, "--pricing-file"),
     check: bool = typer.Option(False, "--check", help="exit 0 if priced, 1 if not; no fetch/write"),
+    input_usd: float | None = typer.Option(
+        None, "--input-usd", help="declared input price per million tokens (gateway-only models)"
+    ),
+    output_usd: float | None = typer.Option(None, "--output-usd", help="declared output price"),
 ) -> None:
     """Ensure the candidate has a pricing.json entry (best-effort, minimal diff)."""
-    raise typer.Exit(pricing.run(name, pricing_file=pricing_file, check=check))
+    if (input_usd is None) != (output_usd is None):
+        raise typer.BadParameter("--input-usd and --output-usd go together, or neither")
+    declared = None if input_usd is None else (input_usd, output_usd)
+    raise typer.Exit(
+        pricing.run(name, pricing_file=pricing_file, check=check, declared=declared)  # type: ignore[arg-type]
+    )
+
+
+@app.command("cert-env-gate")
+def cert_env_gate(
+    model_id: str = typer.Option(..., "--model-id", help="filesystem-safe certificate slug"),
+) -> None:
+    """Print the variable gating this model's live capability probes, if it needs opening."""
+    raise typer.Exit(cert.env_gate(model_id))
 
 
 @app.command("greencheck")

--- a/tools/automation/src/automation/pricing.py
+++ b/tools/automation/src/automation/pricing.py
@@ -90,11 +90,22 @@ def _insert(pricing_file: Path, name: str, entry: dict) -> None:
     pricing_file.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False) -> int:
+def run(
+    name: str,
+    pricing_file: str = DEFAULT_PRICING_FILE,
+    check: bool = False,
+    declared: tuple[float, float] | None = None,
+) -> int:
     """Ensure ``name`` is priced in ``pricing_file``. Returns an exit code.
 
     Default mode is best-effort (always exit 0): fetch OpenRouter and insert the entry
     if found. ``--check`` mode does no fetch/write and exits 1 if the name is unpriced.
+
+    ``declared`` is an operator-supplied ``(input, output)`` price per million tokens,
+    for a model OpenRouter does not carry. It is the only way such a model can satisfy
+    ``cost_usd_populated``, which is a CORE capability and can never be declared
+    unsupported. Nothing here invents a price: absent a declaration the miss is
+    reported and left for a human.
     """
     pf = Path(pricing_file)
     priced = name in _models(pf)
@@ -104,6 +115,11 @@ def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False
         return 0 if priced else 1
     if priced:
         print(f"ensure_pricing: '{name}' already priced - no change")
+        return 0
+    if declared is not None:
+        entry = {"input": declared[0], "output": declared[1]}
+        _insert(pf, name, entry)
+        print(f"ensure_pricing: added '{name}' = {entry} (operator-declared)")
         return 0
     try:
         entry = entry_for(_fetch_openrouter(), name)
@@ -115,7 +131,8 @@ def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False
     if not entry:
         print(
             f"::warning::ensure_pricing: '{name}' not on OpenRouter with non-zero pricing; "
-            "finalize agent must fill it"
+            "pass --input-usd/--output-usd (the run's `pricing` input) for a model only a "
+            "gateway serves, or the finalize agent must fill it"
         )
         return 0
     _insert(pf, name, entry)

--- a/tools/automation/src/automation/prompts/resolve_finalize.md
+++ b/tools/automation/src/automation/prompts/resolve_finalize.md
@@ -18,13 +18,15 @@ normal synchronous Claude Code run; nothing to await.
    NOT broaden a shared glob). If the compose step wrote a new adapter class, it is already in
    the engine + `_POLICY_REGISTRIES` + `__init__.py`; leave it.
 2. Add the candidate cert to `tests/integration/llm/registry.py`: an `MC(...)` entry in `_ALL`
-   with `model_id="{{MODEL_ID}}"`, provider/name, `env_key="OPENROUTER_API_KEY"`,
+   with `model_id="{{MODEL_ID}}"`, provider/name, `env_key="{{CERT_ENV_KEY}}"`,
    `required=frozenset({...})` from decision.json `required`, and
    `known_unsupported=frozenset({...})` from decision.json `ceilings`. Match the surrounding
    style and keep model_ids unique (the canonical registry test enforces this).
 3. ENSURE PRICING. Verify the candidate's litellm name (`{{NAME}}`) has an entry under `models`
    in `tolokaforge/core/data/pricing.json`. The pre-observe step normally adds it, but ALWAYS
-   check and fill it if missing: fetch OpenRouter pricing
+   check and fill it if missing. If OpenRouter does not carry this model (a gateway-only route),
+   there is nothing to fetch: say so in the report and stop rather than inventing a price, since
+   only an operator can supply one (the run's `pricing` input). Otherwise fetch OpenRouter pricing
    (`curl -s https://openrouter.ai/api/v1/models`, find the object whose `id == "{{NAME}}"`),
    convert per-token `prompt` / `completion` to USD-per-1M (multiply by 1e6), and add
    `"{{NAME}}": {"input": <in>, "output": <out>}` (plus `"cache_read"` if the API reports a

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -127,3 +127,54 @@ def test_core_capabilities_mirror_canon():
 
     canon = {c.value for c in _CORE_CAPABILITIES}
     assert canon == cert.CORE_CAPABILITIES, cert.CORE_CAPABILITIES ^ canon
+
+
+class TestTheCertificateGate:
+    """Which variable a curated certificate needs before its live probes will run.
+
+    Re-onboarding a model that already has a certificate reuses THAT certificate, so a
+    run inherits a gate no workflow sets, every probe skips, and the cleanliness gate
+    reads "capability suite did not run" - a transport fact wearing a capability mask.
+    """
+
+    def _registry(self, monkeypatch, certs):
+        import sys
+        import types
+
+        module = types.ModuleType("tests.integration.llm.registry")
+        module.ALL_MODELS = certs
+        monkeypatch.setitem(sys.modules, "tests.integration.llm.registry", module)
+
+    def test_it_names_the_gate_when_the_variable_is_unset(self, monkeypatch, capsys):
+        self._registry(monkeypatch, [_Cert("m", "TF_SOME_GATEWAY_LIVE")])
+        monkeypatch.delenv("TF_SOME_GATEWAY_LIVE", raising=False)
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out.strip() == "TF_SOME_GATEWAY_LIVE"
+
+    def test_a_satisfied_gate_needs_no_opening(self, monkeypatch, capsys):
+        """The provider-key case: the run already supplies it, so opening it with a
+        placeholder would replace a real credential with a lie."""
+        self._registry(monkeypatch, [_Cert("m", "OPENROUTER_API_KEY")])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-real")
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out == ""
+
+    def test_an_unlisted_model_is_silent(self, monkeypatch, capsys):
+        """A first onboarding has no curated certificate; that is the normal case."""
+        self._registry(monkeypatch, [_Cert("other", "TF_X")])
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out == ""
+
+    def test_an_unimportable_registry_fails_loud(self, monkeypatch, capsys):
+        """Silence means "no gate", so a broken import must not look like one."""
+        import sys
+
+        monkeypatch.setitem(sys.modules, "tests.integration.llm.registry", None)
+        assert cert.env_gate("m") == 1
+        assert "::error::" in capsys.readouterr().out
+
+
+class _Cert:
+    def __init__(self, model_id: str, env_key: str) -> None:
+        self.model_id = model_id
+        self.env_key = env_key

--- a/tools/automation/tests/test_pricing.py
+++ b/tools/automation/tests/test_pricing.py
@@ -66,3 +66,38 @@ def test_check_mode_exit_codes(tmp_path):
     )
     assert pricing.run(name="vendor/known", pricing_file=str(pf), check=True) == 0
     assert pricing.run(name="vendor/unknown", pricing_file=str(pf), check=True) == 1
+
+
+class TestADeclaredPrice:
+    """The only way a gateway-only model can satisfy ``cost_usd_populated``.
+
+    OpenRouter is the sole price source here, so a model it does not carry can never
+    be priced by fetching, and that capability is CORE: it can never be declared
+    unsupported, so the run cannot finish clean without this path.
+    """
+
+    def _file(self, tmp_path):
+        pf = tmp_path / "pricing.json"
+        pf.write_text(json.dumps({"_meta": {}, "models": {}}))
+        return pf
+
+    def test_it_is_written_without_any_fetch(self, tmp_path, monkeypatch):
+        def explode():
+            raise AssertionError("a declared price must not reach the network")
+
+        monkeypatch.setattr(pricing, "_fetch_openrouter", explode)
+        pf = self._file(tmp_path)
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf), declared=(0.8, 3.2)) == 0
+        assert json.loads(pf.read_text())["models"]["azure_ai/m"] == {"input": 0.8, "output": 3.2}
+
+    def test_an_existing_entry_is_not_overwritten(self, tmp_path):
+        pf = tmp_path / "pricing.json"
+        pf.write_text(json.dumps({"_meta": {}, "models": {"azure_ai/m": {"input": 1.0}}}))
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf), declared=(9.9, 9.9)) == 0
+        assert json.loads(pf.read_text())["models"]["azure_ai/m"] == {"input": 1.0}
+
+    def test_without_a_declaration_the_miss_is_reported_not_invented(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pricing, "_fetch_openrouter", lambda: [])
+        pf = self._file(tmp_path)
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf)) == 0
+        assert json.loads(pf.read_text())["models"] == {}


### PR DESCRIPTION
## The problem

The auto-integration cannot finish a model that OpenRouter does not carry. Both
reasons were found by tracing why the last gateway-route run (`31172961198`) ended
needs-human, and neither is visible until the run is well under way.

### 1. The certificate gate closes on a re-onboarding

A `ModelCertificate.env_key` names what must be set before its live probes run;
absent, they skip. A **first** onboarding has no certificate, so
`registry._candidate_from_env()` synthesises one gated on `<PROVIDER>_API_KEY`,
which the run supplies. A **re-onboarding** reuses the curated certificate instead,
and for a gateway-only model that gate names the deployment serving the route.
No workflow set it.

Measured in that run: **585 of 585 probe units skipped**, 435 of them on exactly
that reason, `capability_ran: false`, and the cleanliness gate stopped the run at
"capability suite did not run". A transport fact wearing a capability mask.

It re-arms the moment any curated gateway-only certificate lands on `main`.

### 2. A gateway-only model can never be priced

`ensure-pricing` resolves a price by exact id against the OpenRouter catalog, so a
gateway-only id never matches, and nothing else in the pipeline can fetch one.
`COST_USD_POPULATED` is a CORE capability that `reconcile-cert` refuses to accept as
`known_unsupported`, so the run cannot finish clean: either the fix loop burns its
iterations on it, or the agent ships a certificate asserting a capability the
baseline measured at zero.

## The change

**`automation cert-env-gate --model-id <slug>`** reports the variable a curated
certificate declares, and prints nothing when the certificate is the synthesised one
or the variable already carries a value. The run opens it **only on the gateway
route**, because that route is the claim the gate encodes; on the OpenRouter route an
unset gate becomes a warning instead, since nothing there can vouch for it.

**`ensure-pricing --input-usd/--output-usd`**, wired to a new `pricing` dispatch input
(`"<input>,<output>"` per million tokens), writes an operator-declared price verbatim.
Nothing is invented: without a declaration the miss is still reported and left for a
human, which is the only honest answer when no source exists.

**The finalize prompt** stops hardcoding `env_key="OPENROUTER_API_KEY"` and stops
telling the agent to fetch a price from an API that does not carry the model. New
certificates on the gateway route get a **derived** gate name
(`TF_<MODEL_ID>_GATEWAY_LIVE`) rather than an invented one, so a later re-onboarding
finds it again.

## Tests

- `cert-env-gate`: names an unset gate, stays silent on a satisfied one (opening a
  provider key with a placeholder would replace a real credential with a lie), silent
  for an unlisted model, and **fails loud** on an unimportable registry, since silence
  here means "no gate".
- declared pricing: written without any network call (the fetch is monkeypatched to
  raise), an existing entry is not overwritten, and no declaration still leaves the
  file untouched rather than guessing.

`tools/automation/tests`: 254 passed. `ruff check` / `ruff format`: clean.

## Scope

Independent of #1037, which fixes the poller's gateway admission and touches
different files. Together they are what the Cohere `azure_ai/cohere-command-a-plus-05-2026`
integration needs on the engine side.

Not here: the engine release that carries #942 to the eval side, and the
`tolokaforge-tasks` `.env` wiring that would let a leaderboard run use the gateway at
all. Both are tracked separately.
