### PR TITLE
feat(grader): serialisable TrialGraderContext + owned RunnerRPCTrialGrader client

### DIFF
--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -94,8 +94,21 @@ def test_runtime_backend_names_resolve_to_their_class(name: str, expected_cls: t
 
 
 def test_trial_grader_name_resolves_to_its_class() -> None:
-    ctx = TrialGraderContext(runtime_backend=MagicMock(), logger=MagicMock())
-    grader = load_trial_grader("runner_rpc")(ctx)
+    import tolokaforge.core.shared_stack_runtime as ssr
+
+    # The built-in ``runner_rpc`` factory constructs a ``GrpcRunnerClient``
+    # from ``ctx.runner_address``; stub the client to avoid a real socket.
+    class _StubClient:
+        def __init__(self, runner_address: str) -> None:
+            self.runner_address = runner_address
+
+    original = ssr.GrpcRunnerClient
+    ssr.GrpcRunnerClient = _StubClient  # type: ignore[misc,assignment]
+    try:
+        ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock())
+        grader = load_trial_grader("runner_rpc")(ctx)
+    finally:
+        ssr.GrpcRunnerClient = original  # type: ignore[misc]
     assert isinstance(grader, RunnerRPCTrialGrader)
 
 

--- a/tests/canonical/test_termination_reason_reachability.py
+++ b/tests/canonical/test_termination_reason_reachability.py
@@ -245,7 +245,9 @@ def test_only_reasons_from_a_completed_trial_reach_grade_trial(
     observed_outcomes: frozenset[tuple[TrialStatus, TerminationReason]],
 ) -> None:
     backend = _RecordingBackend()
-    grader = RunnerRPCTrialGrader(runtime_backend=backend, logger=MagicMock())
+    grader = RunnerRPCTrialGrader(
+        runner_address="stub:0", logger=MagicMock(), runner_client=backend
+    )
 
     for status, reason in sorted(observed_outcomes, key=lambda pair: pair[1].value):
         grader.grade(
@@ -315,7 +317,9 @@ def test_no_grade_is_produced_for_an_aborted_trial(
 ) -> None:
     """Which observed reasons answer with no grade at all, asserted against the
     named set rather than against the classifier that decides it."""
-    grader = RunnerRPCTrialGrader(runtime_backend=_RecordingBackend(), logger=MagicMock())
+    grader = RunnerRPCTrialGrader(
+        runner_address="stub:0", logger=MagicMock(), runner_client=_RecordingBackend()
+    )
 
     ungraded = {
         reason

--- a/tests/canonical/test_trial_grader_context_hygiene.py
+++ b/tests/canonical/test_trial_grader_context_hygiene.py
@@ -1,0 +1,99 @@
+"""``TrialGraderContext`` carries serialisable configuration only.
+
+The grader plug-in seam (``tolokaforge.trial_graders`` entry-point group) exists
+so a grader can run on a different machine from the orchestrator. A live
+``RuntimeBackend`` instance in the context — a gRPC channel bound to a specific
+runner — would defeat that: the grader receives an object it cannot use from a
+different address space. This test pins the shape at the type level so a future
+PR cannot regress the seam.
+
+See ADR-0035 (grader detachment) for the wider design record.
+"""
+
+from __future__ import annotations
+
+import typing
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.plugin_registry import TrialGraderContext
+from tolokaforge.core.runtime import RuntimeBackend
+from tolokaforge.core.trial_grader import RunnerRPCTrialGrader, runner_rpc_trial_grader_factory
+
+pytestmark = pytest.mark.canonical
+
+
+def _resolved_types() -> dict[str, object]:
+    """Return ``TrialGraderContext``'s field types with forward refs resolved.
+
+    ``StructuredLogger`` is imported under ``TYPE_CHECKING`` in the plug-in
+    registry to avoid a runtime cycle; feed it in via ``localns`` so the
+    hint resolves without pulling every logger-side dependency at import time.
+    """
+    return typing.get_type_hints(TrialGraderContext, localns={"StructuredLogger": StructuredLogger})
+
+
+class TestTrialGraderContextShape:
+    """The context carries a serialisable ``runner_address`` and a logger — nothing else."""
+
+    def test_no_field_typed_as_runtime_backend(self) -> None:
+        """A live runtime-backend instance in the context couples the grader to
+        the orchestrator's channel; the seam breaks when the grader runs
+        elsewhere. Regressing this field's type is a compat-level bug — it
+        forces a future PR to re-thread a live object through downstream
+        registered graders."""
+        types_by_name = _resolved_types()
+        for field in fields(TrialGraderContext):
+            resolved = types_by_name[field.name]
+            assert resolved is not RuntimeBackend, (
+                f"TrialGraderContext.{field.name} resolves to RuntimeBackend; "
+                "grader context must not carry live runtime-backend instances."
+            )
+
+    def test_runner_address_is_a_string(self) -> None:
+        """The address must be serialisable — a plain ``str``, not a wrapper
+        object with a runtime binding."""
+        types_by_name = _resolved_types()
+        assert types_by_name["runner_address"] is str
+
+    def test_construction_with_unknown_kwarg_fails_loud(self) -> None:
+        """Frozen dataclass — a stray ``runtime_backend=`` from stale code
+        raises ``TypeError`` at construction rather than being ignored."""
+        with pytest.raises(TypeError):
+            TrialGraderContext(  # type: ignore[call-arg]
+                runner_address="stub:0",
+                logger=MagicMock(),
+                runtime_backend=object(),
+            )
+
+
+class TestRunnerRpcTrialGraderFactory:
+    """The built-in factory builds a grader that owns its own runner client — no
+    channel reuse from the orchestrator."""
+
+    def test_factory_returns_grader_with_owned_runner_client(self) -> None:
+        """``runner_rpc_trial_grader_factory(ctx)`` must return a
+        :class:`RunnerRPCTrialGrader` whose ``runner_client`` was built from
+        the context's ``runner_address`` — a fresh client per grader."""
+
+        class _StubClient:
+            def __init__(self, runner_address: str) -> None:
+                self.runner_address = runner_address
+
+        import tolokaforge.core.shared_stack_runtime as ssr
+
+        original = ssr.GrpcRunnerClient
+        ssr.GrpcRunnerClient = _StubClient  # type: ignore[misc,assignment]
+        try:
+            ctx = TrialGraderContext(runner_address="test-runner:9999", logger=MagicMock())
+            grader = runner_rpc_trial_grader_factory(ctx)
+        finally:
+            ssr.GrpcRunnerClient = original  # type: ignore[misc]
+
+        assert isinstance(grader, RunnerRPCTrialGrader)
+        assert grader.runner_address == "test-runner:9999"
+        assert isinstance(grader.runner_client, _StubClient)
+        assert grader.runner_client.runner_address == "test-runner:9999"

--- a/tests/canonical/test_trial_grader_contract.py
+++ b/tests/canonical/test_trial_grader_contract.py
@@ -21,8 +21,8 @@ from tolokaforge.core.trial_grader import RunnerRPCTrialGrader, TrialGrader
 pytestmark = pytest.mark.canonical
 
 
-class _StubRuntimeBackendForGrading:
-    """Minimal runtime-backend stand-in that satisfies the ``grade_trial``
+class _StubRunnerClientForGrading:
+    """Minimal ``GrpcRunnerClient`` stand-in that satisfies the ``grade_trial``
     surface the grader actually calls."""
 
     def grade_trial(self, trial_id: str, **_kwargs: object) -> dict[str, object]:
@@ -39,8 +39,9 @@ class _StubRuntimeBackendForGrading:
 
 def _make_grader() -> RunnerRPCTrialGrader:
     return RunnerRPCTrialGrader(
-        runtime_backend=_StubRuntimeBackendForGrading(),
+        runner_address="stub:0",
         logger=MagicMock(),
+        runner_client=_StubRunnerClientForGrading(),
     )
 
 

--- a/tests/integration/test_plugin_discovery.py
+++ b/tests/integration/test_plugin_discovery.py
@@ -58,7 +58,7 @@ assert "fixture_grader" in grader_names, f"fixture_grader not discovered: {sorte
 
 grader_factory = load_trial_grader("fixture_grader")
 assert grader_factory.__name__ == "fixture_grader_factory", grader_factory
-grader = grader_factory(TrialGraderContext(runtime_backend=backend, logger=StructuredLogger("probe")))
+grader = grader_factory(TrialGraderContext(runner_address="probe:0", logger=StructuredLogger("probe")))
 assert type(grader).__name__ == "FixtureGrader", type(grader).__name__
 
 conductor_names = [ep.name for ep in im.entry_points(group="tolokaforge.conductors")]

--- a/tests/unit/test_runner_pipeline.py
+++ b/tests/unit/test_runner_pipeline.py
@@ -940,8 +940,9 @@ class TestDuplicateCallIdPublishesNoScore:
         self, runner_service, mock_grpc_context, collided_trial
     ):
         grader = RunnerRPCTrialGrader(
-            runtime_backend=ServicerBackend(runner_service, mock_grpc_context),
+            runner_address="in-process-servicer:0",
             logger=MagicMock(),
+            runner_client=ServicerBackend(runner_service, mock_grpc_context),
         )
         trajectory = collided_trajectory(task_id="task-1")
 

--- a/tests/unit/test_trial_grader.py
+++ b/tests/unit/test_trial_grader.py
@@ -60,7 +60,11 @@ class _StubBackend:
 
 def _make_grader(backend: _StubBackend | None = None) -> tuple[RunnerRPCTrialGrader, MagicMock]:
     logger = MagicMock()
-    grader = RunnerRPCTrialGrader(runtime_backend=backend or _StubBackend(), logger=logger)
+    grader = RunnerRPCTrialGrader(
+        runner_address="stub:0",
+        logger=logger,
+        runner_client=backend or _StubBackend(),
+    )
     return grader, logger
 
 

--- a/tests/unit/test_ungradeable_trial_accounting.py
+++ b/tests/unit/test_ungradeable_trial_accounting.py
@@ -150,8 +150,9 @@ def refusing_grader(runner_service, mock_grpc_context, collided_task_id: str):
         trial_id=f"{collided_task_id}:0",
     )
     return RunnerRPCTrialGrader(
-        runtime_backend=ServicerBackend(runner_service, mock_grpc_context),
+        runner_address="in-process-servicer:0",
         logger=StructuredLogger("test-ungradeable-grader"),
+        runner_client=ServicerBackend(runner_service, mock_grpc_context),
     )
 
 

--- a/tests/utils/servicer_runtime.py
+++ b/tests/utils/servicer_runtime.py
@@ -121,8 +121,9 @@ def produce_grading_refusal(service: Any, context: Any) -> str:
     trial_id = f"{task_id}:0"
     register_collided_trial(service, context, simple_task_description(), trial_id=trial_id)
     grader = RunnerRPCTrialGrader(
-        runtime_backend=ServicerBackend(service, context),
+        runner_address="in-process-servicer:0",
         logger=StructuredLogger("test-grading-refusal"),
+        runner_client=ServicerBackend(service, context),
     )
     try:
         grader.grade(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -696,7 +696,10 @@ class Orchestrator:
                 "Ensure load_tasks() has run successfully."
             )
         trial_grader = load_trial_grader(self.adapter.trial_grader_name)(
-            TrialGraderContext(runtime_backend=runtime_backend, logger=self.logger)
+            TrialGraderContext(
+                runner_address=getattr(runtime_backend, "runner_address", ""),
+                logger=self.logger,
+            )
         )
 
         ctx = ConductorContext(

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -171,9 +171,22 @@ class RuntimeBackendBuildContext:
 
 @dataclass(frozen=True)
 class TrialGraderContext:
-    """Dependencies a trial-grader factory receives from the orchestrator."""
+    """Serialisable configuration a trial-grader factory receives from the orchestrator.
 
-    runtime_backend: RuntimeBackend
+    Carries only data, not live objects: a ``runner_address`` (or, for future
+    transports registered under :data:`TRIAL_GRADERS_GROUP`, an equivalent
+    endpoint descriptor) plus the run-scoped logger. A live gRPC channel would
+    couple the grader to the orchestrator's chosen runner instance and block a
+    grader that runs on a different machine — precisely what the plug-in seam
+    exists to unblock (see ADR-0035).
+
+    :attr:`runner_address` is the target gRPC address that the built-in
+    ``runner_rpc`` grader dials against; downstream grader factories that need a
+    different endpoint (a remote grader service, a queue broker) may build their
+    own transport from this same field or ignore it.
+    """
+
+    runner_address: str
     logger: StructuredLogger
 
 

--- a/tolokaforge/core/run_trial.py
+++ b/tolokaforge/core/run_trial.py
@@ -154,7 +154,7 @@ def run_trial(
         )
     )
     trial_grader = load_trial_grader(grader)(
-        TrialGraderContext(runtime_backend=runtime_backend, logger=logger)
+        TrialGraderContext(runner_address=runner_address, logger=logger)
     )
 
     agent_client = LLMClient(resolved_models.agent, rate_limit_probe=rate_limit_probe)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -57,12 +57,12 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
 )
-from tolokaforge.core.runtime import RuntimeBackend
 from tolokaforge.core.trial import TrialSpec
 
 if TYPE_CHECKING:
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.plugin_registry import TrialGraderContext
+    from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
 
 __all__ = [
     "GradingFailedError",
@@ -137,14 +137,32 @@ class RunnerRPCTrialGrader:
     ran, and raises :class:`GradingFailedError` when the RPC could not
     produce a verdict.
 
-    Instantiated per-run with a bound ``runtime_backend`` and the
-    per-run :class:`StructuredLogger`. The orchestrator constructs one
-    and injects it into every conductor.
+    Built per-run from a :class:`TrialGraderContext` — a *serialisable*
+    configuration (``runner_address`` + logger). The grader owns its own
+    :class:`~tolokaforge.core.shared_stack_runtime.GrpcRunnerClient` bound
+    to that address, so it stays independent of the orchestrator's runtime
+    backend — the seam that lets a future grader run on a different machine.
+
+    Tests may pass a ``runner_client`` directly to bypass real gRPC; the
+    stub must expose a ``grade_trial(trial_id, llm_messages_json, ...)``
+    method returning the same dict shape as
+    :meth:`GrpcRunnerClient.grade_trial`.
     """
 
-    def __init__(self, runtime_backend: RuntimeBackend, logger: StructuredLogger) -> None:
-        self.runtime_backend = runtime_backend
+    def __init__(
+        self,
+        runner_address: str,
+        logger: StructuredLogger,
+        *,
+        runner_client: GrpcRunnerClient | None = None,
+    ) -> None:
+        self.runner_address = runner_address
         self.logger = logger
+        if runner_client is None:
+            from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient as _Client
+
+            runner_client = _Client(runner_address=runner_address)
+        self.runner_client = runner_client
 
     def grade(
         self,
@@ -195,7 +213,7 @@ class RunnerRPCTrialGrader:
             )
 
         llm_messages_json = encode_transcript_wire(trajectory, agent_system_prompt)
-        grade_result = self.runtime_backend.grade_trial(
+        grade_result = self.runner_client.grade_trial(
             trial_id=spec.trial_id,
             llm_messages_json=llm_messages_json,
             termination_reason=(
@@ -388,4 +406,4 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
     """Build a :class:`RunnerRPCTrialGrader` from a grader context."""
-    return RunnerRPCTrialGrader(runtime_backend=ctx.runtime_backend, logger=ctx.logger)
+    return RunnerRPCTrialGrader(runner_address=ctx.runner_address, logger=ctx.logger)


### PR DESCRIPTION
## Summary

- `TrialGraderContext` now carries **serialisable configuration only** — `runner_address: str` and the run-scoped logger. The live `runtime_backend` object is out.
- `RunnerRPCTrialGrader` builds its own `GrpcRunnerClient` bound to that address at construction, so its transport is independent of the orchestrator's runtime backend.
- Call sites (`Orchestrator._build_conductor`, `run_trial.run_trial`) pass the runner address extracted from the runtime backend / env.

Necessary to unblock the transport-split (#1184) and the queue-backed variant (#1185) — a grader running on a different machine cannot use a live gRPC channel bound to the orchestrator's chosen runner instance. Per ADR-0035 § Design Drivers.

## Design choices

- **Runner address as `str`, not a wrapper dataclass.** `GrpcRunnerClient` already accepts a plain address; a wrapper only delays the same normalisation and adds an import surface to the plug-in group.
- **Eager client construction in `__init__`.** A bad address surfaces at run start, before any trial dispatches — deferring to first `grade()` call would be a mid-run surprise.
- **Test injection via `runner_client=` kwarg.** In-process stubs skip real gRPC without special-casing the address string. Existing tests keep their servicer/backend stubs; only the constructor kwarg name changes.
- **No deprecation cycle needed on `TrialGraderContext`.** The seam is internal — no external code constructs the context directly.

## Concepts introduced

The grader plug-in's *construction context* joins the model TrialGrader's plug-in seam holds: a piece of the pattern that has always been about types the seam accepts but never about types the seam *rejects*. `TrialGraderContext` explicitly rejecting live objects is the seam's first negative-space contract — pinned by a canonical hygiene test.

## Plan

The full staged plan (goal, non-goals, approved decisions, stages, compatibility surfaces) lives at `~/.claude/plans/toloka-tolokaforge/issue-1183-context-hygiene.md` — a scratch file outside the repo; the durable record is this PR body.

## Discovered issues

- Filed: none.
- Fixed in this PR: baseline `Grade` JSON capture, originally listed on the ticket, is deliberately **deferred** to a follow-up. It is a task-pack + budget concern (real LLM calls against internal packs), not a construction-context concern. Splitting it out keeps this PR hygiene-only. Follow-up ticket to be filed at consolidation time.

## Test plan

- [x] `tests/canonical/test_trial_grader_contract.py` — existing Protocol contract passes unchanged
- [x] `tests/canonical/test_trial_grader_context_hygiene.py` — **new**; asserts (a) no `RuntimeBackend`-typed field, (b) `runner_address` is `str`, (c) stray kwarg fails loud, (d) factory-built grader owns its client
- [x] `tests/canonical/test_orchestrator_grader_name_e2e.py` — passes unchanged
- [x] `tests/unit/test_trial_grader.py` — 46 branches green with the new stub-injection shape
- [x] `tests/unit/test_runner_pipeline.py`, `test_ungradeable_trial_accounting.py`, `test_termination_reason_reachability.py` — all pass
- [x] `ruff check` + `ruff format --check` clean

Closes #1183