### PR TITLE
feat(orchestrator): wire hybrid_stack selection + admission (#1365)

### DIFF
--- a/tests/unit/test_backend_capabilities.py
+++ b/tests/unit/test_backend_capabilities.py
@@ -36,8 +36,6 @@ class TestRegistryVocabulary:
         assert expected.issubset(CAPABILITY_REGISTRY.keys())
 
     def test_hybrid_stack_is_registered(self) -> None:
-        """New capability entry added in #1365. HybridRuntimeBackend
-        (registered in #1366) will advertise it."""
         spec = CAPABILITY_REGISTRY["hybrid_stack"]
         assert "shared engine services" in spec.description
         assert "task-declared services per trial" in spec.description

--- a/tests/unit/test_backend_capabilities.py
+++ b/tests/unit/test_backend_capabilities.py
@@ -25,6 +25,7 @@ class TestRegistryVocabulary:
         expected = {
             "per_trial_stack",
             "shared_stack",
+            "hybrid_stack",
             "reset_recipes:sql_dump",
             "reset_recipes:filesystem_dir",
             "reset_recipes:redis_dump",
@@ -33,6 +34,13 @@ class TestRegistryVocabulary:
             "network_isolation:limited_internet",
         }
         assert expected.issubset(CAPABILITY_REGISTRY.keys())
+
+    def test_hybrid_stack_is_registered(self) -> None:
+        """New capability entry added in #1365. HybridRuntimeBackend
+        (registered in #1366) will advertise it."""
+        spec = CAPABILITY_REGISTRY["hybrid_stack"]
+        assert "shared engine services" in spec.description
+        assert "task-declared services per trial" in spec.description
 
     def test_local_docker_advertises_registry_subset(self) -> None:
         assert LOCAL_DOCKER_ADVERTISED.issubset(CAPABILITY_REGISTRY.keys())

--- a/tests/unit/test_backend_selection.py
+++ b/tests/unit/test_backend_selection.py
@@ -237,13 +237,12 @@ class TestConstructRuntimeBackend:
         the factory it invokes — decoupled from installed package metadata.
         """
 
-        # Stub hybrid factory returns a marker so the routing wire-through
-        # is testable before #1366 lands the real HybridRuntimeBackend.
-        # The real hybrid backend registration comes in #1366; this stub
-        # exists only so the loader in _construct_runtime_backend has
-        # something to dispatch to under a synthesised hybrid selection.
+        # No ``hybrid`` factory is registered in the plug-in group today,
+        # so the loader has nothing to dispatch to under a hybrid
+        # selection. Substitute a marker stub so the dispatch wire
+        # (selection → factory) is testable in isolation.
         class _HybridStub:
-            isolation_mode = None  # populated by the real class in #1366
+            isolation_mode = None
             advertised_capabilities = frozenset({"hybrid_stack"})
 
         def _hybrid_stub_factory(ctx: RuntimeBackendBuildContext) -> Any:
@@ -275,7 +274,7 @@ class TestConstructRuntimeBackend:
     def test_task_driven_mixed_picks_hybrid(self) -> None:
         """A mixed-isolation manifest routes through _select_backend_from_tasks
         to the ``hybrid`` name, which _construct_runtime_backend loads via
-        the plug-in registry. Real HybridRuntimeBackend lands in #1366."""
+        the plug-in registry."""
         tasks = [_task_stub("t1")]
         task_descs = {
             "t1": make_task_description(

--- a/tests/unit/test_backend_selection.py
+++ b/tests/unit/test_backend_selection.py
@@ -1,10 +1,12 @@
 """Task-driven backend selection.
 
-The orchestrator picks :class:`PerTrialRuntimeBackend` when any task
-manifest requires per-trial materialisation, otherwise
-:class:`SharedStackRuntimeBackend`. The legacy ``orchestrator.runtime``
-override still wins but emits ``DeprecationWarning``. These tests pin
-every branch of :meth:`Orchestrator._select_backend_from_tasks` and
+The orchestrator picks ``hybrid`` when any task manifest declares a mix
+of ``shared`` and ``reset|ephemeral`` isolation levels (ADR-0043), else
+``per_trial`` when any task manifest requires per-trial materialisation
+(all-``reset|ephemeral`` service maps + empty-services default), else
+``shared``. The legacy ``orchestrator.runtime`` override still wins but
+emits ``DeprecationWarning``. These tests pin every branch of
+:meth:`Orchestrator._select_backend_from_tasks` and
 :meth:`Orchestrator._construct_runtime_backend`.
 """
 
@@ -89,7 +91,9 @@ def _manifest_all_shared() -> EnvironmentManifest:
     )
 
 
-def _manifest_with_reset() -> EnvironmentManifest:
+def _manifest_mixed_reset() -> EnvironmentManifest:
+    """Mixed manifest: ``default: shared`` + ``db: reset``. ADR-0043 hybrid
+    shape — engine service shared, task-declared service reset per trial."""
     return EnvironmentManifest(
         compose_file=_FIXTURES / "safe_two_service.yaml",
         services={
@@ -99,12 +103,38 @@ def _manifest_with_reset() -> EnvironmentManifest:
     )
 
 
-def _manifest_with_ephemeral() -> EnvironmentManifest:
+def _manifest_mixed_ephemeral() -> EnvironmentManifest:
+    """Mixed manifest: ``default: shared`` + ``db: ephemeral``. Canonical
+    T-Bench-shape hybrid manifest."""
     return EnvironmentManifest(
         compose_file=_FIXTURES / "safe_two_service.yaml",
         services={
             "db": ServiceSpec(isolation="ephemeral"),
             "default": ServiceSpec(isolation="shared"),
+        },
+    )
+
+
+def _manifest_all_reset() -> EnvironmentManifest:
+    """All-``reset`` manifest — every service reset per trial with a seed.
+    Not a hybrid shape (no ``shared`` service); routes to per_trial."""
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services={
+            "db": ServiceSpec(isolation="reset", reset=ResetSpec(seed="baseline")),
+            "default": ServiceSpec(isolation="reset", reset=ResetSpec(seed="app")),
+        },
+    )
+
+
+def _manifest_all_ephemeral() -> EnvironmentManifest:
+    """All-``ephemeral`` manifest — every service rematerialised per trial.
+    Not a hybrid shape; routes to per_trial."""
+    return EnvironmentManifest(
+        compose_file=_FIXTURES / "safe_two_service.yaml",
+        services={
+            "db": ServiceSpec(isolation="ephemeral"),
+            "default": ServiceSpec(isolation="ephemeral"),
         },
     )
 
@@ -118,24 +148,69 @@ class TestSelectBackendFromTasks:
         orch = _make_orchestrator(tasks, task_descs)
         assert orch._select_backend_from_tasks() == "shared"
 
-    def test_any_reset_returns_per_trial(self) -> None:
-        tasks = [_task_stub("t1"), _task_stub("t2")]
+    def test_all_reset_returns_per_trial(self) -> None:
+        """All-``reset`` (no ``shared`` service) is a pure per-trial shape,
+        not hybrid. Routes to per_trial."""
+        tasks = [_task_stub("t1")]
         task_descs = {
-            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared()),
-            "t2": make_task_description(task_id="t2", environment_manifest=_manifest_with_reset()),
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_reset())
         }
         orch = _make_orchestrator(tasks, task_descs)
         assert orch._select_backend_from_tasks() == "per_trial"
 
-    def test_any_ephemeral_returns_per_trial(self) -> None:
+    def test_all_ephemeral_returns_per_trial(self) -> None:
+        """All-``ephemeral`` (no ``shared`` service) is a pure per-trial
+        shape, not hybrid. Routes to per_trial."""
         tasks = [_task_stub("t1")]
         task_descs = {
             "t1": make_task_description(
-                task_id="t1", environment_manifest=_manifest_with_ephemeral()
+                task_id="t1", environment_manifest=_manifest_all_ephemeral()
             )
         }
         orch = _make_orchestrator(tasks, task_descs)
         assert orch._select_backend_from_tasks() == "per_trial"
+
+    def test_mixed_shared_and_reset_returns_hybrid(self) -> None:
+        """Mixed ``shared`` + ``reset`` manifest is the hybrid shape per
+        ADR-0043. Routes to hybrid, not per_trial — hybrid branch is
+        evaluated before per_trial so the shared engine slice is not
+        rebuilt every trial."""
+        tasks = [_task_stub("t1"), _task_stub("t2")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_shared()),
+            "t2": make_task_description(task_id="t2", environment_manifest=_manifest_mixed_reset()),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "hybrid"
+
+    def test_mixed_shared_and_ephemeral_returns_hybrid(self) -> None:
+        """Mixed ``shared`` + ``ephemeral`` manifest — the canonical
+        T-Bench-shape — routes to hybrid per ADR-0043."""
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(
+                task_id="t1", environment_manifest=_manifest_mixed_ephemeral()
+            )
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "hybrid"
+
+    def test_hybrid_precedes_per_trial_in_selection_order(self) -> None:
+        """When a run has both a pure per-trial task and a mixed hybrid
+        task, hybrid wins — the shared engine slice would otherwise be
+        rebuilt every trial and defeat the design (ADR-0043 § Decision
+        item 4)."""
+        tasks = [_task_stub("t1"), _task_stub("t2")]
+        task_descs = {
+            "t1": make_task_description(
+                task_id="t1", environment_manifest=_manifest_all_ephemeral()
+            ),
+            "t2": make_task_description(
+                task_id="t2", environment_manifest=_manifest_mixed_ephemeral()
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        assert orch._select_backend_from_tasks() == "hybrid"
 
     def test_no_manifest_defaults_to_shared(self) -> None:
         tasks = [_task_stub("legacy")]
@@ -161,9 +236,23 @@ class TestConstructRuntimeBackend:
         unit tests of dispatch wiring — the name the orchestrator selects and
         the factory it invokes — decoupled from installed package metadata.
         """
+
+        # Stub hybrid factory returns a marker so the routing wire-through
+        # is testable before #1366 lands the real HybridRuntimeBackend.
+        # The real hybrid backend registration comes in #1366; this stub
+        # exists only so the loader in _construct_runtime_backend has
+        # something to dispatch to under a synthesised hybrid selection.
+        class _HybridStub:
+            isolation_mode = None  # populated by the real class in #1366
+            advertised_capabilities = frozenset({"hybrid_stack"})
+
+        def _hybrid_stub_factory(ctx: RuntimeBackendBuildContext) -> Any:
+            return _HybridStub()
+
         factories = {
             "shared": shared_runtime_backend_factory,
             "per_trial": per_trial_runtime_backend_factory,
+            "hybrid": _hybrid_stub_factory,
         }
         monkeypatch.setattr(
             "tolokaforge.core.orchestrator.load_runtime_backend",
@@ -183,10 +272,36 @@ class TestConstructRuntimeBackend:
         )
         assert isinstance(backend, SharedStackRuntimeBackend)
 
-    def test_task_driven_reset_picks_per_trial(self) -> None:
+    def test_task_driven_mixed_picks_hybrid(self) -> None:
+        """A mixed-isolation manifest routes through _select_backend_from_tasks
+        to the ``hybrid`` name, which _construct_runtime_backend loads via
+        the plug-in registry. Real HybridRuntimeBackend lands in #1366."""
         tasks = [_task_stub("t1")]
         task_descs = {
-            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_with_reset())
+            "t1": make_task_description(
+                task_id="t1", environment_manifest=_manifest_mixed_ephemeral()
+            )
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        # Sanity: selection wire → "hybrid".
+        assert orch._select_backend_from_tasks() == "hybrid"
+        # Wire-through: _construct_runtime_backend invokes the hybrid
+        # stub factory (populated in the fixture) — no shared or per_trial
+        # dispatch happens.
+        backend = orch._construct_runtime_backend(
+            runner_address="sentinel:50051",
+            env_manifest=None,
+            run_id="test-run",
+        )
+        assert not isinstance(backend, (SharedStackRuntimeBackend, PerTrialRuntimeBackend))
+        assert "hybrid_stack" in backend.advertised_capabilities
+
+    def test_task_driven_all_reset_picks_per_trial(self) -> None:
+        """All-``reset`` manifest routes to per_trial. Hybrid requires a
+        mix; pure per-trial shapes stay on per_trial."""
+        tasks = [_task_stub("t1")]
+        task_descs = {
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_reset())
         }
         orch = _make_orchestrator(tasks, task_descs)
         backend = orch._construct_runtime_backend(
@@ -224,7 +339,7 @@ class TestConstructRuntimeBackend:
         # elsewhere refuses this configuration at run time.
         tasks = [_task_stub("t1")]
         task_descs = {
-            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_with_reset())
+            "t1": make_task_description(task_id="t1", environment_manifest=_manifest_all_reset())
         }
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)

--- a/tests/unit/test_orchestrator_isolation_enforcement.py
+++ b/tests/unit/test_orchestrator_isolation_enforcement.py
@@ -77,6 +77,17 @@ def _per_trial_backend() -> PerTrialRuntimeBackend:
     return PerTrialRuntimeBackend()
 
 
+def _hybrid_backend() -> Any:
+    """Minimal hybrid-backend stub for the isolation-check test — only
+    ``isolation_mode`` is read by ``_verify_isolation_compatibility``.
+    The full backend lands in #1366."""
+    from tolokaforge.core.runtime import IsolationMode
+
+    stub = MagicMock()
+    stub.isolation_mode = IsolationMode.HYBRID_STACK
+    return stub
+
+
 class TestSharedStackRuntimePath:
     """The load-bearing case: SharedStackRuntimeBackend refuses tasks
     whose manifest requires per-trial materialisation."""
@@ -215,6 +226,54 @@ class TestPerTrialRuntimePath:
         }
         orch = _make_orchestrator(tasks, task_descs)
         orch._verify_isolation_compatibility(_per_trial_backend())
+
+
+class TestHybridRuntimePath:
+    """HybridRuntimeBackend materialises task-declared services per trial
+    (like PerTrialRuntimeBackend), so it satisfies every isolation
+    requirement including ``ephemeral`` — the same short-circuit
+    _verify_isolation_compatibility applies to per_trial. See ADR-0043
+    § Decision item 5."""
+
+    def test_ephemeral_service_passes(self) -> None:
+        tasks = [_make_task_config("tbench-shape")]
+        task_descs = {
+            "tbench-shape": make_task_description(
+                task_id="tbench-shape",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(isolation="ephemeral"),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        # Under the old (per-trial only) short-circuit this would have
+        # raised for the ephemeral service; under the widened check
+        # hybrid honours ephemeral the same way per_trial does.
+        orch._verify_isolation_compatibility(_hybrid_backend())
+
+    def test_reset_service_passes(self) -> None:
+        from tolokaforge.core.models import ResetSpec
+
+        tasks = [_make_task_config("stateful")]
+        task_descs = {
+            "stateful": make_task_description(
+                task_id="stateful",
+                environment_manifest=_manifest_with_services(
+                    {
+                        "db": ServiceSpec(
+                            isolation="reset",
+                            reset=ResetSpec(seed="baseline"),
+                        ),
+                        "default": ServiceSpec(isolation="shared"),
+                    }
+                ),
+            ),
+        }
+        orch = _make_orchestrator(tasks, task_descs)
+        orch._verify_isolation_compatibility(_hybrid_backend())
 
 
 class TestAdapterGuard:

--- a/tests/unit/test_orchestrator_isolation_enforcement.py
+++ b/tests/unit/test_orchestrator_isolation_enforcement.py
@@ -79,8 +79,7 @@ def _per_trial_backend() -> PerTrialRuntimeBackend:
 
 def _hybrid_backend() -> Any:
     """Minimal hybrid-backend stub for the isolation-check test — only
-    ``isolation_mode`` is read by ``_verify_isolation_compatibility``.
-    The full backend lands in #1366."""
+    ``isolation_mode`` is read by ``_verify_isolation_compatibility``."""
     from tolokaforge.core.runtime import IsolationMode
 
     stub = MagicMock()
@@ -229,11 +228,10 @@ class TestPerTrialRuntimePath:
 
 
 class TestHybridRuntimePath:
-    """HybridRuntimeBackend materialises task-declared services per trial
-    (like PerTrialRuntimeBackend), so it satisfies every isolation
-    requirement including ``ephemeral`` — the same short-circuit
-    _verify_isolation_compatibility applies to per_trial. See ADR-0043
-    § Decision item 5."""
+    """A HYBRID_STACK-mode backend materialises task-declared services
+    per trial (like PerTrialRuntimeBackend), so ``_verify_isolation_compatibility``
+    admits ``ephemeral`` and ``reset`` labels the same way it admits them
+    on per_trial. See ADR-0043 § Decision item 5."""
 
     def test_ephemeral_service_passes(self) -> None:
         tasks = [_make_task_config("tbench-shape")]
@@ -249,9 +247,6 @@ class TestHybridRuntimePath:
             ),
         }
         orch = _make_orchestrator(tasks, task_descs)
-        # Under the old (per-trial only) short-circuit this would have
-        # raised for the ephemeral service; under the widened check
-        # hybrid honours ephemeral the same way per_trial does.
         orch._verify_isolation_compatibility(_hybrid_backend())
 
     def test_reset_service_passes(self) -> None:

--- a/tolokaforge/core/backend_capabilities.py
+++ b/tolokaforge/core/backend_capabilities.py
@@ -44,6 +44,10 @@ _LOCAL_DOCKER_BASELINE: tuple[CapabilitySpec, ...] = (
         description="Backend materialises one substrate for the whole run.",
     ),
     CapabilitySpec(
+        name="hybrid_stack",
+        description="Backend materialises shared engine services (runner + db-service + rag-service) once per run, plus task-declared services per trial from a per-service sub-compose. See ADR-0043.",
+    ),
+    CapabilitySpec(
         name="reset_recipes:sql_dump",
         description="Backend can restore a Postgres/SQL dump into a labelled service between trials.",
     ),

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1055,19 +1055,21 @@ class Orchestrator:
         """
         from tolokaforge.core.project_loader import resolve
 
-        # Per-trial short-circuit — resolves via the same signal
+        # Per-trial and hybrid short-circuit — resolves via the same signal
         # ``_construct_runtime_backend`` uses to pick the backend, so the
         # two decisions stay in lock-step. Both the operator override
-        # ``orchestrator.runtime`` and the task-driven per-trial signal
-        # suppress the shared-stack heterogeneity check. Inlined rather
-        # than routed through ``_resolve_effective_runtime_choice`` so
-        # the override path works when the adapter isn't loaded yet
-        # (unit-test seams).
+        # ``orchestrator.runtime`` and the task-driven per-trial/hybrid
+        # signals suppress the shared-stack heterogeneity check: per-trial
+        # resolves ``task.environment_manifest`` per trial, and hybrid's
+        # engine slice is homogeneous across tasks by construction (see
+        # ADR-0043 § Decision item 4). Inlined rather than routed through
+        # ``_resolve_effective_runtime_choice`` so the override path works
+        # when the adapter isn't loaded yet (unit-test seams).
         override = self.config.orchestrator.runtime
-        if override == "per_trial":
+        if override in ("per_trial", "hybrid"):
             return None
         if override is None and self.adapter is not None:
-            if self._select_backend_from_tasks() == "per_trial":
+            if self._select_backend_from_tasks() in ("per_trial", "hybrid"):
                 return None
 
         project_env = self.project.default_environment if self.project is not None else None
@@ -1098,23 +1100,35 @@ class Orchestrator:
         return next(iter(manifests_by_compose.values()))
 
     def _select_backend_from_tasks(self) -> str:
-        """Return ``"per_trial"`` if any task's manifest requires per-trial
-        materialisation, otherwise ``"shared"``.
+        """Return ``"hybrid"`` if any task's manifest requests the shared
+        engine + per-trial task shape (ADR-0043), else ``"per_trial"``
+        if any task requires per-trial materialisation, else ``"shared"``.
 
-        Reads :attr:`EnvironmentManifest.requires_per_trial` for every
-        task; a task without a manifest contributes no signal. When
-        every task with a manifest is fully-``shared`` labelled, the
-        selector picks the shared backend.
+        Reads :attr:`EnvironmentManifest.requires_hybrid_stack` and
+        :attr:`EnvironmentManifest.requires_per_trial` for every task; a
+        task without a manifest contributes no signal.
+
+        Selection order is hybrid → per_trial → shared per ADR-0043
+        § Decision item 4: a mixed-isolation manifest also reports
+        ``requires_per_trial=True`` (it contains ``reset|ephemeral``
+        services), so evaluating hybrid first is the load-bearing
+        precedence — otherwise the run would route to per_trial and
+        rebuild the shared engine services every trial.
         """
         if self.adapter is None:
             raise RuntimeError(
                 "Task-driven backend selection requires the adapter to be loaded first."
             )
+        needs_per_trial = False
         for task in self.tasks:
             manifest = self._task_description(task.task_id).environment_manifest
-            if manifest is not None and manifest.requires_per_trial:
-                return "per_trial"
-        return "shared"
+            if manifest is None:
+                continue
+            if manifest.requires_hybrid_stack:
+                return "hybrid"
+            if manifest.requires_per_trial:
+                needs_per_trial = True
+        return "per_trial" if needs_per_trial else "shared"
 
     def _resolve_effective_runtime_choice(self) -> str:
         """Return the effective runtime choice — the operator override
@@ -1354,19 +1368,28 @@ class Orchestrator:
         cannot provide it.
 
         Task-driven backend selection already routes such runs onto
-        :class:`PerTrialRuntimeBackend`; this guard only fires under
-        the deprecated ``orchestrator.runtime`` override path when the
-        operator forces a shared backend against a per-trial-requiring
-        task set. It also catches an ``ephemeral``-labelled service on
-        a shared backend — that isolation label cannot be honoured
-        without a full compose-down cycle.
+        :class:`PerTrialRuntimeBackend` or :class:`HybridRuntimeBackend`;
+        this guard only fires under the deprecated
+        ``orchestrator.runtime`` override path when the operator forces
+        a shared backend against a per-trial-requiring task set. It also
+        catches an ``ephemeral``-labelled service on a shared backend —
+        that isolation label cannot be honoured without a full
+        compose-down cycle.
+
+        Both per-trial and hybrid backends materialise task-declared
+        services per trial (hybrid also materialises the shared engine
+        slice once per run), so both honour ``reset|ephemeral`` labels
+        and both skip this check. See ADR-0043 § Decision item 5.
 
         Raises :class:`RuntimeError` naming the offending tasks and the
         concrete fix.
         """
         from tolokaforge.core.runtime import IsolationMode
 
-        if runtime_backend.isolation_mode is IsolationMode.PER_TRIAL_STACK:
+        if runtime_backend.isolation_mode in (
+            IsolationMode.PER_TRIAL_STACK,
+            IsolationMode.HYBRID_STACK,
+        ):
             return
 
         if self.adapter is None:

--- a/tolokaforge/core/runtime.py
+++ b/tolokaforge/core/runtime.py
@@ -57,10 +57,17 @@ class IsolationMode(str, Enum):
       trial in the run. Cross-trial state contamination is structural.
     * ``PER_TRIAL_STACK`` — one substrate materialisation per trial.
       Concurrent trials are fully isolated.
+    * ``HYBRID_STACK`` — shared engine services (runner + db-service +
+      rag-service where declared ``isolation: shared``) materialised once
+      per run; task-declared services materialised per trial from a
+      per-service sub-compose. Grading validity is preserved: the shared
+      slice is stateless per-trial (engine services), the per-trial slice
+      is what the grader reads. See ADR-0043.
     """
 
     SHARED_STACK = "shared_stack"
     PER_TRIAL_STACK = "per_trial_stack"
+    HYBRID_STACK = "hybrid_stack"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1365
Part of milestone: [HybridRuntimeBackend for multi-compose task packs](https://github.com/Toloka/tolokaforge/milestone/40)
Depends on: #1370 (ADR-0043), #1371 (manifest signal) — both merged.
Blocks: #1366 (HybridRuntimeBackend impl).

## Summary

Wires the `requires_hybrid_stack` manifest signal from #1364 into backend selection, admission, and isolation compatibility. The real `HybridRuntimeBackend` class lands in #1366; this ticket ships the plumbing so #1366 slots in behind a stable API.

## Changes

- `IsolationMode.HYBRID_STACK` enum value added.
- `hybrid_stack` `CapabilitySpec` registered in `CAPABILITY_REGISTRY`.
- `Orchestrator._select_backend_from_tasks`: **hybrid branch evaluated BEFORE per_trial**. A mixed manifest (which also reports `requires_per_trial=True` because it contains `reset|ephemeral` services) routes to hybrid, not per_trial — the ordering invariant ADR-0043 § Decision item 4 pins.
- `Orchestrator._extract_run_env_manifest` short-circuits when the effective runtime choice is `hybrid` (same treatment as `per_trial`).
- `Orchestrator._verify_isolation_compatibility` accepts `HYBRID_STACK` early — hybrid honours `reset|ephemeral` labels the same way per_trial does.

## Regression note

Fixtures `_manifest_with_reset` and `_manifest_with_ephemeral` in `test_backend_selection.py` were **misleadingly named** — they are actually MIXED manifests (`default:shared` + `db:reset|ephemeral`), which under ADR-0043 are the canonical hybrid shape. Renamed to `_manifest_mixed_*` and added `_manifest_all_*` fixtures that are actually pure per_trial. Existing tests that used the misleading fixtures now assert `'hybrid'` rather than `'per_trial'` — this is the correct semantics under ADR-0043; the old asserts were codifying an implementation detail that ADR-0043 explicitly changes.

## Test plan

- [x] `uv run pytest tests/unit -k "orchestrator or backend or runtime or manifest" -q` — **459 pass** (up from 449; 10 new tests)
- [x] `uv run pytest tests/unit/test_backend_selection.py tests/unit/test_backend_capabilities.py tests/unit/test_orchestrator_isolation_enforcement.py tests/unit/test_orchestrator_extract_run_env_manifest.py -v` — 61 pass
- [x] `ruff check` + `black --check` clean

## What #1366 will add (not this PR)

- Backend registration under name `hybrid` via the plug-in entry-point group.
- The `HybridRuntimeBackend` class itself.

Until then, a run that produces a hybrid selection but has no registered hybrid backend fails loud at `load_runtime_backend` — correct fail-fast behaviour, same shape as existing `TestUnknownRuntimeName` tests.