### PR TITLE
fix(grader): align grader.proto with runner.proto + full Grade payload round-trip

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -4,14 +4,14 @@ The tolokaforge grader — the piece that turns a completed trial into a
 `Grade` — is a plug-in seam. Downstream code selects a grader by name,
 and the seam accepts fundamentally different dispatch shapes: a
 runner-side gRPC that computes deterministic state / transcript checks
-plus an LLM judge, or a host-side judge callable that runs the rubric
-directly with no runner state at all.
+plus an LLM judge, a host-side judge callable that runs the rubric
+directly, a dedicated grader-service RPC bound to its own address, or a
+queue-backed transport that decouples throughput from grader latency.
 
-This document describes the seam as it stands after the *grader detachment*
-milestone, points at the two registered built-ins, and shows how a
+This document describes the seam as it stands after the grader-detachment
+milestone, points at the four registered built-ins, and shows how a
 downstream package can register its own grader without touching engine
-code. For the design record — the decisions behind the seam and the
-work still ahead — see [ADR-0035](adr/0035-grader-detachment.md).
+code. For the design record, see [ADR-0035](adr/0035-grader-detachment.md).
 
 ## The seam
 
@@ -43,9 +43,13 @@ Per-task configuration names the grader by its plug-in name:
 
 ```yaml
 # task.yaml (excerpt)
-grader: runner_rpc         # the default — grades on the runner
+grader: runner_rpc         # runner-side gRPC — the shipping default
 # or
-grader: judge_only          # rubric-only judge dispatch, no runner state
+grader: judge_only          # host-side judge dispatch, no runner state
+# or
+grader: grader_rpc          # standalone tolokaforge-grader service
+# or
+grader: queue               # queue-backed transport (broker + workers)
 ```
 
 The name resolves through the `tolokaforge.trial_graders` entry-point
@@ -54,18 +58,16 @@ registers a grader name becomes selectable via the same field.
 
 ## Built-in graders
 
-Two implementations ship with tolokaforge today.
+Four implementations ship with tolokaforge.
 
 ### `runner_rpc` — `RunnerRPCTrialGrader`
 
-The production grader. Owns a `GrpcRunnerClient` bound to the runner's
+The shipping default. Owns a `GrpcRunnerClient` bound to the runner's
 address (`runner_address` on `TrialGraderContext`), calls
 `GradeTrial` on the runner service, and translates the returned proto
 into a `Grade`. Short-circuits with an auto-fail on
 `TrialStatus.ERROR` / `TrialStatus.TIMEOUT` /
 `TerminationReason.STUCK_DETECTED` before the RPC is dialled.
-
-Registered as:
 
 ```toml
 [project.entry-points."tolokaforge.trial_graders"]
@@ -74,25 +76,79 @@ runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
 
 ### `judge_only` — `JudgeBackedTrialGrader`
 
-A second impl whose dispatch shape is fundamentally different: instead of
-a runner-side RPC that runs the deterministic state / transcript /
-custom-check pipeline plus the LLM judge, `JudgeBackedTrialGrader`
-invokes an injected judge callable directly. Auto-fail branches match
-`RunnerRPCTrialGrader` so both are drop-in swaps for the caller.
+Host-side dispatch to an injected judge callable. No runner state, no
+transcript rules, no custom checks — pure rubric evaluation. Auto-fail
+branches match `RunnerRPCTrialGrader` so both are drop-in swaps for the
+caller.
 
-Registered as:
+The factory ships with an unwired default that raises `NotImplementedError`
+if selected in production before a real `LLMJudge`-backed dispatch is
+wired; direct construction with a real `JudgeGradeFn` works today (for
+tests and offline-replay integration).
 
 ```toml
 [project.entry-points."tolokaforge.trial_graders"]
 judge_only = "tolokaforge.core.trial_grader:judge_backed_trial_grader_factory"
 ```
 
-The default factory dispatch is unwired (raises `NotImplementedError`
-with a clear pointer to the follow-up) — until a production
-`LLMJudge`-backed dispatch lands on the umbrella, `judge_only` is
-useful primarily to prove that the seam accepts more than one shape,
-and to be constructed directly by tests that inject their own
-`JudgeGradeFn`.
+### `grader_rpc` — `GraderRPCTrialGrader`
+
+Dials the standalone `tolokaforge.grader` service. Same call shape as
+`runner_rpc` but bound to the grader service's address instead of the
+runner's — the seam consumer that ADR-0035 built to enable independent
+deploy. The grader service ships as `tolokasoft1/tolokaforge-grader`
+alongside the runner / db-service / rag-service / mock-web images and
+runs `python -m tolokaforge.grader` on port 50052 by default.
+
+The factory reads `ctx.grader_address` when the operator has split the
+runner and grader onto distinct hosts, and falls back to
+`ctx.runner_address` for single-address deployments.
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+grader_rpc = "tolokaforge.core.trial_grader:grader_rpc_trial_grader_factory"
+```
+
+### `queue` — `QueueTrialGrader`
+
+Queue-backed transport. The orchestrator worker publishes a grade job
+and blocks on a `concurrent.futures.Future`; grader workers consume the
+queue in parallel, so orchestrator worker threads no longer serialise
+on grader latency (ADR-0035 Decision 3). The queue backend is a plug-in
+behind the `GradeBroker` Protocol; the reference impl is
+`InMemoryGradeBroker` (thread-safe, `queue.Queue`-backed).
+
+The registered factory raises `NotImplementedError` today: the
+`TrialGraderContext` does not yet carry broker-selection configuration
+and no worker pool is provisioned by the engine, so selecting
+`grader: queue` without one would publish to a broker nothing listens
+to. Direct construction of `QueueTrialGrader` with a custom
+`GradeBroker` works today and is exercised by the canonical tests.
+
+```toml
+[project.entry-points."tolokaforge.trial_graders"]
+queue = "tolokaforge.core.trial_grader:queue_trial_grader_factory"
+```
+
+## Deploying the standalone grader service
+
+The `tolokaforge-grader` image ships alongside the other four first-party
+images and is wired into `deploy/standalone/docker-compose.yaml`:
+
+```yaml
+grader:
+  image: tolokasoft1/tolokaforge-grader:${TOLOKAFORGE_IMAGE_TAG:-latest}
+  ports:
+    - "50052:50052"
+```
+
+`docker compose up` from `deploy/standalone/` brings up the runner and
+the grader side by side; the runner reaches the grader by service-name
+DNS (`grader:50052` on the compose network) or the grader from the host
+(`localhost:50052`).
+
+The runtime command is fixed: `python -m tolokaforge.grader`. Reads
+`--port` (or `$GRADER_SERVICE_PORT`, default `50052`).
 
 ## Registering a downstream grader
 
@@ -111,44 +167,41 @@ my_grader = "my_package.my_module:my_grader_factory"
 
 The engine discovers the entry point on next install and makes
 `grader: my_grader` a valid task-config choice. No engine-side change
-required. See [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) for the
-broader fail-loud registry pattern the seam follows.
+required.
 
 ## The context — serialisable configuration only
 
 The factory receives a `TrialGraderContext` carrying only serialisable
 data:
 
-- `runner_address: str` — the address the built-in `runner_rpc` grader
-  dials against. Downstream graders that need a different endpoint (a
-  remote grader service, a queue broker) may ignore this field or build
-  their own transport from it.
+- `runner_address: str` — the runner service's gRPC address; the
+  `runner_rpc` grader dials it.
+- `grader_address: str | None` — the standalone grader service's address;
+  the `grader_rpc` grader dials it, falling back to `runner_address`
+  when the operator has not split the two.
 - `logger: StructuredLogger` — the run-scoped logger.
 
-The context deliberately does *not* carry the orchestrator's live
-runtime backend. A live gRPC channel would couple the grader to a
-specific runner instance chosen by the orchestrator — precisely the
-coupling this milestone breaks so a grader can run on a different
-machine. A canonical hygiene test
+The context does *not* carry the orchestrator's live runtime backend.
+A canonical hygiene test
 (`tests/canonical/test_trial_grader_context_hygiene.py`) pins that
 negative-space contract at the type level.
 
-## Where the seam is going
+## Migration from earlier tolokaforge
 
-ADR-0035 records the milestone's five load-bearing decisions. Two
-extensions land after this milestone:
+The plug-in-seam contract changed in this milestone. Callers of the
+`TrialGraderContext` constructor need to update:
 
-- **Standalone grader service.** A new `tolokaforge grader-service`
-  binary + a `grader.proto` contract, so the grader can be deployed on
-  a different machine from the runner. `GraderRPCTrialGrader` becomes
-  a third built-in that dials the standalone service.
-- **Queue-backed variant.** A `QueueTrialGrader` that publishes grade
-  jobs to a broker (Redis Streams as the reference backend) so
-  orchestrator throughput on judge-heavy runs is decoupled from
-  grader latency.
+```python
+# Before
+TrialGraderContext(runtime_backend=backend, logger=logger)
 
-Both fit behind the current `TrialGrader` Protocol — no caller-facing
-API change — and both plug in through the same entry-point registry.
+# After
+TrialGraderContext(runner_address=backend.runner_address, logger=logger)
+```
+
+Downstream grader factories that read `ctx.runtime_backend` should read
+`ctx.runner_address` (or `ctx.grader_address`) and build their own gRPC
+client from it.
 
 ## See also
 
@@ -157,5 +210,3 @@ API change — and both plug in through the same entry-point registry.
 - [ADR-0035 — Grader Detachment](adr/0035-grader-detachment.md)
 - [STANDALONE_RUNNER.md](STANDALONE_RUNNER.md) — the sibling doc for the
   runner-as-component surface
-- [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) — fail-loud
-  registry pattern the plug-in seams share

--- a/tests/canonical/test_grader_service_contract.py
+++ b/tests/canonical/test_grader_service_contract.py
@@ -104,7 +104,142 @@ def test_grade_failure_returns_success_false_with_error() -> None:
     assert "judge blew up" in (result["error"] or "")
 
 
-def test_none_from_judge_surfaces_as_no_verdict() -> None:
+def test_full_grade_payload_round_trips_through_the_wire() -> None:
+    """Every field a live :class:`Grade` may carry survives encode + decode.
+
+    The earlier grader.proto encoder populated only a subset (binary_pass /
+    score / reasons / components / custom_checks / criterion_results /
+    judge_status). A judge that returned a Grade with trace-check results
+    or judge audit fields would have silently lost them on the wire. This
+    test constructs a fully-populated Grade, round-trips it through the
+    real gRPC stack, and asserts equality of every field the caller reads.
+    """
+    from tolokaforge.core.models import (
+        CriterionResult,
+        CustomCheckDetail,
+        JudgeInputs,
+        JudgeKbGating,
+        JudgeStatus,
+        JudgeUsage,
+        TraceChecksSummary,
+        TraceConstraintResult,
+        TracePathResult,
+    )
+
+    verdict = Grade(
+        binary_pass=False,
+        score=0.42,
+        components=GradeComponents(
+            state_checks=0.8,
+            transcript_rules=1.0,
+            llm_judge=0.3,
+            custom_checks=None,
+            trace_checks=0.5,
+        ),
+        reasons="rubric partially met | state hash mismatch",
+        state_diff={"orders": {"added": ["a"], "removed": []}},
+        custom_checks_details=[
+            CustomCheckDetail(
+                check_name="c1",
+                status="passed",
+                score=1.0,
+                message="ok",
+                details={"n": 3},
+            )
+        ],
+        criterion_results=[
+            CriterionResult(id="crit-a", met=False, score=0.4, justification="missing X")
+        ],
+        judge_status=JudgeStatus.COMPLETED,
+        judge_usage=JudgeUsage(
+            calls=2,
+            prompt_tokens=100,
+            completion_tokens=50,
+            reasoning_tokens=10,
+            cost_usd=0.0123,
+            tool_calls=1,
+            consistency_rejections=1,
+        ),
+        judge_transcript=[{"role": "user", "content": "hi"}],
+        judge_kb_gating=JudgeKbGating(
+            knowledge_search_disabled=True,
+            offered=["search_kb"],
+            withheld=["search_policy"],
+        ),
+        judge_inputs=JudgeInputs(
+            state_diff_text="orders[1]: open -> shipped",
+            read_tools_offered=["read_file", "get_db_state"],
+        ),
+        judge_custom_prompt=True,
+        judge_agent_prompt_included=False,
+        trace_check_results=[
+            TraceConstraintResult(
+                id="t1",
+                kind="present",
+                passed=False,
+                weight=0.5,
+                message="anchor missing",
+                matched_positions=[3, 7],
+                severity="gate",
+                undecided=False,
+            )
+        ],
+        trace_checks_summary=TraceChecksSummary(
+            winning_path="alt-A",
+            gate_failed=True,
+            failed_gate_ids=["g1"],
+            paths=[TracePathResult(id="alt-A", score=0.6, gate_failed=True)],
+        ),
+    )
+
+    def _judge_fn(*_args, **_kwargs):
+        return verdict
+
+    with _running_service(_judge_fn) as client:
+        result = client.grade(
+            trial_id="task:0",
+            llm_messages_json="[]",
+            termination_reason="",
+        )
+
+    assert result["success"] is True
+    assert result["no_verdict"] is False
+    grade_dict = result["grade"]
+    assert grade_dict is not None
+
+    # Every field the wire carries must survive.
+    assert grade_dict["state_diff_json"] is not None  # state_diff round-tripped
+    assert grade_dict["components"]["trace_checks"] == pytest.approx(0.5)
+    assert grade_dict["custom_checks"][0]["check_name"] == "c1"
+    assert grade_dict["criterion_results"][0]["id"] == "crit-a"
+
+    # Full judge_report round-trip.
+    report = grade_dict["judge_report"]
+    assert report["calls"] == 2
+    assert report["cost_usd"] == pytest.approx(0.0123)
+    assert report["knowledge_search_disabled"] is True
+    assert report["kb_tools_withheld"] == ["search_policy"]
+    assert report["state_diff_text"] == "orders[1]: open -> shipped"
+    assert report["custom_system_prompt"] is True
+    assert report["include_agent_system_prompt"] is False
+    assert "transcript_json" in report
+
+    # Trace-check round-trip — the sub-messages the earlier encoder dropped.
+    assert grade_dict["trace_checks"][0]["severity"] == "gate"
+    assert grade_dict["trace_checks"][0]["undecided"] is False
+    assert grade_dict["trace_checks_summary"]["winning_path"] == "alt-A"
+    assert grade_dict["trace_checks_summary"]["failed_gate_ids"] == ["g1"]
+    assert grade_dict["trace_checks_summary"]["paths"][0]["id"] == "alt-A"
+
+
+def test_none_from_judge_surfaces_as_no_verdict_wire_flag() -> None:
+    """The wire distinguishes "nothing to grade" from a grading failure.
+
+    ``TrialGrader.grade`` returns ``None`` for the former and raises
+    ``GradingFailedError`` for the latter; the transport must preserve the
+    distinction so the seam consumer produces the same top-level outcome
+    regardless of dispatch shape."""
+
     def _judge_fn(*_args, **_kwargs):
         return None
 
@@ -115,25 +250,69 @@ def test_none_from_judge_surfaces_as_no_verdict() -> None:
             termination_reason="",
         )
 
-    assert result["success"] is False
-    assert result["error"] == "no verdict"
+    assert result["success"] is True
+    assert result["no_verdict"] is True
+    assert result["grade"] is None
+    assert result["error"] is None
 
 
 def test_wire_message_types_carry_the_full_grade_shape() -> None:
     """Guards against a runner.proto ↔ grader.proto drift on the Grade payload.
 
-    If a field is added to runner.Grade for a downstream consumer, this test
-    fails until the mirror field is added to grader.Grade — keeping the two
-    RPCs interchangeable at the plug-in-seam layer, per ADR-0035.
+    Recurses into every sub-message on ``Grade`` (``GradeComponents``,
+    ``JudgeReport``, ``CriterionResult``, ``CustomCheckResult``,
+    ``TraceConstraintResult``, ``TraceChecksSummary``, ``TracePathResult``)
+    so a nested-field addition on runner.proto fails the guard until the
+    grader mirror is updated — keeping the two RPCs interchangeable at
+    the plug-in-seam layer, per ADR-0035.
     """
     from tolokaforge.runner import runner_pb2
 
-    grader_fields = {f.name for f in grader_pb2.Grade.DESCRIPTOR.fields}
-    runner_fields = {f.name for f in runner_pb2.Grade.DESCRIPTOR.fields}
-    # The grader payload must be a superset of every field runner.Grade carries
-    # (grader may add its own; runner must not carry a field the grader loses).
-    missing = runner_fields - grader_fields
-    assert missing == set(), (
+    def _fields(descriptor) -> set[str]:  # type: ignore[no-untyped-def]
+        return {f.name for f in descriptor.fields}
+
+    grader_grade_fields = _fields(grader_pb2.Grade.DESCRIPTOR)
+    runner_grade_fields = _fields(runner_pb2.Grade.DESCRIPTOR)
+    missing_top = runner_grade_fields - grader_grade_fields
+    assert missing_top == set(), (
         "runner.Grade carries fields the grader payload does not mirror: "
-        f"{sorted(missing)}. Update grader.proto so the wire stays coherent."
+        f"{sorted(missing_top)}. Update grader.proto so the wire stays coherent."
+    )
+
+    # Match runner sub-messages to grader sub-messages by top-level Grade field
+    # name (identical numbering across the two protos). ``JudgeStatus`` is an
+    # enum, not a message, so it is field-typed comparably but has no nested
+    # descriptor — skip it below.
+    grade_message_fields = [
+        "components",
+        "judge_report",
+        "criterion_results",
+        "custom_checks",
+        "trace_checks",
+        "trace_checks_summary",
+    ]
+    for field_name in grade_message_fields:
+        grader_field = grader_pb2.Grade.DESCRIPTOR.fields_by_name[field_name]
+        runner_field = runner_pb2.Grade.DESCRIPTOR.fields_by_name[field_name]
+        grader_sub_fields = _fields(grader_field.message_type)
+        runner_sub_fields = _fields(runner_field.message_type)
+        missing_nested = runner_sub_fields - grader_sub_fields
+        assert missing_nested == set(), (
+            f"grader.proto's {field_name!r} sub-message drops fields present in "
+            f"runner.proto: {sorted(missing_nested)}. Mirror the runner shape so "
+            "the wire stays coherent — see ADR-0035 § wire alignment."
+        )
+
+    # ``trace_checks_summary.paths`` is a nested repeated sub-message — check
+    # it too so a runner-side ``TracePathResult`` field addition surfaces here.
+    grader_paths_field = grader_pb2.TraceChecksSummary.DESCRIPTOR.fields_by_name[
+        "paths"
+    ].message_type
+    runner_paths_field = runner_pb2.TraceChecksSummary.DESCRIPTOR.fields_by_name[
+        "paths"
+    ].message_type
+    missing_paths = _fields(runner_paths_field) - _fields(grader_paths_field)
+    assert missing_paths == set(), (
+        "grader.proto's TracePathResult drops fields present in runner.proto: "
+        f"{sorted(missing_paths)}. Mirror the runner shape."
     )

--- a/tests/canonical/test_queue_trial_grader.py
+++ b/tests/canonical/test_queue_trial_grader.py
@@ -202,11 +202,14 @@ class TestThroughputProperty:
 
 
 class TestFactoryAndRegistration:
-    def test_factory_builds_grader_with_inmemory_broker(self) -> None:
+    def test_factory_raises_until_broker_wiring_lands(self) -> None:
+        """The registered ``queue`` factory raises loudly instead of building
+        an unusable grader (broker no one is listening to). Once the context
+        carries broker-selection configuration and a worker pool is
+        provisioned, this test flips to construct a working grader."""
         ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock())
-        grader = queue_trial_grader_factory(ctx)
-        assert isinstance(grader, QueueTrialGrader)
-        assert isinstance(grader.broker, InMemoryGradeBroker)
+        with pytest.raises(NotImplementedError, match="not yet wired"):
+            queue_trial_grader_factory(ctx)
 
     def test_registered_under_queue_entry_point(self) -> None:
         factory = load_trial_grader("queue")

--- a/tests/canonical/test_trial_grader_context_hygiene.py
+++ b/tests/canonical/test_trial_grader_context_hygiene.py
@@ -53,11 +53,13 @@ class TestTrialGraderContextShape:
                 "grader context must not carry live runtime-backend instances."
             )
 
-    def test_runner_address_is_a_string(self) -> None:
-        """The address must be serialisable — a plain ``str``, not a wrapper
-        object with a runtime binding."""
+    def test_runner_address_is_a_string_or_none(self) -> None:
+        """The address must be serialisable — a plain ``str`` (or ``None`` when
+        the backend has no runner surface), not a wrapper object with a
+        runtime binding. Downstream graders that read the field are
+        responsible for the None-branch."""
         types_by_name = _resolved_types()
-        assert types_by_name["runner_address"] is str
+        assert types_by_name["runner_address"] == (str | None)
 
     def test_construction_with_unknown_kwarg_fails_loud(self) -> None:
         """Frozen dataclass — a stray ``runtime_backend=`` from stale code

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -695,11 +695,14 @@ class Orchestrator:
                 "Conductor cannot be built before the adapter is loaded. "
                 "Ensure load_tasks() has run successfully."
             )
+        # ``None`` when the backend has no runner surface (in-memory / test);
+        # the built-in address-needing factories (``runner_rpc``, ``grader_rpc``)
+        # raise loudly when they observe it. Downstream graders that do not need
+        # a network address (a stub, a callable-injected grader) receive the
+        # ``None`` verbatim and ignore it.
+        runner_address = getattr(runtime_backend, "runner_address", None)
         trial_grader = load_trial_grader(self.adapter.trial_grader_name)(
-            TrialGraderContext(
-                runner_address=getattr(runtime_backend, "runner_address", ""),
-                logger=self.logger,
-            )
+            TrialGraderContext(runner_address=runner_address, logger=self.logger)
         )
 
         ctx = ConductorContext(

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -173,21 +173,25 @@ class RuntimeBackendBuildContext:
 class TrialGraderContext:
     """Serialisable configuration a trial-grader factory receives from the orchestrator.
 
-    Carries only data, not live objects: a ``runner_address`` (or, for future
-    transports registered under :data:`TRIAL_GRADERS_GROUP`, an equivalent
-    endpoint descriptor) plus the run-scoped logger. A live gRPC channel would
-    couple the grader to the orchestrator's chosen runner instance and block a
-    grader that runs on a different machine — precisely what the plug-in seam
-    exists to unblock (see ADR-0035).
+    Carries only data, not live objects: two endpoint strings plus the
+    run-scoped logger. A live gRPC channel would couple the grader to the
+    orchestrator's chosen runner instance and block a grader that runs on a
+    different machine — precisely the coupling the plug-in seam exists to
+    break (see ADR-0035).
 
-    :attr:`runner_address` is the target gRPC address that the built-in
-    ``runner_rpc`` grader dials against; downstream grader factories that need a
-    different endpoint (a remote grader service, a queue broker) may build their
-    own transport from this same field or ignore it.
+    :attr:`runner_address` is the runner service's gRPC address; the
+    ``runner_rpc`` grader dials it.
+
+    :attr:`grader_address` is the standalone grader service's gRPC address;
+    the ``grader_rpc`` grader dials it. Defaults to ``None`` when the
+    operator hasn't split the two — factories that need a grader-specific
+    endpoint fall back to :attr:`runner_address` in that case, keeping
+    single-address deployments trivially compatible.
     """
 
-    runner_address: str
+    runner_address: str | None
     logger: StructuredLogger
+    grader_address: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -415,8 +415,15 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 
 
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
-    """Build a :class:`RunnerRPCTrialGrader` from a grader context."""
-    return RunnerRPCTrialGrader(runner_address=ctx.runner_address, logger=ctx.logger)
+    """Build a :class:`RunnerRPCTrialGrader` from a grader context.
+
+    Accepts ``ctx.runner_address is None`` at construction so orchestrator
+    fixtures paired with an in-memory backend can still build the grader
+    without touching the network — the misconfiguration surfaces when
+    :meth:`RunnerRPCTrialGrader.grade` is first called against the empty
+    address (see the loud-failure branch inside ``RunnerRPCTrialGrader``).
+    """
+    return RunnerRPCTrialGrader(runner_address=ctx.runner_address or "", logger=ctx.logger)
 
 
 JudgeGradeFn = Callable[[TrialSpec, Trajectory, str], "Grade | None"]
@@ -627,8 +634,8 @@ class GraderRPCTrialGrader:
             ),
         )
 
-        if not (grade_result["success"] and grade_result["grade"]):
-            error_msg = grade_result.get("error", "Unknown grading error")
+        if not grade_result["success"]:
+            error_msg = grade_result.get("error") or "Unknown grading error"
             self.logger.error(
                 "Grader service RPC failed",
                 task_id=task_id,
@@ -636,6 +643,17 @@ class GraderRPCTrialGrader:
                 error=error_msg,
             )
             raise GradingFailedError(f"Grading failed for trial {spec.trial_id!r}: {error_msg}")
+
+        if grade_result.get("no_verdict"):
+            # The wire distinguishes "nothing to grade" (no verdict) from a
+            # grading failure — the ``TrialGrader`` Protocol returns ``None``
+            # for the former and raises ``GradingFailedError`` for the latter.
+            self.logger.info(
+                "Grader service produced no verdict",
+                task_id=task_id,
+                trial_index=trial_idx,
+            )
+            return None
 
         grade = _parse_grade_result(grade_result["grade"])
         self.logger.info(
@@ -651,14 +669,22 @@ class GraderRPCTrialGrader:
 def grader_rpc_trial_grader_factory(ctx: TrialGraderContext) -> GraderRPCTrialGrader:
     """Build a :class:`GraderRPCTrialGrader` from a grader context.
 
-    Reads ``ctx.runner_address`` as the grader-service address — the context
-    field is intentionally reused: on the current wire the grader listens on
-    a companion port to the runner and the address string carries whichever
-    of the two the operator wants to dial. A follow-up will introduce a
-    distinct ``grader_address`` context field when the grader service moves
-    to a truly separate host.
+    Uses ``ctx.grader_address`` when set (grader service on a distinct host)
+    and falls back to ``ctx.runner_address`` when the operator has not split
+    the two — single-address single-host deployments continue to work.
+
+    Fails loud when neither field is set (in-memory backend + grader_rpc is
+    a misconfiguration that would otherwise surface as a 30 s connect hang).
     """
-    return GraderRPCTrialGrader(grader_address=ctx.runner_address, logger=ctx.logger)
+    address = ctx.grader_address if ctx.grader_address is not None else ctx.runner_address
+    if address is None:
+        raise ValueError(
+            "grader_rpc trial grader requires either ``grader_address`` or "
+            "``runner_address`` on the grader context (got None on both). "
+            "Pair a network-reachable backend with the grader_rpc grader, or "
+            "select a grader that does not need an address."
+        )
+    return GraderRPCTrialGrader(grader_address=address, logger=ctx.logger)
 
 
 class QueueTrialGrader:
@@ -782,19 +808,26 @@ class QueueTrialGrader:
         return grade
 
 
-def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
-    """Build a :class:`QueueTrialGrader` from a grader context.
+def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:  # noqa: ARG001
+    """Registered ``queue`` factory. Fails loud until a broker + workers are wired.
 
-    The factory instantiates an in-memory reference broker
-    (:class:`~tolokaforge.grader.queue.InMemoryGradeBroker`) which is
-    useful for tests and single-machine deployments. A Redis Streams or
-    RabbitMQ backend plugs in via a follow-up context field carrying
-    broker-selection configuration.
+    The context has no broker-selection field yet and no consumer pool is
+    provisioned by the engine, so a real ``grade: queue`` selection would
+    publish to a broker no one is listening to and hang for
+    ``QueueTrialGrader.DEFAULT_TIMEOUT_S`` before failing. Raising here
+    surfaces the misconfiguration at orchestrator startup, before any trial
+    dispatches, and points the operator at the follow-up that will thread
+    broker configuration through the context.
+
+    Tests construct :class:`QueueTrialGrader` directly with a broker + a
+    controlled worker pool — see ``tests/canonical/test_queue_trial_grader.py``.
     """
-    from tolokaforge.grader.queue import InMemoryGradeBroker
-
-    broker = InMemoryGradeBroker()
-    return QueueTrialGrader(broker=broker, logger=ctx.logger)
+    raise NotImplementedError(
+        "``queue`` trial grader is registered but not yet wired to a broker + "
+        "worker pool at the engine layer. Instantiate ``QueueTrialGrader`` "
+        "directly with your own ``GradeBroker`` for now; the factory will land "
+        "once ``TrialGraderContext`` carries broker-selection configuration."
+    )
 
 
 def judge_backed_trial_grader_factory(ctx: TrialGraderContext) -> JudgeBackedTrialGrader:

--- a/tolokaforge/grader/client.py
+++ b/tolokaforge/grader/client.py
@@ -69,40 +69,119 @@ class GrpcGraderClient:
             "success": response.success,
             "error": response.error if response.error else None,
             "grade": None,
+            # ``no_verdict`` carries the "nothing to grade" outcome distinct
+            # from a grading failure. The seam consumer translates it back to
+            # ``TrialGrader.grade`` returning ``None``.
+            "no_verdict": response.no_verdict,
         }
-        if response.success and response.grade:
-            grade = response.grade
-            result["grade"] = {
-                "binary_pass": grade.binary_pass,
-                "score": grade.score,
-                "reasons": grade.reasons,
-                "state_diff_json": (grade.state_diff_json if grade.state_diff_json else None),
-                "components": {
-                    "state_checks": grade.components.state_checks,
-                    "transcript_rules": grade.components.transcript_rules,
-                    "llm_judge": grade.components.llm_judge,
-                    "custom_checks": grade.components.custom_checks,
-                    "trace_checks": grade.components.trace_checks,
-                },
-                "custom_checks": [
-                    {
-                        "check_name": cc.check_name,
-                        "status": cc.status,
-                        "score": cc.score,
-                        "message": cc.message,
-                        "details_json": cc.details_json,
-                    }
-                    for cc in grade.custom_checks
-                ],
-                "criterion_results": [
-                    {
-                        "id": cr.id,
-                        "met": cr.met,
-                        "score": cr.score,
-                        "justification": cr.justification,
-                    }
-                    for cr in grade.criterion_results
-                ],
-                "judge_status": grade.judge_status,
-            }
+        if response.success and not response.no_verdict and response.HasField("grade"):
+            result["grade"] = _grade_from_wire(response.grade)
         return result
+
+
+def _grade_from_wire(grade: grader_pb2.Grade) -> dict:
+    """Translate the wire :class:`Grade` back into the dict shape
+    :func:`~tolokaforge.core.trial_grader._parse_grade_result` consumes.
+
+    Symmetric with :func:`~tolokaforge.grader.service._grade_to_wire`: every
+    field the wire may carry is decoded here so the client hands back the
+    same shape a runner-RPC grader's parse path would.
+    """
+    payload: dict = {
+        "binary_pass": grade.binary_pass,
+        "score": grade.score,
+        "reasons": grade.reasons,
+        "state_diff_json": grade.state_diff_json if grade.state_diff_json else None,
+        "components": (
+            _components_from_wire(grade.components) if grade.HasField("components") else {}
+        ),
+        "custom_checks": [
+            {
+                "check_name": cc.check_name,
+                "status": cc.status,
+                "score": cc.score,
+                "message": cc.message,
+                "details_json": cc.details_json,
+            }
+            for cc in grade.custom_checks
+        ],
+        "criterion_results": [
+            {
+                "id": cr.id,
+                "met": cr.met,
+                "score": cr.score,
+                "justification": cr.justification,
+            }
+            for cr in grade.criterion_results
+        ],
+        "judge_status": grade.judge_status,
+        "trace_checks": [
+            {
+                "id": r.id,
+                "kind": r.kind,
+                "passed": r.passed,
+                "weight": r.weight,
+                "message": r.message,
+                "matched_positions": list(r.matched_positions),
+                "severity": r.severity,
+                "undecided": r.undecided,
+            }
+            for r in grade.trace_checks
+        ],
+    }
+    if grade.HasField("judge_report"):
+        payload["judge_report"] = _judge_report_from_wire(grade.judge_report)
+    if grade.HasField("trace_checks_summary"):
+        summary = grade.trace_checks_summary
+        payload["trace_checks_summary"] = {
+            "winning_path": summary.winning_path,
+            "gate_failed": summary.gate_failed,
+            "failed_gate_ids": list(summary.failed_gate_ids),
+            "paths": [
+                {"id": p.id, "score": p.score, "gate_failed": p.gate_failed} for p in summary.paths
+            ],
+        }
+    return payload
+
+
+def _components_from_wire(components: grader_pb2.GradeComponents) -> dict:
+    """Decode :class:`GradeComponents`. ``trace_checks`` uses proto
+    ``optional`` presence — omit the key when the wire did not carry it so
+    the parse path can distinguish "not evaluated" from "-1.0 sentinel"."""
+    out: dict = {
+        "state_checks": components.state_checks,
+        "transcript_rules": components.transcript_rules,
+        "llm_judge": components.llm_judge,
+        "custom_checks": components.custom_checks,
+    }
+    if components.HasField("trace_checks"):
+        out["trace_checks"] = components.trace_checks
+    return out
+
+
+def _judge_report_from_wire(report: grader_pb2.JudgeReport) -> dict:
+    """Decode :class:`JudgeReport` symmetrically with
+    :func:`~tolokaforge.grader.service._populate_judge_report`."""
+    out: dict = {
+        "calls": report.calls,
+        "prompt_tokens": report.prompt_tokens,
+        "completion_tokens": report.completion_tokens,
+        "reasoning_tokens": report.reasoning_tokens,
+        "cost_usd": report.cost_usd,
+        "tool_calls": report.tool_calls,
+        "consistency_rejections": report.consistency_rejections,
+        "knowledge_search_disabled": report.knowledge_search_disabled,
+        "kb_tools_offered": list(report.kb_tools_offered),
+        "kb_tools_withheld": list(report.kb_tools_withheld),
+        "state_diff_text": report.state_diff_text,
+        "read_tools_offered": list(report.read_tools_offered),
+        "custom_system_prompt": report.custom_system_prompt,
+    }
+    if report.transcript_json:
+        out["transcript_json"] = report.transcript_json
+    # ``include_agent_system_prompt`` is proto ``optional`` — presence-gated
+    # so ``_parse_grade_result`` can distinguish the tri-state (True / False /
+    # not-set-by-a-legacy-sender).
+    if report.HasField("include_agent_system_prompt"):
+        out["include_agent_system_prompt"] = report.include_agent_system_prompt
+    return out

--- a/tolokaforge/grader/grader.proto
+++ b/tolokaforge/grader/grader.proto
@@ -2,12 +2,12 @@
 // Host ↔ Grader communication for tolokaforge grader-detachment
 // See docs/GRADER_SERVICE.md and ADR-0035 for the design record.
 //
-// The wire types below intentionally mirror runner.proto's Grade / JudgeReport /
-// CriterionResult / GradeComponents / CustomCheckResult / JudgeStatus messages.
-// The payload does not change across the split — only its hosting does. Keeping
-// the messages in this file (rather than importing runner.proto) lets the grader
-// service ship independently of the runner's release cadence, which is the
-// point of ADR-0035.
+// Message shapes below intentionally MIRROR runner.proto's Grade payload —
+// same field numbers, same enum values, same wire-level semantics. The two
+// services rev on independent cadences (ADR-0035), so the messages live in
+// this file rather than in an imported runner.proto; a canonical test locks
+// the mirror by recursing into every sub-message so a runner.proto change
+// that this file does not mirror fails the drift guard.
 
 syntax = "proto3";
 
@@ -22,15 +22,16 @@ option go_package = "tolokaforge/grader";
 service GraderService {
   // Compute a Grade for a completed trial.
   //
-  // Stateless per call: the caller provides everything the grader needs to
-  // produce a verdict (the transcript encoded as LLM messages, the trial's
-  // termination reason, and — for a future extension carrying rubric config
-  // — the task_config JSON). The grader is expected to be reachable at a
-  // different address from the runner service; the wire types are decoupled
-  // from runner.proto so the two services can rev on their own cadence.
+  // Stateless per call: the caller provides everything the grader needs.
+  // The response carries three distinct outcomes — a failure
+  // (success=false), a "nothing to grade" verdict (success=true,
+  // no_verdict=true), or a computed grade (success=true, no_verdict=false,
+  // grade set). This mirrors the ``TrialGrader.grade`` Protocol's tri-state
+  // return, so a grader-service caller and an in-process grader answer the
+  // same call with the same outcome for the same input.
   rpc Grade(GradeRequest) returns (GradeResponse);
 
-  // Health check — same shape as runner.HealthCheck for operational parity.
+  // Health check.
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
 
@@ -46,25 +47,32 @@ message GradeRequest {
   string llm_messages_json = 2;
 
   // Termination reason (TerminationReason value name); empty when the caller
-  // reports none. Kept as a plain string for wire flexibility, mirroring
-  // runner.GradeTrialRequest.termination_reason.
+  // reports none. Mirrors runner.GradeTrialRequest.termination_reason.
   string termination_reason = 3;
 
-  // Task config JSON — reserved for a future extension. The current MVP
-  // grader service ignores this field; it is threaded through so callers can
-  // start supplying it now without a wire migration.
+  // Task config JSON — reserved for future rubric-carrying dispatch.
   string task_config_json = 4;
 }
 
 message GradeResponse {
-  // Whether grading succeeded.
+  // Whether grading itself succeeded (distinct from the trial's outcome).
+  // false → error is set, grade unset, no_verdict unset.
   bool success = 1;
 
-  // Error message if grading failed.
+  // Error message when success=false.
   string error = 2;
 
-  // The computed grade — populated only when success is true.
+  // The computed grade — populated only when success=true and
+  // no_verdict=false.
   Grade grade = 3;
+
+  // The dispatch produced no verdict (nothing to grade — e.g. an
+  // infrastructure abort). Set alongside success=true, with grade unset.
+  // Callers translate this back to ``TrialGrader.grade`` returning ``None``.
+  // A silent zero would land in success_rate / avg_score / pass@k as an
+  // agent failure that no measurement supports — the wire holds the
+  // distinction.
+  bool no_verdict = 4;
 }
 
 message HealthCheckRequest {}
@@ -81,10 +89,6 @@ message HealthCheckResponse {
 // =============================================================================
 // Grade payload — mirrors runner.Grade
 // =============================================================================
-//
-// The shape is intentionally identical to runner.Grade so the two RPCs remain
-// interchangeable at the plug-in seam layer. See ADR-0035 § "wire + image
-// shape" and the runner.proto reference above for the semantics of each field.
 
 message Grade {
   bool binary_pass = 1;
@@ -100,12 +104,16 @@ message Grade {
   TraceChecksSummary trace_checks_summary = 11;
 }
 
+// GradeComponents — mirrors runner.GradeComponents including the ``optional``
+// presence gate on ``trace_checks``. The first four fields carry the -1.0
+// sentinel for "not evaluated"; ``trace_checks`` uses presence instead so a
+// runner predating the field never lands as a scored zero.
 message GradeComponents {
   double state_checks = 1;
   double transcript_rules = 2;
   double llm_judge = 3;
   double custom_checks = 4;
-  double trace_checks = 5;
+  optional double trace_checks = 5;
 }
 
 message CustomCheckResult {
@@ -129,6 +137,9 @@ enum JudgeStatus {
   JUDGE_STATUS_ERRORED = 2;
 }
 
+// JudgeReport — mirrors runner.JudgeReport EXACTLY, including field numbers.
+// A previous shape carried the fields in a different order which would have
+// silently drifted the wire once the encoder started populating them.
 message JudgeReport {
   int32 calls = 1;
   int32 prompt_tokens = 2;
@@ -136,17 +147,21 @@ message JudgeReport {
   int32 reasoning_tokens = 4;
   double cost_usd = 5;
   int32 tool_calls = 6;
-  int32 consistency_rejections = 7;
-  bool knowledge_search_disabled = 8;
-  repeated string kb_tools_offered = 9;
-  repeated string kb_tools_withheld = 10;
-  bool custom_system_prompt = 11;
+  string transcript_json = 7;
+  int32 consistency_rejections = 8;
+  bool knowledge_search_disabled = 9;
+  repeated string kb_tools_offered = 10;
+  repeated string kb_tools_withheld = 11;
   string state_diff_text = 12;
   repeated string read_tools_offered = 13;
-  string transcript_json = 14;
+  bool custom_system_prompt = 14;
   optional bool include_agent_system_prompt = 15;
 }
 
+// TraceConstraintResult — mirrors runner.TraceConstraintResult including
+// ``severity`` (field 7) and ``undecided`` (field 8). An earlier grader.proto
+// shape dropped both, so a Grade with trace_checks would have decoded on
+// the runner side with those fields silently zeroed.
 message TraceConstraintResult {
   string id = 1;
   string kind = 2;
@@ -154,11 +169,26 @@ message TraceConstraintResult {
   double weight = 4;
   string message = 5;
   repeated int32 matched_positions = 6;
-  string source = 7;
+  string severity = 7;
+  bool undecided = 8;
 }
 
+// One alternative route's own outcome, whether or not it won.
+message TracePathResult {
+  string id = 1;
+  double score = 2;
+  bool gate_failed = 3;
+}
+
+// TraceChecksSummary — mirrors runner.TraceChecksSummary. The earlier
+// grader.proto shape used ``{route, gate_shut, gate_reason}`` which does not
+// match anything the runner produces; the runner side (and its Pydantic
+// model) uses ``{winning_path, gate_failed, failed_gate_ids, paths}``. Now
+// aligned so once the encoder populates the field, the grader-side decoder
+// reads the same shape a downstream conductor's runner-RPC grader would.
 message TraceChecksSummary {
-  string route = 1;
-  bool gate_shut = 2;
-  string gate_reason = 3;
+  string winning_path = 1;
+  bool gate_failed = 2;
+  repeated string failed_gate_ids = 3;
+  repeated TracePathResult paths = 4;
 }

--- a/tolokaforge/grader/grader_pb2.py
+++ b/tolokaforge/grader/grader_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0cgrader.proto\x12\x12tolokaforge.grader"q\n\x0cGradeRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t\x12\x19\n\x11llm_messages_json\x18\x02 \x01(\t\x12\x1a\n\x12termination_reason\x18\x03 \x01(\t\x12\x18\n\x10task_config_json\x18\x04 \x01(\t"Y\n\rGradeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12(\n\x05grade\x18\x03 \x01(\x0b\x32\x19.tolokaforge.grader.Grade"\x14\n\x12HealthCheckRequest"\x98\x01\n\x13HealthCheckResponse\x12\x45\n\x06status\x18\x01 \x01(\x0e\x32\x35.tolokaforge.grader.HealthCheckResponse.ServingStatus":\n\rServingStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07SERVING\x10\x01\x12\x0f\n\x0bNOT_SERVING\x10\x02"\x81\x04\n\x05Grade\x12\x13\n\x0b\x62inary_pass\x18\x01 \x01(\x08\x12\r\n\x05score\x18\x02 \x01(\x01\x12\x37\n\ncomponents\x18\x03 \x01(\x0b\x32#.tolokaforge.grader.GradeComponents\x12\x0f\n\x07reasons\x18\x04 \x01(\t\x12\x17\n\x0fstate_diff_json\x18\x05 \x01(\t\x12<\n\rcustom_checks\x18\x06 \x03(\x0b\x32%.tolokaforge.grader.CustomCheckResult\x12>\n\x11\x63riterion_results\x18\x07 \x03(\x0b\x32#.tolokaforge.grader.CriterionResult\x12\x35\n\x0cjudge_status\x18\x08 \x01(\x0e\x32\x1f.tolokaforge.grader.JudgeStatus\x12\x35\n\x0cjudge_report\x18\t \x01(\x0b\x32\x1f.tolokaforge.grader.JudgeReport\x12?\n\x0ctrace_checks\x18\n \x03(\x0b\x32).tolokaforge.grader.TraceConstraintResult\x12\x44\n\x14trace_checks_summary\x18\x0b \x01(\x0b\x32&.tolokaforge.grader.TraceChecksSummary"\x81\x01\n\x0fGradeComponents\x12\x14\n\x0cstate_checks\x18\x01 \x01(\x01\x12\x18\n\x10transcript_rules\x18\x02 \x01(\x01\x12\x11\n\tllm_judge\x18\x03 \x01(\x01\x12\x15\n\rcustom_checks\x18\x04 \x01(\x01\x12\x14\n\x0ctrace_checks\x18\x05 \x01(\x01"m\n\x11\x43ustomCheckResult\x12\x12\n\ncheck_name\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\x12\x0f\n\x07message\x18\x04 \x01(\t\x12\x14\n\x0c\x64\x65tails_json\x18\x05 \x01(\t"P\n\x0f\x43riterionResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0b\n\x03met\x18\x02 \x01(\x08\x12\r\n\x05score\x18\x03 \x01(\x01\x12\x15\n\rjustification\x18\x04 \x01(\t"\xbc\x03\n\x0bJudgeReport\x12\r\n\x05\x63\x61lls\x18\x01 \x01(\x05\x12\x15\n\rprompt_tokens\x18\x02 \x01(\x05\x12\x19\n\x11\x63ompletion_tokens\x18\x03 \x01(\x05\x12\x18\n\x10reasoning_tokens\x18\x04 \x01(\x05\x12\x10\n\x08\x63ost_usd\x18\x05 \x01(\x01\x12\x12\n\ntool_calls\x18\x06 \x01(\x05\x12\x1e\n\x16\x63onsistency_rejections\x18\x07 \x01(\x05\x12!\n\x19knowledge_search_disabled\x18\x08 \x01(\x08\x12\x18\n\x10kb_tools_offered\x18\t \x03(\t\x12\x19\n\x11kb_tools_withheld\x18\n \x03(\t\x12\x1c\n\x14\x63ustom_system_prompt\x18\x0b \x01(\x08\x12\x17\n\x0fstate_diff_text\x18\x0c \x01(\t\x12\x1a\n\x12read_tools_offered\x18\r \x03(\t\x12\x17\n\x0ftranscript_json\x18\x0e \x01(\t\x12(\n\x1binclude_agent_system_prompt\x18\x0f \x01(\x08H\x00\x88\x01\x01\x42\x1e\n\x1c_include_agent_system_prompt"\x8d\x01\n\x15TraceConstraintResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0e\n\x06passed\x18\x03 \x01(\x08\x12\x0e\n\x06weight\x18\x04 \x01(\x01\x12\x0f\n\x07message\x18\x05 \x01(\t\x12\x19\n\x11matched_positions\x18\x06 \x03(\x05\x12\x0e\n\x06source\x18\x07 \x01(\t"K\n\x12TraceChecksSummary\x12\r\n\x05route\x18\x01 \x01(\t\x12\x11\n\tgate_shut\x18\x02 \x01(\x08\x12\x13\n\x0bgate_reason\x18\x03 \x01(\t*a\n\x0bJudgeStatus\x12\x1c\n\x18JUDGE_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n\x16JUDGE_STATUS_COMPLETED\x10\x01\x12\x18\n\x14JUDGE_STATUS_ERRORED\x10\x02\x32\xbd\x01\n\rGraderService\x12L\n\x05Grade\x12 .tolokaforge.grader.GradeRequest\x1a!.tolokaforge.grader.GradeResponse\x12^\n\x0bHealthCheck\x12&.tolokaforge.grader.HealthCheckRequest\x1a\'.tolokaforge.grader.HealthCheckResponseB\x14Z\x12tolokaforge/graderb\x06proto3'
+    b'\n\x0cgrader.proto\x12\x12tolokaforge.grader"q\n\x0cGradeRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t\x12\x19\n\x11llm_messages_json\x18\x02 \x01(\t\x12\x1a\n\x12termination_reason\x18\x03 \x01(\t\x12\x18\n\x10task_config_json\x18\x04 \x01(\t"m\n\rGradeResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12(\n\x05grade\x18\x03 \x01(\x0b\x32\x19.tolokaforge.grader.Grade\x12\x12\n\nno_verdict\x18\x04 \x01(\x08"\x14\n\x12HealthCheckRequest"\x98\x01\n\x13HealthCheckResponse\x12\x45\n\x06status\x18\x01 \x01(\x0e\x32\x35.tolokaforge.grader.HealthCheckResponse.ServingStatus":\n\rServingStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07SERVING\x10\x01\x12\x0f\n\x0bNOT_SERVING\x10\x02"\x81\x04\n\x05Grade\x12\x13\n\x0b\x62inary_pass\x18\x01 \x01(\x08\x12\r\n\x05score\x18\x02 \x01(\x01\x12\x37\n\ncomponents\x18\x03 \x01(\x0b\x32#.tolokaforge.grader.GradeComponents\x12\x0f\n\x07reasons\x18\x04 \x01(\t\x12\x17\n\x0fstate_diff_json\x18\x05 \x01(\t\x12<\n\rcustom_checks\x18\x06 \x03(\x0b\x32%.tolokaforge.grader.CustomCheckResult\x12>\n\x11\x63riterion_results\x18\x07 \x03(\x0b\x32#.tolokaforge.grader.CriterionResult\x12\x35\n\x0cjudge_status\x18\x08 \x01(\x0e\x32\x1f.tolokaforge.grader.JudgeStatus\x12\x35\n\x0cjudge_report\x18\t \x01(\x0b\x32\x1f.tolokaforge.grader.JudgeReport\x12?\n\x0ctrace_checks\x18\n \x03(\x0b\x32).tolokaforge.grader.TraceConstraintResult\x12\x44\n\x14trace_checks_summary\x18\x0b \x01(\x0b\x32&.tolokaforge.grader.TraceChecksSummary"\x97\x01\n\x0fGradeComponents\x12\x14\n\x0cstate_checks\x18\x01 \x01(\x01\x12\x18\n\x10transcript_rules\x18\x02 \x01(\x01\x12\x11\n\tllm_judge\x18\x03 \x01(\x01\x12\x15\n\rcustom_checks\x18\x04 \x01(\x01\x12\x19\n\x0ctrace_checks\x18\x05 \x01(\x01H\x00\x88\x01\x01\x42\x0f\n\r_trace_checks"m\n\x11\x43ustomCheckResult\x12\x12\n\ncheck_name\x18\x01 \x01(\t\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\x12\x0f\n\x07message\x18\x04 \x01(\t\x12\x14\n\x0c\x64\x65tails_json\x18\x05 \x01(\t"P\n\x0f\x43riterionResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0b\n\x03met\x18\x02 \x01(\x08\x12\r\n\x05score\x18\x03 \x01(\x01\x12\x15\n\rjustification\x18\x04 \x01(\t"\xbc\x03\n\x0bJudgeReport\x12\r\n\x05\x63\x61lls\x18\x01 \x01(\x05\x12\x15\n\rprompt_tokens\x18\x02 \x01(\x05\x12\x19\n\x11\x63ompletion_tokens\x18\x03 \x01(\x05\x12\x18\n\x10reasoning_tokens\x18\x04 \x01(\x05\x12\x10\n\x08\x63ost_usd\x18\x05 \x01(\x01\x12\x12\n\ntool_calls\x18\x06 \x01(\x05\x12\x17\n\x0ftranscript_json\x18\x07 \x01(\t\x12\x1e\n\x16\x63onsistency_rejections\x18\x08 \x01(\x05\x12!\n\x19knowledge_search_disabled\x18\t \x01(\x08\x12\x18\n\x10kb_tools_offered\x18\n \x03(\t\x12\x19\n\x11kb_tools_withheld\x18\x0b \x03(\t\x12\x17\n\x0fstate_diff_text\x18\x0c \x01(\t\x12\x1a\n\x12read_tools_offered\x18\r \x03(\t\x12\x1c\n\x14\x63ustom_system_prompt\x18\x0e \x01(\x08\x12(\n\x1binclude_agent_system_prompt\x18\x0f \x01(\x08H\x00\x88\x01\x01\x42\x1e\n\x1c_include_agent_system_prompt"\xa2\x01\n\x15TraceConstraintResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04kind\x18\x02 \x01(\t\x12\x0e\n\x06passed\x18\x03 \x01(\x08\x12\x0e\n\x06weight\x18\x04 \x01(\x01\x12\x0f\n\x07message\x18\x05 \x01(\t\x12\x19\n\x11matched_positions\x18\x06 \x03(\x05\x12\x10\n\x08severity\x18\x07 \x01(\t\x12\x11\n\tundecided\x18\x08 \x01(\x08"A\n\x0fTracePathResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05score\x18\x02 \x01(\x01\x12\x13\n\x0bgate_failed\x18\x03 \x01(\x08"\x8c\x01\n\x12TraceChecksSummary\x12\x14\n\x0cwinning_path\x18\x01 \x01(\t\x12\x13\n\x0bgate_failed\x18\x02 \x01(\x08\x12\x17\n\x0f\x66\x61iled_gate_ids\x18\x03 \x03(\t\x12\x32\n\x05paths\x18\x04 \x03(\x0b\x32#.tolokaforge.grader.TracePathResult*a\n\x0bJudgeStatus\x12\x1c\n\x18JUDGE_STATUS_UNSPECIFIED\x10\x00\x12\x1a\n\x16JUDGE_STATUS_COMPLETED\x10\x01\x12\x18\n\x14JUDGE_STATUS_ERRORED\x10\x02\x32\xbd\x01\n\rGraderService\x12L\n\x05Grade\x12 .tolokaforge.grader.GradeRequest\x1a!.tolokaforge.grader.GradeResponse\x12^\n\x0bHealthCheck\x12&.tolokaforge.grader.HealthCheckRequest\x1a\'.tolokaforge.grader.HealthCheckResponseB\x14Z\x12tolokaforge/graderb\x06proto3'
 )
 
 _globals = globals()
@@ -28,32 +28,34 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "grader_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
     _globals["DESCRIPTOR"]._loaded_options = None
     _globals["DESCRIPTOR"]._serialized_options = b"Z\022tolokaforge/grader"
-    _globals["_JUDGESTATUS"]._serialized_start = 1928
-    _globals["_JUDGESTATUS"]._serialized_end = 2025
+    _globals["_JUDGESTATUS"]._serialized_start = 2124
+    _globals["_JUDGESTATUS"]._serialized_end = 2221
     _globals["_GRADEREQUEST"]._serialized_start = 36
     _globals["_GRADEREQUEST"]._serialized_end = 149
     _globals["_GRADERESPONSE"]._serialized_start = 151
-    _globals["_GRADERESPONSE"]._serialized_end = 240
-    _globals["_HEALTHCHECKREQUEST"]._serialized_start = 242
-    _globals["_HEALTHCHECKREQUEST"]._serialized_end = 262
-    _globals["_HEALTHCHECKRESPONSE"]._serialized_start = 265
-    _globals["_HEALTHCHECKRESPONSE"]._serialized_end = 417
-    _globals["_HEALTHCHECKRESPONSE_SERVINGSTATUS"]._serialized_start = 359
-    _globals["_HEALTHCHECKRESPONSE_SERVINGSTATUS"]._serialized_end = 417
-    _globals["_GRADE"]._serialized_start = 420
-    _globals["_GRADE"]._serialized_end = 933
-    _globals["_GRADECOMPONENTS"]._serialized_start = 936
-    _globals["_GRADECOMPONENTS"]._serialized_end = 1065
-    _globals["_CUSTOMCHECKRESULT"]._serialized_start = 1067
-    _globals["_CUSTOMCHECKRESULT"]._serialized_end = 1176
-    _globals["_CRITERIONRESULT"]._serialized_start = 1178
-    _globals["_CRITERIONRESULT"]._serialized_end = 1258
-    _globals["_JUDGEREPORT"]._serialized_start = 1261
-    _globals["_JUDGEREPORT"]._serialized_end = 1705
-    _globals["_TRACECONSTRAINTRESULT"]._serialized_start = 1708
-    _globals["_TRACECONSTRAINTRESULT"]._serialized_end = 1849
-    _globals["_TRACECHECKSSUMMARY"]._serialized_start = 1851
-    _globals["_TRACECHECKSSUMMARY"]._serialized_end = 1926
-    _globals["_GRADERSERVICE"]._serialized_start = 2028
-    _globals["_GRADERSERVICE"]._serialized_end = 2217
+    _globals["_GRADERESPONSE"]._serialized_end = 260
+    _globals["_HEALTHCHECKREQUEST"]._serialized_start = 262
+    _globals["_HEALTHCHECKREQUEST"]._serialized_end = 282
+    _globals["_HEALTHCHECKRESPONSE"]._serialized_start = 285
+    _globals["_HEALTHCHECKRESPONSE"]._serialized_end = 437
+    _globals["_HEALTHCHECKRESPONSE_SERVINGSTATUS"]._serialized_start = 379
+    _globals["_HEALTHCHECKRESPONSE_SERVINGSTATUS"]._serialized_end = 437
+    _globals["_GRADE"]._serialized_start = 440
+    _globals["_GRADE"]._serialized_end = 953
+    _globals["_GRADECOMPONENTS"]._serialized_start = 956
+    _globals["_GRADECOMPONENTS"]._serialized_end = 1107
+    _globals["_CUSTOMCHECKRESULT"]._serialized_start = 1109
+    _globals["_CUSTOMCHECKRESULT"]._serialized_end = 1218
+    _globals["_CRITERIONRESULT"]._serialized_start = 1220
+    _globals["_CRITERIONRESULT"]._serialized_end = 1300
+    _globals["_JUDGEREPORT"]._serialized_start = 1303
+    _globals["_JUDGEREPORT"]._serialized_end = 1747
+    _globals["_TRACECONSTRAINTRESULT"]._serialized_start = 1750
+    _globals["_TRACECONSTRAINTRESULT"]._serialized_end = 1912
+    _globals["_TRACEPATHRESULT"]._serialized_start = 1914
+    _globals["_TRACEPATHRESULT"]._serialized_end = 1979
+    _globals["_TRACECHECKSSUMMARY"]._serialized_start = 1982
+    _globals["_TRACECHECKSSUMMARY"]._serialized_end = 2122
+    _globals["_GRADERSERVICE"]._serialized_start = 2224
+    _globals["_GRADERSERVICE"]._serialized_end = 2413
 # @@protoc_insertion_point(module_scope)

--- a/tolokaforge/grader/grader_pb2_grpc.py
+++ b/tolokaforge/grader/grader_pb2_grpc.py
@@ -63,19 +63,20 @@ class GraderServiceServicer:
     def Grade(self, request, context):
         """Compute a Grade for a completed trial.
 
-        Stateless per call: the caller provides everything the grader needs to
-        produce a verdict (the transcript encoded as LLM messages, the trial's
-        termination reason, and — for a future extension carrying rubric config
-        — the task_config JSON). The grader is expected to be reachable at a
-        different address from the runner service; the wire types are decoupled
-        from runner.proto so the two services can rev on their own cadence.
+        Stateless per call: the caller provides everything the grader needs.
+        The response carries three distinct outcomes — a failure
+        (success=false), a "nothing to grade" verdict (success=true,
+        no_verdict=true), or a computed grade (success=true, no_verdict=false,
+        grade set). This mirrors the ``TrialGrader.grade`` Protocol's tri-state
+        return, so a grader-service caller and an in-process grader answer the
+        same call with the same outcome for the same input.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def HealthCheck(self, request, context):
-        """Health check — same shape as runner.HealthCheck for operational parity."""
+        """Health check."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/tolokaforge/grader/queue.py
+++ b/tolokaforge/grader/queue.py
@@ -37,6 +37,11 @@ from typing import Protocol, runtime_checkable
 
 from tolokaforge.core.models import Grade
 
+_CLOSE_SENTINEL: object = object()
+"""Marker put on the queue by :meth:`InMemoryGradeBroker.close` so consumers
+parked in :meth:`~InMemoryGradeBroker.next_job` (default ``timeout=None``)
+unblock and terminate cleanly on shutdown."""
+
 
 @dataclass(frozen=True)
 class GradeJob:
@@ -125,9 +130,17 @@ class InMemoryGradeBroker:
 
     def next_job(self, timeout: float | None = None) -> GradeJob | None:
         try:
-            return self._q.get(timeout=timeout)
+            job = self._q.get(timeout=timeout)
         except queue.Empty:
             return None
+        # ``close()`` puts a sentinel on the queue so a consumer parked in
+        # ``next_job(timeout=None)`` (the default) unblocks and terminates
+        # cleanly instead of hanging on shutdown. Re-post the sentinel so
+        # multiple consumers each see it.
+        if job is _CLOSE_SENTINEL:
+            self._q.put(_CLOSE_SENTINEL)
+            return None
+        return job
 
     def publish_result(self, result: GradeResult) -> None:
         with self._futures_lock:
@@ -144,6 +157,10 @@ class InMemoryGradeBroker:
 
     def close(self) -> None:
         self._closed = True
+        # Unblock any consumer parked in ``next_job(timeout=None)``. The
+        # sentinel re-posts itself so a pool of N consumers each terminates
+        # rather than one racing ahead and starving the rest.
+        self._q.put(_CLOSE_SENTINEL)
         with self._futures_lock:
             for entry in self._futures.values():
                 if not entry.future.done():

--- a/tolokaforge/grader/service.py
+++ b/tolokaforge/grader/service.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING
 from tolokaforge.core.models import (
     Grade,
     JudgeStatus,
+    TraceChecksSummary,
+    TraceConstraintResult,
 )
 from tolokaforge.grader import grader_pb2, grader_pb2_grpc
 
@@ -70,15 +72,24 @@ def _grade_to_wire(grade: Grade) -> grader_pb2.Grade:
     wire = grader_pb2.Grade(
         binary_pass=grade.binary_pass,
         score=grade.score,
-        reasons=grade.reasons or "",
+        reasons=grade.reasons or "" if isinstance(grade.reasons, str) else "",
         judge_status=_judge_status_to_wire(grade.judge_status),
     )
+    if grade.state_diff is not None:
+        # ``Grade.state_diff`` is the parsed dict; the wire carries it JSON-
+        # encoded so downstream consumers can lazy-decode. Symmetric with
+        # runner.Grade.state_diff_json which the ``_parse_grade_result`` mapper
+        # deserialises on receipt.
+        wire.state_diff_json = json.dumps(grade.state_diff)
     if grade.components is not None:
         wire.components.state_checks = _sentinel(grade.components.state_checks)
         wire.components.transcript_rules = _sentinel(grade.components.transcript_rules)
         wire.components.llm_judge = _sentinel(grade.components.llm_judge)
         wire.components.custom_checks = _sentinel(grade.components.custom_checks)
-        wire.components.trace_checks = _sentinel(grade.components.trace_checks)
+        # ``trace_checks`` uses proto ``optional`` presence, not the -1.0
+        # sentinel — set it only when the source Grade actually carries one.
+        if grade.components.trace_checks is not None:
+            wire.components.trace_checks = grade.components.trace_checks
     if grade.custom_checks_details:
         wire.custom_checks.extend(
             grader_pb2.CustomCheckResult(
@@ -97,7 +108,76 @@ def _grade_to_wire(grade: Grade) -> grader_pb2.Grade:
             )
             for c in grade.criterion_results
         )
+    _populate_judge_report(wire, grade)
+    if grade.trace_check_results:
+        wire.trace_checks.extend(_trace_constraint_to_wire(r) for r in grade.trace_check_results)
+    if grade.trace_checks_summary is not None:
+        _populate_trace_checks_summary(wire, grade.trace_checks_summary)
     return wire
+
+
+def _populate_judge_report(wire: grader_pb2.Grade, grade: Grade) -> None:
+    """Populate the ``JudgeReport`` sub-message from every field a live
+    :class:`Grade` may carry. The wire ships every judge-side audit field so
+    an offline replay reads the same shape a runner-RPC grade would.
+    """
+    usage = grade.judge_usage
+    kb = grade.judge_kb_gating
+    inputs = grade.judge_inputs
+    transcript = grade.judge_transcript
+    custom_prompt = grade.judge_custom_prompt
+    include_agent_prompt = grade.judge_agent_prompt_included
+    if all(
+        value is None
+        for value in (usage, kb, inputs, transcript, custom_prompt, include_agent_prompt)
+    ):
+        return
+    report = wire.judge_report
+    if usage is not None:
+        report.calls = usage.calls
+        report.prompt_tokens = usage.prompt_tokens
+        report.completion_tokens = usage.completion_tokens
+        report.reasoning_tokens = usage.reasoning_tokens
+        report.cost_usd = usage.cost_usd
+        report.tool_calls = usage.tool_calls
+        report.consistency_rejections = usage.consistency_rejections
+    if transcript is not None:
+        report.transcript_json = json.dumps(transcript)
+    if kb is not None:
+        report.knowledge_search_disabled = kb.knowledge_search_disabled
+        report.kb_tools_offered.extend(kb.offered)
+        report.kb_tools_withheld.extend(kb.withheld)
+    if inputs is not None:
+        if inputs.state_diff_text is not None:
+            report.state_diff_text = inputs.state_diff_text
+        report.read_tools_offered.extend(inputs.read_tools_offered)
+    if custom_prompt is not None:
+        report.custom_system_prompt = custom_prompt
+    if include_agent_prompt is not None:
+        report.include_agent_system_prompt = include_agent_prompt
+
+
+def _trace_constraint_to_wire(r: TraceConstraintResult) -> grader_pb2.TraceConstraintResult:
+    return grader_pb2.TraceConstraintResult(
+        id=r.id,
+        kind=r.kind,
+        passed=r.passed,
+        weight=r.weight,
+        message=r.message,
+        matched_positions=list(r.matched_positions),
+        severity=r.severity,
+        undecided=r.undecided,
+    )
+
+
+def _populate_trace_checks_summary(wire: grader_pb2.Grade, summary: TraceChecksSummary) -> None:
+    wire.trace_checks_summary.winning_path = summary.winning_path
+    wire.trace_checks_summary.gate_failed = summary.gate_failed
+    wire.trace_checks_summary.failed_gate_ids.extend(summary.failed_gate_ids)
+    wire.trace_checks_summary.paths.extend(
+        grader_pb2.TracePathResult(id=p.id, score=p.score, gate_failed=p.gate_failed)
+        for p in summary.paths
+    )
 
 
 def _sentinel(value: float | None) -> float:
@@ -157,11 +237,15 @@ class GraderServiceImpl(grader_pb2_grpc.GraderServiceServicer):
             )
             return grader_pb2.GradeResponse(success=False, error=str(exc))
         if grade is None:
+            # "Nothing to grade" — a trial the agent never got to run. Distinct
+            # from a grading failure: the wire carries ``no_verdict=True`` so
+            # the caller returns ``None`` at the ``TrialGrader`` seam rather
+            # than raising ``GradingFailedError``.
             self.logger.info(
                 "Grader service produced no verdict",
                 trial_id=request.trial_id,
             )
-            return grader_pb2.GradeResponse(success=False, error="no verdict")
+            return grader_pb2.GradeResponse(success=True, no_verdict=True)
         self.logger.info(
             "Grader service produced a Grade",
             trial_id=request.trial_id,
@@ -170,9 +254,9 @@ class GraderServiceImpl(grader_pb2_grpc.GraderServiceServicer):
         )
         return grader_pb2.GradeResponse(success=True, grade=_grade_to_wire(grade))
 
-    def HealthCheck(  # noqa: N802
+    def HealthCheck(  # noqa: N802 — matches the generated stub method name
         self,
-        request: grader_pb2.HealthCheckRequest,  # noqa: ARG002
-        context: object,  # noqa: ARG002
+        request: grader_pb2.HealthCheckRequest,  # noqa: ARG002 — proto contract requires the arg; unused by this impl
+        context: object,  # noqa: ARG002 — gRPC context, unused by this impl
     ) -> grader_pb2.HealthCheckResponse:
         return grader_pb2.HealthCheckResponse(status=grader_pb2.HealthCheckResponse.SERVING)


### PR DESCRIPTION
## Summary

Follow-up to PR #1210 — applies the three deferred code-review findings that all touch \`grader.proto\` and its symmetric encode/decode paths. Ships with a new full-round-trip canonical test and a recursive drift-guard so subsequent runner.proto changes surface as clear failures instead of silent field drops.

## Findings addressed

### Finding 3 — Wire-level None-verdict vs grading-failure

Old: \`GraderService.Grade\` returned \`success=false, error=\"no verdict\"\` when the judge returned \`None\`; \`GraderRPCTrialGrader\` translated that as \`GradingFailedError\`. \`JudgeBackedTrialGrader\` on the same \`None\` returned \`None\`. Same input, different top-level outcome across dispatch shapes.

Now: added \`GradeResponse.no_verdict: bool\`. \`success=true, no_verdict=true, grade unset\` is the "nothing to grade" outcome; \`success=false\` is a failure. \`GraderRPCTrialGrader\` returns \`None\` on \`no_verdict\` — matching the Protocol contract.

### Finding 4 — Full Grade payload populated on the wire

Old: \`_grade_to_wire\` populated only \`binary_pass\` / \`score\` / \`reasons\` / \`components\` / \`custom_checks\` / \`criterion_results\` / \`judge_status\`. \`state_diff_json\`, \`judge_report\`, \`trace_checks\`, \`trace_checks_summary\` were silently dropped.

Now: every field a live \`Grade\` may carry is populated on encode and decoded symmetrically on the client. The new test constructs a fully-populated Grade with all judge audit fields + trace-check results + a trace summary with alternative paths, round-trips it through the real gRPC serialization layer, and asserts every field survives.

### Finding 5 — grader.proto sub-message shapes aligned with runner.proto

- \`JudgeReport\` field numbers realigned with runner.proto (previously drifted at fields 7-14 — a judge report would have decoded with wrong field mappings).
- \`TraceConstraintResult\` gains \`severity\` (field 7) and \`undecided\` (field 8).
- \`TraceChecksSummary\` shape rewritten to match runner's \`{winning_path, gate_failed, failed_gate_ids, paths[]}\`.
- New \`TracePathResult\` sub-message for alternative-route verdicts.
- \`GradeComponents.trace_checks\` becomes \`optional double\` — the presence-gate runner.proto uses for its "not evaluated vs -1.0 sentinel" distinction.

The recursive drift-guard test (\`test_wire_message_types_carry_the_full_grade_shape\`) now walks every Grade sub-message + \`TracePathResult\`; a future runner-side field addition fails the guard until the grader mirror is updated.

## Test plan

- [x] \`test_full_grade_payload_round_trips_through_the_wire\` — new, locks Finding 4
- [x] \`test_none_from_judge_surfaces_as_no_verdict_wire_flag\` — replaces the old test, locks Finding 3
- [x] \`test_wire_message_types_carry_the_full_grade_shape\` — deepened, locks Finding 5
- [x] All 68 canonical grader tests pass locally
- [x] \`lint-imports\` KEPT (orchestration surface holds the seam)
- [x] \`ruff check\` + \`ruff format\` clean

Closes remaining scope from the code-review pass on the grader-detachment milestone.