### PR TITLE
fix(orchestrator): record run-config path in run_state.json, not the output dir

### DIFF
--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -104,6 +104,22 @@ Written via [`tolokaforge.core.engine_run_state.write_engine_run_state`](../tolo
 
 `adapter_fingerprints` is populated from [`BaseAdapter.fingerprint()`](../tolokaforge/adapters/base.py) — see [`docs/ADAPTER_INTERFACE.md`](ADAPTER_INTERFACE.md) § Optional Methods for the seam an adapter overrides to report one. For the `terminal_bench` namespace, that adapter's [README](../external_adapters/tolokaforge-adapter-terminal-bench/README.md) § "What a run records about its registry" documents its payload.
 
+## `run_state.json`
+
+Written under `{output_dir}/` at run start by `tolokaforge run` and updated as each trial completes. Carries the per-trial ledger `--resume` reads to decide which trials still need to execute (see [`docs/CLI.md`](CLI.md) § Resume). Fields consumed by the resume path are `run_id`, `status`, and the per-trial entries under `trials`; the remaining fields are provenance for post-run inspection.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `run_id` | string | Canonical run identifier — the `{output_dir}` basename. Matches the `run_id` in `engine_run_state.json` and every `TrialSpec.run_id`. |
+| `config_path` | string | Path to the run-config YAML `tolokaforge run` / `prepare` / `worker` was invoked with (relative to CWD when possible; absolute otherwise; `""` when a programmatic caller constructed the orchestrator without one). |
+| `output_dir` | string | The run's output directory (relative to CWD when under it; absolute otherwise). |
+| `start_ts` / `last_updated` | ISO 8601 timestamp | Run start and most-recent update. |
+| `status` | `"running"` \| `"paused"` \| `"completed"` \| `"failed"` | Run-level state. `--resume` short-circuits when every trial is already `completed`. |
+| `total_trials` / `completed_trials` / `failed_trials` | integer | Counters across the `trials` map. |
+| `trials` | object | Per-trial ledger keyed by `"{task_id}:{trial_index}"`, each value carrying `task_id`, `trial_index`, `status` (`pending` / `running` / `completed` / `failed`), timestamps, optional `binary_pass`, `score`, and `error`. |
+
+Written via [`tolokaforge.core.resume.RunStateManager`](../tolokaforge/core/resume.py); the on-disk shape is locked by the `RunState` and `TrialState` Pydantic models. CWD-relative shaping applies to `config_path` and `output_dir` via `RunStateManager._normalize_to_relative`.
+
 ## `LIMIT_HIT.json`
 
 Written under `{output_dir}/` on the first budget crossing during a

--- a/tests/data/projects/tau_retail_mini/output/run_state.json
+++ b/tests/data/projects/tau_retail_mini/output/run_state.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38aaa46014598c0f33503edc01c5ac399013a45a92dbf8778fbaa3c6acb85aea
-size 1173
+oid sha256:40f8c0d65a90917e9c42e04dd7ab822a1fbb6dbb35d1aa8238f015e0586fc429
+size 1129

--- a/tests/unit/test_orchestrator_run_state.py
+++ b/tests/unit/test_orchestrator_run_state.py
@@ -1,0 +1,144 @@
+"""``Orchestrator(config_path=...)`` records the operator's YAML path in ``run_state.json``.
+
+The fresh-run branch of :meth:`Orchestrator.run` threads the constructor's
+``config_path`` verbatim into :meth:`RunStateManager.initialize_run`, which
+normalises it to CWD-relative and writes it to disk. A programmatic caller that
+supplies no path gets the ``""`` sentinel — :class:`RunState.config_path` stays
+``str``.
+
+The test exercises the real seam (``__init__`` → ``run()`` → ``initialize_run``
+→ disk) and short-circuits ``run()`` immediately after the state file lands, by
+patching :func:`write_engine_run_state` — the very next call after the seam
+under test — to raise a sentinel. :class:`RunStateManager` is not stubbed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from tests.canonical._factories import make_task_config
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
+from tolokaforge.core.runtime import InMemoryRuntimeBackend
+from tolokaforge.runner.models import RunnerGradingConfig, TaskDescription
+
+
+class _AbortRunAfterStateWrite(Exception):
+    """Sentinel: ``write_engine_run_state`` fired, so ``run_state.json`` is on disk."""
+
+
+def _stub_task_description(task_id: str) -> TaskDescription:
+    return TaskDescription(
+        task_id=task_id,
+        name=task_id,
+        category="test",
+        description="d",
+        adapter_type="native",
+        system_prompt="sys",
+        grading=RunnerGradingConfig(llm_judge=None),
+    )
+
+
+def _minimal_run_config(output_dir: Path) -> RunConfig:
+    return RunConfig(
+        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        orchestrator=OrchestratorConfig(
+            workers=1,
+            repeats=1,
+            auto_start_services=False,
+            shuffle_trials=False,
+        ),
+        evaluation=EvaluationConfig(output_dir=str(output_dir)),
+    )
+
+
+def _drive_fresh_run_state_write(
+    orch: Orchestrator,
+    *,
+    run_id: str,
+    output_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Call ``orch.run()`` far enough to write ``run_state.json``, then stop.
+
+    Sentinel raised from the ``write_engine_run_state`` call right after
+    ``RunStateManager.initialize_run`` returns, so the state file is on disk
+    when the exception propagates.
+    """
+
+    def _abort(*_args: Any, **_kwargs: Any) -> None:
+        raise _AbortRunAfterStateWrite
+
+    monkeypatch.setattr("tolokaforge.core.orchestrator.write_engine_run_state", _abort)
+    with pytest.raises(_AbortRunAfterStateWrite):
+        orch.run(run_id=run_id, output_dir=output_dir)
+
+
+def _orchestrator_ready_for_fresh_run(
+    config: RunConfig,
+    *,
+    config_path: Path | None,
+    task_id: str = "TASK-A",
+) -> Orchestrator:
+    orch = Orchestrator(
+        config,
+        deps=OrchestratorDeps(runtime_backend=InMemoryRuntimeBackend()),
+        config_path=config_path,
+    )
+    orch.tasks = [make_task_config(task_id)]
+    adapter = MagicMock()
+    adapter.to_task_description.side_effect = _stub_task_description
+    adapter.fingerprint.return_value = None
+    orch.adapter = adapter
+    return orch
+
+
+class TestOrchestratorConfigPathThreading:
+    """``config_path`` supplied at construction reaches ``run_state.json``."""
+
+    def test_relative_cli_path_lands_verbatim_in_run_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cfg_dir = tmp_path / "configs"
+        cfg_dir.mkdir()
+        (cfg_dir / "run.yaml").write_text("# placeholder\n")
+
+        output_dir = tmp_path / "results" / "run_0"
+        run_config = _minimal_run_config(output_dir=output_dir)
+        orch = _orchestrator_ready_for_fresh_run(run_config, config_path=Path("configs/run.yaml"))
+
+        _drive_fresh_run_state_write(
+            orch, run_id="run_0", output_dir=output_dir, monkeypatch=monkeypatch
+        )
+
+        state = json.loads((output_dir / "run_state.json").read_text())
+        assert state["config_path"] == "configs/run.yaml"
+
+    def test_none_config_path_writes_empty_sentinel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        output_dir = tmp_path / "results" / "run_0"
+        run_config = _minimal_run_config(output_dir=output_dir)
+        orch = _orchestrator_ready_for_fresh_run(run_config, config_path=None)
+
+        _drive_fresh_run_state_write(
+            orch, run_id="run_0", output_dir=output_dir, monkeypatch=monkeypatch
+        )
+
+        state = json.loads((output_dir / "run_state.json").read_text())
+        assert state["config_path"] == ""

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -485,11 +485,19 @@ class Orchestrator:
         strict: bool = False,
         deps: OrchestratorDeps | None = None,
         project: ProjectConfig | None = None,
+        *,
+        config_path: Path | None = None,
     ):
         self.config = config
         self.resume = resume
         self.verbose = verbose
         self.strict = strict
+        # Path to the run-config YAML the operator invoked with, threaded from
+        # the CLI (``tolokaforge run`` / ``prepare`` / ``worker``) and stamped
+        # verbatim into ``run_state.json`` at initialize time. ``None`` marks a
+        # programmatic caller that supplied no path — the fresh-run branch
+        # writes ``""`` to keep :class:`RunState.config_path` a plain ``str``.
+        self._config_path: Path | None = config_path
         # Enclosing project (loaded from ``project.yaml``). Adapter
         # instantiation reads ``project.task_defaults`` from here so every
         # task inherits the project-level defaults declared alongside
@@ -1928,7 +1936,7 @@ class Orchestrator:
             task_ids = [task.task_id for task in self.tasks]
             run_state = self.state_manager.initialize_run(
                 run_id=run_id,
-                config_path=str(self.config.evaluation.output_dir),
+                config_path=str(self._config_path) if self._config_path is not None else "",
                 task_ids=task_ids,
                 repeats=self.config.orchestrator.repeats,
             )

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -894,6 +894,7 @@ def run(
                     budget=budget,
                     agent_client_factory=agent_client_factory,
                 ),
+                config_path=Path(config),
             )
 
             # NB: no `console.print` calls between LiveRunDisplay.__enter__ and
@@ -1523,7 +1524,12 @@ def prepare(
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
     orchestrator = Orchestrator(
-        run_config, resume=False, verbose=verbose, strict=strict, project=project
+        run_config,
+        resume=False,
+        verbose=verbose,
+        strict=strict,
+        project=project,
+        config_path=Path(config),
     )
     orchestrator.load_tasks()
     summary = orchestrator.prepare_run(Path(run_dir), reset_queue=reset_queue)
@@ -1588,7 +1594,12 @@ def worker(
         console.print(f"[cyan]Preset overlay: {overlay_path}[/cyan]")
 
     orchestrator = Orchestrator(
-        run_config, resume=False, verbose=verbose, strict=strict, project=project
+        run_config,
+        resume=False,
+        verbose=verbose,
+        strict=strict,
+        project=project,
+        config_path=Path(config),
     )
     orchestrator.load_tasks()
     summary = orchestrator.run_worker(Path(run_dir), max_attempts=max_attempts)


### PR DESCRIPTION
## Summary

- `run_state.json.config_path` now records the path to the run-config YAML `tolokaforge run` / `prepare` / `worker` was invoked with, not the run output directory.
- Programmatic callers that construct `Orchestrator` without a config path get `""` (the "unknown" sentinel); no `str | None` schema flip on `RunState`.
- Zero production readers of the field today, so this is a write-side bugfix with no consumer migration.

## Design choices

- **Kw-only `config_path: Path | None = None` on `Orchestrator.__init__`, not a positional param.** Purely additive; `*,` separator prevents future positional drift.
- **`""` sentinel on disk, not `str | None`.** `RunState` is a Pydantic BaseModel at the `run_state.json` serialisation boundary; keeping `config_path: str` preserves that boundary's shape. `None → ""` is mapped inside the orchestrator at the write site; `RunStateManager.initialize_run(config_path: str)` is unchanged.
- **`Path(config)` at three CLI call sites, not `Path(config).resolve()`.** Matches the existing `load_effective_run_config(Path(config))` / `construct_config(..., source=Path(config))` pattern at the same sites; leaves `_normalize_to_relative` free to shorten to CWD-relative.

## Concepts introduced

None — mechanical change. New kw-only param threads an existing value; no new abstraction, contract, or vocabulary.

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1294-config-path.md`. Single-stage:

- `Orchestrator.__init__` grows `*, config_path: Path | None = None`, stored as `self._config_path`, consumed at the `initialize_run` call site.
- Three CLI call sites (`tolokaforge/dx/cli/main.py:897, 1532, 1602`) pass `config_path=Path(config)`.
- New unit test at `tests/unit/test_orchestrator_run_state.py` exercises the real seam (`__init__` → `run()` → real `RunStateManager` → disk write → JSON read-back). `RunStateManager` is NOT stubbed. Two behaviour locks: `Path("configs/run.yaml")` → `"configs/run.yaml"`; `None` → `""`. Uses a `write_engine_run_state` monkeypatch to short-circuit `run()` immediately after `initialize_run` returns (the full `_run_orchestrator` scaffold hangs on this worktree — the seam under test is fully exercised regardless).
- Fixture `tests/data/projects/tau_retail_mini/output/run_state.json` updated to `""` (no test consumes the value; the honest "unknown" sentinel is the architect's fallback).
- New `## run_state.json` section in `docs/OUTPUT_FORMAT.md`, parallel to the existing `## engine_run_state.json` section.

## Discovered issues

- **Filed:** None new.
- **Fixed in this PR:** `docs/OUTPUT_FORMAT.md` had no `## run_state.json` section — added a focused entry anchoring the corrected semantic. Not a full artifact-reference table; a fuller run_state.json field table remains follow-up work if useful.
- **For main to note:** the `_run_orchestrator`-scaffold tests in `tests/unit/test_ungradeable_trial_accounting.py` hang locally (>300s) on `TestTheRunCountsTheUngradeableAttempt` and `TestTheRunPublishesItsGradingCompleteness`. Adjacent classes in the same file pass in seconds. Environment-specific or a general flake — worth a separate look but not blocking.

## Test plan

- `uv run pytest tests/unit/test_orchestrator_run_state.py tests/unit/test_resume.py -q` → 19 passing.
- `uv run pytest tests/unit/test_orchestrator_logic.py tests/unit/dx/test_cli_resume.py tests/unit/dx/test_cli_status.py -q` → 133 passing.
- `uv run pytest tests/canonical/ -q` → 1707 passing, 1 skipped.
- `rg config_path tolokaforge tests docs` — every hit reflects the corrected semantic; no dead references to `output_dir` as the intended value.
- Sharded review (correctness, hygiene, type-fit): all three APPROVE round 1.

Closes #1294
