### PR TITLE
feat(docker): pull-vs-build policy for tolokaforge run (docker.image_source)

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -92,6 +92,37 @@ provisioning them per the manifest's isolation rules. See
 [RUNTIME_BACKENDS.md](RUNTIME_BACKENDS.md) for
 the backend lifecycle.
 
+### Image resolution — pull vs build
+
+At `tolokaforge run` time the four first-party service images
+(`runner`, `db-service`, `rag-service`, `mock-web`) resolve through a
+`docker.image_source` policy with three values:
+
+| `docker.image_source` | Behavior |
+| --- | --- |
+| `auto` (default) | Pull the published `tolokasoft1/tolokaforge-<svc>:<engine_version>` image from Docker Hub when the engine is a wheel install (`pip install tolokaforge`); build locally from source when running from a repo checkout. Falls back to a local build on any pull failure with a `logger.warning` naming the exact reason. |
+| `pull` | Always pull. On pull failure — 404, 429, unreachable — this is a hard failure with no fallback. Use when you need a strong "pull or die" guarantee (e.g. arena runs where a silent rebuild would waste minutes per fresh host). |
+| `build` | Always build locally. Skip pull entirely. Use when editing Dockerfiles or service code, or in air-gapped environments that never touch Docker Hub. |
+
+Override the config value with the `--image-source` flag on
+`tolokaforge run` or the `TOLOKAFORGE_IMAGE_SOURCE` environment
+variable. Precedence: flag > env > `docker.image_source` in the run
+config > default (`auto`). The engine version used for the pull tag
+comes from `tolokaforge.__version__` (`importlib.metadata.version(
+"tolokaforge")`); a source checkout without a `pip install` reports a
+sentinel and always resolves `auto` to `build`.
+
+For the Docker Hub tag axis (`:X.Y.Z` immutable, `:X.Y` moving,
+`:latest`), see the published-images section of
+[STANDALONE_RUNNER.md](STANDALONE_RUNNER.md#published-images).
+
+Docker Hub rate-limits anonymous pulls to 100 per 6 h per IP. Shared
+CI runners or arena hosts that drive many `tolokaforge run` invocations
+should either configure authenticated pulls via the daemon's standard
+`~/.docker/config.json` (`docker login`), or set `docker.image_source:
+build` to skip pull entirely. A 429 in `auto` mode surfaces as a
+`WARNING` line naming `rate_limited` before the fallback build starts.
+
 ### Runner readiness contract
 
 The runner is gated for readiness at two independent layers, and they answer

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -96,7 +96,9 @@ the backend lifecycle.
 
 At `tolokaforge run` time the four first-party service images
 (`runner`, `db-service`, `rag-service`, `mock-web`) resolve through a
-`docker.image_source` policy with three values:
+`docker.image_source` policy with three values. Design rationale,
+alternatives considered, and the failure-mode contract are captured in
+[ADR-0031](adr/0031-pull-vs-build-default-for-service-images.md).
 
 | `docker.image_source` | Behavior |
 | --- | --- |

--- a/docs/adr/0031-pull-vs-build-default-for-service-images.md
+++ b/docs/adr/0031-pull-vs-build-default-for-service-images.md
@@ -1,0 +1,333 @@
+# 0031. Wheel consumers pull published images by default — `docker.image_source` policy
+
+- **Status:** Proposed
+- **Date:** 2026-08-13
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context and Problem Statement
+
+`tolokaforge run` today builds all four first-party service images
+(`runner`, `db-service`, `rag-service`, `mock-web`) **locally from
+source**, regardless of whether the engine is running from a source
+checkout or from `pip install tolokaforge`. On a fresh host the first
+run pays 2–5 minutes for a docker build (BuildKit setup, ~2 GB of base
+layers, wheel install, subset-build stage) and requires a working local
+Docker build environment.
+
+Post-[ADR-0030](0030-tolokaforge-models-split.md) (shipped as v0.18.0),
+byte-equivalent, rc-smoke-validated images already exist on Docker Hub
+at `tolokasoft1/tolokaforge-<svc>:X.Y.Z`. They are what
+[ADR-0023](0023-runner-image-internals.md)'s tag axis commits to; they
+are what `publish-images.yml` produces from every green release. A wheel
+consumer who could pull instead of build would replace a 2–5 min build
+with a 30–60 s pull — the same content the release pipeline already
+validated, in a fraction of the wall time and with no local Docker
+build environment required.
+
+The gap:
+
+- **The engine has no pull code path.** `Image.build()` is build-only;
+  there is no `Image.pull()`. The `use_prebuilt_image=True` branch used
+  by `dind` / `typesense` stubs an `Image` record and lets Docker
+  implicit-pull at `docker run` time — failures then surface at
+  container-start, not at provisioning.
+- **The image resolution has no policy seam.** `EngineStack.build_
+  images()` unconditionally calls into `_build_one_image` which
+  unconditionally builds. There is no config surface that lets a
+  wheel-installed consumer say "prefer pull" without editing engine
+  code.
+- **The consumer mix is bimodal.** Repo contributors editing
+  `runner.Dockerfile` need to see their edits locally — they must
+  build. Wheel consumers, arena / task drivers, downstream OSS
+  consumers, and CI-on-a-checkout each want a different default. The
+  right shape is a knob, not a hard-coded rule.
+- **Docker Hub rate-limits anonymous pulls** at 100 per 6 h per IP.
+  A shared CI runner or arena host driving many `tolokaforge run`
+  invocations from cold hosts would hit the ceiling and fail — an
+  invisible-until-triggered production hazard for the default that
+  needs an operator-actionable escape.
+
+The public [`Toloka/tolokaforge#1068`](https://github.com/Toloka/tolokaforge/issues/1068)
+ticket named the direction; this ADR captures the shape decision so
+future work has a reference for what was rejected and why.
+
+## Decision Drivers
+
+- **Preserve the "one PyPI wheel" story.**
+  [ADR-0025](0025-runner-wheel-split.md) already committed the engine to
+  a single published wheel. This ADR must not add a new PyPI presence
+  or new consumer package. All changes stay inside the engine wheel;
+  the pull target is the same Docker Hub image
+  [ADR-0023](0023-runner-image-internals.md) already ships.
+- **First-run cost is a user-experience contract.** A new user who types
+  `pip install tolokaforge; tolokaforge run` should not pay 2–5 min of
+  local Docker build for content the release pipeline already
+  produced. Reducing that to a 30–60 s pull is the load-bearing win of
+  this change.
+- **Source-checkout contributors must keep the build loop.** Any
+  contributor editing `runner.Dockerfile` or a service's Python has to
+  see their edits materialise into the running image. The wheel-vs-
+  source discriminator (`(repo_root() / "pyproject.toml").is_file()`)
+  is the same one [ADR-0025](0025-runner-wheel-split.md)'s
+  `_runner_definition` already uses; reusing it here keeps the shape
+  familiar.
+- **Rate-limit and platform edge cases have to be actionable, not
+  silent.** Any failure mode the policy introduces must surface a
+  message an operator can act on (add auth for 429; fall back to
+  build for 404 / network / arm64-only host) — not a generic stack
+  trace that requires a debugger to interpret.
+- **Explicit "pull-or-die" mode exists for consumers who need
+  determinism.** Arena / high-volume drivers cannot afford a silent
+  rebuild if the pull fails. A three-value knob (not a boolean) is
+  necessary because the auto/pull/build distinction has three
+  behaviours, not two.
+- **Reversibility.** If the pull-vs-build policy proves not worth its
+  maintenance overhead, every consumer can opt back into
+  `docker.image_source: build` and the engine reverts to a build-only
+  default with no PyPI or Docker Hub churn.
+
+## Considered Options
+
+**Policy shape — how does a consumer say pull or build?**
+
+1. **Status quo — always build.** No config knob, no pull path. Rejected: 2–5 min tax on every fresh wheel-consumer host, forever.
+2. **Always pull.** Breaks source-checkout contributors — every Dockerfile edit needs an escape hatch. Rejected.
+3. **Boolean knob (`docker.prefer_published: bool`).** Two values (true / false) cover pull-vs-build but not "auto based on install shape". A third state (`auto`) is needed for the default to work without every operator touching config. Rejected as a shape.
+4. **Tri-valued `docker.image_source: auto | pull | build`.** `auto` picks based on install shape (wheel → pull, source → build); `pull` and `build` are explicit escape hatches. Chosen — see § Decision.
+5. **Digest-pinning via a bundled manifest (`sha256:…`).** Supply-chain-clean; immune to `:X.Y.Z` retag drift. Rejected for this ADR — higher implementation cost, no current requirement, would supersede this ADR rather than layer on it.
+
+**Fallback semantics — what happens when pull fails?**
+
+1. **Silent fallback to build on any failure.** Hides the real problem (bad Docker Hub credentials, mirror not configured, network partition). Rejected.
+2. **Log-loud fallback in `auto` mode, hard-fail in `pull` mode.** `auto` treats the fallback as best-effort, with a warning naming the failure kind so the operator can act. `pull` refuses to build — the whole point of the explicit knob is "pull or die". Chosen.
+3. **Retry-only, no fallback.** Makes rate-limit conditions permanently fatal for the auto default. Rejected.
+
+**Failure-kind sub-classification — how much detail?**
+
+1. **Single `ImagePullError`.** Silent about *why*. Operators can't distinguish "wrong version tag" from "add auth". Rejected.
+2. **Three-way kind: `tag_missing` / `rate_limited` / `unreachable`.** Each carries the actionable hint (rate-limit names auth as the fix; tag_missing names the version). Chosen.
+
+**Platform binding — where does `linux/amd64` live?**
+
+1. **Hardcoded in `EngineStack._maybe_pull_service_image`.** Works today; blocks any future arm64-native image without a stack.py edit. Rejected.
+2. **Per-service field on `ServiceDefinition` (`published_image_platform`).** Each service declares its published platform; the pull path forwards it verbatim. A future multi-arch or arm64-native image is a per-service edit. Chosen.
+
+## Decision
+
+We adopt **Policy shape 4** (`docker.image_source: auto | pull | build`),
+**Fallback semantics 2** (log-loud auto fallback, hard-fail pull),
+**Failure-kind sub-classification 2** (three kinds), and
+**Platform binding 2** (per-service `published_image_platform`).
+
+### The knob
+
+`DockerConfig.image_source: Literal["auto", "pull", "build"]` with
+default `"auto"`, wired into `RunConfig.docker: DockerConfig | None`.
+Precedence for override: `--image-source` CLI flag >
+`TOLOKAFORGE_IMAGE_SOURCE` env > `docker.image_source` in YAML >
+default. The Click `Choice` and the env-var check derive the allow-list
+from `typing.get_args(ImageSource)` so the tri-valued literal is a
+single source of truth.
+
+### `auto` mode resolution
+
+`resolve_image_source(request, is_wheel_install, engine_version)` is a
+pure function; the caller passes the two facts it needs:
+
+- `is_wheel_install`: `not (repo_root() / "pyproject.toml").is_file()`
+  (the same discriminator [ADR-0025](0025-runner-wheel-split.md) uses).
+- `engine_version`: `tolokaforge.__version__`, which reads
+  `importlib.metadata.version("tolokaforge")` with the sentinel
+  `"0.0.0+unknown"` when metadata is missing.
+
+Rules:
+
+- `pull` and `build` requests are terminal — the escape hatch always wins.
+- `auto` resolves to `build` when `is_wheel_install is False` (source
+  checkout).
+- `auto` resolves to `build` when the version is the unknown sentinel
+  (no valid pull tag).
+- `auto` resolves to `build` when the version carries a PEP 440 local
+  segment (`+…`) — Docker tags don't accept `+`, so the pull would
+  fail with a misclassified error; a local-version wheel means "not
+  what's on Docker Hub" by definition.
+- Otherwise `auto` resolves to `pull`.
+
+### The pull path
+
+`Image.pull(name, tag, platform=None, log_label=None, client=None)`
+mirrors `Image.build()`:
+
+- Cache-hit short-circuit via `_find_existing_image` — but the cache-hit
+  branch verifies the cached image's `Os`/`Architecture` match the
+  requested platform, re-pulling on mismatch. A wrong-arch cached tag
+  (from an operator's `docker tag` or a stale intermediate state) would
+  otherwise return an image that fails far downstream with `exec format
+  error`.
+- Tenacity retry (5 attempts, exponential 10–60 s), with a selective
+  `_is_transient` predicate: 404 and 429 are terminal (no retry — a
+  retry doesn't change the answer); `ConnectionError` / `TimeoutError` /
+  `OSError` retry the full budget (network flap); bare `DockerException`
+  is terminal (a "daemon socket closed" doesn't get better by waiting).
+- `ImagePullError` sub-classifies failures: `tag_missing` (404),
+  `rate_limited` (429, carries response headers so callers can surface
+  `Retry-After`), `unreachable` (everything else). The `rate_limited`
+  message names authenticated pulls as the fix.
+- `log_label` (defaulting to the service name) prefixes the retry log
+  so concurrent-retry lines from multiple services can be correlated.
+
+### The stack-side wiring
+
+`ServiceDefinition` grows two fields:
+
+- `published_image_repo: str | None` (default `None`) — the Docker Hub
+  repository the pull target resolves against. First-party services in
+  `stacks/core.py` and `stacks/full.py` set this to
+  `tolokasoft1/tolokaforge-<svc>`. Task-declared services and
+  third-party images (`dind`, `typesense`) leave it `None` and take the
+  build path.
+- `published_image_platform: str` (default `"linux/amd64"`) — the
+  platform passed to `Image.pull`. `publish-images.yml` currently
+  produces `linux/amd64`-only manifests, so the default matches. A
+  future arm64-native or multi-arch image sets this per-service — no
+  stack.py edit.
+
+`EngineStack._maybe_pull_service_image` runs before the build path in
+`_build_one_image`. It resolves the policy, attempts the pull, and
+either returns the pulled image (short-circuiting the build) or falls
+through. `use_prebuilt_image=True` (dind / typesense) still
+short-circuits *before* the pull policy — third-party images are
+unaffected.
+
+In explicit `pull` mode two contract corners raise instead of silently
+building:
+
+- `force=True` on `build_images(force=True)` (a caller asking for a
+  fresh build) conflicts with "pull or die" — raise so the operator
+  sees the conflict.
+- `published_image_repo=None` on a service reached in `pull` mode is
+  unpullable — raise so the misconfiguration surfaces.
+
+### The orchestrator surfacing
+
+`Orchestrator.run()`'s auto-start block catches `ImagePullError`
+specifically and logs `kind` / `image` / `message` / `retry_after`
+before re-raising, so the operator sees the actionable hint (e.g.
+"configure Docker Hub authenticated pulls") rather than a generic
+run-start crash trace.
+
+## Consequences
+
+### Positive
+
+- **First-run cost drops from 2–5 min to 30–60 s** for wheel consumers
+  on fresh hosts — the load-bearing win.
+- **rc-smoke-validated bytes ship to every wheel consumer** on the
+  default path. Local rebuilds can drift (base-image tag resolution,
+  transitive deps, buildkit re-serialization); pulling avoids that
+  entire class of surprise.
+- **No new PyPI presence.** [ADR-0025](0025-runner-wheel-split.md)'s
+  "one PyPI wheel" constraint is preserved; the pull target is the
+  same Docker Hub image [ADR-0023](0023-runner-image-internals.md)
+  already ships.
+- **Contributor loop is unchanged.** Source-checkout users still
+  build; every Dockerfile / service-code edit still materialises via
+  the same `Image.build` path.
+- **Explicit modes exist for consumers who need them.**
+  `image_source: pull` gives arena / high-volume consumers a "pull or
+  die" guarantee; `image_source: build` gives air-gapped operators a
+  Docker-Hub-untouching path without editing engine code.
+- **Failure modes are operator-actionable.** Rate-limit hint names
+  auth; tag-missing hint names the version; unreachable names the
+  network error verbatim.
+
+### Negative / Trade-offs
+
+- **Docker Hub rate-limit exposure.** Shared CI runners or arena hosts
+  driving many `tolokaforge run` invocations from cold hosts will
+  eventually hit the anonymous 100-per-6h ceiling. The mitigation is
+  documented (configure auth via `~/.docker/config.json` or switch
+  to `image_source: build`), and `auto` mode falls back with a
+  loud warning naming rate-limit specifically — but the exposure is
+  new.
+- **Byte-identity is a *release-pipeline* property, not a *code*
+  property.** Wheel consumers now get bytes produced by
+  `publish-images.yml`, which may differ layer-for-layer from a local
+  build even at the same source-tree revision (base-image drift,
+  transitive dep resolution, buildkit re-serialization). For the vast
+  majority of consumers this is the *stronger* property (rc-smoke
+  validated it), but it is different from "your `docker build` locally
+  produces the same digest".
+- **Two new fields on `ServiceDefinition`.** `published_image_repo`
+  and `published_image_platform` grow the ServiceDefinition surface.
+  Both are optional with sensible defaults; third-party
+  `ServiceDefinition`s that don't set them take the build path
+  unchanged.
+- **The `use_prebuilt_image` branch is now the least-preferred of
+  three image-resolution paths.** Third-party services (dind,
+  typesense) still take it; it just isn't the model first-party
+  services follow.
+- **Digest-pinning is not delivered here.** Consumers pin by tag; a
+  Docker Hub retag would change the underlying bytes without a
+  version bump. If a supply-chain requirement lands, a follow-up ADR
+  layers digest-pinning on top of this seam.
+
+### Follow-ups
+
+- **Code changes required:** all shipped in the PR that closes
+  [Toloka/tolokaforge#1068](https://github.com/Toloka/tolokaforge/issues/1068).
+- **Documentation to update:** `docs/RUNNER.md` gains the new default
+  and knob (done in the same PR); `docs/RELEASING.md` should name the
+  pull-by-default behaviour so release notes call it out
+  (follow-up); `docs/STANDALONE_RUNNER.md` untouched.
+- **Tests to add:** unit and integration coverage lands in the same
+  PR — see `tests/unit/test_image_pull.py`,
+  `tests/unit/test_image_source_policy.py`,
+  `tests/unit/test_stack_pull_vs_build.py`,
+  `tests/unit/test_stack_container_reuse_tag_ordering.py`,
+  `tests/unit/test_orchestrator_docker_config_forwarding.py`,
+  `tests/canonical/test_wheel_install_runner_context.py` (extended),
+  and `tests/integration/deploy/test_run_pull_default.py`.
+- **Digest-pinning ADR** (future): if a supply-chain requirement
+  emerges, layer digest-pinning on top of this seam via a bundled
+  manifest.
+- **`docker.pull_credentials` field** (future): programmatic Docker
+  Hub auth for arena / task drivers that can't rely on the daemon's
+  `~/.docker/config.json`.
+- **Multi-arch publish** (future, tracked separately): if / when
+  `publish-images.yml` grows an arm64 target, individual services
+  override `published_image_platform` per-service — no ADR update
+  needed at that time.
+
+## Links
+
+- Related ADRs:
+  - [ADR-0022](0022-runtime-independence.md) — the "same package,
+    same wheel" clause this ADR preserves at the PyPI level.
+  - [ADR-0023](0023-runner-image-internals.md) — the image name / tag
+    axis this ADR pulls from.
+  - [ADR-0025](0025-runner-wheel-split.md) — the wheel-vs-source
+    discriminator this ADR reuses; the one-PyPI-wheel constraint this
+    ADR preserves.
+  - [ADR-0030](0030-tolokaforge-models-split.md) — the M29 delivery
+    (v0.18.0) that made the published images available in the shape
+    this ADR relies on.
+- Related code:
+  - `tolokaforge/docker/config.py` — `DockerConfig.image_source`,
+    `ImageSource` literal.
+  - `tolokaforge/docker/image.py` — `Image.pull`, `ImagePullError`,
+    `_cached_image_matches_platform`.
+  - `tolokaforge/docker/image_source_policy.py` —
+    `resolve_image_source` policy helper.
+  - `tolokaforge/docker/stack.py` — `EngineStack._maybe_pull_service_
+    image`, `ServiceDefinition.published_image_repo`,
+    `published_image_platform`.
+  - `tolokaforge/dx/cli/main.py` — `--image-source` flag,
+    `TOLOKAFORGE_IMAGE_SOURCE` env, precedence.
+- External references:
+  - [Toloka/tolokaforge#1068](https://github.com/Toloka/tolokaforge/issues/1068)
+    — public umbrella issue.
+  - [Toloka/tolokaforge#1082](https://github.com/Toloka/tolokaforge/pull/1082)
+    — implementing PR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,3 +61,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0028](0028-multi-actor-turn-policy.md) | Multi-actor turn policy — `interaction_mode` + `Actor` + `TurnPolicy` | Accepted |
 | [0029](0029-build-check-builtin-tool.md) | `build_check` as a generic peer-service HTTP probe in core | Accepted |
 | [0030](0030-tolokaforge-models-split.md) | Model data as a second PyPI wheel — `tolokaforge-models` from the same monorepo | Proposed |
+| [0031](0031-pull-vs-build-default-for-service-images.md) | Wheel consumers pull published images by default — `docker.image_source` policy | Proposed |

--- a/tests/canonical/test_wheel_install_runner_context.py
+++ b/tests/canonical/test_wheel_install_runner_context.py
@@ -237,11 +237,13 @@ def test_core_stack_runner_context_assembles_from_wheel_install(
         import shutil
         from pathlib import Path
 
+        import tolokaforge
         from tolokaforge.docker.builder import (
             assemble_build_context,
             get_image_definition,
             repo_root,
         )
+        from tolokaforge.docker.image_source_policy import resolve_image_source
         from tolokaforge.docker.stacks.core import core_stack
 
         # Confirm the venv actually looks like a wheel install — this is
@@ -255,6 +257,20 @@ def test_core_stack_runner_context_assembles_from_wheel_install(
         svc = core_stack().services["runner"]
         gi = get_image_definition("runner")
         lists_equal = svc.context_files == gi["context_files"]
+        # #1068 — SSOT check across the wheel boundary. On a wheel
+        # install the runner service must declare its published repo,
+        # and the pull-policy resolver (given the engine version
+        # ``importlib.metadata`` reports for THIS venv) must resolve
+        # ``auto`` to ``pull``. A regression that drops
+        # ``published_image_repo`` from the ServiceDefinition, or that
+        # ships a broken ``__version__`` sentinel, would fail here in a
+        # real wheel install — not just in unit-test mocks.
+        engine_version = tolokaforge.__version__
+        resolved_auto = resolve_image_source(
+            request="auto",
+            is_wheel_install=wheel_install,
+            engine_version=engine_version,
+        )
 
         # Assemble the build context via the PRODUCTION path — the exact
         # call ``EngineStack.build_images`` makes on a live run.
@@ -281,6 +297,9 @@ def test_core_stack_runner_context_assembles_from_wheel_install(
             "files_present": files_present,
             "pyproject_has_custom_target": _PYPROJECT_MARKER in pyproject_text,
             "pyproject_size": len(pyproject_text),
+            "runner_published_repo": svc.published_image_repo,
+            "engine_version": engine_version,
+            "resolved_auto": resolved_auto,
         }))
         """).strip()
     probe = probe_prelude + probe_body
@@ -356,4 +375,28 @@ def test_core_stack_runner_context_assembles_from_wheel_install(
         "was force-included or the pyproject's custom target section was "
         "removed. Check ``[tool.hatch.build.targets.wheel.force-include]`` "
         "and ``[tool.hatch.build.targets.custom]`` in the repo-root ``pyproject.toml``."
+    )
+
+    # #1068 — SSOT: the runner ServiceDefinition on a wheel install must
+    # declare its published repo, and the pull-policy resolver must map
+    # ``auto`` to ``pull`` for a real wheel install with a real reported
+    # version. A regression that drops ``published_image_repo`` or that
+    # ships a broken ``__version__`` fallback would silently keep every
+    # wheel-installed user on the slow local-build path.
+    assert probe_data["runner_published_repo"] == "tolokasoft1/tolokaforge-runner", (
+        "runner ServiceDefinition on a wheel install did not declare "
+        f"``published_image_repo=tolokasoft1/tolokaforge-runner`` "
+        f"(got: {probe_data['runner_published_repo']!r}). The pull-vs-build "
+        "policy in ``EngineStack._maybe_pull_service_image`` needs this field "
+        "to resolve to ``pull``; a missing / renamed value silently forces "
+        "every wheel-installed user onto the local-build path."
+    )
+    assert probe_data["resolved_auto"] == "pull", (
+        "``resolve_image_source(request='auto', is_wheel_install=True, "
+        f"engine_version={probe_data['engine_version']!r})`` returned "
+        f"{probe_data['resolved_auto']!r} on a real wheel install. The wheel "
+        "should report a real version from ``importlib.metadata`` and route "
+        "to ``pull``; if it does not, either ``__version__`` fell back to the "
+        "unknown sentinel (metadata missing from the built wheel) or the "
+        "policy resolver's default behaviour changed."
     )

--- a/tests/integration/deploy/test_run_pull_default.py
+++ b/tests/integration/deploy/test_run_pull_default.py
@@ -1,0 +1,367 @@
+"""Integration test — the docker.image_source policy end-to-end.
+
+Verifies the pull path against a real Docker daemon: a wheel-installed
+engine with ``docker.image_source: pull`` reaches Docker Hub, lands
+the published image locally, and satisfies ``EngineStack.get_image``.
+The build-mode counterpart verifies that ``image_source: build``
+never touches Docker Hub.
+
+Isolation guarantees:
+
+- Marked ``integration + requires_docker``. Skipped in the default
+  ``pytest`` collection; runs only under ``-m "integration and
+  requires_docker"``.
+- Skipped when a container named ``tolokaforge-runner`` is already
+  running on the host — that indicates a live dev-loop, and this test
+  would otherwise race the running container. A restart between tests
+  would introduce test order-dependence.
+- Uses ``tolokasoft1/tolokaforge-*`` (Docker Hub-scoped) as the pull
+  target; locally-built engine images use the ``tolokaforge-*`` prefix
+  (no publisher). The two namespaces do not overlap, so a cached local
+  build cannot masquerade as a pulled image, and the test never
+  ``docker rmi``s a shared image the developer built.
+- Every subprocess is capped at ``_SUBPROCESS_TIMEOUT_S`` so a hung
+  ``docker pull`` can't burn the runner's wall-clock budget.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tests.utils.docker_helpers import is_docker_daemon_available
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PUBLISHED_RUNNER_REPO = "tolokasoft1/tolokaforge-runner"
+_SUBPROCESS_TIMEOUT_S = 300  # docker pull on a slow link can be a few minutes
+
+
+def _daemon_available() -> bool:
+    try:
+        return is_docker_daemon_available()
+    except Exception:
+        return False
+
+
+def _live_runner_container_running() -> bool:
+    """True if a container named ``tolokaforge-runner`` is already running
+    on the host — a dev-loop signal. Skipping in that case is deliberate:
+    we do not want to race a live container or accidentally influence its
+    tags."""
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return "tolokaforge-runner" in result.stdout.split()
+
+
+@pytest.fixture(scope="module")
+def _skip_if_dev_loop() -> None:
+    if not _daemon_available():
+        pytest.skip("Docker daemon is not available on this host")
+    if _live_runner_container_running():
+        pytest.skip(
+            "A tolokaforge-runner container is already running on this host — "
+            "skipping to avoid racing a live dev-loop."
+        )
+
+
+@pytest.fixture(scope="module")
+def _built_wheels_dist(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the engine + models wheels once for the module.
+
+    Mirrors ``tests/canonical/test_wheel_install_runner_context.py``'s
+    ``built_wheels_dist`` — reusing the exact invocation the base wheel
+    ships with, so this test exercises the same install surface a real
+    ``pip install tolokaforge`` would."""
+    dist_dir = tmp_path_factory.mktemp("integration_pull_dist")
+    for project_dir, label in (
+        (REPO_ROOT, "engine"),
+        (REPO_ROOT / "tolokaforge_models", "models"),
+    ):
+        result = subprocess.run(
+            [sys.executable, "-m", "hatchling", "build", "-t", "wheel", "-d", str(dist_dir)],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"{label} wheel build failed (exit {result.returncode}):\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+    return dist_dir
+
+
+@pytest.fixture(scope="module")
+def _scratch_venv(
+    tmp_path_factory: pytest.TempPathFactory,
+    _built_wheels_dist: Path,
+    _skip_if_dev_loop: None,
+) -> Path:
+    """Build a scratch venv with the freshly-built engine wheel installed.
+
+    Returns the venv's python interpreter path. Session-scoped and
+    resource-heavy (~30–60 s), so downstream tests share it via
+    module scope."""
+    venv_dir = tmp_path_factory.mktemp("integration_pull_venv")
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        check=True,
+        capture_output=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+    venv_python = venv_dir / "bin" / "python"
+
+    # Find the engine wheel — it's the only one matching ``tolokaforge-*``
+    # (the models sibling is ``tolokaforge_models-*``).
+    wheels = list(_built_wheels_dist.glob("*.whl"))
+    base_wheels = [w for w in wheels if w.name.startswith("tolokaforge-")]
+    assert len(base_wheels) == 1, (
+        f"expected exactly one base tolokaforge wheel in {_built_wheels_dist}, "
+        f"got: {[w.name for w in wheels]}"
+    )
+    base_wheel = base_wheels[0]
+
+    install_cmd = [
+        str(venv_python),
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        "--find-links",
+        str(_built_wheels_dist),
+        str(base_wheel),
+    ]
+    result = subprocess.run(
+        install_cmd,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"wheel install into scratch venv failed (exit {result.returncode}):\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return venv_python
+
+
+def _resolved_engine_version(venv_python: Path) -> str:
+    result = subprocess.run(
+        [str(venv_python), "-c", "import tolokaforge; print(tolokaforge.__version__)"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"failed to resolve engine version:\nstderr:\n{result.stderr}")
+    return result.stdout.strip()
+
+
+def _docker_image_present(reference: str) -> bool:
+    """True when ``docker image inspect <ref>`` succeeds."""
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", reference],
+            capture_output=True,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _docker_image_id(reference: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{.Id}}", reference],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _cleanup_local_alias(alias: str) -> None:
+    """Best-effort ``docker rmi`` of an alias tag this test created.
+
+    Removing the alias is safe: it only untags the reference. The
+    underlying image layers (and any other tags pointing at the same
+    image ID, e.g. the ``:0.18.0`` reference the pull created) are
+    preserved."""
+    subprocess.run(
+        ["docker", "rmi", alias],
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+
+
+class TestPullPathLandsPublishedImage:
+    def test_image_source_pull_leaves_published_reference_in_daemon(
+        self,
+        _scratch_venv: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """A wheel-installed engine calling ``Image.pull`` against Docker
+        Hub for the runner repo lands the published tag in the local
+        daemon. This is the empirical version of ``test_image_pull.py``:
+        no mocks — the real Docker SDK talks to real Docker Hub."""
+        engine_version = _resolved_engine_version(_scratch_venv)
+        assert engine_version != "0.0.0+unknown", (
+            "scratch venv failed to expose an installed version — the "
+            "install-metadata is missing from the built wheel"
+        )
+        published_ref = f"{PUBLISHED_RUNNER_REPO}:{engine_version}"
+
+        # Run the pull from OUTSIDE the repo (probe_cwd trick) so the
+        # scratch venv sees ONLY the wheel-installed tolokaforge, not
+        # any source-tree package that might shadow it via sys.path[0].
+        probe_cwd = tmp_path_factory.mktemp("integration_pull_cwd_outside_repo")
+        probe = textwrap.dedent(f"""
+            import json
+            import tolokaforge
+            from tolokaforge.docker.image import Image
+
+            img = Image.pull(
+                name={PUBLISHED_RUNNER_REPO!r},
+                tag={engine_version!r},
+                platform="linux/amd64",
+            )
+            print(json.dumps({{
+                "full_tag": img.full_tag,
+                "image_id": img.image_id,
+                "context_hash": img.context_hash,
+                "engine_version": tolokaforge.__version__,
+            }}))
+        """).strip()
+
+        try:
+            result = subprocess.run(
+                [str(_scratch_venv), "-c", probe],
+                capture_output=True,
+                text=True,
+                cwd=str(probe_cwd),
+                timeout=_SUBPROCESS_TIMEOUT_S,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Image.pull inside scratch venv failed (exit "
+                    f"{result.returncode}):\nstdout:\n{result.stdout}\n"
+                    f"stderr:\n{result.stderr}"
+                )
+            data = json.loads(result.stdout.strip().splitlines()[-1])
+
+            assert data["full_tag"] == published_ref
+            assert data["context_hash"] == "pulled"
+            assert _docker_image_present(published_ref), (
+                f"Image.pull reported success but {published_ref} is not "
+                "present in the local daemon after the call — either the "
+                "pull code did not actually pull, or a cleanup ran between."
+            )
+            assert data["image_id"] == _docker_image_id(published_ref), (
+                "image_id returned by Image.pull does not match the daemon's "
+                f"inspect for {published_ref}"
+            )
+        finally:
+            shutil.rmtree(probe_cwd, ignore_errors=True)
+
+
+class TestBuildModeSkipsPull:
+    def test_image_source_build_never_pulls(
+        self,
+        _scratch_venv: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """With ``docker.image_source=build``, the stack never calls
+        ``Image.pull``. We can't directly observe absence-of-network-
+        call, but we CAN verify the resolver returns 'build' for every
+        input combination that would otherwise pull — which is
+        equivalent to observing at the layer above what the network
+        would see below."""
+        probe_cwd = tmp_path_factory.mktemp("integration_pull_build_mode_cwd")
+        probe = textwrap.dedent("""
+            import json
+            import tolokaforge
+            from tolokaforge.docker.image_source_policy import resolve_image_source
+
+            # Even the case that would otherwise pull (auto + wheel + known
+            # version) resolves to build when the caller declares build
+            # explicitly.
+            forced_build = resolve_image_source(
+                request="build",
+                is_wheel_install=True,
+                engine_version=tolokaforge.__version__,
+            )
+            print(json.dumps({"forced_build": forced_build}))
+        """).strip()
+
+        try:
+            result = subprocess.run(
+                [str(_scratch_venv), "-c", probe],
+                capture_output=True,
+                text=True,
+                cwd=str(probe_cwd),
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"resolve_image_source probe failed (exit "
+                    f"{result.returncode}):\nstderr:\n{result.stderr}"
+                )
+            data = json.loads(result.stdout.strip().splitlines()[-1])
+            assert data["forced_build"] == "build"
+        finally:
+            shutil.rmtree(probe_cwd, ignore_errors=True)
+
+
+class TestSourceCheckoutResolvesToBuild:
+    def test_auto_from_repo_checkout_yields_build(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """The repo-checkout branch — running Python from THIS worktree
+        (where ``pyproject.toml`` sits alongside ``repo_root()``) —
+        must resolve ``auto`` to ``build``. No wheel install involved;
+        this is the contributor path.
+
+        Uses the outer test's Python (not a scratch venv) so
+        ``repo_root()`` genuinely sees the on-disk ``pyproject.toml``."""
+        # Skip if we somehow lost the pyproject.toml alongside the runtime
+        # tolokaforge tree — the assertion below is only meaningful when
+        # the file exists.
+        from tolokaforge.docker.builder import repo_root
+
+        if not (repo_root() / "pyproject.toml").is_file():
+            pytest.skip(
+                "runtime tolokaforge is not co-located with pyproject.toml — "
+                "this test only checks the source-checkout branch."
+            )
+
+        import tolokaforge
+        from tolokaforge.docker.image_source_policy import resolve_image_source
+
+        resolved = resolve_image_source(
+            request="auto",
+            is_wheel_install=False,
+            engine_version=tolokaforge.__version__,
+        )
+        assert resolved == "build"

--- a/tests/integration/deploy/test_run_pull_default.py
+++ b/tests/integration/deploy/test_run_pull_default.py
@@ -254,6 +254,13 @@ class TestPullPathLandsPublishedImage:
             }}))
         """).strip()
 
+        # Remove the tag reference (not the underlying image) BEFORE
+        # the pull so we exercise the real network path — otherwise a
+        # cached copy from a prior run would short-circuit and hide any
+        # regression in the pull code. Post-run we don't clean up: the
+        # cached image is a fixture for the cache-hit test below.
+        _cleanup_local_alias(published_ref)
+
         try:
             result = subprocess.run(
                 [str(_scratch_venv), "-c", probe],
@@ -291,27 +298,56 @@ class TestBuildModeSkipsPull:
         _scratch_venv: Path,
         tmp_path_factory: pytest.TempPathFactory,
     ) -> None:
-        """With ``docker.image_source=build``, the stack never calls
-        ``Image.pull``. We can't directly observe absence-of-network-
-        call, but we CAN verify the resolver returns 'build' for every
-        input combination that would otherwise pull — which is
-        equivalent to observing at the layer above what the network
-        would see below."""
+        """With ``docker.image_source=build``, the stack's pull path is
+        never entered. We can't directly observe absence-of-network-call
+        across a subprocess boundary, but we CAN exercise the real
+        ``EngineStack._build_one_image`` code path with a monkey-patched
+        ``Image.pull`` that raises if called — and assert the raise
+        never fires. This actually tests the stack wiring rather than
+        the pure resolver (which is separately covered in
+        ``tests/unit/test_image_source_policy.py`` — the previous
+        version of this test only asserted the resolver output, which
+        was a tautology).
+
+        The probe patches ``Image.pull`` to fail loudly if called, then
+        calls ``_build_one_image`` for the runner service with
+        ``image_source=build``, catching any exceptions to see if
+        ``Image.pull`` was invoked."""
         probe_cwd = tmp_path_factory.mktemp("integration_pull_build_mode_cwd")
         probe = textwrap.dedent("""
             import json
-            import tolokaforge
-            from tolokaforge.docker.image_source_policy import resolve_image_source
+            from unittest.mock import MagicMock, patch
 
-            # Even the case that would otherwise pull (auto + wheel + known
-            # version) resolves to build when the caller declares build
-            # explicitly.
-            forced_build = resolve_image_source(
-                request="build",
-                is_wheel_install=True,
-                engine_version=tolokaforge.__version__,
+            from tolokaforge.docker.config import DockerConfig
+            from tolokaforge.docker.image import Image
+            from tolokaforge.docker.stack import EngineStack, ServiceDefinition
+
+            svc = ServiceDefinition(
+                name="runner",
+                image_name="tolokaforge-runner",
+                published_image_repo="tolokasoft1/tolokaforge-runner",
+                dockerfile="/nonexistent",  # ensures the build branch fails
+                context=".",
             )
-            print(json.dumps({"forced_build": forced_build}))
+            stack = EngineStack(config=DockerConfig(image_source="build"))
+
+            pull_called = {"value": False}
+            def _sentinel_pull(**kwargs):
+                pull_called["value"] = True
+                raise AssertionError("Image.pull must never be called in build mode")
+
+            with patch.object(Image, "pull", side_effect=_sentinel_pull):
+                try:
+                    stack._build_one_image(svc, force=False)
+                except AssertionError:
+                    raise
+                except Exception:
+                    # Expected — the build path will fail against the fake
+                    # dockerfile. What matters for this test is that
+                    # Image.pull was NOT called first.
+                    pass
+
+            print(json.dumps({"pull_called": pull_called["value"]}))
         """).strip()
 
         try:
@@ -324,11 +360,16 @@ class TestBuildModeSkipsPull:
             )
             if result.returncode != 0:
                 pytest.fail(
-                    f"resolve_image_source probe failed (exit "
-                    f"{result.returncode}):\nstderr:\n{result.stderr}"
+                    f"build-mode probe failed (exit "
+                    f"{result.returncode}):\nstdout:\n{result.stdout}\n"
+                    f"stderr:\n{result.stderr}"
                 )
             data = json.loads(result.stdout.strip().splitlines()[-1])
-            assert data["forced_build"] == "build"
+            assert data["pull_called"] is False, (
+                "EngineStack._build_one_image called Image.pull in build "
+                "mode — the pull-vs-build policy is broken for the "
+                "'build' branch."
+            )
         finally:
             shutil.rmtree(probe_cwd, ignore_errors=True)
 

--- a/tests/unit/dx/test_cli_image_source.py
+++ b/tests/unit/dx/test_cli_image_source.py
@@ -1,0 +1,219 @@
+"""Run-CLI ``--image-source`` / ``TOLOKAFORGE_IMAGE_SOURCE`` surface.
+
+Uses ``CliRunner`` against a stubbed :class:`Orchestrator` that
+captures the ``RunConfig`` the CLI resolved so we can assert the
+image-source flag / env / YAML precedence produced the correct
+:attr:`RunConfig.docker.image_source`. No real LLM, Docker, or
+filesystem outside the run's own output directory is touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+import tolokaforge.dx.cli.main as cli_main
+from tolokaforge.dx.cli.main import cli
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+def _write_config(tmp_path: Path, docker_block: dict[str, Any] | None = None) -> Path:
+    """Minimal ``run.yaml`` payload that parses. Adds an optional
+    ``docker:`` block so precedence tests can seed a YAML-declared
+    value and verify a CLI flag / env override wins."""
+    payload: dict[str, Any] = {
+        "models": {
+            "agent": {"provider": "openai", "name": "gpt-4"},
+            "user": {"provider": "openai", "name": "gpt-4o"},
+        },
+        "evaluation": {
+            "output_dir": str(tmp_path / "out"),
+            "tasks_glob": str(tmp_path / "tasks" / "*"),
+        },
+        "orchestrator": {"repeats": 1, "auto_start_services": False},
+        "compute": {"workers": 1},
+    }
+    if docker_block is not None:
+        payload["docker"] = docker_block
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text(yaml.safe_dump(payload))
+    return config_path
+
+
+def _make_capturing_orchestrator(captured: dict[str, Any], *, run_return: Path) -> type:
+    class _CapturingOrchestrator:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured["config"] = args[0] if args else kwargs.get("config")
+            self.tasks = [object()]
+
+        def load_tasks(self) -> None:
+            return None
+
+        def run(self, **_: object) -> Path:
+            return run_return
+
+    return _CapturingOrchestrator
+
+
+def _invoke(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config_path: Path,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[Any, dict[str, Any]]:
+    expected_dir = (tmp_path / "results" / "run").resolve()
+    expected_dir.mkdir(parents=True, exist_ok=True)
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        cli_main,
+        "Orchestrator",
+        _make_capturing_orchestrator(captured, run_return=expected_dir),
+    )
+    # Clear TOLOKAFORGE_IMAGE_SOURCE by default so a shell that has it
+    # exported does not silently pollute the test — the env-precedence
+    # tests below re-set it explicitly.
+    monkeypatch.delenv("TOLOKAFORGE_IMAGE_SOURCE", raising=False)
+    if env is not None:
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+    args = ["run", "--config", str(config_path), *(extra_args or [])]
+    result = runner.invoke(cli, args)
+    return result, captured
+
+
+class TestPrecedence:
+    def test_default_is_none_and_docker_block_absent(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No flag, no env, no YAML `docker:` block — RunConfig.docker
+        stays ``None``. The pull-vs-build policy in ``EngineStack``
+        instantiates a default ``DockerConfig`` (image_source='auto')
+        as its own fallback; leaving the block absent here confirms
+        the CLI does not spuriously create it."""
+        config_path = _write_config(tmp_path)
+
+        result, captured = _invoke(runner, tmp_path, monkeypatch, config_path=config_path)
+
+        assert result.exit_code == 0, result.stderr
+        assert captured["config"].docker is None
+
+    def test_yaml_docker_block_survives_without_override(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A YAML ``docker.image_source`` value reaches ``RunConfig``
+        unchanged when no flag or env is provided."""
+        config_path = _write_config(tmp_path, docker_block={"image_source": "build"})
+
+        result, captured = _invoke(runner, tmp_path, monkeypatch, config_path=config_path)
+
+        assert result.exit_code == 0, result.stderr
+        assert captured["config"].docker is not None
+        assert captured["config"].docker.image_source == "build"
+
+    def test_env_var_overrides_yaml(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config_path = _write_config(tmp_path, docker_block={"image_source": "build"})
+
+        result, captured = _invoke(
+            runner,
+            tmp_path,
+            monkeypatch,
+            config_path=config_path,
+            env={"TOLOKAFORGE_IMAGE_SOURCE": "pull"},
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert captured["config"].docker is not None
+        assert captured["config"].docker.image_source == "pull"
+
+    def test_flag_beats_env_and_yaml(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config_path = _write_config(tmp_path, docker_block={"image_source": "build"})
+
+        result, captured = _invoke(
+            runner,
+            tmp_path,
+            monkeypatch,
+            config_path=config_path,
+            extra_args=["--image-source", "auto"],
+            env={"TOLOKAFORGE_IMAGE_SOURCE": "pull"},
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert captured["config"].docker is not None
+        assert captured["config"].docker.image_source == "auto"
+
+
+class TestInputValidation:
+    def test_bad_flag_value_click_error(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Click's ``type=Choice`` rejects unknown values before the
+        run body executes."""
+        config_path = _write_config(tmp_path)
+
+        result, _ = _invoke(
+            runner,
+            tmp_path,
+            monkeypatch,
+            config_path=config_path,
+            extra_args=["--image-source", "pulll"],
+        )
+
+        assert result.exit_code != 0
+        assert "'pulll'" in result.stderr or "pulll" in result.output
+
+    def test_bad_env_value_click_error(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The env var is validated by the run body (Click's Choice
+        only covers the flag), so an invalid ``TOLOKAFORGE_IMAGE_SOURCE``
+        must surface as a Click ``BadParameter`` and not silently pass
+        through to construct_config where it would then produce a
+        pydantic ValidationError with a less-obvious message."""
+        config_path = _write_config(tmp_path)
+
+        result, _ = _invoke(
+            runner,
+            tmp_path,
+            monkeypatch,
+            config_path=config_path,
+            env={"TOLOKAFORGE_IMAGE_SOURCE": "puull"},
+        )
+
+        assert result.exit_code != 0
+        combined = (result.output or "") + (result.stderr or "")
+        assert "TOLOKAFORGE_IMAGE_SOURCE" in combined or "puull" in combined

--- a/tests/unit/dx/test_cli_image_source.py
+++ b/tests/unit/dx/test_cli_image_source.py
@@ -149,6 +149,35 @@ class TestPrecedence:
         assert captured["config"].docker is not None
         assert captured["config"].docker.image_source == "pull"
 
+    def test_null_docker_in_yaml_does_not_typeerror_on_override(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A YAML file with a bare ``docker:`` (which PyYAML parses to
+        ``None``) must not crash with a TypeError when the CLI applies
+        an ``--image-source`` override. Pre-fix behaviour was
+        ``None['image_source'] = 'pull'`` → confusing error with no
+        hint that the underlying issue is a malformed YAML value."""
+        config_path = _write_config(tmp_path)
+        raw = config_path.read_text()
+        # Inject a bare ``docker:`` line the YAML parser will resolve
+        # to ``None`` — the exact pathological input the fix addresses.
+        config_path.write_text(raw + "\ndocker:\n")
+
+        result, captured = _invoke(
+            runner,
+            tmp_path,
+            monkeypatch,
+            config_path=config_path,
+            extra_args=["--image-source", "pull"],
+        )
+
+        assert result.exit_code == 0, result.stderr
+        assert captured["config"].docker is not None
+        assert captured["config"].docker.image_source == "pull"
+
     def test_flag_beats_env_and_yaml(
         self,
         runner: CliRunner,

--- a/tests/unit/test_docker_config_image_source.py
+++ b/tests/unit/test_docker_config_image_source.py
@@ -1,0 +1,88 @@
+"""Unit tests for ``DockerConfig.image_source`` and its wiring into ``RunConfig``.
+
+Covers the config-schema surface for #1068 — the field itself
+(defaults, valid values, invalid values, immutability) and its
+integration into ``RunConfig`` (declared here as a first-party
+sub-block, not an ignored extra).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models.run_config import RunConfig
+from tolokaforge.docker.config import DockerConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _minimal_run_config_data(**overrides: object) -> dict[str, object]:
+    """Smallest ``RunConfig`` payload that parses, with room for overrides."""
+    data: dict[str, object] = {
+        "models": {},
+        "orchestrator": {},
+        "evaluation": {"task_packs": [], "output_dir": "/tmp/tolokaforge-test-out"},
+    }
+    data.update(overrides)
+    return data
+
+
+class TestDockerConfigImageSourceField:
+    def test_defaults_to_auto(self) -> None:
+        cfg = DockerConfig()
+        assert cfg.image_source == "auto"
+
+    @pytest.mark.parametrize("value", ["auto", "pull", "build"])
+    def test_accepts_all_three_values(self, value: str) -> None:
+        cfg = DockerConfig(image_source=value)  # type: ignore[arg-type]
+        assert cfg.image_source == value
+
+    def test_rejects_unknown_value(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            DockerConfig(image_source="pulll")  # type: ignore[arg-type]
+        assert "image_source" in str(excinfo.value)
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            DockerConfig(image_source="")  # type: ignore[arg-type]
+
+    def test_field_is_immutable_when_frozen(self) -> None:
+        cfg = DockerConfig(image_source="pull")
+        with pytest.raises(ValidationError):
+            cfg.image_source = "build"  # type: ignore[misc]
+
+    def test_extra_field_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DockerConfig(image_source="auto", unknown_field=1)  # type: ignore[call-arg]
+
+
+class TestRunConfigDockerBlock:
+    def test_docker_absent_stays_none(self) -> None:
+        run = RunConfig(**_minimal_run_config_data())  # type: ignore[arg-type]
+        assert run.docker is None
+
+    def test_docker_block_parses_to_docker_config(self) -> None:
+        run = RunConfig(
+            **_minimal_run_config_data(docker={"image_source": "pull"})  # type: ignore[arg-type]
+        )
+        assert run.docker is not None
+        assert isinstance(run.docker, DockerConfig)
+        assert run.docker.image_source == "pull"
+
+    def test_docker_block_defaults_when_empty(self) -> None:
+        run = RunConfig(**_minimal_run_config_data(docker={}))  # type: ignore[arg-type]
+        assert run.docker is not None
+        assert run.docker.image_source == "auto"
+
+    def test_docker_block_rejects_invalid_image_source(self) -> None:
+        with pytest.raises(ValidationError):
+            RunConfig(
+                **_minimal_run_config_data(docker={"image_source": "unknown"})  # type: ignore[arg-type]
+            )
+
+    def test_docker_block_rejects_unknown_field(self) -> None:
+        with pytest.raises(ValidationError):
+            RunConfig(
+                **_minimal_run_config_data(docker={"image_source": "auto", "nope": 1})  # type: ignore[arg-type]
+            )

--- a/tests/unit/test_image_pull.py
+++ b/tests/unit/test_image_pull.py
@@ -74,6 +74,22 @@ class TestImagePullHappyPath:
 
         client.images.pull.assert_called_once_with(NAME, tag=TAG)
 
+    def test_platform_kwarg_is_forwarded_when_set(self) -> None:
+        """Published tolokaforge-* images are linux/amd64 only. On an
+        arm64 host a bare ``docker pull`` fails with 'no matching
+        manifest for linux/arm64'; the caller passes an explicit
+        platform so both amd64 hosts (native) and arm64 hosts (under
+        emulation) land the same amd64 image."""
+        from tolokaforge.docker.image import Image
+
+        pulled = MagicMock()
+        pulled.id = "sha256:xyz"
+        client = _mock_client(pull_result=pulled)
+
+        Image.pull(name=NAME, tag=TAG, platform="linux/amd64", client=client)
+
+        client.images.pull.assert_called_once_with(NAME, tag=TAG, platform="linux/amd64")
+
 
 class TestImagePullCacheHit:
     def test_skips_pull_when_local_daemon_already_has_image(self) -> None:

--- a/tests/unit/test_image_pull.py
+++ b/tests/unit/test_image_pull.py
@@ -108,6 +108,72 @@ class TestImagePullCacheHit:
         assert image.image_id == "sha256:already-here"
         client.images.pull.assert_not_called()
 
+    def test_cache_hit_verifies_platform_arch_and_re_pulls_on_mismatch(self) -> None:
+        """If a cached image is present but its Os/Architecture do not
+        match the requested platform (e.g. an operator previously
+        ``docker tag``-ed an arm64 image onto the pulled tag), the pull
+        must NOT short-circuit — otherwise the caller gets a
+        wrong-arch image that fails much later with 'exec format error'."""
+        from tolokaforge.docker.image import Image
+
+        cached_wrong_arch = MagicMock(name="cached_wrong_arch")
+        cached_wrong_arch.id = "sha256:arm64-copy"
+        cached_wrong_arch.attrs = {"Os": "linux", "Architecture": "arm64"}
+
+        pulled_correct = MagicMock(name="pulled_correct")
+        pulled_correct.id = "sha256:amd64-fresh"
+
+        client = _mock_client(get_side_effect=None)
+        client.images.get.side_effect = None
+        client.images.get.return_value = cached_wrong_arch
+        client.images.pull.return_value = pulled_correct
+
+        image = Image.pull(name=NAME, tag=TAG, platform="linux/amd64", client=client)
+
+        # Cache short-circuit was skipped — a fresh pull actually
+        # happened.
+        client.images.pull.assert_called_once_with(NAME, tag=TAG, platform="linux/amd64")
+        assert image.image_id == "sha256:amd64-fresh"
+
+    def test_cache_hit_uses_cached_image_when_platform_matches(self) -> None:
+        from tolokaforge.docker.image import Image
+
+        cached_correct = MagicMock(name="cached_correct")
+        cached_correct.id = "sha256:amd64-cached"
+        cached_correct.attrs = {"Os": "linux", "Architecture": "amd64"}
+
+        client = _mock_client(get_side_effect=None)
+        client.images.get.side_effect = None
+        client.images.get.return_value = cached_correct
+
+        image = Image.pull(name=NAME, tag=TAG, platform="linux/amd64", client=client)
+
+        assert image.image_id == "sha256:amd64-cached"
+        client.images.pull.assert_not_called()
+
+    def test_cache_hit_re_pulls_when_attrs_missing(self) -> None:
+        """When the cached image's attrs don't expose Os/Architecture
+        (unexpected daemon behavior, older docker version, etc.), err
+        on the side of re-pulling rather than returning an unverifiable
+        image."""
+        from tolokaforge.docker.image import Image
+
+        cached_unknown = MagicMock(name="cached_unknown")
+        cached_unknown.id = "sha256:unknown"
+        cached_unknown.attrs = {}
+
+        pulled = MagicMock()
+        pulled.id = "sha256:fresh"
+
+        client = _mock_client(get_side_effect=None)
+        client.images.get.side_effect = None
+        client.images.get.return_value = cached_unknown
+        client.images.pull.return_value = pulled
+
+        Image.pull(name=NAME, tag=TAG, platform="linux/amd64", client=client)
+
+        client.images.pull.assert_called_once()
+
 
 class TestImagePullErrors:
     def test_image_not_found_becomes_tag_missing(self) -> None:
@@ -191,7 +257,12 @@ class TestImagePullErrors:
         assert client.images.pull.call_count == 5
         _ = docker
 
-    def test_docker_exception_becomes_unreachable(self) -> None:
+    def test_docker_exception_becomes_unreachable_without_retries(self) -> None:
+        """Bare ``DockerException`` (e.g. 'daemon socket closed') is
+        NOT retried — it isn't recoverable by waiting, and burning ~130 s
+        of tenacity backoff on it just delays surfacing the real
+        problem. Only network-layer transient errors get the full
+        5-attempt budget (see the 500 test above)."""
         docker = pytest.importorskip("docker")
         from docker.errors import DockerException
 
@@ -205,7 +276,40 @@ class TestImagePullErrors:
                 Image.pull(name=NAME, tag=TAG, client=client)
 
         assert excinfo.value.kind == "unreachable"
+        # Bare DockerException is terminal — no retries.
+        assert client.images.pull.call_count == 1
         _ = docker
+
+    def test_connection_error_becomes_unreachable_after_retries(self) -> None:
+        """``requests.ConnectionError`` and other ``OSError`` subclasses
+        can escape docker-py un-wrapped when the daemon socket becomes
+        unresponsive mid-pull. Classify as transient and burn the full
+        retry budget before surfacing — the daemon might come back."""
+        client = _mock_client()
+        client.images.pull.side_effect = ConnectionError("daemon socket flapping")
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError) as excinfo:
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "unreachable"
+        assert client.images.pull.call_count == 5
+
+    def test_os_error_becomes_unreachable_after_retries(self) -> None:
+        """Raw ``OSError`` (broken socket, EPIPE, etc.) — same shape."""
+        client = _mock_client()
+        client.images.pull.side_effect = OSError("EPIPE")
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError) as excinfo:
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "unreachable"
+        assert client.images.pull.call_count == 5
 
 
 class TestImagePullDoesNotRetryTerminal:

--- a/tests/unit/test_image_pull.py
+++ b/tests/unit/test_image_pull.py
@@ -1,0 +1,233 @@
+"""Unit tests for ``Image.pull()`` and ``ImagePullError``.
+
+Every test uses a mocked ``docker.DockerClient`` — no daemon is touched,
+so this file is safe to run under any environment. The mock shape
+mirrors ``tests/unit/test_network_409_race.py`` (the same pattern is
+used across the docker unit suite).
+
+The retry harness inside ``Image.pull`` is real ``tenacity``; the
+transient-error tests below patch ``tenacity.nap.sleep`` so retries do
+not introduce wall time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+NAME = "tolokasoft1/tolokaforge-runner"
+TAG = "0.18.0"
+FULL_TAG = f"{NAME}:{TAG}"
+
+
+def _mock_client(pull_result: Any = None, get_side_effect: Any | None = None) -> MagicMock:
+    """Build a MagicMock DockerClient wired for a pull test.
+
+    ``get_side_effect`` controls what ``_find_existing_image`` sees.
+    Default: raise ``ImageNotFound`` so the cache-hit branch is skipped
+    and we always exercise the pull path.
+    """
+    docker = pytest.importorskip("docker")
+    from docker.errors import ImageNotFound
+
+    client = MagicMock(spec=docker.DockerClient)
+    client.images = MagicMock()
+    if get_side_effect is None:
+        client.images.get.side_effect = ImageNotFound(f"no such image: {FULL_TAG}")
+    else:
+        client.images.get.side_effect = get_side_effect
+    client.images.pull.return_value = pull_result
+    return client
+
+
+class TestImagePullHappyPath:
+    def test_returns_image_with_pulled_sentinel_on_success(self) -> None:
+        from tolokaforge.docker.image import Image
+
+        pulled = MagicMock(name="pulled_docker_image")
+        pulled.id = "sha256:abc123"
+        client = _mock_client(pull_result=pulled)
+
+        image = Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert image.name == NAME
+        assert image.tag == TAG
+        assert image.full_tag == FULL_TAG
+        assert image.image_id == "sha256:abc123"
+        assert image.context_hash == "pulled"
+        assert image.dockerfile == "pulled"
+        assert image.context == "pulled"
+
+    def test_calls_pull_with_repository_and_tag_kwargs(self) -> None:
+        from tolokaforge.docker.image import Image
+
+        pulled = MagicMock()
+        pulled.id = "sha256:xyz"
+        client = _mock_client(pull_result=pulled)
+
+        Image.pull(name=NAME, tag=TAG, client=client)
+
+        client.images.pull.assert_called_once_with(NAME, tag=TAG)
+
+
+class TestImagePullCacheHit:
+    def test_skips_pull_when_local_daemon_already_has_image(self) -> None:
+        from tolokaforge.docker.image import Image
+
+        existing = MagicMock(name="existing_docker_image")
+        existing.id = "sha256:already-here"
+
+        # Cache hit — client.images.get returns the existing image.
+        client = _mock_client(get_side_effect=None)
+        client.images.get.side_effect = None
+        client.images.get.return_value = existing
+
+        image = Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert image.image_id == "sha256:already-here"
+        client.images.pull.assert_not_called()
+
+
+class TestImagePullErrors:
+    def test_image_not_found_becomes_tag_missing(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import ImageNotFound
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        client.images.pull.side_effect = ImageNotFound(f"pull error: {FULL_TAG}")
+
+        with pytest.raises(ImagePullError) as excinfo:
+            Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "tag_missing"
+        assert excinfo.value.full_tag == FULL_TAG
+        _ = docker  # keep the importorskip in-scope
+
+    def test_api_error_404_becomes_tag_missing(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import APIError
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        response = MagicMock()
+        response.status_code = 404
+        response.headers = {"X-Docker-Reason": "not found"}
+        client.images.pull.side_effect = APIError("not found", response=response)
+
+        with pytest.raises(ImagePullError) as excinfo:
+            Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "tag_missing"
+        _ = docker
+
+    def test_api_error_429_becomes_rate_limited_and_carries_retry_after(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import APIError
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {"Retry-After": "60"}
+        client.images.pull.side_effect = APIError("too many requests", response=response)
+
+        with pytest.raises(ImagePullError) as excinfo:
+            Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "rate_limited"
+        assert excinfo.value.response_headers.get("Retry-After") == "60"
+        # The message names auth as the fix — the actionable hint for a
+        # rate-limited operator.
+        assert "auth" in str(excinfo.value).lower()
+        _ = docker
+
+    def test_api_error_500_becomes_unreachable(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import APIError
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        response = MagicMock()
+        response.status_code = 500
+        response.headers = {}
+        client.images.pull.side_effect = APIError("registry down", response=response)
+
+        # Silence tenacity's sleep during transient-retry loops so a real
+        # 500 test does not introduce wall time. We patch the module the
+        # decorator's wait uses to schedule sleeps.
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError) as excinfo:
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "unreachable"
+        # Retried before failing — we should have called pull the full
+        # 5-attempt budget for a transient error.
+        assert client.images.pull.call_count == 5
+        _ = docker
+
+    def test_docker_exception_becomes_unreachable(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import DockerException
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        client.images.pull.side_effect = DockerException("daemon socket closed")
+
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError) as excinfo:
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert excinfo.value.kind == "unreachable"
+        _ = docker
+
+
+class TestImagePullDoesNotRetryTerminal:
+    def test_404_not_retried(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import APIError
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        response = MagicMock()
+        response.status_code = 404
+        response.headers = {}
+        client.images.pull.side_effect = APIError("not found", response=response)
+
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError):
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        # 404 is terminal: exactly one attempt, no retries.
+        assert client.images.pull.call_count == 1
+        _ = docker
+
+    def test_429_not_retried(self) -> None:
+        docker = pytest.importorskip("docker")
+        from docker.errors import APIError
+
+        from tolokaforge.docker.image import Image, ImagePullError
+
+        client = _mock_client()
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {}
+        client.images.pull.side_effect = APIError("rate limit", response=response)
+
+        with patch("tenacity.nap.time.sleep"):
+            with pytest.raises(ImagePullError):
+                Image.pull(name=NAME, tag=TAG, client=client)
+
+        assert client.images.pull.call_count == 1
+        _ = docker

--- a/tests/unit/test_image_source_policy.py
+++ b/tests/unit/test_image_source_policy.py
@@ -102,16 +102,13 @@ class TestAutoMode:
 
     @pytest.mark.parametrize(
         "engine_version",
-        ["0.18.0.dev5", "0.18.0.post1", "1.2.3+dirty", "0.19.0.rc.1"],
+        ["0.18.0.dev5", "0.18.0.post1", "0.19.0.rc.1"],
     )
     def test_wheel_install_with_prerelease_version_still_attempts_pull(
         self, engine_version: str
     ) -> None:
-        # Prerelease / local versions likely aren't published to Docker
-        # Hub — but the pull attempt is the authoritative check. The
-        # policy says "yes, try pull"; the caller falls back on
-        # ImagePullError. Keeping the denylist OUT of policy avoids a
-        # stale hardcoded rule lying about published tags.
+        # Prerelease versions are legal Docker tag characters and might
+        # be published — let the pull attempt be the authoritative check.
         assert (
             resolve_image_source(
                 request="auto",
@@ -119,6 +116,26 @@ class TestAutoMode:
                 engine_version=engine_version,
             )
             == "pull"
+        )
+
+    @pytest.mark.parametrize(
+        "engine_version",
+        ["0.18.0+dirty", "0.18.0+editable", "1.2.3+abcdef.dirty", "0.19.0+local"],
+    )
+    def test_wheel_install_with_pep440_local_version_falls_back_to_build(
+        self, engine_version: str
+    ) -> None:
+        """PEP 440 local segment (``+something``) is not a legal Docker
+        tag character. Route to build in ``auto`` mode so the caller
+        never emits a malformed tag that the pull error handler would
+        misclassify as ``unreachable``."""
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=True,
+                engine_version=engine_version,
+            )
+            == "build"
         )
 
 

--- a/tests/unit/test_image_source_policy.py
+++ b/tests/unit/test_image_source_policy.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``resolve_image_source()``.
+
+Pure-function tests — no Docker daemon, no filesystem, no mocks.
+Covers all use-case matrix rows from #1068 (contributor, ad-hoc PyPI
+user, arena / task consumer, air-gapped operator, CI, downstream OSS
+consumer) that are expressible at this policy layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import tolokaforge
+from tolokaforge.docker.image_source_policy import (
+    UNKNOWN_VERSION_SENTINEL,
+    resolve_image_source,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestExplicitRequestWins:
+    """``request in {"pull", "build"}`` is the escape hatch — never
+    influenced by install shape or version."""
+
+    @pytest.mark.parametrize("is_wheel_install", [True, False])
+    @pytest.mark.parametrize(
+        "engine_version", ["0.18.0", UNKNOWN_VERSION_SENTINEL, "0.18.0.dev5", "1.2.3+dirty"]
+    )
+    def test_pull_always_yields_pull(self, is_wheel_install: bool, engine_version: str) -> None:
+        assert (
+            resolve_image_source(
+                request="pull",
+                is_wheel_install=is_wheel_install,
+                engine_version=engine_version,
+            )
+            == "pull"
+        )
+
+    @pytest.mark.parametrize("is_wheel_install", [True, False])
+    @pytest.mark.parametrize(
+        "engine_version", ["0.18.0", UNKNOWN_VERSION_SENTINEL, "0.18.0.dev5", "1.2.3+dirty"]
+    )
+    def test_build_always_yields_build(self, is_wheel_install: bool, engine_version: str) -> None:
+        assert (
+            resolve_image_source(
+                request="build",
+                is_wheel_install=is_wheel_install,
+                engine_version=engine_version,
+            )
+            == "build"
+        )
+
+
+class TestAutoMode:
+    """``request="auto"`` falls through to the shape-based decision."""
+
+    def test_wheel_install_with_known_version_pulls(self) -> None:
+        # Case 3 (ad-hoc PyPI user), 4 (arena), 7 (downstream OSS)
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=True,
+                engine_version="0.18.0",
+            )
+            == "pull"
+        )
+
+    def test_source_checkout_with_known_version_builds(self) -> None:
+        # Case 1 (contributor), 6 (CI on a checkout)
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=False,
+                engine_version="0.18.0",
+            )
+            == "build"
+        )
+
+    def test_source_checkout_without_install_builds(self) -> None:
+        # Contributor running from a bare checkout without pip install
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=False,
+                engine_version=UNKNOWN_VERSION_SENTINEL,
+            )
+            == "build"
+        )
+
+    def test_wheel_install_with_unknown_version_builds(self) -> None:
+        # Defensive: an editable install could report the sentinel; auto
+        # must not attempt to pull ``tolokasoft1/tolokaforge-runner:0.0.0+unknown``.
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=True,
+                engine_version=UNKNOWN_VERSION_SENTINEL,
+            )
+            == "build"
+        )
+
+    @pytest.mark.parametrize(
+        "engine_version",
+        ["0.18.0.dev5", "0.18.0.post1", "1.2.3+dirty", "0.19.0.rc.1"],
+    )
+    def test_wheel_install_with_prerelease_version_still_attempts_pull(
+        self, engine_version: str
+    ) -> None:
+        # Prerelease / local versions likely aren't published to Docker
+        # Hub — but the pull attempt is the authoritative check. The
+        # policy says "yes, try pull"; the caller falls back on
+        # ImagePullError. Keeping the denylist OUT of policy avoids a
+        # stale hardcoded rule lying about published tags.
+        assert (
+            resolve_image_source(
+                request="auto",
+                is_wheel_install=True,
+                engine_version=engine_version,
+            )
+            == "pull"
+        )
+
+
+class TestSentinelStaysInSyncWithPackage:
+    """If someone renames the sentinel in ``tolokaforge/__init__.py``
+    without updating ``image_source_policy.py``, ``auto`` mode would
+    silently start pulling ``:0.0.0+unknown`` from Docker Hub. Pin
+    them together so a drift fails CI here first."""
+
+    def test_sentinel_matches_package_version_fallback(self) -> None:
+        # We assert the SHAPE, not the exact string — the package sets
+        # ``__version__`` to whatever ``importlib.metadata`` returns for
+        # an installed distribution, but the sentinel path only runs when
+        # metadata is missing. Verify that whenever ``__version__`` looks
+        # like the sentinel, the policy considers the version unknown.
+        if tolokaforge.__version__ == UNKNOWN_VERSION_SENTINEL:
+            assert (
+                resolve_image_source(
+                    request="auto",
+                    is_wheel_install=True,
+                    engine_version=tolokaforge.__version__,
+                )
+                == "build"
+            )
+        else:
+            # The reverse direction: the sentinel constant itself is the
+            # only value the policy special-cases in auto+wheel mode. Any
+            # other value → pull.
+            assert (
+                resolve_image_source(
+                    request="auto",
+                    is_wheel_install=True,
+                    engine_version=tolokaforge.__version__,
+                )
+                == "pull"
+            )

--- a/tests/unit/test_orchestrator_docker_config_forwarding.py
+++ b/tests/unit/test_orchestrator_docker_config_forwarding.py
@@ -1,0 +1,126 @@
+"""Regression: ``Orchestrator`` must forward ``RunConfig.docker`` to the
+stack factory as ``config=``.
+
+The v1 of #1068 shipped without this plumbing. The unit tests then
+constructed ``EngineStack(config=DockerConfig(image_source=...))``
+directly and the CLI tests captured ``Orchestrator`` — neither exercised
+the wire between the two, so ``--image-source`` /
+``TOLOKAFORGE_IMAGE_SOURCE`` / ``docker.image_source`` in YAML were
+end-to-end inert. This test pins that wire in place.
+
+Two guards, cheap to run and both catching the same regression from
+different angles:
+
+1. **Behavioural** — patches ``core_stack`` / ``full_stack`` in the
+   ``tolokaforge.docker.stacks`` source module (the orchestrator
+   imports them inline, so patching at the source symbol wins) and
+   drives the orchestrator's stack-construction block via a tiny
+   trigger helper that runs the exact source snippet from
+   ``orchestrator.run()``.
+2. **Static** — greps ``orchestrator.py`` for a ``config=`` argument
+   on the ``stack_factory(...)`` call. Cheap belt-and-suspenders — if
+   the behavioural test's trigger drifts from the real ``run()`` path,
+   the static check still fires.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.docker import stacks as stacks_module
+from tolokaforge.docker.config import DockerConfig
+
+pytestmark = pytest.mark.unit
+
+
+ORCHESTRATOR_SOURCE = Path(
+    __import__("tolokaforge.core.orchestrator", fromlist=["__file__"]).__file__
+).read_text()
+
+
+class TestStackFactoryPassesConfigStatically:
+    """Text-level guard: the ``stack_factory(...)`` call in
+    orchestrator.py must include ``config=`` as a kwarg. Cheap
+    regression check independent of any runtime harness — a delete
+    of the fix fails here immediately."""
+
+    def test_stack_factory_call_passes_config_kwarg(self) -> None:
+        # The exact expression the fix installs. Anchored on
+        # ``stack_factory`` to reject accidental matches on unrelated
+        # ``config=`` uses elsewhere in the file.
+        pattern = re.compile(r"stack_factory\s*\(\s*config\s*=", re.MULTILINE)
+        assert pattern.search(ORCHESTRATOR_SOURCE), (
+            "Orchestrator.run() must call stack_factory(config=..., ...) — "
+            "the docker.image_source policy is inert without this wire. See "
+            "the #1 finding on PR #1082's /code-review."
+        )
+
+    def test_docker_config_import_present(self) -> None:
+        # The fix imports DockerConfig at the call site (inline import
+        # matches the existing `from tolokaforge.docker.stacks import
+        # core_stack, full_stack` pattern one line above). A rewrite
+        # that moves the import to the top of the file is fine — this
+        # test just guards against 'import lost during a refactor'.
+        assert "DockerConfig" in ORCHESTRATOR_SOURCE, (
+            "orchestrator.py needs DockerConfig visible so the "
+            "stack-construction block can fall back to DockerConfig() "
+            "when self.config.docker is None."
+        )
+
+
+class TestBehaviouralStackFactoryReceivesConfig:
+    """Runs the exact orchestrator stack-construction snippet with
+    patched factories to confirm the value flowing in matches the
+    RunConfig's ``docker`` block."""
+
+    def _run_snippet(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        docker: DockerConfig | None,
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+
+        def _factory(**kwargs: Any) -> MagicMock:
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        monkeypatch.setattr(stacks_module, "core_stack", _factory)
+        monkeypatch.setattr(stacks_module, "full_stack", _factory)
+
+        # Reproduce the exact orchestrator snippet the fix installs, so
+        # a regression that swaps `config=docker_config, **core_stack_kwargs`
+        # for `**core_stack_kwargs` alone fails here even if the module
+        # source still passes the static check above by coincidence.
+        from tolokaforge.docker.stacks import core_stack
+
+        stack_requirements = None
+        core_stack_kwargs: dict[str, Any] = (
+            stack_requirements.to_core_stack_kwargs() if stack_requirements else {}
+        )
+        docker_config = docker or DockerConfig()
+        core_stack(config=docker_config, **core_stack_kwargs)
+        return captured
+
+    def test_declared_image_source_reaches_factory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = self._run_snippet(monkeypatch, docker=DockerConfig(image_source="build"))
+        assert "config" in captured["kwargs"]
+        assert isinstance(captured["kwargs"]["config"], DockerConfig)
+        assert captured["kwargs"]["config"].image_source == "build"
+
+    def test_none_docker_falls_back_to_default_docker_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``RunConfig.docker`` is None (no ``docker:`` block in
+        run YAML), the orchestrator must still pass a valid ``DockerConfig``
+        (default auto), not None — otherwise the stack factory would
+        receive ``None`` and reintroduce the same 'feature is inert'
+        regression."""
+        captured = self._run_snippet(monkeypatch, docker=None)
+        assert "config" in captured["kwargs"]
+        assert isinstance(captured["kwargs"]["config"], DockerConfig)
+        assert captured["kwargs"]["config"].image_source == "auto"

--- a/tests/unit/test_stack_container_reuse_tag_ordering.py
+++ b/tests/unit/test_stack_container_reuse_tag_ordering.py
@@ -1,0 +1,201 @@
+"""Regression: container reuse must be robust to Docker tag ordering.
+
+The v1 pull path aliases the underlying image with
+``tolokaforge-runner:local`` on top of the pulled
+``tolokasoft1/tolokaforge-runner:X.Y.Z`` tag. Docker's daemon does not
+guarantee the order of ``image.tags`` — so a comparison against
+``existing.image.tags[0]`` alone is a coin flip: sometimes it returns
+the alias, sometimes the pulled tag. The pre-fix comparison would then
+spuriously destroy a healthy container on every subsequent run.
+
+Fix: ``_start_service`` matches on image-id OR membership of the
+expected ``full_tag`` in the container image's tag list. This test pins
+that behaviour on both axes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.docker.config import DockerConfig
+from tolokaforge.docker.container import Container, ContainerStatus
+from tolokaforge.docker.image import Image
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+PUBLISHED_TAG = "tolokasoft1/tolokaforge-runner:0.18.0"
+LOCAL_ALIAS = "tolokaforge-runner:local"
+IMAGE_ID = "sha256:abc123"
+
+
+def _stack_with_running_container(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    published_tag: str,
+    image_id: str,
+    existing_tags: list[str],
+    existing_image_id: str,
+) -> tuple[EngineStack, MagicMock]:
+    """Assemble an EngineStack where _try_reuse_existing returns a
+    running Container, and _inspect_running_image returns the daemon
+    state under test. Returns (stack, destroy_mock)."""
+    svc = ServiceDefinition(
+        name="runner",
+        image_name="tolokaforge-runner",
+        published_image_repo="tolokasoft1/tolokaforge-runner",
+        dockerfile="docker/runner.Dockerfile",
+        context=".",
+    )
+    stack = EngineStack(config=DockerConfig())
+    stack.add_service(svc)
+
+    # Populate the _images map so _start_service does not re-build.
+    pulled_image = Image(
+        name="tolokasoft1/tolokaforge-runner",
+        tag="0.18.0",
+        image_id=image_id,
+        dockerfile="pulled",
+        context="pulled",
+        context_hash="pulled",
+    )
+    assert pulled_image.full_tag == published_tag
+    stack._images["runner"] = pulled_image
+
+    # Stub Container returned by _try_reuse_existing. Container is a
+    # frozen-ish Pydantic model with extra=forbid; monkeypatch the
+    # ``destroy`` method via ``object.__setattr__`` so we can observe
+    # calls without touching the model schema.
+    destroy_mock = MagicMock()
+    fake_container = Container(
+        container_id="cid-existing",
+        name="tolokaforge-runner",
+        image_tag=existing_tags[0] if existing_tags else "unknown",
+        current_status=ContainerStatus.RUNNING,
+    )
+    object.__setattr__(fake_container, "destroy", destroy_mock)
+
+    monkeypatch.setattr(stack, "_try_reuse_existing", lambda *a, **kw: fake_container)
+    monkeypatch.setattr(
+        stack,
+        "_inspect_running_image",
+        lambda name: (list(existing_tags), existing_image_id),
+    )
+    # Suppress the LogRouter attach — the fake Container has no real docker
+    # client behind it, so LogRouter.for_container would fail.
+    monkeypatch.setattr(
+        "tolokaforge.docker.stack.LogRouter.for_container",
+        classmethod(lambda cls, *a, **kw: MagicMock()),
+    )
+    return stack, destroy_mock
+
+
+class TestReuseWhenPulledTagIsSecondaryInTagList:
+    """The pulled image has BOTH the pulled tag and the ``:local`` alias.
+    If the daemon returns the alias in ``tags[0]``, the pre-fix code
+    would destroy the healthy container. The fix compares membership /
+    image id instead."""
+
+    def test_reused_when_alias_first_and_pulled_tag_second(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stack, destroy_mock = _stack_with_running_container(
+            monkeypatch,
+            published_tag=PUBLISHED_TAG,
+            image_id=IMAGE_ID,
+            existing_tags=[LOCAL_ALIAS, PUBLISHED_TAG],
+            existing_image_id=IMAGE_ID,
+        )
+        svc = stack.services["runner"]
+
+        # Drive just the reuse-check block by triggering _start_service.
+        # We stub the downstream network/container-creation path so the
+        # test aborts once we've decided whether to reuse or destroy.
+        try:
+            stack._start_service(svc, wait=False)
+        except Exception:  # noqa: BLE001 — network / container-run stubs abort us
+            pass
+
+        destroy_mock.assert_not_called()
+
+    def test_reused_when_pulled_tag_first_and_alias_second(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, destroy_mock = _stack_with_running_container(
+            monkeypatch,
+            published_tag=PUBLISHED_TAG,
+            image_id=IMAGE_ID,
+            existing_tags=[PUBLISHED_TAG, LOCAL_ALIAS],
+            existing_image_id=IMAGE_ID,
+        )
+        svc = stack.services["runner"]
+
+        try:
+            stack._start_service(svc, wait=False)
+        except Exception:  # noqa: BLE001 — abort past reuse check
+            pass
+
+        destroy_mock.assert_not_called()
+
+    def test_reused_when_only_alias_but_ids_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fallback path: even if the daemon has forgotten the
+        ``tolokasoft1/...`` tag entirely (e.g. an operator manually
+        retagged), image id equality still identifies the reuse."""
+        stack, destroy_mock = _stack_with_running_container(
+            monkeypatch,
+            published_tag=PUBLISHED_TAG,
+            image_id=IMAGE_ID,
+            existing_tags=[LOCAL_ALIAS],
+            existing_image_id=IMAGE_ID,
+        )
+        svc = stack.services["runner"]
+
+        try:
+            stack._start_service(svc, wait=False)
+        except Exception:  # noqa: BLE001 — abort past reuse check
+            pass
+
+        destroy_mock.assert_not_called()
+
+    def test_destroyed_when_neither_tags_nor_ids_match(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Sanity: a truly stale container (different image entirely)
+        must still be destroyed."""
+        stack, destroy_mock = _stack_with_running_container(
+            monkeypatch,
+            published_tag=PUBLISHED_TAG,
+            image_id=IMAGE_ID,
+            existing_tags=["some-other-image:latest"],
+            existing_image_id="sha256:stale-old-image",
+        )
+        svc = stack.services["runner"]
+
+        try:
+            stack._start_service(svc, wait=False)
+        except Exception:  # noqa: BLE001 — abort past reuse check
+            pass
+
+        destroy_mock.assert_called_once()
+
+    def test_destroyed_when_daemon_lookup_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When _inspect_running_image returns ([], None) — e.g. daemon
+        blip — err on the side of recreating."""
+        stack, destroy_mock = _stack_with_running_container(
+            monkeypatch,
+            published_tag=PUBLISHED_TAG,
+            image_id=IMAGE_ID,
+            existing_tags=[],
+            existing_image_id=None,  # type: ignore[arg-type]
+        )
+        svc = stack.services["runner"]
+
+        try:
+            stack._start_service(svc, wait=False)
+        except Exception:  # noqa: BLE001 — abort past reuse check
+            pass
+
+        destroy_mock.assert_called_once()

--- a/tests/unit/test_stack_pull_vs_build.py
+++ b/tests/unit/test_stack_pull_vs_build.py
@@ -32,12 +32,14 @@ def _svc(
     published: str | None = PUBLISHED_REPO,
     use_prebuilt: bool = False,
     dockerfile: str = "docker/runner.Dockerfile",
+    platform: str = "linux/amd64",
 ) -> ServiceDefinition:
     """A minimal runnable ServiceDefinition for stack-branch tests."""
     return ServiceDefinition(
         name="runner",
         image_name="tolokaforge-runner",
         published_image_repo=published,
+        published_image_platform=platform,
         dockerfile=dockerfile if not use_prebuilt else "",
         context=".",
         use_prebuilt_image=use_prebuilt,
@@ -150,7 +152,14 @@ class TestAutoModeWheelInstall:
         assert image.context_hash == "pulled"
         # ``linux/amd64`` is the published-images platform axis; the caller
         # passes it explicitly so arm64 hosts can pull the amd64 variant.
-        pull_mock.assert_called_once_with(name=PUBLISHED_REPO, tag="0.18.0", platform="linux/amd64")
+        # ``log_label`` carries the service name so concurrent-retry log
+        # lines can be correlated back to a specific service.
+        pull_mock.assert_called_once_with(
+            name=PUBLISHED_REPO,
+            tag="0.18.0",
+            platform="linux/amd64",
+            log_label="runner",
+        )
         assert registry.calls == []  # build path never taken
 
     def test_tag_missing_fallback_to_build_with_warning(
@@ -347,6 +356,28 @@ class TestServiceWithoutPublishedRepoAlwaysBuilds:
 
         pull_mock.assert_not_called()
         assert len(registry.calls) == 1
+
+
+class TestServicePlatformOverride:
+    """``published_image_platform`` is a per-service field so a service
+    that publishes multi-arch or arm64-native images can override the
+    default ``linux/amd64`` without touching stack.py."""
+
+    def test_platform_field_reaches_image_pull(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stack, pull_mock, _registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        # Runner declared with a non-default platform — the pull path
+        # must forward it verbatim, not silently coerce to amd64.
+        stack._build_one_image(_svc(platform="linux/arm64"))
+
+        args = pull_mock.call_args
+        assert args.kwargs["platform"] == "linux/arm64"
 
 
 class TestExplicitPullModeContract:

--- a/tests/unit/test_stack_pull_vs_build.py
+++ b/tests/unit/test_stack_pull_vs_build.py
@@ -148,7 +148,9 @@ class TestAutoModeWheelInstall:
 
         assert image is not None
         assert image.context_hash == "pulled"
-        pull_mock.assert_called_once_with(name=PUBLISHED_REPO, tag="0.18.0")
+        # ``linux/amd64`` is the published-images platform axis; the caller
+        # passes it explicitly so arm64 hosts can pull the amd64 variant.
+        pull_mock.assert_called_once_with(name=PUBLISHED_REPO, tag="0.18.0", platform="linux/amd64")
         assert registry.calls == []  # build path never taken
 
     def test_tag_missing_fallback_to_build_with_warning(

--- a/tests/unit/test_stack_pull_vs_build.py
+++ b/tests/unit/test_stack_pull_vs_build.py
@@ -349,6 +349,49 @@ class TestServiceWithoutPublishedRepoAlwaysBuilds:
         assert len(registry.calls) == 1
 
 
+class TestExplicitPullModeContract:
+    """Two contract corners the sibling ``TestExplicitPullMode`` does
+    not cover: explicit ``pull`` mode refuses to fall back to build
+    silently when the request cannot be honoured."""
+
+    def test_force_true_in_explicit_pull_mode_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``force=True`` normally skips the pull path (fresh rebuild),
+        but in explicit ``pull`` mode that would silently violate the
+        pull-or-die contract."""
+        stack, _pull_mock, _registry = _make_stack(
+            monkeypatch,
+            image_source="pull",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            stack._build_one_image(_svc(), force=True)
+
+        assert "pull" in str(excinfo.value).lower()
+        assert "force" in str(excinfo.value).lower()
+
+    def test_missing_published_repo_in_explicit_pull_mode_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A service without ``published_image_repo`` has nothing to
+        pull from; in explicit ``pull`` mode that's a hard configuration
+        error rather than a silent drop to build."""
+        stack, _pull_mock, _registry = _make_stack(
+            monkeypatch,
+            image_source="pull",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            stack._build_one_image(_svc(published=None))
+
+        assert "published_image_repo" in str(excinfo.value)
+
+
 class TestForceRebuildSkipsPull:
     def test_force_true_skips_pull_and_calls_image_build_directly(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_stack_pull_vs_build.py
+++ b/tests/unit/test_stack_pull_vs_build.py
@@ -1,0 +1,373 @@
+"""Unit tests for the pull-vs-build branch inside ``EngineStack._build_one_image``.
+
+Uses monkeypatched ``Image.pull`` and ``Image.build`` so no Docker
+daemon is touched. Every test asserts the exact call shape (arguments,
+call count) rather than just the return value — otherwise a change
+that silently swaps pull for build (or vice versa) would still pass.
+
+The pull-vs-build resolution wraps the pure :func:`resolve_image_source`
+helper (tested exhaustively in ``test_image_source_policy.py``); this
+file is about the CALLER, not the policy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.docker.config import DockerConfig
+from tolokaforge.docker.image import Image, ImagePullError
+from tolokaforge.docker.stack import EngineStack, ServiceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+PUBLISHED_REPO = "tolokasoft1/tolokaforge-runner"
+
+
+def _svc(
+    *,
+    published: str | None = PUBLISHED_REPO,
+    use_prebuilt: bool = False,
+    dockerfile: str = "docker/runner.Dockerfile",
+) -> ServiceDefinition:
+    """A minimal runnable ServiceDefinition for stack-branch tests."""
+    return ServiceDefinition(
+        name="runner",
+        image_name="tolokaforge-runner",
+        published_image_repo=published,
+        dockerfile=dockerfile if not use_prebuilt else "",
+        context=".",
+        use_prebuilt_image=use_prebuilt,
+        prebuilt_tag="latest",
+    )
+
+
+def _fake_pulled_image() -> Image:
+    return Image(
+        name=PUBLISHED_REPO,
+        tag="0.18.0",
+        image_id="sha256:pulled-abc",
+        dockerfile="pulled",
+        context="pulled",
+        context_hash="pulled",
+    )
+
+
+def _fake_built_image() -> Image:
+    return Image(
+        name="tolokaforge-runner",
+        tag="deadbeef",
+        image_id="sha256:built-def",
+        dockerfile="docker/runner.Dockerfile",
+        context=".",
+        context_hash="a" * 64,
+    )
+
+
+class _StubRegistry:
+    """Records calls to ``get_or_build`` — a stand-in for
+    ``ImageRegistry.get_or_build`` that never touches Docker."""
+
+    def __init__(self, ret: Image) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._ret = ret
+
+    def get_or_build(self, **kwargs: Any) -> Image:
+        self.calls.append(kwargs)
+        return self._ret
+
+
+def _make_stack(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    image_source: str,
+    pull_result: Image | Exception,
+    is_wheel_install: bool,
+    engine_version: str,
+) -> tuple[EngineStack, MagicMock, _StubRegistry]:
+    """Wire an EngineStack with the pull/build primitives stubbed.
+
+    Returns (stack, pull_mock, build_registry).
+    """
+    stack = EngineStack(config=DockerConfig(image_source=image_source))  # type: ignore[arg-type]
+
+    # Stub ``resolve_image_source``'s environment inputs — repo_root and
+    # engine_version — inside the stack module namespace where
+    # ``_maybe_pull_service_image`` looks them up.
+    from tolokaforge.docker import builder as builder_module
+
+    class _FakePath:
+        def __init__(self, present: bool) -> None:
+            self._present = present
+
+        def __truediv__(self, _other: object) -> _FakePath:
+            return self
+
+        def is_file(self) -> bool:
+            return self._present
+
+    monkeypatch.setattr(
+        builder_module,
+        "repo_root",
+        lambda: _FakePath(present=not is_wheel_install),
+    )
+
+    import tolokaforge as tolokaforge_pkg
+
+    monkeypatch.setattr(tolokaforge_pkg, "__version__", engine_version)
+
+    pull_mock = MagicMock(name="Image.pull")
+    if isinstance(pull_result, Exception):
+        pull_mock.side_effect = pull_result
+    else:
+        pull_mock.return_value = pull_result
+    monkeypatch.setattr(Image, "pull", pull_mock)
+
+    build_registry = _StubRegistry(_fake_built_image())
+    stack._registry = build_registry  # type: ignore[assignment]
+
+    return stack, pull_mock, build_registry
+
+
+class TestAutoModeWheelInstall:
+    def test_successful_pull_returns_pulled_image_and_skips_build(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        image = stack._build_one_image(_svc())
+
+        assert image is not None
+        assert image.context_hash == "pulled"
+        pull_mock.assert_called_once_with(name=PUBLISHED_REPO, tag="0.18.0")
+        assert registry.calls == []  # build path never taken
+
+    def test_tag_missing_fallback_to_build_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=ImagePullError("tag_missing", f"{PUBLISHED_REPO}:0.18.0", "not found"),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with caplog.at_level("WARNING", logger="tolokaforge.docker.stack"):
+            image = stack._build_one_image(_svc())
+
+        assert image is not None
+        assert image.context_hash != "pulled"  # this is a built image
+        pull_mock.assert_called_once()
+        assert len(registry.calls) == 1
+        # Warning names the failure kind + the falling-back action
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("tag_missing" in r.message for r in warnings), warnings
+        assert any("Falling back to local build" in r.message for r in warnings), warnings
+
+    def test_rate_limited_fallback_to_build_names_kind(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=ImagePullError(
+                "rate_limited",
+                f"{PUBLISHED_REPO}:0.18.0",
+                "Docker Hub rate limit — configure auth",
+                response_headers={"Retry-After": "60"},
+            ),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with caplog.at_level("WARNING", logger="tolokaforge.docker.stack"):
+            image = stack._build_one_image(_svc())
+
+        assert image is not None
+        pull_mock.assert_called_once()
+        assert len(registry.calls) == 1
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("rate_limited" in r.message for r in warnings), warnings
+
+    def test_unreachable_fallback_to_build(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stack, _pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=ImagePullError(
+                "unreachable", f"{PUBLISHED_REPO}:0.18.0", "connection refused"
+            ),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with caplog.at_level("WARNING", logger="tolokaforge.docker.stack"):
+            image = stack._build_one_image(_svc())
+
+        assert image is not None
+        assert len(registry.calls) == 1
+
+
+class TestAutoModeSourceCheckout:
+    def test_source_checkout_builds_without_attempting_pull(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=False,
+            engine_version="0.18.0",
+        )
+
+        stack._build_one_image(_svc())
+
+        pull_mock.assert_not_called()
+        assert len(registry.calls) == 1
+
+    def test_unknown_version_builds_without_attempting_pull(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, _registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.0.0+unknown",
+        )
+
+        stack._build_one_image(_svc())
+
+        pull_mock.assert_not_called()
+
+
+class TestExplicitPullMode:
+    def test_pull_success_returns_pulled_image(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="pull",
+            pull_result=_fake_pulled_image(),
+            # Explicit pull mode overrides install shape — pull even on a
+            # source checkout.
+            is_wheel_install=False,
+            engine_version="0.18.0",
+        )
+
+        image = stack._build_one_image(_svc())
+
+        assert image is not None and image.context_hash == "pulled"
+        pull_mock.assert_called_once()
+        assert registry.calls == []
+
+    def test_pull_failure_is_hard_error_no_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="pull",
+            pull_result=ImagePullError("tag_missing", f"{PUBLISHED_REPO}:0.18.0", "not found"),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        with pytest.raises(ImagePullError) as excinfo:
+            stack._build_one_image(_svc())
+
+        assert excinfo.value.kind == "tag_missing"
+        pull_mock.assert_called_once()
+        # Explicit mode never falls back — build path is untouched.
+        assert registry.calls == []
+
+
+class TestExplicitBuildMode:
+    def test_build_mode_never_calls_pull_even_on_wheel_install(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="build",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        stack._build_one_image(_svc())
+
+        pull_mock.assert_not_called()
+        assert len(registry.calls) == 1
+
+
+class TestPrebuiltImageBranchIsUnchanged:
+    def test_use_prebuilt_image_short_circuits_before_pull_policy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="pull",  # even in explicit pull mode
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        svc = _svc(use_prebuilt=True, published=None)
+
+        image = stack._build_one_image(svc)
+
+        assert image is not None
+        assert image.context_hash == "prebuilt"
+        pull_mock.assert_not_called()
+        assert registry.calls == []
+
+
+class TestServiceWithoutPublishedRepoAlwaysBuilds:
+    def test_no_published_repo_falls_through_to_build_in_auto(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+        svc = _svc(published=None)
+
+        stack._build_one_image(svc)
+
+        pull_mock.assert_not_called()
+        assert len(registry.calls) == 1
+
+
+class TestForceRebuildSkipsPull:
+    def test_force_true_skips_pull_and_calls_image_build_directly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stack, pull_mock, registry = _make_stack(
+            monkeypatch,
+            image_source="auto",
+            pull_result=_fake_pulled_image(),
+            is_wheel_install=True,
+            engine_version="0.18.0",
+        )
+
+        # Also stub Image.build so force-path testing doesn't need a
+        # real dockerfile on disk.
+        build_mock = MagicMock(name="Image.build", return_value=_fake_built_image())
+        monkeypatch.setattr(Image, "build", build_mock)
+
+        stack._build_one_image(_svc(), force=True)
+
+        pull_mock.assert_not_called()
+        build_mock.assert_called_once()
+        # ``force=True`` calls Image.build directly, bypassing the
+        # registry cache.
+        assert registry.calls == []

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -23,10 +23,12 @@ from tolokaforge.core.run_display_events import (
     DEFAULT_PROBE_BUCKET_WIDTH_S,
     DEFAULT_PROBE_MAX_BUCKETS,
 )
+from tolokaforge.docker.config import DockerConfig
 
 __all__ = [
     "ComputeConfig",
     "DOCKER_RUNTIME_ALIAS_TARGET",
+    "DockerConfig",
     "EngineConfig",
     "EvaluationConfig",
     "HarnessAdapterConfig",
@@ -854,6 +856,7 @@ class RunConfig(BaseModel):
     compute: ComputeConfig | None = None
     storage: StorageConfig | None = None
     observability: ObservabilityConfig | None = None
+    docker: DockerConfig | None = None
 
     @property
     def effective_workers(self) -> int:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1777,7 +1777,19 @@ class Orchestrator:
                 else:
                     self.logger.info("Creating service stack (db-service + runner)")
                     stack_factory = core_stack
-                service_stack = stack_factory(**core_stack_kwargs)
+                # Thread the run's docker config through to the stack so
+                # ``docker.image_source`` (CLI flag, TOLOKAFORGE_IMAGE_SOURCE
+                # env, or YAML) actually reaches ``EngineStack._maybe_pull_
+                # service_image``. Without this explicit forwarding the
+                # entire pull-vs-build policy stays inert — the stack
+                # factories default ``config=None`` → ``DockerConfig()`` →
+                # ``image_source='auto'``, so an operator setting
+                # ``--image-source build`` on a wheel install would still
+                # get a silent pull.
+                from tolokaforge.docker.config import DockerConfig
+
+                docker_config = self.config.docker or DockerConfig()
+                service_stack = stack_factory(config=docker_config, **core_stack_kwargs)
                 # Route through the effective-choice helper so both the
                 # operator override and the task-driven per-trial signal
                 # produce the same task-declared-stack decision (see
@@ -1854,7 +1866,26 @@ class Orchestrator:
                         )
                     self._connect_typesense_to_runner_network(service_stack)
             except Exception as e:
-                self.logger.error("Failed to auto-start services", error=str(e))
+                # Special-case ``ImagePullError`` so its kind and the
+                # operator-actionable hint (e.g. "Docker Hub rate limit
+                # hit. Configure authenticated pulls…") land in the log
+                # verbatim, not folded into a generic stack trace. The
+                # exception is re-raised so callers still see the crash;
+                # this only makes sure the actionable text is prominent
+                # in the operator's terminal.
+                from tolokaforge.docker.image import ImagePullError
+
+                if isinstance(e, ImagePullError):
+                    retry_after = e.response_headers.get("Retry-After")
+                    self.logger.error(
+                        "Failed to auto-start services: pull failed",
+                        kind=e.kind,
+                        image=e.full_tag,
+                        message=str(e),
+                        retry_after=retry_after,
+                    )
+                else:
+                    self.logger.error("Failed to auto-start services", error=str(e))
                 raise
         else:
             runner_address = None

--- a/tolokaforge/docker/config.py
+++ b/tolokaforge/docker/config.py
@@ -22,6 +22,24 @@ logger = logging.getLogger(__name__)
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
+ImageSource = Literal["auto", "pull", "build"]
+"""Where a first-party service image comes from at ``tolokaforge run`` time.
+
+``auto`` — pull the published image (``tolokasoft1/tolokaforge-<svc>:<version>``)
+when running from a wheel install and the engine reports a concrete
+version; build locally otherwise (source checkout, unknown version). On
+pull failure in ``auto`` mode the code falls back to a local build with
+a warning naming the exact reason.
+
+``pull`` — always pull. On pull failure this is a hard failure; no
+fallback. The knob is only useful if the caller genuinely wants "pull
+or die".
+
+``build`` — always build locally. Skip pull entirely. The escape hatch
+for contributors editing Dockerfiles or debugging image content, and
+for environments that never touch Docker Hub.
+"""
+
 
 class DockerConfig(BaseModel):
     """Configuration for Docker foundation layer operations.
@@ -36,6 +54,8 @@ class DockerConfig(BaseModel):
         default_memory_limit: Default memory limit for containers (e.g., "256m", "1g").
         default_cpu_limit: Default CPU limit for containers (e.g., 0.5, 2.0).
         log_level: Logging level for docker operations.
+        image_source: Where first-party service images come from ("auto", "pull",
+            or "build"). See :data:`ImageSource` for the full semantics.
 
     Example:
         >>> config = DockerConfig(
@@ -72,6 +92,14 @@ class DockerConfig(BaseModel):
     log_level: LogLevel = Field(
         default="INFO",
         description="Logging level for docker operations",
+    )
+    image_source: ImageSource = Field(
+        default="auto",
+        description=(
+            "Where first-party service images come from. auto = pull on wheel "
+            "installs, build on source checkouts; pull = always pull (hard fail "
+            "on error); build = always build."
+        ),
     )
 
     model_config = {

--- a/tolokaforge/docker/image.py
+++ b/tolokaforge/docker/image.py
@@ -502,6 +502,7 @@ class Image(BaseModel):
         name: str,
         tag: str,
         platform: str | None = None,
+        log_label: str | None = None,
         client: DockerClient | None = None,
     ) -> Image:
         """Pull an image reference from a Docker registry.
@@ -612,13 +613,20 @@ class Image(BaseModel):
             # of exponential backoff before surfacing.
             return False
 
+        # Retry log carries ``log_label`` (usually the service name) so
+        # when multiple services retry concurrently the operator can
+        # correlate the log lines back to a specific service without
+        # having to parse the ``full_tag`` suffix.
+        log_prefix = f"[{log_label}] " if log_label else ""
+
         @retry(
             stop=stop_after_attempt(5),
             wait=wait_exponential(multiplier=10, min=10, max=60),
             retry=retry_if_exception(_is_transient),
             reraise=True,
             before_sleep=lambda rs: logger.warning(
-                "Docker pull attempt %d for '%s' failed, retrying in %ds...",
+                "%sDocker pull attempt %d for '%s' failed, retrying in %ds...",
+                log_prefix,
                 rs.attempt_number,
                 full_tag,
                 rs.next_action.sleep,

--- a/tolokaforge/docker/image.py
+++ b/tolokaforge/docker/image.py
@@ -52,6 +52,30 @@ def _extract_status_code(exc: APIError) -> int | None:
     return inner if isinstance(inner, int) else None
 
 
+def _cached_image_matches_platform(existing: Any, platform: str) -> bool:
+    """True if the daemon-side cached image matches a Docker platform spec.
+
+    Docker platform strings are ``os/arch`` or ``os/arch/variant``; the
+    docker-py image's ``attrs`` carries the ``Os`` and ``Architecture``
+    fields from a ``docker image inspect``. Comparison is defensive: any
+    missing / unexpected attr yields ``False`` (falls through to a fresh
+    pull rather than silently accepting an unverifiable image).
+    """
+    parts = platform.split("/")
+    if len(parts) < 2:
+        return False
+    want_os, want_arch = parts[0], parts[1]
+    try:
+        attrs = existing.attrs or {}
+    except Exception:
+        return False
+    have_os = attrs.get("Os")
+    have_arch = attrs.get("Architecture")
+    if not isinstance(have_os, str) or not isinstance(have_arch, str):
+        return False
+    return have_os == want_os and have_arch == want_arch
+
+
 def _extract_response_headers(exc: APIError) -> Mapping[str, str] | None:
     """Best-effort response-header extraction from an ``APIError``.
 
@@ -532,20 +556,35 @@ class Image(BaseModel):
 
         # Cache hit — same shape as the build path's skip-if-cached
         # short-circuit. Do not spend a pull round-trip if the exact
-        # reference already resolves in the local daemon.
+        # reference already resolves in the local daemon AND the cached
+        # image matches the requested platform (arch/os). Without the
+        # platform check a stale wrong-arch entry (e.g. an operator
+        # locally ``docker tag``-ed an arm64 image onto the pulled tag,
+        # or a partial pull left the previous arch cached) would return
+        # the wrong-arch image with ``context_hash='pulled'`` and the
+        # container would only fail far downstream with "exec format
+        # error".
         existing = cls._find_existing_image(client, full_tag)
         if existing is not None:
-            logger.info("Image '%s' already present in daemon, skipping pull", full_tag)
-            image = cls(
-                name=name,
-                tag=tag,
-                image_id=existing.id,
-                dockerfile="pulled",
-                context="pulled",
-                context_hash="pulled",
-            )
-            object.__setattr__(image, "_client", client)
-            return image
+            if platform is not None and not _cached_image_matches_platform(existing, platform):
+                logger.info(
+                    "Image '%s' present in daemon but architecture does not "
+                    "match requested platform %s; pulling a fresh copy",
+                    full_tag,
+                    platform,
+                )
+            else:
+                logger.info("Image '%s' already present in daemon, skipping pull", full_tag)
+                image = cls(
+                    name=name,
+                    tag=tag,
+                    image_id=existing.id,
+                    dockerfile="pulled",
+                    context="pulled",
+                    context_hash="pulled",
+                )
+                object.__setattr__(image, "_client", client)
+                return image
 
         from tenacity import (
             retry,
@@ -560,10 +599,18 @@ class Image(BaseModel):
                 return False
             if isinstance(exc, APIError):
                 status = _extract_status_code(exc)
-                if status in (404, 429):
-                    return False
-            # Any other APIError / network exception is a candidate for retry.
-            return isinstance(exc, APIError | DockerException)
+                return status not in (404, 429)
+            # Network-layer exceptions (``requests.ConnectionError``,
+            # ``urllib3.ReadTimeoutError``, raw socket errors) can escape
+            # docker-py un-wrapped when the daemon socket becomes
+            # unresponsive mid-pull; retry those the full budget.
+            if isinstance(exc, ConnectionError | TimeoutError | OSError):
+                return True
+            # A bare ``DockerException`` without network context (e.g.
+            # "daemon socket closed", schema errors) is not recoverable
+            # by waiting — treat it as terminal so we don't burn ~130s
+            # of exponential backoff before surfacing.
+            return False
 
         @retry(
             stop=stop_after_attempt(5),
@@ -630,6 +677,16 @@ class Image(BaseModel):
                 "unreachable",
                 full_tag,
                 f"Docker SDK error while pulling: {e}",
+            ) from e
+        except (ConnectionError, TimeoutError, OSError) as e:
+            # Un-wrapped network-layer exceptions escape docker-py when
+            # the daemon socket goes quiet mid-pull. Classify as
+            # ``unreachable`` so the caller's fallback/retry policy sees
+            # a proper ImagePullError instead of a raw stack trace.
+            raise ImagePullError(
+                "unreachable",
+                full_tag,
+                f"Network error while pulling: {e}",
             ) from e
 
         logger.info("Successfully pulled image '%s' (ID: %s)", full_tag, pulled.id)

--- a/tolokaforge/docker/image.py
+++ b/tolokaforge/docker/image.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import anyio
 import docker
@@ -32,6 +33,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+PullFailureKind = Literal["tag_missing", "rate_limited", "unreachable"]
+"""Why an ``Image.pull()`` call failed. See :class:`ImagePullError`."""
+
+
+def _extract_status_code(exc: APIError) -> int | None:
+    """Best-effort HTTP status extraction from a Docker SDK ``APIError``.
+
+    docker-py exposes it as either ``exc.status_code`` (attribute) or
+    ``exc.response.status_code`` (attribute on the underlying HTTPX/requests
+    response), depending on how the error was constructed. Consult both.
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    inner = getattr(response, "status_code", None)
+    return inner if isinstance(inner, int) else None
+
+
+def _extract_response_headers(exc: APIError) -> Mapping[str, str] | None:
+    """Best-effort response-header extraction from an ``APIError``.
+
+    Used by :class:`ImagePullError` to carry ``Retry-After`` on 429
+    responses so the caller can surface it to the operator.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return {str(k): str(v) for k, v in headers.items()}
+    except AttributeError:
+        return None
+
+
 class ImageError(Exception):
     """Raised when an image operation fails."""
 
@@ -39,6 +75,38 @@ class ImageError(Exception):
         self.operation = operation
         self.image_name = image_name
         super().__init__(f"Image {operation} failed for '{image_name}': {message}")
+
+
+class ImagePullError(ImageError):
+    """Raised when ``Image.pull()`` cannot resolve the requested tag.
+
+    Sub-classifies the failure so callers can pick a policy: fall back to a
+    local build (``auto`` mode), surface a specific hint (rate-limit →
+    "configure Docker Hub auth"), or hard-fail (``pull`` mode).
+
+    Attributes:
+        kind: One of ``tag_missing`` (404 — the requested tag is not
+            published), ``rate_limited`` (429 — Docker Hub throttled the
+            request; anonymous limit is 100 pulls per 6 h per IP), or
+            ``unreachable`` (network error, 5xx, or any other Docker SDK
+            failure).
+        full_tag: The ``repository:tag`` reference the pull attempted.
+        response_headers: Response headers from the failed API call, if
+            available. On ``rate_limited`` this carries ``Retry-After``
+            when Docker Hub provides it.
+    """
+
+    def __init__(
+        self,
+        kind: PullFailureKind,
+        full_tag: str,
+        message: str,
+        response_headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.kind: PullFailureKind = kind
+        self.full_tag = full_tag
+        self.response_headers = dict(response_headers) if response_headers else {}
+        super().__init__("pull", full_tag, f"[{kind}] {message}")
 
 
 class Image(BaseModel):
@@ -403,6 +471,159 @@ class Image(BaseModel):
             Path(dockerfile), Path(context), build_args or {}
         )
         return f"{name}:{tag}"
+
+    @classmethod
+    def pull(
+        cls,
+        name: str,
+        tag: str,
+        client: DockerClient | None = None,
+    ) -> Image:
+        """Pull an image reference from a Docker registry.
+
+        Mirror of :meth:`build` for the pull path. Short-circuits on a
+        daemon cache hit via :meth:`_find_existing_image` (same shape as
+        the build path's skip-if-cached logic). Retries transient
+        registry errors with the same tenacity envelope as
+        :meth:`build`, but does NOT retry ``404`` (tag genuinely
+        missing) or ``429`` (rate limit is a caller-actionable
+        condition — retrying without changing anything only wastes the
+        remaining budget).
+
+        Returns an :class:`Image` with ``context_hash="pulled"`` as a
+        sentinel (mirrors ``"prebuilt"`` used elsewhere in the stack for
+        images not owned by content-hash caching) and
+        ``dockerfile="pulled"`` / ``context="pulled"`` so the model's
+        non-empty validators pass without pretending the image came
+        from a Dockerfile the caller could inspect.
+
+        Args:
+            name: The repository, e.g. ``"tolokasoft1/tolokaforge-runner"``.
+            tag: The tag, e.g. ``"0.18.0"``.
+            client: Optional Docker client (for testing / mocking).
+
+        Returns:
+            An :class:`Image` whose ``full_tag`` equals ``f"{name}:{tag}"``
+            and whose ``image_id`` is set to the pulled image's daemon id.
+
+        Raises:
+            ImagePullError: With ``kind="tag_missing"`` on 404,
+                ``kind="rate_limited"`` on 429, or ``kind="unreachable"``
+                on any other Docker SDK / network failure.
+        """
+        if client is None:
+            try:
+                client = docker.from_env()
+            except DockerException as e:
+                raise ImagePullError(
+                    "unreachable", f"{name}:{tag}", f"Failed to connect to Docker: {e}"
+                ) from e
+
+        full_tag = f"{name}:{tag}"
+
+        # Cache hit — same shape as the build path's skip-if-cached
+        # short-circuit. Do not spend a pull round-trip if the exact
+        # reference already resolves in the local daemon.
+        existing = cls._find_existing_image(client, full_tag)
+        if existing is not None:
+            logger.info("Image '%s' already present in daemon, skipping pull", full_tag)
+            image = cls(
+                name=name,
+                tag=tag,
+                image_id=existing.id,
+                dockerfile="pulled",
+                context="pulled",
+                context_hash="pulled",
+            )
+            object.__setattr__(image, "_client", client)
+            return image
+
+        from tenacity import (
+            retry,
+            retry_if_exception,
+            stop_after_attempt,
+            wait_exponential,
+        )
+
+        def _is_transient(exc: BaseException) -> bool:
+            # 404 and 429 are terminal — don't burn the retry budget on them.
+            if isinstance(exc, ImageNotFound):
+                return False
+            if isinstance(exc, APIError):
+                status = _extract_status_code(exc)
+                if status in (404, 429):
+                    return False
+            # Any other APIError / network exception is a candidate for retry.
+            return isinstance(exc, APIError | DockerException)
+
+        @retry(
+            stop=stop_after_attempt(5),
+            wait=wait_exponential(multiplier=10, min=10, max=60),
+            retry=retry_if_exception(_is_transient),
+            reraise=True,
+            before_sleep=lambda rs: logger.warning(
+                "Docker pull attempt %d for '%s' failed, retrying in %ds...",
+                rs.attempt_number,
+                full_tag,
+                rs.next_action.sleep,
+            ),
+        )
+        def _pull_with_retry() -> DockerImage:
+            logger.info("Pulling image '%s'...", full_tag)
+            # docker-py returns a single Image when tag is specified.
+            return cast("DockerImage", client.images.pull(name, tag=tag))
+
+        try:
+            pulled = _pull_with_retry()
+        except ImageNotFound as e:
+            raise ImagePullError(
+                "tag_missing",
+                full_tag,
+                f"Registry has no such tag: {full_tag}",
+            ) from e
+        except APIError as e:
+            status = _extract_status_code(e)
+            headers = _extract_response_headers(e)
+            if status == 404:
+                raise ImagePullError(
+                    "tag_missing",
+                    full_tag,
+                    f"Registry has no such tag: {full_tag}",
+                    response_headers=headers,
+                ) from e
+            if status == 429:
+                raise ImagePullError(
+                    "rate_limited",
+                    full_tag,
+                    "Docker Hub rate limit hit. Configure authenticated pulls "
+                    "via ~/.docker/config.json (docker login) to raise the "
+                    "limit above the 100-per-6h anonymous ceiling.",
+                    response_headers=headers,
+                ) from e
+            raise ImagePullError(
+                "unreachable",
+                full_tag,
+                f"Docker registry unreachable: {e}",
+                response_headers=headers,
+            ) from e
+        except DockerException as e:
+            raise ImagePullError(
+                "unreachable",
+                full_tag,
+                f"Docker SDK error while pulling: {e}",
+            ) from e
+
+        logger.info("Successfully pulled image '%s' (ID: %s)", full_tag, pulled.id)
+        image = cls(
+            name=name,
+            tag=tag,
+            image_id=pulled.id,
+            dockerfile="pulled",
+            context="pulled",
+            context_hash="pulled",
+        )
+        object.__setattr__(image, "_client", client)
+        return image
 
     @classmethod
     def _compute_content_hash(

--- a/tolokaforge/docker/image.py
+++ b/tolokaforge/docker/image.py
@@ -477,6 +477,7 @@ class Image(BaseModel):
         cls,
         name: str,
         tag: str,
+        platform: str | None = None,
         client: DockerClient | None = None,
     ) -> Image:
         """Pull an image reference from a Docker registry.
@@ -500,6 +501,14 @@ class Image(BaseModel):
         Args:
             name: The repository, e.g. ``"tolokasoft1/tolokaforge-runner"``.
             tag: The tag, e.g. ``"0.18.0"``.
+            platform: Optional Docker platform spec (e.g.
+                ``"linux/amd64"``). Required on hosts whose native
+                architecture is not covered by the published manifest —
+                the tolokaforge-* images ship ``linux/amd64`` only, so an
+                Apple-Silicon host pulling them must pass
+                ``platform="linux/amd64"`` to get the amd64 variant
+                under emulation instead of a "no matching manifest for
+                linux/arm64" error.
             client: Optional Docker client (for testing / mocking).
 
         Returns:
@@ -569,9 +578,19 @@ class Image(BaseModel):
             ),
         )
         def _pull_with_retry() -> DockerImage:
-            logger.info("Pulling image '%s'...", full_tag)
+            if platform is None:
+                logger.info("Pulling image '%s'...", full_tag)
+            else:
+                logger.info("Pulling image '%s' (platform: %s)...", full_tag, platform)
             # docker-py returns a single Image when tag is specified.
-            return cast("DockerImage", client.images.pull(name, tag=tag))
+            return cast(
+                "DockerImage",
+                (
+                    client.images.pull(name, tag=tag, platform=platform)
+                    if platform is not None
+                    else client.images.pull(name, tag=tag)
+                ),
+            )
 
         try:
             pulled = _pull_with_retry()

--- a/tolokaforge/docker/image_source_policy.py
+++ b/tolokaforge/docker/image_source_policy.py
@@ -1,0 +1,81 @@
+"""Pull-vs-build decision policy for first-party service images.
+
+Resolves the two-value concrete outcome (``"pull"`` or ``"build"``)
+from the three-value config request (``"auto"``, ``"pull"``, ``"build"``)
+plus the engine's install shape and version. Pure function — no
+filesystem, no Docker SDK, no logging. The caller passes the two facts
+it needs to know, and the caller (``stack._build_one_image``) is
+responsible for the side effect that follows.
+
+Semantics summary (see #1068 and ADR-0025 for the full context):
+
+- Explicit ``"pull"`` or ``"build"`` always wins. That's the whole
+  point of an escape hatch.
+- ``"auto"`` falls through to a shape-based decision: pull only when we
+  are running from a wheel install AND we have a concrete version to
+  form a pull tag with. Otherwise build.
+- The sentinel ``"0.0.0+unknown"`` (the value ``tolokaforge/__init__.py``
+  sets when ``importlib.metadata.version("tolokaforge")`` raises
+  ``PackageNotFoundError`` — a source checkout that hasn't been
+  ``pip install``-ed) is the "no valid pull tag exists" case: fall
+  through to build in ``auto`` mode.
+- Any other version string is treated as pull-eligible in ``auto`` mode.
+  Pre-release / dev / local versions (e.g. ``0.18.0.dev5``,
+  ``0.18.0+dirty``) resolve to ``pull`` here; the pull itself will
+  ``ImagePullError(kind="tag_missing")`` and the caller falls back to
+  build with a warning. Keeping that policy in the caller — not here —
+  is deliberate: the pull attempt is the *authoritative* check for
+  whether an image exists at Docker Hub, and we do not want a stale
+  denylist in this module to lie about it.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ImageSource = Literal["auto", "pull", "build"]
+ResolvedImageSource = Literal["pull", "build"]
+
+UNKNOWN_VERSION_SENTINEL = "0.0.0+unknown"
+"""The value ``tolokaforge.__version__`` reports when the engine is
+running from a source checkout that has not been ``pip install``-ed
+(``importlib.metadata`` raises ``PackageNotFoundError``). Kept in this
+module so both the policy and its tests can reference it symbolically —
+a rename in ``tolokaforge/__init__.py`` will fail the test in
+``tests/unit/test_image_source_policy.py`` that pins the two together.
+"""
+
+
+def resolve_image_source(
+    *,
+    request: ImageSource,
+    is_wheel_install: bool,
+    engine_version: str,
+) -> ResolvedImageSource:
+    """Resolve the tri-valued config request to a two-valued policy.
+
+    Args:
+        request: The tri-valued input, from
+            :attr:`tolokaforge.docker.config.DockerConfig.image_source`.
+        is_wheel_install: ``True`` when the running engine is a
+            ``pip install``-ed wheel (no ``pyproject.toml`` alongside
+            :func:`tolokaforge.docker.builder.repo_root`), ``False`` for
+            a source checkout.
+        engine_version: The engine's reported version, from
+            :data:`tolokaforge.__version__`. The unknown-version
+            sentinel is :data:`UNKNOWN_VERSION_SENTINEL`.
+
+    Returns:
+        ``"pull"`` when the caller should attempt a Docker Hub pull;
+        ``"build"`` when the caller should build locally.
+    """
+    if request == "pull":
+        return "pull"
+    if request == "build":
+        return "build"
+    # request == "auto"
+    if not is_wheel_install:
+        return "build"
+    if engine_version == UNKNOWN_VERSION_SENTINEL:
+        return "build"
+    return "pull"

--- a/tolokaforge/docker/image_source_policy.py
+++ b/tolokaforge/docker/image_source_policy.py
@@ -78,4 +78,18 @@ def resolve_image_source(
         return "build"
     if engine_version == UNKNOWN_VERSION_SENTINEL:
         return "build"
+    # PEP 440 local-version segment (``+something``) is not a legal
+    # Docker tag character (Docker tags match ``[A-Za-z0-9_.-]{1,128}``).
+    # An editable install or a hatch build from a dirty tree emits
+    # versions like ``0.18.0+dirty``, ``0.18.0+editable``, or
+    # ``0.18.0+abcdef.dirty``; feeding these to Image.pull would produce
+    # a client-side tag-format error that the pull-path error handler
+    # would misclassify as ``unreachable`` (no HTTP round-trip, so no
+    # status code). Route these to build in ``auto`` mode instead — the
+    # local version means "this bit of code is not what's on Docker Hub"
+    # by definition, so building is the right choice. Explicit ``pull``
+    # still tries; the resulting tag-format error surfaces as a hard
+    # failure that matches the operator's stated intent.
+    if "+" in engine_version:
+        return "build"
     return "pull"

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -155,6 +155,17 @@ class ServiceDefinition(BaseModel):
             "service (task-declared services, third-party images, etc.)."
         ),
     )
+    published_image_platform: str = Field(
+        default="linux/amd64",
+        description=(
+            "Docker platform spec passed to Image.pull for this service's "
+            "published images. Defaults to linux/amd64 because that's what "
+            "publish-images.yml currently produces for every first-party "
+            "image; an arm64 host pulls the amd64 variant under emulation. "
+            "A service that publishes multi-arch or arm64-native images "
+            "overrides this per-service."
+        ),
+    )
     context_files: list[str | tuple[str, str]] = Field(
         default_factory=list,
         description="Explicit list of files/dirs to include in build context. "
@@ -499,17 +510,18 @@ class EngineStack(BaseModel):
             self.config.image_source,
             "" if self.config.image_source != "auto" else f", wheel_install={is_wheel_install}",
         )
-        # Published tolokaforge-* images are linux/amd64 only. On arm64
-        # hosts (Apple Silicon), docker refuses to pull a manifest that
-        # doesn't declare arm64 unless a platform override is passed —
-        # matches the deploy/standalone/docker-compose.yaml pin at
-        # ``platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}``. amd64 hosts
-        # get the same image without emulation.
+        # Platform pinned per-service via published_image_platform (default
+        # linux/amd64 — the current publish-images.yml target). On arm64
+        # hosts an explicit platform override is required or docker will
+        # refuse the pull with "no matching manifest for linux/arm64/v8"
+        # even if it can emulate. Matches deploy/standalone/docker-
+        # compose.yaml's ``platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}``.
         try:
             return Image.pull(
                 name=svc.published_image_repo,
                 tag=engine_version,
-                platform="linux/amd64",
+                platform=svc.published_image_platform,
+                log_label=svc.name,
             )
         except ImagePullError as exc:
             if self.config.image_source == "pull":

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -144,6 +144,17 @@ class ServiceDefinition(BaseModel):
         default="latest",
         description="Tag for prebuilt image",
     )
+    published_image_repo: str | None = Field(
+        default=None,
+        description=(
+            "Docker Hub repository that publishes this service's images, e.g. "
+            "'tolokasoft1/tolokaforge-runner'. When set, the pull-vs-build "
+            "policy on EngineStack.config.image_source can resolve to pulling "
+            "'{published_image_repo}:{engine_version}' instead of building "
+            "locally. When None, only the build path is available for this "
+            "service (task-declared services, third-party images, etc.)."
+        ),
+    )
     context_files: list[str | tuple[str, str]] = Field(
         default_factory=list,
         description="Explicit list of files/dirs to include in build context. "
@@ -320,12 +331,30 @@ class EngineStack(BaseModel):
         return images
 
     def _build_one_image(self, svc: ServiceDefinition, force: bool = False) -> Image | None:
-        """Build (or fetch) a single service's image.
+        """Build (or pull, or fetch) a single service's image.
 
-        Honors ``svc.context_files`` by assembling an isolated temp build
-        directory and cleaning it up after the build. Returns ``None`` only
-        when the service has neither a dockerfile nor a prebuilt image (a
-        misconfiguration the caller logs and skips).
+        Order of resolution:
+
+        1. ``use_prebuilt_image=True`` — third-party images the engine does
+           not own (``dind``, ``typesense``). Stubbed via ``Image(...,
+           context_hash="prebuilt")``; Docker pulls implicitly at
+           ``docker run`` time.
+        2. Pull path (only when ``force=False`` and the pull-policy
+           resolves to ``"pull"``). Requires ``svc.published_image_repo``
+           and a concrete engine version. On success returns an
+           :class:`Image` with ``context_hash="pulled"`` and the pulled
+           image already resident in the daemon. On failure in ``auto``
+           mode, falls through to the build path with a
+           ``logger.warning`` naming the failure kind; in explicit
+           ``pull`` mode, re-raises.
+        3. Local build via :meth:`Image.build` or the shared
+           :class:`ImageRegistry` cache (content-hash keyed).
+
+        Honors ``svc.context_files`` on the build path by assembling an
+        isolated temp build directory and cleaning it up after the build.
+        Returns ``None`` only when the service has neither a dockerfile
+        nor a prebuilt image (a misconfiguration the caller logs and
+        skips).
         """
         if svc.use_prebuilt_image:
             logger.info(
@@ -341,6 +370,14 @@ class EngineStack(BaseModel):
                 context=svc.context,
                 context_hash="prebuilt",
             )
+
+        # Pull path — resolved against DockerConfig.image_source and the
+        # service's declared published repo. ``force=True`` skips it
+        # unconditionally: the caller explicitly wants a fresh build.
+        if not force:
+            pulled = self._maybe_pull_service_image(svc)
+            if pulled is not None:
+                return pulled
 
         if not svc.dockerfile:
             logger.warning(
@@ -391,6 +428,71 @@ class EngineStack(BaseModel):
             context=svc.context,
             build_args=svc.build_args,
         )
+
+    def _maybe_pull_service_image(self, svc: ServiceDefinition) -> Image | None:
+        """Resolve the pull-vs-build policy for one service and try to pull.
+
+        Returns:
+            An :class:`Image` if the pull path resolved to ``"pull"`` AND
+            the pull actually succeeded. ``None`` when the caller should
+            fall through to the build path — either because the policy
+            resolved to ``"build"``, or because ``"pull"`` was tried and
+            failed under ``auto`` mode (fallback), so a warning was
+            emitted and control is being returned to the build path.
+
+        Raises:
+            ImagePullError: When the config resolves to explicit
+                ``"pull"`` mode and the pull attempt failed. The explicit
+                mode is a "pull or die" contract; hard-fail is the whole
+                point of choosing it.
+        """
+        # No published-repo declaration → no pull target. Task-declared
+        # services, third-party images, and any first-party service not
+        # yet wired up all take this branch.
+        if svc.published_image_repo is None:
+            return None
+
+        import tolokaforge
+        from tolokaforge.docker.builder import repo_root
+        from tolokaforge.docker.image import ImagePullError
+        from tolokaforge.docker.image_source_policy import resolve_image_source
+
+        engine_version = tolokaforge.__version__
+        is_wheel_install = not (repo_root() / "pyproject.toml").is_file()
+
+        resolved = resolve_image_source(
+            request=self.config.image_source,
+            is_wheel_install=is_wheel_install,
+            engine_version=engine_version,
+        )
+        if resolved == "build":
+            return None
+
+        published_ref = f"{svc.published_image_repo}:{engine_version}"
+        logger.info(
+            "Pulling published image '%s' for service '%s' (policy: %s%s)",
+            published_ref,
+            svc.name,
+            self.config.image_source,
+            "" if self.config.image_source != "auto" else f", wheel_install={is_wheel_install}",
+        )
+        try:
+            return Image.pull(name=svc.published_image_repo, tag=engine_version)
+        except ImagePullError as exc:
+            if self.config.image_source == "pull":
+                # Explicit pull mode: hard-fail. The escape hatch means
+                # "I want the published image; refuse anything else."
+                raise
+            # auto mode: log-loud with the specific reason so an operator
+            # can act (e.g. add Docker Hub auth on 'rate_limited'), then
+            # fall through to the build path.
+            logger.warning(
+                "Pull of '%s' failed [%s]: %s. Falling back to local build.",
+                published_ref,
+                exc.kind,
+                exc,
+            )
+            return None
 
     # ── Network Management ──────────────────────────────────────────────
 

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -372,8 +372,20 @@ class EngineStack(BaseModel):
             )
 
         # Pull path — resolved against DockerConfig.image_source and the
-        # service's declared published repo. ``force=True`` skips it
-        # unconditionally: the caller explicitly wants a fresh build.
+        # service's declared published repo.
+        #
+        # ``force=True`` normally skips the pull (the caller wants a
+        # fresh build), BUT in explicit ``pull`` mode that would silently
+        # violate the pull-or-die contract — the operator explicitly
+        # asked for a pulled image. Raise instead so the caller sees the
+        # conflict.
+        if force and self.config.image_source == "pull":
+            raise ValueError(
+                f"force=True is incompatible with docker.image_source='pull' "
+                f"on service '{svc.name}': explicit pull mode refuses to "
+                f"build. Set image_source to 'auto' or 'build', or omit "
+                f"force=True."
+            )
         if not force:
             pulled = self._maybe_pull_service_image(svc)
             if pulled is not None:
@@ -448,8 +460,19 @@ class EngineStack(BaseModel):
         """
         # No published-repo declaration → no pull target. Task-declared
         # services, third-party images, and any first-party service not
-        # yet wired up all take this branch.
+        # yet wired up all take this branch. In explicit ``pull`` mode
+        # this is a contract violation (the operator asked for a pull
+        # but the service has nothing to pull from) — refuse rather than
+        # silently drop to build.
         if svc.published_image_repo is None:
+            if self.config.image_source == "pull":
+                raise ValueError(
+                    f"docker.image_source='pull' but service '{svc.name}' "
+                    "has no published_image_repo declared. Nothing to pull. "
+                    "Either declare a published_image_repo on the "
+                    "ServiceDefinition, switch to image_source='auto' or "
+                    "'build', or exclude this service from the stack."
+                )
             return None
 
         import tolokaforge
@@ -675,6 +698,28 @@ class EngineStack(BaseModel):
 
         return result
 
+    def _inspect_running_image(self, container_name: str) -> tuple[list[str], str | None]:
+        """Read the underlying image's tag list + daemon id for a container.
+
+        Returns ``([], None)`` on any failure — the caller treats that as
+        'we couldn't verify' and destroys the container to be safe.
+        Separate helper so the reuse-check comparison in ``_start_service``
+        stays readable and the raw ``docker`` client call is contained.
+        """
+        import docker as docker_lib
+
+        try:
+            client = docker_lib.from_env()
+            raw = client.containers.get(container_name)
+        except Exception:
+            return [], None
+        try:
+            tags = list(raw.image.tags or [])
+            image_id = raw.image.id
+        except Exception:
+            return [], None
+        return tags, image_id
+
     def _try_reuse_existing(
         self,
         container_name: str,
@@ -853,21 +898,39 @@ class EngineStack(BaseModel):
         component_id = build_component_id("engine", "docker.service", name)
 
         # ── Try to reuse an existing healthy container ──────────────
-        # Verify the running container's image tag matches the freshly-built
-        # tag; otherwise we'd silently keep a stale container after a build_arg
-        # change (e.g., enable_playwright on/off).
+        # Verify the running container's image matches the freshly-built
+        # or freshly-pulled image; otherwise we'd silently keep a stale
+        # container after a build_arg change (e.g., enable_playwright on/off).
+        #
+        # Reuse-check identity: match on either (a) daemon image id (uniquely
+        # identifies the image regardless of tags) OR (b) presence of our
+        # expected full_tag in the container image's tag list. The pull path
+        # aliases the underlying image with ``tolokaforge-runner:local`` on
+        # top of the pulled ``tolokasoft1/tolokaforge-runner:X.Y.Z`` tag; a
+        # single-slot ``existing.image.tags[0]`` compare could pick the alias
+        # in one run and the pulled tag in the next (Docker does not
+        # guarantee tag-list ordering), spuriously destroying healthy
+        # containers on every subsequent run.
         existing = self._try_reuse_existing(container_name, svc)
         if existing:
             reuse = False
             try:
-                running_image = existing.image_tag or ""
-                expected_image = image.full_tag
-                if running_image and running_image != expected_image:
+                expected_full_tag = image.full_tag
+                expected_image_id = image.image_id
+                actual_tags, actual_image_id = self._inspect_running_image(container_name)
+                tags_match = expected_full_tag in actual_tags
+                ids_match = bool(
+                    actual_image_id and expected_image_id and actual_image_id == expected_image_id
+                )
+                if not (tags_match or ids_match):
                     logger.info(
-                        "Existing container '%s' uses image '%s' but expected '%s' — recreating",
+                        "Existing container '%s' uses image (id=%s, tags=%s) but "
+                        "expected id=%s / full_tag='%s' — recreating",
                         container_name,
-                        running_image,
-                        expected_image,
+                        actual_image_id or "unknown",
+                        actual_tags or ["unknown"],
+                        expected_image_id or "unknown",
+                        expected_full_tag,
                     )
                     existing.destroy()
                 else:

--- a/tolokaforge/docker/stack.py
+++ b/tolokaforge/docker/stack.py
@@ -476,8 +476,18 @@ class EngineStack(BaseModel):
             self.config.image_source,
             "" if self.config.image_source != "auto" else f", wheel_install={is_wheel_install}",
         )
+        # Published tolokaforge-* images are linux/amd64 only. On arm64
+        # hosts (Apple Silicon), docker refuses to pull a manifest that
+        # doesn't declare arm64 unless a platform override is passed —
+        # matches the deploy/standalone/docker-compose.yaml pin at
+        # ``platform: ${TOLOKAFORGE_PLATFORM:-linux/amd64}``. amd64 hosts
+        # get the same image without emulation.
         try:
-            return Image.pull(name=svc.published_image_repo, tag=engine_version)
+            return Image.pull(
+                name=svc.published_image_repo,
+                tag=engine_version,
+                platform="linux/amd64",
+            )
         except ImagePullError as exc:
             if self.config.image_source == "pull":
                 # Explicit pull mode: hard-fail. The escape hatch means

--- a/tolokaforge/docker/stacks/core.py
+++ b/tolokaforge/docker/stacks/core.py
@@ -90,6 +90,7 @@ def core_stack(
     db_service = ServiceDefinition(
         name="db-service",
         image_name="tolokaforge-db-service",
+        published_image_repo="tolokasoft1/tolokaforge-db-service",
         dockerfile="tolokaforge/docker/dockerfiles/db_service.Dockerfile",
         context=".",
         context_files=[
@@ -193,6 +194,7 @@ def core_stack(
     runner = ServiceDefinition(
         name="runner",
         image_name="tolokaforge-runner",
+        published_image_repo="tolokasoft1/tolokaforge-runner",
         dockerfile="tolokaforge/docker/dockerfiles/runner.Dockerfile",
         context=".",
         # Sources ``hatch build --target custom`` consumes in the wheel-builder

--- a/tolokaforge/docker/stacks/full.py
+++ b/tolokaforge/docker/stacks/full.py
@@ -91,6 +91,7 @@ def full_stack(
     rag_service = ServiceDefinition(
         name="rag-service",
         image_name="tolokaforge-rag-service",
+        published_image_repo="tolokasoft1/tolokaforge-rag-service",
         dockerfile="tolokaforge/docker/dockerfiles/rag.Dockerfile",
         context=".",
         context_files=[
@@ -131,6 +132,7 @@ def full_stack(
     mock_web_service = ServiceDefinition(
         name="mock-web",
         image_name="tolokaforge-mock-web",
+        published_image_repo="tolokasoft1/tolokaforge-mock-web",
         dockerfile="tolokaforge/docker/dockerfiles/mock_web.Dockerfile",
         context=".",
         # Narrow build-context-hash to what the Dockerfile actually COPYs.

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -638,6 +638,20 @@ def run(
             "--run-dir requires --resume; use it only to point --resume at an existing run directory"
         )
 
+    # Validate TOLOKAFORGE_IMAGE_SOURCE eagerly — Click already checks
+    # ``--image-source`` via its ``Choice`` type, but a typo in the env
+    # var would otherwise not surface until after load_effective_run_config
+    # walks the entire YAML tree, so a two-letter mistake burns seconds.
+    _env_image_source = os.environ.get("TOLOKAFORGE_IMAGE_SOURCE")
+    if _env_image_source:
+        _allowed_sources = _get_type_args(_ImageSourceLiteral)
+        if _env_image_source not in _allowed_sources:
+            raise click.BadParameter(
+                f"TOLOKAFORGE_IMAGE_SOURCE={_env_image_source!r} is not one of "
+                f"{', '.join(repr(v) for v in _allowed_sources)}",
+                param_hint="TOLOKAFORGE_IMAGE_SOURCE",
+            )
+
     console.print(f"[bold blue]Loading configuration from {config}...[/bold blue]")
 
     # Load config with the enclosing project's run_defaults layered under
@@ -705,15 +719,11 @@ def run(
     # images are pulled from Docker Hub or built locally. Precedence:
     # flag > env > YAML config > default (auto). Same ad-hoc pattern as
     # --user-model / --judge-model above.
+    # Both sources are already validated: --image-source by Click's
+    # ``Choice`` at parse time, TOLOKAFORGE_IMAGE_SOURCE by the eager
+    # env check above. This block only applies the resolved value.
     image_source_override = image_source or os.environ.get("TOLOKAFORGE_IMAGE_SOURCE")
     if image_source_override:
-        allowed = _get_type_args(_ImageSourceLiteral)
-        if image_source_override not in allowed:
-            raise click.BadParameter(
-                f"TOLOKAFORGE_IMAGE_SOURCE={image_source_override!r} is not one of "
-                f"{', '.join(repr(v) for v in allowed)}",
-                param_hint="TOLOKAFORGE_IMAGE_SOURCE",
-            )
         # Defensive: PyYAML parses a bare ``docker:`` key with no value
         # as ``None``. ``dict.setdefault('docker', {})`` returns that
         # existing None and ``None['image_source'] = ...`` blows up

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -581,6 +581,21 @@ def _run_dry_run(
         "provider. See docs/CLI.md § Dry run."
     ),
 )
+@click.option(
+    "--image-source",
+    "image_source",
+    type=click.Choice(["auto", "pull", "build"]),
+    default=None,
+    help=(
+        "Where first-party service images come from. 'auto' (the default "
+        "when unset) pulls the published tolokasoft1/tolokaforge-<svc>:<version> "
+        "images from Docker Hub on wheel installs and builds locally from a "
+        "source checkout; 'pull' always pulls and hard-fails if the tag is "
+        "missing or unreachable; 'build' always builds locally. Overrides "
+        "docker.image_source in the run config. Env: TOLOKAFORGE_IMAGE_SOURCE. "
+        "Precedence: flag > env > config > default. See docs/RUNNER.md."
+    ),
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -597,6 +612,7 @@ def run(
     cost_limit: float | None,
     time_limit: str | None,
     dry_run: bool,
+    image_source: str | None,
 ):
     """Run benchmark with specified configuration"""
     if verbose:
@@ -677,6 +693,20 @@ def run(
             time_limit_seconds = parse_duration(time_limit)
         except ValueError as exc:
             raise click.BadParameter(f"--time-limit: {exc}") from exc
+
+    # --image-source / TOLOKAFORGE_IMAGE_SOURCE controls whether service
+    # images are pulled from Docker Hub or built locally. Precedence:
+    # flag > env > YAML config > default (auto). Same ad-hoc pattern as
+    # --user-model / --judge-model above.
+    image_source_override = image_source or os.environ.get("TOLOKAFORGE_IMAGE_SOURCE")
+    if image_source_override:
+        if image_source_override not in ("auto", "pull", "build"):
+            raise click.BadParameter(
+                f"TOLOKAFORGE_IMAGE_SOURCE={image_source_override!r} is not one of "
+                "'auto', 'pull', 'build'",
+                param_hint="TOLOKAFORGE_IMAGE_SOURCE",
+            )
+        config_data.setdefault("docker", {})["image_source"] = image_source_override
 
     run_config = construct_config(RunConfig, config_data, source=Path(config))
 

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from typing import get_args as _get_type_args
 
 import click
 import yaml
@@ -68,6 +69,7 @@ from tolokaforge.core.project_loader import (
 )
 from tolokaforge.core.resume import RunStateManager, resolve_resume_run_directory
 from tolokaforge.core.run_queue import create_run_queue
+from tolokaforge.docker.config import ImageSource as _ImageSourceLiteral
 from tolokaforge.dx._display import (
     DisplayMode,
     console,
@@ -584,7 +586,12 @@ def _run_dry_run(
 @click.option(
     "--image-source",
     "image_source",
-    type=click.Choice(["auto", "pull", "build"]),
+    # SSOT: the allow-list lives on ``DockerConfig.image_source``'s
+    # ``Literal`` type. Deriving the Click Choice values from
+    # ``typing.get_args`` keeps this argparser, the env-var validation
+    # below, and the pydantic model in lock-step — adding a new value
+    # is a one-line edit at the type-alias.
+    type=click.Choice(list(_get_type_args(_ImageSourceLiteral))),
     default=None,
     help=(
         "Where first-party service images come from. 'auto' (the default "
@@ -700,13 +707,21 @@ def run(
     # --user-model / --judge-model above.
     image_source_override = image_source or os.environ.get("TOLOKAFORGE_IMAGE_SOURCE")
     if image_source_override:
-        if image_source_override not in ("auto", "pull", "build"):
+        allowed = _get_type_args(_ImageSourceLiteral)
+        if image_source_override not in allowed:
             raise click.BadParameter(
                 f"TOLOKAFORGE_IMAGE_SOURCE={image_source_override!r} is not one of "
-                "'auto', 'pull', 'build'",
+                f"{', '.join(repr(v) for v in allowed)}",
                 param_hint="TOLOKAFORGE_IMAGE_SOURCE",
             )
-        config_data.setdefault("docker", {})["image_source"] = image_source_override
+        # Defensive: PyYAML parses a bare ``docker:`` key with no value
+        # as ``None``. ``dict.setdefault('docker', {})`` returns that
+        # existing None and ``None['image_source'] = ...`` blows up
+        # with an opaque TypeError. Coerce None → {} first so the
+        # override lands cleanly no matter how the YAML shape looked.
+        if config_data.get("docker") is None:
+            config_data["docker"] = {}
+        config_data["docker"]["image_source"] = image_source_override
 
     run_config = construct_config(RunConfig, config_data, source=Path(config))
 


### PR DESCRIPTION
Closes #1068.

## Summary

Adds a tri-valued policy — `docker.image_source: auto | pull | build` — controlling how `tolokaforge run` resolves the four first-party service images (`runner`, `db-service`, `rag-service`, `mock-web`). Post-M29 (v0.18.0) those images are published as `tolokasoft1/tolokaforge-<svc>:X.Y.Z` on Docker Hub, byte-equivalent to what a wheel-install user would produce with a 2–5 min local build. This PR lets them pull instead in ~30–90 s while preserving the source-checkout build loop for contributors.

## The shape

| `docker.image_source` | Behavior |
|---|---|
| `auto` (default) | Wheel install → pull; source checkout → build. Falls back to build on any pull failure with a `logger.warning` naming the reason (`tag_missing`, `rate_limited`, `unreachable`). |
| `pull` | Always pull. Hard-fail on failure — no fallback. |
| `build` | Always build. Skip pull entirely. |

Override via `--image-source` (Click Choice) or `TOLOKAFORGE_IMAGE_SOURCE`. Precedence: flag > env > YAML config > default.

Version resolution uses `tolokaforge.__version__` (`importlib.metadata`). The `0.0.0+unknown` sentinel (source checkout without `pip install`) resolves `auto` to `build` — never attempts to pull a nonexistent tag.

## Where the code lives

- `DockerConfig.image_source` — Pydantic field on the existing `DockerConfig`, wired into `RunConfig` as `docker: DockerConfig | None = None`.
- `Image.pull()` classmethod on `tolokaforge/docker/image.py` — mirrors `Image.build()`; tenacity retry, but treats 404 (`tag_missing`) and 429 (`rate_limited`) as terminal to avoid burning the retry budget on caller-actionable failures. `ImagePullError` sub-classifies the failure and carries response headers so operators see Retry-After on rate-limit hits.
- `resolve_image_source()` — pure policy helper in `tolokaforge/docker/image_source_policy.py`. Tested against all use-case matrix rows from #1068.
- `EngineStack._maybe_pull_service_image` — runs before the local build path; log-loud fallback in `auto` mode, re-raise in `pull` mode. `use_prebuilt_image=True` services (`dind`, `typesense`) bypass the pull policy entirely; `force=True` on `build_images()` also skips pull.
- `ServiceDefinition.published_image_repo` — new optional field. Set on the four first-party services in `stacks/core.py` and `stacks/full.py`; task-declared services and third-party images leave it `None` and are unaffected.

## Platform pin

The published images ship `linux/amd64` only. A bare `docker pull` on Apple Silicon errors with `no matching manifest for linux/arm64/v8`. The pull path passes `platform=\"linux/amd64\"` explicitly so both native amd64 and arm64 (under emulation) get the same image — matches the pin `deploy/standalone/docker-compose.yaml` already carries via `TOLOKAFORGE_PLATFORM`.

## Test plan

- [x] Unit tests for `DockerConfig.image_source` and `RunConfig.docker` wiring (13 tests)
- [x] Unit tests for `Image.pull()` — happy path, cache hit, `ImageNotFound`, 404/429/500 APIError paths, terminal-error non-retry behavior (11 tests)
- [x] Unit tests for `resolve_image_source()` policy — full parametrize over explicit / auto × install shape × version (25 tests)
- [x] Unit tests for `EngineStack._maybe_pull_service_image` — all 6 use-case branches, plus prebuilt-image short-circuit and `force=True` bypass (12 tests)
- [x] CLI tests for `--image-source` / `TOLOKAFORGE_IMAGE_SOURCE` / YAML precedence + input validation (6 tests)
- [x] Canonical extension in `test_wheel_install_runner_context.py` — probe subprocess in a real scratch-venv wheel install asserts the runner ServiceDefinition declares its published repo AND `resolve_image_source` maps `auto → pull` for the version `importlib.metadata` actually reports
- [x] Integration test (marked `integration + requires_docker`, skipped in default suite) — end-to-end pull from Docker Hub against a real daemon; skips when a live `tolokaforge-runner` container is running to avoid dev-loop collisions. Passed on the test host.
- [x] Full unit suite for docker/image/stack/service/cli — 448 tests, no regressions
- [x] Orchestrator alias-tagging tests still pass — pulled `Image` objects satisfy `add_alias_tag()`, so `_ensure_engine_image_local_aliases` works transparently on either build or pull path

## Docs

`docs/RUNNER.md` gains one section under \"Docker Service Management\" naming the three values, the precedence, the version SSOT, and Docker Hub's 100-per-6h anonymous pull limit as the reason to configure auth or use `build` mode on shared runners. Points at `docs/STANDALONE_RUNNER.md § Published images` for the tag axis rather than duplicating it. `STANDALONE_RUNNER.md` is untouched — the larger doc reshuffle mentioned in #1068 is deferred to a follow-up so this PR stays focused on the code change.

## Non-goals (deferred to follow-ups)

- Digest-pinning via a bundled manifest (supply-chain hardening)
- Multi-arch publish (already out of scope in #1068)
- `docker.pull_credentials` field for programmatic Docker Hub auth — users configure via the daemon's standard `~/.docker/config.json` for now
- The full RUNNER.md ↔ STANDALONE_RUNNER.md doc split proposed in the ticket