### PR TITLE
docs(grader): drop closed K8s follow-up pointer

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -210,9 +210,7 @@ queue = "tolokaforge.core.trial_grader:queue_trial_grader_factory"
 
 `deploy/standalone/docker-compose.yaml` is the operator template — no
 Kubernetes manifest ships in-tree. Adapting the compose recipe to a
-Kubernetes cluster is the operator's job; the follow-up
-[#1272](https://github.com/Toloka/tolokaforge/issues/1272) tracks a
-first-party K8s example.
+Kubernetes cluster is the operator's job.
 
 The `tolokaforge-grader` image ships alongside the other four first-party
 images. `deploy/standalone/docker-compose.yaml` brings the five-service


### PR DESCRIPTION
## Summary
- #1272 was closed as not planned. This PR drops the sentence in `docs/GRADER_SERVICE.md` that pointed at it.

## Test plan
- Docs-only.