### PR TITLE
feat(tbench): move _VENDOR_NAMESPACE_PREFIXES + PROVIDER_ENV_KEYS to data/registry_meta.yaml

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/registry_meta.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/registry_meta.yaml
@@ -1,0 +1,49 @@
+# Registry-wide metadata: catalogs that apply across every harness entry
+# rather than being expressible on ``HarnessSpec`` itself.
+#
+# Both fields were Python constants in ``harness/__init__.py`` before Stage 2
+# of the harness detachment plan; they moved to data so a new OpenRouter
+# vendor namespace or an additional provider env-var name ships as a YAML
+# edit against a canonical snapshot regen, rather than a Python edit that
+# forces an adapter release. Read-side contract lives in
+# ``harness.load_registry_meta``.
+
+# OpenRouter ``vendor/`` namespaces that ``harness_model`` drops from the model
+# name for harnesses declaring ``strip_vendor_namespace=True``. A new
+# OpenRouter namespace (e.g., ``mistralai/``) surfaces here as a one-line
+# YAML addition rather than a Python constant edit.
+openrouter_vendor_namespaces:
+  - "anthropic/"
+  - "openai/"
+  - "google/"
+  - "x-ai/"
+  - "meta-llama/"
+  - "moonshotai/"
+  - "qwen/"
+  - "deepseek/"
+
+# Environment variables a harness CLI may be given inside the task container.
+# A closed allow-list: every forwarded value lands in the per-trial compose
+# ``.env`` and then in the container the agent works in, so an open surface
+# would let a run config shadow the task's own environment with arbitrary
+# values.
+#
+# The Google/Gemini split, the OpenRouter/Kimi vendor-specific slots, and the
+# LiteLLM entries (added when PR #1172 widened the surface) all live here so
+# an operator adding a new CLI's native env-var name does so with a YAML edit
+# instead of a Python edit.
+provider_env_keys:
+  - "ANTHROPIC_API_KEY"
+  - "ANTHROPIC_AUTH_TOKEN"
+  - "ANTHROPIC_BASE_URL"
+  - "OPENAI_API_KEY"
+  - "OPENAI_BASE_URL"
+  - "GOOGLE_API_KEY"
+  - "GEMINI_API_KEY"
+  - "GOOGLE_GEMINI_BASE_URL"
+  - "OPENROUTER_API_KEY"
+  - "OPENROUTER_BASE_URL"
+  - "KIMI_MODEL_API_KEY"
+  - "KIMI_MODEL_BASE_URL"
+  - "LITELLM_API_KEY"
+  - "LITELLM_BASE_URL"

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py
@@ -497,56 +497,84 @@ deliberately blank vendor key, and fails with a 401. So a vendor harness gets
 the prefix stripped, while the engine loop keeps it (litellm needs it).
 """
 
-_VENDOR_NAMESPACE_PREFIXES: tuple[str, ...] = (
-    "anthropic/",
-    "openai/",
-    "google/",
-    "x-ai/",
-    "meta-llama/",
-    "moonshotai/",
-    "qwen/",
-    "deepseek/",
+SHIPPED_REGISTRY_META_FILE: Path = (
+    Path(__file__).resolve().parent.parent / "data" / "registry_meta.yaml"
 )
-"""OpenRouter ``vendor/`` namespaces that :func:`harness_model` drops from the
-model name for harnesses declaring ``strip_vendor_namespace=True``. A new
-OpenRouter namespace would surface as the same "metadata not found" warning
-the field's docstring cites."""
+"""Registry-wide catalog file: OpenRouter vendor namespaces + the closed
+allow-list of provider env-var names. Ships as data so a new namespace or
+env-var name is a YAML edit rather than a Python constant edit."""
 
-PROVIDER_ENV_KEYS: frozenset[str] = frozenset(
-    {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-        "GOOGLE_API_KEY",
-        # gemini-cli reads ``GEMINI_API_KEY`` natively (Google's own name for
-        # a Google-AI-Studio key). ``GOOGLE_API_KEY`` was previously the only
-        # Google-shaped key here, but it's the name Vertex uses; gemini-cli
-        # itself insists on ``GEMINI_API_KEY``. Both are here to accept
-        # whichever a run config declares.
-        "GEMINI_API_KEY",
-        # OpenRouter as its own named provider surface — Grok Build reads
-        # ``env_key = "OPENROUTER_API_KEY"`` from its config.toml when
-        # routing via OpenRouter rather than through the OpenAI-compat
-        # slot. Adding the two names doesn't reduce safety (the set
-        # stays a closed allow-list); a harness declaring an unknown
-        # OpenRouter-shaped variable still fails validate_provider_env_keys.
-        "OPENROUTER_API_KEY",
-        "OPENROUTER_BASE_URL",
-        # Kimi Code CLI reads ``KIMI_MODEL_API_KEY`` / ``KIMI_MODEL_BASE_URL``
-        # natively. No pre-existing OpenRouter alias name covers this — the
-        # CLI's own credentials-loader looks up these two names verbatim.
-        "KIMI_MODEL_API_KEY",
-        "KIMI_MODEL_BASE_URL",
-    }
-)
+
+class _RegistryMeta(BaseModel):
+    """Loader-shape for ``data/registry_meta.yaml``.
+
+    Kept private: no caller outside this module needs the model itself,
+    only :data:`_VENDOR_NAMESPACE_PREFIXES` and :data:`PROVIDER_ENV_KEYS`
+    populated from it."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    openrouter_vendor_namespaces: tuple[str, ...]
+    provider_env_keys: frozenset[str]
+
+    @model_validator(mode="after")
+    def _every_entry_is_a_non_blank_string(self) -> "_RegistryMeta":
+        for value in self.openrouter_vendor_namespaces:
+            if not value or value.strip() != value:
+                raise ValueError(
+                    f"registry_meta.yaml: openrouter_vendor_namespaces entry "
+                    f"{value!r} must be a non-blank string without leading/trailing whitespace."
+                )
+        for value in self.provider_env_keys:
+            if not value or value.strip() != value:
+                raise ValueError(
+                    f"registry_meta.yaml: provider_env_keys entry {value!r} "
+                    "must be a non-blank string without leading/trailing whitespace."
+                )
+        if len(self.openrouter_vendor_namespaces) != len(set(self.openrouter_vendor_namespaces)):
+            raise ValueError(
+                "registry_meta.yaml: openrouter_vendor_namespaces contains duplicates."
+            )
+        if not self.openrouter_vendor_namespaces:
+            raise ValueError("registry_meta.yaml: openrouter_vendor_namespaces must not be empty.")
+        if not self.provider_env_keys:
+            raise ValueError("registry_meta.yaml: provider_env_keys must not be empty.")
+        return self
+
+
+def _load_registry_meta(path: Path) -> _RegistryMeta:
+    """Read the registry-meta YAML at *path*, fail loud on missing / malformed input."""
+    if not path.exists():
+        raise FileNotFoundError(
+            f"registry_meta.yaml not found at {path}; the shipped file ships with "
+            "the tbench adapter wheel and its absence is a packaging error."
+        )
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, Mapping):
+        raise ValueError(
+            f"registry_meta.yaml at {path} must be a YAML mapping; got {type(data).__name__}."
+        )
+    try:
+        return _RegistryMeta.model_validate(dict(data))
+    except ValidationError as exc:
+        raise ValueError(f"registry_meta.yaml at {path}: {exc}") from exc
+
+
+_REGISTRY_META = _load_registry_meta(SHIPPED_REGISTRY_META_FILE)
+
+_VENDOR_NAMESPACE_PREFIXES: tuple[str, ...] = _REGISTRY_META.openrouter_vendor_namespaces
+"""OpenRouter ``vendor/`` namespaces that :func:`harness_model` drops from the
+model name for harnesses declaring ``strip_vendor_namespace=True``. Loaded from
+``data/registry_meta.yaml`` at import; adding a namespace is a YAML edit."""
+
+PROVIDER_ENV_KEYS: frozenset[str] = _REGISTRY_META.provider_env_keys
 """Environment variables a harness CLI may be given inside the task container.
 
 An allow-list, not an open surface: every forwarded value lands in the
 per-trial compose ``.env`` and then in the container the agent works in, so an
 open surface would let a run config shadow the task's own environment with
-arbitrary values."""
+arbitrary values. Loaded from ``data/registry_meta.yaml`` at import; adding a
+key is a YAML edit."""
 
 PROVIDER_ENV_INPUT_PREFIX = "TBENCH_PROVIDER_"
 """Prefix for the compose variable that carries a provider value.

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -1137,6 +1137,94 @@ class TestInstallHarnessScript:
         assert recorded == []
 
 
+class TestHarnessRegistryMeta:
+    """``data/registry_meta.yaml`` — registry-wide catalogs (OpenRouter vendor
+    namespaces + provider env-var allow-list) that used to be Python
+    constants. Fail-loud on malformed data; adding a namespace or a key is a
+    YAML edit."""
+
+    def test_shipped_file_populates_the_module_globals(self):
+        from tolokaforge_adapter_terminal_bench.harness import (
+            _VENDOR_NAMESPACE_PREFIXES,
+            PROVIDER_ENV_KEYS,
+            SHIPPED_REGISTRY_META_FILE,
+        )
+
+        assert SHIPPED_REGISTRY_META_FILE.is_file()
+        assert _VENDOR_NAMESPACE_PREFIXES  # non-empty
+        assert PROVIDER_ENV_KEYS  # non-empty
+        # Existing shipped harnesses' provider_env keys all belong to the
+        # allow-list.
+        from tolokaforge_adapter_terminal_bench.harness import HARNESSES
+
+        for spec in HARNESSES.values():
+            for key in spec.provider_env:
+                assert key in PROVIDER_ENV_KEYS, (
+                    f"harness ships provider_env key {key!r} outside PROVIDER_ENV_KEYS — "
+                    "either add the key to registry_meta.yaml or the harness is broken."
+                )
+
+    def test_missing_file_names_the_path(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        with pytest.raises(FileNotFoundError, match="registry_meta.yaml"):
+            _load_registry_meta(tmp_path / "does_not_exist.yaml")
+
+    def test_non_mapping_yaml_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text("- one\n- two\n")  # a list at the top level
+        with pytest.raises(ValueError, match="must be a YAML mapping"):
+            _load_registry_meta(target)
+
+    def test_unknown_top_level_key_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text(
+            "openrouter_vendor_namespaces: [foo/]\n"
+            "provider_env_keys: [A_KEY]\n"
+            "extra_key: hi\n"
+        )
+        with pytest.raises(ValueError):
+            _load_registry_meta(target)
+
+    def test_empty_namespaces_list_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text("openrouter_vendor_namespaces: []\nprovider_env_keys: [A_KEY]\n")
+        with pytest.raises(ValueError, match="openrouter_vendor_namespaces must not be empty"):
+            _load_registry_meta(target)
+
+    def test_empty_env_keys_list_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text("openrouter_vendor_namespaces: [foo/]\nprovider_env_keys: []\n")
+        with pytest.raises(ValueError, match="provider_env_keys must not be empty"):
+            _load_registry_meta(target)
+
+    def test_duplicate_namespace_entry_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text(
+            "openrouter_vendor_namespaces: [foo/, foo/]\nprovider_env_keys: [A_KEY]\n"
+        )
+        with pytest.raises(ValueError, match="duplicates"):
+            _load_registry_meta(target)
+
+    def test_blank_entry_is_refused(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.harness import _load_registry_meta
+
+        target = tmp_path / "registry_meta.yaml"
+        target.write_text('openrouter_vendor_namespaces: ["foo/"]\nprovider_env_keys: [" "]\n')
+        with pytest.raises(ValueError, match="non-blank"):
+            _load_registry_meta(target)
+
+
 class TestHarnessSpecRegistry:
     """The shipped registry is packaged YAML data, loaded at import."""
 


### PR DESCRIPTION
Closes #1176

## Stage 2 of the harness detachment plan

Migrates the two remaining registry-wide catalogs from Python constants to shipped YAML data. Adding an OpenRouter vendor namespace (e.g., `mistralai/`) or an additional provider env-var name becomes a YAML edit rather than a Python constant edit — a Bucket A move per the Stage 1 replay classifier landed in PR #1173.

## What ships

- **`data/registry_meta.yaml`** — new file with two top-level fields:
  - `openrouter_vendor_namespaces` — the 8 prefixes `harness_model` strips when `strip_vendor_namespace=True`
  - `provider_env_keys` — the 14-entry closed allow-list (includes the 3 LiteLLM / Google-Gemini keys PR #1172 adds; see coordination note below)

- Private `_RegistryMeta` Pydantic model + `_load_registry_meta` loader. `extra=\"forbid\"`, `frozen=True`, per-field `@model_validator` fail-loud on empty sequences, blank entries, duplicates, non-mapping YAML top-level.

- `_VENDOR_NAMESPACE_PREFIXES` and `PROVIDER_ENV_KEYS` now populated at import from the loaded meta. Existing callers (`harness_model`, `validate_provider_env_keys`) read them unchanged.

- `SHIPPED_REGISTRY_META_FILE` public constant (same pattern as `SHIPPED_REGISTRY_FILE`) so out-of-tree tooling can reference the file path.

## Behaviour locked

8 new unit tests under `TestHarnessRegistryMeta`:
- shipped file loads and the module globals expose non-empty values; every existing harness's `provider_env` key is in `PROVIDER_ENV_KEYS` (cross-file consistency check)
- fail-loud paths: missing file, non-mapping top-level, unknown top-level key, empty either list, duplicate namespace entry, blank / whitespace-only entry

201/201 unit + canonical tbench tests pass. No canonical snapshot regen — module-level values are unchanged.

## Movement on the Stage 1 metric

Stage 2 is itself a Bucket B commit (touches Python + tests), but every future PR that adds a vendor namespace or a provider env-var name will land as Bucket A (YAML edit + potentially a snapshot regen) instead of Bucket B (Python constant edit). First such PR flips the metric.

## Coordination with PR #1172

The 14-entry `provider_env_keys` list already includes the three keys PR #1172 (`feat/harness-litellm-routing`) added — `LITELLM_API_KEY`, `LITELLM_BASE_URL`, `GOOGLE_GEMINI_BASE_URL`. Whichever PR merges first, the other will need a small conflict resolution:
- If #1172 first: drop the Python-side addition from this PR (data already has the keys).
- If this first: PR #1172 needs to modify the YAML instead of the Python constant.

## Depends on

- PR #1173 (Stage 1 replay metric) — not a hard dep, but the metric will need a `--update-canon` regen the moment this lands.

## Follow-up stages

- Stage 3 — `SkillDelivery` + `PathResolver` protocols (folds in #1163 sub-2 + sub-3)
- Stage 4 — fingerprint on `engine_run_state.json`
- Stage 5 — the cutover to `tolokaforge_harnesses` wheel (folds in #1163 sub-1)
- Stage 6 — partition test + example plugin bundle
