### PR TITLE
feat(runtime): persist ProvisionError.stage across metrics.yaml and failure_attribution.json

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -240,7 +240,7 @@ record can see whether the attempt counted, and the summary carries
 Evidence payloads include tool name/index, error strings, state-diff keys, and termination reasons when available.
 
 Every attribution record also carries `provision_stage` as a top-level field, taking one of `provision` / `await_ready` / `reset_recipe` / `register_trial` (the closed
-[`ProvisionStage`](../tolokaforge/core/models/trajectory.py:1) vocabulary) when the trial's `termination_reason` is `provision_error`, and `null` otherwise. It is a first-class attribution field, not an entry inside `evidence`, because it answers "which point of the provisioning lifecycle failed" — the operator's question — rather than describing the evidence for the classification. Present-but-null off the provision path so a reader can access `record["provision_stage"]` unconditionally.
+`tolokaforge.core.models.trajectory.ProvisionStage` vocabulary) when the trial's `termination_reason` is `provision_error`, and `null` otherwise. It is a first-class attribution field, not an entry inside `evidence`, because it answers "which point of the provisioning lifecycle failed" — the operator's question — rather than describing the evidence for the classification. Present-but-null off the provision path so a reader can access `record["provision_stage"]` unconditionally.
 
 ## Programmatic Analysis Example
 

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -239,6 +239,9 @@ record can see whether the attempt counted, and the summary carries
 
 Evidence payloads include tool name/index, error strings, state-diff keys, and termination reasons when available.
 
+Every attribution record also carries `provision_stage` as a top-level field, taking one of `provision` / `await_ready` / `reset_recipe` / `register_trial` (the closed
+[`ProvisionStage`](../tolokaforge/core/models/trajectory.py:1) vocabulary) when the trial's `termination_reason` is `provision_error`, and `null` otherwise. It is a first-class attribution field, not an entry inside `evidence`, because it answers "which point of the provisioning lifecycle failed" — the operator's question — rather than describing the evidence for the classification. Present-but-null off the provision path so a reader can access `record["provision_stage"]` unconditionally.
+
 ## Programmatic Analysis Example
 
 Use the runnable script:

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -383,6 +383,7 @@ user_reply_guard_events:                              # [] on a trial no detecto
 | `first_user_message_source` | `"pinned"`, `"simulator"`, or `null` | set once the turn loop delivers message index 0 | Where the opening user turn came from. `pinned` — the task's `initial_user_message`, delivered verbatim with no simulator dispatch; `simulator` — a user-simulator dispatch wrote it. Partitions a run's trials into authored-opener and generated-opener without re-reading the task pack. `null` means the trial never bootstrapped (it failed first), or the bundle was written before the key existed. A bootstrap the reply guard *refused* is one way to reach the first of those: it leaves the source `null` **and** records a `user_reply_guard_events` entry at `message_index: 0` with `outcome: refused`, and that pair is the signature of a guard-refused opening. |
 | `user_reply_guard_events` | list of `{message_index, outcome, rejected[]}` | one entry per user turn the reply guard did not accept on its first generation | What a defective user turn cost. `[]` is the normal state — a turn accepted on its first generation records nothing. `outcome: delivered` means a later attempt passed the guard and the turn was delivered; `outcome: refused` means the attempt budget was spent, so no clean turn could be produced and the trial errored as a `harness_error`. `rejected` carries one `{detector, reason, excerpt}` per discarded attempt, in order, and is never empty — a turn that discarded nothing is recorded by the absence of an entry, not by an empty list. `detector` is the name the detector is registered under, and `excerpt` is the evidence that detector recorded, truncated to 200 characters — the matched phrase for `fourth_wall`, and for `scratchpad` the matched tag plus the text that follows it, because a bare think tag reads the same whether it leaked or was pasted. `message_index` is the position in `messages` the turn was **dispatched at** — for a turn whose accepted reply was a bare `###STOP###`, and for a refused turn, that position holds the loop's own SYSTEM message rather than a USER turn. |
 | `grading_error` | `str` or `null` | non-null when grading ran and refused to produce a verdict | The reason the grading substrate gave. Such a trial has no `grade.yaml` but keeps its own `status` / `termination_reason`, is counted in `total_trials` and `measured_trials`, and is excluded from `scored_trials`. `null` means grading either succeeded or was correctly not attempted — `grade.yaml`'s presence tells those two apart. |
+| `provision_stage` | `"provision"`, `"await_ready"`, `"reset_recipe"`, `"register_trial"`, or `null` | non-null iff `termination_reason == provision_error` | Which point of the provisioning lifecycle raised `ProvisionError`. `provision` — compose-up failed; `await_ready` — the readiness gate rejected the substrate; `reset_recipe` — the per-trial reset hook failed; `register_trial` — the runner-side arming step refused registration after `provision` + `await_ready` succeeded. The same value also lands on the per-trial [`metrics.yaml`](#provision-failure-bundle) as `error_stage`, so a reader of either artifact alone tells the four apart. `null` on every trial whose termination reason is not `provision_error`. |
 
 ### `messages[*].reasoning.summary` — when populated
 
@@ -994,20 +995,30 @@ The schema stamp says which generation wrote the bundle, never which files it
 contains — on this path it is stamped and most of them are absent.
 
 * `trajectory.yaml` — `status: error`, `termination_reason: provision_error`,
+  `provision_stage` set to the lifecycle step that raised (see below),
   `grading_error: null` (grading never ran), empty `messages`.
 * `metrics.yaml` — the default-`Metrics` shape (`cost_usd: null`,
-  `schema_version: 4`, empty `tool_usage`) plus two top-level failure-signal
+  `schema_version: 4`, empty `tool_usage`) plus three top-level failure-signal
   keys:
 
   ```yaml
   error: provision_error
   error_reason: "partial startup — failed after service 'db'"
+  error_stage: provision
   ```
 
   `error` is the `TerminationReason.PROVISION_ERROR` value, so the failure
   vocabulary matches `trajectory.yaml`'s `termination_reason`; `error_reason`
-  carries the underlying `ProvisionError` reason string. `provisioning_duration_s`
-  and `captured_service_logs` are absent on this path.
+  carries the underlying `ProvisionError` reason string; `error_stage` names
+  the point of the provisioning lifecycle that raised, drawn from the closed
+  vocabulary `provision` / `await_ready` / `reset_recipe` / `register_trial`
+  (`tolokaforge.core.models.trajectory.ProvisionStage`) — a reader tells
+  compose-up (`provision`), the readiness gate (`await_ready`), the per-trial
+  reset (`reset_recipe`), and the runner-side registration (`register_trial`)
+  apart without opening a log stream. `error_stage` is present on this bundle
+  and only on this bundle — a `metrics.yaml` from any other trial carries no
+  such key. `provisioning_duration_s` and `captured_service_logs` are absent
+  on this path.
 * `grade.yaml` — **not written**. The trial body never ran, so there is no
   performance to score; a `0.0` would be indistinguishable from a task the model
   failed. The stage and reason live in `metrics.yaml`'s `error` / `error_reason`

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -1021,8 +1021,8 @@ contains — on this path it is stamped and most of them are absent.
   on this path.
 * `grade.yaml` — **not written**. The trial body never ran, so there is no
   performance to score; a `0.0` would be indistinguishable from a task the model
-  failed. The stage and reason live in `metrics.yaml`'s `error` / `error_reason`
-  above, and the trial is excluded from every rate in
+  failed. The failure class and reason live in `metrics.yaml`'s `error` /
+  `error_reason` above, and the trial is excluded from every rate in
   `per_task_metrics.json` (see § Run-level metric denominators).
 
 Writing this bundle is best-effort: an I/O failure while writing it is logged

--- a/docs/RUNTIME_BACKENDS.md
+++ b/docs/RUNTIME_BACKENDS.md
@@ -472,9 +472,9 @@ half-provisioned resources leaked to the daemon.
 
 On the `provision` / `reset_recipe` / `await_ready` failure rows, after
 teardown the executor also writes the per-trial bundle — `trajectory.yaml` +
-`metrics.yaml` (carrying top-level `error: provision_error` + `error_reason`) +
-`grade.yaml` — to `{output_dir}/trials/{task_id}/{trial_index}/`, so cost
-aggregation and post-mortem tooling see a consistent trial-directory shape (see
+`metrics.yaml` + `grade.yaml` — to
+`{output_dir}/trials/{task_id}/{trial_index}/`, so cost aggregation and
+post-mortem tooling see a consistent trial-directory shape (see
 [`OUTPUT_FORMAT.md`](OUTPUT_FORMAT.md) § "Provision-failure bundle").
 
 ## Per-service log capture on failure

--- a/tests/canonical/snapshots/trajectory_reasoning/trajectory.yaml
+++ b/tests/canonical/snapshots/trajectory_reasoning/trajectory.yaml
@@ -5,6 +5,7 @@ start_ts: '2026-01-01T12:00:00+00:00'
 end_ts: '2026-01-01T12:00:00+00:00'
 status: completed
 termination_reason: null
+provision_stage: null
 grading_error: null
 first_user_message_source: null
 messages:

--- a/tests/canonical/test_executor_provision_failure_bundle.py
+++ b/tests/canonical/test_executor_provision_failure_bundle.py
@@ -16,6 +16,7 @@ and an :class:`InMemoryConductor` stands in for the (never-invoked) trial body.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -23,12 +24,22 @@ import yaml
 
 from tests.canonical._factories import make_task_config, make_trial_spec
 from tests.utils.provision_failure import FailProvisionBackend, provisioning_executor
+from tolokaforge.core.conductor import InMemoryConductor
 from tolokaforge.core.logging import StructuredLogger
-from tolokaforge.core.models import Trajectory, TrialStatus
+from tolokaforge.core.models import (
+    Message,
+    MessageRole,
+    Metrics,
+    TerminationReason,
+    Trajectory,
+    TrialStatus,
+)
 from tolokaforge.core.orchestrator import Orchestrator
 from tolokaforge.core.output.artifacts import FileArtifactWriter, InMemoryArtifactWriter
 from tolokaforge.core.output_writer import TRIAL_BUNDLE_SCHEMA_VERSION
-from tolokaforge.core.trial import TrialResult
+from tolokaforge.core.runtime import InMemoryRuntimeBackend, ProvisionError
+from tolokaforge.core.trial import TrialResult, TrialSpec
+from tolokaforge.core.trial_executor import ProvisioningTrialExecutor
 
 pytestmark = pytest.mark.canonical
 
@@ -68,6 +79,7 @@ class TestBundleWrittenOnProvisionFailure:
         trajectory = yaml.safe_load((trial_dir / "trajectory.yaml").read_text())
         assert trajectory["status"] == "error"
         assert trajectory["termination_reason"] == "provision_error"
+        assert trajectory["provision_stage"] == "provision"
 
         metrics = yaml.safe_load((trial_dir / "metrics.yaml").read_text())
         # Default-``Metrics`` shape: ``cost_usd`` is ``None`` until an API call
@@ -76,6 +88,7 @@ class TestBundleWrittenOnProvisionFailure:
         assert metrics["schema_version"] == TRIAL_BUNDLE_SCHEMA_VERSION
         assert metrics["error"] == "provision_error"
         assert metrics["error_reason"] == "no capacity in region"
+        assert metrics["error_stage"] == "provision"
 
         # No ``grade.yaml``: the trial body never ran, so there is no verdict.
         # The failure is recorded where it happened — the trajectory's
@@ -141,3 +154,81 @@ class TestBundleWriteFailureDoesNotMask:
         ]
         assert len(warnings) == 1
         assert warnings[0]["level"] == "WARNING"
+
+
+class _RegisterTrialRefusingConductor(InMemoryConductor):
+    """Conductor whose ``run`` raises ``ProvisionError(stage='register_trial')``.
+
+    The register-trial refusal reaches the trial executor through
+    ``conductor.run``: registration is a per-trial RPC arming step the runner
+    performs inside the trial body, so a stage-``register_trial`` raise is
+    always downstream of a successful ``provision`` + ``await_ready``. This
+    stand-in reproduces that shape without a runner service.
+    """
+
+    def run(self, spec: TrialSpec, task_config):
+        raise ProvisionError(
+            trial_id=spec.trial_id,
+            stage="register_trial",
+            reason="runner refused registration: search plane unavailable",
+        )
+
+
+class TestStageSurvivesToMetricsAndTrajectory:
+    def test_register_trial_stage_survives_from_conductor_raise(self, tmp_path: Path) -> None:
+        """A ``ProvisionError`` raised inside ``conductor.run`` carries its stage
+        onto both durable surfaces — the trajectory field and the metrics key —
+        even though the failure lands after ``provision`` + ``await_ready``
+        succeeded."""
+        executor = ProvisioningTrialExecutor(
+            runtime_backend=InMemoryRuntimeBackend(),
+            conductor=_RegisterTrialRefusingConductor(),
+            logger=StructuredLogger("test-provision-failure-bundle"),
+            output_dir=tmp_path,
+            artifact_writer=FileArtifactWriter(),
+        )
+
+        result = executor.execute(
+            make_trial_spec(trial_id="task-7:0"), make_task_config(task_id="task-7")
+        )
+
+        assert isinstance(result, TrialResult)
+        assert result.trajectory.status is TrialStatus.ERROR
+        assert result.trajectory.termination_reason is TerminationReason.PROVISION_ERROR
+        assert result.trajectory.provision_stage == "register_trial"
+
+        trial_dir = _trial_dir(tmp_path, "task-7", 0)
+        trajectory = yaml.safe_load((trial_dir / "trajectory.yaml").read_text())
+        assert trajectory["provision_stage"] == "register_trial"
+
+        metrics = yaml.safe_load((trial_dir / "metrics.yaml").read_text())
+        assert metrics["error"] == "provision_error"
+        assert metrics["error_stage"] == "register_trial"
+        assert metrics["error_reason"] == "runner refused registration: search plane unavailable"
+
+
+class TestErrorStageIsAbsentOffTheProvisionFailurePath:
+    def test_completed_trial_metrics_yaml_carries_no_error_stage(self, tmp_path: Path) -> None:
+        """The ``error_stage`` key is written only when
+        :meth:`_write_provision_failure_bundle` runs. A ``metrics.yaml`` from a
+        completed trial — the artifact writer's own output, unamended — has no
+        ``error_stage`` key at all, so the invariant "error_stage iff
+        error == provision_error" reads one direction from the file."""
+        trial_dir = _trial_dir(tmp_path, "task-completed", 0)
+        trial_dir.mkdir(parents=True)
+        trajectory = Trajectory(
+            task_id="task-completed",
+            trial_index=0,
+            start_ts=datetime.now(tz=timezone.utc),
+            end_ts=datetime.now(tz=timezone.utc),
+            status=TrialStatus.COMPLETED,
+            termination_reason=TerminationReason.AGENT_DONE,
+            messages=[Message(role=MessageRole.USER, content="hello")],
+            metrics=Metrics(),
+        )
+        FileArtifactWriter().write_metrics(trial_dir, trajectory)
+
+        metrics = yaml.safe_load((trial_dir / "metrics.yaml").read_text())
+        assert "error" not in metrics
+        assert "error_reason" not in metrics
+        assert "error_stage" not in metrics

--- a/tests/canonical/test_run_aggregate_models_snapshot.py
+++ b/tests/canonical/test_run_aggregate_models_snapshot.py
@@ -492,6 +492,26 @@ def test_failure_record_round_trip_from_real_attribution() -> None:
     _round_trip(FailureRecord, payload)
 
 
+def test_failure_record_round_trip_carries_provision_stage() -> None:
+    """A ``PROVISION_ERROR`` attribution round-trips its stage verbatim.
+
+    Locks the real-value path of ``FailureRecord.provision_stage`` beyond the
+    ``None`` case the TIMEOUT test above covers: a bundle where the substrate
+    refused at ``register_trial`` must reach disk with that string intact.
+    """
+    trajectory = _make_trajectory(
+        binary_pass=False,
+        score=0.0,
+        status=TrialStatus.ERROR,
+        termination_reason=TerminationReason.PROVISION_ERROR,
+    )
+    trajectory.provision_stage = "register_trial"
+    payload = attribute_failure(trajectory)
+    assert payload["provision_stage"] == "register_trial"
+
+    _round_trip(FailureRecord, payload)
+
+
 def test_failure_summary_round_trip_zero_failures() -> None:
     """Zero-failure branch — ``deterministic_attribution_coverage`` is
     ``None`` (division-by-zero guarded in the source)."""

--- a/tests/unit/test_failure_attribution.py
+++ b/tests/unit/test_failure_attribution.py
@@ -289,6 +289,12 @@ def test_timeout_classification():
     traj.status = TrialStatus.TIMEOUT
     traj.termination_reason = TerminationReason.TIMEOUT
 
+    # A non-provision trajectory carries no provisioning-lifecycle stage; the
+    # field is populated only when the executor synthesizes a
+    # ``PROVISION_ERROR`` result. Locks the reverse direction of the invariant
+    # ``provision_stage non-None iff termination_reason == PROVISION_ERROR``.
+    assert traj.provision_stage is None
+
     assert is_failed_trajectory(traj) is True
     attribution = attribute_failure(traj)
     assert attribution["failure_class"] == "timeout_or_resource"

--- a/tests/unit/test_failure_attribution.py
+++ b/tests/unit/test_failure_attribution.py
@@ -299,20 +299,30 @@ def test_timeout_classification():
     attribution = attribute_failure(traj)
     assert attribution["failure_class"] == "timeout_or_resource"
     assert attribution["deterministic"] is True
+    # ``provision_stage`` is a first-class field on every attribution record —
+    # present-but-null off the provision path so downstream consumers read it
+    # without a ``.get()`` / ``KeyError`` dance.
+    assert attribution["provision_stage"] is None
 
 
 def test_provision_error_classification():
     """A trajectory carrying ``PROVISION_ERROR`` classifies as ``provision_failure`` —
     substrate came up wrong before the trial body ran, so the failure is
-    infra-side, not model-side."""
+    infra-side, not model-side. The stage that raised is a first-class field
+    on the returned dict alongside the evidence list, not buried inside it: a
+    reader answering "which point of the provisioning lifecycle failed" does
+    not walk ``evidence`` to find out.
+    """
     traj = _base_trajectory()
     traj.status = TrialStatus.ERROR
     traj.termination_reason = TerminationReason.PROVISION_ERROR
+    traj.provision_stage = "register_trial"
 
     assert is_failed_trajectory(traj) is True
     attribution = attribute_failure(traj)
     assert attribution["failure_class"] == "provision_failure"
     assert attribution["deterministic"] is True
+    assert attribution["provision_stage"] == "register_trial"
     assert any(e["kind"] == "termination_reason" for e in attribution["evidence"])
 
     # A provision failure (which a reset-recipe failure surfaces as) counts

--- a/tolokaforge/core/failure_attribution.py
+++ b/tolokaforge/core/failure_attribution.py
@@ -264,6 +264,11 @@ def attribute_failure(trajectory: Trajectory) -> dict[str, Any]:
         "termination_reason": (
             trajectory.termination_reason.value if trajectory.termination_reason else None
         ),
+        # Present-but-null off the provision path so downstream consumers can
+        # read ``record["provision_stage"]`` unconditionally: the first-class
+        # substage answer to "what failed" sits alongside the evidence list,
+        # not inside it.
+        "provision_stage": trajectory.provision_stage,
         "outcome_class": classify_trial_outcome(trajectory).value,
         "failure_class": failure_class,
         "deterministic": deterministic,

--- a/tolokaforge/core/models/trajectory.py
+++ b/tolokaforge/core/models/trajectory.py
@@ -12,7 +12,7 @@ census (:class:`RateLimitProbeRoleMetrics`,
 import dataclasses
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Self, get_args
+from typing import Any, Literal, Self, get_args
 
 from pydantic import (
     BaseModel,
@@ -33,6 +33,7 @@ __all__ = [
     "Message",
     "MessageRole",
     "Metrics",
+    "ProvisionStage",
     "RateLimitProbeBucketMetrics",
     "RateLimitProbeRoleMetrics",
     "ReplyDefect",
@@ -44,6 +45,21 @@ __all__ = [
     "UserReplyGuardEvent",
     "UserReplyOutcome",
 ]
+
+
+ProvisionStage = Literal["provision", "await_ready", "reset_recipe", "register_trial"]
+"""The four points a :class:`~tolokaforge.core.runtime.ProvisionError` can
+be raised at, as a closed vocabulary. The provisioner declares which lifecycle
+step failed — compose-up (``provision``), the readiness gate (``await_ready``),
+the per-trial reset hook (``reset_recipe``), or the runner-side registration
+that arms the trial (``register_trial``) — and the value survives verbatim onto
+:attr:`Trajectory.provision_stage` and the per-trial ``metrics.yaml``
+``error_stage`` key.
+
+Defined here because :class:`Trajectory` carries it as a field; re-exported from
+:mod:`tolokaforge.core.runtime` because :class:`ProvisionError` is the raise
+site and the two names read as one contract there.
+"""
 
 
 class MessageRole(str, Enum):
@@ -585,6 +601,13 @@ class Trajectory(BaseModel):
     # reason it gave. ``None`` means grading either succeeded or was correctly
     # not attempted — it does not distinguish those two, ``grade`` does.
     grading_error: str | None = None
+    # Which point of the provisioning lifecycle raised ``ProvisionError``.
+    # Non-``None`` iff ``termination_reason == PROVISION_ERROR``; ``None`` on
+    # every other trial including bundles the executor writes for a failure
+    # whose stage the raise site did not name (the closed set at
+    # ``ProvisionStage`` is exhaustive today, so this is a defensive default,
+    # not a documented gap).
+    provision_stage: ProvisionStage | None = None
     # Monotonic integer stamped on every trajectory; bumped whenever the
     # simulator prompt shape or the conversation context the simulator sees
     # is revised so that downstream analytics can gate comparisons across

--- a/tolokaforge/core/output/aggregate_models.py
+++ b/tolokaforge/core/output/aggregate_models.py
@@ -415,6 +415,14 @@ class FailureRecord(BaseModel):
     trial_index: int
     status: str
     termination_reason: str | None = None
+    # Which point of the provisioning lifecycle raised ``ProvisionError``. Non-
+    # ``None`` iff ``termination_reason == "provision_error"``; otherwise present
+    # and null so a downstream consumer can read ``record["provision_stage"]``
+    # unconditionally rather than gate the access on ``termination_reason``.
+    # Typed ``str`` (not the ``ProvisionStage`` Literal) for the same reason
+    # ``termination_reason`` is: a bundle written by a future run whose classifier
+    # has heard of a new stage round-trips rather than raising here.
+    provision_stage: str | None = None
     outcome_class: TrialOutcomeClass
     failure_class: str
     deterministic: bool

--- a/tolokaforge/core/output_writer.py
+++ b/tolokaforge/core/output_writer.py
@@ -235,6 +235,7 @@ class OutputWriter:
             "termination_reason": (
                 trajectory.termination_reason.value if trajectory.termination_reason else None
             ),
+            "provision_stage": trajectory.provision_stage,
             "grading_error": trajectory.grading_error,
             "first_user_message_source": (
                 trajectory.first_user_message_source.value

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from tolokaforge.core.models.trajectory import ProvisionStage
 from tolokaforge.core.run_display_events import ContainerSnapshot
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, EnvEndpoints, TrialSpec
 
@@ -86,9 +87,6 @@ class EnvHandle(Protocol):
 # ---------------------------------------------------------------------------
 # ProvisionError — typed failure for the provisioning lifecycle
 # ---------------------------------------------------------------------------
-
-
-ProvisionStage = Literal["provision", "await_ready", "reset_recipe", "register_trial"]
 
 
 class ProvisionError(Exception):

--- a/tolokaforge/core/trial_executor.py
+++ b/tolokaforge/core/trial_executor.py
@@ -245,9 +245,10 @@ class ProvisioningTrialExecutor:
         The conductor never ran, so nothing else writes this trial's directory.
         Reuses the run's ``artifact_writer`` (no schema duplication), then amends
         ``metrics.yaml`` with the top-level failure signal (``error`` /
-        ``error_reason``) via the shared ``_amend_trial_metrics`` path. Any write
-        failure is logged and swallowed — mirrors ``_safe_teardown``; it never
-        masks the synthesized ``ProvisionError`` result the caller returns.
+        ``error_reason`` / ``error_stage``) via the shared ``_amend_trial_metrics``
+        path. Any write failure is logged and swallowed — mirrors
+        ``_safe_teardown``; it never masks the synthesized ``ProvisionError``
+        result the caller returns.
         """
         task_id = trajectory.task_id
         trial_idx = trajectory.trial_index
@@ -271,6 +272,7 @@ class ProvisioningTrialExecutor:
             {
                 "error": TerminationReason.PROVISION_ERROR.value,
                 "error_reason": error.reason,
+                "error_stage": error.stage,
             },
         )
 
@@ -370,6 +372,7 @@ def _synthesize_provision_failure_result(spec: TrialSpec, error: ProvisionError)
         end_ts=now,
         status=TrialStatus.ERROR,
         termination_reason=TerminationReason.PROVISION_ERROR,
+        provision_stage=error.stage,
         messages=[],
         metrics=Metrics(),
     )


### PR DESCRIPTION
## Summary

- `ProvisionError.stage` (closed 4-value `ProvisionStage` Literal: `provision` / `await_ready` / `reset_recipe` / `register_trial`) now survives to both durable per-trial failure surfaces: `metrics.yaml` as `error_stage`, and `failure_attribution.json` (top-level on every classifier entry) as `provision_stage`.
- `Trajectory` gains `provision_stage: ProvisionStage | None = None`; `FailureRecord` (Pydantic `extra="forbid"`) gains `provision_stage: str | None = None`. Additive with matching-pre-fix-behaviour defaults; older bundles read as `None`.
- Operators can now distinguish "compose-up failed" from "register_trial refused" without opening structured logs.

## Design choices

- **`Trajectory.provision_stage: ProvisionStage | None`** (tight Literal) at the source-of-truth Pydantic boundary; **`FailureRecord.provision_stage: str | None`** (loose) at the classifier output boundary. Matches sibling `termination_reason` split; keeps `failure_attribution.json` round-trippable across future stage additions.
- **`error_stage` on `metrics.yaml`** (sibling to `error` / `error_reason`), **`provision_stage` on `trajectory.yaml`** and `failure_attribution.json`. Two field names because the two artifacts use distinct sibling clusters (`error_*` on metrics vs standalone fields on trajectory).
- **Present-but-null on `failure_attribution.json` off-provision path** — downstream consumers read `record["provision_stage"]` unconditionally, no `.get()`/KeyError dance. Consumer ergonomics, not `extra="forbid"` enforcement.
- **No `metrics.yaml` schema_version bump** — additive keys on a failure-only amendment branch; same class of addition that landed `error` / `error_reason` without a bump.

## Concepts introduced

`provision_stage` as a first-class attribution field, distinct from the evidence-payload `{kind: termination_reason, ...}` entry. Answers "what failed" (the operator's question), not "what's the evidence." Mirrors the sibling `termination_reason` shape.

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1295-provision-stage.md`. Two stages plus one doc-hygiene follow-up:

- **Stage 1** (`6323241b`) — `Trajectory` + `metrics.yaml` surface. Added `provision_stage` field, populated in `_synthesize_provision_failure_result`, amended metrics via `_write_provision_failure_bundle`. Three canonical assertions (existing `FailProvisionBackend` extension + new `register_trial` case + reader-side absence assertion) + one unit None-case. `ProvisionStage` promoted from `runtime.py` to `models/trajectory.py` with re-export (direct import cycled).
- **Stage 2** (`53dc14f8`) — `attribute_failure` returns `provision_stage` top-level on every classifier dict; `FailureRecord` adds the field. Unit + canonical round-trip tests including a real-value case (`register_trial`) and the None-case round-trip.
- **Hygiene follow-up** (`60a6855a`) — three doc corrections flagged by the hygiene reviewer: stale inline enumeration in `docs/RUNTIME_BACKENDS.md`, ambiguous "stage and reason" wording in `docs/OUTPUT_FORMAT.md`, wrong line-number citation in `docs/ANALYTICS.md`. Docs only; refactor-resilient dotted-path form.

## Discovered issues

- **Filed:** None new.
- **Fixed in this PR:** `output_writer.write_trajectory` hand-built YAML mapping needed the new field (plumbing hop the plan didn't enumerate); doc-drift on three doc files resolved.
- **For main to note (out of scope for this PR):**
  - `docs/RUNTIME_BACKENDS.md:475` and `tolokaforge/core/trial_executor.py:242` docstring both mention `grade.yaml` in the provision-failure-bundle enumeration; `docs/OUTPUT_FORMAT.md:1022` explicitly says `grade.yaml` is NOT written on the provision-failure path. Contradiction predates this branch (introduced in PR #511) and was not modified — worth a separate cleanup PR.
  - Two pre-existing unit-lane hangs surfaced during work: `tests/unit/test_ungradeable_trial_accounting.py::TestTheRunCounts…` (>300s on `main` too) and `tests/unit/test_persistent_shell_local.py::test_a_session_works_on_a_descriptor_past_select_s_ceiling` (fails on macOS due to missing `/proc/self/fd`). Neither is a milestone-38 regression.
  - Full unit lane OOMs (SIGKILL); the targeted subset passes cleanly. Environmental, not diff-caused.

## Test plan

- `uv run pytest tests/canonical/test_executor_provision_failure_bundle.py tests/canonical/test_run_aggregate_models_snapshot.py tests/unit/test_failure_attribution.py -q` → all green (228+ tests).
- `uv run pytest -m canonical -q` → 1719 passed, 1 skipped.
- `run_python` sanity: `Trajectory(termination_reason=PROVISION_ERROR, provision_stage="register_trial")` → `attribute_failure(traj)["provision_stage"] == "register_trial"` and round-trips byte-identity through `FailureRecord`.
- Sharded review: correctness + type-fit APPROVE R1; hygiene APPROVE WITH NITS R1 → APPROVE R2 after `60a6855a`.

Closes #1295
