### PR TITLE
fix(runtime): reap stale named containers before docker compose up

### DIFF
--- a/tests/unit/test_compose_materialisation.py
+++ b/tests/unit/test_compose_materialisation.py
@@ -35,6 +35,7 @@ from tolokaforge.core.compose_materialisation import (
     first_published_port,
     make_project_temp_dir,
     mount_docker_socket_into_runner,
+    reap_stale_named_containers,
     render_squid_config,
     resolve_env_endpoints,
     resolve_host_port,
@@ -908,3 +909,110 @@ class TestMountDockerSocketIntoRunner:
         assert compose.read_text() == before
         volumes = yaml.safe_load(compose.read_text())["services"]["runner"]["volumes"]
         assert len(volumes) == 1
+
+
+class TestReapStaleNamedContainers:
+    """A prior run's container that survived a killed session refuses ``docker
+    compose up`` with a name-conflict; the reaper clears it before the next
+    provision attempt.
+    """
+
+    def test_reaps_every_container_name_declared_in_compose(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "services:\n"
+            "  main:\n"
+            "    image: t:local\n"
+            "    container_name: tbench_task_0_main\n"
+            "  runner:\n"
+            "    image: r:local\n"
+            "    container_name: tbench_task_0_runner\n"
+        )
+        removed: list[list[str]] = []
+
+        def fake_run(argv, capture_output, text, timeout):  # noqa: ANN001
+            removed.append(list(argv))
+            return _FakeCompletedProcess(returncode=0, stdout=argv[-1] + "\n", stderr="")
+
+        monkeypatch.setattr("tolokaforge.core.compose_materialisation.subprocess.run", fake_run)
+
+        reaped = reap_stale_named_containers(compose)
+
+        assert reaped == ("tbench_task_0_main", "tbench_task_0_runner")
+        assert removed == [
+            ["docker", "rm", "-f", "tbench_task_0_main"],
+            ["docker", "rm", "-f", "tbench_task_0_runner"],
+        ]
+
+    def test_missing_container_is_a_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "services:\n"
+            "  main:\n"
+            "    image: t:local\n"
+            "    container_name: tbench_task_0_main\n"
+        )
+
+        def fake_run(argv, capture_output, text, timeout):  # noqa: ANN001
+            return _FakeCompletedProcess(
+                returncode=1,
+                stdout="",
+                stderr="Error: No such container: tbench_task_0_main\n",
+            )
+
+        monkeypatch.setattr("tolokaforge.core.compose_materialisation.subprocess.run", fake_run)
+
+        reaped = reap_stale_named_containers(compose)
+
+        assert reaped == ()
+
+    def test_services_without_container_name_are_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            "services:\n"
+            "  main:\n"
+            "    image: t:local\n"
+            "    container_name: tbench_task_0_main\n"
+            "  db:\n"
+            "    image: db:local\n"
+        )
+        called: list[list[str]] = []
+
+        def fake_run(argv, capture_output, text, timeout):  # noqa: ANN001
+            called.append(list(argv))
+            return _FakeCompletedProcess(returncode=0, stdout=argv[-1] + "\n", stderr="")
+
+        monkeypatch.setattr("tolokaforge.core.compose_materialisation.subprocess.run", fake_run)
+
+        reap_stale_named_containers(compose)
+
+        assert called == [["docker", "rm", "-f", "tbench_task_0_main"]]
+
+    def test_unreadable_compose_file_is_a_silent_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[list[str]] = []
+
+        def fake_run(argv, capture_output, text, timeout):  # noqa: ANN001
+            called.append(list(argv))
+            return _FakeCompletedProcess(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("tolokaforge.core.compose_materialisation.subprocess.run", fake_run)
+
+        reaped = reap_stale_named_containers(tmp_path / "does_not_exist.yaml")
+
+        assert reaped == ()
+        assert called == []
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr

--- a/tolokaforge/core/compose_materialisation.py
+++ b/tolokaforge/core/compose_materialisation.py
@@ -454,6 +454,50 @@ def copy_compose_context(compose_file: Path, dest_dir: Path) -> None:
             shutil.copy2(entry, target)
 
 
+def reap_stale_named_containers(compose_file: Path) -> tuple[str, ...]:
+    """Force-remove any pre-existing containers whose fixed ``container_name``
+    values appear in ``compose_file``. A prior run's containers can survive
+    a killed session or a crashed docker daemon and refuse ``docker compose up``
+    on the next attempt with an "already in use" conflict.
+
+    Returns the container names that were reaped (empty tuple when nothing
+    was stale). Non-existent names are a no-op — reaping is best-effort.
+    """
+    try:
+        doc = yaml.safe_load(compose_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return ()
+    services = doc.get("services") or {}
+    names = tuple(
+        sorted(
+            {
+                svc["container_name"]
+                for svc in services.values()
+                if isinstance(svc, dict) and isinstance(svc.get("container_name"), str)
+            }
+        )
+    )
+    if not names:
+        return ()
+    reaped: list[str] = []
+    for name in names:
+        proc = subprocess.run(
+            ["docker", "rm", "-f", name],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if proc.returncode == 0 and proc.stdout.strip() == name:
+            reaped.append(name)
+    if reaped:
+        logging.getLogger(__name__).info(
+            "Reaped %d stale named container(s) before compose up: %s",
+            len(reaped),
+            ", ".join(reaped),
+        )
+    return tuple(reaped)
+
+
 # ---------------------------------------------------------------------------
 # Endpoint resolution
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/per_trial_runtime.py
+++ b/tolokaforge/core/per_trial_runtime.py
@@ -51,6 +51,7 @@ from tolokaforge.core.compose_materialisation import (
     first_published_port,
     make_project_temp_dir,
     mount_docker_socket_into_runner,
+    reap_stale_named_containers,
     resolve_env_endpoints,
     resolve_host_port,
     resolve_runner_endpoint,
@@ -282,6 +283,7 @@ class PerTrialRuntimeBackend:
                 mount_docker_socket_into_runner(
                     temp_dir / manifest.compose_file.name, manifest.runner_service
                 )
+            reap_stale_named_containers(temp_dir / manifest.compose_file.name)
             compose = DockerCompose(
                 context=str(temp_dir),
                 compose_file_name=manifest.compose_file.name,


### PR DESCRIPTION
## Summary

- Fix reliability bug: a prior run's containers can survive a killed session or crashed docker daemon and refuse the next \`docker compose up --wait\` with an "already in use" conflict.
- Introduces \`reap_stale_named_containers(compose_file)\` — reads \`container_name\` values from a per-trial compose file and force-removes any that exist. Called right before \`compose.start()\` in \`PerTrialRuntimeBackend.provision\`.
- Silent no-op when nothing is stale; unreadable/absent compose files are also silent no-ops.

## Failure mode this fixes

Repro (matrix run from this Friday's autonomous session):

1. Engine-loop run of \`fix-billing-holds\` creates container \`tbench_fix-billing-holds_0_main\`.
2. Session interrupts before compose teardown — container survives.
3. Next CLI-harness run of the same task provisions a compose file with the SAME fixed \`container_name\`.
4. \`docker compose up --wait\` fails immediately with \`Conflict\`; trial errors with \`provision_error\` and no LLM call is made.

Prior symptom: 4 out of 8 matrix cells (all \`fix-billing-holds\` under any CLI harness after the first engine-loop cell had run) errored at provision time with 0 latency and \$0 spend. Airline-segmentation cells were unaffected because no prior run had claimed their name.

## Design choices

- **Reap by name, from the compose file itself.** The container names live in the compose file the runtime is about to invoke. Reading them there means the reaper can never target a container this run does not intend to own — the trial's own trial_index is the discriminator.
- **Force-remove is safe here.** Terminal-bench trials are single-writer per (task_id, trial_index): a running container by the expected name is by construction a stale one from a prior run. The reserved trial_index prevents in-flight collisions across concurrent workers.
- **Silent no-op on absence.** Docker's \`No such container: X\` is the healthy path, not an error condition. Only successful reaps are logged (INFO), so a clean run stays quiet.

## Verification

- New behaviour-locking unit tests in \`tests/unit/test_compose_materialisation.py::TestReapStaleNamedContainers\`:
  - reaps every named container declared, in sorted order
  - missing container is a no-op
  - services without \`container_name\` are skipped
  - unreadable/absent compose file is a silent no-op
- \`uv run pytest tests/unit/test_compose_materialisation.py\` → 74 passed
- \`ruff check\` + \`black --check\` clean

## Test plan

- [x] Unit tests green
- [ ] Full CI green on this PR
- [ ] Manually re-runs the matrix cell that hit the stale-name conflict and observes it succeeds