### PR TITLE
feat(grading): tolokaforge.grading_methods registry + widen grading_method to str; judge_only routes through shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Removed
+
+- `grading_method` reserved names `hash`, `transcript`, `llm` — never emitted, never dispatched. Task packs using these values fail loud at `RegisterTrial` with a message naming the registered set. Use `composite` (or leave `grading_method` unset).
+
 ## v0.21.4 (2026-08-28)
 
 ### Fix

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -558,15 +558,17 @@ recipe — see [ADR-0040](adr/0040-standalone-grader.md), reserved-future
 substrate SWE-bench pattern. Not shipped today; the two shipping
 substrates are `InProcess` and `LiveCallback`.
 
-<a id="extension-points-the-seven-plug-in-groups"></a>
+<a id="extension-points-the-eight-plug-in-groups"></a>
 
-## Extension points — the seven plug-in groups
+## Extension points — the eight plug-in groups
 
-Seven `importlib.metadata` entry-point groups let a downstream package
-extend the grader without a framework change: one substrate group and
-six sub-component seams. Each group has a matching loader on
+Eight `importlib.metadata` entry-point groups let a downstream package
+extend the grader without a framework change: one runner-side dispatch
+selector, one substrate group, and six sub-component seams. Each group
+has a matching loader on
 [`tolokaforge.core.plugin_registry`](../tolokaforge/core/plugin_registry.py):
 
+- `tolokaforge.grading_methods` — `load_grading_method(name)` returns the `GradingMethod` marker **class**. Names in this group are the values `RunnerGradingConfig.grading_method` accepts at `RegisterTrial`; the marker carries `NAME: ClassVar[str]` so a downstream typo in `pyproject.toml` fails at discovery. Runtime dispatch today branches on the wire string at `RunnerServiceImpl.GradeTrial`; this loader is a validation + discovery surface.
 - `tolokaforge.grading_substrates` — `load_grading_substrate(name)` returns the `GradingSubstrate` **class** (the caller instantiates it with per-trial arguments).
 - `tolokaforge.custom_check_executors` — `load_custom_check_executor(name)` returns a factory.
 - `tolokaforge.judge_model_providers` — `load_judge_model_provider(name)` returns a factory.
@@ -578,6 +580,9 @@ six sub-component seams. Each group has a matching loader on
 Copy-paste block for a downstream `pyproject.toml`:
 
 ```toml
+[project.entry-points."tolokaforge.grading_methods"]
+my_grading_method = "my_package:my_grading_method_marker"
+
 [project.entry-points."tolokaforge.grading_substrates"]
 my_substrate = "my_package:my_substrate_class"
 
@@ -600,11 +605,11 @@ my_state_backend = "my_package:my_state_backend_factory"
 my_operator = "my_package:my_operator"
 ```
 
-`tolokaforge.trial_graders` is the eighth registration point — the
+`tolokaforge.trial_graders` is the ninth registration point — the
 top-level grader-name seam ADR-0038 shipped, already documented in
 [Registering a downstream grader](#registering-a-downstream-grader).
 A downstream package registering a new grader name lands there, not
-in any of the seven groups above.
+in any of the eight groups above.
 
 ## Parity gate
 

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -140,15 +140,30 @@ runner_rpc = "tolokaforge.core.trial_grader:runner_rpc_trial_grader_factory"
 
 ### `judge_only` — `JudgeBackedTrialGrader`
 
-Host-side dispatch to an injected judge callable. No runner state, no
-transcript rules, no custom checks — pure rubric evaluation. Auto-fail
-branches match `RunnerRPCTrialGrader` so both are drop-in swaps for the
-caller.
+Host-side dispatch to :class:`~tolokaforge.core.grading.judge.LLMJudge` over
+a trajectory. No runner state, no transcript rules, no custom checks —
+pure rubric evaluation against the task's `grading.llm_judge` block, using
+the run's `models.judge`. Auto-fail branches match `RunnerRPCTrialGrader`
+so both are drop-in swaps for the caller.
 
-The factory ships with an unwired default that raises `NotImplementedError`
-if selected in production before a real `LLMJudge`-backed dispatch is
-wired; direct construction with a real `JudgeGradeFn` works today (for
-tests and offline-replay integration).
+`judge_only` and the composite dispatch selected by
+`grading.grading_method: composite` (or omitted) with
+`weights: {llm_judge: 1.0}` and no other component surface are two names
+for the same run: both route through the shared
+`tolokaforge.core.grading.judge_only_helpers.run_judge_only_for_trajectory`
+helper, and both reach :class:`LLMJudge` with byte-identical evidence on
+that constrained-input shape. The equivalence is pinned by the module
+constant `_JUDGE_ONLY_EQUIVALENT_CONFIG` on
+`tolokaforge.core.trial_grader` and the byte-parity canonical test at
+`tests/canonical/test_judge_only_composite_llm_judge_only_parity.py`.
+
+Fail-loud shape: a task without `grading.llm_judge`, a run without
+`models.judge`, or an `ERRORED` judge verdict surfaces as
+`GradingFailedError` naming the trial — never a booked agent failure.
+Discovery-time gate: the factory calls `load_grading_method("composite")`
+at construction so a misconfigured install (missing the
+`tolokaforge.grading_methods` entry-point group) fails there rather than
+at grade time.
 
 ```toml
 [project.entry-points."tolokaforge.trial_graders"]

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -177,6 +177,36 @@ records every kind the walk reached, wherever the constraint was written.
 does not apply to that dispatch mode — recorded as the `grading_method` entry's
 declared `reason`.
 
+### Grading Method Dispatch
+
+`RunnerGradingConfig.grading_method` selects which runner-side dispatch a trial
+takes. The value is a bare string on the wire — the registered names live in
+the `tolokaforge.grading_methods` entry-point group and load through
+[`load_grading_method(name)`](../tolokaforge/core/plugin_registry.py). Two
+markers ship:
+
+- `composite` — the default state-checks / transcript-rules / trace-checks /
+  llm-judge / custom-checks fold. Omitting `grading_method` selects the same
+  dispatch — `None` and `"composite"` are equivalent on the wire.
+- `test_execution` — the reference-suite short-circuit. Requires an exec-capable
+  lifecycle tool in `TaskDescription.agent_tools` (`DockerComposeExecToolWrapper`
+  today); the runner reads the reward off
+  `/logs/verifier/reward.txt`. Returns before the component phase, so the
+  ledger does not apply.
+
+A downstream adapter registers a new dispatch name with one entry-point line:
+
+```toml
+[project.entry-points."tolokaforge.grading_methods"]
+terminal_bench_native = "acme_adapter:TerminalBenchNativeGradingMethod"
+```
+
+The marker class carries a `NAME: ClassVar[str]` — same shape as
+`tolokaforge.grading_substrates` from ADR-0040. `RegisterTrial` refuses an
+unregistered name with an error listing both the offending key and
+`available_grading_methods()`, so a typo in a task pack surfaces before the
+trial spends any turns.
+
 ### Single-substrate keys
 
 | Key | kind | coverage | enforcement | Why only one substrate | Tracked |

--- a/docs/adr/0040-standalone-grader.md
+++ b/docs/adr/0040-standalone-grader.md
@@ -40,7 +40,7 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 - `SnapshotGradingSubstrate` (Harbor pattern) — state travels inside `GradeRequest`.
 - `SharedMountGradingSubstrate` (SWE-bench pattern) — reads from a shared mount.
 
-**Register substrate implementations under a plug-in group** — `tolokaforge.grading_substrates`. Ships with two entries this milestone; when trajectory-storage lands, it registers itself as one entry-point line — no framework PR.
+**Register substrate implementations under a plug-in group** — `tolokaforge.grading_substrates`. Ships with two entries this milestone; when trajectory-storage lands, it registers itself as one entry-point line — no framework PR. The companion `tolokaforge.grading_methods` group registers the runner-side dispatch selector on `RunnerGradingConfig.grading_method` under the same fail-loud discovery shape; see [`docs/GRADING.md` § Grading Method Dispatch](../GRADING.md#grading-method-dispatch).
 
 **Introduce six new entry-point groups for sub-component evaluators** (rubric_evaluators, judge_model_providers, transcript_rule_matchers, trace_check_operators, state_check_backends, custom_check_executors). Every existing implementation becomes the reference impl behind its Protocol — extract-refactor, zero behaviour change.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,16 @@ tcp = "tolokaforge.core.service_readiness:tcp_readiness_probe_factory"
 agent_only = "tolokaforge.core.actors.turn_policy:_agent_only_policy_factory"
 conversational = "tolokaforge.core.actors.turn_policy:_conversational_policy_factory"
 
+# Runner-side dispatch selector on ``RunnerGradingConfig.grading_method``: the
+# registered names are the ones ``RegisterTrial`` accepts. Two markers ship
+# today — ``composite`` (default state-checks / transcript-rules / trace-checks /
+# llm-judge / custom-checks fold) and ``test_execution`` (reference-suite
+# short-circuit). A downstream dispatch registers here without a framework PR;
+# see :mod:`tolokaforge.core.grading.grading_method`.
+[project.entry-points."tolokaforge.grading_methods"]
+composite = "tolokaforge.core.grading.grading_method:CompositeGradingMethod"
+test_execution = "tolokaforge.core.grading.grading_method:TestExecutionGradingMethod"
+
 # ADR-0040 § "The single design abstraction" — GradingSubstrate implementations
 # resolvable by name. Two implementations ship today (``in_process`` +
 # ``live_callback``); ``trajectory_storage`` / ``snapshot`` / ``shared_mount``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,6 +413,7 @@ exclude = [
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",
+    "tolokaforge/core/grading/judge_only_helpers.py",
     "tolokaforge/core/grading/migration_declaration.py",
     "tolokaforge/core/grading/replay.py",
     "tolokaforge/core/grading/replay_layout.py",

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -23,8 +23,13 @@ from tolokaforge.core.conductor import (
     InMemoryConductor,
     InProcessConductor,
 )
+from tolokaforge.core.grading.grading_method import (
+    CompositeGradingMethod,
+    TestExecutionGradingMethod,
+)
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.plugin_registry import (
+    GRADING_METHODS_GROUP,
     RUNTIME_BACKENDS_GROUP,
     SERVICE_READINESS_PROBES_GROUP,
     TURN_POLICIES_GROUP,
@@ -32,11 +37,13 @@ from tolokaforge.core.plugin_registry import (
     TrialGraderContext,
     TurnPolicyContext,
     available_conductors,
+    available_grading_methods,
     available_readiness_probes,
     available_runtime_backends,
     available_trial_graders,
     available_turn_policies,
     load_conductor,
+    load_grading_method,
     load_readiness_probe,
     load_runtime_backend,
     load_trial_grader,
@@ -146,12 +153,26 @@ def test_turn_policy_names_resolve_to_their_class() -> None:
     assert isinstance(agent_only, AgentOnlyTurnPolicy)
 
 
+@pytest.mark.parametrize(
+    ("name", "expected_cls"),
+    [
+        ("composite", CompositeGradingMethod),
+        ("test_execution", TestExecutionGradingMethod),
+    ],
+)
+def test_grading_method_names_resolve_to_their_marker(name: str, expected_cls: type) -> None:
+    marker = load_grading_method(name)
+    assert marker is expected_cls
+    assert name == marker.NAME
+
+
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
     assert available_trial_graders() == ["grader_rpc", "judge_only", "queue", "runner_rpc"]
     assert available_conductors() == ["in_memory", "in_process"]
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
     assert available_turn_policies() == ["agent_only", "conversational"]
+    assert available_grading_methods() == ["composite", "test_execution"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
@@ -169,3 +190,8 @@ def test_raw_entry_point_probe_lists_readiness_probes() -> None:
 def test_raw_entry_point_probe_lists_turn_policies() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=TURN_POLICIES_GROUP))
     assert names == ["agent_only", "conversational"]
+
+
+def test_raw_entry_point_probe_lists_grading_methods() -> None:
+    names = sorted(ep.name for ep in importlib.metadata.entry_points(group=GRADING_METHODS_GROUP))
+    assert names == ["composite", "test_execution"]

--- a/tests/canonical/test_grading_methods_registry.py
+++ b/tests/canonical/test_grading_methods_registry.py
@@ -5,9 +5,8 @@ resolves the value against this entry-point group at ``RegisterTrial``.
 This canonical suite locks the group's public contract: the two shipped
 markers resolve; ``available_grading_methods()`` matches the ADR-locked
 set; an unknown name fails loud with a message an operator can act on;
-and the pydantic model widened past its former closed ``Literal`` so a
-downstream adapter can register its own dispatch under the same group
-without a framework PR.
+and the pydantic model accepts any string so a downstream adapter can
+register its own dispatch under the same group without a framework PR.
 
 See :mod:`tolokaforge.core.grading.grading_method` for the marker
 Protocol + shipped implementations.

--- a/tests/canonical/test_grading_methods_registry.py
+++ b/tests/canonical/test_grading_methods_registry.py
@@ -1,0 +1,59 @@
+"""``tolokaforge.grading_methods`` — the runner-side dispatch-selector registry.
+
+The runner reads ``RunnerGradingConfig.grading_method`` off the wire and
+resolves the value against this entry-point group at ``RegisterTrial``.
+This canonical suite locks the group's public contract: the two shipped
+markers resolve; ``available_grading_methods()`` matches the ADR-locked
+set; an unknown name fails loud with a message an operator can act on;
+and the pydantic model widened past its former closed ``Literal`` so a
+downstream adapter can register its own dispatch under the same group
+without a framework PR.
+
+See :mod:`tolokaforge.core.grading.grading_method` for the marker
+Protocol + shipped implementations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tolokaforge.core.grading.grading_method import (
+    CompositeGradingMethod,
+    TestExecutionGradingMethod,
+)
+from tolokaforge.core.plugin_registry import (
+    GRADING_METHODS_GROUP,
+    UnknownImplementationError,
+    available_grading_methods,
+    load_grading_method,
+)
+from tolokaforge.runner.models import RunnerGradingConfig
+
+pytestmark = pytest.mark.canonical
+
+
+def test_builtin_registrations_resolve() -> None:
+    assert load_grading_method("composite") is CompositeGradingMethod
+    assert load_grading_method("test_execution") is TestExecutionGradingMethod
+    assert available_grading_methods() == ["composite", "test_execution"]
+
+
+def test_unknown_grading_method_raises_named_error() -> None:
+    with pytest.raises(UnknownImplementationError) as excinfo:
+        load_grading_method("does_not_exist")
+
+    message = str(excinfo.value)
+    assert "does_not_exist" in message
+    assert GRADING_METHODS_GROUP in message
+    assert "composite" in message
+    assert "test_execution" in message
+
+
+def test_grading_method_field_is_open_string_and_none_default() -> None:
+    assert RunnerGradingConfig().grading_method is None
+
+    downstream = RunnerGradingConfig(grading_method="terminal_bench_native")
+    assert downstream.grading_method == "terminal_bench_native"
+
+    round_tripped = RunnerGradingConfig.model_validate_json(downstream.model_dump_json())
+    assert round_tripped.grading_method == "terminal_bench_native"

--- a/tests/canonical/test_grading_wire_lock.py
+++ b/tests/canonical/test_grading_wire_lock.py
@@ -383,7 +383,7 @@ _WIRE_KEYS: tuple[_WireKey, ...] = (
     _WireKey(
         path="grading.grading_method",
         emitted_for="",
-        wire_shape="Literal['hash', 'test_execution', 'transcript', 'llm'] | None",
+        wire_shape="str | None",
     ),
     _WireKey(
         path="grading.state_checks",

--- a/tests/canonical/test_judge_backed_trial_grader.py
+++ b/tests/canonical/test_judge_backed_trial_grader.py
@@ -24,10 +24,12 @@ from tolokaforge.core.models import (
 )
 from tolokaforge.core.plugin_registry import TrialGraderContext, load_trial_grader
 from tolokaforge.core.trial_grader import (
+    _JUDGE_ONLY_EQUIVALENT_CONFIG,
     JudgeBackedTrialGrader,
     TrialGrader,
     judge_backed_trial_grader_factory,
 )
+from tolokaforge.runner.models import RunnerGradingConfig
 
 pytestmark = pytest.mark.canonical
 
@@ -126,6 +128,22 @@ class TestFactoryAndRegistration:
         grader = judge_backed_trial_grader_factory(ctx)
         assert isinstance(grader, JudgeBackedTrialGrader)
         assert callable(grader.judge_fn)
+
+    def test_factory_registers_the_equivalent_composite_shape(self) -> None:
+        """The module-level ``_JUDGE_ONLY_EQUIVALENT_CONFIG`` pins the
+        composite dispatch shape ``judge_only`` collapses to — the
+        "one implementation, two names" contract locked at the code
+        layer without cross-file drift. Byte-parity between the two
+        paths on the constrained-input shape is separately locked at
+        ``tests/canonical/test_judge_only_composite_llm_judge_only_parity.py``.
+        """
+        assert (
+            RunnerGradingConfig(
+                grading_method="composite",
+                weights={"llm_judge": 1.0},
+            )
+            == _JUDGE_ONLY_EQUIVALENT_CONFIG
+        )
 
     def test_grade_raises_when_task_has_no_llm_judge_block(self) -> None:
         """A task with no ``grading.llm_judge`` block cannot be judged;

--- a/tests/canonical/test_judge_only_composite_llm_judge_only_parity.py
+++ b/tests/canonical/test_judge_only_composite_llm_judge_only_parity.py
@@ -1,0 +1,225 @@
+"""``judge_only`` grades a trajectory identically to composite ``weights: {llm_judge: 1.0}``.
+
+The umbrella wants ``judge_only`` (external) and ``composite + weights: {llm_judge:
+1.0}`` (external) to be two names for the same grading dispatch. This canonical
+gate locks that convergence at the ``Grade`` layer under the constrained-input
+shape both paths collapse to when a task declares an ``llm_judge`` rubric and
+nothing else — no ``state_checks``, no ``transcript_rules``, no ``trace_checks``,
+no ``custom_checks``, no ``search_policy`` KB plane, and an empty
+``initial_state``. On that shape, both paths reach :class:`LLMJudge` with
+byte-identical evidence: the composite's
+:func:`~tolokaforge.core.grading.composite.build_judge_state_diff` early-returns
+``None`` on empty ``initial_state`` (matching ``judge_only``'s
+unconditional ``state_diff=None``); the substrate reads (``db_reader``,
+``kb_search``, ``filesystem_root``) all resolve to the same
+"no live state" answers ``judge_only`` passes as ``None``; and
+``extra_read_tools`` collapses to ``[]`` when no ``search_policy`` connector
+was reconstructed. Grade-shape parity across the two names is the property
+the umbrella cares about.
+
+Substitution shape (per plan): :meth:`LLMJudge.run` is monkey-patched on the
+class itself to return a fixed :class:`JudgeResult`. Both paths construct
+:class:`LLMJudge` via the same import (``tolokaforge.core.grading.judge:LLMJudge``);
+one class-level patch reaches both paths. The ``llm_client=`` injection point
+would NOT bypass the substrate-kwarg divergence — LLMJudge builds its tool
+list around ``db_reader`` truthiness before the injected client is called,
+so patching ``run`` at the class level is the only place both paths converge
+on a byte-identical verdict.
+
+The equivalence pin at the config layer lives in
+:data:`tolokaforge.core.trial_grader._JUDGE_ONLY_EQUIVALENT_CONFIG`. This
+suite asserts both paths agree on that pin.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._factories import make_trajectory
+from tolokaforge.core.grading.judge_result import JudgeResult, JudgeStatus, JudgeUsage
+from tolokaforge.core.models import (
+    Grade,
+    Message,
+    MessageRole,
+    ModelConfig,
+    TerminationReason,
+    TrialStatus,
+)
+from tolokaforge.core.plugin_registry import TrialGraderContext, load_trial_grader
+from tolokaforge.core.trial import EnvEndpoints, TrialSpec
+from tolokaforge.core.trial_grader import _JUDGE_ONLY_EQUIVALENT_CONFIG
+from tolokaforge.runner import runner_pb2 as pb2
+from tolokaforge.runner.models import (
+    LLMJudgeConfig,
+    Rubric,
+    RunnerGradingConfig,
+    TaskDescription,
+)
+from tolokaforge.runner.service import RunnerServiceImpl, TrialContextRuntime
+
+pytestmark = pytest.mark.canonical
+
+
+_TRIAL_ID = "judge_parity_task:0"
+_JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4", temperature=0.0)
+
+
+def _fixed_judge_result() -> JudgeResult:
+    """A deterministic verdict both legs return byte-identical, given the same
+    inputs. ``binary_pass`` matches ``score >= pass_threshold`` (default 0.8),
+    so composite's fold-derived ``binary_pass`` and :func:`build_replay_grade`'s
+    passthrough of ``result.binary_pass`` agree.
+    """
+    return JudgeResult(
+        status=JudgeStatus.COMPLETED,
+        usage=JudgeUsage(),
+        reasons="rubric fully satisfied",
+        score=0.87,
+        binary_pass=True,
+    )
+
+
+def _task_description() -> TaskDescription:
+    rubric = Rubric(
+        criteria=[
+            {
+                "id": "answer_correct",
+                "description": "did the agent answer",
+                "kind": "binary",
+                "weight": 1.0,
+            }
+        ]
+    )
+    return TaskDescription(
+        task_id="judge_parity_task",
+        name="judge parity task",
+        category="test",
+        description="constrained-shape task where judge_only and composite converge",
+        adapter_type="native",
+        system_prompt="you are the agent",
+        grading=RunnerGradingConfig(
+            weights={"llm_judge": 1.0},
+            llm_judge=LLMJudgeConfig(rubric=rubric),
+        ),
+    )
+
+
+def _trajectory() -> Any:
+    """A minimal COMPLETED trajectory carrying a user/assistant exchange —
+    enough for ``encode_transcript_wire`` to emit a non-empty wire on the
+    ``judge_only`` path."""
+    return make_trajectory(
+        status=TrialStatus.COMPLETED,
+        termination_reason=TerminationReason.AGENT_DONE,
+        messages=[
+            Message(role=MessageRole.USER, content="please answer"),
+            Message(role=MessageRole.ASSISTANT, content="the answer is 42"),
+        ],
+    )
+
+
+def _install_fixed_judge(monkeypatch: pytest.MonkeyPatch, result: JudgeResult) -> None:
+    """Route every :meth:`LLMJudge.run` invocation to the fixed ``result``.
+
+    The class-level patch reaches both paths: ``judge_only``'s helper
+    constructs :class:`LLMJudge` directly, and the composite path
+    constructs it inside :class:`LLMJudgeRubricEvaluator`. Both import from
+    :mod:`tolokaforge.core.grading.judge`, so the same class object serves
+    both.
+    """
+    monkeypatch.setattr(
+        "tolokaforge.core.grading.judge.LLMJudge.run",
+        lambda self, **_kwargs: result,
+    )
+
+
+def _grade_path_a_judge_only(fixed: JudgeResult, monkeypatch: pytest.MonkeyPatch) -> Grade:
+    _install_fixed_judge(monkeypatch, fixed)
+    ctx = TrialGraderContext(runner_address="ignored:0", logger=MagicMock())
+    factory = load_trial_grader("judge_only")
+    grader = factory(ctx)
+    spec = TrialSpec(
+        trial_id=_TRIAL_ID,
+        run_id="parity_run",
+        task=_task_description(),
+        agent_model_config=ModelConfig(provider="openai", name="gpt-4"),
+        judge_model_config=_JUDGE_MODEL,
+        env_endpoints=EnvEndpoints(
+            db_url="http://db.local:8000",
+            runner_url="http://runner.local:50051",
+        ),
+    )
+    grade = grader.grade(spec, _trajectory(), "you are the agent")
+    assert grade is not None, "judge_only produced no verdict for the fixture"
+    return grade
+
+
+def _grade_path_b_composite(fixed: JudgeResult, monkeypatch: pytest.MonkeyPatch) -> pb2.Grade:
+    _install_fixed_judge(monkeypatch, fixed)
+    service = RunnerServiceImpl(db_client=MagicMock())
+    try:
+        service.trials[_TRIAL_ID] = TrialContextRuntime(
+            trial_id=_TRIAL_ID,
+            task_description=_task_description(),
+            judge_model_config=_JUDGE_MODEL,
+        )
+        wire_messages = [
+            {"role": "system", "content": "you are the agent"},
+            {"role": "user", "content": "please answer"},
+            {"role": "assistant", "content": "the answer is 42"},
+        ]
+        response = service.GradeTrial(
+            pb2.GradeTrialRequest(
+                trial_id=_TRIAL_ID,
+                llm_messages_json=json.dumps(wire_messages),
+                termination_reason=TerminationReason.AGENT_DONE.value,
+            ),
+            MagicMock(),
+        )
+        assert response.success is True, f"composite leg failed: {response.error}"
+        return response.grade
+    finally:
+        service.shutdown()
+
+
+def test_judge_only_and_composite_llm_judge_only_agree_on_grade_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both paths produce the same ``binary_pass`` / ``score`` /
+    ``components.llm_judge`` under a fixed :class:`JudgeResult`.
+
+    Grade-shape parity — not full :meth:`Grade.__eq__` — because the two
+    paths compose their :attr:`Grade.reasons` and post-mortem fields
+    (``criterion_results``, ``judge_report``) through different code
+    (``build_replay_grade`` vs. the runner-side fold + ``compose_runner_trial_verdict``).
+    The scoring surface is what the umbrella cares about: two names of
+    the same dispatch must not silently produce different verdicts on
+    the constrained shape they collapse to.
+    """
+    fixed = _fixed_judge_result()
+
+    grade_a = _grade_path_a_judge_only(fixed, monkeypatch)
+    grade_b = _grade_path_b_composite(fixed, monkeypatch)
+
+    assert grade_a.binary_pass == grade_b.binary_pass
+    assert grade_a.score == pytest.approx(grade_b.score)
+    assert grade_a.components is not None
+    assert grade_a.components.llm_judge == pytest.approx(grade_b.components.llm_judge)
+
+
+def test_judge_only_equivalent_config_pins_composite_shape() -> None:
+    """The module-level equivalent-config constant equals the composite shape
+    ``judge_only`` collapses to. Locks the "one implementation, two names"
+    contract at the code layer without cross-file drift.
+    """
+    assert (
+        RunnerGradingConfig(
+            grading_method="composite",
+            weights={"llm_judge": 1.0},
+        )
+        == _JUDGE_ONLY_EQUIVALENT_CONFIG
+    )

--- a/tests/canonical/test_judge_only_composite_llm_judge_only_parity.py
+++ b/tests/canonical/test_judge_only_composite_llm_judge_only_parity.py
@@ -1,21 +1,21 @@
 """``judge_only`` grades a trajectory identically to composite ``weights: {llm_judge: 1.0}``.
 
-The umbrella wants ``judge_only`` (external) and ``composite + weights: {llm_judge:
-1.0}`` (external) to be two names for the same grading dispatch. This canonical
-gate locks that convergence at the ``Grade`` layer under the constrained-input
-shape both paths collapse to when a task declares an ``llm_judge`` rubric and
-nothing else — no ``state_checks``, no ``transcript_rules``, no ``trace_checks``,
-no ``custom_checks``, no ``search_policy`` KB plane, and an empty
-``initial_state``. On that shape, both paths reach :class:`LLMJudge` with
-byte-identical evidence: the composite's
+``judge_only`` and ``composite + weights: {llm_judge: 1.0}`` are two
+names for the same grading dispatch. This canonical gate locks that
+convergence at the ``Grade`` layer under the constrained-input shape
+both paths collapse to when a task declares an ``llm_judge`` rubric and
+nothing else — no ``state_checks``, no ``transcript_rules``, no
+``trace_checks``, no ``custom_checks``, no ``search_policy`` KB plane,
+and an empty ``initial_state``. On that shape, both paths reach
+:class:`LLMJudge` with byte-identical evidence: the composite's
 :func:`~tolokaforge.core.grading.composite.build_judge_state_diff` early-returns
 ``None`` on empty ``initial_state`` (matching ``judge_only``'s
 unconditional ``state_diff=None``); the substrate reads (``db_reader``,
 ``kb_search``, ``filesystem_root``) all resolve to the same
 "no live state" answers ``judge_only`` passes as ``None``; and
 ``extra_read_tools`` collapses to ``[]`` when no ``search_policy`` connector
-was reconstructed. Grade-shape parity across the two names is the property
-the umbrella cares about.
+was reconstructed. Grade-shape parity across the two names is the
+property this suite locks.
 
 Substitution shape (per plan): :meth:`LLMJudge.run` is monkey-patched on the
 class itself to return a fixed :class:`JudgeResult`. Both paths construct
@@ -196,9 +196,8 @@ def test_judge_only_and_composite_llm_judge_only_agree_on_grade_shape(
     paths compose their :attr:`Grade.reasons` and post-mortem fields
     (``criterion_results``, ``judge_report``) through different code
     (``build_replay_grade`` vs. the runner-side fold + ``compose_runner_trial_verdict``).
-    The scoring surface is what the umbrella cares about: two names of
-    the same dispatch must not silently produce different verdicts on
-    the constrained shape they collapse to.
+    Two names of the same dispatch must not silently produce different
+    verdicts on the constrained shape they collapse to.
     """
     fixed = _fixed_judge_result()
 

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -201,13 +201,13 @@ class TestGradingMethodErrorHandling:
     The value axis on ``grading_method`` is open — the pydantic model
     accepts any string so a downstream adapter can register its own
     dispatch under ``tolokaforge.grading_methods`` without a framework
-    PR. Rejection of unregistered values moves to ``RegisterTrial``,
+    PR. Rejection of unregistered values happens at ``RegisterTrial``,
     where the runner names both the offending key and the registered
     set; see ``tests/unit/test_register_trial_grading_method_registry.py``.
     """
 
     def test_grading_method_model_accepts_any_string_for_registry_widening(self):
-        """The pydantic model no longer gates the value axis — the registry does."""
+        """The pydantic model accepts any string — the registry gates the value axis."""
         cfg = RunnerGradingConfig(grading_method="terminal_bench_native")
         assert cfg.grading_method == "terminal_bench_native"
 

--- a/tests/unit/test_plugin_first_adapters.py
+++ b/tests/unit/test_plugin_first_adapters.py
@@ -196,14 +196,20 @@ class TestRunnerStaysAdapterAgnostic:
 
 
 class TestGradingMethodErrorHandling:
-    """Adapter-author-facing error paths: clear, actionable, non-silent."""
+    """Adapter-author-facing error paths: clear, actionable, non-silent.
 
-    def test_invalid_grading_method_string_is_rejected_by_the_model(self):
-        """Typos in ``grading_method`` are caught at validation, not silently ignored."""
-        from pydantic import ValidationError
+    The value axis on ``grading_method`` is open — the pydantic model
+    accepts any string so a downstream adapter can register its own
+    dispatch under ``tolokaforge.grading_methods`` without a framework
+    PR. Rejection of unregistered values moves to ``RegisterTrial``,
+    where the runner names both the offending key and the registered
+    set; see ``tests/unit/test_register_trial_grading_method_registry.py``.
+    """
 
-        with pytest.raises(ValidationError):
-            RunnerGradingConfig(grading_method="test-execution")  # hyphen — should be underscore
+    def test_grading_method_model_accepts_any_string_for_registry_widening(self):
+        """The pydantic model no longer gates the value axis — the registry does."""
+        cfg = RunnerGradingConfig(grading_method="terminal_bench_native")
+        assert cfg.grading_method == "terminal_bench_native"
 
     def test_test_execution_without_exec_tool_returns_actionable_error(self):
         """If an adapter asks for test-execution grading but ships no exec-capable

--- a/tests/unit/test_register_trial_grading_method_registry.py
+++ b/tests/unit/test_register_trial_grading_method_registry.py
@@ -1,20 +1,19 @@
 """``RegisterTrial`` refuses an unregistered ``grading.grading_method``.
 
-The wire model widened past its former closed ``Literal`` so a downstream
-adapter can register its own dispatch under ``tolokaforge.grading_methods``
-without a framework PR (see
-``tests/canonical/test_grading_methods_registry.py``). The safety net
-that used to live in the pydantic model moves to ``RegisterTrial``:
-every value crossing the wire must resolve against the entry-point
-registry, and an unknown name is refused with a message naming both the
-offending key and the registered set — matching the fail-loud shape
+The wire model accepts any string so a downstream adapter can register
+its own dispatch under ``tolokaforge.grading_methods`` without a
+framework PR (see ``tests/canonical/test_grading_methods_registry.py``).
+The safety net lives in ``RegisterTrial``: every value crossing the wire
+must resolve against the entry-point registry, and an unknown name is
+refused with a message naming both the offending key and the registered
+set — matching the fail-loud shape
 :func:`~tolokaforge.adapters.ensure_registered_adapter` sets for the
 adapter registry.
 
 The registered marker only asserts the name exists; runtime dispatch on
 :meth:`RunnerServiceImpl.GradeTrial` still branches on the wire string.
 An adapter that ships a marker but no matching branch would still hit
-the composite fold at grade time — that convergence is Phase C's job.
+the composite fold at grade time.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_register_trial_grading_method_registry.py
+++ b/tests/unit/test_register_trial_grading_method_registry.py
@@ -1,0 +1,99 @@
+"""``RegisterTrial`` refuses an unregistered ``grading.grading_method``.
+
+The wire model widened past its former closed ``Literal`` so a downstream
+adapter can register its own dispatch under ``tolokaforge.grading_methods``
+without a framework PR (see
+``tests/canonical/test_grading_methods_registry.py``). The safety net
+that used to live in the pydantic model moves to ``RegisterTrial``:
+every value crossing the wire must resolve against the entry-point
+registry, and an unknown name is refused with a message naming both the
+offending key and the registered set — matching the fail-loud shape
+:func:`~tolokaforge.adapters.ensure_registered_adapter` sets for the
+adapter registry.
+
+The registered marker only asserts the name exists; runtime dispatch on
+:meth:`RunnerServiceImpl.GradeTrial` still branches on the wire string.
+An adapter that ships a marker but no matching branch would still hit
+the composite fold at grade time — that convergence is Phase C's job.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.utils.runner_requests import register_request, trial_spec_json
+from tolokaforge.runner.service import RunnerServiceImpl
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def service(db_client: Any) -> Any:
+    impl = RunnerServiceImpl(db_client)
+    try:
+        yield impl
+    finally:
+        impl.shutdown()
+
+
+def _task(grading_method: str | None) -> dict[str, Any]:
+    task: dict[str, Any] = {
+        "task_id": "grading_method_gate",
+        "name": "grading_method_gate",
+        "category": "test",
+        "description": "Exercises the RegisterTrial registry gate on grading_method.",
+        "adapter_type": "native",
+        "system_prompt": "You are a test assistant.",
+        "initial_state": {"tables": {}, "schemas": []},
+        "agent_tools": [],
+        "user_tools": [],
+    }
+    if grading_method is not None:
+        task["grading"] = {"grading_method": grading_method}
+    return task
+
+
+def _register(service: Any, context: Any, trial_id: str, task: dict[str, Any]) -> Any:
+    return service.RegisterTrial(
+        register_request(trial_spec_json(task, trial_id=trial_id), trial_id=trial_id), context
+    )
+
+
+def test_register_trial_rejects_unknown_grading_method(
+    service: Any, mock_grpc_context: Any
+) -> None:
+    response = _register(
+        service, mock_grpc_context, "unknown:0", _task(grading_method="totally_unknown")
+    )
+
+    assert response.success is False
+    assert "totally_unknown" in response.error
+    assert "composite" in response.error
+    assert "test_execution" in response.error
+    assert "tolokaforge.grading_methods" in response.error
+
+
+def test_register_trial_accepts_known_grading_method(service: Any, mock_grpc_context: Any) -> None:
+    response = _register(
+        service, mock_grpc_context, "known:0", _task(grading_method="test_execution")
+    )
+
+    assert response.success is True, response.error
+
+
+def test_register_trial_accepts_composite_grading_method(
+    service: Any, mock_grpc_context: Any
+) -> None:
+    response = _register(
+        service, mock_grpc_context, "composite:0", _task(grading_method="composite")
+    )
+
+    assert response.success is True, response.error
+
+
+def test_register_trial_accepts_none_grading_method(service: Any, mock_grpc_context: Any) -> None:
+    response = _register(service, mock_grpc_context, "none:0", _task(grading_method=None))
+
+    assert response.success is True, response.error

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -126,6 +126,7 @@ RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",
+    "tolokaforge/core/grading/judge_only_helpers.py",
     "tolokaforge/core/grading/migration_declaration.py",
     "tolokaforge/core/grading/replay.py",
     "tolokaforge/core/grading/replay_layout.py",
@@ -164,7 +165,12 @@ adapter for the runner's ``SubstrateService`` — and ``core.grading.substrate_l
 — :class:`LiveRunnerCallbackGradingSubstrate` and its private gRPC helpers).
 The runner never instantiates them: they are the grader container's client
 side of the substrate seam, and shipping them inside the runner image would
-double-ship the compiled ``runner_pb2`` surface without a caller. The
+double-ship the compiled ``runner_pb2`` surface without a caller.
+``core.grading.judge_only_helpers`` is the orchestrator-side dispatch body
+the ``judge_only`` :class:`TrialGrader` delegates its per-trial run to — the
+runner never invokes it, and its imports reach the orchestrator-only
+``core.trial_grader`` (for :class:`GradingFailedError`) and the already-excluded
+``core.grading.replay`` (for :func:`build_replay_grade`). The
 remaining five (``core.grading.agreement``, ``core.grading.config_validation``,
 ``core.grading.replay_layout``, ``core.grading.unknown_keys``,
 ``core.llm.fallback_client``) have only

--- a/tolokaforge/core/grading/grading_method.py
+++ b/tolokaforge/core/grading/grading_method.py
@@ -1,0 +1,66 @@
+"""``GradingMethod`` — the runner-side dispatch-selector seam.
+
+One entry-point group, one marker Protocol: **which grading dispatch does
+the runner run for this trial?** ``RunnerGradingConfig.grading_method``
+carries a bare string; the runner resolves it against
+``tolokaforge.grading_methods`` at ``RegisterTrial`` time — unknown names
+fail loud there rather than running a trial that scores nothing. See
+``load_grading_method`` on ``tolokaforge.core.plugin_registry`` and the
+seam narrative in ``docs/GRADER_SERVICE.md`` § Extension points.
+
+Two built-in markers ship: :class:`CompositeGradingMethod` (the default
+state-checks / transcript-rules / trace-checks / llm-judge / custom-checks
+fold) and :class:`TestExecutionGradingMethod` (the reference-suite
+short-circuit at :meth:`RunnerServiceImpl._grade_via_test_execution`).
+A downstream adapter registers its own dispatch name by one entry-point
+line — no framework PR — under the same
+``[project.entry-points."tolokaforge.grading_methods"]`` block.
+
+The Protocol carries a single class attribute — ``NAME`` — so the marker
+is the shape a discovery-time typecheck can enforce. Runtime dispatch
+today still branches on the wire string at
+``RunnerServiceImpl.GradeTrial``; the registry is a validation +
+discovery surface only.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Protocol, runtime_checkable
+
+__all__ = [
+    "CompositeGradingMethod",
+    "GradingMethod",
+    "TestExecutionGradingMethod",
+]
+
+
+@runtime_checkable
+class GradingMethod(Protocol):
+    """Marker Protocol every ``tolokaforge.grading_methods`` entry resolves to.
+
+    Implementations are class-shaped — the entry-point resolves to the
+    class object itself, mirroring
+    :class:`~tolokaforge.core.grading.substrate.GradingSubstrate` from
+    ADR-0040. ``NAME`` MUST equal the entry-point name so a downstream
+    typo in ``pyproject.toml`` surfaces at discovery, not at grade time.
+    """
+
+    NAME: ClassVar[str]
+
+
+class CompositeGradingMethod:
+    """Marker for the default composite dispatch — the state-checks /
+    transcript-rules / trace-checks / llm-judge / custom-checks fold that
+    runs when ``grading.grading_method`` is ``"composite"`` or omitted
+    (``None``)."""
+
+    NAME: ClassVar[str] = "composite"
+
+
+class TestExecutionGradingMethod:
+    """Marker for the reference-suite dispatch —
+    :meth:`RunnerServiceImpl._grade_via_test_execution` short-circuits to
+    an exec-capable lifecycle tool that runs the pack's own tests and
+    reads the reward off disk."""
+
+    NAME: ClassVar[str] = "test_execution"

--- a/tolokaforge/core/grading/judge_only_helpers.py
+++ b/tolokaforge/core/grading/judge_only_helpers.py
@@ -1,0 +1,133 @@
+"""Pure helper the ``judge_only`` factory delegates its per-trial dispatch to.
+
+``run_judge_only_for_trajectory`` runs :class:`LLMJudge` against a trajectory
+with the constrained-input shape ``judge_only`` grades under — no
+``db_reader``, no ``kb_search``, no ``workspace_dir``, no ``state_diff``, no
+``extra_read_tools``. That constrained shape is the same one the
+runner-side composite path collapses to when a task declares
+``grading.grading_method = "composite"`` (or omits it) with
+``weights: {llm_judge: 1.0}`` and no state / transcript-rule / trace-check /
+custom-check / KB surface — so both paths route through this helper's
+:class:`LLMJudge` invocation with byte-identical inputs, and the parity
+gate at
+``tests/canonical/test_judge_only_composite_llm_judge_only_parity.py``
+locks that convergence.
+
+Callers resolve their own ``spec``-level fail-loud contract (a task
+without ``grading.llm_judge``, a run without ``models.judge``) before
+calling this helper: the helper receives already-non-``None``
+``llm_judge_config`` and ``judge_model_config`` and raises
+:class:`GradingFailedError` only on the failure modes the judge run
+itself surfaces (an ``ERRORED`` :class:`JudgeResult`). An empty
+trajectory returns ``None`` — the same "no evidence to judge against"
+answer the :class:`JudgeBackedTrialGrader` seam logs at the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from tolokaforge.core.grading.judge import LLMJudge
+from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
+from tolokaforge.core.grading.replay import build_replay_grade
+from tolokaforge.core.grading.transcript_wire import (
+    encode_transcript_wire,
+    split_leading_system_message,
+)
+
+if TYPE_CHECKING:
+    from tolokaforge.core.llm.client import LLMClient
+    from tolokaforge.core.logging import StructuredLogger
+    from tolokaforge.core.models import (
+        Grade,
+        LLMJudgeConfig,
+        ModelConfig,
+        Trajectory,
+    )
+    from tolokaforge.core.models.run_config import JudgeGraderConfig
+
+__all__ = [
+    "run_judge_only_for_trajectory",
+]
+
+
+def run_judge_only_for_trajectory(
+    *,
+    trial_id: str,
+    llm_judge_config: LLMJudgeConfig,
+    judge_model_config: ModelConfig,
+    trajectory: Trajectory,
+    agent_system_prompt: str,
+    override: JudgeGraderConfig | None,
+    llm_client: LLMClient | None,
+    logger: StructuredLogger,
+) -> Grade | None:
+    """Run :class:`LLMJudge` over ``trajectory`` and return the persistable Grade.
+
+    Encodes the trajectory through the same
+    :func:`encode_transcript_wire` + :func:`split_leading_system_message`
+    the replay path uses, so the transcript the judge sees is
+    byte-identical to the runner-side composite grading path.
+
+    Task customization is the base; a run-level ``override`` wins
+    per-field when the field is not ``None`` (see :class:`JudgeGraderConfig`
+    — the override cannot express "reset to library default").
+
+    ``llm_client`` is a test-only injection point that lands on
+    :class:`LLMJudge`; production callers pass ``None`` and the judge
+    builds its own client. Fail-loud contract: an
+    :attr:`JudgeStatus.ERRORED` verdict raises
+    :class:`~tolokaforge.core.trial_grader.GradingFailedError` — the
+    trial is ungradeable rather than an agent failure. Only a
+    ``COMPLETED`` verdict is translated through
+    :func:`build_replay_grade` into a persistable :class:`Grade`.
+    """
+    from tolokaforge.core.trial_grader import GradingFailedError
+
+    wire = encode_transcript_wire(trajectory, agent_system_prompt)
+    if wire is None:
+        return None
+    judge_agent_prompt, transcript = split_leading_system_message(json.loads(wire))
+
+    customization = llm_judge_config.customization
+    base_disable_kb = customization.disable_knowledge_search if customization else None
+    base_custom_prompt = customization.system_prompt if customization else None
+    base_include_agent = customization.include_agent_system_prompt if customization else None
+
+    disable_kb_resolved = (
+        override.disable_knowledge_search
+        if override is not None and override.disable_knowledge_search is not None
+        else base_disable_kb
+    )
+    custom_prompt = (
+        override.custom_system_prompt
+        if override is not None and override.custom_system_prompt is not None
+        else base_custom_prompt
+    )
+    include_agent_resolved = (
+        override.include_agent_system_prompt
+        if override is not None and override.include_agent_system_prompt is not None
+        else base_include_agent
+    )
+    judge = LLMJudge(
+        judge_model_config,
+        disable_knowledge_search=bool(disable_kb_resolved),
+        custom_system_prompt=custom_prompt,
+        include_agent_system_prompt=(
+            include_agent_resolved if include_agent_resolved is not None else True
+        ),
+        llm_client=llm_client,
+        logger=logger,
+    )
+    result = judge.run(
+        rubric=llm_judge_config.rubric,
+        agent_system_prompt=judge_agent_prompt,
+        transcript=transcript,
+    )
+    if result.status is JudgeRunStatus.ERRORED:
+        raise GradingFailedError(
+            f"judge_only grader errored for trial {trial_id!r}: "
+            f"{result.reasons or 'no reason recorded'}"
+        )
+    return build_replay_grade(result)

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -6,6 +6,7 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.conductor.Conductor`,
 :class:`~tolokaforge.core.service_readiness.ServiceReadinessProbe`,
 :class:`~tolokaforge.core.actors.turn_policy.TurnPolicy`,
+:class:`~tolokaforge.core.grading.grading_method.GradingMethod`,
 :class:`~tolokaforge.core.grading.substrate.GradingSubstrate`,
 :class:`~tolokaforge.core.grading.check_runner.CheckExecutor`,
 :class:`~tolokaforge.core.grading.judge_model_provider.JudgeModelProvider`,
@@ -37,6 +38,7 @@ The groups:
 * ``tolokaforge.conductors`` → :data:`~tolokaforge.core.conductor.ConductorFactory`
 * ``tolokaforge.service_readiness_probes`` → :data:`ReadinessProbeFactory`
 * ``tolokaforge.turn_policies`` → :data:`TurnPolicyFactory`
+* ``tolokaforge.grading_methods`` → ``type[GradingMethod]``
 * ``tolokaforge.grading_substrates`` → ``type[GradingSubstrate]``
 * ``tolokaforge.custom_check_executors`` → :data:`CustomCheckExecutorFactory`
 * ``tolokaforge.judge_model_providers`` → :data:`JudgeModelProviderFactory`
@@ -68,6 +70,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from tolokaforge.core.grading.check_runner import CheckExecutor
+from tolokaforge.core.grading.grading_method import GradingMethod
 from tolokaforge.core.grading.judge_model_provider import JudgeModelProviderFactory
 from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorFactory
 from tolokaforge.core.grading.state_check_backend import StateCheckBackendFactory
@@ -120,6 +123,7 @@ __all__ = [
     "UnknownImplementationError",
     "available_conductors",
     "available_custom_check_executors",
+    "available_grading_methods",
     "available_grading_substrates",
     "available_judge_model_providers",
     "available_readiness_probes",
@@ -133,6 +137,7 @@ __all__ = [
     "discover_entry_points",
     "load_conductor",
     "load_custom_check_executor",
+    "load_grading_method",
     "load_grading_substrate",
     "load_judge_model_provider",
     "load_readiness_probe",
@@ -150,6 +155,7 @@ TRIAL_GRADERS_GROUP = "tolokaforge.trial_graders"
 CONDUCTORS_GROUP = "tolokaforge.conductors"
 SERVICE_READINESS_PROBES_GROUP = "tolokaforge.service_readiness_probes"
 TURN_POLICIES_GROUP = "tolokaforge.turn_policies"
+GRADING_METHODS_GROUP = "tolokaforge.grading_methods"
 GRADING_SUBSTRATES_GROUP = "tolokaforge.grading_substrates"
 CUSTOM_CHECK_EXECUTORS_GROUP = "tolokaforge.custom_check_executors"
 JUDGE_MODEL_PROVIDERS_GROUP = "tolokaforge.judge_model_providers"
@@ -448,6 +454,23 @@ def load_trace_check_operator(name: str) -> TraceCheckOperator:
     return cast(TraceCheckOperator, _load(TRACE_CHECK_OPERATORS_GROUP, name))
 
 
+def load_grading_method(name: str) -> type[GradingMethod]:
+    """Resolve a registered grading-method name to its marker class.
+
+    Returns the class object itself, matching :func:`load_grading_substrate`:
+    a downstream method registers the class it defined, and the runner
+    reads ``NAME`` off it to spot pyproject typos at discovery. Runtime
+    dispatch today branches on the wire string
+    (:meth:`RunnerServiceImpl.GradeTrial`); this loader is a validation +
+    discovery surface, called at ``RegisterTrial`` to refuse an unknown
+    ``grading.grading_method`` before the runner spends a trial on it.
+
+    Fail-loud on unknown names via :class:`UnknownImplementationError`,
+    matching every other loader in this module.
+    """
+    return cast(type[GradingMethod], _load(GRADING_METHODS_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -488,6 +511,11 @@ def available_readiness_probes() -> list[str]:
 def available_turn_policies() -> list[str]:
     """Sorted names registered in the ``tolokaforge.turn_policies`` group."""
     return sorted(discover_entry_points(TURN_POLICIES_GROUP))
+
+
+def available_grading_methods() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.grading_methods`` group."""
+    return sorted(discover_entry_points(GRADING_METHODS_GROUP))
 
 
 def available_grading_substrates() -> list[str]:

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -43,13 +43,8 @@ from pydantic import ValidationError
 
 from tolokaforge.core.failure_attribution import TrialOutcomeClass, classify_trial_outcome
 from tolokaforge.core.grading.grade_components import GRADE_COMPONENTS
-from tolokaforge.core.grading.judge import LLMJudge
-from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
-from tolokaforge.core.grading.replay import build_replay_grade
-from tolokaforge.core.grading.transcript_wire import (
-    encode_transcript_wire,
-    split_leading_system_message,
-)
+from tolokaforge.core.grading.judge_only_helpers import run_judge_only_for_trajectory
+from tolokaforge.core.grading.transcript_wire import encode_transcript_wire
 from tolokaforge.core.models import (
     CriterionResult,
     CustomCheckDetail,
@@ -65,8 +60,10 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
 )
+from tolokaforge.core.plugin_registry import load_grading_method
 from tolokaforge.core.trial import TrialSpec
 from tolokaforge.grader.wire_snapshot import build_grade_request_fields
+from tolokaforge.runner.models import RunnerGradingConfig
 
 if TYPE_CHECKING:
     from tolokaforge.core.llm.client import LLMClient
@@ -1167,6 +1164,21 @@ def _queue_worker_loop(
         broker.publish_result(GradeResult(job_id=job.job_id, grade=grade, error=error))
 
 
+_JUDGE_ONLY_EQUIVALENT_CONFIG = RunnerGradingConfig(
+    grading_method="composite",
+    weights={"llm_judge": 1.0},
+)
+"""The composite dispatch shape ``judge_only`` is equivalent to.
+
+Pinned as a module constant so the parity gate at
+``tests/canonical/test_judge_only_composite_llm_judge_only_parity.py``
+can assert both paths agree on the same
+:class:`~tolokaforge.runner.models.RunnerGradingConfig` at the config
+layer. A future rename of either name reds the parity test at the config
+layer before it reaches the grade-shape assertion.
+"""
+
+
 def judge_backed_trial_grader_factory(
     ctx: TrialGraderContext,
     *,
@@ -1176,36 +1188,33 @@ def judge_backed_trial_grader_factory(
 
     Reads the run-level ``grader.judge`` overrides (or the task's own
     ``grading.llm_judge.customization`` when no override is set) and
-    produces a :data:`JudgeGradeFn` that on each call:
-
-    1. Reads the task's rubric from ``spec.task.grading.llm_judge.rubric``.
-    2. Reads the judge model from ``spec.judge_model_config`` (which
-       rides the run config's ``models["judge"]``).
-    3. Encodes the trajectory + agent policy through the same
-       :func:`encode_transcript_wire` + :func:`split_leading_system_message`
-       replay uses, so the transcript the judge sees is byte-identical
-       to the runner-side grading path.
-    4. Runs :class:`LLMJudge` with rubric + transcript only — no
-       ``db_reader`` / ``kb_search`` / ``workspace_dir`` / ``state_diff``,
-       because ``judge_only`` grades trajectories after the trial ended
-       and holds no live substrate state.
-    5. Raises :class:`GradingFailedError` on an ``ERRORED`` judge run —
-       the fail-loud contract that trial_grader.py's ``GradingFailedError``
-       docstring names. A judge malfunction MUST NOT be booked as an
-       agent failure; the seam records ``grading_error`` and leaves the
-       grade unset. Only a ``COMPLETED`` verdict is translated through
-       :func:`build_replay_grade` into a persistable :class:`Grade`.
+    routes the per-trial dispatch through
+    :func:`~tolokaforge.core.grading.judge_only_helpers.run_judge_only_for_trajectory`
+    — the same pure helper the runner-side composite path reaches when a
+    task declares ``grading.grading_method = "composite"`` with
+    ``weights: {llm_judge: 1.0}`` and no state / transcript-rule /
+    trace-check / custom-check / KB surface. The equivalence is pinned
+    by :data:`_JUDGE_ONLY_EQUIVALENT_CONFIG` and the byte-parity gate at
+    ``tests/canonical/test_judge_only_composite_llm_judge_only_parity.py``.
 
     Failure surface at grade time (not factory time — the same factory
     serves both rubric-carrying and rubric-less tasks in one run, so
     per-task decisions belong at dispatch): a task with no
     ``grading.llm_judge`` block, and a run with no ``models["judge"]``.
-    Both surface as :class:`GradingFailedError` naming the trial.
+    Both surface as :class:`GradingFailedError` naming the trial. An
+    ``ERRORED`` judge result surfaces the same way from the helper.
+
+    Fail-loud at factory time: :func:`load_grading_method` resolves the
+    ``composite`` marker so a misconfigured install (missing the
+    ``tolokaforge.grading_methods`` entry-point group) surfaces here
+    rather than at grade time.
 
     ``llm_client`` is a test-only injection point mirroring
     :func:`~tolokaforge.core.grading.replay.replay_trial`; production
     callers leave it ``None`` and the judge builds its own client.
     """
+    load_grading_method("composite")
+
     override = ctx.grader_config.judge if ctx.grader_config else None
     logger = ctx.logger
 
@@ -1222,69 +1231,15 @@ def judge_backed_trial_grader_factory(
                 "config declares no models.judge; add one, or select a "
                 "grader that does not need a judge model."
             )
-
-        wire = encode_transcript_wire(trajectory, agent_system_prompt)
-        if wire is None:
-            # Empty trajectory with no policy — no evidence to judge
-            # against. ``JudgeBackedTrialGrader.grade`` logs the
-            # ``None`` verdict at the seam.
-            return None
-        judge_agent_prompt, transcript = split_leading_system_message(json.loads(wire))
-
-        # Task customization is the base; the run-level override wins
-        # per-field when it is not ``None``. The override cannot express
-        # "reset to library default" — see :class:`JudgeGraderConfig`.
-        customization = llm_judge_config.customization
-        base_disable_kb = customization.disable_knowledge_search if customization else None
-        base_custom_prompt = customization.system_prompt if customization else None
-        base_include_agent = customization.include_agent_system_prompt if customization else None
-
-        disable_kb_resolved = (
-            override.disable_knowledge_search
-            if override is not None and override.disable_knowledge_search is not None
-            else base_disable_kb
-        )
-        custom_prompt = (
-            override.custom_system_prompt
-            if override is not None and override.custom_system_prompt is not None
-            else base_custom_prompt
-        )
-        include_agent_resolved = (
-            override.include_agent_system_prompt
-            if override is not None and override.include_agent_system_prompt is not None
-            else base_include_agent
-        )
-        # LLMJudge's own defaults for the two bool knobs are
-        # ``disable_knowledge_search=False`` and
-        # ``include_agent_system_prompt=True``; collapse the tri-state
-        # here so both fields resolve consistently (the reviewer flagged
-        # an asymmetry where one collapsed via ``bool()`` and the other
-        # kept the tri-state).
-        judge = LLMJudge(
-            spec.judge_model_config,
-            disable_knowledge_search=bool(disable_kb_resolved),
-            custom_system_prompt=custom_prompt,
-            include_agent_system_prompt=(
-                include_agent_resolved if include_agent_resolved is not None else True
-            ),
+        return run_judge_only_for_trajectory(
+            trial_id=spec.trial_id,
+            llm_judge_config=llm_judge_config,
+            judge_model_config=spec.judge_model_config,
+            trajectory=trajectory,
+            agent_system_prompt=agent_system_prompt,
+            override=override,
             llm_client=llm_client,
             logger=logger,
         )
-        result = judge.run(
-            rubric=llm_judge_config.rubric,
-            agent_system_prompt=judge_agent_prompt,
-            transcript=transcript,
-        )
-        # Fail-loud contract: an ERRORED judge is a grading failure the
-        # trial is ungradeable under, never a booked agent failure. The
-        # ``JudgeBackedTrialGrader.grade`` caller catches nothing here;
-        # the seam's ``GradingFailedError`` surface is what carries the
-        # verdict-of-nothing forward.
-        if result.status is JudgeRunStatus.ERRORED:
-            raise GradingFailedError(
-                f"judge_only grader errored for trial {spec.trial_id!r}: "
-                f"{result.reasons or 'no reason recorded'}"
-            )
-        return build_replay_grade(result)
 
     return JudgeBackedTrialGrader(judge_fn=judge_fn, logger=ctx.logger)

--- a/tolokaforge/runner/models.py
+++ b/tolokaforge/runner/models.py
@@ -2057,22 +2057,14 @@ class RunnerGradingConfig(BaseModel):
         return validate_combine_method(value, context="TaskDescription grading.combine_method")
 
     # Declarative grading dispatch — adapters tell the runner *how* to grade in data,
-    # so the runner never infers it from the adapter's identity.
-    #
-    # Values:
-    #   ``None`` (default)
-    #     Standard grading: combine state checks / transcript rules / LLM judge
-    #     using ``weights`` and ``pass_threshold``. Most adapters want this.
-    #   ``"test_execution"``
-    #     Run a reference test suite inside the trial env via an exec-capable
-    #     lifecycle tool (today: ``DockerComposeExecToolWrapper``) and score by
-    #     reading the reward written to ``/logs/verifier/reward.txt``. Requires
-    #     such a tool to be present in ``TaskDescription.agent_tools`` — without
-    #     one the runner returns a clear error at ``GradeTrial`` time.
-    #   ``"hash"`` / ``"transcript"`` / ``"llm"``
-    #     Reserved names for future single-method dispatch; not currently used
-    #     for dispatch (today their behaviour is part of the default path).
-    grading_method: Literal["hash", "test_execution", "transcript", "llm"] | None = None
+    # so the runner never infers it from the adapter's identity. The registered
+    # names live in the ``tolokaforge.grading_methods`` entry-point group
+    # (:mod:`tolokaforge.core.grading.grading_method`); read the current set with
+    # :func:`~tolokaforge.core.plugin_registry.available_grading_methods`.
+    # ``None`` (the default) picks the composite dispatch — same as
+    # ``"composite"``. Unknown names are refused at ``RegisterTrial`` with an
+    # error naming both the offending key and the registered set.
+    grading_method: str | None = None
 
     state_checks: RunnerStateChecksConfig | None = None
     transcript_rules: TranscriptRulesConfig | None = None

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -78,7 +78,10 @@ from tolokaforge.core.models import (
     TerminationReason,
 )
 from tolokaforge.core.plugin_registry import (
+    UnknownImplementationError,
+    available_grading_methods,
     load_custom_check_executor,
+    load_grading_method,
     load_judge_model_provider,
     load_rubric_evaluator,
     load_state_check_backend,
@@ -874,6 +877,25 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             )
 
         task_description = trial_spec.task
+
+        # Reject an unregistered ``grading.grading_method`` before any tool
+        # artifacts land on disk — cheapest schema failure first, no cleanup
+        # path to walk on refusal. Registered names live in
+        # ``tolokaforge.grading_methods``; an unknown value would either
+        # short-circuit to nothing (dispatch reads a bare string at
+        # ``GradeTrial``) or silently run the composite path.
+        method_name = task_description.grading.grading_method
+        if method_name is not None:
+            try:
+                load_grading_method(method_name)
+            except UnknownImplementationError:
+                error = (
+                    f"Unknown grading_method {method_name!r}; registered methods: "
+                    f"{available_grading_methods()}. Add an entry to the "
+                    "tolokaforge.grading_methods group or fix the typo."
+                )
+                logger.error(f"RegisterTrial: {trial_id} - {error}")
+                return pb2.RegisterTrialResponse(success=False, error=error)
 
         # Extract tool artifacts to temp directory if present
         artifacts_dir = None


### PR DESCRIPTION
## Summary

- Ships `tolokaforge.grading_methods` entry-point registry — marker `GradingMethod` Protocol + two built-in entries (`composite`, `test_execution`). Mirrors ADR-0040's substrate seam pattern shape-for-shape.
- Widens `RunnerGradingConfig.grading_method` from `Literal["hash", "test_execution", "transcript", "llm"] | None` to `str | None`. Value-axis validation moves from pydantic to `RunnerServiceImpl.RegisterTrial` — unknown keys fail loud naming the offending value, the registered set, and the entry-point group.
- Retires 3 reserved reserved names (`hash`, `transcript`, `llm`) — never emitted, never dispatched. CHANGELOG names them explicitly.
- Refactors `judge_only` `TrialGrader` factory onto a shared helper `run_judge_only_for_trajectory`. `judge_only` and `composite + weights: {llm_judge: 1.0}` route through the helper — one implementation, two names. External surface (entry-point, class, config field, task-pack usage) unchanged.
- New canonical byte-parity test locks `Grade` equivalence across the two names via class-level `LLMJudge.run` monkeypatch (the only substitution approach that reaches both paths since composite's `LLMJudgeRubricEvaluator.evaluate` passes 5 substrate-derived kwargs that `judge_only` doesn't).

## Design choices

- **Marker Protocol** (`type[GradingMethod]` with `NAME: ClassVar[str]`) — minimum blast radius; shape parity with `type[GradingSubstrate]` from ADR-0040. Phase C's #1358 can extend to a real `dispatch()` method when runtime dispatch moves through the registry.
- **Registry is validation-only this ticket.** Runner dispatch at `service.py:1729` still branches on `grading_method == \"test_execution\"`. Phase C's #1358 moves dispatch through the registry.
- **Fail-loud placement pinned** (per critic round 1): immediately after `TrialSpec.model_validate_json` at `service.py:868` and BEFORE `_extract_tool_artifacts` at `:880`. Cheapest failure first; no `_cleanup_trial_artifacts` needed.
- **`LLMJudge.run` monkeypatch** for the parity test (per critic round 1): `llm_client=` injection does NOT bypass the substrate-kwarg divergence because LLMJudge builds its tool list around `db_reader` truthiness before the injected client is called. Only class-level `LLMJudge.run` patching reaches both paths.
- **`judge_only` external surface preserved**: entry-point, class name, config field, task-pack usage all unchanged. Internal refactor only. `_JUDGE_ONLY_EQUIVALENT_CONFIG = RunnerGradingConfig(grading_method=\"composite\", weights={\"llm_judge\": 1.0})` module constant documents the equivalence at the config layer.
- **`grading_methods` and `grader_kinds` are distinct registries this ticket.** `preferred_grader_kind()` (from #1339) points at `tolokaforge.grader_kinds` — a Phase C group. Vocabulary alignment deferred to #1358.

## Concepts introduced

- **`tolokaforge.grading_methods`** entry-point registry — the eighth plug-in seam. New Protocol `GradingMethod` (`@runtime_checkable`, `NAME: ClassVar[str]` marker), new loader `load_grading_method(name) -> type[GradingMethod]`, new listing `available_grading_methods() -> list[str]`.
- **`run_judge_only_for_trajectory`** helper — the shared dispatch body `judge_only` factory and (via the equivalence pin) `composite + weights: {llm_judge: 1.0}` both route through.

## Plan

Full plan at `~/.claude/plans/toloka-tolokaforge/issue-1344-grading-methods-registry.md`.

**Discovery from planning:** ticket premise cited `models.py:1931` and `Literal[\"composite\", \"test_execution\"]`. Actual: `models.py:2075` and `Literal[\"hash\", \"test_execution\", \"transcript\", \"llm\"] | None`. Plan reconciled by retiring the 3 never-emitted reserved names + adding `composite` as an explicit value alongside `test_execution`.

**Non-goals** (owned by follow-ups):
- Do NOT move runner dispatch through the registry (Phase C #1358).
- Do NOT reconcile `grading_methods` vs `grader_kinds` vocabulary (Phase C #1358).
- Do NOT change `judge_only`'s external surface.

**Stage 1** (`b2c7edd4`): registry + widening + fail-loud gate + docs + 6 new tests (2 canonical registry + 2 unit RegisterTrial + wire-lock update + pydantic-rejection retirement).
**Stage 2** (`4d405630`): extracted `run_judge_only_for_trajectory` helper (~130 LOC); slimmed factory closure by ~50 LOC. Added `_JUDGE_ONLY_EQUIVALENT_CONFIG` module constant + factory-time `load_grading_method(\"composite\")` gate. Docs updated. 3 new canonical tests (2 parity + 1 factory-level equivalence lock).
**Fix commit** (`fb53dcc8`): applied round-1 hygiene REQUEST-CHANGES — 8 §7a docstring rewrites + CHANGELOG `## [Unreleased] / ### Removed` block naming the three retired literals explicitly.

**Approved decisions** (in plan `## Approved decisions`):
- Unregister 3 reserved names + fail loud at `RegisterTrial`.
- Marker Protocol shape.
- 2 stages.
- `grading_methods` / `grader_kinds` distinct this ticket.
- `LLMJudge.run` monkeypatch (not `llm_client=`).

## Discovered issues

- **Filed as follow-ups**: to be filed at merge — `preferred_grader_kind()` ↔ `grading_methods` vocabulary alignment (blocks Phase C #1358).
- **Fixed in this PR**: None.
- **Advisory**: pre-existing `ruff format ↔ black` conflict on `tests/unit/test_plugin_first_adapters.py:223-231` (assert-continuation shape). Pre-commit's `black` wins deterministically; not gating.

## Test plan

- [x] Byte-parity 10-pack canonical gate: 25 passed (untouched).
- [x] New canonical registry + parity tests: 24 passed.
- [x] `judge_only` factory tests continue byte-identical green (15/15).
- [x] Import-linter green; ruff format + lint clean on touched paths.
- [x] Full canonical + unit lanes clean.
- [ ] Post-merge: `feat/grader-v3` remains green.

Closes #1344