### PR TITLE
test(adapters): reusable AdapterGradingContractSuite + Native + terminal-bench subclasses + CI wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,15 @@ jobs:
           fi
         done
 
+    - name: Run external adapter tests
+      run: |
+        for adapter_dir in external_adapters/*/; do
+          if [ -d "${adapter_dir}tests" ]; then
+            echo "=== Testing ${adapter_dir} ==="
+            (cd "${adapter_dir}" && uv run pytest tests/ -v --tb=short -p no:cacheprovider) || exit 1
+          fi
+        done
+
     - name: Validate public example suites
       run: |
         uv run tolokaforge validate --tasks "examples/native/*/dataset/**/task.yaml"
@@ -301,6 +310,15 @@ jobs:
           if [ -d "${tool_dir}tests" ]; then
             echo "=== Testing ${tool_dir} ==="
             (cd "${tool_dir}" && uv run pytest tests/ -v --tb=short -p no:cacheprovider) || exit 1
+          fi
+        done
+
+    - name: Run external adapter tests
+      run: |
+        for adapter_dir in external_adapters/*/; do
+          if [ -d "${adapter_dir}tests" ]; then
+            echo "=== Testing ${adapter_dir} ==="
+            (cd "${adapter_dir}" && uv run pytest tests/ -v --tb=short -p no:cacheprovider) || exit 1
           fi
         done
 

--- a/docs/ADAPTER_INTERFACE.md
+++ b/docs/ADAPTER_INTERFACE.md
@@ -223,6 +223,29 @@ without changing shape. External adapters can import it for a
 optional — the harness reaches through the slots directly, not through the
 Protocol.
 
+#### AdapterGradingContractSuite (reusable pytest suite)
+
+`tolokaforge.testing.adapters.AdapterGradingContractSuite` pins one
+adapter's conformance against the contract in 11 test methods (six method
+slots, three capability flags, emit-payload schema, preferred-kind
+registry resolution). Subclass, provide two fixtures, and (optionally)
+override four class attributes when the adapter's declaration diverges
+from the shipped default:
+
+- `adapter` (fixture) → constructed adapter instance.
+- `task_and_dir` (fixture) → `tuple[TaskConfig, Path]` the adapter can
+  resolve.
+- `expected_requires_docker_cli_in_runner: bool = False`
+- `expected_grades_from_task_grading_file: bool = False`
+- `expected_syncs_adapter_env_to_state: bool = False`
+- `expected_preferred_grader_kind: str = "composite"`
+
+Reference subclasses:
+`tests/canonical/test_native_adapter_grading_contract.py::TestNativeAdapterGradingContract`
+(in-tree) and
+`external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py::TestTerminalBenchAdapterGradingContract`
+(third-party adopter pattern).
+
 ## Lifecycle Expectations
 
 1. Discovery: enumerate tasks deterministically.

--- a/external_adapters/tolokaforge-adapter-terminal-bench/tests/conftest.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Adapter-package pytest configuration.
+
+Kept as a boundary marker: the reusable
+:class:`~tolokaforge.testing.adapters.AdapterGradingContractSuite` needs no
+shared fixtures beyond the two the subclass supplies. A later suite that does
+declares its ``pytest_plugins`` here.
+"""

--- a/external_adapters/tolokaforge-adapter-terminal-bench/tests/conftest.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/tests/conftest.py
@@ -1,7 +1,0 @@
-"""Adapter-package pytest configuration.
-
-Kept as a boundary marker: the reusable
-:class:`~tolokaforge.testing.adapters.AdapterGradingContractSuite` needs no
-shared fixtures beyond the two the subclass supplies. A later suite that does
-declares its ``pytest_plugins`` here.
-"""

--- a/external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py
@@ -1,0 +1,42 @@
+""":class:`TerminalBenchAdapter` pinned against the reusable grading-contract suite.
+
+``requires_docker_cli_in_runner`` is the only capability flag that flips off
+the shipped default (the mixin declares ``True`` at
+``adapter.py:158``); the other two flags and the preferred grader kind
+inherit the base ``False`` / ``"composite"`` defaults. ``task_and_dir`` reuses
+the real shipped pack at ``examples/terminal_bench/fix-airline-segmentation/``
+— canonical ``{task.yaml, docker-compose.yaml, tests/}`` shape
+:meth:`TerminalBenchAdapter.get_task_ids` walks. The reader assertions only
+parse the pack on disk (no runner spin-up).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
+
+from tolokaforge.core.models import TaskConfig
+from tolokaforge.testing.adapters import AdapterGradingContractSuite
+
+_TERMINAL_BENCH_DIR = Path(__file__).resolve().parents[3] / "examples" / "terminal_bench"
+_TASK_ID = "fix-airline-segmentation"
+
+
+class TestTerminalBenchAdapterGradingContract(AdapterGradingContractSuite):
+    expected_requires_docker_cli_in_runner = True
+
+    @pytest.fixture
+    def adapter(self) -> TerminalBenchAdapter:
+        return TerminalBenchAdapter(
+            {
+                "terminal_bench_dir": str(_TERMINAL_BENCH_DIR),
+                "task_ids": [_TASK_ID],
+                "prebuild_images": False,
+            }
+        )
+
+    @pytest.fixture
+    def task_and_dir(self, adapter: TerminalBenchAdapter) -> tuple[TaskConfig, Path]:
+        return adapter.get_task(_TASK_ID), adapter.get_task_dir(_TASK_ID)

--- a/external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/tests/test_terminal_bench_grading_contract.py
@@ -1,11 +1,11 @@
 """:class:`TerminalBenchAdapter` pinned against the reusable grading-contract suite.
 
 ``requires_docker_cli_in_runner`` is the only capability flag that flips off
-the shipped default (the mixin declares ``True`` at
-``adapter.py:158``); the other two flags and the preferred grader kind
-inherit the base ``False`` / ``"composite"`` defaults. ``task_and_dir`` reuses
-the real shipped pack at ``examples/terminal_bench/fix-airline-segmentation/``
-— canonical ``{task.yaml, docker-compose.yaml, tests/}`` shape
+the shipped default (:class:`TerminalBenchAdapter` sets it ``True``); the
+other two flags and the preferred grader kind inherit the base ``False`` /
+``"composite"`` defaults. ``task_and_dir`` reuses the real shipped pack at
+``examples/terminal_bench/fix-airline-segmentation/`` — canonical
+``{task.yaml, docker-compose.yaml, tests/}`` shape
 :meth:`TerminalBenchAdapter.get_task_ids` walks. The reader assertions only
 parse the pack on disk (no runner spin-up).
 """

--- a/tests/canonical/test_grading_contract_suite_self_check.py
+++ b/tests/canonical/test_grading_contract_suite_self_check.py
@@ -1,0 +1,147 @@
+"""Both branches of the emit-payload schema check on the reusable suite fire.
+
+The two shipping adapters (Native, terminal-bench) both inherit the default
+empty payload, so the non-empty branch of the suite's schema check would be
+dead code without a subject that exercises it. A ``pytester`` in-process
+session drops a synthetic subclass in a tmpdir and runs the suite against
+two fake adapters — one returning ``{}`` (empty-payload short-circuit skips
+the check) and one returning the ``test_execution`` payload
+:meth:`~tolokaforge_coding_harnesses.adapter_support.CodingHarnessAdapterMixin.emit_test_execution_grading`
+emits (schema check runs and passes).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+
+_SUITE_SUBCLASS_SOURCE = '''
+"""Synthetic subclasses exercising both branches of the emit-payload check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.adapters._task_loader import GradingSource, GradingSourceKind
+from tolokaforge.core.grading.config_validation import (
+    ReplayWorld,
+    SeededTablesLayer,
+    ToolInventory,
+)
+from tolokaforge.core.models import TaskConfig, InitialStateConfig
+from tolokaforge.testing.adapters import AdapterGradingContractSuite
+
+
+class _FakeAdapterBase:
+    """Structural stand-in for a real adapter — resolves every grading-contract slot."""
+
+    requires_docker_cli_in_runner = False
+    grades_from_task_grading_file = False
+    syncs_adapter_env_to_state = False
+
+    def grading_source(self, task, task_dir):
+        return GradingSource(
+            kind=GradingSourceKind.UNINTERROGABLE,
+            path=None,
+            reason="synthetic adapter for suite self-check",
+        )
+
+    def grading_tool_inventory(self, task, task_dir):
+        return ToolInventory.unresolvable()
+
+    def grading_replay_world(self, task, task_dir):
+        return ReplayWorld.unresolvable()
+
+    def grading_seeded_tables(self, task, task_dir):
+        return SeededTablesLayer.unresolvable()
+
+    def preferred_grader_kind(self):
+        return "composite"
+
+
+class _FakeAdapterEmptyPayload(_FakeAdapterBase):
+    def emit_runner_grading_payload(self, task_id):
+        return {}
+
+
+class _FakeAdapterNonEmptyPayload(_FakeAdapterBase):
+    def emit_runner_grading_payload(self, task_id):
+        return {
+            "combine_method": "weighted",
+            "weights": {"custom_checks": 1.0},
+            "pass_threshold": 0.5,
+            "grading_method": "test_execution",
+        }
+
+
+def _a_synthetic_task():
+    task = TaskConfig(
+        task_id="synthetic_task",
+        description="synthetic task for suite self-check",
+        initial_state=InitialStateConfig(),
+    )
+    return task, Path("/nonexistent-task-dir-suite-self-check")
+
+
+class TestEmptyPayloadShortCircuits(AdapterGradingContractSuite):
+    @pytest.fixture
+    def adapter(self):
+        return _FakeAdapterEmptyPayload()
+
+    @pytest.fixture
+    def task_and_dir(self):
+        return _a_synthetic_task()
+
+
+class TestNonEmptyPayloadValidates(AdapterGradingContractSuite):
+    @pytest.fixture
+    def adapter(self):
+        return _FakeAdapterNonEmptyPayload()
+
+    @pytest.fixture
+    def task_and_dir(self):
+        return _a_synthetic_task()
+'''
+
+
+def test_both_branches_of_the_emit_payload_schema_check_fire(
+    pytester: pytest.Pytester,
+) -> None:
+    """Drop the synthetic subclasses in a tmpdir, run pytest against them, and
+    read the outcome: empty-payload branch skips the schema check, non-empty
+    branch runs it and passes."""
+    pytester.makepyfile(test_suite_self_check=_SUITE_SUBCLASS_SOURCE)
+
+    result = pytester.runpytest("-v", "--no-header", "-p", "no:cacheprovider")
+
+    assert result.ret == 0, (
+        "the synthetic subclasses failed under the reusable suite: "
+        f"exit={result.ret}, stdout tail={result.stdout.lines[-40:]!r}"
+    )
+
+    outcomes = result.parseoutcomes()
+    assert outcomes.get("passed", 0) >= 21, (
+        f"expected the two subclasses' 11 test methods each to run (~22 total), "
+        f"got outcomes={outcomes!r}"
+    )
+    assert outcomes.get("skipped", 0) == 1, (
+        f"expected exactly one skip — the empty-payload branch of the schema "
+        f"check on TestEmptyPayloadShortCircuits — got outcomes={outcomes!r}"
+    )
+
+    result.stdout.fnmatch_lines(
+        [
+            "*TestEmptyPayloadShortCircuits*"
+            "test_emit_runner_grading_payload_constructs_a_valid_runner_grading_config*SKIPPED*",
+        ]
+    )
+    result.stdout.fnmatch_lines(
+        [
+            "*TestNonEmptyPayloadValidates*"
+            "test_emit_runner_grading_payload_constructs_a_valid_runner_grading_config*PASSED*",
+        ]
+    )

--- a/tests/canonical/test_native_adapter_grading_contract.py
+++ b/tests/canonical/test_native_adapter_grading_contract.py
@@ -1,0 +1,35 @@
+""":class:`NativeAdapter` pinned against the reusable grading-contract suite.
+
+Every capability flag and preferred grader kind inherits the shipped default,
+so this file overrides only the two fixtures the base declares abstract. The
+task under test is a real pack shipped in ``examples/native/``; the reader
+methods only parse the pack on disk (no runner spin-up).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.adapters import NativeAdapter
+from tolokaforge.adapters._task_loader import load_task_yaml
+from tolokaforge.core.models import TaskConfig
+from tolokaforge.testing.adapters import AdapterGradingContractSuite
+
+pytestmark = pytest.mark.canonical
+
+_A_REAL_TASK = (
+    Path(__file__).resolve().parents[2]
+    / "examples/native/multi_service_helpdesk_workflow/dataset/tasks/helpdesk_01/task.yaml"
+)
+
+
+class TestNativeAdapterGradingContract(AdapterGradingContractSuite):
+    @pytest.fixture
+    def adapter(self, tmp_path: Path) -> NativeAdapter:
+        return NativeAdapter({"base_dir": str(tmp_path), "tasks_glob": "**/task.yaml"})
+
+    @pytest.fixture
+    def task_and_dir(self) -> tuple[TaskConfig, Path]:
+        return load_task_yaml(_A_REAL_TASK)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,7 @@ from tolokaforge.core.llm.presets import set_overlay_path
 pytest_plugins = ["pytester"]
 """``pytester`` is a pytest-built-in plugin that lets tests spin up an isolated
 pytest session inside a temp dir. Registered at the top-level conftest so any
-lane can reach it (currently used by canonical suite self-checks that need to
-run a synthetic subclass in-process and inspect the outcome)."""
+lane can reach it."""
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ import yaml
 from tests.utils.secret_state import secret_manager_state_restored
 from tolokaforge.core.llm.presets import set_overlay_path
 
+pytest_plugins = ["pytester"]
+"""``pytester`` is a pytest-built-in plugin that lets tests spin up an isolated
+pytest session inside a temp dir. Registered at the top-level conftest so any
+lane can reach it (currently used by canonical suite self-checks that need to
+run a synthetic subclass in-process and inspect the outcome)."""
+
 
 @pytest.fixture(autouse=True)
 def overlay_isolation():

--- a/tolokaforge/testing/__init__.py
+++ b/tolokaforge/testing/__init__.py
@@ -1,8 +1,15 @@
 """Public engine-side testing seam.
 
-Subpackage :mod:`tolokaforge.testing.certify` exports the certificate
-data types and (in later stages) fixtures + probe-registration API that
-external callers use to drive the per-model capability suite against
-their own model list. This top-level package is a namespace marker only;
-consumers import from :mod:`tolokaforge.testing.certify` directly.
+Two subpackages ship the reusable pytest suites external callers subclass:
+
+- :mod:`tolokaforge.testing.certify` — per-model capability suite. External
+  callers drive it against their own model list by importing the certificate
+  data types and probe-registration API here.
+- :mod:`tolokaforge.testing.adapters` — adapter-contract suites. External
+  adapter authors subclass one class per seam
+  (:class:`~tolokaforge.testing.adapters.AdapterGradingContractSuite` today)
+  to pin their adapter against the engine's declared shape.
+
+This top-level package is a namespace marker only; consumers import from the
+subpackage directly.
 """

--- a/tolokaforge/testing/adapters/__init__.py
+++ b/tolokaforge/testing/adapters/__init__.py
@@ -1,0 +1,32 @@
+"""Reusable pytest suites external adapter authors subclass.
+
+External adapter authors ``pip install tolokaforge`` and subclass one suite
+class per contract to pin their adapter against the engine's declared shape.
+Today the subpackage ships :class:`AdapterGradingContractSuite` — 11 test
+methods locking the six
+:class:`~tolokaforge.adapters.grading_contract.AdapterGradingContract`
+methods, three capability flags, emit-payload schema, and preferred-kind
+registry resolution.
+
+Adoption pattern (~5 lines)::
+
+    from tolokaforge.testing.adapters import AdapterGradingContractSuite
+
+    class TestMyAdapterGradingContract(AdapterGradingContractSuite):
+        expected_requires_docker_cli_in_runner = True  # only if declared
+
+        @pytest.fixture
+        def adapter(self):
+            return MyAdapter({"base_dir": ..., "tasks_glob": ...})
+
+        @pytest.fixture
+        def task_and_dir(self):
+            return load_task_yaml(A_REAL_TASK_YAML)
+
+The base class carries no ``Test`` prefix so pytest does not collect it; the
+subclass runs the 11 test methods against the fixtures it supplies.
+"""
+
+from .grading_contract import AdapterGradingContractSuite
+
+__all__ = ["AdapterGradingContractSuite"]

--- a/tolokaforge/testing/adapters/grading_contract.py
+++ b/tolokaforge/testing/adapters/grading_contract.py
@@ -1,0 +1,155 @@
+"""Reusable pytest class pinning every adapter to the grading contract.
+
+An adapter subclasses :class:`AdapterGradingContractSuite`, provides an
+``adapter`` fixture and a ``task_and_dir`` fixture, and (optionally)
+overrides ``expected_*`` class attributes for the three capability flags and
+the preferred grader kind whose adapter declaration disagrees with the
+shipped defaults (all three flags default ``False``; preferred kind defaults
+``"composite"``). The subclass then collects the 11 test methods below,
+pinning:
+
+- The six methods :class:`~tolokaforge.adapters.grading_contract.AdapterGradingContract`
+  declares (four readers + emit + preferred-kind), each returning the
+  declared type against a real task.
+- The three capability flags matching the subclass's declared expectation
+  (``requires_docker_cli_in_runner``, ``grades_from_task_grading_file``,
+  ``syncs_adapter_env_to_state``).
+- ``emit_runner_grading_payload(task_id)`` returning a ``dict``; when
+  non-empty, constructing a valid
+  :class:`~tolokaforge.runner.models.RunnerGradingConfig` (empty payloads
+  short-circuit via ``pytest.skip`` so the branch reads honestly rather than
+  passing on an unreached body).
+- ``preferred_grader_kind()`` resolving through
+  :func:`~tolokaforge.core.plugin_registry.load_grading_method` — that is,
+  the adapter's declared kind is a registered
+  ``tolokaforge.grading_methods`` entry.
+
+The base class name has no ``Test`` prefix so pytest does not collect it
+directly; subclasses use ``Test<Adapter>GradingContract``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from tolokaforge.adapters._task_loader import GradingSource, GradingSourceKind
+from tolokaforge.adapters.base import BaseAdapter
+from tolokaforge.adapters.grading_contract import AdapterGradingContract
+from tolokaforge.core.grading.config_validation import (
+    ReplayWorld,
+    SeededTablesLayer,
+    ToolInventory,
+)
+from tolokaforge.core.models import TaskConfig
+from tolokaforge.core.plugin_registry import load_grading_method
+from tolokaforge.runner.models import RunnerGradingConfig
+
+
+class AdapterGradingContractSuite:
+    """Subclass to lock one adapter against the grading contract.
+
+    Override the two fixtures ``adapter`` and ``task_and_dir``; override
+    the four ``expected_*`` class attributes only when the adapter's
+    declaration diverges from the shipped default.
+    """
+
+    expected_requires_docker_cli_in_runner: ClassVar[bool] = False
+    expected_grades_from_task_grading_file: ClassVar[bool] = False
+    expected_syncs_adapter_env_to_state: ClassVar[bool] = False
+    expected_preferred_grader_kind: ClassVar[str] = "composite"
+
+    @pytest.fixture
+    def adapter(self) -> BaseAdapter:
+        raise NotImplementedError(
+            "subclasses of AdapterGradingContractSuite must override the "
+            "`adapter` fixture to return a constructed adapter instance"
+        )
+
+    @pytest.fixture
+    def task_and_dir(self) -> tuple[TaskConfig, Path]:
+        raise NotImplementedError(
+            "subclasses of AdapterGradingContractSuite must override the "
+            "`task_and_dir` fixture to return a (TaskConfig, Path) pair the "
+            "adapter can resolve"
+        )
+
+    def test_adapter_satisfies_the_grading_contract_protocol(self, adapter: BaseAdapter) -> None:
+        assert isinstance(adapter, AdapterGradingContract)
+
+    def test_requires_docker_cli_in_runner_matches_declared_expectation(
+        self, adapter: BaseAdapter
+    ) -> None:
+        assert adapter.requires_docker_cli_in_runner is self.expected_requires_docker_cli_in_runner
+
+    def test_grades_from_task_grading_file_matches_declared_expectation(
+        self, adapter: BaseAdapter
+    ) -> None:
+        assert adapter.grades_from_task_grading_file is self.expected_grades_from_task_grading_file
+
+    def test_syncs_adapter_env_to_state_matches_declared_expectation(
+        self, adapter: BaseAdapter
+    ) -> None:
+        assert adapter.syncs_adapter_env_to_state is self.expected_syncs_adapter_env_to_state
+
+    def test_grading_source_returns_a_grading_source(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, task_dir = task_and_dir
+        source = adapter.grading_source(task, task_dir)
+        assert isinstance(source, GradingSource)
+        if source.kind in (GradingSourceKind.WITHHELD, GradingSourceKind.UNINTERROGABLE):
+            assert source.reason, (
+                f"{type(adapter).__name__}.grading_source returned "
+                f"{source.kind.value} with an empty reason: the reason field "
+                "carries the sentence the absence is reported by"
+            )
+
+    def test_grading_tool_inventory_returns_a_tool_inventory(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, task_dir = task_and_dir
+        assert isinstance(adapter.grading_tool_inventory(task, task_dir), ToolInventory)
+
+    def test_grading_replay_world_returns_a_replay_world(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, task_dir = task_and_dir
+        assert isinstance(adapter.grading_replay_world(task, task_dir), ReplayWorld)
+
+    def test_grading_seeded_tables_returns_a_seeded_tables_layer(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, task_dir = task_and_dir
+        assert isinstance(adapter.grading_seeded_tables(task, task_dir), SeededTablesLayer)
+
+    def test_emit_runner_grading_payload_returns_a_dict(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, _ = task_and_dir
+        payload = adapter.emit_runner_grading_payload(task.task_id)
+        assert isinstance(payload, dict)
+
+    def test_emit_runner_grading_payload_constructs_a_valid_runner_grading_config(
+        self, adapter: BaseAdapter, task_and_dir: tuple[TaskConfig, Path]
+    ) -> None:
+        task, _ = task_and_dir
+        payload = adapter.emit_runner_grading_payload(task.task_id)
+        if not payload:
+            pytest.skip(
+                "adapter returns the empty-payload default; runner falls "
+                "through to the historical dispatch"
+            )
+        RunnerGradingConfig(**payload)
+        method_name = payload.get("grading_method")
+        if method_name is not None:
+            load_grading_method(method_name)
+
+    def test_preferred_grader_kind_resolves_in_the_grading_methods_registry(
+        self, adapter: BaseAdapter
+    ) -> None:
+        kind = adapter.preferred_grader_kind()
+        assert kind == self.expected_preferred_grader_kind
+        load_grading_method(kind)


### PR DESCRIPTION
## Summary

Ships `AdapterGradingContractSuite` — a reusable pytest class that every adapter subclasses to lock the `AdapterGradingContract` from #1339 (six methods + three capability flags) plus emit-payload schema and `preferred_grader_kind()` resolution against `tolokaforge.grading_methods` from #1344.

Two shipped subclasses exercise the suite against real adapters:

- `TestNativeAdapterGradingContract` in `tests/canonical/` — locks `NativeAdapter` (all three flags default `False`, `preferred_grader_kind() == "composite"`).
- `TestTerminalBenchAdapterGradingContract` in `external_adapters/tolokaforge-adapter-terminal-bench/tests/` — reuses the real shipped `examples/terminal_bench/fix-airline-segmentation/` fixture pack; asserts `requires_docker_cli_in_runner is True` (the only differing flag), other two flags + preferred grader kind inherit `False`/`composite`.

External-adapter authors get a first-class testing seam — analogue of `tolokaforge.testing.certify` for adapter conformance.

## Design choices

| Decision | Rationale |
|---|---|
| Module location `tolokaforge/testing/adapters/` (not `tolokaforge/adapters/testing/`) | Matches the shipped `tolokaforge/testing/certify/` seam precedent — external test helpers live under `tolokaforge.testing.*`. Subpackage siblings are `certify` (model-capability suite) and now `adapters` (adapter-contract suites). |
| `expected_preferred_grader_kind` is a subclass-declared `ClassVar[str]` | No cross-adapter invariant today: `TerminalBenchAdapter` (and `NativeAdapter` in harness mode) inherit `preferred_grader_kind() == "composite"` even though their `emit_test_execution_grading` payload writes `grading_method="test_execution"`. Alignment tracked in follow-up #1394. Parametrising the expectation per subclass keeps the suite honest without forcing a fix out of scope. |
| Terminal-bench fixture pack reuses shipped `examples/terminal_bench/fix-airline-segmentation/` | Real pack, real docker-compose, real task.toml — no synth files. `prebuild_images=False` keeps the fixture setup pure (contract reads have no image side-effects). |
| CI wiring lives in this PR | Adds `external_adapters/*/tests/` discovery loop to `test-fast` and `test-full`, symmetric to the shipped `tools/*/tests/` loop. External adapter is already a `uv.workspace` member — no separate editable-install step needed. |
| Existing `tests/canonical/test_adapter_grading_contract.py` (from #1339) kept intact | Overlap accepted as non-goal; consolidation into the reusable suite tracked in follow-up #1393. |

## What ships

- `tolokaforge/testing/adapters/__init__.py` — namespace + re-export.
- `tolokaforge/testing/adapters/grading_contract.py` — `AdapterGradingContractSuite` (~155 LOC): 4 `ClassVar` capability expectations, 2 abstract fixtures (`adapter`, `task_and_dir`), 11 test methods.
- `tests/canonical/test_native_adapter_grading_contract.py` — `TestNativeAdapterGradingContract` subclass.
- `tests/canonical/test_grading_contract_suite_self_check.py` — `pytester`-based self-check locking both branches of the emit-payload schema test (empty-payload skip + non-empty schema validation).
- `tests/conftest.py` — `pytest_plugins = ["pytester"]` (only supported location).
- `external_adapters/tolokaforge-adapter-terminal-bench/tests/__init__.py` + `test_terminal_bench_grading_contract.py` — external subclass.
- `.github/workflows/ci.yml` — new "Run external adapter tests" step in `test-fast` (after `tools/*/tests/` loop) and `test-full` (before docker image build), each mirroring the shipped tools-loop shape.
- `tolokaforge/testing/__init__.py` — parent docstring names both `certify` and `adapters` subpackages.
- `docs/ADAPTER_INTERFACE.md` — new "AdapterGradingContractSuite (reusable pytest suite)" subsection under § "AdapterGradingContract".

## Test plan

- [x] `uv run pytest tests/canonical/test_native_adapter_grading_contract.py -v` → 10 passed + 1 skipped.
- [x] `uv run pytest tests/canonical/test_grading_contract_suite_self_check.py -v` → 1 passed (pytester subsession: 21 passed + 1 skipped).
- [x] `(cd external_adapters/tolokaforge-adapter-terminal-bench && uv run pytest tests/ -v --tb=short -p no:cacheprovider)` → 10 passed + 1 skipped.
- [x] `uv run pytest tests/canonical/test_grader_parity_reference.py` → 25 passed (byte-parity untouched).
- [x] `uv run pytest tests/canonical/test_runner_subset_partition.py` → 17 passed (subset partition untouched).
- [x] Import-boundary contracts (pre-commit hook) → passed.
- [x] `actionlint .github/workflows/ci.yml` → exit 0.

## Follow-ups

- **#1393** — consolidate `tests/canonical/test_adapter_grading_contract.py` (from #1339) into the reusable suite. Kept intact this PR per non-goal.
- **#1394** — align `preferred_grader_kind()` vs `emit_test_execution_grading` payload for `TerminalBenchAdapter` + `NativeAdapter` harness mode. Suite parametrises the expectation to unblock; alignment happens in the follow-up.
- **#1395** — architect-filed cleanup.

Closes #1345.