### PR TITLE
refactor(grading): extract build_timeline_from_wire; unify both dispatchers

### DIFF
--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -290,7 +290,7 @@ its dispatch consumes and leaves the rest empty.
 | Field                         | # | Purpose                                                                                   |
 | ----------------------------- | - | ----------------------------------------------------------------------------------------- |
 | `trial_id`                    | 1 | Canonical `"{task_id}:{trial_index}"` identifier — the join key for logs and future stores. |
-| `llm_messages_json`           | 2 | Transcript as an LLM-messages JSON string; the timeline builder decodes it. The agent system prompt rides as the leading `role=system` message; the grader recovers it via `split_leading_system_message`. |
+| `llm_messages_json`           | 2 | Transcript as an LLM-messages JSON string; the composite dispatcher hands the decoded list to [`build_timeline_from_wire`](../tolokaforge/core/grading/trace_timeline.py), which splits the leading `role=system` message off (the agent system prompt) and decodes the remaining transcript before joining it with the empty grader-side records. |
 | `termination_reason`          | 3 | `TerminationReason` value name; empty when the caller reports none.                       |
 | `task_config_json`            | 4 | `RunnerGradingConfig` JSON — the whole `grading:` block the composite dispatcher reads.   |
 | `judge_model_config_json`     | 5 | Optional `ModelConfig` JSON for the judge; empty when the task declares no `llm_judge`.   |

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -638,6 +638,18 @@ same thing whichever substrate grades the trial:
 | `recorded_calls` | `trial_context.tool_call_history` | `trajectory.tool_log` |
 | `termination_reason` | `GradeTrialRequest.termination_reason` | `trajectory.termination_reason` |
 
+The `messages` column names one recipe both wire dispatchers share: strip the
+leading `role: system` message off the payload, decode the remaining transcript
+into `Message` objects, and hand the result to `build_trial_timeline`.
+[`build_timeline_from_wire`](../tolokaforge/core/grading/trace_timeline.py)
+owns that recipe. The runner's `_grade_time_views` and the grader's
+`GraderCompositeDispatch.grade` are its two callers — see
+[`docs/GRADER_SERVICE.md` § The `Grade` wire](GRADER_SERVICE.md#the-grade-wire)
+for the `llm_messages_json` row it decodes. An empty message list
+short-circuits to a records-only timeline; the branch reconciles without
+raising, which is what lets a hash-only trial reach the timeline the same
+way a records-only bundle does.
+
 ### Both substrates consume it
 
 Every transcript rule is evaluated off the timeline on both substrates.

--- a/docs/GRPC_PROTOCOL.md
+++ b/docs/GRPC_PROTOCOL.md
@@ -774,9 +774,8 @@ The Runner executes this grading algorithm:
 def grade_trial(trial_id: str, llm_messages: list[dict]) -> Grade:
     # 0. Join the transcript and the tool-call record into the trial's timeline.
     #    Raises TimelineInconsistencyError -> success=false, before any component.
-    _, transcript = split_leading_system_message(llm_messages)
-    timeline = build_trial_timeline(
-        decode_transcript_wire(transcript), trial_context.tool_call_history, termination_reason
+    timeline = build_timeline_from_wire(
+        llm_messages, trial_context.tool_call_history, termination_reason
     )
 
     # 1. Resolve every golden-action name against the tools RegisterTrial registered.

--- a/tests/canonical/test_grader_timeline_from_wire_alone.py
+++ b/tests/canonical/test_grader_timeline_from_wire_alone.py
@@ -1,21 +1,21 @@
-"""Timeline preflight — grader-side ``build_trial_timeline`` from the wire alone.
+"""Timeline preflight — grader-side ``build_timeline_from_wire`` from the wire alone.
 
 The runner reconstructs a trial's :class:`TrialTimeline` from two sources:
 the wire transcript (``llm_messages_json``) and the runner-owned
 ``trial_context.recorded`` tool-call records. The grader has no access to
 the latter — its only inputs are the wire fields — so
 :class:`GraderCompositeDispatch` calls
-``build_trial_timeline(decode_transcript_wire(transcript), [], termination_reason)``
+``build_timeline_from_wire(llm_messages, [], termination_reason)``
 with an empty records list.
 
 This suite locks the preflight-probe outcome documented in
 ``docs/adr/0040-standalone-grader.md``: for a wire that carries no
 assistant tool_calls, the records-empty call reconciles without raising
 and yields the same event count the same fixture reaches through the
-runner-side codepath. If a future change to :func:`build_trial_timeline`
-breaks that equivalence — a shape where the records-empty branch
-diverges — this suite fails before the composite dispatcher relies on a
-divergent timeline.
+runner-side codepath. If a future change to
+:func:`build_timeline_from_wire` breaks that equivalence — a shape where
+the records-empty branch diverges — this suite fails before the composite
+dispatcher relies on a divergent timeline.
 """
 
 from __future__ import annotations
@@ -26,11 +26,7 @@ import pytest
 
 from tolokaforge.core.grading.trace_timeline import (
     TimelineInconsistencyError,
-    build_trial_timeline,
-)
-from tolokaforge.core.grading.transcript_wire import (
-    decode_transcript_wire,
-    split_leading_system_message,
+    build_timeline_from_wire,
 )
 
 pytestmark = pytest.mark.canonical
@@ -47,19 +43,17 @@ def test_grader_timeline_from_wire_alone_reconciles_without_recorded_calls() -> 
     """A wire-only build reconciles without raising and yields two events.
 
     Fixture: a system + user + assistant transcript with no tool calls —
-    the shape the parity gate ships. ``build_trial_timeline`` with
-    ``records=[]`` must NOT raise :class:`TimelineInconsistencyError` and
+    the shape the parity gate ships. ``build_timeline_from_wire`` with
+    ``recorded=[]`` must NOT raise :class:`TimelineInconsistencyError` and
     must produce one event per non-system turn (user + assistant = 2).
     Anything else would mean the grader-side timeline needs a
     ``recorded_calls_json`` wire field before the dispatcher can drop
     ``trial_context.recorded``.
     """
     llm_messages = list(_PARITY_FIXTURE_LLM_MESSAGES)
-    _, transcript = split_leading_system_message(llm_messages)
-    decoded = decode_transcript_wire(transcript)
 
     try:
-        wire_only_timeline = build_trial_timeline(decoded, [], None)
+        wire_only_timeline = build_timeline_from_wire(llm_messages, [], None)
     except TimelineInconsistencyError as exc:
         pytest.fail(f"grader-side timeline (records=[]) failed reconciliation: {exc!r}.")
 
@@ -77,7 +71,7 @@ def test_grader_timeline_from_wire_alone_empty_transcript_is_safe() -> None:
     that was still graded). The composite skips llm_judge in that case;
     the timeline call must not raise before the skip fires.
     """
-    timeline = build_trial_timeline([], [], None)
+    timeline = build_timeline_from_wire([], [], None)
     assert timeline.events == ()
 
 
@@ -85,13 +79,11 @@ def test_grader_timeline_preserves_decoded_events_from_json() -> None:
     """Round-trip the parity fixture messages through the JSON wire.
 
     ``dispatch.llm_messages_json`` arrives as a string; the composite
-    calls ``json.loads`` before splitting the leading system message.
-    Locking the round-trip here surfaces any wire-encoding drift the
-    composite would silently mishandle.
+    calls ``json.loads`` before handing the list to
+    :func:`build_timeline_from_wire`. Locking the round-trip here surfaces
+    any wire-encoding drift the composite would silently mishandle.
     """
     wire = json.dumps(_PARITY_FIXTURE_LLM_MESSAGES)
     llm_messages = json.loads(wire)
-    _, transcript = split_leading_system_message(llm_messages)
-    decoded = decode_transcript_wire(transcript)
-    timeline = build_trial_timeline(decoded, [], None)
+    timeline = build_timeline_from_wire(llm_messages, [], None)
     assert len(timeline.events) == 2  # user + assistant, the two non-system turns

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -60,11 +60,7 @@ from tolokaforge.core.grading.rubric_evaluator import RubricEvaluatorContext
 from tolokaforge.core.grading.state_diff import render_state_diff
 from tolokaforge.core.grading.substrate_live import LiveRunnerCallbackGradingSubstrate
 from tolokaforge.core.grading.trace_checks import TraceChecksResult
-from tolokaforge.core.grading.trace_timeline import build_trial_timeline
-from tolokaforge.core.grading.transcript_wire import (
-    decode_transcript_wire,
-    split_leading_system_message,
-)
+from tolokaforge.core.grading.trace_timeline import build_timeline_from_wire
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import StructuredLogger
@@ -394,10 +390,7 @@ def _reassemble_grade_from_composite(
     try:
         logger = StructuredLogger(name="parity-gate-live-callback")
         llm_messages = list(_LLM_MESSAGES)
-        _, transcript = split_leading_system_message(llm_messages)
-        timeline = build_trial_timeline(
-            decode_transcript_wire(transcript), trial_context.recorded, None
-        )
+        timeline = build_timeline_from_wire(llm_messages, trial_context.recorded, None)
 
         components = RunnerGradeComponents()
         accounted_keys: dict[str, Any] = {}

--- a/tests/canonical/test_timeline_from_wire_defined_once.py
+++ b/tests/canonical/test_timeline_from_wire_defined_once.py
@@ -1,0 +1,96 @@
+"""Guard the "one wire-timeline recipe, two dispatchers" invariant.
+
+Both the runner-side ``_grade_time_views`` and the grader-side
+``GraderCompositeDispatch.grade`` reach the timeline through
+:func:`~tolokaforge.core.grading.trace_timeline.build_timeline_from_wire` —
+one function, one recipe body, and exactly two callers. A third caller in
+the tree, or a dispatcher that re-inlines the raw
+``build_trial_timeline(decode_transcript_wire(``-chain, would silently
+re-collapse the seam.
+
+Text-level assertions rather than an AST pass — the goal is to catch a
+copy-paste of the recipe into a third dispatcher, not to prove semantic
+equivalence, and a text sweep is what a reviewer would run.
+
+Symmetric with ``tests/canonical/test_fold_defined_once.py`` (composite
+fold).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.canonical
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACKAGE_ROOT = _REPO_ROOT / "tolokaforge"
+_TIMELINE_MODULE = _PACKAGE_ROOT / "core" / "grading" / "trace_timeline.py"
+_RUNNER_SITE = _PACKAGE_ROOT / "runner" / "service.py"
+_GRADER_SITE = _PACKAGE_ROOT / "grader" / "composite_dispatch.py"
+
+
+def _iter_package_python_files() -> list[Path]:
+    return sorted(p for p in _PACKAGE_ROOT.rglob("*.py") if p.is_file())
+
+
+def test_build_timeline_from_wire_is_defined_exactly_once_in_the_pure_module() -> None:
+    """The function name appears as a ``def`` header in exactly one file."""
+    def_pattern = re.compile(r"^def\s+build_timeline_from_wire\b", re.MULTILINE)
+    definitions = [
+        path
+        for path in _iter_package_python_files()
+        if def_pattern.search(path.read_text(encoding="utf-8"))
+    ]
+    assert definitions == [_TIMELINE_MODULE], (
+        f"Expected exactly one ``def build_timeline_from_wire`` in "
+        f"{_TIMELINE_MODULE.relative_to(_REPO_ROOT)}, "
+        f"found: {[p.relative_to(_REPO_ROOT) for p in definitions]}"
+    )
+
+
+def test_build_timeline_from_wire_has_exactly_two_call_sites_outside_the_module() -> None:
+    """One call site in the runner service, one in the grader dispatch — no other.
+
+    ``core.grading.combine`` and ``core.grading.trace_replay`` legitimately
+    call :func:`build_trial_timeline` directly on non-wire inputs (stored
+    trajectory data). A ``build_timeline_from_wire`` callsite outside the
+    two dispatcher modules would signal recipe leakage into a codepath the
+    wrapper was not designed for.
+    """
+    call_pattern = re.compile(r"build_timeline_from_wire\(")
+    call_sites = [
+        path
+        for path in _iter_package_python_files()
+        if path != _TIMELINE_MODULE and call_pattern.search(path.read_text(encoding="utf-8"))
+    ]
+    assert sorted(call_sites) == sorted([_RUNNER_SITE, _GRADER_SITE]), (
+        f"Expected exactly two callers of build_timeline_from_wire( "
+        f"({_RUNNER_SITE.relative_to(_REPO_ROOT)}, {_GRADER_SITE.relative_to(_REPO_ROOT)}); "
+        f"found: {[p.relative_to(_REPO_ROOT) for p in call_sites]}"
+    )
+
+
+def test_dispatchers_do_not_re_inline_the_raw_wire_recipe() -> None:
+    """Runner and grader reach through the wrapper, not around it.
+
+    ``build_trial_timeline(decode_transcript_wire(`` is the raw composed
+    recipe :func:`build_timeline_from_wire` was extracted from. Either
+    dispatcher re-inlining it — even once — would fork the recipe and
+    re-split the seam.
+
+    :mod:`tolokaforge.core.grading.combine` and
+    :mod:`tolokaforge.core.grading.trace_replay` remain free to call
+    :func:`build_trial_timeline` directly with non-wire inputs — those are
+    stored-trajectory reconstructions, not wire recipes.
+    """
+    forbidden = re.compile(r"build_trial_timeline\(\s*decode_transcript_wire\(")
+    for path in (_RUNNER_SITE, _GRADER_SITE):
+        text = path.read_text(encoding="utf-8")
+        assert not forbidden.search(text), (
+            f"{path.relative_to(_REPO_ROOT)} re-inlines the raw "
+            f"``build_trial_timeline(decode_transcript_wire(`` chain — "
+            f"route it through build_timeline_from_wire instead."
+        )

--- a/tests/canonical/test_timeline_from_wire_defined_once.py
+++ b/tests/canonical/test_timeline_from_wire_defined_once.py
@@ -77,9 +77,9 @@ def test_dispatchers_do_not_re_inline_the_raw_wire_recipe() -> None:
     """Runner and grader reach through the wrapper, not around it.
 
     ``build_trial_timeline(decode_transcript_wire(`` is the raw composed
-    recipe :func:`build_timeline_from_wire` was extracted from. Either
-    dispatcher re-inlining it — even once — would fork the recipe and
-    re-split the seam.
+    recipe :func:`build_timeline_from_wire` wraps. Either dispatcher
+    re-inlining it — even once — would fork the recipe and re-split the
+    seam.
 
     :mod:`tolokaforge.core.grading.combine` and
     :mod:`tolokaforge.core.grading.trace_replay` remain free to call

--- a/tests/unit/grading/test_build_timeline_from_wire.py
+++ b/tests/unit/grading/test_build_timeline_from_wire.py
@@ -1,10 +1,11 @@
 """The four branches :func:`build_timeline_from_wire` collapses to.
 
-The wrapper composes ``split_leading_system_message`` + ``decode_transcript_wire``
-+ ``build_trial_timeline`` — a fold both grading dispatchers had inlined
-before the extraction. The behaviour it locks is the shape a records-empty
-call produces, the way records join with the message view when both views
-are present, and the pass-through of ``termination_reason``.
+The wrapper composes ``split_leading_system_message`` +
+``decode_transcript_wire`` + ``build_trial_timeline`` — the shared recipe
+both grading dispatchers reach the timeline through. The behaviour it locks
+is the shape a records-empty call produces, the way records join with the
+message view when both views are present, and the pass-through of
+``termination_reason``.
 
 The parity fixture ``_PARITY_FIXTURE_LLM_MESSAGES`` shadows the one
 ``tests/canonical/test_grader_timeline_from_wire_alone.py`` ships so drift

--- a/tests/unit/grading/test_build_timeline_from_wire.py
+++ b/tests/unit/grading/test_build_timeline_from_wire.py
@@ -1,0 +1,133 @@
+"""The four branches :func:`build_timeline_from_wire` collapses to.
+
+The wrapper composes ``split_leading_system_message`` + ``decode_transcript_wire``
++ ``build_trial_timeline`` — a fold both grading dispatchers had inlined
+before the extraction. The behaviour it locks is the shape a records-empty
+call produces, the way records join with the message view when both views
+are present, and the pass-through of ``termination_reason``.
+
+The parity fixture ``_PARITY_FIXTURE_LLM_MESSAGES`` shadows the one
+``tests/canonical/test_grader_timeline_from_wire_alone.py`` ships so drift
+between the two suites is visible: the byte-parity 10-pack exercises the
+same shape end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.utils.recorded_calls import recorded_call
+from tolokaforge.core.grading.trace_timeline import (
+    TraceEventKind,
+    build_timeline_from_wire,
+)
+from tolokaforge.core.models import TerminationReason, ToolExecutionStatus
+
+pytestmark = pytest.mark.unit
+
+
+_PARITY_FIXTURE_LLM_MESSAGES: list[dict[str, Any]] = [
+    {"role": "system", "content": "you are a test assistant"},
+    {"role": "user", "content": "please help"},
+    {"role": "assistant", "content": "done"},
+]
+
+
+def test_empty_wire_and_empty_records_reconciles_to_events_empty_timeline() -> None:
+    """An empty message list with no records builds an events-empty timeline.
+
+    The dispatcher-side shape when the wire carries nothing and the grader
+    holds no records — the composite still needs a timeline to skip
+    ``llm_judge`` and run ``trace_checks``. Reconciliation must not raise.
+    """
+    timeline = build_timeline_from_wire([], [], None)
+
+    assert timeline.events == ()
+    assert timeline.message_view_present is False
+    assert timeline.records_present is False
+    assert timeline.termination_reason is None
+
+
+def test_empty_wire_with_records_emits_records_alone_and_passes_reason_through() -> None:
+    """A records-only trial (hash-only shape) reflects records + termination.
+
+    The runner reaches this branch on a hash-only trial: no messages on
+    the wire, but ``trial_context.recorded`` still carries the executed
+    tool calls. The wrapper must forward records and ``termination_reason``
+    to :func:`build_trial_timeline` unchanged.
+    """
+    record = recorded_call(
+        "read_file",
+        sequence=0,
+        status=ToolExecutionStatus.SUCCESS,
+        output="hello",
+    )
+
+    timeline = build_timeline_from_wire([], [record], TerminationReason.MAX_TURNS)
+
+    assert timeline.message_view_present is False
+    assert timeline.records_present is True
+    assert timeline.termination_reason is TerminationReason.MAX_TURNS
+    kinds = [event.kind for event in timeline.events]
+    assert kinds == [TraceEventKind.TOOL_CALL, TraceEventKind.TOOL_RESULT]
+
+
+def test_system_user_assistant_wire_no_records_yields_two_events() -> None:
+    """System message stripped; user + assistant survive as events.
+
+    The parity-fixture shape: the leading ``role: system`` is stripped by
+    the wrapper's internal ``split_leading_system_message`` and does not
+    become an event. The two non-system turns join the timeline as
+    ``user_message`` then ``assistant_message``.
+    """
+    timeline = build_timeline_from_wire(_PARITY_FIXTURE_LLM_MESSAGES, [], None)
+
+    assert timeline.message_view_present is True
+    assert timeline.records_present is False
+    assert [event.kind for event in timeline.events] == [
+        TraceEventKind.USER_MESSAGE,
+        TraceEventKind.ASSISTANT_MESSAGE,
+    ]
+
+
+def test_wire_with_tool_call_and_matching_record_joins_by_episode_key() -> None:
+    """A wire tool_call joins its matching record; both views mark present.
+
+    Assistant declares a tool call; the record answers the same
+    ``call_id``. The join produces ``TOOL_CALL`` + ``TOOL_RESULT`` events
+    around the assistant turn, with ``termination_reason`` forwarded.
+    """
+    llm_messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "you are a test assistant"},
+        {"role": "user", "content": "read the file"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "toolu_read_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "content": "hello", "tool_call_id": "toolu_read_1"},
+    ]
+    record = recorded_call(
+        "read_file",
+        sequence=0,
+        status=ToolExecutionStatus.SUCCESS,
+        output="hello",
+        call_id="toolu_read_1",
+    )
+
+    timeline = build_timeline_from_wire(llm_messages, [record], TerminationReason.AGENT_DONE)
+
+    assert timeline.message_view_present is True
+    assert timeline.records_present is True
+    assert timeline.termination_reason is TerminationReason.AGENT_DONE
+    kinds = [event.kind for event in timeline.events]
+    assert TraceEventKind.TOOL_CALL in kinds
+    assert TraceEventKind.TOOL_RESULT in kinds

--- a/tolokaforge/core/grading/trace_timeline.py
+++ b/tolokaforge/core/grading/trace_timeline.py
@@ -36,6 +36,10 @@ from typing import Any
 # own it: ``runner.models`` declares ``TraceMatcher`` and reaching in here for the
 # kind would close a cycle through ``core.models``.
 from tolokaforge.core.grading.trace_event_kind import TraceEventKind as TraceEventKind
+from tolokaforge.core.grading.transcript_wire import (
+    decode_transcript_wire,
+    split_leading_system_message,
+)
 from tolokaforge.core.models import (
     Message,
     MessageRole,
@@ -55,6 +59,7 @@ __all__ = [
     "TrialTimeline",
     "assistant_texts",
     "attempted_calls",
+    "build_timeline_from_wire",
     "build_trial_timeline",
 ]
 
@@ -214,6 +219,40 @@ def build_trial_timeline(
         message_view_present=bool(turns),
         records_present=bool(recorded_calls),
     )
+
+
+def build_timeline_from_wire(
+    llm_messages: list[dict[str, Any]],
+    recorded: Sequence[RecordedToolCall],
+    termination_reason: TerminationReason | None,
+) -> TrialTimeline:
+    """Build a :class:`TrialTimeline` from the wire's ``llm_messages`` plus optional records.
+
+    Both grading substrates reach the timeline through the same recipe: split
+    the leading ``role: system`` message off the wire, decode the remaining
+    transcript into :class:`Message` objects, and join it with any tool-call
+    records the caller can offer. The message view is the only view the wire
+    carries; the runner supplies records from its live ``trial_context``, and
+    the grader — which has no live view of the trial by the time it grades —
+    supplies an empty sequence.
+
+    An empty ``llm_messages`` short-circuits to a records-only timeline
+    (``build_trial_timeline([], recorded, termination_reason)``) rather than
+    running the transcript decode over nothing. A records-empty, message-empty
+    call reconciles without raising and returns an events-empty timeline; that
+    is the grader-side preflight shape locked by
+    ``tests/canonical/test_grader_timeline_from_wire_alone.py``.
+
+    Raises:
+        TimelineInconsistencyError: the message view and the record view cannot
+            be joined (propagates from :func:`build_trial_timeline`). The caller
+            translates this to a ``GradingFailedError`` per
+            ``docs/GRADING.md`` § "Trial event timeline".
+    """
+    if not llm_messages:
+        return build_trial_timeline([], recorded, termination_reason)
+    _, transcript = split_leading_system_message(llm_messages)
+    return build_trial_timeline(decode_transcript_wire(transcript), recorded, termination_reason)
 
 
 def assistant_texts(timeline: TrialTimeline) -> tuple[str, ...]:

--- a/tolokaforge/grader/composite_dispatch.py
+++ b/tolokaforge/grader/composite_dispatch.py
@@ -47,11 +47,7 @@ from tolokaforge.core.grading.judge_result import JudgeStatus as JudgeRunStatus
 from tolokaforge.core.grading.substrate import SubstrateUnreachableError
 from tolokaforge.core.grading.tool_artifacts import extract_tool_artifacts
 from tolokaforge.core.grading.trace_checks import TraceChecksResult
-from tolokaforge.core.grading.trace_timeline import build_trial_timeline
-from tolokaforge.core.grading.transcript_wire import (
-    decode_transcript_wire,
-    split_leading_system_message,
-)
+from tolokaforge.core.grading.trace_timeline import build_timeline_from_wire
 from tolokaforge.core.models import (
     CustomCheckDetail,
     Grade,
@@ -250,7 +246,9 @@ class GraderCompositeDispatch:
         """Mirror ``_grade_trial_async`` (runner) minus hash / accounted-keys ledger."""
         trial_id = dispatch.trial_id
         llm_messages: list[dict[str, Any]] = json.loads(dispatch.llm_messages_json or "[]")
-        timeline = _build_timeline(llm_messages, dispatch.termination_reason)
+        timeline = build_timeline_from_wire(
+            llm_messages, [], parse_termination_reason(dispatch.termination_reason)
+        )
         components = RunnerGradeComponents()
         state_checks_config = grading_config.state_checks
         self._grade_state_checks_block(
@@ -494,24 +492,6 @@ class GraderCompositeDispatch:
                 include_agent_system_prompt=include_agent_system_prompt,
             )
         )
-
-
-def _build_timeline(
-    llm_messages: list[dict[str, Any]],
-    raw_termination_reason: str,
-) -> Any:
-    """Build the grader-side :class:`TrialTimeline` from the wire alone.
-
-    Empty ``llm_messages`` produces a records-empty timeline that still
-    reflects the termination reason. The composite skips llm_judge in
-    that case but the timeline call must reconcile without raising so
-    the trace-checks branch runs.
-    """
-    termination_reason = parse_termination_reason(raw_termination_reason)
-    if llm_messages:
-        _, transcript = split_leading_system_message(llm_messages)
-        return build_trial_timeline(decode_transcript_wire(transcript), [], termination_reason)
-    return build_trial_timeline([], [], termination_reason)
 
 
 def _build_grade(

--- a/tolokaforge/runner/service.py
+++ b/tolokaforge/runner/service.py
@@ -65,13 +65,9 @@ from tolokaforge.core.grading.substrate import (
 from tolokaforge.core.grading.trace_timeline import (
     TimelineInconsistencyError,
     TrialTimeline,
-    build_trial_timeline,
+    build_timeline_from_wire,
 )
 from tolokaforge.core.grading.transcript_rule_matcher import TranscriptRuleMatcher
-from tolokaforge.core.grading.transcript_wire import (
-    decode_transcript_wire,
-    split_leading_system_message,
-)
 from tolokaforge.core.models import (
     CriterionResult,
     LLMJudgeConfig,
@@ -2087,13 +2083,11 @@ class RunnerServiceImpl(runner_pb2_grpc.RunnerServiceServicer):
             ValueError: the payload does not decode into a transcript.
             TimelineInconsistencyError: the two views cannot be joined.
         """
-        if not request.llm_messages_json:
-            return [], build_trial_timeline([], trial_context.recorded, termination_reason)
-
-        llm_messages: list[dict[str, Any]] = json.loads(request.llm_messages_json)
-        _, transcript = split_leading_system_message(llm_messages)
-        return llm_messages, build_trial_timeline(
-            decode_transcript_wire(transcript), trial_context.recorded, termination_reason
+        llm_messages: list[dict[str, Any]] = (
+            json.loads(request.llm_messages_json) if request.llm_messages_json else []
+        )
+        return llm_messages, build_timeline_from_wire(
+            llm_messages, trial_context.recorded, termination_reason
         )
 
     def _grade_transcript_rules(


### PR DESCRIPTION
## Summary

Consolidates the wire→timeline recipe (`split_leading_system_message` → `decode_transcript_wire` → `build_trial_timeline`) — previously duplicated across the runner dispatcher, the grader dispatcher, and one canonical parity-gate helper — into a single pure wrapper `build_timeline_from_wire` in `tolokaforge/core/grading/trace_timeline.py`. All three call sites now route through the wrapper; a new grep guard locks the "one recipe, dispatcher callers only" invariant.

Behaviour byte-identical. The 10-pack byte-parity gate runs green with **zero** fixture regeneration.

## Design choices

| Decision | Rationale |
|---|---|
| Wrapper lives at `core.grading.trace_timeline.build_timeline_from_wire` | Same pure module as its primary composition target `build_trial_timeline`. No new module, no re-export shim. `trace_timeline` was already pure — the wrapper inherits that. |
| Signature: `(llm_messages: list[dict[str, Any]], recorded: Sequence[RecordedToolCall], termination_reason: TerminationReason | None) -> TrialTimeline` | (a) `llm_messages` as decoded list, not JSON string — both dispatchers already `json.loads` at their callsite; passing decoded avoids fork of the API. (b) `recorded: Sequence[...]` with no default, forcing the grader to write `[]` explicitly (empty-records is a semantically meaningful state, not an argument omission). (c) `termination_reason` as pre-parsed enum — pulling `parse_termination_reason` (in `runner.protocol`) into the pure module would break the purity invariant; both dispatchers parse at the callsite. (d) Return `TrialTimeline` only, not a tuple — the runner's downstream "judge needs the leading system message" concern stays in the runner-side method wrapper. |
| Keep runner's `_grade_time_views` method wrapper (shrunk, not deleted) | The method carries a load-bearing docstring citing canonical test `test_a_view_of_only_harness_text_is_not_a_message_view` (hash-only-trial invariant). Inlining at `_grade_trial_async` would drop that citation. Docstring preserved verbatim. |
| Delete grader's `_build_timeline` helper | Single-caller wrapper adds nothing over inlining once the recipe is a one-liner. `parse_termination_reason(dispatch.termination_reason)` moves to the callsite; the reach into `runner.protocol` remains (deferred as #1401). |
| Retarget the third recipe copy (parity-gate helper) in this PR | `tests/canonical/test_grading_substrate_dispatch.py::_reassemble_grade_from_composite` (was `_grade_via_dispatch`) inlined the same three-step chain. Leaving it would silently drift the day either dispatcher's contract changes. |
| Add canonical grep guard `test_timeline_from_wire_defined_once.py` | Symmetric with #1346's `test_fold_defined_once.py`. Three invariants: (1) one `def build_timeline_from_wire` in tree; (2) exactly two production call sites (runner + grader); (3) zero raw `build_trial_timeline(decode_transcript_wire(` chains in dispatcher files. |

## What ships

**New pure helper** — `tolokaforge/core/grading/trace_timeline.py::build_timeline_from_wire` (~37 LOC). Empty-guard branch short-circuits to `build_trial_timeline([], recorded, termination_reason)`; non-empty routes through split → decode → build.

**Dispatcher updates:**
- `runner/service.py::_grade_time_views` — shrinks to JSON-decode + wrapper call; retains method + tuple return `(llm_messages, timeline)` + load-bearing docstring.
- `grader/composite_dispatch.py` — `_build_timeline` deleted; caller inlines `parse_termination_reason` + `build_timeline_from_wire`.
- `tests/canonical/test_grading_substrate_dispatch.py::_reassemble_grade_from_composite` (third recipe copy) — retargets to `build_timeline_from_wire(llm_messages, trial_context.recorded, None)`.

**New behaviour locks:**
- `tests/unit/grading/test_build_timeline_from_wire.py` — 4 table-driven cases (empty/empty, empty-wire+records, wire+no-records, wire+matching-record).
- `tests/canonical/test_timeline_from_wire_defined_once.py` — 3 grep guards enforcing the "one recipe, dispatcher-only callers" invariant.
- `tests/canonical/test_grader_timeline_from_wire_alone.py` — retargeted from raw primitives to the wrapper; all 3 test bodies preserve their branch coverage.

**Docs:**
- `docs/GRADING.md` — new paragraph naming `build_timeline_from_wire` as the wire-flow entry point, cross-linked to `GRADER_SERVICE.md`.
- `docs/GRADER_SERVICE.md` — `llm_messages_json` row rewritten to name the wrapper.
- `docs/GRPC_PROTOCOL.md` — `grade_trial` pseudocode step 0 names `build_timeline_from_wire` directly (hygiene round-1 fix).

## Test plan

- [x] `mcp__dev__run_tests marker=canonical` → **1784 passed, 2 skipped** (includes byte-parity 25/25 + new grep guard 3/3 + retargeted preflight 3/3)
- [x] `mcp__dev__run_tests path=tests/unit/grading marker=unit` → **1971 passed** (includes new unit table 4/4)
- [x] `uv run lint-imports` → **3 contracts kept, 0 broken** (including `composite-fold-purity` from #1346)
- [x] Byte-parity 10-pack `test_grader_parity_reference.py` → 25/25 with `git diff --stat tests/canonical/parity tests/data` empty
- [x] Import-boundary contracts (pre-commit hook) → passed
- [x] Sharded reviewer trio (correctness / hygiene / type-fit) — all three APPROVE. Hygiene had one round of §7a/doc-drift fixes shipped as `69f9276`.

## Follow-ups (already filed)

- **#1401** — move `parse_termination_reason` out of `runner.protocol` to a pure home (grader → runner reach cleanup complementing #1349). P2.
- **#1402** — colocate grader's wire-decode boundary (readability follow-up). P3.

Closes #1347.