### PR TITLE
fix(runner): refuse retired expected_hash with an actionable migration message

### DIFF
--- a/tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py
+++ b/tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py
@@ -1,13 +1,13 @@
 """Locks the wire-layer refusal of ``expected_hash`` on ``RunnerStateChecksConfig``.
 
-The retired key ``expected_hash`` used to carry a stored digest; the current wire
-schema replaces it with ``expect_initial_state: bool`` (a comparison-basis
-selector), a different concept on the same name. A caller that even declares the
-key is speaking the retired schema, so ``RunnerStateChecksConfig`` refuses it at
-the wire layer with a message that names the retirement, the two current sources
-(``golden_actions``, ``expect_initial_state``), and the retirement tracker
-(#1304). The generic Pydantic ``extra_forbidden`` message it replaces does not
-appear.
+``expected_hash`` and ``expect_initial_state`` name different concepts on similar
+names — a stored digest vs. a comparison-basis selector — so
+``RunnerStateChecksConfig`` refuses ``expected_hash`` rather than mapping it
+through: a digest silently absorbed into the selector would grade the trial by a
+rule the emitting engine never asked for. The refusal fires at the wire layer
+with an actionable message naming the two current sources (``golden_actions``,
+``expect_initial_state``) and the retirement tracker (#1304); the generic
+Pydantic ``extra_forbidden`` output does not appear.
 
 Locks:
 
@@ -16,10 +16,9 @@ Locks:
   ``value_error`` naming the retirement, the two migration targets and #1304.
 - The refusal message does not carry Pydantic's generic ``Extra inputs are not
   permitted`` / ``extra_forbidden`` string — the specific migration message wins.
-- ``expect_initial_state=True`` and default construction validate and round-trip
-  — the field the retirement points at is unchanged.
-- An unrelated unknown key still raises the pre-existing generic
-  ``extra_forbidden`` (the migration path is scoped, not leaking).
+- ``expect_initial_state=True`` and default construction validate and round-trip.
+- An unrelated unknown key still raises the generic ``extra_forbidden`` (the
+  migration path is scoped, not leaking).
 """
 
 from __future__ import annotations

--- a/tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py
+++ b/tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py
@@ -1,0 +1,93 @@
+"""Locks the wire-layer refusal of ``expected_hash`` on ``RunnerStateChecksConfig``.
+
+The retired key ``expected_hash`` used to carry a stored digest; the current wire
+schema replaces it with ``expect_initial_state: bool`` (a comparison-basis
+selector), a different concept on the same name. A caller that even declares the
+key is speaking the retired schema, so ``RunnerStateChecksConfig`` refuses it at
+the wire layer with a message that names the retirement, the two current sources
+(``golden_actions``, ``expect_initial_state``), and the retirement tracker
+(#1304). The generic Pydantic ``extra_forbidden`` message it replaces does not
+appear.
+
+Locks:
+
+- Presence of ``expected_hash`` under any value — a populated digest string, a
+  bool, ``None`` — fires the same actionable refusal, with a single
+  ``value_error`` naming the retirement, the two migration targets and #1304.
+- The refusal message does not carry Pydantic's generic ``Extra inputs are not
+  permitted`` / ``extra_forbidden`` string — the specific migration message wins.
+- ``expect_initial_state=True`` and default construction validate and round-trip
+  — the field the retirement points at is unchanged.
+- An unrelated unknown key still raises the pre-existing generic
+  ``extra_forbidden`` (the migration path is scoped, not leaking).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.runner.models import RunnerStateChecksConfig
+
+pytestmark = pytest.mark.unit
+
+_REQUIRED_SUBSTRINGS: tuple[str, ...] = (
+    "expected_hash",
+    "golden_actions",
+    "expect_initial_state",
+    "#1304",
+)
+_RETIREMENT_SYNONYMS: tuple[str, ...] = ("retired", "deleted", "removed")
+
+
+def _assert_actionable_refusal(exc: ValidationError) -> None:
+    errors = exc.errors()
+    assert len(errors) == 1, f"expected single error, got {errors!r}"
+    (error,) = errors
+    assert error["type"] == "value_error", error
+    msg = error["msg"]
+    for substring in _REQUIRED_SUBSTRINGS:
+        assert substring in msg, f"{substring!r} missing from refusal message: {msg!r}"
+    matched = [word for word in _RETIREMENT_SYNONYMS if word in msg]
+    assert matched, f"none of {_RETIREMENT_SYNONYMS!r} appear in refusal message: {msg!r}"
+
+
+def test_expected_hash_digest_string_raises_actionable_refusal() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        RunnerStateChecksConfig(expected_hash="deadbeef" * 8)
+    _assert_actionable_refusal(exc_info.value)
+
+
+@pytest.mark.parametrize("value", [True, False, None])
+def test_expected_hash_key_presence_under_any_value_refuses(value: object) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        RunnerStateChecksConfig(expected_hash=value)
+    _assert_actionable_refusal(exc_info.value)
+
+
+def test_refusal_message_does_not_leak_generic_extra_forbidden() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        RunnerStateChecksConfig(expected_hash="deadbeef")
+    (error,) = exc_info.value.errors()
+    msg = error["msg"]
+    assert "Extra inputs are not permitted" not in msg, msg
+    assert "extra_forbidden" not in msg, msg
+
+
+def test_expect_initial_state_true_validates_and_round_trips() -> None:
+    config = RunnerStateChecksConfig(expect_initial_state=True)
+    assert config.expect_initial_state is True
+
+
+def test_default_construction_validates_and_round_trips() -> None:
+    config = RunnerStateChecksConfig()
+    assert config.expect_initial_state is False
+    assert config.hash_enabled is False
+
+
+def test_unrelated_unknown_key_still_raises_generic_extra_forbidden() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        RunnerStateChecksConfig(hash_weightz=0.5)
+    (error,) = exc_info.value.errors()
+    assert error["type"] == "extra_forbidden", error
+    assert "#1304" not in error["msg"], error

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -413,8 +413,33 @@ class HashComparisonBasis(str, Enum):
     """No source at all: the same initial state, reached by falling through."""
 
 
+_RETIRED_EXPECTED_HASH_MESSAGE: str = (
+    "state_checks.expected_hash has been retired — the key carried a stored digest, "
+    "and the current wire schema replaces it with expect_initial_state: bool, a "
+    "comparison-basis selector (a different concept on the same name, so a digest "
+    "silently mapped through would grade the trial by a rule the emitting engine "
+    "never asked for). Declare a source instead: `expect_initial_state: true` for a "
+    "refusal task whose expected final state is the initial state, or "
+    "`golden_actions: [...]` for a task that changes state. Retirement tracked in "
+    "#1304."
+)
+"""The migration a caller that declares the retired ``expected_hash`` key reads.
+
+Named at module scope so the behaviour-locking test asserts against its substrings
+rather than restating the wording — a reviewer wordsmithing the sentence that
+preserves the substrings stays green.
+"""
+
+
 class RunnerStateChecksConfig(BaseModel):
-    """State-based grading configuration."""
+    """State-based grading configuration on the runner wire.
+
+    Presence of the retired key ``expected_hash`` raises a ``ValidationError``
+    naming the two current sources (``golden_actions``, ``expect_initial_state``)
+    and the retirement tracker (#1304); the wire schema itself is unchanged. The
+    ``state_checks.hash.expected_state_hash`` author-surface retirement is
+    separately handled in :mod:`tolokaforge.core.grading.state_composition`.
+    """
 
     # Hash comparison
     hash_enabled: bool = False
@@ -444,6 +469,20 @@ class RunnerStateChecksConfig(BaseModel):
 
     # Substrate SQL assertions against a task-declared postgres DSN
     db_probes: list[DbProbe] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _refuse_retired_expected_hash(cls, data: Any) -> Any:
+        """Raise the migration a caller that declares ``expected_hash`` reads.
+
+        Fires before Pydantic's ``extra_forbidden`` sweep, so the actionable
+        migration message wins over the generic "Extra inputs are not permitted".
+        Presence of the key at all — populated, falsy, or ``None`` — is enough:
+        a caller that even declares it is speaking the retired schema.
+        """
+        if isinstance(data, Mapping) and "expected_hash" in data:
+            raise ValueError(_RETIRED_EXPECTED_HASH_MESSAGE)
+        return data
 
     @field_validator("id_fields")
     @classmethod

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -423,22 +423,18 @@ _RETIRED_EXPECTED_HASH_MESSAGE: str = (
     "`golden_actions: [...]` for a task that changes state. Retirement tracked in "
     "#1304."
 )
-"""The migration a caller that declares the retired ``expected_hash`` key reads.
-
-Named at module scope so the behaviour-locking test asserts against its substrings
-rather than restating the wording — a reviewer wordsmithing the sentence that
-preserves the substrings stays green.
-"""
+"""The migration message a caller that declares the retired ``expected_hash`` key reads."""
 
 
 class RunnerStateChecksConfig(BaseModel):
     """State-based grading configuration on the runner wire.
 
-    Presence of the retired key ``expected_hash`` raises a ``ValidationError``
-    naming the two current sources (``golden_actions``, ``expect_initial_state``)
-    and the retirement tracker (#1304); the wire schema itself is unchanged. The
-    ``state_checks.hash.expected_state_hash`` author-surface retirement is
-    separately handled in :mod:`tolokaforge.core.grading.state_composition`.
+    Declares no ``expected_hash`` field; a ``mode="before"`` validator refuses the
+    retired key with a ``ValidationError`` naming the two current sources
+    (``golden_actions``, ``expect_initial_state``) and the retirement tracker
+    (#1304). The ``state_checks.hash.expected_state_hash`` author-surface
+    retirement is separately handled in
+    :mod:`tolokaforge.core.grading.state_composition`.
     """
 
     # Hash comparison


### PR DESCRIPTION
## Summary

- `RunnerStateChecksConfig(expected_hash=<any value>)` now raises a `ValidationError` whose single `value_error` names the retirement, the two current sources (`golden_actions`, `expect_initial_state`), the retirement tracker (#1304), and a one-clause concept-mismatch reason.
- Callers that pass the retired key get an actionable migration message instead of Pydantic's generic `Extra inputs are not permitted` / `extra_forbidden` output.
- Wire schema unchanged: `RunnerStateChecksConfig` still declares `extra="forbid"` and no `expected_hash` field. `expect_initial_state=True` and default construction validate cleanly; unrelated unknown keys still raise the generic `extra_forbidden`.

## Design choices

- **Hard-refuse via `mode="before"` classmethod validator, not a field alias.** The issue body proposed `Field(alias="expected_hash")` + `populate_by_name=True` + `DeprecationWarning`. The plan explicitly refuses that path on three grounds:
  1. **Semantic mismatch.** Old field was `str` (a stored digest); new field is `bool` (a comparison-basis selector). A pydantic alias would silently coerce a digest string to `True` and grade the trial by a rule the emitting engine never chose.
  2. **`docs/GRADING.md:1146-1214` (Runner-engine version lock).** The section enshrines `expected_hash` refusal as a designed both-directions symmetric wire lock. The paragraph at 1168-1174 explicitly says "the digest it replaces is retired."
  3. **Sibling #1305 (PR for #1290) applied the same reasoning** to `required_actions[*].tool_name → name` as a non-goal.
- **Mirror the `state_composition.py` sibling pattern with inverted disposition.** `tolokaforge/core/grading/state_composition.py:60-76` uses a `mode="before"` classmethod to inspect the author-layer input dict and drop retired hash keys *inertly*. This PR mirrors the pattern one layer down at the wire model, inverted to **refuse-with-message** — because the wire layer's designed behaviour under `docs/GRADING.md:1146-1214` is refusal, not silent absorption.
- **Message-as-module-level-constant, tests substring-match.** `_RETIRED_EXPECTED_HASH_MESSAGE` is the single source of truth for the migration prose. Tests assert five hard substrings (`expected_hash`, one of `retired`/`deleted`/`removed`, `golden_actions`, `expect_initial_state`, `#1304`), not the whole sentence, so message wordsmithing that preserves the substrings does not break the tests.

## Concepts introduced

Wire-layer retirement primitive on `RunnerStateChecksConfig`: a `mode="before"` classmethod validator that inspects the input `Mapping`, detects presence of the retired key under any value (populated, falsy, `None`), and raises a `ValueError` naming the retirement tracker. Distinct from the author-layer sibling in `state_composition.py` (which drops retired keys inertly) and from #1305's module-level symbol-alias mechanism (which resolves deprecated names to canonical classes). Only the retirement tracker #1304 is genuinely shared across the three surfaces.

## Plan

Full plan lives at `~/.claude/plans/toloka-tolokaforge/issue-1291-expected-hash-alias.md`. Single stage; key contract points:

- Module-level `_RETIRED_EXPECTED_HASH_MESSAGE: str` constant adjacent to `RunnerStateChecksConfig` in `tolokaforge/runner/models.py`.
- `_refuse_retired_expected_hash` `mode="before"` classmethod validator: inspects `isinstance(data, Mapping)`, raises `ValueError(_RETIRED_EXPECTED_HASH_MESSAGE)` iff `"expected_hash"` is present under any value; returns input unchanged otherwise.
- Behaviour locked by `tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py` (tier: `unit`, 6 test functions / 8 parametrized cases):
  - presence under populated `str`, `True`, `False`, `None` all fire the same actionable refusal;
  - refusal message does NOT contain `"Extra inputs are not permitted"` or `"extra_forbidden"` (substring negation);
  - `expect_initial_state=True` and default construction validate and round-trip;
  - an unrelated unknown key still raises the pre-existing generic `extra_forbidden` (scoping check).
- Docstrings on the constant and class describe current state only — no PR/history attribution, no "previously X → now Y" narration (hygiene reviewer round 1 caught this, follow-up commit `0b1b0411` fixed it).

## Discovered issues

- **Filed:** None new. #1304 (already open, from #1290) is the shared retirement tracker.
- **Fixed in this PR:** None. Sibling `state_composition.py:60-76` handles the author-layer retirement correctly and is untouched.
- **Flagged for main / downstream repin (no separate issue — noted in the umbrella):**
  - **#1304's title is loose for #1291.** #1291 is a refusal, not a "deprecation alias"; consider amending #1304's title after this PR lands.
  - **Umbrella #1303's claim that E8a and E8b "reuse the same pydantic-alias pattern" is empirically wrong.** Only the retirement tracker is shared; the mechanisms differ (module-level symbol alias vs. wire-field refusal).
  - **Downstream adapters still emitting `expected_hash` must migrate on the emit side.** This PR does not accept the old schema; it strengthens the error message. Downstream repin PRs need to rewrite the emitter to send `expect_initial_state: bool` or `golden_actions: [...]` — a runner-side compat layer is not on offer for this field.

## Test plan

- `dev` MCP `run_tests marker=unit path=tests/unit/runner/test_runner_state_checks_expected_hash_refusal.py` → 8/8 passing.
- `dev` MCP `run_tests marker=canonical path=tests/canonical/test_grading_wire_lock.py` → 13/13 passing (wire-lock canonical unchanged).
- `dev` MCP `run_tests marker=canonical path=tests/canonical/test_runner_models_reconcile.py` → 9/9 passing (reconcile canonical unchanged).
- `dev` MCP `run_tests marker=unit path=tests/unit/dx/test_validate_grading_migrations.py` → 169/169 passing (author-layer retirement untouched).
- `dev` MCP `lint_check` + `format_check` on `tolokaforge/runner/models.py` and `tests/unit/runner/` → clean.
- Precondition grep `rg '"expected_hash"|expected_hash=' tolokaforge/ tests/` with excludes for `state_checks.py`, the new refusal test, `fuzzy_compare.py` (fuzzy-comparator dict key, unrelated), and its snapshot → empty. No other in-tree caller constructs the wire type with the retired key.
- Post-merge smoke: `RunnerStateChecksConfig(expected_hash="deadbeef")` — expect `ValidationError` with the five migration substrings and no `extra_forbidden` leak.

Closes #1291
