### PR TITLE
fix(docker): ship tolokaforge_models sources in the base wheel for wheel-install Docker builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,14 @@ packages = ["tolokaforge"]
 "README.md" = "tolokaforge/_subset_build/README.md"
 "LICENSE" = "tolokaforge/_subset_build/LICENSE"
 "scripts/hatch" = "tolokaforge/_subset_build/scripts/hatch"
+# The runner Dockerfile also builds the tolokaforge-models wheel in-container
+# (Milestone 29, ADR-0030) from a workspace-sibling source tree. Force-include
+# the models project's `pyproject.toml` + `src/` layout so the wheel-install
+# path assembles the same build context the source-checkout path has. Without
+# these entries `_runner_definition()` cannot map the `tolokaforge_models/`
+# context entry to a packaged copy and `COPY tolokaforge_models/` fails.
+"tolokaforge_models/pyproject.toml" = "tolokaforge/_subset_build/tolokaforge_models/pyproject.toml"
+"tolokaforge_models/src" = "tolokaforge/_subset_build/tolokaforge_models/src"
 
 [tool.hatch.build.targets.sdist]
 

--- a/tests/unit/test_docker_build_context.py
+++ b/tests/unit/test_docker_build_context.py
@@ -548,6 +548,10 @@ def test_runner_build_context_resolves_from_installed_wheel(tmp_path: Path, monk
     for name in ("pyproject.toml", "README.md", "LICENSE"):
         (packaged / name).write_text(f"# {name}\n")
     (packaged / "scripts" / "hatch" / "hatch_runner_subset_builder.py").write_text("")
+    # The base wheel also ships tolokaforge_models sources for the
+    # in-container `hatchling build` step (Milestone 29 / ADR-0030).
+    (packaged / "tolokaforge_models" / "src" / "tolokaforge_models").mkdir(parents=True)
+    (packaged / "tolokaforge_models" / "pyproject.toml").write_text("# models pyproject\n")
     (pkg / "_python_version.txt").write_text("3.12\n")
     # The base wheel ships the Dockerfiles inside the package, so
     # ``assemble_build_context`` still finds the runner Dockerfile under
@@ -576,6 +580,8 @@ def test_runner_build_context_resolves_from_installed_wheel(tmp_path: Path, monk
             ".python-version",
             "scripts/hatch",
             "tolokaforge",
+            "tolokaforge_models/pyproject.toml",
+            "tolokaforge_models/src/tolokaforge_models",
         ):
             assert (build_dir / expected).exists(), (
                 f"assembled runner context is missing '{expected}', which the "
@@ -646,6 +652,10 @@ def test_core_stack_runner_context_assembles_on_a_wheel_install(
     for name in ("pyproject.toml", "README.md", "LICENSE"):
         (packaged / name).write_text(f"# {name}\n")
     (packaged / "scripts" / "hatch" / "hatch_runner_subset_builder.py").write_text("")
+    # The base wheel also ships tolokaforge_models sources for the
+    # in-container `hatchling build` step (Milestone 29 / ADR-0030).
+    (packaged / "tolokaforge_models" / "src" / "tolokaforge_models").mkdir(parents=True)
+    (packaged / "tolokaforge_models" / "pyproject.toml").write_text("# models pyproject\n")
     (pkg / "_python_version.txt").write_text("3.12\n")
     dockerfiles = pkg / "docker" / "dockerfiles"
     dockerfiles.mkdir(parents=True)
@@ -663,6 +673,8 @@ def test_core_stack_runner_context_assembles_on_a_wheel_install(
             ".python-version",
             "scripts/hatch",
             "tolokaforge",
+            "tolokaforge_models/pyproject.toml",
+            "tolokaforge_models/src/tolokaforge_models",
         ):
             assert (build_dir / expected).exists(), (
                 f"core_stack()'s runner context is missing '{expected}' on a wheel "

--- a/tolokaforge/docker/builder.py
+++ b/tolokaforge/docker/builder.py
@@ -260,6 +260,14 @@ def _runner_definition() -> dict[str, Any]:
         packaged / "scripts",  # dir -> build_dir/scripts (holds hatch/)
         pkg_dir,  # dir -> build_dir/tolokaforge
         (pkg_dir / "_python_version.txt", ".python-version"),
+        # The runner Dockerfile builds tolokaforge-models wheel in-container
+        # too. The base wheel ships a copy of its source tree at
+        # `tolokaforge/_subset_build/tolokaforge_models/` (via the
+        # force-include entries in the workspace-root pyproject.toml). Its
+        # basename already matches what the Dockerfile expects at
+        # `COPY tolokaforge_models/ /src/tolokaforge_models/`, so a plain
+        # absolute-path entry lands the directory under the right name.
+        packaged / "tolokaforge_models",
     ]
     missing = [
         str(e[0] if isinstance(e, tuple) else e)


### PR DESCRIPTION
## Context

Milestone 29 (v0.18.0) taught the runner Dockerfile to build both tolokaforge and tolokaforge-models wheels in the same wheel-builder stage — a chicken-and-egg fix for the pre-publish period when the models wheel wasn't yet on PyPI. That worked from a source checkout (repo-root carries \`tolokaforge_models/\` as a workspace member), but **broke the wheel-install path**: \`_runner_definition()\` swaps context files to packaged copies at \`tolokaforge/_subset_build/\`, and the base wheel's \`force-include\` block didn't ship the models sources.

Failure mode: fresh \`pip install tolokaforge==0.18.0\` + \`tolokaforge run …\` dies at Dockerfile step 8:

\`\`\`
Step 8/29 : COPY tolokaforge_models/ /src/tolokaforge_models/
ERROR: COPY failed: file not found in build context or excluded by .dockerignore: stat tolokaforge_models/: file does not exist
\`\`\`

This affects every PyPI consumer running a real \`tolokaforge run\` — the primary user-facing path of the milestone.

## Fix

Two-line change:

- \`pyproject.toml\` \`[tool.hatch.build.targets.wheel.force-include]\` gains \`tolokaforge_models/pyproject.toml\` + \`tolokaforge_models/src\` entries pointing at \`tolokaforge/_subset_build/tolokaforge_models/\`. Base wheel now carries the models source tree hatchling needs at Docker build time (~180 KB added to the wheel).
- \`_runner_definition()\` in \`tolokaforge/docker/builder.py\` adds \`packaged / \"tolokaforge_models\"\` as a plain absolute-path entry (not a tuple) so \`assemble_build_context()\` copies the packaged dir under its basename — matching the Dockerfile's \`COPY tolokaforge_models/\`.

## Verification

Rebuilt \`tolokaforge\` wheel locally with these two changes. Fresh venv install from the wheel. Deleted every \`tolokaforge-*\` Docker image to force a full rebuild. Ran \`tolokaforge run --config examples/native/coding/run_configs/dev.yaml\` end-to-end:

- Docker build succeeded (~3 min for runner + db-service).
- Both trials executed (8 turns each, 8-9 tool calls, LLM path exercised).
- \`engine_run_state.json\` carries the correct fingerprint: \`package_version: \"1.0.0\"\`, \`minimum_engine_version: \">=0.17,<1.0\"\`, \`api_version: 1\`, valid 64-hex \`content_sha256\`.

Ships as **v0.18.1** patch release after merge.

## Follow-up not in scope

Grading path exhibits a race: trial completes successfully but \`Grading error: TrialNotFoundError: Trial 'coding_public_example_01:0' not found in DB Service\` fires after DB teardown. Reproduces on the fixed build; almost certainly pre-existing (Milestone 29 didn't touch the grading path). Will file a separate ticket.