### PR TITLE
chore(intake): add GitHub Issue Forms requiring priority + type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Something isn't working — a defect, regression, crash, or incorrect result.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in every required field —
+        `priority` in particular is required so the backlog stays triaged.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What went wrong?
+      description: One or two sentences describing the defect.
+      placeholder: e.g. "Grader returns success for a failing test when jsonpath assertion is nested."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps someone else can follow. Include the exact command, config, or task if relevant.
+      placeholder: |
+        1. Run `uv run tolokaforge run examples/native/tool_use ...`
+        2. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: What should have happened, and what actually happened. Paste error output verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Version / branch / commit, Python, OS, Docker version if applicable.
+      value: |
+        - tolokaforge commit / version:
+        - Python:
+        - OS:
+        - Docker (if relevant):
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: |
+        - **P0** — production down or blocks core user flow, no workaround.
+        - **P1** — important UX/stability/correctness gap.
+        - **P2** — improvement or hardening, not user-blocking.
+        - **P3** — cleanup, nitpick, deferred.
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (optional)
+      description: Which subsystem does this touch? Leave blank if unsure.
+      options:
+        - grading
+        - runtime / runner
+        - orchestrator
+        - cli
+        - harness
+        - testing
+        - docs
+        - ci
+        - other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,58 @@
+name: Chore / tech-debt / documentation
+description: Refactor, cleanup, docs update, tech-debt paydown, or maintenance work with no user-visible behaviour change.
+title: "chore: <short description>"
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for work that isn't a bug or a user-facing feature — cleanup, refactors,
+        docs, dependency bumps, tech-debt paydown, or maintenance. `priority` is required.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What needs to change, and what's the boundary? Include file paths, subsystems, or PRs it follows on from.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why now?
+      description: What triggered this — a recent PR, an incident, an audit finding, a doc drift check, a dependency EOL? Keep it short.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      description: Which flavour of chore is this? (Applies a secondary label on submit — see title prefix.)
+      options:
+        - refactor / tech-debt
+        - documentation
+        - testing
+        - dependencies
+        - ci
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: |
+        - **P0** — blocks a release or a user-facing commitment.
+        - **P1** — meaningful debt or gap; schedule soon.
+        - **P2** — worth doing; not urgent.
+        - **P3** — nice-to-have, opportunistic.
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -29,7 +29,7 @@ body:
     id: kind
     attributes:
       label: Kind
-      description: Which flavour of chore is this? (Applies a secondary label on submit — see title prefix.)
+      description: Which flavour of chore is this? Captured in the issue body for triage; does not change labels.
       options:
         - refactor / tech-debt
         - documentation

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Question / help
-    url: https://github.com/Toloka/tolokaforge/discussions
-    about: Please open a discussion for open-ended questions, feedback, or design chat — issues are for concrete bugs, enhancements, and chores.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / help
+    url: https://github.com/Toloka/tolokaforge/discussions
+    about: Please open a discussion for open-ended questions, feedback, or design chat — issues are for concrete bugs, enhancements, and chores.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,69 @@
+name: Enhancement / feature request
+description: Propose a new feature, improvement, or capability.
+title: "feat: <short description>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an enhancement. Please fill in every required field —
+        `priority` in particular is required so the backlog stays triaged.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who is affected? What's the current pain?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What you'd like to see. API sketch, screenshot, or user-visible behaviour is ideal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Approaches you evaluated and why you didn't pick them. Also list workarounds you're using today, if any.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: |
+        - **P0** — blocks a shipped commitment or core user flow.
+        - **P1** — high-value, requested by users, or needed for a near-term milestone.
+        - **P2** — improvement, nice-to-have with a real user case.
+        - **P3** — cleanup, speculative, or deferred.
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (optional)
+      description: Which subsystem does this touch? Leave blank if unsure.
+      options:
+        - grading
+        - runtime / runner
+        - orchestrator
+        - cli
+        - harness
+        - testing
+        - docs
+        - ci
+        - other
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/{bug,enhancement,chore}.yml` — GitHub Issue Forms with a **required** `priority` dropdown (P0–P3) plus type label auto-applied on submit.
- Adds `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues. (Discussions contact link removed — Discussions is disabled on this repo.)
- No workflow automation added — cadence-only strategy: milestone assignment stays a human triage decision caught by the weekly `/weekly-triage` run.

## Why

Baseline (2026-08-25) on Toloka/tolokaforge:
- 414 open issues, growing ~4/day net over the last 12 days.
- 128 P3 vs 15 P1 vs **1 P0** — priority skewed because it isn't required at intake.
- 31% of issues carry no `type` label; 95% carry no milestone.

Templates fix the intake side: every new issue lands with a type + priority already applied, so the weekly triage only has to decide milestone and dedup rather than re-classify from scratch.

## Reviewer feedback applied

- **`chore.yml:32`** — reworded the `kind` dropdown description; Issue Forms cannot apply labels from a dropdown selection, so the previous "applies a secondary label on submit" claim was inaccurate. The `kind` value is captured in the issue body.
- **`config.yml`** — dropped the `contact_links` entry pointing at `/discussions`; Discussions is not enabled on the repo (`has_discussions: false`), so the link would 404 from the picker.

## Test plan

- [ ] After merge, open a test issue via the "Bug report" template — confirm `priority` blocks submission when empty and the `bug` label auto-applies.
- [ ] Same for "Enhancement" and "Chore" templates.
- [ ] Confirm the blank-issue path is disabled (no "Open a blank issue" link on the template picker).