### PR TITLE
feat(coding-harness): lift agent_harness to a top-level, adapter-agnostic capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,6 +523,17 @@ and [`docs/CODING_HARNESSES.md`](docs/CODING_HARNESSES.md).
    the package) ships in both the sdist and the wheel. Any PR touching
    `tolokaforge_coding_harnesses/pyproject.toml`, its `data/`, or the
    package's non-Python siblings must keep this test green.
+8. **Adapters opt into coding-harness mode by inheriting
+   `CodingHarnessAdapterMixin`.** The orchestrator's config-validation
+   gate refuses `models.agent.harness` against any adapter whose
+   `supports_coding_harness` class attr reads `False` (the `BaseAdapter`
+   default). The mixin sets it as a class-level default, so inheriting is
+   the whole opt-in — a bespoke boolean on an adapter class without the
+   mixin's six helpers is not it. New adapters that accept the harness
+   field MUST inherit
+   [`tolokaforge_coding_harnesses.CodingHarnessAdapterMixin`](tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py)
+   alongside `BaseAdapter`. Design record:
+   [ADR-0039](docs/adr/0039-coding-harness-adapter-agnostic.md).
 
 **Adding a new harness:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **schema**: `models.agent.harness` is the canonical home for the coding-harness selector, alongside `models.agent.name` for the model the CLI receives. A run declares "run this trial under `claude-code` on `openrouter/anthropic/claude-sonnet-4-6`" in one place, not two. See [ADR-0039](docs/adr/0039-coding-harness-adapter-agnostic.md).
+- **coding-harnesses**: `CodingHarnessAdapterMixin` in `tolokaforge_coding_harnesses/` gives any adapter the six wire-artefact helpers (spec resolution, command assembly, metadata handshake, bash tool schema, `test_execution` grading, standalone install-script Dockerfile layer) and the `supports_coding_harness = True` capability flag the orchestrator's config-validation gate reads. Inheriting the mixin alongside `BaseAdapter` is the whole opt-in.
+- **native**: the bundled `NativeAdapter` opts into coding-harness mode. A native run declaring `models.agent.harness` mints a `TaskDescription` with a single `bash` tool routed through `DockerComposeExecToolWrapper` (`service: "main"`, `compose_project_prefix: "tfnative_"`, `agent_visible_dir: "/work"`), `test_execution` grading, and the four-key harness metadata handshake — no MCP wiring required.
+- **examples**: `examples/native/coding_harness/` (fix-factorial) is the first shipped native harness pack — a single-service Python 3.11 compose stack, one small bug the agent fixes, `tests/test.sh` verifier writing `/logs/verifier/reward.txt`. Oracle preflight: buggy 0.667, fixed 1.000.
+- **runner**: harness-mode trials compose with `state_checks` / `transcript` / `rubric` grading, not only `test_execution`. When a trial's metadata carries both `agent_harness_command` and `agent_visible_dir` and a `DockerComposeExecToolWrapper` is registered for it, `_read_filesystem_for_state` snapshots the container's agent-visible directory into `state["filesystem"]` via the new `tolokaforge/runner/harness_state.py`. A JSONPath assertion against `$.filesystem['/work/factorial.py']` resolves against what the CLI actually left behind. `test_execution` still short-circuits at grading time, so terminal-bench's byte-identical replay is preserved naturally.
+
+### Changed
+
+- **schema**: legacy `evaluation.harness_adapter.params.agent_harness` / `agent_model` are lifted at parse time into `models.agent.harness` / `models.agent.name` with a `DeprecationWarning` per key naming the canonical home. Equal-value collisions warn once; differing values raise. Removal target: the next scheduled major-version bump.
+
 ## v0.19.1 (2026-08-19)
 
 ### Feat

--- a/docs/ADAPTER_ARCHITECTURE.md
+++ b/docs/ADAPTER_ARCHITECTURE.md
@@ -183,6 +183,20 @@ defaults:
 | Declaration | Default | Description |
 |--------|--------|-------------|
 | `trial_grader_name` (class attr) | `"runner_rpc"` | Name of the `TrialGrader` the orchestrator loads for this adapter's runs (from the `tolokaforge.trial_graders` entry-point group). Override to ship a custom grader. |
+| `supports_coding_harness` (class attr) | `False` | Whether the adapter accepts `models.agent.harness` (see § Adapter capabilities). |
+
+## Adapter capabilities
+
+`CodingHarnessAdapterMixin` is a shipped capability adapters compose with
+alongside `BaseAdapter`. Inheriting it confers `supports_coding_harness = True`
+(the flag the orchestrator's config-validation gate reads before it will route
+a `models.agent.harness` run to the adapter) plus six helpers that produce
+the wire artefacts a harness trial needs — spec resolution, command
+assembly, the metadata handshake, the bash tool schema payload, the
+`test_execution` grading payload, and the standalone install-script
+Dockerfile layer. See
+[ADR-0039](adr/0039-coding-harness-adapter-agnostic.md) and
+[`tolokaforge_coding_harnesses/README.md § Adopting the mixin`](../tolokaforge_coding_harnesses/README.md#adopting-the-mixin).
 
 ## Adapter-Specific Details
 

--- a/docs/CODING_HARNESSES.md
+++ b/docs/CODING_HARNESSES.md
@@ -19,99 +19,154 @@ Pick by what you are measuring.
 |---|---|---|
 | A model's raw capability on a task | **Engine-loop mode** | The engine's [`ModelCapabilities`](LLM_LAYER.md) policies apply — schema sanitizers, cache markers, reasoning replay, response coercion. Cost and tokens are honestly reported via `litellm`. |
 | A coding CLI's scaffolding on top of a model | **Harness mode** | The CLI's own prompt shape, tool ontology and step logic dominate the outcome — you're evaluating the whole vendor product, not the bare model. |
-| Head-to-head between two CLIs on the same task pack | **Harness mode** | Change one field (`agent_harness`); everything else stays constant. |
+| Head-to-head between two CLIs on the same task pack | **Harness mode** | Change one field (`models.agent.harness`); everything else stays constant. |
 | A model in a way another team can independently reproduce end-to-end | **Harness mode** with a shipped CLI | The CLI version is pinned in the registry; the artifact records the pin. |
 
-## Shipped harnesses
+## Declaring a harness
 
-Six vendor coding-agent CLIs ship in-tree.
-[`tolokaforge_coding_harnesses/`](../tolokaforge_coding_harnesses/) is the
-package; the source of truth for the catalog is
-[`tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml).
+A run config declares the harness alongside the model on `models.agent`:
 
-| `agent_harness` | Vendor CLI | Install | Pin |
-|---|---|---|---|
-| `claude-code` | `@anthropic-ai/claude-code` | npm | 2.1.233 |
-| `codex` | `@openai/codex` | npm | 0.147.0 |
-| `gemini-cli` | `@google/gemini-cli` | npm | 0.55.1 |
-| `kimi-code` | `@moonshot-ai/kimi-code` | npm | 0.28.1 |
-| `opencode` | `opencode-ai` | npm | 1.18.18 |
-| `grok-build` | `x.ai/cli` install script | curl-bash | 0.2.91 |
+```yaml
+models:
+  agent:
+    provider: "openrouter"
+    name: "openrouter/anthropic/claude-sonnet-4-6"
+    harness: "claude-code"          # any shipped harness name; omit for engine loop
+    temperature: 0.0
+evaluation:
+  projects: ["examples/native/coding_harness"]
+  harness_adapter:
+    type: "native"
+```
 
-Adding a harness — in-tree or out-of-tree as a Python entry-point plug-in — is
-covered in the [package README](../tolokaforge_coding_harnesses/README.md#adding-a-harness)
-and [ADR-0034](adr/0034-external-harness-plugin-discovery.md).
+`models.agent.harness = null` (the default) keeps the engine's turn loop.
+A non-empty string is a coding-harness name resolved against the effective
+registry ([ADR-0033](adr/0033-external-harness-registry.md)) and the CLI
+consumes `models.agent.name` verbatim (with per-harness vendor-prefix
+handling declared in the shipped
+[`data/harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml)).
 
-## How the surface composes
+### The capability-flag gate
 
-Three moving parts, each with a clear responsibility.
+Not every adapter runs a coding-harness trial. An adapter opts in by
+inheriting
+[`CodingHarnessAdapterMixin`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py)
+alongside `BaseAdapter`; the mixin sets
+`supports_coding_harness: ClassVar[bool] = True`. The orchestrator's
+`load_tasks` reads that flag on the resolved adapter; a run declaring
+`models.agent.harness` against an adapter whose flag reads `False`
+refuses before any container work, naming both sides of the mismatch
+and the currently-opted-in set. Two adapters ship the opt-in today:
+`native` and `terminal_bench`. See
+[ADR-0039](adr/0039-coding-harness-adapter-agnostic.md).
 
-- **Harness registry** — the catalog of `HarnessSpec` entries. Data-driven, no
-  engine dependency (an external runtime can read the same data without
-  pulling the engine in). Lives in the top-level
-  [`tolokaforge_coding_harnesses/`](../tolokaforge_coding_harnesses/) workspace
-  member ([ADR-0036](adr/0036-tolokaforge-coding-harnesses-split.md)).
-- **Consumer adapter** — the piece that materialises the trial container,
-  installs the CLI (via
-  [`install-harness.sh`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/install-harness.sh)),
-  writes any per-harness config files, boots the middleware proxy if the spec
-  declares one, and `docker exec`s the CLI. The shipped consumer is the
-  [`terminal_bench` adapter](../external_adapters/tolokaforge-adapter-terminal-bench/).
-- **Task pack** — the task-specific compose stack (`docker-compose.yaml` +
-  `environment/Dockerfile`) + instruction (`task.toml` / `task.yaml`) +
-  verifier (`tests/test.sh` writing `/logs/verifier/reward.txt`). Shipped
-  examples: [`examples/terminal_bench/fix-billing-holds/`](../examples/terminal_bench/fix-billing-holds/)
-  and [`examples/terminal_bench/fix-airline-segmentation/`](../examples/terminal_bench/fix-airline-segmentation/).
+## What each shipped adopter provides
 
-The registry stays task-agnostic; the task pack stays harness-agnostic. A
-harness is a fully replaceable slot on the run config, not a coupling.
+Two adapters ship the mixin today. Both accept `models.agent.harness`;
+they differ in how they materialise the trial container around the CLI.
+
+### The native adapter
+
+Bundled with the engine (`tolokaforge.adapters.native.NativeAdapter`).
+In harness mode the adapter mints its own `TaskDescription`, bypassing
+MCP wiring: a single `bash` tool routed through
+`DockerComposeExecToolWrapper` (`service: "main"`,
+`compose_project_prefix: "tfnative_"`, `agent_visible_dir: "/work"`),
+`test_execution` grading against `/logs/verifier/reward.txt`, and the
+four-key harness metadata handshake. The example pack in
+[`examples/native/coding_harness/`](../examples/native/coding_harness/)
+(fix-factorial) is the reference layout — a single-service compose
+stack (Python 3.11), one small bug the agent fixes, a `tests/test.sh`
+verifier.
+
+### The terminal-bench adapter
+
+Ships out-of-tree as
+[`tolokaforge-adapter-terminal-bench`](../external_adapters/tolokaforge-adapter-terminal-bench/).
+Materialises the task's own compose stack, injects `runner` /
+`db-service` sidecars, and layers the harness image via the
+adapter-local
+[`compose_synthesis._write_harness_build_context`](../external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py)
+(which bridges to the mixin's `write_install_script_layer` from the
+compose context root rather than a nested build dir). Example packs live
+under [`examples/terminal_bench/`](../examples/terminal_bench/)
+(`fix-billing-holds`, `fix-airline-segmentation`) with the shipped
+driver [`examples/terminal_bench/run_harness.yaml`](../examples/terminal_bench/run_harness.yaml).
+The trial's agent-visible dir is `/app`.
+
+## Grading composability
+
+Harness mode composes with **any** grading method. Two paths:
+
+- **`test_execution`** — the mixin's default. The runner reads a reward
+  float from `/logs/verifier/reward.txt` and returns before assembling
+  jsonpath state. Both shipped example packs use this shape (`tests/test.sh`
+  writes the file). Byte-identical wire output between adapter versions is
+  proven by the canonical snapshot at
+  `tests/canonical/snapshots/tbench_echo_hello_harness/`.
+- **`state_checks` / `transcript` / `rubric`** — assemble through the
+  standard combiner. When a harness-mode trial's metadata carries both
+  `agent_harness_command` and `agent_visible_dir` AND a
+  `DockerComposeExecToolWrapper` is registered for it, the runner
+  snapshots the container's agent-visible directory into
+  `state["filesystem"]` via
+  [`tolokaforge/runner/harness_state.py`](../tolokaforge/runner/harness_state.py).
+  A `state_checks` assertion against
+  `$.filesystem['/work/factorial.py']` resolves against what the CLI
+  actually left behind — the same shape a non-harness native task uses
+  today.
+
+## The six shipped harnesses
+
+Six vendor coding-agent CLIs ship in-tree. The catalog lives in
+[`tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml);
+the package's [`README.md`](../tolokaforge_coding_harnesses/README.md#shipped-harnesses)
+carries the version-pin table.
+
+| `models.agent.harness` | Vendor CLI | Install |
+|---|---|---|
+| `claude-code` | `@anthropic-ai/claude-code` | npm |
+| `codex` | `@openai/codex` | npm |
+| `gemini-cli` | `@google/gemini-cli` | npm |
+| `kimi-code` | `@moonshot-ai/kimi-code` | npm |
+| `opencode` | `opencode-ai` | npm |
+| `grok-build` | `x.ai/cli` install script | curl-bash |
+
+Provider envelopes, model-name conventions and per-CLI quirks (permission
+flags, root-under-sandbox, config-file precedence) live in the YAML
+alongside each entry with the failure mode each flag prevents recorded
+inline.
 
 ## One-command demo
 
-Run `claude-code` on the shipped `fix-billing-holds` pack:
+Run `claude-code` on the native `fix-factorial` pack:
+
+```bash
+scripts/with_env.sh uv run tolokaforge run --config examples/native/coding_harness/run_harness.yaml
+```
+
+Or on the terminal-bench `fix-billing-holds` pack:
 
 ```bash
 scripts/with_env.sh uv run tolokaforge run --config examples/terminal_bench/run_harness.yaml
 ```
 
-The [`run_harness.yaml`](../examples/terminal_bench/run_harness.yaml) driver
-config carries `agent_harness: claude-code` and `agent_model:
-openrouter/anthropic/claude-sonnet-4-6`; swap either field to matrix over
-harnesses or models. Per-trial artifacts land under
-`results/terminal_bench/fix-billing-holds-claude-code/trials/fix-billing-holds/<N>/`.
+Swap `models.agent.harness` or `models.agent.name` to matrix over CLIs
+or models. Per-trial artifacts land under the run's `evaluation.output_dir`.
 
-Prerequisites (Docker daemon, `uv`, `.env` with a provider key), the switch
-between engine-loop and harness mode, per-harness recipes (Kimi K2.7
-middleware, opencode routing, Gemini LiteLLM gateway) and result-bundle layout
-all live in the end-to-end guide:
+Prerequisites (Docker daemon, `uv`, `.env` with a provider key), the
+switch between engine-loop and harness mode, per-harness recipes
+(Kimi K2.7 middleware, opencode routing, Gemini LiteLLM gateway) and
+result-bundle layout all live in the end-to-end guide:
 [**docs/RUNNING_TERMINAL_BENCH.md**](RUNNING_TERMINAL_BENCH.md).
-
-## The one field that switches modes
-
-```yaml
-evaluation:
-  harness_adapter:
-    type: "terminal_bench"
-    params:
-      agent_harness: "claude-code"     # any of the six above, or "engine-loop"
-      agent_model:   "openrouter/anthropic/claude-sonnet-5"
-```
-
-`agent_harness: engine-loop` (or leaving the field off) keeps the engine's
-turn loop; any accepted harness name layers the vendor CLI into the trial
-image instead. `agent_model` is required in harness mode — the adapter reads
-it directly because the run's `models.agent` config is not visible on this
-code path.
 
 ## Per-harness quick reference
 
 Rows here name the shape you'll write in a run config; per-CLI quirks
-(permission-mode flags, model-name conventions, provider-env envelopes) live
-next to each entry in the shipped
-[`harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml)
-with the reason recorded inline.
+live next to each entry in the shipped
+[`harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml).
 
-| Harness | Example `agent_model` | Notes |
+| Harness | Example `models.agent.name` | Notes |
 |---|---|---|
 | `claude-code` | `openrouter/anthropic/claude-sonnet-5` | Anthropic-compat via OpenRouter. |
 | `codex` | `openrouter/openai/gpt-5.6-sol` | OpenAI-compat via OpenRouter; writes `~/.codex/config.toml` + `auth.json`. |
@@ -133,6 +188,29 @@ Two things about the `opencode` row are load-bearing on 1.18.x:
   OpenRouter's Anthropic-compat surface. That is why the shipped example
   above names `anthropic/claude-sonnet-4-6`, not `openrouter/anthropic/…`.
 
+## Adding a harness
+
+Two shapes. In-tree — edit
+[`data/harnesses.yaml`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml)
+and any new install method in
+[`install-harness.sh`](../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/install-harness.sh);
+out-of-tree — ship a Python entry-point plug-in under
+`HARNESS_REGISTRY_ENTRY_POINT_GROUP` ([ADR-0034](adr/0034-external-harness-plugin-discovery.md)).
+Both are documented in
+[`tolokaforge_coding_harnesses/README.md § Adding a harness`](../tolokaforge_coding_harnesses/README.md#adding-a-harness).
+
+## Adopting the mixin in an adapter
+
+An adapter opts into harness mode by inheriting
+`CodingHarnessAdapterMixin` alongside `BaseAdapter`. The mixin sets
+`supports_coding_harness = True` (which the orchestrator's gate reads)
+and provides six helpers: registry resolution, command assembly, the
+metadata handshake, the bash tool schema payload, the `test_execution`
+grading payload, and the standalone install-script Dockerfile layer.
+The shape and the payload-dict return convention live in
+[`tolokaforge_coding_harnesses/README.md § Adopting the mixin`](../tolokaforge_coding_harnesses/README.md#adopting-the-mixin);
+the design record is [ADR-0039](adr/0039-coding-harness-adapter-agnostic.md).
+
 ## Gateway routing (external runtimes only)
 
 A second consumer that attaches to an already-running container — a runtime
@@ -145,12 +223,35 @@ record. `tests/canonical/test_gateway_route_recipes.py` keeps the
 `gateway_route` data and the shipped
 `harness_presets_file` overlay in lock-step.
 
+## Compatibility — the legacy config shape
+
+A pre-lift shape parses too:
+
+```yaml
+evaluation:
+  harness_adapter:
+    type: "terminal_bench"
+    params:
+      agent_harness: "claude-code"
+      agent_model: "openrouter/anthropic/claude-sonnet-4-6"
+```
+
+`RunConfig._lift_harness_adapter_params_aliases` lifts each key into
+its canonical home on `models.agent.{harness,name}` at parse time,
+emits one `DeprecationWarning` per key naming the new location, and
+drops the legacy entry from `params`. A collision between equal values
+warns once; differing values raise. Removal target: the next scheduled
+major-version bump. The lift keeps existing run configs working through
+one deprecation window; a new run config should write the canonical
+shape.
+
 ## Related docs
 
-- [tolokaforge_coding_harnesses/README.md](../tolokaforge_coding_harnesses/README.md) — the package landing page: how the registry resolves, the middleware proxy, adding a harness.
+- [tolokaforge_coding_harnesses/README.md](../tolokaforge_coding_harnesses/README.md) — the package landing page: how the registry resolves, the middleware proxy, adopting the mixin, adding a harness.
 - [docs/RUNNING_TERMINAL_BENCH.md](RUNNING_TERMINAL_BENCH.md) — the end-to-end how-to. Run configs, per-harness recipes, result-bundle layout, common pitfalls.
-- [external_adapters/tolokaforge-adapter-terminal-bench/README.md](../external_adapters/tolokaforge-adapter-terminal-bench/README.md) — the consumer adapter. Routing options (OpenRouter / LiteLLM / per-harness split), synthesis details, per-trial materialisation.
+- [external_adapters/tolokaforge-adapter-terminal-bench/README.md](../external_adapters/tolokaforge-adapter-terminal-bench/README.md) — the terminal-bench adopter. Routing options (OpenRouter / LiteLLM / per-harness split), synthesis details, per-trial materialisation.
 - [ADR-0033](adr/0033-external-harness-registry.md) — YAML-driven registry design.
 - [ADR-0034](adr/0034-external-harness-plugin-discovery.md) — entry-point plug-in discovery.
 - [ADR-0036](adr/0036-tolokaforge-coding-harnesses-split.md) — the package hoist and boundary invariant.
 - [ADR-0037](adr/0037-runtime-gateway-as-harness-data.md) — gateway routing as harness data.
+- [ADR-0039](adr/0039-coding-harness-adapter-agnostic.md) — the adapter-agnostic lift and the mixin contract.

--- a/docs/adr/0039-coding-harness-adapter-agnostic.md
+++ b/docs/adr/0039-coding-harness-adapter-agnostic.md
@@ -1,0 +1,287 @@
+# 0039. Coding-harness as an adapter-agnostic run-config concept
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:**
+  - [ADR-0033](0033-external-harness-registry.md) — the `HarnessSpec` field
+    list and the operator overlay. Unchanged here; this ADR consumes it.
+  - [ADR-0034](0034-external-harness-plugin-discovery.md) — the entry-point
+    plug-in discovery contract. Unchanged; the mixin threads
+    `plugin_discovery` through so opt-in adapters compose the same three
+    layers.
+  - [ADR-0036](0036-tolokaforge-coding-harnesses-split.md) — why the mixin
+    lives in `tolokaforge_coding_harnesses/` rather than in the engine.
+  - [ADR-0037](0037-runtime-gateway-as-harness-data.md) — the two paths
+    (`gateway_route` on the spec, `harness_presets_file` overlay) both
+    survive the lift because they live on the spec, not on the entry
+    point.
+
+## Context and Problem Statement
+
+The coding-harness surface — `HarnessSpec` registry, `install-harness.sh`,
+`middleware_proxy.py`, `container_injection.py` — ships as a general
+component in [`tolokaforge_coding_harnesses/`](../../tolokaforge_coding_harnesses/)
+([ADR-0036](0036-tolokaforge-coding-harnesses-split.md)). But its **entry
+point** — how a task-pack author declares "run this trial under
+`claude-code`" — was a bespoke field on one adapter's params bag:
+`evaluation.harness_adapter.params.agent_harness` on the terminal-bench
+adapter. A run-config author declaring the model in one place had to
+declare the harness somewhere else, on a knob whose address was owned
+by a specific adapter.
+
+Three forces made the address wrong:
+
+- **The engine's dispatch is already adapter-agnostic.**
+  `Conductor._run_agent_loop` branches on
+  `spec.task.metadata["agent_harness_command"]` with no adapter-identity
+  check. `DockerComposeExecToolWrapper` reads `service` and
+  `compose_project_prefix` off `ToolSource.extra`; it knows nothing
+  about terminal-bench. `RunnerGradingConfig.grading_method` is a
+  `Literal` the runner dispatches on, again without adapter identity.
+  The engine treats "run a coding-harness CLI" as a shape a trial can
+  arrive in; only the *entry* to that shape was single-adapter.
+- **A second adopter had no address.** A native task pack that wanted
+  its trial driven by `claude-code` had no way to say so — the harness
+  selector lived on terminal-bench's params bag, so declaring it on a
+  native run either got ignored or emitted a "unknown param" error,
+  depending on how strictly the run config's schema was parsed.
+- **The model choice and the harness choice belong together.** A
+  benchmark result depends on *which model ran under which scaffold*;
+  the run config already declares the model on `models.agent.name`, and
+  the harness is a co-equal choice recorded on the same artifact key
+  (`agent_harness_version` alongside `agent_harness_model`). Two
+  addresses for one decision leaked the coupling into every consumer.
+
+## Decision Drivers
+
+- **The task author's mental model.** A run declares "which model on
+  which scaffold" in one place, alongside provider and temperature.
+- **Adapter authors compose, don't fork.** An adapter opts into
+  harness mode by inheriting one mixin — no engine edit, no branch on
+  adapter identity anywhere in the engine.
+- **Package-boundary invariant unchanged.** The mixin lives in
+  `tolokaforge_coding_harnesses/`, which imports no engine module
+  (`tests/unit/test_package_boundary.py` refuses regressions). An
+  external runtime that reads the registry can also inherit the mixin
+  without pulling the engine in.
+- **Backward compatibility for one release.** Existing run configs
+  under `evaluation.harness_adapter.params.{agent_harness,agent_model}`
+  keep working; the lift happens at parse time with a
+  `DeprecationWarning` per key naming the canonical location.
+- **Fail-loud gate.** A run declaring `models.agent.harness` against an
+  adapter that has not opted in refuses before any container work,
+  naming both sides of the mismatch and the accepted set — the
+  operator's next action is a one-line config edit.
+
+## Considered Options
+
+1. **Add `harness` to `ModelConfig` + extract a mixin any adapter can
+   inherit.** Selected. Task authors write the harness alongside the
+   model; adapters opt in with one inheritance edit and inherit six
+   helpers plus the capability flag. Byte-identical wire output for the
+   shipped terminal-bench path is provable via canonical replay.
+
+2. **Keep the field on `harness_adapter.params` and register aliases
+   per adapter.** Rejected. The knob's home would still be
+   adapter-specific — each opting-in adapter would have to re-declare
+   the field, and a task pack switching adapters would edit two
+   locations. This is precisely the coupling the ADR retires.
+
+3. **A peer top-level block — e.g. `agent.harness` alongside
+   `agent.model`, `agent.temperature`.** Rejected. `ModelConfig` already
+   carries provider, name, temperature, and `max_tokens` — the fields
+   that together describe *how the LLM turn runs*. `harness` is
+   another such field; splitting it into a peer block would leave two
+   half-populated addresses.
+
+4. **A capability enum instead of a boolean.** Rejected. There is one
+   shape of opt-in today: an adapter either provides the four harness
+   wire artefacts (metadata handshake, bash tool schema,
+   `test_execution` grading payload, image layer) or it does not. A
+   future adapter with a partial subset can add a second flag when the
+   case exists — the boolean stays valid.
+
+## Decision
+
+Adopt **Option 1** — `ModelConfig.harness` as the canonical home, and
+`CodingHarnessAdapterMixin` in `tolokaforge_coding_harnesses/` as the
+adapter-side opt-in.
+
+### `ModelConfig.harness`
+
+`harness: str | None = None` on
+[`tolokaforge/core/models/model_config.py`](../../tolokaforge/core/models/model_config.py).
+`None` (the default) runs the engine's own LLM turn loop; a non-empty
+string is a coding-harness name resolved against the effective registry
+([ADR-0033](0033-external-harness-registry.md)) at adapter time.
+`ModelConfig.name` is the same field the engine loop reads for the
+model — the CLI consumes exactly that string, with the vendor-prefix
+handling declared per-harness in
+[`data/harnesses.yaml`](../../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml).
+
+### `CodingHarnessAdapterMixin`
+
+Lives at
+[`tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py`](../../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py).
+Six helpers, plus the capability flag:
+
+| Helper | Contract |
+|---|---|
+| `supports_coding_harness: ClassVar[bool] = True` | Adapter capability flag. The orchestrator's config gate refuses `models.agent.harness` against any adapter whose flag reads `False` (the `BaseAdapter` default). |
+| `resolve_harness_spec(agent_harness, agent_model, provider_env=None, presets_file=None, plugin_discovery=True) -> HarnessSpec` | Composes the shipped catalog + operator overlay + installed plug-in bundles ([ADR-0033](0033-external-harness-registry.md) § "Registry composition"), then validates. Refuses unknown harness names and empty models. |
+| `build_harness_command(agent_harness, spec, instruction, model, provider_env=None, *, path_resolver=None) -> str` | Wraps `harness_command()`. Assembles the argv, model routing, provider-env, and (if declared) middleware-proxy preamble into one `bash -c`-shaped string. |
+| `emit_harness_metadata(agent_harness, spec, command, model) -> dict` | The four-key handshake the conductor branches on: `agent_harness`, `agent_harness_version`, `agent_harness_model`, `agent_harness_command`. |
+| `emit_harness_tool_schema(*, service, compose_project_prefix, timeout_s, toolset="coding_harness") -> dict` | Payload for `ToolSchema(**payload)`: one `bash` tool routed at the trial container via `InvocationStyle.DOCKER_COMPOSE_EXEC`. `timeout_s` must cover the whole trial — the CLI runs to completion inside a single exec. |
+| `emit_test_execution_grading() -> dict` | Payload for `RunnerGradingConfig(**payload)`: `grading_method="test_execution"`, `weights={"custom_checks": 1.0}`, `pass_threshold=0.5`. The runner reads reward from `/logs/verifier/reward.txt`. |
+| `write_install_script_layer(context_dir, base_image, spec, middleware_proxy=False) -> str` | Materialises a standalone Dockerfile snippet + copies the shipped `install-harness.sh` (and the middleware proxy when the spec declares one) into `context_dir`. Returns the Dockerfile's relative path. Self-contained — the caller wraps compose-specific plumbing (`.dockerignore`, nested contexts) around it. |
+
+### Payload dicts, not engine types
+
+`emit_harness_tool_schema` and `emit_test_execution_grading` return
+**payload dicts** rather than `ToolSchema` / `RunnerGradingConfig`
+instances. The adapter constructs the engine types at its own call site
+(`ToolSchema(**payload)`). This preserves the package-boundary invariant
+— `tolokaforge_coding_harnesses/` imports nothing under `tolokaforge/`,
+so `tests/unit/test_package_boundary.py` stays green — and localises a
+future engine-model schema change to the adapter's construction line,
+not inside the mixin. Payload shapes mirror the pydantic fields
+one-for-one; pydantic v2 reconstructs nested types (`ToolSource` from
+`source={…}`) transparently.
+
+### Config-validation gate at run start
+
+`Orchestrator.load_tasks` reads `agent_model_config.harness`. When set,
+it reads `getattr(self.adapter, "supports_coding_harness", False)` on
+the resolved adapter and refuses the run with a message naming both
+sides of the mismatch and the currently-opted-in set (today: `native`,
+`terminal_bench`). The refusal happens before any container work is
+started, so no image build or compose bring-up ever runs against a
+mismatched pair.
+
+### State-checks composability
+
+Coding-harness trials compose with **any** grading method. Two paths:
+
+- **`test_execution`** (the mixin's default). The runner short-circuits
+  at `service.py:1802` — reads the reward float from
+  `/logs/verifier/reward.txt` and returns before assembling any
+  jsonpath state. Terminal-bench's byte-identical replay is naturally
+  preserved: no filesystem snapshot runs.
+- **`state_checks` / `transcript` / `rubric`** (or any combination
+  through the standard combiner). The runner assembles the trial's
+  jsonpath state via `_assemble_jsonpath_state`. When the trial's
+  metadata carries both `agent_harness_command` and `agent_visible_dir`
+  AND a `DockerComposeExecToolWrapper` is registered for the trial,
+  `_read_filesystem_for_state` snapshots the container's agent-visible
+  directory into `state["filesystem"]` via
+  [`tolokaforge/runner/harness_state.py`](../../tolokaforge/runner/harness_state.py).
+  A `state_checks` assertion against `$.filesystem['/work/factorial.py']`
+  resolves against what the CLI actually left behind.
+
+The shipped adopters set the agent-visible dir as an adapter convention:
+`/work` for the native adapter, `/app` for terminal-bench.
+
+### Backward compatibility
+
+The pre-lift shape —
+`evaluation.harness_adapter.params.{agent_harness,agent_model}` —
+still parses. `RunConfig._lift_harness_adapter_params_aliases` runs at
+parse time, lifts each key into `models.agent.{harness,name}`, emits
+one `DeprecationWarning` per key naming the canonical home, and drops
+the legacy entry from `params` so downstream reads route through one
+address. A collision between an equal value on both sides warns once;
+differing values raise `ValueError` naming both keys.
+
+Removal target: the next scheduled major-version bump that ships after
+this ADR lands. The `DeprecationWarning` is the operator's advance
+notice; the git log for `RunConfig._lift_harness_adapter_params_aliases`
+is the removal record when it lands.
+
+## Consequences
+
+### Positive
+
+- **One address per decision.** A task pack switching harnesses (or
+  matrixing across them) edits `models.agent.harness` in one file. A
+  task pack switching adapters keeps `models.agent.harness` untouched.
+- **Adapter opt-in is one inheritance line.** Any adapter that inherits
+  `CodingHarnessAdapterMixin` alongside `BaseAdapter` gets the six
+  helpers and the capability flag; no engine edit is required to
+  register a new opt-in.
+- **State-checks composability shipped.** A native pack with a JSONPath
+  assertion against `$.filesystem['/work/…']` grades correctly under
+  harness mode today — `test_execution` is the default but not the
+  only option.
+- **Wire output is byte-identical for the terminal-bench path.** The
+  canonical replay at
+  `tests/canonical/snapshots/tbench_echo_hello_harness/` proves it.
+- **Boundary invariant unchanged.** The mixin's payload-dict return
+  convention means `tolokaforge_coding_harnesses/` still imports no
+  engine module, so an external runtime that reads the registry can
+  inherit the mixin without pulling the engine in.
+
+### Negative / Trade-offs
+
+- **A second address exists for one release** — the legacy
+  `harness_adapter.params.{agent_harness,agent_model}` still parses.
+  The trade-off is a deliberate deprecation window; a run using the
+  old shape sees one `DeprecationWarning` per key naming the new home.
+- **`agent_visible_dir` is an adapter convention, not a task-declared
+  field.** Native pins `/work`, terminal-bench pins `/app`. A task pack
+  cannot yet override it. If a future harness adapter surfaces where
+  the trial's agent-visible dir varies per task, this becomes a
+  task-level field — but the current shape carries no evidence of that
+  need.
+- **The capability flag is a boolean.** A future adapter that opts into
+  a subset of harness mode (e.g. gateway-provisioning only, no image
+  layer) needs a richer signal. The boolean is honest today and
+  extends cleanly when the case surfaces.
+
+### Follow-ups
+
+- **`migration-bench` adopter.** The private-repo migration-bench
+  adapter is the natural next opt-in; adopting the mixin there is a
+  one-PR change in `tolokaforge-tools`.
+- **Operator UX polish.** The `tolokaforge adapters list` (or
+  equivalent) subcommand could grow a `supports_coding_harness`
+  column; the gate's error message could then cite it. Deferred as UX,
+  not a correctness gap.
+- **Rename the harness entry-point group** — the group name is still
+  `tolokaforge_adapter_terminal_bench.harness_registries` for the same
+  reason [ADR-0036 § "The entry-point group name is a retained
+  compatibility artefact"](0036-tolokaforge-coding-harnesses-split.md#the-entry-point-group-name-is-a-retained-compatibility-artefact)
+  documents. Renaming it becomes cleaner once the adapter-agnostic
+  entry-point is the only visible surface; not gated on this ADR.
+
+## Links
+
+- Related ADRs:
+  - [ADR-0033](0033-external-harness-registry.md) — `HarnessSpec` and
+    the operator overlay; unchanged.
+  - [ADR-0034](0034-external-harness-plugin-discovery.md) — plug-in
+    entry-point discovery; unchanged.
+  - [ADR-0036](0036-tolokaforge-coding-harnesses-split.md) — the
+    package hoist that made the mixin's address possible.
+  - [ADR-0037](0037-runtime-gateway-as-harness-data.md) — gateway
+    routing on the spec, orthogonal to this ADR.
+- Related code:
+  - [`tolokaforge/core/models/model_config.py`](../../tolokaforge/core/models/model_config.py)
+    — `ModelConfig.harness`.
+  - [`tolokaforge/core/models/run_config.py`](../../tolokaforge/core/models/run_config.py)
+    — `_lift_harness_adapter_params_aliases`.
+  - [`tolokaforge/core/orchestrator.py`](../../tolokaforge/core/orchestrator.py)
+    — the config-validation gate in `load_tasks`.
+  - [`tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py`](../../tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py)
+    — the mixin.
+  - [`tolokaforge/adapters/native.py`](../../tolokaforge/adapters/native.py),
+    [`external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py`](../../external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py)
+    — the two shipped adopters.
+  - [`tolokaforge/runner/harness_state.py`](../../tolokaforge/runner/harness_state.py)
+    — the container-filesystem snapshot for non-`test_execution`
+    grading composability.
+  - [`examples/native/coding_harness/`](../../examples/native/coding_harness/),
+    [`examples/terminal_bench/`](../../examples/terminal_bench/) — the
+    two shipped example packs.

--- a/examples/native/coding_harness/docker-compose.yaml
+++ b/examples/native/coding_harness/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  main:
+    build:
+      context: ./environment
+    container_name: "tfnative_${TOLOKAFORGE_TRIAL_SLUG}_main"
+    command:
+      - sh
+      - -c
+      - sleep infinity

--- a/examples/native/coding_harness/environment/Dockerfile
+++ b/examples/native/coding_harness/environment/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
+
+RUN pip install --no-cache-dir pytest==8.3.3
+
+WORKDIR /work
+
+COPY app/factorial.py /work/factorial.py
+COPY app/tests /work/tests
+
+RUN mkdir -p /logs/verifier

--- a/examples/native/coding_harness/environment/app/factorial.py
+++ b/examples/native/coding_harness/environment/app/factorial.py
@@ -1,0 +1,10 @@
+def factorial(n: int) -> int:
+    """Return the factorial of a non-negative integer *n*.
+
+    Raises ``ValueError`` for negative input.
+    """
+    if n < 0:
+        raise ValueError("factorial is undefined for negative integers")
+    if n <= 1:
+        return 1
+    return n * factorial(n - 2)

--- a/examples/native/coding_harness/environment/app/tests/conftest.py
+++ b/examples/native/coding_harness/environment/app/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/examples/native/coding_harness/environment/app/tests/test_factorial.py
+++ b/examples/native/coding_harness/environment/app/tests/test_factorial.py
@@ -1,0 +1,27 @@
+import pytest
+from factorial import factorial
+
+
+def test_factorial_zero() -> None:
+    assert factorial(0) == 1
+
+
+def test_factorial_one() -> None:
+    assert factorial(1) == 1
+
+
+def test_factorial_two() -> None:
+    assert factorial(2) == 2
+
+
+def test_factorial_five() -> None:
+    assert factorial(5) == 120
+
+
+def test_factorial_ten() -> None:
+    assert factorial(10) == 3628800
+
+
+def test_factorial_negative_raises() -> None:
+    with pytest.raises(ValueError):
+        factorial(-1)

--- a/examples/native/coding_harness/instruction.md
+++ b/examples/native/coding_harness/instruction.md
@@ -1,0 +1,26 @@
+# Task: Fix the Factorial Bug
+
+The Python module `/work/factorial.py` implements a `factorial` function that
+is incorrect for most inputs. Investigate the code and fix the bug so the
+test suite in `/work/tests/` passes.
+
+## Environment
+
+- Python 3.11
+- `pytest` is installed
+
+## Files
+
+- `/work/factorial.py` — implementation to fix
+- `/work/tests/test_factorial.py` — test suite that must pass
+
+## How to verify
+
+Run the tests inside the container:
+
+```bash
+pytest /work/tests -v
+```
+
+The pack's verifier writes the pass fraction to `/logs/verifier/reward.txt`;
+a run that fixes every test scores `1.0`.

--- a/examples/native/coding_harness/run_harness.yaml
+++ b/examples/native/coding_harness/run_harness.yaml
@@ -1,0 +1,43 @@
+# Native-adapter run config exercising `models.agent.harness` end-to-end.
+#
+# This is the exemplar of the adapter-agnostic shape the coding-harness lift
+# introduces: any task on any adapter that opts into `supports_coding_harness`
+# declares the CLI right next to the model, and the engine's turn loop is
+# replaced by one invocation of that CLI inside the trial container.
+#
+# The native adapter (this run's harness_adapter) inherits
+# `CodingHarnessAdapterMixin`, so the run config's `models.agent.harness`
+# survives the orchestrator's config-validation gate.
+
+models:
+  agent:
+    provider: "openrouter"
+    name: "openrouter/anthropic/claude-sonnet-4-6"
+    harness: "claude-code"
+    temperature: 0.0
+    max_tokens: 4096
+
+compute:
+  workers: 1
+
+storage:
+  queue:
+    backend: sqlite
+
+orchestrator:
+  repeats: 1
+  strict_task_load: true
+  timeouts:
+    # The harness runs to completion inside one `docker exec`; the trial has
+    # no LLM turn loop to time-slice, so this budget must cover the whole
+    # invocation.
+    episode_s: 900
+    turn_s: 240
+
+evaluation:
+  projects:
+    - "examples/native/coding_harness"
+  tasks_glob: "task.yaml"
+  output_dir: "results/native-coding-harness"
+  harness_adapter:
+    type: "native"

--- a/examples/native/coding_harness/solution/solve.sh
+++ b/examples/native/coding_harness/solution/solve.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Oracle fix — writes the correct factorial so the verifier gives reward 1.0.
+set -euo pipefail
+
+cat > /work/factorial.py << 'PY'
+def factorial(n: int) -> int:
+    """Return the factorial of a non-negative integer *n*.
+
+    Raises ``ValueError`` for negative input.
+    """
+    if n < 0:
+        raise ValueError("factorial is undefined for negative integers")
+    if n <= 1:
+        return 1
+    return n * factorial(n - 1)
+PY

--- a/examples/native/coding_harness/task.yaml
+++ b/examples/native/coding_harness/task.yaml
@@ -1,0 +1,27 @@
+task_id: "fix_factorial"
+name: "Fix the Factorial Bug"
+category: "coding_harness"
+description: >
+  A Python module implementing `factorial(n)` is buggy — it returns the wrong
+  result for most inputs. Fix the module so its accompanying pytest suite
+  passes. The pack ships an `environment/` Dockerfile that stages the buggy
+  code and the tests into a Python 3.11 image; the pack's `tests/test.sh`
+  runs pytest inside the trial container and writes the pass fraction to
+  `/logs/verifier/reward.txt` for `test_execution` grading.
+adapter_type: "native"
+initial_user_message: |
+  The Python module at /work/factorial.py has a bug — its `factorial`
+  function does not return the correct value for most inputs. Fix the bug
+  so the test suite in /work/tests/ passes. You can run the tests with
+  `pytest /work/tests`.
+system_prompt: null
+initial_state: {}
+tools:
+  agent:
+    enabled: []
+  user:
+    enabled: []
+environment_manifest:
+  stack:
+    compose_file: "./docker-compose.yaml"
+    runner_service: "main"

--- a/examples/native/coding_harness/tests/test.sh
+++ b/examples/native/coding_harness/tests/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -o pipefail
+
+mkdir -p /logs/verifier
+
+echo "Running tests..."
+pytest /work/tests -v 2>&1 | tee /tmp/pytest_output.txt
+
+python3 - << 'PY'
+import re
+from pathlib import Path
+
+TESTS = [
+    "test_factorial_zero",
+    "test_factorial_one",
+    "test_factorial_two",
+    "test_factorial_five",
+    "test_factorial_ten",
+    "test_factorial_negative_raises",
+]
+
+output_path = Path("/tmp/pytest_output.txt")
+reward_path = Path("/logs/verifier/reward.txt")
+
+text = output_path.read_text(errors="ignore") if output_path.exists() else ""
+
+passed = sum(1 for t in TESTS if re.search(rf"::{re.escape(t)}\s+PASSED", text))
+reward = passed / len(TESTS)
+
+reward_path.parent.mkdir(parents=True, exist_ok=True)
+reward_path.write_text(f"{reward:.6f}\n")
+print(f"Tests passed: {passed}/{len(TESTS)}  reward={reward:.6f}")
+PY
+
+exit 0

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -16,6 +16,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from tolokaforge_coding_harnesses.adapter_support import CodingHarnessAdapterMixin
+
 from tolokaforge.adapters.base import (
     AdapterEnvironment,
     BaseAdapter,
@@ -36,7 +38,6 @@ from tolokaforge.core.project_loader import resolve as resolve_environment_patch
 from tolokaforge.runner.models import (
     AdapterType,
     EnvironmentPatch,
-    InvocationStyle,
     NetworkPolicy,
     RunnerGradingConfig,
     RunnerInitialStateConfig,
@@ -44,7 +45,6 @@ from tolokaforge.runner.models import (
     StackPatch,
     TaskDescription,
     ToolSchema,
-    ToolSource,
 )
 from tolokaforge.secrets import expand_secret_refs, get_default
 from tolokaforge_adapter_terminal_bench.compose_synthesis import (
@@ -67,7 +67,6 @@ from tolokaforge_coding_harnesses import (
     ResolvedHarnessRegistry,
     SkillDelivery,
     compute_harness_fingerprint,
-    harness_command,
     provider_env_input,
     resolve_effective_registry,
     validate_harness,
@@ -144,9 +143,16 @@ def _resolve_provider_env(
     return resolved
 
 
-class TerminalBenchAdapter(BaseAdapter):
+class TerminalBenchAdapter(CodingHarnessAdapterMixin, BaseAdapter):
     """Adapter that runs terminal-bench tasks through
     :class:`~tolokaforge.core.per_trial_runtime.PerTrialRuntimeBackend`.
+
+    Inheriting :class:`CodingHarnessAdapterMixin` opts this adapter into the
+    orchestrator's ``models.agent.harness`` config gate (via the mixin's
+    ``supports_coding_harness = True`` flag) and gives it the shared helpers
+    for command assembly, metadata emission, tool-schema payload, and
+    ``test_execution`` grading — leaving only the terminal-bench-specific
+    compose synthesis in this adapter.
     """
 
     def __init__(
@@ -392,51 +398,26 @@ class TerminalBenchAdapter(BaseAdapter):
             environment_manifest=manifest,
             agent_tools=[
                 ToolSchema(
-                    name="bash",
-                    description="Execute a bash command inside the task container",
-                    parameters={
-                        "type": "object",
-                        "properties": {
-                            "command": {
-                                "type": "string",
-                                "description": "Shell command to run",
-                            }
-                        },
-                        "required": ["command"],
-                    },
-                    category="compute",
-                    # The runner-side compose-exec wrapper reads its subprocess
-                    # timeout off this field, so under harness mode it has to
-                    # carry the whole trial's agent budget: the CLI runs to
-                    # completion inside a single exec.
-                    timeout_s=(
-                        _AGENT_TOOL_TIMEOUT_S
-                        if self.agent_harness == ENGINE_LOOP
-                        else meta.agent_timeout_sec
-                    ),
-                    source=ToolSource(
+                    **self.emit_harness_tool_schema(
+                        service=env.agent_service,
+                        compose_project_prefix=PROJECT_PREFIX,
+                        # The runner-side compose-exec wrapper reads its subprocess
+                        # timeout off this field, so under harness mode it has to
+                        # carry the whole trial's agent budget: the CLI runs to
+                        # completion inside a single exec.
+                        timeout_s=(
+                            _AGENT_TOOL_TIMEOUT_S
+                            if self.agent_harness == ENGINE_LOOP
+                            else meta.agent_timeout_sec
+                        ),
                         toolset="terminal_bench",
-                        module_path="",
-                        class_name="bash",
-                        invocation_style=InvocationStyle.DOCKER_COMPOSE_EXEC,
-                        extra={
-                            "service": env.agent_service,
-                            "compose_project_prefix": PROJECT_PREFIX,
-                        },
-                    ),
+                    )
                 )
             ],
             user_tools=[],
             initial_state=RunnerInitialStateConfig(),
             user_simulator=RunnerUserSimulatorConfig(mode="scripted"),
-            grading=RunnerGradingConfig(
-                combine_method="weighted",
-                weights={"custom_checks": 1.0},
-                pass_threshold=0.5,
-                # Score by running the reference test suite in the env container.
-                # The runner dispatches on this method, not on the adapter name.
-                grading_method="test_execution",
-            ),
+            grading=RunnerGradingConfig(**self.emit_test_execution_grading()),
             metadata=self._metadata(meta),
         )
 
@@ -460,15 +441,18 @@ class TerminalBenchAdapter(BaseAdapter):
             "agent_harness": self.agent_harness,
         }
         if self.harness_spec is not None:
-            metadata["agent_harness_version"] = self.harness_spec.version
-            metadata["agent_harness_model"] = self.agent_model
-            metadata["agent_harness_command"] = harness_command(
+            command = self.build_harness_command(
                 self.agent_harness,
+                self.harness_spec,
                 meta.instruction,
                 self.agent_model,
-                self.harnesses,
                 self.agent_provider_env,
                 path_resolver=self.path_resolver,
+            )
+            metadata.update(
+                self.emit_harness_metadata(
+                    self.agent_harness, self.harness_spec, command, self.agent_model
+                )
             )
             skills_dir = installable_skills_dir(meta, self.harness_spec)
             if skills_dir is not None:

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -454,6 +454,14 @@ class TerminalBenchAdapter(CodingHarnessAdapterMixin, BaseAdapter):
                     self.agent_harness, self.harness_spec, command, self.agent_model
                 )
             )
+            # Where the CLI edits inside the trial container — the runner
+            # reads this back for state-checks grading. Terminal-bench packs
+            # conventionally set ``WORKDIR /app`` in their base image and the
+            # harness-install layer does not override it. Only read when a
+            # trial requests non-``test_execution`` grading; the shipped
+            # terminal-bench harness path stays on ``test_execution`` and
+            # bypasses the read.
+            metadata["agent_visible_dir"] = "/app"
             skills_dir = installable_skills_dir(meta, self.harness_spec)
             if skills_dir is not None:
                 metadata["harness_skills_bundle_sha"] = skills_bundle_digest(

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py
@@ -410,6 +410,16 @@ def _write_harness_build_context(staging_dir: Path, *, base_image: str, spec: Ha
 
     A :class:`~tolokaforge_coding_harnesses.SkillDelivery` may
     append to either file afterwards; :class:`ImageLayerSkillDelivery` does.
+
+    Kept in this adapter (rather than delegated to
+    :meth:`~tolokaforge_coding_harnesses.adapter_support.CodingHarnessAdapterMixin.write_install_script_layer`)
+    because the synthesised compose file's ``build.context`` is the staging
+    directory root — not the ``_harness/`` subdirectory the Dockerfile lives
+    in — so a skills bundle at the staging root remains reachable by a single
+    ``COPY`` line. The mixin writes a flat build context whose Dockerfile
+    ``COPY`` paths do not carry a ``_harness/`` prefix, which would drift the
+    dockerfile bytes locked by the ``tbench_echo_hello_harness`` canonical
+    snapshot.
     """
     harness_dir = staging_dir / _HARNESS_STAGING_DIR
     harness_dir.mkdir(exist_ok=True)

--- a/tests/canonical/snapshots/harness_registry_replay/metric.json
+++ b/tests/canonical/snapshots/harness_registry_replay/metric.json
@@ -1,6 +1,6 @@
 {
   "bucket_a_count": 1,
-  "bucket_b_count": 12,
+  "bucket_b_count": 11,
   "commits": [
     {
       "adapter_paths": [
@@ -1749,61 +1749,56 @@
     },
     {
       "adapter_paths": [
-        "AGENTS.md",
-        "README.md",
-        "docs/CODING_HARNESSES.md",
-        "docs/ROADMAP.md",
-        "tolokaforge_coding_harnesses/README.md"
-      ],
-      "bucket": "B",
-      "date": "2026-08-24",
-      "pr": null,
-      "reason": "5 adapter-side path(s) outside Bucket-A allow-list",
-      "sha": "3d591a96142a18f20bd064e02b64cd089edb1000",
-      "subject": "docs(coding-harnesses): make the harness surface discoverable",
-      "touched_files": [
-        "AGENTS.md",
-        "README.md",
-        "docs/CODING_HARNESSES.md",
-        "docs/ROADMAP.md",
-        "examples/terminal_bench/README.md",
-        "tolokaforge_coding_harnesses/README.md"
-      ]
-    },
-    {
-      "adapter_paths": [
-        "AGENTS.md",
-        "docs/CODING_HARNESSES.md",
-        "docs/ROADMAP.md",
-        "tolokaforge_coding_harnesses/README.md"
-      ],
-      "bucket": "B",
-      "date": "2026-08-24",
-      "pr": null,
-      "reason": "4 adapter-side path(s) outside Bucket-A allow-list",
-      "sha": "5580dd86071d62d57a240e54ce0e6db825088bb9",
-      "subject": "docs(coding-harnesses): review fixes \u2014 canonical replay path, run_harness.yaml alignment, signature honesty",
-      "touched_files": [
-        "AGENTS.md",
-        "docs/CODING_HARNESSES.md",
-        "docs/ROADMAP.md",
-        "examples/terminal_bench/README.md",
-        "tolokaforge_coding_harnesses/README.md"
-      ]
-    },
-    {
-      "adapter_paths": [
-        "tests/canonical/snapshots/harness_registry_replay/metric.json"
+        "tolokaforge_coding_harnesses/README.md",
+        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/__init__.py",
+        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py",
+        "tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py",
+        "tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py"
       ],
       "bucket": "B",
       "date": "2026-08-25",
       "pr": null,
-      "reason": "1 adapter-side path(s) outside Bucket-A allow-list",
-      "sha": "80722fb55b365a29e52ccc23b868c373213fd05b",
-      "subject": "docs(harnesses.yaml): correct the opencode routing story on 1.18.18",
+      "reason": "5 adapter-side path(s) outside Bucket-A allow-list",
+      "sha": "02296884bbee2e4996632fe007f808a514c59a83",
+      "subject": "feat(coding-harnesses): extract CodingHarnessAdapterMixin",
       "touched_files": [
+        "tolokaforge_coding_harnesses/README.md",
+        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/__init__.py",
+        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py",
+        "tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py",
+        "tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py"
+      ]
+    },
+    {
+      "adapter_paths": [
+        ".github/workflows/coding-harness-matrix.yml",
+        "AGENTS.md",
+        "README.md",
+        "docs/CODING_HARNESSES.md",
+        "docs/ROADMAP.md",
+        "docs/RUNNING_TERMINAL_BENCH.md",
         "tests/canonical/snapshots/harness_registry_replay/metric.json",
-        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml"
+        "tolokaforge_coding_harnesses/README.md",
+        "tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py"
+      ],
+      "bucket": "B",
+      "date": "2026-08-25",
+      "pr": 1257,
+      "reason": "9 adapter-side path(s) outside Bucket-A allow-list",
+      "sha": "db89028afe58278ffdd2a71a9bcd4007c8b6170e",
+      "subject": "docs(coding-harnesses): make the harness surface discoverable (Stage 1 of harness ecosystem plan) (#1257)",
+      "touched_files": [
+        ".github/workflows/coding-harness-matrix.yml",
+        "AGENTS.md",
+        "README.md",
+        "docs/CODING_HARNESSES.md",
+        "docs/ROADMAP.md",
+        "docs/RUNNING_TERMINAL_BENCH.md",
+        "examples/terminal_bench/README.md",
+        "tests/canonical/snapshots/harness_registry_replay/metric.json",
+        "tolokaforge_coding_harnesses/README.md",
+        "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/data/harnesses.yaml",
+        "tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py"
       ]
     }
   ]

--- a/tests/canonical/snapshots/harness_registry_replay/metric.json
+++ b/tests/canonical/snapshots/harness_registry_replay/metric.json
@@ -1,6 +1,6 @@
 {
   "bucket_a_count": 1,
-  "bucket_b_count": 11,
+  "bucket_b_count": 12,
   "commits": [
     {
       "adapter_paths": [
@@ -1767,6 +1767,24 @@
         "tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py",
         "tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py",
         "tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py"
+      ]
+    },
+    {
+      "adapter_paths": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py",
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py",
+        "tests/unit/test_terminal_bench.py"
+      ],
+      "bucket": "B",
+      "date": "2026-08-25",
+      "pr": null,
+      "reason": "3 adapter-side path(s) outside Bucket-A allow-list",
+      "sha": "381ff8cc29159b254e9e2678f1c3df7c740d884b",
+      "subject": "refactor(tbench): inherit CodingHarnessAdapterMixin",
+      "touched_files": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py",
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py",
+        "tests/unit/test_terminal_bench.py"
       ]
     },
     {

--- a/tests/canonical/snapshots/native_coding_harness_fix_factorial/harness_metadata.json
+++ b/tests/canonical/snapshots/native_coding_harness_fix_factorial/harness_metadata.json
@@ -1,0 +1,6 @@
+{
+  "agent_harness": "claude-code",
+  "agent_harness_command": "export ANTHROPIC_MODEL=anthropic/claude-sonnet-4-6 && export ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-4-6 && export ANTHROPIC_DEFAULT_OPUS_MODEL=anthropic/claude-sonnet-4-6 && export ANTHROPIC_DEFAULT_HAIKU_MODEL=anthropic/claude-sonnet-4-6 && export CLAUDE_CODE_SUBAGENT_MODEL=anthropic/claude-sonnet-4-6 && printf %s 'The Python module at /work/factorial.py has a bug \u2014 its `factorial`\nfunction does not return the correct value for most inputs. Fix the bug\nso the test suite in /work/tests/ passes. You can run the tests with\n`pytest /work/tests`.\n' | claude --verbose --output-format=stream-json --permission-mode=bypassPermissions --print",
+  "agent_harness_model": "openrouter/anthropic/claude-sonnet-4-6",
+  "agent_harness_version": "2.1.233"
+}

--- a/tests/canonical/test_native_coding_harness_example.py
+++ b/tests/canonical/test_native_coding_harness_example.py
@@ -1,0 +1,93 @@
+"""The shipped ``examples/native/coding_harness/`` pack is a whole document
+of its own kind: a native-adapter run config declaring
+``models.agent.harness`` end-to-end, proving the "any adapter" claim of the
+coding-harness lift with something executable.
+
+The run config surviving :class:`RunConfig` validation is the first contract
+this suite locks. The second is the four-key harness metadata handshake the
+conductor branches on — a snapshot of the wire dict a run of the pack under
+``claude-code`` produces, so a byte-level drift in the mixin's command
+assembly or the adapter's metadata dict shape shows up here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.core.models import RunConfig
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_ROOT = _REPO_ROOT / "examples" / "native" / "coding_harness"
+_RUN_CONFIG_PATH = _PACK_ROOT / "run_harness.yaml"
+
+
+def test_run_harness_yaml_loads_as_run_config() -> None:
+    """The pack's exemplar run config validates cleanly."""
+    payload = yaml.safe_load(_RUN_CONFIG_PATH.read_text())
+    cfg = RunConfig(**payload)
+    agent = cfg.models.get("agent")
+    assert agent is not None
+    assert agent.harness == "claude-code"
+    assert cfg.evaluation.harness_adapter is not None
+    assert cfg.evaluation.harness_adapter.type == "native"
+    assert cfg.orchestrator.strict_task_load is True
+
+
+def test_native_adapter_builds_harness_task_description() -> None:
+    """The native adapter loads the pack task cleanly under harness mode."""
+    adapter = NativeAdapter(
+        {
+            "tasks_glob": "task.yaml",
+            "task_packs": [str(_PACK_ROOT)],
+            "agent_harness": "claude-code",
+            "agent_model": "openrouter/anthropic/claude-sonnet-4-6",
+        }
+    )
+    assert adapter.get_task_ids() == ["fix_factorial"]
+    td = adapter.to_task_description("fix_factorial")
+    # Single bash tool via docker_compose_exec — the shape the runner-side
+    # DockerComposeExecToolWrapper factory dispatches on.
+    assert len(td.agent_tools) == 1
+    assert td.agent_tools[0].name == "bash"
+    assert td.agent_tools[0].source is not None
+    assert td.agent_tools[0].source.invocation_style == "docker_compose_exec"
+    # test_execution grading — the runner reads the reward from
+    # /logs/verifier/reward.txt inside the trial container.
+    assert td.grading.grading_method == "test_execution"
+
+
+def test_harness_metadata_snapshot(canon_snapshot) -> None:
+    """Snapshot the four-key harness metadata handshake.
+
+    The dict crosses the wire on ``TaskDescription.metadata`` and the
+    conductor's ``_run_agent_loop`` branches on ``agent_harness_command``;
+    drift in any of the four keys is a wire break. Version-bump coordination
+    is handled by the same commit that bumps the harness registry — the
+    ``harness_registry_replay`` metric moves in lockstep with this snapshot.
+    """
+    adapter = NativeAdapter(
+        {
+            "tasks_glob": "task.yaml",
+            "task_packs": [str(_PACK_ROOT)],
+            "agent_harness": "claude-code",
+            "agent_model": "openrouter/anthropic/claude-sonnet-4-6",
+        }
+    )
+    td = adapter.to_task_description("fix_factorial")
+    metadata = {
+        key: td.metadata[key]
+        for key in (
+            "agent_harness",
+            "agent_harness_version",
+            "agent_harness_model",
+            "agent_harness_command",
+        )
+    }
+    snap = canon_snapshot("native_coding_harness_fix_factorial")
+    snap.assert_match(metadata, "harness_metadata.json")

--- a/tests/canonical/test_terminal_bench_examples_strict_task_load.py
+++ b/tests/canonical/test_terminal_bench_examples_strict_task_load.py
@@ -134,8 +134,13 @@ def test_a_harness_example_exists_and_is_fully_specified() -> None:
     harness_configs = []
     for config_path in _example_run_configs():
         config = RunConfig(**yaml.safe_load(config_path.read_text()))
-        adapter = config.evaluation.harness_adapter
-        harness = (adapter.params.get("agent_harness") if adapter else None) or ENGINE_LOOP
+        # Canonical home post-lift is ``models.agent.harness``; the parse-time
+        # alias validator on ``RunConfig`` moves the legacy
+        # ``evaluation.harness_adapter.params.agent_harness`` value here and
+        # deletes the legacy key, so this single read covers both shipped
+        # example shapes.
+        agent_model_config = config.models.get("agent") if config.models else None
+        harness = (agent_model_config.harness if agent_model_config else None) or ENGINE_LOOP
         if harness != ENGINE_LOOP:
             harness_configs.append((config_path, config, harness))
 
@@ -145,9 +150,12 @@ def test_a_harness_example_exists_and_is_fully_specified() -> None:
     )
     for config_path, config, harness in harness_configs:
         rel = config_path.relative_to(_REPO_ROOT)
-        params = config.evaluation.harness_adapter.params
+        agent_model_config = config.models.get("agent") if config.models else None
         assert harness in HARNESSES, f"{rel}: unknown agent_harness {harness!r}"
-        assert params.get("agent_model"), f"{rel}: a harness run must pin `agent_model`"
+        assert agent_model_config is not None and agent_model_config.name, (
+            f"{rel}: a harness run must declare ``models.agent.name`` "
+            "(also lifted from the legacy ``harness_adapter.params.agent_model``)"
+        )
         # The exec cannot be cut short, so the run budget must cover the
         # harness budget or the adapter refuses the run at trial setup.
         assert config.orchestrator.timeouts.episode_s >= 1800, (

--- a/tests/unit/test_harness_adapter_params_aliases.py
+++ b/tests/unit/test_harness_adapter_params_aliases.py
@@ -1,0 +1,235 @@
+"""Unit tests for the ``harness_adapter.params.*`` → ``models.agent.*`` aliases.
+
+Two config fields once lived inside the ``terminal_bench``-adapter-specific
+``evaluation.harness_adapter.params`` bag:
+
+- ``agent_harness`` (which coding-agent CLI drives the trial)
+- ``agent_model`` (the model the CLI receives)
+
+The coding-harness lift makes ``models.agent.harness`` the canonical home for
+the first and ``models.agent.name`` the canonical home for the second. This
+suite pins the alias behaviour: legacy-only lifts + warns, canonical-only
+passes through, both-agree warns once, both-disagree fails loud. Same shape
+as ``test_dual_home_aliases.py``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from tolokaforge.core.models import RunConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _base(**overrides) -> dict:
+    """Minimal valid run-config kwargs; callers layer overrides in."""
+    return {
+        "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+        "orchestrator": {},
+        "evaluation": {"output_dir": "results/x"},
+        **overrides,
+    }
+
+
+class TestHarnessSelectorAlias:
+    def test_legacy_only_lifts_and_warns(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {
+                            "provider": "openrouter",
+                            "name": "openrouter/anthropic/claude-sonnet-4-6",
+                        },
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {
+                            "type": "terminal_bench",
+                            "params": {"agent_harness": "claude-code"},
+                        },
+                    },
+                )
+            )
+        assert cfg.models["agent"].harness == "claude-code"
+        # Legacy key is dropped from params after lift.
+        assert "agent_harness" not in cfg.evaluation.harness_adapter.params
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "evaluation.harness_adapter.params.agent_harness" in str(w.message)
+            for w in caught
+        )
+
+    def test_canonical_only_no_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {
+                            "provider": "openrouter",
+                            "name": "openrouter/anthropic/claude-sonnet-4-6",
+                            "harness": "claude-code",
+                        },
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {"type": "terminal_bench", "params": {}},
+                    },
+                )
+            )
+        assert cfg.models["agent"].harness == "claude-code"
+        assert not any(
+            issubclass(w.category, DeprecationWarning) and "agent_harness" in str(w.message)
+            for w in caught
+        )
+
+    def test_both_agree_warns_once(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {
+                            "provider": "openrouter",
+                            "name": "openrouter/anthropic/claude-sonnet-4-6",
+                            "harness": "claude-code",
+                        },
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {
+                            "type": "terminal_bench",
+                            "params": {"agent_harness": "claude-code"},
+                        },
+                    },
+                )
+            )
+        assert cfg.models["agent"].harness == "claude-code"
+        matches = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "evaluation.harness_adapter.params.agent_harness" in str(w.message)
+        ]
+        assert len(matches) == 1
+
+    def test_both_disagree_raises(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {
+                            "provider": "openrouter",
+                            "name": "openrouter/anthropic/claude-sonnet-4-6",
+                            "harness": "claude-code",
+                        },
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {
+                            "type": "terminal_bench",
+                            "params": {"agent_harness": "codex"},
+                        },
+                    },
+                )
+            )
+        msg = str(excinfo.value)
+        assert "evaluation.harness_adapter.params.agent_harness" in msg
+        assert "models.agent.harness" in msg
+
+
+class TestAgentModelAlias:
+    def test_legacy_only_lifts_and_warns(self) -> None:
+        # ``models.agent`` carries ``provider`` (required by ``ModelConfig``);
+        # ``name`` is filled from the legacy ``params.agent_model``. The lift
+        # deletes the legacy key and emits ``DeprecationWarning``.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {"provider": "openrouter"},
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {
+                            "type": "terminal_bench",
+                            "params": {
+                                "agent_model": "openrouter/anthropic/claude-sonnet-4-6",
+                            },
+                        },
+                    },
+                )
+            )
+        assert cfg.models["agent"].name == "openrouter/anthropic/claude-sonnet-4-6"
+        assert "agent_model" not in cfg.evaluation.harness_adapter.params
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "evaluation.harness_adapter.params.agent_model" in str(w.message)
+            for w in caught
+        )
+
+    def test_both_disagree_raises(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            RunConfig(
+                **_base(
+                    models={
+                        "user": {"provider": "openai", "name": "gpt-4o"},
+                        "agent": {
+                            "provider": "openrouter",
+                            "name": "openrouter/anthropic/claude-sonnet-4-6",
+                        },
+                    },
+                    evaluation={
+                        "output_dir": "results/x",
+                        "harness_adapter": {
+                            "type": "terminal_bench",
+                            "params": {"agent_model": "openrouter/openai/gpt-5.6-sol"},
+                        },
+                    },
+                )
+            )
+        msg = str(excinfo.value)
+        assert "evaluation.harness_adapter.params.agent_model" in msg
+        assert "models.agent.name" in msg
+
+
+class TestModelConfigHarnessField:
+    def test_harness_field_accepts_string(self) -> None:
+        cfg = RunConfig(
+            **_base(
+                models={
+                    "user": {"provider": "openai", "name": "gpt-4o"},
+                    "agent": {
+                        "provider": "openrouter",
+                        "name": "openrouter/anthropic/claude-sonnet-4-6",
+                        "harness": "claude-code",
+                    },
+                },
+            )
+        )
+        assert cfg.models["agent"].harness == "claude-code"
+
+    def test_harness_field_defaults_to_none(self) -> None:
+        cfg = RunConfig(
+            **_base(
+                models={
+                    "user": {"provider": "openai", "name": "gpt-4o"},
+                    "agent": {
+                        "provider": "openrouter",
+                        "name": "openrouter/anthropic/claude-sonnet-4-6",
+                    },
+                },
+            )
+        )
+        assert cfg.models["agent"].harness is None

--- a/tests/unit/test_harness_state_snapshot.py
+++ b/tests/unit/test_harness_state_snapshot.py
@@ -1,0 +1,230 @@
+"""Snapshot the agent-visible dir of a harness-mode trial container.
+
+Locks the contract of :func:`snapshot_container_filesystem`:
+
+* the ``tar | base64`` payload the exec-wrapper returns decodes into the
+  ``{container_path: text}`` shape ``StateChecker.check_jsonpaths`` reads;
+* per-file and per-run caps drop oversized files without failing the snapshot;
+* an absent agent-visible dir is a silent skip, not a grading error;
+* binary files and symlinks are omitted (the assertion vocabulary is text-only).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import tarfile
+
+import pytest
+
+from tolokaforge.runner.harness_state import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_TOTAL_BYTES,
+    snapshot_container_filesystem,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tarball(files: dict[str, bytes]) -> bytes:
+    """Build a POSIX tarball with the given ``{./path: bytes}`` files.
+
+    Mirrors the exact shape ``tar -cf - .`` produces inside the container —
+    member names begin with ``./`` and are relative to the working directory
+    of the exec call. Empty archives are legal.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files.items():
+            member = tarfile.TarInfo(name=name)
+            member.size = len(data)
+            tar.addfile(member, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _b64(data: bytes) -> str:
+    """Base64-encode ``data`` the way ``| base64`` inside the container does.
+
+    Plain :mod:`base64` is close enough — the receiver's decoder is lenient
+    about the wrap boundaries the two implementations disagree on.
+    """
+    return base64.b64encode(data).decode("ascii")
+
+
+class _ScriptedExec:
+    """Stub for ``DockerComposeExecToolWrapper._exec_sync``.
+
+    Sequenced return values, one per call, and records each command for later
+    assertions. Extra calls raise so an over-eager helper trips a test.
+    """
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, command: str, timeout: float) -> str:
+        self.calls.append((command, timeout))
+        if not self._responses:
+            raise AssertionError(f"unexpected exec call: {command!r}")
+        return self._responses.pop(0)
+
+
+class TestSnapshotHappyPath:
+    def test_returns_files_keyed_under_agent_visible_dir(self) -> None:
+        tar = _make_tarball(
+            {
+                "./factorial.py": b"def factorial(n): return 1\n",
+                "./tests/test_factorial.py": b"assert factorial(1) == 1\n",
+            }
+        )
+        exec_fn = _ScriptedExec(
+            [
+                "1024\t/work\n",  # du output
+                _b64(tar),
+            ]
+        )
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {
+            "/work/factorial.py": "def factorial(n): return 1\n",
+            "/work/tests/test_factorial.py": "assert factorial(1) == 1\n",
+        }
+
+    def test_du_probe_precedes_tar_read(self) -> None:
+        # The probe runs first so an oversized tree is refused before the
+        # (potentially large) tarball flows over the exec channel.
+        tar = _make_tarball({"./x.py": b"y = 1\n"})
+        exec_fn = _ScriptedExec(["512\t/work\n", _b64(tar)])
+
+        snapshot_container_filesystem(exec_fn, "/work")
+
+        assert len(exec_fn.calls) == 2
+        assert "du -sb" in exec_fn.calls[0][0]
+        assert "tar --exclude=./.git" in exec_fn.calls[1][0]
+        assert "base64" in exec_fn.calls[1][0]
+
+    def test_agent_visible_dir_is_shell_quoted(self) -> None:
+        # A dir with a space must survive the shell round-trip intact.
+        tar = _make_tarball({"./ok": b"ok"})
+        exec_fn = _ScriptedExec(["4\tdir\n", _b64(tar)])
+
+        snapshot_container_filesystem(exec_fn, "/work with space")
+
+        for cmd, _ in exec_fn.calls:
+            assert "'/work with space'" in cmd
+
+
+class TestSnapshotAbortsCleanly:
+    def test_missing_agent_visible_dir_returns_empty(self) -> None:
+        # The container answer for an absent dir is `MISSING`; the helper
+        # returns {} rather than crashing the grade or reading /.
+        exec_fn = _ScriptedExec(["MISSING\n"])
+
+        fs = snapshot_container_filesystem(exec_fn, "/nope")
+
+        assert fs == {}
+        assert len(exec_fn.calls) == 1  # tar step never issued
+
+    def test_tree_over_total_cap_is_skipped(self) -> None:
+        # A tree du reports over the cap returns {} before any tar read.
+        exec_fn = _ScriptedExec([f"{DEFAULT_MAX_TOTAL_BYTES + 1}\t/work\n"])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {}
+        assert len(exec_fn.calls) == 1
+
+    def test_malformed_tarball_returns_empty(self) -> None:
+        # A tar step whose payload is not a tarball fails soft: {} instead of
+        # raising, so grading can still report on transcript / judge components.
+        exec_fn = _ScriptedExec(["10\t/work\n", _b64(b"not a tarball")])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {}
+
+    def test_du_unparseable_output_still_attempts_tar(self) -> None:
+        # A busybox du variant reporting KB blocks (or otherwise unparseable
+        # output) does NOT block the snapshot — the tar exec is separately
+        # budgeted, so the worst case is a slow-but-honest read.
+        tar = _make_tarball({"./x": b"ok"})
+        exec_fn = _ScriptedExec(["not-a-number\n", _b64(tar)])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {"/work/x": "ok"}
+
+
+class TestPerFileCap:
+    def test_oversized_file_is_skipped_others_kept(self) -> None:
+        big = b"x" * (DEFAULT_MAX_FILE_BYTES + 1)
+        small = b"y" * 32
+        tar = _make_tarball({"./big.bin": big, "./small.py": small})
+        exec_fn = _ScriptedExec([f"{DEFAULT_MAX_FILE_BYTES + 1000}\t/work\n", _b64(tar)])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert "/work/big.bin" not in fs
+        assert fs["/work/small.py"] == "y" * 32
+
+    def test_custom_caps_are_honoured(self) -> None:
+        # Ten bytes in, cap set to 5 — the file must drop.
+        tar = _make_tarball({"./over.txt": b"0123456789"})
+        exec_fn = _ScriptedExec(["10\t/work\n", _b64(tar)])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work", max_file_bytes=5)
+
+        assert fs == {}
+
+
+class TestBinaryAndSymlinkSkip:
+    def test_non_utf8_file_is_skipped(self) -> None:
+        tar = _make_tarball(
+            {
+                "./image.bin": b"\x89PNG\x00\x01\x02\x03\xff\xfe",
+                "./readme.txt": b"hello\n",
+            }
+        )
+        exec_fn = _ScriptedExec(["16\t/work\n", _b64(tar)])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {"/work/readme.txt": "hello\n"}
+
+    def test_symlink_member_is_skipped(self) -> None:
+        # A symlink member could resolve to any path the container process can
+        # read; the assertion vocabulary was not designed to expose that.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            link = tarfile.TarInfo(name="./link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/etc/hostname"
+            tar.addfile(link)
+            real = tarfile.TarInfo(name="./real.txt")
+            real.size = 3
+            tar.addfile(real, io.BytesIO(b"ok\n"))
+        exec_fn = _ScriptedExec(["4\t/work\n", _b64(buf.getvalue())])
+
+        fs = snapshot_container_filesystem(exec_fn, "/work")
+
+        assert fs == {"/work/real.txt": "ok\n"}
+
+
+class TestLoggingSurface:
+    def test_cap_hit_is_logged_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        exec_fn = _ScriptedExec([f"{DEFAULT_MAX_TOTAL_BYTES + 1}\t/work\n"])
+
+        with caplog.at_level(logging.WARNING):
+            snapshot_container_filesystem(exec_fn, "/work")
+
+        assert any("tree exceeds total cap" in rec.message for rec in caplog.records)
+
+    def test_missing_dir_is_logged_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        exec_fn = _ScriptedExec(["MISSING\n"])
+
+        with caplog.at_level(logging.WARNING):
+            snapshot_container_filesystem(exec_fn, "/nope")
+
+        assert any("agent-visible dir not found" in rec.message for rec in caplog.records)

--- a/tests/unit/test_native_adapter_harness_mode.py
+++ b/tests/unit/test_native_adapter_harness_mode.py
@@ -1,0 +1,161 @@
+"""Unit tests for the native adapter's coding-harness opt-in.
+
+The native adapter inherits :class:`CodingHarnessAdapterMixin` so a run
+declaring ``models.agent.harness`` reaches it. When ``params["agent_harness"]``
+is set, ``to_task_description`` emits the four-key harness metadata handshake
+the conductor branches on, one ``bash`` :class:`ToolSchema` targeting the
+per-trial compose container the CLI execs into, and the ``test_execution``
+grading dispatch — replacing the default MCP tool list and grading path.
+Byte shapes only; identity to the terminal-bench adapter's output is not
+asserted (``toolset``, image tags, and compose synthesis differ).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.adapters.native import NativeAdapter
+from tolokaforge.adapters.native_harness_synthesis import PROJECT_PREFIX
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_ROOT = _REPO_ROOT / "examples" / "native" / "coding_harness"
+
+
+def _params(**overrides: object) -> dict[str, object]:
+    """Base adapter params pointing at the shipped coding-harness pack."""
+    base = {
+        "tasks_glob": "task.yaml",
+        "task_packs": [str(_PACK_ROOT)],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCapabilityFlag:
+    def test_adapter_class_declares_supports_coding_harness(self) -> None:
+        # The orchestrator's config-validation gate reads this attribute to
+        # decide whether ``models.agent.harness`` can route to the adapter.
+        assert NativeAdapter.supports_coding_harness is True
+
+
+class TestEngineLoopUnchanged:
+    """Under the engine loop the harness-mode branch stays off entirely."""
+
+    def test_agent_harness_absent_keeps_default_task_description(self) -> None:
+        adapter = NativeAdapter(_params())
+        td = adapter.to_task_description("fix_factorial")
+        # Engine loop mints no harness metadata.
+        assert "agent_harness_command" not in td.metadata
+
+    def test_docker_stack_requirements_is_empty_under_engine_loop(self) -> None:
+        adapter = NativeAdapter(_params())
+        req = adapter.docker_stack_requirements()
+        assert req.image_builds == []
+
+
+class TestHarnessModeTaskDescription:
+    """With ``agent_harness`` set the description carries the harness shape."""
+
+    @pytest.fixture
+    def adapter(self) -> NativeAdapter:
+        return NativeAdapter(
+            _params(
+                agent_harness="claude-code",
+                agent_model="openrouter/anthropic/claude-sonnet-4-6",
+            )
+        )
+
+    def test_agent_tools_is_a_single_docker_compose_exec_bash(self, adapter: NativeAdapter) -> None:
+        td = adapter.to_task_description("fix_factorial")
+        assert len(td.agent_tools) == 1
+        tool = td.agent_tools[0]
+        assert tool.name == "bash"
+        assert tool.category == "compute"
+        # The runner's ``DockerComposeExecToolWrapper`` reads
+        # ``source.extra['service']`` + ``compose_project_prefix`` to resolve
+        # the per-trial container name; the two must land verbatim.
+        assert tool.source is not None
+        assert tool.source.invocation_style == "docker_compose_exec"
+        assert tool.source.extra == {
+            "service": "main",
+            "compose_project_prefix": PROJECT_PREFIX,
+        }
+        # `toolset="native"` is the native adapter's own identity — a
+        # terminal-bench trial keeps ``toolset="terminal_bench"``, so the
+        # runner-side dispatch factory can tell them apart.
+        assert tool.source.toolset == "native"
+
+    def test_grading_is_test_execution(self, adapter: NativeAdapter) -> None:
+        td = adapter.to_task_description("fix_factorial")
+        assert td.grading is not None
+        assert td.grading.grading_method == "test_execution"
+        assert td.grading.combine_method == "weighted"
+        assert td.grading.weights == {"custom_checks": 1.0}
+        assert td.grading.pass_threshold == 0.5
+
+    def test_metadata_carries_the_four_harness_keys(self, adapter: NativeAdapter) -> None:
+        td = adapter.to_task_description("fix_factorial")
+        for key in (
+            "agent_harness",
+            "agent_harness_version",
+            "agent_harness_model",
+            "agent_harness_command",
+        ):
+            assert key in td.metadata, f"missing metadata key {key!r}"
+        assert td.metadata["agent_harness"] == "claude-code"
+        assert td.metadata["agent_harness_model"] == ("openrouter/anthropic/claude-sonnet-4-6")
+        # The command is not empty and contains the harness argv — the mixin's
+        # exact bytes are locked by test_adapter_support; here we only verify
+        # the field is populated by the mixin path rather than empty.
+        cmd = td.metadata["agent_harness_command"]
+        assert isinstance(cmd, str) and len(cmd) > 0
+        assert "claude" in cmd  # the CLI's binary name
+
+    def test_environment_manifest_points_at_synthesised_compose(
+        self, adapter: NativeAdapter
+    ) -> None:
+        td = adapter.to_task_description("fix_factorial")
+        assert td.environment_manifest is not None
+        compose = td.environment_manifest.compose_file
+        assert compose.exists()
+        # The staged compose lives under a per-task staging root distinct
+        # from the pack: the adapter must synthesise the runner+db-service
+        # sidecars, not exec into the pack's own file.
+        assert compose.parent != _PACK_ROOT
+        # runner_service names the injected sidecar, not the pack's `main`.
+        assert td.environment_manifest.runner_service == "runner"
+
+
+class TestHarnessModeDockerStackRequirements:
+    def test_two_builds_base_then_layered(self) -> None:
+        adapter = NativeAdapter(
+            _params(
+                agent_harness="claude-code",
+                agent_model="openrouter/anthropic/claude-sonnet-4-6",
+            )
+        )
+        req = adapter.docker_stack_requirements()
+        assert len(req.image_builds) == 2
+        # Base-image build first so the harness layer can FROM its tag.
+        assert req.image_builds[0].service == "main_base"
+        assert req.image_builds[1].service == "main"
+        # Both entries reference the synthesised compose file, not the pack's own.
+        for build in req.image_builds:
+            assert build.compose_file.name == "docker-compose.yaml"
+            assert build.compose_file.exists()
+
+
+class TestHarnessSpecValidation:
+    def test_empty_agent_model_is_refused(self) -> None:
+        # Same refusal terminal-bench emits: the CLI's own default would drive
+        # the trial otherwise, silently unpinning the model under measurement.
+        with pytest.raises(ValueError, match="requires .*agent_model"):
+            NativeAdapter(_params(agent_harness="claude-code", agent_model=""))
+
+    def test_unknown_harness_is_refused_at_construction(self) -> None:
+        with pytest.raises(ValueError):
+            NativeAdapter(_params(agent_harness="not-a-harness"))

--- a/tests/unit/test_runner_filesystem_grading_state.py
+++ b/tests/unit/test_runner_filesystem_grading_state.py
@@ -1,4 +1,4 @@
-"""Runner reads /work/ back at grading time so $.filesystem jsonpaths resolve.
+"""Runner reads back the agent-visible tree at grading time.
 
 Task authors write jsonpath state_checks like::
 
@@ -7,9 +7,16 @@ Task authors write jsonpath state_checks like::
         - path: "$.filesystem['/env/fs/agent-visible/buggy_math.py']"
           contains: "amount * (1 + tax_rate)"
 
-For that to match, the runner exposes the on-disk contents of /work/
-back out under the logical /env/fs/agent-visible/ layout the task YAML
-wrote against — the same layout the RegisterTrial provisioner accepts.
+For that to match, the runner exposes the on-disk contents of the agent's
+edit surface back at its logical path. Two routes:
+
+* **Engine-loop trial** — the runner service walks its own ``AGENT_WORK_DIR``,
+  the container it registered the trial into. Keys land under
+  ``/env/fs/agent-visible/<rel>``.
+* **Harness-mode trial** — the CLI edits inside a separate container reached
+  via the exec-wrapper; the runner service execs ``tar | base64`` there and
+  decodes the tree in-process. Keys land under the container's declared
+  ``agent_visible_dir`` (e.g. ``/work/factorial.py``).
 
 The runner catches ``TrialNotFoundError`` from the DB client so a
 filesystem-only trial (one whose task never provisions ``initial_state.tables``
@@ -19,13 +26,17 @@ jsonpath state rooted at ``$.filesystem[…]``.
 
 from __future__ import annotations
 
+import base64
+import io
+import tarfile
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from tolokaforge.runner import service as service_module
 from tolokaforge.runner.db_client import TrialNotFoundError
+from tolokaforge.runner.tool_factory import DockerComposeExecToolWrapper
 
 pytestmark = pytest.mark.unit
 
@@ -41,8 +52,10 @@ class _StubRunnerServiceImpl:
 
     def __init__(self, db_client) -> None:  # noqa: ANN001 — test stub
         self.db_client = db_client
+        self.trials: dict[str, object] = {}
 
     _read_agent_visible_filesystem = service_module.RunnerServiceImpl._read_agent_visible_filesystem
+    _read_filesystem_for_state = service_module.RunnerServiceImpl._read_filesystem_for_state
     _assemble_jsonpath_state = service_module.RunnerServiceImpl._assemble_jsonpath_state
 
 
@@ -154,3 +167,216 @@ async def test_assemble_jsonpath_state_merges_db_and_filesystem(
     assert state["filesystem"] == {
         "/env/fs/agent-visible/buggy_math.py": "amount * (1 + tax_rate)\n",
     }
+
+
+# ---------------------------------------------------------------------------
+# Harness-mode routing — the runner execs into the trial container rather
+# than reading its own /work/. The metadata handshake carries both the CLI's
+# invocation command (which flags harness mode) and the container path the
+# runner mirrors back into ``state["filesystem"]``.
+# ---------------------------------------------------------------------------
+
+
+def _tarball_b64(files: dict[str, bytes]) -> str:
+    """Encode ``{./path: bytes}`` as ``tar | base64`` would emit inside a container."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class _StubBashTool(DockerComposeExecToolWrapper):
+    """Real subclass so :func:`isinstance` recognises it; scripted ``_exec_sync``.
+
+    Inheriting instead of duck-typing keeps the routing logic honest: the
+    runner service looks for the concrete wrapper type, not just anything
+    that answers ``_exec_sync``.
+    """
+
+    def __init__(self, responses: list[str]) -> None:
+        # Skip the base ``__init__`` — its ToolSchemaModel path is out of scope
+        # here. The fields the routing consults (``_container`` for start(),
+        # ``_exec_sync`` for reads) are set explicitly.
+        self._responses = list(responses)
+        self.calls: list[str] = []
+        self._container = "stub_container"
+        self._trial_id = "t-1"
+
+    def _exec_sync(self, command: str, timeout: float) -> str:  # noqa: ARG002 — matches base
+        self.calls.append(command)
+        if not self._responses:
+            raise AssertionError(f"unexpected exec call: {command!r}")
+        return self._responses.pop(0)
+
+
+def _harness_trial_context(
+    *,
+    agent_harness_command: str | None,
+    agent_visible_dir: str | None,
+    bash_tool: DockerComposeExecToolWrapper | None,
+) -> MagicMock:
+    """Minimal ``TrialContextRuntime`` stand-in with the two consulted attrs."""
+    ctx = MagicMock()
+    metadata: dict[str, object] = {}
+    if agent_harness_command is not None:
+        metadata["agent_harness_command"] = agent_harness_command
+    if agent_visible_dir is not None:
+        metadata["agent_visible_dir"] = agent_visible_dir
+    ctx.task_description.metadata = metadata
+    ctx.agent_tools = {"bash": bash_tool} if bash_tool is not None else {}
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_harness_trial_reads_filesystem_via_exec_wrapper() -> None:
+    """When metadata carries ``agent_harness_command`` + ``agent_visible_dir``
+    and an exec-capable tool is registered, the runner execs ``tar | base64``
+    inside the trial container and decodes the tree in-process — keys land
+    under the container's declared path."""
+    bash_tool = _StubBashTool(
+        [
+            "512\t/work\n",  # du probe
+            _tarball_b64({"./factorial.py": b"def factorial(n): return 1\n"}),
+        ]
+    )
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    svc.trials["t-1"] = _harness_trial_context(
+        agent_harness_command="claude --print 'fix it'",
+        agent_visible_dir="/work",
+        bash_tool=bash_tool,
+    )
+
+    fs = await svc._read_filesystem_for_state("t-1")
+
+    assert fs == {"/work/factorial.py": "def factorial(n): return 1\n"}
+    # Both container-side commands actually issued.
+    assert any("du -sb" in cmd for cmd in bash_tool.calls)
+    assert any("tar --exclude=./.git" in cmd for cmd in bash_tool.calls)
+
+
+@pytest.mark.asyncio
+async def test_engine_loop_trial_still_walks_the_runner_workdir(
+    redirect_work_dir: Path,
+) -> None:
+    """A non-harness trial reads back the runner's own ``AGENT_WORK_DIR`` —
+    no exec into any other container. This is the byte-identical path the
+    filesystem-only trials in this file already lock."""
+    (redirect_work_dir / "buggy_math.py").write_text("amount * (1 + tax_rate)\n")
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    # Engine-loop trial: metadata carries no harness command.
+    svc.trials["t-1"] = _harness_trial_context(
+        agent_harness_command=None,
+        agent_visible_dir=None,
+        bash_tool=None,
+    )
+
+    fs = await svc._read_filesystem_for_state("t-1")
+
+    assert fs == {
+        "/env/fs/agent-visible/buggy_math.py": "amount * (1 + tax_rate)\n",
+    }
+
+
+@pytest.mark.asyncio
+async def test_harness_trial_without_exec_tool_falls_back_to_workdir(
+    redirect_work_dir: Path,
+) -> None:
+    """A harness trial that registered no exec-capable tool falls back to
+    the runner's own /work/ walk with a warning — grading proceeds rather
+    than failing on a missing exec surface."""
+    (redirect_work_dir / "left_behind.py").write_text("still here\n")
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    svc.trials["t-1"] = _harness_trial_context(
+        agent_harness_command="claude --print 'fix it'",
+        agent_visible_dir="/work",
+        bash_tool=None,
+    )
+
+    fs = await svc._read_filesystem_for_state("t-1")
+
+    assert fs == {"/env/fs/agent-visible/left_behind.py": "still here\n"}
+
+
+@pytest.mark.asyncio
+async def test_harness_trial_without_agent_visible_dir_falls_back(
+    redirect_work_dir: Path,
+) -> None:
+    """A harness trial whose adapter omitted ``agent_visible_dir`` falls back
+    to the /work/ walk — the runner has nothing to enumerate into, so it
+    reads its own workdir rather than execing ``tar`` against ``/``."""
+    (redirect_work_dir / "runner_side.py").write_text("still here\n")
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    svc.trials["t-1"] = _harness_trial_context(
+        agent_harness_command="claude --print 'fix it'",
+        agent_visible_dir=None,
+        bash_tool=_StubBashTool([]),  # would fail loud on exec attempt
+    )
+
+    fs = await svc._read_filesystem_for_state("t-1")
+
+    assert fs == {"/env/fs/agent-visible/runner_side.py": "still here\n"}
+
+
+@pytest.mark.asyncio
+async def test_unregistered_trial_walks_workdir(
+    redirect_work_dir: Path,
+) -> None:
+    """A read for a trial no longer in ``self.trials`` falls back to the
+    /work/ walk without raising — the state assembly runs against an
+    empty trial state rather than a KeyError."""
+    (redirect_work_dir / "orphan.py").write_text("orphan\n")
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+
+    fs = await svc._read_filesystem_for_state("does-not-exist")
+
+    assert fs == {"/env/fs/agent-visible/orphan.py": "orphan\n"}
+
+
+@pytest.mark.asyncio
+async def test_harness_state_composes_with_jsonpath_check() -> None:
+    """The composition claim: a harness trial's edits are seen by state_checks.
+
+    Assembles the state the runner service would hand to
+    :class:`StateChecker`, drives one JSONPath assertion against a file the
+    "CLI" wrote inside the container, and confirms the assertion resolves.
+    This is the whole point of the lift: any adapter's harness-mode trial can
+    grade under any state-based grading mode.
+    """
+    from tolokaforge.core.grading.state_checks import StateChecker
+
+    bash_tool = _StubBashTool(
+        [
+            "128\t/work\n",
+            _tarball_b64({"./factorial.py": b"def factorial(n): return 1\n"}),
+        ]
+    )
+
+    svc = _StubRunnerServiceImpl(db_client=AsyncMock())
+    svc.trials["t-1"] = _harness_trial_context(
+        agent_harness_command="claude --print 'fix it'",
+        agent_visible_dir="/work",
+        bash_tool=bash_tool,
+    )
+
+    state = await svc._assemble_jsonpath_state("t-1", fetch_db=False)
+    score, reasons = StateChecker().check_jsonpaths(
+        state,
+        [
+            {
+                "path": "$.filesystem['/work/factorial.py']",
+                "contains": "def factorial",
+                "description": "the CLI wrote a factorial definition",
+            }
+        ],
+    )
+
+    assert score == 1.0, reasons
+    assert reasons == []

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -2124,3 +2124,28 @@ class TestHarnessTaskDescriptionMetadata:
             {"terminal_bench_dir": str(fixture_dir), "staging_root": str(tmp_path)}
         )
         assert adapter.to_task_description("echo-hello").agent_tools[0].timeout_s == 120.0
+
+
+class TestTerminalBenchAdapterCodingHarnessOptIn:
+    """The adapter opts into the orchestrator's ``models.agent.harness`` gate.
+
+    The gate is the class-level ``supports_coding_harness`` flag the
+    orchestrator's ``load_tasks`` reads (``tolokaforge/core/orchestrator.py``)
+    before routing a run that names a harness. Any refactor that drops the
+    :class:`CodingHarnessAdapterMixin` inheritance or shadows the flag with a
+    ``False`` here would silently make a shipped ``examples/terminal_bench``
+    harness run refuse to load, so lock the two together.
+    """
+
+    def test_class_inherits_the_coding_harness_mixin(self) -> None:
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+        from tolokaforge_coding_harnesses.adapter_support import (
+            CodingHarnessAdapterMixin,
+        )
+
+        assert issubclass(TerminalBenchAdapter, CodingHarnessAdapterMixin)
+
+    def test_supports_coding_harness_is_true(self) -> None:
+        from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+        assert TerminalBenchAdapter.supports_coding_harness is True

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -19,7 +19,19 @@ from tolokaforge.adapters._task_loader import (
     seeded_tables_from_task,
     tool_configs,
 )
-from tolokaforge.adapters.base import AdapterEnvironment, BaseAdapter
+from tolokaforge.adapters.base import (
+    AdapterEnvironment,
+    BaseAdapter,
+    ComposeImageBuild,
+    DockerStackRequirements,
+)
+from tolokaforge.adapters.native_harness_synthesis import (
+    PROJECT_PREFIX as NATIVE_HARNESS_PROJECT_PREFIX,
+)
+from tolokaforge.adapters.native_harness_synthesis import (
+    MaterialisedHarnessEnvironment,
+    materialise_harness_environment,
+)
 from tolokaforge.core.grading.checks_helpers import custom_checks_enabled
 from tolokaforge.core.grading.config_validation import (
     CombineLayer,
@@ -38,6 +50,14 @@ from tolokaforge.core.project_loader import (
 )
 from tolokaforge.core.project_loader import resolve as resolve_environment
 from tolokaforge.runner.id_resolution import check_id_fields_against_seeded_tables
+from tolokaforge_coding_harnesses import (
+    ENGINE_LOOP,
+    CodingHarnessAdapterMixin,
+    HarnessSpec,
+    ResolvedHarnessRegistry,
+    resolve_effective_registry,
+    validate_harness,
+)
 
 if TYPE_CHECKING:
     from tolokaforge.runner.models import SearchConfig, TaskDescription, ToolSchema
@@ -118,13 +138,20 @@ def _actor_tool_schemas(task: TaskConfig, task_dir: Path, actor: ToolActor) -> l
     return schemas
 
 
-class NativeAdapter(BaseAdapter):
+class NativeAdapter(CodingHarnessAdapterMixin, BaseAdapter):
     """
     Adapter for native TolokaForge file-based tasks.
 
     This is the default adapter used when no harness_adapter is specified.
     It provides the same interface as external adapters while loading tasks
     from YAML files.
+
+    Inheriting :class:`CodingHarnessAdapterMixin` opts this adapter into the
+    orchestrator's ``models.agent.harness`` config gate (via the mixin's
+    ``supports_coding_harness = True`` flag) and gives it the shared helpers
+    for command assembly, metadata emission, tool-schema payload, and
+    ``test_execution`` grading — leaving only the native-side compose
+    synthesis in this adapter.
 
     Expected structure:
         tasks_glob: "tasks/project/tasks/**/task.yaml"
@@ -143,6 +170,11 @@ class NativeAdapter(BaseAdapter):
                 - tasks_glob: Glob pattern for task files (required)
                 - base_dir: Base directory for resolving paths (default: ".")
                 - task_packs: Optional list of pack root directories to search
+                - agent_harness: coding-harness slug to route trials through
+                  a vendor CLI (injected by the orchestrator from
+                  ``models.agent.harness``); omit for the engine loop
+                - agent_model: model string the CLI receives (injected from
+                  ``models.agent.name`` when ``agent_harness`` is set)
         """
         super().__init__(params)
         self.tasks_glob = params["tasks_glob"]
@@ -162,6 +194,26 @@ class NativeAdapter(BaseAdapter):
             "project_default_environment"
         )
 
+        # Coding-harness selector. Empty under the engine loop, which never
+        # reads it: the run config's model reaches litellm through the
+        # engine's own LLM layer there.
+        self._resolved_registry: ResolvedHarnessRegistry = resolve_effective_registry(
+            params.get("harness_presets_file"),
+            discover_plugins=not params.get("disable_harness_plugins", False),
+        )
+        self.agent_harness: str = validate_harness(
+            params.get("agent_harness", ENGINE_LOOP), self._resolved_registry.harnesses
+        )
+        self.agent_model: str = params.get("agent_model") or ""
+        if self.agent_harness != ENGINE_LOOP and not self.agent_model:
+            raise ValueError(
+                f"native adapter: agent_harness {self.agent_harness!r} requires "
+                "`agent_model` — the CLI selects its own default otherwise, so the "
+                "run config's model would not be the one measured. Set "
+                "`models.agent.name` in the run config."
+            )
+        self._harness_environments: dict[str, MaterialisedHarnessEnvironment] = {}
+
         # Validate: tasks_glob must be relative when task_packs is provided
         if self.task_packs and Path(self.tasks_glob).is_absolute():
             raise ValueError(
@@ -180,6 +232,11 @@ class NativeAdapter(BaseAdapter):
         # task_id -> validated TaskConfig. Populated lazily on first
         # get_task() call via :func:`load_task_yaml`.
         self._tasks: dict[str, TaskConfig] = {}
+
+    @property
+    def harness_spec(self) -> HarnessSpec | None:
+        """This run's harness spec. ``None`` under the engine loop, which runs no CLI."""
+        return self._resolved_registry.harnesses.get(self.agent_harness)
 
     def _discover_tasks(self) -> None:
         """Discover tasks matching glob pattern, optionally across task packs."""
@@ -467,6 +524,69 @@ class NativeAdapter(BaseAdapter):
         """
         return None
 
+    def docker_stack_requirements(self) -> DockerStackRequirements:
+        """Declare per-task images the orchestrator builds once per run.
+
+        Under harness mode the layered agent image is ``FROM`` the pack's own
+        image build, so both stages need addressable compose services — the
+        base build first, then the harness layer. Under the engine loop the
+        default (empty requirements) applies: no per-task image build.
+        """
+        if self.agent_harness == ENGINE_LOOP:
+            return DockerStackRequirements()
+        builds: list[ComposeImageBuild] = []
+        for task_id in self.get_task_ids():
+            env = self._resolve_harness_environment(task_id)
+            if env is None:
+                continue
+            builds.append(
+                ComposeImageBuild(compose_file=env.compose_file, service=env.base_build_service)
+            )
+            builds.append(
+                ComposeImageBuild(compose_file=env.compose_file, service=env.agent_service)
+            )
+        return DockerStackRequirements(image_builds=builds)
+
+    def _resolve_harness_environment(self, task_id: str) -> MaterialisedHarnessEnvironment | None:
+        """Cache and return the synthesised harness environment for *task_id*.
+
+        Returns ``None`` under the engine loop or when the task declares no
+        compose file (harness mode requires a per-trial container the CLI's
+        bash tool can exec into). Under harness mode with a compose file the
+        staging dir is materialised once and cached.
+        """
+        if self.agent_harness == ENGINE_LOOP or self.harness_spec is None:
+            return None
+        cached = self._harness_environments.get(task_id)
+        if cached is not None:
+            return cached
+        task = self.get_task(task_id)
+        task_dir = self.get_task_dir(task_id)
+        if task.environment_manifest is None or task.environment_manifest.stack is None:
+            raise ValueError(
+                f"native adapter: task {task_id!r} runs under harness "
+                f"{self.agent_harness!r} but declares no environment_manifest.stack. "
+                "Declare a task-local `docker-compose.yaml` so the CLI has a "
+                "container to exec into."
+            )
+        compose_file = task.environment_manifest.stack.compose_file
+        if compose_file is None:
+            raise ValueError(
+                f"native adapter: task {task_id!r} runs under harness "
+                f"{self.agent_harness!r} but declares no "
+                "environment_manifest.stack.compose_file."
+            )
+        env = materialise_harness_environment(
+            task_id=task_id,
+            task_dir=task_dir,
+            compose_file=Path(compose_file),
+            harness_spec=self.harness_spec,
+            agent_harness=self.agent_harness,
+            layer_writer=self.write_install_script_layer,
+        )
+        self._harness_environments[task_id] = env
+        return env
+
     def to_task_description(self, task_id: str) -> "TaskDescription":
         """
         Convert Native task to serializable TaskDescription for Docker Runner.
@@ -477,6 +597,12 @@ class NativeAdapter(BaseAdapter):
         - Initialization actions from task.yaml
         - Grading config from grading.yaml
         - System prompt from system_prompt file
+
+        A run declaring ``models.agent.harness`` takes the harness-mode
+        branch instead — the description carries a single ``bash`` tool that
+        execs into the per-trial container, ``test_execution`` grading, and
+        the four-key harness metadata handshake the conductor reads on
+        :attr:`~tolokaforge.runner.models.TaskDescription.metadata`.
 
         Args:
             task_id: Task identifier
@@ -499,6 +625,8 @@ class NativeAdapter(BaseAdapter):
                 absent or empty is **not** refused: it reaches the wire as
                 ``tool_name=""`` and fails at resolve time, which is #886.
         """
+        if self.agent_harness != ENGINE_LOOP:
+            return self._to_harness_task_description(task_id)
         from datetime import datetime, timezone
 
         from tolokaforge.runner.models import (
@@ -815,6 +943,98 @@ class NativeAdapter(BaseAdapter):
         )
 
         return task_description
+
+    def _to_harness_task_description(self, task_id: str) -> "TaskDescription":
+        """Build a coding-harness-mode :class:`TaskDescription`.
+
+        The description carries one ``bash`` tool (the CLI's exec surface),
+        ``test_execution`` grading (the mixin's default), the four-key
+        harness metadata handshake the conductor branches on, and an
+        environment manifest pointing at the synthesised per-task compose
+        file that layers the CLI on the pack's own image.
+        """
+        from datetime import datetime, timezone
+
+        from tolokaforge.runner.models import (
+            AdapterType,
+            RunnerGradingConfig,
+            RunnerInitialStateConfig,
+            RunnerUserSimulatorConfig,
+            TaskDescription,
+            ToolSchema,
+        )
+
+        assert self.harness_spec is not None  # guarded by agent_harness != ENGINE_LOOP
+        task = self.get_task(task_id)
+        env = self._resolve_harness_environment(task_id)
+        if env is None:
+            # _resolve_harness_environment only returns None under the engine
+            # loop, which this branch is guarded off of. Any None here is a
+            # programming error surfacing as a typed refusal.
+            raise RuntimeError(
+                f"native adapter: harness-mode _to_harness_task_description called "
+                f"for task {task_id!r} but no harness environment was materialised"
+            )
+
+        instruction = task.initial_user_message or task.description or ""
+        command = self.build_harness_command(
+            self.agent_harness,
+            self.harness_spec,
+            instruction,
+            self.agent_model,
+        )
+        metadata: dict[str, Any] = {
+            "agent_harness": self.agent_harness,
+        }
+        metadata.update(
+            self.emit_harness_metadata(
+                self.agent_harness, self.harness_spec, command, self.agent_model
+            )
+        )
+
+        # Point the environment manifest at the synthesised compose file so
+        # the per-trial runtime provisions the layered stack. The pack's
+        # `runner_service` is authored against its own compose (usually the
+        # pack's `main` service, before the adapter injects the tolokaforge
+        # runner sidecar); overwrite it here to name the injected `runner`.
+        original_patch = task.environment_manifest
+        assert original_patch is not None  # guarded by _resolve_harness_environment
+        stack = original_patch.stack.model_copy(
+            update={"compose_file": env.compose_file, "runner_service": "runner"}
+        )
+        harness_patch = original_patch.model_copy(update={"stack": stack})
+        environment_manifest = resolve_environment(
+            self._project_default_environment,
+            harness_patch,
+        )
+
+        episode_timeout_s = 900.0
+        tool_schema = ToolSchema(
+            **self.emit_harness_tool_schema(
+                service=env.agent_service,
+                compose_project_prefix=NATIVE_HARNESS_PROJECT_PREFIX,
+                timeout_s=episode_timeout_s,
+                toolset="native",
+            )
+        )
+        grading_config = RunnerGradingConfig(**self.emit_test_execution_grading())
+
+        return TaskDescription(
+            task_id=task_id,
+            name=task.name or task_id,
+            category=task.category or "coding_harness",
+            description=task.description or "",
+            adapter_type=AdapterType.NATIVE,
+            system_prompt=self.get_system_prompt(task_id) if task.system_prompt else "",
+            agent_tools=[tool_schema],
+            user_tools=[],
+            initial_state=RunnerInitialStateConfig(),
+            user_simulator=RunnerUserSimulatorConfig(mode="scripted"),
+            grading=grading_config,
+            generated_at=datetime.now(timezone.utc),
+            metadata=metadata,
+            environment_manifest=environment_manifest,
+        )
 
     # ------------------------------------------------------------------
     # Task artifact bundling (for Docker execution)

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -985,6 +985,13 @@ class NativeAdapter(CodingHarnessAdapterMixin, BaseAdapter):
         )
         metadata: dict[str, Any] = {
             "agent_harness": self.agent_harness,
+            # Where the CLI edits inside the trial container — the runner
+            # reads this back for state-checks grading so
+            # ``$.filesystem['/work/...']`` resolves against the harness's
+            # edits, not the runner container's own /work/. Native packs
+            # inherit /work as WORKDIR from the pack's base image, which the
+            # harness-install layer does not override.
+            "agent_visible_dir": "/work",
         }
         metadata.update(
             self.emit_harness_metadata(

--- a/tolokaforge/adapters/native_harness_synthesis.py
+++ b/tolokaforge/adapters/native_harness_synthesis.py
@@ -1,0 +1,329 @@
+"""Compose synthesis for the native adapter's coding-harness mode.
+
+The native adapter runs a per-trial compose stack when it opts into
+``models.agent.harness``: the trial container is the CLI's workspace, the
+tolokaforge runner sidecar carries the gRPC surface the conductor drives
+through, and the db-service sidecar backs the runner's state RPCs.
+
+The pack ships a task-local ``docker-compose.yaml`` declaring only the main
+service; this module materialises a per-task staging directory whose
+synthesised compose file adds:
+
+- a build-only ``main_base`` service pinning the pack's own image build so
+  the harness Dockerfile can ``FROM`` its tag;
+- a harness image layer on ``main`` via
+  :meth:`~tolokaforge_coding_harnesses.adapter_support.CodingHarnessAdapterMixin.write_install_script_layer`;
+- the tolokaforge ``runner`` and ``db-service`` sidecars the trial's gRPC
+  path needs.
+
+The layered image is what :meth:`~tolokaforge.adapters.native.NativeAdapter.docker_stack_requirements`
+declares in :class:`~tolokaforge.adapters.base.ComposeImageBuild` entries so
+the orchestrator pre-builds both stages before any trial provisions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tolokaforge_coding_harnesses import HarnessSpec
+
+PROJECT_PREFIX = "tfnative_"
+"""Compose project prefix baked into the synthesised container names.
+
+Read by the runner-side
+:class:`~tolokaforge.runner.tool_factory.DockerComposeExecToolWrapper` to
+resolve the per-trial container the CLI's bash tool execs into. The
+synthesised compose file interpolates
+``container_name: tfnative_${TOLOKAFORGE_TRIAL_SLUG}_<service>`` so the two
+sides agree on the name docker compose actually starts."""
+
+BASE_SERVICE_SUFFIX = "_base"
+"""Suffix on the build-only service pinning the pack's own image build."""
+
+RUNNER_SERVICE = "runner"
+DB_SERVICE = "db-service"
+
+_DEFAULT_RUNNER_IMAGE = "tolokaforge-runner:local"
+_DEFAULT_DB_SERVICE_IMAGE = "tolokaforge-db-service:local"
+
+_HARNESS_BUILD_PROFILE = "_harness_build_only"
+"""Compose profile that keeps ``main_base`` out of ``docker compose up``."""
+
+_TOLOKAFORGE_TRIAL_SLUG_PLACEHOLDER = "${TOLOKAFORGE_TRIAL_SLUG}"
+
+
+@dataclass(frozen=True)
+class MaterialisedHarnessEnvironment:
+    """One synthesised staging directory for a task under harness mode.
+
+    Attributes:
+        compose_file: Absolute path to the synthesised compose file.
+        agent_service: Compose service the CLI's bash tool execs into.
+        base_build_service: Companion build-only service the harness layer
+            ``FROM``s. The orchestrator builds it before the layered
+            ``agent_service`` (see
+            :meth:`~tolokaforge.adapters.native.NativeAdapter.docker_stack_requirements`).
+        staging_dir: Root of the per-task build context (also the
+            ``build.context`` the layered dockerfile is invoked with).
+    """
+
+    compose_file: Path
+    agent_service: str
+    base_build_service: str
+    staging_dir: Path
+
+
+def resolve_agent_service(compose_file: Path, task_id: str) -> str:
+    """Return the compose service the harness bash tool execs into.
+
+    Picks the service named ``main`` when present; otherwise the sole
+    service. Refuses ambiguity so the wire target is unambiguous.
+
+    Raises:
+        FileNotFoundError: *compose_file* does not exist.
+        ValueError: The compose file declares no services, or several
+            services none of which is named ``main``.
+    """
+    if not compose_file.exists():
+        raise FileNotFoundError(
+            f"native harness adapter: task {task_id!r} declares "
+            f"environment_manifest.stack.compose_file={compose_file!r}, "
+            "but that file does not exist"
+        )
+    doc = yaml.safe_load(compose_file.read_text()) or {}
+    services = doc.get("services") or {}
+    if not services:
+        raise ValueError(
+            f"native harness adapter: task {task_id!r} compose file "
+            f"{compose_file!r} declares no services"
+        )
+    if "main" in services:
+        return "main"
+    if len(services) == 1:
+        return next(iter(services))
+    raise ValueError(
+        f"native harness adapter: task {task_id!r} compose file "
+        f"{compose_file!r} declares {sorted(services)!r} but no service is "
+        "named 'main'; rename one to 'main' or leave a single service in the "
+        "compose file"
+    )
+
+
+def materialise_harness_environment(
+    *,
+    task_id: str,
+    task_dir: Path,
+    compose_file: Path,
+    harness_spec: HarnessSpec,
+    agent_harness: str,
+    layer_writer: Any,
+    staging_root: Path | None = None,
+    runner_image: str = _DEFAULT_RUNNER_IMAGE,
+    db_service_image: str = _DEFAULT_DB_SERVICE_IMAGE,
+) -> MaterialisedHarnessEnvironment:
+    """Stage this task's harness-mode compose stack under *staging_root*.
+
+    Copies the pack directory into a per-task staging directory keyed by a
+    content digest, writes the harness Dockerfile via *layer_writer* (a
+    :meth:`~tolokaforge_coding_harnesses.adapter_support.CodingHarnessAdapterMixin.write_install_script_layer`-shaped
+    callable), and materialises a synthesised compose file with the harness
+    layer + runner + db-service sidecars.
+
+    Raises:
+        ValueError: The pack compose file has no ``main`` service (see
+            :func:`resolve_agent_service`) or the target service's ``build``
+            entry does not name a build context.
+    """
+    agent_service = resolve_agent_service(compose_file, task_id)
+    root = staging_root or Path(tempfile.gettempdir()) / "tolokaforge-native-harness"
+    digest = _content_digest(
+        task_dir,
+        agent_harness=agent_harness,
+        harness_version=harness_spec.version,
+        harness_install_source=harness_spec.install_source,
+    )
+    staging_dir = (root / f"{task_id}-{digest}").resolve()
+    _copy_task_dir(task_dir, staging_dir)
+
+    base_image = _base_image_tag(task_id)
+    layered_image = _layered_image_tag(task_id, agent_harness, harness_spec.version)
+    base_service = f"{agent_service}{BASE_SERVICE_SUFFIX}"
+
+    layer_writer(
+        context_dir=staging_dir,
+        base_image=base_image,
+        spec=harness_spec,
+        middleware_proxy=harness_spec.request_middleware is not None,
+    )
+
+    synthesised = _synthesise_compose(
+        original_compose=yaml.safe_load(compose_file.read_text()) or {},
+        agent_service=agent_service,
+        base_service=base_service,
+        base_image=base_image,
+        layered_image=layered_image,
+        harness_spec=harness_spec,
+        runner_image=runner_image,
+        db_service_image=db_service_image,
+    )
+    staged_compose = staging_dir / "docker-compose.yaml"
+    staged_compose.write_text(yaml.safe_dump(synthesised, sort_keys=False))
+    return MaterialisedHarnessEnvironment(
+        compose_file=staged_compose.resolve(),
+        agent_service=agent_service,
+        base_build_service=base_service,
+        staging_dir=staging_dir,
+    )
+
+
+def _copy_task_dir(task_dir: Path, staging_dir: Path) -> None:
+    """Copy *task_dir* into *staging_dir* excluding the oracle and caches.
+
+    ``solution/`` is dropped so the CLI cannot exec it, ``__pycache__``
+    directories are dropped so a stale cache does not follow the copy.
+    """
+
+    def _ignore(_dir: str, names: list[str]) -> list[str]:
+        return [n for n in names if n in ("solution", "__pycache__")]
+
+    shutil.copytree(task_dir, staging_dir, ignore=_ignore, dirs_exist_ok=True)
+
+
+def _synthesise_compose(
+    *,
+    original_compose: dict[str, Any],
+    agent_service: str,
+    base_service: str,
+    base_image: str,
+    layered_image: str,
+    harness_spec: HarnessSpec,
+    runner_image: str,
+    db_service_image: str,
+) -> dict[str, Any]:
+    """Return the synthesised compose doc — pack layout + harness + sidecars."""
+    doc = deepcopy(original_compose)
+    services: dict[str, Any] = doc.setdefault("services", {})
+
+    agent_body: dict[str, Any] = services.get(agent_service, {})
+    task_build = agent_body.get("build")
+    if task_build is None:
+        raise ValueError(
+            f"native harness adapter: compose service {agent_service!r} must "
+            "declare a `build:` entry the harness layer FROMs; got no build"
+        )
+
+    agent_body["image"] = layered_image
+    agent_body["build"] = {"context": ".", "dockerfile": "harness.Dockerfile"}
+    agent_body["container_name"] = (
+        f"{PROJECT_PREFIX}{_TOLOKAFORGE_TRIAL_SLUG_PLACEHOLDER}_{agent_service}"
+    )
+    # `depends_on: runner` on the agent service would loop — the runner
+    # depends on db-service, and neither depends on the CLI target.
+    agent_body_env = _set_env(agent_body.get("environment"), "TEST_DIR", "/tests")
+    for key, value in sorted(harness_spec.container_env.items()):
+        agent_body_env = _set_env(agent_body_env, key, value)
+    agent_body["environment"] = agent_body_env
+    services[agent_service] = agent_body
+
+    services[base_service] = {
+        "image": base_image,
+        "build": deepcopy(task_build),
+        "profiles": [_HARNESS_BUILD_PROFILE],
+    }
+
+    services[RUNNER_SERVICE] = _runner_service_body(runner_image)
+    services[DB_SERVICE] = _db_service_body(db_service_image)
+    return doc
+
+
+def _runner_service_body(runner_image: str) -> dict[str, Any]:
+    return {
+        "image": runner_image,
+        "ports": ["50051"],
+        "environment": {"DB_SERVICE_URL": "http://db-service:8000"},
+        "healthcheck": {
+            "test": ["CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/50051"],
+            "interval": "2s",
+            "timeout": "3s",
+            "retries": 30,
+            "start_period": "3s",
+        },
+        "depends_on": {
+            DB_SERVICE: {"condition": "service_healthy"},
+        },
+    }
+
+
+def _db_service_body(db_service_image: str) -> dict[str, Any]:
+    return {
+        "image": db_service_image,
+        "ports": ["8000"],
+        "healthcheck": {
+            "test": ["CMD-SHELL", "curl -fs http://localhost:8000/health || exit 1"],
+            "interval": "2s",
+            "timeout": "3s",
+            "retries": 30,
+            "start_period": "3s",
+        },
+    }
+
+
+def _set_env(existing: Any, key: str, value: str) -> Any:
+    """Set ``key=value`` on a compose service's ``environment:`` value.
+
+    Preserves the shape the pack declared (list of ``KEY=value`` strings or
+    mapping); replaces any prior entry for the same key rather than
+    duplicating it.
+    """
+    if isinstance(existing, dict):
+        return {**existing, key: value}
+    if isinstance(existing, list):
+        filtered = [
+            entry
+            for entry in existing
+            if not (isinstance(entry, str) and entry.split("=", 1)[0] == key)
+        ]
+        filtered.append(f"{key}={value}")
+        return filtered
+    return {key: value}
+
+
+def _content_digest(
+    task_dir: Path,
+    *,
+    agent_harness: str,
+    harness_version: str,
+    harness_install_source: str,
+) -> str:
+    """Content hash of *task_dir* + the harness parameters the layer bakes in."""
+    hasher = hashlib.sha256()
+    for path in sorted(task_dir.rglob("*")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = path.relative_to(task_dir).as_posix()
+        hasher.update(b"P|" + rel.encode() + b"\n")
+        if path.is_file():
+            hasher.update(b"C|")
+            hasher.update(path.read_bytes())
+            hasher.update(b"\n")
+    hasher.update(b"|harness|\n")
+    hasher.update(f"agent_harness={agent_harness}\n".encode())
+    hasher.update(f"harness_version={harness_version}\n".encode())
+    hasher.update(f"harness_install_source={harness_install_source}\n".encode())
+    return hasher.hexdigest()[:16]
+
+
+def _base_image_tag(task_id: str) -> str:
+    return f"tolokaforge-native-{task_id}-base:local"
+
+
+def _layered_image_tag(task_id: str, agent_harness: str, harness_version: str) -> str:
+    return f"tolokaforge-native-{task_id}-{agent_harness}-{harness_version}:local"

--- a/tolokaforge/core/models/model_config.py
+++ b/tolokaforge/core/models/model_config.py
@@ -41,6 +41,15 @@ class ModelConfig(BaseModel):
     temperature: float = 0.0
     max_tokens: int | None = None
     seed: int | None = None
+    # Coding-harness selector. When set, the trial's LLM loop is replaced by a
+    # single invocation of the named vendor CLI (``claude-code``, ``codex``,
+    # ``gemini-cli``, ``kimi-code``, ``opencode``, ``grok-build`` — see the
+    # ``tolokaforge_coding_harnesses`` package for the shipped registry) inside
+    # the trial container. Adapter-agnostic: any adapter whose
+    # ``supports_coding_harness`` capability flag is ``True`` accepts this
+    # field. Adapter identity is not checked here; the orchestrator's config
+    # gate refuses the combination when the resolved adapter does not opt in.
+    harness: str | None = None
     # Reasoning / thinking configuration. Must be a struct form —
     # bare strings (``reasoning: medium``) are rejected with a migration
     # pointer. See docs/CONFIG.md § reasoning for the schema.

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -948,6 +948,15 @@ _DUAL_HOME_STORAGE_QUEUE_ALIASES: tuple[tuple[str, str], ...] = (
 pairs. Legacy names carry the ``queue_`` prefix; canonical names
 don't (the ``queue`` sub-block is the namespace)."""
 
+_HARNESS_ADAPTER_PARAMS_ALIASES: tuple[tuple[str, str], ...] = (
+    ("agent_harness", "harness"),
+    ("agent_model", "name"),
+)
+"""``evaluation.harness_adapter.params.<legacy>`` → ``models.agent.<canonical>``
+field pairs. Both once lived in a ``terminal_bench``-adapter-specific
+params bag; the lift makes coding-harness selection a first-class
+run-config concept that any adapter can accept."""
+
 
 class RunConfig(BaseModel):
     """Complete run configuration"""
@@ -1032,6 +1041,72 @@ class RunConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def _lift_harness_adapter_params_aliases(cls, values: Any) -> Any:
+        """Lift legacy ``evaluation.harness_adapter.params.agent_harness`` and
+        ``agent_model`` into their canonical homes on ``models.agent`` at
+        parse time.
+
+        The coding-harness surface's first shipped shape carried the
+        harness selector inside a ``terminal_bench``-adapter-specific
+        params bag. That coupling is retired: the harness rides
+        ``models.agent.harness`` (adapter-agnostic; any adapter whose
+        ``supports_coding_harness`` capability flag is ``True`` accepts
+        it), and the model the CLI receives is ``models.agent.name`` —
+        the same field the engine loop reads. Two lifts:
+
+        * ``harness_adapter.params.agent_harness`` → ``models.agent.harness``
+        * ``harness_adapter.params.agent_model`` → ``models.agent.name``
+
+        Collision policy matches the orchestrator dual-home lift below:
+        equal values warn once, differing values raise ``ValueError``
+        naming both keys. The legacy key is dropped from ``params`` so
+        adapter code has one source of truth.
+        """
+        if not isinstance(values, dict):
+            return values
+        evaluation_input = values.get("evaluation")
+        if not isinstance(evaluation_input, dict):
+            return values
+        harness_adapter_input = evaluation_input.get("harness_adapter")
+        if not isinstance(harness_adapter_input, dict):
+            return values
+        params_input = harness_adapter_input.get("params")
+        if not isinstance(params_input, dict):
+            return values
+        if "agent_harness" not in params_input and "agent_model" not in params_input:
+            return values
+
+        values = dict(values)
+        evaluation = dict(evaluation_input)
+        values["evaluation"] = evaluation
+        harness_adapter = dict(harness_adapter_input)
+        evaluation["harness_adapter"] = harness_adapter
+        params = dict(params_input)
+        harness_adapter["params"] = params
+
+        models_input = values.get("models")
+        models = dict(models_input) if isinstance(models_input, dict) else {}
+        agent_input = models.get("agent")
+        agent = dict(agent_input) if isinstance(agent_input, dict) else {}
+
+        for legacy_key, canonical_key in _HARNESS_ADAPTER_PARAMS_ALIASES:
+            _lift_alias(
+                params,
+                legacy_key,
+                agent,
+                canonical_key,
+                "models.agent",
+                legacy_container_label="evaluation.harness_adapter.params",
+            )
+
+        if agent:
+            models["agent"] = agent
+            values["models"] = models
+
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
     def _lift_orchestrator_dual_home_aliases(cls, values: Any) -> Any:
         """Lift legacy ``orchestrator.*`` fields to their canonical
         ``compute.*`` / ``storage.queue.*`` homes at parse time.
@@ -1099,13 +1174,16 @@ def _lift_alias(
     canonical_container: dict[str, Any],
     canonical_key: str,
     canonical_container_label: str,
+    legacy_container_label: str = "orchestrator",
 ) -> None:
     """Lift a single legacy key into a canonical container in place.
 
     Removes the legacy key from *legacy_container* (so downstream reads
     can't accidentally see both). Emits ``DeprecationWarning`` when the
     legacy key was set; raises ``ValueError`` on a collision with a
-    different canonical value.
+    different canonical value. ``legacy_container_label`` names the path
+    the legacy key sits at (defaults to ``orchestrator`` — the historical
+    caller — so the two dual-home lifts read cleanly).
     """
     if legacy_key not in legacy_container:
         return
@@ -1113,15 +1191,15 @@ def _lift_alias(
     canonical_value = canonical_container.get(canonical_key)
     if canonical_value is not None and canonical_value != legacy_value:
         raise ValueError(
-            f"orchestrator.{legacy_key}={legacy_value!r} conflicts with "
+            f"{legacy_container_label}.{legacy_key}={legacy_value!r} conflicts with "
             f"{canonical_container_label}.{canonical_key}={canonical_value!r}; "
-            f"drop the legacy `orchestrator.{legacy_key}` and keep the "
+            f"drop the legacy `{legacy_container_label}.{legacy_key}` and keep the "
             f"canonical `{canonical_container_label}.{canonical_key}`."
         )
     if canonical_value is None:
         canonical_container[canonical_key] = legacy_value
     warnings.warn(
-        f"orchestrator.{legacy_key} is deprecated; use "
+        f"{legacy_container_label}.{legacy_key} is deprecated; use "
         f"{canonical_container_label}.{canonical_key} instead. Legacy "
         "field will be removed in a future release.",
         DeprecationWarning,

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -601,6 +601,18 @@ class Orchestrator:
             adapter_type = AdapterType.NATIVE
             params = {}
 
+        # Coding-harness selector: canonical home is ``models.agent.harness``
+        # (adapter-agnostic). Inject it into adapter params here so adapters
+        # that already read ``params["agent_harness"]`` keep working; the
+        # legacy ``harness_adapter.params.agent_harness`` shape is lifted to
+        # ``models.agent`` at parse time, so nothing else in this method sees
+        # the old location. ``models.agent.name`` doubles as the model the
+        # CLI receives — the same field the engine loop reads.
+        agent_model_config = self.config.models.get("agent") if self.config.models else None
+        if agent_model_config is not None and agent_model_config.harness is not None:
+            params.setdefault("agent_harness", agent_model_config.harness)
+            params.setdefault("agent_model", agent_model_config.name)
+
         # Add tasks_glob to params for both native and other adapters
         params["tasks_glob"] = self.config.evaluation.tasks_glob
         # ``evaluation.projects`` is the canonical field; the deprecated
@@ -1634,6 +1646,36 @@ class Orchestrator:
         # Create adapter if not already created
         if self.adapter is None:
             self.adapter = self._create_adapter()
+
+        # Coding-harness capability gate: refuse a run declaring
+        # ``models.agent.harness`` on an adapter that has not opted into the
+        # harness surface (``supports_coding_harness`` class attr from
+        # ``CodingHarnessAdapterMixin``). Fail here — before any container
+        # work — with a message that names the adapter and the harness slug
+        # so the operator sees which side of the pair does not match.
+        agent_model_config = self.config.models.get("agent") if self.config.models else None
+        if agent_model_config is not None and agent_model_config.harness is not None:
+            if not getattr(self.adapter, "supports_coding_harness", False):
+                adapter_type_name = (
+                    getattr(
+                        self.config.evaluation.harness_adapter,
+                        "type",
+                        "native",
+                    )
+                    if self.config.evaluation.harness_adapter
+                    else "native"
+                )
+                raise RuntimeError(
+                    f"models.agent.harness={agent_model_config.harness!r} but "
+                    f"adapter {adapter_type_name!r} does not opt into coding-"
+                    "harness mode. An adapter opts in by inheriting "
+                    "``tolokaforge_coding_harnesses.adapter_support."
+                    "CodingHarnessAdapterMixin`` (which sets "
+                    "``supports_coding_harness = True``). Either drop "
+                    "``models.agent.harness`` to run the engine's LLM loop, "
+                    "or switch to an adapter that supports the harness "
+                    "surface (currently: terminal_bench, native)."
+                )
 
         # Get task IDs from adapter
         task_ids = self.adapter.get_task_ids()

--- a/tolokaforge/runner/harness_state.py
+++ b/tolokaforge/runner/harness_state.py
@@ -1,0 +1,262 @@
+"""Snapshot the agent-visible directory of a harness-mode trial container.
+
+A trial driven under a coding-harness CLI runs inside its own container; the
+runner service reaches into that container via a
+:class:`~tolokaforge.runner.tool_factory.DockerComposeExecToolWrapper` when it
+needs to inspect trial-produced state. This module owns that read.
+
+The snapshot is the file tree the CLI could touch, keyed under the container's
+own agent-visible directory (e.g. ``/work/factorial.py``), so a task pack that
+grades under ``state_checks`` can assert against ``$.filesystem['/work/...']``
+verbatim.
+
+Reads and reads only — the container is not modified. Caps are per-file and
+per-run to bound memory when the CLI dropped a large artifact into the tree.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import shlex
+import tarfile
+from collections.abc import Callable
+
+DEFAULT_MAX_FILE_BYTES = 1_000_000
+"""Files strictly larger than this are omitted from the snapshot.
+
+State-checks operators (``contains`` / ``equals`` / ``path_glob``) all read
+short-to-medium text; a multi-megabyte file the CLI dropped is almost certainly
+a build artifact rather than the code the assertion is targeting."""
+
+DEFAULT_MAX_TOTAL_BYTES = 100_000_000
+"""Aggregate raw-bytes ceiling for one snapshot.
+
+The tarball is emitted as base64 over the exec-wrapper's stdout channel, so the
+in-memory footprint here is bounded by the receiver of ``_exec_sync`` — the
+runner service — rather than by the container's own disk. Exceeding this cap
+skips the snapshot rather than truncating it: an assertion that cannot resolve
+its target is better graded as a miss than as a match on partial state."""
+
+
+_TAR_SNAPSHOT_TIMEOUT_S = 60.0
+"""Deadline for the single ``tar | base64`` exec inside the container.
+
+Independent of the CLI's own budget; sized for a tree well under
+:data:`DEFAULT_MAX_TOTAL_BYTES` on typical alpine / debian images."""
+
+_SIZE_PROBE_TIMEOUT_S = 15.0
+"""Deadline for the pre-snapshot ``du`` probe.
+
+Faster than the tar exec — the probe is cheap and refuses expensive work when
+the tree is too large to fit under the cap."""
+
+
+BashExec = Callable[[str, float], str]
+"""Callable shape the snapshot expects.
+
+Matches :meth:`~tolokaforge.runner.tool_factory.DockerComposeExecToolWrapper.
+_exec_sync`: ``(command, timeout_s) -> stdout``. Kept structural rather than
+tied to the concrete class so tests can drive the helper with a stub."""
+
+
+class _SnapshotAborted(Exception):
+    """Signals a size cap or malformed exec output.
+
+    Caught inside :func:`snapshot_container_filesystem` — a snapshot that
+    cannot be completed becomes an empty result rather than a grading failure,
+    because the assertion consumer already reports "path not found" and the
+    trial's *other* grade components (transcript rules, LLM judge) can still
+    reach a verdict."""
+
+
+def snapshot_container_filesystem(
+    exec_fn: BashExec,
+    agent_visible_dir: str,
+    *,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    logger: logging.Logger | None = None,
+) -> dict[str, str]:
+    """Snapshot the container's *agent_visible_dir* file tree via *exec_fn*.
+
+    Runs three commands inside the container over *exec_fn*:
+
+    1. ``du -sb`` for the tree — refuse if it exceeds *max_total_bytes* before
+       any read is issued.
+    2. ``tar --exclude=./.git -cf - . | base64`` — emit a base64-encoded
+       tarball of the tree over stdout.
+    3. Decoded in-process: each POSIX file member with a UTF-8-decodable body
+       under *max_file_bytes* is included, keyed as
+       ``<agent_visible_dir>/<relative posix path>``.
+
+    Binary files and symlinks are skipped. ``.git/`` is skipped whole — its
+    contents are rarely what a state-checks assertion targets, and it is often
+    what pushes a tree over the per-run cap.
+
+    Returns an empty dict rather than raising when:
+
+    * *agent_visible_dir* does not exist inside the container;
+    * the tree exceeds *max_total_bytes*;
+    * the tarball is malformed (the receiver can then fall back — grading a
+      subsequent trial or a same-trial retry — instead of crashing the RPC).
+
+    A file skipped for its own reason (oversized, binary) is logged at
+    ``warning`` and the rest of the snapshot proceeds.
+
+    Args:
+        exec_fn: bash-inside-container execution surface —
+            ``(command, timeout_s) -> stdout``.
+        agent_visible_dir: absolute container path the CLI edits in.
+        max_file_bytes: per-file cap; files strictly larger are dropped.
+        max_total_bytes: aggregate cap; the whole snapshot is dropped when
+            the tree exceeds this.
+        logger: optional structured logger for cap / skip records.
+    """
+    log = logger or logging.getLogger(__name__)
+
+    try:
+        _refuse_if_over_cap(exec_fn, agent_visible_dir, max_total_bytes, log)
+    except _SnapshotAborted:
+        return {}
+
+    b64 = _tar_and_base64(exec_fn, agent_visible_dir, log)
+    if not b64:
+        return {}
+
+    try:
+        raw = base64.b64decode(b64, validate=False)
+    except (ValueError, TypeError) as exc:
+        log.warning(
+            "harness snapshot: base64 decode failed",
+            extra={"agent_visible_dir": agent_visible_dir, "error": str(exc)},
+        )
+        return {}
+
+    return _decode_tar(raw, agent_visible_dir, max_file_bytes, log)
+
+
+def _refuse_if_over_cap(
+    exec_fn: BashExec,
+    agent_visible_dir: str,
+    max_total_bytes: int,
+    log: logging.Logger,
+) -> None:
+    """``du`` probe; raise :class:`_SnapshotAborted` when the tree exceeds *max_total_bytes*.
+
+    Also treats an absent directory as a hard skip: the CLI's edit surface not
+    existing at snapshot time is the same shape as a task pack declaring the
+    wrong path — an empty result is honest, a snapshot from ``/`` would not be.
+    """
+    probe = (
+        f"test -d {shlex.quote(agent_visible_dir)} "
+        f"&& du -sb {shlex.quote(agent_visible_dir)} 2>/dev/null "
+        "|| echo MISSING"
+    )
+    output = exec_fn(probe, _SIZE_PROBE_TIMEOUT_S).strip()
+    if not output or output.startswith("MISSING") or "MISSING" in output.splitlines()[-1]:
+        log.warning(
+            "harness snapshot: agent-visible dir not found in container",
+            extra={"agent_visible_dir": agent_visible_dir},
+        )
+        raise _SnapshotAborted
+    try:
+        total = int(output.splitlines()[-1].split()[0])
+    except (ValueError, IndexError):
+        # A busybox `du` variant emitting KB blocks reads as a positive small
+        # integer, which lands us below the cap incorrectly; but the tar step
+        # itself is separately budgeted, so the worst case is a slow-but-honest
+        # snapshot rather than an unbounded one.
+        return
+    if total > max_total_bytes:
+        log.warning(
+            "harness snapshot: tree exceeds total cap; skipped",
+            extra={
+                "agent_visible_dir": agent_visible_dir,
+                "bytes": total,
+                "cap": max_total_bytes,
+            },
+        )
+        raise _SnapshotAborted
+
+
+def _tar_and_base64(
+    exec_fn: BashExec,
+    agent_visible_dir: str,
+    log: logging.Logger,
+) -> str:
+    """Run ``tar`` piped through ``base64`` inside the container, return stdout.
+
+    The ``cd`` puts tar's paths under ``./`` so :func:`_decode_tar` can strip
+    the leading ``./`` cleanly; ``--exclude=./.git`` drops the SCM directory
+    whole — its contents are rarely what an assertion targets and are often
+    what pushes a tree past the cap.
+    """
+    cmd = (
+        f"cd {shlex.quote(agent_visible_dir)} && tar --exclude=./.git -cf - . 2>/dev/null | base64"
+    )
+    try:
+        return exec_fn(cmd, _TAR_SNAPSHOT_TIMEOUT_S)
+    except Exception as exc:
+        log.warning(
+            "harness snapshot: tar exec failed",
+            extra={"agent_visible_dir": agent_visible_dir, "error": str(exc)},
+        )
+        return ""
+
+
+def _decode_tar(
+    raw: bytes,
+    agent_visible_dir: str,
+    max_file_bytes: int,
+    log: logging.Logger,
+) -> dict[str, str]:
+    """Iterate the tarball, emit ``{path: text}`` for eligible file members.
+
+    Binary payloads (any byte that fails UTF-8) are skipped: state-checks
+    operators can only match text, and passing base64 through here would give
+    an assertion a value neither the author nor a human reader recognises.
+    Symlinks are skipped: the vocabulary was not designed to expose whatever
+    the link resolves to, whether or not that lands inside the tree.
+    """
+    root = agent_visible_dir.rstrip("/") or "/"
+    result: dict[str, str] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
+            for member in tar:
+                if not member.isfile() or member.issym() or member.islnk():
+                    continue
+                if member.size > max_file_bytes:
+                    log.warning(
+                        "harness snapshot: file exceeds per-file cap; skipped",
+                        extra={
+                            "path": member.name,
+                            "size": member.size,
+                            "cap": max_file_bytes,
+                        },
+                    )
+                    continue
+                stream = tar.extractfile(member)
+                if stream is None:
+                    continue
+                payload = stream.read()
+                try:
+                    content = payload.decode("utf-8")
+                except UnicodeDecodeError:
+                    log.debug(
+                        "harness snapshot: skipping non-UTF-8 file",
+                        extra={"path": member.name},
+                    )
+                    continue
+                rel = member.name.lstrip("./") or ""
+                if not rel:
+                    continue
+                result[f"{root}/{rel}"] = content
+    except tarfile.TarError as exc:
+        log.warning(
+            "harness snapshot: tar decode failed",
+            extra={"agent_visible_dir": agent_visible_dir, "error": str(exc)},
+        )
+        return {}
+    return result

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -128,6 +128,7 @@ from tolokaforge.runner.grading_ledger import (
     hash_family_skip_accounting,
     transcript_rules_author_keys,
 )
+from tolokaforge.runner.harness_state import snapshot_container_filesystem
 from tolokaforge.runner.id_resolution import (
     check_id_fields_against_seeded_tables,
     compute_diff_ops,
@@ -181,6 +182,23 @@ from tolokaforge.runner.tool_factory import (
 from tolokaforge.tools.registry import ToolExecutionStatus, raised_tool_failure_text
 
 logger = logging.getLogger(__name__)
+
+
+def _first_docker_compose_exec_tool(
+    tools: Collection[Callable],
+) -> DockerComposeExecToolWrapper | None:
+    """Return the first exec-capable wrapper among *tools*, or ``None``.
+
+    Used from two grade-time paths — ``_grade_via_test_execution`` (running
+    ``test.sh``) and ``_read_filesystem_for_state`` (snapshotting a harness
+    trial's tree) — that both need to reach into the trial container via the
+    same wrapper the runner already registered for the tool.
+    """
+    for tool in tools:
+        if isinstance(tool, DockerComposeExecToolWrapper):
+            return tool
+    return None
+
 
 # Service version
 SERVICE_VERSION = "1.0.0"
@@ -1671,10 +1689,13 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
     ) -> dict[str, Any]:
         # Feeds path: jsonpath state_checks. Two roots: "db"/"tables" carry
         # the DB service's stable state (empty when the trial has no DB —
-        # filesystem-only tasks); "filesystem" mirrors /work/ back out under
-        # the logical /env/fs/agent-visible/ layout the task YAML asserts
-        # against, so ``$.filesystem['/env/fs/agent-visible/foo.py']`` can
-        # match the file the agent actually edited.
+        # filesystem-only tasks); "filesystem" mirrors the agent-visible
+        # directory back out. Harness-mode trials read the tree from inside
+        # the trial container via the exec-wrapper; every other trial mirrors
+        # /work/ under the logical /env/fs/agent-visible/ layout the task
+        # YAML asserts against, so
+        # ``$.filesystem['/env/fs/agent-visible/foo.py']`` matches the file
+        # the agent actually edited.
         db_state: dict[str, Any] = {}
         try:
             if fetch_db:
@@ -1689,11 +1710,43 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             logger.warning(
                 f"GradeTrial: {trial_id} - DB trial not found; grading with empty DB state"
             )
+        filesystem = await self._read_filesystem_for_state(trial_id)
         return {
             "db": db_state,
             "tables": db_state,
-            "filesystem": self._read_agent_visible_filesystem(),
+            "filesystem": filesystem,
         }
+
+    async def _read_filesystem_for_state(self, trial_id: str) -> dict[str, str]:
+        """Snapshot the trial's agent-visible files for jsonpath grading.
+
+        Routes on task metadata: a trial whose adapter emitted
+        ``agent_harness_command`` + ``agent_visible_dir`` runs its CLI inside a
+        separate container, so ``/work/`` inside this runner is not the tree
+        the assertions target. The exec-wrapper the runner already uses to
+        drive the CLI is the same one used here to enumerate the tree under
+        the container's agent-visible dir; every other trial reads back the
+        runner's own ``AGENT_WORK_DIR``.
+        """
+        trial_context = self.trials.get(trial_id)
+        if trial_context is not None:
+            metadata = trial_context.task_description.metadata or {}
+            agent_visible_dir = metadata.get("agent_visible_dir")
+            if metadata.get("agent_harness_command") and isinstance(agent_visible_dir, str):
+                bash_tool = _first_docker_compose_exec_tool(trial_context.agent_tools.values())
+                if bash_tool is not None:
+                    loop = asyncio.get_event_loop()
+                    return await loop.run_in_executor(
+                        None,
+                        snapshot_container_filesystem,
+                        bash_tool._exec_sync,
+                        agent_visible_dir,
+                    )
+                logger.warning(
+                    f"GradeTrial: {trial_id} - harness trial has no exec-capable tool; "
+                    "falling back to the runner's own /work/ walk"
+                )
+        return self._read_agent_visible_filesystem()
 
     def _read_agent_visible_filesystem(self) -> dict[str, str]:
         # Inverse of the RegisterTrial provisioner's
@@ -1805,8 +1858,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
                 return pb2.GradeTrialResponse(
                     success=False,
                     error=(
-                        f"Trial {trial_id!r} cannot be graded as authored: "
-                        f"{state_checks_refusal}"
+                        f"Trial {trial_id!r} cannot be graded as authored: {state_checks_refusal}"
                     ),
                 )
 
@@ -2407,9 +2459,9 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         try:
             final_state_response = await self.db_client.get_state(trial_id)
             final_env_state: dict[str, Any] = final_state_response.data
-        except (
+        except (  # noqa: BLE001 — grade path degrades to empty state; the DB failure surfaces via component metadata, not a crash
             Exception
-        ) as exc:  # noqa: BLE001 — grade path degrades to empty state; the DB failure surfaces via component metadata, not a crash
+        ) as exc:
             logger.warning(
                 "GradeTrial: %s - final DB state fetch failed (%s); grading against empty state",
                 trial_id,
@@ -3005,11 +3057,7 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
         3. Return a ``GradeTrialResponse`` with the reward as score.
         """
         # Find an exec-capable lifecycle tool to run the suite in the env.
-        bash_tool: DockerComposeExecToolWrapper | None = None
-        for tool in trial_context.agent_tools.values():
-            if isinstance(tool, DockerComposeExecToolWrapper):
-                bash_tool = tool
-                break
+        bash_tool = _first_docker_compose_exec_tool(trial_context.agent_tools.values())
 
         if bash_tool is None:
             # Actionable for the adapter author: they asked for test-execution

--- a/tolokaforge_coding_harnesses/README.md
+++ b/tolokaforge_coding_harnesses/README.md
@@ -160,6 +160,56 @@ private to your organisation (out-of-tree plug-in).
   [`src/tolokaforge_coding_harnesses/testing.py`](src/tolokaforge_coding_harnesses/testing.py)
   ships the `isolate_discovery` helper for plug-in test suites.
 
+## Adopting the mixin
+
+An adapter opts a task pack into coding-harness mode by inheriting
+[`CodingHarnessAdapterMixin`](src/tolokaforge_coding_harnesses/adapter_support.py)
+alongside `BaseAdapter`. Class shape:
+
+```python
+from tolokaforge.adapters.base import BaseAdapter
+from tolokaforge_coding_harnesses import CodingHarnessAdapterMixin
+
+
+class MyAdapter(CodingHarnessAdapterMixin, BaseAdapter):
+    ...
+```
+
+The mixin sets `supports_coding_harness: ClassVar[bool] = True` — the
+capability flag the engine's config-validation gate reads. Adapters
+that do not inherit the mixin (or override the flag to `False`) refuse
+a run declaring `models.agent.harness` before any container work.
+
+Six helpers ship on the mixin. Contracts (parameters live in the
+mixin's own docstrings — read those, not this table):
+
+| Helper | Contract |
+|---|---|
+| `resolve_harness_spec(agent_harness, agent_model, provider_env=None, presets_file=None, plugin_discovery=True)` | Resolves against the shipped catalog + operator overlay + installed plug-ins, then validates. Refuses unknown harness names and empty models. |
+| `build_harness_command(agent_harness, spec, instruction, model, provider_env=None, *, path_resolver=None)` | Assembles the `bash -c`-shaped command the trial exec runs. Threads argv, model routing, provider-env, and (when the spec declares it) the middleware-proxy preamble. |
+| `emit_harness_metadata(agent_harness, spec, command, model)` | Four-key handshake the conductor branches on: `agent_harness`, `agent_harness_version`, `agent_harness_model`, `agent_harness_command`. |
+| `emit_harness_tool_schema(*, service, compose_project_prefix, timeout_s, toolset="coding_harness")` | Payload for the runner's `bash` tool routed through `DockerComposeExecToolWrapper`. `timeout_s` must cover the whole trial. |
+| `emit_test_execution_grading()` | Payload for the runner's `RunnerGradingConfig`. Grades by reading `/logs/verifier/reward.txt`. |
+| `write_install_script_layer(context_dir, base_image, spec, middleware_proxy=False)` | Writes a standalone Dockerfile snippet + the shipped install script (and the middleware proxy when declared) into `context_dir`. Returns the Dockerfile's relative path. |
+
+**Payload dicts, not engine types.** `emit_harness_tool_schema` and
+`emit_test_execution_grading` return dicts. Adapters construct the
+engine types at the call site (`ToolSchema(**payload)`,
+`RunnerGradingConfig(**payload)`); pydantic v2 reconstructs nested
+types (`ToolSource` from `source={…}`) transparently. This preserves
+the boundary invariant — `tolokaforge_coding_harnesses/` imports no
+engine module.
+
+**Reference adopters.** The bundled
+[`NativeAdapter`](../tolokaforge/adapters/native.py) drives a native
+task pack via harness mode when `models.agent.harness` is set; the
+out-of-tree
+[`TerminalBenchAdapter`](../external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py)
+adopts the mixin with compose synthesis wrapped around
+`write_install_script_layer` from the compose context root. See
+[ADR-0039](../docs/adr/0039-coding-harness-adapter-agnostic.md) for the
+design record.
+
 ## Related docs
 
 - [docs/RUNNING_TERMINAL_BENCH.md](../docs/RUNNING_TERMINAL_BENCH.md) — the
@@ -179,3 +229,5 @@ private to your organisation (out-of-tree plug-in).
   package hoist and boundary invariant.
 - [ADR-0037](../docs/adr/0037-runtime-gateway-as-harness-data.md) — gateway
   routing as harness data.
+- [ADR-0039](../docs/adr/0039-coding-harness-adapter-agnostic.md) — the
+  adapter-agnostic lift and the mixin contract.

--- a/tolokaforge_coding_harnesses/README.md
+++ b/tolokaforge_coding_harnesses/README.md
@@ -52,6 +52,9 @@ from tolokaforge_coding_harnesses import (
     RuntimeGateway,              # gateway_route consumer surface (ADR-0037)
     ContainerFileInjector,       # deliver config_files into a running container
     SkillDelivery,               # per-task skill bundle delivery
+    CodingHarnessAdapterMixin,   # adapter-side pattern: registry resolve, command,
+                                 # metadata, tool schema, test_execution grading,
+                                 # standalone install-script Dockerfile layer
 )
 ```
 

--- a/tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/__init__.py
+++ b/tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/__init__.py
@@ -50,6 +50,7 @@ from ._registry import (
     validate_harness,
     validate_provider_env_keys,
 )
+from .adapter_support import CodingHarnessAdapterMixin
 from .container_injection import (
     ContainerFileInjector,
     ContainerInjectionError,
@@ -77,6 +78,7 @@ __all__ = [
     "PROVIDER_ENV_KEYS",
     "SHIPPED_REGISTRY_FILE",
     "SHIPPED_REGISTRY_META_FILE",
+    "CodingHarnessAdapterMixin",
     "ContainerFileInjector",
     "ContainerInjectionError",
     "DockerExecInjector",

--- a/tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py
+++ b/tolokaforge_coding_harnesses/src/tolokaforge_coding_harnesses/adapter_support.py
@@ -1,0 +1,292 @@
+"""Adapter-side coding-harness pattern, shared by any adapter that opts in.
+
+An adapter routes a task to a vendor coding-agent CLI by agreeing with the
+engine on four surfaces: the harness metadata the conductor branches on, the
+``docker exec``-shaped tool the runner uses for exec, the ``test_execution``
+grading dispatch, and the image layer that puts the CLI on ``PATH``. Every
+adapter's version of those four is the same shape — only the compose /
+container plumbing around them differs — so this module gives the shape one
+address any adapter can inherit.
+
+The mixin cannot import the engine: this package ships to runtimes that do
+not install ``tolokaforge`` (the boundary invariant in
+``tests/unit/test_package_boundary.py``). The two engine types the pattern
+touches — :class:`~tolokaforge.runner.models.ToolSchema` and
+:class:`~tolokaforge.runner.models.RunnerGradingConfig` — are pydantic
+models, so the mixin returns payload dicts the adapter passes into the
+engine constructors: ``ToolSchema(**payload)`` /
+``RunnerGradingConfig(**payload)``. The dict shape mirrors the pydantic
+fields, so a schema change on either engine model surfaces at the adapter's
+one-line construction call, never inside the mixin.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, ClassVar
+
+from ._registry import (
+    INSTALL_SCRIPT,
+    MIDDLEWARE_PROXY_CONTAINER_PATH,
+    MIDDLEWARE_PROXY_SCRIPT,
+    HarnessSpec,
+    ResolvedHarnessRegistry,
+    harness_command,
+    resolve_effective_registry,
+    validate_harness,
+)
+from .protocols import PathResolver
+
+__all__ = ["CodingHarnessAdapterMixin"]
+
+
+_HARNESS_INSTALL_CONTAINER_PATH = "/opt/tolokaforge/install-harness.sh"
+"""Where the shipped install script lands inside the image the layer builds.
+
+Constant because the ``RUN`` line and the ``COPY`` destination must agree,
+and the install script's own layout is what the six shipped harnesses'
+:attr:`HarnessSpec.install_method` values resolve against."""
+
+_HARNESS_DOCKERFILE_NAME = "harness.Dockerfile"
+"""Name of the standalone Dockerfile snippet the mixin writes into the
+build context. Adapters that layer the harness on top of a task base image
+pass the returned relative path to their build tooling."""
+
+
+class CodingHarnessAdapterMixin:
+    """Shared coding-harness pattern for adapters.
+
+    An adapter that inherits this mixin declares — via
+    :attr:`supports_coding_harness` — that the orchestrator's config gate can
+    route ``models.agent.harness`` runs to it, and gets the five helpers the
+    pattern needs: registry resolution, command assembly, metadata emission,
+    tool-schema payload, ``test_execution`` grading payload, and the standalone
+    install-script Dockerfile layer.
+
+    The mixin is stateless — every helper takes what it needs as arguments — so
+    an adapter can inherit alongside any base class without inheritance-order
+    surprises."""
+
+    supports_coding_harness: ClassVar[bool] = True
+    """Adapter capability flag the orchestrator's config-validation gate reads.
+
+    ``True`` means a run declaring ``models.agent.harness`` reaches this
+    adapter; the orchestrator's gate refuses the run against any adapter whose
+    flag is the ``False`` default (see
+    :mod:`~tolokaforge.core.orchestrator`'s ``load_tasks``)."""
+
+    def resolve_harness_spec(
+        self,
+        agent_harness: str,
+        agent_model: str,
+        provider_env: Mapping[str, str] | None = None,
+        presets_file: str | None = None,
+        plugin_discovery: bool = True,
+    ) -> HarnessSpec:
+        """Resolve *agent_harness* against the effective registry.
+
+        Composes :func:`resolve_effective_registry` — shipped catalog + optional
+        operator overlay + installed plugins — then :func:`validate_harness` to
+        turn a typo into an actionable error naming the accepted set. Refuses
+        :data:`ENGINE_LOOP` (which runs no CLI, so no spec exists) and refuses
+        an empty *agent_model* for a real harness (the CLI's own default would
+        drive the trial otherwise, silently unpinning the model under
+        measurement).
+
+        *provider_env* is not consulted here — its keys drive command assembly
+        and are validated then; it remains on the signature so an adapter can
+        forward the run's envelope in one place.
+
+        Raises:
+            ValueError: *agent_harness* is unknown, is :data:`ENGINE_LOOP`, or
+                *agent_model* is empty for a real harness.
+        """
+        del provider_env  # forwarded by adapters; validated at command-assembly time
+        resolved: ResolvedHarnessRegistry = resolve_effective_registry(
+            presets_file, discover_plugins=plugin_discovery
+        )
+        validate_harness(agent_harness, resolved.harnesses)
+        spec = resolved.harnesses.get(agent_harness)
+        if spec is None:
+            raise ValueError(
+                f"coding harness: agent_harness {agent_harness!r} runs no CLI (the engine "
+                "loop drives the trial through the engine's own LLM turn loop); "
+                "resolve_harness_spec is for CLI-mode runs only."
+            )
+        if not agent_model:
+            raise ValueError(
+                f"coding harness: agent_harness {agent_harness!r} requires a non-empty "
+                "agent_model — the CLI selects its own default otherwise, so the run "
+                "config's model would not be the one measured."
+            )
+        return spec
+
+    def build_harness_command(
+        self,
+        agent_harness: str,
+        spec: HarnessSpec,
+        instruction: str,
+        model: str,
+        provider_env: Mapping[str, str] | None = None,
+        *,
+        path_resolver: PathResolver | None = None,
+    ) -> str:
+        """Shell command that runs *agent_harness*'s CLI against *instruction*.
+
+        Thin wrapper around :func:`harness_command` — kept on the mixin so the
+        adapter code reads as "resolve → build → emit" and doesn't need to
+        thread the harness registry through.
+
+        The command reaches ``bash -c`` inside the task container via the
+        exec-wrapper the payload from :meth:`emit_harness_tool_schema`
+        configures; every argv token is already shell-quoted upstream."""
+        return harness_command(
+            agent_harness,
+            instruction,
+            model,
+            registry={agent_harness: spec},
+            provider_env=provider_env,
+            path_resolver=path_resolver,
+        )
+
+    def emit_harness_metadata(
+        self,
+        agent_harness: str,
+        spec: HarnessSpec,
+        command: str,
+        model: str,
+    ) -> dict[str, Any]:
+        """Metadata handshake the conductor branches on.
+
+        Four keys — the conductor's ``_run_agent_loop`` reads
+        ``agent_harness_command`` and dispatches; the three siblings are
+        recorded on the trajectory so replay can reconstruct which CLI + version
+        + model produced the trial. Adapters that carry their own task-specific
+        metadata (difficulty, tags, timeouts) merge those in around this dict.
+        """
+        return {
+            "agent_harness": agent_harness,
+            "agent_harness_version": spec.version,
+            "agent_harness_model": model,
+            "agent_harness_command": command,
+        }
+
+    def emit_harness_tool_schema(
+        self,
+        *,
+        service: str,
+        compose_project_prefix: str,
+        timeout_s: float,
+        toolset: str = "coding_harness",
+    ) -> dict[str, Any]:
+        """Payload the adapter passes to :class:`~tolokaforge.runner.models.ToolSchema`.
+
+        Shape matches the pydantic model field-for-field; nested ``source`` is
+        the :class:`~tolokaforge.runner.models.ToolSource` payload, with
+        ``invocation_style`` as the ``docker_compose_exec`` enum value string so
+        the engine's :class:`~tolokaforge.runner.models.InvocationStyle` string
+        enum reconstructs it.
+
+        *service* and *compose_project_prefix* land on ``source.extra`` — the
+        two fields the runner's
+        :class:`~tolokaforge.runner.tool_factory.DockerComposeExecToolWrapper`
+        reads to resolve the container name at start time. *timeout_s* has to
+        carry the whole trial's agent budget under harness mode: the CLI runs
+        to completion inside a single ``exec`` — the trial has no LLM turn loop
+        to time-slice.
+
+        The adapter constructs the engine type with ``ToolSchema(**payload)``;
+        pydantic v2 instantiates the nested ``ToolSource`` from the sub-dict.
+        """
+        return {
+            "name": "bash",
+            "description": "Execute a bash command inside the task container",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Shell command to run",
+                    }
+                },
+                "required": ["command"],
+            },
+            "category": "compute",
+            "timeout_s": timeout_s,
+            "source": {
+                "toolset": toolset,
+                "module_path": "",
+                "class_name": "bash",
+                "invocation_style": "docker_compose_exec",
+                "extra": {
+                    "service": service,
+                    "compose_project_prefix": compose_project_prefix,
+                },
+            },
+        }
+
+    def emit_test_execution_grading(self) -> dict[str, Any]:
+        """Payload the adapter passes to :class:`~tolokaforge.runner.models.RunnerGradingConfig`.
+
+        Fixed shape: the runner dispatches on ``grading_method="test_execution"``
+        and scores the trial by reading the reward the task's own verifier
+        wrote to ``/logs/verifier/reward.txt``. Weights and threshold match the
+        historical terminal-bench values so a run switching to the mixin scores
+        byte-identically."""
+        return {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+            "grading_method": "test_execution",
+        }
+
+    def write_install_script_layer(
+        self,
+        context_dir: Path,
+        base_image: str,
+        spec: HarnessSpec,
+        middleware_proxy: bool = False,
+    ) -> str:
+        """Materialise a standalone image-layer build context for *spec*.
+
+        Writes three files into *context_dir* (which the adapter has already
+        created — the mixin does not own the caller's staging tree):
+
+        - ``install-harness.sh`` — the shipped installer, copied verbatim.
+        - :attr:`_HARNESS_DOCKERFILE_NAME` — a Dockerfile snippet that ``FROM``
+          *base_image*, ``COPY``s the installer to
+          :data:`_HARNESS_INSTALL_CONTAINER_PATH`, and ``RUN``s it against
+          :attr:`HarnessSpec.install_method` / :attr:`HarnessSpec.install_source`
+          / :attr:`HarnessSpec.version`.
+        - ``middleware_proxy.py`` — the shipped proxy, only when *middleware_proxy*
+          is ``True`` (typically because ``spec.request_middleware`` is set).
+          The Dockerfile gains one more ``COPY`` line so the proxy lands at
+          :data:`MIDDLEWARE_PROXY_CONTAINER_PATH` inside the image.
+
+        The build context is self-contained: paths in the Dockerfile are
+        relative to *context_dir*, not to the adapter's surrounding compose or
+        staging tree. An adapter with compose-specific plumbing (a
+        ``.dockerignore`` at the compose context root, a nested build-context
+        location) wraps that around this snippet.
+
+        Returns:
+            The Dockerfile's path relative to *context_dir* — the caller's
+            build tooling reads it as the ``dockerfile:`` argument.
+        """
+        install_source = INSTALL_SCRIPT.name
+        shutil.copy2(INSTALL_SCRIPT, context_dir / install_source)
+        lines = [
+            f"FROM {base_image}",
+            f"COPY {install_source} {_HARNESS_INSTALL_CONTAINER_PATH}",
+            f"RUN sh {_HARNESS_INSTALL_CONTAINER_PATH} {spec.install_method} "
+            f"{shlex.quote(spec.install_source)} {shlex.quote(spec.version)}",
+        ]
+        if middleware_proxy:
+            middleware_source = MIDDLEWARE_PROXY_SCRIPT.name
+            shutil.copy2(MIDDLEWARE_PROXY_SCRIPT, context_dir / middleware_source)
+            lines.append(f"COPY {middleware_source} {MIDDLEWARE_PROXY_CONTAINER_PATH}")
+        (context_dir / _HARNESS_DOCKERFILE_NAME).write_text("\n".join(lines) + "\n")
+        return _HARNESS_DOCKERFILE_NAME

--- a/tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py
+++ b/tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py
@@ -39,6 +39,7 @@ PACKAGE_DIR = Path(__file__).resolve().parents[2]
 REQUIRED_SHIPPED_PATHS = (
     "src/tolokaforge_coding_harnesses/__init__.py",
     "src/tolokaforge_coding_harnesses/_registry.py",
+    "src/tolokaforge_coding_harnesses/adapter_support.py",
     "src/tolokaforge_coding_harnesses/container_injection.py",
     "src/tolokaforge_coding_harnesses/fingerprint.py",
     "src/tolokaforge_coding_harnesses/install-harness.sh",

--- a/tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py
+++ b/tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py
@@ -1,0 +1,281 @@
+"""The adapter-side coding-harness pattern one address any adapter can inherit.
+
+The mixin is the "how an adapter adopts coding-harness mode" contract: adapter
+declares the capability flag, resolves a spec, builds the shell command,
+emits the metadata handshake the conductor branches on, emits the two runner
+payloads (bash tool + ``test_execution`` grading), and lays out the standalone
+install-script Dockerfile layer. Every helper here matches — bytes-for-bytes
+where relevant — what the terminal-bench adapter emits today, so the Move 3
+refactor to inherit is a change of caller, not of contract.
+
+The engine's :class:`~tolokaforge.runner.models.ToolSchema` /
+:class:`~tolokaforge.runner.models.RunnerGradingConfig` are pydantic models
+and this test suite asserts the payload dict shape directly: importing the
+engine types from tests would break the same boundary
+``tests/unit/test_package_boundary.py`` guards on the source side.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+
+from tolokaforge_coding_harnesses import (
+    ENGINE_LOOP,
+    HARNESSES,
+    INSTALL_SCRIPT,
+    MIDDLEWARE_PROXY_CONTAINER_PATH,
+    MIDDLEWARE_PROXY_SCRIPT,
+    CodingHarnessAdapterMixin,
+    HarnessSpec,
+    harness_command,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_SHIPPED_HARNESS_NAMES = (
+    "claude-code",
+    "codex",
+    "gemini-cli",
+    "grok-build",
+    "kimi-code",
+    "opencode",
+)
+
+
+class _Adapter(CodingHarnessAdapterMixin):
+    """Bare mixin instance for the tests — a real adapter would inherit from
+    ``BaseAdapter`` alongside; the mixin's helpers touch no adapter state, so a
+    minimal subclass is enough to exercise them."""
+
+
+@pytest.fixture
+def adapter() -> _Adapter:
+    return _Adapter()
+
+
+class TestCapabilityFlag:
+    def test_mixin_declares_supports_coding_harness_true(self) -> None:
+        """The orchestrator's config-validation gate reads this class attribute
+        to decide whether ``models.agent.harness`` can route to the adapter."""
+        assert CodingHarnessAdapterMixin.supports_coding_harness is True
+        assert _Adapter.supports_coding_harness is True
+        assert _Adapter().supports_coding_harness is True
+
+
+class TestResolveHarnessSpec:
+    @pytest.mark.parametrize("name", _SHIPPED_HARNESS_NAMES)
+    def test_accepts_each_of_the_six_shipped_names(self, adapter: _Adapter, name: str) -> None:
+        """The shipped registry is what the default path resolves against;
+        every documented harness must survive the round-trip."""
+        spec = adapter.resolve_harness_spec(name, "vendor/some-model")
+        assert isinstance(spec, HarnessSpec)
+        assert spec == HARNESSES[name]
+
+    def test_rejects_unknown_name(self, adapter: _Adapter) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            adapter.resolve_harness_spec("not-a-harness", "vendor/some-model")
+        # The rejection lists the accepted set so the caller sees the fix
+        # for a typo without reading the registry docs.
+        message = str(excinfo.value)
+        assert "not-a-harness" in message
+        for name in _SHIPPED_HARNESS_NAMES:
+            assert name in message
+
+    def test_rejects_engine_loop_because_it_runs_no_cli(self, adapter: _Adapter) -> None:
+        with pytest.raises(ValueError, match="runs no CLI"):
+            adapter.resolve_harness_spec(ENGINE_LOOP, "vendor/some-model")
+
+    def test_rejects_empty_agent_model_for_real_harness(self, adapter: _Adapter) -> None:
+        # The rejection reason mirrors the terminal-bench check that lifted
+        # into the mixin: a blank model lets the CLI pick its own default,
+        # so what runs is not the config's declared subject-under-test.
+        with pytest.raises(ValueError, match="requires a non-empty agent_model"):
+            adapter.resolve_harness_spec("claude-code", "")
+
+
+class TestBuildHarnessCommand:
+    @pytest.mark.parametrize(
+        "name,model",
+        [
+            ("claude-code", "openrouter/anthropic/claude-sonnet-4-6"),
+            ("codex", "openai/gpt-5-codex"),
+            ("gemini-cli", "google/gemini-2.5-flash"),
+        ],
+    )
+    def test_produces_the_same_bytes_as_direct_harness_command(
+        self, adapter: _Adapter, name: str, model: str
+    ) -> None:
+        """The mixin is a call-forwarder; the assembled command must be
+        byte-identical to what ``harness_command`` produces for the same inputs.
+        Any drift here would ship a different invocation than the artifact
+        records."""
+        spec = adapter.resolve_harness_spec(name, model)
+        instruction = "fix the failing test"
+        via_mixin = adapter.build_harness_command(name, spec, instruction, model)
+        via_direct = harness_command(name, instruction, model)
+        assert via_mixin == via_direct
+
+    def test_forwards_provider_env_to_config_file_rendering(self, adapter: _Adapter) -> None:
+        # codex renders config.toml + auth.json from the provider envelope;
+        # the mixin has to route provider_env through so the rendered
+        # ``base_url`` / ``api_key_env`` match the caller's envelope.
+        model = "openrouter/openai/gpt-5-codex"
+        instruction = "do it"
+        provider_env = {
+            "OPENAI_BASE_URL": "https://custom.gateway.example/v1",
+            "OPENAI_API_KEY": "",
+        }
+        spec = adapter.resolve_harness_spec("codex", model)
+        via_mixin = adapter.build_harness_command(
+            "codex", spec, instruction, model, provider_env=provider_env
+        )
+        via_direct = harness_command("codex", instruction, model, provider_env=provider_env)
+        assert via_mixin == via_direct
+        # And the caller's URL made it into the config-file preamble.
+        assert "custom.gateway.example" in via_mixin
+
+
+class TestEmitHarnessMetadata:
+    def test_returns_exactly_the_four_conductor_keys(self, adapter: _Adapter) -> None:
+        # The conductor branches on ``agent_harness_command`` and records the
+        # other three on the trajectory; anything else is task-specific and
+        # belongs on the adapter's own metadata merge, not this dict.
+        spec = adapter.resolve_harness_spec("claude-code", "vendor/some-model")
+        command = 'printf %s "instr" | claude --print'
+        model = "openrouter/anthropic/claude-sonnet-4-6"
+        metadata = adapter.emit_harness_metadata("claude-code", spec, command, model)
+        assert metadata == {
+            "agent_harness": "claude-code",
+            "agent_harness_version": spec.version,
+            "agent_harness_model": model,
+            "agent_harness_command": command,
+        }
+
+
+class TestEmitHarnessToolSchema:
+    def test_payload_matches_the_shape_the_runner_reads(self, adapter: _Adapter) -> None:
+        # The DOCKER_COMPOSE_EXEC wrapper factory in the runner reads
+        # source.extra['service'] + source.extra['compose_project_prefix']
+        # to resolve the container; those must land on the payload verbatim.
+        payload = adapter.emit_harness_tool_schema(
+            service="agent",
+            compose_project_prefix="tolokaforge-tbench",
+            timeout_s=1200.0,
+        )
+        assert payload["name"] == "bash"
+        assert payload["category"] == "compute"
+        assert payload["timeout_s"] == 1200.0
+        assert payload["parameters"] == {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to run",
+                }
+            },
+            "required": ["command"],
+        }
+        source = payload["source"]
+        assert source["invocation_style"] == "docker_compose_exec"
+        assert source["class_name"] == "bash"
+        assert source["module_path"] == ""
+        # Default toolset is adapter-neutral so an adapter overrides only if
+        # its factory-side dispatch needs the historical label.
+        assert source["toolset"] == "coding_harness"
+        assert source["extra"] == {
+            "service": "agent",
+            "compose_project_prefix": "tolokaforge-tbench",
+        }
+
+    def test_toolset_override_reaches_the_source(self, adapter: _Adapter) -> None:
+        payload = adapter.emit_harness_tool_schema(
+            service="agent",
+            compose_project_prefix="tolokaforge-tbench",
+            timeout_s=1200.0,
+            toolset="terminal_bench",
+        )
+        assert payload["source"]["toolset"] == "terminal_bench"
+
+
+class TestEmitTestExecutionGrading:
+    def test_payload_matches_the_test_execution_grading_dispatch(self, adapter: _Adapter) -> None:
+        # The runner dispatches on grading_method="test_execution"; weights
+        # and threshold match the historical terminal-bench values so a run
+        # switching to the mixin scores byte-identically.
+        assert adapter.emit_test_execution_grading() == {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+            "grading_method": "test_execution",
+        }
+
+
+class TestWriteInstallScriptLayer:
+    def test_writes_dockerfile_and_install_script_flat_under_context_dir(
+        self, adapter: _Adapter, tmp_path: Path
+    ) -> None:
+        spec = HARNESSES["codex"]
+        dockerfile_relpath = adapter.write_install_script_layer(
+            tmp_path, base_image="python:3.11-slim", spec=spec
+        )
+        assert dockerfile_relpath == "harness.Dockerfile"
+
+        # Installer is copied into the context, verbatim.
+        installed = tmp_path / INSTALL_SCRIPT.name
+        assert installed.is_file()
+        assert installed.read_bytes() == INSTALL_SCRIPT.read_bytes()
+
+        dockerfile_text = (tmp_path / dockerfile_relpath).read_text()
+        lines = dockerfile_text.splitlines()
+        # FROM line — base image passthrough.
+        assert lines[0] == "FROM python:3.11-slim"
+        # COPY sources the sibling installer by its bare basename (context is
+        # tmp_path itself), destinations the container-side install path
+        # the RUN line then invokes.
+        assert lines[1] == f"COPY {INSTALL_SCRIPT.name} /opt/tolokaforge/install-harness.sh"
+        assert lines[2] == (
+            "RUN sh /opt/tolokaforge/install-harness.sh "
+            f"{spec.install_method} "
+            f"{shlex.quote(spec.install_source)} {shlex.quote(spec.version)}"
+        )
+
+    def test_middleware_proxy_flag_copies_proxy_and_adds_copy_line(
+        self, adapter: _Adapter, tmp_path: Path
+    ) -> None:
+        spec = HARNESSES["kimi-code"]
+        adapter.write_install_script_layer(
+            tmp_path, base_image="python:3.11-slim", spec=spec, middleware_proxy=True
+        )
+        proxy_dest = tmp_path / MIDDLEWARE_PROXY_SCRIPT.name
+        assert proxy_dest.is_file()
+        assert proxy_dest.read_bytes() == MIDDLEWARE_PROXY_SCRIPT.read_bytes()
+
+        dockerfile_text = (tmp_path / "harness.Dockerfile").read_text()
+        assert (
+            f"COPY {MIDDLEWARE_PROXY_SCRIPT.name} {MIDDLEWARE_PROXY_CONTAINER_PATH}"
+            in dockerfile_text
+        )
+
+    def test_middleware_proxy_default_off_omits_proxy_copy(
+        self, adapter: _Adapter, tmp_path: Path
+    ) -> None:
+        spec = HARNESSES["codex"]
+        adapter.write_install_script_layer(tmp_path, base_image="python:3.11-slim", spec=spec)
+        assert not (tmp_path / MIDDLEWARE_PROXY_SCRIPT.name).exists()
+        dockerfile_text = (tmp_path / "harness.Dockerfile").read_text()
+        assert MIDDLEWARE_PROXY_CONTAINER_PATH not in dockerfile_text
+
+    def test_dockerfile_ends_with_a_trailing_newline(
+        self, adapter: _Adapter, tmp_path: Path
+    ) -> None:
+        # Docker doesn't require it, but every text file we write elsewhere in
+        # the repo ends with one; pinning the convention avoids a churn diff
+        # if the terminal-bench refactor decides to keep the file byte-identical.
+        adapter.write_install_script_layer(
+            tmp_path, base_image="python:3.11-slim", spec=HARNESSES["codex"]
+        )
+        assert (tmp_path / "harness.Dockerfile").read_text().endswith("\n")


### PR DESCRIPTION
## Summary

`agent_harness` is no longer a `terminal_bench`-adapter parameter. It's a first-class run-config field any adapter can accept:

```yaml
models:
  agent:
    provider: openrouter
    name: "openrouter/anthropic/claude-sonnet-4-6"
    harness: "claude-code"           # ← declared alongside the model
```

Two shipped adopters in-tree — `terminal_bench` (refactored to use the shared mixin) and `native` (newly opted in, with a `fix_factorial` example pack). The orchestrator refuses `models.agent.harness` on adapters that haven't opted in via the mixin, before any container work.

Approved plan: `~/.claude/plans/we-recently-introduced-a-reflective-coral.md`. ADR: [`docs/adr/0039-coding-harness-adapter-agnostic.md`](docs/adr/0039-coding-harness-adapter-agnostic.md).

## Anatomy — 10 commits, 6 moves

1. `85d2b2b` **schema** — `ModelConfig.harness` + parse-time alias lift for `evaluation.harness_adapter.params.{agent_harness,agent_model}` → `models.agent.{harness,name}` with `DeprecationWarning`. Orchestrator's `load_tasks` gate refuses harness selection on non-opt-in adapters.
2. `02296884` + `84ff55c6` **mixin** — `tolokaforge_coding_harnesses.adapter_support.CodingHarnessAdapterMixin` extracted. Six helpers, payload-dict returns (adapters do `ToolSchema(**payload)` at call sites) preserve the package's zero-engine-import invariant.
3. `381ff8cc` + `f3e29d65` + `c7c057d2` **terminal-bench refactor** — inherits the mixin. `toolset="terminal_bench"` explicit override preserves byte-identical canonical replay for `examples/terminal_bench/run_harness.yaml`.
4. `6803ac88` + `c3c2700f` **native adopter + example pack** — `NativeAdapter` opts into harness mode when `params["agent_harness"]` is set. New `examples/native/coding_harness/fix_factorial` pack (Python 3.11-slim, pytest verifier). Oracle preflight: buggy=0.667, fixed=1.000, verifier=0.42s.
5. `c2e36e1c` **state-checks composability** — runner service snapshots the trial container's filesystem into `state["filesystem"]` when grading is not `test_execution`. `test_execution` short-circuits before `_assemble_jsonpath_state`, so terminal-bench's byte-identity is preserved naturally. New `tolokaforge/runner/harness_state.py` helper. Adapter conventions: `agent_visible_dir` = `/work` (native), `/app` (terminal-bench).
6. `7ea899fa` **docs** — new ADR-0039, `docs/CODING_HARNESSES.md` rewritten to lead with the canonical shape, `tolokaforge_coding_harnesses/README.md` "Adopting the mixin" section, `docs/ADAPTER_ARCHITECTURE.md` mixin-as-capability paragraph, AGENTS.md rule 8, CHANGELOG entry.

## Non-goals

- No changes to the six shipped harnesses (`claude-code`, `codex`, `gemini-cli`, `kimi-code`, `opencode`, `grok-build`).
- No new wire-format changes (`GradeTrialRequest` untouched; state passes through in-process).
- No changes to the harness registry, provider-env allow-list, or middleware proxy.
- `migration-bench` (private repo) mixin adoption — natural next step but out of scope for this PR.

## Backward compatibility

The pre-lift shape (`evaluation.harness_adapter.params.agent_harness` / `agent_model`) still parses and runs. `RunConfig` model_validator lifts each legacy key to `models.agent.*` at parse time and emits `DeprecationWarning` naming the new location. Collision policy matches the existing dual-home lift for `orchestrator.*` fields: equal warns once, differs raises `ValueError` naming both keys.

The shipped `examples/terminal_bench/run_harness.yaml` is unmodified and still runs — proof the compat path works end-to-end. Deprecation window: one release, per ADR-0039.

## Test plan

- [x] `tests/unit/test_harness_adapter_params_aliases.py` — 8 new cases (alias lift ×2, collision, no-both, canonical-only, harness field type). Green.
- [x] `tolokaforge_coding_harnesses/tests/unit/test_adapter_support.py` — 22 new cases (mixin helpers, boundary-clean, byte-identical against `harness_command()`). Green.
- [x] `tolokaforge_coding_harnesses/tests/unit/test_package_boundary.py` — invariant holds; mixin imports zero engine modules. Green.
- [x] `tolokaforge_coding_harnesses/tests/canonical/test_pypi_ready.py` — `adapter_support.py` in shipped-paths tuple, sdist + wheel carry it. Green.
- [x] `tests/canonical/test_terminal_bench_adapter_canon.py` — 21 canonical anchors byte-identical after Move 3 refactor. Green.
- [x] `tests/canonical/test_terminal_bench_harness_mode.py`, `test_gateway_route_recipes.py`, `test_engine_run_state_harness_fingerprint.py` — 45 canonical harness-mode locks. Green.
- [x] `tests/canonical/test_terminal_bench_examples_strict_task_load.py` — updated to read from the canonical post-lift location. Green with 22 `DeprecationWarning` firings (proof the alias path works on real YAML).
- [x] `tests/canonical/test_harness_registry_replay.py` — metric bumped twice as required (Move 2 mixin extract, Move 3 tbench refactor). Green.
- [x] `tests/unit/test_native_adapter_harness_mode.py` — 10 new cases for the native harness-mode branch. Green.
- [x] `tests/canonical/test_native_coding_harness_example.py` — 3 canonical cases lock the four-key metadata + the run_harness.yaml validates. Green.
- [x] `tests/unit/test_harness_state_snapshot.py` — 13 cases for the container-fs snapshot helper. Green.
- [x] `tests/unit/test_runner_filesystem_grading_state.py` — 11 cases (6 new) locking the four routing branches + composition claim (`state["filesystem"]` composes with `StateChecker.check_jsonpaths`). Green.
- [x] Full harness-surface regression battery: `407 passed` in 16.7s across every test named above.
- [x] `tolokaforge run --dry-run` on the new `examples/native/coding_harness/run_harness.yaml` (canonical shape) → parses cleanly, dry-run renders task fix_factorial.
- [x] `tolokaforge run --dry-run` on the legacy `examples/terminal_bench/run_harness.yaml` → parses cleanly, `DeprecationWarning`s fire naming both aliases.
- [ ] Real-provider smoke on the new native pack under `claude-code` — not gated on merge; the oracle preflight (reward 1.0) is the $0 proof that the pack + adapter wiring resolve end-to-end.