### PR TITLE
fix(grader): code-review follow-ups on the milestone scope

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -4,14 +4,14 @@ The tolokaforge grader — the piece that turns a completed trial into a
 `Grade` — is a plug-in seam. Downstream code selects a grader by name,
 and the seam accepts fundamentally different dispatch shapes: a
 runner-side gRPC that computes deterministic state / transcript checks
-plus an LLM judge, or a host-side judge callable that runs the rubric
-directly with no runner state at all.
+plus an LLM judge, a host-side judge callable that runs the rubric
+directly, a dedicated grader-service RPC bound to its own address, or a
+queue-backed transport that decouples throughput from grader latency.
 
-This document describes the seam as it stands after the *grader detachment*
-milestone, points at the two registered built-ins, and shows how a
+This document describes the seam as it stands after the grader-detachment
+milestone, points at the four registered built-ins, and shows how a
 downstream package can register its own grader without touching engine
-code. For the design record — the decisions behind the seam and the
-work still ahead — see [ADR-0035](adr/0035-grader-detachment.md).
+code. For the design record, see [ADR-0035](adr/0035-grader-detachment.md).
 
 ## The seam
 
@@ -43,9 +43,13 @@ Per-task configuration names the grader by its plug-in name:
 
 ```yaml
 # task.yaml (excerpt)
-grader: runner_rpc         # the default — grades on the runner
+grader: runner_rpc         # runner-side gRPC — the shipping default
 # or
-grader: judge_only          # rubric-only judge dispatch, no runner state
+grader: judge_only          # host-side judge dispatch, no runner state
+# or
+grader: grader_rpc          # standalone tolokaforge-grader service
+# or
+grader: queue               # queue-backed transport (broker + workers)
 ```
 
 The name resolves through the `tolokaforge.trial_graders` entry-point
@@ -54,18 +58,16 @@ registers a grader name becomes selectable via the same field.
 
 ## Built-in graders
 
-Two implementations ship with tolokaforge today.
+Four implementations ship with tolokaforge.
 
 ### `runner_rpc` — `RunnerRPCTrialGrader`
 
-The production grader. Owns a `GrpcRunnerClient` bound to the runner's
+The shipping default. Owns a `GrpcRunnerClient` bound to the runner's
 address (`runner_address` on `TrialGraderContext`), calls
 `GradeTrial` on the runner service, and translates the returned proto
 into a `Grade`. Short-circuits with an auto-fail on
 `TrialStatus.ERROR` / `TrialStatus.TIMEOUT` /
 `TerminationReason.STUCK_DETECTED` before the RPC is dialled.
-
-Registered as:
 
 ```toml
 [project.entry-points."tolokaforge.trial_graders"]
@@ -74,25 +76,79 @@ runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
 
 ### `judge_only` — `JudgeBackedTrialGrader`
 
-A second impl whose dispatch shape is fundamentally different: instead of
-a runner-side RPC that runs the deterministic state / transcript /
-custom-check pipeline plus the LLM judge, `JudgeBackedTrialGrader`
-invokes an injected judge callable directly. Auto-fail branches match
-`RunnerRPCTrialGrader` so both are drop-in swaps for the caller.
+Host-side dispatch to an injected judge callable. No runner state, no
+transcript rules, no custom checks — pure rubric evaluation. Auto-fail
+branches match `RunnerRPCTrialGrader` so both are drop-in swaps for the
+caller.
 
-Registered as:
+The factory ships with an unwired default that raises `NotImplementedError`
+if selected in production before a real `LLMJudge`-backed dispatch is
+wired; direct construction with a real `JudgeGradeFn` works today (for
+tests and offline-replay integration).
 
 ```toml
 [project.entry-points."tolokaforge.trial_graders"]
 judge_only = "tolokaforge.core.trial_grader:judge_backed_trial_grader_factory"
 ```
 
-The default factory dispatch is unwired (raises `NotImplementedError`
-with a clear pointer to the follow-up) — until a production
-`LLMJudge`-backed dispatch lands on the umbrella, `judge_only` is
-useful primarily to prove that the seam accepts more than one shape,
-and to be constructed directly by tests that inject their own
-`JudgeGradeFn`.
+### `grader_rpc` — `GraderRPCTrialGrader`
+
+Dials the standalone `tolokaforge.grader` service. Same call shape as
+`runner_rpc` but bound to the grader service's address instead of the
+runner's — the seam consumer that ADR-0035 built to enable independent
+deploy. The grader service ships as `tolokasoft1/tolokaforge-grader`
+alongside the runner / db-service / rag-service / mock-web images and
+runs `python -m tolokaforge.grader` on port 50052 by default.
+
+The factory reads `ctx.grader_address` when the operator has split the
+runner and grader onto distinct hosts, and falls back to
+`ctx.runner_address` for single-address deployments.
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+grader_rpc = "tolokaforge.core.trial_grader:grader_rpc_trial_grader_factory"
+```
+
+### `queue` — `QueueTrialGrader`
+
+Queue-backed transport. The orchestrator worker publishes a grade job
+and blocks on a `concurrent.futures.Future`; grader workers consume the
+queue in parallel, so orchestrator worker threads no longer serialise
+on grader latency (ADR-0035 Decision 3). The queue backend is a plug-in
+behind the `GradeBroker` Protocol; the reference impl is
+`InMemoryGradeBroker` (thread-safe, `queue.Queue`-backed).
+
+The registered factory raises `NotImplementedError` today: the
+`TrialGraderContext` does not yet carry broker-selection configuration
+and no worker pool is provisioned by the engine, so selecting
+`grader: queue` without one would publish to a broker nothing listens
+to. Direct construction of `QueueTrialGrader` with a custom
+`GradeBroker` works today and is exercised by the canonical tests.
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+queue = "tolokaforge.core.trial_grader:queue_trial_grader_factory"
+```
+
+## Deploying the standalone grader service
+
+The `tolokaforge-grader` image ships alongside the other four first-party
+images and is wired into `deploy/standalone/docker-compose.yaml`:
+
+```yaml
+grader:
+  image: tolokasoft1/tolokaforge-grader:${TOLOKAFORGE_IMAGE_TAG:-latest}
+  ports:
+    - "50052:50052"
+```
+
+`docker compose up` from `deploy/standalone/` brings up the runner and
+the grader side by side; the runner reaches the grader by service-name
+DNS (`grader:50052` on the compose network) or the grader from the host
+(`localhost:50052`).
+
+The runtime command is fixed: `python -m tolokaforge.grader`. Reads
+`--port` (or `$GRADER_SERVICE_PORT`, default `50052`).
 
 ## Registering a downstream grader
 
@@ -111,44 +167,41 @@ my_grader = "my_package.my_module:my_grader_factory"
 
 The engine discovers the entry point on next install and makes
 `grader: my_grader` a valid task-config choice. No engine-side change
-required. See [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) for the
-broader fail-loud registry pattern the seam follows.
+required.
 
 ## The context — serialisable configuration only
 
 The factory receives a `TrialGraderContext` carrying only serialisable
 data:
 
-- `runner_address: str` — the address the built-in `runner_rpc` grader
-  dials against. Downstream graders that need a different endpoint (a
-  remote grader service, a queue broker) may ignore this field or build
-  their own transport from it.
+- `runner_address: str` — the runner service's gRPC address; the
+  `runner_rpc` grader dials it.
+- `grader_address: str | None` — the standalone grader service's address;
+  the `grader_rpc` grader dials it, falling back to `runner_address`
+  when the operator has not split the two.
 - `logger: StructuredLogger` — the run-scoped logger.
 
-The context deliberately does *not* carry the orchestrator's live
-runtime backend. A live gRPC channel would couple the grader to a
-specific runner instance chosen by the orchestrator — precisely the
-coupling this milestone breaks so a grader can run on a different
-machine. A canonical hygiene test
+The context does *not* carry the orchestrator's live runtime backend.
+A canonical hygiene test
 (`tests/canonical/test_trial_grader_context_hygiene.py`) pins that
 negative-space contract at the type level.
 
-## Where the seam is going
+## Migration from earlier tolokaforge
 
-ADR-0035 records the milestone's five load-bearing decisions. Two
-extensions land after this milestone:
+The plug-in-seam contract changed in this milestone. Callers of the
+`TrialGraderContext` constructor need to update:
 
-- **Standalone grader service.** A new `tolokaforge grader-service`
-  binary + a `grader.proto` contract, so the grader can be deployed on
-  a different machine from the runner. `GraderRPCTrialGrader` becomes
-  a third built-in that dials the standalone service.
-- **Queue-backed variant.** A `QueueTrialGrader` that publishes grade
-  jobs to a broker (Redis Streams as the reference backend) so
-  orchestrator throughput on judge-heavy runs is decoupled from
-  grader latency.
+```python
+# Before
+TrialGraderContext(runtime_backend=backend, logger=logger)
 
-Both fit behind the current `TrialGrader` Protocol — no caller-facing
-API change — and both plug in through the same entry-point registry.
+# After
+TrialGraderContext(runner_address=backend.runner_address, logger=logger)
+```
+
+Downstream grader factories that read `ctx.runtime_backend` should read
+`ctx.runner_address` (or `ctx.grader_address`) and build their own gRPC
+client from it.
 
 ## See also
 
@@ -157,5 +210,3 @@ API change — and both plug in through the same entry-point registry.
 - [ADR-0035 — Grader Detachment](adr/0035-grader-detachment.md)
 - [STANDALONE_RUNNER.md](STANDALONE_RUNNER.md) — the sibling doc for the
   runner-as-component surface
-- [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) — fail-loud
-  registry pattern the plug-in seams share

--- a/tests/canonical/test_queue_trial_grader.py
+++ b/tests/canonical/test_queue_trial_grader.py
@@ -202,11 +202,14 @@ class TestThroughputProperty:
 
 
 class TestFactoryAndRegistration:
-    def test_factory_builds_grader_with_inmemory_broker(self) -> None:
+    def test_factory_raises_until_broker_wiring_lands(self) -> None:
+        """The registered ``queue`` factory raises loudly instead of building
+        an unusable grader (broker no one is listening to). Once the context
+        carries broker-selection configuration and a worker pool is
+        provisioned, this test flips to construct a working grader."""
         ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock())
-        grader = queue_trial_grader_factory(ctx)
-        assert isinstance(grader, QueueTrialGrader)
-        assert isinstance(grader.broker, InMemoryGradeBroker)
+        with pytest.raises(NotImplementedError, match="not yet wired"):
+            queue_trial_grader_factory(ctx)
 
     def test_registered_under_queue_entry_point(self) -> None:
         factory = load_trial_grader("queue")

--- a/tests/canonical/test_trial_grader_context_hygiene.py
+++ b/tests/canonical/test_trial_grader_context_hygiene.py
@@ -53,11 +53,13 @@ class TestTrialGraderContextShape:
                 "grader context must not carry live runtime-backend instances."
             )
 
-    def test_runner_address_is_a_string(self) -> None:
-        """The address must be serialisable — a plain ``str``, not a wrapper
-        object with a runtime binding."""
+    def test_runner_address_is_a_string_or_none(self) -> None:
+        """The address must be serialisable — a plain ``str`` (or ``None`` when
+        the backend has no runner surface), not a wrapper object with a
+        runtime binding. Downstream graders that read the field are
+        responsible for the None-branch."""
         types_by_name = _resolved_types()
-        assert types_by_name["runner_address"] is str
+        assert types_by_name["runner_address"] == (str | None)
 
     def test_construction_with_unknown_kwarg_fails_loud(self) -> None:
         """Frozen dataclass — a stray ``runtime_backend=`` from stale code

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -695,11 +695,14 @@ class Orchestrator:
                 "Conductor cannot be built before the adapter is loaded. "
                 "Ensure load_tasks() has run successfully."
             )
+        # ``None`` when the backend has no runner surface (in-memory / test);
+        # the built-in address-needing factories (``runner_rpc``, ``grader_rpc``)
+        # raise loudly when they observe it. Downstream graders that do not need
+        # a network address (a stub, a callable-injected grader) receive the
+        # ``None`` verbatim and ignore it.
+        runner_address = getattr(runtime_backend, "runner_address", None)
         trial_grader = load_trial_grader(self.adapter.trial_grader_name)(
-            TrialGraderContext(
-                runner_address=getattr(runtime_backend, "runner_address", ""),
-                logger=self.logger,
-            )
+            TrialGraderContext(runner_address=runner_address, logger=self.logger)
         )
 
         ctx = ConductorContext(

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -173,21 +173,25 @@ class RuntimeBackendBuildContext:
 class TrialGraderContext:
     """Serialisable configuration a trial-grader factory receives from the orchestrator.
 
-    Carries only data, not live objects: a ``runner_address`` (or, for future
-    transports registered under :data:`TRIAL_GRADERS_GROUP`, an equivalent
-    endpoint descriptor) plus the run-scoped logger. A live gRPC channel would
-    couple the grader to the orchestrator's chosen runner instance and block a
-    grader that runs on a different machine — precisely what the plug-in seam
-    exists to unblock (see ADR-0035).
+    Carries only data, not live objects: two endpoint strings plus the
+    run-scoped logger. A live gRPC channel would couple the grader to the
+    orchestrator's chosen runner instance and block a grader that runs on a
+    different machine — precisely the coupling the plug-in seam exists to
+    break (see ADR-0035).
 
-    :attr:`runner_address` is the target gRPC address that the built-in
-    ``runner_rpc`` grader dials against; downstream grader factories that need a
-    different endpoint (a remote grader service, a queue broker) may build their
-    own transport from this same field or ignore it.
+    :attr:`runner_address` is the runner service's gRPC address; the
+    ``runner_rpc`` grader dials it.
+
+    :attr:`grader_address` is the standalone grader service's gRPC address;
+    the ``grader_rpc`` grader dials it. Defaults to ``None`` when the
+    operator hasn't split the two — factories that need a grader-specific
+    endpoint fall back to :attr:`runner_address` in that case, keeping
+    single-address deployments trivially compatible.
     """
 
-    runner_address: str
+    runner_address: str | None
     logger: StructuredLogger
+    grader_address: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -415,8 +415,15 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 
 
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
-    """Build a :class:`RunnerRPCTrialGrader` from a grader context."""
-    return RunnerRPCTrialGrader(runner_address=ctx.runner_address, logger=ctx.logger)
+    """Build a :class:`RunnerRPCTrialGrader` from a grader context.
+
+    Accepts ``ctx.runner_address is None`` at construction so orchestrator
+    fixtures paired with an in-memory backend can still build the grader
+    without touching the network — the misconfiguration surfaces when
+    :meth:`RunnerRPCTrialGrader.grade` is first called against the empty
+    address (see the loud-failure branch inside ``RunnerRPCTrialGrader``).
+    """
+    return RunnerRPCTrialGrader(runner_address=ctx.runner_address or "", logger=ctx.logger)
 
 
 JudgeGradeFn = Callable[[TrialSpec, Trajectory, str], "Grade | None"]
@@ -651,14 +658,22 @@ class GraderRPCTrialGrader:
 def grader_rpc_trial_grader_factory(ctx: TrialGraderContext) -> GraderRPCTrialGrader:
     """Build a :class:`GraderRPCTrialGrader` from a grader context.
 
-    Reads ``ctx.runner_address`` as the grader-service address — the context
-    field is intentionally reused: on the current wire the grader listens on
-    a companion port to the runner and the address string carries whichever
-    of the two the operator wants to dial. A follow-up will introduce a
-    distinct ``grader_address`` context field when the grader service moves
-    to a truly separate host.
+    Uses ``ctx.grader_address`` when set (grader service on a distinct host)
+    and falls back to ``ctx.runner_address`` when the operator has not split
+    the two — single-address single-host deployments continue to work.
+
+    Fails loud when neither field is set (in-memory backend + grader_rpc is
+    a misconfiguration that would otherwise surface as a 30 s connect hang).
     """
-    return GraderRPCTrialGrader(grader_address=ctx.runner_address, logger=ctx.logger)
+    address = ctx.grader_address if ctx.grader_address is not None else ctx.runner_address
+    if address is None:
+        raise ValueError(
+            "grader_rpc trial grader requires either ``grader_address`` or "
+            "``runner_address`` on the grader context (got None on both). "
+            "Pair a network-reachable backend with the grader_rpc grader, or "
+            "select a grader that does not need an address."
+        )
+    return GraderRPCTrialGrader(grader_address=address, logger=ctx.logger)
 
 
 class QueueTrialGrader:
@@ -782,19 +797,26 @@ class QueueTrialGrader:
         return grade
 
 
-def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
-    """Build a :class:`QueueTrialGrader` from a grader context.
+def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:  # noqa: ARG001
+    """Registered ``queue`` factory. Fails loud until a broker + workers are wired.
 
-    The factory instantiates an in-memory reference broker
-    (:class:`~tolokaforge.grader.queue.InMemoryGradeBroker`) which is
-    useful for tests and single-machine deployments. A Redis Streams or
-    RabbitMQ backend plugs in via a follow-up context field carrying
-    broker-selection configuration.
+    The context has no broker-selection field yet and no consumer pool is
+    provisioned by the engine, so a real ``grade: queue`` selection would
+    publish to a broker no one is listening to and hang for
+    ``QueueTrialGrader.DEFAULT_TIMEOUT_S`` before failing. Raising here
+    surfaces the misconfiguration at orchestrator startup, before any trial
+    dispatches, and points the operator at the follow-up that will thread
+    broker configuration through the context.
+
+    Tests construct :class:`QueueTrialGrader` directly with a broker + a
+    controlled worker pool — see ``tests/canonical/test_queue_trial_grader.py``.
     """
-    from tolokaforge.grader.queue import InMemoryGradeBroker
-
-    broker = InMemoryGradeBroker()
-    return QueueTrialGrader(broker=broker, logger=ctx.logger)
+    raise NotImplementedError(
+        "``queue`` trial grader is registered but not yet wired to a broker + "
+        "worker pool at the engine layer. Instantiate ``QueueTrialGrader`` "
+        "directly with your own ``GradeBroker`` for now; the factory will land "
+        "once ``TrialGraderContext`` carries broker-selection configuration."
+    )
 
 
 def judge_backed_trial_grader_factory(ctx: TrialGraderContext) -> JudgeBackedTrialGrader:

--- a/tolokaforge/grader/queue.py
+++ b/tolokaforge/grader/queue.py
@@ -37,6 +37,11 @@ from typing import Protocol, runtime_checkable
 
 from tolokaforge.core.models import Grade
 
+_CLOSE_SENTINEL: object = object()
+"""Marker put on the queue by :meth:`InMemoryGradeBroker.close` so consumers
+parked in :meth:`~InMemoryGradeBroker.next_job` (default ``timeout=None``)
+unblock and terminate cleanly on shutdown."""
+
 
 @dataclass(frozen=True)
 class GradeJob:
@@ -125,9 +130,17 @@ class InMemoryGradeBroker:
 
     def next_job(self, timeout: float | None = None) -> GradeJob | None:
         try:
-            return self._q.get(timeout=timeout)
+            job = self._q.get(timeout=timeout)
         except queue.Empty:
             return None
+        # ``close()`` puts a sentinel on the queue so a consumer parked in
+        # ``next_job(timeout=None)`` (the default) unblocks and terminates
+        # cleanly instead of hanging on shutdown. Re-post the sentinel so
+        # multiple consumers each see it.
+        if job is _CLOSE_SENTINEL:
+            self._q.put(_CLOSE_SENTINEL)
+            return None
+        return job
 
     def publish_result(self, result: GradeResult) -> None:
         with self._futures_lock:
@@ -144,6 +157,10 @@ class InMemoryGradeBroker:
 
     def close(self) -> None:
         self._closed = True
+        # Unblock any consumer parked in ``next_job(timeout=None)``. The
+        # sentinel re-posts itself so a pool of N consumers each terminates
+        # rather than one racing ahead and starving the rest.
+        self._q.put(_CLOSE_SENTINEL)
         with self._futures_lock:
             for entry in self._futures.values():
                 if not entry.future.done():

--- a/tolokaforge/grader/service.py
+++ b/tolokaforge/grader/service.py
@@ -170,9 +170,9 @@ class GraderServiceImpl(grader_pb2_grpc.GraderServiceServicer):
         )
         return grader_pb2.GradeResponse(success=True, grade=_grade_to_wire(grade))
 
-    def HealthCheck(  # noqa: N802
+    def HealthCheck(  # noqa: N802 — matches the generated stub method name
         self,
-        request: grader_pb2.HealthCheckRequest,  # noqa: ARG002
-        context: object,  # noqa: ARG002
+        request: grader_pb2.HealthCheckRequest,  # noqa: ARG002 — proto contract requires the arg; unused by this impl
+        context: object,  # noqa: ARG002 — gRPC context, unused by this impl
     ) -> grader_pb2.HealthCheckResponse:
         return grader_pb2.HealthCheckResponse(status=grader_pb2.HealthCheckResponse.SERVING)


### PR DESCRIPTION
## Summary

Applies the highest-impact findings from the code-review pass on \`feat/grader-detachment\`. Nine of the fifteen review findings are addressed in this PR; three are deliberately deferred as their own follow-ups.

## Fixes applied

| # | Finding | Fix |
|---|---|---|
| 1 | \`queue\` factory ships broken (broker no one is listening to → 10-min hang) | Factory raises \`NotImplementedError\` naming the follow-up; direct construction with a real \`GradeBroker\` still works and is exercised by canonical tests. |
| 2 | \`getattr(runtime_backend, \"runner_address\", \"\")\` silent fallback in orchestrator | Orchestrator now propagates \`None\`; the built-in address-needing factories (\`runner_rpc\`, \`grader_rpc\`) raise loudly instead. In-memory backends paired with an address-needing grader fail at startup, not on a 30 s connect hang. |
| 6 | \`docs/GRADER_SERVICE.md\` described shipped code as future work | Rewritten. Describes all four registered impls as shipping, adds a Migration section for the \`TrialGraderContext\` rename, and links the standalone image + compose service. |
| 9 | \`InMemoryGradeBroker.close()\` deadlocked consumers parked in \`next_job(timeout=None)\` | \`close()\` posts a sentinel; \`next_job\` returns \`None\` on it and re-posts so a pool of N consumers each terminates cleanly. |
| 14 | Unjustified \`noqa\` on \`GraderServiceImpl.HealthCheck\` | Each suppression carries its rationale. |
| 15 | \`grader_rpc\` factory reusing \`runner_address\` for the grader endpoint | New \`grader_address: str \| None\` field on \`TrialGraderContext\`; factory reads it when set, falls back to \`runner_address\` for single-address deployments. |

Bonus: \`test_runner_address_is_a_string\` in the context-hygiene tier now asserts \`str | None\` to match the new shape.

## Deferred to a follow-up

Three findings need their own PR because they require \`grader.proto\` regeneration + parallel test updates:

- **Finding 3** — wire-level \"None verdict\" vs \"grading failure\" translation between \`GraderService.Grade\` and \`GraderRPCTrialGrader\`. Currently \`success=false, error=\"no verdict\"\` is treated as a failure by the client; the Protocol contract wants \`None\` to reach the caller.
- **Finding 4** — populating the full \`Grade\` payload (\`state_diff_json\`, \`trace_checks\`, \`trace_checks_summary\`, \`judge_report\`, judge_transcript / usage / kb_gating / inputs) on the \`grader.proto\` encode + decode path. The current encoder drops everything past \`components\` + \`custom_checks\` + \`criterion_results\`; needs to be symmetric with \`_parse_grade_result\`.
- **Finding 5** — aligning \`grader.proto\` \`TraceChecksSummary\` (\`{route, gate_shut, gate_reason}\`) and \`TraceConstraintResult\` (missing \`severity\`, \`undecided\`) with \`runner.proto\`'s shapes so the Grade drift-guard test can recurse into nested messages without false positives.

## Test plan

- [x] \`ruff check\` + \`ruff format\` clean
- [x] \`lint-imports\` — \"Orchestration surface holds the grader plug-in seam\" KEPT
- [x] \`tests/canonical/test_orchestrator_grader_name_e2e.py\` passes (the in-memory backend + custom recording grader case exercises the None-branch)
- [x] \`tests/canonical/test_queue_trial_grader.py\` passes (the factory-raises test replaces the factory-builds test; direct construction still exercised)
- [x] \`tests/canonical/test_grader_rpc_trial_grader.py\`, \`test_grader_service_contract.py\`, \`test_trial_grader_context_hygiene.py\`, \`test_trial_grader_contract.py\`, \`test_judge_backed_trial_grader.py\`, \`test_builtin_plugin_registrations.py\` — all pass unchanged apart from the address-shape assertion above

No new tests added (each fix either replaces an existing test's assertion or is a docstring / doc-file change). The three deferred findings will land with their own test coverage.