### PR TITLE
feat(runner): StackDecl + PlanShape types + scalar↔plan coercion (#1379)

### DIFF
--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -24,8 +24,10 @@
       "rag_port": null,
       "rag_service": null,
       "runner_port": null,
-      "runner_service": "runner"
-    }
+      "runner_service": "runner",
+      "stack_scope": null
+    },
+    "stacks": null
   },
   "grading": "__adapter__",
   "initial_state": {

--- a/tests/canonical/snapshots/tbench_echo_hello/task_description.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_description.json
@@ -66,7 +66,16 @@
         "reset": null
       }
     },
-    "stack_inputs": {}
+    "stack_inputs": {},
+    "stacks": [
+      {
+        "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
+        "inputs": {},
+        "runner_service": "runner",
+        "stack_id": "default",
+        "stack_scope": "trial"
+      }
+    ]
   },
   "generated_at": null,
   "grading": {

--- a/tests/canonical/test_composition_plan_types.py
+++ b/tests/canonical/test_composition_plan_types.py
@@ -1,0 +1,318 @@
+"""ADR-0044 composition-plan types — `StackDecl`, `PlanShape`, and the
+backward-compat coercion that keeps every pre-ADR-0044 task pack loading
+byte-identically.
+
+The composition plan is a first-class field on `EnvironmentManifest` (a
+list of :class:`StackDecl` entries each with a lifecycle scope). Manifests
+authored against the pre-ADR-0044 scalar `compose_file` surface still
+resolve to a valid single-entry plan via
+:func:`tolokaforge.core.project_loader.resolve`; this file pins the
+classification of every plan shape and the coercion invariants.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from tolokaforge.core.models import ServiceSpec
+from tolokaforge.core.trial import EnvironmentManifest
+from tolokaforge.runner.models import (
+    EnvironmentPatch,
+    PlanShape,
+    StackDecl,
+    StackPatch,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "environment_manifest"
+
+
+def _fixture(name: str) -> Path:
+    return _FIXTURES / name
+
+
+class TestStackDeclShape:
+    """`StackDecl` — one compose file at one scope."""
+
+    def test_minimal_stackdecl_constructs(self) -> None:
+        decl = StackDecl(
+            stack_id="engine",
+            compose_file=_fixture("safe_two_service.yaml"),
+            stack_scope="run",
+        )
+        assert decl.stack_id == "engine"
+        assert decl.stack_scope == "run"
+        assert decl.runner_service is None
+        assert decl.inputs == {}
+
+    def test_stack_scope_vocab_is_closed(self) -> None:
+        with pytest.raises(ValidationError, match="Input should be 'run', 'task' or 'trial'"):
+            StackDecl(  # type: ignore[call-arg]
+                stack_id="engine",
+                compose_file=_fixture("safe_two_service.yaml"),
+                stack_scope="always",
+            )
+
+    def test_extra_fields_refused(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            StackDecl(  # type: ignore[call-arg]
+                stack_id="engine",
+                compose_file=_fixture("safe_two_service.yaml"),
+                stack_scope="run",
+                bogus=True,
+            )
+
+
+class TestPlanShapeClassification:
+    """`EnvironmentManifest.plan_shape` maps a composition plan to the four
+    canonical shapes ADR-0044 § 5 names. Backend selection reads it."""
+
+    def test_empty_stacks_returns_trial_scoped_only(self) -> None:
+        """Backward-compat default: a manifest without any resolved plan
+        classifies as `TRIAL_SCOPED_ONLY`, matching ADR-0009's
+        `requires_per_trial=True` default."""
+        m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
+        assert m.stacks == []
+        assert m.plan_shape is PlanShape.TRIAL_SCOPED_ONLY
+
+    def test_single_run_scope(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            stacks=[
+                StackDecl(
+                    stack_id="default",
+                    compose_file=_fixture("safe_one_service.yaml"),
+                    stack_scope="run",
+                )
+            ],
+        )
+        assert m.plan_shape is PlanShape.SINGLE_RUN
+
+    def test_single_task_scope(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            stacks=[
+                StackDecl(
+                    stack_id="task",
+                    compose_file=_fixture("safe_one_service.yaml"),
+                    stack_scope="task",
+                )
+            ],
+        )
+        assert m.plan_shape is PlanShape.TASK_SCOPED_ONLY
+
+    def test_single_trial_scope(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            stacks=[
+                StackDecl(
+                    stack_id="task",
+                    compose_file=_fixture("safe_one_service.yaml"),
+                    stack_scope="trial",
+                )
+            ],
+        )
+        assert m.plan_shape is PlanShape.TRIAL_SCOPED_ONLY
+
+    def test_multi_scope_run_and_trial(self) -> None:
+        """The canonical T-Bench balanced-10 shape: engine `run` +
+        task `trial`. Classifies as MULTI_SCOPE per ADR-0044."""
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            stacks=[
+                StackDecl(
+                    stack_id="engine",
+                    compose_file=_fixture("safe_two_service.yaml"),
+                    stack_scope="run",
+                    runner_service="default",
+                ),
+                StackDecl(
+                    stack_id="task",
+                    compose_file=_fixture("safe_one_service.yaml"),
+                    stack_scope="trial",
+                ),
+            ],
+        )
+        assert m.plan_shape is PlanShape.MULTI_SCOPE
+
+    def test_multi_scope_task_and_trial(self) -> None:
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            stacks=[
+                StackDecl(
+                    stack_id="task_stack",
+                    compose_file=_fixture("safe_two_service.yaml"),
+                    stack_scope="task",
+                ),
+                StackDecl(
+                    stack_id="trial_stack",
+                    compose_file=_fixture("safe_one_service.yaml"),
+                    stack_scope="trial",
+                ),
+            ],
+        )
+        assert m.plan_shape is PlanShape.MULTI_SCOPE
+
+
+class TestBackwardCompatCoercion:
+    """A manifest loaded from the pre-ADR-0044 scalar surface must resolve
+    to a valid single-entry composition plan whose scope is inferred from
+    the same `requires_per_trial` derivation today's backend selection uses.
+    Locked here so the coercion in `project_loader.resolve` cannot silently
+    regress."""
+
+    def test_empty_services_infers_trial_scope(self) -> None:
+        """No services declared → `requires_per_trial=True` per ADR-0009 →
+        synthesised stack has `stack_scope="trial"`. Matches today's
+        routing to `PerTrialRuntimeBackend`."""
+        from tolokaforge.core.project_loader import _synthesise_composition_plan
+
+        m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
+        assert m.stacks == []
+        assert m.requires_per_trial is True
+        _synthesise_composition_plan(m, {})
+        assert len(m.stacks) == 1
+        assert m.stacks[0].stack_scope == "trial"
+        assert m.plan_shape is PlanShape.TRIAL_SCOPED_ONLY
+
+    def test_all_shared_services_infers_run_scope(self) -> None:
+        """All `shared` → `requires_per_trial=False` → synthesised stack
+        has `stack_scope="run"`. Matches today's routing to
+        `SharedStackRuntimeBackend`."""
+        from tolokaforge.core.project_loader import _synthesise_composition_plan
+
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        assert m.requires_per_trial is False
+        _synthesise_composition_plan(m, {})
+        assert m.stacks[0].stack_scope == "run"
+        assert m.plan_shape is PlanShape.SINGLE_RUN
+
+    def test_mixed_isolation_infers_trial_scope(self) -> None:
+        """Mixed `shared` + `reset|ephemeral` → `requires_per_trial=True` →
+        synthesised stack has `stack_scope="trial"`. Matches today's
+        routing to per_trial when the pre-ADR-0044 surface was used."""
+        from tolokaforge.core.project_loader import _synthesise_composition_plan
+
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="ephemeral"),
+            },
+        )
+        assert m.requires_per_trial is True
+        _synthesise_composition_plan(m, {})
+        assert m.stacks[0].stack_scope == "trial"
+
+    def test_synthesis_is_idempotent(self) -> None:
+        """A manifest whose `stacks` list is already populated MUST NOT
+        be overwritten by the coercion — an explicit plan wins."""
+        from tolokaforge.core.project_loader import _synthesise_composition_plan
+
+        explicit_stack = StackDecl(
+            stack_id="explicit",
+            compose_file=_fixture("safe_one_service.yaml"),
+            stack_scope="task",
+        )
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_one_service.yaml"),
+            stacks=[explicit_stack],
+        )
+        _synthesise_composition_plan(m, {})
+        assert m.stacks == [explicit_stack]
+
+    def test_scalar_fields_mirror_synthetic_stack(self) -> None:
+        """The scalar-form fields (`compose_file`, `runner_service`,
+        `stack_inputs`) mirror the sole synthetic stack — every existing
+        consumer keeps working unchanged."""
+        from tolokaforge.core.project_loader import _synthesise_composition_plan
+
+        m = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            runner_service="default",
+            stack_inputs={"FOO": "bar"},
+            services={
+                "default": ServiceSpec(isolation="shared"),
+                "db": ServiceSpec(isolation="shared"),
+            },
+        )
+        _synthesise_composition_plan(m, {})
+        assert m.stacks[0].compose_file == m.compose_file
+        assert m.stacks[0].runner_service == m.runner_service
+        assert m.stacks[0].inputs == m.stack_inputs
+
+
+class TestEnvironmentPatchStacksBlockRefusal:
+    """`EnvironmentPatch` refuses the ambiguous case where both the scalar
+    `stack.compose_file` and the plural `stacks` block are set — they are
+    aliases of the same field. See ADR-0044 § 3."""
+
+    def test_stack_and_stacks_together_refused(self) -> None:
+        with pytest.raises(ValidationError, match="aliases of the same field"):
+            EnvironmentPatch(
+                stack=StackPatch(compose_file=_fixture("safe_one_service.yaml")),
+                stacks={"engine": StackPatch(compose_file=_fixture("safe_one_service.yaml"))},
+            )
+
+    def test_stack_alone_is_accepted(self) -> None:
+        """Legacy scalar-only patch — the byte-identical backward-compat
+        path. No `stacks` block; no refusal."""
+        patch = EnvironmentPatch(stack=StackPatch(compose_file=_fixture("safe_one_service.yaml")))
+        assert patch.stacks is None
+
+    def test_stacks_block_alone_is_accepted(self) -> None:
+        """New composition-plan patch — no scalar `stack.compose_file`.
+        The multi-stack merge path is not wired in this ticket (raises
+        `NotImplementedError` on resolve); this test only pins that the
+        patch construction itself accepts the shape."""
+        patch = EnvironmentPatch(
+            stacks={
+                "engine": StackPatch(
+                    compose_file=_fixture("safe_one_service.yaml"), stack_scope="run"
+                )
+            }
+        )
+        assert patch.stack is None
+        assert patch.stacks is not None
+        assert "engine" in patch.stacks
+
+    def test_stack_without_compose_file_and_stacks_together_accepted(self) -> None:
+        """Edge case: `stack` set but ONLY carrying inputs/runner_service
+        overrides (no `compose_file`). The refusal targets the ambiguous
+        compose-file duplicate, not stack-metadata inheritance."""
+        patch = EnvironmentPatch(
+            stack=StackPatch(inputs={"FOO": "bar"}),
+            stacks={
+                "engine": StackPatch(
+                    compose_file=_fixture("safe_one_service.yaml"), stack_scope="run"
+                )
+            },
+        )
+        assert patch.stack is not None
+        assert patch.stack.compose_file is None
+        assert patch.stacks is not None
+
+
+class TestStackPatchScopeField:
+    """`StackPatch.stack_scope` — new optional field per ADR-0044 § 3."""
+
+    def test_scope_absent_defaults_to_none(self) -> None:
+        patch = StackPatch()
+        assert patch.stack_scope is None
+
+    def test_scope_vocab_matches_stackdecl(self) -> None:
+        for scope in ("run", "task", "trial"):
+            patch = StackPatch(stack_scope=scope)  # type: ignore[arg-type]
+            assert patch.stack_scope == scope
+
+    def test_invalid_scope_refused(self) -> None:
+        with pytest.raises(ValidationError, match="Input should be 'run', 'task' or 'trial'"):
+            StackPatch(stack_scope="always")  # type: ignore[arg-type]

--- a/tests/canonical/test_composition_plan_types.py
+++ b/tests/canonical/test_composition_plan_types.py
@@ -163,19 +163,20 @@ class TestBackwardCompatCoercion:
     """A manifest loaded from the pre-ADR-0044 scalar surface must resolve
     to a valid single-entry composition plan whose scope is inferred from
     the same `requires_per_trial` derivation today's backend selection uses.
-    Locked here so the coercion in `project_loader.resolve` cannot silently
-    regress."""
+    Exercises `project_loader.resolve()` — the seam every consumer takes —
+    so a future refactor cannot silently regress the coercion by removing
+    or reordering the internal helper."""
 
     def test_empty_services_infers_trial_scope(self) -> None:
         """No services declared → `requires_per_trial=True` per ADR-0009 →
         synthesised stack has `stack_scope="trial"`. Matches today's
         routing to `PerTrialRuntimeBackend`."""
-        from tolokaforge.core.project_loader import _synthesise_composition_plan
+        from tolokaforge.core.project_loader import resolve
 
-        m = EnvironmentManifest(compose_file=_fixture("safe_one_service.yaml"))
-        assert m.stacks == []
+        patch = EnvironmentPatch(stack=StackPatch(compose_file=_fixture("safe_one_service.yaml")))
+        m = resolve(project_env=patch, task_env=None)
+        assert m is not None
         assert m.requires_per_trial is True
-        _synthesise_composition_plan(m, {})
         assert len(m.stacks) == 1
         assert m.stacks[0].stack_scope == "trial"
         assert m.plan_shape is PlanShape.TRIAL_SCOPED_ONLY
@@ -184,14 +185,15 @@ class TestBackwardCompatCoercion:
         """All `shared` → `requires_per_trial=False` → synthesised stack
         has `stack_scope="run"`. Matches today's routing to
         `SharedStackRuntimeBackend`."""
-        from tolokaforge.core.project_loader import _synthesise_composition_plan
+        from tolokaforge.core.project_loader import resolve
 
-        m = EnvironmentManifest(
-            compose_file=_fixture("safe_one_service.yaml"),
+        patch = EnvironmentPatch(
+            stack=StackPatch(compose_file=_fixture("safe_one_service.yaml")),
             services={"default": ServiceSpec(isolation="shared")},
         )
+        m = resolve(project_env=patch, task_env=None)
+        assert m is not None
         assert m.requires_per_trial is False
-        _synthesise_composition_plan(m, {})
         assert m.stacks[0].stack_scope == "run"
         assert m.plan_shape is PlanShape.SINGLE_RUN
 
@@ -199,22 +201,25 @@ class TestBackwardCompatCoercion:
         """Mixed `shared` + `reset|ephemeral` → `requires_per_trial=True` →
         synthesised stack has `stack_scope="trial"`. Matches today's
         routing to per_trial when the pre-ADR-0044 surface was used."""
-        from tolokaforge.core.project_loader import _synthesise_composition_plan
+        from tolokaforge.core.project_loader import resolve
 
-        m = EnvironmentManifest(
-            compose_file=_fixture("safe_two_service.yaml"),
+        patch = EnvironmentPatch(
+            stack=StackPatch(compose_file=_fixture("safe_two_service.yaml")),
             services={
                 "default": ServiceSpec(isolation="shared"),
                 "db": ServiceSpec(isolation="ephemeral"),
             },
         )
+        m = resolve(project_env=patch, task_env=None)
+        assert m is not None
         assert m.requires_per_trial is True
-        _synthesise_composition_plan(m, {})
         assert m.stacks[0].stack_scope == "trial"
 
     def test_synthesis_is_idempotent(self) -> None:
         """A manifest whose `stacks` list is already populated MUST NOT
-        be overwritten by the coercion — an explicit plan wins."""
+        be overwritten by the coercion — an explicit plan wins. Locks the
+        internal invariant of the helper; end-to-end coverage is provided
+        by the other tests in this class going through `resolve()`."""
         from tolokaforge.core.project_loader import _synthesise_composition_plan
 
         explicit_stack = StackDecl(
@@ -233,18 +238,21 @@ class TestBackwardCompatCoercion:
         """The scalar-form fields (`compose_file`, `runner_service`,
         `stack_inputs`) mirror the sole synthetic stack — every existing
         consumer keeps working unchanged."""
-        from tolokaforge.core.project_loader import _synthesise_composition_plan
+        from tolokaforge.core.project_loader import resolve
 
-        m = EnvironmentManifest(
-            compose_file=_fixture("safe_two_service.yaml"),
-            runner_service="default",
-            stack_inputs={"FOO": "bar"},
+        patch = EnvironmentPatch(
+            stack=StackPatch(
+                compose_file=_fixture("safe_two_service.yaml"),
+                runner_service="default",
+                inputs={"FOO": "bar"},
+            ),
             services={
                 "default": ServiceSpec(isolation="shared"),
                 "db": ServiceSpec(isolation="shared"),
             },
         )
-        _synthesise_composition_plan(m, {})
+        m = resolve(project_env=patch, task_env=None)
+        assert m is not None
         assert m.stacks[0].compose_file == m.compose_file
         assert m.stacks[0].runner_service == m.runner_service
         assert m.stacks[0].inputs == m.stack_inputs
@@ -270,9 +278,10 @@ class TestEnvironmentPatchStacksBlockRefusal:
 
     def test_stacks_block_alone_is_accepted(self) -> None:
         """New composition-plan patch — no scalar `stack.compose_file`.
-        The multi-stack merge path is not wired in this ticket (raises
-        `NotImplementedError` on resolve); this test only pins that the
-        patch construction itself accepts the shape."""
+        The multi-stack merge path is not wired in this ticket; this test
+        only pins that the patch construction itself accepts the shape.
+        The end-to-end refusal on `resolve` is locked by
+        :meth:`test_stacks_block_is_refused_end_to_end`."""
         patch = EnvironmentPatch(
             stacks={
                 "engine": StackPatch(
@@ -283,6 +292,26 @@ class TestEnvironmentPatchStacksBlockRefusal:
         assert patch.stack is None
         assert patch.stacks is not None
         assert "engine" in patch.stacks
+
+    def test_stacks_block_is_refused_end_to_end(self) -> None:
+        """The whole point of accepting the `stacks` block at patch level
+        is that it must be caught at resolve time, not silently degenerate
+        into the scalar coercion path. Locks the guard in the synthesiser —
+        a follow-up refactor that removes it would land here."""
+        from tolokaforge.core.project_loader import resolve
+
+        project_patch = EnvironmentPatch(
+            stack=StackPatch(compose_file=_fixture("safe_one_service.yaml"))
+        )
+        task_patch = EnvironmentPatch(
+            stacks={
+                "engine": StackPatch(
+                    compose_file=_fixture("safe_one_service.yaml"), stack_scope="run"
+                )
+            }
+        )
+        with pytest.raises(NotImplementedError, match="multi-stack merge path is not yet wired"):
+            resolve(project_env=project_patch, task_env=task_patch)
 
     def test_stack_without_compose_file_and_stacks_together_accepted(self) -> None:
         """Edge case: `stack` set but ONLY carrying inputs/runner_service

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -811,6 +811,7 @@ class TestManifestWireShape:
             "db_port",
             "rag_service",
             "rag_port",
+            "stacks",  # ADR-0044 composition plan; default empty list preserves backward compat.
         }
         assert wire["runner_service"] == "default"
         assert wire["limited_internet_allowlist"] == []
@@ -843,6 +844,21 @@ class TestManifestWireShape:
             "capabilities_drop": ["ALL"],
             "capabilities_add": [],
         }
+
+    def test_scalar_only_manifest_byte_round_trips_identically(self) -> None:
+        """Pre-ADR-0044 backward-compat lock. A manifest constructed from
+        the scalar-only surface (no `stacks` block) must dump to wire and
+        reload byte-identically. The new `stacks` field defaults to `[]`
+        so `dict1 == dict2` — that equality is the compat guarantee."""
+        original = EnvironmentManifest(
+            compose_file=_fixture("safe_two_service.yaml"),
+            runner_service="default",
+            services={"default": ServiceSpec(isolation="shared")},
+        )
+        wire = original.model_dump(mode="json")
+        assert wire["stacks"] == []
+        reloaded = EnvironmentManifest.model_validate(wire)
+        assert reloaded.model_dump(mode="json") == wire
 
 
 # ---------------------------------------------------------------------------

--- a/tests/canonical/test_environment_manifest_contract.py
+++ b/tests/canonical/test_environment_manifest_contract.py
@@ -860,6 +860,11 @@ class TestManifestWireShape:
         reloaded = EnvironmentManifest.model_validate(wire)
         assert reloaded.model_dump(mode="json") == wire
 
+        wire_pre_adr = {k: v for k, v in wire.items() if k != "stacks"}
+        reloaded_legacy = EnvironmentManifest.model_validate(wire_pre_adr)
+        assert reloaded_legacy.stacks == []
+        assert reloaded_legacy.model_dump(mode="json") == wire
+
 
 # ---------------------------------------------------------------------------
 # TaskDescription embedding — optional, defaults to None

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -848,6 +848,7 @@ def resolve(
 
     manifest = EnvironmentManifest(**manifest_kwargs)
     _fill_missing_service_defaults(manifest)
+    _synthesise_composition_plan(manifest, merged)
     return manifest
 
 
@@ -865,6 +866,49 @@ def _fill_missing_service_defaults(manifest: EnvironmentManifest) -> None:
         if name in declared:
             continue
         manifest.services[name] = ServiceSpec(isolation="ephemeral")
+
+
+def _synthesise_composition_plan(manifest: EnvironmentManifest, merged: dict[str, Any]) -> None:
+    """Synthesise :attr:`EnvironmentManifest.stacks` from the scalar-form
+    fields when the merged patch declares no ``stacks`` block (ADR-0044
+    § 3 backward-compat coercion).
+
+    In-place on the manifest. Idempotent: no-op if ``stacks`` already
+    populated (from an explicit patch-side declaration).
+
+    The synthesised single-entry plan uses ``stack_id="default"``, the
+    manifest's ``compose_file``, and infers ``stack_scope`` from
+    :attr:`EnvironmentManifest.requires_per_trial` — True (empty services
+    or any non-``shared`` service) → ``trial``; False (all-``shared``) →
+    ``run``. This coercion preserves byte-identical behaviour for every
+    pre-ADR-0044 task pack: the scalar fields remain populated and the
+    synthetic plan captures the same scope information the previous
+    :meth:`Orchestrator._select_backend_from_tasks` would derive.
+    """
+    from tolokaforge.runner.models import StackDecl
+
+    if manifest.stacks:
+        return
+    stacks_patch = merged.get("stacks")
+    if stacks_patch:
+        # An explicit multi-stack patch was authored but did not survive
+        # the scalar merge path; a future ticket wires the multi-stack
+        # merge lifecycle. Refuse loudly rather than silently drop it.
+        raise NotImplementedError(
+            "EnvironmentPatch.stacks (multi-stack composition plan) is declared "
+            "but the multi-stack merge path is not yet wired (see ADR-0044 § 3). "
+            "Use the scalar `stack` field until the composer lands."
+        )
+    inferred_scope = "trial" if manifest.requires_per_trial else "run"
+    manifest.stacks.append(
+        StackDecl(
+            stack_id="default",
+            compose_file=manifest.compose_file,
+            stack_scope=inferred_scope,
+            runner_service=manifest.runner_service,
+            inputs=dict(manifest.stack_inputs),
+        )
+    )
 
 
 def _dump_patch(patch: EnvironmentPatch | None) -> dict[str, Any]:

--- a/tolokaforge/core/project_loader.py
+++ b/tolokaforge/core/project_loader.py
@@ -891,9 +891,6 @@ def _synthesise_composition_plan(manifest: EnvironmentManifest, merged: dict[str
         return
     stacks_patch = merged.get("stacks")
     if stacks_patch:
-        # An explicit multi-stack patch was authored but did not survive
-        # the scalar merge path; a future ticket wires the multi-stack
-        # merge lifecycle. Refuse loudly rather than silently drop it.
         raise NotImplementedError(
             "EnvironmentPatch.stacks (multi-stack composition plan) is declared "
             "but the multi-stack merge path is not yet wired (see ADR-0044 § 3). "
@@ -937,6 +934,13 @@ def _merge_env_patches(
     stack_replacement = isinstance(task_stack, dict) and "compose_file" in task_stack
     if not stack_replacement:
         return deep_merge(project, task)
+
+    if project.get("stacks") or task.get("stacks"):
+        raise NotImplementedError(
+            "EnvironmentPatch.stacks (multi-stack composition plan) is declared "
+            "but the multi-stack merge path is not yet wired (see ADR-0044 § 3). "
+            "Use the scalar `stack` field until the composer lands."
+        )
 
     merged: dict[str, Any] = {"stack": dict(task_stack)}
     for field in _SERVICE_TREATMENT_FIELDS:

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -2219,6 +2219,91 @@ class TaskIsolation(str, Enum):
     SHARED_OK = "shared_ok"
 
 
+StackScope = Literal["run", "task", "trial"]
+"""Per-stack lifecycle scope vocabulary (ADR-0044).
+
+* ``run`` — the stack is materialised once at :meth:`RuntimeBackend.connect`
+  and torn down at :meth:`close`. Its services persist across every trial in
+  the run. Grading substrate is stateless per-trial (engine services).
+* ``task`` — the stack is materialised once at the first :meth:`provision`
+  for a task and torn down when the task exits. Its services persist across
+  every repeat of that task.
+* ``trial`` — the stack is materialised on every :meth:`provision` and
+  torn down on every :meth:`teardown`. Its services are fully isolated per
+  trial. This is the ADR-0009 default when the manifest declares no scope.
+
+Consumed by :class:`SubstrateComposer` at compose-lifecycle bracket time.
+Extension is via `stack_scope` Literal widening (needs its own ADR) plus
+a new dispatcher registration for the scope's between-trial semantics.
+"""
+
+
+class PlanShape(str, Enum):
+    """Classification of an :class:`EnvironmentManifest` composition plan.
+
+    Consumed by :meth:`Orchestrator._construct_runtime_backend` to determine
+    how to instantiate the sole compose-mode backend. See ADR-0044 § 5.
+
+    * ``SINGLE_RUN`` — exactly one stack, ``stack_scope="run"``. Equivalent
+      to today's Case-B `SharedStackRuntimeBackend` behaviour.
+    * ``TASK_SCOPED_ONLY`` — every stack has ``stack_scope="task"``. No
+      run-scope engine substrate; task substrate materialised per task and
+      reused across the task's repeats.
+    * ``TRIAL_SCOPED_ONLY`` — every stack has ``stack_scope="trial"``.
+      Equivalent to today's `PerTrialRuntimeBackend` behaviour. This is the
+      shape ADR-0009 defaults to when the manifest declares no services.
+    * ``MULTI_SCOPE`` — the plan mixes at least two of the above scopes.
+      Canonical T-Bench balanced-10 shape: engine ``run`` + task ``trial``.
+    """
+
+    SINGLE_RUN = "single_run"
+    TASK_SCOPED_ONLY = "task_scoped_only"
+    TRIAL_SCOPED_ONLY = "trial_scoped_only"
+    MULTI_SCOPE = "multi_scope"
+
+
+class StackDecl(BaseModel):
+    """One compose file declared by an :class:`EnvironmentManifest`.
+
+    A composition plan is the ordered list of these on
+    :attr:`EnvironmentManifest.stacks`. Each declaration carries the
+    compose-file pointer, a stack_id unique within the plan, its lifecycle
+    scope, an optional runner-service pointer (exactly one stack in the
+    plan may set this — see ADR-0044 § 7 INV-12), and per-file input
+    substitutions.
+
+    Materialised by a :class:`ComposeMaterialiser` at the scope's bracket
+    (:meth:`connect` for ``run``, :meth:`provision` for ``task``/``trial``).
+    """
+
+    stack_id: str
+    """Identifier unique within the plan. Used as compose-project prefix
+    (see ADR-0044 § 5 INV-10 extension) and as key in the per-stack
+    ``services`` map."""
+
+    compose_file: Path
+    """Absolute path to the docker-compose file. Anchored to the file that
+    declared it — the project directory for project patches, the task
+    directory for task patches — by the loader before this decl is
+    constructed."""
+
+    stack_scope: StackScope
+    """Lifecycle scope. See :data:`StackScope`."""
+
+    runner_service: str | None = None
+    """Name of the compose service in ``compose_file`` that runs the agent.
+    Exactly one :class:`StackDecl` in a composition plan may set this —
+    the composer enforces this at plan resolve time. ``None`` on every
+    other stack in the plan."""
+
+    inputs: dict[str, str] = Field(default_factory=dict)
+    """Compose-file variable substitutions scoped to ``compose_file``.
+    Passed through to the runtime backend at compose-up time; the compose
+    file's ``${var}`` slots resolve against this mapping."""
+
+    model_config = {"extra": "forbid"}
+
+
 ServiceIsolation = Literal["shared", "reset", "ephemeral"]
 """Per-service isolation vocabulary.
 
@@ -2669,6 +2754,13 @@ class StackPatch(BaseModel):
     """Container port for the rag endpoint. ``None`` means inherit
     published-port auto-detect."""
 
+    stack_scope: StackScope | None = None
+    """Lifecycle scope for this stack. ``None`` in a patch means inherit;
+    :func:`tolokaforge.core.project_loader.resolve` synthesises the scope
+    from ADR-0009 default (empty services or any non-``shared`` service →
+    ``trial``; all-``shared`` → ``run``) when the merged patch leaves this
+    unset. See ADR-0044 § 3."""
+
     model_config = {"extra": "forbid"}
 
 
@@ -2780,6 +2872,34 @@ class EnvironmentPatch(BaseModel):
     not the replacement stack. Deep-merges over the project side
     entry-by-entry on non-replacement paths."""
 
+    stacks: dict[str, StackPatch] | None = None
+    """Multi-stack composition-plan surface (ADR-0044). Keyed by
+    ``stack_id``. Each :class:`StackPatch` value carries its own
+    ``compose_file`` + ``stack_scope`` + ``runner_service?`` + ``inputs``.
+    Coexists with the scalar :attr:`stack` field only as a representation
+    choice — a patch layer that sets ``stacks`` MUST NOT also set
+    ``stack.compose_file`` (see :meth:`_refuse_stack_and_stacks_together`);
+    the two are aliases of the same field. When the merged patch has neither
+    ``stacks`` nor ``stack.compose_file`` set, :func:`resolve` synthesises
+    a single-entry composition plan from the scalar-form fields, keeping
+    every pre-ADR-0044 task pack byte-identical."""
+
+    @model_validator(mode="after")
+    def _refuse_stack_and_stacks_together(self) -> EnvironmentPatch:
+        """Refuse a patch that sets both the scalar ``stack.compose_file``
+        AND the plural ``stacks`` block — they are aliases of the same
+        field. Merge semantics between the two representations are
+        undefined; the resolver deliberately does not attempt to merge
+        them. Callers author one or the other (see ADR-0044 § 3)."""
+        if self.stacks and self.stack is not None and self.stack.compose_file is not None:
+            raise ValueError(
+                "EnvironmentPatch: the scalar `stack.compose_file` and the "
+                "plural `stacks` block are aliases of the same field and cannot "
+                "both be set in the same patch layer. Author one or the other "
+                "(see ADR-0044 § 3)."
+            )
+        return self
+
     @model_validator(mode="before")
     @classmethod
     def _accept_legacy_flat_stack_fields(cls, data: Any) -> Any:
@@ -2869,6 +2989,22 @@ class EnvironmentManifest(BaseModel):
     """Container port for the rag endpoint. ``None`` auto-detects the first
     published port."""
 
+    stacks: list[StackDecl] = Field(default_factory=list)
+    """Composition plan — the ordered list of stacks the manifest declares
+    (ADR-0044). Populated by :func:`tolokaforge.core.project_loader.resolve`
+    either from the merged :attr:`EnvironmentPatch.stacks` block OR
+    synthesised from the scalar :attr:`compose_file` legacy fields.
+
+    A manifest loaded from a pre-ADR-0044 patch surface (scalar
+    ``compose_file`` + no ``stacks`` block) produces a single-entry plan
+    whose ``stack_scope`` is inferred from :attr:`requires_per_trial`
+    (``True`` → ``trial``, ``False`` → ``run``). The legacy scalar fields
+    (:attr:`compose_file`, :attr:`runner_service`, etc.) mirror the sole
+    synthetic stack so every existing consumer keeps working unchanged.
+
+    Consumed by :class:`SubstrateComposer` to sequence per-scope
+    materialisation, and by :attr:`plan_shape` for backend selection."""
+
     model_config = {"extra": "forbid"}
 
     @property
@@ -2883,6 +3019,33 @@ class EnvironmentManifest(BaseModel):
         if not self.services:
             return True
         return any(spec.isolation != "shared" for spec in self.services.values())
+
+    @property
+    def plan_shape(self) -> PlanShape:
+        """Classify the composition plan for backend selection (ADR-0044).
+
+        A single-stack ``run``-scope plan produces ``SINGLE_RUN``; a
+        single-stack ``trial``-scope plan produces ``TRIAL_SCOPED_ONLY``;
+        a single-stack ``task``-scope plan produces ``TASK_SCOPED_ONLY``;
+        a plan mixing at least two scopes produces ``MULTI_SCOPE``.
+
+        A manifest with no ``stacks`` (either explicitly-empty list or
+        legacy scalar-only that hasn't been through
+        :func:`~tolokaforge.core.project_loader.resolve`) falls back to
+        ``TRIAL_SCOPED_ONLY`` — the ADR-0009 default, matching today's
+        :attr:`requires_per_trial=True` behaviour.
+        """
+        if not self.stacks:
+            return PlanShape.TRIAL_SCOPED_ONLY
+        scopes = {decl.stack_scope for decl in self.stacks}
+        if len(scopes) > 1:
+            return PlanShape.MULTI_SCOPE
+        (only_scope,) = scopes
+        if only_scope == "run":
+            return PlanShape.SINGLE_RUN
+        if only_scope == "task":
+            return PlanShape.TASK_SCOPED_ONLY
+        return PlanShape.TRIAL_SCOPED_ONLY
 
     @property
     def restricted_services(self) -> frozenset[str]:


### PR DESCRIPTION
Closes #1379.

## Summary

First slice of ADR-0044 (Milestone 41). Adds the composition-plan surface on `EnvironmentManifest` / `EnvironmentPatch` while keeping every pre-ADR-0044 task pack loading byte-identically. No runtime behaviour changes — the new fields are consumed later in the milestone (adapters, composer, orchestrator selection).

## Design choices

- **Closed scope vocab.** `StackScope = Literal["run","task","trial"]` is the plan's lifecycle axis. Extension is via new adapter registrations, never new enum values — the same discipline `ServiceIsolation` follows.
- **`PlanShape` replaces the single-bit `requires_per_trial` signal for future backend selection.** Enum, not a `bool`, so `MULTI_SCOPE` and `TASK_SCOPED_ONLY` (both future) don't need re-modelling.
- **`plan_shape` is a computed property, not a stored field.** The plan is the source of truth; classification is derived.
- **Coercion refuses on unimplemented multi-stack merges rather than silently narrowing.** `_synthesise_composition_plan` handles the scalar surface. If a caller passes an `EnvironmentPatch.stacks` block before the composer lands, `resolve` raises `NotImplementedError` with an ADR-0044 pointer.
- **Byte-round-trip lock.** Wire snapshot rev'd once to add `stacks: []`; `test_scalar_only_manifest_byte_round_trips_identically` pins that pre-ADR-0044 manifests reload identically.
- **Ambiguous-patch refusal.** `stack.compose_file` + `stacks` together is refused at patch construction (they alias the same field); `stack` overrides that omit `compose_file` (only inputs / runner_service) coexist with a `stacks` block so metadata inheritance still works.

## Test plan

- [x] `tests/canonical/test_composition_plan_types.py` — 21 new tests: plan-shape classification for all four shapes, closed scope vocab, extra-fields refusal, coercion idempotency, scope-inference from `requires_per_trial`, `EnvironmentPatch` ambiguous-block refusal.
- [x] `tests/canonical/test_environment_manifest_contract.py` — wire snapshot revved once (`"stacks"` added, comment cites ADR-0044); new `test_scalar_only_manifest_byte_round_trips_identically` locks pre-ADR-0044 backward compat.
- [x] Two T-Bench adapter canonical snapshots regenerated for the new default field (`stacks: []` → resolved single-entry plan).
- [x] Full canonical suite: 1749 passed, 1 pre-existing flake (`test_adapter_convert_entry_point.py::test_entry_point_adapter_convert_smoke` — passes in isolation).
- [x] `ruff check` + `ruff format` clean on all touched files.