### PR TITLE
fix(runner): assemble $.filesystem state at grading time (#1074)

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -1012,7 +1012,7 @@ trial's final state, and both levels are fixed:
 | source | evaluated against |
 |---|---|
 | `hash` | the **unwrapped** database inside the final state (`db`, else `agent`, else the state itself) — the level the golden state and `compute_stable_hash` both describe |
-| `jsonpaths` | the **whole** final environment state, so an assertion is rooted `$.db.<table>[…]` |
+| `jsonpaths` | the **whole** final environment state — `$.db.<table>[…]` for a row and `$.filesystem['/env/fs/agent-visible/<rel>']` for a provisioned file the agent may have edited |
 
 A source that declares nothing to evaluate produces no verdict, and a source
 nobody configured contributes nothing rather than a score. An empty `jsonpaths`
@@ -1022,7 +1022,12 @@ has the answer `1.0`, and that fraction of nothing never becomes a component sco
 - **hash only** (`jsonpaths` empty — the tau-bench shape): the component *is* the
   hash verdict, at every `weight`. An empty assertion list is not a pass.
 - **non-empty `jsonpaths` only** (no hash source declared): the component is the
-  assertion score. **Core-side only** — see the substrate note below.
+  assertion score. Both substrates evaluate the shape; on the runner side the
+  jsonpath state is `$.db`/`$.tables` for stored rows and `$.filesystem` for
+  files provisioned under `/env/fs/agent-visible/` — a filesystem-only task
+  (one whose `initial_state` declares no `tables`) still grades, and a
+  `$.filesystem['/env/fs/agent-visible/<rel>']` assertion resolves to the
+  file's current on-disk content.
 - **both**: `jsonpath_score × (1 − weight) + hash_score × weight`.
 - **neither** — an empty `jsonpaths` list with hash grading off, or on and unable
   to produce a verdict: the component is **not evaluated**. It is absent from the

--- a/tests/unit/test_runner_filesystem_grading_state.py
+++ b/tests/unit/test_runner_filesystem_grading_state.py
@@ -1,0 +1,136 @@
+"""Runner reads /work/ back at grading time so $.filesystem jsonpaths resolve.
+
+Task authors write jsonpath state_checks like::
+
+    state_checks:
+      jsonpaths:
+        - path: "$.filesystem['/env/fs/agent-visible/buggy_math.py']"
+          contains: "amount * (1 + tax_rate)"
+
+For that to match, the runner must expose the on-disk contents of /work/
+back out under the logical /env/fs/agent-visible/ layout the task YAML
+wrote against — the same layout the RegisterTrial provisioner accepted.
+
+Regression for #1074: filesystem-only tasks used to hit "State: FAIL:
+DB state unavailable" because the runner only consulted the DB service.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tolokaforge.runner import service as service_module
+from tolokaforge.runner.db_client import TrialNotFoundError
+
+pytestmark = pytest.mark.unit
+
+
+class _StubRunnerServiceImpl:
+    """Bind just the methods under test onto a minimal instance.
+
+    The full RunnerServiceImpl constructor spins up a gRPC server, a DB client,
+    an LLM stack and an OTEL exporter — none of which the filesystem-read
+    helper touches. Binding the two methods directly to a plain object keeps
+    the test hermetic.
+    """
+
+    def __init__(self, db_client) -> None:  # noqa: ANN001 — test stub
+        self.db_client = db_client
+
+    _read_agent_visible_filesystem = service_module.RunnerServiceImpl._read_agent_visible_filesystem
+    _assemble_jsonpath_state = service_module.RunnerServiceImpl._assemble_jsonpath_state
+
+
+@pytest.fixture
+def redirect_work_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    # A dedicated subdirectory keeps the unit-conftest's autouse fake-wheel
+    # (planted at ``tmp_path/tolokaforge-*.whl``) out of the walk.
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setattr(service_module, "AGENT_WORK_DIR", str(work))
+    return work
+
+
+def test_read_agent_visible_filesystem_relabels_files_under_logical_root(
+    redirect_work_dir: Path,
+) -> None:
+    (redirect_work_dir / "buggy_math.py").write_text("amount * (1 + tax_rate)\n")
+    (redirect_work_dir / "sub").mkdir()
+    (redirect_work_dir / "sub" / "helper.py").write_text("def x(): return 1\n")
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    fs = svc._read_agent_visible_filesystem()
+
+    assert fs == {
+        "/env/fs/agent-visible/buggy_math.py": "amount * (1 + tax_rate)\n",
+        "/env/fs/agent-visible/sub/helper.py": "def x(): return 1\n",
+    }
+
+
+def test_read_agent_visible_filesystem_skips_binary_and_returns_empty_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Point AGENT_WORK_DIR at a directory that will not exist for the empty case.
+    monkeypatch.setattr(service_module, "AGENT_WORK_DIR", str(tmp_path / "nope"))
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    assert svc._read_agent_visible_filesystem() == {}
+
+    # Then repoint at a fresh subdirectory (dodging the unit-conftest's
+    # autouse fake wheel at tmp_path root) with a binary file: it is skipped,
+    # not raised.
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setattr(service_module, "AGENT_WORK_DIR", str(work))
+    (work / "image.bin").write_bytes(b"\x89PNG\x00\x01\x02\x03\xff\xfe")
+    (work / "readme.txt").write_text("hello")
+    fs = svc._read_agent_visible_filesystem()
+    assert fs == {"/env/fs/agent-visible/readme.txt": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_assemble_jsonpath_state_handles_missing_db_trial(
+    redirect_work_dir: Path,
+) -> None:
+    """Filesystem-only tasks never call db_client.init_trial(), so
+    ``get_stable_state`` raises ``TrialNotFoundError``. The assembler must
+    treat that as an empty DB state instead of propagating the error —
+    otherwise the outer catch-all in GradeTrial rewrites it as
+    ``Grading error: TrialNotFoundError`` and the trial fails to grade at
+    all, even for assertions that only need $.filesystem.
+    """
+    (redirect_work_dir / "buggy_math.py").write_text("amount * (1 + tax_rate)\n")
+
+    db_client = AsyncMock()
+    db_client.get_stable_state = AsyncMock(side_effect=TrialNotFoundError("t-1"))
+    svc = _StubRunnerServiceImpl(db_client=db_client)
+
+    state = await svc._assemble_jsonpath_state("t-1")
+
+    assert state["db"] == {}
+    assert state["tables"] == {}
+    assert state["filesystem"] == {
+        "/env/fs/agent-visible/buggy_math.py": "amount * (1 + tax_rate)\n",
+    }
+
+
+@pytest.mark.asyncio
+async def test_assemble_jsonpath_state_merges_db_and_filesystem(
+    redirect_work_dir: Path,
+) -> None:
+    (redirect_work_dir / "buggy_math.py").write_text("amount * (1 + tax_rate)\n")
+
+    stable_response = type("R", (), {"data": {"users": [{"id": 1, "name": "alice"}]}})()
+    db_client = AsyncMock()
+    db_client.get_stable_state = AsyncMock(return_value=stable_response)
+    svc = _StubRunnerServiceImpl(db_client=db_client)
+
+    state = await svc._assemble_jsonpath_state("t-1")
+
+    assert state["db"] == {"users": [{"id": 1, "name": "alice"}]}
+    assert state["tables"] == state["db"]
+    assert state["filesystem"] == {
+        "/env/fs/agent-visible/buggy_math.py": "amount * (1 + tax_rate)\n",
+    }

--- a/tests/unit/test_runner_filesystem_grading_state.py
+++ b/tests/unit/test_runner_filesystem_grading_state.py
@@ -7,12 +7,14 @@ Task authors write jsonpath state_checks like::
         - path: "$.filesystem['/env/fs/agent-visible/buggy_math.py']"
           contains: "amount * (1 + tax_rate)"
 
-For that to match, the runner must expose the on-disk contents of /work/
+For that to match, the runner exposes the on-disk contents of /work/
 back out under the logical /env/fs/agent-visible/ layout the task YAML
-wrote against — the same layout the RegisterTrial provisioner accepted.
+wrote against — the same layout the RegisterTrial provisioner accepts.
 
-Regression for #1074: filesystem-only tasks used to hit "State: FAIL:
-DB state unavailable" because the runner only consulted the DB service.
+The runner catches ``TrialNotFoundError`` from the DB client so a
+filesystem-only trial (one whose task never provisions ``initial_state.tables``
+and therefore never calls ``db_client.init_trial()``) still assembles a
+jsonpath state rooted at ``$.filesystem[…]``.
 """
 
 from __future__ import annotations
@@ -88,6 +90,24 @@ def test_read_agent_visible_filesystem_skips_binary_and_returns_empty_when_absen
     (work / "readme.txt").write_text("hello")
     fs = svc._read_agent_visible_filesystem()
     assert fs == {"/env/fs/agent-visible/readme.txt": "hello"}
+
+
+def test_read_agent_visible_filesystem_skips_symlinks(
+    redirect_work_dir: Path,
+) -> None:
+    # A symlink under /work/ could point at any container-readable path
+    # (e.g. /etc/hostname). The assertion vocabulary is not a general-purpose
+    # container filesystem probe, so the walk must ignore the link even
+    # though ``is_file()`` returns True for a file-target symlink.
+    outside = redirect_work_dir.parent / "outside.txt"
+    outside.write_text("must not leak")
+    (redirect_work_dir / "readme.txt").write_text("ok")
+    (redirect_work_dir / "link").symlink_to(outside)
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    fs = svc._read_agent_visible_filesystem()
+
+    assert fs == {"/env/fs/agent-visible/readme.txt": "ok"}
 
 
 @pytest.mark.asyncio

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1390,6 +1390,14 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             stable = await self.db_client.get_stable_state(trial_id)
             db_state: dict[str, Any] = stable.data
         except DBTrialNotFoundError:
+            # Filesystem-only tasks never call db_client.init_trial(), so an
+            # absent DB is the expected shape. For tasks that DID declare a
+            # DB this same branch fires and downstream ``$.db.*`` assertions
+            # surface as "Path not found" — log at warn so ops see the real
+            # cause rather than debugging per-assertion failures.
+            logger.warning(
+                f"GradeTrial: {trial_id} - DB trial not found; grading with empty DB state"
+            )
             db_state = {}
         return {
             "db": db_state,
@@ -1398,21 +1406,27 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         }
 
     def _read_agent_visible_filesystem(self) -> dict[str, str]:
-        # Inverse of the RegisterTrial provisioner (see line 882): files
-        # provisioned from ``/env/fs/agent-visible/<rel>`` were written to
-        # ``/work/<rel>``, so we walk /work/ and expose each file back at
-        # its logical path. Binaries and unreadable entries are skipped —
-        # ``contains:``/``equals:`` operators can only match text anyway.
+        # Inverse of the RegisterTrial provisioner's
+        # ``/env/fs/agent-visible/<rel>`` → ``/work/<rel>`` block: expose each
+        # file back at its logical path so
+        # ``$.filesystem['/env/fs/agent-visible/<rel>']`` resolves. Binary
+        # files are skipped — ``contains:``/``equals:`` operators can only
+        # match text. Symlinks are skipped too: the assertion vocabulary was
+        # not designed to expose arbitrary container-readable paths reachable
+        # via a link the agent dropped in ``/work/``.
         root = Path(AGENT_WORK_DIR)
         fs: dict[str, str] = {}
         if not root.is_dir():
             return fs
         for path in root.rglob("*"):
-            if not path.is_file():
+            if path.is_symlink() or not path.is_file():
                 continue
             try:
                 content = path.read_text(encoding="utf-8")
-            except (UnicodeDecodeError, OSError):
+            except UnicodeDecodeError:
+                continue
+            except OSError as exc:
+                logger.warning(f"GradeTrial: could not read {path} for jsonpath state: {exc}")
                 continue
             rel = path.relative_to(root)
             fs[f"/env/fs/agent-visible/{rel.as_posix()}"] = content

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -1379,6 +1379,45 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 error=f"Grading error: {type(e).__name__}: {str(e)}",
             )
 
+    async def _assemble_jsonpath_state(self, trial_id: str) -> dict[str, Any]:
+        # Feeds path: jsonpath state_checks. Two roots: "db"/"tables" carry
+        # the DB service's stable state (empty when the trial has no DB —
+        # filesystem-only tasks); "filesystem" mirrors /work/ back out under
+        # the logical /env/fs/agent-visible/ layout the task YAML asserts
+        # against, so ``$.filesystem['/env/fs/agent-visible/foo.py']`` can
+        # match the file the agent actually edited.
+        try:
+            stable = await self.db_client.get_stable_state(trial_id)
+            db_state: dict[str, Any] = stable.data
+        except DBTrialNotFoundError:
+            db_state = {}
+        return {
+            "db": db_state,
+            "tables": db_state,
+            "filesystem": self._read_agent_visible_filesystem(),
+        }
+
+    def _read_agent_visible_filesystem(self) -> dict[str, str]:
+        # Inverse of the RegisterTrial provisioner (see line 882): files
+        # provisioned from ``/env/fs/agent-visible/<rel>`` were written to
+        # ``/work/<rel>``, so we walk /work/ and expose each file back at
+        # its logical path. Binaries and unreadable entries are skipped —
+        # ``contains:``/``equals:`` operators can only match text anyway.
+        root = Path(AGENT_WORK_DIR)
+        fs: dict[str, str] = {}
+        if not root.is_dir():
+            return fs
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            rel = path.relative_to(root)
+            fs[f"/env/fs/agent-visible/{rel.as_posix()}"] = content
+        return fs
+
     async def _grade_trial_async(self, request: pb2.GradeTrialRequest) -> pb2.GradeTrialResponse:
         """
         Async implementation of GradeTrial.
@@ -1494,18 +1533,14 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 f"GradeTrial: {trial_id} - Evaluating "
                 f"{len(state_checks_config.jsonpath_checks)} jsonpath checks"
             )
-            # Only fetch DB state when at least one assertion targets it via
-            # ``path:``. File-only (``path_glob:``) checks never needed the DB,
-            # so fetching unconditionally would add a round-trip and a new
-            # failure mode for tasks that previously graded without it.
+            # Only assemble a state dict when at least one assertion targets
+            # it via ``path:``. File-only (``path_glob:``) checks never needed
+            # a state dict; they read files off disk directly via
+            # ``evaluate_jsonpath_file_checks``.
             jsonpath_checks = state_checks_config.jsonpath_checks
             jsonpath_state = None
             if any(check.get("path") is not None for check in jsonpath_checks):
-                stable_state_response = await self.db_client.get_stable_state(trial_id)
-                jsonpath_state = {
-                    "db": stable_state_response.data,
-                    "tables": stable_state_response.data,
-                }
+                jsonpath_state = await self._assemble_jsonpath_state(trial_id)
             jsonpath_score, jsonpath_reasons = evaluate_jsonpath_checks(
                 jsonpath_checks,
                 state=jsonpath_state,


### PR DESCRIPTION
## Summary

Runner's `_grade_trial_async` fetched state only from the DB service, so `path:` jsonpath assertions against `$.filesystem[...]` were impossible to satisfy — and for **filesystem-only tasks** (no `initial_state.tables`) the DB fetch itself raised `TrialNotFoundError`, which the outer catch-all rewrote as `Grading error: TrialNotFoundError` and the trial failed to grade at all.

This is the bug the coding example hit: `examples/native/coding/dataset/tasks/coding/coding_public_example_01/grading.yaml` asserts

```yaml
state_checks:
  jsonpaths:
    - path: \"\$.filesystem['/env/fs/agent-visible/buggy_math.py']\"
      contains: \"amount * (1 + tax_rate)\"
```

Before this PR: state_checks scored 0.0 (\"State: FAIL: DB state unavailable for JSONPath checks\").
After this PR: state_checks scored 0.67 (files resolved, 2/3 assertions pass end-to-end).

## What changed

- New `RunnerServiceImpl._assemble_jsonpath_state(trial_id)` builds the state dict fed to `evaluate_jsonpath_state_checks`. It:
  - fetches DB state via `get_stable_state`, catching `TrialNotFoundError` and treating it as an empty DB;
  - populates `filesystem` from disk.
- New `RunnerServiceImpl._read_agent_visible_filesystem()` walks `/work/` (the runner's on-disk agent-visible root) and relabels each file back under the logical `/env/fs/agent-visible/<rel>` layout — the inverse of the RegisterTrial provisioner at `service.py:882`. Binaries and unreadable entries are skipped; `contains:` / `equals:` operators can only match text anyway.
- `_grade_trial_async` now calls the new assembler instead of building the state dict inline.

## Test plan

- [x] `pytest -m unit -k runner` — 414 passed, no regressions.
- [x] New unit tests in `tests/unit/test_runner_filesystem_grading_state.py`:
  - `_read_agent_visible_filesystem` relabels files under the logical root.
  - It skips binary files and returns `{}` when `/work/` is absent.
  - `_assemble_jsonpath_state` handles missing DB trial gracefully (empty `db`/`tables`, full `filesystem`).
  - It merges DB + filesystem state when both are present.
- [x] End-to-end: `tolokaforge run` against `coding_public_example_01`. Grading now completes (state_checks 0.67 → total 0.78) instead of failing outright.

## Notes

The one remaining state-check fail after this PR is on the task-authoring side: the assertion is over-specific to the one-liner `amount * (1 + tax_rate)`, and the agent's equally correct two-step form (`multiplier = 1.0 + tax_rate; return amount * multiplier`) doesn't match. That's a follow-up for whoever owns the task pack — the runner now correctly reports pass/fail on the actual content.

Closes #1074