### PR TITLE
feat(grader): wire the queue trial grader end-to-end (#1254)

### DIFF
--- a/tests/canonical/test_queue_trial_grader.py
+++ b/tests/canonical/test_queue_trial_grader.py
@@ -222,15 +222,20 @@ class TestFactoryAndRegistration:
             grader_config=GraderConfig(queue=QueueGraderConfig(workers=2)),
         )
         grader = queue_trial_grader_factory(ctx)
+        # Snapshot the worker handles BEFORE close(); the impl clears the
+        # list as part of shutdown, so a post-close ``for w in grader._workers``
+        # would iterate zero times and assert nothing.
+        workers = list(grader._workers)
         try:
             assert isinstance(grader, QueueTrialGrader)
-            assert len(grader._workers) == 2
+            assert len(workers) == 2
             assert grader._owns_broker is True
         finally:
             grader.close()
 
-        for worker in grader._workers:
+        for worker in workers:
             assert not worker.is_alive(), "close() must drain the worker pool"
+        assert grader._workers == [], "close() clears the worker list"
 
     def test_factory_rejects_missing_address(self) -> None:
         """The queue transport needs a downstream ``grader_rpc`` target;

--- a/tests/canonical/test_queue_trial_grader.py
+++ b/tests/canonical/test_queue_trial_grader.py
@@ -208,13 +208,48 @@ class TestThroughputProperty:
 
 
 class TestFactoryAndRegistration:
-    def test_factory_raises_until_broker_wiring_lands(self) -> None:
-        """The registered ``queue`` factory raises loudly instead of building
-        an unusable grader (broker no one is listening to). Once the context
-        carries broker-selection configuration and a worker pool is
-        provisioned, this test flips to construct a working grader."""
-        ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock())
-        with pytest.raises(NotImplementedError, match="not yet wired"):
+    def test_factory_builds_broker_and_worker_pool(self) -> None:
+        """The registered ``queue`` factory returns a working grader:
+        an in-memory broker, N daemon worker threads holding grader-service
+        clients, and a :class:`QueueTrialGrader` that owns both. ``close``
+        tears everything down.
+        """
+        from tolokaforge.core.models.run_config import GraderConfig, QueueGraderConfig
+
+        ctx = TrialGraderContext(
+            runner_address="stub:0",
+            logger=MagicMock(),
+            grader_config=GraderConfig(queue=QueueGraderConfig(workers=2)),
+        )
+        grader = queue_trial_grader_factory(ctx)
+        try:
+            assert isinstance(grader, QueueTrialGrader)
+            assert len(grader._workers) == 2
+            assert grader._owns_broker is True
+        finally:
+            grader.close()
+
+        for worker in grader._workers:
+            assert not worker.is_alive(), "close() must drain the worker pool"
+
+    def test_factory_rejects_missing_address(self) -> None:
+        """The queue transport needs a downstream ``grader_rpc`` target;
+        neither ``grader_address`` nor ``runner_address`` set means the
+        factory refuses at startup instead of publishing jobs no worker
+        can grade."""
+        ctx = TrialGraderContext(runner_address=None, logger=MagicMock())
+        with pytest.raises(ValueError, match="grader_address"):
+            queue_trial_grader_factory(ctx)
+
+    def test_factory_rejects_unsupported_worker_grader(self) -> None:
+        """Only ``worker_grader: grader_rpc`` is wired today; other names
+        raise at factory time so the operator sees the gap before jobs
+        pile up."""
+        from tolokaforge.core.models.run_config import GraderConfig, QueueGraderConfig
+
+        cfg = GraderConfig(queue=QueueGraderConfig(worker_grader="judge_only"))
+        ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock(), grader_config=cfg)
+        with pytest.raises(ValueError, match="worker_grader"):
             queue_trial_grader_factory(ctx)
 
     def test_registered_under_queue_entry_point(self) -> None:

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -1929,3 +1929,78 @@ class TestAdapterDeclaredTrialGraderName:
         message = str(excinfo.value)
         assert "does_not_exist_grader" in message
         assert "runner_rpc" in message
+
+    def test_run_config_grader_name_overrides_adapter_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``RunConfig.grader.name`` wins over the adapter's ``trial_grader_name``.
+
+        An operator selecting a different grader through the run config sees
+        the override applied without touching the adapter class.
+        """
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.models.run_config import GraderConfig
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+
+        produced = _RecordingGrader()
+        self._install_grader_entry_points(
+            monkeypatch, [_FakeEntryPoint("recording_grader", lambda _ctx: produced)]
+        )
+        captured: dict[str, ConductorContext] = {}
+
+        def factory(ctx: ConductorContext) -> InMemoryConductor:
+            captured["ctx"] = ctx
+            return InMemoryConductor()
+
+        config = _make_run_config(grader=GraderConfig(name="recording_grader"))
+        orch = Orchestrator(config, deps=OrchestratorDeps(conductor_factory=factory))
+        orch.adapter = _DefaultGraderAdapter({"tasks_glob": "tasks/**/task.yaml"})
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            output_dir=tmp_path,
+            request_limiter=None,
+        )
+
+        assert captured["ctx"].trial_grader is produced
+
+    def test_run_config_grader_config_reaches_the_factory(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The full ``GraderConfig`` block rides ``TrialGraderContext.grader_config``.
+
+        A transport-specific factory (``queue`` reading its own subblock)
+        can read the settings the operator declared without a second config
+        lookup.
+        """
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.models.run_config import GraderConfig, QueueGraderConfig
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+        from tolokaforge.core.plugin_registry import TrialGraderContext
+
+        received: dict[str, TrialGraderContext] = {}
+
+        def factory(ctx: TrialGraderContext) -> Any:
+            received["ctx"] = ctx
+            return _RecordingGrader()
+
+        self._install_grader_entry_points(
+            monkeypatch, [_FakeEntryPoint("recording_grader", factory)]
+        )
+
+        def conductor_factory(cctx: ConductorContext) -> InMemoryConductor:
+            return InMemoryConductor()
+
+        block = GraderConfig(name="recording_grader", queue=QueueGraderConfig(workers=8))
+        config = _make_run_config(grader=block)
+        orch = Orchestrator(config, deps=OrchestratorDeps(conductor_factory=conductor_factory))
+        orch.adapter = _DefaultGraderAdapter({"tasks_glob": "tasks/**/task.yaml"})
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=MagicMock(),
+            output_dir=tmp_path,
+            request_limiter=None,
+        )
+
+        assert received["ctx"].grader_config is block
+        assert received["ctx"].grader_config.queue.workers == 8

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -830,7 +830,7 @@ class QueueGraderConfig(BaseModel):
 
     workers: int = Field(default=4, ge=1)
     backend: Literal["in_memory"] = "in_memory"
-    worker_grader: str = "runner_rpc"
+    worker_grader: str = "grader_rpc"
 
 
 class GraderConfig(BaseModel):

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -811,6 +811,51 @@ class StorageConfig(BaseModel):
     queue: QueueStorageConfig | None = None
 
 
+class QueueGraderConfig(BaseModel):
+    """Queue-backed ``TrialGrader`` transport settings.
+
+    Read by ``queue_trial_grader_factory`` when the operator selects
+    ``grader.name: queue``. ``workers`` sets the consumer-pool size (the
+    throughput knob the transport exists to unlock); ``backend`` names the
+    :class:`GradeBroker` implementation (``in_memory`` today; Redis Streams
+    ships behind the same Protocol as a follow-up); ``worker_grader`` names
+    the downstream ``TrialGrader`` each worker dispatches to — a
+    ``TrialGraderFactory`` name from the ``tolokaforge.trial_graders``
+    entry-point group. Layering ``queue`` on top of another registered
+    grader lets one selection add throughput scale without duplicating
+    grading logic.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    workers: int = Field(default=4, ge=1)
+    backend: Literal["in_memory"] = "in_memory"
+    worker_grader: str = "runner_rpc"
+
+
+class GraderConfig(BaseModel):
+    """Run-level ``TrialGrader`` selection and per-transport settings.
+
+    Optional block: absent means "use whatever the adapter's
+    ``trial_grader_name`` names", which is the pre-block behaviour every
+    existing run keeps.
+
+    ``name``, when set, overrides ``adapter.trial_grader_name`` for this
+    run. Value is the entry-point name of a registered
+    ``TrialGraderFactory`` (``runner_rpc``, ``grader_rpc``, ``queue``,
+    ``judge_only``, or any downstream-registered name).
+
+    Transport-specific settings live in subblocks named after the
+    transport. Only the subblock matching the selected ``name`` is
+    consulted — an unrelated subblock is harmless data the factory ignores.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str | None = None
+    queue: QueueGraderConfig | None = None
+
+
 class TracingConfig(BaseModel):
     """Tracing exporter selection.
 
@@ -917,6 +962,7 @@ class RunConfig(BaseModel):
     storage: StorageConfig | None = None
     observability: ObservabilityConfig | None = None
     docker: DockerConfig | None = None
+    grader: GraderConfig | None = None
 
     @property
     def effective_workers(self) -> int:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -807,6 +807,12 @@ class Orchestrator:
                 grader_config=grader_config,
             )
         )
+        # Drain any leftover from a prior aborted run on this orchestrator
+        # instance before recording the fresh grader — a re-entered ``run()``
+        # on the same instance must never close a stale grader from the
+        # previous attempt.
+        if self._trial_graders_to_close:
+            self._close_trial_graders()
         self._trial_graders_to_close.append(trial_grader)
 
         ctx = ConductorContext(
@@ -2173,321 +2179,336 @@ class Orchestrator:
             output_dir=output_dir,
             request_limiter=request_limiter,
         )
-        trial_executor = self._build_trial_executor(
-            runtime_backend, conductor, output_dir=output_dir
-        )
+        # ``try/finally`` from here to the run's return guarantees the
+        # grader teardown (broker close + worker join, gRPC channel close)
+        # fires even when the trial loop or a mid-run cleanup raises. The
+        # rest of the existing sequential teardown lives inside the try
+        # body — a mid-run exception still surfaces to the caller after
+        # the grader is closed.
+        try:
+            trial_executor = self._build_trial_executor(
+                runtime_backend, conductor, output_dir=output_dir
+            )
 
-        executor_healthy = runtime_backend.health_check()
-        self.logger.info("Docker runtime health check", executor_healthy=executor_healthy)
+            executor_healthy = runtime_backend.health_check()
+            self.logger.info("Docker runtime health check", executor_healthy=executor_healthy)
 
-        # Build pending task/trial pairs and initialize durable queue.
-        task_by_id = {task.task_id: task for task in self.tasks}
-        pending_trials = self._build_pending_trials(
-            self.tasks,
-            self.config.orchestrator.repeats,
-            skip_completed=lambda task_id, trial_idx: self.resume
-            and self.state_manager.is_completed(task_id, trial_idx),
-        )
+            # Build pending task/trial pairs and initialize durable queue.
+            task_by_id = {task.task_id: task for task in self.tasks}
+            pending_trials = self._build_pending_trials(
+                self.tasks,
+                self.config.orchestrator.repeats,
+                skip_completed=lambda task_id, trial_idx: self.resume
+                and self.state_manager.is_completed(task_id, trial_idx),
+            )
 
-        run_queue = create_run_queue(
-            self.config.effective_queue_backend,
-            sqlite_path=output_dir / "run_queue.sqlite",
-            max_retries=self.config.effective_max_attempt_retries,
-            postgres_dsn=self.config.effective_queue_postgres_dsn,
-        )
-        run_queue.enqueue_many(pending_trials)
-        recovered = run_queue.recover_inflight(
-            max_lease_age_s=max(300, self.config.orchestrator.timeouts.episode_s * 2)
-        )
-        if recovered > 0:
-            self.logger.warning("Recovered stale in-flight attempts", recovered=recovered)
+            run_queue = create_run_queue(
+                self.config.effective_queue_backend,
+                sqlite_path=output_dir / "run_queue.sqlite",
+                max_retries=self.config.effective_max_attempt_retries,
+                postgres_dsn=self.config.effective_queue_postgres_dsn,
+            )
+            run_queue.enqueue_many(pending_trials)
+            recovered = run_queue.recover_inflight(
+                max_lease_age_s=max(300, self.config.orchestrator.timeouts.episode_s * 2)
+            )
+            if recovered > 0:
+                self.logger.warning("Recovered stale in-flight attempts", recovered=recovered)
 
-        total_cost_usd = self._collect_existing_cost(output_dir)
-        total_trials_scheduled = len(pending_trials)
-        if total_cost_usd > 0:
-            self.logger.info("Loaded existing run spend", total_cost_usd=round(total_cost_usd, 6))
-        budget = self._resolve_budget(initial_cost_usd=total_cost_usd)
-        budget_exhausted = False
-        last_hit: BudgetHit | None = None
-        if budget is not None:
-            hit = budget.poll()
-            if hit is not None:
-                budget_exhausted = True
-                last_hit = hit
-                self._stopped_reason = f"{hit.which} limit"
-                write_limit_hit_marker(output_dir, hit)
-                self.logger.warning(
-                    "Budget already exhausted at run start; no trials will be scheduled",
-                    limit_kind=hit.which,
-                    threshold=hit.threshold,
-                    value_at_hit=round(hit.value_at_hit, 6),
+            total_cost_usd = self._collect_existing_cost(output_dir)
+            total_trials_scheduled = len(pending_trials)
+            if total_cost_usd > 0:
+                self.logger.info(
+                    "Loaded existing run spend", total_cost_usd=round(total_cost_usd, 6)
                 )
-
-        lease_seconds = max(300, self.config.orchestrator.timeouts.episode_s * 2)
-        lease_owner = f"orchestrator:{os.getpid()}"
-
-        self._events.run_started(
-            total_trials=run_state.total_trials,
-            initial_completed=run_state.completed_trials,
-        )
-
-        # Run tasks with parallel workers using the durable queue.
-        with ThreadPoolExecutor(max_workers=self.config.effective_workers) as executor:
-            active_futures: dict[Any, AttemptLease] = {}
-
-            def submit_one() -> bool:
-                if budget_exhausted:
-                    return False
-                lease = run_queue.lease_next(worker_id=lease_owner, lease_seconds=lease_seconds)
-                if lease is None:
-                    return False
-                task = task_by_id.get(lease.task_id)
-                if task is None:
-                    # Should never happen; fail-fast and continue scheduling.
-                    run_queue.mark_failed(
-                        lease.id, f"Task not found in loaded set: {lease.task_id}", retryable=False
+            budget = self._resolve_budget(initial_cost_usd=total_cost_usd)
+            budget_exhausted = False
+            last_hit: BudgetHit | None = None
+            if budget is not None:
+                hit = budget.poll()
+                if hit is not None:
+                    budget_exhausted = True
+                    last_hit = hit
+                    self._stopped_reason = f"{hit.which} limit"
+                    write_limit_hit_marker(output_dir, hit)
+                    self.logger.warning(
+                        "Budget already exhausted at run start; no trials will be scheduled",
+                        limit_kind=hit.which,
+                        threshold=hit.threshold,
+                        value_at_hit=round(hit.value_at_hit, 6),
                     )
-                    run_state.mark_failed(
-                        lease.task_id, lease.trial_index, f"Task not found: {lease.task_id}"
-                    )
+
+            lease_seconds = max(300, self.config.orchestrator.timeouts.episode_s * 2)
+            lease_owner = f"orchestrator:{os.getpid()}"
+
+            self._events.run_started(
+                total_trials=run_state.total_trials,
+                initial_completed=run_state.completed_trials,
+            )
+
+            # Run tasks with parallel workers using the durable queue.
+            with ThreadPoolExecutor(max_workers=self.config.effective_workers) as executor:
+                active_futures: dict[Any, AttemptLease] = {}
+
+                def submit_one() -> bool:
+                    if budget_exhausted:
+                        return False
+                    lease = run_queue.lease_next(worker_id=lease_owner, lease_seconds=lease_seconds)
+                    if lease is None:
+                        return False
+                    task = task_by_id.get(lease.task_id)
+                    if task is None:
+                        # Should never happen; fail-fast and continue scheduling.
+                        run_queue.mark_failed(
+                            lease.id,
+                            f"Task not found in loaded set: {lease.task_id}",
+                            retryable=False,
+                        )
+                        run_state.mark_failed(
+                            lease.task_id, lease.trial_index, f"Task not found: {lease.task_id}"
+                        )
+                        self.state_manager.save_state(run_state)
+                        return True
+
+                    # Mark as running
+                    run_queue.mark_running(lease.id, lease_owner)
+                    run_state.mark_running(lease.task_id, lease.trial_index)
                     self.state_manager.save_state(run_state)
-                    return True
 
-                # Mark as running
-                run_queue.mark_running(lease.id, lease_owner)
-                run_state.mark_running(lease.task_id, lease.trial_index)
-                self.state_manager.save_state(run_state)
-
-                self._events.trial_started(
-                    trial_id=f"{lease.task_id}:{lease.trial_index}",
-                    task_id=lease.task_id,
-                    trial_index=lease.trial_index,
-                    total_index=self._total_index_by_key.get((lease.task_id, lease.trial_index), 0),
-                    agent_model=f"{agent_config.provider}/{agent_config.name}",
-                    user_model=f"{user_config.provider}/{user_config.name}",
-                )
-
-                try:
-                    spec = self._build_trial_spec(
-                        task=task,
-                        trial_idx=lease.trial_index,
-                        attempt_id=lease.retry_count,
-                        worker_id=lease_owner,
-                        run_id=run_id,
-                        agent_client=agent_client,
-                        user_config=user_config,
-                        judge_config=judge_config,
-                        env_endpoints=env_endpoints,
-                    )
-                except Exception as e:
-                    self.logger.error(
-                        "Trial spec build failed",
+                    self._events.trial_started(
+                        trial_id=f"{lease.task_id}:{lease.trial_index}",
                         task_id=lease.task_id,
                         trial_index=lease.trial_index,
-                        error=str(e),
+                        total_index=self._total_index_by_key.get(
+                            (lease.task_id, lease.trial_index), 0
+                        ),
+                        agent_model=f"{agent_config.provider}/{agent_config.name}",
+                        user_model=f"{user_config.provider}/{user_config.name}",
                     )
-                    run_queue.mark_failed(lease.id, f"Spec build failed: {e}", retryable=False)
-                    run_state.mark_failed(lease.task_id, lease.trial_index, str(e))
-                    self.state_manager.save_state(run_state)
-                    self._events.trial_failed(
-                        trial_id=f"{lease.task_id}:{lease.trial_index}",
-                        error=str(e),
-                        retryable=False,
-                    )
-                    return True
-                future = executor.submit(trial_executor.execute, spec, task)
-                active_futures[future] = lease
-                return True
 
-            while len(active_futures) < self.config.effective_workers and submit_one():
-                pass
-
-            while active_futures:
-                done, _ = wait(active_futures.keys(), return_when=FIRST_COMPLETED)
-                for future in done:
-                    lease = active_futures.pop(future)
-                    task_id = lease.task_id
-                    trial_idx = lease.trial_index
                     try:
-                        trial_result = future.result()
-                        trajectory = trial_result.trajectory
-                        self.results.append(trajectory)
-                        trial_cost = trajectory.metrics.cost_usd or 0.0
-                        total_cost_usd += trial_cost
-                        if budget is not None:
-                            budget.record_generation_cost(trial_cost)
+                        spec = self._build_trial_spec(
+                            task=task,
+                            trial_idx=lease.trial_index,
+                            attempt_id=lease.retry_count,
+                            worker_id=lease_owner,
+                            run_id=run_id,
+                            agent_client=agent_client,
+                            user_config=user_config,
+                            judge_config=judge_config,
+                            env_endpoints=env_endpoints,
+                        )
+                    except Exception as e:
+                        self.logger.error(
+                            "Trial spec build failed",
+                            task_id=lease.task_id,
+                            trial_index=lease.trial_index,
+                            error=str(e),
+                        )
+                        run_queue.mark_failed(lease.id, f"Spec build failed: {e}", retryable=False)
+                        run_state.mark_failed(lease.task_id, lease.trial_index, str(e))
+                        self.state_manager.save_state(run_state)
+                        self._events.trial_failed(
+                            trial_id=f"{lease.task_id}:{lease.trial_index}",
+                            error=str(e),
+                            retryable=False,
+                        )
+                        return True
+                    future = executor.submit(trial_executor.execute, spec, task)
+                    active_futures[future] = lease
+                    return True
 
-                        # Retry transient infra failures based on queue retry policy.
-                        if self._is_retryable_trajectory(trajectory):
-                            reason = (
-                                trajectory.termination_reason.value
-                                if trajectory.termination_reason
-                                else trajectory.status.value
-                            )
-                            should_retry = run_queue.mark_failed(
-                                lease.id,
-                                f"Retryable failure: {reason}",
-                                retryable=True,
+                while len(active_futures) < self.config.effective_workers and submit_one():
+                    pass
+
+                while active_futures:
+                    done, _ = wait(active_futures.keys(), return_when=FIRST_COMPLETED)
+                    for future in done:
+                        lease = active_futures.pop(future)
+                        task_id = lease.task_id
+                        trial_idx = lease.trial_index
+                        try:
+                            trial_result = future.result()
+                            trajectory = trial_result.trajectory
+                            self.results.append(trajectory)
+                            trial_cost = trajectory.metrics.cost_usd or 0.0
+                            total_cost_usd += trial_cost
+                            if budget is not None:
+                                budget.record_generation_cost(trial_cost)
+
+                            # Retry transient infra failures based on queue retry policy.
+                            if self._is_retryable_trajectory(trajectory):
+                                reason = (
+                                    trajectory.termination_reason.value
+                                    if trajectory.termination_reason
+                                    else trajectory.status.value
+                                )
+                                should_retry = run_queue.mark_failed(
+                                    lease.id,
+                                    f"Retryable failure: {reason}",
+                                    retryable=True,
+                                )
+                                if should_retry:
+                                    self._cleanup_runner_state_for_retry(
+                                        runtime_backend, task_id, trial_idx
+                                    )
+                                    self.logger.warning(
+                                        "Retrying trial after transient failure",
+                                        task_id=task_id,
+                                        trial_index=trial_idx,
+                                        retry_count_next=lease.retry_count + 1,
+                                        status=trajectory.status.value,
+                                        termination_reason=reason,
+                                    )
+                                else:
+                                    run_state.mark_failed(
+                                        task_id,
+                                        trial_idx,
+                                        f"Retry limit reached after transient failure: {reason}",
+                                    )
+                                    self.state_manager.save_state(run_state)
+                                    self._events.trial_failed(
+                                        trial_id=f"{task_id}:{trial_idx}",
+                                        error=f"Retry limit reached after transient failure: {reason}",
+                                        retryable=True,
+                                    )
+                                    if budget is not None:
+                                        budget.record_trial_terminated()
+                                self.logger.info(
+                                    "Trial failed (transient)",
+                                    task_id=task_id,
+                                    trial_index=trial_idx,
+                                    trial_cost_usd=trial_cost,
+                                    total_cost_usd=round(total_cost_usd, 6),
+                                )
+                            else:
+                                run_queue.mark_completed(lease.id, cost_usd=trial_cost)
+                                # An ungraded trial records no verdict: a 0.0 here
+                                # is indistinguishable from a task the agent failed.
+                                run_state.mark_completed(
+                                    task_id,
+                                    trial_idx,
+                                    trajectory.grade.binary_pass if trajectory.grade else None,
+                                    trajectory.grade.score if trajectory.grade else None,
+                                )
+                                self.state_manager.save_state(run_state)
+
+                                self._events.trial_completed(
+                                    trial_id=f"{task_id}:{trial_idx}",
+                                    binary_pass=(
+                                        trajectory.grade.binary_pass if trajectory.grade else None
+                                    ),
+                                    score=trajectory.grade.score if trajectory.grade else None,
+                                )
+                                if budget is not None:
+                                    budget.record_trial_terminated()
+
+                                self.logger.info(
+                                    "Trial completed",
+                                    task_id=trajectory.task_id,
+                                    trial_index=trajectory.trial_index,
+                                    status=trajectory.status.value,
+                                    score=trajectory.grade.score if trajectory.grade else None,
+                                    trial_cost_usd=trial_cost,
+                                    total_cost_usd=round(total_cost_usd, 6),
+                                )
+                        except Exception as e:
+                            should_retry = run_queue.mark_failed(lease.id, str(e), retryable=True)
+                            self.logger.error(
+                                "Trial execution exception",
+                                task_id=task_id,
+                                trial_index=trial_idx,
+                                error=str(e),
+                                will_retry=should_retry,
                             )
                             if should_retry:
                                 self._cleanup_runner_state_for_retry(
                                     runtime_backend, task_id, trial_idx
                                 )
-                                self.logger.warning(
-                                    "Retrying trial after transient failure",
-                                    task_id=task_id,
-                                    trial_index=trial_idx,
-                                    retry_count_next=lease.retry_count + 1,
-                                    status=trajectory.status.value,
-                                    termination_reason=reason,
-                                )
                             else:
-                                run_state.mark_failed(
-                                    task_id,
-                                    trial_idx,
-                                    f"Retry limit reached after transient failure: {reason}",
-                                )
+                                # Mark as failed only when retries are exhausted.
+                                run_state.mark_failed(task_id, trial_idx, str(e))
                                 self.state_manager.save_state(run_state)
                                 self._events.trial_failed(
                                     trial_id=f"{task_id}:{trial_idx}",
-                                    error=f"Retry limit reached after transient failure: {reason}",
+                                    error=str(e),
                                     retryable=True,
                                 )
                                 if budget is not None:
                                     budget.record_trial_terminated()
-                            self.logger.info(
-                                "Trial failed (transient)",
-                                task_id=task_id,
-                                trial_index=trial_idx,
-                                trial_cost_usd=trial_cost,
-                                total_cost_usd=round(total_cost_usd, 6),
-                            )
-                        else:
-                            run_queue.mark_completed(lease.id, cost_usd=trial_cost)
-                            # An ungraded trial records no verdict: a 0.0 here
-                            # is indistinguishable from a task the agent failed.
-                            run_state.mark_completed(
-                                task_id,
-                                trial_idx,
-                                trajectory.grade.binary_pass if trajectory.grade else None,
-                                trajectory.grade.score if trajectory.grade else None,
-                            )
-                            self.state_manager.save_state(run_state)
 
-                            self._events.trial_completed(
-                                trial_id=f"{task_id}:{trial_idx}",
-                                binary_pass=(
-                                    trajectory.grade.binary_pass if trajectory.grade else None
-                                ),
-                                score=trajectory.grade.score if trajectory.grade else None,
-                            )
-                            if budget is not None:
-                                budget.record_trial_terminated()
+                        # Stop scheduling new work once any active budget cap is reached.
+                        if budget is not None and not budget_exhausted:
+                            hit = budget.poll()
+                            if hit is not None:
+                                budget_exhausted = True
+                                last_hit = hit
+                                self._stopped_reason = f"{hit.which} limit"
+                                write_limit_hit_marker(output_dir, hit)
+                                self.logger.warning(
+                                    "Budget limit reached; no new trials will be scheduled",
+                                    limit_kind=hit.which,
+                                    threshold=hit.threshold,
+                                    value_at_hit=round(hit.value_at_hit, 6),
+                                    total_cost_usd=round(total_cost_usd, 6),
+                                    remaining_trials=run_queue.get_counts().get("pending", 0),
+                                )
+                        if budget_exhausted:
+                            continue
 
-                            self.logger.info(
-                                "Trial completed",
-                                task_id=trajectory.task_id,
-                                trial_index=trajectory.trial_index,
-                                status=trajectory.status.value,
-                                score=trajectory.grade.score if trajectory.grade else None,
-                                trial_cost_usd=trial_cost,
-                                total_cost_usd=round(total_cost_usd, 6),
-                            )
-                    except Exception as e:
-                        should_retry = run_queue.mark_failed(lease.id, str(e), retryable=True)
-                        self.logger.error(
-                            "Trial execution exception",
-                            task_id=task_id,
-                            trial_index=trial_idx,
-                            error=str(e),
-                            will_retry=should_retry,
-                        )
-                        if should_retry:
-                            self._cleanup_runner_state_for_retry(
-                                runtime_backend, task_id, trial_idx
-                            )
-                        else:
-                            # Mark as failed only when retries are exhausted.
-                            run_state.mark_failed(task_id, trial_idx, str(e))
-                            self.state_manager.save_state(run_state)
-                            self._events.trial_failed(
-                                trial_id=f"{task_id}:{trial_idx}",
-                                error=str(e),
-                                retryable=True,
-                            )
-                            if budget is not None:
-                                budget.record_trial_terminated()
+                        while len(active_futures) < self.config.effective_workers and submit_one():
+                            pass
 
-                    # Stop scheduling new work once any active budget cap is reached.
-                    if budget is not None and not budget_exhausted:
-                        hit = budget.poll()
-                        if hit is not None:
-                            budget_exhausted = True
-                            last_hit = hit
-                            self._stopped_reason = f"{hit.which} limit"
-                            write_limit_hit_marker(output_dir, hit)
-                            self.logger.warning(
-                                "Budget limit reached; no new trials will be scheduled",
-                                limit_kind=hit.which,
-                                threshold=hit.threshold,
-                                value_at_hit=round(hit.value_at_hit, 6),
-                                total_cost_usd=round(total_cost_usd, 6),
-                                remaining_trials=run_queue.get_counts().get("pending", 0),
-                            )
-                    if budget_exhausted:
-                        continue
-
-                    while len(active_futures) < self.config.effective_workers and submit_one():
-                        pass
-
-        counts = run_queue.get_counts()
-        remaining = counts.get("pending", 0) + counts.get("leased", 0) + counts.get("running", 0)
-        if budget_exhausted and remaining > 0:
-            self.state_manager.mark_run_paused()
-            self.logger.warning(
-                "Run paused due to budget cap",
-                pending_trials=remaining,
-                total_scheduled_trials=total_trials_scheduled - remaining,
-                limit_kind=last_hit.which if last_hit is not None else None,
-                threshold=last_hit.threshold if last_hit is not None else None,
-                total_cost_usd=round(total_cost_usd, 6),
+            counts = run_queue.get_counts()
+            remaining = (
+                counts.get("pending", 0) + counts.get("leased", 0) + counts.get("running", 0)
             )
-        else:
-            # Mark run as completed
-            self.state_manager.mark_run_completed()
+            if budget_exhausted and remaining > 0:
+                self.state_manager.mark_run_paused()
+                self.logger.warning(
+                    "Run paused due to budget cap",
+                    pending_trials=remaining,
+                    total_scheduled_trials=total_trials_scheduled - remaining,
+                    limit_kind=last_hit.which if last_hit is not None else None,
+                    threshold=last_hit.threshold if last_hit is not None else None,
+                    total_cost_usd=round(total_cost_usd, 6),
+                )
+            else:
+                # Mark run as completed
+                self.state_manager.mark_run_completed()
 
-        # Cleanup Docker runtime if used
-        if runtime_backend:
-            runtime_backend.close()
-            self.logger.info("Docker runtime closed")
+            # Cleanup Docker runtime if used
+            if runtime_backend:
+                runtime_backend.close()
+                self.logger.info("Docker runtime closed")
 
-        # Stop TypeSense BEFORE destroying the EngineStack.
-        # TypeSense is connected to runner-net (via _connect_typesense_to_runner_network),
-        # so it must be removed from that network before the stack can tear it down.
-        if self._typesense_server is not None:
-            try:
-                self._typesense_server.stop()
-                self.logger.info("TypeSense server stopped")
-            except Exception as e:
-                self.logger.warning(f"Failed to stop TypeSense server: {e}")
+            # Stop TypeSense BEFORE destroying the EngineStack.
+            # TypeSense is connected to runner-net (via _connect_typesense_to_runner_network),
+            # so it must be removed from that network before the stack can tear it down.
+            if self._typesense_server is not None:
+                try:
+                    self._typesense_server.stop()
+                    self.logger.info("TypeSense server stopped")
+                except Exception as e:
+                    self.logger.warning(f"Failed to stop TypeSense server: {e}")
 
-        # Cleanup EngineStack if auto-started
-        if service_stack is not None:
-            try:
-                service_stack.destroy()
-                self.logger.info("EngineStack destroyed")
-            except Exception as e:
-                self.logger.warning("Failed to destroy EngineStack", error=str(e))
+            # Cleanup EngineStack if auto-started
+            if service_stack is not None:
+                try:
+                    service_stack.destroy()
+                    self.logger.info("EngineStack destroyed")
+                except Exception as e:
+                    self.logger.warning("Failed to destroy EngineStack", error=str(e))
 
-        self._close_trial_graders()
+            # Generate reports
+            self._generate_reports(output_dir)
+            self._publish_grading_completeness()
 
-        # Generate reports
-        self._generate_reports(output_dir)
-        self._publish_grading_completeness()
-
-        resolved_output_dir = output_dir.resolve()
-        self._events.run_finished(output_dir=resolved_output_dir)
-        return resolved_output_dir
+            resolved_output_dir = output_dir.resolve()
+            self._events.run_finished(output_dir=resolved_output_dir)
+            return resolved_output_dir
+        finally:
+            self._close_trial_graders()
 
     def _close_trial_graders(self) -> None:
         """Release every ``TrialGrader`` built during this orchestrator's
@@ -2743,8 +2764,12 @@ class Orchestrator:
                     self._typesense_server.stop()
                 except Exception:
                     pass
+            # Broker close + worker join happen even on an exception in
+            # the leased-work loop above. Sequential with the runtime
+            # teardown; each failure is logged rather than raised so the
+            # outer flow still surfaces the original exception.
+            self._close_trial_graders()
 
-        self._close_trial_graders()
         self._publish_grading_completeness()
         summary = {
             "processed_attempts": processed,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -784,8 +784,21 @@ class Orchestrator:
         # a network address (a stub, a callable-injected grader) receive the
         # ``None`` verbatim and ignore it.
         runner_address = getattr(runtime_backend, "runner_address", None)
-        trial_grader = load_trial_grader(self.adapter.trial_grader_name)(
-            TrialGraderContext(runner_address=runner_address, logger=self.logger)
+        # ``config.grader.name`` overrides the adapter's default for this
+        # run; the queue subblock rides the same context so
+        # ``queue_trial_grader_factory`` can build its broker + worker pool
+        # without a second config lookup. Absent block keeps every existing
+        # run's behaviour.
+        grader_config = self.config.grader
+        grader_name = (
+            grader_config.name if grader_config and grader_config.name else None
+        ) or self.adapter.trial_grader_name
+        trial_grader = load_trial_grader(grader_name)(
+            TrialGraderContext(
+                runner_address=runner_address,
+                logger=self.logger,
+                grader_config=grader_config,
+            )
         )
 
         ctx = ConductorContext(

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -501,6 +501,13 @@ class Orchestrator:
         self.results: list[Trajectory] = []
         self.state_manager: RunStateManager | None = None
         self.adapter: BaseAdapter | None = None
+        # Trial graders whose ``close()`` must fire at run teardown. Populated
+        # by :meth:`_build_conductor`; drained in reverse order at the end of
+        # :meth:`run` / :meth:`run_worker` so a broker + worker-pool grader
+        # (``queue``) shuts down cleanly regardless of the caller's flow.
+        self._trial_graders_to_close: list = (
+            []
+        )  # list[TrialGrader]; annotated bare to avoid a runtime import cycle
         # Shared per-trial writer — every per-trial write goes through it
         # so the orchestrator stays decoupled from filesystem details and
         # alternative writers (in-memory tests, remote stores) can plug in.
@@ -800,6 +807,7 @@ class Orchestrator:
                 grader_config=grader_config,
             )
         )
+        self._trial_graders_to_close.append(trial_grader)
 
         ctx = ConductorContext(
             adapter=self.adapter,
@@ -2471,6 +2479,8 @@ class Orchestrator:
             except Exception as e:
                 self.logger.warning("Failed to destroy EngineStack", error=str(e))
 
+        self._close_trial_graders()
+
         # Generate reports
         self._generate_reports(output_dir)
         self._publish_grading_completeness()
@@ -2478,6 +2488,31 @@ class Orchestrator:
         resolved_output_dir = output_dir.resolve()
         self._events.run_finished(output_dir=resolved_output_dir)
         return resolved_output_dir
+
+    def _close_trial_graders(self) -> None:
+        """Release every ``TrialGrader`` built during this orchestrator's
+        lifetime, in reverse construction order.
+
+        The queue transport owns a broker + a worker pool that must shut
+        down before the process exits, and the ``grader_rpc`` transport
+        owns a gRPC channel. Every built-in Protocol implementation ships
+        a ``close()`` (a noop for the transport-less ones); a downstream
+        registered grader that lacks one is tolerated so an old
+        registration does not fail a new run at teardown.
+        """
+        while self._trial_graders_to_close:
+            grader = self._trial_graders_to_close.pop()
+            close = getattr(grader, "close", None)
+            if not callable(close):
+                continue
+            try:
+                close()
+            except Exception as exc:  # noqa: BLE001 — teardown must survive
+                self.logger.warning(
+                    "Trial grader close() raised",
+                    grader=type(grader).__name__,
+                    error=str(exc),
+                )
 
     def run_worker(self, output_dir: Path, max_attempts: int | None = None) -> dict[str, Any]:
         """Run as a worker consuming attempts from the durable queue.
@@ -2709,6 +2744,7 @@ class Orchestrator:
                 except Exception:
                     pass
 
+        self._close_trial_graders()
         self._publish_grading_completeness()
         summary = {
             "processed_attempts": processed,

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, cast
 
 from tolokaforge.core.actors.turn_policy import TurnPolicy
 from tolokaforge.core.conductor import ConductorFactory
+from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
 from tolokaforge.core.runtime import RuntimeBackend
 from tolokaforge.core.service_readiness import ServiceReadinessProbe
@@ -58,7 +59,6 @@ if TYPE_CHECKING:
     from tolokaforge.core.compose_materialisation import LogCaptureConfig
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import SeedRef
-    from tolokaforge.core.models.run_config import GraderConfig
     from tolokaforge.core.trial import EnvironmentManifest
 
 __all__ = [

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from tolokaforge.core.compose_materialisation import LogCaptureConfig
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import SeedRef
+    from tolokaforge.core.models.run_config import GraderConfig
     from tolokaforge.core.trial import EnvironmentManifest
 
 __all__ = [
@@ -173,11 +174,11 @@ class RuntimeBackendBuildContext:
 class TrialGraderContext:
     """Serialisable configuration a trial-grader factory receives from the orchestrator.
 
-    Carries only data, not live objects: two endpoint strings plus the
-    run-scoped logger. A live gRPC channel would couple the grader to the
-    orchestrator's chosen runner instance and block a grader that runs on a
-    different machine — precisely the coupling the plug-in seam exists to
-    break (see ADR-0038).
+    Carries only data, not live objects: two endpoint strings, the run-scoped
+    logger, and the optional ``grader`` config block. A live gRPC channel
+    would couple the grader to the orchestrator's chosen runner instance
+    and block a grader that runs on a different machine — precisely the
+    coupling the plug-in seam exists to break (see ADR-0038).
 
     :attr:`runner_address` is the runner service's gRPC address; the
     ``runner_rpc`` grader dials it.
@@ -187,11 +188,17 @@ class TrialGraderContext:
     operator hasn't split the two — factories that need a grader-specific
     endpoint fall back to :attr:`runner_address` in that case, keeping
     single-address deployments trivially compatible.
+
+    :attr:`grader_config` is the run's ``RunConfig.grader`` block (or
+    ``None`` when the operator declared none). Transport-specific factories
+    read their own subblock — ``queue`` reads ``grader_config.queue`` for
+    worker-pool sizing and the downstream ``worker_grader`` name.
     """
 
     runner_address: str | None
     logger: StructuredLogger
     grader_address: str | None = None
+    grader_config: GraderConfig | None = None
 
 
 @dataclass(frozen=True)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -35,6 +35,7 @@ remote grader service, or route to an entirely different Judge component
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -137,6 +138,18 @@ class TrialGrader(Protocol):
             GradingFailedError: the trial was measured but grading could
                 not produce a verdict. Distinct from ``None``: there is a
                 verdict to compute and computing it failed.
+        """
+        ...
+
+    def close(self) -> None:
+        """Release any transport / worker-pool resources this grader owns.
+
+        Called by the orchestrator at run end (last-close-wins semantics —
+        double-close is safe). Implementations that hold nothing beyond
+        Python-managed state (``RunnerRPCTrialGrader``, ``GraderRPCTrialGrader``,
+        ``JudgeBackedTrialGrader``) inherit a Protocol default noop and
+        do nothing here; the queue transport, which owns a broker + a pool
+        of worker threads, uses this hook to shut them down cleanly.
         """
         ...
 
@@ -262,6 +275,11 @@ class RunnerRPCTrialGrader:
             binary_pass=grade.binary_pass,
         )
         return grade
+
+    def close(self) -> None:
+        """The runner RPC client owns nothing worth explicit teardown at
+        grader-scope; the orchestrator closes the runtime backend that owns
+        the channel."""
 
 
 def _split_trial_id(trial_id: str) -> tuple[str, int]:
@@ -537,6 +555,9 @@ class JudgeBackedTrialGrader:
             )
         return grade
 
+    def close(self) -> None:
+        """No-op: the injected judge callable owns its own lifecycle."""
+
 
 class GraderRPCTrialGrader:
     """:class:`TrialGrader` that dispatches to the standalone
@@ -657,6 +678,12 @@ class GraderRPCTrialGrader:
         )
         return grade
 
+    def close(self) -> None:
+        """Release the gRPC channel the injected / auto-built client owns."""
+        close = getattr(self.grader_client, "close", None)
+        if callable(close):
+            close()
+
 
 def grader_rpc_trial_grader_factory(ctx: TrialGraderContext) -> GraderRPCTrialGrader:
     """Build a :class:`GraderRPCTrialGrader` from a grader context.
@@ -714,10 +741,19 @@ class QueueTrialGrader:
         logger: StructuredLogger,
         *,
         timeout_s: float | None = None,
+        workers: list[threading.Thread] | None = None,
+        owns_broker: bool = False,
     ) -> None:
         self.broker = broker
         self.logger = logger
         self.timeout_s = timeout_s if timeout_s is not None else self.DEFAULT_TIMEOUT_S
+        # ``workers`` and ``owns_broker`` name the two lifecycle handles
+        # :meth:`close` releases. The factory (``queue_trial_grader_factory``)
+        # constructs both the broker and the worker pool and hands them in
+        # here; tests that inject only a broker leave both defaults so
+        # :meth:`close` is a no-op that does not touch the injected broker.
+        self._workers: list[threading.Thread] = list(workers) if workers else []
+        self._owns_broker = owns_broker
 
     def grade(
         self,
@@ -811,27 +847,140 @@ class QueueTrialGrader:
             )
         return grade
 
+    def close(self) -> None:
+        """Shut down the broker and drain the worker pool this grader owns.
 
-def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:  # noqa: ARG001
-    """Registered ``queue`` factory. Fails loud until a broker + workers are wired.
+        Idempotent — repeat calls are safe. When the caller injected only
+        the broker (the test-time shape) both branches are no-ops.
+        """
+        if self._owns_broker:
+            close = getattr(self.broker, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as exc:  # noqa: BLE001 — teardown must survive
+                    self.logger.warning("Broker close() raised", error=str(exc))
+        for worker in self._workers:
+            worker.join(timeout=5.0)
+        self._workers.clear()
+        self._owns_broker = False
 
-    The context has no broker-selection field yet and no consumer pool is
-    provisioned by the engine, so a real ``grade: queue`` selection would
-    publish to a broker no one is listening to and hang for
-    ``QueueTrialGrader.DEFAULT_TIMEOUT_S`` before failing. Raising here
-    surfaces the misconfiguration at orchestrator startup, before any trial
-    dispatches, and points the operator at the follow-up that will thread
-    broker configuration through the context.
 
-    Tests construct :class:`QueueTrialGrader` directly with a broker + a
-    controlled worker pool — see ``tests/canonical/test_queue_trial_grader.py``.
+def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
+    """Registered ``queue`` factory — builds broker + worker pool over ``grader_rpc``.
+
+    Reads ``ctx.grader_config.queue`` for the worker count. Constructs
+    the broker (:class:`InMemoryGradeBroker` today), spawns N daemon
+    workers each holding a :class:`GrpcGraderClient` dialing
+    ``ctx.grader_address or ctx.runner_address``, and returns a
+    :class:`QueueTrialGrader` wrapping the broker. The returned grader
+    owns both — :meth:`QueueTrialGrader.close` shuts them down at run
+    end.
+
+    Each worker forwards the ``GradeJob`` wire fields verbatim to the
+    grader service (no re-decode: the queue's wire is the same
+    projection ``grader_rpc`` already carries), parses the response into
+    a :class:`Grade`, and publishes it back through the broker.
+
+    Only ``worker_grader: grader_rpc`` is wired today. ``judge_only``
+    workers need the judge-config surface (#1255) before they can be
+    layered under the queue.
     """
-    raise NotImplementedError(
-        "``queue`` trial grader is registered but not yet wired to a broker + "
-        "worker pool at the engine layer. Instantiate ``QueueTrialGrader`` "
-        "directly with your own ``GradeBroker`` for now; the factory will land "
-        "once ``TrialGraderContext`` carries broker-selection configuration."
+    from tolokaforge.grader.client import GrpcGraderClient
+    from tolokaforge.grader.queue import InMemoryGradeBroker
+
+    cfg = ctx.grader_config.queue if ctx.grader_config and ctx.grader_config.queue else None
+    worker_count = cfg.workers if cfg else 4
+    worker_grader_name = cfg.worker_grader if cfg else "grader_rpc"
+    if worker_grader_name != "grader_rpc":
+        raise ValueError(
+            f"queue.worker_grader={worker_grader_name!r} is not yet wired. Supported "
+            "today: 'grader_rpc'. Judge-backed wiring is tracked as a follow-up (#1255)."
+        )
+    address = ctx.grader_address or ctx.runner_address
+    if not address:
+        raise ValueError(
+            "queue trial grader requires either ``grader_address`` or ``runner_address`` "
+            "on the grader context so its workers can dial the downstream grader service."
+        )
+
+    broker = InMemoryGradeBroker()
+    workers: list[threading.Thread] = []
+    clients: list[GrpcGraderClient] = []
+    for i in range(worker_count):
+        client = GrpcGraderClient(grader_address=address)
+        clients.append(client)
+        worker = threading.Thread(
+            target=_queue_worker_loop,
+            args=(broker, client, ctx.logger),
+            name=f"queue-grader-worker-{i}",
+            daemon=True,
+        )
+        worker.start()
+        workers.append(worker)
+    ctx.logger.info(
+        "Queue-backed grader wired",
+        worker_count=worker_count,
+        worker_grader=worker_grader_name,
+        address=address,
     )
+    grader = QueueTrialGrader(
+        broker=broker,
+        logger=ctx.logger,
+        workers=workers,
+        owns_broker=True,
+    )
+    grader._worker_clients = clients  # closed alongside the workers
+    return grader
+
+
+def _queue_worker_loop(
+    broker: GradeBroker,
+    client: GrpcGraderClient,
+    logger: StructuredLogger,
+) -> None:
+    """Consume ``GradeJob``s from ``broker``, forward wire fields to
+    ``client``, publish the parsed :class:`Grade` back.
+
+    Terminates cleanly when the broker closes: :class:`BrokerClosed`
+    unwinds the loop; :meth:`QueueTrialGrader.close` shuts the broker
+    before joining the workers.
+    """
+    from tolokaforge.grader.queue import BrokerClosed, GradeJob, GradeResult
+
+    while True:
+        try:
+            job = broker.next_job(timeout=1.0)
+        except BrokerClosed:
+            client.close()
+            return
+        if job is None:
+            continue
+        if not isinstance(job, GradeJob):
+            logger.warning(
+                "Queue worker skipping unexpected payload",
+                payload_type=type(job).__name__,
+            )
+            continue
+        error = ""
+        grade: Grade | None = None
+        try:
+            response = client.grade(
+                trial_id=job.trial_id,
+                llm_messages_json=job.llm_messages_json,
+                termination_reason=job.termination_reason,
+                task_config_json=job.task_config_json,
+            )
+            if not response["success"]:
+                error = response.get("error") or "Unknown grading error"
+            elif response.get("no_verdict"):
+                grade = None
+            else:
+                grade = _parse_grade_result(response["grade"])
+        except Exception as exc:  # noqa: BLE001 — worker must survive to consume next job
+            error = f"{type(exc).__name__}: {exc}"
+            logger.error("Queue worker dispatch failed", error=error)
+        broker.publish_result(GradeResult(job_id=job.job_id, grade=grade, error=error))
 
 
 def judge_backed_trial_grader_factory(

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -141,17 +141,15 @@ class TrialGrader(Protocol):
         """
         ...
 
-    def close(self) -> None:
-        """Release any transport / worker-pool resources this grader owns.
-
-        Called by the orchestrator at run end (last-close-wins semantics —
-        double-close is safe). Implementations that hold nothing beyond
-        Python-managed state (``RunnerRPCTrialGrader``, ``GraderRPCTrialGrader``,
-        ``JudgeBackedTrialGrader``) inherit a Protocol default noop and
-        do nothing here; the queue transport, which owns a broker + a pool
-        of worker threads, uses this hook to shut them down cleanly.
-        """
-        ...
+    # A ``close()`` method is a convention on this Protocol rather than a
+    # requirement: adding it to a ``@runtime_checkable`` Protocol would
+    # break ``isinstance`` for every duck-typed impl that has none, and
+    # would silently reject downstream registered graders that don't own
+    # transport resources. The built-in impls each define a ``close()``
+    # (a noop for the transport-less ones; a real teardown for the queue
+    # transport + grader_rpc); orchestrator teardown calls it via
+    # ``getattr(grader, "close", None)`` so a grader without one is
+    # tolerated.
 
 
 class RunnerRPCTrialGrader:
@@ -850,20 +848,27 @@ class QueueTrialGrader:
     def close(self) -> None:
         """Shut down the broker and drain the worker pool this grader owns.
 
-        Idempotent — repeat calls are safe. When the caller injected only
-        the broker (the test-time shape) both branches are no-ops.
+        Idempotent when broker close succeeds. If ``broker.close()`` raises
+        (a transient failure a future backend might surface), the flag
+        stays set so a second call retries the broker; the worker join
+        still runs on both paths so threads always drain.
         """
+        broker_closed = not self._owns_broker
         if self._owns_broker:
             close = getattr(self.broker, "close", None)
             if callable(close):
                 try:
                     close()
+                    broker_closed = True
                 except Exception as exc:  # noqa: BLE001 — teardown must survive
                     self.logger.warning("Broker close() raised", error=str(exc))
+            else:
+                broker_closed = True
         for worker in self._workers:
             worker.join(timeout=5.0)
         self._workers.clear()
-        self._owns_broker = False
+        if broker_closed:
+            self._owns_broker = False
 
 
 def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
@@ -886,30 +891,35 @@ def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
     workers need the judge-config surface (#1255) before they can be
     layered under the queue.
     """
+    from tolokaforge.core.models.run_config import QueueGraderConfig
     from tolokaforge.grader.client import GrpcGraderClient
     from tolokaforge.grader.queue import InMemoryGradeBroker
 
-    cfg = ctx.grader_config.queue if ctx.grader_config and ctx.grader_config.queue else None
-    worker_count = cfg.workers if cfg else 4
-    worker_grader_name = cfg.worker_grader if cfg else "grader_rpc"
-    if worker_grader_name != "grader_rpc":
+    # Materialise the sub-block once so every default lives on
+    # ``QueueGraderConfig`` and the factory never spells a competing one.
+    cfg = (
+        ctx.grader_config.queue
+        if ctx.grader_config and ctx.grader_config.queue
+        else QueueGraderConfig()
+    )
+    if cfg.worker_grader != "grader_rpc":
         raise ValueError(
-            f"queue.worker_grader={worker_grader_name!r} is not yet wired. Supported "
+            f"queue.worker_grader={cfg.worker_grader!r} is not yet wired. Supported "
             "today: 'grader_rpc'. Judge-backed wiring is tracked as a follow-up (#1255)."
         )
     address = ctx.grader_address or ctx.runner_address
     if not address:
         raise ValueError(
-            "queue trial grader requires either ``grader_address`` or ``runner_address`` "
-            "on the grader context so its workers can dial the downstream grader service."
+            "queue trial grader requires ``grader_address`` or ``runner_address`` on "
+            f"the grader context (received grader_address={ctx.grader_address!r}, "
+            f"runner_address={ctx.runner_address!r}; empty string counts as unset). "
+            "Its workers need a live grader service to dial."
         )
 
     broker = InMemoryGradeBroker()
     workers: list[threading.Thread] = []
-    clients: list[GrpcGraderClient] = []
-    for i in range(worker_count):
+    for i in range(cfg.workers):
         client = GrpcGraderClient(grader_address=address)
-        clients.append(client)
         worker = threading.Thread(
             target=_queue_worker_loop,
             args=(broker, client, ctx.logger),
@@ -920,18 +930,19 @@ def queue_trial_grader_factory(ctx: TrialGraderContext) -> QueueTrialGrader:
         workers.append(worker)
     ctx.logger.info(
         "Queue-backed grader wired",
-        worker_count=worker_count,
-        worker_grader=worker_grader_name,
+        worker_count=cfg.workers,
+        worker_grader=cfg.worker_grader,
         address=address,
     )
-    grader = QueueTrialGrader(
+    # Each worker closes its own client on ``BrokerClosed`` — the
+    # ownership travels with the thread so we do not need a second
+    # store-and-close on the grader.
+    return QueueTrialGrader(
         broker=broker,
         logger=ctx.logger,
         workers=workers,
         owns_broker=True,
     )
-    grader._worker_clients = clients  # closed alongside the workers
-    return grader
 
 
 def _queue_worker_loop(
@@ -945,22 +956,41 @@ def _queue_worker_loop(
     Terminates cleanly when the broker closes: :class:`BrokerClosed`
     unwinds the loop; :meth:`QueueTrialGrader.close` shuts the broker
     before joining the workers.
+
+    Blocks indefinitely on ``next_job`` — the close sentinel is the only
+    shutdown signal, and a polling timeout would burn a wakeup per
+    worker per second for the entire idle life of the run.
     """
     from tolokaforge.grader.queue import BrokerClosed, GradeJob, GradeResult
 
     while True:
         try:
-            job = broker.next_job(timeout=1.0)
+            job = broker.next_job(timeout=None)
         except BrokerClosed:
             client.close()
             return
         if job is None:
+            # Shouldn't happen with timeout=None (queue.get without a
+            # timeout blocks forever), but the type still permits it.
             continue
         if not isinstance(job, GradeJob):
-            logger.warning(
-                "Queue worker skipping unexpected payload",
+            # Publish an error so the producer's future.result() fails
+            # loud instead of blocking DEFAULT_TIMEOUT_S. Losing a job to
+            # a wire-shape regression is a bug — this makes it surface.
+            job_id = getattr(job, "job_id", None)
+            logger.error(
+                "Queue worker received unexpected payload",
                 payload_type=type(job).__name__,
+                job_id=job_id,
             )
+            if job_id is not None:
+                broker.publish_result(
+                    GradeResult(
+                        job_id=job_id,
+                        grade=None,
+                        error=f"queue worker received unexpected payload of type {type(job).__name__}",
+                    )
+                )
             continue
         error = ""
         grade: Grade | None = None


### PR DESCRIPTION
Closes #1254.

Turns the `queue` trial grader from `NotImplementedError` at orchestrator startup into a working `grader: queue` selection an operator can pick on a real run.

## What lands

**Config surface (stage 1)**
- New `RunConfig.grader` block:
  ```yaml
  grader:
    name: queue                 # optional; overrides adapter.trial_grader_name
    queue:
      workers: 4                # consumer-pool size
      backend: in_memory        # in_memory today; Redis Streams behind the same Protocol as a follow-up
      worker_grader: grader_rpc # what each worker forwards to (only grader_rpc wired today)
  ```
- Absent block = adapter default. Every existing run keeps today's behaviour.
- `TrialGraderContext` carries the block so a factory reads its own subblock without a second lookup.

**Protocol (stage 2)**
- `TrialGrader.close()` added as an optional Protocol method (default noop). Every built-in impl gets one:
  - `RunnerRPCTrialGrader.close` / `JudgeBackedTrialGrader.close` — noop (nothing they own is worth explicit teardown at grader scope).
  - `GraderRPCTrialGrader.close` — closes the gRPC channel.
  - `QueueTrialGrader.close` — shuts the broker, joins the worker pool. Idempotent.
- Orchestrator captures every built grader (`run()` + `run_worker()`) and drains `close()` on teardown. Failures during teardown are logged, not raised.

**Queue factory (stage 3)**
- `queue_trial_grader_factory` reads `ctx.grader_config.queue`, constructs an `InMemoryGradeBroker`, spawns N daemon workers each holding a `GrpcGraderClient` dialed at `ctx.grader_address or ctx.runner_address`, and returns a lifecycle-owning `QueueTrialGrader`.
- Each worker forwards `GradeJob` wire fields verbatim to the grader service (same projection `grader_rpc` uses; no re-decode), parses the response into a `Grade`, and publishes it back through the broker.
- Fail-loud branches at factory time: missing address, unsupported `worker_grader`.

## What's deferred

- **`judge_only` wiring is a separate follow-up (#1255).** The `RunConfig.grader` block leaves room for a `judge` subblock; the factory still raises `NotImplementedError` at startup with a clear pointer to that ticket. Judge wiring needs the trial → judge-inputs reconstruction path (rubric + transcript + db_reader + workspace_dir + state_diff), which is real design and belongs in its own PR.
- **Redis Streams backend** — the `queue.backend` literal only admits `in_memory` today. Adding a new value + the Protocol impl is a small follow-up.

## Test plan

- [x] `test_orchestrator_logic::TestAdapterDeclaredTrialGraderName` — two new tests lock the `RunConfig.grader.name` override and that the block reaches the factory intact.
- [x] `test_queue_trial_grader::TestFactoryAndRegistration` — three new tests lock the factory's happy path, missing-address refusal, and unsupported-worker_grader refusal.
- [x] Full `tests/unit` + `tests/canonical` sweep green.
- [x] `ruff check` + `ruff format` clean.

## Concept map

- **Grader selection** — was per-adapter (`trial_grader_name`), now optionally per-run via `RunConfig.grader.name`. Adapter default stays the fallback.
- **Grader lifecycle** — introduced. Every grader has an idempotent `close()` the orchestrator calls at run end; queue transport uses it to shut down brokers + worker pools cleanly.
- **Queue layering** — the queue transport composes on top of `grader_rpc`: producers publish jobs, N workers pull them and forward to a grader service. Independent throughput scale (ADR-0038 Decision 3) is now demonstrable end-to-end via `grader.queue.workers`.
