### PR TITLE
fix(review): apply all 15 code-review findings on PR #1196

### DIFF
--- a/tests/canonical/test_example_pack_grading_corpus.py
+++ b/tests/canonical/test_example_pack_grading_corpus.py
@@ -648,18 +648,22 @@ def test_no_shipped_pack_addresses_a_state_its_substrate_cannot_reach() -> None:
         f"{reading_an_absent_database}"
     )
 
+    # ``$.filesystem[…]`` is reachable on the runner (via
+    # ``_read_agent_visible_filesystem``), so it is *not* in the negative-control
+    # set. The residue is ``agent`` / ``user`` / ``mock_web_url`` /
+    # ``rag_corpus_dir`` — roots the core engine composes from a run's live env
+    # that the runner has no equivalent for.
     probed_paths, _ = _states_a_pack_addresses_but_cannot_reach(
         {
             "state_checks": {
                 "jsonpaths": [
-                    {"path": _A_FILESYSTEM_ROOTED_PATH},
                     {"path": _AN_AGENT_ROOTED_PATH},
                 ]
             }
         },
         SeededTablesLayer.unresolvable(),
     )
-    assert probed_paths == [_A_FILESYSTEM_ROOTED_PATH, _AN_AGENT_ROOTED_PATH]
+    assert probed_paths == [_AN_AGENT_ROOTED_PATH]
     _, probed_absent_database = _states_a_pack_addresses_but_cannot_reach(
         {"state_checks": {"jsonpaths": [{"path": _A_DATABASE_ROOTED_PATH}]}},
         SeededTablesLayer(tables={}),

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -2706,36 +2706,33 @@ def test_a_source_less_hash_block_on_a_task_that_seeds_nothing_is_refused_by_nam
     assert "TrialNotFoundError" not in response.error
 
 
-def test_a_filesystem_rooted_path_is_refused_rather_than_scored_against_the_agent(
-    runner_service, mock_grpc_context
-):
-    """The refusal that stops a narrowed state fetch becoming a zero the agent earned.
+def test_a_filesystem_rooted_path_is_graded_not_refused(runner_service, mock_grpc_context):
+    """The runner grades a ``$.filesystem[…]``-rooted path against the
+    agent-visible filesystem — the state
+    :meth:`RunnerServiceImpl._read_agent_visible_filesystem` composes.
 
-    The task seeds a database, so nothing here is about a missing DB service. The
-    assertion addresses a root the runner's JSONPath state does not carry, and the
-    outcome that must not happen is a scored ``0.0``: dropping such an assertion out
-    of the fetch and evaluating it against no state reports
-    ``DB state unavailable for JSONPath checks`` and grades the agent for it.
-
-    ``success is False`` is what carries that claim. The reason text is asserted absent
-    beside it, and on a refusal there is no reason text to search — that assertion
-    speaks only against a build which scores this pack instead of refusing it, which is
-    the build it exists for.
+    The pre-existing refusal at ``_unreachable_state_checks_refusal`` classified
+    every filesystem-rooted path as unreachable and led ``GradeTrial`` to answer
+    ``success=false``. Measurement (reviewer report on the earlier commit) proved
+    the runner actually resolves such paths correctly, so the refusal was removed.
+    This test locks the corrected behaviour: the RPC responds ``success=true`` and
+    hands back a normal ``Grade`` rather than a refusal.
     """
     task = _in_memory_task(
-        "refusal_filesystem",
+        "graded_filesystem",
         state_checks=runner_models.RunnerStateChecksConfig(
             jsonpath_checks=[{"path": _A_FILESYSTEM_PATH, "contains": "def divide"}]
         ),
         seeds_a_database=True,
     )
 
-    response = _refusal_for(runner_service, mock_grpc_context, task, "refusal_filesystem:0")
+    response = _refusal_for(runner_service, mock_grpc_context, task, "graded_filesystem:0")
 
-    assert response.success is False, response.grade.reasons
-    assert "path_glob" in response.error
-    assert _A_FILESYSTEM_PATH in response.error
-    assert "DB state unavailable" not in response.grade.reasons
+    # ``success`` is now True: the assertion is graded rather than refused. The
+    # score itself may be 0.0 because the in-memory test filesystem does not
+    # actually contain ``x.py`` with the asserted content — we assert only the
+    # non-refusal semantic here; the substrate-parity suite covers the score.
+    assert response.success is True, response.error
 
 
 def test_a_path_rooted_where_only_the_core_engine_composes_is_refused(
@@ -2806,9 +2803,14 @@ _REFUSALS_THAT_NAME_THE_TRIAL = (
     ),
     pytest.param(
         runner_models.RunnerStateChecksConfig(
-            jsonpath_checks=[{"path": _A_FILESYSTEM_PATH, "contains": "def divide"}]
+            jsonpath_checks=[
+                {"path": "$.agent.customers[0].balance", "equals": "0"},
+            ]
         ),
         True,
+        # ``$.agent`` roots at state only the core engine composes; the runner
+        # has no equivalent, so the refusal fires here where filesystem no
+        # longer does.
         id="a_path_the_runner_composes_no_root_for",
     ),
 )

--- a/tests/canonical/test_terminal_bench_harness_mode.py
+++ b/tests/canonical/test_terminal_bench_harness_mode.py
@@ -28,6 +28,7 @@ import pytest
 
 from tolokaforge.core import runner as runner_module
 from tolokaforge.core.conductor import InProcessConductor
+from tolokaforge.core.loop import classify_loop_error
 from tolokaforge.core.models import (
     Grade,
     GradeComponents,
@@ -193,6 +194,7 @@ def harness_trial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         grader = _RecordingGrader()
         agent_client = MagicMock()
         agent_client.capabilities.schema_sanitizer.sanitize.side_effect = lambda s: s
+        agent_client.classify_loop_error.side_effect = lambda exc: classify_loop_error(exc, ())
 
         conductor = InProcessConductor(
             adapter=adapter,

--- a/tests/unit/grading/test_grading_authoring_gate.py
+++ b/tests/unit/grading/test_grading_authoring_gate.py
@@ -261,6 +261,13 @@ _A_FILESYSTEM_ROOTED_ASSERTION = {
     "contains": "def divide",
 }
 _A_FILE_ASSERTION = {"path_glob": "/env/fs/agent-visible/x.py", "contains_ci": "def divide"}
+# ``$.agent[…]`` roots at state only the core engine composes (from a run's live
+# env). The runner has no equivalent, so this remains an unreachable-path defect
+# after filesystem paths were promoted to runner-graded.
+_AN_UNREACHABLE_PATH_ASSERTION = {
+    "path": "$.agent.customers[0].balance",
+    "equals": "0",
+}
 
 
 def _keyed_state(id_fields: dict[str, Any]) -> dict[str, Any]:
@@ -312,9 +319,16 @@ _RULES: tuple[_Rule, ...] = (
         seeded_tables=_THE_TASK_SEEDS_NO_TABLES,
     ),
     _Rule(
-        label="a_path_addressing_the_filesystem",
+        # ``$.filesystem[…]`` is *reachable* on the runner (via
+        # ``_read_agent_visible_filesystem``), so the authoring gate should not
+        # refuse it — this rule now exercises the residual unreachable set
+        # (``agent`` / ``user`` / ``mock_web_url`` / ``rag_corpus_dir``), which
+        # the core engine composes from a run's live env and the runner does not.
+        label="a_path_addressing_beyond_the_runners_state",
         task=_HELPDESK,
-        grading={"state_checks": {"jsonpaths": [_A_FILESYSTEM_ROOTED_ASSERTION]}},
+        grading={
+            "state_checks": {"jsonpaths": [{"path": "$.agent.customers[0].balance", "equals": "0"}]}
+        },
         checker="_check_jsonpaths_address_a_reachable_state",
         channel="errors",
         message="addresses state the runner's JSONPath grading does not carry",
@@ -1356,7 +1370,7 @@ def test_an_unresolvable_layer_skips_the_seeded_read_and_still_refuses_the_path(
     read, and a silent pass there would be the shape this rule exists to close.
     """
     report = inspect_grading_authoring(
-        {"state_checks": {"jsonpaths": [_A_JSONPATH_ASSERTION, _A_FILESYSTEM_ROOTED_ASSERTION]}},
+        {"state_checks": {"jsonpaths": [_A_JSONPATH_ASSERTION, _AN_UNREACHABLE_PATH_ASSERTION]}},
         _inventory(_HELPDESK),
         seeded_tables=_NO_CALLER_READ_WHAT_THE_TASK_SEEDS,
     )

--- a/tests/unit/grading/test_jsonpath_addressing.py
+++ b/tests/unit/grading/test_jsonpath_addressing.py
@@ -74,7 +74,11 @@ def test_an_unparseable_path_is_refused_by_name() -> None:
     ("assertion", "reads_the_database", "beyond_the_runner"),
     [
         (_A_DATABASE_ASSERTION, True, None),
-        (_A_FILESYSTEM_ASSERTION, False, JsonPathTarget.FILESYSTEM),
+        # ``$.filesystem[…]`` grades on the runner via
+        # ``_read_agent_visible_filesystem`` — it addresses runner-graded state
+        # (so ``unreachable_target`` returns ``None``) and reads the filesystem
+        # rather than the database (so ``addresses_the_database`` returns ``False``).
+        (_A_FILESYSTEM_ASSERTION, False, None),
         ({"path": "$.agent.customers[0].balance"}, False, JsonPathTarget.BEYOND_THE_RUNNERS_STATE),
         # A file assertion in its authored form addresses neither: it is not a
         # JSONPath expression at all.

--- a/tests/unit/grading/test_trace_checks_matchers.py
+++ b/tests/unit/grading/test_trace_checks_matchers.py
@@ -344,3 +344,32 @@ def test_an_operator_selects_the_call_whose_argument_it_holds_for(operator_name:
     assert len(holds.matched) == 1
     assert fails.matched == ()
     assert fails.undecidable == ()
+
+
+def test_a_status_literal_no_executor_produces_is_rejected_at_load() -> None:
+    """A status predicate naming a non-``ToolExecutionStatus`` value fails at load.
+
+    Loading ``status: {equals: "expired"}`` clean and only failing at grading
+    time would report the typo as an agent failure. The gate keeps this
+    syntactic — closed-vocabulary operators (``equals``, ``not_equals``,
+    ``in_``, ``not_in``) validate every literal against the enum.
+    """
+    with pytest.raises(ValueError, match="expired"):
+        TraceMatcher(
+            kind=TraceEventKind.TOOL_RESULT,
+            status=ValuePredicate(equals="expired"),
+        )
+    with pytest.raises(ValueError, match="pending"):
+        TraceMatcher(
+            kind=TraceEventKind.TOOL_RESULT,
+            status=ValuePredicate(in_=["success", "pending"]),
+        )
+
+
+def test_a_status_literal_that_is_a_real_enum_member_is_admitted() -> None:
+    """Every ``ToolExecutionStatus`` value stays a valid predicate literal."""
+    for admitted in ("success", "error", "timeout", "tool_not_found", "invalid_arguments"):
+        TraceMatcher(
+            kind=TraceEventKind.TOOL_RESULT,
+            status=ValuePredicate(equals=admitted),
+        )

--- a/tests/unit/grading/test_trace_timeline.py
+++ b/tests/unit/grading/test_trace_timeline.py
@@ -219,6 +219,27 @@ def test_result_comes_from_the_record_not_the_message() -> None:
     assert result.result == "already refunded"
 
 
+def test_a_message_only_failure_carries_the_same_text_a_record_would() -> None:
+    """A bundle re-graded without ``tool_log.yaml`` reconstructs the failure text
+    identically: the ``Error: `` prefix ``core/loop.py`` writes onto the
+    message body is stripped so ``result:`` matchers see one text on both
+    substrates (#977).
+
+    Without the strip, ``result: {regex: "^already refunded"}`` would pass on
+    a bundle carrying the log and fail on the same bundle re-graded from
+    messages alone.
+    """
+    messages = [
+        _assistant("", _call("call_A", "refund", order_id="42")),
+        _tool_message("call_A", "Error: already refunded"),
+    ]
+
+    timeline = build_trial_timeline(messages, [], None)
+
+    (result,) = _of_kind(timeline, TraceEventKind.TOOL_RESULT)
+    assert result.result == "already refunded"
+
+
 def test_turn_index_follows_assistant_generations() -> None:
     """Every event of one assistant generation shares its index, and the initial
     user prompt carries turn 0 while preceding the first assistant message."""
@@ -546,9 +567,9 @@ def test_a_bundle_with_no_records_takes_each_result_from_its_tool_message() -> N
     is not written to ``trajectory.yaml``, but the ``role: tool`` messages are, so
     the tool output is on disk and only the record's own fields are missing.
 
-    ``call_B``'s text is the message view's wording, not the record's — the record
-    said ``{"error": ...}`` and this says ``Error: {"error": ...}``, which is the
-    proof this timeline read the messages.
+    ``call_B``'s text is the tool's own failure text — the ``core/loop.py``
+    ``Error: `` prefix is stripped on this branch so ``result:`` matchers see
+    the same text as a bundle re-graded with a ``tool_log.yaml`` (#977).
     """
     messages, _ = _refund_trial()
 
@@ -559,7 +580,7 @@ def test_a_bundle_with_no_records_takes_each_result_from_its_tool_message() -> N
     results = _of_kind(timeline, TraceEventKind.TOOL_RESULT)
     assert {event.call_id: event.result for event in results} == {
         "call_A": '{"ok": true}',
-        "call_B": 'Error: {"error": "already refunded"}',
+        "call_B": '{"error": "already refunded"}',
     }
     populated = {
         field

--- a/tests/unit/test_runner_logic.py
+++ b/tests/unit/test_runner_logic.py
@@ -677,8 +677,14 @@ class TestTrialRunnerRun:
         assert traj.status == TrialStatus.TIMEOUT
 
     def test_agent_error_terminates(self) -> None:
-        """Agent API error → ERROR termination."""
-        agent = MagicMock()
+        """Agent API error → ERROR termination.
+
+        Uses ``_make_agent_client`` so ``classify_loop_error`` is wired to the
+        real helper — the runner's initialization branch routes the opening
+        exception through the classifier to keep pricing consistent between
+        opening-generation faults and mid-loop faults.
+        """
+        agent = _make_agent_client()
         agent.generate.side_effect = Exception("Connection failed")
 
         runner = _make_runner(agent_client=agent)

--- a/tests/unit/test_runner_logic.py
+++ b/tests/unit/test_runner_logic.py
@@ -884,3 +884,23 @@ class TestUserSimulatorIntegration:
 
         with pytest.raises(RuntimeError, match="empty first message"):
             runner._bootstrap_via_simulator()
+
+    def test_a_filler_substituted_bootstrap_refuses(self) -> None:
+        """A tool-call-only opening the LLM client filled with ``"Let me check that."``
+        refuses instead of seeding the transcript with the engine's own words.
+
+        The filler is the only text the engine contributes to a user turn.
+        Accepting it as the bootstrap seed would grade the agent against the
+        engine's fixed placeholder rather than what the task adapter authored.
+        """
+        filled = GenerationResult(
+            text="Let me check that.",
+            tool_calls=[ToolCall(id="call_1", name="lookup_order", arguments={"id": "A-1"})],
+        )
+        filled.filler_substituted = True
+        user_sim = MagicMock()
+        user_sim.reply.return_value = filled
+        runner = _make_runner(user_simulator=user_sim)
+
+        with pytest.raises(RuntimeError, match="empty first message"):
+            runner._bootstrap_via_simulator()

--- a/tests/unit/test_runner_search_plane_refusal.py
+++ b/tests/unit/test_runner_search_plane_refusal.py
@@ -284,11 +284,6 @@ def test_a_usable_client_registers_the_trial(
     [
         ("no-search-block", None, GOOD_CORPUS),
         ("connection-configured-and-no-corpus-arrived", CONNECTION_ONLY_SEARCH, NO_CORPUS),
-        (
-            "kb-task-in-a-typesense-disabled-run",
-            {"enabled": False, "domain_name": DOMAIN, "documents_path": "docindex"},
-            GOOD_CORPUS,
-        ),
     ],
 )
 def test_a_task_without_both_halves_does_no_typesense_work(
@@ -301,18 +296,44 @@ def test_a_task_without_both_halves_does_no_typesense_work(
 ) -> None:
     """The gate is a conjunction: neither half alone reaches the search plane.
 
-    The first shape carries a corpus with no search declaration at all, which is
-    not the disagreement class — no plane was configured for it to contradict.
-    The third is the one both rejected gate formulations got wrong: a
-    knowledge-base task in a run that configured no TypeSense plane, which is
-    also what a ``mode: disabled`` run produces (the orchestrator emits no
-    connection details for it — ``tests/unit/test_orchestrator_logic.py``).
+    The first shape carries a corpus with no search declaration at all, so the
+    task never asked for one to fire; the second declares only a connection
+    with no corpus arriving, so there is nothing to serve. Neither shape is
+    the silently-broken class ``test_a_kb_task_in_a_no_plane_run_refuses`` locks.
     """
     registry = _install_registry(monkeypatch, _Registry())
 
     response = _register(service, mock_grpc_context, f"nokb_{shape}:0", _task(search, artifacts))
 
     assert response.success is True, response.error
+    assert registry.calls == []
+
+
+def test_a_kb_task_in_a_no_plane_run_refuses(
+    service: Any, mock_grpc_context: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A knowledge-base task in a run that resolves no TypeSense plane must refuse loudly.
+
+    An adapter mid-migration can produce this shape: ``search.documents_path``
+    declares a corpus, ``search.plane`` is unset, and the run configured no
+    connection details — the ``mode: disabled`` shape. Silent registration
+    would let every ``search_policy`` call fail on paid turns and grade the
+    agent for the misconfiguration.
+    """
+    registry = _install_registry(monkeypatch, _Registry())
+    search = {"enabled": False, "domain_name": DOMAIN, "documents_path": "docindex"}
+
+    response = _register(
+        service,
+        mock_grpc_context,
+        "nokb_kb-task-in-a-typesense-disabled-run:0",
+        _task(search, GOOD_CORPUS),
+    )
+
+    assert response.success is False
+    assert "neither plane serves" in response.error
+    assert "search.plane is unset" in response.error
+    assert DOMAIN in response.error
     assert registry.calls == []
 
 

--- a/tests/unit/test_trial_executor.py
+++ b/tests/unit/test_trial_executor.py
@@ -165,6 +165,37 @@ class TestProvisionErrorBranches:
         assert conductor.call_log.runs == []
         assert backend.call_log.torn_down_trials, "teardown must fire after await_ready failure"
 
+    def test_register_trial_refusal_synthesises_failed_result_and_tears_down(self) -> None:
+        """A registration refusal after provisioning succeeds surfaces as
+        a synthesised PROVISION_ERROR row, not an uncaught RuntimeError.
+
+        Before the typed conversion, a runner-side refusal (e.g. the
+        search-plane gate) crossed as a bare ``RuntimeError`` and escaped
+        ``conductor.run`` uncaught. The orchestrator's queue-only path
+        dropped the trial out of ``self.results`` and inflated every rate,
+        after the retry budget burned on a deterministic refusal.
+        """
+
+        def _refuse_register(_task_id: str, _idx: int):
+            raise ProvisionError(
+                trial_id="task_registration_refused:0",
+                stage="register_trial",
+                reason="Failed to register trial with executor: search plane unusable",
+            )
+
+        backend = InMemoryRuntimeBackend()
+        conductor = InMemoryConductor(trajectory_factory=_refuse_register)
+        executor, _, _, logger = _make_executor(backend=backend, conductor=conductor)
+
+        result = executor.execute(make_trial_spec(), make_task_config())
+
+        assert result.trajectory.status == TrialStatus.ERROR
+        assert result.trajectory.termination_reason == TerminationReason.PROVISION_ERROR
+        assert result.trajectory.grade is None
+        assert backend.call_log.torn_down_trials, "teardown must fire after register_trial refusal"
+        logger.error.assert_called_once()
+        assert logger.error.call_args.args[0] == "Registration refused after provisioning"
+
 
 class TestSafeTeardown:
     """Teardown after a failed body / failed await_ready is best-effort:

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -63,6 +63,19 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
 
     block = actor_tool_block(task, actor)
     mcp_server_ref: str | None = block.get("mcp_server")
+    if mcp_server_ref is None and actor is ToolActor.USER:
+        # A ``tools.user.enabled`` block that names an mcp-served tool but
+        # declares no ``mcp_server`` of its own falls back to the agent's
+        # server (``task_config.py`` permits the shape). Without this fallback
+        # the ``ToolSource`` is built as ``None`` and the runner's
+        # source-less-dispatch arm routes to the ``builtin`` registry — an 8-
+        # tool name (bash / calculator / browser / http_request / db_query /
+        # db_update / read_file / write_file) can shadow the pack's MCP tool
+        # of the same name, silently substituting the wrong implementation.
+        # A name with no builtin instead raises ``ToolConfigurationError``
+        # at RegisterTrial. Reading the agent block as the fallback matches
+        # the ``core/actors`` convention documented at ``task_config.py:450``.
+        mcp_server_ref = actor_tool_block(task, ToolActor.AGENT).get("mcp_server")
     if mcp_server_ref and not (task_dir / mcp_server_ref).exists():
         raise RuntimeError(f"MCP server script not found: {task_dir / mcp_server_ref}")
 

--- a/tolokaforge/core/actors/reply_guard.py
+++ b/tolokaforge/core/actors/reply_guard.py
@@ -7,8 +7,11 @@ substituted, with one carve-out inside the guarded closure:
 :meth:`~tolokaforge.core.llm.client.UserSimulator._llm_reply` replaces an empty
 reply that carried tool calls with a fixed placeholder before the detectors see
 it. That placeholder is the only text the engine contributes to a user turn, and
-it is unreachable in-tree — the simulator is handed tool schemas only alongside a
-``user_tool_executor``, and the conductor always passes ``None``. Its removal is
+it is reachable in-tree — the conductor wires a ``user_tool_executor`` when the
+task spec declares user tools, so the simulator can carry tool schemas and emit
+a tool-call-only reply. The substitution stamps ``filler_substituted`` on the
+result so the bootstrap can refuse a first message the engine authored rather
+than accept the filler as the agent's seeded task statement. Its removal is
 tracked in #1089. Apart from it, the engine has no path that can put words into a
 turn the model did not write. When the attempt budget
 (:data:`~tolokaforge.core.models.run_config.USER_REPLY_MAX_ATTEMPTS`) is spent,

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -59,7 +59,7 @@ from tolokaforge.core.run_display_events import (
     _NullRunDisplayEvents,
 )
 from tolokaforge.core.runner import TrialRunner
-from tolokaforge.core.runtime import RuntimeBackend
+from tolokaforge.core.runtime import ProvisionError, RuntimeBackend
 from tolokaforge.core.stuck import StuckDetector
 from tolokaforge.core.system_prompt import build_system_prompt
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialResult, TrialSpec
@@ -589,8 +589,18 @@ class InProcessConductor:
         )
         if not register_result["success"]:
             error = register_result.get("error", "Unknown error")
-            raise RuntimeError(
-                f"Failed to register trial with executor for trial {trial_id}: {error}"
+            # Raised typed so the trial executor synthesises a
+            # PROVISION_ERROR trajectory (``trial_executor.py:_synthesize_
+            # provision_failure_result``) and the orchestrator records a row
+            # for it. A bare ``RuntimeError`` here escapes uncaught into the
+            # orchestrator's queue-only path, dropping the trial out of
+            # ``self.results`` entirely — inflating every rate by silently
+            # burning the retry budget on a deterministic refusal with
+            # nothing in the output to show for it.
+            raise ProvisionError(
+                trial_id=trial_id,
+                stage="register_trial",
+                reason=f"Failed to register trial with executor: {error}",
             )
 
         # Tool schemas from register_trial (converted to OpenAI format).

--- a/tolokaforge/core/grading/config_validation.py
+++ b/tolokaforge/core/grading/config_validation.py
@@ -55,7 +55,6 @@ from tolokaforge.core.grading.grade_components import (
     component_requested,
 )
 from tolokaforge.core.grading.jsonpath_addressing import (
-    JsonPathTarget,
     addresses_the_database,
     block_addresses_the_database,
     unreachable_target,
@@ -1670,16 +1669,15 @@ def _check_jsonpaths_address_a_reachable_state(grading: Mapping[str, Any]) -> Au
         target = unreachable_target(assertion)
         if target is None:
             continue
+        # Only ``BEYOND_THE_RUNNERS_STATE`` reaches here now — ``FILESYSTEM``
+        # grades on the runner via ``_read_agent_visible_filesystem``, so the
+        # authoring gate no longer refuses ``$.filesystem[…]``-rooted paths.
         findings.append(
             Finding(
                 _JSONPATHS_ADDRESS,
                 _A_PATH_BEYOND_THE_RUNNERS_STATE.format(
                     path=assertion.get("path"),
-                    remedy=(
-                        _ADDRESS_A_FILE_BY_GLOB
-                        if target is JsonPathTarget.FILESYSTEM
-                        else _ADDRESS_THE_DATABASE
-                    ),
+                    remedy=_ADDRESS_THE_DATABASE,
                 ),
             )
         )

--- a/tolokaforge/core/grading/config_validation.py
+++ b/tolokaforge/core/grading/config_validation.py
@@ -84,7 +84,7 @@ from tolokaforge.core.models import (
     TranscriptRulesConfig,
     ValuePredicate,
 )
-from tolokaforge.runner.id_resolution import id_fields_findings
+from tolokaforge.runner.id_resolution import IdFieldResolutionError, id_fields_findings
 from tolokaforge.runner.models import TRACE_PREDICATE_BINDING_OPERATORS
 
 logger = logging.getLogger(__name__)
@@ -1128,18 +1128,36 @@ def _check_tool_names(sites: tuple[_MatcherSite, ...], inventory: ToolInventory)
 def _check_tool_expectation_names(
     expectations: ToolExpectations | None, inventory: ToolInventory
 ) -> AuthoringReport:
-    """``tool_expectations`` may only name a tool some actor of the task can call."""
+    """``tool_expectations`` may only name a tool the agent of the task can call.
+
+    ``transcript.py`` filters ``call.executor is ToolExecutorIdentity.AGENT`` in
+    the evaluator (renamed ``_executed`` -> ``_executed_by_agent``), so a name
+    in the user's declared set is invisible to the check at runtime: a
+    ``required_tools`` name reaching only ``user_declared`` passes the gate and
+    fails on every trial, indistinguishable from the misspelling this gate
+    exists to catch; a ``disallowed_tools`` name reaching only ``user_declared``
+    passes on every trial even when the simulator calls it. Narrow the
+    membership check to the agent's set.
+    """
     if expectations is None:
         return AuthoringReport()
+    # ``declared_by`` refuses to answer on a recorded-trial inventory whose
+    # actor split is unknown; fall back to the union set there.
+    if inventory.actor_split_known:
+        declared_set = inventory.declared_by(ToolExecutorIdentity.AGENT)
+        actor_label = "for the agent, which the transcript-rules evaluator reads"
+    else:
+        declared_set = inventory.declared
+        actor_label = "for any actor of this task"
     errors = tuple(
         Finding(
             f"transcript_rules.tool_expectations.{expectation}",
-            f"tool {name!r} is not declared by this task, which gives its actors "
-            f"{sorted(inventory.declared)}: {hazard}",
+            f"tool {name!r} is not declared by this task {actor_label}. The declared "
+            f"set is {sorted(declared_set)}: {hazard}",
         )
         for expectation, hazard in _TOOL_EXPECTATION_HAZARDS.items()
         for name in getattr(expectations, expectation)
-        if name not in inventory.declared
+        if name not in declared_set
     )
     return AuthoringReport(errors=errors)
 
@@ -1575,7 +1593,18 @@ def _check_id_fields_against_seeded_tables(
     # __post_init__ makes a known layer with no view unconstructable; the assert
     # narrows ``tables`` for static analysis.
     assert seeded_tables.tables is not None
-    findings = id_fields_findings(id_fields, seeded_tables.tables)
+    # ``id_fields_findings`` calls ``table_key`` which raises
+    # ``IdFieldResolutionError`` for an invalid key component. That exception
+    # would propagate past ``report.fatal(fail_on)`` and become an
+    # unconditional per-task refusal at ``orchestrator.py`` — bypassing the
+    # ``fail_on`` severity, bypassing the ``relaxed_validation`` branch below,
+    # and turning the false-reject mode this gate's docstring says it does
+    # not have into the default. Catch the resolution error and route it
+    # through the same channels a regular finding takes.
+    try:
+        findings = id_fields_findings(id_fields, seeded_tables.tables)
+    except IdFieldResolutionError as exc:
+        findings = (str(exc),)
     if not findings:
         return AuthoringReport()
     if state_checks.get("relaxed_validation"):
@@ -1796,13 +1825,26 @@ def _check_golden_action_names(
     elements — is refused as one resolving to nothing rather than tested for membership,
     which an unhashable value answers with a ``TypeError``.
     """
+    # The runner resolves ``golden_actions`` against the *agent* registry alone
+    # (``service.py`` ``_execute_hash_grading`` step 0 iterates
+    # ``trial_context.agent_tools.keys()``); a name reaching only ``user_declared``
+    # passes the gate here and blows up on the runner with
+    # ``UnresolvableGoldenAction``. Narrow the check to the agent's set when
+    # the inventory knows the split; a recorded-trial inventory that does not
+    # answers only the union ``inventory.declared``, so keep the old behaviour
+    # there (the report's ``unchecked`` channel handles the residual case).
+    declared_set = (
+        inventory.declared_by(ToolExecutorIdentity.AGENT)
+        if inventory.actor_split_known
+        else inventory.declared
+    )
     errors = tuple(
         Finding(
             _GOLDEN_ACTION_NAME_ADDRESS.format(index=index),
             _unreplayable_golden_action_message(name, inventory),
         )
         for index, name in enumerate(_authored_golden_action_names(grading))
-        if not name or not isinstance(name, str) or name not in inventory.declared
+        if not name or not isinstance(name, str) or name not in declared_set
     )
     return AuthoringReport(errors=errors)
 

--- a/tolokaforge/core/grading/jsonpath_addressing.py
+++ b/tolokaforge/core/grading/jsonpath_addressing.py
@@ -95,8 +95,12 @@ def unreachable_target(assertion: Mapping[str, Any]) -> JsonPathTarget | None:
 
     ``None`` for an assertion the runner can resolve, one writing no ``path`` at all,
     and one whose expression cannot be read as JSONPath — a malformed expression, or a
-    ``path`` that is not text. Only an expression that parses can be *shown* to address
-    state the runner lacks, and the evaluators name an unreadable one per assertion.
+    ``path`` that is not text. Only an expression that parses and rooting at a segment
+    the runner does not compose can be *shown* to be unreachable; the runner composes
+    both the trial's database and the agent-visible filesystem (see
+    :meth:`~tolokaforge.runner.service.RunnerServiceImpl._read_agent_visible_filesystem`),
+    so a ``$.filesystem[…]``-rooted path grades on both substrates. The evaluators
+    name an unreadable path per assertion.
     """
     path = assertion.get("path")
     if not isinstance(path, str):
@@ -105,19 +109,31 @@ def unreachable_target(assertion: Mapping[str, Any]) -> JsonPathTarget | None:
         target = jsonpath_target(path)
     except ValueError:
         return None
-    return None if target is JsonPathTarget.TRIAL_DATABASE else target
+    if target is JsonPathTarget.BEYOND_THE_RUNNERS_STATE:
+        return target
+    return None
 
 
 def addresses_the_database(assertion: Mapping[str, Any]) -> bool:
     """Whether one ``jsonpaths`` assertion reads the trial's database.
 
-    Every assertion writing a ``path`` at all does, unless that path is provably rooted
-    outside what the runner composes. Reading it the other way round — classifying
-    whatever cannot be parsed as addressing nothing — would drop those assertions out of
-    the state fetch and grade them against a state never read, replacing the evaluators'
-    own per-assertion diagnosis with ``DB state unavailable``.
+    A path is proven to read the database only when its JSONPath expression parses
+    and roots at a database segment. A ``$.filesystem[…]``-rooted path reads the
+    agent-visible filesystem — not the DB — so it stays out of the DB-fetch
+    population. Unparseable / non-string paths preserve the pre-existing route-to-DB
+    behaviour so the evaluator's per-assertion diagnosis reaches the author instead
+    of a ``DB state unavailable`` blanket message.
     """
-    return assertion.get("path") is not None and unreachable_target(assertion) is None
+    path = assertion.get("path")
+    if path is None:
+        return False
+    if not isinstance(path, str):
+        return True
+    try:
+        target = jsonpath_target(path)
+    except ValueError:
+        return True
+    return target is JsonPathTarget.TRIAL_DATABASE
 
 
 def block_addresses_the_database(state_checks: Mapping[str, Any]) -> bool:

--- a/tolokaforge/core/grading/replay.py
+++ b/tolokaforge/core/grading/replay.py
@@ -64,6 +64,7 @@ from tolokaforge.core.models import (
 )
 from tolokaforge.core.output.artifacts import (
     FileArtifactWriter,
+    RedactedBundleError,
     TrialArtifactWriter,
     refuse_redacted_bundle,
 )
@@ -891,7 +892,14 @@ def run_replay_batch(
                 judge_model_override=judge_model_override,
                 knowledge_search=knowledge_search,
             )
-        except (MissingReplayInputError, ValidationError) as exc:
+        except (MissingReplayInputError, ValidationError, RedactedBundleError) as exc:
+            # ``RedactedBundleError`` is deliberately not a ``ValueError`` (see
+            # ``core/output/artifacts.py``), so without this arm one redacted
+            # bundle in a batch would raise out of the loop and abort every
+            # subsequent bundle — an $$ real judge spend already sunk earlier
+            # in the batch is discarded, and the per-trial "failed, batch
+            # continues" contract in this function's docstring is violated.
+            # ``ReplayOutcomeStatus.FAILED`` already has a slot for it.
             outcomes.append(
                 TrialReplayOutcome(
                     bundle=bundle, status=ReplayOutcomeStatus.FAILED, reason=str(exc)

--- a/tolokaforge/core/grading/trace_timeline.py
+++ b/tolokaforge/core/grading/trace_timeline.py
@@ -150,6 +150,14 @@ _KIND_BY_ROLE = {
 }
 
 
+# The literal prefix ``core/loop.py`` writes onto a failed tool call's
+# message body. Stripping it in the message-only branch of trace-timeline
+# reconstruction is what keeps ``result:`` matchers reading the same on a
+# bundle carrying ``tool_log.yaml`` and on the same bundle re-graded from
+# messages alone (#977).
+_ERROR_MESSAGE_PREFIX = "Error: "
+
+
 @dataclass(frozen=True)
 class _DeclaredCall:
     """One call the message view asks for, under the key the trial joins it by."""
@@ -432,12 +440,23 @@ class _TimelineBuilder:
         )
 
     def _append_message_result(self, declared: _DeclaredCall) -> None:
-        """The result as the message view preserved it: text, and nothing a record carries."""
+        """The result as the message view preserved it: text, and nothing a record carries.
+
+        Strips the ``"Error: "`` prefix ``core/loop.py:460`` writes onto the
+        message body for a failed call, so ``result:`` reads the same on
+        this branch as on ``_append_result`` (which pulls raw ``record.output``).
+        Without this, ``result: {regex: "^insufficient funds"}`` passed on a
+        bundle carrying ``tool_log.yaml`` and failed on the same bundle
+        re-graded without it — the "one text on both substrates" claim (#977)
+        would hold only for records, not for messages.
+        """
+        raw = self._message_results[declared.key]
+        result = raw[len(_ERROR_MESSAGE_PREFIX) :] if raw.startswith(_ERROR_MESSAGE_PREFIX) else raw
         self._append(
             kind=TraceEventKind.TOOL_RESULT,
             call_id=declared.key,
             tool_name=declared.call.name,
-            result=self._message_results[declared.key],
+            result=result,
         )
 
     def _append(

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -537,6 +537,12 @@ class GenerationResult:
         # Stamped only by ``UserSimulator._llm_reply``; every other producer
         # of a result leaves it empty.
         self.guard_rejections: tuple[ReplyDefect, ...] = ()
+        # True iff ``UserSimulator._llm_reply`` substituted the fixed filler
+        # for a tool-call-only reply with no text. Callers whose downstream
+        # semantics depend on the model having written the text (the
+        # bootstrap seed the agent is graded against) refuse on this flag
+        # instead of accepting the engine's own words as the turn.
+        self.filler_substituted: bool = False
 
 
 class LLMClient:
@@ -2460,13 +2466,16 @@ Rules:
                 observation=observation,
             )
             # The one substitution the reply guard wraps rather than forbids, and
-            # the only text the engine contributes to a user turn. Unreachable
-            # while the conductor wires no ``user_tool_executor``: the simulator
-            # is then handed no tool schemas, so no generation carries tool calls.
+            # the only text the engine contributes to a user turn. The conductor
+            # now wires a user_tool_executor when the spec declares user tools,
+            # so this branch is reachable in-tree — callers whose downstream
+            # semantics need the model's own text (the bootstrap seed the agent
+            # is graded against) read ``result.filler_substituted`` and refuse.
             # TODO(#1089): remove it — a universal filler is hazardous (AGENTS.md
             # gotcha 23), so the removal carries its own analysis.
             if result.tool_calls and not result.text.strip():
                 result.text = "Let me check that."
+                result.filler_substituted = True
             return result
 
         # The guard logs under its own logger name, so the trial identity has to

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -768,7 +768,14 @@ class TrialRunner:
                 # the failure mode the seeded-opening fix exists to prevent.
                 # Read before inlining, so a reply that is only a tool call
                 # refuses rather than opening with the tool's own output.
-                if not first_user_result.text.strip():
+                #
+                # ``filler_substituted`` covers the tool-call-only opening the
+                # LLM client rewrites in-closure ("Let me check that."): the
+                # text is no longer empty by the time it reaches here, but the
+                # substituted filler is the engine's own words, not the task
+                # statement the agent must be graded against. Both empty and
+                # filler-only openings fail the same way.
+                if first_user_result.filler_substituted or not first_user_result.text.strip():
                     raise RuntimeError(
                         "User simulator bootstrap produced an empty first message; "
                         "a blank opening cannot seed the conversation."

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -374,12 +374,25 @@ class TrialRunner:
                 # The simulator's opening tool calls run here, before the loop and
                 # its classifier, so the one reason a tool call can end the trial
                 # under is named here too.
+                #
+                # Typed provider faults (API timeout, rate limit, …) that reach
+                # here from the opening ``client.completion`` are the same
+                # class the loop's ``classify_loop_error`` already routes to
+                # ``EXCLUDED_TYPED_REASONS``. Consulting the classifier here
+                # avoids pricing "one 429 on the opening generation" as a
+                # scored agent failure when "the identical 429 one turn later"
+                # is excluded. ``TrialNotRegisteredError`` beats the classifier
+                # (it is the "trial-lost" signal, unrelated to provider health).
                 status = TrialStatus.ERROR
-                termination_reason = (
-                    TerminationReason.TRIAL_LOST
-                    if isinstance(e, TrialNotRegisteredError)
-                    else TerminationReason.ERROR
-                )
+                if isinstance(e, TrialNotRegisteredError):
+                    termination_reason = TerminationReason.TRIAL_LOST
+                else:
+                    # ``classify_loop_error`` maps typed provider faults
+                    # (API_TIMEOUT, RATE_LIMIT) to reasons in
+                    # ``EXCLUDED_TYPED_REASONS`` and everything else back to
+                    # ``ERROR``. Reads them here so a 429 on the opening
+                    # generation and one turn later are classified alike.
+                    termination_reason = self.agent_client.classify_loop_error(e).reason
                 self.logger.error(
                     "Trial initialization error", error=str(e), error_type=type(e).__name__
                 )

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -88,7 +88,7 @@ class EnvHandle(Protocol):
 # ---------------------------------------------------------------------------
 
 
-ProvisionStage = Literal["provision", "await_ready", "reset_recipe"]
+ProvisionStage = Literal["provision", "await_ready", "reset_recipe", "register_trial"]
 
 
 class ProvisionError(Exception):

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -173,7 +173,26 @@ class ProvisioningTrialExecutor:
                 trial_index=trial_idx,
                 runner_url=real_endpoints.runner_url,
             )
-            result = self.conductor.run(final_spec, task_config)
+            try:
+                result = self.conductor.run(final_spec, task_config)
+            except ProvisionError as e:
+                # ``_setup_trial`` may refuse a registration after provisioning
+                # succeeded (e.g. runner-side search-plane refusal). Without
+                # this catch, the RuntimeError formerly raised there escaped
+                # ``conductor.run`` uncaught and reached the orchestrator's
+                # queue-only path — the trial vanished from ``self.results``
+                # and every rate was inflated after the retry budget burned
+                # on the deterministic refusal.
+                self.logger.error(
+                    "Registration refused after provisioning",
+                    task_id=task_id,
+                    trial_index=trial_idx,
+                    stage=e.stage,
+                    error=e.reason,
+                )
+                result = _synthesize_provision_failure_result(spec, e)
+                self._write_provision_failure_bundle(result.trajectory, e)
+                return result
             self._amend_trial_metrics(
                 task_id,
                 trial_idx,

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -950,7 +950,14 @@ def _print_rejudge_summary(
             reason = escape(outcome.reason or "")
             console.print(f"[yellow]skip (no grade)[/yellow] {rel} — {reason}")
         elif outcome.status is ReplayOutcomeStatus.FAILED:
-            console.print(f"[red]failed[/red] {rel} — {outcome.reason}")
+            # ``outcome.reason`` is ``str(exc)`` for a ``MissingReplayInputError``
+            # or a pydantic ``ValidationError`` — user-authored text can carry
+            # rich-markup brackets that Rich would either fail to parse
+            # (``MarkupError``) or silently truncate. Match the sibling SKIP
+            # branch above and escape the reason (and ``rel``, since bundle
+            # paths are authored-adjacent).
+            reason = escape(outcome.reason or "")
+            console.print(f"[red]failed[/red] {escape(rel)} — {reason}")
         else:
             prov = outcome.provenance
             model = prov.judge_model if prov else "?"

--- a/tolokaforge/dx/trace_replay_render.py
+++ b/tolokaforge/dx/trace_replay_render.py
@@ -84,7 +84,10 @@ def _disposition(outcome: TrialTraceReplayOutcome, bundle: str) -> str:
         # fragment prints rather than vanishing as console markup.
         return f"[warn]skip (no task)[/warn] {bundle} — {escape(outcome.reason or '')}"
     if outcome.status is TraceReplayOutcomeStatus.FAILED:
-        return f"[error]failed[/error] {bundle} — {outcome.reason}"
+        # Match the SKIPPED_NO_TASK branch above — the reason may carry
+        # bracketed fragments Rich would misparse. Escape both the reason
+        # and the bundle name.
+        return f"[error]failed[/error] {escape(bundle)} — {escape(outcome.reason or '')}"
     evidence = outcome.evidence
     record = "record present" if evidence and evidence.tool_log_present else "no record"
     result = outcome.result

--- a/tolokaforge/runner/db_proxy.py
+++ b/tolokaforge/runner/db_proxy.py
@@ -42,7 +42,7 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
-from tolokaforge.runner.db_client import DBServiceClient, DBServiceError
+from tolokaforge.runner.db_client import DBServiceClient
 from tolokaforge.runner.id_resolution import (
     IdFieldResolutionError,
     TableKey,
@@ -551,7 +551,17 @@ class DBServiceProxy:
         predicate = " & ".join(f"@.{field}=={literals[field]}" for field in components)
         try:
             response = await self.db_client.query(self.trial_id, f"$.{table_name}[?({predicate})]")
-        except DBServiceError as e:
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 — every miss falls to the scan (see docstring at 442-444)
+            # The docstring promises "Every kind of miss (no literal, a query error, an
+            # unverified hit, no usable key to query at all) falls to the scan, which is
+            # why the query can only ever save a round trip, never change an answer."
+            # ``db_client.query`` only wraps ``httpx.ConnectError``; narrowing to
+            # ``DBServiceError`` lets ``httpx.ReadTimeout``, ``httpx.RemoteProtocolError``
+            # and a ``QueryResponse.model_validate`` failure escape and fail the tool
+            # call instead of falling through to ``get_all``, a different endpoint that
+            # may be healthy. Every branch below already means "fall to the scan".
             logger.warning(f"get_by_id: JSONPath lookup on '{target}' failed: {e} — full scan")
             return None
 

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -763,6 +763,39 @@ class TraceMatcher(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _reject_a_status_literal_no_execution_produces(self) -> TraceMatcher:
+        """Every ``status`` literal must be a real ``ToolExecutionStatus`` member.
+
+        Loading ``status: {equals: timeout}`` clean and only failing at grading
+        time reports a typo as an agent failure. The gate keeps the check
+        syntactic: closed-vocabulary operators (``equals``, ``not_equals``,
+        ``in_``, ``not_in``) validate every literal against the enum; open-form
+        operators (``regex``, ``contains``) reach status only as strings and
+        the enum's canonical members are already substring-safe.
+        """
+        if self.status is None:
+            return self
+        producible = {member.value for member in ToolExecutionStatus}
+        checked: list[tuple[str, Any]] = []
+        for operator in ("equals", "not_equals"):
+            value = getattr(self.status, operator)
+            if value is not None:
+                checked.append((operator, value))
+        for operator in ("in_", "not_in"):
+            values = getattr(self.status, operator)
+            if values is not None:
+                checked.extend((operator, v) for v in values)
+        unproducible = sorted(
+            {str(value) for operator, value in checked if value not in producible}
+        )
+        if unproducible:
+            raise ValueError(
+                f"status predicate names values {unproducible} that no tool executor "
+                f"produces. Executable statuses are {sorted(producible)}"
+            )
+        return self
+
 
 class BoundValue(BaseModel):
     """One name a binding extracts out of the event it selected.

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -360,12 +360,17 @@ def _search_plane_context(
     trial_id: str,
     search_config: SearchConfig,
     resolved_plane: ResolvedSearchPlane | None,
-    binding: ResolvedTypeSenseBinding,
+    binding: ResolvedTypeSenseBinding | None,
 ) -> str:
     """The prefix every search-plane refusal opens with: trial, domain, plane, address, source.
 
     Both bases are the ones the resolvers returned. Re-deriving either here would
     let a message name a plane or an address the client was not built from.
+
+    ``binding`` may be ``None`` for the "kb-task-in-a-typesense-disabled-run"
+    refusal — a run without a TypeSense plane resolves no address to name; the
+    prefix names "no address" in that case rather than crashing on
+    ``binding.host``.
     """
     domain = search_config.domain_name or "default"
     plane = (
@@ -373,10 +378,12 @@ def _search_plane_context(
         if resolved_plane is not None
         else "none declared"
     )
-    return (
-        f"Trial {trial_id}: domain '{domain}', search plane {plane}, "
+    address = (
         f"TypeSense at {binding.host}:{binding.port} (from {binding.basis.value})"
+        if binding is not None
+        else "no TypeSense address resolved"
     )
+    return f"Trial {trial_id}: domain '{domain}', search plane {plane}, {address}"
 
 
 def _bundles_a_docindex(artifacts_dir: Path | None) -> bool:
@@ -385,7 +392,7 @@ def _bundles_a_docindex(artifacts_dir: Path | None) -> bool:
 
 
 def _no_plane_refusal(
-    trial_id: str, search_config: SearchConfig, binding: ResolvedTypeSenseBinding
+    trial_id: str, search_config: SearchConfig, binding: ResolvedTypeSenseBinding | None
 ) -> str:
     """Why a corpus no plane serves is refused — an adapter half-way through migrating.
 
@@ -1544,46 +1551,53 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         error_message = ""
 
         try:
-            result = await self._invoke_tool(tool, tool_name, arguments, timeout_seconds)
+            try:
+                result = await self._invoke_tool(tool, tool_name, arguments, timeout_seconds)
 
-            # Convert result to string
-            if isinstance(result, str):
-                output = result
-            elif result is None:
-                output = "Success"
-            else:
-                output = json.dumps(result, default=str)
+                # Convert result to string
+                if isinstance(result, str):
+                    output = result
+                elif result is None:
+                    output = "Success"
+                else:
+                    output = json.dumps(result, default=str)
 
-            status = pb2.EXECUTION_STATUS_SUCCESS
-            logger.debug(f"ExecuteTool: {tool_name} completed successfully")
+                status = pb2.EXECUTION_STATUS_SUCCESS
+                logger.debug(f"ExecuteTool: {tool_name} completed successfully")
 
-        except asyncio.TimeoutError:
-            status = pb2.EXECUTION_STATUS_TIMEOUT
-            logger.warning(f"ExecuteTool: {tool_name} timed out after {timeout_seconds}s")
-            error_message = await self._reset_backstopped_tool(
-                trial_context, tool, tool_name, executor, timeout_seconds
+            except asyncio.TimeoutError:
+                status = pb2.EXECUTION_STATUS_TIMEOUT
+                logger.warning(f"ExecuteTool: {tool_name} timed out after {timeout_seconds}s")
+                error_message = await self._reset_backstopped_tool(
+                    trial_context, tool, tool_name, executor, timeout_seconds
+                )
+
+            except Exception as e:
+                # Catch all exceptions from tool execution
+                status = pb2.EXECUTION_STATUS_ERROR
+                error_message = raised_tool_failure_text(e)
+                logger.error(f"ExecuteTool: {tool_name} raised {type(e).__name__}: {e}")
+                logger.error(traceback.format_exc())
+        finally:
+            # ``_reset_backstopped_tool`` awaits inside the try/except's
+            # timeout window; ``_run_async`` cancels its slack-deadline
+            # coroutine on RPC timeout, and cancellation cannot interrupt a
+            # coroutine already blocked inside ``run_in_executor``. Without
+            # this ``finally`` the ``trial_context.record(...)`` below is
+            # skipped, and the runner-side ``GradeTrial`` reads a timeline
+            # missing the call — a forbidden tool that ran shows as "never
+            # called" and passes ``_check_disallowed_tool``. Latency is best-
+            # effort even on cancellation; the write is not.
+            latency_seconds = time.time() - start_time
+            trial_context.record(
+                call_id=call_id,
+                tool_name=tool_name,
+                arguments=arguments,
+                output=output if status == pb2.EXECUTION_STATUS_SUCCESS else error_message,
+                status=recorded_status(status),
+                executor=executor,
+                latency_seconds=latency_seconds,
             )
-
-        except Exception as e:
-            # Catch all exceptions from tool execution
-            status = pb2.EXECUTION_STATUS_ERROR
-            error_message = raised_tool_failure_text(e)
-            logger.error(f"ExecuteTool: {tool_name} raised {type(e).__name__}: {e}")
-            logger.error(traceback.format_exc())
-
-        # Calculate latency
-        latency_seconds = time.time() - start_time
-
-        # Record tool call in history
-        trial_context.record(
-            call_id=call_id,
-            tool_name=tool_name,
-            arguments=arguments,
-            output=output if status == pb2.EXECUTION_STATUS_SUCCESS else error_message,
-            status=recorded_status(status),
-            executor=executor,
-            latency_seconds=latency_seconds,
-        )
 
         # Build response
         return pb2.ExecuteToolResponse(
@@ -3379,9 +3393,18 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             return self._init_typesense_for_trial(
                 trial_id, search_config, resolved_plane, binding, artifacts_dir
             )
-        no_plane_serves_the_corpus = (
-            task_declares_kb and address_resolved and resolved_plane is None
-        )
+        # A KB-declaring task in a run with no TypeSense plane must refuse loudly:
+        # otherwise nothing registers, every ``search_policy`` call fails on
+        # paid turns, and the trial grades the agent for the misconfiguration.
+        # Gating on ``address_resolved`` here was wrong — ``resolved_plane is
+        # None`` already implies ``search_config.plane`` and ``search_config.host``
+        # are both None, so ``address_resolved`` could only come from the stack
+        # env, which is injected exclusively by a run that HAS TypeSense. The
+        # KB-task-in-a-no-plane run therefore never triggered the refusal.
+        # Dropping ``address_resolved`` from the predicate reaches the intended
+        # cases; the refusal message names "no plane" independent of address
+        # resolution.
+        no_plane_serves_the_corpus = task_declares_kb and resolved_plane is None
         if no_plane_serves_the_corpus and not search_config.enabled:
             return _no_plane_refusal(trial_id, search_config, binding)
         if address_resolved and not task_declares_kb and _bundles_a_docindex(artifacts_dir):

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -66,7 +66,6 @@ from tolokaforge.core.grading.golden_replay import (
 )
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
 from tolokaforge.core.grading.jsonpath_addressing import (
-    JsonPathTarget,
     addresses_the_database,
     block_addresses_the_database,
     unreachable_target,
@@ -456,19 +455,18 @@ def _unreachable_state_checks_refusal(
         target = unreachable_target(assertion)
         if target is None:
             continue
+        # Only ``BEYOND_THE_RUNNERS_STATE`` (``agent`` / ``user`` /
+        # ``mock_web_url`` / ``rag_corpus_dir``) reaches here. ``FILESYSTEM``
+        # is graded by the runner via ``_read_agent_visible_filesystem`` and
+        # ``TRIAL_DATABASE`` returns ``None`` from :func:`unreachable_target`.
         described = assertion.get("description")
-        remedy = (
-            "Address a file with path_glob: and contains_ci:, which both substrates read "
-            "the same way."
-            if target is JsonPathTarget.FILESYSTEM
-            else "Address the trial's database, which is rooted at db or tables."
-        )
         return (
             f"state_checks.jsonpaths declares path {assertion.get('path')!r}"
             + (f" ({described})" if described else "")
-            + ", which addresses state the runner's JSONPath grading does not carry: it "
-            "composes db and tables from the trial's database and nothing else, so this "
-            f"assertion can never match there. {remedy}"
+            + ", which addresses state neither substrate carries at grading time: the "
+            "core engine composes agent / user / mock_web_url / rag_corpus_dir from a "
+            "run's live env, none of which are the runner's to reach. Address the "
+            "trial's database (rooted at db or tables), or drop the assertion."
         )
     return None
 

--- a/tolokaforge/secrets/log_filter.py
+++ b/tolokaforge/secrets/log_filter.py
@@ -27,6 +27,7 @@ Engineers must still avoid logging secret-bearing objects directly.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -51,12 +52,30 @@ def _current_redaction_values() -> frozenset[str]:
     if manager is not _cached_manager:
         _cached_manager = manager
         resolved = manager.known_values()
-        # A credential also travels in its compose-escaped form, written into a
-        # materialised compose file. That form is not the value the manager
-        # holds, so without it a compose error quoting the file back scrubs to
-        # nothing. Escaping a value with no ``$`` is the identity, so the union
-        # only grows for the values that need it.
-        _cached_values = resolved | {compose_escaped(value) for value in resolved}
+        # A credential travels in three surfaces the log stream may quote:
+        #   1. The raw value the manager holds.
+        #   2. Its compose-escaped form (``$`` -> ``$$``), written into a
+        #      materialised compose file. A compose error quoting the file
+        #      back would leak the doubled form without this entry.
+        #   3. Its JSON-encoded form (`` `` -> ``\`` -> ``\\``, quotes -> ``\"``,
+        #      non-ASCII -> ``\uXXXX``), written to ``TOLOKAFORGE_SECRETS_JSON``
+        #      by :func:`~tolokaforge.secrets.manager.container_secrets_env`.
+        #      Without this a log line quoting the materialised env-file back
+        #      would leak a value that carries a backslash or a non-ASCII byte
+        #      — the raw form is not a substring of the on-disk form there.
+        #   The three-way union grows only for values that carry chars the
+        #   escapes touch; alphanumeric values collapse to the raw entry.
+        json_forms: set[str] = set()
+        for value in resolved:
+            json_encoded = json.dumps(value)[1:-1]  # strip the surrounding quotes
+            if json_encoded and json_encoded != value:
+                json_forms.add(json_encoded)
+                # And the compose-escape of the JSON form, for the file the
+                # engine-built stack materialises for the runner container.
+                json_compose_escaped = compose_escaped(json_encoded)
+                if json_compose_escaped != json_encoded:
+                    json_forms.add(json_compose_escaped)
+        _cached_values = resolved | {compose_escaped(value) for value in resolved} | json_forms
     return _cached_values
 
 


### PR DESCRIPTION
Applies every one of @bberkes-toloka's fifteen code-review findings on #1196 on top of `feat/trace-checks-tail`. Merge this into that branch before shipping #1196 to `main`.

## Blocker — finding #1

`$.filesystem[…]`-rooted `path:` assertions were classified as unreachable by the runner and refused, but the runner actually grades them via `_read_agent_visible_filesystem()` + `_assemble_jsonpath_state` — measured 1.0 on a match and 0.0 on a mismatch. The refusal + the authoring gate are both removed:

- `jsonpath_addressing.unreachable_target`: only `BEYOND_THE_RUNNERS_STATE` counts as unreachable now; `FILESYSTEM` joins `TRIAL_DATABASE` as runner-graded.
- `jsonpath_addressing.addresses_the_database`: decoupled from `unreachable_target` so filesystem stays out of the DB fetch (matches the pre-PR semantic).
- Dead `FILESYSTEM` branches removed from `service._unreachable_state_checks_refusal` and `config_validation._check_jsonpaths_address_a_reachable_state`; refusal text now names only the genuinely-unreachable roots.

Tests updated to lock the corrected behaviour:
- `test_a_filesystem_rooted_path_is_refused_rather_than_scored_against_the_agent` → `test_a_filesystem_rooted_path_is_graded_not_refused` (inverted assertion — `success is True`).
- `test_grading_authoring_gate` rule row `a_path_addressing_the_filesystem` → `a_path_addressing_beyond_the_runners_state` (`$.agent[…]` shape).
- Corpus negative-control drops the filesystem row.
- `test_jsonpath_addressing` locks both `unreachable_target` and `addresses_the_database` returning the right thing for filesystem paths.

## Findings applied by area

### Registration and provisioning
- **#7 — Conductor drops the trial out of every metric.** `conductor.py:590` used to raise a bare `RuntimeError` on register-trial refusal. It now raises `ProvisionError(stage="register_trial")`, and `trial_executor.py` catches it around `conductor.run` and routes through `_synthesize_provision_failure_result` — the trial gets a `PROVISION_ERROR` row, is non-retryable per the classifier, and stops burning the retry budget on deterministic refusals. `ProvisionStage` gains the `"register_trial"` literal.
- **#8 — no-plane refusal gate.** `service._no_plane_refusal` predicate drops `address_resolved`: a KB-declaring task in a run with `resolved_plane is None` now refuses loudly, independent of whether the stack injected a TypeSense address. `_search_plane_context` / `_no_plane_refusal` accept `binding=None` so the message names "no TypeSense address resolved" without crashing on `binding.host`. Locked by a new `test_a_kb_task_in_a_no_plane_run_refuses`.

### Runner
- **#2 — ExecuteTool record on cancellation.** Wraps the invoke/handle body in an outer `try/finally` so `trial_context.record()` runs even when the RPC deadline cancels the slack coroutine.
- **#12 — Init-branch classifier.** Non-`TrialNotRegisteredError` exceptions route through `classify_loop_error` so a 429 or `api_timeout` on the opening `client.completion` is priced the same as the identical fault one turn later.
- **#13 — db_proxy exception narrowing.** Reverts to `except Exception` + `# noqa: BLE001` — the block is defensive around a broader class than `DBServiceError`.

### Bootstrap and user-tool split
- **#6 — Bootstrap guard.** `GenerationResult` gains `filler_substituted`. `UserSimulator._llm_reply` sets it when substituting `"Let me check that."` for a tool-call-only reply; `_bootstrap_via_simulator` refuses on the flag, so the engine's own filler no longer becomes the task statement the agent is graded against. Stale comments at `client.py:2464` and `reply_guard.py:11` are corrected.
- **#3 — USER-actor tool routing.** `adapters/native._actor_tool_schemas` falls back to the agent block's `mcp_server` for `USER` when the user block has none, so a spec with a USER actor and no user-side `mcp_server` still routes.
- **#4, #5 — actor-split gates.** `config_validation._check_golden_action_names` and `_check_tool_expectation_names` use `inventory.declared_by(ToolExecutorIdentity.AGENT)` only when `inventory.actor_split_known`; fall back to `inventory.declared` otherwise so a spec whose tool-set came off a recorded trial (split unknown) no longer raises `ValueError`.

### Grading
- **#9 — RedactedBundleError in replay.** Adds `RedactedBundleError` to the except tuple so a redacted trajectory bundle surfaces as an expected replay failure.
- **#10 — id_fields resolution catch.** `_check_id_fields_against_seeded_tables` catches `IdFieldResolutionError` from `id_fields_findings` so a malformed override doesn't blow up the config check.
- **#11 — `status` enum validation + `Error:` prefix strip.** `TraceMatcher.status` gains a load-time validator against `ToolExecutionStatus` for closed-vocabulary operators (`equals`, `not_equals`, `in_`, `not_in`), so `status: {equals: "expired"}` fails at authoring time. `_append_message_result` strips the `"Error: "` prefix `core/loop.py` writes onto a failed call's message body, so `result:` matchers see one text on both substrates (#977) — the message-view drift the review flagged. See "Follow-up" below for the sibling `TIMEOUT` / `INVALID_ARGUMENTS` parity gap.

### Hygiene
- **#14 — Log-filter misses the JSON-encoded value form.** `secrets/log_filter.py` scrub set unions three surfaces (raw / compose-escaped / JSON-encoded).
- **#15 — Rich markup unescaped in FAILED branches.** `dx/cli/main.py:953` and `dx/trace_replay_render.py:87` escape both `outcome.reason` and `rel` in the failed branches.

## Follow-up left open

Called out in the review but not landed here:
- **#11 sibling: `TIMEOUT` and `INVALID_ARGUMENTS` substrate parity.** The reviewer flagged that #977's "one failure has one text on both" unification covers tool-authored error text but not these two classes. Their in-process and runner-service paths write different strings, so a `result:` matcher over them still varies by substrate. This is a substrate-parity pass wider than one review can land — worth its own PR against the existing `test_trace_timeline_substrate_parity` gate.

## Test plan

- [x] `test_jsonpath_addressing` (unit)
- [x] `test_grading_authoring_gate` (unit)
- [x] `test_grading_substrate_parity` (canonical)
- [x] `test_example_pack_grading_corpus` (canonical)
- [x] `test_runner_search_plane_refusal` (unit) — new refusal test locks #8
- [x] `test_runner_logic` (unit) — new `test_a_filler_substituted_bootstrap_refuses` locks #6
- [x] `test_trial_executor` (unit) — new `test_register_trial_refusal_synthesises_failed_result_and_tears_down` locks #7
- [x] `test_trace_checks_matchers` (unit) — two new tests lock the enum-membership guard (#11)
- [x] `test_trace_timeline` (unit) — new `test_a_message_only_failure_carries_the_same_text_a_record_would` locks the `Error:` prefix strip (#11)
- [x] `test_terminal_bench_harness_mode` (canonical) — fixture wires `classify_loop_error` on the agent-client MagicMock (#12)
- [x] `test_log_filter` + `test_redaction` (unit)
- [x] `ruff check` + `ruff format` clean
- [x] Full `tests/unit` + `tests/canonical` sweep — green

Review reference: https://github.com/Toloka/tolokaforge/pull/1196#pullrequestreview-3282817608
