### PR TITLE
docs(grader): Phase 5 — GRADER_SERVICE.md operator surface + ADR-0039 Accepted

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -56,6 +56,70 @@ The name resolves through the `tolokaforge.trial_graders` entry-point
 registry (backed by `importlib.metadata`), so a downstream package that
 registers a grader name becomes selectable via the same field.
 
+<a id="configuration-runconfig-grader"></a>
+
+## Configuration — `RunConfig.grader.*`
+
+`RunConfig.grader` is the run-level block that selects the `TrialGrader`
+implementation and carries transport-specific settings. Absent means
+"use whatever the adapter's `trial_grader_name` names" — the pre-block
+behaviour every existing run keeps. Fields:
+
+| Field | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `name` | `str \| None` | `None` | Overrides `adapter.trial_grader_name` for this run when set. Value is the entry-point name of a registered `TrialGraderFactory` — one of the four built-ins (`runner_rpc`, `judge_only`, `grader_rpc`, `queue`) or a downstream-registered name. |
+| `expose_substrate` | `bool` | `false` | When true, the runner registers `SubstrateService` on its listen port so an independent grader container can read the trial's substrate. Off by default so a brownfield deploy never accidentally opens the surface. See [SubstrateService (runner-side, read-only)](#substrateservice-runner-side-read-only). |
+| `queue` | `QueueGraderConfig \| None` | `None` | Consumed only when `name: queue`. |
+| `judge` | `JudgeGraderConfig \| None` | `None` | Consumed only when `name: judge_only`. |
+
+Only the subblock matching the selected `name` is consulted; an
+unrelated subblock is data the factory ignores.
+
+`QueueGraderConfig` — transport settings for `name: queue`:
+
+| Field | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `workers` | `int` (≥ 1) | `4` | Consumer-pool size — the throughput knob the transport exists to unlock. |
+| `backend` | `"in_memory"` | `"in_memory"` | Names the `GradeBroker` implementation. |
+| `worker_grader` | `str` | `"grader_rpc"` | Downstream `TrialGrader` each worker dispatches to — a `TrialGraderFactory` name from `tolokaforge.trial_graders`. Layering `queue` on top of another registered grader adds throughput scale without duplicating grading logic. |
+
+`JudgeGraderConfig` — overrides for `name: judge_only`. Absent means
+"use the task's own `grading.llm_judge.customization` exactly"; every
+field is an optional override, and `None` on a field means the task's
+own value wins.
+
+| Field | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `disable_knowledge_search` | `bool \| None` | `None` | Optional override of the task-level customization; `None` inherits. |
+| `custom_system_prompt` | `str \| None` | `None` | Optional override. Blank or whitespace-only is refused fail-loud (`grader.judge.custom_system_prompt must not be empty or whitespace-only`); omit the field to inherit. |
+| `include_agent_system_prompt` | `bool \| None` | `None` | Optional override; `None` inherits. |
+
+Two-state override, not three: the `judge` block cannot express "reset
+a task-level customization back to library defaults". A flight that
+needs the default judge prompt against a pack whose tasks set a strict
+prompt edits the tasks' `grading.yaml`.
+
+Worked `run_config.yaml` excerpt with all four `grader.*` fields
+side-by-side:
+
+```yaml
+grader:
+  name: queue                # selects QueueTrialGrader
+  expose_substrate: true     # runner registers SubstrateService on 50051
+  queue:                     # consumed because name == queue
+    workers: 8
+    backend: in_memory
+    worker_grader: grader_rpc  # each worker dials the standalone grader
+  judge:                     # ignored while name != judge_only
+    disable_knowledge_search: true
+    custom_system_prompt: "Strict factual judge."
+    include_agent_system_prompt: false
+```
+
+Shipped source of truth:
+[`GraderConfig` / `QueueGraderConfig` / `JudgeGraderConfig`](../tolokaforge/core/models/run_config.py)
+in `tolokaforge.core.models.run_config`.
+
 ## Built-in graders
 
 Four implementations ship with tolokaforge.
@@ -143,6 +207,12 @@ queue = "tolokaforge.core.trial_grader:queue_trial_grader_factory"
 ```
 
 ## Deploying the standalone grader service
+
+`deploy/standalone/docker-compose.yaml` is the operator template — no
+Kubernetes manifest ships in-tree. Adapting the compose recipe to a
+Kubernetes cluster is the operator's job; the follow-up
+[#1272](https://github.com/Toloka/tolokaforge/issues/1272) tracks a
+first-party K8s example.
 
 The `tolokaforge-grader` image ships alongside the other four first-party
 images. `deploy/standalone/docker-compose.yaml` brings the five-service
@@ -443,6 +513,102 @@ reset → replay → snapshot → restore) that the read-only substrate cannot
 serve; hash grading stays runner-integrated on
 `RunnerServiceImpl._execute_hash_grading`, called by `_grade_trial_async`
 above the composite dispatch.
+
+## Wire cost per grade component
+
+On `runner_rpc` / `InProcessGradingSubstrate`, every entry on this
+table is a direct object access — no wire, no materialisation. The
+`grader_rpc` column names the substrate reads each component triggers
+on `LiveRunnerCallbackGradingSubstrate`; each RPC is documented in the
+[SubstrateService section](#substrateservice-runner-side-read-only).
+
+| Component | `runner_rpc` (`InProcessGradingSubstrate`) | `grader_rpc` (`LiveRunnerCallbackGradingSubstrate`) |
+| --- | --- | --- |
+| `state_checks.jsonpath` | direct access | 1 × `ReadFinalDBStateStable` (cached); when a jsonpath references the filesystem view, 1 × `ListFilesystemDir` + N × `ReadFilesystemPath` via the first `filesystem_state` read (cached). |
+| `state_checks.db_probes` | direct access | No substrate RPC — probes open their task-declared DSN directly, same as InProcess. |
+| `transcript_rules` | direct access | No substrate RPC — evaluated over the in-memory transcript. |
+| `trace_checks` | direct access | No substrate RPC — evaluated over the in-memory event timeline. |
+| `custom_checks` | direct access | Eager materialisation of `filesystem_root` on first read: 1 × `ListFilesystemDir` + N × `ReadFilesystemPath` (one per non-symlink, UTF-8-decodable file under `AGENT_WORK_DIR`). Plus 1 × `ReadFinalDBState` when a check touches `db_reader`. |
+| `llm_judge` | direct access | 1 × `ReadInitialState` + 1 × `ReadFinalDBState` for the state-diff; per `search_kb` tool call, 1 × `KBSearch`; per `read_file` tool call, the same eager `filesystem_root` materialisation as `custom_checks` on first use (subsequent reads served from the private temp tree). |
+
+Substrate accessors cache: once
+`LiveRunnerCallbackGradingSubstrate.final_state()` /
+`.final_state_stable()` / `.initial_state()` / `.filesystem_state()` /
+`.filesystem_root()` has returned once, a second call in the same trial
+pays no RPC.
+
+`filesystem_root` is the notable asymmetry: on first read,
+`LiveRunnerCallbackGradingSubstrate` walks the runner's agent-visible
+tree via `ListFilesystemDir` and eagerly downloads every file to a
+private temp directory — matching the runner's shipping filter
+(non-symlink, UTF-8-decodable) with no path-component excluder. A large
+workspace pays a one-off wire cost proportional to the tree size on the
+first component that reads it.
+
+**When to prefer `runner_rpc` for coding-task deploys.** Coding tasks
+that leave large workspaces — Python-workspace or terminal-bench packs
+where the agent produces hundreds of megabytes under `AGENT_WORK_DIR` —
+pay the `filesystem_root` materialisation cost on `grader_rpc` and gain
+nothing from the split, since the grader-side composite dispatch has no
+throughput advantage over the runner-side one for a single trial. For
+those packs, keep `grader.name: runner_rpc` (the shipping default): the
+grader runs in-process against the trial's live substrate and skips the
+wire.
+
+**Reserved future: shared-mount cheap substrate.** The single-host
+topology where an independent grader container reads the substrate off
+a shared filesystem/DB mount is the reserved `SharedMountGradingSubstrate`
+recipe — see [ADR-0039](adr/0039-standalone-grader.md), reserved-future
+substrate SWE-bench pattern. Not shipped today; the two shipping
+substrates are `InProcess` and `LiveCallback`.
+
+<a id="extension-points-the-seven-plug-in-groups"></a>
+
+## Extension points — the seven plug-in groups
+
+Seven `importlib.metadata` entry-point groups let a downstream package
+extend the grader without a framework change: one substrate group and
+six sub-component seams. Each group has a matching loader on
+[`tolokaforge.core.plugin_registry`](../tolokaforge/core/plugin_registry.py):
+
+- `tolokaforge.grading_substrates` — `load_grading_substrate(name)` returns the `GradingSubstrate` **class** (the caller instantiates it with per-trial arguments).
+- `tolokaforge.custom_check_executors` — `load_custom_check_executor(name)` returns a factory.
+- `tolokaforge.judge_model_providers` — `load_judge_model_provider(name)` returns a factory.
+- `tolokaforge.rubric_evaluators` — `load_rubric_evaluator(name)` returns a factory.
+- `tolokaforge.transcript_rule_matchers` — `load_transcript_rule_matcher(name)` returns a factory.
+- `tolokaforge.state_check_backends` — `load_state_check_backend(name)` returns a factory.
+- `tolokaforge.trace_check_operators` — `load_trace_check_operator(name)` returns the **operator callable** directly (no factory wrapper; the callable itself is the contract).
+
+Copy-paste block for a downstream `pyproject.toml`:
+
+```toml
+[project.entry-points."tolokaforge.grading_substrates"]
+my_substrate = "my_package:my_substrate_class"
+
+[project.entry-points."tolokaforge.custom_check_executors"]
+my_check_executor = "my_package:my_check_executor_factory"
+
+[project.entry-points."tolokaforge.judge_model_providers"]
+my_judge = "my_package:my_judge_provider_factory"
+
+[project.entry-points."tolokaforge.rubric_evaluators"]
+my_rubric = "my_package:my_rubric_evaluator_factory"
+
+[project.entry-points."tolokaforge.transcript_rule_matchers"]
+my_matcher = "my_package:my_matcher_factory"
+
+[project.entry-points."tolokaforge.state_check_backends"]
+my_state_backend = "my_package:my_state_backend_factory"
+
+[project.entry-points."tolokaforge.trace_check_operators"]
+my_operator = "my_package:my_operator"
+```
+
+`tolokaforge.trial_graders` is the eighth registration point — the
+top-level grader-name seam ADR-0038 shipped, already documented in
+[Registering a downstream grader](#registering-a-downstream-grader).
+A downstream package registering a new grader name lands there, not
+in any of the seven groups above.
 
 ## Parity gate
 

--- a/docs/adr/0039-standalone-grader.md
+++ b/docs/adr/0039-standalone-grader.md
@@ -1,7 +1,8 @@
 # 0039. Standalone-Grader Substrate — Multi-Topology Grading Behind One Protocol
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-24
+- **Accepted-on:** 2026-08-25
 - **Deciders:** @CiroGamboa
 - **Consulted:** Harbor framework, Inspect AI (UK AISI), Braintrust, SWE-bench, METR
 - **Milestone:** [#36](https://github.com/Toloka/tolokaforge/milestone/36) (umbrella: #1259)
@@ -43,7 +44,7 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 
 **Introduce six new entry-point groups for sub-component evaluators** (rubric_evaluators, judge_model_providers, transcript_rule_matchers, trace_check_operators, state_check_backends, custom_check_executors). Every existing implementation becomes the reference impl behind its Protocol — extract-refactor, zero behaviour change.
 
-**The composite dispatch** (`GraderServiceImpl.Grade`) resolves the substrate from `RunConfig.grader.substrate`, constructs it, then runs each selected component evaluator over it. `runner_rpc` uses the same dispatch with `InProcessGradingSubstrate`; the code path is unified.
+**The composite dispatch** runs the same component evaluator code over whichever substrate the deployment topology hands it. `GraderCompositeDispatch` (grader-side, standalone image) is hard-wired to `LiveRunnerCallbackGradingSubstrate` — it dials the runner's `SubstrateService` per trial. The in-runner composite dispatch behind `runner_rpc` (runner-side) is hard-wired to `InProcessGradingSubstrate` — it wraps the runner's live objects directly. Selection between the two topologies is by grader-name: `grader.name: runner_rpc` vs `grader.name: grader_rpc` on `RunConfig.grader`, combined with `expose_substrate: true` on the runner so the standalone grader has a substrate surface to dial. The `GradingSubstrate` Protocol is what keeps the evaluator code above the substrate identical across both paths; there is no runtime substrate-selector field.
 
 **Backward compatibility is a first-class deliverable.** `runner_rpc` behaviour is preserved from the operator's view. Every existing `grading.yaml` runs untouched. No task auto-migrates to `grader_rpc`.
 
@@ -56,6 +57,8 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 - Snapshot mode and shared-mount mode become documented, additive future shifts — the Protocol is already shaped for them.
 - Component evaluators become individually pluggable; operators can extend judges / rules / trace ops without touching the framework.
 - Extract-refactor of runner-side grading code onto the Protocol path unifies the codebase and locks behaviour parity by construction.
+- **Phase 1 landing (issue #1261).** `GradingSubstrate` Protocol + `InProcessGradingSubstrate` + `LiveRunnerCallbackGradingSubstrate` shipped; `SubstrateService` gRPC (7 read-only RPCs, gated by `RunConfig.grader.expose_substrate: false`); five composite grading functions extracted to `tolokaforge.core.grading.composite`.
+- **Phase 2 landing (issue #1262).** Six sub-component plug-in seams shipped: `custom_check_executors`, `judge_model_providers`, `rubric_evaluators`, `transcript_rule_matchers`, `trace_check_operators`, `state_check_backends`. `.importlinter` `composite-sub-component-seams` contract locks the negative-space.
 - **Phase 3 landing (issue #1263).** `GraderCompositeDispatch` (`tolokaforge/grader/composite_dispatch.py`) is mounted by `python -m tolokaforge.grader`: it deserialises the wire v2 fields, builds `LiveRunnerCallbackGradingSubstrate` per trial, runs the composite grading pipeline, and returns a real `Grade` on the `grader_rpc` path.
 - **Phase 4 parity gate (issue #1264).** `tests/canonical/test_grader_parity_reference.py` operationalizes the multi-substrate parity claim across the six sub-component seams; hash grading refusal and KB passthrough divergence are recorded per-pack on `parity.yaml`.
 
@@ -68,17 +71,26 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 
 - One more Protocol in the codebase. Familiar shape (identical to `TrialGrader`); low cognitive cost.
 
+## How substrate selection reaches the grader today
+
+Substrate selection is not a wire-carried enum. The shipping mechanism is: `grader.name: grader_rpc` on `RunConfig.grader` selects the standalone-grader transport; `expose_substrate: true` on the runner opens the read-only `SubstrateService` surface the standalone grader dials; and `GraderCompositeDispatch` inside the standalone image is hard-wired to construct `LiveRunnerCallbackGradingSubstrate` per trial (see `tolokaforge/grader/composite_dispatch.py`). The in-runner counterpart, selected by `grader.name: runner_rpc`, hard-wires `InProcessGradingSubstrate`. Reserved substrates that ship later either register alongside under `tolokaforge.grading_substrates` and add their own selector on `GraderConfig` (a typed subblock, same shape as the shipped `queue` / `judge` subblocks), or ride under a new grader-name registration on `tolokaforge.trial_graders`.
+
 ## Reserved future substrate — `TrajectoryStorageGradingSubstrate`
 
 **When to ship:** trajectory-storage service is live and stable. Grader wants to grade completed trials whose runners have been torn down (bulk rescoring, cross-run analysis).
 
 **Wiring recipe:**
 
-1. Add `SUBSTRATE_MODE_TRAJECTORY_STORAGE` to the `SubstrateMode` enum in `grader.proto`.
-2. Implement `TrajectoryStorageGradingSubstrate(client: TrajectoryStorageClient, trial_id: str)`. Its methods delegate to storage-service RPCs: `client.get_trial_db(trial_id) -> DBSnapshot`, `client.read_trial_file(trial_id, path) -> bytes`, etc.
-3. Register under `tolokaforge.grading_substrates` entry point: `trajectory_storage = tolokaforge.core.grading.substrate:TrajectoryStorageGradingSubstrate`.
-4. Extend `RunConfig.grader.trajectory_storage_address` to carry the service URL when the operator selects `substrate: trajectory_storage`.
-5. Ship as a separate PR against `main`, coordinated with the trajectory-storage team.
+1. Implement `TrajectoryStorageGradingSubstrate(client: TrajectoryStorageClient, trial_id: str)`. Its methods delegate to storage-service RPCs: `client.get_trial_db(trial_id) -> DBSnapshot`, `client.read_trial_file(trial_id, path) -> bytes`, etc.
+2. Register under the shipping entry-point group:
+
+   ```toml
+   [project.entry-points."tolokaforge.grading_substrates"]
+   trajectory_storage = "tolokaforge.core.grading.substrate:TrajectoryStorageGradingSubstrate"
+   ```
+
+3. Extend `GraderConfig` with a `trajectory_storage_address: str | None = None` field so operators name the storage service, and extend `GraderCompositeDispatch` to consult that field before falling back to `LiveRunnerCallbackGradingSubstrate`. The grader-name stays `grader_rpc`; the composite dispatch picks the substrate — no runtime selector on the wire.
+4. Ship as a separate PR against `main`, coordinated with the trajectory-storage team.
 
 **No changes to evaluator code, `runner_rpc`, or the aggregate image path.**
 
@@ -88,16 +100,23 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 
 **Wiring recipe:**
 
-1. Extend `grader.proto` `GradeRequest` v3 with snapshot fields:
+1. Extend `grader.proto` to wire v3 with additive snapshot-bundle fields on `GradeRequest`:
    - `initial_state_json`, `final_state_json` — DB snapshots at trial start / end.
    - `filesystem_snapshot: bytes` — tar of agent-visible files (already filtered by the runner's `_read_agent_visible_filesystem` — never `node_modules`, `.venv`, `.git`).
    - `checks_module_bytes: bytes` — `checks.py` bytes when `custom_checks` is enabled.
-   - `id_fields`, `unstable_fields`, `judge_model_config` — authored inputs.
    - `kb_snapshot` — for tasks with deterministic KB corpora, the vector-store manifest. Live-TypeSense tasks stay on live-callback.
+
+   `id_fields`, `unstable_fields`, and `judge_model_config` already ride on `task_description_json` / `judge_model_config_json` from wire v2 and need no addition.
 2. Implement `SnapshotGradingSubstrate` unpacking the fields into the same shape `LiveRunnerCallbackGradingSubstrate` produces.
-3. Register under `tolokaforge.grading_substrates`.
-4. **Filesystem cap policy** — 32 MB soft cap. Tasks exceeding the cap auto-fall-back to `LiveRunnerCallbackGradingSubstrate` (documented behaviour; not a bug). Config: `RunConfig.grader.fallback_on_snapshot_error: live_callback` (default).
-5. Snapshot builder in the client (`GraderRPCTrialGrader.grade`) reads the filesystem into a tar and skips the wire path when the cap is exceeded.
+3. Register under the shipping entry-point group:
+
+   ```toml
+   [project.entry-points."tolokaforge.grading_substrates"]
+   snapshot = "tolokaforge.core.grading.substrate:SnapshotGradingSubstrate"
+   ```
+
+4. **Filesystem cap policy** — 32 MB soft cap. Tasks exceeding the cap auto-fall-back to `LiveRunnerCallbackGradingSubstrate` (documented behaviour; not a bug). Config: extend `GraderConfig` with a typed `snapshot: SnapshotGraderConfig | None` subblock — same shape as the shipped `queue` / `judge` subblocks — carrying an explicit `fallback_on_snapshot_error` field (default `live_callback`).
+5. The snapshot builder replaces `LiveRunnerCallbackGradingSubstrate` construction inside a new `GraderRPCSnapshotTrialGrader` (or an extended `GraderRPCTrialGrader`) — no wire-carried selector; the client-side transport decides.
 
 **Why this is riskier than live-callback:** coding tasks with ~100 MB workspaces would need the auto-fallback path; a bug in the size check could break existing pipelines. Shipping later when the platform has learned the wire behaviours.
 
@@ -107,14 +126,23 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 
 **Wiring recipe:**
 
-1. Add `SUBSTRATE_MODE_SHARED_MOUNT` to the enum.
-2. Implement `SharedMountGradingSubstrate(mount_root: Path, trial_id: str)`. Reads from a shared filesystem/DB mount populated by the runner.
-3. Register under `tolokaforge.grading_substrates`.
-4. Extend the standalone compose recipe with `volumes:` shared between runner + grader.
-5. **Constraint:** grader and runner must be on the same host. Documented.
+1. Implement `SharedMountGradingSubstrate(mount_root: Path, trial_id: str)`. Reads from a shared filesystem/DB mount populated by the runner.
+2. Register under the shipping entry-point group:
+
+   ```toml
+   [project.entry-points."tolokaforge.grading_substrates"]
+   shared_mount = "tolokaforge.core.grading.substrate:SharedMountGradingSubstrate"
+   ```
+
+3. Extend the standalone compose recipe with `volumes:` shared between runner + grader.
+4. **Constraint:** grader and runner must be on the same host. Documented.
+5. Extend `GraderConfig` with a typed `shared_mount: SharedMountGraderConfig | None` subblock carrying the mount root; `GraderCompositeDispatch` consults it and constructs `SharedMountGradingSubstrate` when set, falling back to `LiveRunnerCallbackGradingSubstrate` otherwise. Same shape as the other reserved-substrate subblocks.
 
 ## References
 
+- [`docs/GRADER_SERVICE.md`](../GRADER_SERVICE.md) — operator-facing surface.
+- [`docs/GRADER_SERVICE.md#parity-gate`](../GRADER_SERVICE.md#parity-gate) — acceptance enforcement.
+- [`docs/adr/0038-grader-detachment.md`](0038-grader-detachment.md) — predecessor ADR.
 - [Harbor `verifier.environment_mode = "separate"`](https://www.harborframework.com/docs/tasks)
 - [Inspect AI scorer callback + deferred scoring](https://inspect.aisi.org.uk/scorers.html)
 - [Braintrust sandboxed scorer](https://www.braintrust.dev/docs/platform/functions/scorers)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,4 +69,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0036](0036-tolokaforge-coding-harnesses-split.md) | Coding-harness code as a top-level workspace package — `tolokaforge_coding_harnesses` | Accepted |
 | [0037](0037-runtime-gateway-as-harness-data.md) | A runtime gateway is harness data, and its token dialect belongs to the runtime that provisions it | Accepted |
 | [0038](0038-grader-detachment.md) | Grader detachment — grader as an independently deployable and scalable component | Proposed |
-| [0039](0039-standalone-grader.md) | Standalone-grader substrate — multi-topology grading behind one Protocol | Proposed |
+| [0039](0039-standalone-grader.md) | Standalone-grader substrate — multi-topology grading behind one Protocol | Accepted |


### PR DESCRIPTION
## Summary
- `docs/GRADER_SERVICE.md` extended with a `Configuration — RunConfig.grader.*` section, a wire-cost-per-component table with two substrate columns, a copy-paste `[project.entry-points]` block for all seven plug-in groups, and a K8s call-out. Verify-current pass done on every pre-existing section.
- `docs/adr/0039-standalone-grader.md` flipped Proposed → Accepted. The `## Decision` paragraph and the three reserved-substrate wiring recipes are reconciled to the shipping selection mechanism — `grader.name: grader_rpc` + `expose_substrate: true` on the runner + entry-point discovery via `tolokaforge.grading_substrates`. The `substrate_mode` enum and `RunConfig.grader.substrate` field that were planned in Phase 0's drafting never landed and are no longer referenced.
- `docs/adr/README.md` index row for ADR-0039 flipped to Accepted.

## Design choices
- **`## Decision` paragraph rewritten in-place, not appended.** The stale `RunConfig.grader.substrate` claim would have contradicted the shipping `GraderCompositeDispatch` even with new "How substrate selection reaches the grader today" prose below it. Both altitudes now say the same thing (Core Rule 8 — no split-brain in the design record).
- **Reserved-substrate recipes reconciled, not deleted.** The three future substrates keep their wiring recipes but stop referencing abstractions that never shipped. Each recipe is now independently implementable by a future PR against the shipping seam.
- **Configuration section names the actual `GraderConfig` shape** — `name` / `expose_substrate` / `queue` / `judge` — not a hypothetical `substrate` selector.
- **Wire-cost table pins the InProcess baseline explicitly.** "On `runner_rpc` / `InProcessGradingSubstrate`, every entry on this table is a direct object access — no wire, no materialisation." Two substrate columns; the `grader_rpc` column names each RPC.
- **Seven-group entry-point block, `my_package` placeholder.** Matches Phase 4's parity-gate corpus + the `plugin_registry` loader contract per group. Disambiguates the sixth-vs-seventh-vs-eighth registration point at the bottom.
- **K8s explicitly out of scope; follow-up filed as #1272.** No K8s manifest ships; docker-compose is the operator template.

## Concepts introduced
- **`Configuration — RunConfig.grader.*`** section on `docs/GRADER_SERVICE.md` — operator-facing surface for the four `GraderConfig` fields + two subblocks (`QueueGraderConfig`, `JudgeGraderConfig`) with a worked YAML excerpt.
- **`Wire cost per grade component`** section — first place in the docs where the InProcess vs LiveRunnerCallback trade-off lives with a table an operator can read.
- **`Extension points — the seven plug-in groups`** section — first copy-paste `pyproject.toml` block covering all seven groups (Phase 1 substrate + Phase 2 six sub-component seams).
- **"How substrate selection reaches the grader today"** paragraph in ADR-0039 — makes the reserved-substrate recipes coherent by explaining the shipping selection mechanism the recipes extend.
- **ADR-0039 as Accepted** — the milestone's design record moves from Proposed to Accepted, with Phase 1 + 2 + 3 + 4 landing bullets in Consequences.

## Plan
Full plan (2 stages; docs-only; 1 critic round ending REVISE → 1 revision → APPROVE) at `~/.claude/plans/toloka-tolokaforge/issue-1265-docs-and-adr-finalised.md`. Stage summaries:

- **Stage 1 (`87b438c7`)** — `docs/GRADER_SERVICE.md`: 3 new sections + K8s note; verify-current pass on all pre-existing sections. 166 insertions, 0 deletions.
- **Stage 2 (`f5d657ec`)** — `docs/adr/0039-standalone-grader.md` Proposed → Accepted; `## Decision` paragraph rewritten; 3 reserved-substrate recipes reconciled; new "How substrate selection reaches the grader today" section; References extended. `docs/adr/README.md` index row updated.

## Discovered issues
- **Filed by architect during planning:**
  - **#1272** — K8s example for the standalone grader.
  - **#1273** — in-image `ScriptedJudgeModelProvider` (would promote RC-smoke judge packs to deterministic tier).
  - **#1274** — KB-passthrough ADR-0039 recipe when the grader image gains its own KB source.
- **Fixed in this PR:** the stale `## Decision` paragraph on line 46 of ADR-0039 (critic round 1 flagged; architect fixed in revision).
- **Known pre-existing CI failures** (same set as PRs #1268/#1269/#1270/#1271): `test_harness_registry_replay`, `test_models_wheel_replay`, `test_tolokaforge_models_bootstrap`, `test_config_validator::TestPreflightConsultsTheOverlay`, `test_run_display` × 9. None branch-caused.

## Test plan
- Docs-only phase. No new tests. Every claim locked by Phase 1–4 tests (`test_grading_substrate.py`, `test_grading_substrate_dispatch.py`, `test_composite_no_direct_reference_impl_import.py`, `test_grader_parity_reference.py`, `test_rc_smoke_parity_reference.py`, `.importlinter composite-sub-component-seams`).
- Validation on the doc changes:
  - `rg 'substrate_mode|SUBSTRATE_MODE_|RunConfig\.grader\.substrate' docs/` — empty (verified).
  - `rg 'GraderConfig|QueueGraderConfig|JudgeGraderConfig' docs/GRADER_SERVICE.md tolokaforge/core/models/run_config.py` — matched.
  - `rg '\[project\.entry-points\."tolokaforge\.' docs/GRADER_SERVICE.md pyproject.toml` — 7-group match.
  - `docs/adr/README.md` ADR-0039 row shows `Accepted`.

Closes #1265