### PR TITLE
fix(grader): route RunnerRPCTrialGrader through runtime_backend for per-trial runtimes

### DIFF
--- a/docs/adr/0038-grader-detachment.md
+++ b/docs/adr/0038-grader-detachment.md
@@ -64,7 +64,7 @@ Adopt the extraction target #1, the throughput property #2 (both variants ship),
 
 Concretely:
 
-1. **Grader plug-in receives serialisable configuration only.** The construction context becomes endpoint URL + auth token + timeout + run-scoped logger. No live runtime-backend object crosses the seam.
+1. **Grader plug-in receives configuration only — nothing live crosses the seam.** The construction context is endpoint URL + auth token + timeout + run-scoped logger, plus one optional in-process routing shim (`runtime_backend`) populated only for backends whose runner endpoints are reachable per-trial (`PerTrialRuntimeBackend` — each trial owns its own endpoint, so no static address applies). The shim MUST be `None` whenever the grader will cross an address boundary; every out-of-process factory (`grader_rpc`, `queue`, `judge_backed`) MUST ignore the field. The hygiene test at `tests/canonical/test_trial_grader_context_hygiene.py` pins the ignore contract statically (AST) and at runtime (sentinel-backend) for every bundled out-of-process factory.
 2. **New RPC contract for the grader, owned by the grader.** The runner's grade RPC ships one more release with a deprecation notice, then goes away.
 3. **Standalone grader service binary.** Embeds the pure evaluator plus the runner-specific grader glue. No tool execution, no sandbox, no env-state.
 4. **New grader plug-in registered under the existing plugin group,** reaching the new service.

--- a/tests/canonical/test_trial_grader_context_hygiene.py
+++ b/tests/canonical/test_trial_grader_context_hygiene.py
@@ -132,7 +132,17 @@ class TestOutOfProcessFactoriesIgnoreRuntimeBackend:
     every out-of-process factory. A leak of the field into ``grader_rpc``,
     ``queue``, or ``judge_backed`` is a Blocker — a live backend at
     deployment time it cannot marshal. Both static (``ast.walk``) and runtime
-    (sentinel-backend) checks are enforced here."""
+    (sentinel-backend) checks are enforced here.
+
+    Static AST checks cover all three factories via
+    ``test_factory_source_does_not_reference_runtime_backend``. Runtime
+    sentinel-backend checks cover ``grader_rpc`` and ``judge_backed`` — the
+    queue factory spawns worker threads and constructs real
+    ``GrpcGraderClient`` instances mid-body, so a runtime sentinel would
+    either need broad monkey-patching (opaque) or skip the second half of
+    the factory body (weak); the AST check is strictly stronger for that
+    factory anyway.
+    """
 
     _OUT_OF_PROCESS_FACTORIES = (
         grader_rpc_trial_grader_factory,
@@ -191,17 +201,6 @@ class TestOutOfProcessFactoriesIgnoreRuntimeBackend:
         grader = judge_backed_trial_grader_factory(ctx, llm_client=MagicMock())
         assert isinstance(grader, JudgeBackedTrialGrader)
 
-    def test_queue_factory_source_check_is_authoritative(self) -> None:
-        """The queue factory spawns worker threads and constructs real
-        ``GrpcGraderClient`` instances mid-body, so a sentinel-backend
-        runtime check would either need broad monkey-patching (opaque) or
-        skip the second half of the factory body (weak). The parametrised
-        ``test_factory_source_does_not_reference_runtime_backend`` above
-        already covers ``queue_trial_grader_factory`` at the strictly
-        stronger static level, and this method's presence documents why
-        no separate runtime test exists here."""
-        assert queue_trial_grader_factory in self._OUT_OF_PROCESS_FACTORIES
-
 
 class TestRunnerRpcTrialGraderFactory:
     """The built-in factory builds a grader that owns its own runner client — no
@@ -230,3 +229,8 @@ class TestRunnerRpcTrialGraderFactory:
         assert grader.runner_address == "test-runner:9999"
         assert isinstance(grader.runner_client, _StubClient)
         assert grader.runner_client.runner_address == "test-runner:9999"
+        # Shared-stack + P2/P3 shape: when the context carries an address,
+        # the in-process routing shim MUST stay ``None`` so ADR-0038's
+        # "grader owns its own client, independent of the orchestrator"
+        # invariant holds for every backend that can honour it.
+        assert grader.runtime_backend is None

--- a/tests/canonical/test_trial_grader_context_hygiene.py
+++ b/tests/canonical/test_trial_grader_context_hygiene.py
@@ -1,17 +1,25 @@
-"""``TrialGraderContext`` carries serialisable configuration only.
+"""``TrialGraderContext`` carries serialisable configuration only, plus one
+optional in-process routing shim.
 
 The grader plug-in seam (``tolokaforge.trial_graders`` entry-point group) exists
-so a grader can run on a different machine from the orchestrator. A live
-``RuntimeBackend`` instance in the context — a gRPC channel bound to a specific
-runner — would defeat that: the grader receives an object it cannot use from a
-different address space. This test pins the shape at the type level so a future
-PR cannot regress the seam.
+so a grader can run on a different machine from the orchestrator (ADR-0038). A
+required live ``RuntimeBackend`` instance in the context would defeat that: a
+grader crossing an address boundary cannot use an object bound to another
+process. The ``runtime_backend`` field on the context is therefore ``Optional``
+and MUST be ``None`` whenever the grader will cross an address boundary; when
+set (in-process case), only ``RunnerRPCTrialGrader`` reads it, and every
+out-of-process factory MUST ignore it. This test pins the shape at the type
+level and pins the ignore contract for every bundled out-of-process factory so
+a future PR cannot regress the seam.
 
 See ADR-0038 (grader detachment) for the wider design record.
 """
 
 from __future__ import annotations
 
+import ast
+import dataclasses
+import inspect
 import typing
 from dataclasses import fields
 from unittest.mock import MagicMock
@@ -19,9 +27,18 @@ from unittest.mock import MagicMock
 import pytest
 
 from tolokaforge.core.logging import StructuredLogger
+from tolokaforge.core.models.run_config import GraderConfig
 from tolokaforge.core.plugin_registry import TrialGraderContext
 from tolokaforge.core.runtime import RuntimeBackend
-from tolokaforge.core.trial_grader import RunnerRPCTrialGrader, runner_rpc_trial_grader_factory
+from tolokaforge.core.trial_grader import (
+    GraderRPCTrialGrader,
+    JudgeBackedTrialGrader,
+    RunnerRPCTrialGrader,
+    grader_rpc_trial_grader_factory,
+    judge_backed_trial_grader_factory,
+    queue_trial_grader_factory,
+    runner_rpc_trial_grader_factory,
+)
 
 pytestmark = pytest.mark.canonical
 
@@ -29,28 +46,54 @@ pytestmark = pytest.mark.canonical
 def _resolved_types() -> dict[str, object]:
     """Return ``TrialGraderContext``'s field types with forward refs resolved.
 
-    ``StructuredLogger`` is imported under ``TYPE_CHECKING`` in the plug-in
-    registry to avoid a runtime cycle; feed it in via ``localns`` so the
-    hint resolves without pulling every logger-side dependency at import time.
+    ``StructuredLogger`` and ``RuntimeBackend`` are imported under
+    ``TYPE_CHECKING`` in the plug-in registry to avoid runtime cycles; feed
+    them in via ``localns`` so the hints resolve without pulling every
+    logger-side or runtime-side dependency at import time.
     """
-    return typing.get_type_hints(TrialGraderContext, localns={"StructuredLogger": StructuredLogger})
+    return typing.get_type_hints(
+        TrialGraderContext,
+        localns={"StructuredLogger": StructuredLogger, "RuntimeBackend": RuntimeBackend},
+    )
+
+
+class _SentinelBackend:
+    """Sentinel that fails loud if any out-of-process factory reads it.
+
+    Every attribute access raises — including the ``runner_address``
+    ``getattr`` in ``grader_rpc``/``queue`` — so an out-of-process factory
+    that even *looks* at ``ctx.runtime_backend`` would blow up. Combined with
+    the static ``ast`` check below, this pins the ignore contract both at
+    static analysis and at runtime.
+    """
+
+    def __getattr__(self, name: str) -> None:
+        raise AssertionError(
+            f"Out-of-process factory read TrialGraderContext.runtime_backend.{name}; "
+            "runtime_backend is an in-process-only escape hatch and MUST be ignored "
+            "by any factory whose grader can cross an address boundary. See ADR-0038."
+        )
 
 
 class TestTrialGraderContextShape:
-    """The context carries a serialisable ``runner_address`` and a logger — nothing else."""
+    """The context carries serialisable configuration plus one optional in-process shim."""
 
     def test_no_field_typed_as_runtime_backend(self) -> None:
-        """A live runtime-backend instance in the context couples the grader to
-        the orchestrator's channel; the seam breaks when the grader runs
-        elsewhere. Regressing this field's type is a compat-level bug — it
-        forces a future PR to re-thread a live object through downstream
-        registered graders."""
+        """A required live runtime-backend instance in the context couples the
+        grader to the orchestrator's channel; the seam breaks when the grader
+        runs elsewhere. Regressing this field's type is a compat-level bug —
+        it forces a future PR to re-thread a live object through downstream
+        registered graders. ``RuntimeBackend | None`` still passes this test
+        because the resolved union type is not identical to the bare
+        ``RuntimeBackend`` class."""
         types_by_name = _resolved_types()
         for field in fields(TrialGraderContext):
             resolved = types_by_name[field.name]
             assert resolved is not RuntimeBackend, (
                 f"TrialGraderContext.{field.name} resolves to RuntimeBackend; "
-                "grader context must not carry live runtime-backend instances."
+                "grader context must not carry a required live runtime-backend "
+                "instance. Use ``RuntimeBackend | None`` if this is the in-process "
+                "escape hatch."
             )
 
     def test_runner_address_is_a_string_or_none(self) -> None:
@@ -61,15 +104,103 @@ class TestTrialGraderContextShape:
         types_by_name = _resolved_types()
         assert types_by_name["runner_address"] == (str | None)
 
+    def test_runtime_backend_is_optional_and_defaults_to_none(self) -> None:
+        """The in-process routing escape hatch must be strictly optional. A
+        default of ``None`` keeps every out-of-process factory unable to rely
+        on it, and keeps the ADR-0038 wire invariant: the field never crosses
+        a serialisation boundary. Widening this to a non-Optional type or
+        removing the default is a Blocker."""
+        types_by_name = _resolved_types()
+        assert types_by_name["runtime_backend"] == (RuntimeBackend | None)
+
+        ctx = TrialGraderContext(runner_address="stub:0", logger=MagicMock())
+        assert ctx.runtime_backend is None
+
     def test_construction_with_unknown_kwarg_fails_loud(self) -> None:
-        """Frozen dataclass — a stray ``runtime_backend=`` from stale code
-        raises ``TypeError`` at construction rather than being ignored."""
+        """Frozen dataclass — a stray kwarg from stale code raises
+        ``TypeError`` at construction rather than being ignored."""
         with pytest.raises(TypeError):
             TrialGraderContext(  # type: ignore[call-arg]
                 runner_address="stub:0",
                 logger=MagicMock(),
-                runtime_backend=object(),
+                some_field_that_will_never_exist=object(),
             )
+
+
+class TestOutOfProcessFactoriesIgnoreRuntimeBackend:
+    """The in-process escape hatch ``ctx.runtime_backend`` MUST be inert for
+    every out-of-process factory. A leak of the field into ``grader_rpc``,
+    ``queue``, or ``judge_backed`` is a Blocker — a live backend at
+    deployment time it cannot marshal. Both static (``ast.walk``) and runtime
+    (sentinel-backend) checks are enforced here."""
+
+    _OUT_OF_PROCESS_FACTORIES = (
+        grader_rpc_trial_grader_factory,
+        queue_trial_grader_factory,
+        judge_backed_trial_grader_factory,
+    )
+
+    @pytest.mark.parametrize(
+        "factory",
+        _OUT_OF_PROCESS_FACTORIES,
+        ids=lambda f: f.__name__,
+    )
+    def test_factory_source_does_not_reference_runtime_backend(
+        self, factory: typing.Callable[..., object]
+    ) -> None:
+        """Every out-of-process factory's source MUST NOT load
+        ``ctx.runtime_backend``. Static check via ``ast.walk`` so a future
+        PR cannot slip in a ``ctx.runtime_backend`` read that the runtime
+        sentinel check might miss (e.g. behind a conditional branch)."""
+        source = inspect.getsource(factory)
+        tree = ast.parse(source)
+        leaks: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "runtime_backend":
+                if isinstance(node.value, ast.Name) and node.value.id == "ctx":
+                    leaks.append(f"line {node.lineno}: ctx.runtime_backend")
+        assert not leaks, (
+            f"{factory.__name__} reads ctx.runtime_backend at {leaks}; "
+            "the in-process escape hatch must not be read by any factory whose "
+            "grader can cross an address boundary. See ADR-0038."
+        )
+
+    def test_grader_rpc_factory_ignores_runtime_backend_at_runtime(self) -> None:
+        """Sentinel-backend runtime check: any attribute read on
+        ``ctx.runtime_backend`` inside the factory would raise
+        AssertionError. The factory must build without touching it."""
+        ctx = dataclasses.replace(
+            TrialGraderContext(runner_address="test-runner:9999", logger=MagicMock()),
+            runtime_backend=_SentinelBackend(),  # type: ignore[arg-type]
+        )
+        grader = grader_rpc_trial_grader_factory(ctx)
+        assert isinstance(grader, GraderRPCTrialGrader)
+
+    def test_judge_backed_factory_ignores_runtime_backend_at_runtime(self) -> None:
+        """Same sentinel check for the judge-only factory. Judge-backed
+        grading is a pure trajectory replay; no runtime state needed and
+        certainly no in-process backend read."""
+        ctx = dataclasses.replace(
+            TrialGraderContext(
+                runner_address="stub:0",
+                logger=MagicMock(),
+                grader_config=GraderConfig(),
+            ),
+            runtime_backend=_SentinelBackend(),  # type: ignore[arg-type]
+        )
+        grader = judge_backed_trial_grader_factory(ctx, llm_client=MagicMock())
+        assert isinstance(grader, JudgeBackedTrialGrader)
+
+    def test_queue_factory_source_check_is_authoritative(self) -> None:
+        """The queue factory spawns worker threads and constructs real
+        ``GrpcGraderClient`` instances mid-body, so a sentinel-backend
+        runtime check would either need broad monkey-patching (opaque) or
+        skip the second half of the factory body (weak). The parametrised
+        ``test_factory_source_does_not_reference_runtime_backend`` above
+        already covers ``queue_trial_grader_factory`` at the strictly
+        stronger static level, and this method's presence documents why
+        no separate runtime test exists here."""
+        assert queue_trial_grader_factory in self._OUT_OF_PROCESS_FACTORIES
 
 
 class TestRunnerRpcTrialGraderFactory:

--- a/tests/canonical/test_trial_grader_per_trial_backend_routing.py
+++ b/tests/canonical/test_trial_grader_per_trial_backend_routing.py
@@ -1,0 +1,177 @@
+"""Regression lock: ``PerTrialRuntimeBackend`` + ``RunnerRPCTrialGrader``
+must produce a real :class:`Grade`, not a phantom-address gRPC error.
+
+Before this fix, ``orchestrator._build_conductor`` did
+``runner_address = getattr(runtime_backend, "runner_address", None)`` and
+passed the resulting ``None`` into ``TrialGraderContext``. The
+``runner_rpc`` factory then built a ``GrpcRunnerClient(runner_address="")``.
+On the first ``grade_trial`` call, that client's connect health-check spun
+for ~30 s and raised, so ``RunnerRPCTrialGrader.grade`` raised
+:class:`GradingFailedError`, ``binary_pass`` stayed ``None`` for every
+completed trial, and no ``grade.yaml`` was ever written. On the
+``eval/tbench-balanced-10-engine-loop`` sample sweep this shape produced
+110/110 ungraded trials on $50 of real LLM spend.
+
+This test pins the fix — ``ctx.runtime_backend`` is threaded through the
+context and the grader delegates to ``backend.grade_trial(trial_id, ...)``,
+which ``PerTrialRuntimeBackend._client_for(trial_id)`` routes to the
+correct per-trial runner client. The companion test locks that the
+out-of-process (P2/P3) shape ADR-0038 pins is not regressed by the change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_trajectory, make_trial_spec
+from tolokaforge.core.models import Grade, TerminationReason, TrialStatus
+from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
+from tolokaforge.core.plugin_registry import TrialGraderContext
+from tolokaforge.core.trial_grader import runner_rpc_trial_grader_factory
+
+pytestmark = pytest.mark.canonical
+
+
+class _FakePerTrialRunnerClient:
+    """Stub that satisfies the ``RunnerClient`` Protocol slice
+    ``PerTrialRuntimeBackend`` calls into.
+
+    ``connect()`` is a no-op — the real client's connect gates on a runner
+    health-check; the test bypasses that by adding ``trial_id`` to
+    ``_connected_trials`` before ``grade`` runs. ``health_check()`` returns
+    ``True`` so any late invariant probe stays satisfied.
+    """
+
+    def __init__(self, grade_result: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._grade_result = grade_result or {
+            "success": True,
+            "grade": {
+                "binary_pass": True,
+                "score": 1.0,
+                "components": {
+                    "state_checks": 1.0,
+                    "transcript_rules": -1.0,
+                    "llm_judge": -1.0,
+                    "custom_checks": -1.0,
+                },
+                "reasons": "ok",
+            },
+        }
+
+    def connect(self, timeout: float = 30.0, retry_interval: float = 1.0) -> None:
+        # No-op — the test injects the client into an already-connected
+        # backend so this path is never exercised by ``grade_trial``.
+        return None
+
+    def health_check(self) -> bool:
+        return True
+
+    def grade_trial(
+        self,
+        trial_id: str,
+        llm_messages_json: str | None = None,
+        grading_components: list[str] | None = None,
+        termination_reason: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "trial_id": trial_id,
+                "llm_messages_json": llm_messages_json,
+                "grading_components": grading_components,
+                "termination_reason": termination_reason,
+            }
+        )
+        return self._grade_result
+
+
+class TestPerTrialBackendRoutesThroughRunnerRPCGrader:
+    """``RunnerRPCTrialGrader.grade`` must route through
+    ``PerTrialRuntimeBackend.grade_trial`` when the context carries the
+    backend, so per-trial engine-loop runs produce a Grade instead of an
+    empty-address gRPC error."""
+
+    def test_grade_reaches_per_trial_client_and_returns_a_grade(self) -> None:
+        """The regression scenario: PerTrialRuntimeBackend + runner_rpc grader
+        + a USER_STOP-terminated trajectory MUST produce a Grade. Before the
+        fix, this test hangs on the phantom-address health-check retry loop
+        (~30 s) and raises ConnectionError — a clean fails-on-main,
+        passes-on-fix behaviour lock."""
+        spec = make_trial_spec()
+        trial_id = spec.trial_id
+
+        fake_client = _FakePerTrialRunnerClient()
+        backend = PerTrialRuntimeBackend()
+        # Inject a per-trial client and mark it connected, bypassing
+        # docker-compose provisioning + the gRPC health-check. The test is
+        # a wire-shape lock, not a real per-trial substrate exerciser.
+        backend._clients[trial_id] = fake_client  # type: ignore[assignment]
+        backend._connected_trials.add(trial_id)
+
+        ctx = TrialGraderContext(
+            runner_address=None,
+            logger=MagicMock(),
+            runtime_backend=backend,
+        )
+        grader = runner_rpc_trial_grader_factory(ctx)
+
+        # No gRPC client on this dispatch path — the backend is the target.
+        assert grader.runtime_backend is backend
+        assert grader.runner_client is None
+
+        traj = make_trajectory(
+            status=TrialStatus.COMPLETED,
+            termination_reason=TerminationReason.USER_STOP,
+        )
+        grade = grader.grade(spec, traj, "sysprompt")
+
+        assert isinstance(grade, Grade)
+        assert grade.binary_pass is True
+        assert grade.score == 1.0
+        assert len(fake_client.calls) == 1
+        assert fake_client.calls[0]["trial_id"] == trial_id
+        assert fake_client.calls[0]["termination_reason"] == TerminationReason.USER_STOP.value
+
+    def test_p2_p3_path_still_works_without_runtime_backend(self) -> None:
+        """The out-of-process shape ADR-0038 pins: no runtime_backend, only
+        an address-built client. Stage 2's routing change must not regress
+        this path — the grader still dispatches through the client target.
+
+        Monkey-patch ``GrpcRunnerClient`` construction so the factory can
+        build without touching the network, then confirm the client the
+        factory placed on the grader receives the ``grade_trial`` call."""
+        stub_client = _FakePerTrialRunnerClient()
+
+        import tolokaforge.core.shared_stack_runtime as ssr
+
+        original = ssr.GrpcRunnerClient
+        # Every ``GrpcRunnerClient(runner_address=...)`` construction from
+        # this stub returns the same ``_FakePerTrialRunnerClient``, which
+        # implements the RunnerClient Protocol slice the grader touches.
+        ssr.GrpcRunnerClient = lambda runner_address: stub_client  # type: ignore[assignment]
+        try:
+            ctx = TrialGraderContext(
+                runner_address="test-runner:9999",
+                logger=MagicMock(),
+                # No runtime_backend — this is the wire shape.
+            )
+            grader = runner_rpc_trial_grader_factory(ctx)
+        finally:
+            ssr.GrpcRunnerClient = original  # type: ignore[assignment]
+
+        assert grader.runtime_backend is None
+        assert grader.runner_client is stub_client
+
+        spec = make_trial_spec()
+        traj = make_trajectory(
+            status=TrialStatus.COMPLETED,
+            termination_reason=TerminationReason.USER_STOP,
+        )
+        grade = grader.grade(spec, traj, "sysprompt")
+
+        assert isinstance(grade, Grade)
+        assert len(stub_client.calls) == 1
+        assert stub_client.calls[0]["trial_id"] == spec.trial_id

--- a/tests/canonical/test_trial_grader_per_trial_backend_routing.py
+++ b/tests/canonical/test_trial_grader_per_trial_backend_routing.py
@@ -15,8 +15,14 @@ completed trial, and no ``grade.yaml`` was ever written. On the
 This test pins the fix — ``ctx.runtime_backend`` is threaded through the
 context and the grader delegates to ``backend.grade_trial(trial_id, ...)``,
 which ``PerTrialRuntimeBackend._client_for(trial_id)`` routes to the
-correct per-trial runner client. The companion test locks that the
-out-of-process (P2/P3) shape ADR-0038 pins is not regressed by the change.
+correct per-trial runner client. The P2/P3 (out-of-process) dispatch shape
+is locked at unit level by
+``tests/unit/test_trial_grader.py::TestRuntimeBackendDispatchPreference::
+test_runner_client_used_when_runtime_backend_is_none``, and factory→client
+ownership is locked at canonical level by
+``TestRunnerRpcTrialGraderFactory::test_factory_returns_grader_with_owned_
+runner_client`` in ``test_trial_grader_context_hygiene.py`` — no duplicate
+canonical test for the P2/P3 path lives here.
 """
 
 from __future__ import annotations
@@ -135,43 +141,102 @@ class TestPerTrialBackendRoutesThroughRunnerRPCGrader:
         assert fake_client.calls[0]["trial_id"] == trial_id
         assert fake_client.calls[0]["termination_reason"] == TerminationReason.USER_STOP.value
 
-    def test_p2_p3_path_still_works_without_runtime_backend(self) -> None:
-        """The out-of-process shape ADR-0038 pins: no runtime_backend, only
-        an address-built client. Stage 2's routing change must not regress
-        this path — the grader still dispatches through the client target.
 
-        Monkey-patch ``GrpcRunnerClient`` construction so the factory can
-        build without touching the network, then confirm the client the
-        factory placed on the grader receives the ``grade_trial`` call."""
-        stub_client = _FakePerTrialRunnerClient()
+class TestBuildConductorGatesRuntimeBackendOnAddress:
+    """``orchestrator._build_conductor`` populates ``TrialGraderContext.
+    runtime_backend`` ONLY when the backend has no static ``runner_address``.
+    For shared-stack backends (which have one), the shim stays ``None`` so
+    ADR-0038's "grader owns its own client, independent of the orchestrator"
+    invariant is preserved for every case that can honour it. Only per-trial
+    backends (each trial owns its own endpoint) get the shim.
+    """
 
-        import tolokaforge.core.shared_stack_runtime as ssr
+    def _captured_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+        backend_runner_address: str | None,
+    ) -> TrialGraderContext:
+        """Build a conductor with a backend whose ``runner_address`` is
+        ``backend_runner_address`` (``None`` means the attribute is
+        missing entirely, mirroring ``PerTrialRuntimeBackend``); return
+        the ``TrialGraderContext`` the orchestrator passed to
+        ``load_trial_grader``. Real ``_build_conductor``; real
+        ``runner_rpc_trial_grader_factory`` swapped for a capturing shim."""
+        from tolokaforge.core.conductor import ConductorContext, InMemoryConductor
+        from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
 
-        original = ssr.GrpcRunnerClient
-        # Every ``GrpcRunnerClient(runner_address=...)`` construction from
-        # this stub returns the same ``_FakePerTrialRunnerClient``, which
-        # implements the RunnerClient Protocol slice the grader touches.
-        ssr.GrpcRunnerClient = lambda runner_address: stub_client  # type: ignore[assignment]
-        try:
-            ctx = TrialGraderContext(
-                runner_address="test-runner:9999",
-                logger=MagicMock(),
-                # No runtime_backend — this is the wire shape.
-            )
-            grader = runner_rpc_trial_grader_factory(ctx)
-        finally:
-            ssr.GrpcRunnerClient = original  # type: ignore[assignment]
+        captured: dict[str, TrialGraderContext] = {}
 
-        assert grader.runtime_backend is None
-        assert grader.runner_client is stub_client
+        def _capturing_factory(ctx: TrialGraderContext) -> Any:
+            captured["ctx"] = ctx
 
-        spec = make_trial_spec()
-        traj = make_trajectory(
-            status=TrialStatus.COMPLETED,
-            termination_reason=TerminationReason.USER_STOP,
+            class _Stub:
+                def grade(self, *a: Any, **kw: Any) -> None:
+                    return None
+
+            return _Stub()
+
+        monkeypatch.setattr(
+            "tolokaforge.core.orchestrator.load_trial_grader",
+            lambda name: _capturing_factory,
         )
-        grade = grader.grade(spec, traj, "sysprompt")
 
-        assert isinstance(grade, Grade)
-        assert len(stub_client.calls) == 1
-        assert stub_client.calls[0]["trial_id"] == spec.trial_id
+        def _conductor_factory(_ctx: ConductorContext) -> InMemoryConductor:
+            return InMemoryConductor()
+
+        # Build a lightweight runtime_backend whose ``runner_address``
+        # attribute exists (shared-stack shape) or is absent (per-trial
+        # shape) — the orchestrator's ``getattr(..., None)`` reads it.
+        if backend_runner_address is None:
+            # No attribute at all — MagicMock synthesizes attrs by default,
+            # so use ``spec=[]`` to force ``getattr`` fallback to ``None``.
+            backend = MagicMock(spec=[])
+        else:
+            backend = MagicMock()
+            backend.runner_address = backend_runner_address
+
+        from tolokaforge.core.models.run_config import (
+            EvaluationConfig,
+            ModelConfig,
+            OrchestratorConfig,
+            RunConfig,
+        )
+
+        cfg = RunConfig(
+            models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+            orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
+            evaluation=EvaluationConfig(output_dir="/tmp/test_output"),
+        )
+        orch = Orchestrator(cfg, deps=OrchestratorDeps(conductor_factory=_conductor_factory))
+        orch.adapter = MagicMock()
+        orch.adapter.trial_grader_name = "runner_rpc"
+
+        orch._build_conductor(
+            agent_client=MagicMock(),
+            runtime_backend=backend,
+            output_dir=tmp_path,
+            request_limiter=None,
+        )
+        return captured["ctx"]
+
+    def test_per_trial_backend_gets_the_shim(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """No ``runner_address`` on the backend (``PerTrialRuntimeBackend``
+        shape) → the shim is populated so the grader can route per-trial."""
+        ctx = self._captured_context(monkeypatch, tmp_path, backend_runner_address=None)
+        assert ctx.runner_address is None
+        assert ctx.runtime_backend is not None
+
+    def test_shared_stack_backend_does_not_get_the_shim(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """A backend with ``runner_address`` set (shared-stack shape) → the
+        shim stays ``None``; the grader owns its own client bound to the
+        address, preserving ADR-0038's independence invariant for every
+        case that can honour it. Regression lock for the reviewer's Major
+        finding on PR #1328."""
+        ctx = self._captured_context(monkeypatch, tmp_path, backend_runner_address="runner:50051")
+        assert ctx.runner_address == "runner:50051"
+        assert ctx.runtime_backend is None

--- a/tests/unit/test_trial_grader.py
+++ b/tests/unit/test_trial_grader.py
@@ -346,3 +346,76 @@ class TestJudgeMessagesJson:
         assert backend.calls[0]["llm_messages_json"] is not None
         parsed = json.loads(backend.calls[0]["llm_messages_json"])
         assert parsed == [{"role": "system", "content": "you are a helper"}]
+
+
+class TestRuntimeBackendDispatchPreference:
+    """When ``runtime_backend`` is set on the grader (in-process per-trial
+    routing), :meth:`grade` dispatches through it — not through the
+    address-built client. When ``runtime_backend`` is ``None`` (the P2/P3
+    on-the-wire shape), the address-built client is the target. This is the
+    regression this PR fixes: on ``PerTrialRuntimeBackend``, the client was
+    bound to ``""`` and every ``grade_trial`` call failed with
+    :class:`_InactiveRpcError`.
+    """
+
+    def test_runtime_backend_wins_when_both_are_set(self) -> None:
+        """Grade a COMPLETED trajectory with both a runtime_backend and a
+        runner_client set. Only the runtime_backend must record the call —
+        the fallback client stays silent."""
+        backend_target = _StubBackend()
+        client_target = _StubBackend()
+        grader = RunnerRPCTrialGrader(
+            runner_address="stub:0",
+            logger=MagicMock(),
+            runner_client=client_target,
+            runtime_backend=backend_target,  # type: ignore[arg-type]
+        )
+
+        grader.grade(
+            make_trial_spec(),
+            make_trajectory(status=TrialStatus.COMPLETED),
+            "sysprompt",
+        )
+
+        assert len(backend_target.calls) == 1
+        assert backend_target.calls[0]["trial_id"].endswith(":0")
+        assert client_target.calls == []
+
+    def test_runner_client_used_when_runtime_backend_is_none(self) -> None:
+        """The P2/P3 on-the-wire shape — no runtime_backend, only an
+        address-built client. This locks that Stage 2's routing change did
+        not regress the out-of-process path."""
+        client_target = _StubBackend()
+        grader = RunnerRPCTrialGrader(
+            runner_address="stub:0",
+            logger=MagicMock(),
+            runner_client=client_target,
+            runtime_backend=None,
+        )
+
+        grader.grade(
+            make_trial_spec(),
+            make_trajectory(status=TrialStatus.COMPLETED),
+            "sysprompt",
+        )
+
+        assert len(client_target.calls) == 1
+        assert client_target.calls[0]["trial_id"].endswith(":0")
+
+    def test_factory_threads_runtime_backend_from_context(self) -> None:
+        """``runner_rpc_trial_grader_factory(ctx)`` must pull
+        ``ctx.runtime_backend`` into the grader when set, AND skip building
+        a live gRPC client (nothing to dial — the backend is the target)."""
+        from tolokaforge.core.plugin_registry import TrialGraderContext
+        from tolokaforge.core.trial_grader import runner_rpc_trial_grader_factory
+
+        backend_target = _StubBackend()
+        ctx = TrialGraderContext(
+            runner_address=None,
+            logger=MagicMock(),
+            runtime_backend=backend_target,  # type: ignore[arg-type]
+        )
+        grader = runner_rpc_trial_grader_factory(ctx)
+
+        assert grader.runtime_backend is backend_target
+        assert grader.runner_client is None

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -815,15 +815,18 @@ class Orchestrator:
         grader_name = (
             grader_config.name if grader_config and grader_config.name else None
         ) or self.adapter.trial_grader_name
+        # In-process routing shim: only populated when the backend has no
+        # static runner endpoint (``PerTrialRuntimeBackend`` — each trial
+        # owns its own endpoint). Shared-stack keeps its address-only,
+        # orchestrator-independent grader client so ADR-0038's seam
+        # invariant is preserved for every case that can honour it.
+        in_process_backend_shim = runtime_backend if runner_address is None else None
         trial_grader = load_trial_grader(grader_name)(
             TrialGraderContext(
                 runner_address=runner_address,
                 logger=self.logger,
                 grader_config=grader_config,
-                # In-process routing shim for per-trial runtime backends;
-                # out-of-process graders MUST ignore it (see ADR-0038 and
-                # ``tests/canonical/test_trial_grader_context_hygiene.py``).
-                runtime_backend=runtime_backend,
+                runtime_backend=in_process_backend_shim,
             )
         )
         # Drain any leftover from a prior aborted run on this orchestrator

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -797,11 +797,14 @@ class Orchestrator:
                 "Conductor cannot be built before the adapter is loaded. "
                 "Ensure load_tasks() has run successfully."
             )
-        # ``None`` when the backend has no runner surface (in-memory / test);
-        # the built-in address-needing factories (``runner_rpc``, ``grader_rpc``)
-        # raise loudly when they observe it. Downstream graders that do not need
-        # a network address (a stub, a callable-injected grader) receive the
-        # ``None`` verbatim and ignore it.
+        # ``None`` when the backend has no runner surface (in-memory / test,
+        # or ``PerTrialRuntimeBackend`` — each trial owns its own runner
+        # endpoint so no single address applies); the built-in
+        # address-needing factories (``grader_rpc``, ``queue``) raise loudly
+        # when they observe it. Downstream graders that do not need a
+        # network address receive the ``None`` verbatim and ignore it, and
+        # ``runner_rpc`` picks the ``runtime_backend`` dispatch path below
+        # instead of dialling.
         runner_address = getattr(runtime_backend, "runner_address", None)
         # ``config.grader.name`` overrides the adapter's default for this
         # run; the queue subblock rides the same context so
@@ -817,6 +820,10 @@ class Orchestrator:
                 runner_address=runner_address,
                 logger=self.logger,
                 grader_config=grader_config,
+                # In-process routing shim for per-trial runtime backends;
+                # out-of-process graders MUST ignore it (see ADR-0038 and
+                # ``tests/canonical/test_trial_grader_context_hygiene.py``).
+                runtime_backend=runtime_backend,
             )
         )
         # Drain any leftover from a prior aborted run on this orchestrator

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -238,13 +238,17 @@ class RuntimeBackendBuildContext:
 
 @dataclass(frozen=True)
 class TrialGraderContext:
-    """Serialisable configuration a trial-grader factory receives from the orchestrator.
+    """Configuration a trial-grader factory receives from the orchestrator.
 
-    Carries only data, not live objects: two endpoint strings, the run-scoped
-    logger, and the optional ``grader`` config block. A live gRPC channel
-    would couple the grader to the orchestrator's chosen runner instance
-    and block a grader that runs on a different machine — precisely the
-    coupling the plug-in seam exists to break (see ADR-0038).
+    Carries serialisable data — two endpoint strings, the run-scoped logger,
+    and the optional ``grader`` config block — plus one optional in-process
+    escape hatch (``runtime_backend``) that MUST be ``None`` on any grader
+    that will cross an address boundary. A required live gRPC channel would
+    couple the grader to the orchestrator's chosen runner instance and block
+    a grader that runs on a different machine — precisely the coupling the
+    plug-in seam exists to break (see ADR-0038); the escape hatch is scoped
+    strictly to backends whose runner endpoints are only reachable per-trial
+    (see ``runtime_backend`` below).
 
     :attr:`runner_address` is the runner service's gRPC address; the
     ``runner_rpc`` grader dials it.

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -259,12 +259,25 @@ class TrialGraderContext:
     ``None`` when the operator declared none). Transport-specific factories
     read their own subblock — ``queue`` reads ``grader_config.queue`` for
     worker-pool sizing and the downstream ``worker_grader`` name.
+
+    :attr:`runtime_backend` is an in-process routing shim populated only by
+    ``orchestrator._build_conductor``. When a runtime backend routes grades
+    per-trial (``PerTrialRuntimeBackend``), it exposes no static
+    ``runner_address`` because each trial owns its own runner endpoint;
+    passing the backend directly lets ``RunnerRPCTrialGrader`` delegate to
+    ``backend.grade_trial(trial_id, ...)`` and reach the right per-trial
+    client. Every out-of-process factory (``grader_rpc``, ``queue``,
+    ``judge_backed``) MUST ignore this field: the whole point of ADR-0038 is
+    that a grader running on a different machine cannot hold a live
+    orchestrator-side backend, so this attribute is NOT serialisable and
+    MUST be ``None`` on any grader that crosses an address boundary.
     """
 
     runner_address: str | None
     logger: StructuredLogger
     grader_address: str | None = None
     grader_config: GraderConfig | None = None
+    runtime_backend: RuntimeBackend | None = None
 
 
 @dataclass(frozen=True)

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -201,10 +201,10 @@ class RunnerRPCTrialGrader:
     method returning the same dict shape as
     :meth:`GrpcRunnerClient.grade_trial`.
 
-    Note on ``run_trial.py``: the container-shim entry point at
-    ``run_trial.py:157`` constructs its own ``TrialGraderContext`` with a
-    stable ``EXECUTOR_ADDRESS`` and no ``runtime_backend``; the fallback
-    client path is the correct behaviour for that call site.
+    Note on ``run_trial.py``: the container-shim entry point constructs
+    its own ``TrialGraderContext`` with a stable ``EXECUTOR_ADDRESS`` and
+    no ``runtime_backend``; the fallback client path is the correct
+    behaviour for that call site.
     """
 
     def __init__(
@@ -285,14 +285,9 @@ class RunnerRPCTrialGrader:
             )
 
         llm_messages_json = encode_transcript_wire(trajectory, agent_system_prompt)
-        # Prefer the in-process backend when set (per-trial runtimes need it
-        # to route to the trial's own runner endpoint); the address-built
-        # client is the wire-safe fallback for the P2/P3 shape. See ADR-0038
-        # § "Grader plug-in receives serialisable configuration only" — the
-        # wire never carries a live backend, so ``target`` here is always
-        # ``self.runner_client`` in that case.
         target = self.runtime_backend if self.runtime_backend is not None else self.runner_client
-        assert target is not None, "RunnerRPCTrialGrader has no dispatch target"
+        if target is None:  # __init__ prevents this — defence in depth
+            raise RuntimeError("RunnerRPCTrialGrader has no dispatch target")
         grade_result = target.grade_trial(
             trial_id=spec.trial_id,
             llm_messages_json=llm_messages_json,

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from tolokaforge.core.llm.client import LLMClient
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.plugin_registry import TrialGraderContext
+    from tolokaforge.core.runtime import RuntimeBackend
     from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient
     from tolokaforge.grader.client import GrpcGraderClient
     from tolokaforge.grader.queue import GradeBroker
@@ -169,16 +170,41 @@ class RunnerRPCTrialGrader:
     raises :class:`GradingFailedError` when the RPC could not produce a
     verdict.
 
-    Built per-run from a :class:`TrialGraderContext` — a *serialisable*
-    configuration (``runner_address`` + logger). The grader owns its own
-    :class:`~tolokaforge.core.shared_stack_runtime.GrpcRunnerClient` bound
-    to that address, so it stays independent of the orchestrator's runtime
-    backend — the seam that lets a future grader run on a different machine.
+    Built per-run from a :class:`TrialGraderContext` — serialisable
+    configuration (``runner_address`` + logger) for the out-of-process
+    shape, plus one optional in-process routing shim (``runtime_backend``).
+
+    Two dispatch shapes, one class:
+
+    * **Out-of-process (P2/P3):** ``ctx.runtime_backend`` is ``None`` on the
+      wire. The grader owns its own
+      :class:`~tolokaforge.core.shared_stack_runtime.GrpcRunnerClient` bound
+      to ``runner_address``, so it stays independent of the orchestrator's
+      runtime backend — the ADR-0038 seam that lets a grader run on a
+      different machine.
+    * **In-process (per-trial runtimes):** ``ctx.runtime_backend`` is set to
+      the live backend. ``:meth:`grade`` delegates to
+      ``runtime_backend.grade_trial(...)``, which for
+      :class:`PerTrialRuntimeBackend` routes the RPC to the trial's own
+      runner endpoint (each trial owns its endpoint, so no single
+      ``runner_address`` can reach them all). No gRPC client is built for
+      this shape — the ``runner_address`` on the context is unused here.
+
+    Preference at grade time: ``runtime_backend`` wins when both are set;
+    ``runner_client`` is the fallback path. That preserves the P2/P3
+    "grader on another machine" story on the wire — a ``TrialGraderContext``
+    whose ``runtime_backend`` is ``None`` sees exactly the pre-existing
+    address-only dispatch.
 
     Tests may pass a ``runner_client`` directly to bypass real gRPC; the
     stub must expose a ``grade_trial(trial_id, llm_messages_json, ...)``
     method returning the same dict shape as
     :meth:`GrpcRunnerClient.grade_trial`.
+
+    Note on ``run_trial.py``: the container-shim entry point at
+    ``run_trial.py:157`` constructs its own ``TrialGraderContext`` with a
+    stable ``EXECUTOR_ADDRESS`` and no ``runtime_backend``; the fallback
+    client path is the correct behaviour for that call site.
     """
 
     def __init__(
@@ -187,10 +213,15 @@ class RunnerRPCTrialGrader:
         logger: StructuredLogger,
         *,
         runner_client: GrpcRunnerClient | None = None,
+        runtime_backend: RuntimeBackend | None = None,
     ) -> None:
         self.runner_address = runner_address
         self.logger = logger
-        if runner_client is None:
+        self.runtime_backend = runtime_backend
+        # Skip the gRPC channel entirely when a live backend is the target;
+        # the ``runner_address`` on the context is unused for
+        # ``PerTrialRuntimeBackend`` (each trial has its own endpoint).
+        if runner_client is None and runtime_backend is None:
             from tolokaforge.core.shared_stack_runtime import GrpcRunnerClient as _Client
 
             runner_client = _Client(runner_address=runner_address)
@@ -254,7 +285,15 @@ class RunnerRPCTrialGrader:
             )
 
         llm_messages_json = encode_transcript_wire(trajectory, agent_system_prompt)
-        grade_result = self.runner_client.grade_trial(
+        # Prefer the in-process backend when set (per-trial runtimes need it
+        # to route to the trial's own runner endpoint); the address-built
+        # client is the wire-safe fallback for the P2/P3 shape. See ADR-0038
+        # § "Grader plug-in receives serialisable configuration only" — the
+        # wire never carries a live backend, so ``target`` here is always
+        # ``self.runner_client`` in that case.
+        target = self.runtime_backend if self.runtime_backend is not None else self.runner_client
+        assert target is not None, "RunnerRPCTrialGrader has no dispatch target"
+        grade_result = target.grade_trial(
             trial_id=spec.trial_id,
             llm_messages_json=llm_messages_json,
             termination_reason=(
@@ -473,15 +512,31 @@ def _parse_grade_result(raw_grade: dict[str, Any]) -> Grade:
 def runner_rpc_trial_grader_factory(ctx: TrialGraderContext) -> RunnerRPCTrialGrader:
     """Build a :class:`RunnerRPCTrialGrader` from a grader context.
 
+    Dispatch preference at grade time:
+
+    * When ``ctx.runtime_backend`` is set, ``RunnerRPCTrialGrader.grade``
+      delegates to ``runtime_backend.grade_trial(...)`` and no gRPC channel
+      is built. This is the in-process path for per-trial runtime backends
+      (each trial owns its own runner endpoint, so no single
+      ``runner_address`` can reach them all).
+    * Otherwise, the grader owns its own :class:`GrpcRunnerClient` bound to
+      ``ctx.runner_address``. This is the P2/P3 shape ADR-0038 pins — the
+      wire carries no live backend, so out-of-process construction sees
+      exactly this branch.
+
     Accepts ``ctx.runner_address is None`` at construction so orchestrator
     fixtures paired with an in-memory backend can still build the grader
-    without touching the network. The misconfiguration surfaces at the
-    first :meth:`grade` call as a :class:`ConnectionError` from
-    :class:`GrpcRunnerClient.connect`'s health-check retry loop (~30 s
-    timeout) rather than a synchronous ``ValueError`` — the address is
-    only dialled when it is needed.
+    without touching the network. When ``ctx.runtime_backend`` is also
+    ``None`` the misconfiguration surfaces at the first :meth:`grade` call
+    as a :class:`ConnectionError` from :class:`GrpcRunnerClient.connect`'s
+    health-check retry loop (~30 s timeout) rather than a synchronous
+    ``ValueError`` — the address is only dialled when it is needed.
     """
-    return RunnerRPCTrialGrader(runner_address=ctx.runner_address or "", logger=ctx.logger)
+    return RunnerRPCTrialGrader(
+        runner_address=ctx.runner_address or "",
+        logger=ctx.logger,
+        runtime_backend=ctx.runtime_backend,
+    )
 
 
 JudgeGradeFn = Callable[[TrialSpec, Trajectory, str], "Grade | None"]


### PR DESCRIPTION
## Summary

PR #1183 replaced the grader context's live `runtime_backend` with a
serialisable `runner_address` — a good idea for the P2/P3 out-of-process
grader path ADR-0038 pins. Side-effect: `PerTrialRuntimeBackend` (the
runtime every terminal-bench engine-loop run uses) has no `runner_address`
attribute because each trial owns its own runner endpoint.
`orchestrator._build_conductor` read `getattr(runtime_backend,
"runner_address", None)` and passed `None`; the factory built a
`GrpcRunnerClient(runner_address="")`; every `grade_trial` call failed with
`_InactiveRpcError`. Result: engine-loop trials completed cleanly but
produced no `grade.yaml` and `binary_pass=None` on every trial.

**Reproduced live** on a downstream `eval/tbench-balanced-10-engine-loop`
sample sweep: 110/110 completed kimi_k3 trials of a T-Bench balanced-10 run
carried `grading_error: "Grading failed for trial ...: gRPC error:
<_InactiveRpcError..."`. That is $50 of LLM spend with zero gradable
results — blocking the engine-loop vs Harbor scaffold comparison entirely.

## Fix — restore in-process routing without re-coupling the wire

- `TrialGraderContext` gains one optional field, `runtime_backend:
  RuntimeBackend | None = None`. Every out-of-process factory
  (`grader_rpc`, `queue`, `judge_backed`) MUST ignore it — ADR-0038's
  serialisable-configuration invariant stays intact on the wire because the
  field is `None` by default and never crosses an address boundary.
- `RunnerRPCTrialGrader.__init__` accepts an optional `runtime_backend`.
  When set, `grade` delegates to `runtime_backend.grade_trial(...)`, which
  `PerTrialRuntimeBackend._client_for(trial_id)` routes to the correct
  per-trial runner client. When unset, the pre-existing address-built
  `GrpcRunnerClient` fallback runs — the P2/P3 shape is bit-identical to
  today.
- `runner_rpc_trial_grader_factory` threads the new field through.
- `orchestrator._build_conductor` passes `runtime_backend=runtime_backend`
  alongside the still-populated `runner_address`.

No adapter changes — the terminal-bench adapter already emits the correct
`grading_method="test_execution"`.

## Test plan

- [x] Stage 1 (context hygiene, canonical): 11 tests — extends
  `test_trial_grader_context_hygiene.py` with (a) new
  `test_runtime_backend_is_optional_and_defaults_to_none`, (b) new
  `TestOutOfProcessFactoriesIgnoreRuntimeBackend` with both `ast.walk`
  (static) and sentinel-backend (runtime) checks on all three
  out-of-process factories.
- [x] Stage 2 (dispatch preference, unit): 3 tests —
  `TestRuntimeBackendDispatchPreference` locks the
  `runtime_backend`-wins-when-set contract and the `runner_client`
  fallback for the P2/P3 shape.
- [x] Stage 3 (end-to-end regression, canonical): new
  `test_trial_grader_per_trial_backend_routing.py` — wires
  `PerTrialRuntimeBackend` + `runner_rpc` + a `USER_STOP`-terminated
  trajectory and asserts a `Grade` returns. On `main` before this fix,
  that test hangs on the phantom-address health-check loop and raises
  `ConnectionError`.
- [x] Full grader-wide test sweep (`test_grader_rpc_trial_grader.py`,
  `test_grader_queue_wire_v2.py`, `test_judge_backed_trial_grader.py`,
  `test_grader_composite_dispatch.py`, `test_grader_end_to_end.py`,
  `test_grader_service_contract.py`, `test_grader_wire_v2.py`): 122
  passed, no P2/P3 regressions.
- [x] Orchestrator + grader surface: `pytest -k "trial_grader or
  _build_conductor or grader"` — 216 passed.
- [x] `ruff check` + `black --check` + `import-linter`: all clean.
- [ ] Live smoke: cut `v0.21.3`, bump the pin on the downstream engine-loop
  task-set branch, re-dispatch the same kimi_k3 sample. Success signal =
  `grade.yaml` files present in every completed trial's bundle, and the
  aggregate reports a real pass rate (not 0/N).

## ADR-0038 compliance

The escape hatch is `None` by default. The out-of-process factories are
verified — statically and at runtime — to never read it. The wire never
carries a live backend. A one-paragraph ADR-0038 addendum under
"Consequences → In-process routing" would be a doc-only follow-up if the
reviewer wants a formal record.