### PR TITLE
feat(tbench): document + enable LiteLLM as an alternative harness routing option

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -783,6 +783,14 @@ nothing about any specific gateway product or organisation. Everything
 deployment-specific, including the attribution headers a given gateway
 demands, is supplied as configuration.
 
+**This layer is engine-loop only.** Harness mode (see the terminal-bench
+adapter's `README.md` § Routing options) drives the vendor CLI directly inside
+the task container and does not call `litellm.completion()` for the agent's
+LLM traffic. There, routing is expressed by the URL literal in
+`HarnessSpec.provider_env` — an operator overlay can point the CLI at
+OpenRouter, a LiteLLM gateway, or any other endpoint the CLI's native env-var
+names honour, without touching `LLM_PROXY_*` at all.
+
 **"The same surface" is a narrower contract than "OpenAI-compatible".** What is
 actually required is: *for each routed provider, the gateway serves the route
 that litellm's transport for that provider targets.* This layer only overrides

--- a/examples/terminal_bench/gemini_litellm_overlay.yaml
+++ b/examples/terminal_bench/gemini_litellm_overlay.yaml
@@ -1,0 +1,65 @@
+# harness_presets_file overlay — route gemini-cli via a LiteLLM gateway
+#
+# The shipped gemini-cli entry in ``data/harnesses.yaml`` targets Google's
+# ``generativelanguage.googleapis.com`` endpoint and needs a real
+# ``GEMINI_API_KEY`` (Google AI Studio or Vertex SA). That's the honest
+# default: the CLI speaks Google's native ``generateContent`` schema and no
+# OpenAI-compat surface can proxy it.
+#
+# This overlay is the alternative when a team runs a LiteLLM gateway with
+# Google credentials centralised at the gateway side. gemini-cli's
+# ``AuthType.GATEWAY`` mode (triggered by ``GOOGLE_GEMINI_BASE_URL``) keeps
+# emitting ``generateContent`` requests but sends them to the gateway URL;
+# LiteLLM's Gemini passthrough at ``{base}/gemini/v1beta/models/…`` serves
+# them and forwards to Google using the gateway's own credential.
+#
+# Apply this file via the run config's harness-adapter params:
+#
+#   evaluation:
+#     harness_adapter:
+#       type: terminal_bench
+#       params:
+#         agent_harness: gemini-cli
+#         harness_presets_file: examples/terminal_bench/gemini_litellm_overlay.yaml
+#
+# ADR-0033 does whole-entry replacement, so this file redeclares every
+# HarnessSpec field the shipped default carries — a partial overlay would
+# drop the fields it doesn't restate.
+#
+# Two operator env vars need to be set:
+#
+#   ``LITELLM_API_KEY``   the virtual key or master key the gateway issues.
+#   ``LITELLM_BASE_URL``  the gateway URL, e.g. ``https://litellm.example/`` —
+#                         the ``/gemini`` suffix in the URL below is the
+#                         passthrough's own path, NOT part of the base URL.
+#
+# Both keys are in ``PROVIDER_ENV_KEYS`` (allow-listed by the adapter), so
+# no adapter code change is needed to run this overlay.
+
+harnesses:
+  gemini-cli:
+    install_method: "npm"
+    install_source: "@google/gemini-cli"
+    version: "0.55.1"
+    argv_prefix: ["gemini"]
+    argv_suffix: ["--yolo", "--prompt"]
+    strip_vendor_namespace: true
+    # ``GEMINI_CLI_TRUST_WORKSPACE=true`` prevents ``--yolo`` from silently
+    # falling back to "default" mode in a non-git workspace and blocking
+    # every tool call. ``GOOGLE_GEMINI_BASE_URL`` activates GATEWAY mode.
+    container_env:
+      GEMINI_CLI_TRUST_WORKSPACE: "true"
+      GOOGLE_GEMINI_BASE_URL: "${secret:LITELLM_BASE_URL}/gemini"
+    # Headless ``--prompt`` mode 400s with "Invalid auth method selected"
+    # without a pre-pinned ``selectedType``. GATEWAY mode requires
+    # ``"gateway"`` here — the shipped default ships ``"gemini-api-key"``
+    # for the direct-to-Google path.
+    config_files:
+      "/root/.gemini/settings.json": |-
+        {"security":{"auth":{"selectedType":"gateway"}},"experimental":{"skills":true}}
+    # ``GEMINI_API_KEY`` is what gemini-cli reads for the ``x-goog-api-key``
+    # header it sends to the gateway. LITELLM_API_KEY is the credential
+    # the gateway expects — the header value is a virtual key, not a
+    # Google credential.
+    provider_env:
+      GEMINI_API_KEY: "${secret:LITELLM_API_KEY}"

--- a/external_adapters/tolokaforge-adapter-terminal-bench/README.md
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/README.md
@@ -192,11 +192,10 @@ complete working config.
 Values resolve through `expand_secret_refs`, so a run config names a
 credential rather than carrying it. A value containing a newline or a `$` is
 refused: each becomes one line of the per-trial `.env`, where a newline splits
-the line and a `$` starts an interpolation. Keys are checked against an
-allow-list —
-`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`,
-`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `GOOGLE_API_KEY` — and anything else is
-refused naming the accepted set.
+the line and a `$` starts an interpolation. Keys are checked against
+`PROVIDER_ENV_KEYS` — a closed allow-list covering the Anthropic, OpenAI,
+Google/Gemini, OpenRouter, Kimi, and LiteLLM name families — and anything
+outside it is refused naming the accepted set.
 
 The path from config to container:
 
@@ -219,6 +218,41 @@ happens to hold silently replace the declared value. That puts a real
 production key inside a benchmark container and into its trial artifacts.
 Nothing sets the prefixed name by accident, so the container's environment is
 exactly what the run config declared.
+
+### Routing options — OpenRouter, LiteLLM, or a mix
+
+`HarnessSpec.provider_env` names CLI-native env vars (`ANTHROPIC_BASE_URL`,
+`OPENAI_BASE_URL`, …); its values name literal URLs and credential keys. The
+adapter has no opinion on which gateway or vendor those URLs belong to — an
+overlay swaps the whole `provider_env` block, and the CLI reads whatever it
+was handed. That leaves the operator free to choose:
+
+**OpenRouter (the shipped default).** Every shipped harness ships a
+`provider_env` that targets `openrouter.ai/api` (Anthropic-compat surface for
+claude-code / opencode, OpenAI-compat surface for codex / grok-build /
+kimi-code). One credential — `OPENROUTER_API_KEY` — covers all five. gemini-cli
+is the one exception: its wire protocol (Google's `generateContent`) is not on
+OpenRouter's surface, so the shipped default targets Google directly and
+`GEMINI_API_KEY` is required.
+
+**LiteLLM (operator overlay).** A team-hosted LiteLLM gateway centralises
+credentials at the gateway and can serve wire protocols OpenRouter does not —
+most notably Google's `generateContent`, via LiteLLM's Gemini passthrough at
+`{base}/gemini/v1beta/models/…`. The route is a `harness_presets_file` overlay
+that whole-replaces the harness entry with a LiteLLM-flavoured `provider_env`
+and `container_env`. A worked example ships at
+[`examples/terminal_bench/gemini_litellm_overlay.yaml`](../../examples/terminal_bench/gemini_litellm_overlay.yaml)
+for gemini-cli.
+
+**Per-harness split.** Because each harness's `provider_env` resolves
+independently, one run can leave four harnesses on OpenRouter and route
+gemini-cli through LiteLLM by naming a `harness_presets_file` that only
+overlays the gemini-cli entry — the other five stay as shipped. This is the
+current recommended shape.
+
+`LITELLM_API_KEY`, `LITELLM_BASE_URL`, and `GOOGLE_GEMINI_BASE_URL` are in
+`PROVIDER_ENV_KEYS`, so switching a harness to LiteLLM does not need an
+adapter release — it is a data-only change on the overlay side.
 
 ### Harness parity policy
 

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
@@ -133,6 +133,16 @@ harnesses:
     # SecretManager fails at trial start (loudly), which is the right shape:
     # a run measuring a model against a laptop the operator can't
     # authenticate would silently degrade to the baseline container score.
+    #
+    # Alternative — LiteLLM gateway: a team that hosts a LiteLLM gateway
+    # with a Google credential can route gemini-cli through it and avoid
+    # distributing Google keys to operator laptops. gemini-cli's
+    # `AuthType.GATEWAY` mode (activated by `GOOGLE_GEMINI_BASE_URL`)
+    # keeps emitting `generateContent` requests but sends them to the
+    # gateway's Gemini passthrough at `{base}/gemini/v1beta/models/…`.
+    # A worked overlay ships at
+    # `examples/terminal_bench/gemini_litellm_overlay.yaml`; see
+    # `README.md` § Routing options for the general pattern.
     provider_env:
       GEMINI_API_KEY: "${secret:GEMINI_API_KEY}"
 

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py
@@ -539,6 +539,23 @@ PROVIDER_ENV_KEYS: frozenset[str] = frozenset(
         # CLI's own credentials-loader looks up these two names verbatim.
         "KIMI_MODEL_API_KEY",
         "KIMI_MODEL_BASE_URL",
+        # gemini-cli's ``AuthType.GATEWAY`` mode reads ``GOOGLE_GEMINI_BASE_URL``
+        # to route ``generateContent`` requests away from Google's own
+        # endpoint at ``generativelanguage.googleapis.com``. Widening the
+        # allow-list here lets an overlay point gemini-cli at a LiteLLM
+        # passthrough (or any Gemini-schema-serving gateway) without touching
+        # the shipped default — see ``examples/terminal_bench/
+        # gemini_litellm_overlay.yaml``.
+        "GOOGLE_GEMINI_BASE_URL",
+        # LiteLLM as a first-class routing surface. ``LITELLM_API_KEY`` is
+        # the virtual key a team-hosted LiteLLM gateway issues, and
+        # ``LITELLM_BASE_URL`` names the gateway's base URL. Their presence
+        # in the allow-list is what makes a "route through LiteLLM" overlay
+        # a data-only change on any harness whose CLI accepts alternate
+        # endpoint URLs — no adapter code moves. See ``README.md``
+        # § Routing options.
+        "LITELLM_API_KEY",
+        "LITELLM_BASE_URL",
     }
 )
 """Environment variables a harness CLI may be given inside the task container.

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -2341,6 +2341,50 @@ class TestHarnessProviderEnvOverlay:
             self._adapter(fixture_dir, tmp_path)
 
 
+class TestProviderEnvKeysAllowList:
+    """``PROVIDER_ENV_KEYS`` is a closed allow-list; every forwarded value
+    lands in the per-trial compose ``.env`` and then in the container, so
+    additions and removals are explicit contract changes and get pinned
+    here rather than surfacing as a snapshot diff.
+
+    The set is a routing-neutral surface: it names what a CLI can receive,
+    not what gateway or provider anything talks to. The two LiteLLM keys
+    and ``GOOGLE_GEMINI_BASE_URL`` are here to make routing-via-LiteLLM a
+    data-only overlay on any CLI whose native env-var names honour an
+    alternate base URL — see ``README.md`` § Routing options."""
+
+    def test_the_shipped_allow_list_is_pinned(self):
+        from tolokaforge_adapter_terminal_bench.harness import PROVIDER_ENV_KEYS
+
+        assert (
+            frozenset(
+                {
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "ANTHROPIC_BASE_URL",
+                    "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL",
+                    "GOOGLE_API_KEY",
+                    "GEMINI_API_KEY",
+                    "GOOGLE_GEMINI_BASE_URL",
+                    "OPENROUTER_API_KEY",
+                    "OPENROUTER_BASE_URL",
+                    "KIMI_MODEL_API_KEY",
+                    "KIMI_MODEL_BASE_URL",
+                    "LITELLM_API_KEY",
+                    "LITELLM_BASE_URL",
+                }
+            )
+            == PROVIDER_ENV_KEYS
+        )
+
+    def test_a_key_outside_the_allow_list_is_refused(self):
+        from tolokaforge_adapter_terminal_bench.harness import validate_provider_env_keys
+
+        with pytest.raises(ValueError, match="not forwardable"):
+            validate_provider_env_keys(["MY_CUSTOM_TOKEN"])
+
+
 class TestHarnessPresetsFileOverlay:
     """An operator ships harness entries without an adapter release."""
 
@@ -2438,6 +2482,28 @@ class TestHarnessPresetsFileOverlay:
         from tolokaforge_adapter_terminal_bench.harness import HARNESSES
 
         assert self._adapter(fixture_dir, tmp_path, None).harnesses == HARNESSES
+
+    def test_shipped_gemini_litellm_overlay_resolves(self, fixture_dir, tmp_path, monkeypatch):
+        """The shipped overlay example at
+        ``examples/terminal_bench/gemini_litellm_overlay.yaml`` is the sanctioned
+        path to route gemini-cli via a LiteLLM gateway. It must resolve into a
+        valid ``HarnessSpec`` — a stale field name or a missed allow-list widen
+        surfaces here rather than as a load-time crash on the operator's
+        machine."""
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-litellm-test")
+        monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.example.test")
+        examples_dir = Path(__file__).parent.parent.parent / "examples" / "terminal_bench"
+        overlay = examples_dir / "gemini_litellm_overlay.yaml"
+        adapter = self._adapter(
+            fixture_dir, tmp_path, overlay, agent_harness="gemini-cli", agent_model="gemini-3-pro"
+        )
+        spec = adapter.harnesses["gemini-cli"]
+        assert spec.container_env["GEMINI_CLI_TRUST_WORKSPACE"] == "true"
+        assert spec.container_env["GOOGLE_GEMINI_BASE_URL"] == ("${secret:LITELLM_BASE_URL}/gemini")
+        assert spec.provider_env == {"GEMINI_API_KEY": "${secret:LITELLM_API_KEY}"}
+        # The resolved envelope on the adapter has secrets expanded — this is
+        # what the trial container actually sees.
+        assert adapter.agent_provider_env == {"GEMINI_API_KEY": "sk-litellm-test"}
 
 
 class _FakeDistribution:


### PR DESCRIPTION
## Summary

Broadens the harness routing surface so an operator can point any shipped harness at a LiteLLM gateway via a YAML overlay, without an adapter release. **OpenRouter remains the shipped default for all six harnesses** — this PR does NOT change any default. LiteLLM becomes an operator-owned alternative, useful primarily for gemini-cli (whose native `generateContent` wire protocol has no OpenAI-compat surface OpenRouter serves).

Design analysis in `~/.claude/plans/toloka-tolokaforge/*.md` (not committed — internal planning). Three Explore agents mapped the current provider abstraction, existing LiteLLM precedent, and how `tolokaforge-tasks` routes today. Findings: the harness registry is routing-neutral by design; making LiteLLM viable is a data-only change plus an allow-list widen.

## What ships

### `PROVIDER_ENV_KEYS` allow-list widened

Adds `GOOGLE_GEMINI_BASE_URL`, `LITELLM_API_KEY`, `LITELLM_BASE_URL` to the closed allow-list in the terminal-bench adapter. Three variables an overlay needs to name in either `container_env` (for `GOOGLE_GEMINI_BASE_URL`) or `provider_env`. No other adapter code moves.

`TestProviderEnvKeysAllowList` pins the shipped set so future additions or removals are explicit contract changes (rather than silent diffs), and locks the refusal path for unknown keys.

### `examples/terminal_bench/gemini_litellm_overlay.yaml`

New worked example that whole-replaces the shipped gemini-cli entry (per ADR-0033 whole-entry replacement) with LiteLLM routing:

- `GOOGLE_GEMINI_BASE_URL` set to `${secret:LITELLM_BASE_URL}/gemini` — activates gemini-cli 0.55.1's `AuthType.GATEWAY` mode.
- `~/.gemini/settings.json` written with `security.auth.selectedType: "gateway"` — the shipped `"gemini-api-key"` value 400s in gateway mode.
- `GEMINI_API_KEY` sourced from `${secret:LITELLM_API_KEY}` (the value becomes the CLI's `x-goog-api-key` header on the gateway).

`test_shipped_gemini_litellm_overlay_resolves` proves the overlay parses into a valid `HarnessSpec` and the resolved envelope reaches the adapter's `agent_provider_env` with secrets expanded.

### Documentation

- **Adapter README** gets a new `Routing options — OpenRouter, LiteLLM, or a mix` subsection under `Harness mode`. Explains the per-harness-split shape (5 harnesses on OpenRouter + gemini-cli on LiteLLM is natively supported), references the overlay example, names the three allow-listed LiteLLM keys.
- **`docs/LLM_LAYER.md` § `proxy`** gets a note that the `LLM_PROXY_*` engine-loop path is orthogonal to harness-mode routing — harness routing lives in `HarnessSpec.provider_env`, not in `ProxyConfig`.
- The shipped `harnesses.yaml` gemini-cli comment gets an `Alternative — LiteLLM gateway` paragraph pointing at the overlay example.

## What does NOT change

- **No shipped-default change.** `data/harnesses.yaml`'s six entries still target OpenRouter (or, for gemini-cli, Google directly).
- **No `routing_layer` enum** on `HarnessSpec` or model presets. The URL literal in `provider_env` and the recorded `agent_harness_command` already carry that information; a second source of truth would drift.
- **No adapter code path change.** The whole story is data + an allow-list widening.
- **No engine-loop change.** `LLM_PROXY_BASE_URL` and `ProxyConfig` are untouched — that path is engine-loop only and has its own routing story.

## What this enables (not this PR)

- Once a team-hosted LiteLLM gateway is confirmed reachable from harness containers, the three Gemini priority-table rows can be run against it via the overlay — no code change needed.
- Any future model whose native protocol OpenRouter doesn't serve can take the same overlay path.

## Test plan

- [x] 196/196 unit + canonical tests pass locally.
- [x] `TestProviderEnvKeysAllowList::test_the_shipped_allow_list_is_pinned` locks the new 14-key set.
- [x] `TestHarnessPresetsFileOverlay::test_shipped_gemini_litellm_overlay_resolves` confirms the shipped example overlay parses and resolves.
- [ ] Empirical: run one matrix cell `gemini-cli × <model> × <task>` with the overlay + a LiteLLM URL + a virtual key. Deferred until a gateway URL is confirmed reachable — the code path is data-only, so no adapter regression risk if the gateway is broken; the operator just gets an HTTP error.

## Related

- PR #1164 (open) — gemini-cli hardenings for the direct-Google path (TRUST_WORKSPACE + settings.json with `selectedType: gemini-api-key`). This PR is complementary: it enables the LiteLLM alternative to the same harness. Both paths coexist in the shipped registry (default direct-Google, opt-in LiteLLM via overlay).
- Design analysis discussed in the internal evaluation-tracking doc.