### PR TITLE
fix(runner): re-alias RunnerTranscriptRulesConfig and RunnerRequiredAction

### DIFF
--- a/tests/unit/runner/__init__.py
+++ b/tests/unit/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for tolokaforge/runner surface."""

--- a/tests/unit/runner/test_runner_models_deprecated_aliases.py
+++ b/tests/unit/runner/test_runner_models_deprecated_aliases.py
@@ -1,4 +1,8 @@
-"""Back-compat aliases for the two runner wire types un-prefixed by PR #906.
+"""Locks the module-level back-compat aliases ``RunnerTranscriptRulesConfig`` and
+``RunnerRequiredAction`` on ``tolokaforge.runner.models``: they resolve to the
+canonical ``TranscriptRulesConfig`` / ``RequiredAction``, emit exactly one
+``DeprecationWarning`` per (message, caller-module) citing the retirement
+tracker (#1304), and stay invisible to ``vars()`` / ``dir()``.
 
 Locks:
 
@@ -71,9 +75,9 @@ def test_aliases_do_not_leak_into_module_vars_or_dir() -> None:
 
     If the resolver ever writes into ``globals()``, the alias would appear
     in ``vars(module)`` and be picked up by the reconcile canonical's
-    ``_basemodel_names`` walker, re-introducing the collision PR #906
-    removed. Resolves both aliases first so a caching implementation would
-    have taken effect before the assertions.
+    ``_basemodel_names`` walker, re-creating a duplicate-name collision the
+    reconcile check bans. Resolves both aliases first so a caching
+    implementation would have taken effect before the assertions.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)

--- a/tests/unit/runner/test_runner_models_deprecated_aliases.py
+++ b/tests/unit/runner/test_runner_models_deprecated_aliases.py
@@ -1,0 +1,121 @@
+"""Back-compat aliases for the two runner wire types un-prefixed by PR #906.
+
+Locks:
+
+- Canonical names (``TranscriptRulesConfig``, ``RequiredAction``) resolve
+  without emitting any ``DeprecationWarning``.
+- The deprecated aliases (``RunnerTranscriptRulesConfig``,
+  ``RunnerRequiredAction``) resolve to the *same* class objects and emit
+  exactly one ``DeprecationWarning`` naming both the legacy and canonical
+  spelling and the ``(tracked in #1304)`` retirement suffix.
+- The aliases stay invisible to ``vars()`` / ``dir()`` after resolution —
+  the reconcile canonical walks ``vars(module).items()`` and must not
+  observe a shadow of a canonical class.
+- Genuine typos still raise ``AttributeError`` naming the module.
+- A payload built through the alias classes round-trips through the
+  canonical class equivalently.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from pydantic import BaseModel
+
+from tolokaforge.runner import models as runner_models
+from tolokaforge.runner.models import RequiredAction, TranscriptRulesConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_canonical_names_import_without_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from tolokaforge.runner.models import (  # noqa: F401
+            RequiredAction as _RequiredAction,
+        )
+        from tolokaforge.runner.models import (  # noqa: F401
+            TranscriptRulesConfig as _TranscriptRulesConfig,
+        )
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    messages = [str(w.message) for w in deprecations]
+    assert deprecations == [], f"Canonical imports emitted DeprecationWarning(s): {messages}"
+
+
+def test_runner_transcript_rules_config_alias_returns_canonical_class() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"RunnerTranscriptRulesConfig .*deprecated.*TranscriptRulesConfig.*"
+        r"\(tracked in #1304\)",
+    ):
+        alias = runner_models.RunnerTranscriptRulesConfig
+    assert alias is TranscriptRulesConfig
+    assert alias.__name__ == "TranscriptRulesConfig"
+    assert issubclass(alias, BaseModel)
+
+
+def test_runner_required_action_alias_returns_canonical_class() -> None:
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"RunnerRequiredAction .*deprecated.*RequiredAction.*" r"\(tracked in #1304\)",
+    ):
+        alias = runner_models.RunnerRequiredAction
+    assert alias is RequiredAction
+    assert alias.__name__ == "RequiredAction"
+    assert issubclass(alias, BaseModel)
+
+
+def test_aliases_do_not_leak_into_module_vars_or_dir() -> None:
+    """Invisibility invariant — guards a caching regression.
+
+    If the resolver ever writes into ``globals()``, the alias would appear
+    in ``vars(module)`` and be picked up by the reconcile canonical's
+    ``_basemodel_names`` walker, re-introducing the collision PR #906
+    removed. Resolves both aliases first so a caching implementation would
+    have taken effect before the assertions.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        _ = runner_models.RunnerTranscriptRulesConfig
+        _ = runner_models.RunnerRequiredAction
+    module_vars = vars(runner_models)
+    assert "RunnerTranscriptRulesConfig" not in module_vars
+    assert "RunnerRequiredAction" not in module_vars
+    module_dir = dir(runner_models)
+    assert "RunnerTranscriptRulesConfig" not in module_dir
+    assert "RunnerRequiredAction" not in module_dir
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError, match=r"tolokaforge\.runner\.models.*NotAThing"):
+        _ = runner_models.NotAThing
+
+
+def test_alias_built_payload_round_trips_through_canonical_class() -> None:
+    """A payload constructed via the alias classes validates identically
+    through the canonical class, closing the loop that class identity is
+    the whole of the alias contract — no accidental subclass, no shadow
+    validator, no divergent JSON shape.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        alias_action_cls = runner_models.RunnerRequiredAction
+        alias_rules_cls = runner_models.RunnerTranscriptRulesConfig
+    alias_action = alias_action_cls(
+        action_id="a1",
+        requestor="assistant",
+        name="submit",
+        arguments={"reason": "done"},
+    )
+    alias_rules = alias_rules_cls(required_actions=[alias_action])
+    canonical_action = RequiredAction(
+        action_id="a1",
+        requestor="assistant",
+        name="submit",
+        arguments={"reason": "done"},
+    )
+    canonical_rules = TranscriptRulesConfig(required_actions=[canonical_action])
+    assert alias_rules == canonical_rules
+    round_tripped = TranscriptRulesConfig.model_validate_json(alias_rules.model_dump_json())
+    assert round_tripped == canonical_rules

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -30,8 +30,9 @@ All models use Pydantic v2 ``BaseModel`` for validation and serialization.
 **Back-compat import aliases.** ``RunnerTranscriptRulesConfig`` and
 ``RunnerRequiredAction`` remain importable as aliases for the canonical
 ``TranscriptRulesConfig`` and ``RequiredAction``; access emits a
-``DeprecationWarning`` (tracked for removal in #1304). No other pre-PR-#906
-name is aliased.
+``DeprecationWarning`` (tracked for removal in #1304). The alias set is
+closed to these two names; no other ``Runner``-prefixed variant of a wire
+type is aliased.
 """
 
 from __future__ import annotations

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -26,6 +26,12 @@ The types in this module fall into three tiers:
   travel only on the runner service surface.
 
 All models use Pydantic v2 ``BaseModel`` for validation and serialization.
+
+**Back-compat import aliases.** ``RunnerTranscriptRulesConfig`` and
+``RunnerRequiredAction`` remain importable as aliases for the canonical
+``TranscriptRulesConfig`` and ``RequiredAction``; access emits a
+``DeprecationWarning`` (tracked for removal in #1304). No other pre-PR-#906
+name is aliased.
 """
 
 from __future__ import annotations
@@ -47,6 +53,7 @@ from tolokaforge.core.deprecations import (
     coerce_flat_stack_fields,
     coerce_network_policy_case,
     coerce_security_context_aliases,
+    warn_deprecated,
 )
 from tolokaforge.core.grading.combine_method import CombineMethod, validate_combine_method
 from tolokaforge.core.grading.golden_replay import GoldenReplayRecord
@@ -3345,3 +3352,20 @@ class HashGradingResult(BaseModel):
     def hash_score(self) -> float:
         """Derived from ``hash_match``, so a non-binary or contradictory verdict cannot exist."""
         return 1.0 if self.hash_match else 0.0
+
+
+_DEPRECATED_MODEL_ALIASES: dict[str, str] = {
+    "RunnerTranscriptRulesConfig": "TranscriptRulesConfig",
+    "RunnerRequiredAction": "RequiredAction",
+}
+
+
+def __getattr__(name: str) -> Any:
+    canonical = _DEPRECATED_MODEL_ALIASES.get(name)
+    if canonical is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    warn_deprecated(legacy=name, canonical=canonical, follow_up_issue="1304")
+    # Resolve without caching in ``globals()``: caching would leak the alias
+    # into ``vars(module)`` / ``dir(module)`` and re-collide with the
+    # reconcile canonical's ``_basemodel_names`` walker.
+    return globals()[canonical]


### PR DESCRIPTION
## Summary

- `from tolokaforge.runner.models import RunnerTranscriptRulesConfig` and `RunnerRequiredAction` succeed again and resolve to the canonical `TranscriptRulesConfig` / `RequiredAction` classes (`is` identity, `isinstance` / `issubclass` behave identically).
- Each alias access emits exactly one `DeprecationWarning` per (message, caller-module) via `tolokaforge.core.deprecations.warn_deprecated`, citing #1304 as the retirement tracker.
- Wire schema is unchanged: `required_actions[*].name` stays version-locked in both directions; no field aliases were added.

## Design choices

- **PEP-562 `__getattr__` with no `globals()` cache** — the resolver returns the canonical class directly. Caching (as in the lazy-import idiom at `tolokaforge/runner/__init__.py:55-70`) would leak the alias name into `vars(module)` and `dir(module)` after first access and break the `tests/canonical/test_runner_models_reconcile.py` `_basemodel_names` non-collision invariant. A dedicated unit test locks the invisibility invariant so a future caching regression fails loud.
- **Reuse `warn_deprecated`, don't build a bespoke warning path** — `tolokaforge.core.deprecations.warn_deprecated(legacy=, canonical=, follow_up_issue="1304")` already ships the `(tracked in #<n>)` suffix and the (message, caller-module) dedup shape this ticket needs. Sibling #1291 will reuse this helper too, though its alias mechanism is field-level rather than module-level (see #1304 for the semantic-mismatch discussion).
- **No wire field alias for `tool_name → name`** — deliberately out of scope. `docs/GRADING.md` § "Runner-engine version lock (both directions)" (~1146-1214) documents this rename as a symmetric wire lock; aliasing it would silently accept a version-skewed engine's payload. This PR only widens the Python import surface, not the wire schema.

## Concepts introduced

Back-compat import-alias mechanism on `tolokaforge.runner.models`: a `_DEPRECATED_MODEL_ALIASES: dict[str, str]` mapping plus a module-level PEP-562 `__getattr__` that resolves deprecated names to their canonical classes without polluting `vars(module)` / `dir(module)`, keeping the reconcile canonical's non-collision walker blind to the aliases. The set is closed to two names — no other `Runner`-prefixed variant of a wire type is aliased.

## Plan

Full plan lives at `~/.claude/plans/toloka-tolokaforge/issue-1290-wire-model-aliases.md`. Single stage; key contract points:

- `tolokaforge.runner.models` grows a PEP-562 `__getattr__(name)` beside a `_DEPRECATED_MODEL_ALIASES` mapping.
- Aliases handled: `RunnerTranscriptRulesConfig → TranscriptRulesConfig`, `RunnerRequiredAction → RequiredAction`. Any other unknown attribute raises `AttributeError` unchanged.
- Resolver returns the canonical class object directly; does **not** write to `globals()`.
- Behaviour locked by `tests/unit/runner/test_runner_models_deprecated_aliases.py` (tier: `unit`, 6 test functions):
  - canonical names import silently (`warnings.catch_warnings(record=True)` empty),
  - both aliases return the canonical class (`is` check) and emit one `DeprecationWarning` matching `RunnerX .*deprecated.*Canonical.*\(tracked in #1304\)`,
  - invisibility invariant (`"RunnerX" not in vars(models)` and `not in dir(models)` after alias access),
  - unknown attribute raises `AttributeError` naming the module,
  - a payload built via `RunnerRequiredAction(...)` round-trips through `TranscriptRulesConfig.model_validate_json`.

## Discovered issues

- **Filed:** #1304 — retirement schedule for the deprecation aliases from #1290 (and #1291 if applicable). Every `warn_deprecated` call cites this tracker as `follow_up_issue="1304"`.
- **Fixed in this PR:** None. The "shim at `models.py:3352-3355`" reference in the original issue body was a stale line-number quote — the file is 3347 lines and no shim existed; nothing to remove.
- **Flagged for sibling planning (no separate issue):**
  - Sibling #1291's `expected_hash` alias is not the same alias pattern as this PR. Old field is `str` (a stored digest); new field is `bool` (a comparison-basis selector). Its plan will need a field-level coercer with a semantic-mismatch decision, not a module-level symbol alias. #1304 tracks the disposition.
  - The issue body's third bullet — a validator to coerce `communicate_info: list[dict]` to `list[CommunicateInfo]` — is a no-op today. Pydantic's default coercion already does it; empirically verified with a `TranscriptRulesConfig(communicate_info=[{...}])` round-trip.

## Test plan

- `dev` MCP `run_tests marker=unit path=tests/unit/runner/test_runner_models_deprecated_aliases.py` → 6/6 passing.
- `dev` MCP `run_tests marker=canonical path=tests/canonical/test_runner_models_reconcile.py` → 9/9 passing (untouched, verifies the alias mechanism does not leak into `vars(module)`).
- `dev` MCP `lint_check` + `format_check` on `tolokaforge/runner/models.py` and `tests/unit/runner/` → clean.
- Precondition grep `rg 'RunnerTranscriptRulesConfig|RunnerRequiredAction' docs/ tolokaforge/ tests/` (excluding the alias site + its test + the `_DEPRECATED_MODEL_ALIASES` mapping) → empty. Baseline is clean on `feat/engine-repin-unblock`; nothing else references the deprecated names.
- Post-merge smoke: import both aliases from `tolokaforge.runner.models`, confirm identity + one warning each. Downstream repin (`tolokaforge-tools` `frozen_mcp_core` adapter) can now import the deprecated names and get the canonical classes.

Closes #1290
