### PR TITLE
fix(conductor): skip Runner GetState RPC when task declares no json_db + demote no-target log

### DIFF
--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -42,7 +42,7 @@ from tolokaforge.core.models import (
 )
 from tolokaforge.core.output.artifacts import FileArtifactWriter
 from tolokaforge.core.trial import EnvEndpoints, EnvironmentManifest, TrialSpec
-from tolokaforge.runner.models import TaskDescription
+from tolokaforge.runner.models import TaskDescription, provisions_database
 
 pytestmark = pytest.mark.unit
 
@@ -240,11 +240,15 @@ class TestTrialSpecWireExclusion:
         assert '"adapter_type":"native"' in wire_json
 
 
-class TestCaptureFinalStateEnvironmentBlock:
-    """``_capture_final_state`` records the resolved environment identity under
-    ``final_env_state["environment"]`` only when the trial's task carries an
-    ``environment_manifest``. Manifest-less trials keep the JSON-DB-only shape —
-    the additive/back-compat guarantee the descriptor rests on.
+class TestCaptureFinalState:
+    """Invariants on ``InProcessConductor._capture_final_state``.
+
+    Covers: (a) the ``environment_manifest`` → ``final_env_state["environment"]``
+    block projection, additive over the JSON-DB-only shape;
+    (b) the ``GetState`` RPC skip when the task provisions no runner-side DB
+    (:func:`~tolokaforge.runner.models.provisions_database` == False), so the
+    conductor doesn't burn a doomed round-trip against a DB Service that
+    ``RegisterTrial`` never initialised.
     """
 
     def _conductor(self) -> InProcessConductor:
@@ -312,16 +316,16 @@ class TestCaptureFinalStateEnvironmentBlock:
 
         assert "environment" not in trajectory.final_env_state
 
-    def test_skips_get_state_rpc_when_task_declares_no_json_db(self) -> None:
-        """No ``initial_state.json_db`` → ``RegisterTrial`` never provisioned
-        the DB Service (:func:`~tolokaforge.runner.models.provisions_database`),
+    def test_skips_get_state_rpc_when_task_provisions_no_db(self) -> None:
+        """No tables / schemas / unstable_fields on the runner-side
+        ``initial_state`` → ``RegisterTrial`` never provisioned the DB Service
+        (:func:`~tolokaforge.runner.models.provisions_database` == False),
         so ``GetState`` has no target and the RPC is skipped."""
-        spec = _make_spec()
-        setup = self._setup()
-        setup.env_state.config.json_db = None
+        spec = _make_spec()  # TaskDescription default: RunnerInitialStateConfig() empty
+        assert not provisions_database(spec.task.initial_state)
         conductor = self._conductor()
 
-        conductor._capture_final_state(spec, setup, _default_success_trajectory("t1", 0))
+        conductor._capture_final_state(spec, self._setup(), _default_success_trajectory("t1", 0))
 
         conductor.runtime_backend.get_state.assert_not_called()
 

--- a/tests/unit/test_conductor.py
+++ b/tests/unit/test_conductor.py
@@ -312,6 +312,19 @@ class TestCaptureFinalStateEnvironmentBlock:
 
         assert "environment" not in trajectory.final_env_state
 
+    def test_skips_get_state_rpc_when_task_declares_no_json_db(self) -> None:
+        """No ``initial_state.json_db`` → ``RegisterTrial`` never provisioned
+        the DB Service (:func:`~tolokaforge.runner.models.provisions_database`),
+        so ``GetState`` has no target and the RPC is skipped."""
+        spec = _make_spec()
+        setup = self._setup()
+        setup.env_state.config.json_db = None
+        conductor = self._conductor()
+
+        conductor._capture_final_state(spec, setup, _default_success_trajectory("t1", 0))
+
+        conductor.runtime_backend.get_state.assert_not_called()
+
 
 class TestResolveMaxTurns:
     def test_orchestrator_default_is_50(self) -> None:

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -888,10 +888,13 @@ class InProcessConductor:
         service and stash it on ``trajectory.final_env_state``.
 
         The Runner's ``GetState`` RPC syncs the subprocess state to
-        db-service before reading, so this read covers every adapter.
-        ``adapter_env.data`` (from :meth:`BaseAdapter.create_environment`)
-        is a snapshot from before the trial ran; it is used as a fallback
-        only when the Runner-side read fails.
+        db-service before reading, so this read covers every adapter that
+        seeds a JSON DB. Tasks that declare no ``initial_state.json_db``
+        get a matching skip: ``RegisterTrial`` never initialised the DB
+        Service for them (see :func:`provisions_database`), so the RPC has
+        no target and only ``adapter_env.data`` — the pre-trial snapshot
+        from :meth:`BaseAdapter.create_environment` — is available for the
+        final-state stash.
 
         When the trial's task carries an ``environment_manifest`` (a
         Project-layer / multi-container substrate), the resolved
@@ -900,26 +903,27 @@ class InProcessConductor:
         the trial. Manifest-less trials keep the JSON-DB-only shape.
         """
         runner_state: dict[str, Any] | None = None
-        try:
-            state_result = self.runtime_backend.get_state(setup.trial_id)
-            if state_result.get("success") and state_result.get("state_json"):
-                import json as _json
+        if setup.env_state.config.json_db:
+            try:
+                state_result = self.runtime_backend.get_state(setup.trial_id)
+                if state_result.get("success") and state_result.get("state_json"):
+                    import json as _json
 
-                decoded = _json.loads(state_result["state_json"])
-                if isinstance(decoded, dict) and decoded:
-                    runner_state = decoded
+                    decoded = _json.loads(state_result["state_json"])
+                    if isinstance(decoded, dict) and decoded:
+                        runner_state = decoded
+                    else:
+                        self.logger.debug("Runner DB state empty, falling back to adapter env data")
                 else:
-                    self.logger.debug("Runner DB state empty, falling back to adapter env data")
-            else:
-                self.logger.debug(
-                    "Failed to fetch Runner DB state, falling back to adapter env data",
-                    error=state_result.get("error"),
+                    self.logger.debug(
+                        "Failed to fetch Runner DB state, falling back to adapter env data",
+                        error=state_result.get("error"),
+                    )
+            except Exception as e:
+                self.logger.warning(
+                    "Could not fetch state from Runner, using adapter env data",
+                    error=str(e),
                 )
-        except Exception as e:
-            self.logger.warning(
-                "Could not fetch state from Runner, using adapter env data",
-                error=str(e),
-            )
 
         if runner_state is not None:
             setup.env_state.db_state = runner_state

--- a/tolokaforge/core/conductor.py
+++ b/tolokaforge/core/conductor.py
@@ -64,6 +64,7 @@ from tolokaforge.core.stuck import StuckDetector
 from tolokaforge.core.system_prompt import build_system_prompt
 from tolokaforge.core.trial import DEFAULT_TOOL_TIMEOUT_S, TrialResult, TrialSpec
 from tolokaforge.core.trial_grader import GradingFailedError, TrialGrader
+from tolokaforge.runner.models import provisions_database
 
 if TYPE_CHECKING:
     from tolokaforge.core.logging import StructuredLogger
@@ -888,12 +889,13 @@ class InProcessConductor:
         service and stash it on ``trajectory.final_env_state``.
 
         The Runner's ``GetState`` RPC syncs the subprocess state to
-        db-service before reading, so this read covers every adapter that
-        seeds a JSON DB. Tasks that declare no ``initial_state.json_db``
-        get a matching skip: ``RegisterTrial`` never initialised the DB
-        Service for them (see :func:`provisions_database`), so the RPC has
-        no target and only ``adapter_env.data`` — the pre-trial snapshot
-        from :meth:`BaseAdapter.create_environment` — is available for the
+        db-service before reading, so this read covers every adapter whose
+        task provisions a database on the runner side (tables, schemas, or
+        unstable_fields — see :func:`~tolokaforge.runner.models.provisions_database`).
+        Tasks that provision none of those get a matching skip: ``RegisterTrial``
+        never initialised the DB Service for them, so the RPC has no target and
+        only ``adapter_env.data`` — the pre-trial snapshot from
+        :meth:`BaseAdapter.create_environment` — is available for the
         final-state stash.
 
         When the trial's task carries an ``environment_manifest`` (a
@@ -903,7 +905,7 @@ class InProcessConductor:
         the trial. Manifest-less trials keep the JSON-DB-only shape.
         """
         runner_state: dict[str, Any] | None = None
-        if setup.env_state.config.json_db:
+        if provisions_database(spec.task.initial_state):
             try:
                 state_result = self.runtime_backend.get_state(setup.trial_id)
                 if state_result.get("success") and state_result.get("state_json"):

--- a/tolokaforge/core/shared_stack_runtime.py
+++ b/tolokaforge/core/shared_stack_runtime.py
@@ -748,7 +748,7 @@ class GrpcRunnerClient:
             if response.success:
                 logger.debug(f"Got state for trial {trial_id}: stable_hash={response.stable_hash}")
             else:
-                logger.error(f"Failed to get state for trial {trial_id}: {response.error}")
+                logger.warning(f"Failed to get state for trial {trial_id}: {response.error}")
 
             return result
 


### PR DESCRIPTION
Closes #1413.

## Summary

- Guard \`InProcessConductor._capture_final_state\` on \`env_state.config.json_db\` — the host-side proxy for \`provisions_database\`. When a task seeds no JSON DB (Terminal-Bench packs, native tasks without \`initial_state.json_db\`), \`RegisterTrial\` never initialised the DB Service and the RPC has no target. Skip it and fall through to the \`adapter_env.data\` path.
- Demote \`GrpcRunnerClient.get_state\`'s response-error log (\`shared_stack_runtime.py:751\`) from \`error\` to \`warning\`. The conductor caller already logs at \`.debug\` for the expected-failure case; the server-side ERROR in \`RunnerServiceImpl.GetState\` (\`service.py:2667\`) still fires for real DB Service crashes.

Behavior only changes for trials that had no reason to hit DB Service in the first place — no observable change to grading, artifacts, or wire contracts. The docstring on \`_capture_final_state\` is extended to record the new invariant.

## Test plan
- [x] New unit test in \`tests/unit/test_conductor.py::TestCaptureFinalStateEnvironmentBlock::test_skips_get_state_rpc_when_task_declares_no_json_db\` asserts \`runtime_backend.get_state\` is not called when \`env_state.config.json_db is None\`.
- [x] \`uv run pytest tests/unit/test_conductor.py -q\` → 32/32 pass.
- [x] \`uv run pytest tests/unit -q -k \"conductor or capture or _capture_final_state\"\` → 94/94 pass.
- [x] Real-task smoke: a pack with no \`initial_state.json_db\` (previously the source of the ERROR every trial) now emits zero \`Failed to get state for trial\` lines. \`grade.yaml\` still populated by the appropriate grading path.