### PR TITLE
feat(grader): register JudgeBackedTrialGrader under judge_only entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ in_memory = "tolokaforge.core.runtime:in_memory_runtime_backend_factory"
 
 [project.entry-points."tolokaforge.trial_graders"]
 runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
+# Second impl proves the plug-in seam accepts fundamentally different grader
+# shapes (not just runner-RPC-with-different-transport). Ships with an unwired
+# default judge dispatch — see JudgeBackedTrialGrader docstring and ADR-0035.
+judge_only = "tolokaforge.core.trial_grader:judge_backed_trial_grader_factory"
 
 [project.entry-points."tolokaforge.conductors"]
 in_process = "tolokaforge.core.conductor:in_process_conductor_factory"

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -148,7 +148,7 @@ def test_turn_policy_names_resolve_to_their_class() -> None:
 
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
-    assert available_trial_graders() == ["runner_rpc"]
+    assert available_trial_graders() == ["judge_only", "runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
     assert available_turn_policies() == ["agent_only", "conversational"]

--- a/tests/canonical/test_judge_backed_trial_grader.py
+++ b/tests/canonical/test_judge_backed_trial_grader.py
@@ -1,0 +1,133 @@
+"""``JudgeBackedTrialGrader`` — the plug-in seam's second registered impl.
+
+The seam accepts more than the runner-RPC shape: a grader can also dispatch
+to an injected judge callable directly, no runner state / transcript /
+custom-check machinery. This test locks that shape and pins the entry-point
+registration so a downstream grader can rely on the same discovery path as
+``runner_rpc``.
+
+See ADR-0035 § Design Drivers (Decision 5 — a second impl proves the seam).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_trajectory, make_trial_spec
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    TerminationReason,
+    TrialStatus,
+)
+from tolokaforge.core.plugin_registry import TrialGraderContext, load_trial_grader
+from tolokaforge.core.trial_grader import (
+    JudgeBackedTrialGrader,
+    TrialGrader,
+    judge_backed_trial_grader_factory,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _make_grader(
+    judge_return: Grade | None = None,
+) -> tuple[JudgeBackedTrialGrader, MagicMock]:
+    """Build a grader whose judge dispatch returns ``judge_return`` unconditionally."""
+    judge_fn = MagicMock(return_value=judge_return)
+    grader = JudgeBackedTrialGrader(judge_fn=judge_fn, logger=MagicMock())
+    return grader, judge_fn
+
+
+class TestProtocolContract:
+    def test_satisfies_trial_grader_protocol(self) -> None:
+        grader, _ = _make_grader()
+        assert isinstance(grader, TrialGrader)
+
+
+class TestSuccessPath:
+    def test_grade_delegates_to_judge_fn_and_returns_its_verdict(self) -> None:
+        expected = Grade(
+            binary_pass=True,
+            score=0.87,
+            components=GradeComponents(llm_judge=0.87),
+            reasons="rubric met",
+        )
+        grader, judge_fn = _make_grader(judge_return=expected)
+        spec = make_trial_spec()
+        trajectory = make_trajectory(status=TrialStatus.COMPLETED)
+
+        result = grader.grade(spec, trajectory, "you are the agent")
+
+        judge_fn.assert_called_once_with(spec, trajectory, "you are the agent")
+        assert result is expected
+
+    def test_none_from_judge_is_propagated(self) -> None:
+        grader, _ = _make_grader(judge_return=None)
+        result = grader.grade(
+            make_trial_spec(), make_trajectory(status=TrialStatus.COMPLETED), "sys"
+        )
+        assert result is None
+
+
+class TestAutoFailBranches:
+    """Matches ``RunnerRPCTrialGrader``: error / timeout / stuck short-circuit to
+    an auto-fail :class:`Grade` before the judge is invoked."""
+
+    def test_error_status_short_circuits_without_calling_judge(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(make_trial_spec(), make_trajectory(status=TrialStatus.ERROR), "sys")
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        assert result.score == 0.0
+        judge_fn.assert_not_called()
+
+    def test_timeout_status_short_circuits(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(make_trial_spec(), make_trajectory(status=TrialStatus.TIMEOUT), "sys")
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        judge_fn.assert_not_called()
+
+    def test_stuck_termination_short_circuits(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(
+            make_trial_spec(),
+            make_trajectory(
+                status=TrialStatus.COMPLETED,
+                termination_reason=TerminationReason.STUCK_DETECTED,
+            ),
+            "sys",
+        )
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        judge_fn.assert_not_called()
+
+
+class TestFactoryAndRegistration:
+    def test_factory_builds_grader_from_context(self) -> None:
+        ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+        grader = judge_backed_trial_grader_factory(ctx)
+        assert isinstance(grader, JudgeBackedTrialGrader)
+
+    def test_registered_under_judge_only_entry_point(self) -> None:
+        """The plug-in registry resolves ``judge_only`` to the factory —
+        proving the second impl ships as a first-class seam consumer."""
+        factory = load_trial_grader("judge_only")
+        assert factory is judge_backed_trial_grader_factory
+
+    def test_default_judge_dispatch_raises_until_wired(self) -> None:
+        """The factory's default dispatch is unwired; invoking it raises
+        NotImplementedError with a clear pointer to the follow-up. This is
+        the guard against silent zero-scores while the production wiring
+        (offline replay, LLMJudge integration) is deferred."""
+        ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+        grader = judge_backed_trial_grader_factory(ctx)
+        with pytest.raises(NotImplementedError, match="not yet wired"):
+            grader.grade(
+                make_trial_spec(),
+                make_trajectory(status=TrialStatus.COMPLETED),
+                "sys",
+            )

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -35,6 +35,7 @@ remote grader service, or route to an entirely different Judge component
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import ValidationError
@@ -66,8 +67,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GradingFailedError",
+    "JudgeBackedTrialGrader",
+    "JudgeGradeFn",
     "RunnerRPCTrialGrader",
     "TrialGrader",
+    "judge_backed_trial_grader_factory",
 ]
 
 
@@ -407,3 +411,135 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
     """Build a :class:`RunnerRPCTrialGrader` from a grader context."""
     return RunnerRPCTrialGrader(runner_address=ctx.runner_address, logger=ctx.logger)
+
+
+JudgeGradeFn = Callable[[TrialSpec, Trajectory, str], "Grade | None"]
+"""The judge-backed grader's dispatch surface: given the trial's spec, its
+completed trajectory, and the agent's system prompt, return the :class:`Grade`
+the judge produced (or ``None`` when the trial produced nothing to grade).
+
+Kept as a plain ``Callable`` alias so the seam accepts any host-side wiring
+that reaches a judge: the offline replay path (``dx.cli.rejudge``), a
+JudgeBackedTrialGrader wrapping :class:`~tolokaforge.core.grading.judge.LLMJudge`
+directly, or a downstream package's judge integration.
+"""
+
+
+class JudgeBackedTrialGrader:
+    """:class:`TrialGrader` that invokes an injected judge callable directly,
+    without the runner's state / transcript / custom-check machinery.
+
+    The seam's second registered implementation (see ADR-0035, Decision 5):
+    a grader that dispatches to a judge rather than a runner-side RPC. Ships
+    as the plug-in shape for judge-only tasks (rubric-only fixtures, offline
+    replay); production integration with :class:`LLMJudge` is deferred as a
+    follow-up (see the milestone umbrella #1181).
+
+    The Protocol contract is unchanged: :meth:`grade` returns a :class:`Grade`,
+    or ``None`` when the trial produced nothing to grade. Auto-fail on
+    error / timeout / stuck-detected matches :class:`RunnerRPCTrialGrader` so
+    both implementations are drop-in swaps for the caller.
+    """
+
+    def __init__(self, judge_fn: JudgeGradeFn, logger: StructuredLogger) -> None:
+        self.judge_fn = judge_fn
+        self.logger = logger
+
+    def grade(
+        self,
+        spec: TrialSpec,
+        trajectory: Trajectory,
+        agent_system_prompt: str,
+    ) -> Grade | None:
+        task_id, trial_idx = _split_trial_id(spec.trial_id)
+
+        if classify_trial_outcome(trajectory) is TrialOutcomeClass.INFRASTRUCTURE_ABORT:
+            self.logger.info(
+                "Trial aborted by infrastructure - not graded",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
+                termination_reason=(
+                    trajectory.termination_reason.value if trajectory.termination_reason else None
+                ),
+            )
+            return None
+
+        if trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT):
+            self.logger.info(
+                "Trial did not complete successfully - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(llm_judge=0.0),
+                reasons=f"Trial failed with status: {trajectory.status.value}",
+            )
+
+        if trajectory.termination_reason == TerminationReason.STUCK_DETECTED:
+            self.logger.info(
+                "Trial stuck - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(llm_judge=0.0),
+                reasons="Agent got stuck (repeated actions without progress)",
+            )
+
+        grade = self.judge_fn(spec, trajectory, agent_system_prompt)
+        if grade is None:
+            self.logger.info(
+                "Judge returned no verdict",
+                task_id=task_id,
+                trial_index=trial_idx,
+            )
+        else:
+            self.logger.info(
+                "Grading via judge callable",
+                task_id=task_id,
+                trial_index=trial_idx,
+                score=grade.score,
+                binary_pass=grade.binary_pass,
+            )
+        return grade
+
+
+def _unwired_judge_fn(
+    spec: TrialSpec,  # noqa: ARG001 — Protocol arg accepted at the seam
+    trajectory: Trajectory,  # noqa: ARG001
+    agent_system_prompt: str,  # noqa: ARG001
+) -> Grade | None:
+    """Default judge dispatch for the ``judge_only`` entry point.
+
+    The factory has no way to receive a real judge instance through the current
+    ``TrialGraderContext`` — production wiring (offline-replay integration,
+    live :class:`~tolokaforge.core.grading.judge.LLMJudge` construction from
+    per-task rubric config) is deferred as a follow-up on the umbrella. Until
+    that ships, invoking the grader raises loud rather than degrading to a
+    silent zero score.
+    """
+    raise NotImplementedError(
+        "judge_only trial grader is registered but not yet wired to a production "
+        "judge. Inject a JudgeGradeFn callable via JudgeBackedTrialGrader(...) "
+        "directly, or wait for the follow-up that folds offline rejudge onto this "
+        "seam. See ADR-0035 and the grader-detachment umbrella."
+    )
+
+
+def judge_backed_trial_grader_factory(ctx: TrialGraderContext) -> JudgeBackedTrialGrader:
+    """Build a :class:`JudgeBackedTrialGrader` from a grader context.
+
+    The default judge dispatch raises :class:`NotImplementedError` until a
+    production judge is wired through the context (see the follow-up on the
+    grader-detachment umbrella). The class is directly constructible with a
+    real :data:`JudgeGradeFn` for tests and for the future offline-replay
+    integration.
+    """
+    return JudgeBackedTrialGrader(judge_fn=_unwired_judge_fn, logger=ctx.logger)


### PR DESCRIPTION
## Summary

Second registered impl for the \`TrialGrader\` plug-in seam. \`JudgeBackedTrialGrader\` dispatches to an injected judge callable — no runner state, no transcript rules, no custom checks — and mirrors \`RunnerRPCTrialGrader\`'s auto-fail branches so both are drop-in swaps for the caller.

Registered as \`tolokaforge.trial_graders / judge_only\` so downstream code can select it by name.

Stacked on #1197 (needs the P1 context refactor).

## Design choices

- **Judge dispatch as an injected \`Callable\`, not a Protocol object.** Kept as a \`JudgeGradeFn\` type alias (\`Callable[[TrialSpec, Trajectory, str], Grade | None]\`) so the seam accepts any host-side wiring — offline replay, an \`LLMJudge\`-backed adapter, a downstream judge integration — without a Protocol import cycle across the grading package.
- **Ships with an unwired default that raises.** The factory's default \`judge_fn\` raises \`NotImplementedError\` with a clear pointer to the follow-up. Silent zero-scores would be worse than an obvious failure while the production wiring lands.
- **Auto-fail branches identical to \`RunnerRPCTrialGrader\`.** Same three short-circuits (infrastructure abort → None; error/timeout → auto-fail; stuck-detected → auto-fail) so a downstream conductor that swaps graders sees no behaviour change on the pre-judge paths.

## Concepts introduced

- The plug-in seam's second shape: a grader that dispatches to a host-side judge instead of a runner-side RPC. Together with \`runner_rpc\`, the two registrations demonstrate that \`TrialGrader\` accepts fundamentally different dispatch models, not just runner-RPC-with-a-different-address.

## Deferred to follow-up (on the umbrella #1181)

- Wire \`LLMJudge\` (\`tolokaforge.core.grading.judge\`) as the default \`judge_fn\` — needs per-task rubric config threaded through the trial spec or context.
- Fold \`tolokaforge rejudge\` (\`dx/cli/main.py\`) onto this seam so the current three grader call paths (production, tests, rejudge) collapse to one.

## Test plan

- [x] Protocol contract: \`isinstance(grader, TrialGrader)\`
- [x] Delegation to \`judge_fn\` on the success path (spec/trajectory/prompt threaded verbatim)
- [x] Auto-fail branches (error / timeout / stuck) short-circuit before the judge is invoked
- [x] Factory builds from context; \`load_trial_grader(\"judge_only\")\` resolves to the factory
- [x] Default judge dispatch raises \`NotImplementedError\` with a clear pointer to the follow-up

Closes #1188