### PR TITLE
fix(tbench): opencode ANTHROPIC_BASE_URL /v1 + kimi-code multi-turn docs

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
@@ -236,12 +236,24 @@ harnesses:
     # HarnessSpec.config_files. Default: OpenRouter's Anthropic-compat
     # surface (matches claude-code's routing). An operator targeting an
     # OpenAI or Gemini variant overlays this via harness_presets_file.
+    #
+    # `ANTHROPIC_BASE_URL` MUST end in `/v1`. opencode 1.x routes
+    # anthropic-provider traffic through `@ai-sdk/anthropic` (bundled;
+    # `packages/opencode/src/provider/provider.ts:110`), which composes
+    # the request URL as `${config.baseURL}/messages` — no `/v1` prepend.
+    # Anthropic's own OFFICIAL SDK (which claude-code uses) prepends
+    # `/v1` itself, so the same `openrouter.ai/api` string reaches
+    # `.../api/v1/messages` there. For opencode we must ship the `/v1`
+    # in the URL, or the SDK hits `.../api/messages` (404), no response
+    # comes back, and `deriveStepStopReason` falls to the default
+    # `"unknown"`. Diagnostic signature of this misconfiguration:
+    # `step_finish reason:"unknown"`, 0 tokens, ~3 s wall-clock.
     config_files:
       "/root/.config/opencode/opencode.json": |-
         {"provider":{"anthropic":{"options":{"baseURL":"{{ base_url }}"}}}}
     provider_env:
       ANTHROPIC_API_KEY: "${secret:OPENROUTER_API_KEY}"
-      ANTHROPIC_BASE_URL: "https://openrouter.ai/api"
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api/v1"
 
   grok-build:
     # Grok Build's installer is a curl-piped shell script from x.ai — the

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
@@ -174,6 +174,22 @@ harnesses:
       KIMI_CODE_NO_AUTO_UPDATE: "true"
       NO_COLOR: "true"
       KIMI_MODEL_MAX_COMPLETION_TOKENS: "16384"
+    # NOTE on multi-turn iteration in `--prompt` mode: the CLI iterates
+    # while the model returns tool calls, and terminates normally the
+    # first time the model emits `end_turn` (no tool calls). There is
+    # NO env var, config key, or CLI flag that overrides this. The
+    # `applyPrintModeConfigDefaults` seed of `maxStepsPerTurn: 0` (see
+    # 0.28.1's `dist/main.mjs`) means "unlimited" — a positive TOML
+    # override only tightens the cap. The single escape hatch is a
+    # `Stop` hook (fires once per turn, exit 2 re-enters the loop),
+    # which is a nag pattern we deliberately do NOT ship.
+    #
+    # Practical consequence: models that iterate briefly on multi-file
+    # diagnostic tasks (empirically some smaller kimi variants — plans
+    # + a batch of parallel Reads + a single-space second turn) end the
+    # session at score ~= baseline-container. This is model behavior,
+    # not a CLI or tolokaforge misconfiguration. The shipped example
+    # uses `kimi-k3`, which does not exhibit the pattern.
     # OpenRouter emits `moonshotai/kimi-k2.5`; the CLI wants bare
     # `kimi-k2.5`. Same shape as codex and gemini-cli.
     strip_vendor_namespace: true


### PR DESCRIPTION
## Two data-only fixes to `data/harnesses.yaml`

Follow-up to PR #1083. Force-pushed clean history — replaces earlier commits whose hypotheses did not validate empirically.

### Commit 1 — opencode `ANTHROPIC_BASE_URL` needs `/v1`

opencode 1.x routes anthropic-provider traffic through `@ai-sdk/anthropic` (bundled — `packages/opencode/src/provider/provider.ts:110`), not through Anthropic's official SDK. `@ai-sdk/anthropic` composes the request URL as `` `${config.baseURL}/messages` `` — **no `/v1` prepend**. The shipped `ANTHROPIC_BASE_URL=https://openrouter.ai/api` became `.../api/messages` (a 404 on OpenRouter, whose Anthropic-compat endpoint lives at `.../api/v1/messages`). No response → `deriveStepStopReason` fell to default `"unknown"` → the diagnostic signature is `{"type":"step_finish","reason":"unknown","tokens":{"input":0,"output":0}}` in ~3 s wall-clock with no API call.

`claude-code` works with the same `openrouter.ai/api` URL because Anthropic's OFFICIAL Python/TS SDK prepends `/v1` itself. Different SDK, different envelope requirement.

**Empirical validation** (single-cell harness smoke, `opencode × sonnet-4.6` on the shipped example task):

| Metric | Pre-fix | Post-fix |
|---|---|---|
| Wall clock | ~3 s | ~470 s |
| step_start / step_finish rounds | 0 | 29 |
| Tool calls (opencode-side) | 0 | 35 (bash × 21, todowrite × 7, read × 5, edit + write × 1 each) |
| Output tokens | 0 | ~12.7 k |
| Cost | \$0 | \$0.52 |
| Trial score | 0.433 (baseline — did nothing) | 0.400 (model tried, scored below baseline on this task) |

The harness now runs end-to-end. The trial score reflects the MODEL's diagnostic quality on the example task, not a harness bug — Sonnet 4.6 edited code + ran tests + broke previously-passing ones. That is a legitimate benchmark outcome; the harness delivered the model's actual behavior to the grader.

**Refuted hypotheses from prior investigation** (all confirmed against `github.com/sst/opencode`):
- `--auto` IS a real 1.x flag (`cli/cmd/run.ts`) and IS an alias for `--dangerously-skip-permissions` — not the bug.
- `{env:VAR}` interpolation IS a real syntax (`config/variable.ts:29-31`) — not the bug.
- Config path `/root/.config/opencode/opencode.json` IS correct in 1.x (`config/config.ts:258-260`) — not the bug.
- Explicit `options.apiKey` is not required — `provider.key` fallback from `ANTHROPIC_API_KEY` env already works (`provider.ts:1527,1720`).

### Commit 2 — kimi-code `--prompt`-mode early stop is model behavior, not a CLI limit

Documentation only. YAML comment added to the `kimi-code` entry explaining what governs multi-turn iteration in `--prompt` mode.

**Investigation**: re-reading the prior trajectory revealed the kimi CLI DID iterate. The second assistant message was `{"role":"assistant","content":" "}` — a single space with zero tool calls. `deriveStepStopReason` (`dist/main.mjs:138499`) treats "completed + zero tool calls" as `end_turn`, and `runStepLoop` (`156642-156659`) exits normally on `end_turn`. This is correct CLI behavior.

The earlier `[loop_control] max_steps_per_turn = 100` hypothesis was a genuine no-op. `applyPrintModeConfigDefaults` (`64259-64274`) seeds `maxStepsPerTurn: 0` = unlimited; a positive TOML override only tightens the cap.

Kimi has NO env var, config key, or CLI flag that overrides a model-emitted `end_turn`. `taskEnvBindings` (`258643`) only binds `KIMI_CODE_BACKGROUND_KEEP_ALIVE_ON_EXIT`. The one escape hatch is a `Stop` hook (fires once per turn, exit 2 re-enters the loop) — this is a nag pattern and we deliberately do NOT ship it.

**Practical consequence**: smaller kimi variants that give up early on multi-file diagnostic tasks end the session at ~baseline-container score. Model behavior, not a tolokaforge or kimi-CLI bug. The shipped example uses `kimi-k3`, which does not exhibit the pattern (regression check: `binary_pass=True`, no regression from PR #1083).

## What was force-pushed and why

Earlier commits on this branch implemented plausible-but-wrong fixes based on binary-string inspection. Empirical validation disproved both. Rather than layering revert-and-fix commits on top, the branch was reset to the PR #1083 merge and rewritten with two clean commits carrying the correct root-cause diagnosis. Old commits are gone; no consumers had based work on them.

## Test plan

- [x] `data/harnesses.yaml` parses (verified locally).
- [x] Harness smoke: `opencode × sonnet-4.6` on the shipped example — pipeline A completes with 29 step_finish rounds, ~12.7 k output tokens, \$0.52 cost. Trajectory shows real tool use.
- [x] Harness smoke: `kimi-code × k3` on the shipped example — pipeline A completes with `binary_pass=True`. No regression from PR #1083.
- [x] Static hygiene: no snapshot ripple (canonical snapshot pins `claude-code`'s URL, not opencode's — intentional, per the different-SDK explainer in the code comment).