### PR TITLE
fix(tbench): pin claude-code to 2.1.233 (close matrix Δ vs harbor)

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/data/harnesses.yaml
@@ -9,7 +9,7 @@ harnesses:
     # Pinned to the version the out-of-tree host we compared against resolved
     # when the matrix comparison was baselined. The pin closes the CLI-code
     # delta with that host while keeping reproducibility.
-    version: "2.1.231"
+    version: "2.1.233"
     argv_prefix: ["claude"]
     # `--verbose --output-format=stream-json` matches the reference vendor-CLI
     # invocation. Aligning the flag block aligns the CLI's internal reasoning

--- a/tests/canonical/snapshots/tbench_echo_hello_harness/harness_dockerfile.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_harness/harness_dockerfile.json
@@ -1,3 +1,3 @@
 {
-  "dockerfile": "FROM tbench-echo-hello:local\nCOPY _harness/install-harness.sh /opt/tolokaforge/install-harness.sh\nRUN sh /opt/tolokaforge/install-harness.sh npm @anthropic-ai/claude-code 2.1.231\n"
+  "dockerfile": "FROM tbench-echo-hello:local\nCOPY _harness/install-harness.sh /opt/tolokaforge/install-harness.sh\nRUN sh /opt/tolokaforge/install-harness.sh npm @anthropic-ai/claude-code 2.1.233\n"
 }

--- a/tests/canonical/snapshots/tbench_echo_hello_harness/harness_spec.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_harness/harness_spec.json
@@ -34,5 +34,5 @@
   },
   "skills_dir_target": "/root/.claude/skills/",
   "strip_vendor_namespace": false,
-  "version": "2.1.231"
+  "version": "2.1.233"
 }

--- a/tests/canonical/snapshots/tbench_echo_hello_harness/synthesised_compose.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_harness/synthesised_compose.json
@@ -35,7 +35,7 @@
         "CLAUDE_CONFIG_DIR=/root/.claude",
         "IS_SANDBOX=1"
       ],
-      "image": "tbench-echo-hello:local-claude-code-2.1.231",
+      "image": "tbench-echo-hello:local-claude-code-2.1.233",
       "volumes": [
         "./tests:/tests",
         "./_logs:/logs"

--- a/tests/canonical/snapshots/tbench_echo_hello_skills_harness/harness_dockerfile.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_skills_harness/harness_dockerfile.json
@@ -1,3 +1,3 @@
 {
-  "dockerfile": "FROM tbench-echo-hello-skills:local\nCOPY _harness/install-harness.sh /opt/tolokaforge/install-harness.sh\nRUN sh /opt/tolokaforge/install-harness.sh npm @anthropic-ai/claude-code 2.1.231\nCOPY skills/. /root/.claude/skills/\n"
+  "dockerfile": "FROM tbench-echo-hello-skills:local\nCOPY _harness/install-harness.sh /opt/tolokaforge/install-harness.sh\nRUN sh /opt/tolokaforge/install-harness.sh npm @anthropic-ai/claude-code 2.1.233\nCOPY skills/. /root/.claude/skills/\n"
 }

--- a/tests/canonical/snapshots/tbench_echo_hello_skills_harness/synthesised_compose.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_skills_harness/synthesised_compose.json
@@ -35,7 +35,7 @@
         "CLAUDE_CONFIG_DIR=/root/.claude",
         "IS_SANDBOX=1"
       ],
-      "image": "tbench-echo-hello-skills:local-claude-code-2.1.231",
+      "image": "tbench-echo-hello-skills:local-claude-code-2.1.233",
       "volumes": [
         "./tests:/tests",
         "./_logs:/logs"

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -1637,7 +1637,7 @@ class TestComposeSynthesisHarnessLayer:
         assert base["profiles"] == ["tolokaforge-build"]
 
         main = compose["services"]["main"]
-        assert main["image"] == "tbench-layered:local-claude-code-2.1.231"
+        assert main["image"] == "tbench-layered:local-claude-code-2.1.233"
         assert main["build"] == {
             "context": ".",
             "dockerfile": "_harness/harness.Dockerfile",
@@ -1687,7 +1687,7 @@ class TestComposeSynthesisHarnessLayer:
         compose = _load_synthesised(env)
         assert "main-base" not in compose["services"]
         assert env.base_build_service is None
-        assert compose["services"]["main"]["image"] == "tbench-prebuilt:local-claude-code-2.1.231"
+        assert compose["services"]["main"]["image"] == "tbench-prebuilt:local-claude-code-2.1.233"
 
     def test_registry_base_is_pulled_not_built(self, tmp_path):
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
@@ -2674,7 +2674,7 @@ class TestHarnessTaskDescriptionMetadata:
             "claude --verbose --output-format=stream-json "
             "--permission-mode=bypassPermissions --print"
         )
-        assert td.metadata["agent_harness_version"] == "2.1.231"
+        assert td.metadata["agent_harness_version"] == "2.1.233"
 
     def test_default_harness_publishes_no_command(self, fixture_dir, tmp_path):
         from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter


### PR DESCRIPTION
## Summary

- Bump \`data/harnesses.yaml\` \`claude-code\` pin from \`2.1.231\` → \`2.1.233\` to match harbor 0.21's own claude-code install.
- The version drift was the root cause of a real Δ observed on opus-4.7 during n=3 head-to-head runs this morning: TF averaged 0.955 on \`fix-billing-holds\` while harbor averaged 0.800 (Δ -0.155, ~2.6σ). Bumping the pin closed the gap to +0.022 (billing) and 0.000 (segmentation).

## Why the pin, not just \`latest\`

Same reason the docstring already gives: reproducibility. Every trial-image tag encodes \`local-claude-code-<version>\`, so a floating \`latest\` would silently change what the matrix is measuring. Pinning to whatever harbor's pinned to keeps the two pipelines running the same agent code without giving up the tag stability.

## Verification

- Opus 4.7 × claude-code × 2 tasks × n=3 × both pipelines (12 cells) run with the mismatched pin: TF billing 0.955 (σ 0.031), harbor 0.800 (σ 0.098), TF seg 1.000 (σ 0), harbor 0.911 (σ 0.063).
- Same 12 cells re-run with matched 2.1.233: TF billing 0.878 (σ 0.079), harbor 0.900 (σ 0.094), TF seg 0.956 (σ 0.063), harbor 0.956 (σ 0.063). Δ collapses to +0.022 and 0.000, inside both pipelines' shared noise floor.
- Four earlier matched rows (fable-5, sonnet-5, gpt-5.5, gpt-5.6-sol) already agreed within 0.011 across pipelines, so the fix isn't retroactively wrong for them — this pin change is what makes the whole priority-table comparison consistent going forward.

## Test plan

- [x] Local Opus 4.7 n=3 matrix confirms Δ collapse
- [ ] CI green on this PR