### PR TITLE
feat(adapters): AdapterGradingContract Protocol + capability flags on BaseAdapter

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -6,7 +6,10 @@ their own section.
 
 For adapter architecture and interface contracts, see
 [ADAPTER_ARCHITECTURE.md](ADAPTER_ARCHITECTURE.md) and
-[ADAPTER_INTERFACE.md](ADAPTER_INTERFACE.md).
+[ADAPTER_INTERFACE.md](ADAPTER_INTERFACE.md). The grading-side contract every
+adapter satisfies — the four readers, two emit seams, and three capability
+flags — is `AdapterGradingContract` in
+[ADAPTER_INTERFACE.md § Optional Methods](ADAPTER_INTERFACE.md#optional-methods).
 
 ---
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -9,7 +9,7 @@ For adapter architecture and interface contracts, see
 [ADAPTER_INTERFACE.md](ADAPTER_INTERFACE.md). The grading-side contract every
 adapter satisfies — the four readers, two emit seams, and three capability
 flags — is `AdapterGradingContract` in
-[ADAPTER_INTERFACE.md § Optional Methods](ADAPTER_INTERFACE.md#optional-methods).
+[ADAPTER_INTERFACE.md § AdapterGradingContract](ADAPTER_INTERFACE.md#adaptergradingcontract).
 
 ---
 

--- a/docs/ADAPTER_INTERFACE.md
+++ b/docs/ADAPTER_INTERFACE.md
@@ -155,6 +155,74 @@ Each adapter must subclass `BaseAdapter` and implement:
     it once it has resolved inputs worth naming.  See
     [Output Format](OUTPUT_FORMAT.md) § `engine_run_state.json`.
 
+18. `grading_source(task: TaskConfig, task_dir: Path) -> GradingSource`
+
+    The grading block one run of *task* reads, resolved against this adapter.
+    Where a task naming a file that is on disk is `GradingSourceKind.ON_DISK`
+    whatever the adapter, an absence is answered off the adapter: an adapter
+    that grades from the task file (native) refuses one it has no block to
+    read; an adapter that grades from a source the pack does not carry
+    (external) pronounces on the absence through its own registered kind.
+
+    The default answers `GradingSourceKind.UNINTERROGABLE` with `path=None`
+    and a non-empty reason — the honest "the adapter has not declared its
+    grading source". An adapter that resolves the block against its own run
+    configuration overrides.
+
+    An instance method, unlike the four readers in items 13 - 16: `grading_source`
+    resolves the source an adapter *actually reads* against its instance state
+    (pack roots, project defaults), which a classmethod cannot see. The static
+    gate `tolokaforge validate` reaches the source through a dispatch helper
+    that handles the not-installed arm without needing an instance.
+
+19. `emit_runner_grading_payload(task_id: str) -> dict[str, Any]`
+
+    The payload this adapter emits for the runner's `RunnerGradingConfig`
+    construction. The default is `{}` — the runner falls through to the
+    historical dispatch. Adapters that grade by their own registered kind
+    (`test_execution`, `preference_pair`, …) override to return the payload
+    their grader reads at trial time.
+
+20. `preferred_grader_kind() -> str`
+
+    The registered `tolokaforge.grader_kinds` key this adapter prefers.  The
+    default is `"composite"`, the shipped default kind. Adapters shipping
+    their own kind override to return its registered name.
+
+### Capability flags
+
+Three `ClassVar[bool]` slots declare adapter-level runtime facts callers
+otherwise infer from adapter identity. Each default is `False` on
+`BaseAdapter`; an adapter that answers `True` for one flips it on the class:
+
+- `requires_docker_cli_in_runner: ClassVar[bool] = False` — the runner needs
+  the host Docker CLI to grade this adapter's trials. Adapters whose grading
+  runs commands against Docker daemons (build/exec) flip this to `True`; the
+  harness reads the flag to decide whether the runner stack must carry a
+  Docker socket bind.
+- `grades_from_task_grading_file: ClassVar[bool] = False` — this adapter
+  grades from the `grading:` block the task names on disk. Native-shaped
+  adapters flip this to `True`; external adapters that synthesise grading
+  config from their own fixtures leave it `False`. The `grading:` presence
+  gate reads the flag to decide whether an absent block is a refusal or an
+  unchecked pronouncement.
+- `syncs_adapter_env_to_state: ClassVar[bool] = False` — the conductor
+  should sync `AdapterEnvironment` into runner state. Adapters whose
+  environment holds runtime facts the runner reads back into `TrialState`
+  (Tau-family) flip this to `True`; adapters whose runner owns the state
+  end-to-end leave it `False`.
+
+### AdapterGradingContract
+
+The Protocol at `tolokaforge.adapters.AdapterGradingContract` names the six
+grading methods (items 13 - 16, 18 - 20) plus the three capability flags as
+one addressable contract. `BaseAdapter` satisfies it structurally through
+the defaults documented above, so every adapter shipping today matches
+without changing shape. External adapters can import it for a
+`runtime_checkable` `isinstance` check or for a mypy contract; adoption is
+optional — the harness reaches through the slots directly, not through the
+Protocol.
+
 ## Lifecycle Expectations
 
 1. Discovery: enumerate tasks deterministically.

--- a/tests/canonical/test_adapter_grading_contract.py
+++ b/tests/canonical/test_adapter_grading_contract.py
@@ -1,0 +1,177 @@
+"""Every registered adapter satisfies :class:`AdapterGradingContract`.
+
+Two locks. First, :class:`NativeAdapter` — the built-in shape — passes
+``isinstance`` against :class:`AdapterGradingContract` at runtime, resolves
+every slot the Protocol declares on the class, and returns the shipped
+defaults from :class:`BaseAdapter` for the three new emit seams and three
+capability flags. Second, a registry-wide name-presence sweep: every adapter
+class discoverable through :func:`available_adapters` carries each declared
+slot as an attribute, so a future refactor cannot silently drop a slot from
+:class:`BaseAdapter` without at least one entry-plugin dropping it too.
+
+The sweep is name-only — matching the runtime-checkable Protocol's own
+signature-blindness — and the :class:`NativeAdapter` assertions on the
+individual defaults are the tighter lock the Protocol cannot enforce alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.adapters import (
+    AdapterGradingContract,
+    NativeAdapter,
+    adapter_class,
+    available_adapters,
+)
+from tolokaforge.adapters._task_loader import GradingSource, GradingSourceKind
+from tolokaforge.core.models import TaskConfig
+
+pytestmark = pytest.mark.canonical
+
+
+_PROTOCOL_METHOD_SLOTS = (
+    "grading_source",
+    "grading_tool_inventory",
+    "grading_replay_world",
+    "grading_seeded_tables",
+    "emit_runner_grading_payload",
+    "preferred_grader_kind",
+)
+
+_PROTOCOL_CAPABILITY_FLAGS = (
+    "requires_docker_cli_in_runner",
+    "grades_from_task_grading_file",
+    "syncs_adapter_env_to_state",
+)
+
+
+_A_REAL_TASK = (
+    Path(__file__).resolve().parents[2]
+    / "examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml"
+)
+
+
+@pytest.fixture
+def a_native_adapter(tmp_path: Path) -> NativeAdapter:
+    """A minimal :class:`NativeAdapter` constructed for slot resolution.
+
+    The tasks-glob does not need to resolve any task — the slot resolutions
+    tested here read the shipped defaults on :class:`BaseAdapter`, not
+    :class:`NativeAdapter`-specific overrides, so ``get_task_ids`` is never
+    called.
+    """
+    return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "**/task.yaml"})
+
+
+@pytest.fixture
+def a_task_and_dir() -> tuple[TaskConfig, Path]:
+    """A real task and its directory, since :meth:`grading_source` reads them."""
+    from tolokaforge.adapters._task_loader import load_task_yaml
+
+    return load_task_yaml(_A_REAL_TASK)
+
+
+def test_a_native_adapter_instance_satisfies_the_grading_contract(
+    a_native_adapter: NativeAdapter,
+) -> None:
+    """Runtime ``isinstance`` against the ``@runtime_checkable`` Protocol.
+
+    Locks that every declared slot resolves as an attribute on a real
+    :class:`NativeAdapter`; a future refactor that drops a slot from
+    :class:`BaseAdapter` fails this before any caller notices.
+    """
+    assert isinstance(a_native_adapter, AdapterGradingContract)
+
+
+def test_the_native_adapter_class_resolves_every_declared_slot(
+    a_native_adapter: NativeAdapter,
+) -> None:
+    """Class-level resolution of the six method slots and three capability flags.
+
+    ``hasattr`` on the instance covers both class-level classmethods and
+    instance methods, and the capability flags being ``ClassVar[bool]``
+    means they resolve as class attributes too.
+    """
+    for slot in _PROTOCOL_METHOD_SLOTS:
+        assert hasattr(a_native_adapter, slot), f"{slot} missing on NativeAdapter instance"
+    for flag in _PROTOCOL_CAPABILITY_FLAGS:
+        assert hasattr(NativeAdapter, flag), f"{flag} missing on NativeAdapter class"
+
+
+def test_the_three_capability_flags_read_false_on_a_bare_native_adapter(
+    a_native_adapter: NativeAdapter,
+) -> None:
+    """The shipped defaults are ``False`` for every capability the flags name.
+
+    :class:`NativeAdapter` neither drives the host Docker CLI to grade, nor
+    grades from a task ``grading:`` file yet (the reader body still lives in
+    ``_task_loader``), nor syncs adapter env into runner state (that pattern
+    is Tau-family). The three defaults each read ``False``.
+    """
+    assert a_native_adapter.requires_docker_cli_in_runner is False
+    assert a_native_adapter.grades_from_task_grading_file is False
+    assert a_native_adapter.syncs_adapter_env_to_state is False
+
+
+def test_the_grading_source_default_answers_uninterrogable_with_a_reason(
+    a_native_adapter: NativeAdapter,
+    a_task_and_dir: tuple[TaskConfig, Path],
+) -> None:
+    """Locks the return type and the shipped default value of :meth:`grading_source`.
+
+    The default is :attr:`~GradingSourceKind.UNINTERROGABLE` with a non-empty
+    reason — the honest "the adapter has not declared its grading source"
+    every plugin starts with until it overrides. The reason is asserted
+    non-empty rather than pinned to an exact string, because a future
+    reader-body migration (issue #1340) will replace the default with a
+    concrete override, and locking the exact prose here would refuse the
+    migration for nothing.
+    """
+    task, task_dir = a_task_and_dir
+
+    source = a_native_adapter.grading_source(task, task_dir)
+
+    assert isinstance(source, GradingSource)
+    assert source.kind is GradingSourceKind.UNINTERROGABLE
+    assert source.path is None
+    assert source.reason
+
+
+def test_the_emit_runner_grading_payload_default_is_empty(
+    a_native_adapter: NativeAdapter,
+) -> None:
+    """The default payload is ``{}`` — the runner falls through to the historical dispatch."""
+    assert a_native_adapter.emit_runner_grading_payload("calc_basic") == {}
+
+
+def test_the_preferred_grader_kind_default_is_composite(
+    a_native_adapter: NativeAdapter,
+) -> None:
+    """The default kind is ``composite`` — the shipped default grader kind."""
+    assert a_native_adapter.preferred_grader_kind() == "composite"
+
+
+def test_every_registered_adapter_class_carries_every_declared_slot() -> None:
+    """Registry-wide name-presence sweep across every discoverable adapter class.
+
+    Iterates :func:`available_adapters` and asserts each class carries each
+    method slot and capability flag by name. Name-only — matching the
+    ``@runtime_checkable`` Protocol's signature-blindness — but locks the
+    shape for every in-registry adapter (not just :class:`NativeAdapter`),
+    catching a future refactor that silently drops a slot from
+    :class:`BaseAdapter`.
+    """
+    names = available_adapters()
+
+    assert names, "expected at least one adapter (NativeAdapter is built-in)"
+
+    for name in names:
+        cls = adapter_class(name)
+        assert cls is not None, f"{name} discovered but adapter_class returned None"
+        for slot in _PROTOCOL_METHOD_SLOTS:
+            assert hasattr(cls, slot), f"{name}.{slot} missing"
+        for flag in _PROTOCOL_CAPABILITY_FLAGS:
+            assert hasattr(cls, flag), f"{name}.{flag} missing"

--- a/tests/canonical/test_adapter_grading_contract.py
+++ b/tests/canonical/test_adapter_grading_contract.py
@@ -3,7 +3,7 @@
 Two locks. First, :class:`NativeAdapter` — the built-in shape — passes
 ``isinstance`` against :class:`AdapterGradingContract` at runtime, resolves
 every slot the Protocol declares on the class, and returns the shipped
-defaults from :class:`BaseAdapter` for the three new emit seams and three
+defaults from :class:`BaseAdapter` for the three emit seams and three
 capability flags. Second, a registry-wide name-presence sweep: every adapter
 class discoverable through :func:`available_adapters` carries each declared
 slot as an attribute, so a future refactor cannot silently drop a slot from
@@ -106,10 +106,9 @@ def test_the_three_capability_flags_read_false_on_a_bare_native_adapter(
 ) -> None:
     """The shipped defaults are ``False`` for every capability the flags name.
 
-    :class:`NativeAdapter` neither drives the host Docker CLI to grade, nor
-    grades from a task ``grading:`` file yet (the reader body still lives in
-    ``_task_loader``), nor syncs adapter env into runner state (that pattern
-    is Tau-family). The three defaults each read ``False``.
+    :class:`NativeAdapter` neither drives the host Docker CLI, nor grades
+    from a task ``grading:`` file through the class hook, nor syncs adapter
+    env into runner state — the three defaults each read ``False``.
     """
     assert a_native_adapter.requires_docker_cli_in_runner is False
     assert a_native_adapter.grades_from_task_grading_file is False
@@ -124,11 +123,7 @@ def test_the_grading_source_default_answers_uninterrogable_with_a_reason(
 
     The default is :attr:`~GradingSourceKind.UNINTERROGABLE` with a non-empty
     reason — the honest "the adapter has not declared its grading source"
-    every plugin starts with until it overrides. The reason is asserted
-    non-empty rather than pinned to an exact string, because a future
-    reader-body migration (issue #1340) will replace the default with a
-    concrete override, and locking the exact prose here would refuse the
-    migration for nothing.
+    every plugin starts with until it overrides.
     """
     task, task_dir = a_task_and_dir
 
@@ -137,7 +132,7 @@ def test_the_grading_source_default_answers_uninterrogable_with_a_reason(
     assert isinstance(source, GradingSource)
     assert source.kind is GradingSourceKind.UNINTERROGABLE
     assert source.path is None
-    assert source.reason
+    assert source.reason  # non-empty, not exact prose
 
 
 def test_the_emit_runner_grading_payload_default_is_empty(

--- a/tests/unit/adapters/test_grading_contract_defaults.py
+++ b/tests/unit/adapters/test_grading_contract_defaults.py
@@ -1,0 +1,127 @@
+"""What :class:`BaseAdapter` answers for the grading-contract slots by default.
+
+A minimal :class:`BaseAdapter` subclass that stubs the abstract lifecycle
+methods and inherits every grading-contract slot from :class:`BaseAdapter`.
+Each test reads one default and locks it: three ``False`` capability flags,
+an :attr:`~GradingSourceKind.UNINTERROGABLE` grading source with a non-empty
+reason, an empty runner payload, and the ``composite`` grader kind.
+
+The stub adapter registers *nothing* — the tests do not go through the
+registry, so no fixture is needed. The adapter's only purpose is to make
+:class:`BaseAdapter` instantiable so the instance-method defaults can be
+called.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.adapters._task_loader import GradingSource, GradingSourceKind
+from tolokaforge.adapters.base import AdapterEnvironment, BaseAdapter
+from tolokaforge.core.models import Grade, GradingConfig, TaskConfig, Trajectory
+from tolokaforge.tools.registry import Tool
+
+pytestmark = pytest.mark.unit
+
+
+class _AStubAdapter(BaseAdapter):
+    """The minimum :class:`BaseAdapter` subclass a defaults test can construct.
+
+    Every abstract method raises: the tests below never call one, and a raise
+    surfaces the miss loudly if a future default starts reading through one.
+    """
+
+    def get_task_ids(self) -> list[str]:
+        raise NotImplementedError
+
+    def get_task(self, task_id: str) -> TaskConfig:
+        raise NotImplementedError
+
+    def get_task_dir(self, task_id: str) -> Path:
+        raise NotImplementedError
+
+    def create_environment(self, task_id: str) -> AdapterEnvironment:
+        raise NotImplementedError
+
+    def get_tools(self, task_id: str) -> list[Any]:
+        raise NotImplementedError
+
+    def get_registry_tools(self, task_id: str, env: AdapterEnvironment) -> list[Tool]:
+        raise NotImplementedError
+
+    def get_system_prompt(self, task_id: str) -> str:
+        raise NotImplementedError
+
+    def get_grading_config(self, task_id: str) -> GradingConfig:
+        raise NotImplementedError
+
+    def reset_environment(self, env: AdapterEnvironment) -> None:
+        raise NotImplementedError
+
+    def compute_golden_hash(self, task_id: str, env: AdapterEnvironment) -> str | None:
+        raise NotImplementedError
+
+    def to_task_description(self, task_id: str) -> Any:
+        raise NotImplementedError
+
+    def grade(  # type: ignore[override]
+        self,
+        task_id: str,
+        trajectory: Trajectory,
+        final_state: dict[str, Any],
+        env: AdapterEnvironment,
+    ) -> Grade:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def a_stub_adapter(tmp_path: Path) -> _AStubAdapter:
+    """A stub adapter constructed in an isolated dir, for reading the defaults."""
+    return _AStubAdapter({"base_dir": str(tmp_path)})
+
+
+def test_the_three_capability_flags_default_to_false_on_base_adapter(
+    a_stub_adapter: _AStubAdapter,
+) -> None:
+    """The shipped defaults are ``False`` for every capability the flags name."""
+    assert a_stub_adapter.requires_docker_cli_in_runner is False
+    assert a_stub_adapter.grades_from_task_grading_file is False
+    assert a_stub_adapter.syncs_adapter_env_to_state is False
+
+
+def test_the_grading_source_default_is_uninterrogable_with_a_non_empty_reason(
+    a_stub_adapter: _AStubAdapter,
+    tmp_path: Path,
+) -> None:
+    """The default :meth:`grading_source` answers the honest "cannot say" shape.
+
+    The kind is :attr:`~GradingSourceKind.UNINTERROGABLE` (nothing here can
+    pronounce on the absence), the path is ``None`` (no file resolved), and
+    the reason is non-empty so the ``unchecked`` channel that reads this
+    carries a sentence naming the absence.
+    """
+    task = TaskConfig.model_construct(task_id="none")
+
+    source = a_stub_adapter.grading_source(task, tmp_path)
+
+    assert isinstance(source, GradingSource)
+    assert source.kind is GradingSourceKind.UNINTERROGABLE
+    assert source.path is None
+    assert source.reason
+
+
+def test_the_emit_runner_grading_payload_default_is_empty(
+    a_stub_adapter: _AStubAdapter,
+) -> None:
+    """The default is an empty dict — the runner falls through to the historical dispatch."""
+    assert a_stub_adapter.emit_runner_grading_payload("some_task_id") == {}
+
+
+def test_the_preferred_grader_kind_default_is_composite(
+    a_stub_adapter: _AStubAdapter,
+) -> None:
+    """The default kind is ``composite`` — the shipped default grader kind."""
+    assert a_stub_adapter.preferred_grader_kind() == "composite"

--- a/tolokaforge/adapters/__init__.py
+++ b/tolokaforge/adapters/__init__.py
@@ -18,6 +18,7 @@ from tolokaforge.adapters.base import (
     DockerStackRequirements,
     NativeTaskBundle,
 )
+from tolokaforge.adapters.grading_contract import AdapterGradingContract
 from tolokaforge.runner.models import AdapterType
 
 logger = logging.getLogger(__name__)
@@ -177,8 +178,9 @@ def get_adapter(adapter_type: str | None, params: dict[str, Any]) -> BaseAdapter
 from tolokaforge.adapters.native import NativeAdapter  # noqa: E402
 
 __all__ = [
-    "BaseAdapter",
     "AdapterEnvironment",
+    "AdapterGradingContract",
+    "BaseAdapter",
     "DockerStackRequirements",
     "NativeAdapter",
     "NativeTaskBundle",

--- a/tolokaforge/adapters/base.py
+++ b/tolokaforge/adapters/base.py
@@ -6,8 +6,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from tolokaforge.adapters._task_loader import GradingSource, GradingSourceKind
 from tolokaforge.core.grading.config_validation import (
     CombineLayer,
     HashSourceLayer,
@@ -380,6 +381,28 @@ class BaseAdapter(ABC):
         """
         return SeededTablesLayer.unresolvable()
 
+    def grading_source(self, task: TaskConfig, task_dir: Path) -> GradingSource:
+        """The grading block one run of *task* reads, resolved against this adapter.
+
+        The honest default: an :attr:`~GradingSourceKind.UNINTERROGABLE` source
+        with no path and a sentence saying the adapter has not declared where
+        its grading block comes from. An adapter that grades from a file the
+        task names (native) overrides to answer :attr:`~GradingSourceKind.ON_DISK`
+        with the resolved path; an adapter that grades from a source the pack
+        does not carry (external) leaves the default in place and pronounces on
+        the absence through its own registered kind.
+
+        An instance method, not a classmethod, unlike the four readers above:
+        an adapter that resolves the grading source against its own run
+        configuration (pack roots, project defaults) needs the instance to
+        answer, so the shape locked here is the shape overrides use.
+        """
+        return GradingSource(
+            kind=GradingSourceKind.UNINTERROGABLE,
+            path=None,
+            reason="adapter has not declared its grading source",
+        )
+
     @abstractmethod
     def get_task_ids(self) -> list[str]:
         """
@@ -533,6 +556,49 @@ class BaseAdapter(ABC):
     # tolokaforge.trial_graders entry-point group) override this; the default
     # keeps runner-owned RPC grading.
     trial_grader_name: str = "runner_rpc"
+
+    requires_docker_cli_in_runner: ClassVar[bool] = False
+    """The runner needs the host Docker CLI to grade this adapter's trials.
+
+    Adapters whose grading runs commands against Docker daemons (build/exec)
+    flip this to ``True``; the harness reads the flag to decide whether the
+    runner stack must carry a Docker socket bind.
+    """
+
+    grades_from_task_grading_file: ClassVar[bool] = False
+    """This adapter grades from the ``grading:`` block the task names on disk.
+
+    Native-shaped adapters flip this to ``True``; external adapters that
+    synthesise grading config from their own fixtures leave it ``False``. The
+    ``grading:`` presence gate reads the flag to decide whether an absent
+    block is a refusal or an unchecked pronouncement.
+    """
+
+    syncs_adapter_env_to_state: ClassVar[bool] = False
+    """The conductor should sync :class:`AdapterEnvironment` into runner state.
+
+    Adapters whose environment holds runtime facts the runner reads back into
+    ``TrialState`` (Tau-family) flip this to ``True``; adapters whose runner
+    owns the state end-to-end leave it ``False``.
+    """
+
+    def emit_runner_grading_payload(self, task_id: str) -> dict[str, Any]:
+        """The payload this adapter emits for ``RunnerGradingConfig`` construction.
+
+        Default: empty — the runner falls through to the historical dispatch.
+        Adapters that grade by their own registered kind (``test_execution``,
+        ``preference_pair``, …) override to return the payload their grader
+        reads at trial time.
+        """
+        return {}
+
+    def preferred_grader_kind(self) -> str:
+        """The registered ``tolokaforge.grader_kinds`` key this adapter prefers.
+
+        Default: ``composite``, the shipped default kind. Adapters shipping
+        their own kind override to return its registered name.
+        """
+        return "composite"
 
     def docker_stack_requirements(self) -> DockerStackRequirements:
         """Declare extra Docker stack needs for this adapter.

--- a/tolokaforge/adapters/grading_contract.py
+++ b/tolokaforge/adapters/grading_contract.py
@@ -10,8 +10,8 @@ The four readers and two emit seams answer the two questions grading asks: what
 the block a run reads is (and where it came from), and what the runner needs to
 build ``RunnerGradingConfig``. The three capability flags answer the runtime
 questions the surrounding stack asks — Docker CLI in the runner, task-file
-grading source, adapter-env sync — off data on the class, so callers stop
-name-branching on ``AdapterType.NATIVE.value``.
+grading source, adapter-env sync — off data on the class, so callers can read
+the flag instead of name-branching on ``AdapterType.NATIVE.value``.
 """
 
 from __future__ import annotations

--- a/tolokaforge/adapters/grading_contract.py
+++ b/tolokaforge/adapters/grading_contract.py
@@ -1,0 +1,55 @@
+"""The grading contract every adapter satisfies.
+
+:class:`AdapterGradingContract` is the single addressable name for the readers,
+emit seams, and capability flags the harness reaches through to grade a trial
+under any adapter. Every adapter shipping today satisfies it structurally via
+the defaults on :class:`~tolokaforge.adapters.base.BaseAdapter`; adapters that
+grade by their own kind or from their own source override.
+
+The four readers and two emit seams answer the two questions grading asks: what
+the block a run reads is (and where it came from), and what the runner needs to
+build ``RunnerGradingConfig``. The three capability flags answer the runtime
+questions the surrounding stack asks — Docker CLI in the runner, task-file
+grading source, adapter-env sync — off data on the class, so callers stop
+name-branching on ``AdapterType.NATIVE.value``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+from tolokaforge.adapters._task_loader import GradingSource
+from tolokaforge.core.grading.config_validation import (
+    ReplayWorld,
+    SeededTablesLayer,
+    ToolInventory,
+)
+from tolokaforge.core.models import TaskConfig
+
+
+@runtime_checkable
+class AdapterGradingContract(Protocol):
+    """The six methods + three capability flags every adapter answers grading with.
+
+    Matched structurally by :class:`~tolokaforge.adapters.base.BaseAdapter`'s
+    defaults. A concrete adapter overrides only the slots whose default it
+    diverges from; every shipped adapter satisfies the contract without
+    changing shape.
+    """
+
+    requires_docker_cli_in_runner: ClassVar[bool]
+    grades_from_task_grading_file: ClassVar[bool]
+    syncs_adapter_env_to_state: ClassVar[bool]
+
+    def grading_source(self, task: TaskConfig, task_dir: Path) -> GradingSource: ...
+
+    def grading_tool_inventory(self, task: TaskConfig, task_dir: Path) -> ToolInventory: ...
+
+    def grading_replay_world(self, task: TaskConfig, task_dir: Path) -> ReplayWorld: ...
+
+    def grading_seeded_tables(self, task: TaskConfig, task_dir: Path) -> SeededTablesLayer: ...
+
+    def emit_runner_grading_payload(self, task_id: str) -> dict[str, Any]: ...
+
+    def preferred_grader_kind(self) -> str: ...


### PR DESCRIPTION
## Summary

- Ships `AdapterGradingContract` `typing.Protocol` at `tolokaforge/adapters/grading_contract.py` — six method slots + three `ClassVar[bool]` capability flags. `@runtime_checkable`, structural matching.
- Adds three capability-flag defaults (`requires_docker_cli_in_runner`, `grades_from_task_grading_file`, `syncs_adapter_env_to_state` — all `False`) and three new default methods (`grading_source` → `UNINTERROGABLE`, `emit_runner_grading_payload` → `{}`, `preferred_grader_kind` → `"composite"`) on `BaseAdapter`.
- Zero call-site changes; every shipped adapter satisfies the Protocol structurally with byte-identical behaviour. Unblocks the six follow-up Phase-A tickets that read the new hooks.

## Design choices

- **Instance method for `grading_source`** (departure from sibling readers' classmethod pattern): the umbrella positions `grading_source` as the reader an adapter resolves against its run configuration (task-pack roots, project defaults), which is instance state. Sibling readers stay classmethod. Reversal is a one-line signature swap if issue #1340 shows the classmethod pattern suffices.
- **`@runtime_checkable = True`**: standard pattern for `Protocol` types callers `isinstance`-check. Signature-blindness of `runtime_checkable` mitigated by the canonical conformance test asserting return *types* on a real `NativeAdapter`, plus a registry-wide name-presence sweep across `available_adapters()`.
- **BaseAdapter defaults preserve today's runtime behaviour byte-identically**: nothing in the runtime path yet reads the new hooks — the byte-parity 10-pack canonical gate remains green (verified, 25/25).
- **`judge_only` / `grading_method` / the six name-branch smells** are NOT touched here — those are subsequent Phase-A issues (#1340-#1345) that depend on the Protocol shipped in this PR.

## Concepts introduced

- `AdapterGradingContract` — the first-class Protocol every adapter satisfies structurally. Names the six methods and three capability flags follow-up tickets read to migrate the four current `adapter_type == AdapterType.NATIVE` branches (`_task_loader.py:815-1080`) and the two class-identity branches (`orchestrator.py:212`, `conductor.py:555`) onto capability-based dispatch. This is Phase A's foundation stone in the Grader v3 milestone.

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1339-adapter-grading-contract.md` (scratch, outside the repo — plans have no in-repo home; this PR body is the durable record).

**Goal:** Ship `AdapterGradingContract` + `BaseAdapter` defaults so every adapter shipping today (in-tree `NativeAdapter`, external `TerminalBenchAdapter`, `frozen_mcp_core`, Tau) satisfies the Protocol structurally without changes, and `AdapterGradingContract` becomes the single addressable name for follow-up tickets to reference.

**Non-goals (deferred to follow-up issues in Milestone #39):**
- Do NOT move `_task_loader.py:815-1080` reader bodies onto `NativeAdapter` (issue #1340).
- Do NOT wire `orchestrator.py:212` / `conductor.py:555` / `rubric_migration.py:1364-1372` to read the new flags (issues #1341-#1343).
- Do NOT touch `serialise_grade` or the byte-parity 10-pack canonical projection.
- Do NOT change any existing method signature (`grading_tool_inventory`, `grading_replay_world`, `grading_seeded_tables`, `grading_hash_source_layer`, `grading_combine_layer`).
- Do NOT touch `supports_coding_harness` (stays where it is; consolidation deferred to #1341).

**Stage 1 (one commit — `a3d972cb`):** Introduced Protocol + defaults; shipped 7 canonical + 4 unit tests. Docs updated in the same commit (`docs/ADAPTER_INTERFACE.md` +68 lines, `docs/ADAPTERS.md` pointer).

**Fix commit (`fb94c5db`):** Applied round-1 reviewer corrections (removed issue-attribution + migration-tense from test docstrings per §7a, plus three nits).

**Approved decisions** (recorded in the plan file):
- `grading_source` as instance method.
- `@runtime_checkable = True`.
- No `GradingSource.unresolvable()` factory this ticket.
- Re-export `AdapterGradingContract` from `tolokaforge.adapters`.
- Docs land in `docs/ADAPTER_INTERFACE.md` with a pointer from `docs/ADAPTERS.md`.

## Discovered issues

- **Filed as follow-ups (pre-existing on `main`, not milestone-blocking):**
  - #1373 — pre-existing OOM in `test_ungradeable_trial_accounting.py` on the full unit lane (macOS).
  - #1374 — `test_persistent_shell_local test_a_session_works_on_a_descriptor_past_select_s_ceiling` needs macOS skip guard.
- **Fixed in this PR:** None (scope tight).

## Test plan

- [x] Byte-parity 10-pack canonical gate green: `uv run pytest tests/canonical/test_grader_parity_reference.py` — 25 passed.
- [x] New tests green: `uv run pytest tests/canonical/test_adapter_grading_contract.py tests/unit/adapters/test_grading_contract_defaults.py` — 11 passed.
- [x] Full canonical lane green: 1743 passed, 1 skipped, 0 failed.
- [x] Import-linter green: `uv run lint-imports` — 2 contracts kept, 0 broken.
- [x] Ruff format-check + lint-check green on touched paths.
- [ ] Post-merge: verify base `feat/grader-v3` still green after this squash-merges in.

Closes #1339