### PR TITLE
docs(testing): reframe harness replay metric as data-vs-code migration progress

### DIFF
--- a/tests/canonical/_harness_registry_replay/git_walk.py
+++ b/tests/canonical/_harness_registry_replay/git_walk.py
@@ -16,8 +16,11 @@ multi-turn docs`` is a harness commit by any reasonable read but has
 no ``harness`` token in the subject). A path-based filter is the only
 one that captures both without an ever-growing subject regex.
 
-Analog of :mod:`tests.canonical._models_wheel_replay.git_walk` for the
-harness surface. Same subprocess primitives, same field separator.
+Same subprocess primitives + field separator as
+:mod:`tests.canonical._models_wheel_replay.git_walk`; the differences
+are the path-based filter (paragraph above) and the return shape
+(harness commits are heterogeneous, so there is no "one integration =
+one model slug" invariant).
 """
 
 from __future__ import annotations
@@ -40,12 +43,12 @@ _LOG_FORMAT = f"%H{_FIELD_SEP}%cs{_FIELD_SEP}%s"
 #
 # Kept deliberately tight so pre-harness commits that touched other bits
 # of the tbench adapter (``adapter.py``, ``task_parser.py``, etc.) do
-# not dilute the metric. The surface is exactly the files a future
-# ``tolokaforge-harnesses`` wheel would carry (data + harness/ + install
-# script), the compose-synthesis file that hosts the skill-delivery
-# logic Stage 3 factors out, the adapter README that documents the
-# harness surface, the two harness-mode canonical snapshot trees, the
-# harness-mode examples, and the two harness ADRs.
+# not dilute the metric. The surface is exactly the harness-touching
+# files: shipped data under ``data/``, the ``harness/`` Python module,
+# the compose-synthesis file that hosts the skill-delivery logic, the
+# adapter README that documents the harness surface, the two
+# harness-mode canonical snapshot trees, the harness-mode examples, and
+# the two harness ADRs.
 HARNESS_SURFACE_PATHS: tuple[str, ...] = (
     "external_adapters/tolokaforge-adapter-terminal-bench/src/"
     "tolokaforge_adapter_terminal_bench/data/",

--- a/tests/canonical/snapshots/harness_registry_replay/metric.json
+++ b/tests/canonical/snapshots/harness_registry_replay/metric.json
@@ -1,6 +1,6 @@
 {
   "bucket_a_count": 1,
-  "bucket_b_count": 6,
+  "bucket_b_count": 7,
   "commits": [
     {
       "adapter_paths": [
@@ -1356,6 +1356,23 @@
         "tolokaforge/runner/compose_naming.py",
         "tolokaforge/runner/models.py",
         "tolokaforge/runner/tool_factory.py"
+      ]
+    },
+    {
+      "adapter_paths": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py",
+        "tests/unit/test_terminal_bench.py"
+      ],
+      "bucket": "B",
+      "date": "2026-08-14",
+      "pr": 1174,
+      "reason": "2 adapter-side path(s) outside Bucket-A allow-list",
+      "sha": "a7e4a60a88e1ce48da97f8d1c35fd09a33ea295f",
+      "subject": "feat(tbench): move _VENDOR_NAMESPACE_PREFIXES + PROVIDER_ENV_KEYS to data/registry_meta.yaml (#1174)",
+      "touched_files": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/registry_meta.yaml",
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/harness/__init__.py",
+        "tests/unit/test_terminal_bench.py"
       ]
     },
     {

--- a/tests/canonical/test_harness_registry_replay.py
+++ b/tests/canonical/test_harness_registry_replay.py
@@ -1,13 +1,11 @@
-"""Acceptance test — fraction of harness-touching commits that would land
-Bucket A under the `tolokaforge-harnesses` split proposed in the harness
-detachment plan (mirrors ADR-0030's models-wheel replay).
+"""Acceptance test — fraction of harness-touching commits that ship as
+pure DATA (Bucket A) vs. CODE (Bucket B).
 
-See the detachment plan at
-``~/.claude/plans/toloka-tolokaforge/harnesses-detachment-2026-08-14.md`` for
-the target this test reports against, and
-:mod:`automation.harness_bucket_classifier` for the Bucket A / Bucket B
-classifier.
-"""
+Measures data-vs-code migration progress on the coding-harness surface.
+The higher the Bucket-A fraction, the more of the surface is expressible
+as YAML edits an operator can make without an adapter release.
+
+See :mod:`automation.harness_bucket_classifier` for the classifier."""
 
 from __future__ import annotations
 

--- a/tools/automation/src/automation/harness_bucket_classifier.py
+++ b/tools/automation/src/automation/harness_bucket_classifier.py
@@ -1,18 +1,18 @@
-"""Bucket A/B classifier for the coding-harness registry taxonomy.
+"""Data-vs-code taxonomy classifier for the coding-harness surface.
 
-Analog of :mod:`automation.bucket_classifier` for coding-harness commits.
-Reads the set of files a commit touched and decides whether the change is
-Bucket A (data / example config / doc content only, would ship without
-requiring a ``tolokaforge-adapter-terminal-bench`` release under the
-`tolokaforge-harnesses` split proposed in the detachment plan) or Bucket B
-(any touched file falls outside the Bucket-A allow-list — Python or shell
+Analog of :mod:`automation.bucket_classifier` for coding-harness
+commits. Reads the set of files a commit touched and decides whether
+the change is Bucket A (data / example config / doc only — the
+extension surface a plugin bundle would exercise) or Bucket B (any
+touched file falls outside the Bucket-A allow-list — Python or shell
 that lives in the adapter or in a test that exercises adapter code).
 
-The primitive is the sole source of truth for the harness bucket split and
-feeds one caller today:
+The primitive measures progress in migrating the harness surface from
+code to data — an ongoing hygiene metric independent of any future
+packaging decision. It feeds one caller today:
 
 - ``tests/canonical/test_harness_registry_replay.py`` — replays every
-  ``^(feat|fix|refactor)(tbench):.*harness`` commit reachable from HEAD and
+  commit reachable from HEAD that touched the harness surface and
   asserts the historical distribution against a canonical snapshot.
 
 Never opens a git repository and never reads any of the files it
@@ -43,8 +43,8 @@ BUCKET_A_ALLOWED_FILES: frozenset[str] = frozenset(
 
 
 BUCKET_A_ALLOWED_PREFIXES: tuple[str, ...] = (
-    # Shipped YAML data (harnesses.yaml today; registry_meta.yaml when
-    # Stage 2 lands; anything else the wheel ships under data/ later).
+    # Shipped YAML data (harnesses.yaml, registry_meta.yaml, and
+    # anything else the adapter ships under data/ later).
     "external_adapters/tolokaforge-adapter-terminal-bench/src/"
     "tolokaforge_adapter_terminal_bench/data/",
     # The two canonical-snapshot trees the harness surface pins. Regenerating

--- a/tools/automation/tests/test_harness_bucket_classifier.py
+++ b/tools/automation/tests/test_harness_bucket_classifier.py
@@ -1,8 +1,8 @@
-"""Unit test for the harness-registry Bucket A/B classifier.
+"""Unit test for the harness-registry data-vs-code classifier.
 
-Locks the path taxonomy independently of any git state — same discipline
-as ``tests/unit/test_models_wheel_replay_classifier.py`` for the
-models-wheel classifier."""
+Locks the path taxonomy (data → Bucket A, code → Bucket B) independently
+of any git state — same discipline as
+``tests/unit/test_models_wheel_replay_classifier.py``."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Small comment/doc-only follow-up on the integration branch. The Stage 1 replay classifier + git-walk + test landed with docstrings framing the metric as "adapter releases avoided under a hypothetical wheel split". That commits to a wheel split we haven't decided to make.

Reframes the metric as it actually functions: **data-vs-code migration progress on the coding-harness surface** — the higher the Bucket-A fraction, the more of the surface is expressible as YAML edits an operator can make without an adapter release.

**Zero behaviour change:**
- Classifier logic unchanged (same allow-list, same taxonomy)
- Test assertions unchanged
- Snapshot regen only reflects the new baseline commit (Stage 2's registry_meta.yaml merge as a9c9f7f0)

18/18 replay + classifier tests pass. Post-reframe baseline: 8 harness-touching commits, 1 Bucket A, 7 Bucket B.

Part of the adjusted scope for milestone #31 (Harness surface hygiene). Wheel-committing Stages 5 + 6 (issues #1179, #1180) were closed as deferred.