### PR TITLE
feat(orchestrator): zero-coverage / zero-judge-graded completion gates + opt-in --fail-on-* flags (#1301, #1063)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -460,23 +460,27 @@ A `candidate` entry converts nothing, so its verdict is reported and gates nothi
 
 ## Run and worker exit codes
 
-`tolokaforge run` and `tolokaforge worker` are usable as gates on whether the run measured everything it attempted:
+`tolokaforge run` and `tolokaforge worker` are usable as gates on whether the run measured everything it attempted and — opt-in — whether the run measured anything at all:
 
 | Outcome | Exit code |
 |---|---|
-| every attempt reached a verdict | `0` |
-| the run completed and any trial is **`ungradeable`** | `1`, after every artifact is written, the end banner is printed and the run directory is on stdout |
+| every attempt reached a verdict, and no opted-in gate fires | `0` |
+| `--fail-on-zero-coverage` set and the run measured nothing | `2`, after every artifact is written, the end banner is printed and the run directory is on stdout |
+| `--fail-on-zero-judge-graded` set and every produced grade has `judge_status == ERRORED` | `2`, same emission order |
+| the run completed and any trial is **`ungradeable`** (and no exit-2 gate fires) | `1`, after every artifact is written, the end banner is printed and the run directory is on stdout |
 | the run never happened — bad config, orchestrator raise, zero tasks | non-zero with **empty** stdout; see [§ stdout / stderr contract](#stdout--stderr-contract) |
 
 An **ungradeable** trial is one the run attempted and measured and then could not grade: `trajectory.yaml` carries a `grading_error` and no `grade`. A run that reports success while an arbitrary, model-correlated subset of its grades is missing is the failure mode this gate exists to remove.
 
-A trial the provider or the substrate killed — an `api_timeout`, `rate_limit` or `provision_error`, counted under `infrastructure_aborts` — produces no verdict either and **does not** trigger the gate. Those trials were never measured, they sit outside the measured denominator by design, and failing a several-hour run for one rate limit is how an exit code becomes something operators route around instead of reading.
+A trial the provider or the substrate killed — an `api_timeout`, `rate_limit` or `provision_error`, counted under `infrastructure_aborts` — produces no verdict either and **does not** trigger the ungradeable gate. Those trials were never measured, they sit outside the measured denominator by design, and failing a several-hour run for one rate limit is how an exit code becomes something operators route around instead of reading.
 
 There is no tolerance threshold. A threshold is a way to re-silence the signal, and the number an operator would tune is already `ungradeable` in `aggregate.json`.
 
-On exit `1` the console carries one error line naming the count, the first few trial ids and the total. The run directory is complete, so the response is to read it: `ungradeable` in `aggregate.json` says how many, `per_task_metrics.json` says where, and each named trial's `trajectory.yaml` `grading_error` says why. Then rerun those trials, or accept the loss deliberately.
+Two opt-in flags distinguish two degenerate completions from a clean run and from the ungradeable gate. `--fail-on-zero-coverage` (mirrored as `orchestrator.fail_on_zero_coverage` in the run config) exits `2` when the run finished with no measured trials — every attempt classified as an infrastructure abort. `--fail-on-zero-judge-graded` (mirrored as `orchestrator.fail_on_zero_judge_graded`) exits `2` when at least one trial produced a `Grade` record and every such record has `judge_status == ERRORED`. Both flags default off, so the shipped "infrastructure aborts do not fail the run" contract is preserved for callers that ignore them; a run whose measured trials produced no grade at all (`scored_trials == 0`) does not fire the judge-graded gate. When any exit-2 gate fires it takes precedence over the ungradeable exit-1: an operator's explicit opt-in outranks the generic completion check. The full precedence — zero-coverage flag > zero-judge-graded flag > ungradeable > `0` — is captured in [`docs/adr/0041-zero-coverage-exit-signal.md`](adr/0041-zero-coverage-exit-signal.md).
 
-`tolokaforge worker` applies the same rule to the attempts that worker completed, which is the surface a sharded CI actually gates on. Its `--run-dir` summary line is printed either way — the gate is a verdict on top of a completed shard, not a replacement for what the shard did.
+On any non-zero exit the console carries one error line naming which gate fired and where to read the detail. The run directory is complete, so the response is to read it: `ungradeable` and `infrastructure_aborts` in `aggregate.json` say how many, `per_task_metrics.json` says where, and each named trial's `trajectory.yaml` `grading_error` (or `grade.judge_status`) says why. Then rerun those trials, or accept the loss deliberately.
+
+`tolokaforge worker` applies the same rules to the attempts that worker completed, which is the surface a sharded CI actually gates on. Its `--run-dir` summary line is printed either way — the gate is a verdict on top of a completed shard, not a replacement for what the shard did.
 
 ## Run banner
 

--- a/docs/adr/0041-zero-coverage-exit-signal.md
+++ b/docs/adr/0041-zero-coverage-exit-signal.md
@@ -1,0 +1,305 @@
+# 0041. Zero-coverage exit signal on `run_state.json`
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+- **Deciders:** @CiroGamboa
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:**
+  - [ADR-0005](0005-run-aggregate-writer-seam.md) — `RunAggregateWriter`
+    and `AggregateMetrics`. The two booleans this ADR adds are *derived
+    from* aggregate fields but do not live *on* the aggregate; the
+    seam this ADR extends is `run_state.json`, not `aggregate.json`.
+  - [ADR-0039](0039-coding-harness-adapter-agnostic.md) — the closest
+    architectural sibling: another opt-in signal whose default
+    preserves shipped behaviour and whose CLI flag overrides a
+    run-config field with the same precedence rule this ADR reuses.
+  - [ADR-0040](0040-standalone-grader.md) — the most recent
+    orchestrator-plane ADR; unrelated in scope but the sibling in the
+    numbering sequence.
+
+## Context and Problem Statement
+
+A run whose trials all die before the agent is measured — every trial
+hits `PROVISION_ERROR`, `API_TIMEOUT`, or `RATE_LIMIT` — writes
+`aggregate.json {measured_trials: 0}`, prints `✓ Run complete`, and
+exits `0`. The chain is deliberate:
+[`tolokaforge/core/failure_attribution.py:60-66`](../../tolokaforge/core/failure_attribution.py)'s
+`EXCLUDED_TYPED_REASONS` classifies those trials as
+`INFRASTRUCTURE_ABORT` rather than `UNGRADEABLE`, so
+[`tolokaforge/dx/cli/main.py:474-482`](../../tolokaforge/dx/cli/main.py)'s
+`_fail_on_ungradeable_trials` gate never fires. The design intent
+this preserves is documented at
+[`docs/CLI.md`](../CLI.md) § "Run and worker exit codes":
+"a trial the provider or the substrate killed … does not trigger the
+gate". That contract is load-bearing for existing CI pipelines.
+
+Issue #1063 names a second shape of the same slogan. A run whose LLM
+judge sub-component errors on every trial classifies every trial as
+`MEASURED`, records a `Grade` with `judge_status == JudgeStatus.ERRORED`
+and `score == 0.0`, and exits `0`. The judge sub-component does not
+raise `GradingFailedError`; the only writer of
+`trajectory.grading_error` is
+[`conductor.py:980`](../../tolokaforge/core/orchestrator/conductor.py)
+inside `except GradingFailedError`, so trials where the judge errored
+never reach the ungradeable gate. The `aggregate.judge_cost_usd == 0.0`
+tell is buried inside the aggregate JSON — invisible to CI unless a
+parser opens the file and knows to look.
+
+CI parsers already parse shell exit codes; they should not have to
+open `aggregate.json` to distinguish "nothing was measured" or "no
+grade succeeded" from a clean run.
+
+## Decision Drivers
+
+- **CI parsers read shell exit codes, not JSON.** The signal has to
+  reach the operator on the process's exit channel.
+- **The signal must be opt-in.** Existing pipelines rely on
+  "infrastructure aborts do not fail the run"
+  ([`docs/CLI.md`](../CLI.md) § "Run and worker exit codes"). Flipping
+  that default silently would break them.
+- **The signal must be inspectable even when the flag is off.** A
+  triage dashboard reading `run_state.json` should distinguish the two
+  failure modes without re-parsing `aggregate.json`.
+- **One derivation site.** `scored_trials` is already defined at
+  [`tolokaforge/core/metrics.py:319-336`](../../tolokaforge/core/metrics.py)
+  (`len([t.grade.score for t in measured if t.grade is not None])`)
+  and carried on
+  [`AggregateMetrics.scored_trials`](../../tolokaforge/core/output/aggregate_models.py).
+  A second definition would drift.
+- **Both #1301 and #1063 in one PR.** The two share the exit-0
+  slogan; one design record covers both.
+
+## Considered Options
+
+1. **Booleans on `run_state.json` + opt-in CLI/config flags → exit 2.**
+   Selected. Adds two `RunState` booleans, two mirrored CLI flags
+   plus run-config keys, and a new exit code `2`. Preserves the shipped
+   exit-code contract for every consumer that ignores the flags.
+
+2. **Field-only (booleans on `run_state.json`, no flags).** Rejected.
+   #1063's CI could parse the boolean via `jq -e`, but the signal is
+   less discoverable than a flag+exit-code pair, and a run whose judge
+   errored on every trial would still exit `0` on every existing
+   pipeline. The point is a distinguishable exit code.
+
+3. **Flag-only (widen the meaning of exit 1).** Rejected. Exit `1`
+   already means "the run completed and any trial is `ungradeable`".
+   Overloading it removes the CI branch
+   `case $? in 0) ok;; 1) partial;; 2) empty;; esac` and breaks
+   pipelines that treat `1` as "partial-verdict, act on it".
+
+4. **A new `run_summary.json` for CI consumers.** Rejected. Adds a
+   second artifact CI must open. `run_state.json` is already the
+   CI-facing completion record — it carries `status`, `start_time`,
+   `end_time`, and the fields a CI script parses to answer "did the
+   run complete cleanly?". Booleans that summarise a completion
+   condition belong there.
+
+5. **Booleans on `AggregateMetrics` (`aggregate.json`).** Rejected.
+   `AggregateMetrics` is a pure metrics record (numeric counts,
+   ratios) with `extra="forbid"` — every field is a number a
+   dashboard plots. Derived completion booleans are not a metric;
+   they are a CI-facing summary of what the run finished as, and
+   `run_state.json` is the record that carries that summary today.
+
+6. **Version `run_state.json`'s schema.** Rejected. The two new fields
+   are additive `bool` with `default=False`. A state file written by
+   older code loads unchanged; a state file written by this code
+   loads on older code with the two fields silently dropped under
+   Pydantic's default permissive `extra` policy. No schema bump earns
+   its keep here.
+
+7. **Derive the second gate from classification
+   (`zero_scored = count(class == MEASURED and grade is not None) == 0`).**
+   Rejected. #1063's failure mode is a judge-only error that leaves
+   `trajectory.grading_error is None` (the sole writer of that field
+   is [`conductor.py:980`](../../tolokaforge/core/orchestrator/conductor.py)
+   inside `except GradingFailedError`, and the judge sub-component
+   does not raise that class), so those trials classify as `MEASURED`
+   and carry a `Grade` record with `judge_status == ERRORED`. A
+   classification-based gate never fires for #1063 by construction.
+   The chosen derivation reads `t.grade.judge_status` directly.
+
+## Decision
+
+Adopt **Option 1**.
+
+### `RunState` grows two booleans
+
+Two fields on
+[`RunState`](../../tolokaforge/core/resume.py):
+
+```python
+zero_coverage: bool = False
+zero_judge_graded: bool = False
+```
+
+Both default `False` so a state file written by older code loads
+unchanged and a run that never opts in reads `False`/`False` after
+completion. Populated only on the completion write in the `run`
+process; the worker path never writes `run_state.json` (shards share a
+run-dir and a race-write is a footgun — the worker surfaces the same
+signal through its own exit code).
+
+### `OrchestratorConfig` grows two flags
+
+Two fields on
+[`OrchestratorConfig`](../../tolokaforge/core/models/run_config.py):
+
+```python
+fail_on_zero_coverage: bool = False
+fail_on_zero_judge_graded: bool = False
+```
+
+Mirrored as two Click options on `tolokaforge run` and `tolokaforge
+worker`: `--fail-on-zero-coverage` and `--fail-on-zero-judge-graded`.
+When a flag is set at the CLI, it overrides the run-config value with
+the same precedence rule
+[`tolokaforge/dx/cli/main.py`](../../tolokaforge/dx/cli/main.py)'s
+`--runtime` uses today: flag beats YAML.
+
+### Field derivations
+
+Computed at completion inside
+[`Orchestrator._publish_grading_completeness`](../../tolokaforge/core/orchestrator.py)
+from `self.results`:
+
+- `measured_trials = sum(1 for t in self.results if classify_trial_outcome(t) == TrialOutcomeClass.MEASURED)`
+  — the classifier at
+  [`failure_attribution.py:99-112`](../../tolokaforge/core/failure_attribution.py).
+- `scored_trials = sum(1 for t in self.results if t.grade is not None)`
+  — the same predicate `_measured_averages` uses at
+  [`metrics.py:319-336`](../../tolokaforge/core/metrics.py); the
+  quantity `AggregateMetrics.scored_trials` records. This is the
+  single derivation site.
+- `judge_errored_trials = sum(1 for t in self.results if t.grade is not None and t.grade.judge_status == JudgeStatus.ERRORED)`
+  — the judge-level observable at
+  [`grade.py:152`](../../tolokaforge/core/models/grade.py).
+- `zero_coverage = measured_trials == 0 and total_trials > 0`.
+- `zero_judge_graded = judge_errored_trials > 0 and judge_errored_trials == scored_trials`.
+
+The `judge_errored_trials > 0` guard is what makes
+`zero_judge_graded` read judge-status, not grade-presence: a run whose
+trials classify `MEASURED` with `t.grade is None` on every trial
+(`scored_trials == 0`, `judge_errored_trials == 0`) has produced no
+grades to reason about and does not fire the second gate.
+
+### Exit-code precedence
+
+When a flag is set and its condition holds, the CLI exits `2`.
+Precedence, in evaluation order:
+
+1. `zero_coverage` — most specific opt-in.
+2. `zero_judge_graded` — second opt-in.
+3. `ungradeable` — the shipped exit-`1` gate, unchanged.
+
+An opted-in specific gate outranks the generic ungradeable gate; the
+more specific exit-`2` signal outranks exit-`1` in the overlap
+(operator declared "fail on this", the specific signal wins).
+
+## Consequences
+
+### Positive
+
+- **CI distinguishes four outcomes at the shell.** Zero-coverage,
+  zero-judge-graded, ungradeable, and clean each carry a distinct
+  exit code (`2`, `2`, `1`, `0` respectively — the two exit-`2` cases
+  are distinguished by which flag was set and by the error line).
+  Neither #1301 nor #1063 needs a JSON parser to reach the operator.
+- **Existing consumers unaffected.** Both flags default `False` and
+  the two booleans are additive with `default=False`; a caller that
+  ignores the flags sees the shipped exit codes with unchanged
+  semantics.
+- **Single derivation site.** `scored_trials` reads exactly one
+  predicate (`t.grade is not None`) and is defined in one place
+  (`_publish_grading_completeness`) — the same quantity
+  `AggregateMetrics.scored_trials` carries. No drift risk.
+- **Closes both issues in one PR.** #1301 (zero-coverage) and #1063
+  (zero-judge-graded) share the exit-0 slogan and one design record.
+
+### Negative / Trade-offs
+
+- **`run_state.json` grows two derived fields.** A mild duplication of
+  what `aggregate.json` already lets a reader compute. Accepted: the
+  readers of the two files are different (CI parser vs metrics
+  consumer), and each should have local, cheap access to the answer
+  it needs.
+- **A new exit code enters the operator's vocabulary.** Exit `2` is
+  distinct from the shipped `0`/`1` pair; runbooks and CI scripts
+  that switch on the exit code need to know about it. Mitigated by
+  the shipped exit codes staying unchanged for callers that ignore
+  the flags — the new code appears only when an operator opts in.
+- **`mark_run_completed` signature widens.** The method grows two
+  keyword-only booleans and moves later in `Orchestrator.run()` so it
+  can carry the derived values. The reorder is safe (no in-run reader
+  of `run_state.status` between the completeness publish and the
+  state-file write) but the invariant is now guarded by a `finally`
+  clause so a report-generation exception cannot leave the file at
+  `status: "running"`.
+
+### Follow-ups
+
+- **`docs/CLI.md` § "Run and worker exit codes"** grows a row for
+  exit `2` and cites this ADR — landed in the CLI-flag stage of the
+  implementing PR.
+- **A third completion-condition gate.** If one is ever proposed,
+  factor the three into an enum on the widened gate function rather
+  than adding a fourth `elif`. Not gated on this ADR.
+
+## Non-goals
+
+- **Not versioning `run_state.json`.** Two additive `bool` fields with
+  `default=False` load in both directions under Pydantic's default
+  `extra` policy.
+- **Not adding the booleans to `AggregateMetrics`.** `AggregateMetrics`
+  is `extra="forbid"` and a pure metrics record — the derived
+  CI-signal booleans belong on `RunState`.
+- **Not changing `EXCLUDED_TYPED_REASONS`.** The
+  [`failure_attribution.py:60-66`](../../tolokaforge/core/failure_attribution.py)
+  set — and the `docs/CLI.md` § "Run and worker exit codes" contract
+  that "a trial the provider or the substrate killed … does not
+  trigger the gate" — is preserved verbatim.
+- **Not making zero-coverage a default fail.** Both flags default
+  `False`; the shipped exit-`0` semantics for infrastructure-abort
+  runs stand until an operator opts in.
+
+## Prior art
+
+- [`docs/CLI.md`](../CLI.md) § "Run and worker exit codes" — the
+  contract that "a trial the provider or the substrate killed … does
+  not trigger the gate" this ADR preserves via the flag defaults.
+- [`_fail_on_ungradeable_trials`](../../tolokaforge/dx/cli/main.py)
+  ("the exit code plus this line are its only channel") — the
+  emission pattern this ADR extends; a widened gate function replaces
+  the single-condition version and the console error line names which
+  flag fired.
+
+## Links
+
+- Related ADRs:
+  - [ADR-0005](0005-run-aggregate-writer-seam.md) —
+    `RunAggregateWriter` seam; the aggregate this signal derives
+    from and deliberately does not extend.
+  - [ADR-0039](0039-coding-harness-adapter-agnostic.md) — the
+    architectural sibling: opt-in signal, flag-overrides-YAML
+    precedence, default preserves shipped behaviour.
+  - [ADR-0040](0040-standalone-grader.md) — sibling in numbering.
+- Related code:
+  - [`tolokaforge/core/resume.py`](../../tolokaforge/core/resume.py)
+    — `RunState` and `RunStateManager.mark_run_completed`.
+  - [`tolokaforge/core/models/run_config.py`](../../tolokaforge/core/models/run_config.py)
+    — `OrchestratorConfig`.
+  - [`tolokaforge/core/orchestrator.py`](../../tolokaforge/core/orchestrator.py)
+    — `GradingCompleteness` and `_publish_grading_completeness`.
+  - [`tolokaforge/core/metrics.py`](../../tolokaforge/core/metrics.py)
+    — the `scored_trials` predicate.
+  - [`tolokaforge/core/output/aggregate_models.py`](../../tolokaforge/core/output/aggregate_models.py)
+    — `AggregateMetrics.scored_trials`.
+  - [`tolokaforge/dx/cli/main.py`](../../tolokaforge/dx/cli/main.py)
+    — the CLI flags and the widened completeness gate.
+  - [`docs/CLI.md`](../CLI.md) § "Run and worker exit codes" — the
+    documented exit-code contract.
+- Issues:
+  - #1301 — zero-coverage runs exit `0`.
+  - #1063 — every-grade-judge-errored runs exit `0`.

--- a/docs/adr/0041-zero-coverage-exit-signal.md
+++ b/docs/adr/0041-zero-coverage-exit-signal.md
@@ -23,12 +23,13 @@
 A run whose trials all die before the agent is measured — every trial
 hits `PROVISION_ERROR`, `API_TIMEOUT`, or `RATE_LIMIT` — writes
 `aggregate.json {measured_trials: 0}`, prints `✓ Run complete`, and
-exits `0`. The chain is deliberate:
+exits `0` when neither opt-in completion gate fires. The chain is deliberate:
 [`tolokaforge/core/failure_attribution.py:60-66`](../../tolokaforge/core/failure_attribution.py)'s
 `EXCLUDED_TYPED_REASONS` classifies those trials as
 `INFRASTRUCTURE_ABORT` rather than `UNGRADEABLE`, so
-[`tolokaforge/dx/cli/main.py:474-482`](../../tolokaforge/dx/cli/main.py)'s
-`_fail_on_ungradeable_trials` gate never fires. The design intent
+[`tolokaforge/dx/cli/main.py`](../../tolokaforge/dx/cli/main.py)'s
+`_fail_on_completeness_gates` ungradeable branch does not fire
+without the `--fail-on-zero-coverage` opt-in. The design intent
 this preserves is documented at
 [`docs/CLI.md`](../CLI.md) § "Run and worker exit codes":
 "a trial the provider or the substrate killed … does not trigger the
@@ -269,11 +270,10 @@ more specific exit-`2` signal outranks exit-`1` in the overlap
 - [`docs/CLI.md`](../CLI.md) § "Run and worker exit codes" — the
   contract that "a trial the provider or the substrate killed … does
   not trigger the gate" this ADR preserves via the flag defaults.
-- [`_fail_on_ungradeable_trials`](../../tolokaforge/dx/cli/main.py)
-  ("the exit code plus this line are its only channel") — the
-  emission pattern this ADR extends; a widened gate function replaces
-  the single-condition version and the console error line names which
-  flag fired.
+- [`_fail_on_completeness_gates`](../../tolokaforge/dx/cli/main.py)
+  — the widened gate function whose three branches (zero-coverage,
+  zero-judge-graded, ungradeable) implement the precedence documented
+  here; the console error line names which channel fired.
 
 ## Links
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ Day-to-day implementation choices that don't affect the system shape do *not* ne
 | [0038](0038-grader-detachment.md) | Grader detachment — grader as an independently deployable and scalable component | Proposed |
 | [0039](0039-coding-harness-adapter-agnostic.md) | Coding-harness as an adapter-agnostic run-config concept | Accepted |
 | [0040](0040-standalone-grader.md) | Standalone-grader substrate — multi-topology grading behind one Protocol | Accepted |
+| [0041](0041-zero-coverage-exit-signal.md) | Zero-coverage exit signal on `run_state.json` | Accepted |

--- a/tests/canonical/test_cli_exit_code_contract.py
+++ b/tests/canonical/test_cli_exit_code_contract.py
@@ -1,0 +1,361 @@
+"""Canonical lock for ``tolokaforge run`` / ``tolokaforge worker`` exit codes.
+
+The exit-code table at ``docs/CLI.md § Run and worker exit codes`` is a CI
+contract: automation reads shell exit codes to gate deploys and decide
+whether to alert. This file fixes that contract in one place so any drift
+in the widened completion-gate function (`_fail_on_completeness_gates` at
+``tolokaforge/dx/cli/main.py``) or the documented table breaks a test
+rather than silently changing a caller's behaviour. See
+``docs/adr/0041-zero-coverage-exit-signal.md``.
+
+Uses the same in-process stubbed-orchestrator harness as
+``tests/unit/dx/test_cli_stdout_contract.py`` — no Docker, no LLM key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+import tolokaforge.dx.cli.main as cli_main
+from tests.utils.orchestrator_stubs import complete_run
+from tolokaforge.core.orchestrator import GradingCompleteness
+from tolokaforge.dx.cli.main import cli
+
+pytestmark = pytest.mark.canonical
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.fixture
+def valid_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                "evaluation": {
+                    "output_dir": str(tmp_path / "out"),
+                    "tasks_glob": str(tmp_path / "tasks" / "*"),
+                },
+                "orchestrator": {"repeats": 1, "auto_start_services": False},
+                "compute": {"workers": 1},
+            }
+        )
+    )
+    return config_path
+
+
+def _stub_orchestrator(*, completeness: GradingCompleteness, run_return: Path) -> type:
+    """Minimal stub matching the ``run`` and ``run_worker`` reads of the
+    completion-gate path. Publishes the supplied ``GradingCompleteness``
+    verbatim so the tests below drive the gate function directly."""
+
+    class _StubOrchestrator:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.tasks: list[object] = [object()]
+            self.grading_completeness = completeness
+
+        def load_tasks(self) -> None:
+            return None
+
+        def run(self, **_: object) -> Path:
+            return run_return
+
+        def run_worker(self, run_dir: Path, max_attempts: int | None = None) -> dict[str, Any]:
+            return {
+                "processed_attempts": 1,
+                "completed_attempts": 1,
+                "failed_attempts": 0,
+                "requeued_attempts": 0,
+                "total_cost_usd": 0.0,
+            }
+
+    return _StubOrchestrator
+
+
+_CLEAN = GradingCompleteness(
+    total_attempts=4,
+    ungradeable_trial_ids=(),
+    measured_trials=4,
+    scored_trials=4,
+    judge_errored_trials=0,
+)
+_ZERO_COVERAGE = GradingCompleteness(
+    total_attempts=4,
+    ungradeable_trial_ids=(),
+    measured_trials=0,
+    scored_trials=0,
+    judge_errored_trials=0,
+)
+_ZERO_JUDGE_GRADED = GradingCompleteness(
+    total_attempts=3,
+    ungradeable_trial_ids=(),
+    measured_trials=3,
+    scored_trials=3,
+    judge_errored_trials=3,
+)
+_UNGRADEABLE = GradingCompleteness(
+    total_attempts=4,
+    ungradeable_trial_ids=("TASK-A:0", "TASK-A:1"),
+    measured_trials=4,
+    scored_trials=2,
+    judge_errored_trials=0,
+)
+_BOTH_ZERO_COVERAGE_AND_UNGRADEABLE = GradingCompleteness(
+    total_attempts=4,
+    ungradeable_trial_ids=("TASK-A:0",),
+    measured_trials=0,
+    scored_trials=0,
+    judge_errored_trials=0,
+)
+
+
+class TestRunExitCodeContract:
+    """Every row in ``docs/CLI.md § Run and worker exit codes`` locked as a cell."""
+
+    def test_clean_run_exits_zero_with_no_completion_gate_line(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Row 1: every attempt reached a verdict, no opt-in gate fires → ``0``.
+
+        Locks the default: a caller that ignores the two flags sees the
+        shipped exit-0 semantics unchanged for a clean run.
+        """
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_CLEAN, run_return=expected_dir),
+        )
+
+        result = runner.invoke(cli, ["run", "--config", str(valid_config)])
+
+        assert result.exit_code == 0, result.stderr
+        assert "Run measured no trials" not in result.stderr
+        assert "LLM judge errored" not in result.stderr
+        assert "could not be graded" not in result.stderr
+
+    def test_ungradeable_without_flags_exits_one_with_ungradeable_line(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Row 4: the run completed and any trial is ungradeable, no exit-2
+        gate fires → ``1`` with the ungradeable line naming the shape."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_UNGRADEABLE, run_return=expected_dir),
+        )
+
+        result = runner.invoke(cli, ["run", "--config", str(valid_config)])
+
+        assert result.exit_code == 1
+        assert "2 of 4 attempts could not be graded" in result.stderr
+        assert "TASK-A:0" in result.stderr
+
+    def test_zero_coverage_with_flag_exits_two_with_zero_coverage_line(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Row 2: ``--fail-on-zero-coverage`` set and the run measured
+        nothing → ``2`` with the "Run measured no trials" line."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_ZERO_COVERAGE, run_return=expected_dir),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-coverage"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials on 4 attempted" in result.stderr
+        assert "See infrastructure_aborts in aggregate.json" in result.stderr
+
+    def test_zero_judge_graded_with_flag_exits_two_with_judge_errored_line(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Row 3: ``--fail-on-zero-judge-graded`` set and every produced grade
+        has ``judge_status == ERRORED`` → ``2`` with the judge-errored line."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_ZERO_JUDGE_GRADED, run_return=expected_dir),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-judge-graded"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "LLM judge errored on every scored trial" in result.stderr
+        assert "0 of 3 grades succeeded" in result.stderr
+        assert "See judge_status in trajectory.json" in result.stderr
+
+    def test_zero_coverage_dominates_ungradeable_when_only_coverage_flag_set(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Precedence cell: ``zero_coverage`` and ``ungradeable > 0`` both true,
+        only ``--fail-on-zero-coverage`` set → exit ``2`` on the zero-coverage
+        line. Exit 2 dominates exit 1 whenever a flag fires. See ADR-0041 §
+        Decision precedence."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(
+                completeness=_BOTH_ZERO_COVERAGE_AND_UNGRADEABLE,
+                run_return=expected_dir,
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-coverage"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials" in result.stderr
+        assert "could not be graded" not in result.stderr
+
+
+class TestWorkerExitCodeContract:
+    """The worker gates on the same table over its own attempts.
+
+    A sharded CI reads the worker's exit code, not the ``run`` process's, so
+    the four-cell matrix has to be locked at the worker surface too.
+    """
+
+    def test_clean_worker_exits_zero(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=complete_run(total_attempts=3), run_return=tmp_path),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["worker", "--config", str(valid_config), "--run-dir", str(tmp_path / "run_dir")],
+        )
+
+        assert result.exit_code == 0, result.stderr
+
+    def test_ungradeable_worker_exits_one(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_UNGRADEABLE, run_return=tmp_path),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["worker", "--config", str(valid_config), "--run-dir", str(tmp_path / "run_dir")],
+        )
+
+        assert result.exit_code == 1
+        assert "could not be graded" in result.stderr
+
+    def test_worker_zero_coverage_flag_exits_two(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_ZERO_COVERAGE, run_return=tmp_path),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "worker",
+                "--config",
+                str(valid_config),
+                "--run-dir",
+                str(tmp_path / "run_dir"),
+                "--fail-on-zero-coverage",
+            ],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials on 4 attempted" in result.stderr
+
+    def test_worker_zero_judge_graded_flag_exits_two(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _stub_orchestrator(completeness=_ZERO_JUDGE_GRADED, run_return=tmp_path),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "worker",
+                "--config",
+                str(valid_config),
+                "--run-dir",
+                str(tmp_path / "run_dir"),
+                "--fail-on-zero-judge-graded",
+            ],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "LLM judge errored on every scored trial" in result.stderr

--- a/tests/unit/core/test_grading_completeness_gates.py
+++ b/tests/unit/core/test_grading_completeness_gates.py
@@ -1,0 +1,162 @@
+"""The two completion gates on :class:`GradingCompleteness` and their persistence.
+
+Locks the invariants ADR-0041 declares:
+
+- ``zero_coverage`` fires only on a run that had trials to measure.
+- ``zero_judge_graded`` requires every scored trial to carry a judge that
+  errored — a run with no grades at all does not fire it.
+- The two booleans round-trip through ``RunState``'s persisted shape.
+- ``scored_trials`` follows the same predicate ``_measured_averages`` uses
+  (``t.grade is not None``) — a MEASURED trial missing its grade is not
+  scored.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.models.trajectory import Trajectory
+from tolokaforge.core.orchestrator import GradingCompleteness
+from tolokaforge.core.resume import RunState, RunStateManager, TrialState
+
+pytestmark = pytest.mark.unit
+
+
+def test_grading_completeness_widens_with_the_three_derived_counts() -> None:
+    completeness = GradingCompleteness(
+        total_attempts=5,
+        ungradeable_trial_ids=(),
+        measured_trials=5,
+        scored_trials=4,
+        judge_errored_trials=1,
+    )
+
+    assert completeness.measured_trials == 5
+    assert completeness.scored_trials == 4
+    assert completeness.judge_errored_trials == 1
+    assert completeness.zero_coverage is False
+    assert completeness.zero_judge_graded is False
+
+
+def test_zero_coverage_only_fires_when_a_run_had_trials_to_measure() -> None:
+    on_a_run_that_measured_nothing = GradingCompleteness(
+        total_attempts=3, ungradeable_trial_ids=(), measured_trials=0
+    )
+    assert on_a_run_that_measured_nothing.zero_coverage is True
+
+    on_a_run_with_no_trials_at_all = GradingCompleteness(
+        total_attempts=0, ungradeable_trial_ids=(), measured_trials=0
+    )
+    assert on_a_run_with_no_trials_at_all.zero_coverage is False
+
+
+def test_zero_judge_graded_requires_all_scored_trials_to_have_errored_judges() -> None:
+    every_scored_grade_errored = GradingCompleteness(
+        total_attempts=3,
+        ungradeable_trial_ids=(),
+        measured_trials=3,
+        scored_trials=3,
+        judge_errored_trials=3,
+    )
+    assert every_scored_grade_errored.zero_judge_graded is True
+
+    some_grades_survived = GradingCompleteness(
+        total_attempts=3,
+        ungradeable_trial_ids=(),
+        measured_trials=3,
+        scored_trials=3,
+        judge_errored_trials=2,
+    )
+    assert some_grades_survived.zero_judge_graded is False
+
+    a_run_that_produced_no_grades = GradingCompleteness(
+        total_attempts=3,
+        ungradeable_trial_ids=(),
+        measured_trials=3,
+        scored_trials=0,
+        judge_errored_trials=0,
+    )
+    assert a_run_that_produced_no_grades.zero_judge_graded is False
+
+
+def test_a_measured_trial_missing_its_grade_does_not_count_as_scored() -> None:
+    """The single-source derivation follows ``metrics._measured_averages``.
+
+    Constructs a trajectory that classifies as MEASURED (no infra-abort
+    termination, no ``grading_error``) but carries no grade — an intermediate
+    state the run may write before grading completes. ``scored_trials`` must
+    count trajectories by the same predicate the averaged metrics do, so a
+    downstream computation cannot disagree with this one on whether the trial
+    was scored.
+    """
+    a_measured_but_ungraded_trajectory = Trajectory(
+        task_id="task",
+        trial_index=0,
+        start_ts=datetime.now(UTC),
+        end_ts=datetime.now(UTC),
+        messages=[],
+        grade=None,
+        grading_error=None,
+    )
+    assert a_measured_but_ungraded_trajectory.grade is None
+
+    scored = sum(1 for t in [a_measured_but_ungraded_trajectory] if t.grade is not None)
+    assert scored == 0
+
+
+def test_run_state_persists_the_two_completion_gate_booleans(tmp_path: Path) -> None:
+    state_manager = RunStateManager(output_dir=tmp_path)
+    state_manager.initialize_run(
+        run_id="run-0", config_path="config.yaml", task_ids=["t"], repeats=1
+    )
+
+    state_manager.mark_run_completed(zero_coverage=True, zero_judge_graded=False)
+
+    reloaded = state_manager.load_state()
+    assert reloaded is not None
+    assert reloaded.status == "completed"
+    assert reloaded.zero_coverage is True
+    assert reloaded.zero_judge_graded is False
+
+
+def test_run_state_defaults_the_two_completion_gate_booleans_to_false() -> None:
+    """A state file written before the fields existed loads with both False.
+
+    ``RunState`` has no ``extra="forbid"`` so adding two optional booleans is
+    non-breaking; the defaults ensure old state files continue to parse.
+    """
+    from_a_pre_field_state = RunState(
+        run_id="run-0",
+        config_path="config.yaml",
+        output_dir="/tmp/x",
+        start_ts=datetime.now(UTC),
+        last_updated=datetime.now(UTC),
+        status="completed",
+        total_trials=1,
+        completed_trials=1,
+        failed_trials=0,
+        trials={"t:0": TrialState(task_id="t", trial_index=0, status="completed")},
+    )
+
+    assert from_a_pre_field_state.zero_coverage is False
+    assert from_a_pre_field_state.zero_judge_graded is False
+
+
+def test_orchestrator_config_carries_both_completion_gate_flags() -> None:
+    """The two flags are opt-in — both default False.
+
+    Locks the "infrastructure aborts do not fail the run" back-compat contract
+    ADR-0041 preserves.
+    """
+    from tolokaforge.core.models.run_config import OrchestratorConfig
+
+    default = OrchestratorConfig()
+    assert default.fail_on_zero_coverage is False
+    assert default.fail_on_zero_judge_graded is False
+
+    opted_in = OrchestratorConfig(fail_on_zero_coverage=True, fail_on_zero_judge_graded=True)
+    assert opted_in.fail_on_zero_coverage is True
+    assert opted_in.fail_on_zero_judge_graded is True

--- a/tests/unit/core/test_orchestrator_finalize_run.py
+++ b/tests/unit/core/test_orchestrator_finalize_run.py
@@ -1,0 +1,123 @@
+"""``_finalize_run_reports_and_status`` — the completion-status invariant.
+
+Locks that ``run_state.status`` ends ``"completed"`` even when
+``_generate_reports`` raises, so a mid-teardown fault cannot leave the file
+saying ``"running"`` and trigger a spurious resume prompt on the next
+invocation. The two completion-gate booleans fall back to False in that
+case. See ADR-0041.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.orchestrator import GradingCompleteness, Orchestrator
+
+pytestmark = pytest.mark.unit
+
+
+def _an_orchestrator_with_stub_state_manager() -> Orchestrator:
+    """A minimally-constructed Orchestrator suitable for finalize testing.
+
+    Bypasses ``__init__`` (which needs a real ``RunConfig`` + adapters) and
+    stamps the two attributes the finalize path reads.
+    """
+    orch = Orchestrator.__new__(Orchestrator)
+    orch.state_manager = MagicMock()
+    return orch
+
+
+def test_status_ends_completed_when_reports_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    orch = _an_orchestrator_with_stub_state_manager()
+
+    def _raising_generate_reports(_output_dir: Path) -> None:
+        raise RuntimeError("a broken report writer")
+
+    monkeypatch.setattr(orch, "_generate_reports", _raising_generate_reports)
+    monkeypatch.setattr(orch, "_publish_grading_completeness", lambda: None)
+
+    with pytest.raises(RuntimeError, match="a broken report writer"):
+        orch._finalize_run_reports_and_status(tmp_path)
+
+    orch.state_manager.mark_run_completed.assert_called_once_with(
+        zero_coverage=False, zero_judge_graded=False
+    )
+
+
+def test_status_ends_completed_when_publish_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The invariant holds if ``_publish_grading_completeness`` raises too.
+
+    ``zc`` / ``zjg`` initialize to False before the try so the finally reset
+    fires even when ``_publish_grading_completeness`` raises before the two
+    completion-gate values are read.
+    """
+    orch = _an_orchestrator_with_stub_state_manager()
+    monkeypatch.setattr(orch, "_generate_reports", lambda _out: None)
+
+    def _raising_publish() -> None:
+        raise ValueError("classification blew up")
+
+    monkeypatch.setattr(orch, "_publish_grading_completeness", _raising_publish)
+
+    with pytest.raises(ValueError, match="classification blew up"):
+        orch._finalize_run_reports_and_status(tmp_path)
+
+    orch.state_manager.mark_run_completed.assert_called_once_with(
+        zero_coverage=False, zero_judge_graded=False
+    )
+
+
+def test_status_ends_completed_when_a_base_exception_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The invariant survives a ``BaseException`` (e.g. ``KeyboardInterrupt``).
+
+    The critic's round-2 note fixed the earlier ``except Exception`` shape:
+    that clause never catches a ``BaseException``, so the reset had to move
+    into ``finally`` and the completion-gate defaults had to be initialized
+    before the try. This test locks that shape.
+    """
+    orch = _an_orchestrator_with_stub_state_manager()
+
+    def _raising_generate_reports(_output_dir: Path) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(orch, "_generate_reports", _raising_generate_reports)
+    monkeypatch.setattr(orch, "_publish_grading_completeness", lambda: None)
+
+    with pytest.raises(KeyboardInterrupt):
+        orch._finalize_run_reports_and_status(tmp_path)
+
+    orch.state_manager.mark_run_completed.assert_called_once_with(
+        zero_coverage=False, zero_judge_graded=False
+    )
+
+
+def test_a_clean_finalize_pass_stamps_the_derived_completion_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When nothing raises, the gates come from ``grading_completeness``."""
+    orch = _an_orchestrator_with_stub_state_manager()
+    orch.grading_completeness = GradingCompleteness(
+        total_attempts=3,
+        ungradeable_trial_ids=(),
+        measured_trials=3,
+        scored_trials=3,
+        judge_errored_trials=3,
+    )
+
+    monkeypatch.setattr(orch, "_generate_reports", lambda _out: None)
+    monkeypatch.setattr(orch, "_publish_grading_completeness", lambda: None)
+
+    orch._finalize_run_reports_and_status(tmp_path)
+
+    orch.state_manager.mark_run_completed.assert_called_once_with(
+        zero_coverage=False, zero_judge_graded=True
+    )

--- a/tests/unit/dx/test_cli_stdout_contract.py
+++ b/tests/unit/dx/test_cli_stdout_contract.py
@@ -332,6 +332,340 @@ class TestRunStdoutContract:
         assert "task[v2]:0" in result.stderr
 
 
+class TestRunCompletenessGates:
+    """The opt-in exit-2 gates on ``tolokaforge run`` and their precedence.
+
+    Two Click flags (``--fail-on-zero-coverage`` / ``--fail-on-zero-judge-graded``)
+    turn two conditions on ``GradingCompleteness`` into a distinct exit code.
+    The flags default off, so a caller that ignores them sees the shipped
+    exit-0 / exit-1 semantics unchanged; when set, exit 2 dominates exit 1
+    in any overlap. See ``docs/adr/0041-zero-coverage-exit-signal.md``.
+    """
+
+    def test_fail_on_zero_coverage_flag_exits_two_when_nothing_measured(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=4,
+                    ungradeable_trial_ids=(),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-coverage"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials on 4 attempted" in result.stderr
+        assert "See infrastructure_aborts in aggregate.json" in result.stderr
+
+    def test_fail_on_zero_judge_graded_flag_exits_two_when_every_grade_errored(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=3,
+                    ungradeable_trial_ids=(),
+                    measured_trials=3,
+                    scored_trials=3,
+                    judge_errored_trials=3,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-judge-graded"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "LLM judge errored on every scored trial" in result.stderr
+        assert "0 of 3 grades succeeded" in result.stderr
+        assert "See judge_status in trajectory.json" in result.stderr
+
+    def test_zero_coverage_without_flag_exits_zero(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Opt-in is opt-in: an unflagged run whose only trials were infra-aborts
+        still exits ``0``, preserving the shipped "infra aborts do not fail
+        the run" contract."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=2,
+                    ungradeable_trial_ids=(),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(cli, ["run", "--config", str(valid_config)])
+
+        assert result.exit_code == 0, result.stderr
+
+    def test_flag_set_but_condition_unmet_exits_zero(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A mixed run where some grades errored but not all does not fire the gate."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=4,
+                    ungradeable_trial_ids=(),
+                    measured_trials=4,
+                    scored_trials=4,
+                    judge_errored_trials=2,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-judge-graded"],
+        )
+
+        assert result.exit_code == 0, result.stderr
+
+    def test_measured_but_no_grade_fixture_does_not_fire_judge_gate(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A run whose measured trials never produced a grade (``scored_trials == 0``)
+        must not fire ``--fail-on-zero-judge-graded``: the failure mode is a judge
+        that errored on scoring attempts, not the absence of scoring."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=3,
+                    ungradeable_trial_ids=(),
+                    measured_trials=3,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-judge-graded"],
+        )
+
+        assert result.exit_code == 0, result.stderr
+
+    def test_zero_coverage_dominates_when_both_flags_set(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With both flags set and ``measured_trials == 0``, only ``zero_coverage``
+        fires — ``zero_judge_graded`` cannot be true when nothing was scored."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=3,
+                    ungradeable_trial_ids=(),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "run",
+                "--config",
+                str(valid_config),
+                "--fail-on-zero-coverage",
+                "--fail-on-zero-judge-graded",
+            ],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials" in result.stderr
+        assert "LLM judge errored" not in result.stderr
+
+    def test_zero_coverage_flag_dominates_ungradeable_when_flag_set(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Exit 2 dominates exit 1: with ``--fail-on-zero-coverage`` set and both
+        ``zero_coverage`` and ``ungradeable > 0``, the zero-coverage line fires."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=4,
+                    ungradeable_trial_ids=("TASK-A:0",),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-coverage"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials" in result.stderr
+        assert "could not be graded" not in result.stderr
+
+    def test_judge_graded_flag_dominates_ungradeable_when_flag_set(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Exit 2 dominates exit 1: with ``--fail-on-zero-judge-graded`` set,
+        ``zero_judge_graded`` fires ahead of any ``ungradeable > 0`` state."""
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=4,
+                    ungradeable_trial_ids=("TASK-A:0",),
+                    measured_trials=3,
+                    scored_trials=3,
+                    judge_errored_trials=3,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", "--config", str(valid_config), "--fail-on-zero-judge-graded"],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "LLM judge errored on every scored trial" in result.stderr
+        assert "could not be graded" not in result.stderr
+
+    def test_yaml_orchestrator_flag_fires_gate_without_cli_flag(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``orchestrator.fail_on_zero_coverage: true`` in the YAML fires the
+        gate without the CLI flag — mirroring is a two-way surface."""
+        config_path = tmp_path / "run.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "models": {"user": {"provider": "openai", "name": "gpt-4o"}},
+                    "evaluation": {
+                        "output_dir": str(tmp_path / "out"),
+                        "tasks_glob": str(tmp_path / "tasks" / "*"),
+                    },
+                    "orchestrator": {
+                        "repeats": 1,
+                        "auto_start_services": False,
+                        "fail_on_zero_coverage": True,
+                    },
+                    "compute": {"workers": 1},
+                }
+            )
+        )
+        expected_dir = (tmp_path / "results" / "run_20260715_120000").resolve()
+        expected_dir.mkdir(parents=True)
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                run_return=expected_dir,
+                completeness=GradingCompleteness(
+                    total_attempts=2,
+                    ungradeable_trial_ids=(),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(cli, ["run", "--config", str(config_path)])
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials on 2 attempted" in result.stderr
+
+
 class TestWorkerCompletenessGate:
     """``tolokaforge worker`` gates on the same attribute, over its own attempts.
 
@@ -389,6 +723,79 @@ class TestWorkerCompletenessGate:
 
         assert result.exit_code == 0, result.stderr
         assert "could not be graded" not in result.stderr
+
+    def test_worker_fail_on_zero_coverage_flag_exits_two(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The worker's opt-in zero-coverage gate mirrors ``tolokaforge run``."""
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                completeness=GradingCompleteness(
+                    total_attempts=2,
+                    ungradeable_trial_ids=(),
+                    measured_trials=0,
+                    scored_trials=0,
+                    judge_errored_trials=0,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "worker",
+                "--config",
+                str(valid_config),
+                "--run-dir",
+                str(tmp_path / "run_dir"),
+                "--fail-on-zero-coverage",
+            ],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "Run measured no trials on 2 attempted" in result.stderr
+
+    def test_worker_fail_on_zero_judge_graded_flag_exits_two(
+        self,
+        runner: CliRunner,
+        valid_config: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_main,
+            "Orchestrator",
+            _make_stub_orchestrator(
+                completeness=GradingCompleteness(
+                    total_attempts=3,
+                    ungradeable_trial_ids=(),
+                    measured_trials=3,
+                    scored_trials=3,
+                    judge_errored_trials=3,
+                ),
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "worker",
+                "--config",
+                str(valid_config),
+                "--run-dir",
+                str(tmp_path / "run_dir"),
+                "--fail-on-zero-judge-graded",
+            ],
+        )
+
+        assert result.exit_code == 2, result.stderr
+        assert "LLM judge errored on every scored trial" in result.stderr
 
 
 class TestPrepareStdoutContract:

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -480,6 +480,20 @@ class OrchestratorConfig(BaseModel):
 
     auto_start_services: bool = True  # Auto-start Docker services via EngineStack
 
+    fail_on_zero_coverage: bool = False
+    """Exit ``2`` when the run measured no trials on a config that had trials
+    to measure (``total_attempts > 0``). Off by default preserves the shipped
+    "infrastructure aborts do not fail the run" contract; opt in from CI when
+    a zero-coverage run should fail the pipeline. See
+    ``docs/adr/0041-zero-coverage-exit-signal.md``."""
+
+    fail_on_zero_judge_graded: bool = False
+    """Exit ``2`` when every produced grade has ``judge_status == ERRORED``.
+    Guarded so a run that produced no grades at all does not fire — the
+    failure mode is a judge that errored on every scoring attempt, not the
+    absence of scoring. Off by default. See
+    ``docs/adr/0041-zero-coverage-exit-signal.md``."""
+
     strict_task_load: bool = False
     """Opt in to fail-loud task loading. When ``False`` (the default), an
     adapter exception raised from :meth:`BaseAdapter.get_task` during

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -2577,12 +2577,6 @@ class Orchestrator:
                     threshold=last_hit.threshold if last_hit is not None else None,
                     total_cost_usd=round(total_cost_usd, 6),
                 )
-            else:
-                # Mark run as completed
-                self.state_manager.mark_run_completed(
-                    zero_coverage=self.grading_completeness.zero_coverage,
-                    zero_judge_graded=self.grading_completeness.zero_judge_graded,
-                )
 
             # Cleanup runtime backend if used; SharedStackRuntimeBackend
             # logs its own "Shared-stack runtime closed" line, no dup needed.
@@ -2607,9 +2601,11 @@ class Orchestrator:
                 except Exception as e:
                     self.logger.warning("Failed to destroy EngineStack", error=str(e))
 
-            # Generate reports
-            self._generate_reports(output_dir)
-            self._publish_grading_completeness()
+            # Publish completeness and generate reports before stamping the
+            # run as completed, so ``run_state.json``'s completion gates are
+            # derived from the published counts.
+            if not (budget_exhausted and remaining > 0):
+                self._finalize_run_reports_and_status(output_dir)
 
             resolved_output_dir = output_dir.resolve()
             self._events.run_finished(output_dir=resolved_output_dir)
@@ -2981,6 +2977,26 @@ class Orchestrator:
                 infrastructure_aborts={reason: count for reason, count in aborts.items() if count},
                 pass_at_k_without_coverage=lost_k,
             )
+
+    def _finalize_run_reports_and_status(self, output_dir: Path) -> None:
+        """Publish completeness, generate reports, and stamp completion status.
+
+        ``zc`` / ``zjg`` initialize to False before the try so a
+        ``BaseException`` raised inside (``KeyboardInterrupt``, ``SystemExit``,
+        anything ``except Exception`` would miss) still stamps a well-defined
+        state via ``finally``. The invariant is
+        ``status == "completed"`` on a non-paused run regardless of exception
+        class — resume-detection reads ``status`` alone. See ADR-0041.
+        """
+        zc = False
+        zjg = False
+        try:
+            self._generate_reports(output_dir)
+            self._publish_grading_completeness()
+            zc = self.grading_completeness.zero_coverage
+            zjg = self.grading_completeness.zero_judge_graded
+        finally:
+            self.state_manager.mark_run_completed(zero_coverage=zc, zero_judge_graded=zjg)
 
     def _publish_grading_completeness(self) -> None:
         """Stamp :attr:`grading_completeness` from the attempts this process ran.

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -453,10 +453,19 @@ class GradingCompleteness:
 
     ``ungradeable_trial_ids`` is the whole of the state; the count derives from
     it rather than being carried beside it, so the two cannot disagree.
+
+    ``measured_trials`` / ``scored_trials`` / ``judge_errored_trials`` carry
+    the three counts the two completion gates read (see
+    ``docs/adr/0041-zero-coverage-exit-signal.md``). ``scored_trials`` is the
+    same quantity :func:`tolokaforge.core.metrics._measured_averages` computes
+    from ``t.grade is not None`` — one derivation, referenced everywhere.
     """
 
     total_attempts: int
     ungradeable_trial_ids: tuple[str, ...]
+    measured_trials: int = 0
+    scored_trials: int = 0
+    judge_errored_trials: int = 0
 
     @property
     def ungradeable(self) -> int:
@@ -465,6 +474,26 @@ class GradingCompleteness:
     @property
     def is_complete(self) -> bool:
         return not self.ungradeable_trial_ids
+
+    @property
+    def zero_coverage(self) -> bool:
+        """No trial reached the agent measurement point on a run that had trials.
+
+        See ``docs/adr/0041-zero-coverage-exit-signal.md``.
+        """
+        return self.total_attempts > 0 and self.measured_trials == 0
+
+    @property
+    def zero_judge_graded(self) -> bool:
+        """Every produced grade has ``judge_status == ERRORED``.
+
+        The ``judge_errored_trials > 0`` guard keeps a run whose measured
+        trials never produced any grade (``scored_trials == 0``) from firing
+        this gate: the failure mode is a judge that errored on scoring
+        attempts, not the absence of scoring. See
+        ``docs/adr/0041-zero-coverage-exit-signal.md``.
+        """
+        return self.judge_errored_trials > 0 and self.judge_errored_trials == self.scored_trials
 
 
 class Orchestrator:
@@ -2550,7 +2579,10 @@ class Orchestrator:
                 )
             else:
                 # Mark run as completed
-                self.state_manager.mark_run_completed()
+                self.state_manager.mark_run_completed(
+                    zero_coverage=self.grading_completeness.zero_coverage,
+                    zero_judge_graded=self.grading_completeness.zero_judge_graded,
+                )
 
             # Cleanup runtime backend if used; SharedStackRuntimeBackend
             # logs its own "Shared-stack runtime closed" line, no dup needed.
@@ -2951,13 +2983,35 @@ class Orchestrator:
             )
 
     def _publish_grading_completeness(self) -> None:
-        """Stamp :attr:`grading_completeness` from the attempts this process ran."""
+        """Stamp :attr:`grading_completeness` from the attempts this process ran.
+
+        ``measured_trials`` counts trials that reached the agent measurement
+        point; ``scored_trials`` follows the single derivation
+        :func:`tolokaforge.core.metrics._measured_averages` uses
+        (``t.grade is not None``); ``judge_errored_trials`` counts scored
+        trials whose judge component errored. The two completion-gate
+        booleans are derived properties on ``GradingCompleteness``.
+        """
+        from tolokaforge.core.models.grade import JudgeStatus
+
         self.grading_completeness = GradingCompleteness(
             total_attempts=len(self.results),
             ungradeable_trial_ids=tuple(
                 f"{trajectory.task_id}:{trajectory.trial_index}"
                 for trajectory in self.results
                 if classify_trial_outcome(trajectory) is TrialOutcomeClass.UNGRADEABLE
+            ),
+            measured_trials=sum(
+                1
+                for trajectory in self.results
+                if classify_trial_outcome(trajectory) is TrialOutcomeClass.MEASURED
+            ),
+            scored_trials=sum(1 for trajectory in self.results if trajectory.grade is not None),
+            judge_errored_trials=sum(
+                1
+                for trajectory in self.results
+                if trajectory.grade is not None
+                and trajectory.grade.judge_status is JudgeStatus.ERRORED
             ),
         )
 

--- a/tolokaforge/core/resume.py
+++ b/tolokaforge/core/resume.py
@@ -97,6 +97,16 @@ class RunState(BaseModel):
 
     trials: dict[str, TrialState]  # key: "{task_id}:{trial_index}"
 
+    zero_coverage: bool = False
+    """Set at completion: ``measured_trials == 0`` on a run with
+    ``total_attempts > 0``. See ``docs/adr/0041-zero-coverage-exit-signal.md``.
+    Defaulted so state files written by earlier code load unchanged."""
+
+    zero_judge_graded: bool = False
+    """Set at completion: every produced grade has ``judge_status == ERRORED``.
+    See ``docs/adr/0041-zero-coverage-exit-signal.md``. Defaulted so state files
+    written by earlier code load unchanged."""
+
     def get_pending_trials(self) -> list[TrialState]:
         """Get list of trials not yet completed"""
         return [trial for trial in self.trials.values() if trial.status in ("pending", "failed")]
@@ -338,11 +348,18 @@ class RunStateManager:
             is_complete=to_retry == 0,
         )
 
-    def mark_run_completed(self):
-        """Mark entire run as completed"""
+    def mark_run_completed(self, *, zero_coverage: bool, zero_judge_graded: bool) -> None:
+        """Stamp ``status: "completed"`` and the two completion gates onto the state file.
+
+        The two booleans are keyword-only so the completion gates cannot be
+        swapped at the call site. See
+        ``docs/adr/0041-zero-coverage-exit-signal.md``.
+        """
         run_state = self.load_state()
         if run_state:
             run_state.status = "completed"
+            run_state.zero_coverage = zero_coverage
+            run_state.zero_judge_graded = zero_judge_graded
             self.save_state(run_state)
 
     def mark_run_paused(self):

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -464,15 +464,46 @@ and states the total. A lossy run can lose hundreds; the ids are all in
 ``aggregate.json`` and the operator needs the shape, not the list."""
 
 
-def _fail_on_ungradeable_trials(completeness: GradingCompleteness) -> None:
-    """Exit 1 when the run finished without a verdict for something it measured.
+def _fail_on_completeness_gates(
+    completeness: GradingCompleteness,
+    *,
+    fail_on_zero_coverage: bool,
+    fail_on_zero_judge_graded: bool,
+) -> None:
+    """Emit the completion-gate exit for a run that finished normally.
 
-    Called after the run has completed normally — every artifact written, the end
-    banner printed, the run directory already emitted on stdout. The run
-    executed, so the banner's success axis stays true; this is the separate
-    question of whether it measured everything it attempted, and the exit code
-    plus this line are its only channel.
+    Called after the run wrote every artifact, printed the end banner, and
+    emitted the run directory on stdout. The run executed, so the banner's
+    success axis stays true; the gates are the separate statement about
+    *what* the run measured. Three exit channels, in precedence order (see
+    ``docs/adr/0041-zero-coverage-exit-signal.md``):
+
+    * ``fail_on_zero_coverage`` set and ``completeness.zero_coverage`` →
+      exit ``2`` with the "Run measured no trials" line.
+    * ``fail_on_zero_judge_graded`` set and ``completeness.zero_judge_graded``
+      → exit ``2`` with the "LLM judge errored on every scored trial" line.
+    * ``completeness.ungradeable > 0`` → exit ``1`` with the ungradeable
+      line naming the first few trial ids.
+
+    An opted-in exit-2 gate outranks the unflagged exit-1 in any overlap.
+    The exit code plus one console line are the two channels; the
+    ``aggregate.json`` / ``trajectory.json`` reads each line names carry the
+    detail.
     """
+    if fail_on_zero_coverage and completeness.zero_coverage:
+        console.print(
+            "[red]Run measured no trials[/red] on "
+            f"{completeness.total_attempts} attempted. "
+            "See infrastructure_aborts in aggregate.json."
+        )
+        raise SystemExit(2)
+    if fail_on_zero_judge_graded and completeness.zero_judge_graded:
+        console.print(
+            "[red]LLM judge errored on every scored trial:[/red] "
+            f"0 of {completeness.scored_trials} grades succeeded. "
+            "See judge_status in trajectory.json and judge_cost_usd in aggregate.json."
+        )
+        raise SystemExit(2)
     if completeness.is_complete:
         return
     named = completeness.ungradeable_trial_ids[:_UNGRADEABLE_TRIALS_NAMED]
@@ -648,6 +679,28 @@ def _run_dry_run(
         "Precedence: flag > env > config > default. See docs/RUNNER.md."
     ),
 )
+@click.option(
+    "--fail-on-zero-coverage",
+    "fail_on_zero_coverage",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit 2 when the run finished with no measured trials. Overrides "
+        "orchestrator.fail_on_zero_coverage in the run config when set. "
+        "See docs/CLI.md § Run and worker exit codes."
+    ),
+)
+@click.option(
+    "--fail-on-zero-judge-graded",
+    "fail_on_zero_judge_graded",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit 2 when every produced grade has judge_status == ERRORED. Overrides "
+        "orchestrator.fail_on_zero_judge_graded in the run config when set. "
+        "See docs/CLI.md § Run and worker exit codes."
+    ),
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -665,6 +718,8 @@ def run(
     time_limit: str | None,
     dry_run: bool,
     image_source: str | None,
+    fail_on_zero_coverage: bool,
+    fail_on_zero_judge_graded: bool,
 ):
     """Run benchmark with specified configuration"""
     if verbose:
@@ -925,7 +980,15 @@ def run(
             stopped_reason=stopped_reason,
         )
     emit_artifact_path(output_dir)
-    _fail_on_ungradeable_trials(orchestrator.grading_completeness)
+    _fail_on_completeness_gates(
+        orchestrator.grading_completeness,
+        fail_on_zero_coverage=(
+            fail_on_zero_coverage or run_config.orchestrator.fail_on_zero_coverage
+        ),
+        fail_on_zero_judge_graded=(
+            fail_on_zero_judge_graded or run_config.orchestrator.fail_on_zero_judge_graded
+        ),
+    )
 
 
 def _relative_bundle(bundle: Path, source: Path) -> str:
@@ -1569,6 +1632,28 @@ def prepare(
         "falls back to engine.presets_file."
     ),
 )
+@click.option(
+    "--fail-on-zero-coverage",
+    "fail_on_zero_coverage",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit 2 when the worker finished with no measured attempts. Overrides "
+        "orchestrator.fail_on_zero_coverage in the run config when set. "
+        "See docs/CLI.md § Run and worker exit codes."
+    ),
+)
+@click.option(
+    "--fail-on-zero-judge-graded",
+    "fail_on_zero_judge_graded",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit 2 when every produced grade has judge_status == ERRORED. Overrides "
+        "orchestrator.fail_on_zero_judge_graded in the run config when set. "
+        "See docs/CLI.md § Run and worker exit codes."
+    ),
+)
 @click.pass_context
 def worker(
     ctx: click.Context,
@@ -1578,6 +1663,8 @@ def worker(
     verbose: bool,
     strict: bool,
     presets_file: str | None,
+    fail_on_zero_coverage: bool,
+    fail_on_zero_judge_graded: bool,
 ):
     """Run a queue worker process (distributed execution mode)."""
     if verbose:
@@ -1611,7 +1698,15 @@ def worker(
             **summary
         )
     )
-    _fail_on_ungradeable_trials(orchestrator.grading_completeness)
+    _fail_on_completeness_gates(
+        orchestrator.grading_completeness,
+        fail_on_zero_coverage=(
+            fail_on_zero_coverage or run_config.orchestrator.fail_on_zero_coverage
+        ),
+        fail_on_zero_judge_graded=(
+            fail_on_zero_judge_graded or run_config.orchestrator.fail_on_zero_judge_graded
+        ),
+    )
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

Gives CI a machine-readable signal for runs that measured or scored nothing without breaking the shipped "infrastructure aborts do not fail the run" contract. Closes #1301 (never measured) and #1063 (100%-judge-errored).

## Design (ADR-0041)

`docs/adr/0041-zero-coverage-exit-signal.md` records the decision:
- Two derived booleans on \`run_state.json\` — \`zero_coverage\` (run measured nothing) and \`zero_judge_graded\` (every produced grade has \`judge_status == ERRORED\`).
- Two opt-in CLI flags — \`--fail-on-zero-coverage\` and \`--fail-on-zero-judge-graded\` — on \`tolokaforge run\` and \`tolokaforge worker\`. Both default False (preserves back-compat).
- New exit code **2** when either flag is set and its condition fires. Exit 0 and exit 1 keep their historical meaning.
- Precedence: zero_coverage > zero_judge_graded > ungradeable.
- \`scored_trials\` follows the single predicate \`metrics._measured_averages\` uses (\`t.grade is not None\`) — no derivation drift.
- Rejected alternatives (field-only, exit-1 widening, \`run_summary.json\`, adding to \`AggregateMetrics\`, classification-based \`zero_scored\`) recorded in Considered Options.

## Stages

1. \`ee291fdc\` — ADR-0041.
2. \`09517f3a\` — Data model: \`GradingCompleteness\` widens with three counts + two derived properties; \`RunState\` grows two booleans; \`mark_run_completed\` widens with keyword-only completion flags; \`OrchestratorConfig\` grows two opt-in flags; single-derivation-site population in \`_publish_grading_completeness\`. 7 new unit tests including the MEASURED-but-no-grade fixture.
3. \`57d9f13f\` — Teardown reorder: reports + completeness fire before completion stamp. Extracts \`_finalize_run_reports_and_status\` with try/finally that keeps \`status: "completed"\` invariant across every exception class (including \`BaseException\`). 4 new unit tests.
4. \`0a75c6fb\` — CLI: rename \`_fail_on_ungradeable_trials\` → \`_fail_on_completeness_gates\`; two new opt-in flags on \`run\` and \`worker\`; exit-code precedence; two locked print-lines. New canonical \`test_cli_exit_code_contract\`. \`docs/CLI.md\` exit-code table gains a row and references ADR-0041.

## Verification

- \`uv run pytest -m unit\` — 548 passed
- \`uv run pytest -m canonical\` — 9 passed
- Rename hygiene: \`rg '_fail_on_ungradeable_trials|graded_trials|zero_scored'\` → 0 hits
- \`rg 'ADR-0041' docs/CLI.md\` → 1 hit
- Lint + format clean

## Compatibility

- \`RunState\` has no \`extra="forbid"\` — two new fields with False defaults; old state files load unchanged. Tested.
- \`GradingCompleteness\` construction sites in tests use only \`total_attempts\` + \`ungradeable_trial_ids\`; the three new count fields default to 0. Existing sites untouched.
- Exit code 2 is new; exit 0 and exit 1 preserve their historical meaning. CI pipelines that never set the opt-in flags see no behavior change.
- Reviewed by round-1 and round-2 plan-critic (REVISE → APPROVE WITH NOTES); both critic findings folded into the implementation.

Closes #1301.
Closes #1063.