### PR TITLE
integrate: azure_ai/cohere-command-a-plus-05-2026

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -65,6 +65,10 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  # `gh workflow run release-models.yml` after a successful auto-merge. Needed
+  # because a GITHUB_TOKEN squash-push cannot trigger the push-event release
+  # workflow (Actions recursion guard); dispatching is the documented exception.
+  actions: write
 
 concurrency:
   # One run per PR at a time. A re-label while a run is in flight queues a second run that
@@ -841,6 +845,20 @@ jobs:
                   fi ;;
               esac
             fi
+            # Cut the models release ourselves when WE merged. The squash above pushes with
+            # GITHUB_TOKEN, and a GITHUB_TOKEN push does not trigger `push`-event workflows (the
+            # same Actions recursion guard this file documents at the top for the label path), so
+            # `release-models-on-integrate.yml` would never see it. `workflow_dispatch` is one of
+            # the two exceptions to that guard, so dispatch the release directly. A HUMAN merge
+            # is not affected by the guard and is picked up by the push trigger instead - hence
+            # this fires only on MERGED=yes, and the two paths cannot double-release.
+            if [ "$MERGED" = "yes" ]; then
+              if gh workflow run release-models.yml -R "$REPO" --ref main -f bump=minor -f dry_run=false; then
+                echo "dispatched models release (minor) for the merged integration"
+              else
+                echo "::warning::models release dispatch failed - cut it by hand from the Actions tab (Release tolokaforge-models, bump=minor)"
+              fi
+            fi
             # One settings deep-link (the Actions variables page where
             # ARENA_AUTOMATION_AUTO_MERGE_ENABLED lives) rendered as "configure <here>" (only
             # the word "here" is the link) on every auto-merge outcome. Derived from env +
@@ -881,6 +899,15 @@ jobs:
         run: |
           gh pr edit "$PR" -R "$REPO" --remove-label 'automation:resolve-running' \
             --add-label 'automation:integrate-needs-human' || true
+          # The labelling above always runs - a needs-human PR must carry the label whatever
+          # sent the notification. The NOTIFICATION below is skipped when a more specific
+          # handler already spoke (e.g. the Bucket B refusal in finalize, which names the
+          # engine paths). Without this the reader gets the precise message followed by a
+          # generic "did not converge" that is simply wrong about why the run stopped.
+          if [ -f "$RUNNER_TEMP/slack_terminal_sent" ]; then
+            echo "terminal notification already sent by a specific handler -> label only"
+            exit 0
+          fi
           if [ "${NEEDS_HUMAN:-}" = "yes" ]; then
             # The agent itself requested a human: it lacked the data for a correct policy.
             BODY="The resolve agent requested human review: ${NEEDS_HUMAN_REASON}. It judged it cannot produce a correct policy from the observe data alone (a data-bound quirk) and did not fabricate a fix. Marked \`automation:integrate-needs-human\`. Latest artifacts are on the run. Run: ${RUN_URL}"

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -710,9 +710,10 @@ jobs:
           # Classify the staged tree BEFORE the verify-time `stash --keep-index` (the stash drops
           # every non-staged file so the worktree matches the future commit; classification must
           # read `git diff --cached` while the staged set is intact). Bucket A = models-wheel
-          # only; Bucket B = any engine-side path touched. The classifier is a taxonomy, not a
-          # policy check -- both buckets flow through the SAME commit + push code path; only the
-          # commit subject and the Slack surface differ. `--format plain` yields
+          # only; Bucket B = any engine-side path touched. Post-split the classifier is a POLICY
+          # GATE, not a taxonomy: this pipeline commits Bucket A only. `tolokaforge/core/llm` is
+          # still staged above so an engine-side write is *seen* here rather than left behind as
+          # an unstaged file the classifier would miss. `--format plain` yields
           # `bucket=A|B\nreason=...\nengine_paths=<csv>` (greppable from bash without jq). Fail
           # loud if the bucket parse returns anything other than A or B -- neither an empty
           # bucket nor an unrecognised value is a scenario the workflow should silently continue.
@@ -722,6 +723,22 @@ jobs:
           ENGINE_PATHS="$(printf '%s\n' "$CLASSIFICATION" | grep '^engine_paths=' | cut -d= -f2-)"
           if [ "$BUCKET" != "A" ] && [ "$BUCKET" != "B" ]; then
             echo "::error::classify-paths returned an unknown bucket: '$BUCKET' (raw output: $CLASSIFICATION)"
+            exit 1
+          fi
+          # Bucket B -> refuse. Per-model policy code belongs in the models wheel
+          # (`tolokaforge_models/.../policies/<family>.py` + an entry point); an engine-side write
+          # means the candidate needs a new base hook, a new slot, or a new capability category,
+          # and that is a human decision on the engine's own release axis. Nothing is committed:
+          # the staged tree is discarded with the runner. Send the terminal Slack ourselves and
+          # set the dedup marker so the catch-all handler does not double-ping.
+          if [ "$BUCKET" = "B" ]; then
+            echo "::error::engine-side paths written - refusing to commit (${ENGINE_PATHS})"
+            uv run automation slack reply \
+              --channel "$SLACK_CHANNEL" --pr "$PR" --model "$TF_NAME" --mention \
+              --icon needs_human \
+              --text "$(printf '%s\n%s' 'Needs human: the fix requires engine-side code' "This automation commits models-wheel changes only. The resolve agent wrote to: ${ENGINE_PATHS}. A new base-class hook, policy slot or capability category is an engine decision - land it on the engine release axis first, then re-run the integration.")" \
+              --pr-url "$PR_URL" --run-url "$RUN_URL" || true
+            touch "$RUNNER_TEMP/slack_terminal_sent" || true
             exit 1
           fi
           # Cert-vs-baseline reconciliation - run BEFORE the stash so observation/findings.json is
@@ -761,16 +778,11 @@ jobs:
             exit 1
           fi
           # Commit subject tags the ADR-0030 bucket AFTER the model slug so the replay walker's
-          # `_MODEL_RE = ^integrate: (\S+?)(?:\s|$)` still parses the slug identically. Body
-          # names the bucket + the classifier reason so a reviewer sees why the taxonomy fired
-          # this way without opening the run log.
-          if [ "$BUCKET" = "A" ]; then
-            COMMIT_SUBJECT="integrate: ${TF_NAME} via auto-resolve (Bucket A: preset + cert)"
-            COMMIT_BODY="Bucket A per ADR-0030 (models-wheel only, no engine change). Reason: ${REASON}. See the PR comment for the reprobe evidence and known_unsupported ceilings. Do not merge if this is a disposable test branch."
-          else
-            COMMIT_SUBJECT="integrate: ${TF_NAME} via auto-resolve (Bucket B: engine + models-wheel)"
-            COMMIT_BODY="Bucket B per ADR-0030 (engine change alongside models-wheel). Engine paths touched: ${ENGINE_PATHS}. See the PR comment for the reprobe evidence and known_unsupported ceilings. Do not merge if this is a disposable test branch."
-          fi
+          # `_MODEL_RE = ^integrate: (\S+?)(?:\s|$)` still parses the slug identically, and so the
+          # models auto-release trigger (`release-models-on-integrate.yml`) can match `^integrate: `
+          # on the merge commit. Only Bucket A reaches this line -- Bucket B exited above.
+          COMMIT_SUBJECT="integrate: ${TF_NAME} via auto-resolve (Bucket A: preset + cert)"
+          COMMIT_BODY="Bucket A per ADR-0030 (models-wheel only, no engine change). Reason: ${REASON}. See the PR comment for the reprobe evidence and known_unsupported ceilings. Do not merge if this is a disposable test branch."
           git commit -m "$COMMIT_SUBJECT" -m "$COMMIT_BODY"
           # persist-credentials:false on checkout left no ambient token; supply one explicitly for
           # this push only (github.token is masked in logs; git redacts it from URL errors).
@@ -836,12 +848,10 @@ jobs:
             SETTINGS_URL="${GITHUB_SERVER_URL:-https://github.com}/$REPO/settings/variables/actions"
             # Every non-data-scope Slack surface carries the ADR-0030 bucket -- merged /
             # auto-merge-attempted-failed / auto-merge-off. A reader must be able to see the
-            # taxonomy without opening the PR or the run log.
-            if [ "$BUCKET" = "A" ]; then
-              BUCKET_LABEL="Bucket A: preset + cert (models-wheel only, no engine change)"
-            else
-              BUCKET_LABEL="Bucket B: engine + models-wheel (engine paths touched: ${ENGINE_PATHS})"
-            fi
+            # taxonomy without opening the PR or the run log. Only Bucket A can reach here; the
+            # label is kept explicit rather than dropped so the Slack surface still states which
+            # release axis the change lands on.
+            BUCKET_LABEL="Bucket A: preset + cert (models-wheel only, no engine change)"
             if [ "$MERGED" = "yes" ]; then
               ICON_ROLE=integrated_merged
               MSG="$(printf '%s\n%s' "Integrated + auto-merged (squash) - ${BUCKET_LABEL} landed on the base branch." "Auto-merge is on - squash-merged automatically on success (configure <$SETTINGS_URL|here>).")"

--- a/.github/workflows/release-models-on-integrate.yml
+++ b/.github/workflows/release-models-on-integrate.yml
@@ -1,0 +1,48 @@
+name: Release tolokaforge-models on integrate
+
+# Closes the loop ADR-0030 opened: once a model integration lands on main, the
+# models wheel releases itself. Without this the split still leaves a human in
+# the release path, and "one engine version absorbs any number of model
+# integrations" only holds on paper — a consumer cannot pick a model up until
+# somebody remembers to cut `models-vX.Y.Z` by hand.
+#
+# Trigger is deliberately narrow: an `integrate:` commit that touched the models
+# wheel. A hand edit to `tolokaforge_models/` (fixing a price, editing a
+# docstring) does NOT release — that stays the manual `workflow_dispatch` on
+# `release-models.yml`, so routine maintenance does not consume version numbers.
+#
+# Increment is `minor` rather than `auto`: `integrate:` is not a Conventional
+# Commit type, so `auto` has nothing to derive from. Minor also keeps the patch
+# axis free for fixing a model that shipped wrong (bad price, over-broad preset)
+# without it reading as a new model.
+#
+# Test branches never reach here — this fires on pushes to `main` only, and the
+# arena's disposable `test/*` / `observe-*` integration branches are never
+# merged out.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tolokaforge_models/**"
+
+# Share the release lane with the manual workflow. A second integration merging
+# while a release is in flight queues behind it rather than racing it to the tag
+# push (`cancel-in-progress: false` — a queued model release must still happen).
+concurrency:
+  group: release-models
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # `head_commit` is the tip of the push. A squash-merged integration PR
+    # carries the `integrate: <slug>` subject through to main, which is the same
+    # prefix `tests/canonical/test_models_wheel_replay.py` walks, so the release
+    # trigger and the acceptance metric agree on what an integration is.
+    # Quoted: the `: ` inside the literal would otherwise read as a YAML mapping.
+    if: "startsWith(github.event.head_commit.message, 'integrate: ')"
+    uses: ./.github/workflows/release-models.yml
+    with:
+      bump: minor
+      dry_run: false
+    secrets: inherit

--- a/.github/workflows/release-models-on-integrate.yml
+++ b/.github/workflows/release-models-on-integrate.yml
@@ -26,6 +26,15 @@ on:
     paths:
       - "tolokaforge_models/**"
 
+# Deliberately `write`, not the `contents: read` a permissions linter suggests by
+# default. Permissions can only be maintained or reduced down a reusable-workflow
+# chain, never elevated, so a caller granting `read` would cap the called
+# workflow below the `contents: write` it declares for pushing the bump commit
+# and tag. This is the minimum that lets `release-models.yml` run, not a widening:
+# without a block at all the job would inherit whatever the repository default is.
+permissions:
+  contents: write
+
 # Share the release lane with the manual workflow. A second integration merging
 # while a release is in flight queues behind it rather than racing it to the tag
 # push (`cancel-in-progress: false` — a queued model release must still happen).

--- a/.github/workflows/release-models-on-integrate.yml
+++ b/.github/workflows/release-models-on-integrate.yml
@@ -35,12 +35,17 @@ on:
 permissions:
   contents: write
 
-# Share the release lane with the manual workflow. A second integration merging
-# while a release is in flight queues behind it rather than racing it to the tag
-# push (`cancel-in-progress: false` — a queued model release must still happen).
-concurrency:
-  group: release-models
-  cancel-in-progress: false
+# No `concurrency` here on purpose. `release-models.yml` already declares
+# `group: release-models`, which serializes the lane for every entry point.
+# Repeating the same group on a caller of a reusable workflow makes the caller
+# and the job it is waiting on contend for one slot, which GitHub warns against
+# and which can wedge the run rather than queue it.
+#
+# Note the callee's `cancel-in-progress: false` bounds the lane at one running
+# plus one pending: a third arrival cancels the pending one. Model releases are
+# additive and the next integration re-cuts anyway, so a dropped middle release
+# costs a version number, not a model. If that stops being true, the callee
+# wants `queue: max`, not a second group here.
 
 jobs:
   release:

--- a/.github/workflows/release-models.yml
+++ b/.github/workflows/release-models.yml
@@ -1,7 +1,7 @@
 name: Release tolokaforge-models (cz bump)
 
-# Human-initiated release for the `tolokaforge-models` wheel — orthogonal to
-# the engine's own `Release (cz bump)` workflow. Runs `cz bump` against the
+# Release for the `tolokaforge-models` wheel — orthogonal to the engine's own
+# `Release (cz bump)` workflow. Runs `cz bump` against the
 # per-project commitizen config in `tolokaforge_models/pyproject.toml`,
 # regenerates `tolokaforge_models/CHANGELOG.md` from the Conventional Commit
 # history scoped to that project, commits, and pushes a `models-vX.Y.Z`
@@ -9,6 +9,14 @@ name: Release tolokaforge-models (cz bump)
 # `publish-tolokaforge-models.yml` (PyPI trusted publishing + GitHub Release).
 # No engine files are touched — the engine's `pyproject.toml`, `CHANGELOG.md`,
 # and `vX.Y.Z` tag axis are all independent.
+#
+# Two entry points, one body:
+#   * `workflow_dispatch` — a human cuts a release by hand.
+#   * `workflow_call` — `release-models-on-integrate.yml` calls it after an
+#     `integrate:` commit lands on main, so a model onboarding publishes itself
+#     without anyone in the release path (ADR-0030's independent-cadence goal).
+# `workflow_call` inputs cannot be `type: choice`, so the shared `bump` value is
+# a plain string there and validated in the body instead.
 #
 # See `docs/RELEASING.md` ("Cutting a tolokaforge-models release").
 
@@ -30,6 +38,21 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      bump:
+        description: "Version increment: auto | patch | minor | major"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (compute the bump + changelog, do not commit/tag/push)"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      RELEASE_SSH_KEY:
+        description: "Deploy key allowed to bypass the main branch ruleset"
+        required: true
 
 # Independent of the engine's `release` group — the two wheels release on
 # separate cadences and must be free to run in parallel.
@@ -73,14 +96,23 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # `workflow_call` hands `bump` through as a free-form string (choice is
+      # dispatch-only), so validate here rather than trusting the caller. An
+      # unrecognised value must fail the release, not silently fall through to
+      # `auto` and cut an unintended version.
       - name: Compute increment argument
         id: incr
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
-          if [ "${{ inputs.bump }}" = "auto" ]; then
-            echo "arg=" >> "$GITHUB_OUTPUT"
-          else
-            echo "arg=--increment ${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
-          fi
+          case "$BUMP" in
+            auto)                 echo "arg=" >> "$GITHUB_OUTPUT" ;;
+            patch|minor|major)    echo "arg=--increment $BUMP" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::unknown bump increment '$BUMP' (expected auto|patch|minor|major)"
+              exit 1
+              ;;
+          esac
 
       # Working directory is `tolokaforge_models/` so commitizen reads the
       # per-project `[tool.commitizen]` block and its relative paths

--- a/docs/ADD_NEW_MODEL.md
+++ b/docs/ADD_NEW_MODEL.md
@@ -50,6 +50,15 @@ A Bucket B change ships on the engine's `vX.Y.Z` tag axis. Land the Bucket B
 PR first when the model needs a hook the engine does not yet expose, then land
 a follow-up Bucket A PR for the model itself.
 
+**The auto-integration pipeline commits Bucket A only.** If the resolve agent
+writes anything under `tolokaforge/`,
+[`integrate-model.yml`](../.github/workflows/integrate-model.yml) classifies the
+staged tree as Bucket B and refuses to commit, routing the run to needs-human
+with the offending paths named in Slack. It does not commit the change under a
+different label and it does not partially commit the models-wheel half. A
+Bucket B candidate is a deliberate human decision about the engine's release
+axis, so the two-PR sequence above is driven by a person, not by the pipeline.
+
 ## Pre-flight: 30-second checklist
 
 Before writing any code, verify the model exists and decide which files

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -83,7 +83,8 @@ DID produce and routes it for a post-hoc human scope-check.)
   [`tolokaforge_models/src/tolokaforge_models/policies/`](../tolokaforge_models/src/tolokaforge_models/policies/)
   (plus the `[project.entry-points."tolokaforge.policies"]` line in
   [`tolokaforge_models/pyproject.toml`](../tolokaforge_models/pyproject.toml)). A Bucket B fix
-  additionally writes into [`tolokaforge/core/llm/`](../tolokaforge/core/llm/). Before committing,
+  additionally writes into [`tolokaforge/core/llm/`](../tolokaforge/core/llm/), which this pipeline
+  refuses to commit (see the classification bullet below). Before committing,
   the workflow VERIFIES the staged tree (what it is about to commit, via `git stash --keep-index`):
   it must import, must not turn any already-valid tool-call arg invalid
   (`test_policy_no_regression`, the anti-over-reach gate), and must recover the array-corruption
@@ -94,15 +95,18 @@ DID produce and routes it for a post-hoc human scope-check.)
   passing (>= 0.9) may be `known_unsupported` - catching the free-form cert's under-declaration and
   false-pessimism.
 - The workflow then classifies the staged tree via `automation classify-paths --paths-from-cached`
-  (see [`tools/automation/src/automation/bucket_classifier.py`](../tools/automation/src/automation/bucket_classifier.py))
-  and tags the commit accordingly: a Bucket A result (models-wheel only) commits with
+  (see [`tools/automation/src/automation/bucket_classifier.py`](../tools/automation/src/automation/bucket_classifier.py)).
+  The classification is a **gate**, not a label. A Bucket A result (models-wheel only) commits with
   `(Bucket A: preset + cert)` after the model slug and the Slack notification names
-  `Bucket A: preset + cert (models-wheel only, no engine change)`; a Bucket B result (engine
-  change touched) commits with `(Bucket B: engine + models-wheel)` and the Slack notification
-  names `Bucket B: engine + models-wheel (engine paths touched: <csv>)`. Both buckets flow through
-  the same commit + push code path — the taxonomy is informational, not gating. See
-  [ADR-0030](adr/0030-tolokaforge-models-split.md) for the release-cadence implication (Bucket A
-  ships on the `tolokaforge-models` tag axis; Bucket B forces an engine release).
+  `Bucket A: preset + cert (models-wheel only, no engine change)`. A Bucket B result (any engine
+  path touched) is **refused**: nothing is committed, the run exits non-zero, and a needs-human
+  Slack reply names the offending paths. A Bucket B candidate needs a new base hook, policy slot,
+  or capability category, which is a human decision on the engine's own release axis — see
+  [ADR-0030](adr/0030-tolokaforge-models-split.md) and
+  [`docs/ADD_NEW_MODEL.md`](ADD_NEW_MODEL.md) § Bucket B.
+- `tolokaforge/core/llm` stays in the `git add` whitelist deliberately, even though the workflow
+  will never commit it. Staging is how the classifier *sees* an engine-side write; leaving it
+  unstaged would hide it and the run would commit a models-wheel half with a dangling reference.
 - Only then does it commit to the PR branch, comment the record, and label
   `automation:integrate-done`. A broken / over-reaching / divergent fix (or a cert that does not
   reconcile) fails verification here and goes to `automation:integrate-needs-human`. NEVER merges.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1556,13 +1556,14 @@ runtime checks parse each entry's source via `ast` and walk
 * **`test_no_private_symbol_imports`** — rejects any `from tolokaforge.core.llm.<mod> import _<name>` in the subclass module.
 * **`test_no_private_base_method_override`** — rejects a subclass method starting with `_` that shadows a base-class method of the same name (via `inspect.getmembers` on the concrete base).
 * **`test_no_private_attribute_access_on_self_or_super`** — rejects `self._<attr>` / `cls._<attr>` / `super()._<attr>` reads whose `<attr>` is not defined locally in the subclass body.
-* **`test_per_model_subclasses_covers_registered_non_base_classes`** — walks `_POLICY_REGISTRIES` and asserts every registered class inheriting from another in-registry class appears in the guardrail's `PER_MODEL_SUBCLASSES` list. Composite classes that inherit only from `object` (e.g. `MinimaxM3TagRecoveryResponse`) carry no automatic audit and must be added manually to `PER_MODEL_SUBCLASSES` when a new composite lands.
+* **`test_no_per_model_subclass_is_registered_engine_side`** — walks `_POLICY_REGISTRIES` and asserts no class registered from `tolokaforge.core.llm.*` extends another registered class. That shape is a per-model subclass sitting on the engine side of the boundary, which is what the pre-split tree looked like and what the auto-integration would recreate if a resolve agent wrote into an engine module.
 
 A per-model subclass added to a preset registry that regresses into a
 `_`-prefixed name fails one of the four checks at test-import time — before
 the [#938](https://github.com/Toloka/tolokaforge/issues/938) cutover can
 bake the violation into `tolokaforge_models/policies/`. When adding a new
-per-model subclass, list it in `PER_MODEL_SUBCLASSES` and either compose the
+per-model subclass, put it under `tolokaforge_models/.../policies/<family>.py` (the guardrail
+derives its audit set from the registries, so there is no list to update) and either compose the
 public helpers above or promote the private you need to public API in the
 same PR (see [ADR-0030 § Follow-ups (8)](adr/0030-tolokaforge-models-split.md)).
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -62,8 +62,21 @@ The `tolokaforge-models` wheel — model data files, the 39 `ModelCertificate`
 registry, and the eight per-model policy subclasses — ships on its own release
 cadence. The release is driven entirely by
 [`.github/workflows/release-models.yml`](../.github/workflows/release-models.yml)
-("Release tolokaforge-models (cz bump)"). Run it from the Actions tab as a
-manual `workflow_dispatch`:
+("Release tolokaforge-models (cz bump)").
+
+**Model onboardings release themselves.** When an `integrate:` commit touching
+`tolokaforge_models/` lands on `main`,
+[`release-models-on-integrate.yml`](../.github/workflows/release-models-on-integrate.yml)
+calls the workflow below with `bump: minor`, so a new model reaches PyPI with
+nobody in the release path. That is the whole point of ADR-0030's split: a
+consumer picks the model up by moving its `tolokaforge-models` pin, and the
+engine version does not move. `minor` rather than `auto` because `integrate:`
+is not a Conventional Commit type — `auto` would have nothing to derive from —
+and it leaves the patch axis free for fixing a model that shipped wrong.
+
+Everything else (a hand-edited price, a docstring, a certificate correction) is
+still a manual `workflow_dispatch` from the Actions tab, so routine maintenance
+does not consume version numbers:
 
 - **`bump`** — `auto` (derive the increment from the Conventional Commits
   since the last `models-v*` tag: `fix` → patch, `feat` → minor,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,7 +59,7 @@ cleanly without cutting a release.
 ## PyPI package — tolokaforge-models `models-vX.Y.Z` (automated)
 
 The `tolokaforge-models` wheel — model data files, the 39 `ModelCertificate`
-registry, and the eight per-model policy subclasses — ships on its own release
+registry, and the per-model policy subclasses — ships on its own release
 cadence. The release is driven entirely by
 [`.github/workflows/release-models.yml`](../.github/workflows/release-models.yml)
 ("Release tolokaforge-models (cz bump)").

--- a/observation/TEST_RUN.md
+++ b/observation/TEST_RUN.md
@@ -1,0 +1,11 @@
+# Disposable test branch
+
+Exercises the auto-integration end to end against
+`feat/auto-integrate-models-only` (PR #1067): models-wheel-only commits, the
+Bucket B refusal, and the derived public-API boundary audit.
+
+Candidate: `azure_ai/cohere-command-a-plus-05-2026` — chosen because its
+`<|START_TEXT|>` wrapper needs an `assistant_text_policy`, i.e. a NEW per-model
+class, which is exactly the path this PR is meant to move off the engine.
+
+**Never merged.** Delete after the run.

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -238,9 +238,9 @@ def test_finalize_refuses_to_commit_bucket_b() -> None:
         "the Bucket B guard must send a needs-human Slack reply so the refusal "
         "reaches a person instead of only the run log"
     )
-    assert "slack_terminal_sent" in guard, (
-        "the Bucket B guard must set the dedup marker so the catch-all handler does not double-ping"
-    )
+    assert (
+        "slack_terminal_sent" in guard
+    ), "the Bucket B guard must set the dedup marker so the catch-all handler does not double-ping"
 
 
 def test_bucket_b_guard_precedes_the_commit() -> None:
@@ -269,9 +269,9 @@ def test_release_trigger_fires_only_on_integrate_commits_touching_the_models_whe
     # `on` is the YAML 1.1 boolean True, not the string "on".
     push = doc[True]["push"]
     assert push["branches"] == ["main"], "auto-release must fire on main only"
-    assert push["paths"] == ["tolokaforge_models/**"], (
-        "a push that does not touch the models wheel has nothing to release"
-    )
+    assert push["paths"] == [
+        "tolokaforge_models/**"
+    ], "a push that does not touch the models wheel has nothing to release"
     job = doc["jobs"]["release"]
     assert "startsWith(github.event.head_commit.message, 'integrate: ')" in job["if"], (
         "only an integration commit auto-releases; a hand edit to the models "
@@ -365,9 +365,9 @@ def test_generic_needs_human_defers_to_a_specific_handler() -> None:
                     "refusal) is followed by a generic one that is wrong about why "
                     "the run stopped"
                 )
-                assert run.index("slack_terminal_sent") < run.index("gh pr comment"), (
-                    "the dedup check must precede the PR comment, not only the Slack call"
-                )
+                assert run.index("slack_terminal_sent") < run.index(
+                    "gh pr comment"
+                ), "the dedup check must precede the PR comment, not only the Slack call"
                 return
     raise AssertionError("no `Flag needs-human` step found")
 

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -4,9 +4,8 @@
 The finalize step stages the models-wheel + engine surfaces produced by the
 resolve/finalize agent, classifies the staged tree as Bucket A (models-wheel
 only) or Bucket B (any engine-side path touched) via ``automation
-classify-paths``, and tags the commit subject + Slack notification with the
-result. This test locks four properties that a future refactor could
-silently regress:
+classify-paths``, and — post-ADR-0030 — commits Bucket A only. This test locks
+the properties a future refactor could silently regress:
 
 1. The ``git add`` whitelist references the current models-wheel layout
    (current) and drops the pre-cutover paths.
@@ -18,6 +17,10 @@ silently regress:
 4. The finalize ``git add`` no longer swallows missing-path errors via
    ``2>/dev/null || true`` — every whitelist entry exists in the tree, so a
    missing path signals a workflow bug, not a legitimate skip.
+5. Bucket B is refused before anything is committed, and the refusal reaches a
+   person (needs-human Slack + dedup marker) rather than only the run log.
+6. An ``integrate:`` commit on ``main`` auto-releases the models wheel at
+   ``minor``, and the release workflow it calls validates the increment.
 
 Runs under the ``canonical`` marker alongside
 ``test_python_version_single_source.py``; the same YAML-parse +
@@ -151,8 +154,9 @@ def test_commit_subject_carries_bucket_suffix() -> None:
     body = _finalize_step_body()
     a_msg = "finalize commit-subject template for Bucket A missing"
     assert re.search(r"Bucket A: preset \+ cert", body), a_msg
-    b_msg = "finalize commit-subject template for Bucket B missing"
-    assert re.search(r"Bucket B: engine \+ models-wheel", body), b_msg
+    # No Bucket B counterpart: post-split the finalize step refuses that tree
+    # instead of committing it under a different subject. See
+    # `test_finalize_refuses_to_commit_bucket_b`.
     integrate_subjects = re.findall(r"integrate: \$\{TF_NAME\}[^\"]*", body)
     template_msg = "expected at least one `integrate: ${TF_NAME}` commit-subject template"
     assert integrate_subjects, template_msg
@@ -203,3 +207,100 @@ def test_finalize_preserves_existing_verification_gates() -> None:
     for pattern, label in required_gates:
         msg = f"finalize step no longer contains the {label} - the retarget must not drop it"
         assert re.search(pattern, body), msg
+
+
+# ---------------------------------------------------------------------------
+# Post-split policy: this pipeline commits Bucket A only.
+#
+# Before the split the classifier was a taxonomy and both buckets flowed through
+# the same commit + push path, differing only in the commit subject. Per-model
+# policy code now belongs in the models wheel, so an engine-side write means the
+# candidate needs a base hook / slot / capability category that is a human
+# decision on the engine's release axis. These lock the refusal in shape.
+# ---------------------------------------------------------------------------
+
+_RELEASE_TRIGGER_PATH = _REPO_ROOT / ".github" / "workflows" / "release-models-on-integrate.yml"
+_RELEASE_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "release-models.yml"
+
+
+def test_finalize_refuses_to_commit_bucket_b() -> None:
+    body = _finalize_step_body()
+    # `_finalize_step_body` returns the YAML block scalar with its block
+    # indentation already stripped, so the closing `fi` sits at column 0.
+    match = re.search(r'if \[ "\$BUCKET" = "B" \]; then\n(.*?)\n *fi\n', body, re.DOTALL)
+    assert match is not None, (
+        "finalize must refuse Bucket B explicitly — expected an "
+        '`if [ "$BUCKET" = "B" ]; then ... fi` guard'
+    )
+    guard = match.group(1)
+    assert "exit 1" in guard, "the Bucket B guard must exit non-zero, not merely warn"
+    assert "needs_human" in guard, (
+        "the Bucket B guard must send a needs-human Slack reply so the refusal "
+        "reaches a person instead of only the run log"
+    )
+    assert "slack_terminal_sent" in guard, (
+        "the Bucket B guard must set the dedup marker so the catch-all handler does not double-ping"
+    )
+
+
+def test_bucket_b_guard_precedes_the_commit() -> None:
+    body = _finalize_step_body()
+    guard = body.index('if [ "$BUCKET" = "B" ]')
+    commit = body.index("git commit -m")
+    assert guard < commit, "the Bucket B refusal must run before anything is committed"
+
+
+def test_commit_subject_no_longer_branches_on_bucket() -> None:
+    body = _finalize_step_body()
+    subject_block = body[body.index("COMMIT_SUBJECT=") : body.index("git commit -m")]
+    assert "Bucket B" not in subject_block, (
+        "Bucket B cannot reach the commit, so the subject must not offer it as an "
+        "alternative — a dead branch here reads as if the old flow still exists"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto-release: an `integrate:` commit on main publishes the models wheel.
+# ---------------------------------------------------------------------------
+
+
+def test_release_trigger_fires_only_on_integrate_commits_touching_the_models_wheel() -> None:
+    doc = yaml.safe_load(_RELEASE_TRIGGER_PATH.read_text())
+    # `on` is the YAML 1.1 boolean True, not the string "on".
+    push = doc[True]["push"]
+    assert push["branches"] == ["main"], "auto-release must fire on main only"
+    assert push["paths"] == ["tolokaforge_models/**"], (
+        "a push that does not touch the models wheel has nothing to release"
+    )
+    job = doc["jobs"]["release"]
+    assert "startsWith(github.event.head_commit.message, 'integrate: ')" in job["if"], (
+        "only an integration commit auto-releases; a hand edit to the models "
+        "wheel stays on the manual workflow_dispatch"
+    )
+
+
+def test_release_trigger_requests_a_minor_bump() -> None:
+    doc = yaml.safe_load(_RELEASE_TRIGGER_PATH.read_text())
+    job = doc["jobs"]["release"]
+    assert job["uses"] == "./.github/workflows/release-models.yml"
+    assert job["with"]["bump"] == "minor", (
+        "`integrate:` is not a Conventional Commit type so `auto` derives "
+        "nothing; minor also keeps the patch axis free for fixing a model that "
+        "shipped wrong"
+    )
+    assert job["with"]["dry_run"] is False
+
+
+def test_release_workflow_is_callable_and_validates_the_increment() -> None:
+    doc = yaml.safe_load(_RELEASE_WORKFLOW_PATH.read_text())
+    triggers = doc[True]
+    assert "workflow_call" in triggers, (
+        "release-models.yml must be callable so the auto-release reuses it "
+        "rather than duplicating the bump + tag body"
+    )
+    assert "workflow_dispatch" in triggers, "the manual release path must survive"
+    body = _RELEASE_WORKFLOW_PATH.read_text()
+    assert "unknown bump increment" in body, (
+        "workflow_call passes `bump` as a free string (choice is dispatch-only), "
+        "so an unrecognised value must fail loud instead of silently meaning auto"
+    )

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -304,3 +304,81 @@ def test_release_workflow_is_callable_and_validates_the_increment() -> None:
         "workflow_call passes `bump` as a free string (choice is dispatch-only), "
         "so an unrecognised value must fail loud instead of silently meaning auto"
     )
+
+
+# ---------------------------------------------------------------------------
+# The auto-merge path has to dispatch its own release.
+#
+# `gh pr merge` pushes with GITHUB_TOKEN, and a GITHUB_TOKEN push does not
+# trigger `push`-event workflows (the Actions recursion guard this workflow
+# already documents for the label path). So on the auto-merge path the push
+# trigger never fires and the release must be dispatched explicitly.
+# ---------------------------------------------------------------------------
+
+
+def _report_step_body() -> str:
+    doc = yaml.safe_load(_WORKFLOW_PATH.read_text())
+    for job in doc["jobs"].values():
+        for step in job.get("steps", []):
+            run = step.get("run")
+            if isinstance(run, str) and "gh pr merge" in run:
+                return run
+    raise AssertionError("no step invoking `gh pr merge` found")
+
+
+def test_auto_merge_dispatches_the_models_release() -> None:
+    body = _report_step_body()
+    assert "gh workflow run release-models.yml" in body, (
+        "a GITHUB_TOKEN squash-push cannot trigger the push-event release "
+        "workflow, so the auto-merge path must dispatch the release itself"
+    )
+    assert "-f bump=minor" in body, "the dispatched release must request the minor increment"
+    guard = re.search(r'if \[ "\$MERGED" = "yes" \]; then(.*?)\n *fi\n', body, re.DOTALL)
+    assert guard is not None, "the dispatch must be gated on the merge having succeeded"
+    assert "gh workflow run" in guard.group(1), (
+        "the dispatch belongs inside the MERGED guard — dispatching when we did not "
+        "merge would release a model that is not on main, and a human merge is "
+        "already covered by the push trigger"
+    )
+
+
+def test_workflow_can_dispatch_workflows() -> None:
+    doc = yaml.safe_load(_WORKFLOW_PATH.read_text())
+    assert doc["permissions"].get("actions") == "write", (
+        "`gh workflow run` needs `actions: write`; without it the release "
+        "dispatch fails at the end of an otherwise successful integration"
+    )
+
+
+def test_generic_needs_human_defers_to_a_specific_handler() -> None:
+    doc = yaml.safe_load(_WORKFLOW_PATH.read_text())
+    for job in doc["jobs"].values():
+        for step in job.get("steps", []):
+            name = step.get("name", "")
+            run = step.get("run")
+            if not isinstance(name, str) or not name.startswith("Flag needs-human"):
+                continue
+            if isinstance(run, str):
+                assert "slack_terminal_sent" in run, (
+                    "the generic needs-human notifier must skip when a specific "
+                    "handler already spoke, or a precise message (e.g. the Bucket B "
+                    "refusal) is followed by a generic one that is wrong about why "
+                    "the run stopped"
+                )
+                assert run.index("slack_terminal_sent") < run.index("gh pr comment"), (
+                    "the dedup check must precede the PR comment, not only the Slack call"
+                )
+                return
+    raise AssertionError("no `Flag needs-human` step found")
+
+
+def test_release_trigger_does_not_share_the_callee_concurrency_group() -> None:
+    doc = yaml.safe_load(_RELEASE_TRIGGER_PATH.read_text())
+    callee = yaml.safe_load(_RELEASE_WORKFLOW_PATH.read_text())
+    caller_group = (doc.get("concurrency") or {}).get("group")
+    callee_group = (callee.get("concurrency") or {}).get("group")
+    assert callee_group == "release-models", "the callee is the one that serializes the lane"
+    assert caller_group != callee_group, (
+        "a caller sharing its callee's concurrency group contends with the job it "
+        "is waiting on; the callee's group already serializes every entry point"
+    )

--- a/tests/unit/llm/test_public_api_boundary.py
+++ b/tests/unit/llm/test_public_api_boundary.py
@@ -13,11 +13,11 @@ runtime checks:
 * **Test 3 (private-attr reach)** — no ``self._x`` / ``cls._x`` /
   ``super()._x`` where ``_x`` is a base-class method name and not
   locally defined by the subclass.
-* **Test 4 (registry audit)** — every class in
-  :data:`tolokaforge.core.llm.presets._POLICY_REGISTRIES` that inherits
-  from another in-registry class appears in :data:`PER_MODEL_SUBCLASSES`,
-  so a new per-model subclass added to a preset registry cannot slip past
-  unlisted.
+* **Test 4 (boundary direction)** — no class registered from
+  ``tolokaforge.core.llm.*`` extends another in-registry class. That shape
+  is a per-model subclass on the engine side of the boundary, which is what
+  the pre-split tree looked like and what the auto-integration would
+  recreate if a resolve agent wrote into an engine module.
 
 Tests 1-3 parse the subclass' host-module source via :mod:`ast`; no runtime
 import of the subclass is required. Test 4 walks the registries at import
@@ -25,7 +25,7 @@ time.
 
 Entries in :data:`PER_MODEL_SUBCLASSES` name concrete-module dotted paths in
 :mod:`tolokaforge_models.policies` (e.g. ``tolokaforge_models.policies.gemini``)
-where the eight per-model subclasses actually live; the engine's public shim
+where the per-model subclasses actually live; the engine's public shim
 in ``tolokaforge.core.llm.__init__.py`` still resolves them for a one-release
 deprecation window but is not the boundary the AST walk audits.
 """
@@ -44,15 +44,9 @@ pytestmark = pytest.mark.unit
 
 
 #: Per-model subclasses and composite helpers under the boundary guardrail.
-#: Two shapes qualify:
-#:
-#: (a) subclasses of a concrete engine base already registered in a
-#:     ``_POLICY_REGISTRIES`` slot (``StrictSchema``, ``DictMapHints``,
-#:     ``OpenAIReasoningCodec``, ``ArrayDictMapResponse``, ...);
-#: (b) composite helper classes registered in ``_POLICY_REGISTRIES`` that
-#:     inherit only from ``object`` and wire up other in-tree policy
-#:     instances internally (``JsonRecursiveCoerceResponse``,
-#:     ``ItemRecursiveUnwrapResponse``, ``MinimaxM3TagRecoveryResponse``).
+#: Two shapes qualify: subclasses of a concrete engine base registered in a
+#: ``_POLICY_REGISTRIES`` slot, and composite helpers that inherit only from
+#: ``object`` and wire up other policy instances internally.
 #:
 #: The set is DERIVED from the merged ``_POLICY_REGISTRIES`` at collection time,
 #: not hand-maintained. A hand-maintained list would make every models-wheel
@@ -62,27 +56,40 @@ pytestmark = pytest.mark.unit
 #: Registration via the ``tolokaforge.policies`` entry-point group is mandatory
 #: for a class to be usable at all, so the registries are a complete source.
 #:
-#: ``_UNREGISTERED_COMPOSITES`` covers shape (b) classes that ship in the models
-#: wheel but are composed into a registered class rather than registered
-#: themselves, so the registry walk cannot see them. Short and stable by
-#: construction: a new per-model class the resolve agent writes is registered
-#: (otherwise no preset could name it) and is therefore picked up automatically.
-_UNREGISTERED_COMPOSITES: Final[tuple[tuple[str, str], ...]] = (
-    ("tolokaforge_models.policies.minimax", "JsonRecursiveCoerceResponse"),
-    ("tolokaforge_models.policies.minimax", "ItemRecursiveUnwrapResponse"),
-)
-
-
+#: Derivation is by MODULE, not by registered class. Shape (b) composites are
+#: composed into a registered class rather than registered themselves, so a
+#: registry-only walk cannot see them — and ``resolve_agent.md`` holds exactly
+#: that composition up as the pattern to copy, so unregistered per-model code is
+#: the expected case, not an exception worth hardcoding. Taking every public
+#: class defined in a contributing module audits the composites for free and
+#: keeps growing on its own as new families land.
 def _derive_per_model_subclasses() -> tuple[tuple[str, str], ...]:
-    """Every registered class contributed from outside the engine LLM package."""
+    """Every public class defined in a module that contributes a registered policy.
+
+    A models-wheel module earns its place by registering at least one class
+    through the ``tolokaforge.policies`` entry-point group (mandatory — an
+    unregistered class could not be named by a preset). Everything public that
+    module defines then ships to the same consumers under the same boundary
+    rules, so it is audited too.
+    """
     presets = importlib.import_module("tolokaforge.core.llm.presets")
-    found = {
-        (cls.__module__, cls.__name__)
+    contributing_modules = {
+        cls.__module__
         for registry in presets._POLICY_REGISTRIES.values()
         for cls in registry.values()
         if not cls.__module__.startswith("tolokaforge.core.llm.")
     }
-    return tuple(sorted(found | set(_UNREGISTERED_COMPOSITES)))
+    found: set[tuple[str, str]] = set()
+    for module_dotted in contributing_modules:
+        module = importlib.import_module(module_dotted)
+        for name, obj in vars(module).items():
+            if name.startswith("_") or not inspect.isclass(obj):
+                continue
+            # Imported symbols keep their defining module; only classes this
+            # module actually defines are its responsibility.
+            if obj.__module__ == module_dotted:
+                found.add((module_dotted, name))
+    return tuple(sorted(found))
 
 
 PER_MODEL_SUBCLASSES: Final[tuple[tuple[str, str], ...]] = _derive_per_model_subclasses()
@@ -207,8 +214,8 @@ def _base_method_names(base_cls: type[Any]) -> set[str]:
 
 
 def test_per_model_subclasses_is_populated() -> None:
-    assert PER_MODEL_SUBCLASSES, (
-        "PER_MODEL_SUBCLASSES must enumerate at least one subclass — an empty "
+    assert len(PER_MODEL_SUBCLASSES) >= 8, (
+        "PER_MODEL_SUBCLASSES must enumerate the shipped per-model classes — a short "
         "list disables the boundary guardrail."
     )
 

--- a/tests/unit/llm/test_public_api_boundary.py
+++ b/tests/unit/llm/test_public_api_boundary.py
@@ -54,23 +54,38 @@ pytestmark = pytest.mark.unit
 #:     instances internally (``JsonRecursiveCoerceResponse``,
 #:     ``ItemRecursiveUnwrapResponse``, ``MinimaxM3TagRecoveryResponse``).
 #:
-#: Test 4 below is the authoritative audit for BOTH shapes: it walks
-#: ``_POLICY_REGISTRIES`` at runtime and asserts that every registered class
-#: NOT under ``tolokaforge.core.llm.*`` (i.e. every per-model class the models
-#: wheel contributes) appears here. Composites inheriting only from ``object``
-#: (shape b) are covered by the same walk — a registered class must be listed
-#: regardless of ancestor shape. The manual-add caveat applied to the older
-#: filter shape (ancestor-gated) and no longer stands.
-PER_MODEL_SUBCLASSES: Final[tuple[tuple[str, str], ...]] = (
-    ("tolokaforge_models.policies.gemini", "GeminiSchema"),
-    ("tolokaforge_models.policies.gemini", "GeminiRecursiveSchema"),
-    ("tolokaforge_models.policies.gemini", "ScalarArrayDictMapResponse"),
-    ("tolokaforge_models.policies.inkling", "RefResolvingDictMapHints"),
-    ("tolokaforge_models.policies.minimax", "MinimaxM3TagRecoveryResponse"),
+#: The set is DERIVED from the merged ``_POLICY_REGISTRIES`` at collection time,
+#: not hand-maintained. A hand-maintained list would make every models-wheel
+#: class an engine-repo edit to add it — which is Bucket B under
+#: ``bucket_classifier.py`` and would put the auto-integration pipeline back on
+#: the engine release axis for exactly the integrations ADR-0030 moved off it.
+#: Registration via the ``tolokaforge.policies`` entry-point group is mandatory
+#: for a class to be usable at all, so the registries are a complete source.
+#:
+#: ``_UNREGISTERED_COMPOSITES`` covers shape (b) classes that ship in the models
+#: wheel but are composed into a registered class rather than registered
+#: themselves, so the registry walk cannot see them. Short and stable by
+#: construction: a new per-model class the resolve agent writes is registered
+#: (otherwise no preset could name it) and is therefore picked up automatically.
+_UNREGISTERED_COMPOSITES: Final[tuple[tuple[str, str], ...]] = (
     ("tolokaforge_models.policies.minimax", "JsonRecursiveCoerceResponse"),
     ("tolokaforge_models.policies.minimax", "ItemRecursiveUnwrapResponse"),
-    ("tolokaforge_models.policies.deepseek", "OpenAISummaryReplayReasoningCodec"),
 )
+
+
+def _derive_per_model_subclasses() -> tuple[tuple[str, str], ...]:
+    """Every registered class contributed from outside the engine LLM package."""
+    presets = importlib.import_module("tolokaforge.core.llm.presets")
+    found = {
+        (cls.__module__, cls.__name__)
+        for registry in presets._POLICY_REGISTRIES.values()
+        for cls in registry.values()
+        if not cls.__module__.startswith("tolokaforge.core.llm.")
+    }
+    return tuple(sorted(found | set(_UNREGISTERED_COMPOSITES)))
+
+
+PER_MODEL_SUBCLASSES: Final[tuple[tuple[str, str], ...]] = _derive_per_model_subclasses()
 
 #: Engine slot Protocols — the abstract slot definitions. They never appear in
 #: ``_POLICY_REGISTRIES`` (only concrete classes are registered), but Test 4
@@ -301,53 +316,48 @@ def _classify_receiver(node: ast.expr) -> str | None:
     return None
 
 
-def test_per_model_subclasses_covers_registered_non_base_classes() -> None:
-    """Every registered per-model class that lives outside the engine base
-    modules must appear in :data:`PER_MODEL_SUBCLASSES`, whether it inherits
-    from an in-registry slot base or is a composite inheriting only from
-    ``object``.
+def test_no_per_model_subclass_is_registered_engine_side() -> None:
+    """No per-model policy class may live under ``tolokaforge.core.llm.*``.
 
-    Filter shape: engine-owned base classes and slot Protocols
-    (``StrictSchema``, ``DictMapHints``, ``ArrayDictMapResponse``, …) live
-    under ``tolokaforge.core.llm.*`` and stay engine-side; the AST audit
-    does not run against them because they define the abstract surface,
-    not implement it. Every OTHER registered class — the per-model
-    subclasses and composites the models wheel ships — must be enumerated
-    here so tests 1-3 audit each one.
+    :data:`PER_MODEL_SUBCLASSES` is derived from the registries, so "is it
+    listed" is no longer a question worth asking. The invariant that still
+    needs guarding is the direction of the boundary: per-model policy code
+    belongs in the models wheel, and the engine LLM package holds only slot
+    Protocols and the concrete *bases* those per-model classes extend.
 
-    Composite classes (shape (b) in the module docstring) inherit only
-    from ``object`` and wire up sibling policy instances internally. They
-    have no in-registry ancestor, so the older "must inherit from a
-    registered base" filter would silently exempt them. This walk requires
-    every non-engine class to be listed regardless of ancestor shape.
+    A class registered from ``tolokaforge.core.llm.*`` that itself inherits
+    from another registered class is a per-model subclass sitting on the
+    wrong side. That is how the pre-split shape looked (``GeminiSchema`` and
+    friends lived in ``schema_sanitizer.py``), and it is what the auto
+    integration would recreate if a resolve agent wrote a new adapter into an
+    engine module. `.github/workflows/integrate-model.yml` refuses to commit
+    that tree; this test is the same rule enforced against the merged
+    registries, so a hand-written engine-side subclass cannot slip past
+    either.
+
+    Engine-side classes that inherit only from ``object`` or from a slot
+    Protocol are bases, not per-model adaptations, and are left alone.
     """
     presets = importlib.import_module("tolokaforge.core.llm.presets")
-    listed = set(PER_MODEL_SUBCLASSES)
-    missing: list[str] = []
+    offenders: list[str] = []
     for slot, registry in presets._POLICY_REGISTRIES.items():
         registered = set(registry.values())
         for cls in registry.values():
-            # Engine-owned base classes and slot Protocols are the abstract
-            # surface — skip them. Everything else must be enumerated.
-            if cls.__module__.startswith("tolokaforge.core.llm."):
+            if not cls.__module__.startswith("tolokaforge.core.llm."):
                 continue
             if cls.__name__ in _SLOT_PROTOCOLS:
                 continue
-            key = (cls.__module__, cls.__name__)
-            if key not in listed:
-                in_slot_ancestors = [
-                    base for base in cls.__mro__[1:] if base is not object and base in registered
-                ]
-                shape = (
-                    f"inherits from registered slot base(s) "
-                    f"{[b.__name__ for b in in_slot_ancestors]!r}"
-                    if in_slot_ancestors
-                    else "is a composite (inherits only from object)"
+            in_slot_ancestors = [
+                base for base in cls.__mro__[1:] if base is not object and base in registered
+            ]
+            if in_slot_ancestors:
+                offenders.append(
+                    f"{slot}: {cls.__module__}.{cls.__name__} extends registered "
+                    f"base(s) {[b.__name__ for b in in_slot_ancestors]!r} but lives "
+                    f"in the engine LLM package. Per-model policy classes belong in "
+                    f"tolokaforge_models/src/tolokaforge_models/policies/<family>.py, "
+                    f"registered via the `tolokaforge.policies` entry-point group. "
+                    f"If this really is a new engine base, it must not be a subclass "
+                    f"of another registered class."
                 )
-                missing.append(
-                    f"{slot}: {cls.__module__}.{cls.__name__} {shape} "
-                    f"but is not in PER_MODEL_SUBCLASSES. Add it to the "
-                    f"list so tests 1-3 audit it against the engine's "
-                    f"public API boundary."
-                )
-    assert not missing, "\n".join(missing)
+    assert not offenders, "\n".join(offenders)


### PR DESCRIPTION
**Disposable test branch — do not merge.**

End-to-end exercise of the auto-integration against #1067 (`feat/auto-integrate-models-only`), which makes the pipeline commit models-wheel content only and adds the models auto-release.

Candidate is `azure_ai/cohere-command-a-plus-05-2026` on purpose: its response text arrives wrapped in `<|START_TEXT|>…<|END_TEXT|>`, which needs an `assistant_text_policy` — a NEW per-model class. That is precisely the case ADR-0030 moved off the engine axis, and the one this PR is meant to keep off it.

What this run should show:

- the new class lands under `tolokaforge_models/src/tolokaforge_models/policies/` with an entry point, not in `tolokaforge/core/llm/`
- the staged tree classifies Bucket A and commits
- the derived `PER_MODEL_SUBCLASSES` picks the new class up, so `test_public_api_boundary.py` stays green without an engine-repo edit
- if the agent does reach for engine code, the run refuses to commit and routes to needs-human naming the paths

Not covered here: the auto-release. `test/*` head branches skip auto-merge by design, and the release dispatch is gated on a successful merge — so a test run cannot fire a real PyPI release.

Base is the feature branch deliberately: the workflow YAML comes from the dispatch ref, but the prompts and automation CLI come from the checked-out head, so both halves have to be the PR-1067 versions.