### PR TITLE
fix(test): migrate test_lost_trial_attribution to RunnerRPCTrialGrader's runner_client injection

### DIFF
--- a/tests/canonical/test_lost_trial_attribution.py
+++ b/tests/canonical/test_lost_trial_attribution.py
@@ -219,13 +219,21 @@ def test_a_lost_trial_is_counted_against_the_run_and_scored_not_at_all(
     describing agent performance with a fault of ours.
     """
     trajectory, _, _ = loop_route
-    backend = MagicMock()
-    grader = RunnerRPCTrialGrader(runtime_backend=backend, logger=MagicMock())
+    # PR #1202 migrated ``RunnerRPCTrialGrader`` off a live ``runtime_backend``
+    # onto an injectable ``runner_client``. The intent — a TRIAL_LOST
+    # trajectory returns ``None`` without dialing the runner — is unchanged;
+    # only the injection surface moved.
+    runner_client = MagicMock()
+    grader = RunnerRPCTrialGrader(
+        runner_address="ignored:0",
+        logger=MagicMock(),
+        runner_client=runner_client,
+    )
 
     trajectory.grade = grader.grade(make_trial_spec(), trajectory, "You are an agent.")
 
     assert trajectory.grade is None
-    backend.grade_trial.assert_not_called()
+    runner_client.grade_trial.assert_not_called()
 
     passed = make_trajectory(termination_reason=TerminationReason.AGENT_DONE)
     passed.grade = Grade(


### PR DESCRIPTION
Phase 0 of milestone #36 (#1260).

PR #1202 migrated `RunnerRPCTrialGrader` off a live `runtime_backend` onto an injectable `runner_client`. Seven of the eight construction sites migrated at merge time; this one at `tests/canonical/test_lost_trial_attribution.py:223` was missed and has been failing `test-full` on `main` ever since (the specific error was `TypeError: RunnerRPCTrialGrader.__init__() got an unexpected keyword argument 'runtime_backend'`).

Test intent unchanged: a TRIAL_LOST trajectory yields `None` without dialing the runner. Only the injection surface moved.

## Test plan

- [x] `tests/canonical/test_lost_trial_attribution.py` passes locally (5/5).
- [x] `ruff check` clean.
- [ ] `test-full` on main returns to green after this + the other 13 pre-existing flakes documented on the umbrella (out of scope here).

Part of #1259.