### PR TITLE
fix(tbench-adapter): make pass_threshold task-authored, default to 1.0

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -366,11 +366,24 @@ class TerminalBenchAdapter(BaseAdapter):
     # -- grading config -------------------------------------------------------
 
     def get_grading_config(self, task_id: str) -> GradingConfig:
+        # Terminal-bench grades by running the reference test suite in the env
+        # container (``grading_method="test_execution"`` in the runner-side
+        # config below), so ``pass_threshold`` is the fraction of the suite
+        # that must pass for the trial to grade PASS. Task-authored via
+        # ``[verifier].pass_threshold`` in task.toml, defaulting to 1.0 —
+        # the natural semantics of a test suite is binary "all tests pass".
+        # A silent low default inflates pass rates on partial credit (surfaced
+        # by Arena's task_design_oracle verdict on GH Actions run 32337928139
+        # in toloka-partners/tolokaforge-tasks: 6/10 Opus-4.7 trials passed
+        # only via the previous hardcoded 0.5 threshold; micro pass@1 reported
+        # 1.00 vs 0.40 under all-tests-pass).
+        self._ensure_discovered()
+        meta = self._tasks[task_id]
         return GradingConfig(
             combine=GradingCombineConfig(
                 method="weighted",
                 weights={"custom_checks": 1.0},
-                pass_threshold=0.5,
+                pass_threshold=meta.pass_threshold,
             ),
         )
 
@@ -432,7 +445,9 @@ class TerminalBenchAdapter(BaseAdapter):
             grading=RunnerGradingConfig(
                 combine_method="weighted",
                 weights={"custom_checks": 1.0},
-                pass_threshold=0.5,
+                # Task-authored via [verifier].pass_threshold in task.toml,
+                # defaulting to 1.0 — see the rationale on get_grading_config.
+                pass_threshold=meta.pass_threshold,
                 # Score by running the reference test suite in the env container.
                 # The runner dispatches on this method, not on the adapter name.
                 grading_method="test_execution",

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/task_parser.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/task_parser.py
@@ -23,6 +23,14 @@ class TerminalBenchTask:
     tags: list[str] = field(default_factory=list)
     agent_timeout_sec: float = 1800.0
     verifier_timeout_sec: float = 120.0
+    pass_threshold: float = 1.0
+    """Fraction of the reference test suite that must pass for the trial to
+    grade PASS. Read from ``task.toml`` ``[verifier].pass_threshold``; defaults
+    to ``1.0`` because ``grading_method="test_execution"`` is binary by
+    nature — a "test suite" that grades PASS on half its own failures loses
+    its meaning as a suite. Task authors can lower it when they explicitly
+    want partial credit (a bug remediation task whose suite exercises many
+    facets and the interesting subset is well below the whole)."""
     cpus: float = 2
     memory_mb: int = 4096
     harness_skills_dir: str | None = None
@@ -136,6 +144,7 @@ def discover_tasks(base_dir: Path) -> dict[str, TerminalBenchTask]:
             tags=metadata.get("tags", []),
             agent_timeout_sec=agent.get("timeout_sec", 1800.0),
             verifier_timeout_sec=verifier.get("timeout_sec", 120.0),
+            pass_threshold=float(verifier.get("pass_threshold", 1.0)),
             cpus=environment.get("cpus", 2),
             memory_mb=environment.get("memory_mb", 4096),
             harness_skills_dir=_parse_harness_skills_dir(task_id, task_dir, yaml_data),

--- a/tests/canonical/snapshots/tbench_echo_hello/grading_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/grading_config.json
@@ -1,7 +1,7 @@
 {
   "combine": {
     "method": "weighted",
-    "pass_threshold": 0.5,
+    "pass_threshold": 1.0,
     "weights": {
       "custom_checks": 1.0
     }

--- a/tests/canonical/snapshots/tbench_echo_hello/task_description.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_description.json
@@ -74,7 +74,7 @@
     "custom_checks": null,
     "grading_method": "test_execution",
     "llm_judge": null,
-    "pass_threshold": 0.5,
+    "pass_threshold": 1.0,
     "state_checks": null,
     "trace_checks": null,
     "transcript_rules": null,

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -473,6 +473,79 @@ class TestTerminalBenchAdapterEnvironmentManifest:
         assert extra == {"service": env.agent_service, "compose_project_prefix": "tbench_"}
 
 
+class TestTerminalBenchAdapterPassThreshold:
+    """Task-authored ``[verifier].pass_threshold`` flows into both grading
+    configs the adapter emits (the tolokaforge-side ``GradingConfig`` and the
+    runner-side ``RunnerGradingConfig``). Prior to the fix the adapter
+    hardcoded ``0.5`` in both places, silently inflating pass rates when a
+    trial passed only some of its own reference tests."""
+
+    def _make_task(self, tmp_path: Path, task_id: str, task_toml: str) -> Path:
+        tbench_dir = tmp_path / "tasks"
+        tbench_dir.mkdir()
+        task_dir = tbench_dir / task_id
+        task_dir.mkdir()
+        (task_dir / "docker-compose.yaml").write_text("services: {main: {image: alpine}}\n")
+        (task_dir / "task.toml").write_text(task_toml)
+        (task_dir / "instruction.md").write_text("do the thing")
+        return tbench_dir
+
+    def test_grading_config_default_is_one(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        tbench_dir = self._make_task(
+            tmp_path,
+            "default-thresh",
+            '[metadata]\nauthor_name = "t"\n[verifier]\ntimeout_sec = 60.0\n',
+        )
+        adapter = TerminalBenchAdapter(
+            {"terminal_bench_dir": str(tbench_dir), "staging_root": str(tmp_path / "staging")}
+        )
+        cfg = adapter.get_grading_config("default-thresh")
+        assert cfg.combine.pass_threshold == 1.0
+
+    def test_grading_config_reads_task_authored_override(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        tbench_dir = self._make_task(
+            tmp_path,
+            "half-thresh",
+            '[metadata]\nauthor_name = "t"\n[verifier]\npass_threshold = 0.5\n',
+        )
+        adapter = TerminalBenchAdapter(
+            {"terminal_bench_dir": str(tbench_dir), "staging_root": str(tmp_path / "staging")}
+        )
+        cfg = adapter.get_grading_config("half-thresh")
+        assert cfg.combine.pass_threshold == 0.5
+
+    def test_task_description_default_is_one(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        tbench_dir = self._make_task(
+            tmp_path, "default-thresh-td", '[metadata]\nauthor_name = "t"\n'
+        )
+        adapter = TerminalBenchAdapter(
+            {"terminal_bench_dir": str(tbench_dir), "staging_root": str(tmp_path / "staging")}
+        )
+        td = adapter.to_task_description("default-thresh-td")
+        assert td.grading.pass_threshold == 1.0
+        assert td.grading.grading_method == "test_execution"
+
+    def test_task_description_reads_task_authored_override(self, tmp_path):
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        tbench_dir = self._make_task(
+            tmp_path,
+            "quarter-thresh-td",
+            '[metadata]\nauthor_name = "t"\n[verifier]\npass_threshold = 0.25\n',
+        )
+        adapter = TerminalBenchAdapter(
+            {"terminal_bench_dir": str(tbench_dir), "staging_root": str(tmp_path / "staging")}
+        )
+        td = adapter.to_task_description("quarter-thresh-td")
+        assert td.grading.pass_threshold == 0.25
+
+
 class TestTerminalBenchAdapterInstructionlessTask:
     """A pack whose instruction carries no text pins no opener, so the simulator
     writes turn 1.
@@ -633,6 +706,56 @@ class TestTaskParser:
 
         tasks = discover_tasks(tmp_path)
         assert tasks == {}
+
+    def test_pass_threshold_defaults_to_one_when_task_toml_is_silent(self, fixture_dir):
+        # echo-hello's task.toml declares [verifier].timeout_sec but no
+        # pass_threshold. The parser must default to 1.0 so a silent task
+        # authors ``all reference tests must pass`` — the natural semantics
+        # of test_execution grading. Older revisions of the adapter
+        # hardcoded 0.5, inflating pass rates on partial credit; this test
+        # locks the default that replaces that hardcode.
+        from tolokaforge_adapter_terminal_bench.task_parser import discover_tasks
+
+        tasks = discover_tasks(fixture_dir)
+        assert tasks["echo-hello"].pass_threshold == 1.0
+
+    def test_pass_threshold_reads_from_verifier_section(self, tmp_path):
+        # A task author who WANTS partial credit declares it via
+        # [verifier].pass_threshold in task.toml; the parser must surface it.
+        from tolokaforge_adapter_terminal_bench.task_parser import discover_tasks
+
+        task_dir = tmp_path / "partial-credit"
+        task_dir.mkdir()
+        (task_dir / "docker-compose.yaml").write_text("services: {main: {image: alpine}}\n")
+        (task_dir / "task.toml").write_text(
+            "[metadata]\n"
+            'author_name = "test"\n'
+            'difficulty = "easy"\n'
+            "\n"
+            "[verifier]\n"
+            "timeout_sec = 60.0\n"
+            "pass_threshold = 0.75\n"
+        )
+        (task_dir / "instruction.md").write_text("do the thing")
+        tasks = discover_tasks(tmp_path)
+        assert tasks["partial-credit"].pass_threshold == 0.75
+
+    def test_pass_threshold_coerces_int_to_float(self, tmp_path):
+        # tomllib returns int for ``pass_threshold = 1`` (a plausible author
+        # typo); the parser must coerce to float so downstream Pydantic
+        # models that require ``float`` do not raise.
+        from tolokaforge_adapter_terminal_bench.task_parser import discover_tasks
+
+        task_dir = tmp_path / "int-threshold"
+        task_dir.mkdir()
+        (task_dir / "docker-compose.yaml").write_text("services: {main: {image: alpine}}\n")
+        (task_dir / "task.toml").write_text(
+            "[metadata]\n" 'author_name = "test"\n' "\n" "[verifier]\n" "pass_threshold = 1\n"
+        )
+        (task_dir / "instruction.md").write_text("do the thing")
+        tasks = discover_tasks(tmp_path)
+        assert tasks["int-threshold"].pass_threshold == 1.0
+        assert isinstance(tasks["int-threshold"].pass_threshold, float)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The terminal-bench adapter hardcoded `pass_threshold=0.5` in both grading config sites (`get_grading_config` and `to_task_description`). Under `grading_method="test_execution"` — where the score IS the fraction of a reference test suite that passed — a 0.5 threshold silently graded a half-broken trial as PASS.

**Surfaced by Arena's `task_design_oracle` five-dimension verdict** on GitHub Actions run 32337928139 in `toloka-partners/tolokaforge-tasks`: 6/10 Opus 4.7 trials on TBench balanced-10 passed only via the 0.5 threshold; micro pass@1 reported 1.00 vs 0.40 under all-tests-pass. Analyzer's recommendation: *"Make the threshold task-authored (or 1.0 for test_execution grading) and regrade."*

## Fix

Follows both parts of the recommendation. Task-authoring path matches how `[verifier].timeout_sec` is already surfaced from `task.toml`:

- `TerminalBenchTask` gains a `pass_threshold` field, default `1.0`.
- `task_parser` reads `verifier.get("pass_threshold", 1.0)` with float coercion (a plain `1` in `task.toml` parses as int in `tomllib` and would fail downstream Pydantic validation).
- Both adapter sites (`get_grading_config`, `to_task_description`) read `meta.pass_threshold` instead of hardcoding.

Task authors who want partial credit declare it explicitly:

```toml
[verifier]
pass_threshold = 0.75
```

Nothing declares that today across the shipped example tasks or the `echo-hello` fixture, so the default of `1.0` kicks in and every task now grades under all-tests-pass semantics — matching how the `frozen-mcp-core` and `tlk-mcp-core` adapters grade their reference test runs.

## Test plan

- [x] 3 new parser tests: default, task-authored override, int→float coercion
- [x] 4 new adapter tests: both `get_grading_config` and `to_task_description`, each covering default and override
- [x] 2 canonical snapshots regenerated (`grading_config.json`, `task_description.json` for `tbench_echo_hello`) — the diff is `pass_threshold: 0.5 → 1.0`
- [x] Full terminal-bench test suite: 163 passed, 1 warning
- [ ] Downstream: `toloka-partners/tolokaforge-tasks` eval branches that repin will start reporting all-tests-pass numbers on TBench — expected behaviour, matches other adapters