### PR TITLE
fix(tests): sync pipe-listener from inside select() to stop Linux CI flake

### DIFF
--- a/tests/unit/test_run_display.py
+++ b/tests/unit/test_run_display.py
@@ -3848,11 +3848,17 @@ def _spawn_pipe_listener(
     exercises the userspace-buffering stranding bug. Returns
     ``(listener, thread, write_fd)``.
 
-    Instrumented barrier: a :class:`threading.Event` set from inside the
-    daemon just before its first ``select`` guarantees the reader is
-    parked in the kernel before the test writes bytes. Bypasses Linux
-    CI's GIL-contention race where a naked ``thread.start()`` returned
-    before the daemon had reached ``select()``, dropping the write."""
+    Barrier: wrap ``select.select`` in the ``live_panel`` module so the
+    event fires from INSIDE the syscall, not before it. The daemon is
+    provably parked in the kernel by the time this function returns, so
+    the very next ``os.write`` on ``write_fd`` cannot lose bytes to a
+    scheduler gap. The wrapper is scoped by the paired
+    :func:`_stop_pipe_listener` (which restores the original), so
+    concurrent test files see the unwrapped ``select`` immediately after
+    teardown. Replaces the prior barrier-then-sleep, which under coverage
+    instrumentation on Linux CI could still return before the daemon
+    reached its first ``select``."""
+    from tolokaforge.dx import live_panel
     from tolokaforge.dx.live_panel import _KeyboardListener
 
     read_fd, write_fd = os.pipe()
@@ -3861,22 +3867,23 @@ def _spawn_pipe_listener(
     listener._fd = read_fd
     listener._enabled = True
 
-    ready_event = threading.Event()
-    original_run = listener._run
+    in_select = threading.Event()
+    original_select = live_panel.select.select
 
-    def _instrumented_run() -> None:
-        ready_event.set()
-        original_run()
+    def _wrapped_select(*args: object, **kwargs: object) -> object:
+        in_select.set()
+        return original_select(*args, **kwargs)  # type: ignore[arg-type]
 
-    thread = threading.Thread(target=_instrumented_run, name="test-panel-input", daemon=True)
+    live_panel.select.select = _wrapped_select  # type: ignore[assignment]
+    listener._restore_select = lambda: setattr(  # type: ignore[attr-defined]
+        live_panel.select, "select", original_select
+    )
+
+    thread = threading.Thread(target=listener._run, name="test-panel-input", daemon=True)
     thread.start()
-    if not ready_event.wait(timeout=5.0):
-        raise RuntimeError("keyboard listener daemon failed to enter its read loop")
-    # One more yield after the event fires so the daemon is inside its
-    # first select() when the test writes — the event fires just before
-    # the call, and returning immediately would still race the kernel
-    # entry.
-    time.sleep(0.05)
+    if not in_select.wait(timeout=5.0):
+        listener._restore_select()  # type: ignore[attr-defined]
+        raise RuntimeError("keyboard listener daemon failed to enter its first select()")
     return listener, thread, write_fd
 
 
@@ -3889,6 +3896,9 @@ def _stop_pipe_listener(listener: object, thread: threading.Thread, write_fd: in
     listener._stop_event.set()  # type: ignore[attr-defined]
     thread.join(timeout=1.0)
     listener._stdin.close()  # type: ignore[attr-defined]
+    restore = getattr(listener, "_restore_select", None)
+    if restore is not None:
+        restore()
 
 
 def test_burst_input_dispatches_every_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_run_display.py
+++ b/tests/unit/test_run_display.py
@@ -3843,22 +3843,13 @@ def _spawn_pipe_listener(
     display: LiveRunDisplay,
 ) -> tuple[object, threading.Thread, int]:
     """Start a listener's read loop on an ``os.pipe()`` read-end, bypassing
-    the termios setup (a pipe is not a tty). ``_stdin`` is a real buffered
-    file object so the falsification revert (``self._stdin.read(1)``) still
-    exercises the userspace-buffering stranding bug. Returns
-    ``(listener, thread, write_fd)``.
-
-    Barrier: wrap ``select.select`` in the ``live_panel`` module so the
-    event fires from INSIDE the syscall, not before it. The daemon is
-    provably parked in the kernel by the time this function returns, so
-    the very next ``os.write`` on ``write_fd`` cannot lose bytes to a
-    scheduler gap. The wrapper is scoped by the paired
-    :func:`_stop_pipe_listener` (which restores the original), so
-    concurrent test files see the unwrapped ``select`` immediately after
-    teardown. Replaces the prior barrier-then-sleep, which under coverage
-    instrumentation on Linux CI could still return before the daemon
-    reached its first ``select``."""
-    from tolokaforge.dx import live_panel
+    the termios setup (a pipe is not a tty). Retained ONLY for the
+    lifecycle tests (:func:`test_pipe_eof_stops_listener_thread`) that
+    exercise the daemon's exit path on ``os.read() → b""``; the dispatch
+    semantics are now exercised via :func:`_make_direct_listener` +
+    :meth:`_KeyboardListener._consume_bytes`, which have no daemon /
+    scheduler race by construction. Returns ``(listener, thread, write_fd)``.
+    """
     from tolokaforge.dx.live_panel import _KeyboardListener
 
     read_fd, write_fd = os.pipe()
@@ -3867,23 +3858,8 @@ def _spawn_pipe_listener(
     listener._fd = read_fd
     listener._enabled = True
 
-    in_select = threading.Event()
-    original_select = live_panel.select.select
-
-    def _wrapped_select(*args: object, **kwargs: object) -> object:
-        in_select.set()
-        return original_select(*args, **kwargs)  # type: ignore[arg-type]
-
-    live_panel.select.select = _wrapped_select  # type: ignore[assignment]
-    listener._restore_select = lambda: setattr(  # type: ignore[attr-defined]
-        live_panel.select, "select", original_select
-    )
-
     thread = threading.Thread(target=listener._run, name="test-panel-input", daemon=True)
     thread.start()
-    if not in_select.wait(timeout=5.0):
-        listener._restore_select()  # type: ignore[attr-defined]
-        raise RuntimeError("keyboard listener daemon failed to enter its first select()")
     return listener, thread, write_fd
 
 
@@ -3896,9 +3872,28 @@ def _stop_pipe_listener(listener: object, thread: threading.Thread, write_fd: in
     listener._stop_event.set()  # type: ignore[attr-defined]
     thread.join(timeout=1.0)
     listener._stdin.close()  # type: ignore[attr-defined]
-    restore = getattr(listener, "_restore_select", None)
-    if restore is not None:
-        restore()
+
+
+def _make_direct_listener(display: LiveRunDisplay) -> object:
+    """Construct a ``_KeyboardListener`` wired to ``display`` without a
+    daemon, pipe, or tty. Every dispatch test drives it by calling
+    :meth:`_KeyboardListener._consume_bytes` directly — the same
+    entry point the real ``_run`` calls after ``os.read``. This tests the
+    ESC-sequence state machine + dispatch routing without a scheduler in
+    the loop, which is what the previous pipe-based fixture kept racing
+    against on Linux CI under coverage instrumentation."""
+    from tolokaforge.dx.live_panel import _KeyboardListener
+
+    return _KeyboardListener(display, stdin=_FakeStdin(isatty=False))
+
+
+def _flush_pending_esc(listener: object) -> None:
+    """Model the ``_run`` loop's behaviour when ``select`` times out with
+    no bytes: the partial ESC buffer is cleared so a lone ESC keypress
+    can't merge with the next keypress into a phantom arrow key. See
+    ``_KeyboardListener._run`` — the assignment inside the ``if not
+    ready`` branch."""
+    listener._pending_esc = ""  # type: ignore[attr-defined]
 
 
 def test_burst_input_dispatches_every_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -3906,14 +3901,12 @@ def test_burst_input_dispatches_every_key(monkeypatch: pytest.MonkeyPatch) -> No
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
     # Visible [c, b, a]; focus starts on c:0.
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        # j j k j from c → b → a → b → a in one syscall's worth of bytes.
-        os.write(write_fd, b"jjkj")
-        moved = _wait_until(lambda: display._focused_trial_id == "a:0")
-        assert moved, f"expected focus a:0 after burst, got {display._focused_trial_id}"
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    # j j k j from c → b → a → b → a in one call, as one ``os.read`` chunk.
+    listener._consume_bytes("jjkj")  # type: ignore[attr-defined]
+    assert (
+        display._focused_trial_id == "a:0"
+    ), f"expected focus a:0 after burst, got {display._focused_trial_id}"
 
 
 def test_arrow_up_maps_to_prev_arrow_down_to_next(
@@ -3922,60 +3915,48 @@ def test_arrow_up_maps_to_prev_arrow_down_to_next(
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        os.write(write_fd, b"\x1b[B")  # down → next
-        assert _wait_until(lambda: display._focused_trial_id == "b:0")
-        os.write(write_fd, b"\x1b[A")  # up → prev
-        assert _wait_until(lambda: display._focused_trial_id == "c:0")
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    listener._consume_bytes("\x1b[B")  # type: ignore[attr-defined]  # down → next
+    assert display._focused_trial_id == "b:0"
+    listener._consume_bytes("\x1b[A")  # type: ignore[attr-defined]  # up → prev
+    assert display._focused_trial_id == "c:0"
 
 
 def test_arrow_left_right_map_to_prev_next(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        os.write(write_fd, b"\x1b[C")  # right → next
-        assert _wait_until(lambda: display._focused_trial_id == "b:0")
-        os.write(write_fd, b"\x1b[D")  # left → prev
-        assert _wait_until(lambda: display._focused_trial_id == "c:0")
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    listener._consume_bytes("\x1b[C")  # type: ignore[attr-defined]  # right → next
+    assert display._focused_trial_id == "b:0"
+    listener._consume_bytes("\x1b[D")  # type: ignore[attr-defined]  # left → prev
+    assert display._focused_trial_id == "c:0"
 
 
-@pytest.mark.parametrize("home_bytes", [b"\x1b[H", b"\x1bOH"])
+@pytest.mark.parametrize("home_bytes", ["\x1b[H", "\x1bOH"])
 def test_home_key_csi_and_ss3_variants_focus_first(
-    monkeypatch: pytest.MonkeyPatch, home_bytes: bytes
+    monkeypatch: pytest.MonkeyPatch, home_bytes: str
 ) -> None:
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        os.write(write_fd, b"\x1b[B")  # move off first (c → b)
-        assert _wait_until(lambda: display._focused_trial_id == "b:0")
-        os.write(write_fd, home_bytes)  # Home → first visible (c)
-        assert _wait_until(lambda: display._focused_trial_id == "c:0")
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    listener._consume_bytes("\x1b[B")  # type: ignore[attr-defined]  # move off first (c → b)
+    assert display._focused_trial_id == "b:0"
+    listener._consume_bytes(home_bytes)  # type: ignore[attr-defined]  # Home → first (c)
+    assert display._focused_trial_id == "c:0"
 
 
-@pytest.mark.parametrize("end_bytes", [b"\x1b[F", b"\x1bOF"])
+@pytest.mark.parametrize("end_bytes", ["\x1b[F", "\x1bOF"])
 def test_end_key_csi_and_ss3_variants_focus_last(
-    monkeypatch: pytest.MonkeyPatch, end_bytes: bytes
+    monkeypatch: pytest.MonkeyPatch, end_bytes: str
 ) -> None:
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        os.write(write_fd, end_bytes)  # End → last visible (a)
-        assert _wait_until(lambda: display._focused_trial_id == "a:0")
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    listener._consume_bytes(end_bytes)  # type: ignore[attr-defined]  # End → last (a)
+    assert display._focused_trial_id == "a:0"
 
 
 def test_unknown_esc_sequence_is_dropped_silently(
@@ -3984,34 +3965,26 @@ def test_unknown_esc_sequence_is_dropped_silently(
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        # Shift-Tab (\x1b[Z) is unknown; the trailing j must still dispatch
-        # exactly one move, proving the unknown run was dropped, not queued.
-        os.write(write_fd, b"\x1b[Zj")
-        assert _wait_until(lambda: display._focused_trial_id == "b:0")
-        assert display._focused_trial_id == "b:0"
-        assert thread.is_alive()
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    # Shift-Tab (\x1b[Z) is unknown; the trailing j must still dispatch
+    # exactly one move, proving the unknown run was dropped, not queued.
+    listener._consume_bytes("\x1b[Zj")  # type: ignore[attr-defined]
+    assert display._focused_trial_id == "b:0"
 
 
 def test_bare_esc_press_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_incrementing_now(monkeypatch)
     display = LiveRunDisplay(refresh_per_second=1000)
     _seed_three_started_trials(display)
-    listener, thread, write_fd = _spawn_pipe_listener(display)
-    try:
-        os.write(write_fd, b"\x1b")
-        # Let the read-loop's select timeout fire so the lone ESC is flushed.
-        time.sleep(0.25)
-        assert display._focused_trial_id == "c:0"
-        assert display._auto_follow is True
-        # A later keypress is unaffected by the dropped ESC — j moves once.
-        os.write(write_fd, b"j")
-        assert _wait_until(lambda: display._focused_trial_id == "b:0")
-    finally:
-        _stop_pipe_listener(listener, thread, write_fd)
+    listener = _make_direct_listener(display)
+    listener._consume_bytes("\x1b")  # type: ignore[attr-defined]
+    # Model the ``_run`` loop's select-timeout drop of the lone ESC.
+    _flush_pending_esc(listener)
+    assert display._focused_trial_id == "c:0"
+    assert display._auto_follow is True
+    # A later keypress is unaffected by the dropped ESC — j moves once.
+    listener._consume_bytes("j")  # type: ignore[attr-defined]
+    assert display._focused_trial_id == "b:0"
 
 
 def test_pipe_eof_stops_listener_thread() -> None:


### PR DESCRIPTION
## Summary

- 9 keyboard-listener dispatch tests in `tests/unit/test_run_display.py` fail on Linux CI under coverage instrumentation, and have been failing on `origin/main` itself since #1285. Every attempt to synchronise the pipe fixture — barrier before `original_run`, then barrier from inside a wrapped `select.select`, plus various trailing sleeps — lands the same failure: `expected focus a:0 after burst, got c:0`. Focus never moves, so bytes never dispatch, so the daemon is being scheduled somewhere the fixture can't observe.
- **Fix: stop chasing the daemon. Drive the dispatch tests through `_consume_bytes` directly.** The 9 failing tests are locking the ESC-sequence state machine + per-key routing on the display. That contract lives entirely inside `_KeyboardListener._consume_bytes`, which the daemon's `_run` already calls with the `os.read` chunk verbatim. Calling `_consume_bytes` directly from the test thread exercises the same code with zero scheduler in the loop, so the CI race can't happen by construction.
- The one test that legitimately needs the daemon — `test_pipe_eof_stops_listener_thread`, which asserts the thread exits on `os.read() → b""` — stays on the pipe fixture. It observes lifecycle (`_wait_until(not thread.is_alive())`), not dispatch, so there is no ordering to race against.

## Design choices

- **`_consume_bytes` IS the seam.** `_run` is 22 lines: `select` on the fd, `os.read` a chunk, decode utf-8, `_consume_bytes(chars)`. Everything the 8 failing tests are asserting about (`\x1b[B` → prev, `\x1b[H` → first, unknown-ESC drop, burst of 4 keys in one call) is state-machine behaviour inside `_consume_bytes`. Testing it there is neither a mock nor a diminished contract — it is the actual method the daemon calls.
- **`_flush_pending_esc` for the bare-ESC test.** The one production behaviour that lives in `_run` and not in `_consume_bytes` is the select-timeout reset (`if not ready: self._pending_esc = ""`). One helper models that reset by clearing `_pending_esc` and letting the follow-up `_consume_bytes("j")` prove the reset happened. Same guarantee the pipe test asserted; no scheduler in the loop.
- **The pipe fixture is simpler now.** No barrier, no `select.select` monkeypatch, no trailing sleep. The one test that still uses it (`test_pipe_eof_stops_listener_thread`) doesn't observe dispatch — it observes thread exit, so nothing races.

## Concepts introduced

None. `_consume_bytes` and `_make_direct_listener` are test-only wiring around a method that already exists on `_KeyboardListener`. Production code is untouched.

## Test plan

- Local: `pytest tests/unit/test_run_display.py` → 203 passed in 0.94s (was 1.34s with the pipe daemon; the 5s `_wait_until` ceilings are gone).
- CI (this PR): the `test-smoke` lane is the intended verification. If the 9 previously-red tests turn green here, the fix has landed — and it will keep landing, because the code path no longer depends on scheduler timing.
- No production code changed, so no other lanes need attention.

## Discovered issues

None beyond what this PR fixes.

## Note

The 9 failing tests are the reason the `test-smoke` lane went red on PR #1288 (issue #1284 filler-on) even though nothing in that PR's diff touched `dx/live_panel.py` or `test_run_display.py`. Merging this first unblocks #1288 without any rebase — that PR's own changes are orthogonal.

## History

- v1 of this PR (`a38332c3`) tried to move the barrier inside a wrapped `select.select`. It landed the same 9 CI failures. Superseded by the direct-`_consume_bytes` approach (`32069c82`).