### PR TITLE
feat(manifest): EnvironmentManifest.requires_hybrid_stack property

### DIFF
--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -220,8 +220,8 @@ class TestServiceIsolationContract:
         )
         assert m.requires_hybrid_stack is True
         # requires_per_trial is *also* True (the ephemeral service).
-        # Selection order guarantees hybrid wins over per-trial —
-        # see ADR-0043 § Decision item 4 and _select_backend_from_tasks.
+        # ADR-0043 § Decision item 4 requires _select_backend_from_tasks
+        # to evaluate hybrid before per-trial when it lands (#1365).
         assert m.requires_per_trial is True
 
     def test_mixed_shared_and_reset_requires_hybrid_stack(self) -> None:

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -162,6 +162,81 @@ class TestServiceIsolationContract:
         )
         assert m.requires_per_trial is False
 
+    def test_empty_services_map_does_not_require_hybrid_stack(self) -> None:
+        """Safety default: an empty services map does not opt into hybrid.
+        The ADR-0009 default keeps routing through :attr:`requires_per_trial`
+        so existing task packs stay on the per_trial path."""
+        m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
+        assert m.services == {}
+        assert m.requires_hybrid_stack is False
+        assert m.requires_per_trial is True
+
+    def test_all_shared_services_do_not_require_hybrid_stack(self) -> None:
+        """All-shared routes to :class:`SharedStackRuntimeBackend`, not
+        hybrid. Hybrid requires a mix of isolation levels."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        assert m.requires_hybrid_stack is False
+        assert m.requires_per_trial is False
+
+    def test_all_ephemeral_services_do_not_require_hybrid_stack(self) -> None:
+        """All-per-trial routes to :class:`PerTrialRuntimeBackend`, not
+        hybrid."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            services={
+                "default": ServiceSpec(isolation="ephemeral"),
+                "db": ServiceSpec(isolation="ephemeral"),
+            },
+        )
+        assert m.requires_hybrid_stack is False
+        assert m.requires_per_trial is True
+
+    def test_all_reset_services_do_not_require_hybrid_stack(self) -> None:
+        """All-reset (reset-recipe-based per-trial state restoration) is
+        still per-trial routing at the manifest level, not hybrid."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            services={
+                "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="a")),
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="b")),
+            },
+        )
+        assert m.requires_hybrid_stack is False
+        assert m.requires_per_trial is True
+
+    def test_mixed_shared_and_ephemeral_requires_hybrid_stack(self) -> None:
+        """Canonical T-Bench-shape manifest: engine services `shared`,
+        task-declared services `ephemeral`. Routes to hybrid — this is
+        the missing quadrant ADR-0043 fills."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="ephemeral"),
+            },
+        )
+        assert m.requires_hybrid_stack is True
+        # requires_per_trial is *also* True (the ephemeral service).
+        # Selection order guarantees hybrid wins over per-trial —
+        # see ADR-0043 § Decision item 4 and _select_backend_from_tasks.
+        assert m.requires_per_trial is True
+
+    def test_mixed_shared_and_reset_requires_hybrid_stack(self) -> None:
+        """The other mixed shape: shared engine + reset-restored
+        task-declared services. Also routes to hybrid."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            },
+        )
+        assert m.requires_hybrid_stack is True
+        assert m.requires_per_trial is True
+
     def test_round_trip_preserves_services(self) -> None:
         m = EnvironmentManifest(
             compose_file=_fixture("safe_two_service.yaml"),

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -2902,11 +2902,12 @@ class EnvironmentManifest(BaseModel):
         - Mixed (at least one ``shared`` AND at least one
           ``reset|ephemeral``) → ``True``.
 
-        Consumed by :meth:`Orchestrator._select_backend_from_tasks` —
-        the hybrid branch is evaluated BEFORE the per-trial branch, so a
-        mixed manifest (which also reports :attr:`requires_per_trial=True`
-        because it contains non-``shared`` services) routes to hybrid,
-        not per-trial. See ADR-0043 § Decision item 4.
+        Designed for consumption by
+        :meth:`Orchestrator._select_backend_from_tasks` per ADR-0043
+        § Decision item 4: the hybrid branch is evaluated before the
+        per-trial branch so a mixed manifest (which also reports
+        :attr:`requires_per_trial=True` because it contains non-``shared``
+        services) will route to hybrid, not per-trial. Wired by #1365.
         """
         if not self.services:
             return False

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -2885,6 +2885,37 @@ class EnvironmentManifest(BaseModel):
         return any(spec.isolation != "shared" for spec in self.services.values())
 
     @property
+    def requires_hybrid_stack(self) -> bool:
+        """True iff the manifest declares a *mix* of ``shared`` and
+        ``reset|ephemeral`` isolation levels — the shape that argues for
+        :class:`HybridRuntimeBackend` (shared engine services materialised
+        once per run + task-declared services materialised per trial).
+
+        Return-value semantics:
+
+        - All-shared → ``False`` (routes to :class:`SharedStackRuntimeBackend`).
+        - All-per-trial (``reset|ephemeral``) → ``False``;
+          :attr:`requires_per_trial` is ``True`` and routes to
+          :class:`PerTrialRuntimeBackend` unchanged.
+        - Empty ``services`` → ``False``; the ADR-0009 default
+          (:attr:`requires_per_trial=True`) still routes to per-trial.
+        - Mixed (at least one ``shared`` AND at least one
+          ``reset|ephemeral``) → ``True``.
+
+        Consumed by :meth:`Orchestrator._select_backend_from_tasks` —
+        the hybrid branch is evaluated BEFORE the per-trial branch, so a
+        mixed manifest (which also reports :attr:`requires_per_trial=True`
+        because it contains non-``shared`` services) routes to hybrid,
+        not per-trial. See ADR-0043 § Decision item 4.
+        """
+        if not self.services:
+            return False
+        kinds = {spec.isolation for spec in self.services.values()}
+        has_shared = "shared" in kinds
+        has_per_trial = bool(kinds & {"reset", "ephemeral"})
+        return has_shared and has_per_trial
+
+    @property
     def restricted_services(self) -> frozenset[str]:
         """Names of services marked ``network_access="restricted"``.
 


### PR DESCRIPTION
Closes #1364
Part of milestone: [HybridRuntimeBackend for multi-compose task packs](https://github.com/Toloka/tolokaforge/milestone/40)
Depends on: #1370 (ADR-0043) — merged.
Blocks: #1365 (backend selection widening), #1366 (hybrid backend impl).

## Summary

Manifest-side signal that #1365 will read to route mixed-isolation task packs to the new `HybridRuntimeBackend` (design in ADR-0043).

**Semantics**:
- All-shared → `False` (routes to `SharedStackRuntimeBackend`, unchanged).
- All-per-trial (`reset`/`ephemeral`) → `False`; `requires_per_trial=True` and routes to `PerTrialRuntimeBackend`, unchanged.
- Empty `services` map → `False`; the ADR-0009 default `requires_per_trial=True` routes to per_trial, unchanged.
- Mixed (≥1 `shared` AND ≥1 `reset|ephemeral`) → `True`. This is the new routing signal — the canonical T-Bench-shape.

**Backward compatibility**: existing manifests without a `services` map (the majority of shipped task packs) return `False` on the new property and continue routing through `requires_per_trial`. No behavior change until #1365 wires selection.

## Test plan

- [x] `uv run pytest tests/canonical/test_environment_manifest_contract.py -v` — 126 pass (adds 6 new)
- [x] `ruff check` + `black --check` clean
- [x] Wire-shape snapshot (`test_canonical_wire_shape`) unchanged — `@property` is not a Pydantic field, doesn't affect JSON schema

## Files changed

- `tolokaforge/runner/models.py` — new `requires_hybrid_stack` property + docstring
- `tests/canonical/test_environment_manifest_contract.py` — 6 new cases (empty / all-shared / all-ephemeral / all-reset / shared+ephemeral / shared+reset)