### PR TITLE
feat(llm): namespace-matched gateway wildcards, one provider-pin rule, route provenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # LLM_PROXY_PROVIDERS=openrouter,openai
 # Namespace that wins when the gateway serves one model under several names:
 # LLM_PROXY_PREFERRED_ROUTE=openrouter/
+#
+# Trust <ns>/* catalog wildcards for provider <ns> models (default false):
+# LLM_PROXY_TRUST_NAMESPACE_WILDCARDS=true

--- a/.github/workflows/integrate-model.yml
+++ b/.github/workflows/integrate-model.yml
@@ -238,6 +238,8 @@ jobs:
           PROXY_API_KEY: ${{ secrets.ARENA_AUTOMATION_LLM_PROXY_API_KEY }}
           # A VARIABLE, not a secret: see the note in slack-integrate.yml.
           PROXY_HEADERS: ${{ vars.LLM_PROXY_HEADERS }}
+          PROXY_TRUST_WILDCARDS: ${{ vars.LLM_PROXY_TRUST_NAMESPACE_WILDCARDS }}
+          PROXY_PREFERRED_ROUTE: ${{ vars.LLM_PROXY_PREFERRED_ROUTE }}
         # OPENROUTER_API_KEY is always written: it is what the non-gateway route uses, and the
         # OpenRouter pricing/catalog HTTP calls need it on either route. LLM_PROXY_* is added
         # only when the gateway route was requested AND configured -- writing a base URL without
@@ -268,6 +270,14 @@ jobs:
                     ;;
                 esac
                 printf '%s\n' "LLM_PROXY_HEADERS=$PROXY_HEADERS" >> .env
+              fi
+              # Deployment routing policy rides along or the run cannot honour
+              # what the poller's catalog lookup promised (wildcard coverage).
+              if [ -n "$PROXY_TRUST_WILDCARDS" ]; then
+                printf '%s\n' "LLM_PROXY_TRUST_NAMESPACE_WILDCARDS=$PROXY_TRUST_WILDCARDS" >> .env
+              fi
+              if [ -n "$PROXY_PREFERRED_ROUTE" ]; then
+                printf '%s\n' "LLM_PROXY_PREFERRED_ROUTE=$PROXY_PREFERRED_ROUTE" >> .env
               fi
               echo "every openrouter/openai call in this run (candidate + user simulator) goes through the LLM gateway"
             else

--- a/.github/workflows/slack-integrate.yml
+++ b/.github/workflows/slack-integrate.yml
@@ -87,6 +87,10 @@ jobs:
       # this list and integrate-model.yml's before adding a third reference: an unresolved
       # one makes the gateway reject the request.
       LLM_PROXY_SUNDAY_ORDER_ID: ${{ secrets.LLM_PROXY_SUNDAY_ORDER_ID }}
+      # The poller reads the catalog with the same routing policy a run uses,
+      # so its wildcard-coverage verdicts match what the run will honour.
+      LLM_PROXY_TRUST_NAMESPACE_WILDCARDS: ${{ vars.LLM_PROXY_TRUST_NAMESPACE_WILDCARDS }}
+      LLM_PROXY_PREFERRED_ROUTE: ${{ vars.LLM_PROXY_PREFERRED_ROUTE }}
       LLM_PROXY_GATEWAY_RUNNER_KEY: ${{ secrets.LLM_PROXY_GATEWAY_RUNNER_KEY }}
     steps:
       - uses: actions/checkout@v4

--- a/docs/AUTO_INTEGRATION.md
+++ b/docs/AUTO_INTEGRATION.md
@@ -217,24 +217,30 @@ advisory on purpose: a gateway route may be backed by a *different upstream* for
 name, which is a comparability decision for a human, not a transport detail the automaton should
 take on itself.
 
-The names looked up are the ones that actually reach the gateway. The engine resolves a route
-from this same catalog, trying `openrouter/<slug>` and then the bare `<slug>`, and addresses the
-gateway by whichever it finds
-([`docs/LLM_LAYER.md` § speaking to the gateway](LLM_LAYER.md#speaking-to-the-gateway)), so this
-lookup checks both in that order and a prefixed-only entry *is* evidence.
+The names looked up are the ones that actually reach the gateway, because the lookup **calls the
+engine's resolver** rather than restating its rules: it asks about `<provider>/<slug>`, the model
+string the integration run will build, and reports what the run would get
+([`docs/LLM_LAYER.md` § speaking to the gateway](LLM_LAYER.md#speaking-to-the-gateway)). A
+prefixed-only entry *is* evidence, and so is a bare one.
 
-The two agree except on a catalog carrying **both** names for one model: this lookup reports the
-prefixed one, while the engine refuses to guess and requires `LLM_PROXY_PREFERRED_ROUTE`, because
-the two names can be backed by different upstreams. On such a catalog the reply promises a route
-the run will not take until that variable is set.
+Delegation rather than a second implementation because the two drifted once: a hand-mirrored copy
+of the rule reported a vendor wildcard (`x-ai/*`) as covering a model the run addresses as
+`openrouter/<slug>`, which the engine refuses - that wildcard is a different upstream. The reply
+said `via litellm` for a run that went to OpenRouter direct.
+
+Two deployment variables therefore change what the poller reports, and they are the same two the
+run reads: `LLM_PROXY_TRUST_NAMESPACE_WILDCARDS` (whether a passthrough counts as coverage at all)
+and `LLM_PROXY_PREFERRED_ROUTE` (which name wins when the catalog carries several). A catalog
+carrying **both** names for one model with no preference set is reported as *unknown* rather than
+reachable, because that is what a run does with it: it refuses to guess and raises.
 
 The report distinguishes two strengths, because they are not equally trustworthy:
 
 | Reply says | Means |
 |---|---|
 | `also on the gateway as <route>` | an explicit catalog entry for one of the two names, so someone configured this model |
-| `probably reachable … (matched a passthrough)` | only a wildcard over the slug's own namespace (`x-ai/*`, or a bare `*`) covers it; a live call is the real proof |
-| `not on the gateway` | the catalog was read and does not cover it |
+| `probably reachable … (matched a passthrough)` | no explicit entry: only a wildcard over the namespace the run addresses (`openrouter/*`) covers it, and only where the deployment sets `LLM_PROXY_TRUST_NAMESPACE_WILDCARDS`. A bare `*` never counts. A live call is the real proof |
+| `not on the gateway` | the catalog was read and does not cover it (an untrusted passthrough included) |
 
 A requester can choose the route with `via litellm` / `via openrouter` (also `through the
 gateway`, `using the proxy`, `via OR`). The directive is stripped before model-phrase parsing,

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -878,8 +878,9 @@ posting to a route the gateway does not serve.
 | `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
 | `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
 | `LLM_PROXY_PREFERRED_ROUTE` | Namespace that wins when the gateway serves one model under several names, e.g. `openrouter/`. Without it an ambiguous lookup raises rather than guessing a serving path. |
+| `LLM_PROXY_TRUST_NAMESPACE_WILDCARDS` | `true`/`false` (default `false`). When true, a catalog entry of `<ns>/*` routes models whose own `provider` is `<ns>`, addressed by their untranslated name. Namespace-matched only - a foreign wildcard never routes. Exact entries always win. |
 
-All six resolve through `SecretManager`, so `.env`, the process environment,
+All seven resolve through `SecretManager`, so `.env`, the process environment,
 and the runner container's `TOLOKAFORGE_SECRETS_JSON` behave identically.
 A malformed value raises `ProxyConfigError` at the first `LLMClient`
 construction rather than running a whole evaluation with unattributed spend. Setting
@@ -1000,14 +1001,18 @@ per-client warning. On a gateway-only model that direct call fails; on any other
 runs unattributed. If a deployment cannot rename such a route, the exact-name entry
 has to be added alongside the alias.
 
-Wildcard entries (`openrouter/*`, `anthropic/*`) are deliberately **not** accepted as
-evidence: a wildcard says the gateway will forward the request, not that the model
+Wildcard entries (`openrouter/*`, `anthropic/*`) are **not** accepted as evidence by
+default: a wildcard says the gateway will forward the request, not that the model
 exists behind it. Measured on a live gateway, `anthropic/*` accepted a name that its
 Bedrock backing then rejected as invalid, while the very same wildcard also "covered"
-a nonexistent model. If routing every model through the gateway ever becomes the
-goal, the extension point is a *namespace-matched* wildcard (accept `openrouter/*`
-only for `provider: openrouter` configs, where the fallback is the same upstream the
-board is calibrated on), not looser matching.
+a nonexistent model. The opt-in (`LLM_PROXY_TRUST_NAMESPACE_WILDCARDS=true`)
+implements exactly the safe extension point that incident left room for: a
+*namespace-matched* wildcard - `<ns>/*` routes only `provider: <ns>` models, where
+the passthrough forwards to the same upstream the board is calibrated on, addressed
+by the untranslated model string. A foreign-namespace wildcard never routes, exact
+entries always win, and a wildcard-resolved call is recorded as such on the per-call
+usage (`gateway_route_kind: "wildcard"`), so a board audit can tell the serving
+paths apart.
 
 Preset resolution and pricing are unaffected: both key off `ModelConfig.provider` /
 `.name`, not off the wire name.
@@ -1106,11 +1111,16 @@ couplings described below:
   but verify it for reasoning models before trusting a run.
 
 What `_build_kwargs` does differs by path. **On a resolved route** it rewrites
-`model` to the gateway's route name, forces `custom_llm_provider="openai"`, and
-drops OpenRouter-only body fields (`extra_body.provider`). **On the
-unrouted / unreadable-catalog path** it sets only `api_base`, `api_key` and
-`extra_headers`; the model string keeps its `<provider>/<name>` shape, and
-OpenRouter's headers and provider pin still apply. Two distinct couplings hang off
+`model` to the gateway's route name and forces `custom_llm_provider="openai"`.
+**On the unrouted / unreadable-catalog path** it sets only `api_base`, `api_key`
+and `extra_headers`; the model string keeps its `<provider>/<name>` shape. The
+provider pin follows **one rule on both paths**: `extra_body.provider` survives
+exactly when the wire name's first segment is the model's own provider
+namespace - an `openrouter/...` route (or the untranslated `openrouter/<name>`
+string) forwards to the same upstream family the pin was written for, so the
+pin rides; a route into any other namespace is another upstream, so the pin is
+dropped with a warning rather than sent to a server that rejects or silently
+ignores it. Two distinct couplings hang off
 model naming, and only the second is to the formatted string:
 
 - Preset `match:` globs resolve off `ModelConfig.name` and the `providers:`
@@ -1126,8 +1136,13 @@ model naming, and only the second is to the formatted string:
 
 `ModelConfig.provider` is untouched either way, so OpenRouter's
 `HTTP-Referer` / `X-Title` headers still apply on top of the gateway; the
-`extra_body.provider` upstream pin applies only on the unrouted path (a resolved
-route drops it, since a non-OpenRouter upstream rejects it as an unknown field).
+`extra_body.provider` upstream pin follows the namespace rule above (kept
+whenever the wire name stays in the model's own provider namespace, resolved or
+not; dropped otherwise). A pinned model on a same-namespace route is only
+FAITHFULLY pinned if the gateway forwards the field to the upstream - which is
+gateway-version-dependent, so the live suite verifies the actually-serving
+upstream through the OpenRouter generation id rather than trusting the request
+shape (see below).
 On a header-name collision the gateway's configured header wins, since that is
 explicit operator configuration and the other is an engine default.
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -877,7 +877,7 @@ posting to a route the gateway does not serve.
 | `LLM_PROXY_HEADERS` | JSON object of static headers added to every request, e.g. `{"X-Team-Id": "research"}`. Wins over the engine's own provider headers on a name collision. A value may reference a secret as `${secret:NAME}`, see below. |
 | `LLM_PROXY_REQUEST_ID_HEADER` | Header *name* that receives a fresh UUID4 per request. A static env var cannot express "new value per call". |
 | `LLM_PROXY_PROVIDERS` | Comma-separated provider allow-list, replacing the default. Read the routing table below before widening it. |
-| `LLM_PROXY_PREFERRED_ROUTE` | Namespace that wins when the gateway serves one model under several names, e.g. `openrouter/`. Without it an ambiguous lookup raises rather than guessing a serving path. |
+| `LLM_PROXY_PREFERRED_ROUTE` | Namespace(s) that win when the gateway serves one model under several names. A comma-separated list is honoured in order (`openrouter/,nebius/`), so multi-provider gateways can rank their routes. Without a matching entry an ambiguous lookup raises rather than guessing a serving path. |
 | `LLM_PROXY_TRUST_NAMESPACE_WILDCARDS` | `true`/`false` (default `false`). When true, a catalog entry of `<ns>/*` routes models whose own `provider` is `<ns>`, addressed by their untranslated name. Namespace-matched only - a foreign wildcard never routes. Exact entries always win. |
 
 All seven resolve through `SecretManager`, so `.env`, the process environment,
@@ -1013,6 +1013,31 @@ by the untranslated model string. A foreign-namespace wildcard never routes, exa
 entries always win, and a wildcard-resolved call is recorded as such on the per-call
 usage (`gateway_route_kind: "wildcard"`), so a board audit can tell the serving
 paths apart.
+
+### Serving a NEW provider behind the gateway
+
+Wiring an additional upstream (a self-hosted vLLM fleet, a direct vendor
+account) into the gateway needs **no engine change**. The recipe:
+
+1. The gateway operator adds the catalog entries - exact names
+   (`nebius-llmqa-vllm/qwen3-32b`) or the namespace wildcard
+   (`nebius-llmqa-vllm/*`).
+2. The deployment allow-lists the provider: `LLM_PROXY_PROVIDERS=
+   openrouter,openai,nebius-llmqa-vllm` - deliberate fail-closed, so a new
+   catalog namespace never reroutes configs by itself.
+3. Configs name the provider as the FACT it is: `provider: nebius-llmqa-vllm`,
+   `name: qwen3-32b`. A resolved route forces the OpenAI-compatible dialect,
+   so litellm does not need to know the provider natively - which also means
+   such a provider works **only while the catalog is readable**: on the
+   unreadable-catalog path the call keeps the provider-native dialect and
+   fails loudly for a provider litellm cannot speak to directly.
+4. With several gateway namespaces in play, rank them:
+   `LLM_PROXY_PREFERRED_ROUTE=openrouter/,nebius-llmqa-vllm/`.
+5. Pricing and presets follow the normal registration path (they key off
+   `provider`/`name`, so nothing is lost by the gateway hop), and a new
+   serving path is a new calibration - never mix it with another path
+   inside one comparable set; the per-call `gateway_route` /
+   `gateway_route_kind` provenance is what audits the split.
 
 Preset resolution and pricing are unaffected: both key off `ModelConfig.provider` /
 `.name`, not off the wire name.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1189,10 +1189,14 @@ credential is present**, so a checkout without the secret is quiet:
 | `LLM_PROXY_INT_TEST_MODEL` | no | The model name **as the gateway routes it**. Required rather than defaulted: a wrong guess would exercise the gateway's fallback behaviour instead of this transport. Plain config — belongs in a workflow's `env:`. |
 | `LLM_PROXY_INT_TEST_BASE_URL` | depends | Gateway base URL; falls back to `LLM_PROXY_BASE_URL`. Keep it out of a public workflow file if the hostname is internal. |
 | `LLM_PROXY_INT_TEST_PROVIDER` | no | Optional, default `openai` — see the model-naming section above. |
+| `LLM_PROXY_INT_TEST_PINNED_MODEL` | no | Optional opt-in for the pinned-upstream check: an OpenRouter-namespace slug (`nvidia/nemotron-3-super-120b-a12b`). Both pinned vars must be set together. |
+| `LLM_PROXY_INT_TEST_PINNED_PROVIDER` | no | The exact OpenRouter provider name expected to serve the pinned call (`Together`). Needs `OPENROUTER_API_KEY` for the retroactive `/generation` lookup. |
 
-Three tests: one asserts the transport is applied and billed to the test key
+Four tests: one asserts the transport is applied and billed to the test key
 without spending, two make one small call each (a completion and a tool call,
-capped at 256 output tokens).
+capped at 256 output tokens), and the opt-in pinned-upstream check makes one
+provider-pinned call and verifies the actually-serving upstream through
+OpenRouter's `/generation` endpoint.
 
 **The gating is asymmetric on purpose.** No credential → skip, quietly, which is
 the state of any checkout without the secret. Credential present but a companion

--- a/docs/OUTPUT_FORMAT.md
+++ b/docs/OUTPUT_FORMAT.md
@@ -575,7 +575,9 @@ first-class fields; a `provider_raw` dump of the litellm usage block is
 included for forensics. Each LLM API call is also recorded in
 `usage.calls[]` as a `ProviderRawCall` carrying its per-call tokens,
 `cost_usd`, `cost_source` (`"litellm"` / `"local"` / `"unknown"`),
-`latency_s`, and `openrouter_generation_id` — the trial-level `cost_usd` is the
+`latency_s`, `gateway_route` + `gateway_route_kind` (`"exact"` / `"wildcard"`,
+the serving-path provenance when the call went through an LLM gateway, else
+null), and `openrouter_generation_id` — the trial-level `cost_usd` is the
 sum of those entries.
 
 `openrouter_generation_ids` lists every OpenRouter generation id the trial's
@@ -628,6 +630,8 @@ usage:
       cost_usd: 0.00912
       cost_source: litellm
       latency_s: 1.23
+      gateway_route: openrouter/anthropic/claude-sonnet-4.6
+      gateway_route_kind: exact
       openrouter_generation_id: gen-1787132417-e6DthuPJjrFMFf46ae5F
 openrouter_generation_ids:   # one per OpenRouter-served call, in call order
   - gen-1787132417-e6DthuPJjrFMFf46ae5F

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -16,7 +16,7 @@ installs a SecretManager that overrides that name for the test's duration, so a
 CI budget for integration tests stays separate from a deployment's production
 gateway budget, and a local ``.env`` cannot accidentally charge the wrong key.
 
-Two calls reach the network, each capped at a few dozen output tokens.
+Three calls reach the network (the pinned-upstream check is opt-in), each capped at a few dozen output tokens.
 
 Environment contract
 --------------------
@@ -64,7 +64,10 @@ from tolokaforge.core.llm.proxy import (
     ENV_API_KEY,
     ENV_BASE_URL,
     ENV_HEADERS,
+    ENV_PREFERRED_ROUTE,
+    ENV_PROVIDERS,
     ENV_REQUEST_ID_HEADER,
+    ENV_TRUST_WILDCARDS,
 )
 from tolokaforge.core.llm.reasoning import ReasoningConfig
 from tolokaforge.core.models import Message, MessageRole, ModelConfig
@@ -154,7 +157,13 @@ def gateway_client(gateway_key: str) -> Iterator[LLMClient]:
     # Override the gateway credential so this run bills to the test budget even
     # when a production LLM_PROXY_API_KEY is present in .env or the environment.
     secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: gateway_key}
-    for passthrough in (ENV_HEADERS, ENV_REQUEST_ID_HEADER):
+    for passthrough in (
+        ENV_HEADERS,
+        ENV_REQUEST_ID_HEADER,
+        ENV_PROVIDERS,
+        ENV_PREFERRED_ROUTE,
+        ENV_TRUST_WILDCARDS,
+    ):
         value = _secret(passthrough)
         if value:
             secrets[passthrough] = value
@@ -281,7 +290,11 @@ def test_pinned_provider_reaches_the_upstream(gateway_key: str) -> None:
         )
     openrouter_key = _secret("OPENROUTER_API_KEY")
     if not openrouter_key:
-        pytest.skip("OPENROUTER_API_KEY not set - the /generation lookup needs it.")
+        pytest.fail(
+            f"{ENV_TEST_PINNED_MODEL} is set but OPENROUTER_API_KEY is not - the "
+            "/generation lookup needs it. Unset the pinned-model envs to disable "
+            "this test deliberately."
+        )
 
     base_url = _secret(ENV_TEST_BASE_URL) or _secret(ENV_BASE_URL)
     if not base_url:
@@ -291,7 +304,13 @@ def test_pinned_provider_reaches_the_upstream(gateway_key: str) -> None:
         )
 
     secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: gateway_key}
-    for passthrough in (ENV_HEADERS, ENV_REQUEST_ID_HEADER):
+    for passthrough in (
+        ENV_HEADERS,
+        ENV_REQUEST_ID_HEADER,
+        ENV_PROVIDERS,
+        ENV_PREFERRED_ROUTE,
+        ENV_TRUST_WILDCARDS,
+    ):
         value = _secret(passthrough)
         if value:
             secrets[passthrough] = value

--- a/tests/integration/llm/test_gateway_live.py
+++ b/tests/integration/llm/test_gateway_live.py
@@ -77,6 +77,12 @@ ENV_TEST_API_KEY = "LLM_PROXY_INT_TEST_API_KEY"
 ENV_TEST_MODEL = "LLM_PROXY_INT_TEST_MODEL"
 ENV_TEST_BASE_URL = "LLM_PROXY_INT_TEST_BASE_URL"
 ENV_TEST_PROVIDER = "LLM_PROXY_INT_TEST_PROVIDER"
+# Optional pinned-upstream check (skipped when unset): an OpenRouter-namespace
+# slug plus the exact OpenRouter provider name expected to serve it. Needs a
+# gateway that forwards openrouter/... routes AND an OPENROUTER_API_KEY for the
+# retroactive /generation lookup.
+ENV_TEST_PINNED_MODEL = "LLM_PROXY_INT_TEST_PINNED_MODEL"
+ENV_TEST_PINNED_PROVIDER = "LLM_PROXY_INT_TEST_PINNED_PROVIDER"
 
 _WEATHER_TOOL = {
     "type": "function",
@@ -251,3 +257,85 @@ def test_gateway_serves_a_tool_call(gateway_client: LLMClient) -> None:
     # tool payload shows up as a missing key rather than a silent pass.
     assert "city" in arguments
     assert "unit" in arguments
+
+
+def test_pinned_provider_reaches_the_upstream(gateway_key: str) -> None:
+    """A provider-pinned call through the gateway is served by THE pinned upstream.
+
+    This is the check the request shape cannot give: litellm's proxy may or may
+    not forward ``extra_body.provider`` to OpenRouter depending on its version,
+    and an upstream silently ignoring the field is invisible in the response
+    body. OpenRouter's ``/generation`` endpoint reports which provider actually
+    served the call, keyed by the generation id the engine already extracts
+    (``usage.openrouter_generation_id``).
+    """
+    import json
+    import urllib.request
+
+    pinned_model = _secret(ENV_TEST_PINNED_MODEL)
+    pinned_provider = _secret(ENV_TEST_PINNED_PROVIDER)
+    if not pinned_model or not pinned_provider:
+        pytest.skip(
+            f"{ENV_TEST_PINNED_MODEL} / {ENV_TEST_PINNED_PROVIDER} not set - "
+            "skipping the pinned-upstream check."
+        )
+    openrouter_key = _secret("OPENROUTER_API_KEY")
+    if not openrouter_key:
+        pytest.skip("OPENROUTER_API_KEY not set - the /generation lookup needs it.")
+
+    base_url = _secret(ENV_TEST_BASE_URL) or _secret(ENV_BASE_URL)
+    if not base_url:
+        pytest.fail(
+            f"{ENV_TEST_PINNED_MODEL} is set but no gateway base URL is; set "
+            f"{ENV_TEST_BASE_URL} or {ENV_BASE_URL}."
+        )
+
+    secrets: dict[str, str] = {ENV_BASE_URL: base_url, ENV_API_KEY: gateway_key}
+    for passthrough in (ENV_HEADERS, ENV_REQUEST_ID_HEADER):
+        value = _secret(passthrough)
+        if value:
+            secrets[passthrough] = value
+
+    original = secrets_manager._default_manager
+    secrets_manager._default_manager = SecretManager([DictProvider(secrets)])
+    try:
+        client = LLMClient(
+            ModelConfig(
+                provider="openrouter",
+                name=pinned_model,
+                temperature=0.0,
+                max_tokens=64,
+                reasoning=ReasoningConfig(mode="off"),
+                openrouter={"provider_order": [pinned_provider], "allow_fallbacks": False},
+            )
+        )
+        assert client._proxy is not None, "gateway did not claim the openrouter provider"
+        result = client.generate(
+            system="Answer with a single word.",
+            messages=[Message(role=MessageRole.USER, content="Say OK")],
+        )
+    finally:
+        secrets_manager._default_manager = original
+
+    generation_ids = [
+        call.openrouter_generation_id
+        for call in result.usage.calls
+        if call.openrouter_generation_id
+    ]
+    assert generation_ids, (
+        "no OpenRouter generation id on the response: either the gateway does not "
+        "forward upstream response headers (attribution is then impossible on this "
+        "route) or the call never reached OpenRouter"
+    )
+
+    request = urllib.request.Request(
+        f"https://openrouter.ai/api/v1/generation?id={generation_ids[-1]}",
+        headers={"Authorization": f"Bearer {openrouter_key}"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    served_by = (payload.get("data") or {}).get("provider_name")
+    assert served_by == pinned_provider, (
+        f"the pin did not hold through the gateway: pinned {pinned_provider!r}, "
+        f"served by {served_by!r} - the proxy dropped extra_body.provider"
+    )

--- a/tests/unit/llm/test_gateway_route.py
+++ b/tests/unit/llm/test_gateway_route.py
@@ -92,6 +92,16 @@ class TestNamespaceWildcard:
         assert route == "anthropic/claude-sonnet-4.6"
         assert route.kind == "exact"
 
+    def test_a_non_openrouter_namespace_works_the_same_way(self) -> None:
+        """The rule is generic: any provider namespace, e.g. a self-hosted vLLM."""
+        route = resolve_gateway_route(
+            "nebius-llmqa-vllm/qwen3-32b",
+            frozenset({"nebius-llmqa-vllm/*"}),
+            trust_namespace_wildcards=True,
+        )
+        assert route == "nebius-llmqa-vllm/qwen3-32b"
+        assert route.kind == "wildcard"
+
     def test_a_bare_global_star_is_not_trusted(self) -> None:
         """Only the namespace form carries meaning; ``*`` says nothing."""
         assert (
@@ -129,6 +139,15 @@ class TestAmbiguityIsRefused:
             resolve_gateway_route("openrouter/anthropic/claude-sonnet-4.6", self.both, preference)
             == expected
         )
+
+    def test_a_preference_list_is_honoured_in_order(self) -> None:
+        """Multi-namespace deployments rank their routes; the first match wins."""
+        route = resolve_gateway_route(
+            "openrouter/anthropic/claude-sonnet-4.6",
+            self.both,
+            "gemini/,anthropic/,openrouter/",
+        )
+        assert route == "anthropic/claude-sonnet-4.6"
 
     def test_a_preference_matching_neither_still_raises(self) -> None:
         """Silently ignoring the preference would pick a serving path nobody asked for."""

--- a/tests/unit/llm/test_gateway_route.py
+++ b/tests/unit/llm/test_gateway_route.py
@@ -180,3 +180,36 @@ class TestUnreadableIsNotAbsent:
     def test_an_empty_catalog_is_treated_as_no_information(self) -> None:
         """A gateway that answers with zero models is broken, not authoritative."""
         assert resolve_gateway_route("openrouter/x/y", frozenset()) is None
+
+
+class TestResolvedRouteSurvivesCopying:
+    """The route rides inside ProviderRawCall records, and dataclasses.asdict
+    DEEPCOPIES every one of them on the way into metrics.yaml - so a str
+    subclass that cannot reconstruct itself kills every routed run at the
+    first artifact write, whatever the wildcard flag says."""
+
+    def test_deepcopy_and_pickle_round_trip(self) -> None:
+        import copy
+        import pickle
+
+        from tolokaforge.core.llm.gateway_route import ResolvedGatewayRoute
+
+        route = ResolvedGatewayRoute("openrouter/minimax/minimax-m3", kind="wildcard")
+        for clone in (copy.copy(route), copy.deepcopy(route), pickle.loads(pickle.dumps(route))):
+            assert clone == "openrouter/minimax/minimax-m3"
+            assert clone.kind == "wildcard"
+
+    def test_a_call_record_carrying_a_route_serializes(self) -> None:
+        import dataclasses
+
+        from tolokaforge.core.llm.gateway_route import ResolvedGatewayRoute
+        from tolokaforge.core.llm.usage import ProviderRawCall
+
+        call = ProviderRawCall(
+            prompt_tokens=1,
+            completion_tokens=1,
+            gateway_route=ResolvedGatewayRoute("openrouter/x", kind="exact"),
+            gateway_route_kind="exact",
+        )
+        dumped = dataclasses.asdict(call)
+        assert dumped["gateway_route"] == "openrouter/x"

--- a/tests/unit/llm/test_gateway_route.py
+++ b/tests/unit/llm/test_gateway_route.py
@@ -46,6 +46,63 @@ class TestRouteName:
     def test_a_provider_less_model_string_has_one_candidate(self) -> None:
         assert resolve_gateway_route("solo", frozenset({"solo"})) == "solo"
 
+    def test_an_exact_hit_reports_its_kind(self) -> None:
+        route = resolve_gateway_route(
+            "openrouter/anthropic/claude-sonnet-4.6",
+            frozenset({"openrouter/anthropic/claude-sonnet-4.6"}),
+        )
+        assert route.kind == "exact"
+
+
+class TestNamespaceWildcard:
+    """``<ns>/*`` routes a ``provider: <ns>`` model - opt-in, exact wins."""
+
+    catalog = frozenset({"openrouter/*", "anthropic/*"})
+
+    def test_off_by_default(self) -> None:
+        assert resolve_gateway_route("openrouter/minimax/minimax-m3", self.catalog) is None
+
+    def test_the_models_own_namespace_wildcard_routes_it_untranslated(self) -> None:
+        route = resolve_gateway_route(
+            "openrouter/minimax/minimax-m3",
+            self.catalog,
+            trust_namespace_wildcards=True,
+        )
+        assert route == "openrouter/minimax/minimax-m3"
+        assert route.kind == "wildcard"
+
+    def test_a_foreign_namespace_wildcard_is_not_a_route(self) -> None:
+        """``anthropic/*`` for an openrouter model is another upstream."""
+        assert (
+            resolve_gateway_route(
+                "openrouter/minimax/minimax-m3",
+                frozenset({"anthropic/*"}),
+                trust_namespace_wildcards=True,
+            )
+            is None
+        )
+
+    def test_an_exact_entry_wins_over_the_wildcard(self) -> None:
+        catalog = frozenset({"openrouter/*", "anthropic/claude-sonnet-4.6"})
+        route = resolve_gateway_route(
+            "openrouter/anthropic/claude-sonnet-4.6",
+            catalog,
+            trust_namespace_wildcards=True,
+        )
+        assert route == "anthropic/claude-sonnet-4.6"
+        assert route.kind == "exact"
+
+    def test_a_bare_global_star_is_not_trusted(self) -> None:
+        """Only the namespace form carries meaning; ``*`` says nothing."""
+        assert (
+            resolve_gateway_route(
+                "openrouter/minimax/minimax-m3",
+                frozenset({"*"}),
+                trust_namespace_wildcards=True,
+            )
+            is None
+        )
+
 
 class TestAmbiguityIsRefused:
     """Two names for one model can be two different upstreams, so guessing is refused."""

--- a/tests/unit/llm/test_gateway_routing_applied.py
+++ b/tests/unit/llm/test_gateway_routing_applied.py
@@ -142,11 +142,11 @@ class TestModelConfigIsUntouched:
         assert client.config.provider == "openrouter"
 
 
-class TestOpenRouterOnlyBodyFieldsAreDropped:
-    def test_the_provider_pin_does_not_ride_to_the_gateway(
+class TestProviderPinFollowsTheNamespaceRule:
+    def test_the_pin_rides_when_the_route_stays_in_the_models_namespace(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Same class as the usage extension: a non-OpenRouter upstream rejects it."""
+        """An ``openrouter/...`` route forwards to OpenRouter, which honours the pin."""
         from tolokaforge.core.models import OpenRouterConfig
 
         secrets_manager._default_manager = SecretManager(
@@ -169,8 +169,72 @@ class TestOpenRouterOnlyBodyFieldsAreDropped:
             openrouter=OpenRouterConfig(provider_order=["anthropic"]),
         )
         kwargs = _kwargs(LLMClient(config))
+        assert kwargs["extra_body"]["provider"]["order"] == ["anthropic"]
+        assert kwargs["custom_llm_provider"] == "openai"
+
+    def test_the_pin_is_dropped_when_the_route_leaves_the_namespace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare-name route targets another upstream, which rejects the field."""
+        from tolokaforge.core.models import OpenRouterConfig
+
+        secrets_manager._default_manager = SecretManager(
+            [
+                DictProvider(
+                    {
+                        "OPENROUTER_API_KEY": "sk-or",
+                        "LLM_PROXY_BASE_URL": GATEWAY,
+                        "LLM_PROXY_API_KEY": "sk-gw",
+                    }
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            "tolokaforge.core.llm.client.fetch_gateway_catalog",
+            lambda *_a, **_k: frozenset({MODEL}),
+        )
+        config = ModelConfig(
+            provider="openrouter",
+            name=MODEL,
+            openrouter=OpenRouterConfig(provider_order=["anthropic"]),
+        )
+        kwargs = _kwargs(LLMClient(config))
         assert "provider" not in kwargs.get("extra_body", {})
         assert kwargs["custom_llm_provider"] == "openai"
+
+    def test_a_trusted_wildcard_routes_untranslated_and_keeps_the_pin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The openrouter/* passthrough forwards to OpenRouter, which honours the pin."""
+        from tolokaforge.core.models import OpenRouterConfig
+
+        secrets_manager._default_manager = SecretManager(
+            [
+                DictProvider(
+                    {
+                        "OPENROUTER_API_KEY": "sk-or",
+                        "LLM_PROXY_BASE_URL": GATEWAY,
+                        "LLM_PROXY_API_KEY": "sk-gw",
+                        "LLM_PROXY_TRUST_NAMESPACE_WILDCARDS": "true",
+                    }
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            "tolokaforge.core.llm.client.fetch_gateway_catalog",
+            lambda *_a, **_k: frozenset({"openrouter/*"}),
+        )
+        config = ModelConfig(
+            provider="openrouter",
+            name=MODEL,
+            openrouter=OpenRouterConfig(provider_order=["anthropic"]),
+        )
+        client = LLMClient(config)
+        assert client._gateway_route_kind == "wildcard"
+        kwargs = _kwargs(client)
+        assert kwargs["model"] == FULL
+        assert kwargs["custom_llm_provider"] == "openai"
+        assert kwargs["extra_body"]["provider"]["order"] == ["anthropic"]
 
     def test_it_still_rides_when_the_call_is_not_routed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/llm/test_llm_proxy.py
+++ b/tests/unit/llm/test_llm_proxy.py
@@ -593,3 +593,35 @@ class TestGatewayQuotaRejection:
         assert client._current_key_index == 2
         assert os.environ.get("OPENROUTER_API_KEY") == "k3"
         assert "All API keys exhausted" in message
+
+
+class TestTrustWildcardsFlag:
+    def test_default_is_off(self, install_secrets) -> None:
+        install_secrets({"LLM_PROXY_BASE_URL": "https://gateway.example.com"})
+        assert resolve_proxy_config().trust_namespace_wildcards is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes"])
+    def test_truthy_values(self, install_secrets, value: str) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_TRUST_NAMESPACE_WILDCARDS": value,
+            }
+        )
+        assert resolve_proxy_config().trust_namespace_wildcards is True
+
+    def test_garbage_is_refused(self, install_secrets) -> None:
+        install_secrets(
+            {
+                "LLM_PROXY_BASE_URL": "https://gateway.example.com",
+                "LLM_PROXY_TRUST_NAMESPACE_WILDCARDS": "openrouter",
+            }
+        )
+        with pytest.raises(ProxyConfigError):
+            resolve_proxy_config()
+
+    def test_set_without_a_base_url_is_an_orphan(self, install_secrets) -> None:
+        """A companion without the on-switch means a typo, never silent direct."""
+        install_secrets({"LLM_PROXY_TRUST_NAMESPACE_WILDCARDS": "true"})
+        with pytest.raises(ProxyConfigError):
+            resolve_proxy_config()

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -1867,12 +1867,16 @@ class LLMClient:
                 extra_body = kwargs.get("extra_body")
                 if isinstance(extra_body, dict) and "provider" in extra_body:
                     extra_body.pop("provider")
-                    self.logger.warning(
-                        "Dropping the OpenRouter provider pin: the gateway route "
-                        "targets another namespace, whose upstream rejects it",
-                        route=wire_model,
-                        provider=self.provider,
-                    )
+                    if not getattr(self, "_pin_drop_warned", False):
+                        # Once per client, not per call: a full eval makes
+                        # thousands of calls and the fact does not change.
+                        self._pin_drop_warned = True
+                        self.logger.warning(
+                            "Dropping the OpenRouter provider pin: the gateway route "
+                            "targets another namespace, whose upstream rejects it",
+                            route=wire_model,
+                            provider=self.provider,
+                        )
                     if not extra_body:
                         kwargs.pop("extra_body")
             kwargs["api_base"] = self._proxy.base_url
@@ -2204,7 +2208,9 @@ class LLMClient:
             latency_s=latency_s,
             cost_usd=cost_usd,
             cost_source=cost_source,
-            gateway_route=self._gateway_route,
+            # Plain str on purpose: the artifact carries data, not the resolver's
+            # str subclass (asdict deepcopies every call record).
+            gateway_route=str(self._gateway_route) if self._gateway_route is not None else None,
             gateway_route_kind=self._gateway_route_kind,
         )
 

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -614,6 +614,7 @@ class LLMClient:
         # to the direct provider rather than post a name it cannot route.
         # docs/LLM_LAYER.md § Speaking to the gateway.
         self._gateway_route: str | None = None
+        self._gateway_route_kind: str | None = None
         if self._proxy is not None:
             catalog = fetch_gateway_catalog(self._proxy)
             if catalog is None:
@@ -628,8 +629,18 @@ class LLMClient:
                 # A readable catalog is never empty here: the fetch maps an empty
                 # answer to None, so resolver-None below can only mean "omitted".
                 self._gateway_route = resolve_gateway_route(
-                    self.model_name, catalog, self._proxy.preferred_route
+                    self.model_name,
+                    catalog,
+                    self._proxy.preferred_route,
+                    trust_namespace_wildcards=self._proxy.trust_namespace_wildcards,
                 )
+                self._gateway_route_kind = getattr(self._gateway_route, "kind", None)
+                if self._gateway_route_kind == "wildcard":
+                    self.logger.info(
+                        "Gateway route resolved via the model namespace wildcard",
+                        base_url=self._proxy.base_url,
+                        model=self.model_name,
+                    )
                 if self._gateway_route is None:
                     self.logger.warning(
                         "Gateway does not serve this model; calling the provider directly",
@@ -1843,11 +1854,25 @@ class LLMClient:
             if route is not None:
                 kwargs["model"] = route
                 kwargs["custom_llm_provider"] = "openai"
-                # Same class as the usage extension the dialect switch removes: an
-                # OpenRouter-only body field a non-OpenRouter upstream rejects.
+            # ONE rule for the provider pin on BOTH gateway paths (resolved route
+            # and unreadable catalog): ``extra_body.provider`` survives the hop
+            # exactly when the wire name's first segment IS the model's own
+            # provider namespace - the upstream behind such a route is the same
+            # family the pin was written for, and honours it. A route into any
+            # other namespace is another upstream, which rejects the field or,
+            # worse, silently ignores it. docs/LLM_LAYER.md § Speaking to the
+            # gateway.
+            wire_model = str(kwargs.get("model", self.model_name))
+            if wire_model.split("/", 1)[0] != self.provider.split("/", 1)[0]:
                 extra_body = kwargs.get("extra_body")
-                if isinstance(extra_body, dict):
-                    extra_body.pop("provider", None)
+                if isinstance(extra_body, dict) and "provider" in extra_body:
+                    extra_body.pop("provider")
+                    self.logger.warning(
+                        "Dropping the OpenRouter provider pin: the gateway route "
+                        "targets another namespace, whose upstream rejects it",
+                        route=wire_model,
+                        provider=self.provider,
+                    )
                     if not extra_body:
                         kwargs.pop("extra_body")
             kwargs["api_base"] = self._proxy.base_url
@@ -2179,6 +2204,8 @@ class LLMClient:
             latency_s=latency_s,
             cost_usd=cost_usd,
             cost_source=cost_source,
+            gateway_route=self._gateway_route,
+            gateway_route_kind=self._gateway_route_kind,
         )
 
         return GenerationResult(

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -45,7 +45,12 @@ from tenacity.wait import wait_base
 from tolokaforge.core.actors.actor import Actor
 from tolokaforge.core.actors.reply_guard import UserReplyGuard
 from tolokaforge.core.llm.capabilities import ModelCapabilities
-from tolokaforge.core.llm.gateway_route import fetch_gateway_catalog, resolve_gateway_route
+from tolokaforge.core.llm.gateway_route import (
+    ResolvedGatewayRoute,
+    RouteKind,
+    fetch_gateway_catalog,
+    resolve_gateway_route,
+)
 from tolokaforge.core.llm.litellm_params import allowed_openai_params
 from tolokaforge.core.llm.params_policy import RuleAction
 from tolokaforge.core.llm.presets import build_capabilities
@@ -613,8 +618,11 @@ class LLMClient:
         # A gateway that does not serve this model must not intercept it: fall back
         # to the direct provider rather than post a name it cannot route.
         # docs/LLM_LAYER.md § Speaking to the gateway.
-        self._gateway_route: str | None = None
-        self._gateway_route_kind: str | None = None
+        self._gateway_route: ResolvedGatewayRoute | None = None
+        self._gateway_route_kind: RouteKind | None = None
+        # Declared here rather than created on the first pin drop, so the flag stays
+        # inside the client's attribute set. See the drop site in _call_with_retry.
+        self._pin_drop_warned: bool = False
         if self._proxy is not None:
             catalog = fetch_gateway_catalog(self._proxy)
             if catalog is None:
@@ -634,7 +642,9 @@ class LLMClient:
                     self._proxy.preferred_route,
                     trust_namespace_wildcards=self._proxy.trust_namespace_wildcards,
                 )
-                self._gateway_route_kind = getattr(self._gateway_route, "kind", None)
+                self._gateway_route_kind = (
+                    self._gateway_route.kind if self._gateway_route is not None else None
+                )
                 if self._gateway_route_kind == "wildcard":
                     self.logger.info(
                         "Gateway route resolved via the model namespace wildcard",
@@ -1867,7 +1877,7 @@ class LLMClient:
                 extra_body = kwargs.get("extra_body")
                 if isinstance(extra_body, dict) and "provider" in extra_body:
                     extra_body.pop("provider")
-                    if not getattr(self, "_pin_drop_warned", False):
+                    if not self._pin_drop_warned:
                         # Once per client, not per call: a full eval makes
                         # thousands of calls and the fact does not change.
                         self._pin_drop_warned = True

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -142,8 +142,10 @@ def resolve_gateway_route(
         catalog: Route ids from :func:`fetch_gateway_catalog`. ``None`` means the
             catalog could not be read, which the caller treats as "keep the gateway,
             skip rewriting" rather than as "not served".
-        preferred_prefix: Namespace that wins when the gateway serves the model under
-            more than one name.
+        preferred_prefix: Namespace(s) that win when the gateway serves the model
+            under more than one name. A comma-separated list is honoured in
+            order (first matching prefix wins), so a deployment serving several
+            provider namespaces can rank them: ``"openrouter/,nebius/"``.
         trust_namespace_wildcards: Whether a catalog entry of ``<ns>/*`` counts
             as a route for a model whose OWN provider namespace is ``<ns>`` (an
             ``openrouter/*`` passthrough then serves ``provider: openrouter``
@@ -171,12 +173,15 @@ def resolve_gateway_route(
         return ResolvedGatewayRoute(hits[0], kind="exact")
 
     if preferred_prefix:
-        for hit in hits:
-            if hit.startswith(preferred_prefix):
-                return ResolvedGatewayRoute(hit, kind="exact")
+        prefixes = [p.strip() for p in preferred_prefix.split(",") if p.strip()]
+        for prefix in prefixes:
+            for hit in hits:
+                if hit.startswith(prefix):
+                    return ResolvedGatewayRoute(hit, kind="exact")
     raise GatewayRouteError(
         f"the gateway serves {model_string!r} under {len(hits)} names ({', '.join(hits)}) "
         f"and no preference picks one. They can be backed by different upstreams, so "
         f"this is a serving-path choice rather than a transport detail: set "
-        f"LLM_PROXY_PREFERRED_ROUTE to the namespace you want."
+        f"LLM_PROXY_PREFERRED_ROUTE to the namespace you want "
+        f"(a comma-separated list is honoured in order)."
     )

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -58,6 +58,13 @@ class ResolvedGatewayRoute(str):
         route.kind = kind
         return route
 
+    def __getnewargs__(self) -> tuple[str, str]:
+        # str.__getnewargs__ returns only the string value, so copy.copy,
+        # copy.deepcopy and pickle would reconstruct with a missing ``kind``
+        # and die - and dataclasses.asdict deepcopies every ProviderRawCall
+        # on its way into metrics.yaml, which is every routed call's path.
+        return (str(self), self.kind)
+
 
 class GatewayRouteError(Exception):
     """The gateway serves this model under more than one name and none was chosen."""

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GatewayRouteError",
+    "ResolvedGatewayRoute",
     "resolve_gateway_route",
     "fetch_gateway_catalog",
     "clear_catalog_cache",
@@ -39,6 +40,23 @@ _RETRY_AFTER: dict[str, float] = {}
 
 #: How long to stop asking after a failure.
 CATALOG_RETRY_COOLDOWN_S = 60.0
+
+
+class ResolvedGatewayRoute(str):
+    """A gateway route name that also says HOW it matched.
+
+    A ``str`` subclass so every existing caller keeps treating the route as
+    the wire model name, while ``kind`` records whether the catalog held the
+    exact entry ("exact") or only the model's own namespace wildcard
+    ("wildcard") - a provenance distinction the run artifacts carry.
+    """
+
+    kind: str
+
+    def __new__(cls, name: str, kind: str) -> ResolvedGatewayRoute:
+        route = super().__new__(cls, name)
+        route.kind = kind
+        return route
 
 
 class GatewayRouteError(Exception):
@@ -114,7 +132,9 @@ def resolve_gateway_route(
     model_string: str,
     catalog: frozenset[str] | None,
     preferred_prefix: str | None = None,
-) -> str | None:
+    *,
+    trust_namespace_wildcards: bool = False,
+) -> ResolvedGatewayRoute | None:
     """Return the gateway's name for ``model_string``, or ``None`` if it serves none.
 
     Args:
@@ -124,6 +144,13 @@ def resolve_gateway_route(
             skip rewriting" rather than as "not served".
         preferred_prefix: Namespace that wins when the gateway serves the model under
             more than one name.
+        trust_namespace_wildcards: Whether a catalog entry of ``<ns>/*`` counts
+            as a route for a model whose OWN provider namespace is ``<ns>`` (an
+            ``openrouter/*`` passthrough then serves ``provider: openrouter``
+            models, addressed by their untranslated name). Namespace-matched on
+            purpose: a foreign wildcard is a DIFFERENT upstream, the measured
+            serving-path break documented in ``docs/LLM_LAYER.md``. Exact
+            entries always win over a wildcard.
 
     Raises:
         GatewayRouteError: Several names match and ``preferred_prefix`` picks none of
@@ -135,14 +162,18 @@ def resolve_gateway_route(
 
     hits = [c for c in _candidates(model_string) if c in catalog]
     if not hits:
+        if trust_namespace_wildcards and "/" in model_string:
+            namespace = model_string.split("/", 1)[0]
+            if f"{namespace}/*" in catalog:
+                return ResolvedGatewayRoute(model_string, kind="wildcard")
         return None
     if len(hits) == 1:
-        return hits[0]
+        return ResolvedGatewayRoute(hits[0], kind="exact")
 
     if preferred_prefix:
         for hit in hits:
             if hit.startswith(preferred_prefix):
-                return hit
+                return ResolvedGatewayRoute(hit, kind="exact")
     raise GatewayRouteError(
         f"the gateway serves {model_string!r} under {len(hits)} names ({', '.join(hits)}) "
         f"and no preference picks one. They can be backed by different upstreams, so "

--- a/tolokaforge/core/llm/gateway_route.py
+++ b/tolokaforge/core/llm/gateway_route.py
@@ -12,7 +12,7 @@ import logging
 import time
 import urllib.error
 import urllib.request
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from tolokaforge.core.llm.proxy import ProxyConfig
@@ -20,10 +20,15 @@ if TYPE_CHECKING:
 __all__ = [
     "GatewayRouteError",
     "ResolvedGatewayRoute",
+    "RouteKind",
     "resolve_gateway_route",
     "fetch_gateway_catalog",
     "clear_catalog_cache",
 ]
+
+#: How a route matched the catalog. Named so the run artifacts, the client field and
+#: the automation's availability lookup all state the same two-value contract.
+RouteKind = Literal["exact", "wildcard"]
 
 logger = logging.getLogger(__name__)
 
@@ -51,14 +56,14 @@ class ResolvedGatewayRoute(str):
     ("wildcard") - a provenance distinction the run artifacts carry.
     """
 
-    kind: str
+    kind: RouteKind
 
-    def __new__(cls, name: str, kind: str) -> ResolvedGatewayRoute:
+    def __new__(cls, name: str, kind: RouteKind) -> ResolvedGatewayRoute:
         route = super().__new__(cls, name)
         route.kind = kind
         return route
 
-    def __getnewargs__(self) -> tuple[str, str]:
+    def __getnewargs__(self) -> tuple[str, RouteKind]:
         # str.__getnewargs__ returns only the string value, so copy.copy,
         # copy.deepcopy and pickle would reconstruct with a missing ``kind``
         # and die - and dataclasses.asdict deepcopies every ProviderRawCall

--- a/tolokaforge/core/llm/proxy.py
+++ b/tolokaforge/core/llm/proxy.py
@@ -119,6 +119,7 @@ ENV_HEADERS = "LLM_PROXY_HEADERS"
 ENV_REQUEST_ID_HEADER = "LLM_PROXY_REQUEST_ID_HEADER"
 ENV_PROVIDERS = "LLM_PROXY_PROVIDERS"
 ENV_PREFERRED_ROUTE = "LLM_PROXY_PREFERRED_ROUTE"
+ENV_TRUST_WILDCARDS = "LLM_PROXY_TRUST_NAMESPACE_WILDCARDS"
 
 #: Providers routed when ``LLM_PROXY_PROVIDERS`` is unset.
 #:
@@ -170,6 +171,9 @@ class ProxyConfig:
     request_id_header: str | None = None
     providers: frozenset[str] | None = None
     preferred_route: str | None = None
+    # Whether a catalog entry of ``<ns>/*`` routes models whose own provider
+    # namespace is ``<ns>``. Off by default: exact-entry-only resolution.
+    trust_namespace_wildcards: bool = False
 
     def applies_to(self, provider: str) -> bool:
         """Return whether ``provider`` should be routed through the gateway.
@@ -306,6 +310,7 @@ def resolve_proxy_config(secrets: SecretManager | None = None) -> ProxyConfig | 
                 ENV_REQUEST_ID_HEADER,
                 ENV_PROVIDERS,
                 ENV_PREFERRED_ROUTE,
+                ENV_TRUST_WILDCARDS,
             )
             if (secrets.get_secret(name) or "").strip()
         )
@@ -324,4 +329,23 @@ def resolve_proxy_config(secrets: SecretManager | None = None) -> ProxyConfig | 
         request_id_header=(secrets.get_secret(ENV_REQUEST_ID_HEADER) or "").strip() or None,
         providers=_parse_providers(secrets.get_secret(ENV_PROVIDERS)),
         preferred_route=(secrets.get_secret(ENV_PREFERRED_ROUTE) or "").strip() or None,
+        trust_namespace_wildcards=_parse_trust_wildcards(secrets.get_secret(ENV_TRUST_WILDCARDS)),
     )
+
+
+def _parse_trust_wildcards(raw: str | None) -> bool:
+    """Strict boolean for ``LLM_PROXY_TRUST_NAMESPACE_WILDCARDS``.
+
+    Unset / blank is the conservative default (exact-entry-only routing).
+    Anything but a plain true/false is refused: a typo silently resolving
+    to False would quietly put runs back on the per-model direct fallback,
+    which is the drift this variable exists to eliminate.
+    """
+    value = (raw or "").strip().lower()
+    if not value:
+        return False
+    if value in ("true", "1", "yes"):
+        return True
+    if value in ("false", "0", "no"):
+        return False
+    raise ProxyConfigError(f"{ENV_TRUST_WILDCARDS} must be true or false, got {raw!r}.")

--- a/tolokaforge/core/llm/usage.py
+++ b/tolokaforge/core/llm/usage.py
@@ -87,6 +87,20 @@ class ProviderRawCall:
     cost_usd: float | None = None
     cost_source: CostSource = "unknown"
     latency_s: float = 0.0
+    gateway_route: str | None = None
+    """The gateway route name this call was addressed to, else ``None``.
+
+    ``None`` on the direct-provider path and on the unreadable-catalog path
+    (where the untranslated model string goes to the gateway unresolved).
+    """
+
+    gateway_route_kind: str | None = None
+    """How the route matched the catalog: ``"exact"`` or ``"wildcard"``.
+
+    The serving-path provenance a board audit needs: a wildcard route says
+    the gateway forwarded by namespace rather than by an explicit entry.
+    """
+
     openrouter_generation_id: str | None = None
     """OpenRouter's id for the generation this call produced, else ``None``.
 
@@ -295,6 +309,8 @@ class UsageExtractor:
         latency_s: float = 0.0,
         cost_usd: float | None = None,
         cost_source: CostSource = "unknown",
+        gateway_route: str | None = None,
+        gateway_route_kind: str | None = None,
     ) -> Usage:
         usage = getattr(response, "usage", None)
         if usage is None and isinstance(response, dict):
@@ -339,6 +355,8 @@ class UsageExtractor:
             cost_usd=cost_usd,
             cost_source=cost_source,
             latency_s=latency_s,
+            gateway_route=gateway_route,
+            gateway_route_kind=gateway_route_kind,
             openrouter_generation_id=extract_openrouter_generation_id(response),
         )
 

--- a/tolokaforge/core/llm/usage.py
+++ b/tolokaforge/core/llm/usage.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from tolokaforge.core.llm.gateway_route import RouteKind
+
 __all__ = [
     "OPENROUTER_GENERATION_ID_HEADER",
     "CostSource",
@@ -94,7 +96,7 @@ class ProviderRawCall:
     (where the untranslated model string goes to the gateway unresolved).
     """
 
-    gateway_route_kind: str | None = None
+    gateway_route_kind: RouteKind | None = None
     """How the route matched the catalog: ``"exact"`` or ``"wildcard"``.
 
     The serving-path provenance a board audit needs: a wildcard route says
@@ -310,7 +312,7 @@ class UsageExtractor:
         cost_usd: float | None = None,
         cost_source: CostSource = "unknown",
         gateway_route: str | None = None,
-        gateway_route_kind: str | None = None,
+        gateway_route_kind: RouteKind | None = None,
     ) -> Usage:
         usage = getattr(response, "usage", None)
         if usage is None and isinstance(response, dict):

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -15,11 +15,11 @@ Which name reaches the gateway
 ------------------------------
 
 The engine resolves the gateway's route name from this same catalog and addresses
-the gateway by it, trying ``openrouter/<slug>`` and then the bare ``<slug>``
-(``tolokaforge.core.llm.gateway_route``). So both shapes are reachable and this
-lookup checks both, in the same order - for wildcards too: an ``openrouter/*``
-passthrough covers the prefixed candidate and a vendor wildcard (``x-ai/*``)
-covers the bare one. A wildcard still only says the gateway will forward the
+the gateway by it (``tolokaforge.core.llm.gateway_route``), so :func:`lookup` asks
+THAT resolver rather than restating its rules. Both shapes are reachable - the
+prefixed ``openrouter/<slug>`` and the bare ``<slug>`` - and a wildcard entry is
+honoured only for the namespace the run addresses, because a foreign namespace is
+a different upstream. A wildcard still only says the gateway will forward the
 request, not that the model exists behind it.
 
 An exact entry and a wildcard are **not** equally strong evidence, so they are
@@ -42,7 +42,11 @@ import dataclasses
 import os
 import sys
 
-from tolokaforge.core.llm.gateway_route import fetch_gateway_catalog
+from tolokaforge.core.llm.gateway_route import (
+    GatewayRouteError,
+    fetch_gateway_catalog,
+    resolve_gateway_route,
+)
 from tolokaforge.core.llm.proxy import ProxyConfigError, resolve_proxy_config
 from tolokaforge.secrets import EnvProvider, SecretManager
 
@@ -53,6 +57,11 @@ ROUTE_GATEWAY = "litellm"
 #: The default route. OpenRouter is what the leaderboard is calibrated on, so a
 #: request that does not say otherwise must not silently change serving path.
 DEFAULT_ROUTE = ROUTE_OPENROUTER
+
+#: The provider an OpenRouter-sourced slug runs under (``integrate-model.yml``). The engine
+#: builds its model string as ``<provider>/<slug>`` and resolves the gateway route from
+#: THAT, so a lookup asking about any other name would answer a question nobody asked.
+RUN_PROVIDER = "openrouter"
 
 STATUS_EXACT = "exact"
 STATUS_WILDCARD = "wildcard"
@@ -66,8 +75,9 @@ class Availability:
 
     ``status`` is one of :data:`STATUS_EXACT` (a catalog entry names this model),
     :data:`STATUS_WILDCARD` (a passthrough covers it), :data:`STATUS_ABSENT` (the
-    catalog was read and does not cover it), or :data:`STATUS_UNKNOWN` (no
-    gateway configured, or the catalog could not be read).
+    catalog was read and does not cover it), or :data:`STATUS_UNKNOWN` (no gateway
+    configured, the catalog could not be read, or it serves the model under several
+    names and the deployment ranks none of them - a run would refuse that too).
     """
 
     slug: str
@@ -121,33 +131,74 @@ def fetch_configured_catalog(timeout: int = 15) -> list[str] | None:
     return None if served is None else sorted(served)
 
 
-def lookup(slug: str, catalog: list[str] | None) -> Availability:
+@dataclasses.dataclass(frozen=True)
+class GatewayPolicy:
+    """The routing policy the engine's resolver takes, as this deployment sets it.
+
+    Defaults are the ENGINE's defaults, so a caller that passes nothing gets the
+    strictest reading rather than a more permissive one - the direction a poller
+    has to err in, since it promises a route a run then has to honour.
+    """
+
+    preferred_route: str | None = None
+    trust_namespace_wildcards: bool = False
+
+
+def configured_policy() -> GatewayPolicy:
+    """This deployment's routing policy, or the engine defaults when there is no gateway.
+
+    Env-only for the same reason as :func:`fetch_configured_catalog`: a developer's
+    local ``.env`` must not decide what a real poll reports.
+    """
+    try:
+        proxy = resolve_proxy_config(SecretManager([EnvProvider()]))
+    except ProxyConfigError:
+        # Already annotated by the catalog read on the same poll; warning twice for one
+        # misconfiguration reads as two problems.
+        return GatewayPolicy()
+    if proxy is None:
+        return GatewayPolicy()
+    return GatewayPolicy(
+        preferred_route=proxy.preferred_route,
+        trust_namespace_wildcards=proxy.trust_namespace_wildcards,
+    )
+
+
+def lookup(
+    slug: str, catalog: list[str] | None, policy: GatewayPolicy | None = None
+) -> Availability:
     """Classify how (or whether) ``slug`` is reachable on the gateway.
 
-    Both names the engine can reach are checked, in its order: the prefixed
-    ``openrouter/<slug>`` first, then the bare ``<slug>``. The engine resolves the
-    route name from this same catalog and addresses the gateway by it, so a
-    prefixed-only entry IS reachable. See ``tolokaforge.core.llm.gateway_route``.
+    Asks the engine's own resolver rather than restating its rules, because the verdict
+    reported here is acted on by a run: a second implementation of "which name reaches
+    the gateway" drifted from the first once already (a vendor wildcard was reported as
+    covering a model the run addresses as ``openrouter/<slug>``, which the engine refuses
+    - that wildcard is a different upstream). Delegation makes the two agree by
+    construction instead of by review.
+
+    ``policy`` is what the deployment trusts; omitted, the engine's own default, which
+    trusts no wildcard at all.
     """
     if catalog is None:
         return Availability(slug=slug, status=STATUS_UNKNOWN)
-
-    entries = set(catalog)
-    candidates = (f"openrouter/{slug}", slug)
-    for candidate in candidates:
-        if candidate in entries:
-            return Availability(slug=slug, status=STATUS_EXACT, route=candidate)
-    # The wildcard namespace is derived PER CANDIDATE, in the same order as
-    # the exact check: an ``openrouter/*`` passthrough covers the prefixed
-    # candidate, a vendor wildcard (``x-ai/*``) covers the bare one. Deriving
-    # it only from the bare slug reported ABSENT on gateways whose only
-    # wildcard is the openrouter passthrough - which made the poller DOWNGRADE
-    # explicit "via litellm" requests to OpenRouter.
-    for candidate in candidates:
-        namespace = candidate.split("/", 1)[0]
-        if f"{namespace}/*" in entries or "*" in entries:
-            return Availability(slug=slug, status=STATUS_WILDCARD, route=candidate)
-    return Availability(slug=slug, status=STATUS_ABSENT)
+    policy = policy or GatewayPolicy()
+    try:
+        route = resolve_gateway_route(
+            f"{RUN_PROVIDER}/{slug}",
+            frozenset(catalog),
+            policy.preferred_route,
+            trust_namespace_wildcards=policy.trust_namespace_wildcards,
+        )
+    except GatewayRouteError as exc:
+        # A run raises this rather than guessing, so "cannot confirm" is the honest
+        # verdict: the plan keeps the OpenRouter default instead of queueing a run
+        # that dies on the first client construction.
+        _warn(f"gateway route for {slug!r} is ambiguous, availability is unknown: {exc}")
+        return Availability(slug=slug, status=STATUS_UNKNOWN)
+    if route is None:
+        return Availability(slug=slug, status=STATUS_ABSENT)
+    status = STATUS_EXACT if route.kind == "exact" else STATUS_WILDCARD
+    return Availability(slug=slug, status=status, route=str(route))
 
 
 def describe(availability: Availability) -> str:

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -132,12 +132,20 @@ def lookup(slug: str, catalog: list[str] | None) -> Availability:
         return Availability(slug=slug, status=STATUS_UNKNOWN)
 
     entries = set(catalog)
-    for candidate in (f"openrouter/{slug}", slug):
+    candidates = (f"openrouter/{slug}", slug)
+    for candidate in candidates:
         if candidate in entries:
             return Availability(slug=slug, status=STATUS_EXACT, route=candidate)
-    namespace = slug.split("/", 1)[0]
-    if f"{namespace}/*" in entries or "*" in entries:
-        return Availability(slug=slug, status=STATUS_WILDCARD, route=slug)
+    # The wildcard namespace is derived PER CANDIDATE, in the same order as
+    # the exact check: an ``openrouter/*`` passthrough covers the prefixed
+    # candidate, a vendor wildcard (``x-ai/*``) covers the bare one. Deriving
+    # it only from the bare slug reported ABSENT on gateways whose only
+    # wildcard is the openrouter passthrough - which made the poller DOWNGRADE
+    # explicit "via litellm" requests to OpenRouter.
+    for candidate in candidates:
+        namespace = candidate.split("/", 1)[0]
+        if f"{namespace}/*" in entries or "*" in entries:
+            return Availability(slug=slug, status=STATUS_WILDCARD, route=candidate)
     return Availability(slug=slug, status=STATUS_ABSENT)
 
 

--- a/tools/automation/src/automation/gateway_catalog.py
+++ b/tools/automation/src/automation/gateway_catalog.py
@@ -17,9 +17,10 @@ Which name reaches the gateway
 The engine resolves the gateway's route name from this same catalog and addresses
 the gateway by it, trying ``openrouter/<slug>`` and then the bare ``<slug>``
 (``tolokaforge.core.llm.gateway_route``). So both shapes are reachable and this
-lookup checks both, in the same order. The wildcard that counts is still one
-covering the slug's own namespace (``x-ai/*``), because a wildcard says the
-gateway will forward the request, not that the model exists behind it.
+lookup checks both, in the same order - for wildcards too: an ``openrouter/*``
+passthrough covers the prefixed candidate and a vendor wildcard (``x-ai/*``)
+covers the bare one. A wildcard still only says the gateway will forward the
+request, not that the model exists behind it.
 
 An exact entry and a wildcard are **not** equally strong evidence, so they are
 reported separately: an exact entry means someone configured this model; a

--- a/tools/automation/src/automation/poller.py
+++ b/tools/automation/src/automation/poller.py
@@ -330,6 +330,9 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
     catalog: list[str] | None = None
     # Distinct from None: None is a *fetched* answer meaning "no gateway info".
     gateway_models: list[str] | None = _UNFETCHED
+    # Read next to the catalog: the availability verdict has to be the one a run will
+    # honour, and the run reads the same policy from the same environment.
+    gateway_policy = gateway_catalog.GatewayPolicy()
     for message in messages:
         if not is_request(message, bot_id):
             continue
@@ -354,6 +357,7 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             # phrase OpenRouter cannot match, which is the only way a gateway-only model
             # (`azure_ai/...`) can be requested at all.
             gateway_models = gateway_catalog.fetch_configured_catalog()
+            gateway_policy = gateway_catalog.configured_policy()
         text = message.get("text", "")
         resolutions = model_resolver.resolve_all(text, catalog, ALIASES, gateway_models)
         if not resolutions:  # mention + "integrate" but no parseable model phrase
@@ -365,7 +369,7 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
         # Gateway lookup for the reply: advisory for an OpenRouter-sourced model, and simply
         # confirmation for a gateway-sourced one (it came out of this catalog).
         availability = {
-            r.slug: gateway_catalog.lookup(r.slug, gateway_models)
+            r.slug: gateway_catalog.lookup(r.slug, gateway_models, gateway_policy)
             for r in resolutions
             if r.status == "resolved" and r.slug
         }
@@ -378,7 +382,9 @@ def run(channel: str, allowed_users: str | None, out_path: str, window_hours: fl
             resolutions,
             availability,
             requested_route,
-            simulator=gateway_catalog.lookup(gateway_catalog.USER_SIMULATOR_SLUG, gateway_models),
+            simulator=gateway_catalog.lookup(
+                gateway_catalog.USER_SIMULATOR_SLUG, gateway_models, gateway_policy
+            ),
         )
         reply = model_resolver.format_resolution_reply(
             requester,

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -63,6 +63,13 @@ class TestLookup:
         assert found.reachable
         assert "passthrough" in gateway_catalog.describe(found)
 
+    def test_the_openrouter_passthrough_covers_the_prefixed_candidate(self) -> None:
+        """An ``openrouter/*``-only gateway serves every openrouter model."""
+        found = gateway_catalog.lookup("x-ai/grok-4.5", ["openrouter/*"])
+        assert found.status == gateway_catalog.STATUS_WILDCARD
+        assert found.route == "openrouter/x-ai/grok-4.5"
+        assert found.reachable
+
     def test_absent_when_catalog_covers_nothing(self) -> None:
         found = gateway_catalog.lookup("x-ai/grok-4.5", ["anthropic/claude-sonnet-4-5"])
         assert found.status == gateway_catalog.STATUS_ABSENT

--- a/tools/automation/tests/test_gateway_catalog.py
+++ b/tools/automation/tests/test_gateway_catalog.py
@@ -27,6 +27,10 @@ from tolokaforge.secrets import manager as secrets_manager
 
 pytestmark = pytest.mark.unit
 
+#: A deployment that has turned wildcard trust on. Off is the engine default, and the
+#: poller inherits it, so every wildcard case has to say which one it is testing.
+_TRUSTING = gateway_catalog.GatewayPolicy(trust_namespace_wildcards=True)
+
 _CATALOG = [
     "anthropic/claude-sonnet-4-5",
     "azure_ai/cohere-command-a-plus-05-2026",
@@ -45,11 +49,6 @@ class TestLookup:
         assert found.route == "openrouter/anthropic/claude-opus-4.7"
         assert found.reachable
 
-    def test_the_prefixed_entry_wins_over_the_bare_one(self) -> None:
-        """Same order the engine tries, so the two never disagree."""
-        catalog = ["openrouter/a/b", "a/b"]
-        assert gateway_catalog.lookup("a/b", catalog).route == "openrouter/a/b"
-
     def test_bare_slug_entry_is_the_exact_match(self) -> None:
         found = gateway_catalog.lookup("azure_ai/cohere-command-a-plus-05-2026", _CATALOG)
         assert found.status == gateway_catalog.STATUS_EXACT
@@ -57,18 +56,48 @@ class TestLookup:
 
     def test_wildcard_is_reported_separately_from_exact(self) -> None:
         """A passthrough means 'probably', and the reply must not overstate it."""
-        found = gateway_catalog.lookup("x-ai/grok-4.5", _CATALOG)
-        assert found.status == gateway_catalog.STATUS_WILDCARD
-        assert found.route == "x-ai/grok-4.5"
-        assert found.reachable
-        assert "passthrough" in gateway_catalog.describe(found)
-
-    def test_the_openrouter_passthrough_covers_the_prefixed_candidate(self) -> None:
-        """An ``openrouter/*``-only gateway serves every openrouter model."""
-        found = gateway_catalog.lookup("x-ai/grok-4.5", ["openrouter/*"])
+        found = gateway_catalog.lookup("x-ai/grok-4.5", ["openrouter/*"], _TRUSTING)
         assert found.status == gateway_catalog.STATUS_WILDCARD
         assert found.route == "openrouter/x-ai/grok-4.5"
         assert found.reachable
+        assert "passthrough" in gateway_catalog.describe(found)
+
+    def test_the_openrouter_passthrough_covers_the_addressed_name(self) -> None:
+        """An ``openrouter/*``-only gateway serves every model the run runs over OpenRouter,
+        addressed by its untranslated name - the case that made this lookup DOWNGRADE
+        explicit `via litellm` requests before."""
+        found = gateway_catalog.lookup("anthropic/claude-opus-4.9", ["openrouter/*"], _TRUSTING)
+        assert found.status == gateway_catalog.STATUS_WILDCARD
+        assert found.route == "openrouter/anthropic/claude-opus-4.9"
+
+    def test_a_wildcard_is_not_trusted_unless_the_deployment_says_so(self) -> None:
+        """The engine's default trusts no wildcard, so neither may the poller: promising
+        a route the run then refuses is the misattribution this lookup exists to avoid."""
+        found = gateway_catalog.lookup("x-ai/grok-4.5", ["openrouter/*"])
+        assert found.status == gateway_catalog.STATUS_ABSENT
+        assert not found.reachable
+
+    def test_a_foreign_namespace_wildcard_does_not_cover_the_model(self) -> None:
+        """`x-ai/*` forwards to xAI; the run addresses this model as `openrouter/...` and
+        the engine refuses to swap upstream. Reported reachable, the reply would have said
+        `via litellm` for a run that went to OpenRouter direct."""
+        found = gateway_catalog.lookup("x-ai/grok-4.5", _CATALOG, _TRUSTING)
+        assert found.status == gateway_catalog.STATUS_ABSENT
+        assert not found.reachable
+
+    def test_ambiguous_route_is_unknown_and_annotated(self, capsys) -> None:
+        """Both names served and no preference: the run raises rather than guessing, so the
+        poller must not promise the gateway either."""
+        found = gateway_catalog.lookup("a/b", ["openrouter/a/b", "a/b"])
+        assert found.status == gateway_catalog.STATUS_UNKNOWN
+        assert not found.reachable
+        assert "ambiguous" in capsys.readouterr().err
+
+    def test_a_preference_resolves_the_ambiguity_like_the_engine(self) -> None:
+        policy = gateway_catalog.GatewayPolicy(preferred_route="openrouter/")
+        found = gateway_catalog.lookup("a/b", ["openrouter/a/b", "a/b"], policy)
+        assert found.status == gateway_catalog.STATUS_EXACT
+        assert found.route == "openrouter/a/b"
 
     def test_absent_when_catalog_covers_nothing(self) -> None:
         found = gateway_catalog.lookup("x-ai/grok-4.5", ["anthropic/claude-sonnet-4-5"])
@@ -214,6 +243,37 @@ class TestTheConfiguredCatalogIsReadLikeARunReadsIt:
         # The reply blames the model ("could not confirm the gateway serves..."), so
         # without an annotation the real cause is one stderr line in a green job.
         assert "::warning title=Gateway configuration unusable::" in captured.out
+
+
+class TestTheConfiguredPolicyIsTheRunsPolicy:
+    """The lookup's verdict is only worth reporting if a run would honour it.
+
+    The engine reads the trust flag and the route preference from the environment; the
+    poller reads the same two, so a promise of `via litellm` matches what the run does.
+    """
+
+    def test_no_gateway_configured_is_the_engine_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("LLM_PROXY_BASE_URL", raising=False)
+        monkeypatch.delenv("LLM_PROXY_TRUST_NAMESPACE_WILDCARDS", raising=False)
+        monkeypatch.delenv("LLM_PROXY_PREFERRED_ROUTE", raising=False)
+        policy = gateway_catalog.configured_policy()
+        assert policy.trust_namespace_wildcards is False
+        assert policy.preferred_route is None
+
+    def test_the_deployments_policy_is_picked_up(self, gateway, monkeypatch) -> None:
+        monkeypatch.setenv("LLM_PROXY_TRUST_NAMESPACE_WILDCARDS", "true")
+        monkeypatch.setenv("LLM_PROXY_PREFERRED_ROUTE", "openrouter/,nebius/")
+        policy = gateway_catalog.configured_policy()
+        assert policy.trust_namespace_wildcards is True
+        assert policy.preferred_route == "openrouter/,nebius/"
+
+    def test_a_malformed_policy_is_the_strict_default_not_a_crash(
+        self, gateway, monkeypatch
+    ) -> None:
+        """A poll must never fail on an operator's typo, and the fallback has to be the
+        strict reading: trusting a wildcard the engine will not is the misattribution."""
+        monkeypatch.setenv("LLM_PROXY_TRUST_NAMESPACE_WILDCARDS", "yes-please")
+        assert gateway_catalog.configured_policy().trust_namespace_wildcards is False
 
 
 class TestALocalEnvCannotAnswerARealPoll:
@@ -407,17 +467,34 @@ class TestPlanRows:
         assert "via *openrouter*" in posted[0]
 
     def test_explicit_gateway_route_reaches_the_plan(self, monkeypatch, tmp_path) -> None:
+        # Explicit entries, not a wildcard: a poll with no gateway policy in its environment
+        # trusts none (the engine's default), so a `x-ai/*` catalog would be DOWNGRADED here
+        # - the run would have gone to OpenRouter direct anyway.
         # The catalog covers the user simulator too: the integration run's gateway `.env` is
-        # job-wide, so a gateway serving only `x-ai/*` could not serve this run at all.
+        # job-wide, so a gateway serving only the candidate could not serve this run at all.
         plan, posted = self._plan(
             monkeypatch,
             tmp_path,
             "<@B1> integrate Grok 4.5 via litellm",
-            ["x-ai/*", gateway_catalog.USER_SIMULATOR_SLUG],
+            ["openrouter/x-ai/grok-4.5", gateway_catalog.USER_SIMULATOR_SLUG],
         )
         assert [row["route"] for row in plan] == ["litellm", "litellm"]
         # The reply must state the route it actually queued, not the default.
         assert "via *litellm*" in posted[0]
+
+    def test_untrusted_wildcard_downgrades_an_explicit_gateway_request(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A gateway whose only coverage is a passthrough the deployment does not trust: the
+        request is refused in the reply rather than queued as a run the engine sends direct."""
+        plan, posted = self._plan(
+            monkeypatch,
+            tmp_path,
+            "<@B1> integrate Grok 4.5 via litellm",
+            ["openrouter/*", gateway_catalog.USER_SIMULATOR_SLUG],
+        )
+        assert [row["route"] for row in plan] == ["openrouter", "openrouter"]
+        assert "could not confirm the gateway serves every model" in posted[0]
 
     def test_row_shape_is_the_workflow_contract(self, monkeypatch, tmp_path) -> None:
         plan, posted = self._plan(


### PR DESCRIPTION
## Motivation (live findings on a production LiteLLM deployment)

Two measured defects when routing evals through an OpenAI-compatible gateway whose OpenRouter coverage is the `openrouter/*` passthrough:

1. **Every OpenRouter model fell back to direct calls.** `resolve_gateway_route` accepts exact catalog entries only; a live probe proved all 19 "missing" models actually work through the gateway as `openrouter/<slug>`. The per-model fallback is loud but silently splits one run across two wire paths (agent direct, sim/judge via gateway).
2. **Provider pinning silently dropped on the resolved path.** `_build_kwargs` popped `extra_body.provider` whenever a route resolved, even when the route forwards to OpenRouter itself, which honours the pin. Meanwhile the unreadable-catalog path forwarded the pin - two unit tests enshrined the contradiction (`test_llm_proxy.py` vs `test_gateway_routing_applied.py`).

## What changes

- **One provider-pin rule on both gateway paths:** `extra_body.provider` survives exactly when the wire name's first segment is the model's own provider namespace; any other namespace drops it with a warning. Docs and both tests now state the same rule.
- **Opt-in namespace-matched wildcards** (`LLM_PROXY_TRUST_NAMESPACE_WILDCARDS`, default `false`, strict-bool, included in the orphan check): `<ns>/*` routes `provider: <ns>` models by their untranslated name. This implements exactly the extension point the existing wildcard ban in `docs/LLM_LAYER.md` reserved - a foreign-namespace wildcard never routes (the measured `anthropic/*`-to-Bedrock serving-path break stays impossible), exact entries always win, and the `GatewayRouteError` ambiguity semantics are untouched.
- **Per-call route provenance:** `gateway_route` + `gateway_route_kind` (`exact`|`wildcard`) on `ProviderRawCall`, so run artifacts record which serving path produced a number (additive optional fields; `ModelConfig` and grading hashes untouched - `ModelConfig` feeds no hash/fingerprint).
- **Live verification, not declaration:** new `test_gateway_live.py` case sends a provider-pinned call through the gateway and checks the actually-serving upstream via OpenRouter's `/generation` lookup, because litellm proxies may drop `extra_body` fields version-dependently and the request shape alone proves nothing. Opt-in via `LLM_PROXY_INT_TEST_PINNED_MODEL` / `_PINNED_PROVIDER`, auto-skips otherwise.
- **Companion automation fix:** `gateway_catalog.lookup()` derived the wildcard namespace only from the bare slug, so an `openrouter/*`-only gateway reported every model ABSENT and the Slack poller downgraded explicit "via litellm" requests. Namespace now derives per candidate, in the exact-check's order, and `route` is the matched candidate.

## Deployment-neutrality

No deployment specifics enter the engine: the new variable is a generic statement about any gateway ("do you trust namespace passthroughs"), default-off preserves today's behavior byte-for-byte for every existing deployment, and all values keep resolving through `SecretManager`.

## Verification

- `tests/unit/llm/` green (the 3 `test_rate_limit_probe_retry.py` failures pre-exist on `main@41537dc0`, unrelated); resolver, proxy-parse, client-routing and automation-lookup suites extended.
- Canonical contracts green: `test_llm_gateway_envelope_contract.py`, `test_cost_extraction_canon.py`.
- ruff check + format clean on touched files.

Internal ref: TECHDEL-598.