### PR TITLE
fix(runner): _finalise preserves first_user_message_source + user_reply_guard_events

### DIFF
--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -540,7 +540,9 @@ class TrialRunner:
             end_ts=end_ts,
             status=status,
             termination_reason=termination_reason,
+            first_user_message_source=self._first_user_message_source,
             messages=self.messages,
+            user_reply_guard_events=list(self._user_reply_guard_events),
             metrics=self.metrics,
             tool_log=list(recorded_calls),
         )


### PR DESCRIPTION
## Symptom

`main`'s CI has been failing on the last 3+ runs. Ten unit tests failed identically across `test_pinned_opener.py` and `test_user_reply_guard.py`, with two failure shapes:

```
FAILED tests/unit/test_pinned_opener.py::TestPinnedOpener::test_declared_opener_is_message_zero_verbatim
    assert trajectory.first_user_message_source is FirstUserMessageSource.PINNED
E   AssertionError: assert None is <FirstUserMessageSource.PINNED: 'pinned'>

FAILED tests/unit/test_user_reply_guard.py::…::test_a_mid_conversation_turn_rejected_once_records_one_delivered_event
    (event,) = trajectory.user_reply_guard_events
E   ValueError: not enough values to unpack (expected 1, got 0)
```

The runner logged the events correctly (`"First user message delivered"`, `"User simulator broke frame"`) — the internal state was right. Two documented Trajectory fields were just never written.

## Root cause

PR #1083 extracted `_finalise` to share the metrics-and-trajectory tail between the engine-loop path and the new harness path. In doing so, the `Trajectory(...)` constructor call dropped two kwargs:

- `first_user_message_source=self._first_user_message_source`
- `user_reply_guard_events=list(self._user_reply_guard_events)`

Both accumulate correctly on the runner (`self._first_user_message_source` at `runner.py:660,663`; `self._user_reply_guard_events` at `runner.py:697`), but nothing plumbed them into the returned Trajectory. On every trial since `a9c9f7f0` merged, both surfaced as their type defaults (`None` and `[]`).

Downstream impact:

- `output_writer.py:112` reads `trajectory.first_user_message_source.value` when writing the trial bundle — the sidecar recorded `null` for every trial that shipped with a pinned opener.
- The user-reply-guard subsystem exists to record dispatched-and-refused user turns. Every one of those was silently dropped from the trajectory.

Neither surfaced in production because it was diagnosed only via the bundle sidecar (`first_user_message_source`) or as an aggregate diagnostic that read as "no events" (the honest baseline).

## Verification

Diff comparison — pre-#1083 (`git show ec8b93cb:tolokaforge/core/runner.py` — the merge base for #1083) built the Trajectory inline with 12 kwargs; `_finalise` today copies 10 of them. The two missing lines are exactly the two failing fields.

Test results:

- Pre-fix on `main` (all commits since `a9c9f7f0`): `10 failed, 182 passed` in the two affected files.
- Post-fix: `192 passed` in the same two files. Full unit + canonical lane clean (no new failures elsewhere).

## What this does NOT do

- Does NOT change any contract, schema, or Trajectory-model definition. Both fields already exist on the model with correct defaults; the fix is pure plumbing.
- Does NOT touch the harness-mode path — but harness-mode also benefits, because both branches now assemble the same 12-field Trajectory via the shared `_finalise`.

## Why individual PR

Every PR opened on `main` since #1083 is blocked by `test-smoke` on these 10 failures. Landing this on its own unblocks the queue.