### PR TITLE
integrate: azure_ai/cohere-command-a-plus-05-2026

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -52,6 +52,14 @@ on:
         options:
           - openrouter
           - litellm
+      pricing:
+        description: >-
+          "<input>,<output>" USD per million tokens, for a model OpenRouter does not carry (a
+          gateway-only route). Nothing can fetch such a price, and COST_USD_POPULATED is a CORE
+          capability that can never be declared unsupported, so without this the run cannot
+          finish clean. Leave empty for an OpenRouter model: the price is fetched.
+        required: false
+        default: ""
 
 # Optional workspace restyling: a JSON map from icon ROLE to the emoji the
 # workspace uploaded, e.g. {"observe_started":":tf-observe-started:"}. Keyed on
@@ -280,8 +288,39 @@ jobs:
         # tops it up, and the auto-merge price gate is the backstop).
         env:
           TF_NAME: ${{ steps.parse.outputs.name }}
+          DECLARED: ${{ inputs.pricing }}
         run: |
-          uv run automation ensure-pricing --name "$TF_NAME" || true
+          if [ -n "$DECLARED" ]; then
+            IN="${DECLARED%%,*}"; OUT="${DECLARED##*,}"
+            if [ "$IN" = "$DECLARED" ] || [ -z "$IN" ] || [ -z "$OUT" ]; then
+              echo "::error title=pricing input malformed::expected \"<input>,<output>\", got '$DECLARED'"
+              exit 1
+            fi
+            uv run automation ensure-pricing --name "$TF_NAME" --input-usd "$IN" --output-usd "$OUT"
+          else
+            uv run automation ensure-pricing --name "$TF_NAME" || true
+          fi
+
+      - name: Open the capability gate a curated certificate declares
+        # Re-onboarding a model that already has a certificate reuses THAT certificate
+        # (registry._candidate_from_env), so the run inherits its env_key rather than the
+        # synthesised OPENROUTER_API_KEY one. A gateway-only model's gate names the deployment
+        # that serves the route, which no workflow sets, so every probe would skip and the
+        # cleanliness gate would read "capability suite did not run". Only on the gateway
+        # route: that route is chosen deliberately, and it is the claim the gate encodes.
+        env:
+          MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          ROUTE: ${{ inputs.route || 'openrouter' }}
+          OPENROUTER_API_KEY: ${{ secrets.ARENA_AUTOMATION_OPENROUTER_API_KEY }}
+        run: |
+          GATE="$(uv run automation cert-env-gate --model-id "$MODEL_ID")"
+          if [ -z "$GATE" ]; then echo "no certificate gate to open"; exit 0; fi
+          if [ "$ROUTE" = "litellm" ]; then
+            echo "$GATE=1" >> "$GITHUB_ENV"
+            echo "opened the capability gate $GATE for the gateway route"
+          else
+            echo "::warning title=Capability suite will skip::the certificate for $MODEL_ID gates on $GATE, which is unset on the $ROUTE route; its live probes will skip and observe will read as not-run"
+          fi
 
       # ---------------------------------------------------------------- OBSERVE
       - name: Capability integration probes (report-only, CAPABILITY_K repeats)
@@ -654,12 +693,23 @@ jobs:
           TF_PROVIDER: ${{ steps.parse.outputs.provider }}
           TF_NAME: ${{ steps.parse.outputs.name }}
           MODEL_ID: ${{ steps.slug.outputs.model_id }}
+          ROUTE: ${{ inputs.route || 'openrouter' }}
         run: |
           set -euo pipefail
           P=tools/automation/src/automation/prompts
+          # A gateway-only model has no OpenRouter key to gate on, so its certificate names the
+          # deployment that serves the route instead. Derived rather than agent-invented, so the
+          # "Open the capability gate" step can find it again on a re-onboarding.
+          if [ "$ROUTE" = "litellm" ]; then
+            CERT_ENV_KEY="TF_$(printf '%s' "$MODEL_ID" | tr 'a-z.-' 'A-Z__' | tr -cd 'A-Z0-9_')_GATEWAY_LIVE"
+          else
+            CERT_ENV_KEY=OPENROUTER_API_KEY
+          fi
+          echo "certificate gate for this run: $CERT_ENV_KEY"
           fill () {
             sed -e "s|{{OBS_DIR}}|observation|g" -e "s|{{PROVIDER}}|${TF_PROVIDER}|g" \
-              -e "s|{{NAME}}|${TF_NAME}|g" -e "s|{{MODEL_ID}}|${MODEL_ID}|g" -e "s|{{PR}}|${PR}|g" "$1"
+              -e "s|{{NAME}}|${TF_NAME}|g" -e "s|{{MODEL_ID}}|${MODEL_ID}|g" -e "s|{{PR}}|${PR}|g" \
+              -e "s|{{CERT_ENV_KEY}}|${CERT_ENV_KEY}|g" "$1"
           }
           fill "$P/resolve_finalize.md" > /tmp/finalize.md
           # `|| true`: if the agent hits --max-turns it exits non-zero; do not abort - the commit

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -248,6 +248,32 @@ GOTCHA: `schedule` and `workflow_dispatch` only activate once this file is on th
 (a brand-new workflow on a feature branch is not yet registered). Before then, exercise the poller
 by TEMPORARILY adding a `push:` trigger on the feature branch (remove it before merge).
 
+### Integrating a model only the gateway serves
+
+Two things do not follow from the route alone, and both would surface late.
+
+**Pricing.** `ensure-pricing` resolves a price by exact id against the OpenRouter catalog, so a
+gateway-only id never matches, and nothing else can fetch one. `COST_USD_POPULATED` is a CORE
+capability that can never be a `known_unsupported` ceiling, so the run cannot finish clean
+without a price. Supply it at dispatch as the `pricing` input, `"<input>,<output>"` in USD per
+million tokens; it is written verbatim. Nothing invents a price: without the input the miss is
+reported and left for a human.
+
+**The certificate gate.** A certificate's `env_key` names what must be set before its live
+probes run; absent, they skip. The first onboarding of a model has no certificate, so the
+registry synthesises one gated on the provider key the run already supplies. A **re-onboarding**
+reuses the curated certificate instead, and a gateway-only model's gate names the deployment that
+serves the route, which no workflow sets. Every probe would then skip and the cleanliness gate
+would read "capability suite did not run", which is a transport fact wearing a capability mask.
+
+So the run opens that gate itself: `automation cert-env-gate --model-id <slug>` reports the
+variable a curated certificate declares and the workflow sets it, but only on the gateway route,
+because that route is the claim the gate encodes. On the OpenRouter route an unset gate is a
+warning instead, since nothing there can vouch for it.
+
+New certificates the finalize agent writes get a derived gate name on the gateway route
+(`TF_<MODEL_ID>_GATEWAY_LIVE`) rather than an invented one, so a later re-onboarding finds it.
+
 ## Slack notifications (optional)
 
 One Slack thread per integration PR: a root the pipeline posts once

--- a/tolokaforge/core/data/model_presets.yaml
+++ b/tolokaforge/core/data/model_presets.yaml
@@ -28,6 +28,71 @@ default:
     reasoning_via_extra_body: false
 
 presets:
+  # Cohere Command A+ (reached here through a LiteLLM gateway's ``azure_ai`` route).
+  #
+  # ``supports_tool_choice_auto: false`` is PERMANENT AND CORRECT, not a workaround.
+  # Cohere's Chat API accepts only ``REQUIRED`` and ``NONE`` for ``tool_choice``,
+  # there is no ``AUTO`` (https://docs.cohere.com/reference/chat), and its documented
+  # behaviour when the parameter is OMITTED is "the model is free to choose whether to
+  # use the specified tools or not". That is exactly what ``auto`` means, and ``auto``
+  # is the only value this codebase ever sends. So omitting it reproduces the intended
+  # semantics natively; measurements stay comparable with every other board model.
+  #
+  # What surfaces the problem is litellm refusing the parameter first
+  # (``UnsupportedParamsError: azure_ai does not support parameters:
+  # ['tool_choice']``), which reads as "the model cannot do tool calling" when the
+  # truth is "this value does not exist in Cohere's enum". Verified live 2026-08-01:
+  # identical client, prompt and tools, WITHOUT the parameter the model returns a
+  # correct ``get_weather({'city': 'Budapest', 'unit': 'c'})``, WITH
+  # ``tool_choice="auto"`` the call never leaves litellm.
+  #
+  # The flag is deliberately about the VALUE, not the parameter: Cohere does support
+  # ``tool_choice`` with ``REQUIRED``/``NONE``, and those still go through untouched.
+  #
+  # Do NOT "fix" this proxy-side with ``allowed_openai_params: ['tool_choice']`` or a
+  # ``model_info: supports_tool_choice: true`` override: both would push the
+  # non-existent ``auto`` through to Cohere, trading a clear client-side error for a
+  # provider-side one. And do NOT enable ``drop_params`` gateway-wide, since that silently
+  # discards unsupported parameters for every model and every consumer of that gateway.
+  #
+  # Matched on the model NAME rather than the provider, because the ``tool_choice``
+  # constraint belongs to Cohere's API and not to this route. Note what the globs
+  # below actually cover, though: the gateway's ``azure_ai/`` route name and a bare
+  # alias. The OpenRouter naming (``cohere/command-a-plus-*``) and the direct-Cohere
+  # naming (``command-a-plus-*``) both LACK the literal ``cohere-command-a-plus``
+  # substring, so they would fall through to ``default``. Add them here if the model
+  # is ever reached that way.
+  #
+  # ``schema_sanitizer: strict`` + ``response_policy: array_dict_map`` are a PAIR, and
+  # unlike the flag above they ARE route-specific. The Azure serving stack's own
+  # JSON-schema converter cannot resolve ``$ref``/``$defs``: it 500s with
+  # ``json_schema_converter.cc:3370: Cannot find field $defs in #/$defs/_LineItem``
+  # (verified 2026-08-01), taking down every probe whose tool schema uses a
+  # ``$defs`` block. ``strict`` inlines refs and drops ``$defs`` in its pre-pass,
+  # which is the documented remedy for a schema-dialect gap (docs/ADD_NEW_MODEL.md
+  # section "Field-rename failures are a schema-dialect symptom"). It also rewrites
+  # typed dict-maps to arrays, and ``array_dict_map`` is the counterpart that converts
+  # them back, so removing either one alone silently corrupts every dict-map tool
+  # argument. Same pairing as ``openai_gpt5`` and ``xai_grok``. ``dict_map_hints`` was
+  # tried and rejected: it contradicts the array schema ``strict`` sends (see the
+  # ``qwen`` preset comment for the same finding).
+  #
+  # ``reasoning_codec: openai`` is set on purpose despite the thinking probes failing.
+  # It is a strict superset of ``none`` (both return ``None`` when the message carries
+  # no ``reasoning_content``, and both replay as a no-op), the Azure catalog advertises
+  # "reasoning" for this model, and with ``none`` the engine would silently discard any
+  # reasoning the gateway does surface for a whole eval. See the certificate in
+  # tests/integration/llm/registry.py for what that means for the measurement.
+  cohere_command_a_plus:
+    match:
+      - "azure_ai/cohere-command-a-plus*"
+      - "*cohere-command-a-plus*"
+    schema_sanitizer: strict
+    response_policy: array_dict_map
+    reasoning_codec: openai
+    params:
+      supports_tool_choice_auto: false
+
   # Claude 4.8 (Opus + Sonnet) — same adaptive-thinker contract as 4.7:
   # ignores ``reasoning_effort``, requires the canonical litellm ``thinking=``
   # kwarg + explicit ``budget_tokens``. Listed FIRST so first-match-wins

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1724,7 +1724,9 @@ class LLMClient:
 
         Composes four independent parameter sources: ``params_policy.adapt``
         (temperature / seed / reasoning routing), explicit per-call overrides
-        (``top_p`` / ``max_tokens`` / ``tool_choice`` / ``tools``), provider
+        (``top_p`` / ``max_tokens`` / ``tools``, plus ``tool_choice``, which is an
+        override the params policy can still veto per value, see
+        ``supports_tool_choice_auto``), provider
         routing (OpenRouter headers + ``custom_llm_provider``), and
         :meth:`_convert_messages` (content policy + reasoning-codec replay).
         Nova's special-casing is deferred to :meth:`_call_with_key_rotation`
@@ -1759,7 +1761,13 @@ class LLMClient:
 
         if tools:
             kwargs["tools"] = tools
-            if tool_choice:
+            # Suppress only the value the provider has no word for; an explicit
+            # REQUIRED/NONE still goes through (see GenerationParams).
+            suppressed = (
+                tool_choice == "auto"
+                and not self.capabilities.params_policy.supports_tool_choice_auto
+            )
+            if tool_choice and not suppressed:
                 kwargs["tool_choice"] = tool_choice
 
         kwargs["messages"] = self._convert_messages(system, messages)

--- a/tolokaforge/core/llm/params_policy.py
+++ b/tolokaforge/core/llm/params_policy.py
@@ -88,6 +88,7 @@ class GenerationParams:
         drop_sampling_when_thinking: bool = False,
         reasoning_budget_default: int | None = None,
         unsupported_effort_levels: frozenset[str] | list[str] | tuple[str, ...] | None = None,
+        supports_tool_choice_auto: bool = True,
     ):
         self._fixed_temperature = fixed_temperature
         self._supports_seed = supports_seed
@@ -109,6 +110,34 @@ class GenerationParams:
         self._unsupported_effort_levels: frozenset[str] = frozenset(
             e.lower() for e in (unsupported_effort_levels or ())
         )
+        # Whether the provider's ``tool_choice`` enum contains ``"auto"``, NOT whether
+        # it supports ``tool_choice`` at all. Cohere's Chat API, for one, supports the
+        # parameter with ``REQUIRED`` and ``NONE`` but has no ``AUTO``
+        # (https://docs.cohere.com/reference/chat); omitting it is its documented way to
+        # say "the model is free to choose whether to use the specified tools or not".
+        #
+        # So only ``"auto"`` is suppressed, and only when this is False. ``REQUIRED`` /
+        # ``NONE`` still go through, because a provider in this position DOES honour
+        # them and silently dropping a caller's explicit forcing would change what the
+        # model was asked to do.
+        #
+        # Suppressing ``auto`` is semantically free: omission yields exactly the
+        # behaviour ``auto`` names, so a model measured under this flag stays comparable
+        # with one measured without it. The symptom that leads here is a transport
+        # refusing the parameter up front (litellm 400s with ``UnsupportedParamsError:
+        # azure_ai does not support parameters: ['tool_choice']``), which reads as a
+        # missing capability when it is really a missing enum value.
+        self._supports_tool_choice_auto = supports_tool_choice_auto
+
+    @property
+    def supports_tool_choice_auto(self) -> bool:
+        """Whether the provider's ``tool_choice`` enum contains ``"auto"``.
+
+        Read by :meth:`LLMClient._build_kwargs`, which is where ``tool_choice`` is
+        attached, since it is set alongside ``tools`` and therefore after :meth:`adapt`
+        has run, so this cannot be a rewrite inside ``adapt``.
+        """
+        return self._supports_tool_choice_auto
 
     def adapt(
         self,

--- a/tools/automation/src/automation/cert.py
+++ b/tools/automation/src/automation/cert.py
@@ -17,11 +17,16 @@ so a hard false-pessimism flag requires EVERY parameter to pass.
 
 ``run`` returns an exit code (1 on any violation, 0 otherwise); the pure helpers
 below are unit-tested without importing the engine registry.
+
+:func:`env_gate` answers a different question for the same registry: which variable
+gates a curated certificate's live probes. See ``docs/AUTO_INTEGRATION.md``
+§ "Integrating a model only the gateway serves".
 """
 
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import sys
 
@@ -133,6 +138,27 @@ def _load_cert(model_id: str) -> tuple[set[str], set[str], list[str]]:
                 cap_values,
             )
     raise SystemExit(f"cert_reconcile: model_id {model_id!r} not found in ALL_MODELS")
+
+
+def env_gate(model_id: str) -> int:
+    """Print the variable gating ``model_id``'s live probes, if it needs opening.
+
+    Prints nothing when no certificate names one, when the certificate is the
+    synthesised candidate (whose gate is the provider key the run already sets),
+    or when the variable already carries a value. Exit code is 0 either way: a
+    model with no curated certificate is the normal case, not a failure.
+    """
+    try:
+        sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[4]))
+        from tests.integration.llm.registry import ALL_MODELS
+    except Exception as exc:  # fail loud - a silent empty answer reads as "no gate"
+        print(f"::error::cert_env_gate could not import the registry: {exc}")
+        return 1
+    for mc in ALL_MODELS:
+        if mc.model_id == model_id and mc.env_key and not os.environ.get(mc.env_key):
+            print(mc.env_key)
+            break
+    return 0
 
 
 def run(model_id: str, findings_path: str) -> int:

--- a/tools/automation/src/automation/cli.py
+++ b/tools/automation/src/automation/cli.py
@@ -53,9 +53,26 @@ def ensure_pricing(
     name: str = typer.Option(..., "--name", help="litellm model name, e.g. xiaomi/mimo-v2.5-pro"),
     pricing_file: str = typer.Option(pricing.DEFAULT_PRICING_FILE, "--pricing-file"),
     check: bool = typer.Option(False, "--check", help="exit 0 if priced, 1 if not; no fetch/write"),
+    input_usd: float | None = typer.Option(
+        None, "--input-usd", help="declared input price per million tokens (gateway-only models)"
+    ),
+    output_usd: float | None = typer.Option(None, "--output-usd", help="declared output price"),
 ) -> None:
     """Ensure the candidate has a pricing.json entry (best-effort, minimal diff)."""
-    raise typer.Exit(pricing.run(name, pricing_file=pricing_file, check=check))
+    if (input_usd is None) != (output_usd is None):
+        raise typer.BadParameter("--input-usd and --output-usd go together, or neither")
+    declared = None if input_usd is None else (input_usd, output_usd)
+    raise typer.Exit(
+        pricing.run(name, pricing_file=pricing_file, check=check, declared=declared)  # type: ignore[arg-type]
+    )
+
+
+@app.command("cert-env-gate")
+def cert_env_gate(
+    model_id: str = typer.Option(..., "--model-id", help="filesystem-safe certificate slug"),
+) -> None:
+    """Print the variable gating this model's live capability probes, if it needs opening."""
+    raise typer.Exit(cert.env_gate(model_id))
 
 
 @app.command("greencheck")

--- a/tools/automation/src/automation/pricing.py
+++ b/tools/automation/src/automation/pricing.py
@@ -90,11 +90,22 @@ def _insert(pricing_file: Path, name: str, entry: dict) -> None:
     pricing_file.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False) -> int:
+def run(
+    name: str,
+    pricing_file: str = DEFAULT_PRICING_FILE,
+    check: bool = False,
+    declared: tuple[float, float] | None = None,
+) -> int:
     """Ensure ``name`` is priced in ``pricing_file``. Returns an exit code.
 
     Default mode is best-effort (always exit 0): fetch OpenRouter and insert the entry
     if found. ``--check`` mode does no fetch/write and exits 1 if the name is unpriced.
+
+    ``declared`` is an operator-supplied ``(input, output)`` price per million tokens,
+    for a model OpenRouter does not carry. It is the only way such a model can satisfy
+    ``cost_usd_populated``, which is a CORE capability and can never be declared
+    unsupported. Nothing here invents a price: absent a declaration the miss is
+    reported and left for a human.
     """
     pf = Path(pricing_file)
     priced = name in _models(pf)
@@ -104,6 +115,11 @@ def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False
         return 0 if priced else 1
     if priced:
         print(f"ensure_pricing: '{name}' already priced - no change")
+        return 0
+    if declared is not None:
+        entry = {"input": declared[0], "output": declared[1]}
+        _insert(pf, name, entry)
+        print(f"ensure_pricing: added '{name}' = {entry} (operator-declared)")
         return 0
     try:
         entry = entry_for(_fetch_openrouter(), name)
@@ -115,7 +131,8 @@ def run(name: str, pricing_file: str = DEFAULT_PRICING_FILE, check: bool = False
     if not entry:
         print(
             f"::warning::ensure_pricing: '{name}' not on OpenRouter with non-zero pricing; "
-            "finalize agent must fill it"
+            "pass --input-usd/--output-usd (the run's `pricing` input) for a model only a "
+            "gateway serves, or the finalize agent must fill it"
         )
         return 0
     _insert(pf, name, entry)

--- a/tools/automation/src/automation/prompts/resolve_finalize.md
+++ b/tools/automation/src/automation/prompts/resolve_finalize.md
@@ -18,13 +18,15 @@ normal synchronous Claude Code run; nothing to await.
    NOT broaden a shared glob). If the compose step wrote a new adapter class, it is already in
    the engine + `_POLICY_REGISTRIES` + `__init__.py`; leave it.
 2. Add the candidate cert to `tests/integration/llm/registry.py`: an `MC(...)` entry in `_ALL`
-   with `model_id="{{MODEL_ID}}"`, provider/name, `env_key="OPENROUTER_API_KEY"`,
+   with `model_id="{{MODEL_ID}}"`, provider/name, `env_key="{{CERT_ENV_KEY}}"`,
    `required=frozenset({...})` from decision.json `required`, and
    `known_unsupported=frozenset({...})` from decision.json `ceilings`. Match the surrounding
    style and keep model_ids unique (the canonical registry test enforces this).
 3. ENSURE PRICING. Verify the candidate's litellm name (`{{NAME}}`) has an entry under `models`
    in `tolokaforge/core/data/pricing.json`. The pre-observe step normally adds it, but ALWAYS
-   check and fill it if missing: fetch OpenRouter pricing
+   check and fill it if missing. If OpenRouter does not carry this model (a gateway-only route),
+   there is nothing to fetch: say so in the report and stop rather than inventing a price, since
+   only an operator can supply one (the run's `pricing` input). Otherwise fetch OpenRouter pricing
    (`curl -s https://openrouter.ai/api/v1/models`, find the object whose `id == "{{NAME}}"`),
    convert per-token `prompt` / `completion` to USD-per-1M (multiply by 1e6), and add
    `"{{NAME}}": {"input": <in>, "output": <out>}` (plus `"cache_read"` if the API reports a

--- a/tools/automation/tests/test_cert.py
+++ b/tools/automation/tests/test_cert.py
@@ -127,3 +127,54 @@ def test_core_capabilities_mirror_canon():
 
     canon = {c.value for c in _CORE_CAPABILITIES}
     assert canon == cert.CORE_CAPABILITIES, cert.CORE_CAPABILITIES ^ canon
+
+
+class TestTheCertificateGate:
+    """Which variable a curated certificate needs before its live probes will run.
+
+    Re-onboarding a model that already has a certificate reuses THAT certificate, so a
+    run inherits a gate no workflow sets, every probe skips, and the cleanliness gate
+    reads "capability suite did not run" - a transport fact wearing a capability mask.
+    """
+
+    def _registry(self, monkeypatch, certs):
+        import sys
+        import types
+
+        module = types.ModuleType("tests.integration.llm.registry")
+        module.ALL_MODELS = certs
+        monkeypatch.setitem(sys.modules, "tests.integration.llm.registry", module)
+
+    def test_it_names_the_gate_when_the_variable_is_unset(self, monkeypatch, capsys):
+        self._registry(monkeypatch, [_Cert("m", "TF_SOME_GATEWAY_LIVE")])
+        monkeypatch.delenv("TF_SOME_GATEWAY_LIVE", raising=False)
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out.strip() == "TF_SOME_GATEWAY_LIVE"
+
+    def test_a_satisfied_gate_needs_no_opening(self, monkeypatch, capsys):
+        """The provider-key case: the run already supplies it, so opening it with a
+        placeholder would replace a real credential with a lie."""
+        self._registry(monkeypatch, [_Cert("m", "OPENROUTER_API_KEY")])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-real")
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out == ""
+
+    def test_an_unlisted_model_is_silent(self, monkeypatch, capsys):
+        """A first onboarding has no curated certificate; that is the normal case."""
+        self._registry(monkeypatch, [_Cert("other", "TF_X")])
+        assert cert.env_gate("m") == 0
+        assert capsys.readouterr().out == ""
+
+    def test_an_unimportable_registry_fails_loud(self, monkeypatch, capsys):
+        """Silence means "no gate", so a broken import must not look like one."""
+        import sys
+
+        monkeypatch.setitem(sys.modules, "tests.integration.llm.registry", None)
+        assert cert.env_gate("m") == 1
+        assert "::error::" in capsys.readouterr().out
+
+
+class _Cert:
+    def __init__(self, model_id: str, env_key: str) -> None:
+        self.model_id = model_id
+        self.env_key = env_key

--- a/tools/automation/tests/test_pricing.py
+++ b/tools/automation/tests/test_pricing.py
@@ -66,3 +66,38 @@ def test_check_mode_exit_codes(tmp_path):
     )
     assert pricing.run(name="vendor/known", pricing_file=str(pf), check=True) == 0
     assert pricing.run(name="vendor/unknown", pricing_file=str(pf), check=True) == 1
+
+
+class TestADeclaredPrice:
+    """The only way a gateway-only model can satisfy ``cost_usd_populated``.
+
+    OpenRouter is the sole price source here, so a model it does not carry can never
+    be priced by fetching, and that capability is CORE: it can never be declared
+    unsupported, so the run cannot finish clean without this path.
+    """
+
+    def _file(self, tmp_path):
+        pf = tmp_path / "pricing.json"
+        pf.write_text(json.dumps({"_meta": {}, "models": {}}))
+        return pf
+
+    def test_it_is_written_without_any_fetch(self, tmp_path, monkeypatch):
+        def explode():
+            raise AssertionError("a declared price must not reach the network")
+
+        monkeypatch.setattr(pricing, "_fetch_openrouter", explode)
+        pf = self._file(tmp_path)
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf), declared=(0.8, 3.2)) == 0
+        assert json.loads(pf.read_text())["models"]["azure_ai/m"] == {"input": 0.8, "output": 3.2}
+
+    def test_an_existing_entry_is_not_overwritten(self, tmp_path):
+        pf = tmp_path / "pricing.json"
+        pf.write_text(json.dumps({"_meta": {}, "models": {"azure_ai/m": {"input": 1.0}}}))
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf), declared=(9.9, 9.9)) == 0
+        assert json.loads(pf.read_text())["models"]["azure_ai/m"] == {"input": 1.0}
+
+    def test_without_a_declaration_the_miss_is_reported_not_invented(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pricing, "_fetch_openrouter", lambda: [])
+        pf = self._file(tmp_path)
+        assert pricing.run(name="azure_ai/m", pricing_file=str(pf)) == 0
+        assert json.loads(pf.read_text())["models"] == {}


### PR DESCRIPTION
**Disposable test branch. Do not merge.**

Purpose: exercise the model auto-integration end to end on the **LiteLLM gateway route**,
which has never completed a run since the transport was fixed.

## What is staged here

| From | What | Why |
|---|---|---|
| `main` | engine + automation | the route resolution from #942 is in |
| #1064 | `cert-env-gate`, declared pricing, the `pricing` input | needed for a gateway-only model |
| #738 | `params_policy.py` + the `client.py` tool_choice hunk + the preset entry | without it every tool probe 400s and observe can never be clean |

**Not** staged: #738's certificate. Leaving it out keeps the synthesised candidate
certificate in play, so the capability suite runs on the provider key the workflow already
sets. Pricing comes from the run's `pricing` input rather than a committed line.

## Verified before dispatch

The same tool call that fails on plain `main` with
`azure_ai does not support parameters: ['tool_choice']` returns a correct
`get_weather({"city": "Budapest"})` on this branch, through the gateway.

## What the run is expected to answer

1. Does the candidate probe cleanly over the gateway on the default preset?
2. Does the wire-probe user simulator resolve to its gateway route now (it went to Bedrock before #942)?
3. Does the declared-pricing path satisfy `COST_USD_POPULATED`?
4. Does a clean observe chain into resolve and finalize?
