### PR TITLE
fix(config): refuse TypeSenseConfig(mode="remote", port="auto") at parse time

### DIFF
--- a/tests/unit/test_orchestrator_typesense_stack_address.py
+++ b/tests/unit/test_orchestrator_typesense_stack_address.py
@@ -104,16 +104,20 @@ def test_a_plane_this_process_did_not_start_is_injected_verbatim(tmp_path: Path)
     assert (address.host, address.port) == ("ts.example", 8108)
 
 
-@pytest.mark.parametrize("mode", ["local", "remote"])
-def test_an_unresolved_port_refuses_to_build_the_stack(tmp_path: Path, mode: str) -> None:
+def test_an_unresolved_port_refuses_to_build_the_stack(tmp_path: Path) -> None:
     """``auto`` is not an address, and it must not reach a container as one.
 
     Reached when ``run()`` is handed pre-loaded tasks: it then skips
     ``load_tasks()``, so ``_ensure_typesense_started`` never resolves a port
     and no server handle exists to derive an alias from.
+
+    Only the ``mode="local"`` case reaches this refusal: ``mode="remote" +
+    port="auto"`` is refused at ``TypeSenseConfig`` parse time
+    (see :mod:`tests.unit.test_typesense_config_port_auto_guard`), so the
+    stack-address path never sees that combination.
     """
     orchestrator = _orchestrator(
-        tmp_path, TypeSenseConfig(enabled=True, mode=mode, host="ts.example", port="auto")
+        tmp_path, TypeSenseConfig(enabled=True, mode="local", host="ts.example", port="auto")
     )
 
     with pytest.raises(RuntimeError) as raised:
@@ -122,7 +126,7 @@ def test_an_unresolved_port_refuses_to_build_the_stack(tmp_path: Path, mode: str
     message = str(raised.value)
     assert message.startswith("orchestrator.typesense:")
     assert "auto" in message
-    assert mode in message
+    assert "local" in message
 
 
 def test_a_pinned_local_config_that_skipped_the_start_refuses_its_loopback_address(

--- a/tests/unit/test_typesense_config_port_auto_guard.py
+++ b/tests/unit/test_typesense_config_port_auto_guard.py
@@ -1,0 +1,74 @@
+"""Guard: `TypeSenseConfig` refuses `mode="remote" + port="auto"` at parse time.
+
+The `"auto"` sentinel is meaningful only for `mode="local"` (auto-allocate a
+local server port). Nothing resolves it for `mode="remote"`, and the downstream
+`int(port)` cast in the adapter surface crashes on the string. The validator
+moves the refusal from stack-build time (where it already raises) to config
+parse time (fail-fast).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from tolokaforge.core.models.run_config import TypeSenseConfig
+
+pytestmark = pytest.mark.unit
+
+
+def test_remote_with_auto_port_refused_at_parse_time() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        TypeSenseConfig(enabled=True, mode="remote", host="ts.example", port="auto")
+
+    message = str(exc_info.value)
+    assert 'mode="remote" requires a concrete port' in message
+
+
+def test_local_with_auto_port_parses() -> None:
+    """`mode="local" + port="auto"` is the default configuration; it must
+    continue to parse so a future maintainer does not over-tighten the
+    validator."""
+    config = TypeSenseConfig(enabled=True, mode="local", port="auto")
+
+    assert config.mode == "local"
+    assert config.port == "auto"
+
+
+def test_remote_with_concrete_port_parses() -> None:
+    config = TypeSenseConfig(enabled=True, mode="remote", host="ts.example", port=443)
+
+    assert config.mode == "remote"
+    assert config.port == 443
+
+
+def test_disabled_enabled_false_with_auto_port_parses() -> None:
+    """`enabled=False` and `mode="disabled"` render the port inert
+    (`effective_typesense()` returns `None`); coercing the sentinel there
+    would be mute-error territory. Leave it alone."""
+    config_disabled_flag = TypeSenseConfig(enabled=False, port="auto")
+    assert config_disabled_flag.port == "auto"
+
+    config_disabled_mode = TypeSenseConfig(enabled=True, mode="disabled", port="auto")
+    assert config_disabled_mode.mode == "disabled"
+    assert config_disabled_mode.port == "auto"
+
+
+def test_yaml_load_of_invalid_combo_raises_at_parse_time() -> None:
+    """YAML is the primary loading path for run configs — the validator must
+    fire there too, not just on kwargs construction."""
+    yaml_text = textwrap.dedent("""
+        enabled: true
+        mode: remote
+        host: ts.example
+        port: auto
+        """)
+    payload = yaml.safe_load(yaml_text)
+
+    with pytest.raises(ValidationError) as exc_info:
+        TypeSenseConfig.model_validate(payload)
+
+    assert 'mode="remote" requires a concrete port' in str(exc_info.value)

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -386,13 +386,43 @@ class TypeSenseConfig(BaseModel):
     enabled: bool = True  # Whether TypeSense is enabled
     mode: Literal["local", "remote", "disabled"] = "local"  # Server mode
     host: str = "127.0.0.1"  # TypeSense server host
-    port: int | Literal["auto"] = "auto"  # Port ("auto" finds available port)
+    port: int | Literal["auto"] = "auto"
+    """Port TypeSense answers on.
+
+    The ``"auto"`` sentinel is valid only for ``mode="local"`` (bind to
+    OS-assigned free port, then reuse it). ``mode="remote"`` requires a
+    concrete int — nothing resolves ``"auto"`` for the remote case, and the
+    downstream ``int(port)`` cast in the adapter surface crashes on the
+    string. Refused at parse time by
+    :meth:`TypeSenseConfig._refuse_auto_port_on_remote_mode`.
+    """
     api_key: str | None = None  # API key (auto-generated if None for local mode)
     data_dir: str = ".cache/typesense"  # Data directory for local mode
     image: str = "typesense/typesense:26.0"  # Docker image for local mode
     container_name: str = "tolokaforge-typesense"  # Container name for local mode
     timeout: float = 30.0  # Connection timeout
     cleanup_on_exit: bool = True  # Remove container on exit (local mode)
+
+    @model_validator(mode="after")
+    def _refuse_auto_port_on_remote_mode(self) -> "TypeSenseConfig":
+        """Reject the semantically-invalid ``mode="remote" + port="auto"`` combo.
+
+        The ``"auto"`` sentinel means "auto-allocate a local server port" and
+        only ``_start_local_typesense_server`` resolves it. Nothing resolves
+        it for remote mode: the orchestrator's stack-address path already
+        raises for this combination, and adapters reading the raw config via
+        ``model_dump()`` crash on ``int("auto")``. Fail-fast at parse time.
+        """
+        if self.enabled and self.mode == "remote" and self.port == "auto":
+            raise ValueError(
+                'orchestrator.typesense: mode="remote" requires a concrete '
+                'port, got port="auto". "auto" is a sentinel for mode="local" '
+                "(auto-allocate a local server); nothing resolves it for "
+                'mode="remote". Set orchestrator.typesense.port to the port '
+                'the remote server answers on, or use mode="local" if you '
+                "want a local auto-allocated server."
+            )
+        return self
 
 
 LEGACY_DOCKER_RUNTIME_ALIAS = "docker"


### PR DESCRIPTION
## Summary

- `TypeSenseConfig` refuses the semantically-invalid `mode="remote" + port="auto"` combination at Pydantic parse time via a new `model_validator(mode="after")`.
- Every legitimate combination continues to parse unchanged: `mode="local" + port="auto"` (the default), `mode="remote" + port=<int>`, `enabled=False`, `mode="disabled"`.
- Fail-fast per AGENTS.md Core Rule 1 — the invalid combo now surfaces at config load instead of at stack-build (`_injected_typesense_address`) or downstream `int(port)` casts in adapter code.

## Design choices

- **Option C narrowed (refuse-at-parse), not Option A (`effective_port` property) or Option B (schema split `port: int` + `auto_assign_port: bool`).** Option A is YAGNI — no consumer asking for it, and it doesn't stop new callers from reading `.port` naively. Option B is a breaking config-surface migration with real blast radius for a bug that already has no in-repo crash today. Option C narrows the surface at parse time without breaking any valid config.
- **Refuse only `mode="remote" + port="auto"`; do not coerce `enabled=False + port="auto"` or `mode="disabled" + port="auto"` to a concrete int.** Coercing would be mute-error territory. `effective_typesense()` returns `None` for those modes so the port is inert; leave the field alone.
- **No `effective_port() -> int` computed property.** YAGNI; the docstring is the contract, no in-repo consumer asks for it. Easy to add later if downstream consumers proliferate.

## Concepts introduced

None — mechanical hardening. The `TypeSenseConfig.port` field's `int | Literal["auto"]` type is unchanged; the validator enforces an invariant that already effectively held (the orchestrator's `_injected_typesense_address` raised for the same combination at stack-build time).

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1298-typesense-port.md`. Single-stage direct edit (per user preference — semantic validator + one test file + docstring + one test migration is small enough to skip the plan-stage-implementer round-trip):

- `tolokaforge/core/models/run_config.py` — new `_refuse_auto_port_on_remote_mode` `@model_validator(mode="after")` on `TypeSenseConfig`; docstring on `.port` rewritten to name the invariant.
- `tests/unit/test_typesense_config_port_auto_guard.py` (new) — 5 unit tests locking the four legitimate combinations + the invalid refusal + YAML load path.
- `tests/unit/test_orchestrator_typesense_stack_address.py` — pre-existing `test_an_unresolved_port_refuses_to_build_the_stack` parametrized `["local", "remote"]` migrated to `local`-only; the `remote` case is now covered by the parse-time guard.

## Discovered issues

- **Filed:** None.
- **Fixed in this PR:** None additional.
- **Noted but not filed** (marginal type-hygiene, deferred):
  - `SearchConfig.port or _DEFAULT_PORT` at `tolokaforge/runner/search_plane.py:127` — `or` idiom treats 0 as falsy; blast radius is zero since TypeSense never listens on port 0.
  - `create_typesense_server(port: int | str = "auto", ...)` at `tolokaforge/core/search/typesense_server.py:349` — `str` typing is loose (accepts more than `"auto"`); could tighten to `int | Literal["auto"]`.
  - Dry-run + worker mode still forward `port="auto"` to adapters via `params["typesense"] = typesense_config.model_dump()` — documented behaviour for `--dry-run` inspection; related to #359.

## Test plan

- `uv run pytest tests/unit/test_typesense_config_port_auto_guard.py tests/unit/test_orchestrator_typesense_startup.py tests/unit/test_orchestrator_typesense_stack_address.py -q` → 29 passing.
- `run_python` sanity: `TypeSenseConfig(mode="remote", port="auto")` now raises `ValidationError` at construction; every other combo parses.

Closes #1298
