### PR TITLE
fix(db-service): document container-only deployment; friendlier ImportError on fastapi

### DIFF
--- a/tolokaforge/env/json_db_service/app.py
+++ b/tolokaforge/env/json_db_service/app.py
@@ -6,6 +6,15 @@ This module provides a schema-aware JSON state storage with:
 - Snapshot/Restore: Supports golden path execution during grading
 - SQL queries: SQLite-based querying on JSON data
 - JSONPath queries: Query state using JSONPath expressions
+
+Deployment. This service ships as a container built from
+:file:`tolokaforge/docker/dockerfiles/db_service.Dockerfile`, which installs
+`fastapi` / `uvicorn` / `jsonpath-ng` from :file:`requirements.txt` next to
+this file. The core `tolokaforge` wheel does NOT depend on `fastapi`; a
+plain `pip install tolokaforge` will not import this module. Callers that
+run the service outside the container (typically the test suite, which
+uses `TestClient`) need `pip install 'tolokaforge[runner]'` — the `runner`
+extra carries `fastapi>=0.108.0`.
 """
 
 import copy
@@ -16,7 +25,17 @@ import sqlite3
 from threading import Lock
 from typing import Any, NoReturn
 
-from fastapi import FastAPI, HTTPException, Query
+try:
+    from fastapi import FastAPI, HTTPException, Query
+except ImportError as exc:  # noqa: BLE001 -- explicit re-raise below
+    raise ImportError(
+        "tolokaforge.env.json_db_service.app requires `fastapi`. "
+        "The service ships as a container that installs its own dependencies "
+        "(tolokaforge/env/json_db_service/requirements.txt). To run this "
+        "module outside the container — for example the test suite — install "
+        "the runner extra: `pip install 'tolokaforge[runner]'`."
+    ) from exc
+
 from jsonpath_ng.ext import parse  # .ext: supports filter exprs, superset of base grammar
 from pydantic import BaseModel, Field, PrivateAttr
 


### PR DESCRIPTION
## Summary

- The `json_db_service` module now documents its container-only deployment path in its module docstring.
- The bare `from fastapi import ...` is wrapped in a `try/except ImportError` that raises a friendly error naming the `tolokaforge[runner]` extra (which carries `fastapi>=0.108.0`). Direct callers running the service outside the container — typically test suites via `TestClient` — get an actionable error instead of a bare `ModuleNotFoundError: No module named 'fastapi'`.
- No change to `pyproject.toml`. The core `tolokaforge` wheel does NOT depend on `fastapi`.

## Design choices

- **Documentation + friendly ImportError, not `fastapi` in core deps.** The `json_db_service` ships as a container built from `tolokaforge/docker/dockerfiles/db_service.Dockerfile`, which installs its own `requirements.txt`. Nothing in `tolokaforge/` (outside test suites) imports the module. Moving `fastapi` (+`starlette`/`anyio`/`click`/`h11`/`httptools`/... transitive chain) into core deps would grow every `pip install tolokaforge` for a container-only service most callers never touch. The runner extra already carries `fastapi` for exactly the test-suite / standalone-launch case the finding surfaced.
- **Module docstring, not `docs/*.md` entry.** The truth belongs next to the code — a reader who lands on `app.py` gets the deployment story immediately. `docs/DB_SERVICE_API.md` already describes the API; the deployment path is a `tolokaforge/env/`-level concern, not an API concern.

## Concepts introduced

None — mechanical fix.

## Plan

Direct edit (per the "no fresh implementer for one-line changes" preference). One file, ~20 lines including the docstring and the wrapper.

## Discovered issues

- **Filed:** None. The finding correctly surfaced a fragile spot; the fix is small.
- **Fixed in this PR:** the `app.py` module docstring now names the deployment options (container OR runner extra for tests).

## Test plan

- `uv run pytest tests/unit/test_json_db_service_query.py tests/unit/env/test_json_db_composite_upsert.py tests/unit/env/test_json_db_upsert_key_presence.py -q` → 17 passing (unchanged behaviour with fastapi present).
- Manual sanity: `uv run python -c "from tolokaforge.env.json_db_service.app import app; print(app.title)"` → `JSON DB Service`.
- Direct-invocation smoke: with `fastapi` absent from the venv, the module raises the friendly `ImportError` naming `tolokaforge[runner]` instead of the bare `ModuleNotFoundError`.

Closes #1297
