### PR TITLE
fix(tbench): gemini-cli hardenings — TRUST_WORKSPACE + settings.json pre-pin

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
@@ -123,16 +123,43 @@ harnesses:
     # gemini-cli's model catalog uses bare names.
     strip_vendor_namespace: true
     # gemini-cli speaks Google's native Gemini schema (`generateContent`),
-    # not OpenAI-compat, so an OpenRouter key does not authenticate its
-    # requests — pointing `GOOGLE_GEMINI_BASE_URL` at OpenRouter returns 400.
-    # The reference vendor-CLI invocation reads `GEMINI_API_KEY` and 401s otherwise
-    # (empirically verified: no matrix run of any pipeline ever produced a
-    # real gemini trajectory without a real Google AI Studio key).
-    # The operator supplies `GEMINI_API_KEY=<google-key>` in `.env`; the
-    # secret ref below is honest about what is required. Without the secret,
-    # SecretManager fails at trial start (loudly), which is the right shape:
-    # a run measuring a model against a laptop the operator can't
-    # authenticate would silently degrade to the baseline container score.
+    # not OpenAI-compat, so the CLI cannot be pointed at OpenRouter:
+    #
+    # 1. OpenRouter exposes only OpenAI-compat (`/chat/completions`) and
+    #    Anthropic-compat (`/messages`) surfaces. There is no
+    #    `POST /v1beta/models/{model}:generateContent` endpoint (confirmed
+    #    against OpenRouter's own API reference, and explicitly declined
+    #    upstream at github.com/google-gemini/gemini-cli/issues/1515).
+    # 2. `@google/gemini-cli@0.55.1`'s bundle has zero code paths that
+    #    emit OpenAI-schema requests (grep on `dist/main.mjs`:
+    #    `chat/completions` → 0 hits, `openai.com` → 0 hits). All six
+    #    auth types — `USE_GEMINI`, `USE_VERTEX_AI`, `LOGIN_WITH_GOOGLE`,
+    #    `COMPUTE_ADC`, `LEGACY_CLOUD_SHELL`, `GATEWAY` — call
+    #    `new GoogleGenAI(...)` which hardcodes the `generateContent`
+    #    wire protocol. The `GATEWAY` mode reached via
+    #    `GOOGLE_GEMINI_BASE_URL` still speaks Google's schema, just to a
+    #    different endpoint.
+    #
+    # The operator must supply a Google-issued credential — the
+    # secret ref below is honest about that. Without it, SecretManager
+    # fails loudly at trial start, which is the right shape: a run
+    # measuring a model the operator can't authenticate would silently
+    # degrade to the baseline container score.
+    #
+    # `GEMINI_CLI_TRUST_WORKSPACE=true` is mandatory: without it, `--yolo`
+    # is silently demoted to "default" mode in an untrusted workspace and
+    # the CLI blocks every tool call. `~/.gemini/settings.json` is
+    # emitted with `security.auth.selectedType` pinned to `gemini-api-key`
+    # because gemini-cli's headless `--prompt` mode 400s with "Invalid
+    # auth method selected" without a pre-pinned auth type — auto-
+    # detection breaks in the same non-interactive path we run in.
+    # `experimental.skills: true` matches the reference vendor-CLI
+    # invocation's baseline settings write.
+    container_env:
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
+    config_files:
+      "/root/.gemini/settings.json": |-
+        {"security":{"auth":{"selectedType":"gemini-api-key"}},"experimental":{"skills":true}}
     provider_env:
       GEMINI_API_KEY: "${secret:GEMINI_API_KEY}"
 

--- a/tests/canonical/test_terminal_bench_adapter_canon.py
+++ b/tests/canonical/test_terminal_bench_adapter_canon.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+from tolokaforge_adapter_terminal_bench.harness import HARNESSES
 
 pytestmark = [pytest.mark.canonical, pytest.mark.usefixtures("env_backed_secrets")]
 
@@ -166,24 +167,38 @@ class TestTerminalBenchHarnessModeCanon:
         assert "ANTHROPIC_BASE_URL=${TBENCH_PROVIDER_ANTHROPIC_BASE_URL}" in agent_env
         assert "sk-openrouter-test" not in env.compose_file.read_text()
 
-    def test_synthesised_compose_carries_container_env(self, tbench_harness_adapter):
+    @pytest.mark.parametrize(
+        "harness_name",
+        sorted(name for name, spec in HARNESSES.items() if spec.container_env),
+    )
+    def test_synthesised_compose_carries_container_env(self, harness_name, test_data_dir, tmp_path):
         """``HarnessSpec.container_env`` must reach the agent service's env
-        block — every static hardening key claude-code declares (``IS_SANDBOX``,
-        ``CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC``) has to survive the
-        synthesis pass. This is a direct behavioural pin so a regression here
-        is not merely a snapshot diff."""
+        block — every static hardening key each harness declares
+        (claude-code's ``IS_SANDBOX``, gemini-cli's
+        ``GEMINI_CLI_TRUST_WORKSPACE``, kimi's telemetry disables, etc.) has
+        to survive the synthesis pass. Parametrised across every shipped
+        harness with a non-empty ``container_env`` so a regression on any
+        one entry is caught here, not on a real matrix cell."""
         import yaml
-        from tolokaforge_adapter_terminal_bench.harness import HARNESSES
 
-        env = tbench_harness_adapter._environment("echo-hello")
+        tbench_tasks_dir = test_data_dir / "terminal_bench_tasks"
+        adapter = TerminalBenchAdapter(
+            {
+                "terminal_bench_dir": str(tbench_tasks_dir),
+                "staging_root": str(tmp_path / f"staging-{harness_name}"),
+                "agent_harness": harness_name,
+                "agent_model": "openrouter/anthropic/claude-sonnet-4-6",
+            }
+        )
+        env = adapter._environment("echo-hello")
         with env.compose_file.open() as f:
             compose = yaml.safe_load(f)
         agent_env = compose["services"]["main"]["environment"]
         assert isinstance(agent_env, list)
-        for key, value in HARNESSES["claude-code"].container_env.items():
+        for key, value in HARNESSES[harness_name].container_env.items():
             assert (
                 f"{key}={value}" in agent_env
-            ), f"container_env pair {key}={value!r} missing from synthesised compose"
+            ), f"{harness_name}: container_env pair {key}={value!r} missing from synthesised compose"
 
 
 class TestTerminalBenchSkillsBundleCanon:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,12 @@ def env_backed_secrets(monkeypatch):
     from tolokaforge.secrets.providers import EnvProvider
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    # gemini-cli's shipped provider_env references ${secret:GEMINI_API_KEY} —
+    # its wire protocol (`generateContent`) is not spoken by OpenRouter, so
+    # the harness cannot share the OpenRouter key. Seed a placeholder so
+    # adapters for gemini can construct in tests. The value is never
+    # asserted on; only the resolution path is exercised.
+    monkeypatch.setenv("GEMINI_API_KEY", "google-ai-studio-test")
     monkeypatch.setattr(
         "tolokaforge.secrets.manager._default_manager", SecretManager([EnvProvider()])
     )

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -1292,11 +1292,19 @@ class TestHarnessCommand:
         ]
 
     def test_gemini_argv_shape(self):
+        """The CLI portion, after the config_files preamble's final ``&&``,
+        matches the pinned shape. The preamble emits
+        ``~/.gemini/settings.json`` before invoking the CLI — gemini-cli's
+        headless ``--prompt`` mode 400s without a pre-pinned
+        ``security.auth.selectedType``."""
         import shlex
 
         from tolokaforge_adapter_terminal_bench.harness import harness_command
 
-        assert shlex.split(harness_command("gemini-cli", "do it", "google/gemini-2.5-flash")) == [
+        _, _, cli = harness_command("gemini-cli", "do it", "google/gemini-2.5-flash").rpartition(
+            " && "
+        )
+        assert shlex.split(cli) == [
             "gemini",
             "--model",
             "gemini-2.5-flash",
@@ -1322,16 +1330,21 @@ class TestHarnessCommand:
         assert "auth.json" in preamble
         assert "OPENAI_API_KEY" in preamble
 
-    def test_gemini_has_no_preamble_no_stdin(self):
-        """A CLI without config_files, without env_model_vars, and with
-        argv-channel instruction publishes the CLI command alone — no shell
-        scaffolding for readers of the metadata to peel off."""
+    def test_gemini_uses_argv_instruction_not_stdin(self):
+        """gemini-cli reads the instruction from a positional argument
+        after ``--prompt``, not from stdin. The command scaffolds the
+        settings.json emission but never pipes the instruction — every
+        stdin marker (``|`` between pipeline stages, ``&& printf %s
+        "$INSTRUCTION" | cli``) must be absent."""
         from tolokaforge_adapter_terminal_bench.harness import harness_command
 
         command = harness_command("gemini-cli", "go", "google/gemini-2.5-flash")
-        assert "&&" not in command
-        assert "printf" not in command
-        assert command.startswith("gemini ")
+        # No stdin pipe into the CLI itself. The `printf ... > file` in the
+        # preamble writes settings.json to disk (redirect, not pipe).
+        assert " | gemini" not in command
+        assert command.rstrip().endswith(
+            " go"
+        ), "instruction must sit as the trailing positional argv token"
 
     def test_instruction_is_one_shell_argument(self):
         import shlex
@@ -1509,7 +1522,10 @@ class TestModelFlagStyle:
 
         from tolokaforge_adapter_terminal_bench.harness import harness_command
 
-        argv = shlex.split(harness_command("gemini-cli", "go", "google/gemini-2.5-flash"))
+        _, _, cli = harness_command("gemini-cli", "go", "google/gemini-2.5-flash").rpartition(
+            " && "
+        )
+        argv = shlex.split(cli)
         assert argv[1:3] == ["--model", "gemini-2.5-flash"]
 
     def test_equals_style_is_one_argv_word(self):

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -1336,15 +1336,32 @@ class TestHarnessCommand:
         settings.json emission but never pipes the instruction — every
         stdin marker (``|`` between pipeline stages, ``&& printf %s
         "$INSTRUCTION" | cli``) must be absent."""
+        import shlex
+
         from tolokaforge_adapter_terminal_bench.harness import harness_command
 
         command = harness_command("gemini-cli", "go", "google/gemini-2.5-flash")
         # No stdin pipe into the CLI itself. The `printf ... > file` in the
         # preamble writes settings.json to disk (redirect, not pipe).
         assert " | gemini" not in command
-        assert command.rstrip().endswith(
-            " go"
-        ), "instruction must sit as the trailing positional argv token"
+        _, _, cli = command.rpartition(" && ")
+        argv = shlex.split(cli)
+        assert argv[-1] == "go", "instruction must sit as the trailing positional argv token"
+
+    def test_gemini_writes_settings_json_before_the_cli(self):
+        """gemini-cli's headless ``--prompt`` mode 400s without a pre-pinned
+        ``security.auth.selectedType`` in ``~/.gemini/settings.json`` — the
+        CLI's auth auto-detection breaks in non-interactive mode. The
+        preamble emits the file with ``gemini-api-key`` selected before the
+        CLI runs; without it, gemini reaches the model call and dies."""
+        from tolokaforge_adapter_terminal_bench.harness import harness_command
+
+        preamble, sep, _ = harness_command(
+            "gemini-cli", "do it", "google/gemini-2.5-flash"
+        ).rpartition(" && ")
+        assert sep, "gemini-cli must chain a preamble before the CLI"
+        assert "/root/.gemini/settings.json" in preamble
+        assert "gemini-api-key" in preamble
 
     def test_instruction_is_one_shell_argument(self):
         import shlex


### PR DESCRIPTION
## Two silent-failure knobs the shipped default currently misses

Both are prerequisite for gemini-cli to actually work in headless `--prompt` mode when an operator supplies `GEMINI_API_KEY`. Without them the trial degrades silently — the CLI runs but blocks tool calls (case 1) or 400s on auth resolution (case 2).

Empirically derived from reference-invocation practice observed in an out-of-tree reference host we compared against, and cross-checked against the shipped `@google/gemini-cli@0.55.1` bundle.

### The two knobs

1. **`container_env.GEMINI_CLI_TRUST_WORKSPACE: "true"`** — without this, `--yolo` gets silently demoted to "default" mode in an untrusted workspace (the task container is not a git repo, so gemini-cli treats it as untrusted). The demotion blocks every tool call. Reference-invocation practice always sets this env.

2. **`config_files["/root/.gemini/settings.json"]`** writing `{"security":{"auth":{"selectedType":"gemini-api-key"}},"experimental":{"skills":true}}` before the CLI runs. Headless `--prompt` mode 400s with "Invalid auth method selected" without a pre-pinned `selectedType` — the CLI's auto-detection breaks in the non-interactive path. Reference-invocation practice always emits this settings file.

### YAML comment sharpened with citations for the OpenRouter impossibility

Anyone reading the entry will now see the specific evidence chain:

- **OpenRouter's API reference** declares only OpenAI-compat and Anthropic-compat surfaces — no `generateContent` endpoint.
- **gemini-cli 0.55.1's bundle** — `dist/main.mjs` grep: `chat/completions` → 0 hits, `openai.com` → 0 hits, `openrouter.ai` → 0 hits, `generateContent` → 558 hits. All six auth types (`USE_GEMINI`, `USE_VERTEX_AI`, `LOGIN_WITH_GOOGLE`, `COMPUTE_ADC`, `LEGACY_CLOUD_SHELL`, `GATEWAY`) call `new GoogleGenAI(...)` which hardcodes the Google wire protocol. The `GATEWAY` mode reached via `GOOGLE_GEMINI_BASE_URL` still speaks Google's schema — only the endpoint changes.
- **[gemini-cli issue #1515](https://github.com/google-gemini/gemini-cli/issues/1515)** — Google maintainer explicitly declining OpenRouter support upstream.

Ruled out escape hatches: self-hosted `generateContent`-to-OpenAI shim (still needs a Google credential upstream — same operator burden, extra hop), community forks (unmaintained, out of policy).

## Test updates

Three unit tests pinned the pre-change gemini command shape (no `config_files` → no `mkdir && printf && ...` preamble). Updated to the new shape:

- `test_gemini_argv_shape` — uses `.rpartition(" && ")` to strip the preamble and pin the CLI portion. Same pattern the existing `test_codex_writes_config_toml_and_auth_json_before_the_cli` test uses.
- `test_gemini_has_no_preamble_no_stdin` → renamed to `test_gemini_uses_argv_instruction_not_stdin`. The preamble now exists (config_files emits), but the intent — no stdin pipe into the CLI — is preserved and pinned by asserting no `" | gemini"` in the command.
- `test_space_style_is_two_argv_words` — same `.rpartition(" && ")` pattern.

**Reviewer nit follow-up** (commit `e4775611`): added `test_gemini_writes_settings_json_before_the_cli` locking the settings.json preamble mechanism (mirrors the codex `config.toml + auth.json` pattern), tightened `test_synthesised_compose_carries_container_env` to parametrise across every shipped harness with a non-empty `container_env` so a regression on any entry surfaces here rather than in a live matrix cell, and swapped the fragile `endswith(" go")` tail-bytes check for a parsed-argv assertion. Seeded `GEMINI_API_KEY` in the `env_backed_secrets` fixture — gemini-cli's wire protocol isn't OpenAI-compat, so it can't share the OpenRouter key.

## Verification

- [x] 198/198 unit + canonical tests pass locally.
- [x] No canonical snapshot ripple — snapshots pin claude-code, not gemini.
- [ ] Empirical validation deferred until `GEMINI_API_KEY` is available. The hardenings prevent silent failure but can't be positively verified without a real Google key.

**Note on CI test-smoke**: main-branch CI has been failing on unrelated `test_pinned_opener` + `test_user_reply_guard` tests on the last three runs — same 10 failures reproduce on `main` locally. Not introduced by this PR; unblocking requires a separate fix on the frame-guard subsystem.

## What this does NOT do

- Does NOT enable gemini via OpenRouter — confirmed impossible.
- Does NOT change any other harness's behavior — YAML edit is scoped to `gemini-cli`.
- Does NOT add proxy shims or community forks.

Follow-up: when `GEMINI_API_KEY` arrives, we run one matrix cell (`gemini-cli × gemini-2.5-flash × fix-billing-holds`) to confirm the harness runs end-to-end.