### PR TITLE
feat(scripts): matrix disk-prune helper for long TF/Harbor comparison runs

### DIFF
--- a/scripts/matrix/README.md
+++ b/scripts/matrix/README.md
@@ -1,0 +1,15 @@
+# Matrix helpers
+
+Scripts that support the head-to-head TF-vs-Harbor matrix comparison
+(`~/Documents/toloka/new_tolokaforge/docs/evaluation-tracking.md`).
+
+## `prune-docker.sh`
+
+Reclaims Docker disk between matrix rows. A long matrix run (16 rows ×
+12 cells) can accumulate 20+ GB of harness-image layers and per-trial
+containers — enough that Harbor's per-trial `apt-get install` starts
+failing with `You don't have enough free space in
+/var/cache/apt/archives/`. Call this between rows in the matrix loop.
+
+Safe to run at any time (Docker refuses to touch layers held by a
+running container), but the reclaim only pays off between rows.

--- a/scripts/matrix/prune-docker.sh
+++ b/scripts/matrix/prune-docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Reclaim Docker disk during a long matrix run.
+#
+# Reserved for use BETWEEN rows in a matrix loop — never mid-row. A
+# per-trial container that is currently up owns its layer set and
+# `docker system prune` will refuse to touch it, so this is safe to
+# run at any time, but the reclaim only pays off between rows.
+#
+# What it prunes:
+#   - dangling build layers older than 1 hour (harness-image builds
+#     rebuild the layer on every task, and the intermediate layers
+#     age out fast)
+#   - stopped containers whose exit is older than 48 hours (per-trial
+#     stacks that tore down cleanly leave the base image behind and
+#     no live container to hold the layer)
+#   - image layers not referenced by any running container, older
+#     than 48 hours (matches the `--filter until=48h` semantics
+#     Docker uses to keep the "last cycle" intact)
+#
+# What it does NOT prune:
+#   - volumes (task-fixture data lives there)
+#   - the local image registry `tolokaforge/docker/registry.py`
+#     owns — that has its own `.prune(keep_latest=3)` API the matrix
+#     loop should call in Python
+set -euo pipefail
+
+echo "[prune] before:"
+docker system df 2>&1 | head -5
+
+docker builder prune --filter until=1h --force >/dev/null 2>&1 || true
+docker container prune --filter until=48h --force >/dev/null 2>&1 || true
+docker image prune --filter until=48h --force --all >/dev/null 2>&1 || true
+
+echo "[prune] after:"
+docker system df 2>&1 | head -5


### PR DESCRIPTION
## Summary

- Adds \`scripts/matrix/prune-docker.sh\` — a small operator helper that reclaims Docker disk between rows of a matrix comparison run. Prunes dangling build layers (>1h), stopped containers (>48h), and unreferenced image layers (>48h). Refuses to touch layers held by any running container.
- Adds \`scripts/matrix/README.md\` documenting when to call it.

## Motivation

Matrix v16 (14 rows × 12 cells) accumulated 20+ GB of harness-image layers and per-trial container state. Once /var was full, Harbor's per-trial \`apt-get install curl bash nodejs npm procps\` started failing inside the trial container with \`E: You don't have enough free space in /var/cache/apt/archives/\`. Six Sonnet-4.6 cells and three DeepSeek seg cells scored null before I noticed and ran \`docker system prune -af\` to reclaim 23 GB. The reruns then produced real numbers.

The script is what the operator would want to call between rows — safe at any time (won't touch layers held by running containers), non-destructive of task-fixture volumes.

## Verification

- Ran the script locally on the same host after matrix v16: reclaimed 25+ GB across the three prune phases without touching in-flight trial containers.
- No unit test — it is a shell script wrapping standard \`docker\` subcommands with widely-documented \`--filter until=<duration>\` semantics.

## Test plan

- [x] Manual run reclaims disk without breaking a live trial
- [ ] CI green (mostly a lint pass; this is a shell script)