### PR TITLE
docs(grader): describe the TrialGrader plug-in seam and the two built-ins

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -1,0 +1,161 @@
+# Grader Plug-in Seam
+
+The tolokaforge grader — the piece that turns a completed trial into a
+`Grade` — is a plug-in seam. Downstream code selects a grader by name,
+and the seam accepts fundamentally different dispatch shapes: a
+runner-side gRPC that computes deterministic state / transcript checks
+plus an LLM judge, or a host-side judge callable that runs the rubric
+directly with no runner state at all.
+
+This document describes the seam as it stands after the *grader detachment*
+milestone, points at the two registered built-ins, and shows how a
+downstream package can register its own grader without touching engine
+code. For the design record — the decisions behind the seam and the
+work still ahead — see [ADR-0035](adr/0035-grader-detachment.md).
+
+## The seam
+
+`tolokaforge.core.trial_grader.TrialGrader` is a `@runtime_checkable`
+Protocol with one method:
+
+```python
+def grade(
+    self,
+    spec: TrialSpec,
+    trajectory: Trajectory,
+    agent_system_prompt: str,
+) -> Grade | None: ...
+```
+
+- Returns `Grade` on a completed trial the grader could measure.
+- Returns `None` on a trial the agent never got to run
+  (infrastructure abort — no measurement to score).
+- Raises `GradingFailedError` when the trial *was* measured but the
+  grading substrate could not produce a verdict.
+
+The conductor holds a `TrialGrader` and delegates the grading phase to
+it. Callers do not need to know which implementation is behind the
+Protocol.
+
+## Selecting a grader
+
+Per-task configuration names the grader by its plug-in name:
+
+```yaml
+# task.yaml (excerpt)
+grader: runner_rpc         # the default — grades on the runner
+# or
+grader: judge_only          # rubric-only judge dispatch, no runner state
+```
+
+The name resolves through the `tolokaforge.trial_graders` entry-point
+registry (backed by `importlib.metadata`), so a downstream package that
+registers a grader name becomes selectable via the same field.
+
+## Built-in graders
+
+Two implementations ship with tolokaforge today.
+
+### `runner_rpc` — `RunnerRPCTrialGrader`
+
+The production grader. Owns a `GrpcRunnerClient` bound to the runner's
+address (`runner_address` on `TrialGraderContext`), calls
+`GradeTrial` on the runner service, and translates the returned proto
+into a `Grade`. Short-circuits with an auto-fail on
+`TrialStatus.ERROR` / `TrialStatus.TIMEOUT` /
+`TerminationReason.STUCK_DETECTED` before the RPC is dialled.
+
+Registered as:
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
+```
+
+### `judge_only` — `JudgeBackedTrialGrader`
+
+A second impl whose dispatch shape is fundamentally different: instead of
+a runner-side RPC that runs the deterministic state / transcript /
+custom-check pipeline plus the LLM judge, `JudgeBackedTrialGrader`
+invokes an injected judge callable directly. Auto-fail branches match
+`RunnerRPCTrialGrader` so both are drop-in swaps for the caller.
+
+Registered as:
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+judge_only = "tolokaforge.core.trial_grader:judge_backed_trial_grader_factory"
+```
+
+The default factory dispatch is unwired (raises `NotImplementedError`
+with a clear pointer to the follow-up) — until a production
+`LLMJudge`-backed dispatch lands on the umbrella, `judge_only` is
+useful primarily to prove that the seam accepts more than one shape,
+and to be constructed directly by tests that inject their own
+`JudgeGradeFn`.
+
+## Registering a downstream grader
+
+A downstream `pip install` adds a new grader by:
+
+1. Implementing the Protocol (any object with the right `grade` method
+   satisfies `isinstance(obj, TrialGrader)`).
+2. Providing a factory `Callable[[TrialGraderContext], TrialGrader]`.
+3. Declaring the entry point in the downstream package's
+   `pyproject.toml`:
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+my_grader = "my_package.my_module:my_grader_factory"
+```
+
+The engine discovers the entry point on next install and makes
+`grader: my_grader` a valid task-config choice. No engine-side change
+required. See [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) for the
+broader fail-loud registry pattern the seam follows.
+
+## The context — serialisable configuration only
+
+The factory receives a `TrialGraderContext` carrying only serialisable
+data:
+
+- `runner_address: str` — the address the built-in `runner_rpc` grader
+  dials against. Downstream graders that need a different endpoint (a
+  remote grader service, a queue broker) may ignore this field or build
+  their own transport from it.
+- `logger: StructuredLogger` — the run-scoped logger.
+
+The context deliberately does *not* carry the orchestrator's live
+runtime backend. A live gRPC channel would couple the grader to a
+specific runner instance chosen by the orchestrator — precisely the
+coupling this milestone breaks so a grader can run on a different
+machine. A canonical hygiene test
+(`tests/canonical/test_trial_grader_context_hygiene.py`) pins that
+negative-space contract at the type level.
+
+## Where the seam is going
+
+ADR-0035 records the milestone's five load-bearing decisions. Two
+extensions land after this milestone:
+
+- **Standalone grader service.** A new `tolokaforge grader-service`
+  binary + a `grader.proto` contract, so the grader can be deployed on
+  a different machine from the runner. `GraderRPCTrialGrader` becomes
+  a third built-in that dials the standalone service.
+- **Queue-backed variant.** A `QueueTrialGrader` that publishes grade
+  jobs to a broker (Redis Streams as the reference backend) so
+  orchestrator throughput on judge-heavy runs is decoupled from
+  grader latency.
+
+Both fit behind the current `TrialGrader` Protocol — no caller-facing
+API change — and both plug in through the same entry-point registry.
+
+## See also
+
+- [ADR-0014 — TrialGrader Protocol](adr/0014-trial-grader-protocol.md)
+- [ADR-0022 — Runtime Independence](adr/0022-runtime-independence.md)
+- [ADR-0035 — Grader Detachment](adr/0035-grader-detachment.md)
+- [STANDALONE_RUNNER.md](STANDALONE_RUNNER.md) — the sibling doc for the
+  runner-as-component surface
+- [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) — fail-loud
+  registry pattern the plug-in seams share

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ in_memory = "tolokaforge.core.runtime:in_memory_runtime_backend_factory"
 
 [project.entry-points."tolokaforge.trial_graders"]
 runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
+# Second impl proves the plug-in seam accepts fundamentally different grader
+# shapes (not just runner-RPC-with-different-transport). Ships with an unwired
+# default judge dispatch — see JudgeBackedTrialGrader docstring and ADR-0035.
+judge_only = "tolokaforge.core.trial_grader:judge_backed_trial_grader_factory"
 
 [project.entry-points."tolokaforge.conductors"]
 in_process = "tolokaforge.core.conductor:in_process_conductor_factory"

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -148,7 +148,7 @@ def test_turn_policy_names_resolve_to_their_class() -> None:
 
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
-    assert available_trial_graders() == ["runner_rpc"]
+    assert available_trial_graders() == ["judge_only", "runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
     assert available_turn_policies() == ["agent_only", "conversational"]

--- a/tests/canonical/test_judge_backed_trial_grader.py
+++ b/tests/canonical/test_judge_backed_trial_grader.py
@@ -1,0 +1,133 @@
+"""``JudgeBackedTrialGrader`` — the plug-in seam's second registered impl.
+
+The seam accepts more than the runner-RPC shape: a grader can also dispatch
+to an injected judge callable directly, no runner state / transcript /
+custom-check machinery. This test locks that shape and pins the entry-point
+registration so a downstream grader can rely on the same discovery path as
+``runner_rpc``.
+
+See ADR-0035 § Design Drivers (Decision 5 — a second impl proves the seam).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_trajectory, make_trial_spec
+from tolokaforge.core.models import (
+    Grade,
+    GradeComponents,
+    TerminationReason,
+    TrialStatus,
+)
+from tolokaforge.core.plugin_registry import TrialGraderContext, load_trial_grader
+from tolokaforge.core.trial_grader import (
+    JudgeBackedTrialGrader,
+    TrialGrader,
+    judge_backed_trial_grader_factory,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+def _make_grader(
+    judge_return: Grade | None = None,
+) -> tuple[JudgeBackedTrialGrader, MagicMock]:
+    """Build a grader whose judge dispatch returns ``judge_return`` unconditionally."""
+    judge_fn = MagicMock(return_value=judge_return)
+    grader = JudgeBackedTrialGrader(judge_fn=judge_fn, logger=MagicMock())
+    return grader, judge_fn
+
+
+class TestProtocolContract:
+    def test_satisfies_trial_grader_protocol(self) -> None:
+        grader, _ = _make_grader()
+        assert isinstance(grader, TrialGrader)
+
+
+class TestSuccessPath:
+    def test_grade_delegates_to_judge_fn_and_returns_its_verdict(self) -> None:
+        expected = Grade(
+            binary_pass=True,
+            score=0.87,
+            components=GradeComponents(llm_judge=0.87),
+            reasons="rubric met",
+        )
+        grader, judge_fn = _make_grader(judge_return=expected)
+        spec = make_trial_spec()
+        trajectory = make_trajectory(status=TrialStatus.COMPLETED)
+
+        result = grader.grade(spec, trajectory, "you are the agent")
+
+        judge_fn.assert_called_once_with(spec, trajectory, "you are the agent")
+        assert result is expected
+
+    def test_none_from_judge_is_propagated(self) -> None:
+        grader, _ = _make_grader(judge_return=None)
+        result = grader.grade(
+            make_trial_spec(), make_trajectory(status=TrialStatus.COMPLETED), "sys"
+        )
+        assert result is None
+
+
+class TestAutoFailBranches:
+    """Matches ``RunnerRPCTrialGrader``: error / timeout / stuck short-circuit to
+    an auto-fail :class:`Grade` before the judge is invoked."""
+
+    def test_error_status_short_circuits_without_calling_judge(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(make_trial_spec(), make_trajectory(status=TrialStatus.ERROR), "sys")
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        assert result.score == 0.0
+        judge_fn.assert_not_called()
+
+    def test_timeout_status_short_circuits(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(make_trial_spec(), make_trajectory(status=TrialStatus.TIMEOUT), "sys")
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        judge_fn.assert_not_called()
+
+    def test_stuck_termination_short_circuits(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(
+            make_trial_spec(),
+            make_trajectory(
+                status=TrialStatus.COMPLETED,
+                termination_reason=TerminationReason.STUCK_DETECTED,
+            ),
+            "sys",
+        )
+        assert isinstance(result, Grade)
+        assert result.binary_pass is False
+        judge_fn.assert_not_called()
+
+
+class TestFactoryAndRegistration:
+    def test_factory_builds_grader_from_context(self) -> None:
+        ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+        grader = judge_backed_trial_grader_factory(ctx)
+        assert isinstance(grader, JudgeBackedTrialGrader)
+
+    def test_registered_under_judge_only_entry_point(self) -> None:
+        """The plug-in registry resolves ``judge_only`` to the factory —
+        proving the second impl ships as a first-class seam consumer."""
+        factory = load_trial_grader("judge_only")
+        assert factory is judge_backed_trial_grader_factory
+
+    def test_default_judge_dispatch_raises_until_wired(self) -> None:
+        """The factory's default dispatch is unwired; invoking it raises
+        NotImplementedError with a clear pointer to the follow-up. This is
+        the guard against silent zero-scores while the production wiring
+        (offline replay, LLMJudge integration) is deferred."""
+        ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+        grader = judge_backed_trial_grader_factory(ctx)
+        with pytest.raises(NotImplementedError, match="not yet wired"):
+            grader.grade(
+                make_trial_spec(),
+                make_trajectory(status=TrialStatus.COMPLETED),
+                "sys",
+            )

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -35,6 +35,7 @@ remote grader service, or route to an entirely different Judge component
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import ValidationError
@@ -66,8 +67,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GradingFailedError",
+    "JudgeBackedTrialGrader",
+    "JudgeGradeFn",
     "RunnerRPCTrialGrader",
     "TrialGrader",
+    "judge_backed_trial_grader_factory",
 ]
 
 
@@ -407,3 +411,135 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
     """Build a :class:`RunnerRPCTrialGrader` from a grader context."""
     return RunnerRPCTrialGrader(runner_address=ctx.runner_address, logger=ctx.logger)
+
+
+JudgeGradeFn = Callable[[TrialSpec, Trajectory, str], "Grade | None"]
+"""The judge-backed grader's dispatch surface: given the trial's spec, its
+completed trajectory, and the agent's system prompt, return the :class:`Grade`
+the judge produced (or ``None`` when the trial produced nothing to grade).
+
+Kept as a plain ``Callable`` alias so the seam accepts any host-side wiring
+that reaches a judge: the offline replay path (``dx.cli.rejudge``), a
+JudgeBackedTrialGrader wrapping :class:`~tolokaforge.core.grading.judge.LLMJudge`
+directly, or a downstream package's judge integration.
+"""
+
+
+class JudgeBackedTrialGrader:
+    """:class:`TrialGrader` that invokes an injected judge callable directly,
+    without the runner's state / transcript / custom-check machinery.
+
+    The seam's second registered implementation (see ADR-0035, Decision 5):
+    a grader that dispatches to a judge rather than a runner-side RPC. Ships
+    as the plug-in shape for judge-only tasks (rubric-only fixtures, offline
+    replay); production integration with :class:`LLMJudge` is deferred as a
+    follow-up (see the milestone umbrella #1181).
+
+    The Protocol contract is unchanged: :meth:`grade` returns a :class:`Grade`,
+    or ``None`` when the trial produced nothing to grade. Auto-fail on
+    error / timeout / stuck-detected matches :class:`RunnerRPCTrialGrader` so
+    both implementations are drop-in swaps for the caller.
+    """
+
+    def __init__(self, judge_fn: JudgeGradeFn, logger: StructuredLogger) -> None:
+        self.judge_fn = judge_fn
+        self.logger = logger
+
+    def grade(
+        self,
+        spec: TrialSpec,
+        trajectory: Trajectory,
+        agent_system_prompt: str,
+    ) -> Grade | None:
+        task_id, trial_idx = _split_trial_id(spec.trial_id)
+
+        if classify_trial_outcome(trajectory) is TrialOutcomeClass.INFRASTRUCTURE_ABORT:
+            self.logger.info(
+                "Trial aborted by infrastructure - not graded",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
+                termination_reason=(
+                    trajectory.termination_reason.value if trajectory.termination_reason else None
+                ),
+            )
+            return None
+
+        if trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT):
+            self.logger.info(
+                "Trial did not complete successfully - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(llm_judge=0.0),
+                reasons=f"Trial failed with status: {trajectory.status.value}",
+            )
+
+        if trajectory.termination_reason == TerminationReason.STUCK_DETECTED:
+            self.logger.info(
+                "Trial stuck - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(llm_judge=0.0),
+                reasons="Agent got stuck (repeated actions without progress)",
+            )
+
+        grade = self.judge_fn(spec, trajectory, agent_system_prompt)
+        if grade is None:
+            self.logger.info(
+                "Judge returned no verdict",
+                task_id=task_id,
+                trial_index=trial_idx,
+            )
+        else:
+            self.logger.info(
+                "Grading via judge callable",
+                task_id=task_id,
+                trial_index=trial_idx,
+                score=grade.score,
+                binary_pass=grade.binary_pass,
+            )
+        return grade
+
+
+def _unwired_judge_fn(
+    spec: TrialSpec,  # noqa: ARG001 — Protocol arg accepted at the seam
+    trajectory: Trajectory,  # noqa: ARG001
+    agent_system_prompt: str,  # noqa: ARG001
+) -> Grade | None:
+    """Default judge dispatch for the ``judge_only`` entry point.
+
+    The factory has no way to receive a real judge instance through the current
+    ``TrialGraderContext`` — production wiring (offline-replay integration,
+    live :class:`~tolokaforge.core.grading.judge.LLMJudge` construction from
+    per-task rubric config) is deferred as a follow-up on the umbrella. Until
+    that ships, invoking the grader raises loud rather than degrading to a
+    silent zero score.
+    """
+    raise NotImplementedError(
+        "judge_only trial grader is registered but not yet wired to a production "
+        "judge. Inject a JudgeGradeFn callable via JudgeBackedTrialGrader(...) "
+        "directly, or wait for the follow-up that folds offline rejudge onto this "
+        "seam. See ADR-0035 and the grader-detachment umbrella."
+    )
+
+
+def judge_backed_trial_grader_factory(ctx: TrialGraderContext) -> JudgeBackedTrialGrader:
+    """Build a :class:`JudgeBackedTrialGrader` from a grader context.
+
+    The default judge dispatch raises :class:`NotImplementedError` until a
+    production judge is wired through the context (see the follow-up on the
+    grader-detachment umbrella). The class is directly constructible with a
+    real :data:`JudgeGradeFn` for tests and for the future offline-replay
+    integration.
+    """
+    return JudgeBackedTrialGrader(judge_fn=_unwired_judge_fn, logger=ctx.logger)


### PR DESCRIPTION
## Summary

Adds \`docs/GRADER_SERVICE.md\` — the public entry point for the grader plug-in seam. Covers the Protocol shape, per-task grader selection, the two built-ins (\`runner_rpc\` + \`judge_only\`), how to register a downstream grader via entry-points, the serialisable-context contract, and forward pointers to the standalone-service + queue-backed extensions that fit behind the same Protocol.

Stacked on #1199 (needs \`judge_only\` to reference an actual registered impl).

## Design choices

- **One doc page, not several.** The grader is a single consumable surface — splitting the doc adds cross-references without adding clarity.
- **Sibling to \`STANDALONE_RUNNER.md\`, same tone and structure.** Readers familiar with the runner doc land on a familiar shape when they reach the grader doc.
- **Includes forward pointers to unshipped extensions.** ADR-0035 is the design record; \`GRADER_SERVICE.md\` is the user surface. Naming the standalone-service and queue-backed variants makes the roadmap discoverable from the doc, not just from the ADR.

## Concepts introduced

- The public entry point for the grader plug-in seam as a *user surface*, not just an internal Protocol. Downstream code selects a grader by plug-in name from task config — same discovery path adapter / runtime-backend authors already use.

## Test plan

- [x] Doc renders on GitHub with no broken links
- [x] Cross-links to ADR-0014, ADR-0022, ADR-0035, and sibling docs resolve
- [x] Code snippets are consistent with the current \`pyproject.toml\` entry-point registrations

Closes #1189