### PR TITLE
fix(runtime): rename shared-stack log lines and drop the duplicated close

### DIFF
--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -2552,10 +2552,10 @@ class Orchestrator:
                 # Mark run as completed
                 self.state_manager.mark_run_completed()
 
-            # Cleanup Docker runtime if used
+            # Cleanup runtime backend if used; SharedStackRuntimeBackend
+            # logs its own "Shared-stack runtime closed" line, no dup needed.
             if runtime_backend:
                 runtime_backend.close()
-                self.logger.info("Docker runtime closed")
 
             # Stop TypeSense BEFORE destroying the EngineStack.
             # TypeSense is connected to runner-net (via _connect_typesense_to_runner_network),

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -1030,7 +1030,7 @@ class SharedStackRuntimeBackend:
                     "not both. env_manifest mode resolves endpoints from the "
                     "materialised compose stack at connect() time."
                 )
-        logger.info("Docker runtime initialized")
+        logger.info("Shared-stack runtime initialized")
 
     def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
         """Connect to Runner service with health check retry.
@@ -1052,7 +1052,7 @@ class SharedStackRuntimeBackend:
         if self._env_manifest is not None:
             self._materialise_manifest()
         self.runner_client.connect(timeout=timeout, retry_interval=retry_interval)
-        logger.info("Docker runtime connected")
+        logger.info("Shared-stack runtime connected")
 
     def close(self):
         """Close Runner connection and tear down the task-declared stack
@@ -1082,7 +1082,7 @@ class SharedStackRuntimeBackend:
             if self._temp_dir is not None:
                 shutil.rmtree(self._temp_dir, ignore_errors=True)
                 self._temp_dir = None
-        logger.info("Docker runtime closed")
+        logger.info("Shared-stack runtime closed")
 
     def _materialise_manifest(self) -> None:
         """Bring up the task-declared compose stack once for the run and


### PR DESCRIPTION
## Summary

- `SharedStackRuntimeBackend`'s three `logger.info` lines now say "Shared-stack runtime {initialized,connected,closed}" instead of "Docker runtime …". Matches the class name; still reflects the actual (Docker Compose) substrate.
- `Orchestrator._run_trials`'s cleanup branch no longer emits a duplicate `logger.info("Docker runtime closed")` — `SharedStackRuntimeBackend.close()` already logs its own close line, so the previous 2-per-run count collapses to 1.

## Design choices

- **"Shared-stack runtime" over "Runtime".** `SharedStackRuntimeBackend` IS Docker-Compose-based (`mount_docker_socket`, `docker compose`, network `runner-net`), so calling it fully substrate-agnostic ("Runtime initialized") would lose information — a future non-compose backend implementing the same protocol would log the same phrase, and a reader couldn't tell which is running. "Shared-stack runtime" describes the specific backend without hardcoding "Docker".
- **Class name `DockerRunnerAdapter` left alone.** It IS substrate-agnostic (delegates to the abstract `RuntimeBackend` protocol, per ADR-0013), and the finding is right that "Docker" in the name is misleading — but a class rename touches every import site, well beyond a cosmetic fix. Filed as follow-up **#1325**.

## Concepts introduced

None — mechanical string rename + one deletion.

## Plan

Direct edit (per the user's "no fresh implementer for one-line changes" preference). Two files, five lines total:

- `tolokaforge/core/shared_stack_runtime.py:1033, 1055, 1085` — three `logger.info` renames.
- `tolokaforge/core/orchestrator.py:2555-2558` — comment rewrite + duplicate `logger.info` deletion. The `if runtime_backend: runtime_backend.close()` call stays; only the redundant host-side log line is dropped.

## Discovered issues

- **Filed:** #1325 — refactor(runtime): rename `DockerRunnerAdapter` to a substrate-agnostic name. Out of cosmetic scope for #1296; separate refactor PR.
- **Fixed in this PR:** none additional.

## Test plan

- `grep -n "Docker runtime" tolokaforge/` — one remaining hit in `orchestrator.py:2269` (a legitimate Docker-specific health-check log inside the docker-runtime path); every other reference now reads "Shared-stack runtime" or is the comment.
- No existing test asserts on the old log strings (verified via `grep "Docker runtime" tests/`).
- Manual smoke: any evaluation run — count `"Shared-stack runtime closed"` in the aggregated logs → 1 per run (was 2 as `"Docker runtime closed"`).

Closes #1296
