### PR TITLE
fix(automation): score observe contamination as a rate, not a boolean

### DIFF
--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -460,14 +460,22 @@ jobs:
           # and `findings.json` carries the infra counters for it to read. Above
           # 5% the word "transient" stops being credible.
           #
+          # The four summed counters are the transport ones. `api_timeout` sits
+          # beside `api_error` in the producer (observe.py) precisely so a wire
+          # run that died on provider 5xx/timeouts cannot read as clean, and
+          # "an outage" -- which this gate claims to catch -- most often
+          # arrives as timeouts. `max_turns` and `stuck` are excluded on
+          # purpose: those are the model failing to finish, which is exactly
+          # what the agent is here to analyse.
+          #
           # `capability_ran` stays absolute -- a suite that never ran is not a
           # rate question. Zero trials with any noise counts as fully dirty
           # rather than dividing by zero. Counts are echoed so a reader can see
           # how close the call was, and so the real noise floor becomes visible
           # over the next few runs rather than staying a guess.
-          GATE="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); w=f.get("wire",{}); i=w.get("infra",{}); t=w.get("trials") or 0; n=sum(i.get(k,0) for k in ("rate_limit","api_error","status_error")); r=(n/t) if t else (1.0 if n else 0.0); print("dirty" if not f.get("capability_ran") else ("dirty" if r>0.05 else "clean"), n, t, round(r,4))')"
+          GATE="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); w=f.get("wire",{}); i=w.get("infra",{}); t=w.get("trials") or 0; n=sum(i.get(k,0) for k in ("rate_limit","api_error","api_timeout","status_error")); r=(n/t) if t else (1.0 if n else 0.0); print("dirty" if not f.get("capability_ran") else ("dirty" if r>0.05 else "clean"), "capability-suite-did-not-run" if not f.get("capability_ran") else "infra-noise", n, t, round(r,4))')"
           CLEAN="${GATE%% *}"
-          echo "observe gate: $GATE  (verdict noise trials rate)"
+          echo "observe gate: $GATE  (verdict reason noise trials rate)"
           if [ "$CLEAN" = "clean" ]; then
             gh pr edit "$PR" -R "$REPO" --remove-label 'automation:integrate-running' \
               --add-label 'automation:resolve-running' || true
@@ -482,7 +490,7 @@ jobs:
             echo "clean=no" >> "$GITHUB_OUTPUT"
             uv run automation slack reply \
               --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
-              --icon needs_human --text "Needs human: observe infra-dirty ($GATE - verdict noise trials rate; threshold 5% of trials)" \
+              --icon needs_human --text "Needs human: observe infra-dirty ($GATE - verdict reason noise trials rate; threshold 5% of trials)" \
               --pr-url "$PR_URL" --run-url "$RUN_URL" || true
             touch "$RUNNER_TEMP/slack_terminal_sent" || true
             echo "observe infra-dirty or did-not-run -> needs human"

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -437,7 +437,26 @@ jobs:
             touch "$RUNNER_TEMP/slack_terminal_sent" || true
             echo "no findings.json -> needs human"; exit 0
           fi
-          CLEAN="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); i=f.get("wire",{}).get("infra",{}); print("dirty" if (not f.get("capability_ran")) or any(i.get(k,0) for k in ("rate_limit","api_error","status_error")) else "clean")')"
+          # Infra contamination is a RATE, not a boolean. This gate exists so the
+          # agent never analyses failures the transport caused rather than the
+          # model, and a systematic problem -- throttling, an outage, a broken
+          # route -- shows up as many errors across the pack. A single transient
+          # hiccup does not, and cannot bias which quirks the agent sees, but
+          # `any(...)` discarded the whole observe for one. Measured on run
+          # 31694131208: status_error=1 of 200 trials (0.5%) aborted an
+          # otherwise healthy observe -- 22/31 capability probes green, 0
+          # tool-arg rejections across 911 tool calls -- and sent a clean
+          # candidate to a human at full observe cost.
+          #
+          # The threshold is a fraction of wire trials so it scales with pack
+          # size: 1 error in 200 passes, 3 do not, and on a 10-trial pack one
+          # error is 10% and still fails. `capability_ran` stays absolute -- a
+          # suite that never ran is not a rate question. Zero trials with any
+          # noise counts as fully dirty rather than dividing by zero. Counts are
+          # echoed so a reader can see how close the call was.
+          GATE="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); w=f.get("wire",{}); i=w.get("infra",{}); t=w.get("trials") or 0; n=sum(i.get(k,0) for k in ("rate_limit","api_error","status_error")); r=(n/t) if t else (1.0 if n else 0.0); print("dirty" if not f.get("capability_ran") else ("dirty" if r>0.01 else "clean"), n, t, round(r,4))')"
+          CLEAN="${GATE%% *}"
+          echo "observe gate: $GATE  (verdict noise trials rate)"
           if [ "$CLEAN" = "clean" ]; then
             gh pr edit "$PR" -R "$REPO" --remove-label 'automation:integrate-running' \
               --add-label 'automation:resolve-running' || true
@@ -452,7 +471,7 @@ jobs:
             echo "clean=no" >> "$GITHUB_OUTPUT"
             uv run automation slack reply \
               --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
-              --icon needs_human --text 'Needs human: observe infra-dirty (rate-limit / API error / capability suite did not run)' \
+              --icon needs_human --text "Needs human: observe infra-dirty ($GATE - verdict noise trials rate; threshold 1% of trials)" \
               --pr-url "$PR_URL" --run-url "$RUN_URL" || true
             touch "$RUNNER_TEMP/slack_terminal_sent" || true
             echo "observe infra-dirty or did-not-run -> needs human"

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -449,12 +449,23 @@ jobs:
           # candidate to a human at full observe cost.
           #
           # The threshold is a fraction of wire trials so it scales with pack
-          # size: 1 error in 200 passes, 3 do not, and on a 10-trial pack one
-          # error is 10% and still fails. `capability_ran` stays absolute -- a
-          # suite that never ran is not a rate question. Zero trials with any
-          # noise counts as fully dirty rather than dividing by zero. Counts are
-          # echoed so a reader can see how close the call was.
-          GATE="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); w=f.get("wire",{}); i=w.get("infra",{}); t=w.get("trials") or 0; n=sum(i.get(k,0) for k in ("rate_limit","api_error","status_error")); r=(n/t) if t else (1.0 if n else 0.0); print("dirty" if not f.get("capability_ran") else ("dirty" if r>0.01 else "clean"), n, t, round(r,4))')"
+          # size: on a 200-trial pack 10 errors pass and 11 do not, while on a
+          # 10-trial pack a single error is 10% and still fails.
+          #
+          # 5% rather than something tighter because the two ways to be wrong
+          # cost very differently. A false "dirty" throws away a paid observe
+          # run and puts a clean candidate in a human queue. A false "clean"
+          # hands the agent slightly noisy data -- which is work it does anyway,
+          # since separating model quirks from transport failures is its job,
+          # and `findings.json` carries the infra counters for it to read. Above
+          # 5% the word "transient" stops being credible.
+          #
+          # `capability_ran` stays absolute -- a suite that never ran is not a
+          # rate question. Zero trials with any noise counts as fully dirty
+          # rather than dividing by zero. Counts are echoed so a reader can see
+          # how close the call was, and so the real noise floor becomes visible
+          # over the next few runs rather than staying a guess.
+          GATE="$(uv run python -c 'import json; f=json.load(open("observation/findings.json")); w=f.get("wire",{}); i=w.get("infra",{}); t=w.get("trials") or 0; n=sum(i.get(k,0) for k in ("rate_limit","api_error","status_error")); r=(n/t) if t else (1.0 if n else 0.0); print("dirty" if not f.get("capability_ran") else ("dirty" if r>0.05 else "clean"), n, t, round(r,4))')"
           CLEAN="${GATE%% *}"
           echo "observe gate: $GATE  (verdict noise trials rate)"
           if [ "$CLEAN" = "clean" ]; then
@@ -471,7 +482,7 @@ jobs:
             echo "clean=no" >> "$GITHUB_OUTPUT"
             uv run automation slack reply \
               --channel "$SLACK_CHANNEL" --pr "$PR" --model "$CANDIDATE_NAME" --mention \
-              --icon needs_human --text "Needs human: observe infra-dirty ($GATE - verdict noise trials rate; threshold 1% of trials)" \
+              --icon needs_human --text "Needs human: observe infra-dirty ($GATE - verdict noise trials rate; threshold 5% of trials)" \
               --pr-url "$PR_URL" --run-url "$RUN_URL" || true
             touch "$RUNNER_TEMP/slack_terminal_sent" || true
             echo "observe infra-dirty or did-not-run -> needs human"

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -254,3 +254,41 @@ def test_the_verdict_and_its_numbers_are_surfaced() -> None:
     body = _gate_step_body()
     assert "observe gate:" in body, "the decision must be greppable in the run log"
     assert "$GATE" in body, "the needs-human Slack must name the counts, not just say dirty"
+
+
+def test_the_gate_sums_every_transport_counter_the_producer_emits() -> None:
+    """The consumed counter list must match the producer's transport set.
+
+    `api_timeout` was missing from the sum, so a wire run where every trial
+    died on a provider timeout scored zero noise and chained to resolve — the
+    exact case the producer's own comment says those counters exist to catch.
+    Nothing locked the list, which is why it survived a rewrite of that very
+    expression.
+    """
+    body = _strip_comments(_gate_step_body())
+    producer = (_REPO_ROOT / "tools/automation/src/automation/observe.py").read_text()
+    infra_block = producer[producer.index('"infra": {') : producer.index('"infra": {') + 600]
+
+    transport = {"rate_limit", "status_error", "api_error", "api_timeout"}
+    for counter in transport:
+        assert f'"{counter}"' in infra_block, f"{counter} is no longer produced; revisit the gate"
+        assert f'"{counter}"' in body, (
+            f"the gate ignores {counter!r}, so a run contaminated only that way "
+            f"scores zero noise and reaches the agent as clean data"
+        )
+
+    # Model-behaviour counters must stay out: a model that fails to finish is
+    # the finding, not contamination.
+    for counter in ("max_turns", "stuck"):
+        assert f'"{counter}"' not in body, (
+            f"{counter!r} measures the model, not the transport; counting it "
+            f"would discard exactly the runs worth analysing"
+        )
+
+
+def test_the_verdict_carries_a_reason_token() -> None:
+    # `dirty … 0 200 0.0` on its own reads as a contradiction; the reason says
+    # whether the rate was exceeded or the capability suite never ran.
+    body = _strip_comments(_gate_step_body())
+    assert "capability-suite-did-not-run" in body
+    assert "infra-noise" in body

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -240,7 +240,7 @@ def test_the_gate_scores_a_rate_not_a_boolean() -> None:
         "transient error; the gate must weigh them against the trial count"
     )
     assert "trials" in body, "the rate needs the denominator"
-    assert "r>0.01" in body or "r > 0.01" in body, "expected the 1%-of-trials threshold"
+    assert "r>0.05" in body or "r > 0.05" in body, "expected the 5%-of-trials threshold"
 
 
 def test_a_suite_that_never_ran_is_still_absolute() -> None:

--- a/tests/canonical/test_integrate_model_bucket_flow.py
+++ b/tests/canonical/test_integrate_model_bucket_flow.py
@@ -203,3 +203,54 @@ def test_finalize_preserves_existing_verification_gates() -> None:
     for pattern, label in required_gates:
         msg = f"finalize step no longer contains the {label} - the retarget must not drop it"
         assert re.search(pattern, body), msg
+
+
+# ---------------------------------------------------------------------------
+# The observe cleanliness gate treats infra contamination as a rate.
+#
+# `any(non-zero)` discarded an entire observe run for one transient error in
+# 200 trials — a full-cost run thrown away and a clean candidate sent to a
+# human. The gate's job is to keep the agent away from transport-caused
+# failures, which arrive in bulk; a single hiccup cannot bias what it sees.
+# ---------------------------------------------------------------------------
+
+
+def _strip_comments(body: str) -> str:
+    """Shell body minus comment lines — the rationale mentions the construct it
+    replaced, and a substring check must not trip on the explanation."""
+    return "\n".join(ln for ln in body.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _gate_step_body() -> str:
+    doc = yaml.safe_load(_WORKFLOW_PATH.read_text())
+    for job in doc["jobs"].values():
+        for step in job.get("steps", []):
+            name = step.get("name", "")
+            if isinstance(name, str) and name.startswith("Cleanliness gate"):
+                run = step.get("run")
+                assert isinstance(run, str)
+                return run
+    raise AssertionError("no `Cleanliness gate` step found")
+
+
+def test_the_gate_scores_a_rate_not_a_boolean() -> None:
+    body = _strip_comments(_gate_step_body())
+    assert "any(" not in body, (
+        "a boolean over the infra counters fails the whole observe on one "
+        "transient error; the gate must weigh them against the trial count"
+    )
+    assert "trials" in body, "the rate needs the denominator"
+    assert "r>0.01" in body or "r > 0.01" in body, "expected the 1%-of-trials threshold"
+
+
+def test_a_suite_that_never_ran_is_still_absolute() -> None:
+    # Not a rate question: no capability data at all means nothing to analyse,
+    # however quiet the wire pack was.
+    body = _gate_step_body()
+    assert 'not f.get("capability_ran")' in body
+
+
+def test_the_verdict_and_its_numbers_are_surfaced() -> None:
+    body = _gate_step_body()
+    assert "observe gate:" in body, "the decision must be greppable in the run log"
+    assert "$GATE" in body, "the needs-human Slack must name the counts, not just say dirty"


### PR DESCRIPTION
The observe cleanliness gate refused a run if **any** of `rate_limit`, `api_error` or `status_error` was non-zero:

```python
"dirty" if (not capability_ran) or any(infra[k] for k in (...)) else "clean"
```

## What that cost

Run [31694131208](https://github.com/Toloka/tolokaforge/actions/runs/31694131208), the first live exercise of the auto-integration since the models split: `status_error=1` out of **200** wire trials — 0.5% — discarded the whole observe and sent the candidate to a human.

That run was healthy by every other measure: 22 of 31 capability probes green, 200 wire trials with **0** tool-arg rejections across 911 tool calls, `rate_limit` and `api_error` both zero.

So a full-cost observe was thrown away and the resolve stage — the part that actually produces the integration — never ran. The re-run on this branch scored `status_error=0` on the same model over the same route, confirming the one error was noise rather than a systematic problem.

## The fix

Contamination is a **rate**. The gate exists so the agent never analyses failures the transport caused rather than the model, and a systematic problem arrives in bulk. A single transient hiccup cannot bias which quirks the agent sees.

| scenario | verdict |
|---|---|
| 1 error / 200 trials (0.5%) | clean |
| 3 / 200 (1.5%) | clean |
| 10 / 200 (5.0%) | clean |
| 11 / 200 (5.5%) | dirty |
| 1 / 10 (10%) | dirty |
| every trial timed out (200 / 200) | dirty |
| systematic throttling, 40 / 200 | dirty |
| capability suite never ran | dirty, regardless of rate |
| 0 trials with any noise | dirty, no division by zero |
| `max_turns=196`, `stuck=1` | clean — model behaviour, not transport |

**5% rather than something tighter** because the two ways to be wrong cost very differently. A false "dirty" throws away a paid observe run and puts a clean candidate in a human queue. A false "clean" hands the agent slightly noisy data — which is work it does anyway, since separating model quirks from transport failures is its job, and `findings.json` carries the infra counters for it to read. Above 5% the word "transient" stops being credible.

The number is a judgment call from one data point, not a measurement. That is why the rate is echoed to the run log and the Slack message: the next few runs will show where the real noise floor sits.

## `api_timeout` (from review)

The gate summed three counters but the producer emits four transport ones. `api_timeout` sits beside `api_error` in `observe.py` specifically so a wire run that died on provider 5xx/timeouts cannot read as clean — and the gate ignored it, so that run scored zero noise and chained to resolve. Pre-existing, but this PR rewrote that expression and its rationale claims to catch outages, which usually arrive as timeouts.

Nothing locked the counter list, which is how it survived. A canonical test now reads the producer's infra block and asserts the gate consumes every transport counter it emits, and that `max_turns` / `stuck` stay excluded.

## Visibility

The verdict, a reason token, the raw counts and the rate reach the run log and the needs-human Slack. Previously a reader was told "infra-dirty" and had to download the artifact to learn whether that meant one blip or an outage. The reason token also disambiguates `dirty … 0 200 0.0`, which otherwise reads as a contradiction.

## Verification

Exercised against the real `findings.json` from the run above plus the scenarios in the table. Five canonical tests lock the shape: rate not boolean, `capability_ran` absolute, numbers surfaced, the counter list matched against the producer, and the reason token. `pre-commit` clean including actionlint. 14/14 in the affected suite.