### PR TITLE
fix(ci): bump Claude Code Action pin to v1.0.209

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,24 +43,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Pinned to the SHA of v1.0.173 (the moving @beta tag broke overnight
-      # on 2026-07-13 — a rolling update crashed the runner mid-review).
-      # Bumping is a one-line diff; commit SHAs are immutable so this is
-      # supply-chain safer than a floating tag.
-      - uses: anthropics/claude-code-action@1281377b9fdacad00368735a20d0d153fa1b82bd  # v1.0.173
+      # Pinned to the SHA of v1.0.209. Commit SHAs are immutable, so this is
+      # supply-chain safer than a floating tag; bumping is a one-line diff.
+      - uses: anthropics/claude-code-action@a130d017f515bcf0e1367bcd7c04572909b81332  # v1.0.209
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # v1.0 renamed several inputs — see the action's migration guide.
-          # ``direct_prompt`` → ``prompt`` (direct rename); ``model`` moves
-          # into ``claude_args`` as a CLI flag. Old input names silently
-          # no-op'd (workflow ran but the review didn't fire); this fix
-          # brings coverage back.
-          # ``track_progress: true`` restores the tag-mode tracking comments
-          # v0.x posted by default so future PR readers see the review
-          # progress the same way they did before the upgrade.
+          # ``prompt`` is the v1.0 input name (renamed from ``direct_prompt``);
+          # ``model`` moves into ``claude_args`` as a CLI flag.
+          # ``track_progress: true`` posts tag-mode tracking comments so PR
+          # readers see review progress in the timeline.
           track_progress: true
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-5
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,7 +54,7 @@ jobs:
           # ``track_progress: true`` posts tag-mode tracking comments so PR
           # readers see review progress in the timeline.
           track_progress: true
-          claude_args: --model claude-opus-5
+          claude_args: --model claude-opus-4-8
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The pinned v1.0.173 (2026-07-13) started returning \`is_error:true\` at init on 2026-08-27 across every PR — 292ms duration, \$0 cost, 1 turn. No workflow changes between the last green run (2026-08-27 15:56) and the first failure (2026-08-27 16:05), which points at the action's bundled CLI drifting from the current API surface.

Fix: bump the action pin v1.0.173 → v1.0.209 (SHA \`a130d017…\`, released 2026-08-28). Review model stays on \`claude-opus-4-8\` per cost preference.

This PR itself will trigger claude-review on the old pin (still on main), so it'll fail same as everything else — that's expected. Admin-merge to break the catch-22; subsequent PRs use the new pin.