### PR TITLE
feat(grading): Phase 2 — six component-level plug-in seams

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -40,3 +40,37 @@ forbidden_modules =
     tolokaforge.core.grading
     tolokaforge.runner.service
 allow_indirect_imports = true
+
+
+# Sub-component seam invariants (ADR-0039, milestone #36 Phase 2).
+#
+# composite.py is the topology-neutral dispatch above the substrate. It
+# must reach every sub-component through its Protocol via a resolved
+# instance, never through a direct import of the reference-impl module.
+# A direct import would silently re-collapse the seam this milestone
+# builds and force every future substrate + evaluator to co-locate with
+# the composite.
+#
+# Six sub-component seams; six forbidden targets. The four ``default_*.py``
+# modules were carved out explicitly so this contract can fence them at
+# module granularity — a downstream can never accidentally reach through
+# composite into a reference impl. Protocol / Context / FactoryAlias
+# modules (rubric_evaluator, judge_model_provider, transcript_rule_matcher,
+# state_check_backend, trace_check_operator) are IMPLICIT-ALLOW — composite
+# legitimately imports the Protocol types under TYPE_CHECKING.
+# ``check_runner`` stays implicit-allow because composite has never
+# imported CheckRunner / InMemoryCheckExecutor directly (a resolved-
+# instance kwarg is the sole route).
+[importlinter:contract:composite-sub-component-seams]
+name = Composite dispatch holds every sub-component plug-in seam
+type = forbidden
+source_modules =
+    tolokaforge.core.grading.composite
+forbidden_modules =
+    tolokaforge.core.grading.judge
+    tolokaforge.core.llm.client
+    tolokaforge.core.grading.default_rubric_evaluator
+    tolokaforge.core.grading.default_judge_model_provider
+    tolokaforge.core.grading.default_transcript_rule_matcher
+    tolokaforge.core.grading.default_state_check_backends
+allow_indirect_imports = true

--- a/.importlinter
+++ b/.importlinter
@@ -42,14 +42,13 @@ forbidden_modules =
 allow_indirect_imports = true
 
 
-# Sub-component seam invariants (ADR-0039, milestone #36 Phase 2).
+# Sub-component seam invariants (ADR-0039).
 #
 # composite.py is the topology-neutral dispatch above the substrate. It
 # must reach every sub-component through its Protocol via a resolved
 # instance, never through a direct import of the reference-impl module.
-# A direct import would silently re-collapse the seam this milestone
-# builds and force every future substrate + evaluator to co-locate with
-# the composite.
+# A direct import would silently re-collapse the seam and force every
+# substrate + evaluator to co-locate with the composite.
 #
 # Six sub-component seams; six forbidden targets. The four ``default_*.py``
 # modules were carved out explicitly so this contract can fence them at

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -268,6 +268,38 @@ is booked as ungradeable rather than as an agent failure.
 `tolokaforge/core/grading/substrate_client.py::GrpcSubstrateClient` is the
 underlying wire adapter — one instance per `(channel, trial_id)` pair.
 
+## Sub-component plug-in seams
+
+Below the composite dispatch, individual grade sub-components are Protocol
+seams a downstream package extends by registering an `importlib.metadata`
+entry point. Each seam has a shipped reference impl registered under a
+default name; the loader lives on `tolokaforge.core.plugin_registry` and
+follows the fail-loud shape [ADR-0022](adr/0022-runtime-independence.md)
+pins for every seam in the engine.
+
+| Seam | Entry-point group | Default | Contract |
+| --- | --- | --- | --- |
+| Custom check executor | `tolokaforge.custom_check_executors` | `check_runner` (production), `in_memory` (test fixture) | [`CheckExecutor`](../tolokaforge/core/grading/check_runner.py) — runs the pack's `checks.py` against the trial's evidence and returns a `CheckResultSet`. |
+| Judge model provider | `tolokaforge.judge_model_providers` | `litellm` (fronts [`LLMClient`](../tolokaforge/core/llm/client.py)) | [`JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) — builds a `JudgeModel` (the `.generate` + `.classify_loop_error` surface `LLMJudge` drives) from a `ModelConfig`. |
+
+Register a downstream impl the same way as a `TrialGrader`:
+
+```toml
+# downstream package pyproject.toml
+[project.entry-points."tolokaforge.judge_model_providers"]
+openai_direct = "acme_judge:_openai_direct_provider_factory"
+```
+
+The runner resolves both defaults at startup via
+`load_custom_check_executor("check_runner")` and
+`load_judge_model_provider("litellm")` and caches the resulting instances
+on `RunnerServiceImpl`. The check executor is threaded through the
+composite `grade_custom_checks` dispatch (the seam the executor Protocol
+was written for); the judge model provider is available for rubric-side
+consumers. A downstream `pip install` of a package that registers under
+either group is picked up on the runner's next start with no framework
+change.
+
 ## See also
 
 - [ADR-0014 — TrialGrader Protocol](adr/0014-trial-grader-protocol.md)

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -282,6 +282,7 @@ pins for every seam in the engine.
 | Custom check executor | `tolokaforge.custom_check_executors` | `check_runner` (production), `in_memory` (test fixture) | [`CheckExecutor`](../tolokaforge/core/grading/check_runner.py) — runs the pack's `checks.py` against the trial's evidence and returns a `CheckResultSet`. |
 | Judge model provider | `tolokaforge.judge_model_providers` | `litellm` (fronts [`LLMClient`](../tolokaforge/core/llm/client.py)) | [`JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) — builds a `JudgeModel` (the `.generate` + `.classify_loop_error` surface `LLMJudge` drives) from a `ModelConfig`. |
 | Rubric evaluator | `tolokaforge.rubric_evaluators` | `llm_judge` (wraps [`LLMJudge`](../tolokaforge/core/grading/judge.py)) | [`RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) — grades one trial's rubric evidence into a `JudgeResult`. Constructed from a `RubricEvaluatorContext` carrying the resolved `JudgeModelProvider` + customization flags; receives the per-trial evidence at `.evaluate()`. |
+| Transcript rule matcher | `tolokaforge.transcript_rule_matchers` | `default` (wraps [`evaluate_transcript_rules`](../tolokaforge/core/grading/transcript.py)) | [`TranscriptRuleMatcher`](../tolokaforge/core/grading/transcript_rule_matcher.py) — scores the whole `TranscriptRulesConfig` against a `TrialTimeline` and returns one `TranscriptEvaluationResult`. Holistic seam (one matcher per config); the events-less-trial gate and per-key accounting stay in the composite. |
 
 Register a downstream impl the same way as a `TrialGrader`:
 
@@ -295,16 +296,20 @@ deterministic_rules = "acme_grader:_rules_evaluator_factory"
 ```
 
 The runner resolves the shipping defaults at startup via
-`load_custom_check_executor("check_runner")` and
-`load_judge_model_provider("litellm")` and caches the resulting instances
+`load_custom_check_executor("check_runner")`,
+`load_judge_model_provider("litellm")`, and
+`load_transcript_rule_matcher("default")`, and caches the resulting instances
 on `RunnerServiceImpl`. The check executor is threaded through the
 composite `grade_custom_checks` dispatch. The judge model provider is
 threaded into the `RubricEvaluatorContext` that the runner constructs at
 grade time — `load_rubric_evaluator("llm_judge")(ctx)` — and the composite
 `grade_llm_judge` receives the resolved evaluator; no LLM transport ever
-appears in composite. A downstream `pip install` of a package that
-registers under any of these groups is picked up on the runner's next
-start with no framework change.
+appears in composite. The transcript-rule matcher is threaded through the
+composite `grade_transcript_rules` dispatch; the events-less-trial gate
+(`scored_transcript_rules`) and the per-key accounting stay in the
+composite so every deployment topology applies them identically. A
+downstream `pip install` of a package that registers under any of these
+groups is picked up on the runner's next start with no framework change.
 
 ## See also
 

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -281,6 +281,7 @@ pins for every seam in the engine.
 | --- | --- | --- | --- |
 | Custom check executor | `tolokaforge.custom_check_executors` | `check_runner` (production), `in_memory` (test fixture) | [`CheckExecutor`](../tolokaforge/core/grading/check_runner.py) — runs the pack's `checks.py` against the trial's evidence and returns a `CheckResultSet`. |
 | Judge model provider | `tolokaforge.judge_model_providers` | `litellm` (fronts [`LLMClient`](../tolokaforge/core/llm/client.py)) | [`JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) — builds a `JudgeModel` (the `.generate` + `.classify_loop_error` surface `LLMJudge` drives) from a `ModelConfig`. |
+| Rubric evaluator | `tolokaforge.rubric_evaluators` | `llm_judge` (wraps [`LLMJudge`](../tolokaforge/core/grading/judge.py)) | [`RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) — grades one trial's rubric evidence into a `JudgeResult`. Constructed from a `RubricEvaluatorContext` carrying the resolved `JudgeModelProvider` + customization flags; receives the per-trial evidence at `.evaluate()`. |
 
 Register a downstream impl the same way as a `TrialGrader`:
 
@@ -288,17 +289,22 @@ Register a downstream impl the same way as a `TrialGrader`:
 # downstream package pyproject.toml
 [project.entry-points."tolokaforge.judge_model_providers"]
 openai_direct = "acme_judge:_openai_direct_provider_factory"
+
+[project.entry-points."tolokaforge.rubric_evaluators"]
+deterministic_rules = "acme_grader:_rules_evaluator_factory"
 ```
 
-The runner resolves both defaults at startup via
+The runner resolves the shipping defaults at startup via
 `load_custom_check_executor("check_runner")` and
 `load_judge_model_provider("litellm")` and caches the resulting instances
 on `RunnerServiceImpl`. The check executor is threaded through the
-composite `grade_custom_checks` dispatch (the seam the executor Protocol
-was written for); the judge model provider is available for rubric-side
-consumers. A downstream `pip install` of a package that registers under
-either group is picked up on the runner's next start with no framework
-change.
+composite `grade_custom_checks` dispatch. The judge model provider is
+threaded into the `RubricEvaluatorContext` that the runner constructs at
+grade time — `load_rubric_evaluator("llm_judge")(ctx)` — and the composite
+`grade_llm_judge` receives the resolved evaluator; no LLM transport ever
+appears in composite. A downstream `pip install` of a package that
+registers under any of these groups is picked up on the runner's next
+start with no framework change.
 
 ## See also
 

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -275,15 +275,22 @@ seams a downstream package extends by registering an `importlib.metadata`
 entry point. Each seam has a shipped reference impl registered under a
 default name; the loader lives on `tolokaforge.core.plugin_registry` and
 follows the fail-loud shape [ADR-0022](adr/0022-runtime-independence.md)
-pins for every seam in the engine.
+pins for every seam in the engine. Six sub-component seams cover the six
+evaluators the composite dispatch reaches. The [`.importlinter`
+`composite-sub-component-seams` contract](../.importlinter) enforces the
+negative-space of the seam by forbidding
+[`composite.py`](../tolokaforge/core/grading/composite.py) from importing
+any of the six reference-impl-holding modules — the composite reaches every
+sub-component only through its Protocol via a resolved-instance kwarg.
 
-| Seam | Entry-point group | Default | Contract |
+| Group | Protocol module | Reference impls | Granularity |
 | --- | --- | --- | --- |
-| Custom check executor | `tolokaforge.custom_check_executors` | `check_runner` (production), `in_memory` (test fixture) | [`CheckExecutor`](../tolokaforge/core/grading/check_runner.py) — runs the pack's `checks.py` against the trial's evidence and returns a `CheckResultSet`. |
-| Judge model provider | `tolokaforge.judge_model_providers` | `litellm` (fronts [`LLMClient`](../tolokaforge/core/llm/client.py)) | [`JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) — builds a `JudgeModel` (the `.generate` + `.classify_loop_error` surface `LLMJudge` drives) from a `ModelConfig`. |
-| Rubric evaluator | `tolokaforge.rubric_evaluators` | `llm_judge` (wraps [`LLMJudge`](../tolokaforge/core/grading/judge.py)) | [`RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) — grades one trial's rubric evidence into a `JudgeResult`. Constructed from a `RubricEvaluatorContext` carrying the resolved `JudgeModelProvider` + customization flags; receives the per-trial evidence at `.evaluate()`. |
-| Transcript rule matcher | `tolokaforge.transcript_rule_matchers` | `default` (wraps [`evaluate_transcript_rules`](../tolokaforge/core/grading/transcript.py)) | [`TranscriptRuleMatcher`](../tolokaforge/core/grading/transcript_rule_matcher.py) — scores the whole `TranscriptRulesConfig` against a `TrialTimeline` and returns one `TranscriptEvaluationResult`. Holistic seam (one matcher per config); the events-less-trial gate and per-key accounting stay in the composite. |
-| Trace check operator | `tolokaforge.trace_check_operators` | 15 non-binding names (`equals`, `equals_ci`, `contains`, `contains_ci`, `not_equals`, `regex`, `gt`, `gte`, `lt`, `lte`, `in_`, `not_in`, `len_gt`, `len_gte`, `exists`) + 2 binding names (`equals_binding`, `contains_binding`) | [`TraceCheckOperator`](../tolokaforge/core/grading/trace_check_operator.py) — one callable per operator name a `ValuePredicate` may declare, resolved per-call via the registry cache. **Per-operator granularity** (the only seam that is not holistic): a downstream `equals_semver` registration extends the operator vocabulary without a framework PR. Binding operators are identified by the `_binding` suffix on the registered name. |
+| `tolokaforge.custom_check_executors` | [`check_runner.py::CheckExecutor`](../tolokaforge/core/grading/check_runner.py) | `CheckRunner` (production), `InMemoryCheckExecutor` (test fixture) | holistic |
+| `tolokaforge.judge_model_providers` | [`judge_model_provider.py::JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) | `LiteLLMJudgeModelProvider` (fronts `LLMClient`) | holistic |
+| `tolokaforge.rubric_evaluators` | [`rubric_evaluator.py::RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) | `LLMJudgeRubricEvaluator` (wraps `LLMJudge`) | holistic |
+| `tolokaforge.transcript_rule_matchers` | [`transcript_rule_matcher.py::TranscriptRuleMatcher`](../tolokaforge/core/grading/transcript_rule_matcher.py) | `DefaultTranscriptRuleMatcher` (wraps `evaluate_transcript_rules`) | holistic |
+| `tolokaforge.trace_check_operators` | [`trace_check_operator.py::TraceCheckOperator`](../tolokaforge/core/grading/trace_check_operator.py) | 17 shipped operator functions — 15 non-binding (`equals`, `equals_ci`, `contains`, `contains_ci`, `not_equals`, `regex`, `gt`, `gte`, `lt`, `lte`, `in_`, `not_in`, `len_gt`, `len_gte`, `exists`) + 2 binding (`equals_binding`, `contains_binding`) | per-operator |
+| `tolokaforge.state_check_backends` | [`state_check_backend.py::StateCheckBackend`](../tolokaforge/core/grading/state_check_backend.py) | `JsonpathStateCheckBackend`, `DbProbesStateCheckBackend` (hash is NOT a backend — runner-integrated) | per-source |
 
 Register a downstream impl the same way as a `TrialGrader`:
 
@@ -294,27 +301,43 @@ openai_direct = "acme_judge:_openai_direct_provider_factory"
 
 [project.entry-points."tolokaforge.rubric_evaluators"]
 deterministic_rules = "acme_grader:_rules_evaluator_factory"
+
+[project.entry-points."tolokaforge.state_check_backends"]
+s3_diff = "acme_grader:_s3_diff_state_check_backend_factory"
 ```
 
 The runner resolves the shipping defaults at startup via
 `load_custom_check_executor("check_runner")`,
-`load_judge_model_provider("litellm")`, and
-`load_transcript_rule_matcher("default")`, and caches the resulting instances
-on `RunnerServiceImpl`. The check executor is threaded through the
-composite `grade_custom_checks` dispatch. The judge model provider is
-threaded into the `RubricEvaluatorContext` that the runner constructs at
-grade time — `load_rubric_evaluator("llm_judge")(ctx)` — and the composite
+`load_judge_model_provider("litellm")`,
+`load_transcript_rule_matcher("default")`, and
+`load_state_check_backend("jsonpath")` + `load_state_check_backend("db_probes")`,
+and caches the resulting instances on `RunnerServiceImpl`. The check
+executor is threaded through the composite `grade_custom_checks`
+dispatch. The judge model provider is threaded into the
+`RubricEvaluatorContext` that the runner constructs at grade time —
+`load_rubric_evaluator("llm_judge")(ctx)` — and the composite
 `grade_llm_judge` receives the resolved evaluator; no LLM transport ever
 appears in composite. The transcript-rule matcher is threaded through the
 composite `grade_transcript_rules` dispatch; the events-less-trial gate
 (`scored_transcript_rules`) and the per-key accounting stay in the
-composite so every deployment topology applies them identically.
-Trace-check operators resolve per-call inside
+composite so every deployment topology applies them identically. The
+state-check backends dict (`{"jsonpath": ..., "db_probes": ...}`) is
+threaded through the composite `grade_state_checks_reads` dispatch; each
+backend owns its source's read strategy so the composite dispatches
+without knowing either evaluator's internals. Trace-check operators
+resolve per-call inside
 `tolokaforge.core.grading.trace_checks._operator_holds`, which reads
 `load_trace_check_operator(name)` — the entry-point discovery cache means
 a name only pays the loader cost on its first mention. A
 downstream `pip install` of a package that registers under any of these
 groups is picked up on the runner's next start with no framework change.
+
+**Hash grading is deliberately NOT a state-check backend.** The
+`state_checks.hash` component has state-mutation semantics (snapshot →
+reset → replay → snapshot → restore) that the read-only substrate cannot
+serve; hash grading stays runner-integrated on
+`RunnerServiceImpl._execute_hash_grading`, called by `_grade_trial_async`
+above the composite dispatch.
 
 ## See also
 

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -283,6 +283,7 @@ pins for every seam in the engine.
 | Judge model provider | `tolokaforge.judge_model_providers` | `litellm` (fronts [`LLMClient`](../tolokaforge/core/llm/client.py)) | [`JudgeModelProvider`](../tolokaforge/core/grading/judge_model_provider.py) — builds a `JudgeModel` (the `.generate` + `.classify_loop_error` surface `LLMJudge` drives) from a `ModelConfig`. |
 | Rubric evaluator | `tolokaforge.rubric_evaluators` | `llm_judge` (wraps [`LLMJudge`](../tolokaforge/core/grading/judge.py)) | [`RubricEvaluator`](../tolokaforge/core/grading/rubric_evaluator.py) — grades one trial's rubric evidence into a `JudgeResult`. Constructed from a `RubricEvaluatorContext` carrying the resolved `JudgeModelProvider` + customization flags; receives the per-trial evidence at `.evaluate()`. |
 | Transcript rule matcher | `tolokaforge.transcript_rule_matchers` | `default` (wraps [`evaluate_transcript_rules`](../tolokaforge/core/grading/transcript.py)) | [`TranscriptRuleMatcher`](../tolokaforge/core/grading/transcript_rule_matcher.py) — scores the whole `TranscriptRulesConfig` against a `TrialTimeline` and returns one `TranscriptEvaluationResult`. Holistic seam (one matcher per config); the events-less-trial gate and per-key accounting stay in the composite. |
+| Trace check operator | `tolokaforge.trace_check_operators` | 15 non-binding names (`equals`, `equals_ci`, `contains`, `contains_ci`, `not_equals`, `regex`, `gt`, `gte`, `lt`, `lte`, `in_`, `not_in`, `len_gt`, `len_gte`, `exists`) + 2 binding names (`equals_binding`, `contains_binding`) | [`TraceCheckOperator`](../tolokaforge/core/grading/trace_check_operator.py) — one callable per operator name a `ValuePredicate` may declare, resolved per-call via the registry cache. **Per-operator granularity** (the only seam that is not holistic): a downstream `equals_semver` registration extends the operator vocabulary without a framework PR. Binding operators are identified by the `_binding` suffix on the registered name. |
 
 Register a downstream impl the same way as a `TrialGrader`:
 
@@ -307,7 +308,11 @@ grade time — `load_rubric_evaluator("llm_judge")(ctx)` — and the composite
 appears in composite. The transcript-rule matcher is threaded through the
 composite `grade_transcript_rules` dispatch; the events-less-trial gate
 (`scored_transcript_rules`) and the per-key accounting stay in the
-composite so every deployment topology applies them identically. A
+composite so every deployment topology applies them identically.
+Trace-check operators resolve per-call inside
+`tolokaforge.core.grading.trace_checks._operator_holds`, which reads
+`load_trace_check_operator(name)` — the entry-point discovery cache means
+a name only pays the loader cost on its first mention. A
 downstream `pip install` of a package that registers under any of these
 groups is picked up on the runner's next start with no framework change.
 

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -1710,6 +1710,14 @@ tool-call record alone, so on a bundle re-graded without one a matcher reading
 either is [undecided](#when-a-constraint-cannot-be-decided) rather than unmatched
 — a named failing sub-check, never a pass in the agent's favour.
 
+**Every operator name resolves through the `tolokaforge.trace_check_operators`
+entry-point group.** `_operator_holds` looks up the registered callable per
+mention (cached in the entry-point discovery table); binding operators are
+identified by the `_binding` suffix on the registered name, no marker
+attribute. Registering `equals_semver` in a downstream package's
+`pyproject.toml` under this group extends the operator vocabulary without a
+framework PR — see `docs/GRADER_SERVICE.md` § "Sub-component plug-in seams".
+
 ### The config surface
 
 ```yaml

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -1247,6 +1247,19 @@ operator is therefore a runner-side pass that asserts nothing, and a core-side
 verdict that can disagree with it
 ([#466](https://github.com/toloka/tolokaforge/issues/466)).
 
+**The two source-scoring bodies resolve through the `tolokaforge.state_check_backends`
+entry-point group.** `jsonpath` scores `jsonpath_checks` against the substrate's
+STABLE DB view + agent-visible filesystem; `db_probes` opens each probe's declared
+postgres connection and applies its `expect` block. The composite
+`grade_state_checks_reads` dispatches through resolved `StateCheckBackend` instances
+the runner supplies at startup; a downstream package registering an alternative
+source (e.g. an `s3_diff` backend) alongside these two extends the state-check
+vocabulary without a framework PR — see `docs/GRADER_SERVICE.md` § "Sub-component
+plug-in seams". Hash grading is NOT part of the seam: its snapshot-and-replay
+semantics need write access to the trial's DB, so hash grading stays runner-
+integrated on `RunnerServiceImpl._execute_hash_grading` above the composite
+dispatch.
+
 ### Folding the hash verdict with `jsonpaths`
 
 `state_checks` has two possible sources — the state hash and the JSONPath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,10 +202,10 @@ agent_only = "tolokaforge.core.actors.turn_policy:_agent_only_policy_factory"
 conversational = "tolokaforge.core.actors.turn_policy:_conversational_policy_factory"
 
 # ADR-0039 § "The single design abstraction" — GradingSubstrate implementations
-# resolvable by name. `in_process` and `live_callback` ship this milestone;
-# `trajectory_storage` / `snapshot` / `shared_mount` are reserved future
-# substrates and register themselves when they ship (no framework change
-# needed at that time).
+# resolvable by name. Two implementations ship today (``in_process`` +
+# ``live_callback``); ``trajectory_storage`` / ``snapshot`` / ``shared_mount``
+# are reserved future substrates and register themselves when they ship (no
+# framework change needed then).
 [project.entry-points."tolokaforge.grading_substrates"]
 in_process = "tolokaforge.core.grading.substrate:InProcessGradingSubstrate"
 live_callback = "tolokaforge.core.grading.substrate_live:LiveRunnerCallbackGradingSubstrate"
@@ -259,7 +259,7 @@ db_probes = "tolokaforge.core.grading.default_state_check_backends:_db_probes_st
 # entry-point. A downstream package registering ``equals_semver`` alongside
 # these 17 defaults extends the trace-check vocabulary without a framework
 # PR. The two binding operators are identified by the ``_binding`` suffix
-# on the registered name (Approved Decision #2 on ADR-0039); no marker
+# on the registered name (see ADR-0039); no marker
 # attribute, no parallel registry.
 [project.entry-points."tolokaforge.trace_check_operators"]
 equals = "tolokaforge.core.grading.trace_check_operator:equals"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,20 @@ conversational = "tolokaforge.core.actors.turn_policy:_conversational_policy_fac
 in_process = "tolokaforge.core.grading.substrate:InProcessGradingSubstrate"
 live_callback = "tolokaforge.core.grading.substrate_live:LiveRunnerCallbackGradingSubstrate"
 
+# Custom-check executor Protocol (``tolokaforge/core/grading/check_runner.py``).
+# ``check_runner`` is the production default (in-process ThreadPoolExecutor);
+# ``in_memory`` is the deterministic fixture the canonical tests reach.
+[project.entry-points."tolokaforge.custom_check_executors"]
+check_runner = "tolokaforge.core.grading.check_runner:_check_runner_factory"
+in_memory = "tolokaforge.core.grading.check_runner:_in_memory_check_executor_factory"
+
+# Judge model provider Protocol
+# (``tolokaforge/core/grading/judge_model_provider.py``). ``litellm`` matches
+# the underlying transport; a downstream ``openai_direct`` or ``vertex_ai``
+# provider registers alongside without a framework PR.
+[project.entry-points."tolokaforge.judge_model_providers"]
+litellm = "tolokaforge.core.grading.default_judge_model_provider:_litellm_judge_model_provider_factory"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,14 @@ in_memory = "tolokaforge.core.grading.check_runner:_in_memory_check_executor_fac
 [project.entry-points."tolokaforge.judge_model_providers"]
 litellm = "tolokaforge.core.grading.default_judge_model_provider:_litellm_judge_model_provider_factory"
 
+# Rubric evaluator Protocol
+# (``tolokaforge/core/grading/rubric_evaluator.py``). ``llm_judge`` is the
+# reference impl wrapping :class:`LLMJudge`; a downstream package registers
+# an alternative evaluator (e.g. a deterministic ruleset over the transcript)
+# alongside without a framework PR.
+[project.entry-points."tolokaforge.rubric_evaluators"]
+llm_judge = "tolokaforge.core.grading.default_rubric_evaluator:_llm_judge_rubric_evaluator_factory"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,14 @@ litellm = "tolokaforge.core.grading.default_judge_model_provider:_litellm_judge_
 [project.entry-points."tolokaforge.rubric_evaluators"]
 llm_judge = "tolokaforge.core.grading.default_rubric_evaluator:_llm_judge_rubric_evaluator_factory"
 
+# Transcript-rule matcher Protocol
+# (``tolokaforge/core/grading/transcript_rule_matcher.py``). ``default`` is
+# the reference impl wrapping :func:`evaluate_transcript_rules`; a downstream
+# package registers an alternative matcher (e.g. a stricter policy over the
+# same rule vocabulary) alongside without a framework PR.
+[project.entry-points."tolokaforge.transcript_rule_matchers"]
+default = "tolokaforge.core.grading.default_transcript_rule_matcher:_default_transcript_rule_matcher_factory"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,19 @@ llm_judge = "tolokaforge.core.grading.default_rubric_evaluator:_llm_judge_rubric
 [project.entry-points."tolokaforge.transcript_rule_matchers"]
 default = "tolokaforge.core.grading.default_transcript_rule_matcher:_default_transcript_rule_matcher_factory"
 
+# State-check backend Protocol
+# (``tolokaforge/core/grading/state_check_backend.py``). ``jsonpath`` scores
+# jsonpath assertions against the substrate's STABLE DB view + filesystem;
+# ``db_probes`` opens task-declared postgres connections and applies each
+# probe's ``expect`` block. Hash grading is deliberately NOT registered
+# here — its snapshot-and-replay semantics need write access to the trial's
+# DB, so hash grading stays runner-integrated on
+# ``RunnerServiceImpl._execute_hash_grading`` (see the seam module docstring
+# and ``docs/GRADER_SERVICE.md`` § "Sub-component plug-in seams").
+[project.entry-points."tolokaforge.state_check_backends"]
+jsonpath = "tolokaforge.core.grading.default_state_check_backends:_jsonpath_state_check_backend_factory"
+db_probes = "tolokaforge.core.grading.default_state_check_backends:_db_probes_state_check_backend_factory"
+
 # Trace-check operator seam
 # (``tolokaforge/core/grading/trace_check_operator.py``). Per-operator
 # granularity: every operator a ``ValuePredicate`` may declare is one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -369,6 +369,7 @@ only-include = [
     "tolokaforge/core/loop.py",
     "tolokaforge/core/model_data.py",
     "tolokaforge/core/netpolicy_constants.py",
+    "tolokaforge/core/plugin_registry.py",
     "tolokaforge/core/pricing.py",
     "tolokaforge/core/redaction.py",
     "tolokaforge/core/run_display_events.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,33 @@ llm_judge = "tolokaforge.core.grading.default_rubric_evaluator:_llm_judge_rubric
 [project.entry-points."tolokaforge.transcript_rule_matchers"]
 default = "tolokaforge.core.grading.default_transcript_rule_matcher:_default_transcript_rule_matcher_factory"
 
+# Trace-check operator seam
+# (``tolokaforge/core/grading/trace_check_operator.py``). Per-operator
+# granularity: every operator a ``ValuePredicate`` may declare is one
+# entry-point. A downstream package registering ``equals_semver`` alongside
+# these 17 defaults extends the trace-check vocabulary without a framework
+# PR. The two binding operators are identified by the ``_binding`` suffix
+# on the registered name (Approved Decision #2 on ADR-0039); no marker
+# attribute, no parallel registry.
+[project.entry-points."tolokaforge.trace_check_operators"]
+equals = "tolokaforge.core.grading.trace_check_operator:equals"
+equals_ci = "tolokaforge.core.grading.trace_check_operator:equals_ci"
+contains = "tolokaforge.core.grading.trace_check_operator:contains_op"
+contains_ci = "tolokaforge.core.grading.trace_check_operator:contains_ci"
+not_equals = "tolokaforge.core.grading.trace_check_operator:not_equals"
+regex = "tolokaforge.core.grading.trace_check_operator:regex_matches"
+gt = "tolokaforge.core.grading.trace_check_operator:gt"
+gte = "tolokaforge.core.grading.trace_check_operator:gte"
+lt = "tolokaforge.core.grading.trace_check_operator:lt"
+lte = "tolokaforge.core.grading.trace_check_operator:lte"
+in_ = "tolokaforge.core.grading.trace_check_operator:in_op"
+not_in = "tolokaforge.core.grading.trace_check_operator:not_in_op"
+len_gt = "tolokaforge.core.grading.trace_check_operator:len_gt"
+len_gte = "tolokaforge.core.grading.trace_check_operator:len_gte"
+exists = "tolokaforge.core.grading.trace_check_operator:exists"
+equals_binding = "tolokaforge.core.grading.trace_check_operator:equals_binding"
+contains_binding = "tolokaforge.core.grading.trace_check_operator:contains_binding"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",

--- a/tests/canonical/test_composite_no_direct_reference_impl_import.py
+++ b/tests/canonical/test_composite_no_direct_reference_impl_import.py
@@ -7,10 +7,15 @@ one implementation into the dispatch surface.
 
 Reads the composite module's source and asserts, via ``ast``, that none of
 the shipping reference-impl names appear on any ``import`` statement's
-imported symbol list. Later stages extend this list as each seam lands
-(``evaluate_transcript_rules``, per-operator trace impls,
-``JsonpathStateCheckBackend``, …). Stage 2 lands the first assertion —
-``LLMJudge`` is not imported from :mod:`tolokaforge.core.grading.judge`.
+imported symbol list. Every seam that lands adds one assertion: the
+rubric-evaluator seam forbids importing
+:class:`~tolokaforge.core.grading.judge.LLMJudge`, and the
+transcript-rule-matcher seam forbids importing
+:func:`~tolokaforge.core.grading.transcript.evaluate_transcript_rules`.
+Later stages extend this list as each seam lands (per-operator trace
+impls, ``JsonpathStateCheckBackend``, …). Utility symbols the composite
+legitimately reuses — ``scored_transcript_rules`` (events-less-trial
+gate), ``transcript_rules_author_keys`` (accounting) — are NOT forbidden.
 
 Complements the ``.importlinter`` contract Stage 5 adds — the linter
 enforces module-level forbid rules across the codebase; this test locks
@@ -61,4 +66,27 @@ def test_composite_does_not_import_llm_judge() -> None:
     assert ("tolokaforge.core.grading.judge", "LLMJudge") not in imports, (
         "composite.py must not import LLMJudge — the RubricEvaluator seam owns "
         "the reach through the reference impl."
+    )
+
+
+def test_composite_does_not_import_evaluate_transcript_rules() -> None:
+    """The transcript-rule-matcher seam owns the ``evaluate_transcript_rules``
+    reach — the composite must not import it directly. The gate + accounting
+    utilities from the same module (``scored_transcript_rules`` and
+    ``transcript_rules_author_keys``) remain permitted.
+    """
+    imports = _imported_names(_COMPOSITE_PATH.read_text())
+    assert (
+        "tolokaforge.core.grading.transcript",
+        "evaluate_transcript_rules",
+    ) not in imports, (
+        "composite.py must not import evaluate_transcript_rules — the "
+        "TranscriptRuleMatcher seam owns the reach through the reference impl."
+    )
+    assert (
+        "tolokaforge.core.grading.transcript",
+        "scored_transcript_rules",
+    ) in imports, (
+        "composite.py must keep scored_transcript_rules — it is the "
+        "events-less-trial gate that runs above the matcher."
     )

--- a/tests/canonical/test_composite_no_direct_reference_impl_import.py
+++ b/tests/canonical/test_composite_no_direct_reference_impl_import.py
@@ -7,20 +7,23 @@ one implementation into the dispatch surface.
 
 Reads the composite module's source and asserts, via ``ast``, that none of
 the shipping reference-impl names appear on any ``import`` statement's
-imported symbol list. Every seam that lands adds one assertion: the
-rubric-evaluator seam forbids importing
-:class:`~tolokaforge.core.grading.judge.LLMJudge`, and the
-transcript-rule-matcher seam forbids importing
-:func:`~tolokaforge.core.grading.transcript.evaluate_transcript_rules`.
-Later stages extend this list as each seam lands (per-operator trace
-impls, ``JsonpathStateCheckBackend``, …). Utility symbols the composite
-legitimately reuses — ``scored_transcript_rules`` (events-less-trial
-gate), ``transcript_rules_author_keys`` (accounting) — are NOT forbidden.
+imported symbol list. Six sub-component seams cover the six reference-impl
+holdings the composite is fenced from: :class:`LLMJudge`, :class:`LLMClient`,
+:class:`LLMJudgeRubricEvaluator`, :class:`LiteLLMJudgeModelProvider`,
+:class:`DefaultTranscriptRuleMatcher`, and the two state-check backends
+:class:`JsonpathStateCheckBackend` + :class:`DbProbesStateCheckBackend`.
+The underlying utility functions those reference impls wrap
+(:func:`evaluate_transcript_rules`, :func:`evaluate_jsonpath_checks`,
+:func:`evaluate_db_probes`) are forbidden by name for the same reason;
+so is :func:`render_state_diff` — its construction lives runner-side per
+Phase 2 Stage 2. Utility symbols the composite legitimately reuses —
+:func:`scored_transcript_rules` (events-less-trial gate),
+:func:`transcript_rules_author_keys` (accounting) — are NOT forbidden.
 
-Complements the ``.importlinter`` contract Stage 5 adds — the linter
-enforces module-level forbid rules across the codebase; this test locks
-the composite specifically, at unit-tier cost, so a regression trips
-even when the linter is not yet run.
+Complements the ``.importlinter`` ``composite-sub-component-seams``
+contract — the linter enforces module-level forbid rules across the
+codebase; this test locks the composite specifically, at unit-tier cost,
+so a regression trips even when the linter is not yet run.
 """
 
 from __future__ import annotations
@@ -89,4 +92,38 @@ def test_composite_does_not_import_evaluate_transcript_rules() -> None:
     ) in imports, (
         "composite.py must keep scored_transcript_rules — it is the "
         "events-less-trial gate that runs above the matcher."
+    )
+
+
+def test_composite_does_not_import_any_reference_impl_symbol() -> None:
+    """Every seam's reference-impl symbol is fenced by name.
+
+    Six seams, six reference-impl holdings; three underlying utility
+    functions those impls wrap; and :func:`render_state_diff` — construction
+    of ``state_diff_text`` lives runner-side. A direct import of any of
+    these would silently re-collapse the seam it belongs to.
+    """
+    imports = _imported_names(_COMPOSITE_PATH.read_text())
+    imported_symbol_names = {name for _module, name in imports}
+    forbidden = {
+        # Reference impls the four `default_*.py` + two `judge.py`/`llm.client` modules hold
+        "LLMJudge",
+        "LLMClient",
+        "LLMJudgeRubricEvaluator",
+        "LiteLLMJudgeModelProvider",
+        "DefaultTranscriptRuleMatcher",
+        "JsonpathStateCheckBackend",
+        "DbProbesStateCheckBackend",
+        # Underlying utility functions each reference impl wraps
+        "evaluate_transcript_rules",
+        "evaluate_jsonpath_checks",
+        "evaluate_db_probes",
+        # State-diff construction moved runner-side in Phase 2 Stage 2
+        "render_state_diff",
+    }
+    leaked = forbidden & imported_symbol_names
+    assert not leaked, (
+        f"composite.py imports forbidden reference-impl symbols {sorted(leaked)!r}. "
+        "Every sub-component seam requires the reference impl reach only through "
+        "its resolved-instance kwarg, never through a direct import."
     )

--- a/tests/canonical/test_composite_no_direct_reference_impl_import.py
+++ b/tests/canonical/test_composite_no_direct_reference_impl_import.py
@@ -1,0 +1,64 @@
+"""Structural lock: ``composite.py`` does not import reference impls.
+
+The composite reaches every sub-component through its Protocol via a
+resolved instance passed as a kwarg. It must never name the reference
+impl at module load time — that would defeat the plug-in seam by pinning
+one implementation into the dispatch surface.
+
+Reads the composite module's source and asserts, via ``ast``, that none of
+the shipping reference-impl names appear on any ``import`` statement's
+imported symbol list. Later stages extend this list as each seam lands
+(``evaluate_transcript_rules``, per-operator trace impls,
+``JsonpathStateCheckBackend``, …). Stage 2 lands the first assertion —
+``LLMJudge`` is not imported from :mod:`tolokaforge.core.grading.judge`.
+
+Complements the ``.importlinter`` contract Stage 5 adds — the linter
+enforces module-level forbid rules across the codebase; this test locks
+the composite specifically, at unit-tier cost, so a regression trips
+even when the linter is not yet run.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+
+_COMPOSITE_PATH = (
+    Path(__file__).resolve().parents[2] / "tolokaforge" / "core" / "grading" / "composite.py"
+)
+
+
+def _imported_names(module_source: str) -> set[tuple[str, str]]:
+    """Return the set of ``(from_module, imported_name)`` pairs.
+
+    Covers both ``from X import Y`` (yielding ``(X, Y)``) and
+    ``import X`` / ``import X as Z`` (yielding ``(X, X)`` — the imported
+    module is its own name at the callsite). Ignores relative imports
+    (they cannot reach a reference-impl module by rule).
+    """
+    tree = ast.parse(module_source)
+    pairs: set[tuple[str, str]] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            for alias in node.names:
+                pairs.add((node.module, alias.name))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                pairs.add((alias.name, alias.name))
+    return pairs
+
+
+def test_composite_does_not_import_llm_judge() -> None:
+    """The rubric-evaluator seam owns the ``LLMJudge`` reach — the composite
+    must not import it directly.
+    """
+    imports = _imported_names(_COMPOSITE_PATH.read_text())
+    assert ("tolokaforge.core.grading.judge", "LLMJudge") not in imports, (
+        "composite.py must not import LLMJudge — the RubricEvaluator seam owns "
+        "the reach through the reference impl."
+    )

--- a/tests/canonical/test_composite_no_direct_reference_impl_import.py
+++ b/tests/canonical/test_composite_no_direct_reference_impl_import.py
@@ -15,8 +15,8 @@ holdings the composite is fenced from: :class:`LLMJudge`, :class:`LLMClient`,
 The underlying utility functions those reference impls wrap
 (:func:`evaluate_transcript_rules`, :func:`evaluate_jsonpath_checks`,
 :func:`evaluate_db_probes`) are forbidden by name for the same reason;
-so is :func:`render_state_diff` — its construction lives runner-side per
-Phase 2 Stage 2. Utility symbols the composite legitimately reuses —
+so is :func:`render_state_diff` — its construction lives runner-side.
+Utility symbols the composite legitimately reuses —
 :func:`scored_transcript_rules` (events-less-trial gate),
 :func:`transcript_rules_author_keys` (accounting) — are NOT forbidden.
 
@@ -118,7 +118,7 @@ def test_composite_does_not_import_any_reference_impl_symbol() -> None:
         "evaluate_transcript_rules",
         "evaluate_jsonpath_checks",
         "evaluate_db_probes",
-        # State-diff construction moved runner-side in Phase 2 Stage 2
+        # State-diff construction lives runner-side.
         "render_state_diff",
     }
     leaked = forbidden & imported_symbol_names

--- a/tests/canonical/test_grading_composite_llm_judge.py
+++ b/tests/canonical/test_grading_composite_llm_judge.py
@@ -1,9 +1,11 @@
 """``composite.grade_llm_judge`` — end-to-end judge dispatch parity lock.
 
-The composite owns the judge dispatch (rubric plumbing, tool-surface gating,
-diff-first default, ``LLMJudge`` construction and drive); the runner path
-delegates to it via ``run_in_executor``. This suite constructs an
-:class:`InProcessGradingSubstrate` over a hand-built ``{initial_tables,
+The composite delegates to a resolved :class:`RubricEvaluator` seam; the
+reference impl (``llm_judge``, :class:`LLMJudgeRubricEvaluator`) constructs
+an :class:`LLMJudge` per :meth:`.evaluate` and drives it. The runner path
+resolves the evaluator + renders the ``initial → final`` state diff and
+hands both to the composite via ``run_in_executor``. This suite constructs
+an :class:`InProcessGradingSubstrate` over a hand-built ``{initial_tables,
 final_tables, filesystem_root, kb_search, db_reader}`` fixture, drives
 :func:`composite.grade_llm_judge` with a scripted ``LLMClient`` (so the loop
 is deterministic), and asserts that the ``JudgeResult`` carries the same
@@ -11,10 +13,11 @@ status, score, and per-criterion verdicts the judge would report against
 the same evidence.
 
 The scripted client is injected by monkeypatching ``LLMClient`` where
-``LLMJudge`` imports it — ``LLMJudge`` builds its own client per :meth:`run`
-via ``LLMClient(model_config)``, and we override that constructor to return
+:class:`LLMJudge` imports it — ``LLMJudge`` builds its own client per
+:meth:`run` via ``LLMClient(model_config)`` when its
+``llm_client`` kwarg is ``None``, and we override that constructor to return
 a queued script instead. The judge orchestration under test is the composite's
-call site, not the LLM.
+call site + Protocol dispatch, not the LLM.
 """
 
 from __future__ import annotations
@@ -25,7 +28,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.grading import composite
-from tolokaforge.core.grading.judge import JudgeStatus
+from tolokaforge.core.grading.default_rubric_evaluator import LLMJudgeRubricEvaluator
+from tolokaforge.core.grading.judge_result import JudgeStatus
+from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
+from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
@@ -81,14 +87,66 @@ class _ScriptedClient:
         return classify_loop_error(exc, ())
 
 
-def _install_scripted_client(monkeypatch: pytest.MonkeyPatch, script: list[Any]) -> _ScriptedClient:
-    """Route ``LLMJudge``'s ``LLMClient(model_config)`` to a scripted stand-in."""
-    client = _ScriptedClient(script)
-    monkeypatch.setattr(
-        "tolokaforge.core.grading.judge.LLMClient",
-        lambda *args, **kwargs: client,
+class _ScriptedJudgeModelProvider:
+    """Test :class:`JudgeModelProvider` — returns a preloaded scripted client
+    as the ``JudgeModel``. Bypasses the shipped ``litellm`` transport so the
+    canonical suite drives the judge loop deterministically."""
+
+    def __init__(self, client: _ScriptedClient) -> None:
+        self._client = client
+
+    def build(self, model_config: ModelConfig):
+        return self._client
+
+
+def _rubric_evaluator(
+    script: list[Any], config: LLMJudgeConfig | None = None
+) -> tuple[RubricEvaluator, _ScriptedClient]:
+    """Build the reference :class:`LLMJudgeRubricEvaluator` with the effective
+    customization flags a run-config would apply — matches the runner's
+    ``_grade_llm_judge`` construction one-for-one.
+
+    The evaluator's :class:`JudgeModelProvider` returns the scripted client
+    directly so the judge loop is deterministic — the shipped ``litellm``
+    transport never runs in the canonical path.
+    """
+    customization = config.customization if config is not None else None
+    disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
+    custom_system_prompt = customization.system_prompt if customization else None
+    include_agent_system_prompt = (
+        customization.include_agent_system_prompt
+        if customization and customization.include_agent_system_prompt is not None
+        else True
     )
-    return client
+    client = _ScriptedClient(script)
+    evaluator = LLMJudgeRubricEvaluator(
+        _ScriptedJudgeModelProvider(client),
+        disable_knowledge_search=disable_knowledge_search,
+        custom_system_prompt=custom_system_prompt,
+        include_agent_system_prompt=include_agent_system_prompt,
+    )
+    return evaluator, client
+
+
+def _render_diff(
+    substrate: InProcessGradingSubstrate,
+    schemas: list[TableSchema],
+) -> str | None:
+    """Reproduce the runner-side state-diff render for a canonical test.
+
+    Mirrors :meth:`RunnerServiceImpl._grade_llm_judge` — an empty
+    ``initial_state`` declines outright, otherwise the schemas' primary keys
+    layer under any per-trial ``id_fields`` (empty in these fixtures)."""
+    initial_tables = substrate.initial_state()
+    if not initial_tables:
+        return None
+    primary_keys: dict[str, str | list[str]] = {s.table_name: s.primary_key for s in schemas}
+    return render_state_diff(
+        initial_tables,
+        substrate.final_state(),
+        primary_keys=primary_keys,
+        unstable_fields=set(),
+    )
 
 
 def _rubric() -> Rubric:
@@ -129,9 +187,10 @@ def _substrate(
     initial_tables: dict[str, Any] | None = None,
     final_tables: dict[str, Any] | None = None,
 ) -> InProcessGradingSubstrate:
-    """Substrate exposing the reads ``grade_llm_judge`` touches: DB reader
-    seam (the judge's read-only tools bridge to it), initial + final tables
-    (for the state-diff), no KB and no filesystem in this fixture."""
+    """Substrate exposing the reads the judge touches: DB reader seam (the
+    judge's read-only tools bridge to it), initial + final tables (rendered
+    into ``state_diff`` runner-side), no KB and no filesystem in this
+    fixture."""
     return InProcessGradingSubstrate(
         db_reader=MagicMock(),
         knowledge_search=None,
@@ -150,19 +209,19 @@ class TestGradeLlmJudgeVerdicts:
     score, and per-criterion verdicts the judge would report against the
     same evidence."""
 
-    def test_completed_run_returns_scored_criterion_results(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        _install_scripted_client(
-            monkeypatch,
-            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
-        )
+    def test_completed_run_returns_scored_criterion_results(self) -> None:
         config = LLMJudgeConfig(rubric=_rubric())
+        substrate = _substrate()
+        evaluator, _ = _rubric_evaluator(
+            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
+            config,
+        )
 
         result = composite.grade_llm_judge(
             trial_id="task:0",
             config=config,
-            substrate=_substrate(),
+            substrate=substrate,
+            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "you are a refund agent"},
                 {"role": "user", "content": "please refund me"},
@@ -170,9 +229,7 @@ class TestGradeLlmJudgeVerdicts:
             ],
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
-            id_fields={},
-            unstable_fields=set(),
-            initial_state_schemas=[],
+            state_diff=_render_diff(substrate, []),
             logger=_logger(),
         )
 
@@ -184,36 +241,35 @@ class TestGradeLlmJudgeVerdicts:
         assert by_id["refund_done"].met is True
         assert by_id["tone"].score == pytest.approx(1.0)
 
-    def test_state_diff_is_built_from_substrate_reads(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        _install_scripted_client(
-            monkeypatch,
-            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
-        )
+    def test_state_diff_is_built_from_substrate_reads(self) -> None:
         config = LLMJudgeConfig(rubric=_rubric())
         initial = {"orders": [{"id": 1, "status": "open"}]}
         final = {"orders": [{"id": 1, "status": "refunded"}]}
+        substrate = _substrate(initial_tables=initial, final_tables=final)
+        schemas = [
+            TableSchema(
+                table_name="orders",
+                fields={"id": "integer", "status": "string"},
+                primary_key="id",
+            )
+        ]
+        evaluator, _ = _rubric_evaluator(
+            [[("submit_report", _submit_args(refund_done=True, tone=1.0))]],
+            config,
+        )
 
         result = composite.grade_llm_judge(
             trial_id="task:0",
             config=config,
-            substrate=_substrate(initial_tables=initial, final_tables=final),
+            substrate=substrate,
+            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "please refund me"},
             ],
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
-            id_fields={},
-            unstable_fields=set(),
-            initial_state_schemas=[
-                TableSchema(
-                    table_name="orders",
-                    fields={"id": "integer", "status": "string"},
-                    primary_key="id",
-                )
-            ],
+            state_diff=_render_diff(substrate, schemas),
             logger=_logger(),
         )
         assert result.status is JudgeStatus.COMPLETED
@@ -221,26 +277,26 @@ class TestGradeLlmJudgeVerdicts:
         assert "orders: 1 modified" in result.state_diff
         assert 'status: "open" → "refunded"' in result.state_diff
 
-    def test_no_initial_state_yields_no_state_diff(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _install_scripted_client(
-            monkeypatch,
-            [[("submit_report", _submit_args(refund_done=False, tone=0.4))]],
-        )
+    def test_no_initial_state_yields_no_state_diff(self) -> None:
         config = LLMJudgeConfig(rubric=_rubric())
+        substrate = _substrate()
+        evaluator, _ = _rubric_evaluator(
+            [[("submit_report", _submit_args(refund_done=False, tone=0.4))]],
+            config,
+        )
 
         result = composite.grade_llm_judge(
             trial_id="task:0",
             config=config,
-            substrate=_substrate(),
+            substrate=substrate,
+            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "hi"},
             ],
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
-            id_fields={},
-            unstable_fields=set(),
-            initial_state_schemas=[],
+            state_diff=_render_diff(substrate, []),
             logger=_logger(),
         )
         assert result.status is JudgeStatus.COMPLETED
@@ -249,31 +305,26 @@ class TestGradeLlmJudgeVerdicts:
         assert by_id["refund_done"].met is False
         assert by_id["tone"].score == pytest.approx(0.4)
 
-    def test_judge_malfunction_returns_errored_with_no_score(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_judge_malfunction_returns_errored_with_no_score(self) -> None:
         """A judge that never calls ``submit_report`` exhausts its budget and
         returns ERRORED with no numeric score — the fail-loud contract the
         composite preserves from the runner."""
-        _install_scripted_client(
-            monkeypatch,
-            ["turn one, no tool call"] * 20,
-        )
         config = LLMJudgeConfig(rubric=_rubric())
+        substrate = _substrate()
+        evaluator, _ = _rubric_evaluator(["turn one, no tool call"] * 20, config)
 
         result = composite.grade_llm_judge(
             trial_id="task:0",
             config=config,
-            substrate=_substrate(),
+            substrate=substrate,
+            rubric_evaluator=evaluator,
             llm_messages=[
                 {"role": "system", "content": "policy"},
                 {"role": "user", "content": "hi"},
             ],
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
-            id_fields={},
-            unstable_fields=set(),
-            initial_state_schemas=[],
+            state_diff=_render_diff(substrate, []),
             logger=_logger(),
         )
         assert result.status is JudgeStatus.ERRORED

--- a/tests/canonical/test_grading_composite_state_checks.py
+++ b/tests/canonical/test_grading_composite_state_checks.py
@@ -1,12 +1,14 @@
 """``composite.grade_state_checks_reads`` — end-to-end shape parity lock.
 
-The composite owns jsonpath + probes scoring. This suite constructs an
-:class:`InProcessGradingSubstrate` over a hand-built ``{tables: [rows],
-filesystem: {rel: text}}`` fixture, drives the composite, and asserts the
+The composite dispatches jsonpath + probes scoring through the resolved
+``state_check_backends`` mapping the runner supplies. This suite constructs
+an :class:`InProcessGradingSubstrate` over a hand-built ``{tables: [rows],
+filesystem: {rel: text}}`` fixture, drives the composite through the
+shipping ``jsonpath`` + ``db_probes`` backends, and asserts the
 ``(jsonpath_score, jsonpath_reasons)`` pair matches what
 :func:`evaluate_jsonpath_checks` produces over the same reshaped state
-(``{db, tables, filesystem}``). A drift in the composite's reshaping /
-gating / STABLE routing surfaces here.
+(``{db, tables, filesystem}``). A drift in the ``jsonpath`` backend's
+reshaping / gating / STABLE routing surfaces here.
 
 The three semantic contracts under test:
 - STABLE routing: ``substrate.final_state_stable()`` feeds ``$.db.*`` /
@@ -29,6 +31,7 @@ import pytest
 from tolokaforge.core.grading.composite import grade_state_checks_reads
 from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
 from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.plugin_registry import load_state_check_backend
 from tolokaforge.runner.grading import evaluate_jsonpath_checks
 from tolokaforge.runner.grading_ledger import DB_PROBES_KEY, JSONPATHS_KEY
 from tolokaforge.runner.models import RunnerStateChecksConfig
@@ -69,6 +72,14 @@ def _logger() -> StructuredLogger:
     return StructuredLogger(name="test-composite-state-checks")
 
 
+def _shipped_backends() -> dict[str, Any]:
+    """Resolved backends the runner supplies to every composite call."""
+    return {
+        "jsonpath": load_state_check_backend("jsonpath")(),
+        "db_probes": load_state_check_backend("db_probes")(),
+    }
+
+
 def _runner_shipped_shape(
     stable: dict[str, Any] | None, filesystem: dict[str, str] | None
 ) -> dict[str, Any]:
@@ -80,8 +91,10 @@ def _runner_shipped_shape(
 
 
 class TestJsonpathCompositeParity:
-    """The composite is a reshape + call over ``evaluate_jsonpath_checks``;
-    every jsonpath scoring is byte-equal to the runner's direct call."""
+    """The composite dispatches through the ``jsonpath`` state-check backend;
+    every jsonpath scoring is byte-equal to a direct call over the same
+    reshaped state — the backend owns the reshape, the composite owns the
+    dispatch."""
 
     def test_db_addressing_pack_matches_the_runner_path(self) -> None:
         checks = [
@@ -94,6 +107,7 @@ class TestJsonpathCompositeParity:
             trial_id="task:0",
             config=config,
             substrate=_substrate(stable_tables=_STABLE_TABLES),
+            state_check_backends=_shipped_backends(),
             logger=_logger(),
         )
         expected_score, expected_reasons = evaluate_jsonpath_checks(
@@ -123,6 +137,7 @@ class TestJsonpathCompositeParity:
             trial_id="task:0",
             config=config,
             substrate=_substrate(filesystem=_FILESYSTEM),
+            state_check_backends=_shipped_backends(),
             logger=_logger(),
         )
         expected_score, expected_reasons = evaluate_jsonpath_checks(
@@ -146,6 +161,7 @@ class TestJsonpathCompositeParity:
             trial_id="task:0",
             config=config,
             substrate=_substrate(stable_tables=_STABLE_TABLES, filesystem=_FILESYSTEM),
+            state_check_backends=_shipped_backends(),
             logger=_logger(),
         )
         expected_score, expected_reasons = evaluate_jsonpath_checks(
@@ -175,6 +191,7 @@ class TestJsonpathCompositeParity:
             trial_id="task:0",
             config=config,
             substrate=_substrate(),
+            state_check_backends=_shipped_backends(),
             logger=_logger(),
         )
         expected_score, expected_reasons = evaluate_jsonpath_checks(checks, state=None)
@@ -193,6 +210,7 @@ class TestEmptyPacksLeaveTheComponentsUntouched:
             trial_id="task:0",
             config=config,
             substrate=_substrate(),
+            state_check_backends=_shipped_backends(),
             logger=_logger(),
         )
         assert result.jsonpath_score is None

--- a/tests/canonical/test_grading_rubric_evaluator_dispatch.py
+++ b/tests/canonical/test_grading_rubric_evaluator_dispatch.py
@@ -1,0 +1,174 @@
+"""``load_rubric_evaluator`` discovery + composite dispatch through the seam.
+
+Locks two seams the :class:`RubricEvaluator` design commits to:
+
+1. :func:`~tolokaforge.core.plugin_registry.load_rubric_evaluator` resolves
+   an evaluator registered via ``importlib.metadata`` entry-points. The
+   dispatch case injects a synthetic entry-point pointing at
+   :class:`DeterministicRubricEvaluator` under the group
+   ``tolokaforge.rubric_evaluators`` and asserts the loader returns the
+   deterministic factory. No wheel pollution: the demo stays discoverable
+   only under the monkeypatched mapping.
+
+2. **Composite dispatch through the Protocol.**
+   :func:`composite.grade_llm_judge` drives the resolved evaluator and
+   its ``JudgeResult.score`` matches the deterministic hash the demo
+   emits — proving the composite reaches the plug-in evaluator without
+   ever touching :class:`LLMJudge`.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils.rubric_evaluator_demo import (
+    DeterministicRubricEvaluator,
+    _hash_to_score,
+    _rubric_signature,
+    _test_rubric_evaluator_factory,
+)
+from tolokaforge.core.grading import composite
+from tolokaforge.core.grading.judge_result import JudgeStatus
+from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models import ModelConfig
+from tolokaforge.core.plugin_registry import (
+    RUBRIC_EVALUATORS_GROUP,
+    _clear_discovery_cache,
+    load_rubric_evaluator,
+)
+from tolokaforge.runner.models import (
+    Criterion,
+    LLMJudgeConfig,
+    Rubric,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+_JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
+
+
+class _EntryPointStub:
+    """Duck-typed ``importlib.metadata.EntryPoint`` for the discovery scan.
+
+    Enumerates ``name`` / ``dist`` and returns ``value`` on ``load()`` — the
+    surface :func:`discover_entry_points` reads.
+    """
+
+    def __init__(self, name: str, value: Any, dist_name: str = "tests-fixture") -> None:
+        self.name = name
+        self.value = value
+
+        class _Dist:
+            def __init__(self, dn: str) -> None:
+                self.name = dn
+
+        self.dist = _Dist(dist_name)
+
+    def load(self) -> Any:
+        return self.value
+
+
+def _inject_demo_evaluator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register the demo evaluator alongside the shipped ``llm_judge``.
+
+    Shape-identical to :func:`test_load_grading_substrate_resolves_a_monkeypatched_entry_point`
+    in the substrate suite — the fail-loud registry discovery contract."""
+    _clear_discovery_cache()
+    shipped = list(importlib.metadata.entry_points(group=RUBRIC_EVALUATORS_GROUP))
+    injected = _EntryPointStub("test_rubric_evaluator", _test_rubric_evaluator_factory)
+
+    def fake_entry_points(*, group: str) -> list[Any]:
+        if group == RUBRIC_EVALUATORS_GROUP:
+            return [*shipped, injected]
+        return list(importlib.metadata.entry_points(group=group))
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    _clear_discovery_cache()
+
+
+def _rubric() -> Rubric:
+    return Rubric(
+        criteria=[
+            Criterion(
+                id="refund_done",
+                description="Refund issued to the customer",
+                kind="binary",
+                weight=2.0,
+            ),
+            Criterion(
+                id="tone",
+                description="Polite tone throughout the exchange",
+                kind="graded",
+                weight=1.0,
+            ),
+        ]
+    )
+
+
+def _substrate() -> InProcessGradingSubstrate:
+    return InProcessGradingSubstrate(
+        db_reader=MagicMock(),
+        knowledge_search=None,
+        filesystem_root=None,
+        initial_state={},
+        final_state={},
+    )
+
+
+def _logger() -> StructuredLogger:
+    return StructuredLogger(name="test-rubric-evaluator-dispatch")
+
+
+def test_loader_resolves_the_monkeypatched_demo_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inject_demo_evaluator(monkeypatch)
+    try:
+        factory = load_rubric_evaluator("test_rubric_evaluator")
+        assert factory is _test_rubric_evaluator_factory
+        instance = factory(MagicMock())
+        assert isinstance(instance, DeterministicRubricEvaluator)
+    finally:
+        _clear_discovery_cache()
+
+
+def test_composite_dispatches_through_the_resolved_demo_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composite's ``grade_llm_judge`` produces a :class:`JudgeResult`
+    whose score is the deterministic hash the demo emits — end-to-end
+    proof the seam threads the resolved evaluator through the dispatch.
+    """
+    _inject_demo_evaluator(monkeypatch)
+    try:
+        rubric = _rubric()
+        config = LLMJudgeConfig(rubric=rubric)
+        evaluator = load_rubric_evaluator("test_rubric_evaluator")(MagicMock())
+
+        result = composite.grade_llm_judge(
+            trial_id="task:0",
+            config=config,
+            substrate=_substrate(),
+            rubric_evaluator=evaluator,
+            llm_messages=[
+                {"role": "system", "content": "policy"},
+                {"role": "user", "content": "please refund me"},
+            ],
+            judge_model_config=_JUDGE_MODEL,
+            extra_read_tools=[],
+            state_diff=None,
+            logger=_logger(),
+        )
+
+        expected_score = _hash_to_score(_rubric_signature(rubric))
+        assert result.status is JudgeStatus.COMPLETED
+        assert result.score == pytest.approx(expected_score)
+        assert {cr.id for cr in result.criterion_results} == {"refund_done", "tone"}
+    finally:
+        _clear_discovery_cache()

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -49,8 +49,10 @@ import pytest
 from tests.utils.dummy_grading_substrate import DummyGradingSubstrate
 from tolokaforge.core.grading import composite
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
-from tolokaforge.core.grading.judge import JudgeStatus
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.key_manifest import EVALUATED
+from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
+from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate_live import LiveRunnerCallbackGradingSubstrate
 from tolokaforge.core.grading.trace_checks import TraceChecksResult
 from tolokaforge.core.grading.trace_timeline import build_trial_timeline
@@ -66,6 +68,7 @@ from tolokaforge.core.plugin_registry import (
     GRADING_SUBSTRATES_GROUP,
     _clear_discovery_cache,
     load_grading_substrate,
+    load_rubric_evaluator,
 )
 from tolokaforge.runner import (
     add_RunnerServiceServicer_to_server,
@@ -356,9 +359,12 @@ def _running_runner():
 
 
 def _install_scripted_client(monkeypatch: pytest.MonkeyPatch, script: list[Any]) -> None:
-    """Route ``LLMJudge``'s ``LLMClient(model_config)`` to a scripted stand-in."""
+    """Route :class:`LiteLLMJudgeModelProvider`'s ``LLMClient(model_config)``
+    to a scripted stand-in. Fires both when the runner path resolves the
+    shipping ``litellm`` provider (composite grade) and when composite
+    dispatch is driven directly against the same provider."""
     monkeypatch.setattr(
-        "tolokaforge.core.grading.judge.LLMClient",
+        "tolokaforge.core.grading.default_judge_model_provider.LLMClient",
         lambda *args, **kwargs: _ScriptedClient(script),
     )
 
@@ -434,16 +440,33 @@ def _reassemble_grade_from_composite(
         judge_reasons: str | None = None
         judge_gate_failed = False
         judge_report: pb2.JudgeReport | None = None
+        rubric_evaluator = load_rubric_evaluator("llm_judge")(
+            RubricEvaluatorContext(
+                judge_model_provider=runner._judge_model_provider,
+                logger=logger,  # type: ignore[arg-type]
+            )
+        )
+        initial_tables = substrate.initial_state()
+        state_diff_text: str | None = None
+        if initial_tables:
+            primary_keys: dict[str, str | list[str]] = {
+                s.table_name: s.primary_key for s in task_description.initial_state.schemas
+            }
+            state_diff_text = render_state_diff(
+                initial_tables,
+                substrate.final_state(),
+                primary_keys=primary_keys,
+                unstable_fields=set(),
+            )
         judge_result = composite.grade_llm_judge(
             trial_id=_TRIAL_ID,
             config=grading_config.llm_judge,
             substrate=substrate,
+            rubric_evaluator=rubric_evaluator,
             llm_messages=llm_messages,
             judge_model_config=_JUDGE_MODEL,
             extra_read_tools=[],
-            id_fields={},
-            unstable_fields=set(),
-            initial_state_schemas=list(task_description.initial_state.schemas),
+            state_diff=state_diff_text,
             logger=logger,  # type: ignore[arg-type]
         )
         accounted_keys[LLM_JUDGE_KEY] = EVALUATED

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -69,6 +69,7 @@ from tolokaforge.core.plugin_registry import (
     _clear_discovery_cache,
     load_grading_substrate,
     load_rubric_evaluator,
+    load_transcript_rule_matcher,
 )
 from tolokaforge.runner import (
     add_RunnerServiceServicer_to_server,
@@ -418,6 +419,7 @@ def _reassemble_grade_from_composite(
             trial_id=_TRIAL_ID,
             config=grading_config.transcript_rules,
             timeline=timeline,
+            matcher=load_transcript_rule_matcher("default")(),
             logger=logger,  # type: ignore[arg-type]
         )
         accounted_keys.update(transcript_accounting)

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -69,6 +69,7 @@ from tolokaforge.core.plugin_registry import (
     _clear_discovery_cache,
     load_grading_substrate,
     load_rubric_evaluator,
+    load_state_check_backend,
     load_transcript_rule_matcher,
 )
 from tolokaforge.runner import (
@@ -405,6 +406,10 @@ def _reassemble_grade_from_composite(
             trial_id=_TRIAL_ID,
             config=grading_config.state_checks,
             substrate=substrate,
+            state_check_backends={
+                "jsonpath": load_state_check_backend("jsonpath")(),
+                "db_probes": load_state_check_backend("db_probes")(),
+            },
             logger=logger,  # type: ignore[arg-type]
         )
         if state_reads.jsonpath_score is not None:

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -151,7 +151,7 @@ from tolokaforge.core.grading.combine_weights import MissingComponentWeight
 from tolokaforge.core.grading.composite import _build_runner_check_transcript
 from tolokaforge.core.grading.golden_replay import GoldenReplayRecord, resolve_initial_state
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
-from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
 from tolokaforge.core.grading.key_manifest import (
     GRADING_KEYS,
     Enforcement,
@@ -3543,10 +3543,13 @@ _PROBE_ROWS = [{"reason_code": "CAPA-01", "status": "open"}]
 
 
 class _StubJudge:
-    """Stands in for the model provider at the seam ``service.LLMJudge`` names.
+    """Stands in for the LLM call the reference :class:`LLMJudge` would make.
 
-    What it replaces is an external LLM call, not a recording site, an evaluator's
-    decision, the audit or the combine — all of those stay real on this path.
+    :class:`LLMJudgeRubricEvaluator` constructs one of these per
+    ``.evaluate()`` and drives its ``.run(...)``. Replacing the ``LLMJudge``
+    class in :mod:`default_rubric_evaluator` swaps out the external LLM
+    call, leaving the recording site, the evaluator's decision, the audit
+    and the combine real on this path.
     """
 
     def __init__(self, model_config: Any, **_kwargs: Any) -> None:
@@ -3657,9 +3660,9 @@ def _drive_llm_judge(
     before it ever constructs the judge without one, so the row would otherwise
     red on claim 2 for a reason with nothing to do with the recording site.
     """
-    from tolokaforge.core.grading import composite
+    from tolokaforge.core.grading import default_rubric_evaluator
 
-    monkeypatch.setattr(composite, "LLMJudge", _StubJudge)
+    monkeypatch.setattr(default_rubric_evaluator, "LLMJudge", _StubJudge)
     task_description = runner_models.TaskDescription.model_validate(_JUDGE_DRIVER_TASK)
     _register_pack(
         servicer,

--- a/tests/canonical/test_grading_substrate_parity.py
+++ b/tests/canonical/test_grading_substrate_parity.py
@@ -144,6 +144,9 @@ from tests.utils.runner_requests import execute_request, register_request, trial
 from tolokaforge.adapters.native import NativeAdapter
 from tolokaforge.core import models as core_models
 from tolokaforge.core.grading import composite as composite_module
+from tolokaforge.core.grading import (
+    default_transcript_rule_matcher as default_transcript_rule_matcher_module,
+)
 from tolokaforge.core.grading.checks_helpers import CUSTOM_CHECKS_REASON_PREFIX
 from tolokaforge.core.grading.combine import GradingEngine
 from tolokaforge.core.grading.combine_method import COMBINE_METHODS
@@ -3807,22 +3810,32 @@ def test_the_site_lock_rejects_a_site_that_filed_a_skip_where_it_evaluated(
 
 
 @pytest.mark.parametrize(
-    ("evaluator_name", "author_key"),
+    ("evaluator_module", "evaluator_name", "author_key"),
     [
-        ("evaluate_trace_checks", _INJECTION_TRACE),
-        ("evaluate_transcript_rules", _INJECTION_TRANSCRIPT),
+        (composite_module, "evaluate_trace_checks", _INJECTION_TRACE),
+        (
+            default_transcript_rule_matcher_module,
+            "evaluate_transcript_rules",
+            _INJECTION_TRANSCRIPT,
+        ),
     ],
 )
 def test_the_site_lock_rejects_an_evaluator_that_stopped_accounting(
-    evaluator_name, author_key, test_data_dir, runner_service, mock_grpc_context, monkeypatch
+    evaluator_module,
+    evaluator_name,
+    author_key,
+    test_data_dir,
+    runner_service,
+    mock_grpc_context,
+    monkeypatch,
 ):
     """Claim 2: the evaluator still scores, but records no key — the audit fails the RPC."""
-    real = getattr(composite_module, evaluator_name)
+    real = getattr(evaluator_module, evaluator_name)
 
     def drifted(*args: Any, **kwargs: Any) -> Any:
         return real(*args, **kwargs).model_copy(update={"accounted_keys": {}})
 
-    monkeypatch.setattr(composite_module, evaluator_name, drifted)
+    monkeypatch.setattr(evaluator_module, evaluator_name, drifted)
 
     grading_config, response = _drive_parity_pack(
         author_key,
@@ -3841,12 +3854,12 @@ def test_the_site_lock_rejects_an_evaluated_record_over_an_evaluation_that_did_n
     test_data_dir, runner_service, mock_grpc_context, monkeypatch
 ):
     """Claim 4: real accounting filed EVALUATED while the component stayed unscored."""
-    real = composite_module.evaluate_transcript_rules
+    real = default_transcript_rule_matcher_module.evaluate_transcript_rules
 
     def hollow(*args: Any, **kwargs: Any) -> Any:
         return real(*args, **kwargs).model_copy(update={"score": _UNSCORED_COMPONENT})
 
-    monkeypatch.setattr(composite_module, "evaluate_transcript_rules", hollow)
+    monkeypatch.setattr(default_transcript_rule_matcher_module, "evaluate_transcript_rules", hollow)
 
     grading_config, response = _drive_parity_pack(
         _INJECTION_TRANSCRIPT,

--- a/tests/canonical/test_grading_trace_check_operator_config_integration.py
+++ b/tests/canonical/test_grading_trace_check_operator_config_integration.py
@@ -130,7 +130,7 @@ def test_binding_operator_names_filters_the_registry_by_suffix(
     """Site B — the walk projects the ``_binding`` suffix over the registry.
 
     A registered ``<name>_binding`` appears in the walk; a non-suffixed
-    sibling does not. Locks Approved Decision #2's convention against a
+    sibling does not. Locks the ``_binding``-suffix convention against a
     hand-written binding-operator list drifting from the entry-point set.
     """
     try:

--- a/tests/canonical/test_grading_trace_check_operator_config_integration.py
+++ b/tests/canonical/test_grading_trace_check_operator_config_integration.py
@@ -1,0 +1,153 @@
+"""The registry IS the dispatch table both trace-check sites read.
+
+Locks the two invariants of the entry-point rewrite in
+``tolokaforge/core/grading/trace_checks.py``:
+
+* **Site A — ``_operator_holds`` reads the loader.** Swapping the ``equals``
+  entry-point for a callable that returns the opposite boolean flips
+  ``_operator_holds("equals", ...)``. Any hard-coded fallback path — a
+  module-level ``_OPERATORS`` dict, an ``if name == "equals"`` shortcut —
+  would let the shipped boolean survive the swap; this test would fail.
+
+* **Site B — the binding-references walk filters the registry by the
+  ``_binding`` suffix.** A registered ``<name>_binding`` appears in
+  :func:`_binding_operator_names`; a non-suffixed sibling does not. Any
+  fallback to a hand-written binding-operator list would let one of them
+  drift.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.grading.trace_checks import _binding_operator_names, _operator_holds
+from tolokaforge.core.plugin_registry import (
+    TRACE_CHECK_OPERATORS_GROUP,
+    _clear_discovery_cache,
+    load_trace_check_operator,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+class _EntryPointStub:
+    """Duck-typed ``importlib.metadata.EntryPoint`` for the discovery scan."""
+
+    def __init__(self, name: str, value: Any, dist_name: str = "tests-fixture") -> None:
+        self.name = name
+        self.value = value
+
+        class _Dist:
+            def __init__(self, dn: str) -> None:
+                self.name = dn
+
+        self.dist = _Dist(dist_name)
+
+    def load(self) -> Any:
+        return self.value
+
+
+def _inject(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    replace: Mapping[str, Any] | None = None,
+    add: Mapping[str, Any] | None = None,
+) -> None:
+    """Replace / add entry points in the trace-check operators group.
+
+    ``replace`` overrides shipped entries by name; ``add`` appends fresh ones.
+    Other groups pass through unchanged.
+    """
+    _clear_discovery_cache()
+    shipped = list(importlib.metadata.entry_points(group=TRACE_CHECK_OPERATORS_GROUP))
+    replace = replace or {}
+    add = add or {}
+    kept = [ep for ep in shipped if ep.name not in replace]
+    replaced = [_EntryPointStub(name, callable_) for name, callable_ in replace.items()]
+    added = [_EntryPointStub(name, callable_) for name, callable_ in add.items()]
+    stubs = [*kept, *replaced, *added]
+
+    def fake_entry_points(*, group: str) -> list[Any]:
+        if group == TRACE_CHECK_OPERATORS_GROUP:
+            return stubs
+        return list(importlib.metadata.entry_points(group=group))
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    _clear_discovery_cache()
+
+
+def _always_false(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return False
+
+
+def _always_true(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return True
+
+
+def test_operator_holds_reads_the_registered_equals_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site A — the loader path IS the dispatch path.
+
+    Shipped ``equals`` holds for two equal values; swapping the entry point
+    for ``_always_false`` flips it. A hard-coded dispatch shortcut would let
+    the shipped answer survive the swap.
+    """
+    try:
+        assert _operator_holds("equals", "PAY-1", "PAY-1", {}) is True
+
+        _inject(monkeypatch, replace={"equals": _always_false})
+        assert load_trace_check_operator("equals") is _always_false
+        assert _operator_holds("equals", "PAY-1", "PAY-1", {}) is False
+    finally:
+        _clear_discovery_cache()
+
+
+def test_operator_holds_reads_the_registered_equals_binding_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site A — the binding branch dispatches through the same loader path.
+
+    Swapping ``equals_binding`` for ``_always_true`` flips the verdict over a
+    binding environment that would otherwise fail equality.
+    """
+    try:
+        assert _operator_holds("equals_binding", "PAY-2", "case", {"case": "PAY-1"}) is False
+
+        _inject(monkeypatch, replace={"equals_binding": _always_true})
+        assert _operator_holds("equals_binding", "PAY-2", "case", {"case": "PAY-1"}) is True
+    finally:
+        _clear_discovery_cache()
+
+
+def test_binding_operator_names_filters_the_registry_by_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site B — the walk projects the ``_binding`` suffix over the registry.
+
+    A registered ``<name>_binding`` appears in the walk; a non-suffixed
+    sibling does not. Locks Approved Decision #2's convention against a
+    hand-written binding-operator list drifting from the entry-point set.
+    """
+    try:
+        assert _binding_operator_names() == ["contains_binding", "equals_binding"]
+
+        _inject(
+            monkeypatch,
+            add={
+                "custom_semver_binding": _always_true,
+                "custom_semver_check": _always_true,
+            },
+        )
+        names = _binding_operator_names()
+
+        assert "custom_semver_binding" in names
+        assert "custom_semver_check" not in names
+        assert names == sorted(names)
+        assert set(names) == {"contains_binding", "custom_semver_binding", "equals_binding"}
+    finally:
+        _clear_discovery_cache()

--- a/tests/canonical/test_grading_trace_check_operator_dispatch.py
+++ b/tests/canonical/test_grading_trace_check_operator_dispatch.py
@@ -1,0 +1,116 @@
+"""``load_trace_check_operator`` discovery + ``_operator_holds`` dispatch.
+
+Locks the two seams the trace-check operator design commits to:
+
+1. :func:`~tolokaforge.core.plugin_registry.load_trace_check_operator` resolves
+   an operator registered via ``importlib.metadata`` entry-points. The
+   dispatch case injects a synthetic entry-point pointing at
+   :func:`tests.utils.trace_check_operator_demo.is_positive_number` under the
+   group ``tolokaforge.trace_check_operators`` and asserts the loader returns
+   the demo callable. No wheel pollution: the demo stays discoverable only
+   under the monkeypatched mapping.
+
+2. **Evaluator dispatch through the resolved callable.**
+   :func:`~tolokaforge.core.grading.trace_checks._operator_holds` invokes
+   the resolved custom operator by name — proving the registry-lookup path
+   IS the dispatch path.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any
+
+import pytest
+
+from tests.utils.trace_check_operator_demo import is_positive_number
+from tolokaforge.core.grading.trace_checks import _operator_holds
+from tolokaforge.core.plugin_registry import (
+    TRACE_CHECK_OPERATORS_GROUP,
+    _clear_discovery_cache,
+    load_trace_check_operator,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+class _EntryPointStub:
+    """Duck-typed ``importlib.metadata.EntryPoint`` for the discovery scan.
+
+    Enumerates ``name`` / ``dist`` and returns ``value`` on ``load()`` — the
+    surface :func:`discover_entry_points` reads.
+    """
+
+    def __init__(self, name: str, value: Any, dist_name: str = "tests-fixture") -> None:
+        self.name = name
+        self.value = value
+
+        class _Dist:
+            def __init__(self, dn: str) -> None:
+                self.name = dn
+
+        self.dist = _Dist(dist_name)
+
+    def load(self) -> Any:
+        return self.value
+
+
+def _inject_demo_operator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register the demo operator alongside the 17 shipped names."""
+    _clear_discovery_cache()
+    shipped = list(importlib.metadata.entry_points(group=TRACE_CHECK_OPERATORS_GROUP))
+    injected = _EntryPointStub("test_trace_operator", is_positive_number)
+
+    def fake_entry_points(*, group: str) -> list[Any]:
+        if group == TRACE_CHECK_OPERATORS_GROUP:
+            return [*shipped, injected]
+        return list(importlib.metadata.entry_points(group=group))
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    _clear_discovery_cache()
+
+
+def test_loader_resolves_the_monkeypatched_demo_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inject_demo_operator(monkeypatch)
+    try:
+        resolved = load_trace_check_operator("test_trace_operator")
+        assert resolved is is_positive_number
+    finally:
+        _clear_discovery_cache()
+
+
+def test_operator_holds_dispatches_through_the_registered_demo_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_operator_holds`` reaches the plug-in operator by name.
+
+    A positive number holds; a non-positive one does not. Proves the dispatch
+    site itself reads the entry-point registry — no hard-coded fallback path.
+    """
+    _inject_demo_operator(monkeypatch)
+    try:
+        assert _operator_holds("test_trace_operator", 3, None, {}) is True
+        assert _operator_holds("test_trace_operator", 0, None, {}) is False
+        assert _operator_holds("test_trace_operator", -5, None, {}) is False
+        assert _operator_holds("test_trace_operator", "abc", None, {}) is False
+    finally:
+        _clear_discovery_cache()
+
+
+def test_operator_holds_preserves_the_none_dispatch_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``None`` value short-circuits before the registered operator is called.
+
+    Every operator but ``exists`` is false on ``None``; the gate is a dispatch
+    invariant declared once in ``_operator_holds`` rather than repeated inside
+    every operator. Locks that the extraction moved the operators without
+    duplicating the gate.
+    """
+    _inject_demo_operator(monkeypatch)
+    try:
+        assert _operator_holds("test_trace_operator", None, 0, {}) is False
+    finally:
+        _clear_discovery_cache()

--- a/tests/canonical/test_grading_trace_check_operator_dispatch.py
+++ b/tests/canonical/test_grading_trace_check_operator_dispatch.py
@@ -106,8 +106,8 @@ def test_operator_holds_preserves_the_none_dispatch_gate(
 
     Every operator but ``exists`` is false on ``None``; the gate is a dispatch
     invariant declared once in ``_operator_holds`` rather than repeated inside
-    every operator. Locks that the extraction moved the operators without
-    duplicating the gate.
+    every operator. Locks that the ``None`` gate is declared once in
+    ``_operator_holds``, not duplicated inside every registered operator.
     """
     _inject_demo_operator(monkeypatch)
     try:

--- a/tests/canonical/test_judge_contract.py
+++ b/tests/canonical/test_judge_contract.py
@@ -17,9 +17,9 @@ from tolokaforge.core.grading.judge import (
     InMemoryJudge,
     Judge,
     JudgeCallLog,
-    JudgeStatus,
     LLMJudge,
 )
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.models import ModelConfig
 from tolokaforge.runner.models import Rubric
 

--- a/tests/canonical/test_redaction_at_artifact_write.py
+++ b/tests/canonical/test_redaction_at_artifact_write.py
@@ -56,8 +56,8 @@ from tests.utils.conductor_phases import (
     runner_stub,
 )
 from tests.utils.provision_failure import FailProvisionBackend, provisioning_executor
-from tolokaforge.core.grading.judge import JudgeResult, JudgeUsage
-from tolokaforge.core.grading.judge import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeUsage
+from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.replay import (
     FidelityMode,
     KnowledgeSearchMode,

--- a/tests/canonical/test_replay_report.py
+++ b/tests/canonical/test_replay_report.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
 from tolokaforge.core.grading.replay import (
     FidelityMode,
     KnowledgeSearchMode,

--- a/tests/canonical/test_runner_subset_partition.py
+++ b/tests/canonical/test_runner_subset_partition.py
@@ -91,6 +91,22 @@ LAZY_LOADABLE_SUBSET_MODULES: frozenset[str] = frozenset(
         # Shipped in the subset because pip's ``[project.scripts]`` binds
         # ``tolokaforge = tolokaforge.runner._cli:main`` at install time.
         "tolokaforge/runner/_cli.py",
+        # Sub-component seam reference impls resolved through
+        # ``importlib.metadata`` entry-points at ``RunnerServiceImpl.__init__``
+        # (``load_judge_model_provider('litellm')`` /
+        # ``load_rubric_evaluator('llm_judge')`` /
+        # ``load_transcript_rule_matcher('default')`` /
+        # ``load_state_check_backend('jsonpath'|'db_probes')``), not by a
+        # module-level import. ``judge.py`` is reached at grade time from
+        # ``default_rubric_evaluator``; ``rubric.py`` is reached at grade
+        # time from ``judge.py``. Shipped in the subset because the runner
+        # container calls each one on the grading path.
+        "tolokaforge/core/grading/default_judge_model_provider.py",
+        "tolokaforge/core/grading/default_rubric_evaluator.py",
+        "tolokaforge/core/grading/default_state_check_backends.py",
+        "tolokaforge/core/grading/default_transcript_rule_matcher.py",
+        "tolokaforge/core/grading/judge.py",
+        "tolokaforge/core/grading/rubric.py",
     }
 )
 

--- a/tests/integration/test_rejudge_live.py
+++ b/tests/integration/test_rejudge_live.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from tolokaforge.core.grading.judge import JudgeStatus
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.replay import ReplayOutcomeStatus, run_replay_batch
 from tolokaforge.core.models import (
     CriterionResult,

--- a/tests/integration/test_rubric_judge_live.py
+++ b/tests/integration/test_rubric_judge_live.py
@@ -25,10 +25,10 @@ import yaml
 
 from tests.utils.docker_helpers import current_runner_image_id, is_docker_daemon_available
 from tolokaforge.core.grading.judge import (
-    JudgeStatus,
     LLMJudge,
     model_config_from_ref,
 )
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.grading.kb_search import SearchHit
 from tolokaforge.core.grading.rubric import SubmitReportValidationError, parse_submit_report
 from tolokaforge.runner.models import Rubric

--- a/tests/unit/grading/test_composite_state_checks_gating.py
+++ b/tests/unit/grading/test_composite_state_checks_gating.py
@@ -39,7 +39,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.grading.composite import grade_state_checks_reads
-from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
+from tolokaforge.core.grading.default_state_check_backends import JsonpathStateCheckBackend
+from tolokaforge.core.grading.substrate import (
+    InProcessGradingSubstrate,
+    SubstrateUnreachableError,
+)
 from tolokaforge.core.plugin_registry import load_state_check_backend
 from tolokaforge.runner.db_client import TrialNotFoundError as DBTrialNotFoundError
 from tolokaforge.runner.models import RunnerStateChecksConfig
@@ -59,7 +63,7 @@ class _Counter:
         self.calls += 1
         if self._value is None:
             raise AssertionError(
-                f"factory {self._name!r} was invoked but this case requires it " "never fires"
+                f"factory {self._name!r} was invoked but this case requires it never fires"
             )
         return self._value
 
@@ -256,7 +260,7 @@ class TestDbTrialNotFoundDegrades:
             result = _run(config=config, substrate=substrate)
         assert result.jsonpath_score == pytest.approx(0.5)
         assert any(
-            "DB trial not found; grading with empty DB state" in rec.message
+            "GradeTrial: task:0 - DB trial not found; grading with empty DB state" in rec.message
             for rec in caplog.records
         ), caplog.text
         assert fs_factory.calls == 1
@@ -287,3 +291,34 @@ class TestConstructionInvariants:
         )
         with pytest.raises(RuntimeError, match="final_state_stable_factory"):
             substrate.final_state_stable()
+
+
+def test_jsonpath_backend_propagates_substrate_unreachable() -> None:
+    """A ``SubstrateUnreachableError`` from ``substrate.final_state_stable``
+    must NOT degrade — it propagates so the caller can book the trial as
+    ungradeable.
+
+    ``JsonpathStateCheckBackend.query`` catches only ``DBTrialNotFoundError``
+    (the absent-trial degradation). Any other read failure is a substrate
+    transport error the audit surfaces. Locking here catches a future
+    tightening of the ``except`` clause back over
+    :class:`SubstrateUnreachableError`. Parallels the custom-checks lock
+    at ``tests/unit/grading/test_composite_custom_checks_degradation.py``.
+    """
+
+    def raising_stable() -> dict[str, Any]:
+        raise SubstrateUnreachableError("grader lost the runner mid-grade")
+
+    substrate = InProcessGradingSubstrate(
+        db_reader=MagicMock(),
+        knowledge_search=None,
+        filesystem_root=None,
+        initial_state={},
+        final_state_stable_factory=raising_stable,
+    )
+    backend = JsonpathStateCheckBackend()
+    with pytest.raises(SubstrateUnreachableError):
+        backend.query(
+            expression=[{"path": "$.db.users[0].name", "equals": "Alice"}],
+            substrate=substrate,
+        )

--- a/tests/unit/grading/test_composite_state_checks_gating.py
+++ b/tests/unit/grading/test_composite_state_checks_gating.py
@@ -40,6 +40,7 @@ import pytest
 
 from tolokaforge.core.grading.composite import grade_state_checks_reads
 from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
+from tolokaforge.core.plugin_registry import load_state_check_backend
 from tolokaforge.runner.db_client import TrialNotFoundError as DBTrialNotFoundError
 from tolokaforge.runner.models import RunnerStateChecksConfig
 
@@ -67,6 +68,13 @@ def _logger() -> logging.Logger:
     return logging.getLogger("test-composite-gating")
 
 
+def _shipped_backends() -> dict[str, Any]:
+    return {
+        "jsonpath": load_state_check_backend("jsonpath")(),
+        "db_probes": load_state_check_backend("db_probes")(),
+    }
+
+
 def _run(
     *,
     config: RunnerStateChecksConfig,
@@ -76,6 +84,7 @@ def _run(
         trial_id="task:0",
         config=config,
         substrate=substrate,
+        state_check_backends=_shipped_backends(),
         logger=_logger(),  # type: ignore[arg-type]  # StructuredLogger satisfied at runtime
     )
 

--- a/tests/unit/grading/test_grading_ledger.py
+++ b/tests/unit/grading/test_grading_ledger.py
@@ -1106,9 +1106,10 @@ def test_a_degenerate_trial_leaves_trace_checks_unscored(runner_service, mock_gr
 
 
 @pytest.mark.parametrize(
-    ("evaluator_name", "grading", "unaccounted_key", "message"),
+    ("evaluator_module", "evaluator_name", "grading", "unaccounted_key", "message"),
     [
         (
+            "tolokaforge.core.grading.default_transcript_rule_matcher",
             "evaluate_transcript_rules",
             {
                 "combine_method": "weighted",
@@ -1120,6 +1121,7 @@ def test_a_degenerate_trial_leaves_trace_checks_unscored(runner_service, mock_gr
             [{"role": "assistant", "content": "All done"}],
         ),
         (
+            "tolokaforge.core.grading.composite",
             "evaluate_trace_checks",
             _TRACE_CHECKS_GRADING,
             TRACE_CONSTRAINT_KEY_BY_KIND["all_of"],
@@ -1128,6 +1130,7 @@ def test_a_degenerate_trial_leaves_trace_checks_unscored(runner_service, mock_gr
     ],
 )
 def test_grade_trial_fails_loud_when_an_evaluator_stops_decomposing_a_key(
+    evaluator_module,
     evaluator_name,
     grading,
     unaccounted_key,
@@ -1144,15 +1147,21 @@ def test_grade_trial_fails_loud_when_an_evaluator_stops_decomposing_a_key(
     leaf-granular case: the block key alone being accounted would leave a kind
     evaluated by neither substrate invisible, so the key the error must name is
     the kind's.
-    """
-    from tolokaforge.core.grading import composite as composite_module
 
-    real = getattr(composite_module, evaluator_name)
+    ``evaluator_module`` names the module the drift is injected on: composite
+    for :func:`evaluate_trace_checks` (still imported directly at composite
+    load time), and the default matcher module for :func:`evaluate_transcript_rules`
+    (reached through the :class:`TranscriptRuleMatcher` seam).
+    """
+    import importlib
+
+    module = importlib.import_module(evaluator_module)
+    real = getattr(module, evaluator_name)
 
     def drifted(*args: Any, **kwargs: Any) -> Any:
         return real(*args, **kwargs).model_copy(update={"accounted_keys": {}})
 
-    monkeypatch.setattr(composite_module, evaluator_name, drifted)
+    monkeypatch.setattr(module, evaluator_name, drifted)
 
     response = _grade(
         runner_service,

--- a/tests/unit/grading/test_grading_predicates.py
+++ b/tests/unit/grading/test_grading_predicates.py
@@ -6,14 +6,16 @@ The only thing that holds a hand-written table honest is running the shipped
 operators over real values of each type, which is what the brute-force cell test
 does: every cell is one parameter, so a flipped cell names itself.
 
-The comparisons it is measured against are ``trace_checks._BINDING_OPERATORS``
-rather than a second copy of that dispatch written here — a table answering for an
-operator the evaluator no longer calls answers for nothing.
+The comparisons it is measured against are the registered binding operators the
+evaluator itself dispatches through — resolved from the
+``tolokaforge.trace_check_operators`` entry-point group — rather than a second
+copy of that dispatch written here. A table answering for an operator the
+evaluator no longer calls answers for nothing.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from itertools import product
 from typing import Any
 
@@ -25,8 +27,26 @@ from tolokaforge.core.grading.predicates import (
     ever_satisfiable,
     json_type_of,
 )
-from tolokaforge.core.grading.trace_checks import _BINDING_OPERATORS
+from tolokaforge.core.plugin_registry import load_trace_check_operator
 from tolokaforge.runner.models import TRACE_PREDICATE_BINDING_OPERATORS
+
+
+def _binding_op(name: str) -> Callable[[Any, Any], bool]:
+    """Two-arg view of a registered binding operator, bound through a synthetic name.
+
+    A binding operator dispatches through a name in the constraint's ``bind``
+    environment — its signature is ``(value, expected_name, bindings) -> bool``.
+    The comparison the operator makes over one bound value is what this table
+    holds honest, so the wrapper binds ``expected`` to a fresh key and reads the
+    real bound value out of ``bindings``.
+    """
+    op = load_trace_check_operator(name)
+    return lambda value, bound: op(value, "b", {"b": bound})
+
+
+_BINDING_OPERATORS: Mapping[str, Callable[[Any, Any], bool]] = {
+    name: _binding_op(name) for name in TRACE_PREDICATE_BINDING_OPERATORS
+}
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/grading/test_judge.py
+++ b/tests/unit/grading/test_judge.py
@@ -14,11 +14,11 @@ import pytest
 from tolokaforge.core.grading.judge import (
     _JUDGE_MARKER_CONTRACT,
     _JUDGE_SYSTEM_PROMPT,
-    JudgeStatus,
     LLMJudge,
     _build_opening_message,
     _compose_judge_system_prompt,
 )
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.models import Message, MessageRole, ModelConfig, ToolCall

--- a/tests/unit/grading/test_judge_model_provider.py
+++ b/tests/unit/grading/test_judge_model_provider.py
@@ -1,0 +1,50 @@
+"""``LiteLLMJudgeModelProvider`` — reference impl structural lock.
+
+The shipping ``JudgeModelProvider`` builds an
+:class:`~tolokaforge.core.llm.client.LLMClient` from a
+:class:`~tolokaforge.core.models.ModelConfig`. This test pins the two-method
+:class:`JudgeModel` shape the judge consumes (``.generate`` from
+:class:`LoopLLMClient`, plus ``.classify_loop_error``) so a rename of either
+method — or a swap of the reference impl for one that does not carry them —
+trips before it lands. No LLM call is made; the client is not driven, only
+inspected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.default_judge_model_provider import (
+    LiteLLMJudgeModelProvider,
+)
+from tolokaforge.core.grading.judge_model_provider import JudgeModel
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.models import ModelConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _model_config() -> ModelConfig:
+    return ModelConfig(provider="anthropic", name="claude")
+
+
+def test_build_returns_an_llm_client_instance() -> None:
+    """The reference provider fronts :class:`LLMClient` — locks the impl choice."""
+    judge_model = LiteLLMJudgeModelProvider().build(_model_config())
+    assert isinstance(judge_model, LLMClient)
+
+
+def test_built_judge_model_exposes_generate_and_classify_loop_error() -> None:
+    """The two-method :class:`JudgeModel` shape the judge consumes.
+
+    Structural check via :func:`hasattr` (no LLM call — no API key needed).
+    """
+    judge_model = LiteLLMJudgeModelProvider().build(_model_config())
+    assert callable(getattr(judge_model, "generate", None))
+    assert callable(getattr(judge_model, "classify_loop_error", None))
+
+
+def test_built_judge_model_satisfies_the_judge_model_protocol() -> None:
+    """Runtime-checkable :class:`JudgeModel` accepts the built client."""
+    judge_model = LiteLLMJudgeModelProvider().build(_model_config())
+    assert isinstance(judge_model, JudgeModel)

--- a/tests/unit/grading/test_llm_judge_runner.py
+++ b/tests/unit/grading/test_llm_judge_runner.py
@@ -149,7 +149,7 @@ def test_judge_model_rides_on_trial_spec():
 
 
 # ---------------------------------------------------------------------------
-# composite._build_judge_state_diff — the diff-first default over the substrate
+# runner.service._build_judge_state_diff — the diff-first default over the substrate
 # ---------------------------------------------------------------------------
 
 
@@ -180,7 +180,7 @@ def _logger():
 def test_build_judge_state_diff_none_when_no_initial_tables():
     """An empty ``initial_state`` has no baseline to diff against — the judge
     falls back to its read-only tools and no diff is injected."""
-    from tolokaforge.core.grading.composite import _build_judge_state_diff
+    from tolokaforge.runner.service import _build_judge_state_diff
 
     out = _build_judge_state_diff(
         trial_id="trial",
@@ -194,8 +194,8 @@ def test_build_judge_state_diff_none_when_no_initial_tables():
 
 
 def test_build_judge_state_diff_renders_modified_row():
-    from tolokaforge.core.grading.composite import _build_judge_state_diff
     from tolokaforge.runner.models import TableSchema
+    from tolokaforge.runner.service import _build_judge_state_diff
 
     out = _build_judge_state_diff(
         trial_id="trial",
@@ -226,8 +226,8 @@ def test_build_judge_state_diff_layers_declared_id_fields_over_schema_pk():
     composite key — layered over the schema entry — can match the edit as a
     modification; dropping the layer (or reversing it) degrades to add/remove.
     """
-    from tolokaforge.core.grading.composite import _build_judge_state_diff
     from tolokaforge.runner.models import TableSchema
+    from tolokaforge.runner.service import _build_judge_state_diff
 
     initial = {
         "positions": [
@@ -269,11 +269,11 @@ def test_build_judge_state_diff_substrate_unreachable_propagates():
 
     import pytest
 
-    from tolokaforge.core.grading.composite import _build_judge_state_diff
     from tolokaforge.core.grading.substrate import (
         InProcessGradingSubstrate,
         SubstrateUnreachableError,
     )
+    from tolokaforge.runner.service import _build_judge_state_diff
 
     def _explode():
         raise SubstrateUnreachableError("the runner went away")
@@ -303,8 +303,8 @@ def test_build_judge_state_diff_generic_final_state_failure_degrades_to_none():
     """
     from unittest.mock import MagicMock
 
-    from tolokaforge.core.grading.composite import _build_judge_state_diff
     from tolokaforge.core.grading.substrate import InProcessGradingSubstrate
+    from tolokaforge.runner.service import _build_judge_state_diff
 
     def _explode():
         raise RuntimeError("db hiccup")

--- a/tests/unit/grading/test_replay.py
+++ b/tests/unit/grading/test_replay.py
@@ -35,7 +35,7 @@ from tests.unit.grading.test_judge import ScriptedClient
 from tests.utils.five_shape_run import write_five_shape_run
 from tests.utils.provision_failure import write_provision_failure_bundle
 from tolokaforge.core.failure_attribution import TrialOutcomeClass
-from tolokaforge.core.grading.judge import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.replay import (
     REPLAY_UNAVAILABLE,
     FidelityMode,

--- a/tests/unit/grading/test_trace_checks_matchers.py
+++ b/tests/unit/grading/test_trace_checks_matchers.py
@@ -22,7 +22,7 @@ import pytest
 
 from tests.utils.recorded_calls import recorded_call
 from tests.utils.timelines import build_timeline
-from tolokaforge.core.grading.trace_checks import _BINDING_OPERATORS, select_events
+from tolokaforge.core.grading.trace_checks import _binding_operator_names, select_events
 from tolokaforge.core.grading.trace_timeline import (
     TraceEvent,
     TraceEventKind,
@@ -313,7 +313,7 @@ def test_the_answer_table_spans_the_operators_a_predicate_declares():
     """
     assert set(_OPERATOR_ANSWERS) == TRACE_PREDICATE_OPERATORS
     assert set(ValuePredicate.model_fields) == TRACE_PREDICATE_OPERATORS
-    assert set(_BINDING_OPERATORS) == TRACE_PREDICATE_BINDING_OPERATORS
+    assert set(_binding_operator_names()) == TRACE_PREDICATE_BINDING_OPERATORS
     misrowed = {
         name: sorted(answer.predicate)
         for name, answer in _OPERATOR_ANSWERS.items()

--- a/tests/unit/test_plugin_registry_load_custom_check_executor.py
+++ b/tests/unit/test_plugin_registry_load_custom_check_executor.py
@@ -1,0 +1,73 @@
+"""``plugin_registry.load_custom_check_executor`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.custom_check_executors`` entry-point
+group:
+
+* the two shipped factories (``check_runner``, ``in_memory``) resolve to the
+  callables ``pyproject.toml`` registers them against, so a future refactor
+  renaming either symbol trips this test before it lands;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.check_runner import (
+    CheckRunner,
+    InMemoryCheckExecutor,
+    _check_runner_factory,
+    _in_memory_check_executor_factory,
+)
+from tolokaforge.core.plugin_registry import (
+    CUSTOM_CHECK_EXECUTORS_GROUP,
+    UnknownImplementationError,
+    available_custom_check_executors,
+    load_custom_check_executor,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_check_runner_resolves_to_the_shipped_factory() -> None:
+    assert load_custom_check_executor("check_runner") is _check_runner_factory
+
+
+def test_in_memory_resolves_to_the_shipped_factory() -> None:
+    assert load_custom_check_executor("in_memory") is _in_memory_check_executor_factory
+
+
+def test_check_runner_factory_returns_a_check_runner_instance() -> None:
+    """The factory the loader hands back builds the production executor.
+
+    Locks the two-step "loader → factory() → instance" chain end-to-end so a
+    future refactor that hooks ``pyproject.toml`` to the class directly
+    (skipping the factory) trips this test.
+    """
+    factory = load_custom_check_executor("check_runner")
+    assert isinstance(factory(), CheckRunner)
+
+
+def test_in_memory_factory_returns_an_in_memory_check_executor_instance() -> None:
+    factory = load_custom_check_executor("in_memory")
+    assert isinstance(factory(), InMemoryCheckExecutor)
+
+
+def test_available_lists_both_shipped_names() -> None:
+    names = available_custom_check_executors()
+    assert "check_runner" in names
+    assert "in_memory" in names
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_custom_check_executor("nonexistent")
+    message = str(excinfo.value)
+    assert CUSTOM_CHECK_EXECUTORS_GROUP in message
+    assert "check_runner" in message
+    assert "in_memory" in message
+    assert excinfo.value.group == CUSTOM_CHECK_EXECUTORS_GROUP
+    assert "check_runner" in excinfo.value.known
+    assert "in_memory" in excinfo.value.known

--- a/tests/unit/test_plugin_registry_load_judge_model_provider.py
+++ b/tests/unit/test_plugin_registry_load_judge_model_provider.py
@@ -1,0 +1,53 @@
+"""``plugin_registry.load_judge_model_provider`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.judge_model_providers`` entry-point
+group:
+
+* the shipped factory (``litellm``) resolves to the callable
+  ``pyproject.toml`` registers it against, so a future refactor renaming
+  the symbol trips this test before it lands;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.default_judge_model_provider import (
+    LiteLLMJudgeModelProvider,
+    _litellm_judge_model_provider_factory,
+)
+from tolokaforge.core.plugin_registry import (
+    JUDGE_MODEL_PROVIDERS_GROUP,
+    UnknownImplementationError,
+    available_judge_model_providers,
+    load_judge_model_provider,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_litellm_resolves_to_the_shipped_factory() -> None:
+    assert load_judge_model_provider("litellm") is _litellm_judge_model_provider_factory
+
+
+def test_litellm_factory_returns_a_litellm_judge_model_provider_instance() -> None:
+    """Locks the two-step "loader → factory() → instance" chain end-to-end."""
+    factory = load_judge_model_provider("litellm")
+    assert isinstance(factory(), LiteLLMJudgeModelProvider)
+
+
+def test_available_lists_the_shipped_name() -> None:
+    assert "litellm" in available_judge_model_providers()
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_judge_model_provider("nonexistent")
+    message = str(excinfo.value)
+    assert JUDGE_MODEL_PROVIDERS_GROUP in message
+    assert "litellm" in message
+    assert excinfo.value.group == JUDGE_MODEL_PROVIDERS_GROUP
+    assert "litellm" in excinfo.value.known

--- a/tests/unit/test_plugin_registry_load_rubric_evaluator.py
+++ b/tests/unit/test_plugin_registry_load_rubric_evaluator.py
@@ -1,0 +1,69 @@
+"""``plugin_registry.load_rubric_evaluator`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.rubric_evaluators`` entry-point
+group:
+
+* the shipped factory (``llm_judge``) resolves to the callable
+  ``pyproject.toml`` registers it against, so a future refactor renaming
+  the symbol trips this test before it lands;
+* the two-step "loader → factory(ctx) → instance" chain returns the
+  reference :class:`LLMJudgeRubricEvaluator`;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.grading.default_rubric_evaluator import (
+    LLMJudgeRubricEvaluator,
+    _llm_judge_rubric_evaluator_factory,
+)
+from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
+from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.plugin_registry import (
+    RUBRIC_EVALUATORS_GROUP,
+    UnknownImplementationError,
+    available_rubric_evaluators,
+    load_rubric_evaluator,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _context() -> RubricEvaluatorContext:
+    """Minimum viable context — the reference impl reads
+    :attr:`judge_model_provider` lazily inside ``.evaluate()``, so a
+    :class:`MagicMock` is sufficient here."""
+    return RubricEvaluatorContext(
+        judge_model_provider=MagicMock(),
+        logger=StructuredLogger(name="test-load-rubric-evaluator"),
+    )
+
+
+def test_llm_judge_resolves_to_the_shipped_factory() -> None:
+    assert load_rubric_evaluator("llm_judge") is _llm_judge_rubric_evaluator_factory
+
+
+def test_llm_judge_factory_returns_a_llm_judge_rubric_evaluator_instance() -> None:
+    """Locks the two-step ``loader → factory(ctx) → instance`` chain end-to-end."""
+    factory = load_rubric_evaluator("llm_judge")
+    assert isinstance(factory(_context()), LLMJudgeRubricEvaluator)
+
+
+def test_available_lists_the_shipped_name() -> None:
+    assert "llm_judge" in available_rubric_evaluators()
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_rubric_evaluator("nonexistent")
+    message = str(excinfo.value)
+    assert RUBRIC_EVALUATORS_GROUP in message
+    assert "llm_judge" in message
+    assert excinfo.value.group == RUBRIC_EVALUATORS_GROUP
+    assert "llm_judge" in excinfo.value.known

--- a/tests/unit/test_plugin_registry_load_state_check_backend.py
+++ b/tests/unit/test_plugin_registry_load_state_check_backend.py
@@ -1,0 +1,85 @@
+"""``plugin_registry.load_state_check_backend`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.state_check_backends`` entry-point
+group:
+
+* the two shipped factories (``jsonpath`` and ``db_probes``) resolve to the
+  callables ``pyproject.toml`` registers them against, so a future refactor
+  renaming either symbol trips this test before it lands;
+* both factories return instances of the corresponding reference impl —
+  the two-step "loader -> factory() -> instance" chain end-to-end;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use;
+* hash grading is explicitly NOT reachable through this group — ``hash`` is
+  not a registered backend and lookup fails loud like any other unknown
+  name. (Hash grading stays runner-integrated on
+  ``RunnerServiceImpl._execute_hash_grading``.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.default_state_check_backends import (
+    DbProbesStateCheckBackend,
+    JsonpathStateCheckBackend,
+    _db_probes_state_check_backend_factory,
+    _jsonpath_state_check_backend_factory,
+)
+from tolokaforge.core.plugin_registry import (
+    STATE_CHECK_BACKENDS_GROUP,
+    UnknownImplementationError,
+    available_state_check_backends,
+    load_state_check_backend,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_jsonpath_resolves_to_the_shipped_factory() -> None:
+    assert load_state_check_backend("jsonpath") is _jsonpath_state_check_backend_factory
+
+
+def test_db_probes_resolves_to_the_shipped_factory() -> None:
+    assert load_state_check_backend("db_probes") is _db_probes_state_check_backend_factory
+
+
+def test_jsonpath_factory_returns_a_jsonpath_backend_instance() -> None:
+    """Locks the two-step "loader -> factory() -> instance" chain end-to-end."""
+    factory = load_state_check_backend("jsonpath")
+    assert isinstance(factory(), JsonpathStateCheckBackend)
+
+
+def test_db_probes_factory_returns_a_db_probes_backend_instance() -> None:
+    factory = load_state_check_backend("db_probes")
+    assert isinstance(factory(), DbProbesStateCheckBackend)
+
+
+def test_available_lists_both_shipped_names() -> None:
+    names = available_state_check_backends()
+    assert "jsonpath" in names
+    assert "db_probes" in names
+
+
+def test_hash_is_not_a_registered_backend() -> None:
+    """Hash grading has state-mutation semantics the read-only substrate
+    cannot serve; it stays runner-integrated on
+    ``RunnerServiceImpl._execute_hash_grading`` and is not reachable through
+    this seam. Lookup fails loud like any other unknown name.
+    """
+    assert "hash" not in available_state_check_backends()
+    with pytest.raises(UnknownImplementationError):
+        load_state_check_backend("hash")
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_state_check_backend("nonexistent")
+    message = str(excinfo.value)
+    assert STATE_CHECK_BACKENDS_GROUP in message
+    assert "jsonpath" in message
+    assert "db_probes" in message
+    assert excinfo.value.group == STATE_CHECK_BACKENDS_GROUP
+    assert "jsonpath" in excinfo.value.known
+    assert "db_probes" in excinfo.value.known

--- a/tests/unit/test_plugin_registry_load_trace_check_operator.py
+++ b/tests/unit/test_plugin_registry_load_trace_check_operator.py
@@ -1,0 +1,78 @@
+"""``plugin_registry.load_trace_check_operator`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.trace_check_operators`` entry-point
+group:
+
+* every shipped operator (15 non-binding + 2 binding = 17) resolves to the
+  module-level callable ``pyproject.toml`` registers it against, so a
+  future refactor renaming any symbol trips this test before it lands;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use.
+
+The loader returns the callable directly — no factory wrapper — so a
+resolved operator is invoked as ``op(value, expected, bindings)`` at the
+dispatch site.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading import trace_check_operator
+from tolokaforge.core.plugin_registry import (
+    TRACE_CHECK_OPERATORS_GROUP,
+    UnknownImplementationError,
+    available_trace_check_operators,
+    load_trace_check_operator,
+)
+from tolokaforge.runner.models import TRACE_PREDICATE_OPERATORS
+
+pytestmark = pytest.mark.unit
+
+
+_SHIPPED_NAME_TO_SYMBOL = {
+    "equals": trace_check_operator.equals,
+    "equals_ci": trace_check_operator.equals_ci,
+    "contains": trace_check_operator.contains_op,
+    "contains_ci": trace_check_operator.contains_ci,
+    "not_equals": trace_check_operator.not_equals,
+    "regex": trace_check_operator.regex_matches,
+    "gt": trace_check_operator.gt,
+    "gte": trace_check_operator.gte,
+    "lt": trace_check_operator.lt,
+    "lte": trace_check_operator.lte,
+    "in_": trace_check_operator.in_op,
+    "not_in": trace_check_operator.not_in_op,
+    "len_gt": trace_check_operator.len_gt,
+    "len_gte": trace_check_operator.len_gte,
+    "exists": trace_check_operator.exists,
+    "equals_binding": trace_check_operator.equals_binding,
+    "contains_binding": trace_check_operator.contains_binding,
+}
+
+
+def test_every_registered_name_matches_the_predicate_vocabulary() -> None:
+    """The registered set and ``ValuePredicate``'s operator field set agree.
+
+    A name in one and not the other is a plug-in the schema cannot address, or a
+    schema field the loader cannot resolve — both of which the load tier would
+    catch only after a real config drove them into the dispatch.
+    """
+    assert set(_SHIPPED_NAME_TO_SYMBOL) == TRACE_PREDICATE_OPERATORS
+    assert set(available_trace_check_operators()) == TRACE_PREDICATE_OPERATORS
+
+
+@pytest.mark.parametrize("name", sorted(_SHIPPED_NAME_TO_SYMBOL))
+def test_each_shipped_name_resolves_to_its_module_level_callable(name: str) -> None:
+    assert load_trace_check_operator(name) is _SHIPPED_NAME_TO_SYMBOL[name]
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_trace_check_operator("nonexistent_operator")
+    message = str(excinfo.value)
+    assert TRACE_CHECK_OPERATORS_GROUP in message
+    assert "equals" in message
+    assert excinfo.value.group == TRACE_CHECK_OPERATORS_GROUP
+    assert "equals" in excinfo.value.known

--- a/tests/unit/test_plugin_registry_load_transcript_rule_matcher.py
+++ b/tests/unit/test_plugin_registry_load_transcript_rule_matcher.py
@@ -1,0 +1,53 @@
+"""``plugin_registry.load_transcript_rule_matcher`` — fail-loud resolution.
+
+Locks the loader for the ``tolokaforge.transcript_rule_matchers`` entry-point
+group:
+
+* the shipped factory (``default``) resolves to the callable
+  ``pyproject.toml`` registers it against, so a future refactor renaming
+  the symbol trips this test before it lands;
+* an unknown name raises :class:`UnknownImplementationError` listing every
+  known name in the group — the same fail-loud shape ``load_grading_substrate``
+  and the other loaders use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.default_transcript_rule_matcher import (
+    DefaultTranscriptRuleMatcher,
+    _default_transcript_rule_matcher_factory,
+)
+from tolokaforge.core.plugin_registry import (
+    TRANSCRIPT_RULE_MATCHERS_GROUP,
+    UnknownImplementationError,
+    available_transcript_rule_matchers,
+    load_transcript_rule_matcher,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_resolves_to_the_shipped_factory() -> None:
+    assert load_transcript_rule_matcher("default") is _default_transcript_rule_matcher_factory
+
+
+def test_default_factory_returns_a_default_transcript_rule_matcher_instance() -> None:
+    """Locks the two-step "loader -> factory() -> instance" chain end-to-end."""
+    factory = load_transcript_rule_matcher("default")
+    assert isinstance(factory(), DefaultTranscriptRuleMatcher)
+
+
+def test_available_lists_the_shipped_name() -> None:
+    assert "default" in available_transcript_rule_matchers()
+
+
+def test_unknown_name_raises_unknown_implementation_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_transcript_rule_matcher("nonexistent")
+    message = str(excinfo.value)
+    assert TRANSCRIPT_RULE_MATCHERS_GROUP in message
+    assert "default" in message
+    assert excinfo.value.group == TRANSCRIPT_RULE_MATCHERS_GROUP
+    assert "default" in excinfo.value.known

--- a/tests/unit/test_rate_limit_probe_wiring.py
+++ b/tests/unit/test_rate_limit_probe_wiring.py
@@ -41,7 +41,8 @@ from tolokaforge.core.conductor import (
     conductor_supports_rate_limit_probe,
     require_rate_limit_probe_support,
 )
-from tolokaforge.core.grading.judge import JudgeStatus, LLMJudge
+from tolokaforge.core.grading.judge import LLMJudge
+from tolokaforge.core.grading.judge_result import JudgeStatus
 from tolokaforge.core.llm import LLMClient, UserSimulator
 from tolokaforge.core.llm.fallback_client import FallbackLLMClient
 from tolokaforge.core.logging import get_logger

--- a/tests/unit/test_runner_judge_kb_gate.py
+++ b/tests/unit/test_runner_judge_kb_gate.py
@@ -409,7 +409,7 @@ def _empty_substrate():
 def test_grade_llm_judge_constructs_with_effective_disable_flag(
     monkeypatch, customization, expected
 ):
-    from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+    from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
     from tolokaforge.core.models import ModelConfig
     from tolokaforge.runner.models import JudgeCustomization, LLMJudgeConfig, Rubric
 
@@ -424,7 +424,7 @@ def test_grade_llm_judge_constructs_with_effective_disable_flag(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.composite.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -461,7 +461,7 @@ def test_grade_llm_judge_constructs_with_effective_custom_prompt(
 ):
     """``_grade_llm_judge`` computes the effective ``system_prompt`` from the merged
     customization and constructs the judge with it — ``None`` when no layer set it."""
-    from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+    from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
     from tolokaforge.core.models import ModelConfig
     from tolokaforge.runner.models import JudgeCustomization, LLMJudgeConfig, Rubric
 
@@ -476,7 +476,7 @@ def test_grade_llm_judge_constructs_with_effective_custom_prompt(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.composite.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -516,7 +516,7 @@ def test_grade_llm_judge_constructs_with_effective_include_agent_system_prompt(
     from the merged customization and constructs the judge with it — defaulting to
     ``True`` (include) when no layer sets it, not collapsing an unset flag to
     ``False``."""
-    from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+    from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
     from tolokaforge.core.models import ModelConfig
     from tolokaforge.runner.models import JudgeCustomization, LLMJudgeConfig, Rubric
 
@@ -531,7 +531,7 @@ def test_grade_llm_judge_constructs_with_effective_include_agent_system_prompt(
                 status=JudgeStatus.COMPLETED, usage=JudgeUsage(), reasons="ok", score=1.0
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.composite.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
 
     service = _service(None)
     try:
@@ -560,7 +560,7 @@ def test_grade_trial_populates_judge_report_kb_gating(monkeypatch):
     ``custom_system_prompt`` / ``include_agent_system_prompt`` plus the replay inputs
     ``state_diff_text`` / ``read_tools_offered`` land on ``response.grade.judge_report``
     exactly as the judge reported them."""
-    from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus, JudgeUsage
+    from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
     from tolokaforge.core.models import ModelConfig
     from tolokaforge.runner import runner_pb2 as pb2
     from tolokaforge.runner.models import (
@@ -590,7 +590,7 @@ def test_grade_trial_populates_judge_report_kb_gating(monkeypatch):
                 include_agent_system_prompt=False,
             )
 
-    monkeypatch.setattr("tolokaforge.core.grading.composite.LLMJudge", _SpyJudge)
+    monkeypatch.setattr("tolokaforge.core.grading.default_rubric_evaluator.LLMJudge", _SpyJudge)
 
     rubric = Rubric(criteria=[{"id": "a", "description": "d", "kind": "binary", "weight": 1.0}])
     task_desc = TaskDescription(

--- a/tests/utils/rubric_evaluator_demo.py
+++ b/tests/utils/rubric_evaluator_demo.py
@@ -1,0 +1,106 @@
+"""Deterministic :class:`RubricEvaluator` for the composite-dispatch canonical test.
+
+Ignores the LLM path entirely — no ``LLMJudge``, no network, no substrate
+read. Returns a :class:`JudgeResult` whose score is derived by hashing the
+joined ``criterion.description`` fields into ``[0.0, 1.0]``, proving the
+seam's registry lookup + Protocol dispatch reach an external evaluator
+with no framework change.
+
+The file name deliberately avoids the ``test_`` prefix — pytest's
+``python_files = ["test_*.py"]`` would otherwise collect this fixture as
+a test module. The REGISTERED entry-point name in the dispatch canonical
+is ``test_rubric_evaluator``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+from tolokaforge.core.grading.judge_result import (
+    JudgeResult,
+    JudgeStatus,
+    JudgeUsage,
+)
+from tolokaforge.core.grading.rubric_evaluator import (
+    RubricEvaluator,
+    RubricEvaluatorContext,
+)
+from tolokaforge.runner.models import CriterionResult
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.substrate import GradingSubstrate
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.runner.models import Rubric
+    from tolokaforge.tools.registry import Tool
+
+__all__ = [
+    "DeterministicRubricEvaluator",
+    "_hash_to_score",
+    "_rubric_signature",
+    "_test_rubric_evaluator_factory",
+]
+
+
+def _hash_to_score(text: str) -> float:
+    """Fold ``text`` into ``[0.0, 1.0]`` via a SHA-256 prefix.
+
+    Deterministic across processes so the canonical test asserts the exact
+    score, not just presence.
+    """
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") / (1 << 64)
+
+
+def _rubric_signature(rubric: Rubric) -> str:
+    """Stable text projection of a rubric — joined criterion descriptions."""
+    return "\n".join(criterion.description for criterion in rubric.criteria)
+
+
+class DeterministicRubricEvaluator:
+    """Returns a :class:`JudgeResult` whose weighted score is
+    :func:`_hash_to_score` over :func:`_rubric_signature`.
+
+    Every criterion carries the same score; the rubric-level ``score`` is
+    trivially equal. ``criterion_results`` is populated so the composite's
+    downstream wire assembly sees the same shape a real judge produces.
+    """
+
+    def evaluate(
+        self,
+        *,
+        rubric: Rubric,
+        agent_system_prompt: str,
+        transcript: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+        judge_model_config: ModelConfig,
+        extra_read_tools: list[Tool],
+        state_diff: str | None,
+    ) -> JudgeResult:
+        score = _hash_to_score(_rubric_signature(rubric))
+        criterion_results = tuple(
+            CriterionResult(
+                id=criterion.id,
+                met=score >= 0.5,
+                score=score,
+                justification=f"deterministic hash score {score:.3f}",
+            )
+            for criterion in rubric.criteria
+        )
+        return JudgeResult(
+            status=JudgeStatus.COMPLETED,
+            usage=JudgeUsage(),
+            reasons=f"Deterministic hash score {score:.3f}",
+            score=score,
+            binary_pass=score >= 0.5,
+            criterion_results=criterion_results,
+        )
+
+
+def _test_rubric_evaluator_factory(
+    ctx: RubricEvaluatorContext,
+) -> RubricEvaluator:
+    """Entry-point factory for the demo evaluator. Ignores ``ctx`` — the
+    deterministic evaluator has no build-time dependency to accept."""
+    del ctx
+    return DeterministicRubricEvaluator()

--- a/tests/utils/trace_check_operator_demo.py
+++ b/tests/utils/trace_check_operator_demo.py
@@ -1,0 +1,23 @@
+"""Deterministic custom operator for the composite-dispatch canonical test.
+
+``is_positive_number`` — returns True iff value is a numeric > 0. Not present
+in the shipped operator set. Proves the seam's registry-lookup path resolves
+custom names alongside the 17 defaults.
+
+The file name avoids the ``test_`` prefix so pyproject's ``python_files``
+collection does not pick this module up as a test — it is a fixture the
+canonical dispatch test wires up through a monkeypatched entry point.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+__all__ = ["is_positive_number"]
+
+
+def is_positive_number(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return value > 0

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -65,10 +65,19 @@ RUNNER_SUBSET_LOOSE_FILES: tuple[str, ...] = (
     # compose materialisation, engine run state, backend capabilities,
     # runtime / conductor / trial-grader protocol definitions, the
     # ``run_trial`` library entry, run queue, resume, project loader,
-    # plugin registry, metrics, budgets, ``model_data_fingerprint``, and
-    # the remaining utility modules — is orchestrator-only. ``model_data``
-    # is included; its orchestrator-only compute sibling
-    # ``model_data_fingerprint`` is not.
+    # metrics, budgets, ``model_data_fingerprint``, and the remaining
+    # utility modules — is orchestrator-only. ``model_data`` is included;
+    # its orchestrator-only compute sibling ``model_data_fingerprint`` is
+    # not. ``plugin_registry`` is included: the runner reaches it through
+    # ``load_custom_check_executor`` / ``load_judge_model_provider`` /
+    # ``load_rubric_evaluator`` / ``load_state_check_backend`` /
+    # ``load_transcript_rule_matcher`` at ``RunnerServiceImpl.__init__``
+    # and again through ``trace_checks``'s ``load_trace_check_operator``,
+    # so the module must ship with the subset. Its orchestrator-side
+    # Protocol imports (``Conductor``, ``RuntimeBackend``,
+    # ``ServiceReadinessProbe``, ``TrialGrader``, ``TurnPolicy``) are
+    # TYPE_CHECKING only; the runtime closure of ``plugin_registry`` is
+    # grader-side.
     "tolokaforge/core/__init__.py",
     "tolokaforge/core/_runner_subset.py",
     "tolokaforge/core/deprecations.py",
@@ -77,6 +86,7 @@ RUNNER_SUBSET_LOOSE_FILES: tuple[str, ...] = (
     "tolokaforge/core/loop.py",
     "tolokaforge/core/model_data.py",
     "tolokaforge/core/netpolicy_constants.py",
+    "tolokaforge/core/plugin_registry.py",
     "tolokaforge/core/pricing.py",
     "tolokaforge/core/redaction.py",
     "tolokaforge/core/run_display_events.py",

--- a/tolokaforge/core/grading/check_runner.py
+++ b/tolokaforge/core/grading/check_runner.py
@@ -765,6 +765,30 @@ class InMemoryCheckExecutor:
 
 
 # =============================================================================
+# Entry-point factories — registered under ``tolokaforge.custom_check_executors``
+# =============================================================================
+
+
+def _check_runner_factory() -> CheckExecutor:
+    """Arg-less factory for the production :class:`CheckRunner`.
+
+    Registered as the ``check_runner`` entry point in
+    ``tolokaforge.custom_check_executors``.
+    """
+    return CheckRunner()
+
+
+def _in_memory_check_executor_factory() -> CheckExecutor:
+    """Arg-less factory for the deterministic :class:`InMemoryCheckExecutor`.
+
+    Registered as the ``in_memory`` entry point in
+    ``tolokaforge.custom_check_executors`` — the fixture the canonical
+    tests reach for.
+    """
+    return InMemoryCheckExecutor()
+
+
+# =============================================================================
 # Public API exports
 # =============================================================================
 

--- a/tolokaforge/core/grading/composite.py
+++ b/tolokaforge/core/grading/composite.py
@@ -212,6 +212,7 @@ def grade_state_checks_reads(
         jsonpath_score, jsonpath_reasons = state_check_backends["jsonpath"].query(
             expression=jsonpath_checks,
             substrate=substrate,
+            trial_id=trial_id,
         )
         accounted[JSONPATHS_KEY] = EVALUATED
         if jsonpath_score is not None:
@@ -225,6 +226,7 @@ def grade_state_checks_reads(
         db_probe_score, db_probe_reasons = state_check_backends["db_probes"].query(
             expression=probes,
             substrate=substrate,
+            trial_id=trial_id,
         )
         accounted[DB_PROBES_KEY] = EVALUATED
         if db_probe_score is not None:

--- a/tolokaforge/core/grading/composite.py
+++ b/tolokaforge/core/grading/composite.py
@@ -48,9 +48,8 @@ from tolokaforge.core.grading.checks_interface import (
     ToolCall as CheckToolCall,
 )
 from tolokaforge.core.grading.jsonpath_addressing import addresses_the_database
-from tolokaforge.core.grading.judge import JudgeResult, LLMJudge
+from tolokaforge.core.grading.judge_result import JudgeResult
 from tolokaforge.core.grading.key_manifest import EVALUATED, NO_TIMELINE_EVENTS_SKIP
-from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.trace_checks import evaluate_trace_checks
 from tolokaforge.core.grading.transcript import (
@@ -71,6 +70,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from tolokaforge.core.grading.judge_tools import DelegatingReadTool
+    from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
     from tolokaforge.core.grading.substrate import GradingSubstrate
     from tolokaforge.core.grading.trace_checks import TraceChecksResult
     from tolokaforge.core.grading.trace_timeline import TrialTimeline
@@ -83,7 +83,6 @@ if TYPE_CHECKING:
     from tolokaforge.runner.models import (
         LLMJudgeConfig,
         RunnerStateChecksConfig,
-        TableSchema,
         TaskDescription,
         TraceChecksConfig,
     )
@@ -276,136 +275,59 @@ def grade_llm_judge(
     trial_id: str,
     config: LLMJudgeConfig,
     substrate: GradingSubstrate,
+    rubric_evaluator: RubricEvaluator,
     llm_messages: list[dict[str, Any]],
     judge_model_config: ModelConfig,
     extra_read_tools: list[DelegatingReadTool],
-    id_fields: dict[str, str | list[str]],
-    unstable_fields: set[tuple[str, str]],
-    initial_state_schemas: list[TableSchema],
+    state_diff: str | None,
     logger: StructuredLogger,
 ) -> JudgeResult:
     """Run the read-only rubric judge against ``substrate`` and return its verdict.
 
-    The judge reads through the substrate seam for all live evidence:
+    The evaluator reads through the substrate seam for all live evidence:
     :meth:`substrate.db_reader` for the read-only DB tools it exposes,
-    :meth:`substrate.knowledge_search` for ``search_kb``,
-    :meth:`substrate.filesystem_root` for ``read_file`` (``None`` withholds it),
-    :meth:`substrate.initial_state` + :meth:`substrate.final_state` for the
-    ``initial → final`` state-diff shown in the judge's opening message
-    — RAW final rows are what the diff needs to catch every stored field the
-    author's rubric might reference.
+    :meth:`substrate.knowledge_search` for ``search_kb``, and
+    :meth:`substrate.filesystem_root` for ``read_file`` (``None`` withholds it).
+    ``state_diff`` is a runner-resolved passthrough — the caller renders the
+    ``initial → final`` DB delta and hands it in; the composite forwards it
+    verbatim.
 
     ``extra_read_tools`` is a runner-resolved passthrough: the caller reconstructs
     the agent's ``search_policy`` connector as :class:`DelegatingReadTool` s so
     the judge can reuse the SAME TypeSense connector the agent used. The composite
-    forwards ``extra_read_tools`` verbatim to :meth:`LLMJudge.run`.
+    forwards ``extra_read_tools`` verbatim to the evaluator.
+
+    ``rubric_evaluator`` is the resolved :class:`RubricEvaluator` seam the
+    runner supplies — a plug-in impl (``llm_judge`` in the shipping config,
+    a downstream deterministic ruleset alongside) that owns the actual grade
+    dispatch. The trial's :attr:`LLMJudgeConfig.customization` (KB gate,
+    custom system-prompt, include-agent-system-prompt) is applied
+    construction-side on the evaluator instance itself — the composite only
+    forwards the per-trial evidence to :meth:`evaluator.evaluate`.
 
     Fail-loud contract: any judge malfunction — malformed ``submit_report`` past
     retries, budget/turn exhaustion, or a loop-terminal exception — surfaces as
     :attr:`JudgeStatus.ERRORED` with ``score is None``. Never a 0.0 / 0.5
-    fallback. :class:`SubstrateUnreachableError` from the substrate is NOT
-    swallowed by the state-diff best-effort block below — it propagates so the
-    dispatch site can translate it to ``GradingFailedError``.
+    fallback. :class:`SubstrateUnreachableError` from a substrate read
+    propagates so the dispatch site can translate it to ``GradingFailedError``.
 
     Sync-in-async note: the composite is a **sync** function. The InProcess
-    substrate's ``final_state`` factory blocks on ``run_coroutine_threadsafe`` to
-    bridge to the runner's dedicated event-loop thread, which deadlocks when
-    called from that loop. The runner therefore dispatches this function via
+    substrate's factories block on ``run_coroutine_threadsafe`` to bridge to
+    the runner's dedicated event-loop thread, which deadlocks when called
+    from that loop. The runner therefore dispatches this function via
     ``loop.run_in_executor(None, ...)`` — matching the shipped
     ``grade_state_checks_reads`` bridge — so the substrate's blocking reads
-    (and the judge loop's own DB reads inside :meth:`LLMJudge.run`) land off
-    the loop thread.
+    (and the evaluator's own DB reads) land off the loop thread.
     """
     agent_system_prompt, transcript = split_leading_system_message(list(llm_messages))
-
-    state_diff_text = _build_judge_state_diff(
-        trial_id=trial_id,
-        substrate=substrate,
-        initial_state_schemas=initial_state_schemas,
-        id_fields=id_fields,
-        unstable_fields=unstable_fields,
-        logger=logger,
-    )
-
-    customization = config.customization
-    disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
-    custom_system_prompt = customization.system_prompt if customization else None
-    include_agent_system_prompt = (
-        customization.include_agent_system_prompt
-        if customization and customization.include_agent_system_prompt is not None
-        else True
-    )
-
-    return LLMJudge(
-        judge_model_config,
-        disable_knowledge_search=disable_knowledge_search,
-        custom_system_prompt=custom_system_prompt,
-        include_agent_system_prompt=include_agent_system_prompt,
-    ).run(
+    return rubric_evaluator.evaluate(
         rubric=config.rubric,
         agent_system_prompt=agent_system_prompt,
         transcript=transcript,
-        db_reader=substrate.db_reader(),
-        kb_search=substrate.knowledge_search(),
+        substrate=substrate,
+        judge_model_config=judge_model_config,
         extra_read_tools=list(extra_read_tools),
-        workspace_dir=substrate.filesystem_root(),
-        state_diff=state_diff_text,
-    )
-
-
-def _build_judge_state_diff(
-    *,
-    trial_id: str,
-    substrate: GradingSubstrate,
-    initial_state_schemas: list[TableSchema],
-    id_fields: dict[str, str | list[str]],
-    unstable_fields: set[tuple[str, str]],
-    logger: StructuredLogger,
-) -> str | None:
-    """Render the ``initial → final`` DB state diff for the judge, or ``None``.
-
-    ``None`` is the diff-first default declining itself when there is nothing to
-    diff against: an empty ``initial_state`` — the shape non-DB tasks carry, and
-    what filesystem-only tasks report — has no baseline, so the judge falls back
-    to its read-only tools and (when available) the state-diff-free opening
-    message. The distinction between "no diff" and "diff unavailable" stays with
-    :func:`render_state_diff`'s explicit "No changes" body for a diff that DID
-    build but found no edits.
-
-    The trial's declared ``state_checks.id_fields`` is layered over the task
-    schemas' primary keys — the two together are the row-matching contract the
-    diff renders against — and ``unstable_fields`` drops server-marked noise so
-    only meaningful edits appear.
-
-    Best-effort context, not a grade component: :class:`SubstrateUnreachableError`
-    propagates so the seam can book the trial as ungradeable, but any other
-    substrate read failure (DB hiccup, unexpected shape) degrades to ``None`` —
-    the judge still has its read-only tools and the components already computed
-    by this call site are preserved. The judge's own fail-loud contract still
-    governs grading.
-    """
-    initial_tables = substrate.initial_state()
-    if not initial_tables:
-        return None
-    try:
-        final_state = substrate.final_state()
-    except SubstrateUnreachableError:
-        raise
-    except Exception as exc:  # noqa: BLE001 — optional context, never fail the grade
-        logger.warning(
-            "Failed to build judge state diff; grading without it "
-            f"(trial_id={trial_id}, error={exc})"
-        )
-        return None
-    primary_keys: dict[str, str | list[str]] = {
-        s.table_name: s.primary_key for s in initial_state_schemas
-    }
-    primary_keys.update(id_fields)
-    return render_state_diff(
-        initial_tables,
-        final_state,
-        primary_keys=primary_keys,
-        unstable_fields=unstable_fields,
+        state_diff=state_diff,
     )
 
 

--- a/tolokaforge/core/grading/composite.py
+++ b/tolokaforge/core/grading/composite.py
@@ -52,10 +52,7 @@ from tolokaforge.core.grading.judge_result import JudgeResult
 from tolokaforge.core.grading.key_manifest import EVALUATED, NO_TIMELINE_EVENTS_SKIP
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.trace_checks import evaluate_trace_checks
-from tolokaforge.core.grading.transcript import (
-    evaluate_transcript_rules,
-    scored_transcript_rules,
-)
+from tolokaforge.core.grading.transcript import scored_transcript_rules
 from tolokaforge.core.grading.transcript_wire import split_leading_system_message
 from tolokaforge.runner import runner_pb2 as pb2
 from tolokaforge.runner.db_client import TrialNotFoundError as DBTrialNotFoundError
@@ -78,6 +75,7 @@ if TYPE_CHECKING:
         TranscriptEvaluationResult,
         TranscriptRulesConfig,
     )
+    from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import KeyAccountingRecord, ModelConfig
     from tolokaforge.runner.models import (
@@ -93,6 +91,7 @@ def grade_transcript_rules(
     trial_id: str,
     config: TranscriptRulesConfig,
     timeline: TrialTimeline,
+    matcher: TranscriptRuleMatcher,
     logger: StructuredLogger,
 ) -> tuple[TranscriptEvaluationResult | None, dict[str, KeyAccountingRecord]]:
     """Score the pack's transcript rules against a trial timeline.
@@ -102,6 +101,14 @@ def grade_transcript_rules(
     ``NO_TIMELINE_EVENTS_SKIP`` record. When only the activity floor is scored,
     its siblings are recorded skipped first so the floor's own record survives
     the blanket skip.
+
+    :func:`scored_transcript_rules` stays inside this composite — it is the
+    events-less-trial gate every deployment topology needs applied at the same
+    layer, not per-matcher policy. The resolved
+    :class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`
+    is invoked with the gate-narrowed config: a plug-in impl (``default`` in
+    the shipping config; a downstream ruleset alongside) that owns the
+    actual per-rule scoring.
 
     Substrate-independent: reads only the timeline (the runner already built
     it from the transcript). Called identically by every deployment topology.
@@ -123,7 +130,7 @@ def grade_transcript_rules(
         )
         skipped_siblings = dict.fromkeys(transcript_rules_author_keys(), NO_TIMELINE_EVENTS_SKIP)
 
-    result = evaluate_transcript_rules(timeline, scored_rules)
+    result = matcher.evaluate(rules=scored_rules, timeline=timeline)
     return result, {**skipped_siblings, **result.accounted_keys}
 
 

--- a/tolokaforge/core/grading/composite.py
+++ b/tolokaforge/core/grading/composite.py
@@ -6,20 +6,32 @@ runs one composite grade against a :class:`GradingSubstrate`. This module
 carries the per-component helpers so they can be reused verbatim by every
 topology.
 
+Sub-component seams. Every sub-component evaluator reaches the composite
+through its Protocol via a resolved instance passed as a kwarg — never a
+direct import of the reference impl. The six shipped seams
+(:class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
+:class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
+:class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`,
+:class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`,
+:class:`~tolokaforge.core.grading.trace_check_operator.TraceCheckOperator`,
+:class:`~tolokaforge.core.grading.state_check_backend.StateCheckBackend`)
+resolve through :mod:`tolokaforge.core.plugin_registry` at the runner
+boundary and are threaded here as constructor args. The ``.importlinter``
+``composite-sub-component-seams`` contract enforces the negative-space of
+this rule by forbidding module-level imports of the six reference-impl
+modules from this file.
+
 Layering exception. The composite lives at ``tolokaforge/core/grading/``
 and imports a handful of symbols from the runner package: the wire-shape
 config models and the ``pb2`` proto types from :mod:`tolokaforge.runner`,
-``transcript_rules_author_keys`` from
-:mod:`tolokaforge.runner.grading_ledger`, and ``TrialNotFoundError`` from
-:mod:`tolokaforge.runner.db_client`. The runner is the sole owner of the
-wire shapes and of the DB-service error hierarchy the composite catches; a
-composite → runner import for those is the accepted one-way exception
-documented in ADR-0039.
+and ``transcript_rules_author_keys`` from
+:mod:`tolokaforge.runner.grading_ledger`. The runner is the sole owner of
+the wire shapes; a composite → runner import for those is the accepted
+one-way exception documented in ADR-0039.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -47,7 +59,6 @@ from tolokaforge.core.grading.checks_interface import (
 from tolokaforge.core.grading.checks_interface import (
     ToolCall as CheckToolCall,
 )
-from tolokaforge.core.grading.jsonpath_addressing import addresses_the_database
 from tolokaforge.core.grading.judge_result import JudgeResult
 from tolokaforge.core.grading.key_manifest import EVALUATED, NO_TIMELINE_EVENTS_SKIP
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
@@ -55,8 +66,6 @@ from tolokaforge.core.grading.trace_checks import evaluate_trace_checks
 from tolokaforge.core.grading.transcript import scored_transcript_rules
 from tolokaforge.core.grading.transcript_wire import split_leading_system_message
 from tolokaforge.runner import runner_pb2 as pb2
-from tolokaforge.runner.db_client import TrialNotFoundError as DBTrialNotFoundError
-from tolokaforge.runner.grading import evaluate_db_probes, evaluate_jsonpath_checks
 from tolokaforge.runner.grading_ledger import (
     DB_PROBES_KEY,
     JSONPATHS_KEY,
@@ -64,10 +73,12 @@ from tolokaforge.runner.grading_ledger import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from tolokaforge.core.grading.judge_tools import DelegatingReadTool
     from tolokaforge.core.grading.rubric_evaluator import RubricEvaluator
+    from tolokaforge.core.grading.state_check_backend import StateCheckBackend
     from tolokaforge.core.grading.substrate import GradingSubstrate
     from tolokaforge.core.grading.trace_checks import TraceChecksResult
     from tolokaforge.core.grading.trace_timeline import TrialTimeline
@@ -159,39 +170,37 @@ def grade_state_checks_reads(
     trial_id: str,
     config: RunnerStateChecksConfig,
     substrate: GradingSubstrate,
+    state_check_backends: Mapping[str, StateCheckBackend],
     logger: StructuredLogger,
 ) -> StateChecksReadResult:
     """Score the pack's ``jsonpaths`` and ``db_probes`` against ``substrate``.
 
-    Config-time gates live here so the substrate does exactly the reads the
-    assertions require: a path-glob-only pack fetches neither DB nor
-    filesystem; a DB-addressing pack fetches only STABLE DB state via
-    :meth:`substrate.final_state_stable`; a filesystem-only-``path:`` pack
-    fetches only :meth:`substrate.filesystem_state`. The STABLE DB view is
-    the one jsonpath grading resolves against — the shipped runner reads
-    ``db_client.get_stable_state`` here, so a per-run ``session_token``
-    never drags an author's ``$.db.users[0].session_token == 'S-1'``.
+    ``state_check_backends`` is a name → resolved
+    :class:`~tolokaforge.core.grading.state_check_backend.StateCheckBackend`
+    mapping the runner resolves at startup — the shipping runner supplies
+    ``{"jsonpath": JsonpathStateCheckBackend(), "db_probes":
+    DbProbesStateCheckBackend()}``. Each backend owns its source's read
+    strategy (which substrate accessors it consumes, how it handles absent
+    state, whether it opens its own connections) so the composite dispatches
+    without knowing either evaluator's internals. A downstream package
+    registering a third source under the ``tolokaforge.state_check_backends``
+    entry-point group (say, ``s3_diff``) becomes reachable here without a
+    framework change.
 
-    A :class:`~tolokaforge.runner.db_client.TrialNotFoundError` from the
-    substrate's STABLE read is graceful degradation — filesystem-only tasks
-    never call ``db_client.init_trial()``, so an absent DB is the expected
-    shape for them, and DB-declared tasks whose ``$.db.*`` assertions cannot
-    match still get the per-assertion "Path not found" diagnosis from
-    :func:`evaluate_jsonpath_checks` rather than a blanket refusal.
-
-    ``db_probes`` scoring is orthogonal to the substrate: each probe carries
-    its own ``dsn`` and hits its task's postgres directly via
-    :func:`evaluate_db_probes`. The composite only bookkeeps the accounting
-    entry when a probe actually ran.
+    Substrate-independent: the composite forwards ``substrate`` verbatim and
+    the resolved backend consumes only the accessors it needs. Hash grading
+    is NOT part of this seam — its snapshot-and-replay semantics need write
+    access to the trial's DB and stay runner-integrated on
+    :meth:`RunnerServiceImpl._execute_hash_grading` (see the seam module
+    docstring and ``docs/GRADER_SERVICE.md`` § "Sub-component plug-in seams").
 
     Sync-in-async note: the composite is a **sync** function. The InProcess
     substrate's factories block on ``run_coroutine_threadsafe`` to bridge to
     the runner's dedicated event-loop thread, which deadlocks when called
     from that loop. The runner therefore dispatches this function via
     ``loop.run_in_executor(None, ...)`` — matching the shipped
-    ``_grade_llm_judge`` bridge — so the substrate's blocking reads land off
-    the loop thread. Inside, ``evaluate_db_probes`` (async, asyncpg-backed)
-    is driven by an ephemeral :func:`asyncio.run` on the executor thread.
+    ``_grade_llm_judge`` bridge — so the substrate's blocking reads and the
+    ``db_probes`` backend's :func:`asyncio.run` land off the loop thread.
     """
     accounted: dict[str, KeyAccountingRecord] = {}
 
@@ -200,46 +209,26 @@ def grade_state_checks_reads(
     jsonpath_reasons: str | None = None
     if jsonpath_checks:
         logger.info(f"GradeTrial: {trial_id} - Evaluating {len(jsonpath_checks)} jsonpath checks")
-        path_checks = [check for check in jsonpath_checks if check.get("path") is not None]
-        state_dict_needed = bool(path_checks)
-        db_state_needed = any(addresses_the_database(check) for check in path_checks)
-        fs_state_needed = any(not addresses_the_database(check) for check in path_checks)
-        jsonpath_state: dict[str, Any] | None = None
-        if state_dict_needed:
-            db_state: dict[str, Any] = {}
-            if db_state_needed:
-                try:
-                    db_state = substrate.final_state_stable()
-                except DBTrialNotFoundError:
-                    # Filesystem-only tasks never call db_client.init_trial(), so
-                    # an absent DB is the expected shape. For tasks that DID
-                    # declare a DB this same branch fires and downstream
-                    # ``$.db.*`` assertions surface as "Path not found" — log
-                    # at warn so ops see the real cause rather than debugging
-                    # per-assertion failures.
-                    logger.warning(
-                        f"GradeTrial: {trial_id} - DB trial not found; grading with empty DB state"
-                    )
-            fs_state = substrate.filesystem_state() if fs_state_needed else None
-            jsonpath_state = {
-                "db": db_state,
-                "tables": db_state,
-                "filesystem": fs_state or {},
-            }
-        jsonpath_score, jsonpath_reasons = evaluate_jsonpath_checks(
-            jsonpath_checks, state=jsonpath_state
+        jsonpath_score, jsonpath_reasons = state_check_backends["jsonpath"].query(
+            expression=jsonpath_checks,
+            substrate=substrate,
         )
         accounted[JSONPATHS_KEY] = EVALUATED
-        logger.info(f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}")
+        if jsonpath_score is not None:
+            logger.info(f"GradeTrial: {trial_id} - Jsonpath checks: score={jsonpath_score:.2f}")
 
     db_probe_score: float | None = None
     db_probe_reasons: str | None = None
     if config.db_probes:
         logger.info(f"GradeTrial: {trial_id} - Evaluating {len(config.db_probes)} db probes")
         probes = [probe.model_dump() for probe in config.db_probes]
-        db_probe_score, db_probe_reasons = asyncio.run(evaluate_db_probes(probes))
+        db_probe_score, db_probe_reasons = state_check_backends["db_probes"].query(
+            expression=probes,
+            substrate=substrate,
+        )
         accounted[DB_PROBES_KEY] = EVALUATED
-        logger.info(f"GradeTrial: {trial_id} - DB probes: score={db_probe_score:.2f}")
+        if db_probe_score is not None:
+            logger.info(f"GradeTrial: {trial_id} - DB probes: score={db_probe_score:.2f}")
 
     return StateChecksReadResult(
         jsonpath_score=jsonpath_score,

--- a/tolokaforge/core/grading/default_judge_model_provider.py
+++ b/tolokaforge/core/grading/default_judge_model_provider.py
@@ -1,0 +1,44 @@
+"""Reference impl of :class:`JudgeModelProvider` wrapping
+:class:`~tolokaforge.core.llm.client.LLMClient`.
+
+Registered under the name ``litellm`` in the
+``tolokaforge.judge_model_providers`` entry-point group. The name matches
+the underlying transport (LiteLLM); a downstream ``openai_direct`` or
+``vertex_ai`` provider registers alongside without touching this module.
+
+This module holds the ONLY concrete impl of :class:`JudgeModelProvider` in
+the shipping distribution, so the ``.importlinter`` contract can forbid
+composite from importing it without also forbidding the Protocol module.
+"""
+
+from __future__ import annotations
+
+from tolokaforge.core.grading.judge_model_provider import (
+    JudgeModel,
+    JudgeModelProvider,
+)
+from tolokaforge.core.llm.client import LLMClient
+from tolokaforge.core.models import ModelConfig
+
+__all__ = [
+    "LiteLLMJudgeModelProvider",
+]
+
+
+class LiteLLMJudgeModelProvider:
+    """Build a :class:`JudgeModel` backed by
+    :class:`~tolokaforge.core.llm.client.LLMClient`.
+
+    :class:`LLMClient` structurally satisfies :class:`JudgeModel` (it
+    already carries ``.generate`` per :class:`LoopLLMClient` and
+    ``.classify_loop_error`` bound to its provider's rate-limit
+    patterns), so ``build`` just constructs the client and returns it.
+    """
+
+    def build(self, model_config: ModelConfig) -> JudgeModel:
+        return LLMClient(model_config)
+
+
+def _litellm_judge_model_provider_factory() -> JudgeModelProvider:
+    """Entry-point factory. Arg-less; returns a fresh provider instance."""
+    return LiteLLMJudgeModelProvider()

--- a/tolokaforge/core/grading/default_rubric_evaluator.py
+++ b/tolokaforge/core/grading/default_rubric_evaluator.py
@@ -1,0 +1,108 @@
+"""Reference impl of :class:`RubricEvaluator` — wraps
+:class:`~tolokaforge.core.grading.judge.LLMJudge`.
+
+Registered under the name ``llm_judge`` in the
+``tolokaforge.rubric_evaluators`` entry-point group. Constructs the
+:class:`~tolokaforge.core.grading.judge.LLMJudge` per ``.evaluate()`` call
+using the :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`
+handed via :class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluatorContext`,
+and delegates the run.
+
+This module holds the only concrete impl of :class:`RubricEvaluator` in
+the shipping distribution, so the ``.importlinter`` contract can forbid
+composite from importing it without also forbidding the Protocol module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from tolokaforge.core.grading.judge import LLMJudge
+from tolokaforge.core.grading.rubric_evaluator import (
+    RubricEvaluator,
+    RubricEvaluatorContext,
+)
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
+    from tolokaforge.core.grading.judge_result import JudgeResult
+    from tolokaforge.core.grading.substrate import GradingSubstrate
+    from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.runner.models import Rubric
+    from tolokaforge.tools.registry import Tool
+
+__all__ = [
+    "LLMJudgeRubricEvaluator",
+]
+
+
+class LLMJudgeRubricEvaluator:
+    """Build the :class:`LLMJudge` per :meth:`evaluate` and delegate to its ``run``.
+
+    The judge model itself is built lazily from :attr:`judge_model_provider`
+    inside :meth:`evaluate` — the provider takes the run-level
+    :class:`~tolokaforge.core.models.ModelConfig` and returns a
+    :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModel` the
+    judge injects into its loop, so a downstream transport swap (LiteLLM,
+    OpenAI-direct, Vertex, …) requires no change to this evaluator.
+    """
+
+    def __init__(
+        self,
+        judge_model_provider: JudgeModelProvider,
+        *,
+        disable_knowledge_search: bool = False,
+        custom_system_prompt: str | None = None,
+        include_agent_system_prompt: bool = True,
+        logger: StructuredLogger | None = None,
+    ) -> None:
+        self._judge_model_provider = judge_model_provider
+        self._disable_knowledge_search = disable_knowledge_search
+        self._custom_system_prompt = custom_system_prompt
+        self._include_agent_system_prompt = include_agent_system_prompt
+        self._logger = logger
+
+    def evaluate(
+        self,
+        *,
+        rubric: Rubric,
+        agent_system_prompt: str,
+        transcript: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+        judge_model_config: ModelConfig,
+        extra_read_tools: list[Tool],
+        state_diff: str | None,
+    ) -> JudgeResult:
+        judge_model = self._judge_model_provider.build(judge_model_config)
+        return LLMJudge(
+            judge_model_config,
+            disable_knowledge_search=self._disable_knowledge_search,
+            custom_system_prompt=self._custom_system_prompt,
+            include_agent_system_prompt=self._include_agent_system_prompt,
+            llm_client=judge_model,
+            logger=self._logger,
+        ).run(
+            rubric=rubric,
+            agent_system_prompt=agent_system_prompt,
+            transcript=transcript,
+            db_reader=substrate.db_reader(),
+            kb_search=substrate.knowledge_search(),
+            extra_read_tools=list(extra_read_tools),
+            workspace_dir=substrate.filesystem_root(),
+            state_diff=state_diff,
+        )
+
+
+def _llm_judge_rubric_evaluator_factory(
+    ctx: RubricEvaluatorContext,
+) -> RubricEvaluator:
+    """Entry-point factory. Adapts :class:`RubricEvaluatorContext` to the
+    :class:`LLMJudgeRubricEvaluator` constructor."""
+    return LLMJudgeRubricEvaluator(
+        ctx.judge_model_provider,
+        disable_knowledge_search=ctx.disable_knowledge_search,
+        custom_system_prompt=ctx.custom_system_prompt,
+        include_agent_system_prompt=ctx.include_agent_system_prompt,
+        logger=ctx.logger,
+    )

--- a/tolokaforge/core/grading/default_state_check_backends.py
+++ b/tolokaforge/core/grading/default_state_check_backends.py
@@ -1,0 +1,130 @@
+"""Reference impls of :class:`StateCheckBackend` — ``jsonpath`` + ``db_probes``.
+
+Registered under those two names in the ``tolokaforge.state_check_backends``
+entry-point group. Each wraps the corresponding
+:mod:`tolokaforge.runner.grading` evaluator and reshapes / bridges around it
+so :func:`~tolokaforge.core.grading.composite.grade_state_checks_reads` can
+dispatch through the seam without importing either evaluator.
+
+Hash grading is deliberately NOT a registered backend. Its snapshot-and-replay
+semantics need write access to the trial's DB — the read-only substrate
+cannot serve them — so hash grading stays runner-integrated on
+:meth:`~tolokaforge.runner.service.RunnerServiceImpl._execute_hash_grading`,
+called from :meth:`_grade_trial_async` above the composite dispatch.
+
+This module holds both concrete impls of :class:`StateCheckBackend` in the
+shipping distribution, so the ``.importlinter`` contract can forbid
+composite from importing it without also forbidding the Protocol module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from tolokaforge.core.grading.jsonpath_addressing import addresses_the_database
+from tolokaforge.core.grading.state_check_backend import StateCheckBackend
+from tolokaforge.runner.db_client import TrialNotFoundError as DBTrialNotFoundError
+from tolokaforge.runner.grading import evaluate_db_probes, evaluate_jsonpath_checks
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.substrate import GradingSubstrate
+
+__all__ = [
+    "DbProbesStateCheckBackend",
+    "JsonpathStateCheckBackend",
+]
+
+# The absent-trial degradation logs the shipped wording downstream tooling
+# (ops greps, canonical unit locks) reads. Kept on a module-level logger
+# rather than a per-call handle so the seam signature stays sync + evidence-only.
+_logger = logging.getLogger(__name__)
+
+
+class JsonpathStateCheckBackend:
+    """Score ``jsonpath_checks`` against the substrate's STABLE DB view + filesystem.
+
+    Reshapes :meth:`substrate.final_state_stable` (the STABLE view jsonpath
+    grading resolves against, so a run-scoped ``session_token`` never drags
+    an author's ``$.db.users[0].session_token == 'S-1'``) and
+    :meth:`substrate.filesystem_state` into the ``{db, tables, filesystem}``
+    shape :func:`evaluate_jsonpath_checks` addresses. Gates each read on the
+    expression: a path-glob-only pack fetches nothing; a DB-addressing pack
+    fetches only STABLE; a filesystem-only-``path:`` pack fetches only the
+    workspace walk.
+
+    A :class:`DBTrialNotFoundError` from the STABLE read is graceful
+    degradation — filesystem-only tasks never call ``db_client.init_trial()``,
+    so an absent DB is the expected shape for them, and DB-declared tasks
+    whose ``$.db.*`` assertions cannot match still get the per-assertion
+    "Path not found" diagnosis from :func:`evaluate_jsonpath_checks` rather
+    than a blanket refusal.
+    """
+
+    def query(
+        self,
+        *,
+        expression: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+    ) -> tuple[float | None, str | None]:
+        if not expression:
+            return None, None
+        path_checks = [check for check in expression if check.get("path") is not None]
+        state_dict_needed = bool(path_checks)
+        db_state_needed = any(addresses_the_database(check) for check in path_checks)
+        fs_state_needed = any(not addresses_the_database(check) for check in path_checks)
+        jsonpath_state: dict[str, Any] | None = None
+        if state_dict_needed:
+            db_state: dict[str, Any] = {}
+            if db_state_needed:
+                try:
+                    db_state = substrate.final_state_stable()
+                except DBTrialNotFoundError:
+                    # Filesystem-only tasks never call db_client.init_trial(),
+                    # so an absent DB is the expected shape. For tasks that
+                    # DID declare a DB this same branch fires and downstream
+                    # ``$.db.*`` assertions surface as "Path not found" — log
+                    # at warn so ops see the real cause rather than debugging
+                    # per-assertion failures.
+                    _logger.warning("DB trial not found; grading with empty DB state")
+            fs_state = substrate.filesystem_state() if fs_state_needed else None
+            jsonpath_state = {
+                "db": db_state,
+                "tables": db_state,
+                "filesystem": fs_state or {},
+            }
+        return evaluate_jsonpath_checks(expression, state=jsonpath_state)
+
+
+class DbProbesStateCheckBackend:
+    """Score ``db_probes`` by opening task-declared postgres connections.
+
+    Each probe carries its own ``dsn`` and hits its task's postgres directly
+    via :func:`evaluate_db_probes`; the substrate does not intermediate — a
+    probe DSN resolves only inside the task's docker network, which is the
+    connection the probe itself opens. :meth:`query` is sync so the seam
+    matches the sync composite dispatch; the async evaluator runs under an
+    ephemeral :func:`asyncio.run` on the executor thread the runner already
+    parks the composite on via ``loop.run_in_executor(None, ...)``.
+    """
+
+    def query(
+        self,
+        *,
+        expression: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+    ) -> tuple[float | None, str | None]:
+        if not expression:
+            return None, None
+        return asyncio.run(evaluate_db_probes(expression))
+
+
+def _jsonpath_state_check_backend_factory() -> StateCheckBackend:
+    """Entry-point factory. Arg-less; returns a fresh backend instance."""
+    return JsonpathStateCheckBackend()
+
+
+def _db_probes_state_check_backend_factory() -> StateCheckBackend:
+    """Entry-point factory. Arg-less; returns a fresh backend instance."""
+    return DbProbesStateCheckBackend()

--- a/tolokaforge/core/grading/default_state_check_backends.py
+++ b/tolokaforge/core/grading/default_state_check_backends.py
@@ -67,6 +67,7 @@ class JsonpathStateCheckBackend:
         *,
         expression: list[dict[str, Any]],
         substrate: GradingSubstrate,
+        trial_id: str | None = None,
     ) -> tuple[float | None, str | None]:
         if not expression:
             return None, None
@@ -87,7 +88,9 @@ class JsonpathStateCheckBackend:
                     # ``$.db.*`` assertions surface as "Path not found" — log
                     # at warn so ops see the real cause rather than debugging
                     # per-assertion failures.
-                    _logger.warning("DB trial not found; grading with empty DB state")
+                    _logger.warning(
+                        f"GradeTrial: {trial_id} - DB trial not found; grading with empty DB state"
+                    )
             fs_state = substrate.filesystem_state() if fs_state_needed else None
             jsonpath_state = {
                 "db": db_state,
@@ -114,6 +117,7 @@ class DbProbesStateCheckBackend:
         *,
         expression: list[dict[str, Any]],
         substrate: GradingSubstrate,
+        trial_id: str | None = None,
     ) -> tuple[float | None, str | None]:
         if not expression:
             return None, None

--- a/tolokaforge/core/grading/default_transcript_rule_matcher.py
+++ b/tolokaforge/core/grading/default_transcript_rule_matcher.py
@@ -1,0 +1,49 @@
+"""Reference impl of :class:`TranscriptRuleMatcher` — wraps
+:func:`~tolokaforge.core.grading.transcript.evaluate_transcript_rules`.
+
+Registered under the name ``default`` in the
+``tolokaforge.transcript_rule_matchers`` entry-point group. The reference
+impl scores every kind of rule the shipped
+:class:`~tolokaforge.runner.models.TranscriptRulesConfig` schema declares;
+a downstream package that wants to score a different vocabulary registers
+an alternative matcher alongside — no framework PR.
+
+This module holds the only concrete impl of :class:`TranscriptRuleMatcher`
+in the shipping distribution, so the ``.importlinter`` contract can forbid
+composite from importing it without also forbidding the Protocol module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.grading.transcript import evaluate_transcript_rules
+from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.trace_timeline import TrialTimeline
+    from tolokaforge.runner.models import (
+        TranscriptEvaluationResult,
+        TranscriptRulesConfig,
+    )
+
+__all__ = [
+    "DefaultTranscriptRuleMatcher",
+]
+
+
+class DefaultTranscriptRuleMatcher:
+    """Delegate to :func:`evaluate_transcript_rules` for the whole config."""
+
+    def evaluate(
+        self,
+        *,
+        rules: TranscriptRulesConfig,
+        timeline: TrialTimeline,
+    ) -> TranscriptEvaluationResult:
+        return evaluate_transcript_rules(timeline, rules)
+
+
+def _default_transcript_rule_matcher_factory() -> TranscriptRuleMatcher:
+    """Entry-point factory. Arg-less; returns a fresh matcher instance."""
+    return DefaultTranscriptRuleMatcher()

--- a/tolokaforge/core/grading/judge.py
+++ b/tolokaforge/core/grading/judge.py
@@ -38,11 +38,11 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from tolokaforge.core.grading.judge_model_provider import JudgeModel
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
 from tolokaforge.core.grading.judge_tools import (
     GetDbStateTool,
     QueryDbTool,
@@ -113,103 +113,6 @@ class DBReader(Protocol):
     def get_state(self, tables: list[str] | None = None) -> dict[str, Any]: ...
 
     def query(self, jsonpath: str) -> dict[str, Any]: ...
-
-
-# ---------------------------------------------------------------------------
-# Judge status + outcome
-# ---------------------------------------------------------------------------
-
-
-class JudgeStatus(str, Enum):
-    """Mirror of the proto ``JudgeStatus`` (kept as a host-side value object).
-
-    ``ERRORED`` is the fail-loud marker: the judge malfunctioned and there is no
-    trustworthy numeric score. ``COMPLETED`` means per-criterion results exist.
-    ``UNSPECIFIED`` is never produced by this module (the caller uses it for the
-    "no judge configured" case).
-    """
-
-    UNSPECIFIED = "unspecified"
-    COMPLETED = "completed"
-    ERRORED = "errored"
-
-
-@dataclass(frozen=True)
-class JudgeUsage:
-    """The judge's own accounting — recorded to the output bundle (plan: judge cost).
-
-    ``consistency_rejections`` counts ``submit_report`` attempts rejected for a
-    verdict/justification marker mismatch (a :class:`VerdictConsistencyError`) on
-    this trial — distinct from generic schema rejections, which are not counted.
-    """
-
-    calls: int = 0
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    reasoning_tokens: int = 0
-    cost_usd: float = 0.0
-    tool_calls: int = 0
-    consistency_rejections: int = 0
-
-
-@dataclass(frozen=True)
-class JudgeResult:
-    """Outcome of a rubric-judge run.
-
-    ``status == ERRORED`` carries NO score (``score is None``) and NO criterion
-    results — the fail-loud contract. ``status == COMPLETED`` carries the
-    weighted ``score`` in ``[0, 1]``, the per-criterion ``criterion_results``,
-    and ``gate_failed`` (a failed required criterion). ``reasons`` is always a
-    human-readable diagnostic.
-    """
-
-    status: JudgeStatus
-    usage: JudgeUsage
-    reasons: str
-    score: float | None = None
-    binary_pass: bool | None = None
-    gate_failed: bool = False
-    criterion_results: tuple[CriterionResult, ...] = ()
-    failed_required_ids: tuple[str, ...] = ()
-    # Which KB backend(s) the judge was offered this trial — the visible signal
-    # that the judge graded WITH (or WITHOUT) the knowledge base the agent used
-    # (issue #95). ``("search_kb",)`` for rag-service, ``("search_policy",)`` for
-    # the TypeSense passthrough, ``()`` for none offered. Surfaced verbatim into
-    # ``reasons`` as a "Judge KB: …" note. Empty is NOT an error — we cannot
-    # statically know a rubric needs KB — just an observability fact.
-    kb_tools_offered: tuple[str, ...] = ()
-    # KB-tagged tools the agent had this trial that the judge was constructed to
-    # withhold (``disable_knowledge_search``). Empty when nothing was gated — either
-    # the flag was off or the agent had no KB. ``knowledge_search_disabled`` records
-    # the construction flag itself, so a disabled judge over a KB-less trial reads
-    # ``knowledge_search_disabled=True`` with an empty ``kb_tools_withheld``.
-    kb_tools_withheld: tuple[str, ...] = ()
-    knowledge_search_disabled: bool = False
-    # Whether the judge ran with a custom system-prompt body (the default marker
-    # contract is always appended regardless). The full custom text is recorded in
-    # the bundle's ``task.yaml`` grading config, not here — this is the honest bool.
-    custom_system_prompt: bool = False
-    # Whether the harness was configured to embed the agent's policy / system
-    # prompt in the judge's opening-message evidence. Records the construction
-    # setting, not whether a block physically appeared — a trial with an empty
-    # agent prompt still reads ``True`` when the setting is default/on. Default
-    # ``True``: the harness includes the agent policy unless gated off.
-    include_agent_system_prompt: bool = True
-    # Non-KB read-only tools the judge was offered this trial: ``get_db_state`` /
-    # ``query_db`` (a DB reader was supplied), ``read_file`` (a workspace existed).
-    # The KB surface is ``kb_tools_offered`` / ``kb_tools_withheld``. Recorded so an
-    # offline replay knows which live backends to shim.
-    read_tools_offered: tuple[str, ...] = ()
-    # The ``initial → final`` state-delta string handed to the judge as its primary
-    # outcome view (``None`` when no diff was built). Echoed from the ``run()`` input
-    # so an offline replay can rebuild the judge's opening message from this exact
-    # string rather than re-reading a live DB.
-    state_diff: str | None = None
-    # The judge's own message transcript (role / content / tool_calls dicts),
-    # captured for audit/reproducibility (plan open question #2). Populated for
-    # both COMPLETED and ERRORED runs — an errored judge's partial transcript is
-    # the most useful artifact for debugging WHY it failed.
-    transcript: tuple[dict[str, Any], ...] = ()
 
 
 # ---------------------------------------------------------------------------

--- a/tolokaforge/core/grading/judge.py
+++ b/tolokaforge/core/grading/judge.py
@@ -42,6 +42,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from tolokaforge.core.grading.judge_model_provider import JudgeModel
 from tolokaforge.core.grading.judge_tools import (
     GetDbStateTool,
     QueryDbTool,
@@ -669,9 +670,10 @@ class LLMJudge:
     marker contract is always appended), ``include_agent_system_prompt`` (embed the
     agent's policy in the judge's opening-message evidence — default on; gate off for
     self-contained rubrics), an
-    optionally injected ``llm_client`` (tests pass a scripted client; production
-    passes ``None`` and the judge builds one ``LLMClient(model_config)`` per
-    :meth:`run`), and the logger. :meth:`run` carries only the per-trial evidence.
+    optionally injected ``llm_client`` (any :class:`JudgeModel` — tests pass a
+    scripted client; production passes ``None`` and the judge builds one
+    ``LLMClient(model_config)`` per :meth:`run`), and the logger. :meth:`run`
+    carries only the per-trial evidence.
     """
 
     def __init__(
@@ -684,7 +686,7 @@ class LLMJudge:
         disable_knowledge_search: bool = False,
         custom_system_prompt: str | None = None,
         include_agent_system_prompt: bool = True,
-        llm_client: LLMClient | None = None,
+        llm_client: JudgeModel | None = None,
         logger: StructuredLogger | None = None,
     ) -> None:
         self._model_config = model_config
@@ -726,7 +728,7 @@ class LLMJudge:
         logger = self._logger or get_logger("rubric_judge")
         metrics = _JudgeMetricsSink()
 
-        client: LLMClient
+        client: JudgeModel
         if self._llm_client is not None:
             client = self._llm_client
         else:

--- a/tolokaforge/core/grading/judge_model_provider.py
+++ b/tolokaforge/core/grading/judge_model_provider.py
@@ -1,0 +1,72 @@
+"""Judge model provider seam — Protocol + factory alias.
+
+A :class:`JudgeModel` is the LLM callable surface an :class:`LLMJudge`
+consumes. It composes :class:`~tolokaforge.core.loop.LoopLLMClient` — the
+``.generate`` seam the shared :class:`~tolokaforge.core.loop.ToolCallingLoop`
+already drives — with the ``.classify_loop_error`` method the judge passes
+as the loop's ``classify_error=`` argument (see
+:meth:`~tolokaforge.core.grading.judge.LLMJudge.run`). Any provider that
+implements those two methods is a valid judge model; the shipping
+:class:`~tolokaforge.core.llm.client.LLMClient` structurally satisfies the
+composed shape.
+
+A :class:`JudgeModelProvider` builds a :class:`JudgeModel` from a
+:class:`~tolokaforge.core.models.ModelConfig`. Discovery goes through
+:func:`~tolokaforge.core.plugin_registry.load_judge_model_provider` over
+the ``tolokaforge.judge_model_providers`` entry-point group; a downstream
+package registers an ``openai_direct`` or ``vertex_ai`` provider alongside
+the shipping ``litellm`` one without a framework PR.
+
+The reference impl lives in
+:mod:`tolokaforge.core.grading.default_judge_model_provider` — this
+Protocol module carries no behaviour so the composite dispatch can name
+:class:`JudgeModel` / :class:`JudgeModelProvider` without ever reaching
+the reference impl through it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from tolokaforge.core.loop import LoopLLMClient, TerminationDecision
+from tolokaforge.core.models import ModelConfig
+
+__all__ = [
+    "JudgeModel",
+    "JudgeModelProvider",
+    "JudgeModelProviderFactory",
+]
+
+
+@runtime_checkable
+class JudgeModel(LoopLLMClient, Protocol):
+    """The LLM callable surface an :class:`LLMJudge` consumes.
+
+    Inherits :class:`~tolokaforge.core.loop.LoopLLMClient` for the
+    ``.generate(...)`` seam the shared :class:`ToolCallingLoop` drives, and
+    adds :meth:`classify_loop_error` because ``LLMJudge.run`` binds
+    ``client.classify_loop_error`` as the loop's ``classify_error=``
+    argument. A downstream provider fronts a different LLM engine by
+    implementing these two methods and nothing more;
+    :class:`~tolokaforge.core.llm.client.LLMClient` already satisfies the
+    composed shape structurally.
+    """
+
+    def classify_loop_error(self, exc: Exception) -> TerminationDecision: ...
+
+
+@runtime_checkable
+class JudgeModelProvider(Protocol):
+    """Build a :class:`JudgeModel` from a
+    :class:`~tolokaforge.core.models.ModelConfig`.
+
+    Providers front different LLM transports (``litellm`` today; ``openai_direct``
+    or ``vertex_ai`` alongside a downstream provider) without leaking the
+    transport into the judge.
+    """
+
+    def build(self, model_config: ModelConfig) -> JudgeModel: ...
+
+
+JudgeModelProviderFactory = Callable[[], JudgeModelProvider]

--- a/tolokaforge/core/grading/judge_result.py
+++ b/tolokaforge/core/grading/judge_result.py
@@ -1,0 +1,117 @@
+"""Judge outcome types — ``JudgeStatus``, ``JudgeUsage``, ``JudgeResult``.
+
+Types-only module: no ``LLMJudge`` import, no behaviour. Every consumer of
+the three outcome types imports them from here, keeping the composite
+dispatch's judge-return surface reachable without pulling in the reference
+impl in :mod:`tolokaforge.core.grading.judge`.
+
+See :mod:`tolokaforge.core.grading.judge` for the ``LLMJudge`` /
+``InMemoryJudge`` implementations that construct these outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tolokaforge.runner.models import CriterionResult
+
+__all__ = [
+    "JudgeResult",
+    "JudgeStatus",
+    "JudgeUsage",
+]
+
+
+class JudgeStatus(str, Enum):
+    """Mirror of the proto ``JudgeStatus`` (kept as a host-side value object).
+
+    ``ERRORED`` is the fail-loud marker: the judge malfunctioned and there is no
+    trustworthy numeric score. ``COMPLETED`` means per-criterion results exist.
+    ``UNSPECIFIED`` is never produced by a judge implementation (the caller uses
+    it for the "no judge configured" case).
+    """
+
+    UNSPECIFIED = "unspecified"
+    COMPLETED = "completed"
+    ERRORED = "errored"
+
+
+@dataclass(frozen=True)
+class JudgeUsage:
+    """The judge's own accounting — recorded to the output bundle (plan: judge cost).
+
+    ``consistency_rejections`` counts ``submit_report`` attempts rejected for a
+    verdict/justification marker mismatch (a ``VerdictConsistencyError``) on
+    this trial — distinct from generic schema rejections, which are not counted.
+    """
+
+    calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    reasoning_tokens: int = 0
+    cost_usd: float = 0.0
+    tool_calls: int = 0
+    consistency_rejections: int = 0
+
+
+@dataclass(frozen=True)
+class JudgeResult:
+    """Outcome of a rubric-judge run.
+
+    ``status == ERRORED`` carries NO score (``score is None``) and NO criterion
+    results — the fail-loud contract. ``status == COMPLETED`` carries the
+    weighted ``score`` in ``[0, 1]``, the per-criterion ``criterion_results``,
+    and ``gate_failed`` (a failed required criterion). ``reasons`` is always a
+    human-readable diagnostic.
+    """
+
+    status: JudgeStatus
+    usage: JudgeUsage
+    reasons: str
+    score: float | None = None
+    binary_pass: bool | None = None
+    gate_failed: bool = False
+    criterion_results: tuple[CriterionResult, ...] = ()
+    failed_required_ids: tuple[str, ...] = ()
+    # Which KB backend(s) the judge was offered this trial — the visible signal
+    # that the judge graded WITH (or WITHOUT) the knowledge base the agent used
+    # (issue #95). ``("search_kb",)`` for rag-service, ``("search_policy",)`` for
+    # the TypeSense passthrough, ``()`` for none offered. Surfaced verbatim into
+    # ``reasons`` as a "Judge KB: …" note. Empty is NOT an error — we cannot
+    # statically know a rubric needs KB — just an observability fact.
+    kb_tools_offered: tuple[str, ...] = ()
+    # KB-tagged tools the agent had this trial that the judge was constructed to
+    # withhold (``disable_knowledge_search``). Empty when nothing was gated — either
+    # the flag was off or the agent had no KB. ``knowledge_search_disabled`` records
+    # the construction flag itself, so a disabled judge over a KB-less trial reads
+    # ``knowledge_search_disabled=True`` with an empty ``kb_tools_withheld``.
+    kb_tools_withheld: tuple[str, ...] = ()
+    knowledge_search_disabled: bool = False
+    # Whether the judge ran with a custom system-prompt body (the default marker
+    # contract is always appended regardless). The full custom text is recorded in
+    # the bundle's ``task.yaml`` grading config, not here — this is the honest bool.
+    custom_system_prompt: bool = False
+    # Whether the harness was configured to embed the agent's policy / system
+    # prompt in the judge's opening-message evidence. Records the construction
+    # setting, not whether a block physically appeared — a trial with an empty
+    # agent prompt still reads ``True`` when the setting is default/on. Default
+    # ``True``: the harness includes the agent policy unless gated off.
+    include_agent_system_prompt: bool = True
+    # Non-KB read-only tools the judge was offered this trial: ``get_db_state`` /
+    # ``query_db`` (a DB reader was supplied), ``read_file`` (a workspace existed).
+    # The KB surface is ``kb_tools_offered`` / ``kb_tools_withheld``. Recorded so an
+    # offline replay knows which live backends to shim.
+    read_tools_offered: tuple[str, ...] = ()
+    # The ``initial → final`` state-delta string handed to the judge as its primary
+    # outcome view (``None`` when no diff was built). Echoed from the ``run()`` input
+    # so an offline replay can rebuild the judge's opening message from this exact
+    # string rather than re-reading a live DB.
+    state_diff: str | None = None
+    # The judge's own message transcript (role / content / tool_calls dicts),
+    # captured for audit/reproducibility (plan open question #2). Populated for
+    # both COMPLETED and ERRORED runs — an errored judge's partial transcript is
+    # the most useful artifact for debugging WHY it failed.
+    transcript: tuple[dict[str, Any], ...] = ()

--- a/tolokaforge/core/grading/replay.py
+++ b/tolokaforge/core/grading/replay.py
@@ -35,11 +35,11 @@ from pydantic import BaseModel, ValidationError, model_validator
 from tolokaforge.core.failure_attribution import TrialOutcomeClass, classify_trial_outcome
 from tolokaforge.core.grading.judge import (
     DBReader,
-    JudgeResult,
     LLMJudge,
     model_config_from_ref,
 )
-from tolokaforge.core.grading.judge import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.judge_result import JudgeResult
+from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, SearchHit
 from tolokaforge.core.grading.replay_layout import (
     JUDGE_REPLAY_DIRNAME,

--- a/tolokaforge/core/grading/rubric_evaluator.py
+++ b/tolokaforge/core/grading/rubric_evaluator.py
@@ -77,11 +77,14 @@ class RubricEvaluatorContext:
 
     The reference impl reads :attr:`judge_model_provider` plus the three
     policy flags; a downstream evaluator is free to ignore fields it does
-    not use.
+    not use. :attr:`logger` is optional so a caller can defer to the
+    evaluator's own :func:`~tolokaforge.core.logging.get_logger` fallback
+    — the shipping reference impl does that when ``None`` reaches
+    :class:`~tolokaforge.core.grading.judge.LLMJudge`.
     """
 
     judge_model_provider: JudgeModelProvider
-    logger: StructuredLogger
+    logger: StructuredLogger | None = None
     disable_knowledge_search: bool = False
     custom_system_prompt: str | None = None
     include_agent_system_prompt: bool = True

--- a/tolokaforge/core/grading/rubric_evaluator.py
+++ b/tolokaforge/core/grading/rubric_evaluator.py
@@ -1,0 +1,90 @@
+"""Rubric evaluator seam — Protocol + Context + FactoryAlias.
+
+A :class:`RubricEvaluator` grades one trial's rubric evidence into a
+:class:`~tolokaforge.core.grading.judge_result.JudgeResult`. It consumes a
+:class:`~tolokaforge.core.grading.substrate.GradingSubstrate` for state /
+KB / filesystem reads and ignores deterministic-oracle fields by
+construction — the same narrow input surface
+:class:`~tolokaforge.core.grading.judge.Judge` enforces.
+
+Two-phase construction: factories accept a :class:`RubricEvaluatorContext`
+carrying the :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`
+plus policy flags; the evaluator instance receives the per-trial evidence
+at ``.evaluate()`` time. Discovery goes through
+:func:`~tolokaforge.core.plugin_registry.load_rubric_evaluator` over the
+``tolokaforge.rubric_evaluators`` entry-point group; a downstream package
+registers an alternative evaluator alongside the shipping
+``llm_judge`` reference impl without a framework PR.
+
+The reference impl lives in
+:mod:`tolokaforge.core.grading.default_rubric_evaluator` — this Protocol
+module carries no behaviour so the composite dispatch can name
+:class:`RubricEvaluator` without ever reaching the reference impl through
+it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
+    from tolokaforge.core.grading.judge_result import JudgeResult
+    from tolokaforge.core.grading.substrate import GradingSubstrate
+    from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import ModelConfig
+    from tolokaforge.runner.models import Rubric
+    from tolokaforge.tools.registry import Tool
+
+__all__ = [
+    "RubricEvaluator",
+    "RubricEvaluatorContext",
+    "RubricEvaluatorFactory",
+]
+
+
+@runtime_checkable
+class RubricEvaluator(Protocol):
+    """Grade one trial's rubric evidence into a :class:`JudgeResult`.
+
+    The per-trial *evidence* surface only. How an evaluator is built —
+    judge model provider, budgets, customization flags — is a
+    construction-time concern of the concrete impl carried in
+    :class:`RubricEvaluatorContext`, NOT part of this contract. Never the
+    deterministic-oracle fields (``golden_actions`` /
+    ``expect_initial_state`` / ``jsonpath_checks``) — they are not on the
+    Protocol surface.
+    """
+
+    def evaluate(
+        self,
+        *,
+        rubric: Rubric,
+        agent_system_prompt: str,
+        transcript: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+        judge_model_config: ModelConfig,
+        extra_read_tools: list[Tool],
+        state_diff: str | None,
+    ) -> JudgeResult: ...
+
+
+@dataclass(frozen=True)
+class RubricEvaluatorContext:
+    """Everything a rubric-evaluator factory may need at construction.
+
+    The reference impl reads :attr:`judge_model_provider` plus the three
+    policy flags; a downstream evaluator is free to ignore fields it does
+    not use.
+    """
+
+    judge_model_provider: JudgeModelProvider
+    logger: StructuredLogger
+    disable_knowledge_search: bool = False
+    custom_system_prompt: str | None = None
+    include_agent_system_prompt: bool = True
+
+
+RubricEvaluatorFactory = Callable[[RubricEvaluatorContext], RubricEvaluator]

--- a/tolokaforge/core/grading/state_check_backend.py
+++ b/tolokaforge/core/grading/state_check_backend.py
@@ -1,0 +1,67 @@
+"""State-check backend seam — Protocol + FactoryAlias.
+
+A :class:`StateCheckBackend` scores one source of state-check evidence
+against a :class:`~tolokaforge.core.grading.substrate.GradingSubstrate` and
+returns ``(score, reasons)`` — the same shape
+:func:`~tolokaforge.core.grading.composite.grade_state_checks_reads`
+produces per source. Discovery goes through
+:func:`~tolokaforge.core.plugin_registry.load_state_check_backend` over the
+``tolokaforge.state_check_backends`` entry-point group.
+
+Two reference impls ship: ``jsonpath`` reshapes the substrate's STABLE DB
+view + agent-visible filesystem into the ``{db, tables, filesystem}`` state
+:func:`evaluate_jsonpath_checks` addresses; ``db_probes`` opens task-declared
+postgres connections and applies each probe's ``expect`` block. A downstream
+package registers a third source (e.g. an S3-bucket-diff backend) alongside
+without a framework PR.
+
+Hash grading is deliberately NOT a registered backend. The
+``state_checks.hash`` component has state-mutation semantics (snapshot →
+reset → replay → snapshot → restore) that the read-only substrate cannot
+serve; hash grading stays runner-integrated on
+:meth:`~tolokaforge.runner.service.RunnerServiceImpl._execute_hash_grading`,
+called by :meth:`_grade_trial_async` above the composite dispatch.
+
+The reference impls live in
+:mod:`tolokaforge.core.grading.default_state_check_backends` — this
+Protocol module carries no behaviour so the composite dispatch can name
+:class:`StateCheckBackend` without ever reaching a reference impl through
+it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.substrate import GradingSubstrate
+
+__all__ = [
+    "StateCheckBackend",
+    "StateCheckBackendFactory",
+]
+
+
+@runtime_checkable
+class StateCheckBackend(Protocol):
+    """Score one source of state-check evidence against ``substrate``.
+
+    ``expression`` is the source-specific config (a list of jsonpath check
+    dicts for the ``jsonpath`` backend; a list of probe dicts for the
+    ``db_probes`` backend). Return the ``(score, reasons)`` pair the
+    composite folds into :class:`StateChecksReadResult`; ``(None, None)``
+    is a first-class "no evidence to score" signal — an empty expression
+    list, or a source-specific gate — that leaves the corresponding
+    component slot untouched.
+    """
+
+    def query(
+        self,
+        *,
+        expression: list[dict[str, Any]],
+        substrate: GradingSubstrate,
+    ) -> tuple[float | None, str | None]: ...
+
+
+StateCheckBackendFactory = Callable[[], StateCheckBackend]

--- a/tolokaforge/core/grading/state_check_backend.py
+++ b/tolokaforge/core/grading/state_check_backend.py
@@ -54,6 +54,11 @@ class StateCheckBackend(Protocol):
     is a first-class "no evidence to score" signal — an empty expression
     list, or a source-specific gate — that leaves the corresponding
     component slot untouched.
+
+    ``trial_id`` is optional context a backend may weave into audit
+    warnings so a multi-trial log stream stays attributable — the
+    reference ``jsonpath`` backend prefixes its DB-absent warning with
+    it. Backends that emit no per-trial warning ignore the field.
     """
 
     def query(
@@ -61,6 +66,7 @@ class StateCheckBackend(Protocol):
         *,
         expression: list[dict[str, Any]],
         substrate: GradingSubstrate,
+        trial_id: str | None = None,
     ) -> tuple[float | None, str | None]: ...
 
 

--- a/tolokaforge/core/grading/substrate.py
+++ b/tolokaforge/core/grading/substrate.py
@@ -15,8 +15,8 @@ The runtime picture
 +-------------------------------------+----------------------------------------+
 | Deployment shape                    | Substrate implementation               |
 +=====================================+========================================+
-| Aggregate image (this milestone)    | :class:`InProcessGradingSubstrate`     |
-| Independent grader (this milestone) | :class:`LiveRunnerCallbackGradingSub-  |
+| Aggregate image (shipping)          | :class:`InProcessGradingSubstrate`     |
+| Independent grader (shipping)       | :class:`LiveRunnerCallbackGradingSub-  |
 |                                     | strate`                                |
 | Trajectory-storage service (future) | :class:`TrajectoryStorageGradingSub-   |
 |                                     | strate` (recipe in ADR-0039)           |

--- a/tolokaforge/core/grading/trace_check_operator.py
+++ b/tolokaforge/core/grading/trace_check_operator.py
@@ -1,0 +1,131 @@
+"""Per-operator seam under the trace-check evaluator.
+
+Every operator a ``ValuePredicate`` may declare is one entry-point in the
+``tolokaforge.trace_check_operators`` group. The registry is the sole
+dispatch table :func:`~tolokaforge.core.grading.trace_checks._operator_holds`
+reads: a downstream package registering ``equals_semver`` under that name
+starts scoring every trace-check config in the wild that writes
+``equals_semver`` in a :class:`~tolokaforge.core.models.ValuePredicate`,
+with no framework PR.
+
+Two arities collapse to one Protocol. The 15 non-binding operators ignore
+``bindings``; the two binding operators (identified by the ``_binding``
+suffix on their registered name) read ``bindings[expected]`` — the name
+their author wrote in the constraint's ``bind`` block. The suffix is the
+sole marker: no attribute on the callable, no parallel registry.
+
+See ``docs/GRADING.md`` § "Trace checks" for the authored vocabulary and
+``docs/GRADER_SERVICE.md`` § "Sub-component plug-in seams" for the seam
+row.
+"""
+
+from __future__ import annotations
+
+import operator as _operator
+import re
+from collections.abc import Callable, Mapping, Sized
+from typing import Any, TypeAlias
+
+from tolokaforge.core.grading.predicates import contains
+
+__all__ = [
+    "TraceCheckOperator",
+    "contains_binding",
+    "contains_ci",
+    "contains_op",
+    "equals",
+    "equals_binding",
+    "equals_ci",
+    "exists",
+    "gt",
+    "gte",
+    "in_op",
+    "len_gt",
+    "len_gte",
+    "lt",
+    "lte",
+    "not_equals",
+    "not_in_op",
+    "regex_matches",
+]
+
+TraceCheckOperator: TypeAlias = Callable[[Any, Any, Mapping[str, Any]], bool]
+
+
+def equals(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return value == expected
+
+
+def not_equals(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return value != expected
+
+
+def equals_ci(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return isinstance(value, str) and value.casefold() == expected.casefold()
+
+
+def contains_op(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return contains(value, expected)
+
+
+def contains_ci(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return contains(value, expected, ci=True)
+
+
+def regex_matches(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return isinstance(value, str) and re.search(expected, value) is not None
+
+
+def gt(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return _numeric(value, expected, _operator.gt)
+
+
+def gte(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return _numeric(value, expected, _operator.ge)
+
+
+def lt(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return _numeric(value, expected, _operator.lt)
+
+
+def lte(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return _numeric(value, expected, _operator.le)
+
+
+def in_op(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return value in expected
+
+
+def not_in_op(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return value not in expected
+
+
+def len_gt(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return isinstance(value, Sized) and len(value) > expected
+
+
+def len_gte(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return isinstance(value, Sized) and len(value) >= expected
+
+
+def exists(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return (value is not None) is expected
+
+
+def equals_binding(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return value == bindings[expected]
+
+
+def contains_binding(value: Any, expected: Any, bindings: Mapping[str, Any]) -> bool:
+    return contains(value, bindings[expected])
+
+
+def _as_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
+
+
+def _numeric(value: Any, expected: Any, compare: Callable[[float, float], bool]) -> bool:
+    number = _as_number(value)
+    return number is not None and compare(number, expected)

--- a/tolokaforge/core/grading/trace_checks.py
+++ b/tolokaforge/core/grading/trace_checks.py
@@ -83,11 +83,9 @@ from tolokaforge.core.models import (
     TurnWindow,
     ValuePredicate,
 )
-from tolokaforge.core.plugin_registry import (
-    TRACE_CHECK_OPERATORS_GROUP,
-    discover_entry_points,
-    load_trace_check_operator,
-)
+
+# ``plugin_registry`` is imported lazily inside the two functions below that
+# use it (``_operator_holds`` + ``_binding_operator_names``) — see their bodies.
 
 __all__ = ["MatcherOutcome", "evaluate_trace_checks", "select_events"]
 
@@ -467,6 +465,8 @@ def _operator_holds(name: str, value: Any, expected: Any, bindings: Mapping[str,
     """
     if value is None and name != "exists":
         return False
+    from tolokaforge.core.plugin_registry import load_trace_check_operator
+
     op = load_trace_check_operator(name)
     return op(value, expected, bindings)
 
@@ -475,11 +475,15 @@ def _binding_operator_names() -> list[str]:
     """Registered operator names whose semantics substitute a bound value.
 
     Materialised from the entry-point registry, filtered by the ``_binding``
-    suffix — the sole marker for binding operators (Approved Decision #2 on
-    ADR-0039). The discovery scan is cached in ``plugin_registry``, so a per-call
-    filter is O(N) over the registry size (17 shipped + downstream) and does not
-    fire the loader.
+    suffix — the sole marker for binding operators (ADR-0039). The discovery
+    scan is cached in ``plugin_registry``, so a per-call filter is O(N) over
+    the registry size (17 shipped + downstream) and does not fire the loader.
     """
+    from tolokaforge.core.plugin_registry import (
+        TRACE_CHECK_OPERATORS_GROUP,
+        discover_entry_points,
+    )
+
     return sorted(
         n for n in discover_entry_points(TRACE_CHECK_OPERATORS_GROUP) if n.endswith("_binding")
     )

--- a/tolokaforge/core/grading/trace_checks.py
+++ b/tolokaforge/core/grading/trace_checks.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import itertools
 import operator
 import re
-from collections.abc import Callable, Iterable, Mapping, Sequence, Sized
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -48,7 +48,7 @@ from tolokaforge.core.grading.key_manifest import (
     TRACE_CONSTRAINTS_KEY,
     UNBOUND_BINDING_SKIP,
 )
-from tolokaforge.core.grading.predicates import contains, ever_satisfiable, json_type_of
+from tolokaforge.core.grading.predicates import ever_satisfiable, json_type_of
 from tolokaforge.core.grading.trace_timeline import (
     TraceEvent,
     TraceEventKind,
@@ -82,6 +82,11 @@ from tolokaforge.core.models import (
     TracePathResult,
     TurnWindow,
     ValuePredicate,
+)
+from tolokaforge.core.plugin_registry import (
+    TRACE_CHECK_OPERATORS_GROUP,
+    discover_entry_points,
+    load_trace_check_operator,
 )
 
 __all__ = ["MatcherOutcome", "evaluate_trace_checks", "select_events"]
@@ -332,7 +337,7 @@ def _comparison_records(
     A predicate is a conjunction, so both references are read: an author who wrote
     two of them made two mistakes and is owed both.
     """
-    references = [(name, getattr(predicate, name)) for name in sorted(_BINDING_OPERATORS)]
+    references = [(name, getattr(predicate, name)) for name in _binding_operator_names()]
     return [
         _ComparisonRecord(
             event=event,
@@ -454,75 +459,30 @@ def _operator_holds(name: str, value: Any, expected: Any, bindings: Mapping[str,
     Only ``exists`` reads a ``None``. Every other operator is false there rather
     than answering about a value the trial does not have — ``not_equals`` against an
     absent argument would otherwise hold, which is the vacuous truth the timeline
-    contract forbids.
+    contract forbids. The gate is a dispatch invariant declared once here rather
+    than repeated inside every registered operator.
 
-    A binding operator substitutes and delegates: ``expected`` is a name rather than
-    a value, and the comparison is the one the literal form makes, so a constraint
-    over a single candidate scores exactly as the same constraint with that value
-    written out. The name is in the environment by construction — a reference to a
-    name the constraint does not bind is a load error.
+    ``name`` resolves through the ``tolokaforge.trace_check_operators`` entry-point
+    group — the only dispatch table this evaluator reads.
     """
     if value is None and name != "exists":
         return False
-    if name in _BINDING_OPERATORS:
-        return _BINDING_OPERATORS[name](value, bindings[expected])
-    return _OPERATORS[name](value, expected)
+    op = load_trace_check_operator(name)
+    return op(value, expected, bindings)
 
 
-def _as_number(value: Any) -> float | None:
-    """``value`` as a number, or ``None`` when it is not one — ``bool`` is not one."""
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        return None
-    return float(value)
+def _binding_operator_names() -> list[str]:
+    """Registered operator names whose semantics substitute a bound value.
 
-
-def _numeric(compare: Callable[[float, float], bool]) -> Callable[[Any, Any], bool]:
-    def holds(value: Any, bound: float) -> bool:
-        number = _as_number(value)
-        return number is not None and compare(number, bound)
-
-    return holds
-
-
-def _by_length(compare: Callable[[int, int], bool]) -> Callable[[Any, Any], bool]:
-    def holds(value: Any, bound: int) -> bool:
-        return isinstance(value, Sized) and compare(len(value), bound)
-
-    return holds
-
-
-def _equals_ci(value: Any, expected: str) -> bool:
-    return isinstance(value, str) and value.casefold() == expected.casefold()
-
-
-def _matches_regex(value: Any, pattern: str) -> bool:
-    return isinstance(value, str) and re.search(pattern, value) is not None
-
-
-_OPERATORS: Mapping[str, Callable[[Any, Any], bool]] = {
-    "equals": operator.eq,
-    "equals_ci": _equals_ci,
-    "contains": contains,
-    "contains_ci": lambda value, needle: contains(value, needle, ci=True),
-    "not_equals": operator.ne,
-    "regex": _matches_regex,
-    "gt": _numeric(operator.gt),
-    "gte": _numeric(operator.ge),
-    "lt": _numeric(operator.lt),
-    "lte": _numeric(operator.le),
-    "in_": lambda value, allowed: value in allowed,
-    "not_in": lambda value, rejected: value not in rejected,
-    "len_gt": _by_length(operator.gt),
-    "len_gte": _by_length(operator.ge),
-    "exists": lambda value, expected: (value is not None) is expected,
-}
-
-# A reference substitutes its bound value into the comparison the literal operator
-# already makes, so the two spellings cannot drift into two readings of one word.
-_BINDING_OPERATORS: Mapping[str, Callable[[Any, Any], bool]] = {
-    "equals_binding": operator.eq,
-    "contains_binding": contains,
-}
+    Materialised from the entry-point registry, filtered by the ``_binding``
+    suffix — the sole marker for binding operators (Approved Decision #2 on
+    ADR-0039). The discovery scan is cached in ``plugin_registry``, so a per-call
+    filter is O(N) over the registry size (17 shipped + downstream) and does not
+    fire the loader.
+    """
+    return sorted(
+        n for n in discover_entry_points(TRACE_CHECK_OPERATORS_GROUP) if n.endswith("_binding")
+    )
 
 
 def evaluate_trace_checks(timeline: TrialTimeline, config: TraceChecksConfig) -> TraceChecksResult:

--- a/tolokaforge/core/grading/transcript_rule_matcher.py
+++ b/tolokaforge/core/grading/transcript_rule_matcher.py
@@ -1,0 +1,55 @@
+"""Transcript-rule matcher seam — Protocol + FactoryAlias.
+
+A :class:`TranscriptRuleMatcher` scores the WHOLE
+:class:`~tolokaforge.runner.models.TranscriptRulesConfig` against a
+:class:`~tolokaforge.core.grading.trace_timeline.TrialTimeline` and returns
+one :class:`~tolokaforge.runner.models.TranscriptEvaluationResult`. The
+seam is holistic — one matcher per config, NOT one matcher per rule kind —
+because a per-kind seam would only be extensible via a
+:class:`TranscriptRulesConfig` schema extension, and that schema is what
+would truly gate the operator win.
+
+Discovery goes through
+:func:`~tolokaforge.core.plugin_registry.load_transcript_rule_matcher` over
+the ``tolokaforge.transcript_rule_matchers`` entry-point group; a downstream
+package registers an alternative matcher alongside the shipping ``default``
+reference impl without a framework PR.
+
+The reference impl lives in
+:mod:`tolokaforge.core.grading.default_transcript_rule_matcher` — this
+Protocol module carries no behaviour so the composite dispatch can name
+:class:`TranscriptRuleMatcher` without ever reaching the reference impl
+through it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from tolokaforge.core.grading.trace_timeline import TrialTimeline
+    from tolokaforge.runner.models import (
+        TranscriptEvaluationResult,
+        TranscriptRulesConfig,
+    )
+
+__all__ = [
+    "TranscriptRuleMatcher",
+    "TranscriptRuleMatcherFactory",
+]
+
+
+@runtime_checkable
+class TranscriptRuleMatcher(Protocol):
+    """Score one :class:`TranscriptRulesConfig` against one :class:`TrialTimeline`."""
+
+    def evaluate(
+        self,
+        *,
+        rules: TranscriptRulesConfig,
+        timeline: TrialTimeline,
+    ) -> TranscriptEvaluationResult: ...
+
+
+TranscriptRuleMatcherFactory = Callable[[], TranscriptRuleMatcher]

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -9,15 +9,17 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.grading.substrate.GradingSubstrate`,
 :class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
 :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
+:class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`,
 and
-:class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`
+:class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`
 Protocols through ``importlib.metadata`` entry-point groups — no in-tree
 edit, no monkey-patch. Each entry point resolves to a *factory callable*,
 mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
 idiom. Five of the seams adapt divergent impl constructors to a per-group
 frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
-probes, custom-check executors, and judge model providers need no build
-dependencies, so their factories are arg-less (``Callable[[], <Impl>]``).
+probes, custom-check executors, judge model providers, and transcript-rule
+matchers need no build dependencies, so their factories are arg-less
+(``Callable[[], <Impl>]``).
 The grading-substrate loader resolves directly to the ``GradingSubstrate``
 implementation *class* — the substrate seam is constructed per-trial with
 topology-specific arguments the plug-in group cannot generically supply,
@@ -34,6 +36,7 @@ The groups:
 * ``tolokaforge.custom_check_executors`` → :data:`CustomCheckExecutorFactory`
 * ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
 * ``tolokaforge.rubric_evaluators`` → :data:`RubricEvaluatorFactory`
+* ``tolokaforge.transcript_rule_matchers`` → :data:`TranscriptRuleMatcherFactory`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -63,6 +66,7 @@ from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
 from tolokaforge.core.grading.substrate import GradingSubstrate
+from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcherFactory
 from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
 from tolokaforge.core.runtime import RuntimeBackend
@@ -88,6 +92,7 @@ __all__ = [
     "RubricEvaluatorFactory",
     "RuntimeBackendBuildContext",
     "RuntimeBackendFactory",
+    "TranscriptRuleMatcherFactory",
     "TrialGraderContext",
     "TrialGraderFactory",
     "TurnPolicyContext",
@@ -100,6 +105,7 @@ __all__ = [
     "available_readiness_probes",
     "available_rubric_evaluators",
     "available_runtime_backends",
+    "available_transcript_rule_matchers",
     "available_trial_graders",
     "available_turn_policies",
     "discover_entry_points",
@@ -110,6 +116,7 @@ __all__ = [
     "load_readiness_probe",
     "load_rubric_evaluator",
     "load_runtime_backend",
+    "load_transcript_rule_matcher",
     "load_trial_grader",
     "load_turn_policy",
 ]
@@ -123,6 +130,7 @@ GRADING_SUBSTRATES_GROUP = "tolokaforge.grading_substrates"
 CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
 RUBRIC_EVALUATORS_GROUP = "tolokaforge.rubric_evaluators"
+TRANSCRIPT_RULE_MATCHERS_GROUP = "tolokaforge.transcript_rule_matchers"
 
 
 # ---------------------------------------------------------------------------
@@ -369,6 +377,11 @@ def load_rubric_evaluator(name: str) -> RubricEvaluatorFactory:
     return cast(RubricEvaluatorFactory, _load(RUBRIC_EVALUATORS_GROUP, name))
 
 
+def load_transcript_rule_matcher(name: str) -> TranscriptRuleMatcherFactory:
+    """Resolve a registered transcript-rule-matcher name to its factory callable."""
+    return cast(TranscriptRuleMatcherFactory, _load(TRANSCRIPT_RULE_MATCHERS_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -429,3 +442,8 @@ def available_judge_model_providers() -> list[str]:
 def available_rubric_evaluators() -> list[str]:
     """Sorted names registered in the ``tolokaforge.rubric_evaluators`` group."""
     return sorted(discover_entry_points(RUBRIC_EVALUATORS_GROUP))
+
+
+def available_transcript_rule_matchers() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.transcript_rule_matchers`` group."""
+    return sorted(discover_entry_points(TRANSCRIPT_RULE_MATCHERS_GROUP))

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -67,8 +67,6 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
-from tolokaforge.core.actors.turn_policy import TurnPolicy
-from tolokaforge.core.conductor import ConductorFactory
 from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
@@ -78,18 +76,29 @@ from tolokaforge.core.grading.trace_check_operator import TraceCheckOperator
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcherFactory
 from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
-from tolokaforge.core.runtime import RuntimeBackend
-from tolokaforge.core.service_readiness import ServiceReadinessProbe
-from tolokaforge.core.trial_grader import TrialGrader
 
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
 
     from tolokaforge.core.actors.actor import Actor
+    from tolokaforge.core.actors.turn_policy import TurnPolicy
     from tolokaforge.core.compose_materialisation import LogCaptureConfig
+    from tolokaforge.core.conductor import Conductor, ConductorContext
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import SeedRef
+    from tolokaforge.core.runtime import RuntimeBackend
+    from tolokaforge.core.service_readiness import ServiceReadinessProbe
     from tolokaforge.core.trial import EnvironmentManifest
+    from tolokaforge.core.trial_grader import TrialGrader
+
+# Orchestrator-side Protocol modules (``conductor``, ``runtime``, ``service_readiness``,
+# ``trial_grader``, ``actors.turn_policy``) are TYPE_CHECKING imports above. Their
+# module-level closures reach ``adapters``, ``LLMClient``, ``LLMJudge``, and other
+# orchestrator-only surface that the runner subset does not ship. The Factory
+# aliases below carry the Protocol names as string forward references so
+# ``typing.Callable[...]`` can subscript them at runtime without triggering the
+# heavy import — ``cast()`` erases the alias, so the runtime object never needs
+# the concrete class.
 
 __all__ = [
     "ConductorFactory",
@@ -270,10 +279,11 @@ class TurnPolicyContext:
     user_simulator: Actor | None = None
 
 
-RuntimeBackendFactory = Callable[[RuntimeBackendBuildContext], RuntimeBackend]
-TrialGraderFactory = Callable[[TrialGraderContext], TrialGrader]
-ReadinessProbeFactory = Callable[[], ServiceReadinessProbe]
-TurnPolicyFactory = Callable[[TurnPolicyContext], TurnPolicy]
+RuntimeBackendFactory = Callable[[RuntimeBackendBuildContext], "RuntimeBackend"]
+TrialGraderFactory = Callable[[TrialGraderContext], "TrialGrader"]
+ReadinessProbeFactory = Callable[[], "ServiceReadinessProbe"]
+TurnPolicyFactory = Callable[[TurnPolicyContext], "TurnPolicy"]
+ConductorFactory = Callable[["ConductorContext"], "Conductor"]
 CustomCheckExecutorFactory = Callable[[], CheckExecutor]
 
 
@@ -415,8 +425,8 @@ def load_trace_check_operator(name: str) -> TraceCheckOperator:
 
     The seam is per-operator, and the callable itself IS the contract: no
     factory wrapper. A binding operator is identified by the ``_binding``
-    suffix on its registered name (Approved Decision #2 on ADR-0039); the
-    callable's shape does not change.
+    suffix on its registered name (ADR-0039); the callable's shape does
+    not change.
     """
     return cast(TraceCheckOperator, _load(TRACE_CHECK_OPERATORS_GROUP, name))
 

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -10,10 +10,11 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
 :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
 :class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`,
+:class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`,
 and
-:class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`
+:data:`~tolokaforge.core.grading.trace_check_operator.TraceCheckOperator`
 Protocols through ``importlib.metadata`` entry-point groups — no in-tree
-edit, no monkey-patch. Each entry point resolves to a *factory callable*,
+edit, no monkey-patch. Each holistic seam resolves to a *factory callable*,
 mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
 idiom. Five of the seams adapt divergent impl constructors to a per-group
 frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
@@ -24,6 +25,9 @@ The grading-substrate loader resolves directly to the ``GradingSubstrate``
 implementation *class* — the substrate seam is constructed per-trial with
 topology-specific arguments the plug-in group cannot generically supply,
 so callers instantiate the returned class themselves (see ADR-0039).
+The trace-check-operator loader resolves directly to the operator callable
+— one operator per entry point, no factory wrapper, since the callable
+itself IS the seam contract.
 
 The groups:
 
@@ -37,6 +41,7 @@ The groups:
 * ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
 * ``tolokaforge.rubric_evaluators`` → :data:`RubricEvaluatorFactory`
 * ``tolokaforge.transcript_rule_matchers`` → :data:`TranscriptRuleMatcherFactory`
+* ``tolokaforge.trace_check_operators`` → :data:`TraceCheckOperator`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -66,6 +71,7 @@ from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
 from tolokaforge.core.grading.substrate import GradingSubstrate
+from tolokaforge.core.grading.trace_check_operator import TraceCheckOperator
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcherFactory
 from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
@@ -92,6 +98,7 @@ __all__ = [
     "RubricEvaluatorFactory",
     "RuntimeBackendBuildContext",
     "RuntimeBackendFactory",
+    "TraceCheckOperator",
     "TranscriptRuleMatcherFactory",
     "TrialGraderContext",
     "TrialGraderFactory",
@@ -105,6 +112,7 @@ __all__ = [
     "available_readiness_probes",
     "available_rubric_evaluators",
     "available_runtime_backends",
+    "available_trace_check_operators",
     "available_transcript_rule_matchers",
     "available_trial_graders",
     "available_turn_policies",
@@ -116,6 +124,7 @@ __all__ = [
     "load_readiness_probe",
     "load_rubric_evaluator",
     "load_runtime_backend",
+    "load_trace_check_operator",
     "load_transcript_rule_matcher",
     "load_trial_grader",
     "load_turn_policy",
@@ -131,6 +140,7 @@ CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
 RUBRIC_EVALUATORS_GROUP = "tolokaforge.rubric_evaluators"
 TRANSCRIPT_RULE_MATCHERS_GROUP = "tolokaforge.transcript_rule_matchers"
+TRACE_CHECK_OPERATORS_GROUP = "tolokaforge.trace_check_operators"
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +392,17 @@ def load_transcript_rule_matcher(name: str) -> TranscriptRuleMatcherFactory:
     return cast(TranscriptRuleMatcherFactory, _load(TRANSCRIPT_RULE_MATCHERS_GROUP, name))
 
 
+def load_trace_check_operator(name: str) -> TraceCheckOperator:
+    """Resolve a registered trace-check operator name to its callable.
+
+    The seam is per-operator, and the callable itself IS the contract: no
+    factory wrapper. A binding operator is identified by the ``_binding``
+    suffix on its registered name (Approved Decision #2 on ADR-0039); the
+    callable's shape does not change.
+    """
+    return cast(TraceCheckOperator, _load(TRACE_CHECK_OPERATORS_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -447,3 +468,8 @@ def available_rubric_evaluators() -> list[str]:
 def available_transcript_rule_matchers() -> list[str]:
     """Sorted names registered in the ``tolokaforge.transcript_rule_matchers`` group."""
     return sorted(discover_entry_points(TRANSCRIPT_RULE_MATCHERS_GROUP))
+
+
+def available_trace_check_operators() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.trace_check_operators`` group."""
+    return sorted(discover_entry_points(TRACE_CHECK_OPERATORS_GROUP))

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -7,12 +7,14 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe`,
 :class:`~tolokaforge.core.actors.turn_policy.TurnPolicy`,
 :class:`~tolokaforge.core.grading.substrate.GradingSubstrate`,
-:class:`~tolokaforge.core.grading.check_runner.CheckExecutor`, and
-:class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`
+:class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
+:class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
+and
+:class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`
 Protocols through ``importlib.metadata`` entry-point groups — no in-tree
 edit, no monkey-patch. Each entry point resolves to a *factory callable*,
 mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
-idiom. Four of the seams adapt divergent impl constructors to a per-group
+idiom. Five of the seams adapt divergent impl constructors to a per-group
 frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
 probes, custom-check executors, and judge model providers need no build
 dependencies, so their factories are arg-less (``Callable[[], <Impl>]``).
@@ -31,6 +33,7 @@ The groups:
 * ``tolokaforge.grading_substrates`` → ``type[GradingSubstrate]``
 * ``tolokaforge.custom_check_executors`` → :data:`CustomCheckExecutorFactory`
 * ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
+* ``tolokaforge.rubric_evaluators`` → :data:`RubricEvaluatorFactory`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -58,6 +61,7 @@ from tolokaforge.core.actors.turn_policy import TurnPolicy
 from tolokaforge.core.conductor import ConductorFactory
 from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
+from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
 from tolokaforge.core.grading.substrate import GradingSubstrate
 from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
@@ -81,6 +85,7 @@ __all__ = [
     "JudgeModelProviderFactory",
     "ReadinessProbeFactory",
     "RegistryError",
+    "RubricEvaluatorFactory",
     "RuntimeBackendBuildContext",
     "RuntimeBackendFactory",
     "TrialGraderContext",
@@ -93,6 +98,7 @@ __all__ = [
     "available_grading_substrates",
     "available_judge_model_providers",
     "available_readiness_probes",
+    "available_rubric_evaluators",
     "available_runtime_backends",
     "available_trial_graders",
     "available_turn_policies",
@@ -102,6 +108,7 @@ __all__ = [
     "load_grading_substrate",
     "load_judge_model_provider",
     "load_readiness_probe",
+    "load_rubric_evaluator",
     "load_runtime_backend",
     "load_trial_grader",
     "load_turn_policy",
@@ -115,6 +122,7 @@ TURN_POLICIES_GROUP = "tolokaforge.turn_policies"
 GRADING_SUBSTRATES_GROUP = "tolokaforge.grading_substrates"
 CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
+RUBRIC_EVALUATORS_GROUP = "tolokaforge.rubric_evaluators"
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +359,16 @@ def load_judge_model_provider(name: str) -> JudgeModelProviderFactory:
     return cast(JudgeModelProviderFactory, _load(JUDGE_MODEL_PROVIDERS_GROUP, name))
 
 
+def load_rubric_evaluator(name: str) -> RubricEvaluatorFactory:
+    """Resolve a registered rubric-evaluator name to its factory callable.
+
+    The factory adapts a :class:`RubricEvaluatorContext` to a
+    :class:`RubricEvaluator`; the runner constructs the context (judge model
+    provider + policy flags) per trial.
+    """
+    return cast(RubricEvaluatorFactory, _load(RUBRIC_EVALUATORS_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -406,3 +424,8 @@ def available_custom_check_executors() -> list[str]:
 def available_judge_model_providers() -> list[str]:
     """Sorted names registered in the ``tolokaforge.judge_model_providers`` group."""
     return sorted(discover_entry_points(JUDGE_MODEL_PROVIDERS_GROUP))
+
+
+def available_rubric_evaluators() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.rubric_evaluators`` group."""
+    return sorted(discover_entry_points(RUBRIC_EVALUATORS_GROUP))

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -11,6 +11,7 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
 :class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`,
 :class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`,
+:class:`~tolokaforge.core.grading.state_check_backend.StateCheckBackend`,
 and
 :data:`~tolokaforge.core.grading.trace_check_operator.TraceCheckOperator`
 Protocols through ``importlib.metadata`` entry-point groups — no in-tree
@@ -18,9 +19,9 @@ edit, no monkey-patch. Each holistic seam resolves to a *factory callable*,
 mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
 idiom. Five of the seams adapt divergent impl constructors to a per-group
 frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
-probes, custom-check executors, judge model providers, and transcript-rule
-matchers need no build dependencies, so their factories are arg-less
-(``Callable[[], <Impl>]``).
+probes, custom-check executors, judge model providers, transcript-rule
+matchers, and state-check backends need no build dependencies, so their
+factories are arg-less (``Callable[[], <Impl>]``).
 The grading-substrate loader resolves directly to the ``GradingSubstrate``
 implementation *class* — the substrate seam is constructed per-trial with
 topology-specific arguments the plug-in group cannot generically supply,
@@ -41,6 +42,7 @@ The groups:
 * ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
 * ``tolokaforge.rubric_evaluators`` → :data:`RubricEvaluatorFactory`
 * ``tolokaforge.transcript_rule_matchers`` → :data:`TranscriptRuleMatcherFactory`
+* ``tolokaforge.state_check_backends`` → :data:`StateCheckBackendFactory`
 * ``tolokaforge.trace_check_operators`` → :data:`TraceCheckOperator`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
@@ -70,6 +72,7 @@ from tolokaforge.core.conductor import ConductorFactory
 from tolokaforge.core.grading.check_runner import CheckExecutor
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
+from tolokaforge.core.grading.state_check_backend import StateCheckBackendFactory
 from tolokaforge.core.grading.substrate import GradingSubstrate
 from tolokaforge.core.grading.trace_check_operator import TraceCheckOperator
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcherFactory
@@ -98,6 +101,7 @@ __all__ = [
     "RubricEvaluatorFactory",
     "RuntimeBackendBuildContext",
     "RuntimeBackendFactory",
+    "StateCheckBackendFactory",
     "TraceCheckOperator",
     "TranscriptRuleMatcherFactory",
     "TrialGraderContext",
@@ -112,6 +116,7 @@ __all__ = [
     "available_readiness_probes",
     "available_rubric_evaluators",
     "available_runtime_backends",
+    "available_state_check_backends",
     "available_trace_check_operators",
     "available_transcript_rule_matchers",
     "available_trial_graders",
@@ -124,6 +129,7 @@ __all__ = [
     "load_readiness_probe",
     "load_rubric_evaluator",
     "load_runtime_backend",
+    "load_state_check_backend",
     "load_trace_check_operator",
     "load_transcript_rule_matcher",
     "load_trial_grader",
@@ -140,6 +146,7 @@ CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
 RUBRIC_EVALUATORS_GROUP = "tolokaforge.rubric_evaluators"
 TRANSCRIPT_RULE_MATCHERS_GROUP = "tolokaforge.transcript_rule_matchers"
+STATE_CHECK_BACKENDS_GROUP = "tolokaforge.state_check_backends"
 TRACE_CHECK_OPERATORS_GROUP = "tolokaforge.trace_check_operators"
 
 
@@ -392,6 +399,17 @@ def load_transcript_rule_matcher(name: str) -> TranscriptRuleMatcherFactory:
     return cast(TranscriptRuleMatcherFactory, _load(TRANSCRIPT_RULE_MATCHERS_GROUP, name))
 
 
+def load_state_check_backend(name: str) -> StateCheckBackendFactory:
+    """Resolve a registered state-check-backend name to its factory callable.
+
+    The seam covers substrate-consuming backends; hash grading is
+    deliberately not registered here — its snapshot-and-replay semantics
+    need write access to the trial's DB and stay runner-integrated on
+    :meth:`RunnerServiceImpl._execute_hash_grading`.
+    """
+    return cast(StateCheckBackendFactory, _load(STATE_CHECK_BACKENDS_GROUP, name))
+
+
 def load_trace_check_operator(name: str) -> TraceCheckOperator:
     """Resolve a registered trace-check operator name to its callable.
 
@@ -468,6 +486,11 @@ def available_rubric_evaluators() -> list[str]:
 def available_transcript_rule_matchers() -> list[str]:
     """Sorted names registered in the ``tolokaforge.transcript_rule_matchers`` group."""
     return sorted(discover_entry_points(TRANSCRIPT_RULE_MATCHERS_GROUP))
+
+
+def available_state_check_backends() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.state_check_backends`` group."""
+    return sorted(discover_entry_points(STATE_CHECK_BACKENDS_GROUP))
 
 
 def available_trace_check_operators() -> list[str]:

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -1,25 +1,27 @@
-"""Fail-loud entry-point registries for the six swappable seams.
+"""Fail-loud entry-point registries for the swappable seams.
 
 External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.runtime.RuntimeBackend`,
 :class:`~tolokaforge.core.trial_grader.TrialGrader`,
 :class:`~tolokaforge.core.conductor.Conductor`,
 :class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe`,
-:class:`~tolokaforge.core.actors.turn_policy.TurnPolicy`, and
-:class:`~tolokaforge.core.grading.substrate.GradingSubstrate` Protocols
-through ``importlib.metadata`` entry-point groups — no in-tree edit, no
-monkey-patch. Each entry point resolves to a *factory callable*, mirroring the
-existing :data:`~tolokaforge.core.conductor.ConductorFactory` idiom. Four of
-the seams adapt divergent impl constructors to a per-group frozen-dataclass
-context (``Callable[[<Context>], <Impl>]``); the readiness probes need no
-build dependencies, so their factory is arg-less
-(``Callable[[], ServiceReadinessProbe]``). The grading-substrate loader
-resolves directly to the ``GradingSubstrate`` implementation *class* — the
-substrate seam is constructed per-trial with topology-specific arguments the
-plug-in group cannot generically supply, so callers instantiate the returned
-class themselves (see ADR-0039).
+:class:`~tolokaforge.core.actors.turn_policy.TurnPolicy`,
+:class:`~tolokaforge.core.grading.substrate.GradingSubstrate`,
+:class:`~tolokaforge.core.grading.check_runner.CheckExecutor`, and
+:class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`
+Protocols through ``importlib.metadata`` entry-point groups — no in-tree
+edit, no monkey-patch. Each entry point resolves to a *factory callable*,
+mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
+idiom. Four of the seams adapt divergent impl constructors to a per-group
+frozen-dataclass context (``Callable[[<Context>], <Impl>]``); the readiness
+probes, custom-check executors, and judge model providers need no build
+dependencies, so their factories are arg-less (``Callable[[], <Impl>]``).
+The grading-substrate loader resolves directly to the ``GradingSubstrate``
+implementation *class* — the substrate seam is constructed per-trial with
+topology-specific arguments the plug-in group cannot generically supply,
+so callers instantiate the returned class themselves (see ADR-0039).
 
-The six groups:
+The groups:
 
 * ``tolokaforge.runtime_backends`` → :data:`RuntimeBackendFactory`
 * ``tolokaforge.trial_graders`` → :data:`TrialGraderFactory`
@@ -27,6 +29,8 @@ The six groups:
 * ``tolokaforge.service_readiness_probes`` → :data:`ReadinessProbeFactory`
 * ``tolokaforge.turn_policies`` → :data:`TurnPolicyFactory`
 * ``tolokaforge.grading_substrates`` → ``type[GradingSubstrate]``
+* ``tolokaforge.custom_check_executors`` → :data:`CustomCheckExecutorFactory`
+* ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -52,6 +56,8 @@ from typing import TYPE_CHECKING, cast
 
 from tolokaforge.core.actors.turn_policy import TurnPolicy
 from tolokaforge.core.conductor import ConductorFactory
+from tolokaforge.core.grading.check_runner import CheckExecutor
+from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.substrate import GradingSubstrate
 from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.run_display_events import RunDisplayEvents, _NullRunDisplayEvents
@@ -70,7 +76,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ConductorFactory",
+    "CustomCheckExecutorFactory",
     "DuplicateRegistrationError",
+    "JudgeModelProviderFactory",
     "ReadinessProbeFactory",
     "RegistryError",
     "RuntimeBackendBuildContext",
@@ -81,14 +89,18 @@ __all__ = [
     "TurnPolicyFactory",
     "UnknownImplementationError",
     "available_conductors",
+    "available_custom_check_executors",
     "available_grading_substrates",
+    "available_judge_model_providers",
     "available_readiness_probes",
     "available_runtime_backends",
     "available_trial_graders",
     "available_turn_policies",
     "discover_entry_points",
     "load_conductor",
+    "load_custom_check_executor",
     "load_grading_substrate",
+    "load_judge_model_provider",
     "load_readiness_probe",
     "load_runtime_backend",
     "load_trial_grader",
@@ -101,6 +113,8 @@ CONDUCTORS_GROUP = "tolokaforge.conductors"
 SERVICE_READINESS_PROBES_GROUP = "tolokaforge.service_readiness_probes"
 TURN_POLICIES_GROUP = "tolokaforge.turn_policies"
 GRADING_SUBSTRATES_GROUP = "tolokaforge.grading_substrates"
+CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
+JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +241,7 @@ RuntimeBackendFactory = Callable[[RuntimeBackendBuildContext], RuntimeBackend]
 TrialGraderFactory = Callable[[TrialGraderContext], TrialGrader]
 ReadinessProbeFactory = Callable[[], ServiceReadinessProbe]
 TurnPolicyFactory = Callable[[TurnPolicyContext], TurnPolicy]
+CustomCheckExecutorFactory = Callable[[], CheckExecutor]
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +341,16 @@ def load_turn_policy(name: str) -> TurnPolicyFactory:
     return cast(TurnPolicyFactory, _load(TURN_POLICIES_GROUP, name))
 
 
+def load_custom_check_executor(name: str) -> CustomCheckExecutorFactory:
+    """Resolve a registered custom-check-executor name to its factory callable."""
+    return cast(CustomCheckExecutorFactory, _load(CUSTOM_CHECK_EXECUTORS_GROUP, name))
+
+
+def load_judge_model_provider(name: str) -> JudgeModelProviderFactory:
+    """Resolve a registered judge-model-provider name to its factory callable."""
+    return cast(JudgeModelProviderFactory, _load(JUDGE_MODEL_PROVIDERS_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -371,3 +396,13 @@ def available_turn_policies() -> list[str]:
 def available_grading_substrates() -> list[str]:
     """Sorted names registered in the ``tolokaforge.grading_substrates`` group."""
     return sorted(discover_entry_points(GRADING_SUBSTRATES_GROUP))
+
+
+def available_custom_check_executors() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.custom_check_executors`` group."""
+    return sorted(discover_entry_points(CUSTOM_CHECK_EXECUTORS_GROUP))
+
+
+def available_judge_model_providers() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.judge_model_providers`` group."""
+    return sorted(discover_entry_points(JUDGE_MODEL_PROVIDERS_GROUP))

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -43,8 +43,8 @@ from pydantic import ValidationError
 
 from tolokaforge.core.failure_attribution import TrialOutcomeClass, classify_trial_outcome
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
-from tolokaforge.core.grading.judge import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.judge import LLMJudge
+from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.replay import build_replay_grade
 from tolokaforge.core.grading.transcript_wire import (
     encode_transcript_wire,

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -56,6 +56,7 @@ from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
 from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
+from tolokaforge.core.grading.state_check_backend import StateCheckBackend
 from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate import (
     GradingSubstrate,
@@ -82,6 +83,7 @@ from tolokaforge.core.plugin_registry import (
     load_custom_check_executor,
     load_judge_model_provider,
     load_rubric_evaluator,
+    load_state_check_backend,
     load_transcript_rule_matcher,
 )
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
@@ -655,6 +657,10 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         self._transcript_rule_matcher: TranscriptRuleMatcher = load_transcript_rule_matcher(
             "default"
         )()
+        self._state_check_backends: dict[str, StateCheckBackend] = {
+            "jsonpath": load_state_check_backend("jsonpath")(),
+            "db_probes": load_state_check_backend("db_probes")(),
+        }
         self.trials: dict[str, TrialContextRuntime] = {}
         self._available_adapters = list(BUILTIN_ADAPTERS)
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup
@@ -1852,6 +1858,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                     trial_id=trial_id,
                     config=state_checks_config,
                     substrate=substrate,
+                    state_check_backends=self._state_check_backends,
                     logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
                 ),
             )

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -52,11 +52,16 @@ from tolokaforge.core.grading.jsonpath_addressing import (
     block_addresses_the_database,
     unreachable_target,
 )
-from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
-from tolokaforge.core.grading.substrate import GradingSubstrate, InProcessGradingSubstrate
+from tolokaforge.core.grading.state_diff import render_state_diff
+from tolokaforge.core.grading.substrate import (
+    GradingSubstrate,
+    InProcessGradingSubstrate,
+    SubstrateUnreachableError,
+)
 from tolokaforge.core.grading.trace_timeline import (
     TimelineInconsistencyError,
     TrialTimeline,
@@ -75,6 +80,7 @@ from tolokaforge.core.models import (
 from tolokaforge.core.plugin_registry import (
     load_custom_check_executor,
     load_judge_model_provider,
+    load_rubric_evaluator,
 )
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
@@ -377,6 +383,61 @@ def _unreachable_state_checks_refusal(
             "trial's database (rooted at db or tables), or drop the assertion."
         )
     return None
+
+
+def _build_judge_state_diff(
+    *,
+    trial_id: str,
+    substrate: GradingSubstrate,
+    initial_state_schemas: list[Any],
+    id_fields: dict[str, str | list[str]],
+    unstable_fields: set[tuple[str, str]],
+    logger: "logging.Logger",
+) -> str | None:
+    """Render the ``initial → final`` DB state diff for the judge, or ``None``.
+
+    ``None`` is the diff-first default declining itself when there is nothing to
+    diff against: an empty ``initial_state`` — the shape non-DB tasks carry, and
+    what filesystem-only tasks report — has no baseline, so the judge falls back
+    to its read-only tools. The distinction between "no diff" and "diff
+    unavailable" stays with :func:`render_state_diff`'s explicit "No changes"
+    body for a diff that DID build but found no edits.
+
+    The trial's declared ``state_checks.id_fields`` is layered over the task
+    schemas' primary keys — the two together are the row-matching contract the
+    diff renders against — and ``unstable_fields`` drops server-marked noise so
+    only meaningful edits appear.
+
+    Best-effort context, not a grade component: :class:`SubstrateUnreachableError`
+    propagates so the seam can book the trial as ungradeable, but any other
+    substrate read failure (DB hiccup, unexpected shape) degrades to ``None`` —
+    the judge still has its read-only tools and the components already computed
+    by this call site are preserved. The judge's own fail-loud contract still
+    governs grading.
+    """
+    initial_tables = substrate.initial_state()
+    if not initial_tables:
+        return None
+    try:
+        final_state = substrate.final_state()
+    except SubstrateUnreachableError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — optional context, never fail the grade
+        logger.warning(
+            "Failed to build judge state diff; grading without it "
+            f"(trial_id={trial_id}, error={exc})"
+        )
+        return None
+    primary_keys: dict[str, str | list[str]] = {
+        s.table_name: s.primary_key for s in initial_state_schemas
+    }
+    primary_keys.update(id_fields)
+    return render_state_diff(
+        initial_tables,
+        final_state,
+        primary_keys=primary_keys,
+        unstable_fields=unstable_fields,
+    )
 
 
 def _backstop_seconds(tool: Any, trial_default: float) -> float:
@@ -2111,23 +2172,26 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
     ) -> "JudgeResult":
         """Delegate to :func:`composite.grade_llm_judge` over the runner's substrate.
 
-        The composite owns the judge dispatch (rubric, tool gating, state-diff,
-        loop drive); this wrapper collects the trial-context passthroughs
-        (judge ``ModelConfig``, ``search_policy`` connector reuse, id_fields,
-        unstable_fields, schema PKs) and delegates. The ``InProcessGradingSubstrate``
-        built once by :meth:`_build_grading_substrate` at the outer level is
-        shared here — the judge's read-only DB tools go through
+        The composite owns the judge dispatch (rubric plumbing, forwarding to
+        the resolved :class:`RubricEvaluator`); this wrapper collects the
+        trial-context passthroughs (judge ``ModelConfig``, ``search_policy``
+        connector reuse), constructs the ``RubricEvaluator`` from the run-level
+        :attr:`_judge_model_provider` and per-trial customization flags,
+        renders the ``initial → final`` state diff for the evaluator's opening
+        message, and delegates. The ``InProcessGradingSubstrate`` built once
+        by :meth:`_build_grading_substrate` at the outer level is shared
+        here — the judge's read-only DB tools go through
         ``substrate.db_reader()``, the same ``_LoopBridgeDBReader`` closure the
-        state-checks path uses, and the diff-first default reads
-        ``substrate.initial_state()`` / ``substrate.final_state()`` (RAW).
+        state-checks path uses.
 
         Sync-in-async: :func:`composite.grade_llm_judge` is a sync function whose
-        substrate reads (and the judge loop's own DB tool calls) bridge back to
+        substrate reads (and the evaluator's own DB tool calls) bridge back to
         this loop via ``run_coroutine_threadsafe``; driving it on the loop thread
         would deadlock at the first call. ``run_in_executor`` lands the work on
         a worker thread so the bridges resolve.
         """
         from tolokaforge.core.grading.composite import grade_llm_judge
+        from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
 
         # The judge model is a run-level config that rides the TrialSpec. The
         # orchestrator validates up front that it is present whenever any selected
@@ -2152,21 +2216,46 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         # runner-side; the composite receives the resolved list.
         extra_read_tools = self._build_judge_search_policy_tools(trial_context)
 
-        return await self._loop.run_in_executor(
-            None,
-            lambda: grade_llm_judge(
+        customization = llm_judge_config.customization
+        disable_knowledge_search = bool(customization and customization.disable_knowledge_search)
+        custom_system_prompt = customization.system_prompt if customization else None
+        include_agent_system_prompt = (
+            customization.include_agent_system_prompt
+            if customization and customization.include_agent_system_prompt is not None
+            else True
+        )
+        rubric_evaluator = load_rubric_evaluator("llm_judge")(
+            RubricEvaluatorContext(
+                judge_model_provider=self._judge_model_provider,
+                logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
+                disable_knowledge_search=disable_knowledge_search,
+                custom_system_prompt=custom_system_prompt,
+                include_agent_system_prompt=include_agent_system_prompt,
+            )
+        )
+
+        def _run() -> "JudgeResult":
+            state_diff_text = _build_judge_state_diff(
+                trial_id=trial_id,
+                substrate=substrate,
+                initial_state_schemas=list(initial_state.schemas),
+                id_fields=id_fields,
+                unstable_fields=unstable_fields,
+                logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
+            )
+            return grade_llm_judge(
                 trial_id=trial_id,
                 config=llm_judge_config,
                 substrate=substrate,
+                rubric_evaluator=rubric_evaluator,
                 llm_messages=llm_messages,
                 judge_model_config=judge_model_config,
                 extra_read_tools=extra_read_tools,
-                id_fields=id_fields,
-                unstable_fields=unstable_fields,
-                initial_state_schemas=initial_state.schemas,
+                state_diff=state_diff_text,
                 logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
-            ),
-        )
+            )
+
+        return await self._loop.run_in_executor(None, _run)
 
     async def _grade_custom_checks(
         self,

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -2240,7 +2240,6 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         rubric_evaluator = load_rubric_evaluator("llm_judge")(
             RubricEvaluatorContext(
                 judge_model_provider=self._judge_model_provider,
-                logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
                 disable_knowledge_search=disable_knowledge_search,
                 custom_system_prompt=custom_system_prompt,
                 include_agent_system_prompt=include_agent_system_prompt,

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -36,7 +36,6 @@ from pydantic import ValidationError
 from tolokaforge.core.grading import composite
 from tolokaforge.core.grading.check_runner import (
     CheckExecutor,
-    CheckRunner,
     validate_checks_module,
 )
 from tolokaforge.core.grading.checks_helpers import custom_checks_enabled
@@ -54,6 +53,7 @@ from tolokaforge.core.grading.jsonpath_addressing import (
     unreachable_target,
 )
 from tolokaforge.core.grading.judge import JudgeResult, JudgeStatus
+from tolokaforge.core.grading.judge_model_provider import JudgeModelProvider
 from tolokaforge.core.grading.judge_tools import DelegatingReadTool
 from tolokaforge.core.grading.kb_search import KnowledgeSearch, RagServiceKnowledgeSearch
 from tolokaforge.core.grading.substrate import GradingSubstrate, InProcessGradingSubstrate
@@ -71,6 +71,10 @@ from tolokaforge.core.models import (
     LLMJudgeConfig,
     ModelConfig,
     TerminationReason,
+)
+from tolokaforge.core.plugin_registry import (
+    load_custom_check_executor,
+    load_judge_model_provider,
 )
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
@@ -572,13 +576,19 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         Args:
             db_client: HTTP client for DB Service communication
             rag_client: Optional RAG service client for search tools
-            check_executor: Executor for the pack's ``checks.py``. Defaults to the
-                in-process :class:`CheckRunner`; tests inject
+            check_executor: Executor for the pack's ``checks.py``. Defaults to
+                the ``check_runner`` entry point of
+                ``tolokaforge.custom_check_executors``; tests inject
                 :class:`InMemoryCheckExecutor`.
         """
         self.db_client = db_client
         self.rag_client = rag_client
-        self.check_executor: CheckExecutor = check_executor or CheckRunner()
+        self.check_executor: CheckExecutor = (
+            check_executor
+            if check_executor is not None
+            else load_custom_check_executor("check_runner")()
+        )
+        self._judge_model_provider: JudgeModelProvider = load_judge_model_provider("litellm")()
         self.trials: dict[str, TrialContextRuntime] = {}
         self._available_adapters = list(BUILTIN_ADAPTERS)
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -67,6 +67,7 @@ from tolokaforge.core.grading.trace_timeline import (
     TrialTimeline,
     build_trial_timeline,
 )
+from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
 from tolokaforge.core.grading.transcript_wire import (
     decode_transcript_wire,
     split_leading_system_message,
@@ -81,6 +82,7 @@ from tolokaforge.core.plugin_registry import (
     load_custom_check_executor,
     load_judge_model_provider,
     load_rubric_evaluator,
+    load_transcript_rule_matcher,
 )
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialSpec
 from tolokaforge.runner import runner_pb2 as pb2
@@ -650,6 +652,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             else load_custom_check_executor("check_runner")()
         )
         self._judge_model_provider: JudgeModelProvider = load_judge_model_provider("litellm")()
+        self._transcript_rule_matcher: TranscriptRuleMatcher = load_transcript_rule_matcher(
+            "default"
+        )()
         self.trials: dict[str, TrialContextRuntime] = {}
         self._available_adapters = list(BUILTIN_ADAPTERS)
         self._artifact_dirs: dict[str, Path] = {}  # trial_id -> temp dir for cleanup
@@ -2145,6 +2150,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             trial_id=trial_id,
             config=transcript_rules_config,
             timeline=timeline,
+            matcher=self._transcript_rule_matcher,
             logger=logger,  # type: ignore[arg-type]  # module logger, satisfies StructuredLogger protocol at runtime
         )
 


### PR DESCRIPTION
## Summary
- Six entry-point-discoverable Protocol seams under grading (`custom_check_executors`, `judge_model_providers`, `rubric_evaluators`, `transcript_rule_matchers`, `trace_check_operators`, `state_check_backends`).
- Reference impls extracted into dedicated `default_*.py` modules so composite dispatch reaches every sub-component through its Protocol via a resolved instance — locked by a new `.importlinter` contract and a belt-to-braces AST test.
- Extract-refactor with zero behaviour change: every existing canonical grading test passes byte-for-byte under Protocol dispatch.

## Design choices
- **Protocol / reference-impl module split.** Four holistic seams (rubric_evaluators, judge_model_providers, transcript_rule_matchers, state_check_backends) get `{seam}.py` for Protocol/Context/FactoryAlias and `default_{seam}.py` for the shipped reference impl. `.importlinter` fences the reference-impl modules from composite at module granularity; Protocol modules stay implicit-allow. Trace_check_operators is per-operator so all 17 shipped ops live in one `trace_check_operator.py` behind a plain callable alias.
- **`JudgeModel(LoopLLMClient, Protocol)`** — reuses the shipped `.generate` seam from `tolokaforge.core.loop.LoopLLMClient` and adds only `classify_loop_error(exc) -> TerminationDecision`. `LLMClient` structurally satisfies the composed shape.
- **`judge_result.py` extraction** — `JudgeStatus` / `JudgeUsage` / `JudgeResult` moved out of `judge.py` so the import-linter contract can fence `judge.py` from composite without breaking composite's `JudgeResult` return-type import. `judge.py` re-imports the three types so downstream call sites that predate the extraction keep working.
- **Trace-operator binding-identification via `_binding` suffix** on the registered name (Approved Decision #2) — no marker attribute, no separate set. `trace_checks._binding_operator_names()` projects the suffix-filter over the registry.
- **Hash grading NOT registered as a `state_check_backend`** — state-mutation semantics can't ride a read-only substrate. Stays runner-integrated exactly as Phase 1 left it; documented in the module docstring and in `docs/GRADER_SERVICE.md`.
- **Loader shapes match Phase 1 precedent** — five loaders return factory callables; `load_trace_check_operator` returns the callable directly (no factory wrapper for a plain `Callable[[Any, Any, Mapping[str, Any]], bool]`).

## Concepts introduced
- **Six sub-component plug-in seams under grading.** Every seam is one Protocol + at least one shipped reference impl + one entry-point group + one `plugin_registry` loader. Downstream code registers a custom rubric evaluator / judge model provider / trace operator / etc. with one entry-point line; no framework PR needed.
- **`RubricEvaluatorContext`** — frozen dataclass carrying `judge_model_provider` + logger + three policy flags. Two-phase construction: factories receive the context; the evaluator receives per-trial evidence at `.evaluate()`.
- **Composite → runner one-way import stays one-way, and tightens.** The `DBTrialNotFoundError` catch that Phase 1 kept in composite for jsonpath degradation moves into `JsonpathStateCheckBackend.query` in Stage 5 — composite no longer imports that runner-side exception.
- **`composite-sub-component-seams` .importlinter contract** — six forbidden reference-impl modules; Protocol / Context / FactoryAlias modules stay implicit-allow. Belt-to-braces AST test in `test_composite_no_direct_reference_impl_import.py` catches the same violations without the import-linter dependency.
- **Two demo custom evaluators** — `tests/utils/rubric_evaluator_demo.py` (`DeterministicRubricEvaluator`) and `tests/utils/trace_check_operator_demo.py` (`is_positive_number`). Both files avoid the `test_` prefix per pytest collection convention; the REGISTERED entry-point names (`test_rubric_evaluator`, `test_trace_operator`) live inside monkeypatched `EntryPoint` objects in the dispatch canonical tests.

## Plan
Full plan (5 stages, 3 critic rounds) lives at `~/.claude/plans/toloka-tolokaforge/issue-1262-six-plugin-seams.md`. Stage summaries:

- **Stage 1 (`2f16e4e3`)** — `custom_check_executors` + `judge_model_providers`. Both loaders + reference impls; `LLMJudge.__init__` annotation widening to `JudgeModel | None`; runner caches `check_executor` (public — canonical test reads it) + `_judge_model_provider`.
- **Stage 2 (`6d8c0786`)** — `judge_result.py` extraction (types only; `judge.py` re-imports); `rubric_evaluators` seam; `default_rubric_evaluator.py`; `composite.grade_llm_judge` signature delta (removed `id_fields`/`unstable_fields`/`initial_state_schemas`, added `rubric_evaluator`/`state_diff`); runner-side `_build_judge_state_diff` helper; demo `DeterministicRubricEvaluator`; structural AST test scaffold.
- **Stage 3 (`25aae059`)** — `transcript_rule_matchers` seam (holistic — Approved Decision #7); `default_transcript_rule_matcher.py`; composite delegates through `matcher.evaluate(...)`; direct `evaluate_transcript_rules` import DELETED from composite; runner caches `_transcript_rule_matcher`.
- **Stage 4 (`4c16e091`)** — `trace_check_operators` seam (per-operator); 17 operators as module-level functions; TWO dispatch-site rewrites in `trace_checks.py` (`_operator_holds` → registry lookup; binding-references iteration → `_binding_operator_names()` filter); `_OPERATORS` + `_BINDING_OPERATORS` dicts deleted; demo `is_positive_number` operator + canonical dispatch tests.
- **Stage 5 (`2323893a`)** — `state_check_backends` seam; `default_state_check_backends.py` with `JsonpathStateCheckBackend` + `DbProbesStateCheckBackend` (hash grading NOT registered); `composite.grade_state_checks_reads` gains `state_check_backends: Mapping[str, StateCheckBackend]`; DELETED composite imports of `evaluate_jsonpath_checks`, `evaluate_db_probes`, `DBTrialNotFoundError`; new `.importlinter` contract (2 kept, 0 broken); final AST assertion set on the structural test; consolidated seams table in `docs/GRADER_SERVICE.md`.

## Discovered issues
- **Filed:** none (GitHub MCP not exposed in the planning session's tool surface).
- **Fixed in this PR:** parity + fault-injection test retargeting after every seam pivot (Stage 3's transcript matcher swap; Stage 4's trace-checks operator dispatch); test import path rewrites for the `judge_result.py` extraction (5 in-repo + 10 test files enumerated + 2 more found via grep during Stage 2, per critic round-3 note).
- **For main to file or schedule:**
  - `test_runner_subset_partition::test_subset_files_are_reachable` flags the four `default_*.py` modules as "dead weight in the runner image" — entry-point-loaded modules aren't recognised as reachable by the subset closure. Same class of issue as #1268's `substrate_client.py` / `substrate_live.py`; a single fix would enumerate the entry-point-registered modules per group.
  - `test_runner_subset_install_smoke::test_subset_venv_runner_boot_import_graph` fails because `trace_checks.py` imports from `plugin_registry`, which is not shipped in the runner subset. Add `plugin_registry.py` (and its minimal closure) to `RUNNER_SUBSET_LOOSE_FILES`.
- **Known pre-existing failures** (verified on `main` and on the base `feat/standalone-grader`): `test_harness_registry_replay` + `test_models_wheel_replay` (issue #1234); `test_tolokaforge_models_bootstrap` (hardcoded `1.0.0` vs current `1.2.0`); `test_config_validator::TestPreflightConsultsTheOverlay` (warning-message drift); `test_run_display` (9 terminal-input dispatch tests); `test_ungradeable_trial_accounting` (unit-lane OOM). None branch-caused.

## Test plan
- CI runs `-m canonical`; every new canonical test in this PR passes locally in isolation:
  - `test_grading_rubric_evaluator_dispatch.py`, `test_composite_no_direct_reference_impl_import.py`, `test_grading_trace_check_operator_dispatch.py`, `test_grading_trace_check_operator_config_integration.py`.
- Unit lane: 5 new loader-lock files (`test_plugin_registry_load_{custom_check_executor,judge_model_provider,rubric_evaluator,transcript_rule_matcher,trace_check_operator,state_check_backend}.py`), plus the annotation-widening structural check via `test_judge_model_provider.py`.
- Structural: `uv run lint-imports` — new `composite-sub-component-seams` contract kept; total contracts kept 2 / broken 0.
- Post-merge validation: `make docker-status` green.

## Review notes
Three architect + critic rounds (round-3 verdict: APPROVE WITH NOTES — the `judge_result.py` extraction resolved round-2's 🟠, all round-1 findings clean, one minor completeness gap on test-rewrite enumeration handled during Stage 2's implementer grep). Sharded reviewer pass pending on this branch.

Closes #1262