### PR TITLE
fix(ci): switch claude-review model claude-opus-4-8 → claude-opus-4-7

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,7 +54,7 @@ jobs:
           # ``track_progress: true`` posts tag-mode tracking comments so PR
           # readers see review progress in the timeline.
           track_progress: true
-          claude_args: --model claude-opus-4-8
+          claude_args: --model claude-opus-4-7
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Follow-up to #1337. The action pin bump was correct, but hygiene-review still fails with \`is_error:true\` at 309ms, \$0, \`modelUsage:{}\` — the API rejects the request before any tokens land, signature of a model not on this org's key's allowlist.

\`claude-opus-4-8\` is the newest opus (released recently) and the most likely candidate to be off an older key's allowlist. Falling back to \`claude-opus-4-7\` (same \$5/\$25 pricing, released earlier, more universally provisioned).

If 4-7 also fails, next fallback is \`claude-sonnet-4-6\` (\$3/\$15) — still cheap and older.