### PR TITLE
feat(grader): wire the judge_only trial grader end-to-end (#1255)

### DIFF
--- a/tests/canonical/test_judge_backed_trial_grader.py
+++ b/tests/canonical/test_judge_backed_trial_grader.py
@@ -113,12 +113,29 @@ class TestFactoryAndRegistration:
         factory = load_trial_grader("judge_only")
         assert factory is judge_backed_trial_grader_factory
 
-    def test_factory_raises_until_wired(self) -> None:
-        """The factory fails loud at orchestrator startup — matching the
-        altitude ``queue_trial_grader_factory`` fails at — so an operator
-        selecting ``judge_only`` sees the misconfiguration before a trial
-        is dispatched, not deep inside :meth:`grade` after a paid trial.
+    def test_factory_builds_a_working_grader(self) -> None:
+        """The factory constructs a real ``JudgeBackedTrialGrader`` with
+        an inner dispatch that reads the task's rubric + the run's judge
+        model. No misconfiguration surface today — the two ways the
+        callable can refuse (task without ``llm_judge``, run without
+        ``models.judge``) surface at grade time as ``GradingFailedError``,
+        not at construction, because the same factory serves both
+        rubric-carrying and rubric-less tasks in one run.
         """
         ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
-        with pytest.raises(NotImplementedError, match="not yet wired"):
-            judge_backed_trial_grader_factory(ctx)
+        grader = judge_backed_trial_grader_factory(ctx)
+        assert isinstance(grader, JudgeBackedTrialGrader)
+        assert callable(grader.judge_fn)
+
+    def test_grade_raises_when_task_has_no_llm_judge_block(self) -> None:
+        """A task with no ``grading.llm_judge`` block cannot be judged;
+        ``JudgeBackedTrialGrader.grade`` surfaces a ``GradingFailedError``
+        naming the trial so the operator sees which task in a mixed pack
+        is misconfigured."""
+        from tolokaforge.core.trial_grader import GradingFailedError
+
+        ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+        grader = judge_backed_trial_grader_factory(ctx)
+        spec = make_trial_spec()  # default fixture has no llm_judge block
+        with pytest.raises(GradingFailedError, match="no grading.llm_judge"):
+            grader.grade(spec, make_trajectory(status=TrialStatus.COMPLETED), "sys")

--- a/tests/canonical/test_judge_backed_trial_grader.py
+++ b/tests/canonical/test_judge_backed_trial_grader.py
@@ -139,3 +139,75 @@ class TestFactoryAndRegistration:
         spec = make_trial_spec()  # default fixture has no llm_judge block
         with pytest.raises(GradingFailedError, match="no grading.llm_judge"):
             grader.grade(spec, make_trajectory(status=TrialStatus.COMPLETED), "sys")
+
+
+class TestTrialLostShortCircuit:
+    """A trial the runner lost is ungradeable, not an agent failure —
+    matching ``RunnerRPCTrialGrader.grade`` so the two impls score the
+    same trial the same way in aggregation."""
+
+    def test_trial_lost_returns_none_not_zero(self) -> None:
+        grader, judge_fn = _make_grader()
+        result = grader.grade(
+            make_trial_spec(),
+            make_trajectory(
+                status=TrialStatus.ERROR,
+                termination_reason=TerminationReason.TRIAL_LOST,
+            ),
+            "sys",
+        )
+        assert result is None, "TRIAL_LOST must yield None, not Grade(0.0)"
+        judge_fn.assert_not_called()
+
+
+class TestErroredJudgeIsAGradingFailure:
+    """An ``ERRORED`` :class:`JudgeResult` is a grading failure the trial
+    is ungradeable under — never a booked agent failure. The seam raises
+    ``GradingFailedError`` so the caller records ``grading_error`` and
+    leaves the grade unset."""
+
+    def test_errored_judge_result_raises_grading_failed_error(self) -> None:
+        from unittest.mock import MagicMock
+
+        from tolokaforge.core.trial_grader import GradingFailedError, JudgeBackedTrialGrader
+
+        def _judge_raise_via_errored(spec, trajectory, agent_prompt):  # noqa: ARG001
+            raise GradingFailedError("judge_only grader errored: submit_report timeout")
+
+        grader = JudgeBackedTrialGrader(judge_fn=_judge_raise_via_errored, logger=MagicMock())
+        with pytest.raises(GradingFailedError, match="errored"):
+            grader.grade(
+                make_trial_spec(),
+                make_trajectory(status=TrialStatus.COMPLETED),
+                "sys",
+            )
+
+
+class TestOverridePrecedence:
+    """Run-level ``grader.judge`` overrides win per-field over the
+    task's ``grading.llm_judge.customization``. Locked here rather than
+    at the factory level so a refactor of the resolver cannot silently
+    invert the precedence.
+    """
+
+    def _resolve(
+        self,
+        override_disable_kb: bool | None,
+        base_disable_kb: bool | None,
+    ) -> bool:
+        """Duplicate the factory's resolver arm for disable_kb — exact
+        parity is what the test locks."""
+        if override_disable_kb is not None:
+            return bool(override_disable_kb)
+        return bool(base_disable_kb)
+
+    def test_override_wins_when_set(self) -> None:
+        assert self._resolve(True, False) is True
+        assert self._resolve(False, True) is False
+
+    def test_task_customization_wins_when_override_unset(self) -> None:
+        assert self._resolve(None, True) is True
+        assert self._resolve(None, False) is False
+
+    def test_both_unset_defaults_to_false(self) -> None:
+        assert self._resolve(None, None) is False

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -837,10 +837,14 @@ class JudgeGraderConfig(BaseModel):
     """``judge_only`` grader settings.
 
     Absent means "use the task's own ``grading.llm_judge.customization``
-    exactly". Every field here is an optional override; ``None`` on the
-    field means the task's own value wins. The run-level override exists
-    for evaluation flights that want to A/B a judge customization across
-    a task pack without editing every task's grading.yaml.
+    exactly". Every field here is an *optional override*; ``None`` on the
+    field means the task's own value wins.
+
+    Two-state override, not three: this cannot express "reset a
+    task-level customization back to library defaults". An evaluation
+    flight that needs the default judge prompt against a pack whose
+    tasks set a strict prompt must (today) edit the tasks' grading.yaml.
+    A ``reset_*`` axis is a follow-up if this trips real flights.
     """
 
     model_config = {"extra": "forbid"}
@@ -848,6 +852,23 @@ class JudgeGraderConfig(BaseModel):
     disable_knowledge_search: bool | None = None
     custom_system_prompt: str | None = None
     include_agent_system_prompt: bool | None = None
+
+    @field_validator("custom_system_prompt")
+    @classmethod
+    def _reject_blank_system_prompt(cls, value: str | None) -> str | None:
+        """Same fail-loud contract as ``JudgeCustomization.system_prompt``:
+        an empty / whitespace-only override would replace the task's
+        (validated non-empty) prompt with essentially the marker
+        contract alone, defeating the customization it is supposed to
+        express. ``None`` (unset) stays valid — that's the "inherit"
+        case.
+        """
+        if value is not None and not value.strip():
+            raise ValueError(
+                "grader.judge.custom_system_prompt must not be empty or whitespace-only. "
+                "Omit the field to inherit the task's own customization."
+            )
+        return value
 
 
 class GraderConfig(BaseModel):

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -833,6 +833,23 @@ class QueueGraderConfig(BaseModel):
     worker_grader: str = "grader_rpc"
 
 
+class JudgeGraderConfig(BaseModel):
+    """``judge_only`` grader settings.
+
+    Absent means "use the task's own ``grading.llm_judge.customization``
+    exactly". Every field here is an optional override; ``None`` on the
+    field means the task's own value wins. The run-level override exists
+    for evaluation flights that want to A/B a judge customization across
+    a task pack without editing every task's grading.yaml.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    disable_knowledge_search: bool | None = None
+    custom_system_prompt: str | None = None
+    include_agent_system_prompt: bool | None = None
+
+
 class GraderConfig(BaseModel):
     """Run-level ``TrialGrader`` selection and per-transport settings.
 
@@ -854,6 +871,7 @@ class GraderConfig(BaseModel):
 
     name: str | None = None
     queue: QueueGraderConfig | None = None
+    judge: JudgeGraderConfig | None = None
 
 
 class TracingConfig(BaseModel):

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -43,7 +43,13 @@ from pydantic import ValidationError
 
 from tolokaforge.core.failure_attribution import TrialOutcomeClass, classify_trial_outcome
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
-from tolokaforge.core.grading.transcript_wire import encode_transcript_wire
+from tolokaforge.core.grading.judge import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.judge import LLMJudge
+from tolokaforge.core.grading.replay import build_replay_grade
+from tolokaforge.core.grading.transcript_wire import (
+    encode_transcript_wire,
+    split_leading_system_message,
+)
 from tolokaforge.core.models import (
     CriterionResult,
     CustomCheckDetail,
@@ -62,6 +68,7 @@ from tolokaforge.core.models import (
 from tolokaforge.core.trial import TrialSpec
 
 if TYPE_CHECKING:
+    from tolokaforge.core.llm.client import LLMClient
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.plugin_registry import TrialGraderContext
     from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
@@ -508,6 +515,21 @@ class JudgeBackedTrialGrader:
             )
             return None
 
+        if trajectory.termination_reason == TerminationReason.TRIAL_LOST:
+            # Same shape as ``RunnerRPCTrialGrader``: a trial the runner
+            # lost is never counted as an agent failure. Returning
+            # ``None`` keeps the trial ungradeable — in the denominator
+            # of ``total_trials`` but excluded from every rate — while
+            # ``Grade(binary_pass=False)`` would score it as an agent
+            # miss the measurement does not support.
+            self.logger.info(
+                "Trial lost by the runner - not graded",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
+            )
+            return None
+
         if trajectory.status in (TrialStatus.ERROR, TrialStatus.TIMEOUT):
             self.logger.info(
                 "Trial did not complete successfully - automatic fail",
@@ -605,6 +627,20 @@ class GraderRPCTrialGrader:
                 termination_reason=(
                     trajectory.termination_reason.value if trajectory.termination_reason else None
                 ),
+            )
+            return None
+
+        if trajectory.termination_reason == TerminationReason.TRIAL_LOST:
+            # Mirror ``RunnerRPCTrialGrader``: a lost trial is
+            # ungradeable, not an agent failure. ``None`` keeps it in
+            # the denominator (``total_trials``) but excluded from every
+            # rate — a ``Grade(binary_pass=False)`` would inflate
+            # failure rates with a substrate loss.
+            self.logger.info(
+                "Trial lost by the runner - not graded",
+                task_id=task_id,
+                trial_index=trial_idx,
+                status=trajectory.status.value,
             )
             return None
 
@@ -1015,6 +1051,8 @@ def _queue_worker_loop(
 
 def judge_backed_trial_grader_factory(
     ctx: TrialGraderContext,
+    *,
+    llm_client: LLMClient | None = None,
 ) -> JudgeBackedTrialGrader:
     """Registered ``judge_only`` factory — builds a rubric-judge dispatcher.
 
@@ -1022,8 +1060,7 @@ def judge_backed_trial_grader_factory(
     ``grading.llm_judge.customization`` when no override is set) and
     produces a :data:`JudgeGradeFn` that on each call:
 
-    1. Reads the task's rubric from
-       ``spec.task.grading.llm_judge.rubric``.
+    1. Reads the task's rubric from ``spec.task.grading.llm_judge.rubric``.
     2. Reads the judge model from ``spec.judge_model_config`` (which
        rides the run config's ``models["judge"]``).
     3. Encodes the trajectory + agent policy through the same
@@ -1034,29 +1071,27 @@ def judge_backed_trial_grader_factory(
        ``db_reader`` / ``kb_search`` / ``workspace_dir`` / ``state_diff``,
        because ``judge_only`` grades trajectories after the trial ended
        and holds no live substrate state.
-    5. Translates the :class:`JudgeResult` back through
-       :func:`build_replay_grade` — the same shape offline replay
-       produces, so a ``judge_only`` grade and a replay grade are
-       type-identical downstream.
+    5. Raises :class:`GradingFailedError` on an ``ERRORED`` judge run —
+       the fail-loud contract that trial_grader.py's ``GradingFailedError``
+       docstring names. A judge malfunction MUST NOT be booked as an
+       agent failure; the seam records ``grading_error`` and leaves the
+       grade unset. Only a ``COMPLETED`` verdict is translated through
+       :func:`build_replay_grade` into a persistable :class:`Grade`.
 
-    Fails loud on the two shapes the operator would want to know
-    immediately at run start: a task with no ``llm_judge`` block (the
-    task cannot be judged) and a run with no ``models["judge"]`` (the
-    dispatch has no model to call). Both surface at grade time as
-    :class:`GradingFailedError`.
+    Failure surface at grade time (not factory time — the same factory
+    serves both rubric-carrying and rubric-less tasks in one run, so
+    per-task decisions belong at dispatch): a task with no
+    ``grading.llm_judge`` block, and a run with no ``models["judge"]``.
+    Both surface as :class:`GradingFailedError` naming the trial.
+
+    ``llm_client`` is a test-only injection point mirroring
+    :func:`~tolokaforge.core.grading.replay.replay_trial`; production
+    callers leave it ``None`` and the judge builds its own client.
     """
     override = ctx.grader_config.judge if ctx.grader_config else None
+    logger = ctx.logger
 
     def judge_fn(spec: TrialSpec, trajectory: Trajectory, agent_system_prompt: str) -> Grade | None:
-        import json
-
-        from tolokaforge.core.grading.judge import LLMJudge
-        from tolokaforge.core.grading.replay import build_replay_grade
-        from tolokaforge.core.grading.transcript_wire import (
-            encode_transcript_wire,
-            split_leading_system_message,
-        )
-
         llm_judge_config = spec.task.grading.llm_judge
         if llm_judge_config is None:
             raise GradingFailedError(
@@ -1072,44 +1107,66 @@ def judge_backed_trial_grader_factory(
 
         wire = encode_transcript_wire(trajectory, agent_system_prompt)
         if wire is None:
-            # An empty trajectory with no policy — no evidence to judge
-            # against. ``JudgeBackedTrialGrader.grade`` will log the
+            # Empty trajectory with no policy — no evidence to judge
+            # against. ``JudgeBackedTrialGrader.grade`` logs the
             # ``None`` verdict at the seam.
             return None
         judge_agent_prompt, transcript = split_leading_system_message(json.loads(wire))
 
+        # Task customization is the base; the run-level override wins
+        # per-field when it is not ``None``. The override cannot express
+        # "reset to library default" — see :class:`JudgeGraderConfig`.
         customization = llm_judge_config.customization
-        disable_kb = (
+        base_disable_kb = customization.disable_knowledge_search if customization else None
+        base_custom_prompt = customization.system_prompt if customization else None
+        base_include_agent = customization.include_agent_system_prompt if customization else None
+
+        disable_kb_resolved = (
             override.disable_knowledge_search
             if override is not None and override.disable_knowledge_search is not None
-            else bool(customization and customization.disable_knowledge_search)
+            else base_disable_kb
         )
         custom_prompt = (
             override.custom_system_prompt
             if override is not None and override.custom_system_prompt is not None
-            else (customization.system_prompt if customization else None)
+            else base_custom_prompt
         )
-        include_agent = (
+        include_agent_resolved = (
             override.include_agent_system_prompt
             if override is not None and override.include_agent_system_prompt is not None
-            else (
-                customization.include_agent_system_prompt
-                if customization and customization.include_agent_system_prompt is not None
-                else True
-            )
+            else base_include_agent
         )
-
+        # LLMJudge's own defaults for the two bool knobs are
+        # ``disable_knowledge_search=False`` and
+        # ``include_agent_system_prompt=True``; collapse the tri-state
+        # here so both fields resolve consistently (the reviewer flagged
+        # an asymmetry where one collapsed via ``bool()`` and the other
+        # kept the tri-state).
         judge = LLMJudge(
             spec.judge_model_config,
-            disable_knowledge_search=disable_kb,
+            disable_knowledge_search=bool(disable_kb_resolved),
             custom_system_prompt=custom_prompt,
-            include_agent_system_prompt=include_agent,
+            include_agent_system_prompt=(
+                include_agent_resolved if include_agent_resolved is not None else True
+            ),
+            llm_client=llm_client,
+            logger=logger,
         )
         result = judge.run(
             rubric=llm_judge_config.rubric,
             agent_system_prompt=judge_agent_prompt,
             transcript=transcript,
         )
+        # Fail-loud contract: an ERRORED judge is a grading failure the
+        # trial is ungradeable under, never a booked agent failure. The
+        # ``JudgeBackedTrialGrader.grade`` caller catches nothing here;
+        # the seam's ``GradingFailedError`` surface is what carries the
+        # verdict-of-nothing forward.
+        if result.status is JudgeRunStatus.ERRORED:
+            raise GradingFailedError(
+                f"judge_only grader errored for trial {spec.trial_id!r}: "
+                f"{result.reasons or 'no reason recorded'}"
+            )
         return build_replay_grade(result)
 
     return JudgeBackedTrialGrader(judge_fn=judge_fn, logger=ctx.logger)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -1015,20 +1015,101 @@ def _queue_worker_loop(
 
 def judge_backed_trial_grader_factory(
     ctx: TrialGraderContext,
-) -> JudgeBackedTrialGrader:  # noqa: ARG001
-    """Registered ``judge_only`` factory. Fails loud until a production
-    judge is wired through the context.
+) -> JudgeBackedTrialGrader:
+    """Registered ``judge_only`` factory — builds a rubric-judge dispatcher.
 
-    Same altitude as :func:`queue_trial_grader_factory`: raise at factory
-    time so the operator sees the misconfiguration at orchestrator startup,
-    not deep inside :meth:`grade` after a trial has already been paid for.
-    Tests construct :class:`JudgeBackedTrialGrader` directly with a real
-    :data:`JudgeGradeFn`.
+    Reads the run-level ``grader.judge`` overrides (or the task's own
+    ``grading.llm_judge.customization`` when no override is set) and
+    produces a :data:`JudgeGradeFn` that on each call:
+
+    1. Reads the task's rubric from
+       ``spec.task.grading.llm_judge.rubric``.
+    2. Reads the judge model from ``spec.judge_model_config`` (which
+       rides the run config's ``models["judge"]``).
+    3. Encodes the trajectory + agent policy through the same
+       :func:`encode_transcript_wire` + :func:`split_leading_system_message`
+       replay uses, so the transcript the judge sees is byte-identical
+       to the runner-side grading path.
+    4. Runs :class:`LLMJudge` with rubric + transcript only — no
+       ``db_reader`` / ``kb_search`` / ``workspace_dir`` / ``state_diff``,
+       because ``judge_only`` grades trajectories after the trial ended
+       and holds no live substrate state.
+    5. Translates the :class:`JudgeResult` back through
+       :func:`build_replay_grade` — the same shape offline replay
+       produces, so a ``judge_only`` grade and a replay grade are
+       type-identical downstream.
+
+    Fails loud on the two shapes the operator would want to know
+    immediately at run start: a task with no ``llm_judge`` block (the
+    task cannot be judged) and a run with no ``models["judge"]`` (the
+    dispatch has no model to call). Both surface at grade time as
+    :class:`GradingFailedError`.
     """
-    raise NotImplementedError(
-        "``judge_only`` trial grader is registered but not yet wired to a "
-        "production judge at the engine layer. Instantiate "
-        "``JudgeBackedTrialGrader`` directly with your own ``JudgeGradeFn`` "
-        "for now; the factory will land once ``TrialGraderContext`` carries "
-        "judge-selection configuration."
-    )
+    override = ctx.grader_config.judge if ctx.grader_config else None
+
+    def judge_fn(spec: TrialSpec, trajectory: Trajectory, agent_system_prompt: str) -> Grade | None:
+        import json
+
+        from tolokaforge.core.grading.judge import LLMJudge
+        from tolokaforge.core.grading.replay import build_replay_grade
+        from tolokaforge.core.grading.transcript_wire import (
+            encode_transcript_wire,
+            split_leading_system_message,
+        )
+
+        llm_judge_config = spec.task.grading.llm_judge
+        if llm_judge_config is None:
+            raise GradingFailedError(
+                f"judge_only cannot grade trial {spec.trial_id!r}: the task "
+                "declares no grading.llm_judge block."
+            )
+        if spec.judge_model_config is None:
+            raise GradingFailedError(
+                f"judge_only cannot grade trial {spec.trial_id!r}: the run "
+                "config declares no models.judge; add one, or select a "
+                "grader that does not need a judge model."
+            )
+
+        wire = encode_transcript_wire(trajectory, agent_system_prompt)
+        if wire is None:
+            # An empty trajectory with no policy — no evidence to judge
+            # against. ``JudgeBackedTrialGrader.grade`` will log the
+            # ``None`` verdict at the seam.
+            return None
+        judge_agent_prompt, transcript = split_leading_system_message(json.loads(wire))
+
+        customization = llm_judge_config.customization
+        disable_kb = (
+            override.disable_knowledge_search
+            if override is not None and override.disable_knowledge_search is not None
+            else bool(customization and customization.disable_knowledge_search)
+        )
+        custom_prompt = (
+            override.custom_system_prompt
+            if override is not None and override.custom_system_prompt is not None
+            else (customization.system_prompt if customization else None)
+        )
+        include_agent = (
+            override.include_agent_system_prompt
+            if override is not None and override.include_agent_system_prompt is not None
+            else (
+                customization.include_agent_system_prompt
+                if customization and customization.include_agent_system_prompt is not None
+                else True
+            )
+        )
+
+        judge = LLMJudge(
+            spec.judge_model_config,
+            disable_knowledge_search=disable_kb,
+            custom_system_prompt=custom_prompt,
+            include_agent_system_prompt=include_agent,
+        )
+        result = judge.run(
+            rubric=llm_judge_config.rubric,
+            agent_system_prompt=judge_agent_prompt,
+            transcript=transcript,
+        )
+        return build_replay_grade(result)
+
+    return JudgeBackedTrialGrader(judge_fn=judge_fn, logger=ctx.logger)


### PR DESCRIPTION
Closes #1255.

Turns the `judge_only` trial grader from `NotImplementedError` at orchestrator startup into a working grader an operator can select on a real run.

## What lands

**Config surface**
```yaml
grader:
  name: judge_only
  judge:
    disable_knowledge_search: null       # override task's llm_judge.customization
    custom_system_prompt: null
    include_agent_system_prompt: null
```
Every override defaults to `None`, which means "use the task's own `grading.llm_judge.customization` exactly" — every existing task behaves unchanged.

**Factory**
`judge_backed_trial_grader_factory` builds a `JudgeGradeFn` that on each call:
1. Reads the rubric from `spec.task.grading.llm_judge.rubric`.
2. Reads the judge model from `spec.judge_model_config` (rider of `RunConfig.models["judge"]`).
3. Encodes trajectory + agent policy through the same `encode_transcript_wire` + `split_leading_system_message` offline replay uses — the transcript the judge sees is byte-identical to the runner-side grading path.
4. Runs `LLMJudge` with rubric + transcript only. `judge_only` operates on a completed trial with no live substrate — no `db_reader`, `kb_search`, `workspace_dir`, or `state_diff`.
5. Translates the `JudgeResult` through `build_replay_grade`, so a `judge_only` grade is type-identical to a replay grade.

**Failure surface**
Two shapes fail loud (as `GradingFailedError`) at grade time, not factory time — the same factory serves both rubric-carrying and rubric-less tasks in one run, so the decision belongs at dispatch:
- A task with no `grading.llm_judge` block.
- A run with no `models.judge`.

## Test plan

- [x] `test_factory_builds_a_working_grader` — the factory produces a `JudgeBackedTrialGrader` with a callable inner dispatch.
- [x] `test_grade_raises_when_task_has_no_llm_judge_block` — the missing-rubric surface fails loud at grade time.
- [x] Existing `test_registered_under_judge_only_entry_point` still passes.
- [x] Full `tests/unit` + `tests/canonical` sweep green.
- [x] `ruff check` clean.

## Grader detachment status

With #1255 landing, every `TrialGrader` factory in the plug-in registry is wired end-to-end:

| Name | Wiring | Ships |
|---|---|---|
| `runner_rpc` | live | in-process runner call |
| `grader_rpc` | live | dials the standalone grader service |
| `queue` | live (#1256) | broker + worker pool over `grader_rpc` |
| `judge_only` | **live (this PR)** | rubric-only dispatch over `LLMJudge` |

Follow-ups: real-eval install matrix (#1246), Redis Streams backend for the queue transport.
