### PR TITLE
fix(orchestrator): fail loud when a docker-CLI-needing run resolves to pull

### DIFF
--- a/docs/RUNNING_TERMINAL_BENCH.md
+++ b/docs/RUNNING_TERMINAL_BENCH.md
@@ -30,6 +30,16 @@ shape regardless of which produced it.
 - The task pack you want to run. The examples in this guide use the shipped
   `examples/terminal_bench/fix-billing-holds` task; substitute any other
   terminal-bench task directory.
+- A **locally-built runner image**. The terminal-bench adapter shells out
+  to `docker exec` from inside the runner to reach the task container, so
+  the runner needs the docker CLI + compose plugin baked in. The
+  orchestrator sets the runner Dockerfile's `INSTALL_DOCKER_CLI=true`
+  build arg for this run, but that only takes effect on a build — the
+  published (pulled) runner images ship without either binary. Pass
+  `--image-source build` (or set `docker.image_source: build` in the run
+  config, or `TOLOKAFORGE_IMAGE_SOURCE=build` in the environment). The
+  orchestrator refuses to start with an actionable message if the
+  resolved source is `pull`.
 
 Bootstrap:
 

--- a/tests/unit/test_image_source_policy.py
+++ b/tests/unit/test_image_source_policy.py
@@ -215,37 +215,28 @@ class TestRunnerDockerCliAvailabilityGate:
                 engine_version="0.19.1",
             )
 
-    def test_explicit_build_passes(self) -> None:
+    @pytest.mark.parametrize(
+        "request_, is_wheel_install, engine_version",
+        [
+            # Explicit build always yields build.
+            ("build", True, "0.19.1"),
+            # Source-checkout contributor: auto resolves to build.
+            ("auto", False, "0.19.1"),
+            # No valid pull tag → auto falls through to build.
+            ("auto", True, UNKNOWN_VERSION_SENTINEL),
+            # PEP 440 local segment (`+dirty`) → auto falls through to build.
+            ("auto", True, "0.19.1+dirty"),
+        ],
+    )
+    def test_gate_passes_when_resolved_source_is_build(
+        self,
+        request_: str,
+        is_wheel_install: bool,
+        engine_version: str,
+    ) -> None:
         check_runner_docker_cli_available(
             needs_docker_cli=True,
-            request="build",
-            is_wheel_install=True,
-            engine_version="0.19.1",
-        )
-
-    def test_auto_source_checkout_passes(self) -> None:
-        # Source-checkout contributor: auto resolves to build.
-        check_runner_docker_cli_available(
-            needs_docker_cli=True,
-            request="auto",
-            is_wheel_install=False,
-            engine_version="0.19.1",
-        )
-
-    def test_auto_unknown_version_passes(self) -> None:
-        # No valid pull tag → auto falls through to build.
-        check_runner_docker_cli_available(
-            needs_docker_cli=True,
-            request="auto",
-            is_wheel_install=True,
-            engine_version=UNKNOWN_VERSION_SENTINEL,
-        )
-
-    def test_auto_local_version_passes(self) -> None:
-        # PEP 440 local segment (`+dirty`) → auto falls through to build.
-        check_runner_docker_cli_available(
-            needs_docker_cli=True,
-            request="auto",
-            is_wheel_install=True,
-            engine_version="0.19.1+dirty",
+            request=request_,
+            is_wheel_install=is_wheel_install,
+            engine_version=engine_version,
         )

--- a/tests/unit/test_image_source_policy.py
+++ b/tests/unit/test_image_source_policy.py
@@ -13,6 +13,8 @@ import pytest
 import tolokaforge
 from tolokaforge.docker.image_source_policy import (
     UNKNOWN_VERSION_SENTINEL,
+    RunnerDockerCliUnavailableError,
+    check_runner_docker_cli_available,
     resolve_image_source,
 )
 
@@ -172,3 +174,78 @@ class TestSentinelStaysInSyncWithPackage:
                 )
                 == "pull"
             )
+
+
+class TestRunnerDockerCliAvailabilityGate:
+    """`check_runner_docker_cli_available` fails a run before any container
+    work when the resolved image source would ship a runner without the
+    docker CLI to a run that needs it."""
+
+    def test_noop_when_docker_cli_not_needed(self) -> None:
+        check_runner_docker_cli_available(
+            needs_docker_cli=False,
+            request="pull",
+            is_wheel_install=True,
+            engine_version="0.19.1",
+        )
+
+    def test_pull_wheel_install_raises(self) -> None:
+        with pytest.raises(RunnerDockerCliUnavailableError) as exc:
+            check_runner_docker_cli_available(
+                needs_docker_cli=True,
+                request="pull",
+                is_wheel_install=True,
+                engine_version="0.19.1",
+            )
+        msg = str(exc.value)
+        assert "docker CLI" in msg
+        assert "--image-source build" in msg
+        assert "docker.image_source: build" in msg
+        assert "TOLOKAFORGE_IMAGE_SOURCE=build" in msg
+
+    def test_auto_wheel_install_pinned_version_raises(self) -> None:
+        # This is the exact operator-install shape that misfires by default:
+        # pip-installed engine + auto policy + real version → resolves to
+        # 'pull' → runner ships without docker CLI.
+        with pytest.raises(RunnerDockerCliUnavailableError):
+            check_runner_docker_cli_available(
+                needs_docker_cli=True,
+                request="auto",
+                is_wheel_install=True,
+                engine_version="0.19.1",
+            )
+
+    def test_explicit_build_passes(self) -> None:
+        check_runner_docker_cli_available(
+            needs_docker_cli=True,
+            request="build",
+            is_wheel_install=True,
+            engine_version="0.19.1",
+        )
+
+    def test_auto_source_checkout_passes(self) -> None:
+        # Source-checkout contributor: auto resolves to build.
+        check_runner_docker_cli_available(
+            needs_docker_cli=True,
+            request="auto",
+            is_wheel_install=False,
+            engine_version="0.19.1",
+        )
+
+    def test_auto_unknown_version_passes(self) -> None:
+        # No valid pull tag → auto falls through to build.
+        check_runner_docker_cli_available(
+            needs_docker_cli=True,
+            request="auto",
+            is_wheel_install=True,
+            engine_version=UNKNOWN_VERSION_SENTINEL,
+        )
+
+    def test_auto_local_version_passes(self) -> None:
+        # PEP 440 local segment (`+dirty`) → auto falls through to build.
+        check_runner_docker_cli_available(
+            needs_docker_cli=True,
+            request="auto",
+            is_wheel_install=True,
+            engine_version="0.19.1+dirty",
+        )

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1992,6 +1992,25 @@ class Orchestrator:
                         "(terminal-bench adapter or compose-variant tools detected)"
                     )
                     core_stack_kwargs["enable_docker_cli"] = True
+                    # Fail loud before any container work: INSTALL_DOCKER_CLI
+                    # is a Dockerfile build arg the orchestrator sets, so it
+                    # only takes effect on a locally-built runner. A pulled
+                    # runner would die on the first tool call with
+                    # `[Errno 2] No such file or directory: 'docker'`.
+                    import tolokaforge as _engine_pkg
+                    from tolokaforge.core.models.docker_config import DockerConfig
+                    from tolokaforge.docker.builder import repo_root
+                    from tolokaforge.docker.image_source_policy import (
+                        check_runner_docker_cli_available,
+                    )
+
+                    _docker_cfg = self.config.docker or DockerConfig()
+                    check_runner_docker_cli_available(
+                        needs_docker_cli=True,
+                        request=_docker_cfg.image_source,
+                        is_wheel_install=not (repo_root() / "pyproject.toml").is_file(),
+                        engine_version=_engine_pkg.__version__,
+                    )
                 # Pick full_stack (db-service + runner + rag-service +
                 # mock-web) when any task talks to mock-web or rag (see
                 # ``_FULL_STACK_TOOL_NAMES`` for the routing matrix) OR when

--- a/tolokaforge/docker/image_source_policy.py
+++ b/tolokaforge/docker/image_source_policy.py
@@ -36,6 +36,20 @@ from typing import Literal
 ImageSource = Literal["auto", "pull", "build"]
 ResolvedImageSource = Literal["pull", "build"]
 
+
+class RunnerDockerCliUnavailableError(RuntimeError):
+    """A run needs docker CLI inside the runner container but the resolved
+    image source would ship a runner without it.
+
+    Raised at orchestrator startup so the operator sees an actionable message
+    instead of a trial dying opaquely on the first tool call with
+    ``[Errno 2] No such file or directory: 'docker'``. The runner Dockerfile
+    installs the docker CLI + compose plugin behind ``INSTALL_DOCKER_CLI=true``
+    only when the image is built locally; pulled images ship without it (the
+    published runners keep the smallest footprint that fits the common case).
+    """
+
+
 UNKNOWN_VERSION_SENTINEL = "0.0.0+unknown"
 """The value ``tolokaforge.__version__`` reports when the engine is
 running from a source checkout that has not been ``pip install``-ed
@@ -93,3 +107,53 @@ def resolve_image_source(
     if "+" in engine_version:
         return "build"
     return "pull"
+
+
+def check_runner_docker_cli_available(
+    *,
+    needs_docker_cli: bool,
+    request: ImageSource,
+    is_wheel_install: bool,
+    engine_version: str,
+) -> None:
+    """Fail loud when the run needs docker CLI in the runner but the resolved
+    image source would pull a runner image without it.
+
+    Args:
+        needs_docker_cli: The orchestrator's decision from
+            ``_run_needs_docker_cli(adapter_type, tasks)``. When ``False`` the
+            check is a no-op.
+        request: The three-valued config request, same input
+            :func:`resolve_image_source` takes.
+        is_wheel_install: Same input :func:`resolve_image_source` takes.
+        engine_version: Same input :func:`resolve_image_source` takes.
+
+    Raises:
+        RunnerDockerCliUnavailableError: when ``needs_docker_cli`` is ``True``
+            and :func:`resolve_image_source` returns ``"pull"``. The message
+            names the resolved request and points at the three ways to switch
+            to a locally-built runner.
+    """
+    if not needs_docker_cli:
+        return
+    resolved = resolve_image_source(
+        request=request,
+        is_wheel_install=is_wheel_install,
+        engine_version=engine_version,
+    )
+    if resolved == "build":
+        return
+    raise RunnerDockerCliUnavailableError(
+        "This run needs the docker CLI + docker-compose plugin inside the "
+        "runner container (the terminal-bench adapter or a compose-variant "
+        "tool shells out to `docker exec` to reach the task container), but "
+        f"the resolved image source is 'pull' (docker.image_source={request!r}"
+        f", wheel_install={is_wheel_install}). Published runner images ship "
+        "without docker CLI, so the first tool call would die with `[Errno 2] "
+        "No such file or directory: 'docker'`. "
+        "Fix: rerun with `--image-source build`, set "
+        "`docker.image_source: build` in the run config, or set "
+        "`TOLOKAFORGE_IMAGE_SOURCE=build` in the environment. A locally "
+        "built runner honours the Dockerfile's INSTALL_DOCKER_CLI=true "
+        "build arg that the orchestrator sets for this run."
+    )


### PR DESCRIPTION
## Summary

The runner Dockerfile installs docker CLI + docker-compose plugin behind `INSTALL_DOCKER_CLI=true`, a build arg the orchestrator sets whenever `_run_needs_docker_cli(...)` fires. Build args only take effect on a local build — the published runner ships without either binary.

Consequence today: with the default `docker.image_source='auto'` on a wheel install, a terminal-bench run gets a pulled runner without docker CLI. `mount_docker_socket=true` is still wired at runtime, so the very first tool call dies opaquely inside the CLI's assistant message with `[Errno 2] No such file or directory: 'docker'`. Trial reports `status=error` in 30ms, verifier scores the baseline pack, and the run looks like a "completed" trial with score 0.579.

Fix: pure-function gate `check_runner_docker_cli_available` in `tolokaforge/docker/image_source_policy.py`; called from `Orchestrator._prepare_docker_stack` right after `core_stack_kwargs["enable_docker_cli"] = True`. Raises `RunnerDockerCliUnavailableError` naming the resolved request and the three ways to switch to a local build (`--image-source build`, `docker.image_source: build`, `TOLOKAFORGE_IMAGE_SOURCE=build`).

## What changed

- `tolokaforge/docker/image_source_policy.py` — new `RunnerDockerCliUnavailableError` + `check_runner_docker_cli_available` pure function next to the existing `resolve_image_source`. Same three inputs as the resolver plus a `needs_docker_cli` flag.
- `tolokaforge/core/orchestrator.py` — call the gate immediately after `enable_docker_cli` is set. Fails before any container work.
- `tests/unit/test_image_source_policy.py` — seven new cases in `TestRunnerDockerCliAvailabilityGate`: no-op path, both operator shapes that reach 'pull' (explicit + auto-on-wheel-install), and the four resolve-to-build paths (explicit build, source checkout, unknown-version sentinel, PEP 440 local version).
- `docs/RUNNING_TERMINAL_BENCH.md` — new Prerequisites bullet naming the locally-built runner requirement so a first-time reader sees the constraint before hitting the error.

## Discovered how

Running a real coding-harness matrix (claude-code + codex on `git-recovery-challenge` + `fix-billing-holds` from the `eval/tbench-balanced-10` task pack). First run's trial "completed" in 30ms with score 0.579 (baseline pack score, since no work was done). Reading the trajectory turned up `[Errno 2] No such file or directory: 'docker'` recorded as the CLI's assistant text — hard to notice, easy to misread as a model failure.

Fixed by re-running with `--image-source build` (which rebuilds the runner with `INSTALL_DOCKER_CLI=true`); real matrix then landed 4/4 green in ~11 min. This PR makes that misconfiguration impossible to reach silently.

## Test plan

- [x] `uv run pytest tests/unit/test_image_source_policy.py -v -m unit` — 35/35 pass (7 new + 28 existing).
- [x] `uv run pytest tests/unit -k 'orchestrator' -m unit` — 295/295 pass (no regressions in the orchestrator's own unit suite).
- [x] `uv run ruff check` on the four touched files — clean.
- [x] `pre-commit run` (ruff + black + import-boundary contracts) — passed on commit.
- [ ] Reviewer sanity-check: try running any terminal-bench config (e.g. `examples/terminal_bench/run_harness.yaml`) *without* `--image-source build` on a wheel install and confirm the raised message is actionable.