### PR TITLE
refactor(adapters): NativeAdapter.grading_source override reproducing NATIVE branch

### DIFF
--- a/docs/ADAPTER_INTERFACE.md
+++ b/docs/ADAPTER_INTERFACE.md
@@ -167,7 +167,8 @@ Each adapter must subclass `BaseAdapter` and implement:
     The default answers `GradingSourceKind.UNINTERROGABLE` with `path=None`
     and a non-empty reason — the honest "the adapter has not declared its
     grading source". An adapter that resolves the block against its own run
-    configuration overrides.
+    configuration overrides. See `NativeAdapter.grading_source` for the
+    native reading — the shape any adapter's override here can consult.
 
     An instance method, unlike the four readers in items 13 - 16: `grading_source`
     resolves the source an adapter *actually reads* against its instance state

--- a/tests/canonical/test_adapter_grading_contract.py
+++ b/tests/canonical/test_adapter_grading_contract.py
@@ -59,9 +59,8 @@ def a_native_adapter(tmp_path: Path) -> NativeAdapter:
     """A minimal :class:`NativeAdapter` constructed for slot resolution.
 
     The tasks-glob does not need to resolve any task — the slot resolutions
-    tested here read the shipped defaults on :class:`BaseAdapter`, not
-    :class:`NativeAdapter`-specific overrides, so ``get_task_ids`` is never
-    called.
+    tested here call each hook against a task supplied directly and never
+    reach ``get_task_ids``.
     """
     return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "**/task.yaml"})
 
@@ -115,24 +114,28 @@ def test_the_three_capability_flags_read_false_on_a_bare_native_adapter(
     assert a_native_adapter.syncs_adapter_env_to_state is False
 
 
-def test_the_grading_source_default_answers_uninterrogable_with_a_reason(
+def test_the_native_adapter_grading_source_reports_the_pack_grading_yaml_when_present(
     a_native_adapter: NativeAdapter,
     a_task_and_dir: tuple[TaskConfig, Path],
 ) -> None:
-    """Locks the return type and the shipped default value of :meth:`grading_source`.
+    """Locks the ON_DISK answer :class:`NativeAdapter` returns for a pack shipping ``grading.yaml``.
 
-    The default is :attr:`~GradingSourceKind.UNINTERROGABLE` with a non-empty
-    reason — the honest "the adapter has not declared its grading source"
-    every plugin starts with until it overrides.
+    The helpdesk_01 fixture ships a sibling ``grading.yaml``, which
+    ``load_task_yaml`` resolves as the declared source; the native override
+    reads that file off disk and answers :attr:`~GradingSourceKind.ON_DISK`
+    with the resolved path and no reason. The default-lock intent —
+    :attr:`~GradingSourceKind.UNINTERROGABLE` for a bare adapter — is
+    covered by ``_AStubAdapter`` in
+    ``tests/unit/adapters/test_grading_contract_defaults.py``.
     """
     task, task_dir = a_task_and_dir
 
     source = a_native_adapter.grading_source(task, task_dir)
 
     assert isinstance(source, GradingSource)
-    assert source.kind is GradingSourceKind.UNINTERROGABLE
-    assert source.path is None
-    assert source.reason  # non-empty, not exact prose
+    assert source.kind is GradingSourceKind.ON_DISK
+    assert source.path == task_dir / "grading.yaml"
+    assert source.reason == ""
 
 
 def test_the_emit_runner_grading_payload_default_is_empty(

--- a/tests/canonical/test_native_adapter_grading_source_override.py
+++ b/tests/canonical/test_native_adapter_grading_source_override.py
@@ -8,10 +8,6 @@ dataclass so ``==`` covers ``kind``, ``path``, and ``reason``. Second, the
 author-facing sentences the two absence rows carry are locked by substring
 against the same prose the free-function tests hold, so a divergence in either
 copy of the reason strings breaks this file.
-
-Transitional guardrail: when :func:`grading_source_under_adapter` delegates
-through the adapter (issue #1341) and the free-function inline body goes,
-this file goes with it.
 """
 
 from __future__ import annotations

--- a/tests/canonical/test_native_adapter_grading_source_override.py
+++ b/tests/canonical/test_native_adapter_grading_source_override.py
@@ -1,0 +1,162 @@
+"""Equivalence lock: :meth:`NativeAdapter.grading_source` reproduces the
+NATIVE arm of :func:`grading_source_under_adapter` byte-for-byte.
+
+Two things locked. First, for every row of the semantics matrix (declared +
+on-disk, declared + missing, undeclared) the override and the free function
+return equal :class:`GradingSource` values — ``GradingSource`` is a frozen
+dataclass so ``==`` covers ``kind``, ``path``, and ``reason``. Second, the
+author-facing sentences the two absence rows carry are locked by substring
+against the same prose the free-function tests hold, so a divergence in either
+copy of the reason strings breaks this file.
+
+Transitional guardrail: when :func:`grading_source_under_adapter` delegates
+through the adapter (issue #1341) and the free-function inline body goes,
+this file goes with it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tolokaforge.adapters._task_loader import (
+    GradingSource,
+    GradingSourceKind,
+    grading_source_under_adapter,
+    load_task_yaml,
+)
+from tolokaforge.adapters.native import NativeAdapter
+
+pytestmark = pytest.mark.canonical
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+
+def _write_minimal_task(task_dir: Path, **extra: object) -> Path:
+    data: dict = {"task_id": "min", "description": "minimal task"}
+    data.update(extra)
+    _write_yaml(task_dir / "task.yaml", data)
+    return task_dir / "task.yaml"
+
+
+def _write_grading(path: Path) -> None:
+    _write_yaml(
+        path,
+        {
+            "combine": {
+                "method": "weighted",
+                "weights": {"state_checks": 1.0},
+                "pass_threshold": 1.0,
+            }
+        },
+    )
+
+
+def _a_native_adapter(base_dir: Path) -> NativeAdapter:
+    return NativeAdapter({"tasks_glob": "*/task.yaml", "base_dir": str(base_dir)})
+
+
+@pytest.mark.parametrize(
+    ("declares_grading", "writes_the_file", "expected_kind"),
+    [
+        (True, True, GradingSourceKind.ON_DISK),
+        (True, False, GradingSourceKind.WITHHELD),
+        (False, False, GradingSourceKind.WITHHELD),
+    ],
+    ids=[
+        "declared_and_on_disk_resolves_to_on_disk",
+        "declared_and_missing_is_withheld",
+        "undeclared_is_withheld",
+    ],
+)
+def test_the_override_returns_the_same_grading_source_the_free_function_returns_under_native(
+    tmp_path: Path,
+    declares_grading: bool,
+    writes_the_file: bool,
+    expected_kind: GradingSourceKind,
+) -> None:
+    """Structural equality across the three-row semantics matrix.
+
+    The override and the free-function NATIVE arm must produce equal
+    :class:`GradingSource` values for every combination of declared /
+    on-disk state; the frozen dataclass equality covers ``kind``, ``path``,
+    and the full reason prose so a per-branch divergence trips here.
+    """
+    task_dir = tmp_path / "flat_task"
+    extra: dict[str, object] = {"adapter_type": "native"}
+    if declares_grading:
+        extra["grading"] = "grading.yaml"
+    task_path = _write_minimal_task(task_dir, **extra)
+    if writes_the_file:
+        _write_grading(task_dir / "grading.yaml")
+    task, resolved_dir = load_task_yaml(task_path)
+
+    adapter = _a_native_adapter(tmp_path)
+    override_source = adapter.grading_source(task, resolved_dir)
+    free_function_source = grading_source_under_adapter(task, resolved_dir, "native")
+
+    assert override_source == free_function_source
+    assert override_source.kind is expected_kind
+    if expected_kind is GradingSourceKind.ON_DISK:
+        assert override_source.path == task_dir / "grading.yaml"
+        assert override_source.reason == ""
+    else:
+        assert override_source.path is None
+
+
+def test_the_override_reason_for_a_declared_missing_file_names_the_ref_and_both_fixes(
+    tmp_path: Path,
+) -> None:
+    """Prose lock on the declared-but-missing branch of the override.
+
+    Mirrors the free-function prose test at
+    ``tests/unit/test_task_loader.py::test_a_declared_file_that_is_not_there_names_the_path_and_both_ways_to_supply_it``
+    — the two implementations must carry the same author-facing sentence.
+    """
+    task_dir = tmp_path / "flat_task"
+    task, resolved_dir = load_task_yaml(
+        _write_minimal_task(task_dir, adapter_type="native", grading="grading.yaml")
+    )
+
+    reason = _a_native_adapter(tmp_path).grading_source(task, resolved_dir).reason
+
+    assert "'min'" in reason
+    assert "'grading.yaml'" in reason
+    assert "Correct the `grading:` path" in reason
+    assert "create that file" in reason
+    assert "no `grading:` field" not in reason
+
+
+def test_the_override_reason_for_an_undeclared_source_names_the_task_and_both_supply_ways(
+    tmp_path: Path,
+) -> None:
+    """Prose lock on the undeclared branch of the override.
+
+    Mirrors the free-function prose test at
+    ``tests/unit/test_task_loader.py::test_a_withheld_source_names_the_task_and_both_ways_to_supply_one``
+    — the two implementations must carry the same author-facing sentence.
+    """
+    task_path = _write_minimal_task(tmp_path / "flat_task", adapter_type="native")
+    task, task_dir = load_task_yaml(task_path)
+
+    reason = _a_native_adapter(tmp_path).grading_source(task, task_dir).reason
+
+    assert "'min'" in reason
+    assert "`grading:`" in reason
+    assert "grading.yaml beside its task.yaml" in reason
+    assert "before any trial is scheduled" in reason
+
+
+def test_the_override_returns_a_grading_source(tmp_path: Path) -> None:
+    """The return type is :class:`GradingSource` — the shape callers destructure."""
+    task_path = _write_minimal_task(tmp_path / "flat_task", adapter_type="native")
+    task, task_dir = load_task_yaml(task_path)
+
+    source = _a_native_adapter(tmp_path).grading_source(task, task_dir)
+
+    assert isinstance(source, GradingSource)

--- a/tolokaforge/adapters/native.py
+++ b/tolokaforge/adapters/native.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from tolokaforge.adapters._task_loader import (
+    GradingSource,
+    GradingSourceKind,
     ToolActor,
     _detect_task_root,
     actor_tool_block,
@@ -629,6 +631,43 @@ class NativeAdapter(CodingHarnessAdapterMixin, BaseAdapter):
         before the trial is paid for rather than raising during grading.
         """
         return SeededTablesLayer(tables=seeded_tables_from_task(task, task_dir))
+
+    def grading_source(self, task: TaskConfig, task_dir: Path) -> GradingSource:
+        """The grading block a native pack reads for *task*.
+
+        ``task.grading`` naming a file that is on disk resolves to
+        :attr:`~GradingSourceKind.ON_DISK` with the absolute path. Every other
+        case — a declared file that is not on disk, or no ``grading:`` field
+        and no sibling ``grading.yaml`` — resolves to
+        :attr:`~GradingSourceKind.WITHHELD` with the sentence naming the
+        author-facing fix.
+        """
+        if task.grading is not None:
+            declared = task_dir / task.grading
+            if declared.exists():
+                return GradingSource(kind=GradingSourceKind.ON_DISK, path=declared)
+            return GradingSource(
+                kind=GradingSourceKind.WITHHELD,
+                path=None,
+                reason=(
+                    f"task {task.task_id!r} declares grading source {task.grading!r} and no "
+                    f"file is at {declared}. Adapter 'native' grades from that file, so "
+                    "this task cannot be graded and is refused before any trial is scheduled. "
+                    "Correct the `grading:` path to the block this task grades by, or create "
+                    "that file."
+                ),
+            )
+        return GradingSource(
+            kind=GradingSourceKind.WITHHELD,
+            path=None,
+            reason=(
+                f"task {task.task_id!r} declares no grading source: no `grading:` field and no "
+                "sibling grading.yaml. Adapter 'native' grades from that file, so this "
+                "task cannot be graded and is refused before any trial is scheduled. "
+                "Declare `grading:` pointing at the block this task grades by, or add a "
+                "grading.yaml beside its task.yaml."
+            ),
+        )
 
     def _project_combine_defaults(self) -> dict[str, Any] | None:
         return project_grading_combine(self._project_task_defaults)


### PR DESCRIPTION
## Summary

- Adds `NativeAdapter.grading_source(self, task, task_dir) -> GradingSource` — the fourth per-adapter reader override on `NativeAdapter`. Reproduces the NATIVE arm of `grading_source_under_adapter` (`tolokaforge/adapters/_task_loader.py:1010-1087`) byte-identically.
- New canonical file locks the override-vs-free-function equivalence across the three semantics rows (declared+on-disk / declared+missing / undeclared) via structural equality on the frozen `GradingSource` dataclass.
- Zero call-site changes; `_task_loader.py` and `base.py` untouched.

## Design choices

- **Instance method** (matches `BaseAdapter.grading_source`'s #1339 signature). `self` is currently unused but future-proofs pack-root-aware overrides.
- **Inline literal `'native'` with single quotes** — reproduces `{adapter_type!r}` interpolation exactly. Byte-parity with the free function's reason strings.
- **Retargeted `test_the_grading_source_default_answers_uninterrogable_with_a_reason`** on the same helpdesk_01 fixture (renamed `test_the_native_adapter_grading_source_reports_the_pack_grading_yaml_when_present`) — it read the UNINTERROGABLE base default via `NativeAdapter` before this PR; after the override lands the same fixture returns ON_DISK. The default-lock intent stays covered by `_AStubAdapter` at `tests/unit/adapters/test_grading_contract_defaults.py:95-113`.
- **Transitional guardrail via canonical equivalence lock**: the override and the free function's inline NATIVE arm carry the same three-branch logic in two places during the transitional window. The new canonical file asserts byte-equality until the follow-up refactor delegates the free function.

## Concepts introduced

None — this PR fills in the `NativeAdapter` override of a Protocol slot that already exists (`BaseAdapter.grading_source` from #1339). No new abstraction, no new registry, no new capability flag.

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1340-nativeadapter-branch-moves.md`.

**Discovery from planning:** Ticket body implied "four NATIVE-branch bodies to move". Verified only **one** still branches inline (`grading_source_under_adapter`). Three siblings (`tool_inventory_under_adapter`, `replay_world_under_adapter`, `seeded_tables_under_adapter`) already delegate to matching classmethod overrides on `NativeAdapter` (`native.py:598/609/623`) — migrated in PR #1302, commit `af02ca42`. Also `hash_source_layer_under_adapter` (a fifth reader) already delegates too. So the substantive work here was one method addition + one canonical retarget + one new equivalence-lock file.

**Non-goals** (deferred to the follow-up refactor that kills the free function's inline branch):
- Do NOT modify `_task_loader.py` — the `adapter_type == AdapterType.NATIVE.value` string compare at line 1039 stays for the follow-up.
- Do NOT wire callers (`dx/cli/main.py:1908`, `orchestrator.py:1855`, `rubric_migration.py:1365`).
- Do NOT change the base signature or flip to classmethod — that's the follow-up's call.

**Stage 1** (`178a5c27`): added override + 6-test equivalence lock + retargeted canonical test + doc pointer on item 18 of `docs/ADAPTER_INTERFACE.md`.
**Fix commit** (`eae16704`): removed §7a violation (issue-attribution + future-tense in module docstring) per round-1 hygiene finding.

**Approved decisions** (in plan file):
- Instance method for `NativeAdapter.grading_source`.
- Retarget canonical test on same fixture (option 1); no delete-and-recreate.
- Inline literal `'native'` (with single quotes since `!r`).
- Canonical tier for the new equivalence-lock test.

## Discovered issues

- **Filed as follow-ups:** None. Two consistency notes tracked in the plan (both flagged in #1339's plan risks too — `GradingSource.unresolvable()` factory deferred, ticket-body scope-narrower-than-it-reads noted).
- **Fixed in this PR:** None.

## Test plan

- [x] Byte-parity 10-pack canonical gate: 25 passed (unaffected — new method uncalled).
- [x] New canonical equivalence-lock file: 6 passed.
- [x] Retargeted canonical test: file's 7 tests all pass.
- [x] Free-function tests `tests/unit/test_task_loader.py -k grading_source`: 6 byte-identical green.
- [x] Import-linter green; ruff format + lint clean.
- [ ] Post-merge: `feat/grader-v3` remains green.

Closes #1340