### PR TITLE
integrate: azure_ai/cohere-command-a-plus-05-2026

### DIFF
--- a/observation/TEST_RUN.md
+++ b/observation/TEST_RUN.md
@@ -1,0 +1,15 @@
+# Disposable test branch
+
+First live exercise of the post-split auto-integration, on top of PR #1110
+(`param_value_rules`).
+
+The Cohere `tool_choice: auto` gap is pre-declared as DATA in the models wheel,
+because it blocks the observe stage outright — every tool probe fails at the
+gateway before the model is ever reached, so the resolve agent would never see
+anything to work with. It is a precondition, not the thing under test.
+
+What IS under test: whether the agent handles the `<|START_TEXT|>` markers by
+writing an `assistant_text_policy` subclass into
+`tolokaforge_models/.../policies/`, rather than into the engine.
+
+**Never merged.** Delete after the run.

--- a/tolokaforge_models/pyproject.toml
+++ b/tolokaforge_models/pyproject.toml
@@ -40,9 +40,11 @@ dependencies = []
 
 [project.entry-points."tolokaforge.policies"]
 # key = "<slot>.<policy-name>" ; value = "<module>:<class>"
+"schema_sanitizer.cohere_recursive" = "tolokaforge_models.policies.cohere:CohereRecursiveSchema"
 "schema_sanitizer.gemini" = "tolokaforge_models.policies.gemini:GeminiSchema"
 "schema_sanitizer.gemini_recursive" = "tolokaforge_models.policies.gemini:GeminiRecursiveSchema"
 "prompt_policy.dict_map_hints_ref" = "tolokaforge_models.policies.inkling:RefResolvingDictMapHints"
+"response_policy.cohere_root_key_repair" = "tolokaforge_models.policies.cohere:CohereRootKeyRepairResponse"
 "response_policy.scalar_array_dict_map" = "tolokaforge_models.policies.gemini:ScalarArrayDictMapResponse"
 "response_policy.minimax_m3_tags" = "tolokaforge_models.policies.minimax:MinimaxM3TagRecoveryResponse"
 "reasoning_codec.openai_summary_replay" = "tolokaforge_models.policies.deepseek:OpenAISummaryReplayReasoningCodec"

--- a/tolokaforge_models/src/tolokaforge_models/certificates/registry.py
+++ b/tolokaforge_models/src/tolokaforge_models/certificates/registry.py
@@ -2645,6 +2645,108 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # -----------------------------------------------------------------
+    # Cohere Command A+ 05-2026 (the gateway ``azure_ai`` route, reached
+    # through OpenRouter) — landed via auto-resolve (Slack-requested
+    # integration, PR #1124). Routes through the model-specific
+    # ``cohere_command_a_plus_05_2026`` preset (see model_presets.yaml),
+    # declared ahead of the shared ``cohere_command_a_plus`` preset and a
+    # strict superset of it: ``schema_sanitizer: cohere_recursive``,
+    # ``response_policy: cohere_root_key_repair``,
+    # ``reasoning_codec: openai_summary_replay``, and the shared preset's
+    # ``tool_choice``/``auto`` drop rule carried over verbatim.
+    #
+    # The observe (default) baseline surfaced three preset-fixable clusters,
+    # each 0/15 and each reprobed 5/5 under the preset above:
+    #
+    #   * ``RECURSIVE_REF_TOOL_CALL`` — ``strict`` raised "$ref resolution
+    #     exceeded depth 16" IN-ENGINE on the recursive ``_TreeNode``, so the
+    #     model never saw ``submit_tree`` (0/15 on all four shapes). Cycle-
+    #     tolerant ``$ref`` inlining fixes the engine-side raise; the residual
+    #     ``simple`` / ``deep_chain`` / ``wide_tree`` misses were a root-key
+    #     mangling artifact (``{"submit_treeroot": …}`` carrying a correct
+    #     tree), repaired by the depth-0 rename in the response policy. Stays
+    #     ``required`` — the recursion itself was never wrong.
+    #   * ``DICT_MAP_TOOL_CALL`` / ``DISCRIMINATED_UNION_TOOL_CALL`` — both
+    #     15/15 native on the base probes, so both stay ``required``. Three
+    #     structural *variants* regressed because a dict-map value schema with
+    #     no ``properties`` to lift reached the wire as ``items: {key}`` alone:
+    #     ``dict_map__scalar_values`` packed the value into the key string,
+    #     ``dict_map__nested_in_object`` emitted a list, and
+    #     ``discriminated_union__union_in_dict_map`` emitted key-only items.
+    #     ``carry_scalar_dict_map_value`` + the ``{key, value}`` reversal took
+    #     all three 0/15 → 5/5.
+    #   * ``UNSIGNED_THINKING_REPLAY`` — the ``openai`` codec extracts the flat
+    #     reasoning summary but emitted nothing on replay, so the outgoing
+    #     assistant dict carried no ``reasoning_details`` (0/15).
+    #     ``OpenAISummaryReplayReasoningCodec`` rebuilds the unsigned
+    #     OpenRouter envelope. ``THINKING_EMITS_BLOCKS`` was already 15/15.
+    #
+    # The four ``known_unsupported`` ceilings are the observe-run ceilings
+    # (decision.json), each 0/15 at baseline and not preset-fixable:
+    #
+    #   * ``RE2_PATTERN_TOLERANCE`` — the route COMPILES ``pattern`` values
+    #     rather than treating them as inert hints, and returns HTTP 500 on
+    #     lookaround ("regex_converter.cc:75: Regex parsing error at position
+    #     4: Lookahead is not supported yet"). The sanitiser strips
+    #     RE2-incompatible patterns so real tool schemas survive, which is
+    #     precisely why the tolerance itself cannot be claimed.
+    #   * ``PROMPT_CACHING`` / ``IMPLICIT_PROMPT_CACHING`` — neither cache
+    #     surface is wired on this route: on an 8k-token prompt call 1 created
+    #     0 ``cache_creation_input_tokens`` and an identical call 2 read 0
+    #     ``cache_read_input_tokens``, 15/15 reps. Unlike inkling's flaky
+    #     auto-cache this is a flat zero, so both are demoted rather than one.
+    #   * ``THINKING_REPLAY_ROUNDTRIP`` — the model surfaces summary-only
+    #     reasoning and emits no signed blocks on turn 1, so the signed-replay
+    #     probe has nothing to assert. The replay codec synthesises no
+    #     signature, so fixing ``UNSIGNED_THINKING_REPLAY`` deliberately does
+    #     not lift this one.
+    #
+    # ``COST_USD_POPULATED`` is ``required`` and priced: litellm does not carry
+    # this gateway route, and it is not on OpenRouter's public model list, so
+    # ``pricing.json`` gets the rates derived from the observe run's own live
+    # billing — input $0.80/1M, output $3.20/1M, an exact zero-residual fit
+    # across all 1317 ``cost_source: litellm`` calls in the wire-probe metrics.
+    # No call in that run ever reported cached tokens, consistent with the two
+    # caching ceilings above, so the entry carries no ``cache_read`` rate.
+    # -----------------------------------------------------------------
+    MC(
+        model_id="openrouter__azure_ai_cohere-command-a-plus-05-2026",
+        provider="openrouter",
+        name="azure_ai/cohere-command-a-plus-05-2026",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.BASIC_COMPLETION,
+                C.SIMPLE_TOOL_CALL,
+                C.MULTI_TURN_TOOL_USE,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.DICT_MAP_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.TOOL_NAME_DISCIPLINE,
+                C.LEXICAL_TOOL_INVENTION,
+                C.PROGRESS_AFTER_SUCCESS,
+                C.THINKING_EMITS_BLOCKS,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.USAGE_METRICS_POPULATED,
+                C.COST_USD_POPULATED,
+            }
+        ),
+        known_unsupported=frozenset(
+            {
+                C.PROMPT_CACHING,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.RE2_PATTERN_TOLERANCE,
+                C.THINKING_REPLAY_ROUNDTRIP,
+            }
+        ),
+    ),
 ]
 
 

--- a/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
+++ b/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
@@ -42,6 +42,61 @@ default:
     reasoning_via_extra_body: false
 
 presets:
+  # Cohere Command A+ 05-2026 (the gateway ``azure_ai`` route) — landed via
+  # auto-resolve (Slack-requested integration, PR #1124). Declared BEFORE the
+  # generic ``cohere_command_a_plus`` preset so first-match-wins routing picks
+  # it up; its match globs name this dated route only, so no sibling
+  # cohere-command-* route is affected.
+  #
+  # This entry is a strict SUPERSET of the shared preset below — each axis is a
+  # subclass of the axis it replaces, and the ``tool_choice``/``auto`` drop rule
+  # is carried over verbatim (without it litellm refuses the request on this
+  # route and every tool probe fails at once). Three observed 0/15 failures on
+  # the ``default`` observe baseline, each fixed and reprobed 5/5:
+  #
+  #   * ``schema_sanitizer: cohere_recursive`` (``CohereRecursiveSchema``) —
+  #     ``strict`` raised "$ref resolution exceeded depth 16" IN-ENGINE on the
+  #     recursive ``_TreeNode``, so the model never saw ``submit_tree``:
+  #     ``recursive_ref_tool_call`` 0/15 on all four shapes. The subclass adds
+  #     cycle-tolerant ``$ref`` inlining plus ``carry_scalar_dict_map_value``
+  #     (which took ``dict_map__scalar_values``, ``dict_map__nested_in_object``
+  #     and ``discriminated_union__union_in_dict_map`` from 0/15 to 5/5), and
+  #     keeps ``strip_re2_incompatible_patterns`` — load-bearing here, since
+  #     this route compiles lookaround patterns and returns HTTP 500
+  #     ("regex_converter.cc:75: Lookahead is not supported yet").
+  #   * ``response_policy: cohere_root_key_repair``
+  #     (``CohereRootKeyRepairResponse``) — reverses the sanitiser's
+  #     ``{key, value}`` carriage (as ``array_dict_map`` did), and adds a
+  #     schema-gated depth-0 root-key rename: on a single-``object``-root tool
+  #     this route sometimes emits the parameter key with the tool's own name
+  #     glued on (``{"submit_treeroot": {...}}`` for ``submit_tree({"root": …})``)
+  #     with a fully correct tree underneath.
+  #   * ``reasoning_codec: openai_summary_replay``
+  #     (``OpenAISummaryReplayReasoningCodec``) — ``openai`` extracts the flat
+  #     reasoning summary but emits nothing on replay, so the outgoing assistant
+  #     dict carried no ``reasoning_details``: ``unsigned_thinking_replay``
+  #     0/15. The subclass keeps ``extract`` verbatim and rebuilds the unsigned
+  #     OpenRouter envelope. It synthesises no signature, so
+  #     THINKING_REPLAY_ROUNDTRIP remains a declared ceiling.
+  cohere_command_a_plus_05_2026:
+    match:
+      - "azure_ai/cohere-command-a-plus-05-2026"
+      - "*cohere-command-a-plus-05-2026*"
+    schema_sanitizer: cohere_recursive
+    response_policy: cohere_root_key_repair
+    reasoning_codec: openai_summary_replay
+    params:
+      param_value_rules:
+        tool_choice:
+          auto:
+            action: drop
+            evidence: >-
+              2026-08-01, verified live: identical client, prompt and tools,
+              WITHOUT tool_choice the model returns a correct tool call; WITH
+              tool_choice='auto' the call never leaves litellm
+              (UnsupportedParamsError on the azure_ai route). Cohere's Chat API
+              has no AUTO: https://docs.cohere.com/reference/chat
+
   # Cohere Command A+ (reached through a LiteLLM gateway's ``azure_ai`` route).
   #
   # Cohere's Chat API accepts only REQUIRED and NONE for tool_choice — there is

--- a/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
+++ b/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
@@ -42,6 +42,37 @@ default:
     reasoning_via_extra_body: false
 
 presets:
+  # Cohere Command A+ (reached through a LiteLLM gateway's ``azure_ai`` route).
+  #
+  # Cohere's Chat API accepts only REQUIRED and NONE for tool_choice — there is
+  # no AUTO — and its documented behaviour when the parameter is OMITTED is
+  # "the model is free to choose whether to use the specified tools or not".
+  # That is what auto means, so dropping it reproduces the intended semantics
+  # natively rather than working around anything.
+  #
+  # What surfaces the problem is litellm refusing the parameter first
+  # (UnsupportedParamsError: azure_ai does not support parameters:
+  # ['tool_choice']), which reads as "this model cannot call tools" when every
+  # tool probe fails at once.
+  cohere_command_a_plus:
+    match:
+      - "azure_ai/cohere-command-a-plus*"
+      - "*cohere-command-a-plus*"
+    schema_sanitizer: strict
+    response_policy: array_dict_map
+    reasoning_codec: openai
+    params:
+      param_value_rules:
+        tool_choice:
+          auto:
+            action: drop
+            evidence: >-
+              2026-08-01, verified live: identical client, prompt and tools,
+              WITHOUT tool_choice the model returns a correct tool call; WITH
+              tool_choice='auto' the call never leaves litellm
+              (UnsupportedParamsError on the azure_ai route). Cohere's Chat API
+              has no AUTO: https://docs.cohere.com/reference/chat
+
   # Claude 4.8 (Opus + Sonnet) — same adaptive-thinker contract as 4.7:
   # ignores ``reasoning_effort``, requires the canonical litellm ``thinking=``
   # kwarg + explicit ``budget_tokens``. Listed FIRST so first-match-wins

--- a/tolokaforge_models/src/tolokaforge_models/data/pricing.json
+++ b/tolokaforge_models/src/tolokaforge_models/data/pricing.json
@@ -266,6 +266,10 @@
       "input": 0.75,
       "output": 1.2
     },
+    "azure_ai/cohere-command-a-plus-05-2026": {
+      "input": 0.8,
+      "output": 3.2
+    },
     "baidu/ernie-4.5-21b-a3b": {
       "input": 0.07,
       "output": 0.28

--- a/tolokaforge_models/src/tolokaforge_models/policies/__init__.py
+++ b/tolokaforge_models/src/tolokaforge_models/policies/__init__.py
@@ -16,6 +16,10 @@ import GeminiSchema``).
 
 from __future__ import annotations
 
+from tolokaforge_models.policies.cohere import (
+    CohereRecursiveSchema,
+    CohereRootKeyRepairResponse,
+)
 from tolokaforge_models.policies.deepseek import OpenAISummaryReplayReasoningCodec
 from tolokaforge_models.policies.gemini import (
     GeminiRecursiveSchema,
@@ -30,6 +34,8 @@ from tolokaforge_models.policies.minimax import (
 )
 
 __all__ = [
+    "CohereRecursiveSchema",
+    "CohereRootKeyRepairResponse",
     "GeminiRecursiveSchema",
     "GeminiSchema",
     "ItemRecursiveUnwrapResponse",

--- a/tolokaforge_models/src/tolokaforge_models/policies/cohere.py
+++ b/tolokaforge_models/src/tolokaforge_models/policies/cohere.py
@@ -1,0 +1,214 @@
+"""Per-model policies for the Cohere Command family.
+
+Two classes ship in this module:
+
+* :class:`CohereRecursiveSchema` — schema sanitiser combining the *cyclic*
+  ``$ref`` tolerance that :class:`GeminiRecursiveSchema` introduced with
+  none of the three presentational relaxations that class carries for
+  Gemini — one of which (keeping RE2-incompatible ``pattern`` values) is
+  actively fatal on this route.
+* :class:`CohereRootKeyRepairResponse` — response policy renaming the
+  tool-name-prefixed root argument key this route emits back to the
+  declared parameter name.
+
+Both ship here so the Cohere preset composes shipped behaviour instead of
+re-deriving it.
+
+Registered with the engine via the ``tolokaforge.policies`` entry-point
+group (see :mod:`tolokaforge.core.model_data.load_policy_registrations`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from tolokaforge_models.policies.gemini import (
+    GeminiRecursiveSchema,
+    ScalarArrayDictMapResponse,
+)
+
+__all__ = ["CohereRecursiveSchema", "CohereRootKeyRepairResponse"]
+
+
+class CohereRecursiveSchema(GeminiRecursiveSchema):
+    """Cyclic-``$ref``-tolerant ``StrictSchema`` for the Cohere Command family.
+
+    Inherits from :class:`GeminiRecursiveSchema` — **for its mechanism, not
+    its Gemini tuning**. Two inherited behaviours are exactly what the Cohere
+    observe run needs, and re-implementing either here would risk losing a
+    documented recovery (see the parent classes for the authoritative
+    descriptions):
+
+    * **Cycle-tolerant ``$ref`` inlining** (``inline_refs_in_tool`` /
+      ``_inline_refs_cycle_tolerant``, inherited verbatim). Every *non-cyclic*
+      ``$ref`` inlines exactly as :class:`StrictSchema` does; a ref that
+      re-enters a def already on the active resolution stack is replaced by
+      ``{"type": "object", "additionalProperties": true}``. Cycle detection is
+      by def-name on the active stack, so a diamond still inlines on each
+      branch. Without it ``StrictSchema.inline_refs_in_tool`` raises
+      ``"$ref resolution exceeded depth 16"`` *in-engine, before the request is
+      sent* — observed on ``azure_ai/cohere-command-a-plus-05-2026`` as
+      ``test_recursive_ref_tool_call`` failing 0/15 on all four shapes
+      (simple / deep_chain / wide_tree / nested_in_object), every rep with that
+      identical sanitiser ``ValueError``, i.e. the model never saw the tool.
+    * **``carry_scalar_dict_map_value = True``** (inherited). A dict-map whose
+      *value* schema has no ``properties`` to lift — a scalar ``Dict[str, int]``
+      or a discriminated-union value — otherwise reaches the wire as
+      ``items: {key}`` alone, dropping the value. Observed live on this model,
+      0/15 each: ``dict_map__scalar_values`` packed the value into the key
+      string (``{'SKU-A:10': {}}``) and ``discriminated_union__union_in_dict_map``
+      emitted key-only items (``{'t1': {}, 'c1': {}}``, kinds ``{None}``).
+      Pairs with ``response_policy: scalar_array_dict_map``, which reverses
+      ``{key, value}`` back to the bare value.
+
+    The three Gemini-specific relaxations are reset to their
+    :class:`StrictSchema` defaults, which is what this model was measured under
+    (26/31 capability probes passing on ``schema_sanitizer: strict``). Each
+    reset is required by Cohere evidence, not by caution:
+
+    * ``strip_re2_incompatible_patterns = True`` — **the load-bearing one.**
+      The parent keeps lookaround patterns because Gemini treats them as inert
+      format hints. This route does not: it compiles them and returns HTTP 500
+      (``regex_converter.cc:75: Regex parsing error at position 4: Lookahead is
+      not supported yet``) — the exact failure ``test_re2_pattern_tolerance``
+      records 0/15, there via a deliberately forced passthrough sanitiser.
+      Inheriting the parent's ``False`` would carry that 500 into every domain
+      tool schema bearing a Pydantic Decimal-string pattern.
+    * ``flatten_oneof_discriminator = False`` — Cohere handles ``oneOf`` +
+      ``discriminator`` natively: ``discriminated_union_tool_call_two_turns``
+      passed 15/15 on both ``bare_union`` and ``explicit_discriminator``, as
+      did the ``array_of_unions`` and ``nested_union`` variants. Flattening is
+      a workaround for a gap this model does not have, and it would reshape the
+      union value schema now carried under the synthetic ``value`` field.
+    * ``strip_parameters_root_description = True`` — the parent keeps the
+      redundant Pydantic class-docstring at the parameters root because it
+      anchors *Gemini's* optional-field selection. There is no such evidence
+      on this route, and ``required_fields_complete`` already passes 15/15
+      with it stripped.
+
+    Firing condition and depth are therefore precisely
+    :class:`GeminiRecursiveSchema`'s, unchanged: the cycle stub is substituted
+    only where a ``#/$defs/`` ref re-enters a def on the current resolution
+    path, and the scalar/union value carriage fires only where the sanitised
+    dict-map value schema is non-empty and contributes no ``properties``. This
+    class adds no new traversal and overrides no method — only the three
+    ``ClassVar`` flags above.
+    """
+
+    flatten_oneof_discriminator = False
+    strip_parameters_root_description = True
+    strip_re2_incompatible_patterns = True
+
+
+class CohereRootKeyRepairResponse(ScalarArrayDictMapResponse):
+    """:class:`ScalarArrayDictMapResponse` plus a **root key rename**.
+
+    Motivation — ``azure_ai/cohere-command-a-plus-05-2026``. On a tool whose
+    arguments are a single ``object`` root parameter, this route sometimes
+    emits that parameter's key with **the tool's own name prefixed onto it**,
+    while the value underneath is entirely correct::
+
+        # declared:  submit_tree({"root": {...}})
+        # emitted:   {"submit_treeroot": {"label": "A", "children": [...]}}
+        #                 ^^^^^^^^^^^ = "submit_tree" + "root"
+
+    The receiving validator sees the declared parameter as simply absent, so
+    the symptom presents as ``root`` being ``None`` — which is what an earlier
+    iteration of this integration mis-read as a *dropped envelope*, and
+    "restored" by re-nesting the whole mapping one level deeper (producing
+    ``{"root": {"submit_treeroot": {...}}}``, the shape recorded in
+    ``observation/resolve/reprobe_2``). That restore is what made the true
+    mechanism visible: string concatenation, not elision.
+
+    **The evidence, from this model's own observe artifacts.**
+
+    * Iteration 1 (parent policy alone, no root recovery):
+      ``test_recursive_ref_tool_call`` 0/5 on all three ``submit_tree``
+      shapes, each reporting ``root`` as ``NoneType``.
+    * Iteration 2 (envelope re-nest): still 0/5, but the assertion messages
+      now print the arguments verbatim, and every one of the 10 failing
+      ``submit_tree`` reports contains the literal key ``submit_treeroot``
+      carrying a well-formed tree — ``simple`` reaches depth 3 with both
+      ``B`` and ``C`` present, ``deep_chain`` reaches ``A→B→C→D``. The
+      recursion the capability actually probes was never wrong.
+    * ``nested_in_object`` passes 5/5 in both iterations. Its tool is
+      ``submit_document`` with root parameter ``doc``, and no report in
+      either run contains ``submit_documentdoc``. So the quirk is
+      intermittent per tool rather than universal, which is why it is a
+      repair keyed on an exact expected string and not a blanket rewrite.
+
+    Because the mangled key is *derived from* the declared name, the repair is
+    fully determined: there is exactly one candidate spelling to look for, and
+    no guessing about which emitted key was "meant" to be the parameter.
+
+    **Firing condition (schema-gated, depth 0 — a key rename only).** The
+    rename fires only when ALL of the following hold:
+
+    * ``param_types`` declares exactly ONE root parameter, and its declared
+      type is ``object`` (the type comes from the sanitised schema, so the
+      gate is schema-visible — never keyed on the data's shape);
+    * that declared parameter name is ABSENT from the emitted arguments;
+    * the emitted arguments contain exactly ONE key, and that key is
+      **byte-equal to some tool name concatenated with the declared
+      parameter name** — i.e. it ends with the declared name and the
+      remaining prefix is non-empty. The prefix is required to be a
+      non-empty proper prefix, so a correctly-spelled key can never match.
+
+    On a match the single key is renamed to the declared parameter name and
+    its value is passed through untouched. Nothing is re-nested, no value is
+    rewritten, and no recursion is added: an argument set that already spells
+    the parameter correctly, or that carries more than one key, or whose lone
+    key is not the concatenated spelling, is returned unchanged and reaches
+    the parent exactly as before.
+
+    Everything else — empty-container coercion, stringified-JSON recovery,
+    the dict-map array→dict pivot, the scalar ``value`` unwrap and the
+    one-level nested dict-map pivot — is inherited from
+    :class:`ScalarArrayDictMapResponse` and runs on the repaired arguments.
+    That parent is the policy the earlier Cohere overlays already used (it is
+    what took ``dict_map__scalar_values``, ``dict_map__nested_in_object`` and
+    ``discriminated_union__union_in_dict_map`` from 0/15 to 5/5, and it
+    round-trips a correct ``root`` tree unchanged), so inheriting rather than
+    re-implementing keeps every one of those recoveries; this class adds only
+    the rename above.
+    """
+
+    def parse_arguments(
+        self,
+        arguments: dict[str, Any],
+        *,
+        param_types: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        repaired = self._repair_root_key(arguments, param_types)
+        return super().parse_arguments(repaired, param_types=param_types)
+
+    @staticmethod
+    def _repair_root_key(
+        arguments: dict[str, Any],
+        param_types: Mapping[str, str] | None,
+    ) -> dict[str, Any]:
+        """Rename a ``<tool_name><param>`` root key back to ``<param>``.
+
+        Schema-gated on ``param_types`` declaring exactly one root parameter
+        of declared type ``object``; a no-op whenever that parameter is
+        already present, whenever more than one key was emitted, or whenever
+        the lone key is not the declared name carrying a non-empty prefix.
+        See the class docstring for the full condition.
+        """
+        if not param_types or len(param_types) != 1:
+            return arguments
+        if not isinstance(arguments, dict) or len(arguments) != 1:
+            return arguments
+        ((param_name, declared),) = param_types.items()
+        if declared != "object" or param_name in arguments:
+            return arguments
+        ((emitted_key, value),) = arguments.items()
+        if not isinstance(emitted_key, str):
+            return arguments
+        # The mangled spelling is the declared name with a non-empty prefix
+        # glued on (observed: the tool's own name). Requiring a *proper*
+        # prefix means a correctly-spelled key never reaches here anyway.
+        if len(emitted_key) <= len(param_name) or not emitted_key.endswith(param_name):
+            return arguments
+        return {param_name: value}


### PR DESCRIPTION
**Disposable test branch — do not merge.**

First live exercise of the auto-integration since the models split landed. Nothing has run through it yet: the last `integrate:` commit on `main` is 2026-08-04, and the split merged on 08-12.

The Cohere `tool_choice: auto` gap is **pre-declared as data**, using the mechanism that merged in #1110:

```yaml
cohere_command_a_plus:
  params:
    param_value_rules:
      tool_choice:
        auto: { action: drop, evidence: "2026-08-01, verified live: ..." }
```

That is a precondition, not part of the test. `tool_choice` is refused by the `azure_ai` route before the model is reached, so all 31 capability probes and all 6 shape variants fail at once and the resolve agent never sees anything. A previous attempt (#1070) died exactly there. Notably this declaration needs **no engine code** — which is the ADR-0030 claim, exercised for the first time on a real model.

**What is actually under test:** whether the agent handles the `<|START_TEXT|>…<|END_TEXT|>` markers by writing an `assistant_text_policy` subclass into `tolokaforge_models/.../policies/` with an entry point, rather than into `tolokaforge/core/llm/`. That case is why the ninth slot exists and it has never run end to end.

Also being watched: whether the derived `PER_MODEL_SUBCLASSES` audit picks a newly written class up without an engine-repo edit.

Not covered: the auto-release, and the Bucket B refusal — both live in #1067, still open. On `main` today a Bucket B result still commits, under a different label.