### PR TITLE
test(grading): a trace-check gate fails a trial inside a real runner container, keyless

### DIFF
--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -2351,6 +2351,30 @@ where it applies whichever route was taken. A block whose routes are *all* gate-
 is admitted: there is no scored sibling for one to stand in front of, and the block
 asks the gates' own question whichever route the agent walked.
 
+The gate is read out of a real container as well, in
+[`tests/integration/test_docker_grading_trace_gate.py`](../tests/integration/test_docker_grading_trace_gate.py):
+the committed `trace_checks_gate` parity pack driven through `RegisterTrial` →
+`GradeTrial` over real gRPC, one trial that trips the gate beside one that does not. That
+pack's `pass_threshold` is `0.0` and its scored constraint holds in both trials, so a
+tripped gate is the only thing that can fail one and the only thing that can move the
+component. The two trials pin the verdict, the zeroed component,
+`trace_checks_summary.gate_failed`, `failed_gate_ids`, the per-constraint `severity`
+values and the `FAILED trace gates:` sentence.
+
+**What that proves and what it does not.** The shipped runner image — a separately built
+artefact, installed from a wheel whose file partition excludes twelve `core/grading`
+modules — carries the gate: it reads `severity` off an authored pack and reports which
+gate shut. Measured by dropping `severity: gate` from that pack, which turns the failing
+trial into a passing one scoring `0.5`: the difference between a gate and a low score is
+what those two trials are. What they do not reach is a gate over records the container
+wrote itself — every `TOOL_CALL` event there derives from the message view the host
+supplies in `llm_messages_json`, the shape production sends, which leaves the record half
+of the timeline empty. Nor does the canonical suite prove this test *passes*: the job that
+runs on every pull request is `test-smoke`, whose repo-suite pytest step is
+`tests/unit/ tests/canonical/` and which has no integration step at all. `tests/integration/`
+runs in `test-full` (push and schedule) and in `test-gate`, which is triggered by the
+`ready-to-merge` label.
+
 ### Alternative paths
 
 `alternatives` declares two or more routes, each a `TracePath` carrying an `id`, a

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -276,10 +276,10 @@ plain product of the two scores, each turn every cell red. No cell there lists a
 `numeric_string_fields` entry; that key is proven by its own differential, below.
 Nor does the canonical suite prove this test *passes*: it resolves the nodeid and stops
 there. The job that runs on every pull request is `test-smoke`, whose repo-suite pytest
-step is `tests/unit/ tests/canonical/` and which has no integration step at all; `test-gate`
-is the job that runs `tests/integration/`, and it is triggered by the `ready-to-merge`
-label — so the canonical tier gates every pull request, and this tier's output is
-quoted from a local run until that label lands.
+step is `tests/unit/ tests/canonical/` and which has no integration step at all;
+`tests/integration/` runs in `test-full` (push and schedule) and in `test-gate`, which is
+triggered by the `ready-to-merge` label — so the canonical tier gates every pull request,
+and this tier's output is quoted from a local run until that label lands.
 
 **`numeric_string_fields` folds by name, on both substrates.** A six-cell matrix in the
 parity suite declares one money field at `"130.00"` and grades a trial that left it at
@@ -2362,8 +2362,8 @@ component. The two trials pin the verdict, the zeroed component,
 values and the `FAILED trace gates:` sentence.
 
 **What that proves and what it does not.** The shipped runner image — a separately built
-artefact, installed from a wheel whose file partition excludes twelve `core/grading`
-modules — carries the gate: it reads `severity` off an authored pack and reports which
+artefact, installed from a wheel whose file partition excludes part of `core/grading`
+— carries the gate: it reads `severity` off an authored pack and reports which
 gate shut. Measured by dropping `severity: gate` from that pack, which turns the failing
 trial into a passing one scoring `0.5`: the difference between a gate and a low score is
 what those two trials are. What they do not reach is a gate over records the container

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests/
     ├── servicer_runtime.py   # RuntimeBackend over the in-process servicer + the duplicate-call_id refusal
     ├── search_plane_harness.py  # RegisterTrial through the search plane: registry stand-in, kb task, both address sources
     ├── timelines.py          # Coherent TrialTimeline fixtures (message view + records)
-    ├── grading_parity_packs.py  # A grading_parity pack's trial.yaml, decoded once into each substrate's input shape — every tier driving a parity trial reads it here
+    ├── grading_parity_packs.py  # A grading_parity pack's trial.yaml, decoded once into each substrate's input shape — the canonical differential and the docker gate suite read one set of bytes
     ├── trace_constraints.py  # One trace constraint evaluated, for single-verdict assertions
     ├── trace_checks_configs.py  # One authored trace_checks block spanning the whole vocabulary
     ├── trace_overrides.py    # A supplied constraint block, written to a file and loaded back
@@ -396,6 +396,21 @@ family and for `state_checks.numeric_string_fields`,
 resolves each nodeid without importing it — every entry carrying one, whatever its
 enforcement tier — so renaming one of those test functions fails the canonical tier
 naming the manifest entry.
+
+`test_docker_grading_trace_gate.py` drives the committed `trace_checks_gate`
+parity pack — the one the canonical differential reads, through the one decoder in
+`utils/grading_parity_packs.py` — through a containerised runner: `RegisterTrial`
+with the pack as `NativeAdapter` resolves it, then `GradeTrial` over real gRPC with
+the authored trajectory as `llm_messages_json`. What it locks that no canonical
+test can is the **image**: the parity suite's runner half is an in-process servicer
+built from the working tree, while the image installs the
+`tolokaforge-runner-subset` wheel, whose file partition already excludes twelve
+`core/grading` modules. Off the wire it pins the verdict, the `trace_checks`
+component, `trace_checks_summary.gate_failed`, `failed_gate_ids`, the per-constraint
+`severity` values and the sentence naming the gate that tripped. Every run — green
+or red — names the container's image id and the current tree's expected image ref,
+and a run where the tree's image is built but `:latest` is a different one fails
+naming the retag remedy. Keyless: no LLM, no API key, and no tool is executed.
 
 `tests/integration/docker/test_terminal_bench_per_trial.py` is the end-to-end
 lock for the terminal-bench per-trial substrate: it materialises the

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,6 +126,7 @@ tests/
     ├── servicer_runtime.py   # RuntimeBackend over the in-process servicer + the duplicate-call_id refusal
     ├── search_plane_harness.py  # RegisterTrial through the search plane: registry stand-in, kb task, both address sources
     ├── timelines.py          # Coherent TrialTimeline fixtures (message view + records)
+    ├── grading_parity_packs.py  # A grading_parity pack's trial.yaml, decoded once into each substrate's input shape — every tier driving a parity trial reads it here
     ├── trace_constraints.py  # One trace constraint evaluated, for single-verdict assertions
     ├── trace_checks_configs.py  # One authored trace_checks block spanning the whole vocabulary
     ├── trace_overrides.py    # A supplied constraint block, written to a file and loaded back

--- a/tests/README.md
+++ b/tests/README.md
@@ -404,13 +404,15 @@ with the pack as `NativeAdapter` resolves it, then `GradeTrial` over real gRPC w
 the authored trajectory as `llm_messages_json`. What it locks that no canonical
 test can is the **image**: the parity suite's runner half is an in-process servicer
 built from the working tree, while the image installs the
-`tolokaforge-runner-subset` wheel, whose file partition already excludes twelve
-`core/grading` modules. Off the wire it pins the verdict, the `trace_checks`
+`tolokaforge-runner-subset` wheel, whose file partition already excludes part of
+`core/grading`. Off the wire it pins the verdict, the `trace_checks`
 component, `trace_checks_summary.gate_failed`, `failed_gate_ids`, the per-constraint
-`severity` values and the sentence naming the gate that tripped. Every run — green
-or red — names the container's image id and the current tree's expected image ref,
-and a run where the tree's image is built but `:latest` is a different one fails
-naming the retag remedy. Keyless: no LLM, no API key, and no tool is executed.
+`severity` values and the sentence naming the gate that tripped. It refuses to grade
+against an image the current tree did not build: the container's image must carry
+`expected_image_ref("runner")` among its tags, which is what the fixture's own
+build-and-tag path leaves there, so a stale `:latest` fails naming
+`uv run tolokaforge docker build --core` rather than grading under an older tree.
+Keyless: no LLM, no API key, and no tool is executed.
 
 `tests/integration/docker/test_terminal_bench_per_trial.py` is the end-to-end
 lock for the terminal-bench per-trial substrate: it materialises the

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -134,6 +134,12 @@ from tests.utils.combine_method_verdicts import (
     COMBINE_METHOD_PASS_THRESHOLD,
     COMBINE_METHOD_VERDICTS,
 )
+from tests.utils.grading_parity_packs import (
+    FIXTURE_TIMESTAMP,
+    TrialCase,
+    load_case,
+    wire_message,
+)
 from tests.utils.runner_requests import execute_request, register_request, trial_spec_json
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core import models as core_models
@@ -156,14 +162,12 @@ from tolokaforge.core.grading.key_manifest import (
 )
 from tolokaforge.core.grading.state_checks import StateChecker, extract_db_state, state_digest
 from tolokaforge.core.grading.trace_checks import evaluate_trace_checks
-from tolokaforge.core.grading.trace_timeline import TrialTimeline, build_trial_timeline
+from tolokaforge.core.grading.trace_timeline import TrialTimeline
 from tolokaforge.core.grading.transcript import evaluate_transcript_rules
 from tolokaforge.core.models import (
     Message,
     RecordedToolCall,
     ToolCall,
-    ToolExecutionStatus,
-    ToolExecutorIdentity,
     Trajectory,
 )
 from tolokaforge.runner import grading as runner_grading
@@ -619,24 +623,6 @@ def _declared_hash_verdict_producers() -> dict[tuple[str, str], Any]:
 # Fixture-pack helpers
 # --------------------------------------------------------------------------
 
-# The one shape a ``trial.yaml`` case may take. Every key is read; anything else
-# is rejected, so a pack cannot carry a field the loader silently drops.
-_CASE_KEYS = frozenset({"messages", "state"})
-_MESSAGE_KEYS = frozenset({"role", "content", "tool_calls"})
-_CALL_KEYS = frozenset({"tool_name", "executor", "status", "arguments", "output"})
-
-_FIXTURE_TIMESTAMP = "2026-01-01T00:00:00+00:00"
-
-
-@dataclass(frozen=True)
-class _TrialCase:
-    """One satisfying-or-violating trial, in each substrate's own input shape."""
-
-    core_trajectory: Trajectory
-    runner_messages: list[dict[str, Any]]
-    runner_timeline: TrialTimeline
-    state: dict[str, Any]
-
 
 def _task_id_for(author_key: str) -> str:
     return author_key.replace(".", "_")
@@ -765,95 +751,6 @@ def _top_level_constraint_kinds(grading_yaml: dict[str, Any]) -> set[str]:
     }
 
 
-def _reject_unknown(authored: dict[str, Any], allowed: frozenset[str], *, what: str) -> None:
-    """A fixture key nothing reads expresses less than its author wrote — so it is an error."""
-    unknown = sorted(set(authored) - allowed)
-    assert not unknown, f"{what} declares {unknown}; the loader reads only {sorted(allowed)}"
-
-
-def _authored_call(raw_call: dict[str, Any], *, sequence: int) -> tuple[ToolCall, RecordedToolCall]:
-    """One authored call, as the message view declares it and as the record kept it.
-
-    ``latency_seconds`` is not authorable and is pinned at ``0.0``: wall time is
-    not compared across substrates, so a fixture varying it would pin a number no
-    parity claim reads.
-    """
-    call_id = f"call_{sequence}"
-    return (
-        ToolCall(id=call_id, name=raw_call["tool_name"], arguments=raw_call["arguments"]),
-        RecordedToolCall(
-            call_id=call_id,
-            sequence=sequence,
-            tool_name=raw_call["tool_name"],
-            arguments=raw_call["arguments"],
-            executor=ToolExecutorIdentity(raw_call["executor"]),
-            output=raw_call.get("output", ""),
-            status=ToolExecutionStatus(raw_call["status"]),
-            latency_seconds=0.0,
-            timestamp=_FIXTURE_TIMESTAMP,
-        ),
-    )
-
-
-def _wire_message(message: Message) -> dict[str, Any]:
-    """One turn as the runner receives it, in ``llm_messages_json``'s OpenAI shape."""
-    wire: dict[str, Any] = {"role": message.role.value, "content": message.content}
-    if message.tool_calls:
-        wire["tool_calls"] = [
-            {
-                "id": call.id,
-                "type": "function",
-                "function": {"name": call.name, "arguments": json.dumps(call.arguments)},
-            }
-            for call in message.tool_calls
-        ]
-    return wire
-
-
-def _load_case(pack_dir: Path, case: str) -> _TrialCase:
-    """One authored trial, in the input shape each substrate really takes.
-
-    A call is authored inside the message that requested it, so a fixture places
-    its calls across turns and the timeline's ``turn_index`` and event order follow
-    what the author wrote.
-    """
-    fixture = yaml.safe_load((pack_dir / "trial.yaml").read_text())[case]
-    where = f"{pack_dir.name}/trial.yaml case {case!r}"
-    _reject_unknown(fixture, _CASE_KEYS, what=where)
-
-    # One recorded-tool-call list feeds both substrates: the core engine holds it
-    # on the Trajectory, the runner's evaluators read its dump. A per-substrate
-    # fixture could disagree with itself, which is the divergence this suite exists
-    # to catch. The message view declares every one of them, or the trial's two
-    # views disagree and neither substrate will grade it.
-    view: list[Message] = []
-    recorded: list[RecordedToolCall] = []
-    for index, raw in enumerate(fixture["messages"]):
-        _reject_unknown(raw, _MESSAGE_KEYS, what=f"{where} message {index}")
-        declared: list[ToolCall] = []
-        for raw_call in raw.get("tool_calls", ()):
-            _reject_unknown(raw_call, _CALL_KEYS, what=f"{where} message {index} tool call")
-            call, record = _authored_call(raw_call, sequence=len(recorded))
-            declared.append(call)
-            recorded.append(record)
-        view.append(Message(role=raw["role"], content=raw["content"], tool_calls=declared or None))
-
-    trajectory = Trajectory(
-        task_id=pack_dir.name,
-        trial_index=0,
-        start_ts=_FIXTURE_TIMESTAMP,
-        end_ts=_FIXTURE_TIMESTAMP,
-        messages=view,
-        tool_log=recorded,
-    )
-    return _TrialCase(
-        core_trajectory=trajectory,
-        runner_messages=[_wire_message(message) for message in view],
-        runner_timeline=build_trial_timeline(view, recorded, None),
-        state=fixture["state"],
-    )
-
-
 class _FixtureStateDBClient:
     """Serves a table map where a real trial reads it from the DB service.
 
@@ -875,7 +772,7 @@ class _FixtureStateDBClient:
 def _core_verdict(
     family: str,
     grading_config: core_models.GradingConfig,
-    case: _TrialCase,
+    case: TrialCase,
     task_dir: Path,
     *,
     task_initial_state: core_models.InitialStateConfig | None,
@@ -899,7 +796,7 @@ def _core_verdict(
 
 
 def _runner_custom_checks_score(
-    task_description: runner_models.TaskDescription, case: _TrialCase
+    task_description: runner_models.TaskDescription, case: TrialCase
 ) -> float:
     """The runner's ``custom_checks`` component, via its real delivery + executor.
 
@@ -944,7 +841,7 @@ def _write_case_state_into_the_trial_database(
 
 def _runner_state_checks_hash_verdict(
     task_description: runner_models.TaskDescription,
-    case: _TrialCase,
+    case: TrialCase,
     servicer: RunnerServiceImpl,
     context: Any,
     *,
@@ -981,7 +878,7 @@ def _runner_state_checks_hash_verdict(
 def _runner_verdict(
     family: str,
     task_description: runner_models.TaskDescription,
-    case: _TrialCase,
+    case: TrialCase,
     *,
     servicer: RunnerServiceImpl,
     context: Any,
@@ -1233,8 +1130,8 @@ def _drive_both_substrates(
     core_config = adapter.get_grading_config(task_id)
     task_description = adapter.to_task_description(task_id)
     initial_state = adapter.get_task(task_id).initial_state
-    satisfying = _load_case(pack, "satisfying")
-    violating = _load_case(pack, "violating")
+    satisfying = load_case(pack, "satisfying")
+    violating = load_case(pack, "violating")
     # The core engine imports the pack's ``checks.py`` from its task dir, which
     # writes ``__pycache__`` beside the fixture; grade from a copy so a canonical
     # run leaves the repo clean.
@@ -1580,7 +1477,7 @@ def _composition_verdict(
     task_id = _task_id_for(_COMPOSITION_KEY)
     core_config = adapter.get_grading_config(task_id)
     runner_grading = adapter.to_task_description(task_id).grading
-    trial = _load_case(pack, case)
+    trial = load_case(pack, case)
 
     core_component, core_total = _core_verdict(
         "state_checks",
@@ -1884,7 +1781,7 @@ def test_the_hash_verdict_is_binary_on_both_substrates(test_data_dir):
         )
     )
     for case, hash_score in _COMPOSITION_HASH_CASES:
-        db_state = extract_db_state(_load_case(pack, case).state)
+        db_state = extract_db_state(load_case(pack, case).state)
         actual, _ = StateChecker().check_hash(db_state, expected_hash)
         assert actual == hash_score, (
             f"the composition fixture's {case!r} case scores {actual} against the hash of "
@@ -2104,7 +2001,7 @@ def _core_method_verdict(test_data_dir: Path, root: Path, *, method: str) -> _Me
         f"the pack's authored pass_threshold is {grading_config.combine.pass_threshold}, so "
         f"the flags pinned against {COMBINE_METHOD_PASS_THRESHOLD} answer a different question"
     )
-    case = _load_case(_pack_dir(test_data_dir, _METHOD_KEY), _METHOD_CASE)
+    case = load_case(_pack_dir(test_data_dir, _METHOD_KEY), _METHOD_CASE)
     grade = GradingEngine(grading_config, task_dir=_pack_dir(root, _METHOD_KEY)).grade_trajectory(
         case.core_trajectory, case.state
     )
@@ -2133,7 +2030,7 @@ def _runner_method_verdict(test_data_dir: Path, root: Path, *, method: str) -> _
         f"the adapter translated pass_threshold {grading.pass_threshold}, so "
         f"the flags pinned against {COMBINE_METHOD_PASS_THRESHOLD} answer a different question"
     )
-    case = _load_case(_pack_dir(test_data_dir, _METHOD_KEY), _METHOD_CASE)
+    case = load_case(_pack_dir(test_data_dir, _METHOD_KEY), _METHOD_CASE)
     jsonpath_score, _ = evaluate_jsonpath_checks(
         grading.state_checks.jsonpath_checks, state=case.state
     )
@@ -2198,7 +2095,7 @@ _TRACE_CHECKS_TASK = "trace_checks_constraints"
 
 
 def _replay_authored_calls(
-    servicer: RunnerServiceImpl, context: Any, trial_id: str, case: _TrialCase
+    servicer: RunnerServiceImpl, context: Any, trial_id: str, case: TrialCase
 ) -> None:
     """Execute each authored call through the runner, in the order it was written.
 
@@ -2272,7 +2169,7 @@ def _grade_pack_through_the_runner(
     servicer: RunnerServiceImpl,
     context: Any,
     task_description: runner_models.TaskDescription,
-    case: _TrialCase,
+    case: TrialCase,
     trial_id: str,
 ) -> pb2.GradeTrialResponse:
     """Register the task, replay ``case``'s calls, grade — the runner's whole path.
@@ -2291,7 +2188,7 @@ def _grade_pack_through_the_runner(
 def _runner_trace_checks_grade(
     servicer: RunnerServiceImpl,
     task_description: runner_models.TaskDescription,
-    case: _TrialCase,
+    case: TrialCase,
     trial_id: str,
     context: Any,
 ) -> pb2.Grade:
@@ -2318,8 +2215,8 @@ def test_both_substrates_score_trace_checks_through_their_own_grading_path(
     adapter = _parity_adapter(test_data_dir)
     core_config = adapter.get_grading_config(_TRACE_CHECKS_TASK)
     task_description = adapter.to_task_description(_TRACE_CHECKS_TASK)
-    satisfying = _load_case(pack, "satisfying")
-    violating = _load_case(pack, "violating")
+    satisfying = load_case(pack, "satisfying")
+    violating = load_case(pack, "violating")
 
     initial_state = adapter.get_task(_TRACE_CHECKS_TASK).initial_state
     core_ok, _ = _core_verdict(
@@ -2376,8 +2273,8 @@ def test_a_trace_gate_fails_the_trial_on_both_substrates(
     adapter = _parity_adapter(test_data_dir)
     core_config = adapter.get_grading_config(_TRACE_GATE_TASK)
     task_description = adapter.to_task_description(_TRACE_GATE_TASK)
-    satisfying = _load_case(pack, "satisfying")
-    violating = _load_case(pack, "violating")
+    satisfying = load_case(pack, "satisfying")
+    violating = load_case(pack, "violating")
 
     core_ok = GradingEngine(core_config, task_dir=tmp_path).grade_trajectory(
         satisfying.core_trajectory, satisfying.state
@@ -2458,7 +2355,7 @@ def test_the_winning_route_crosses_the_wire(
     adapter = _parity_adapter(test_data_dir)
     core_config = adapter.get_grading_config(_TRACE_ALTERNATIVES_TASK)
     task_description = adapter.to_task_description(_TRACE_ALTERNATIVES_TASK)
-    ledger, cherry_picked = _load_case(pack, "satisfying"), _load_case(pack, "violating")
+    ledger, cherry_picked = load_case(pack, "satisfying"), load_case(pack, "violating")
 
     core_won = GradingEngine(core_config, task_dir=tmp_path).grade_trajectory(
         ledger.core_trajectory, ledger.state
@@ -2564,7 +2461,7 @@ def _runner_undecided_grade(
     response = servicer.GradeTrial(
         pb2.GradeTrialRequest(
             trial_id=trial_id,
-            llm_messages_json=json.dumps([_wire_message(message) for message in _UNDECIDED_VIEW]),
+            llm_messages_json=json.dumps([wire_message(message) for message in _UNDECIDED_VIEW]),
         ),
         context,
     )
@@ -2582,8 +2479,8 @@ def _core_undecided_verdict(
         Trajectory(
             task_id=_TRACE_UNDECIDED_TASK,
             trial_index=0,
-            start_ts=_FIXTURE_TIMESTAMP,
-            end_ts=_FIXTURE_TIMESTAMP,
+            start_ts=FIXTURE_TIMESTAMP,
+            end_ts=FIXTURE_TIMESTAMP,
             messages=_UNDECIDED_VIEW,
             tool_log=list(recorded),
         ),
@@ -2691,7 +2588,7 @@ def test_a_state_reading_pack_grades_through_the_runners_own_registration(
     """
     adapter = _parity_adapter(test_data_dir)
     task_description = adapter.to_task_description(task_id)
-    case = _load_case(test_data_dir / "grading_parity" / task_id, case_name)
+    case = load_case(test_data_dir / "grading_parity" / task_id, case_name)
 
     response = _grade_pack_through_the_runner(
         runner_service,
@@ -3021,8 +2918,8 @@ def _messageless_trajectory(task_id: str) -> Trajectory:
     return Trajectory(
         task_id=task_id,
         trial_index=0,
-        start_ts=_FIXTURE_TIMESTAMP,
-        end_ts=_FIXTURE_TIMESTAMP,
+        start_ts=FIXTURE_TIMESTAMP,
+        end_ts=FIXTURE_TIMESTAMP,
         messages=[],
     )
 
@@ -3078,7 +2975,7 @@ def test_an_empty_assertion_list_is_unscored_on_both_substrates(declared, test_d
         f"{pack}/grading.yaml declares no JSONPath assertions, so the declared column "
         "below carries an empty list too and this test compares one cell against itself"
     )
-    case = _load_case(pack, "satisfying")
+    case = load_case(pack, "satisfying")
 
     core, runner = _jsonpath_presence(authored if declared else [], case.state)
 
@@ -3251,7 +3148,7 @@ def test_a_scored_component_with_no_declared_weight_refuses_on_both_substrates(c
     """
     pack = _pack_dir(test_data_dir, _JSONPATHS_KEY)
     authored = yaml.safe_load((pack / "grading.yaml").read_text())["state_checks"]["jsonpaths"]
-    trial = _load_case(pack, "violating")
+    trial = load_case(pack, "violating")
     weights = _WEIGHT_MAPS[case]
     core_config, runner_config = _scored_pair_configs(authored, weights)
     jsonpath_score, _ = evaluate_jsonpath_checks(authored, state=trial.state)
@@ -3301,7 +3198,7 @@ def test_a_zero_total_weight_decides_under_weighted_alone_on_both_substrates(
     """
     pack = _pack_dir(test_data_dir, _JSONPATHS_KEY)
     authored = yaml.safe_load((pack / "grading.yaml").read_text())["state_checks"]["jsonpaths"]
-    trial = _load_case(pack, case)
+    trial = load_case(pack, case)
     core_config = core_models.GradingConfig(
         state_checks={"jsonpaths": authored},
         combine={
@@ -3508,7 +3405,7 @@ def _drive_parity_pack(
 ) -> tuple[runner_models.RunnerGradingConfig, pb2.GradeTrialResponse]:
     """Grade the key's own pack, and hand back the config the runner actually graded."""
     task_description = _parity_adapter(test_data_dir).to_task_description(_task_id_for(author_key))
-    case = _load_case(_pack_dir(test_data_dir, author_key), "satisfying")
+    case = load_case(_pack_dir(test_data_dir, author_key), "satisfying")
     response = _grade_pack_through_the_runner(servicer, context, task_description, case, trial_id)
     return servicer.trials[trial_id].grading_config, response
 
@@ -4065,7 +3962,7 @@ def _runner_custom_checks_grade(
     servicer: RunnerServiceImpl,
     context: Any,
     task_description: runner_models.TaskDescription,
-    case: _TrialCase,
+    case: TrialCase,
     trial_id: str,
 ) -> pb2.Grade:
     """The runner's own ``GradeTrial`` verdict, over the case's state.
@@ -4114,7 +4011,7 @@ def custom_checks_grades(
     caller = re.sub(r"[^0-9a-zA-Z_]", "_", request.node.name)
     grades: dict[str, tuple[core_models.Grade, pb2.Grade]] = {}
     for case_name in ("satisfying", "violating"):
-        case = _load_case(pack, case_name)
+        case = load_case(pack, case_name)
         core_grade = GradingEngine(
             core_config, task_dir=core_task_dir, task_initial_state=initial_state
         ).grade_trajectory(case.core_trajectory, case.state)
@@ -4514,8 +4411,8 @@ def test_an_unmakeable_comparison_fails_its_own_call_on_both_substrates(
     core_config = adapter.get_grading_config(_NESTED_BINDING_PACK)
     task_description = adapter.to_task_description(_NESTED_BINDING_PACK)
     initial_state = adapter.get_task(_NESTED_BINDING_PACK).initial_state
-    satisfying = _load_case(pack, "satisfying")
-    violating = _load_case(pack, "violating")
+    satisfying = load_case(pack, "satisfying")
+    violating = load_case(pack, "violating")
 
     core_ok, _ = _core_verdict(
         "trace_checks", core_config, satisfying, tmp_path, task_initial_state=initial_state
@@ -4635,7 +4532,7 @@ def test_the_fixture_loader_places_each_turns_calls_where_the_author_wrote_them(
     — with no expressible fixture at all.
     """
     pack = _write_pack(tmp_path, _MULTI_TURN_FIXTURE)
-    trial = _load_case(pack, _MULTI_TURN_CASE)
+    trial = load_case(pack, _MULTI_TURN_CASE)
 
     assert _produced_events(trial.runner_timeline) == _MULTI_TURN_EVENTS
 
@@ -4657,7 +4554,7 @@ def test_the_fixture_loader_hands_the_runner_wire_shaped_tool_calls(tmp_path):
     call — the parity suite's own silent divergence.
     """
     pack = _write_pack(tmp_path, _MULTI_TURN_FIXTURE)
-    transcript = _build_runner_check_transcript(_load_case(pack, _MULTI_TURN_CASE).runner_messages)
+    transcript = _build_runner_check_transcript(load_case(pack, _MULTI_TURN_CASE).runner_messages)
 
     assert [
         (call.name, call.arguments)
@@ -4705,4 +4602,4 @@ def test_the_fixture_loader_rejects_a_key_it_would_not_read(what, mutate, reject
     pack = _write_pack(tmp_path, fixture)
 
     with pytest.raises(AssertionError, match=re.escape(rejected)):
-        _load_case(pack, _MULTI_TURN_CASE)
+        load_case(pack, _MULTI_TURN_CASE)

--- a/tests/integration/test_docker_grading_trace_gate.py
+++ b/tests/integration/test_docker_grading_trace_gate.py
@@ -1,0 +1,227 @@
+"""A trace gate fails a trial inside a real runner container, over real gRPC.
+
+``tests/canonical/test_grading_substrate_parity.py`` drives this same pack —
+``tests/data/grading_parity/trace_checks_gate`` — through the core engine and through the
+runner's ``GradeTrial`` handlers, but its runner half is an in-process servicer built from
+the working tree. The image is a separately built artefact: it installs the
+``tolokaforge-runner-subset`` wheel, whose file partition
+(``tolokaforge/core/_runner_subset.py``) already excludes twelve ``core/grading`` modules,
+and which resolves its own dependencies. Whether the shipped image can grade a gate is
+therefore a fact about the image, and this is where it is read — ``RegisterTrial`` then
+``GradeTrial`` over a real channel into a real container, with the verdict taken off the
+wire.
+
+The pack passes at any score (``pass_threshold: 0.0``) and its scored constraint holds in
+both trials, so a gate is the only thing that can fail a trial here and the only thing
+that can move the ``trace_checks`` component. Nothing is paid for: no LLM, no API key, no
+``.env``.
+
+**What this proves and what it does not.** Every ``TOOL_CALL`` event the container grades
+derives from the message view the host hands it in ``llm_messages_json``. That is the
+production shape — the host always sends the trajectory and the runner joins it with
+whatever it recorded — but nothing inside the container produced a record here: no tool is
+executed, so the record half of the timeline is empty and this suite says nothing about
+it. The stronger variant, the pack's own ``read_meter`` / ``reset_meter`` driven through
+``ExecuteTool`` so the container grades records it wrote itself, is unreachable: no
+``mcp_server``-backed tool can start inside the runner image, because
+``tolokaforge/core/tools_interface.py`` is outside the runner subset and the subset wheel
+requires ``mcp>=0.1.0``, which resolves to an ``mcp`` with no ``mcp.server.fastmcp``.
+Substituting a builtin tool would grade a different pack than the one this suite exists
+for.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.utils.docker_helpers import current_runner_image_id
+from tests.utils.grading_parity_packs import load_case
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+from tolokaforge.docker import builder
+from tolokaforge.runner.models import TaskDescription
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_docker]
+
+_TASK_ID = "trace_checks_gate"
+_PARITY_GLOB = "grading_parity/**/task.yaml"
+_TEST_DATA = Path(__file__).resolve().parents[1] / "data"
+_PACK_DIR = _TEST_DATA / "grading_parity" / _TASK_ID
+
+# The tag the container fixtures pin. The builder tags by content hash and never moves
+# this one (#740), so it can name an image built from any tree.
+_RUNNER_TAG = "tolokaforge-runner:latest"
+
+_SCORED_CONSTRAINT = "the_meter_was_read"
+_GATE_CONSTRAINT = "the_meter_was_not_reset"
+
+_CASES = ("satisfying", "violating")
+
+
+def _trial_spec_json(trial_id: str, task: TaskDescription) -> str:
+    """A complete ``TrialSpec``, which is what ``RegisterTrial`` validates.
+
+    The model config is a placeholder: this pack declares no judge and runs no agent, so
+    nothing reads it.
+    """
+    return TrialSpec(
+        trial_id=trial_id,
+        run_id="trace_checks_gate_wire_run",
+        task=task,
+        agent_model_config=ModelConfig(name="test-model", provider="test"),
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.test:8000",
+            runner_url="http://runner.test:50051",
+        ),
+    ).model_dump_json()
+
+
+@pytest.fixture(scope="module")
+def task_description() -> TaskDescription:
+    """The pack, resolved through the production adapter.
+
+    ``to_task_description`` is what puts the pack's ``mcp_server.py``, its
+    ``fixtures/tools.json`` and its yaml into ``TaskDescription.tool_artifacts``, which is
+    what lets ``RegisterTrial`` accept the task inside the container.
+    """
+    adapter = NativeAdapter({"base_dir": str(_TEST_DATA), "tasks_glob": _PARITY_GLOB})
+    return adapter.to_task_description(_TASK_ID)
+
+
+@pytest.fixture(scope="module")
+def runner_client(runner_container) -> GrpcRunnerClient:
+    """RunnerClient connected to the testcontainer Runner over gRPC."""
+    host = runner_container.get_container_host_ip()
+    port = runner_container.get_exposed_port(50051)
+    client = GrpcRunnerClient(runner_address=f"{host}:{port}")
+    client.connect()
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def runner_image_under_test(request: pytest.FixtureRequest, runner_container) -> str:
+    """The image id these trials are graded by, named on every run, green or red.
+
+    A suite whose subject is "the image carries this" cannot be allowed to pass against an
+    image that does not, so the two ids are reported unconditionally rather than only when
+    they disagree: what the running container was created from, and the content-hash ref
+    the current tree would build.
+
+    The comparison is only possible when the current tree's runner image exists locally.
+    When it does not, ``current_runner_image_id()`` answers ``None`` and this fixture says
+    nothing further — which covers two states at once: nothing to compare, and the tree's
+    image never built while a ``:latest`` from some older tree is tagged. That second one
+    is the default state of a fresh checkout, so the guard closes the ``:latest`` trap
+    (#740) for a developer who has built and for nobody else. The reported ids are what
+    make a green run attributable either way.
+    """
+    container_image_id = runner_container.get_wrapped_container().image.id
+    expected_ref = builder.expected_image_ref("runner")
+    writer = request.config.get_terminal_writer()
+    writer.line(f"runner container image id: {container_image_id}")
+    writer.line(f"current tree's runner image ref: {expected_ref}")
+
+    fresh_image_id = current_runner_image_id()
+    if fresh_image_id is not None and fresh_image_id != container_image_id:
+        pytest.fail(
+            f"{_RUNNER_TAG} is {container_image_id}, but the current tree builds "
+            f"{expected_ref} ({fresh_image_id}) — these trials would be graded by an image "
+            f"that is not this tree. Retag: docker tag {expected_ref} {_RUNNER_TAG}"
+        )
+    return container_image_id
+
+
+@pytest.fixture(scope="module")
+def graded_cases(
+    runner_client: GrpcRunnerClient, task_description: TaskDescription
+) -> dict[str, dict[str, Any]]:
+    """Each authored case, driven as production drives one: register, grade, clean up.
+
+    One registered trial per case, and the grade is read off the ``GradeTrial`` response
+    rather than recomputed here.
+    """
+    grades: dict[str, dict[str, Any]] = {}
+    for case in _CASES:
+        trial_id = f"{_TASK_ID}_{case}:0"
+        registered = runner_client.register_trial(
+            trial_id=trial_id, trial_spec_json=_trial_spec_json(trial_id, task_description)
+        )
+        assert registered["success"] is True, registered["error"]
+        try:
+            result = runner_client.grade_trial(
+                trial_id=trial_id,
+                llm_messages_json=json.dumps(load_case(_PACK_DIR, case).runner_messages),
+            )
+        finally:
+            runner_client.cleanup_trial(trial_id=trial_id)
+        assert result["success"] is True, result["error"]
+        assert result["grade"] is not None, result
+        grades[case] = result["grade"]
+    return grades
+
+
+def _trace_checks_summary(grade: dict[str, Any]) -> dict[str, Any]:
+    """The grade's gate report, refused when the runner sent none.
+
+    The client maps a runner predating the field to ``None``, and a default-valued summary
+    would satisfy ``gate_failed is False`` for the wrong reason.
+    """
+    summary = grade["trace_checks_summary"]
+    assert summary is not None, (
+        "the runner returned no trace_checks_summary — the image predates the field, so "
+        f"nothing here reads a gate verdict: {grade['reasons']!r}"
+    )
+    return summary
+
+
+def test_the_container_fails_the_violating_trial_on_the_gate(
+    graded_cases: dict[str, dict[str, Any]],
+) -> None:
+    """The trial that reset the meter fails, and the grade says the gate is why.
+
+    Every fact a reviewer would read off this grade is pinned, because the score alone
+    cannot distinguish a tripped gate from a component that scored badly: the verdict, the
+    zeroed component, the gate report naming the constraint that shut, the sentence in
+    ``reasons`` that names it, and the per-constraint severities — which are what say the
+    scored constraint passed while the gate failed, rather than both failing.
+    """
+    grade = graded_cases["violating"]
+    summary = _trace_checks_summary(grade)
+
+    assert grade["binary_pass"] is False
+    assert grade["score"] == pytest.approx(0.0)
+    assert grade["components"]["trace_checks"] == pytest.approx(0.0)
+    assert summary["gate_failed"] is True
+    assert summary["failed_gate_ids"] == [_GATE_CONSTRAINT]
+    assert f"FAILED trace gates: {_GATE_CONSTRAINT}" in grade["reasons"], grade["reasons"]
+    assert [
+        (check["id"], check["severity"], check["passed"]) for check in grade["trace_checks"]
+    ] == [
+        (_SCORED_CONSTRAINT, "scored", True),
+        (_GATE_CONSTRAINT, "gate", False),
+    ]
+
+
+def test_the_container_passes_the_satisfying_trial(
+    graded_cases: dict[str, dict[str, Any]],
+) -> None:
+    """The trial that only read the meter passes, at full marks and with no gate tripped.
+
+    This is what makes the failing case a discrimination rather than a pack that fails
+    everything: one authored trajectory apart, over the same registered task.
+    """
+    grade = graded_cases["satisfying"]
+    summary = _trace_checks_summary(grade)
+
+    assert grade["binary_pass"] is True
+    assert grade["score"] == pytest.approx(1.0)
+    assert grade["components"]["trace_checks"] == pytest.approx(1.0)
+    assert summary["gate_failed"] is False
+    assert summary["failed_gate_ids"] == []

--- a/tests/integration/test_docker_grading_trace_gate.py
+++ b/tests/integration/test_docker_grading_trace_gate.py
@@ -5,8 +5,8 @@
 runner's ``GradeTrial`` handlers, but its runner half is an in-process servicer built from
 the working tree. The image is a separately built artefact: it installs the
 ``tolokaforge-runner-subset`` wheel, whose file partition
-(``tolokaforge/core/_runner_subset.py``) already excludes twelve ``core/grading`` modules,
-and which resolves its own dependencies. Whether the shipped image can grade a gate is
+(``tolokaforge/core/_runner_subset.py``) already excludes part of ``core/grading``, and
+which resolves its own dependencies. Whether the shipped image can grade a gate is
 therefore a fact about the image, and this is where it is read — ``RegisterTrial`` then
 ``GradeTrial`` over a real channel into a real container, with the verdict taken off the
 wire.
@@ -25,9 +25,9 @@ it. The stronger variant, the pack's own ``read_meter`` / ``reset_meter`` driven
 ``ExecuteTool`` so the container grades records it wrote itself, is unreachable: no
 ``mcp_server``-backed tool can start inside the runner image, because
 ``tolokaforge/core/tools_interface.py`` is outside the runner subset and the subset wheel
-requires ``mcp>=0.1.0``, which resolves to an ``mcp`` with no ``mcp.server.fastmcp``.
-Substituting a builtin tool would grade a different pack than the one this suite exists
-for.
+requires ``mcp>=0.1.0``, which resolves to an ``mcp`` with no ``mcp.server.fastmcp``
+(#1114). Substituting a builtin tool would grade a different pack than the one this suite
+exists for.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ from typing import Any
 
 import pytest
 
-from tests.utils.docker_helpers import current_runner_image_id
+from tests.utils.containers import RUNNER_IMAGE
 from tests.utils.grading_parity_packs import load_case
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core.models import ModelConfig
@@ -53,10 +53,6 @@ _TASK_ID = "trace_checks_gate"
 _PARITY_GLOB = "grading_parity/**/task.yaml"
 _TEST_DATA = Path(__file__).resolve().parents[1] / "data"
 _PACK_DIR = _TEST_DATA / "grading_parity" / _TASK_ID
-
-# The tag the container fixtures pin. The builder tags by content hash and never moves
-# this one (#740), so it can name an image built from any tree.
-_RUNNER_TAG = "tolokaforge-runner:latest"
 
 _SCORED_CONSTRAINT = "the_meter_was_read"
 _GATE_CONSTRAINT = "the_meter_was_not_reset"
@@ -106,36 +102,37 @@ def runner_client(runner_container) -> GrpcRunnerClient:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def runner_image_under_test(request: pytest.FixtureRequest, runner_container) -> str:
-    """The image id these trials are graded by, named on every run, green or red.
+def runner_image_under_test(request: pytest.FixtureRequest, runner_container) -> None:
+    """Refuse to grade against an image the current tree did not build.
 
     A suite whose subject is "the image carries this" cannot be allowed to pass against an
-    image that does not, so the two ids are reported unconditionally rather than only when
-    they disagree: what the running container was created from, and the content-hash ref
-    the current tree would build.
+    image that does not. What says whose tree an image came from is its own tag list: the
+    builder tags by content hash, and ``runner_container`` builds the runner image when
+    ``RUNNER_IMAGE`` is absent and tags what it built as ``:latest`` — so an image this
+    tree produced carries ``expected_image_ref("runner")`` beside ``:latest``, and one
+    built from another tree carries a different hash. The reachable failure is a developer
+    whose ``:latest`` predates their checkout (#740); CI builds, so it passes there.
 
-    The comparison is only possible when the current tree's runner image exists locally.
-    When it does not, ``current_runner_image_id()`` answers ``None`` and this fixture says
-    nothing further — which covers two states at once: nothing to compare, and the tree's
-    image never built while a ``:latest`` from some older tree is tagged. That second one
-    is the default state of a fresh checkout, so the guard closes the ``:latest`` trap
-    (#740) for a developer who has built and for nobody else. The reported ids are what
-    make a green run attributable either way.
+    The one image this refuses that a person might defend is a current one carrying no
+    content-hash tag at all — pulled, or hand-tagged. Nothing about such an image says
+    which tree it came from, so it fails here too.
+
+    The ids are written to the terminal beside the check, which a serial run shows. Under
+    ``-n auto`` a worker's output never reaches the master, so on a distributed run it is
+    the tag assertion — not the line — that makes a green run attributable.
     """
-    container_image_id = runner_container.get_wrapped_container().image.id
+    container_image = runner_container.get_wrapped_container().image
     expected_ref = builder.expected_image_ref("runner")
     writer = request.config.get_terminal_writer()
-    writer.line(f"runner container image id: {container_image_id}")
+    writer.line(f"runner container image: {container_image.id} {container_image.tags}")
     writer.line(f"current tree's runner image ref: {expected_ref}")
 
-    fresh_image_id = current_runner_image_id()
-    if fresh_image_id is not None and fresh_image_id != container_image_id:
+    if expected_ref not in container_image.tags:
         pytest.fail(
-            f"{_RUNNER_TAG} is {container_image_id}, but the current tree builds "
-            f"{expected_ref} ({fresh_image_id}) — these trials would be graded by an image "
-            f"that is not this tree. Retag: docker tag {expected_ref} {_RUNNER_TAG}"
+            f"{RUNNER_IMAGE} is {container_image.id}, tagged {container_image.tags}, and "
+            f"the current tree builds {expected_ref} — these trials would be graded by an "
+            "image that is not this tree. Build it: uv run tolokaforge docker build --core"
         )
-    return container_image_id
 
 
 @pytest.fixture(scope="module")
@@ -160,7 +157,10 @@ def graded_cases(
                 llm_messages_json=json.dumps(load_case(_PACK_DIR, case).runner_messages),
             )
         finally:
-            runner_client.cleanup_trial(trial_id=trial_id)
+            cleaned = runner_client.cleanup_trial(trial_id=trial_id)
+        # Reached only when grading propagated nothing, so a cleanup that failed is
+        # reported without standing in front of the failure that caused it.
+        assert cleaned["success"] is True, cleaned["error"]
         assert result["success"] is True, result["error"]
         assert result["grade"] is not None, result
         grades[case] = result["grade"]

--- a/tests/utils/containers.py
+++ b/tests/utils/containers.py
@@ -21,6 +21,10 @@ from testcontainers.core.wait_strategies import (
 
 logger = logging.getLogger(__name__)
 
+#: The image ``runner_container`` starts. The builder tags by content hash and never
+#: moves this tag, so a suite reading the running container's provenance names it too.
+RUNNER_IMAGE = "tolokaforge-runner:latest"
+
 _LOG_TAIL_LINES = 40
 
 
@@ -203,7 +207,7 @@ def runner_container(
     Note:
         Skips gracefully if the Docker image is not available locally.
     """
-    image_name = "tolokaforge-runner:latest"
+    image_name = RUNNER_IMAGE
     _check_image_available(image_name)
 
     container = DockerContainer(image_name)

--- a/tests/utils/grading_parity_packs.py
+++ b/tests/utils/grading_parity_packs.py
@@ -1,0 +1,135 @@
+"""Decoder for a ``grading_parity`` pack's authored ``trial.yaml``.
+
+One trial, read once, handed to each substrate in the input shape that substrate
+really takes: the core engine's :class:`Trajectory`, the runner's wire-shaped
+``llm_messages_json`` turns and its :class:`TrialTimeline`. The canonical
+differential and the docker gate suite both read a pack through here, so "the two
+substrates agree" is a statement about the same bytes rather than about two
+hand-written readings of them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tolokaforge.core.grading.trace_timeline import TrialTimeline, build_trial_timeline
+from tolokaforge.core.models import (
+    Message,
+    RecordedToolCall,
+    ToolCall,
+    ToolExecutionStatus,
+    ToolExecutorIdentity,
+    Trajectory,
+)
+
+# The one shape a ``trial.yaml`` case may take. Every key is read; anything else
+# is rejected, so a pack cannot carry a field the loader silently drops.
+_CASE_KEYS = frozenset({"messages", "state"})
+_MESSAGE_KEYS = frozenset({"role", "content", "tool_calls"})
+_CALL_KEYS = frozenset({"tool_name", "executor", "status", "arguments", "output"})
+
+FIXTURE_TIMESTAMP = "2026-01-01T00:00:00+00:00"
+
+
+@dataclass(frozen=True)
+class TrialCase:
+    """One satisfying-or-violating trial, in each substrate's own input shape."""
+
+    core_trajectory: Trajectory
+    runner_messages: list[dict[str, Any]]
+    runner_timeline: TrialTimeline
+    state: dict[str, Any]
+
+
+def _reject_unknown(authored: dict[str, Any], allowed: frozenset[str], *, what: str) -> None:
+    """A fixture key nothing reads expresses less than its author wrote — so it is an error."""
+    unknown = sorted(set(authored) - allowed)
+    assert not unknown, f"{what} declares {unknown}; the loader reads only {sorted(allowed)}"
+
+
+def _authored_call(raw_call: dict[str, Any], *, sequence: int) -> tuple[ToolCall, RecordedToolCall]:
+    """One authored call, as the message view declares it and as the record kept it.
+
+    ``latency_seconds`` is not authorable and is pinned at ``0.0``: wall time is
+    not compared across substrates, so a fixture varying it would pin a number no
+    parity claim reads.
+    """
+    call_id = f"call_{sequence}"
+    return (
+        ToolCall(id=call_id, name=raw_call["tool_name"], arguments=raw_call["arguments"]),
+        RecordedToolCall(
+            call_id=call_id,
+            sequence=sequence,
+            tool_name=raw_call["tool_name"],
+            arguments=raw_call["arguments"],
+            executor=ToolExecutorIdentity(raw_call["executor"]),
+            output=raw_call.get("output", ""),
+            status=ToolExecutionStatus(raw_call["status"]),
+            latency_seconds=0.0,
+            timestamp=FIXTURE_TIMESTAMP,
+        ),
+    )
+
+
+def wire_message(message: Message) -> dict[str, Any]:
+    """One turn as the runner receives it, in ``llm_messages_json``'s OpenAI shape."""
+    wire: dict[str, Any] = {"role": message.role.value, "content": message.content}
+    if message.tool_calls:
+        wire["tool_calls"] = [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {"name": call.name, "arguments": json.dumps(call.arguments)},
+            }
+            for call in message.tool_calls
+        ]
+    return wire
+
+
+def load_case(pack_dir: Path, case: str) -> TrialCase:
+    """One authored trial, in the input shape each substrate really takes.
+
+    A call is authored inside the message that requested it, so a fixture places
+    its calls across turns and the timeline's ``turn_index`` and event order follow
+    what the author wrote.
+    """
+    fixture = yaml.safe_load((pack_dir / "trial.yaml").read_text())[case]
+    where = f"{pack_dir.name}/trial.yaml case {case!r}"
+    _reject_unknown(fixture, _CASE_KEYS, what=where)
+
+    # One recorded-tool-call list feeds both substrates: the core engine holds it
+    # on the Trajectory, the runner's evaluators read its dump. A per-substrate
+    # fixture could disagree with itself, which is the divergence this suite exists
+    # to catch. The message view declares every one of them, or the trial's two
+    # views disagree and neither substrate will grade it.
+    view: list[Message] = []
+    recorded: list[RecordedToolCall] = []
+    for index, raw in enumerate(fixture["messages"]):
+        _reject_unknown(raw, _MESSAGE_KEYS, what=f"{where} message {index}")
+        declared: list[ToolCall] = []
+        for raw_call in raw.get("tool_calls", ()):
+            _reject_unknown(raw_call, _CALL_KEYS, what=f"{where} message {index} tool call")
+            call, record = _authored_call(raw_call, sequence=len(recorded))
+            declared.append(call)
+            recorded.append(record)
+        view.append(Message(role=raw["role"], content=raw["content"], tool_calls=declared or None))
+
+    trajectory = Trajectory(
+        task_id=pack_dir.name,
+        trial_index=0,
+        start_ts=FIXTURE_TIMESTAMP,
+        end_ts=FIXTURE_TIMESTAMP,
+        messages=view,
+        tool_log=recorded,
+    )
+    return TrialCase(
+        core_trajectory=trajectory,
+        runner_messages=[wire_message(message) for message in view],
+        runner_timeline=build_trial_timeline(view, recorded, None),
+        state=fixture["state"],
+    )


### PR DESCRIPTION
## TL;DR

An integration suite now proves, keyless and off the wire, that a trace-check gate fails a real trial inside a real runner container — the milestone's code-based grading demonstrated end-to-end on the shipped image rather than only in-process. A green run is attributable by construction: the suite fails unless the running container's image carries the current tree's content-hash tag.

Closes #774.

## What changed

1. **One decoder** (`3a39183e`) — the grading-parity trial-fixture decoder moved verbatim from the 4,700-line canonical parity module to `tests/utils/grading_parity_packs.py`, so the canonical differential and the container suite read the pack through one set of bytes. Purity proven mechanically: 160/160 collected and passed in both parity suites before and after, zero skips either side.
2. **The gate through the container** (`a4b7a4b0`) — `tests/integration/test_docker_grading_trace_gate.py` drives `trace_checks_gate`'s satisfying and violating trials through `RegisterTrial → GradeTrial → CleanupTrial` over real gRPC and asserts the full verdict surface: `binary_pass`, `score`, the `trace_checks` component, `gate_failed`, `failed_gate_ids`, per-constraint `(id, severity, passed)` tuples, and the `FAILED trace gates:` reasons sentence. ~13s, no API key, no LLM, no tool executed.
3. **Review fixes** (`3fead74e`) — the freshness guard re-designed onto tag-list comparison (below), a wrong module count dropped from three docs, and six smaller items.

## Design choices

| Decision | Rationale |
|---|---|
| The suite fails unless the container's image tags include `builder.expected_image_ref("runner")` | the fixture that provides the container builds-when-absent and tags both the content-hash and `:latest` onto one id — so the only reachable silent state was exactly the stale-`:latest` trap (#740); a green run now *means* "this tree's image graded these trials" |
| Host-supplied message view, not container-written records | the records-joined variant is unreachable until #1114 (no MCP-backed tool can execute in the runner image — found during this issue's planning); the module docstring states what is and is not proven |
| Configuration falsifiers, not source patches | the container runs baked code, so source-level falsifiers cannot bite; dropping `severity: gate` from the pack flips all six violating-trial assertions (component 0.5, passes) — measured, and the same limitation the sibling suites document |
| Decoder extracted before the suite exists | two decoders of one pack format can drift silently, which would undercut "the canonical claim and the container agree" |

## Verification

- Canonical 1387 / unit 6798 passed (+ the 8 known environmental), lint/format clean; the parity purity proof (160/160 both sides).
- The suite verified in both guard states, live: the resting state of the dev machine (stale `:latest`) errors both tests naming the image, its tags, the expected ref, and the build remedy; with the expected ref tagged, 2 passed in 12.65s with the gate verdicts pinned.
- Falsifiers: gate-drop (all six assertions flip, the measured 0.5), severity-tuple-alone, wrong-trajectory discrimination, and the guard's loud branch via transient retag.
- Note for local runs: on a machine whose runner image predates the current tree, the suite is red by design until `uv run tolokaforge docker build --core` — the failure message says exactly that. CI is unaffected (the fixture builds).

## Follow-ups filed

#1112 (parity tier doesn't discriminate call_id assignment), #1114 (P1: MCP-backed tools cannot execute in the runner image; blocks the records-joined variant), #1121 (second hand-written encoder of the llm_messages_json wire contract), #1122 (RUNNER.md's exclusion table lists three of eleven).
