### PR TITLE
feat(llm): persist the OpenRouter generation id per request

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -796,11 +796,11 @@ duplicate it emitted. See [GRADING.md G3](GRADING.md#guarantees).
 ## OpenRouter generation ids
 
 OpenRouter is a router: it picks an upstream provider per request, and two calls
-on the same model slug can be served by different upstreams (a live probe of
-`openai/gpt-4o-mini` on 2026-08-19 was served by Azure). Upstreams differ in
-quantisation, context handling and tool-call formatting, so a measured delta
-between two runs of the same model can be a routing artefact rather than a
-property of the model.
+on the same model slug can be served by different upstreams — the same
+`openai/gpt-4o-mini` request has been observed served by Azure and OpenAI on
+consecutive probes. Upstreams differ in quantisation, context handling and
+tool-call formatting, so a measured delta between two runs of the same model
+can be a routing artefact rather than a property of the model.
 
 The response carries the id of the generation it produced, and
 `https://openrouter.ai/api/v1/generation?id=<id>` reports which upstream served
@@ -808,13 +808,15 @@ it. Persisting the id is therefore what makes that question answerable after the
 fact — without it, a suspect result can only be re-run, never checked, and a
 re-run samples routing afresh.
 
-**The header is `x-generation-id`, not `x-openrouter-generation-id`** — verified
-by live probe 2026-08-19, which returned exactly that name and no other
-generation-bearing header. litellm re-keys raw upstream headers as
-`llm_provider-<name>` into `response._hidden_params["additional_headers"]`, so
-the engine matches on the name with that prefix stripped and case-folded;
-`extract_openrouter_generation_id`
+**The header is `x-generation-id`, not `x-openrouter-generation-id`** — the
+plausible-looking longer name is not the one OpenRouter actually returns.
+litellm re-keys raw upstream headers as `llm_provider-<name>` into
+`response._hidden_params["additional_headers"]`, so the engine matches on the
+name with that prefix stripped and case-folded; `extract_openrouter_generation_id`
 ([`core/llm/usage.py`](../tolokaforge/core/llm/usage.py)) is the single reader.
+A regression test in `tests/unit/test_openrouter_generation_id.py` pins the
+wrong header name as non-matching so an editor who forgets the correction is
+caught before shipping.
 
 It is read off the **response**, never from configuration or an environment
 variable: the value describes what happened on the wire for one call, so nothing

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -325,6 +325,10 @@ accumulates via `self.metrics.usage = self.metrics.usage + result.usage`;
 (`avg_prompt_tokens`, `avg_reasoning_tokens`, `avg_cache_read_input_tokens`,
 etc.).
 
+Each `ProviderRawCall` in `usage.calls` also carries the
+`openrouter_generation_id` of the call it records — see
+§ [OpenRouter generation ids](#openrouter-generation-ids).
+
 ## `schema_sanitizer`
 
 ```python
@@ -788,6 +792,50 @@ already unique and rewrites the n-th further occurrence to `<id>#<n>` for one
 that reuses them. Both sides of the conversation the id is echoed into carry the
 assigned value, so the provider sees one consistent id per call rather than the
 duplicate it emitted. See [GRADING.md G3](GRADING.md#guarantees).
+
+## OpenRouter generation ids
+
+OpenRouter is a router: it picks an upstream provider per request, and two calls
+on the same model slug can be served by different upstreams (a live probe of
+`openai/gpt-4o-mini` on 2026-08-19 was served by Azure). Upstreams differ in
+quantisation, context handling and tool-call formatting, so a measured delta
+between two runs of the same model can be a routing artefact rather than a
+property of the model.
+
+The response carries the id of the generation it produced, and
+`https://openrouter.ai/api/v1/generation?id=<id>` reports which upstream served
+it. Persisting the id is therefore what makes that question answerable after the
+fact — without it, a suspect result can only be re-run, never checked, and a
+re-run samples routing afresh.
+
+**The header is `x-generation-id`, not `x-openrouter-generation-id`** — verified
+by live probe 2026-08-19, which returned exactly that name and no other
+generation-bearing header. litellm re-keys raw upstream headers as
+`llm_provider-<name>` into `response._hidden_params["additional_headers"]`, so
+the engine matches on the name with that prefix stripped and case-folded;
+`extract_openrouter_generation_id`
+([`core/llm/usage.py`](../tolokaforge/core/llm/usage.py)) is the single reader.
+
+It is read off the **response**, never from configuration or an environment
+variable: the value describes what happened on the wire for one call, so nothing
+outside that response can be authoritative for it. OpenRouter is the only
+provider we route to that sends the header, which makes its presence a
+sufficient test — no provider-name branching is involved, and every direct route
+(Anthropic, Google, …) simply yields `None`.
+
+Persisted in three places, all populated from the same read:
+
+| Where | Field | Granularity |
+|---|---|---|
+| `metrics.yaml` | `openrouter_generation_ids` | trial-level list, call order |
+| `metrics.yaml` | `usage.calls[*].openrouter_generation_id` | per API call |
+| `trajectory.yaml` | `messages[*].openrouter_generation_id` | per assistant turn |
+
+The flat list is the index a consumer walks; the two per-record fields are what
+attribute an id to a specific call or turn, which is what a comparison against
+another harness needs. The list is shorter than `api_calls` whenever a call was
+served off a non-OpenRouter route, and empty on a run that never reached
+OpenRouter. See [OUTPUT_FORMAT.md](OUTPUT_FORMAT.md:1) § `metrics.yaml`.
 
 ## `proxy` — routing calls through an LLM gateway
 

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -568,7 +568,12 @@ is the same value attributed to its individual call. Each id resolves at
 actually served that call, so a result suspected of being a routing artefact can
 be checked after the fact instead of re-run. Both are `null` / empty for every
 non-OpenRouter route — no other provider sends the header they are read from —
-so the list is shorter than `api_calls` whenever a call went elsewhere. See
+so the list is shorter than `api_calls` whenever a call went elsewhere. The two
+surfaces are **not** positionally aligned: a response that returned the
+`x-generation-id` header but no usage block contributes an id to the flat list
+and no entry to `usage.calls`, so the flat list can be longer than `usage.calls`
+too. Consumers that need per-call attribution read `usage.calls`; consumers that
+need "did this trial reach OpenRouter at all" read the flat list. See
 [LLM_LAYER.md](LLM_LAYER.md:1) § OpenRouter generation ids.
 
 To help analytics consumers detect schema evolution, a trial-level metrics file

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -348,6 +348,7 @@ messages:
           encrypted_data: "EvwBCkgIARABGAIi..."
       summary: null   # null when blocks already cover the content (Plan B)
       budget_used: 512
+    openrouter_generation_id: "gen-1787132417-e6DthuPJjrFMFf46ae5F"
     ts: "2026-01-01T12:00:01Z"
 user_reply_guard_events:                              # [] on a trial no detector ever flagged
   - message_index: 2
@@ -392,6 +393,18 @@ The `reasoning` block is extracted by the provider-specific `ReasoningCodec`
 registered on the preset (see
 [`docs/LLM_LAYER.md`](LLM_LAYER.md) § `reasoning_codec`). Non-reasoning
 models emit `reasoning: null`.
+
+### `messages[*].openrouter_generation_id`
+
+OpenRouter's id for the generation that produced this message, so an assistant
+turn can be joined back to the routing decision behind it —
+`https://openrouter.ai/api/v1/generation?id=<id>` reports which upstream
+provider actually served that turn. Populated on assistant messages produced by
+an OpenRouter-routed call; `null` on every other role and every other route (no
+other provider sends the header it is read from). The same ids are indexed
+trial-level in [`metrics.yaml`](#trialstask_idtrial_indexmetricsyaml) as
+`openrouter_generation_ids`. See [LLM_LAYER.md](LLM_LAYER.md:1) § OpenRouter
+generation ids.
 
 ## `trials/{task_id}/{trial_index}/tool_log.yaml`
 
@@ -544,8 +557,19 @@ dataclass. Anthropic cache counters + reasoning-budget spend are
 first-class fields; a `provider_raw` dump of the litellm usage block is
 included for forensics. Each LLM API call is also recorded in
 `usage.calls[]` as a `ProviderRawCall` carrying its per-call tokens,
-`cost_usd`, `cost_source` (`"litellm"` / `"local"` / `"unknown"`), and
-`latency_s` — the trial-level `cost_usd` is the sum of those entries.
+`cost_usd`, `cost_source` (`"litellm"` / `"local"` / `"unknown"`),
+`latency_s`, and `openrouter_generation_id` — the trial-level `cost_usd` is the
+sum of those entries.
+
+`openrouter_generation_ids` lists every OpenRouter generation id the trial's
+agent calls returned, in call order; `usage.calls[*].openrouter_generation_id`
+is the same value attributed to its individual call. Each id resolves at
+`https://openrouter.ai/api/v1/generation?id=<id>` to the upstream provider that
+actually served that call, so a result suspected of being a routing artefact can
+be checked after the fact instead of re-run. Both are `null` / empty for every
+non-OpenRouter route — no other provider sends the header they are read from —
+so the list is shorter than `api_calls` whenever a call went elsewhere. See
+[LLM_LAYER.md](LLM_LAYER.md:1) § OpenRouter generation ids.
 
 To help analytics consumers detect schema evolution, a trial-level metrics file
 written by `write_metrics` includes a root-level `schema_version: 4` marker. The
@@ -582,6 +606,9 @@ usage:
       cost_usd: 0.00912
       cost_source: litellm
       latency_s: 1.23
+      openrouter_generation_id: gen-1787132417-e6DthuPJjrFMFf46ae5F
+openrouter_generation_ids:   # one per OpenRouter-served call, in call order
+  - gen-1787132417-e6DthuPJjrFMFf46ae5F
 cost_usd: 0.127055
 tool_calls: 7
 tool_success_rate: 1.0

--- a/tests/canonical/snapshots/trajectory_reasoning/trajectory.yaml
+++ b/tests/canonical/snapshots/trajectory_reasoning/trajectory.yaml
@@ -14,6 +14,7 @@ messages:
   tool_calls: null
   tool_call_id: null
   reasoning: null
+  openrouter_generation_id: null
   ts: '2026-01-01T12:00:00Z'
 - role: assistant
   content: I'll help with that.
@@ -35,5 +36,6 @@ messages:
     summary: Short summary of the model's private rationale.
     budget_used: 512
     transport: null
+  openrouter_generation_id: null
   ts: '2026-01-01T12:00:00Z'
 user_reply_guard_events: []

--- a/tests/unit/test_openrouter_generation_id.py
+++ b/tests/unit/test_openrouter_generation_id.py
@@ -1,0 +1,280 @@
+"""OpenRouter generation-id capture, from response header to persisted bundle.
+
+The id is the only key that joins a call we made to the routing decision
+OpenRouter made for it: querying
+``https://openrouter.ai/api/v1/generation?id=<id>`` afterwards reports which
+upstream provider actually served the call. Without it persisted, a result
+suspected of being a routing artefact can only be re-run, never checked.
+
+Header name is ``x-generation-id`` — verified by live probe 2026-08-19, which
+returned exactly that and no ``x-openrouter-generation-id``. litellm re-keys
+raw provider headers as ``llm_provider-<name>`` into
+``_hidden_params['additional_headers']``, so the tests below drive the
+prefixed form the engine actually sees, and the bare form a direct-httpx
+caller would hand it.
+
+Every non-OpenRouter route (Anthropic direct, Google direct, …) sends no such
+header, so the absent path is pinned at every layer alongside the present one:
+absence must persist as ``None`` / an empty list, never as a crash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from tolokaforge.core.llm import LLMClient, ReasoningConfig
+from tolokaforge.core.llm.usage import (
+    OPENROUTER_GENERATION_ID_HEADER,
+    UsageExtractor,
+    extract_openrouter_generation_id,
+)
+from tolokaforge.core.models import Message, MessageRole, Metrics, ModelConfig, Trajectory
+from tolokaforge.core.output_writer import OutputWriter
+from tolokaforge.core.runner import _AgentMetricsSink
+
+pytestmark = pytest.mark.unit
+
+
+_GEN_ID = "gen-1787132417-e6DthuPJjrFMFf46ae5F"
+
+
+def _response(
+    *,
+    headers: dict[str, Any] | None = None,
+    hidden_params: dict[str, Any] | None = None,
+    with_usage: bool = True,
+) -> Any:
+    """A litellm-shaped response, optionally carrying provider headers."""
+    mock_message = MagicMock()
+    mock_message.content = "ok"
+    mock_message.tool_calls = None
+    mock_message.reasoning_content = None
+
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+
+    response = MagicMock()
+    response.choices = [mock_choice]
+    if with_usage:
+        response.usage = MagicMock()
+        response.usage.prompt_tokens = 100
+        response.usage.completion_tokens = 50
+        response.usage.cache_read_input_tokens = 0
+        response.usage.cache_creation_input_tokens = 0
+        response.usage.prompt_tokens_details = None
+        response.usage.completion_tokens_details = None
+    else:
+        response.usage = None
+
+    params = dict(hidden_params or {})
+    if headers is not None:
+        params["additional_headers"] = headers
+    response._hidden_params = params
+    return response
+
+
+def _client(provider: str = "openrouter", name: str = "moonshotai/kimi-k3") -> LLMClient:
+    cfg = ModelConfig(
+        provider=provider,
+        name=name,
+        temperature=0.0,
+        reasoning=ReasoningConfig(mode="off"),
+    )
+    return LLMClient(cfg)
+
+
+def _generate(client: LLMClient, response: Any) -> Any:
+    with patch("tolokaforge.core.llm.client.completion", return_value=response):
+        return client.generate(
+            system="You are helpful.",
+            messages=[Message(role=MessageRole.USER, content="Hi")],
+        )
+
+
+class TestExtractFromResponseHeaders:
+    """The extractor reads the header litellm actually surfaces."""
+
+    def test_reads_litellm_prefixed_header(self) -> None:
+        response = _response(headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": _GEN_ID})
+        assert extract_openrouter_generation_id(response) == _GEN_ID
+
+    def test_reads_unprefixed_header(self) -> None:
+        """A direct-httpx caller hands us the bare provider name."""
+        response = _response(headers={OPENROUTER_GENERATION_ID_HEADER: _GEN_ID})
+        assert extract_openrouter_generation_id(response) == _GEN_ID
+
+    def test_header_match_is_case_insensitive(self) -> None:
+        """HTTP header names are case-insensitive; libraries normalise differently."""
+        response = _response(headers={"LLM_PROVIDER-X-Generation-Id": _GEN_ID})
+        assert extract_openrouter_generation_id(response) == _GEN_ID
+
+    def test_absent_header_yields_none(self) -> None:
+        """The normal state for Anthropic direct / Google direct."""
+        response = _response(headers={"llm_provider-content-type": "application/json"})
+        assert extract_openrouter_generation_id(response) is None
+
+    def test_no_additional_headers_yields_none(self) -> None:
+        response = _response(hidden_params={"response_cost": 0.001})
+        assert extract_openrouter_generation_id(response) is None
+
+    def test_no_hidden_params_yields_none(self) -> None:
+        response = MagicMock(spec=[])
+        assert extract_openrouter_generation_id(response) is None
+
+    def test_empty_header_value_yields_none(self) -> None:
+        """An empty id joins to nothing, so it is absence, not a value."""
+        response = _response(headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": ""})
+        assert extract_openrouter_generation_id(response) is None
+
+    def test_wrong_header_name_is_not_matched(self) -> None:
+        """Guards the name itself: the header is NOT x-openrouter-generation-id."""
+        response = _response(headers={"llm_provider-x-openrouter-generation-id": _GEN_ID})
+        assert extract_openrouter_generation_id(response) is None
+
+
+class TestUsageExtractorCarriesTheId:
+    """The per-call record carries the id alongside cost / latency."""
+
+    def test_call_record_carries_id(self) -> None:
+        response = _response(headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": _GEN_ID})
+        usage = UsageExtractor().extract(response)
+        assert len(usage.calls) == 1
+        assert usage.calls[0].openrouter_generation_id == _GEN_ID
+
+    def test_call_record_id_is_none_without_header(self) -> None:
+        usage = UsageExtractor().extract(_response(headers={}))
+        assert usage.calls[0].openrouter_generation_id is None
+
+
+class TestGenerationResultCarriesTheId:
+    """``LLMClient.generate`` surfaces the id on the result it returns."""
+
+    def test_generate_surfaces_id(self) -> None:
+        response = _response(headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": _GEN_ID})
+        result = _generate(_client(), response)
+        assert result.openrouter_generation_id == _GEN_ID
+        assert result.usage.calls[0].openrouter_generation_id == _GEN_ID
+
+    def test_generate_without_header_yields_none(self) -> None:
+        """A direct-Anthropic route must not crash and must not invent an id."""
+        result = _generate(_client(provider="anthropic", name="claude-opus-4-7"), _response())
+        assert result.openrouter_generation_id is None
+
+    def test_id_survives_a_response_with_no_usage_block(self) -> None:
+        """No usage block means no call record, but the routing is still recorded."""
+        response = _response(
+            headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": _GEN_ID},
+            with_usage=False,
+        )
+        result = _generate(_client(), response)
+        assert result.usage.calls == ()
+        assert result.openrouter_generation_id == _GEN_ID
+
+
+class TestMetricsAccumulation:
+    """One id per agent call, in call order, on the trial's metrics."""
+
+    def test_ids_accumulate_in_call_order(self) -> None:
+        metrics = Metrics()
+        recorder = _AgentMetricsSink(metrics)
+        client = _client()
+        for suffix in ("a", "b"):
+            headers = {f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": f"gen-{suffix}"}
+            recorder.record_generation(_generate(client, _response(headers=headers)))
+
+        assert metrics.openrouter_generation_ids == ["gen-a", "gen-b"]
+
+    def test_unrouted_calls_contribute_no_entry(self) -> None:
+        """The list is shorter than ``api_calls`` rather than padded with nulls."""
+        metrics = Metrics()
+        recorder = _AgentMetricsSink(metrics)
+        client = _client()
+        recorder.record_generation(
+            _generate(
+                client,
+                _response(headers={f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": _GEN_ID}),
+            )
+        )
+        recorder.record_generation(_generate(client, _response(headers={})))
+
+        assert metrics.api_calls == 2
+        assert metrics.openrouter_generation_ids == [_GEN_ID]
+
+
+class TestPersistedBundle:
+    """The id reaches disk in both artifacts and survives the round-trip."""
+
+    @staticmethod
+    def _trajectory(generation_id: str | None) -> Trajectory:
+        from datetime import datetime, timezone
+
+        ts = datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc)
+        metrics = Metrics()
+        recorder = _AgentMetricsSink(metrics)
+        headers = (
+            {f"llm_provider-{OPENROUTER_GENERATION_ID_HEADER}": generation_id}
+            if generation_id is not None
+            else {}
+        )
+        result = _generate(_client(), _response(headers=headers))
+        recorder.record_generation(result)
+        return Trajectory(
+            task_id="openrouter-gen-id-001",
+            trial_index=0,
+            start_ts=ts,
+            end_ts=ts,
+            messages=[
+                Message(role=MessageRole.USER, content="Hi", ts=ts),
+                Message(
+                    role=MessageRole.ASSISTANT,
+                    content=result.text,
+                    openrouter_generation_id=result.openrouter_generation_id,
+                    ts=ts,
+                ),
+            ],
+            metrics=metrics,
+        )
+
+    def test_metrics_yaml_carries_flat_list_and_per_call_id(self, tmp_path: Path) -> None:
+        OutputWriter(tmp_path).write_metrics(self._trajectory(_GEN_ID))
+
+        persisted = yaml.safe_load((tmp_path / "metrics.yaml").read_text())
+        assert persisted["openrouter_generation_ids"] == [_GEN_ID]
+        assert persisted["usage"]["calls"][0]["openrouter_generation_id"] == _GEN_ID
+
+    def test_metrics_yaml_omits_nothing_when_route_is_not_openrouter(self, tmp_path: Path) -> None:
+        OutputWriter(tmp_path).write_metrics(self._trajectory(None))
+
+        persisted = yaml.safe_load((tmp_path / "metrics.yaml").read_text())
+        assert persisted["openrouter_generation_ids"] == []
+        assert persisted["usage"]["calls"][0]["openrouter_generation_id"] is None
+
+    def test_trajectory_yaml_attaches_id_to_the_assistant_message(self, tmp_path: Path) -> None:
+        OutputWriter(tmp_path).write_trajectory(self._trajectory(_GEN_ID))
+
+        persisted = yaml.safe_load((tmp_path / "trajectory.yaml").read_text())
+        by_role = {m["role"]: m for m in persisted["messages"]}
+        assert by_role["assistant"]["openrouter_generation_id"] == _GEN_ID
+        assert by_role["user"]["openrouter_generation_id"] is None
+
+    def test_bundle_round_trips_through_model_validate(self, tmp_path: Path) -> None:
+        """Judge replay and trace replay both re-validate a persisted bundle."""
+        writer = OutputWriter(tmp_path)
+        trajectory = self._trajectory(_GEN_ID)
+        writer.write_trajectory(trajectory)
+        writer.write_metrics(trajectory)
+
+        raw = yaml.safe_load((tmp_path / "trajectory.yaml").read_text())
+        raw["metrics"] = yaml.safe_load((tmp_path / "metrics.yaml").read_text())
+        raw["metrics"].pop("schema_version", None)
+        raw["metrics"].pop("tool_usage_detail", None)
+        restored = Trajectory.model_validate(raw)
+
+        assert restored.metrics.openrouter_generation_ids == [_GEN_ID]
+        assert restored.metrics.usage.calls[0].openrouter_generation_id == _GEN_ID
+        assert restored.messages[1].openrouter_generation_id == _GEN_ID

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -53,7 +53,12 @@ from tolokaforge.core.llm.prompt_policy import detect_dict_maps
 from tolokaforge.core.llm.providers import compile_rate_limit_patterns, get_provider_binding
 from tolokaforge.core.llm.proxy import resolve_proxy_config
 from tolokaforge.core.llm.reasoning import ReasoningConfig, StructuredReasoning
-from tolokaforge.core.llm.usage import CostSource, Usage, UsageExtractor
+from tolokaforge.core.llm.usage import (
+    CostSource,
+    Usage,
+    UsageExtractor,
+    extract_openrouter_generation_id,
+)
 from tolokaforge.core.logging import get_logger
 from tolokaforge.core.models import (
     Message,
@@ -519,6 +524,7 @@ class GenerationResult:
         cost_usd: float | None = None,
         reasoning: StructuredReasoning | None = None,
         effective_system_prompt: str | None = None,
+        openrouter_generation_id: str | None = None,
     ):
         self.text = text
         self.tool_calls = tool_calls or []
@@ -533,6 +539,10 @@ class GenerationResult:
         self.reasoning = reasoning
         # Final system prompt after policy enrichment
         self.effective_system_prompt = effective_system_prompt
+        # OpenRouter's id for this generation; None on every other route. Also
+        # on ``usage.calls[-1]`` — carried here so the turn loop can stamp it
+        # onto the assistant message without reaching into the usage record.
+        self.openrouter_generation_id = openrouter_generation_id
         # Defects of the attempts discarded before this reply was accepted.
         # Stamped only by ``UserSimulator._llm_reply``; every other producer
         # of a result leaves it empty.
@@ -2099,6 +2109,8 @@ class LLMClient:
           containers for declared array / object params.
         * :class:`UsageExtractor` — pulls full prompt / completion / reasoning
           / cache counters (see docs/LLM_LAYER.md § ``usage``).
+        * :func:`extract_openrouter_generation_id` — lifts OpenRouter's
+          generation id off the response headers (``None`` elsewhere).
 
         ``cost_usd`` is computed iff usage is populated; unknown pricing
         surfaces as ``None``.
@@ -2177,6 +2189,10 @@ class LLMClient:
             cost_usd=cost_usd,
             reasoning=reasoning_result,
             effective_system_prompt=effective_system_prompt,
+            # Read off the response rather than off ``usage.calls``: a provider
+            # that returned no usage block contributes no call record, and the
+            # routing decision is still worth recording for that turn.
+            openrouter_generation_id=extract_openrouter_generation_id(response),
         )
 
     # ------------------------------------------------------------------

--- a/tolokaforge/core/llm/usage.py
+++ b/tolokaforge/core/llm/usage.py
@@ -32,6 +32,13 @@ cache activity into the same ``Usage.cache_creation_input_tokens`` /
 aggregation, analytics tools) stays routing-agnostic.
 
 See plan § Canonical litellm surface for the full surface.
+
+**OpenRouter generation id.** Alongside the usage block, an OpenRouter-served
+response carries the id of the generation it produced. It is the only key that
+joins a call we made to the routing decision OpenRouter made for it, so
+:class:`UsageExtractor` lifts it onto the call record — see
+:func:`extract_openrouter_generation_id` and ``docs/LLM_LAYER.md``
+§ "OpenRouter generation ids".
 """
 
 from __future__ import annotations
@@ -39,7 +46,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-__all__ = ["CostSource", "ProviderRawCall", "Usage", "UsageExtractor"]
+__all__ = [
+    "OPENROUTER_GENERATION_ID_HEADER",
+    "CostSource",
+    "ProviderRawCall",
+    "Usage",
+    "UsageExtractor",
+    "extract_openrouter_generation_id",
+]
 
 
 CostSource = Literal["litellm", "local", "unknown"]
@@ -73,6 +87,12 @@ class ProviderRawCall:
     cost_usd: float | None = None
     cost_source: CostSource = "unknown"
     latency_s: float = 0.0
+    openrouter_generation_id: str | None = None
+    """OpenRouter's id for the generation this call produced, else ``None``.
+
+    ``None`` for every route that is not OpenRouter — no other provider sends
+    the header this is read from. See
+    :func:`extract_openrouter_generation_id`."""
 
 
 @dataclass(frozen=True)
@@ -127,6 +147,56 @@ class Usage:
             provider_raw=dict(other.provider_raw) if other.provider_raw else {},
             calls=self.calls + other.calls,
         )
+
+
+OPENROUTER_GENERATION_ID_HEADER = "x-generation-id"
+"""Response header carrying OpenRouter's generation id.
+
+The name is ``x-generation-id``, **not** ``x-openrouter-generation-id`` —
+verified by live probe of ``openrouter.ai/api/v1/chat/completions``
+2026-08-19, which returned ``x-generation-id: gen-…`` and no other
+generation-bearing header. OpenRouter is the only provider we route to that
+sends it, which is what makes its presence a sufficient test.
+"""
+
+_LITELLM_PROVIDER_HEADER_PREFIX = "llm_provider-"
+"""Prefix litellm stamps on every raw upstream header it forwards.
+
+``process_response_headers`` re-keys provider headers as
+``llm_provider-<name>`` before they land in
+``_hidden_params['additional_headers']``, so the bare name never appears.
+Stripped rather than hardcoded into the lookup so a direct-httpx caller
+handing us unprefixed headers resolves identically.
+"""
+
+
+def extract_openrouter_generation_id(response: Any) -> str | None:
+    """Lift OpenRouter's generation id off a litellm response, else ``None``.
+
+    The id is a *response header* value, surfaced by litellm on
+    ``response._hidden_params['additional_headers']``. Querying
+    ``https://openrouter.ai/api/v1/generation?id=<id>`` afterwards reports
+    which upstream provider actually served the call — the retroactive
+    disambiguation this exists for (``docs/LLM_LAYER.md``
+    § "OpenRouter generation ids").
+
+    Returns ``None`` whenever the header is absent, which is the normal state
+    for every non-OpenRouter route (Anthropic direct, Google direct, …). Never
+    raises: like the rest of this module, this is telemetry, not control flow.
+    """
+    hidden = getattr(response, "_hidden_params", None)
+    if not isinstance(hidden, dict):
+        return None
+    headers = hidden.get("additional_headers")
+    if not isinstance(headers, dict):
+        return None
+    for key, value in headers.items():
+        if not isinstance(key, str):
+            continue
+        name = key.lower().removeprefix(_LITELLM_PROVIDER_HEADER_PREFIX)
+        if name == OPENROUTER_GENERATION_ID_HEADER and value:
+            return str(value)
+    return None
 
 
 def _int_attr(obj: Any, name: str) -> int:
@@ -209,7 +279,8 @@ class UsageExtractor:
     degrades gracefully when a provider returns a partial usage block.
     Each call also yields a :class:`ProviderRawCall` in ``Usage.calls``
     when usage is present, carrying the per-call ``cost_usd``,
-    ``cost_source``, and ``latency_s`` supplied by the caller.
+    ``cost_source``, and ``latency_s`` supplied by the caller, plus the
+    ``openrouter_generation_id`` read off the response's own headers.
     """
 
     def extract(
@@ -263,6 +334,7 @@ class UsageExtractor:
             cost_usd=cost_usd,
             cost_source=cost_source,
             latency_s=latency_s,
+            openrouter_generation_id=extract_openrouter_generation_id(response),
         )
 
         return Usage(

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -524,6 +524,7 @@ class ToolCallingLoop:
             content=result.text,
             tool_calls=result.tool_calls if result.tool_calls else None,
             reasoning=result.reasoning,
+            openrouter_generation_id=result.openrouter_generation_id,
             ts=_now(),
         )
 

--- a/tolokaforge/core/models/trajectory.py
+++ b/tolokaforge/core/models/trajectory.py
@@ -117,6 +117,11 @@ class Message(BaseModel):
     # Bare strings are rejected (Stage 0 migration); callers must pass
     # ``StructuredReasoning`` or a dict parsable by it.
     reasoning: StructuredReasoning | None = None
+    # OpenRouter's id for the generation that produced this message, so a
+    # request/response record in ``trajectory.yaml`` can be joined back to the
+    # routing decision behind it. Set on assistant messages produced by an
+    # OpenRouter-routed call; None on every other message and every other route.
+    openrouter_generation_id: str | None = None
     ts: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 
     @field_validator("reasoning", mode="before")
@@ -346,6 +351,22 @@ class Metrics(BaseModel):
     turns: int = 0
     api_calls: int = 0
     usage: Usage = Field(default_factory=Usage)
+    openrouter_generation_ids: list[str] = Field(default_factory=list)
+    """Every OpenRouter generation id the trial's agent calls returned, in call order.
+
+    Each id resolves at ``https://openrouter.ai/api/v1/generation?id=<id>`` to
+    the upstream provider that actually served that call, so a trial whose
+    result is suspected of being a routing artefact can be checked after the
+    fact instead of re-run. Empty on a trial that never reached OpenRouter.
+
+    A list, not a scalar: OpenRouter routes each request independently, so one
+    trial's turns can be served by different upstreams. Shorter than
+    ``api_calls`` whenever a call was served off an unrouted provider. The
+    per-call view — which id belongs to which turn — is
+    ``usage.calls[*].openrouter_generation_id``; this flat list is the
+    trial-level index, the same relationship the ``probe_*`` scalars have to
+    ``rate_limit_by_role_model``."""
+
     cost_usd: float | None = None
     tool_calls: int = 0
     tool_success_rate: float = 0.0

--- a/tolokaforge/core/models/trajectory.py
+++ b/tolokaforge/core/models/trajectory.py
@@ -363,9 +363,12 @@ class Metrics(BaseModel):
     trial's turns can be served by different upstreams. Shorter than
     ``api_calls`` whenever a call was served off an unrouted provider. The
     per-call view — which id belongs to which turn — is
-    ``usage.calls[*].openrouter_generation_id``; this flat list is the
-    trial-level index, the same relationship the ``probe_*`` scalars have to
-    ``rate_limit_by_role_model``."""
+    ``usage.calls[*].openrouter_generation_id``. The two are **not** positionally
+    aligned and this list is not derivable from ``usage.calls``: a response
+    that carried an ``x-generation-id`` header but no usage block contributes
+    an id here and no ``ProviderRawCall`` there. Consumers that need per-call
+    attribution read ``usage.calls``; consumers that need "did this trial
+    reach OpenRouter at all" read this list."""
 
     cost_usd: float | None = None
     tool_calls: int = 0

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -1037,6 +1037,8 @@ class _AgentMetricsSink(MetricsSink):
     def record_generation(self, result: GenerationResult) -> None:
         self._metrics.api_calls += 1
         self._metrics.usage = self._metrics.usage + result.usage
+        if result.openrouter_generation_id is not None:
+            self._metrics.openrouter_generation_ids.append(result.openrouter_generation_id)
         if result.cost_usd is not None:
             if self._metrics.cost_usd is None:
                 self._metrics.cost_usd = result.cost_usd


### PR DESCRIPTION
## Why

OpenRouter is a router: it picks an upstream provider per request, and two calls on the same model slug can be served by different upstreams (a live probe of `openai/gpt-4o-mini` was served by **Azure**; the run below was served by **OpenAI**). Upstreams differ in quantisation, context handling and tool-call formatting, so a measured delta between two runs of the same model can be a routing artefact rather than a property of the model.

Nothing in a trial bundle let us tell those apart after the fact. Re-running does not answer it either — a re-run samples routing afresh. Persisting the id is what makes the question answerable, and it is a prerequisite for interpreting any measurement on an OpenRouter-routed model.

## What

`x-generation-id` is lifted off every response and persisted in three places, all populated from one read:

| Where | Field | Granularity |
|---|---|---|
| `metrics.yaml` | `openrouter_generation_ids` | trial-level list, call order |
| `metrics.yaml` | `usage.calls[*].openrouter_generation_id` | per API call |
| `trajectory.yaml` | `messages[*].openrouter_generation_id` | per assistant turn |

Each id resolves at `https://openrouter.ai/api/v1/generation?id=<id>` to the upstream that actually served the call.

The flat list is the index a consumer walks; the two per-record fields are what attribute an id to a specific call or turn, which is what a cross-harness comparison needs.

## The header name is not what we assumed

**The header is `x-generation-id`, not `x-openrouter-generation-id`.** Verified by live probe of `openrouter.ai/api/v1/chat/completions` — it returned exactly that name and no other generation-bearing header. A test pins the wrong name as *not* matching, so this cannot silently regress.

litellm re-keys raw upstream headers as `llm_provider-<name>` into `_hidden_params["additional_headers"]`, so the match strips that prefix and case-folds; that also resolves the bare name a direct-httpx caller would hand it.

## Design notes

- **Read off the response, never from config or the environment.** The value describes what happened on the wire for one call, so nothing outside that response can be authoritative for it.
- **No provider-name branching.** OpenRouter is the only provider we route to that sends the header, so its presence is a sufficient test. Every direct route (Anthropic, Google) yields `None` rather than raising — graceful absence falls out of the design instead of being special-cased.
- **`ProviderRawCall` was already the right home.** It is the existing per-call record appended to `Usage.calls` for every LLM call, already serialised into `metrics.yaml` via `dataclasses.asdict` and coerced back through `_coerce_calls` — so the per-request requirement needed a field, not plumbing.
- **`Message` already carries response-derived metadata** (`reasoning`), so the per-turn id follows an established pattern rather than introducing one.
- **Scope held.** No generic response-header tracing, no public-interface change beyond one optional keyword on `GenerationResult`, no touching of `tolokaforge-tools` or `tolokaforge_coding_harnesses`.

## Backwards compatibility

Additive throughout. Both new fields are optional with defaults and serialise via the existing paths, so bundles written before this change still `model_validate` (exercised by a round-trip test), and non-OpenRouter bundles are unchanged apart from the new null key. The `trajectory_reasoning` canonical snapshot is refreshed for that null key — the only intended shape change.

`metrics.yaml` `schema_version` is deliberately **not** bumped: the change is purely additive, matching how earlier additive keys were handled.

## Tests

`tests/unit/test_openrouter_generation_id.py` — 19 unit tests, all passing. Present *and* absent paths pinned at every layer:

- extractor: litellm-prefixed / bare / mixed-case names, absent header, no `additional_headers`, no `_hidden_params`, empty value, and the wrong header name
- `UsageExtractor` call record, with and without the header
- `LLMClient.generate` surfacing, including a response with **no usage block** (no call record, id still recorded)
- metrics accumulation in call order, and unrouted calls contributing no entry
- persistence: `metrics.yaml` both fields, `trajectory.yaml` per-message, and a full `Trajectory.model_validate` round-trip

Lanes: `-m unit` and `-m canonical` both show **no new failures**. Four failures exist on the branch; all four were confirmed pre-existing on `origin/main` by re-running them against a clean tree (`test_harness_registry_replay`, `test_models_wheel_replay`, `test_tolokaforge_models_bootstrap` — a 1.2.0 version-contract mismatch; plus a stall in `test_ungradeable_trial_accounting` and 3 unrelated unit failures, all reproduced on the clean baseline).

## Real-run verification

A real OpenRouter run of `examples/native/tool_use` (2 trials, \$0.0013):

```
api_calls = 6 | ids = 6

[0] user      openrouter_generation_id=None
[1] assistant openrouter_generation_id=gen-1787134260-uKPONaH2ycEitncxuNuf
[2] tool      openrouter_generation_id=None
[3] assistant openrouter_generation_id=gen-1787134261-MgZyqYxvyGvp0Q5zAlGG
...

=== /api/v1/generation?id=gen-1787134260-uKPONaH2ycEitncxuNuf -> HTTP 200 ===
  id            = gen-1787134260-uKPONaH2ycEitncxuNuf
  model         = openai/gpt-4o-mini
  provider_name = OpenAI
```

One id per agent call, every assistant turn tagged, every other role null — and a persisted id resolving to the serving upstream, which is the whole point of the field.

## Docs

- `docs/LLM_LAYER.md` — new § "OpenRouter generation ids" (why routing matters, the header-name correction, where it lands), plus a cross-reference from § `usage`
- `docs/OUTPUT_FORMAT.md` — both artifacts' field docs and YAML examples updated

`CHANGELOG.md` is **not** hand-edited: `docs/RELEASING.md` states it is owned by commitizen and regenerated from Conventional Commits, so the entry rides in the commit subject (`feat(llm): …`) and lands on the next `cz bump`.