### PR TITLE
feat(tbench): two-stack composition plan for T-Bench adapter (#1385, code portion)

### DIFF
--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py
@@ -329,15 +329,31 @@ class TerminalBenchAdapter(CodingHarnessAdapterMixin, BaseAdapter):
         )
 
     def _environment_patch(self, task_id: str) -> EnvironmentPatch:
+        """Two-stack composition plan (ADR-0044 § 5 ``MULTI_SCOPE``).
+
+        The ``engine`` stack (run-scope) owns the runner + db-service — one
+        substrate held live for every trial in the run. The ``task`` stack
+        (trial-scope) owns the agent service and any task-authored siblings
+        — materialised fresh per trial so state never leaks across trials.
+        Only the engine stack sets ``runner_service`` (INV-12).
+        """
         env = self._environment(task_id)
         return EnvironmentPatch(
-            stack=StackPatch(
-                compose_file=env.compose_file,
-                runner_service="runner",
-                inputs={
-                    provider_env_input(key): value for key, value in self.agent_provider_env.items()
-                },
-            ),
+            stacks={
+                "engine": StackPatch(
+                    compose_file=env.engine_compose_file,
+                    stack_scope="run",
+                    runner_service="runner",
+                ),
+                "task": StackPatch(
+                    compose_file=env.compose_file,
+                    stack_scope="trial",
+                    inputs={
+                        provider_env_input(key): value
+                        for key, value in self.agent_provider_env.items()
+                    },
+                ),
+            },
             network_policy=self.network_policy,
         )
 

--- a/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py
+++ b/external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py
@@ -1,20 +1,35 @@
-"""Synthesise an engine-provisionable compose file from a terminal-bench task.
+"""Synthesise the two compose files a terminal-bench trial provisions.
 
 Terminal-bench tasks author their ``docker-compose.yaml`` for terminal-bench's
 own provisioner, which injects a ``T_BENCH_*`` variable set (plus ``CPUS`` /
 ``MEMORY``) at up-time. The tolokaforge engine never sets those, so
 provisioning would fail at compose parse or leave the container name
 unresolved. This module resolves the adapter-owned variable set at synthesis
-time, pins the agent-service image, replaces the log bind-mounts with
-relative mounts against the staging directory, and injects the engine's
-``runner`` + ``db-service`` alongside the task's own services — so the
-emitted compose file is a self-contained trial substrate the engine's
-per-trial runtime can bring up unchanged.
+time, pins the agent-service image, and replaces the log bind-mounts with
+relative mounts against the staging directory.
+
+The output is a two-stack composition plan (ADR-0044 § 5 ``MULTI_SCOPE``):
+
+* an **engine** stack, ``stack_scope="run"``, whose compose file declares just
+  the engine's ``runner`` + ``db-service`` — brought up once at run start and
+  held live for every trial;
+* a **task** stack, ``stack_scope="trial"``, whose compose file declares the
+  agent service plus any task-authored siblings (and the harness ``-base``
+  build-only service under harness mode) — materialised fresh per trial.
+
+Splitting the plan keeps the runner's gRPC socket stable across the run while
+each trial gets a fresh task substrate. Every service in the task compose
+that actually runs is stamped with ``container_name:
+tbench_${TOLOKAFORGE_TRIAL_SLUG}_<service>`` so a task-authored sibling can
+never carry a fixed name that collides with the previous trial's teardown
+(the run-scope engine services keep compose's own project-scoped naming —
+their scope carries no trial slug).
 
 Under harness mode the agent image is split in two: the task's own build
-becomes a build-only ``-base`` service, and the agent service builds a thin
-layer on top that installs the requested coding-harness CLI. Both images are
-declared to the orchestrator's pre-build seam, base first.
+becomes a build-only ``-base`` service on the task stack, and the agent
+service builds a thin layer on top that installs the requested coding-harness
+CLI. Both images are declared to the orchestrator's pre-build seam, base
+first.
 
 The module runs no subprocess. Both adapter surfaces that call it
 (``get_task`` and ``to_task_description``) stay daemon-free, which the
@@ -64,7 +79,13 @@ AGENT_SERVICE_DEFAULT = "main"
 PROJECT_PREFIX = "tbench_"
 
 _SYNTHESISED_COMPOSE_FILENAME = "docker-compose.tolokaforge.yaml"
-_INJECTED_SERVICE_NAMES = ("runner", "db-service")
+_ENGINE_COMPOSE_FILENAME = "docker-compose.engine.yaml"
+_ENGINE_STAGING_DIRNAME = "engine"
+_ENGINE_STACK_ID = "engine"
+_TASK_STACK_ID = "task"
+_ENGINE_RUNNER_SERVICE = "runner"
+_ENGINE_DB_SERVICE = "db-service"
+_INJECTED_SERVICE_NAMES = (_ENGINE_RUNNER_SERVICE, _ENGINE_DB_SERVICE)
 _TOLOKAFORGE_TRIAL_SLUG_PLACEHOLDER = "${TOLOKAFORGE_TRIAL_SLUG}"
 
 _HARNESS_STAGING_DIR = "_harness"
@@ -82,16 +103,33 @@ _SUBSTITUTION_PATTERN = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}")
 
 @dataclass(frozen=True)
 class MaterialisedEnvironment:
-    """A task's engine-ready environment materialised on disk."""
+    """A task's engine-ready environment materialised on disk.
+
+    Carries the two compose files the two-stack plan brings up: the
+    trial-scope task compose (``compose_file``) and the run-scope engine
+    compose (``engine_compose_file``). Both surfaces of the adapter that
+    consume this object (``get_task`` and ``to_task_description``) build the
+    plan against the same pair.
+    """
 
     compose_file: Path
-    """Absolute path to the synthesised ``docker-compose.tolokaforge.yaml``."""
+    """Absolute path to the synthesised task-stack ``docker-compose.tolokaforge.yaml``
+    — declares the agent service, task-authored siblings, and the harness
+    ``-base`` build-only service under harness mode. Materialised per trial."""
+
+    engine_compose_file: Path
+    """Absolute path to the shared engine-stack ``docker-compose.engine.yaml``
+    — declares just ``runner`` + ``db-service``. Bytes are deterministic from
+    ``runner_image`` + ``db_service_image`` so every task in a run points at
+    the same content (their engine folder is deduplicated by digest), which
+    is what :func:`Orchestrator._extract_run_env_manifest`'s per-scope INV-1
+    cross-task agreement check requires."""
 
     agent_service: str
     """The compose service the bash tool execs into."""
 
     staging_dir: Path
-    """Absolute path to the staging directory the compose file lives in."""
+    """Absolute path to the staging directory the task compose file lives in."""
 
     base_build_service: str | None = None
     """Compose service that builds the un-layered task image, when the
@@ -228,7 +266,7 @@ def materialise_task_environment(
     staging_dir = (staging_root / f"{meta.task_id}-{digest}").resolve()
     _write_staging(meta.task_dir, staging_dir)
 
-    synthesised, base_build_service = _build_synthesised_compose(
+    task_doc, engine_doc, base_build_service = _build_synthesised_compose(
         original=original,
         meta=meta,
         agent_service=agent_service,
@@ -269,14 +307,38 @@ def materialise_task_environment(
                 )
             )
     compose_file = staging_dir / _SYNTHESISED_COMPOSE_FILENAME
-    compose_file.write_text(yaml.safe_dump(synthesised, sort_keys=False))
+    compose_file.write_text(yaml.safe_dump(task_doc, sort_keys=False))
+
+    engine_compose_file = _write_engine_stack(staging_root, engine_doc)
 
     return MaterialisedEnvironment(
         compose_file=compose_file.resolve(),
+        engine_compose_file=engine_compose_file,
         agent_service=agent_service,
         staging_dir=staging_dir,
         base_build_service=base_build_service,
     )
+
+
+def _write_engine_stack(staging_root: Path, engine_doc: dict[str, Any]) -> Path:
+    """Materialise the run-scope engine compose under a digest-named
+    subdirectory of ``staging_root`` and return its resolved path.
+
+    The digest hashes the emitted bytes; tasks whose engine services share
+    the same ``runner_image`` + ``db_service_image`` produce identical bytes
+    and land on the same file, so every task in a run pointing at the same
+    engine parameters lands on the same absolute path. Writes only when the
+    file is not already there — concurrent adapter instantiations reading
+    identical parameters see the same bytes and skip the second write.
+    """
+    engine_bytes = yaml.safe_dump(engine_doc, sort_keys=False)
+    digest = hashlib.sha256(engine_bytes.encode("utf-8")).hexdigest()[:16]
+    engine_dir = (staging_root / f"{_ENGINE_STAGING_DIRNAME}-{digest}").resolve()
+    engine_dir.mkdir(parents=True, exist_ok=True)
+    engine_compose_file = engine_dir / _ENGINE_COMPOSE_FILENAME
+    if not engine_compose_file.exists():
+        engine_compose_file.write_text(engine_bytes)
+    return engine_compose_file
 
 
 def _load_compose(path: Path) -> dict[str, Any]:
@@ -502,19 +564,23 @@ def _build_synthesised_compose(
     provider_env_keys: Sequence[str],
     runner_image: str,
     db_service_image: str,
-) -> tuple[dict[str, Any], str | None]:
-    """Synthesised compose document, plus the base-build service name.
+) -> tuple[dict[str, Any], dict[str, Any], str | None]:
+    """Synthesised task-stack + engine-stack compose docs, plus the
+    base-build service name.
 
-    The second element is the service the orchestrator must build *before*
-    the agent service — non-``None`` only when a harness layer sits on top of
-    a locally-built task image.
+    The two-stack split (ADR-0044 § 5): the run-scope engine stack owns
+    ``runner`` + ``db-service``; the trial-scope task stack owns the agent
+    service, task-authored siblings, and (under harness mode) the ``-base``
+    build-only service. The third element is the service the orchestrator
+    must build *before* the agent service — non-``None`` only when a harness
+    layer sits on top of a locally-built task image.
     """
     base_image = _agent_image(meta.task_id, image_registry, image_tag)
     if harness_spec is None:
         agent_image = base_image
     else:
         agent_image = f"{base_image}-{agent_harness}-{harness_spec.version}"
-    agent_container_name = f"{PROJECT_PREFIX}{_TOLOKAFORGE_TRIAL_SLUG_PLACEHOLDER}_{agent_service}"
+    agent_container_name = _trial_scoped_container_name(agent_service)
 
     resolved_vars = {
         "T_BENCH_TASK_DOCKER_CLIENT_IMAGE_NAME": agent_image,
@@ -527,9 +593,9 @@ def _build_synthesised_compose(
         "CPUS": str(meta.cpus),
         "MEMORY": f"{meta.memory_mb}M",
     }
-    doc = _substitute_tree(deepcopy(original), resolved_vars)
+    task_doc = _substitute_tree(deepcopy(original), resolved_vars)
 
-    services: dict[str, Any] = doc["services"]
+    services: dict[str, Any] = task_doc["services"]
     agent_body: dict[str, Any] = services[agent_service]
     task_build = agent_body.get("build")
     agent_body["image"] = agent_image
@@ -560,9 +626,49 @@ def _build_synthesised_compose(
             services[base_service] = _harness_base_service_body(base_image, task_build)
             base_build_service = base_service
 
-    services["runner"] = _runner_service_body(runner_image, agent_service)
-    services["db-service"] = _db_service_body(db_service_image)
-    return doc, base_build_service
+    _stamp_trial_container_names(services)
+
+    engine_doc = _engine_compose_doc(runner_image, db_service_image)
+    return task_doc, engine_doc, base_build_service
+
+
+def _trial_scoped_container_name(service_name: str) -> str:
+    """Container name interpolating ``${TOLOKAFORGE_TRIAL_SLUG}`` for a
+    trial-scope service.
+
+    Compose resolves the placeholder from the per-trial ``.env`` the
+    composer writes at ``provision_trial`` time, so each trial's container
+    for the same service gets a distinct name — a task-authored sibling
+    that would otherwise carry a fixed ``container_name:`` from its own
+    compose file cannot collide with the previous trial's leftover on the
+    same host.
+    """
+    return f"{PROJECT_PREFIX}{_TOLOKAFORGE_TRIAL_SLUG_PLACEHOLDER}_{service_name}"
+
+
+def _stamp_trial_container_names(task_services: dict[str, Any]) -> None:
+    """Set ``container_name`` on every task-stack service in place.
+
+    Applied to *every* declared service, including task-authored siblings
+    and the harness ``-base`` build-only entry. The build-only service is
+    profile-gated so it never brings a container up — the write is inert
+    there and buys uniform behaviour for the ones that do run.
+    """
+    for name, body in task_services.items():
+        if not isinstance(body, dict):
+            continue
+        body["container_name"] = _trial_scoped_container_name(name)
+
+
+def _engine_compose_doc(runner_image: str, db_service_image: str) -> dict[str, Any]:
+    """Run-scope engine compose document — deterministic in its inputs so
+    every task in the run points at byte-identical content."""
+    return {
+        "services": {
+            _ENGINE_RUNNER_SERVICE: _runner_service_body(runner_image),
+            _ENGINE_DB_SERVICE: _db_service_body(db_service_image),
+        }
+    }
 
 
 def _substitute_tree(node: Any, values: dict[str, str]) -> Any:
@@ -622,7 +728,15 @@ def _harness_base_service_body(base_image: str, task_build: Any) -> dict[str, An
     }
 
 
-def _runner_service_body(runner_image: str, agent_service: str) -> dict[str, Any]:
+def _runner_service_body(runner_image: str) -> dict[str, Any]:
+    """Engine-stack runner service.
+
+    ``depends_on`` names ``db-service`` only — the agent service lives on the
+    trial-scope task stack (a separate compose project), so a compose
+    dependency across projects would neither compile nor resolve. The runner
+    reaches the agent container by explicit name via ``docker exec`` from
+    the runner-side wrapper, not via a compose dependency graph.
+    """
     return {
         "image": runner_image,
         "ports": ["50051"],
@@ -635,7 +749,6 @@ def _runner_service_body(runner_image: str, agent_service: str) -> dict[str, Any
             "start_period": "3s",
         },
         "depends_on": {
-            agent_service: {"condition": "service_started"},
             "db-service": {"condition": "service_healthy"},
         },
     }

--- a/tests/canonical/snapshots/harness_registry_replay/metric.json
+++ b/tests/canonical/snapshots/harness_registry_replay/metric.json
@@ -1,6 +1,6 @@
 {
   "bucket_a_count": 1,
-  "bucket_b_count": 12,
+  "bucket_b_count": 13,
   "commits": [
     {
       "adapter_paths": [
@@ -1942,6 +1942,34 @@
         "tolokaforge/core/run_trial.py",
         "tolokaforge/core/shared_stack_runtime.py",
         "tolokaforge/runner/models.py"
+      ]
+    },
+    {
+      "adapter_paths": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py",
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py",
+        "tests/canonical/snapshots/tbench_echo_hello/task_config.json",
+        "tests/canonical/snapshots/tbench_echo_hello/task_description.json",
+        "tests/canonical/test_terminal_bench_adapter_canon.py",
+        "tests/unit/test_terminal_bench.py",
+        "tolokaforge/core/default_substrate_composer.py"
+      ],
+      "bucket": "B",
+      "date": "2026-09-02",
+      "pr": null,
+      "reason": "7 adapter-side path(s) outside Bucket-A allow-list",
+      "sha": "8f6846fe51b3581ad3683a811e2f450289e71f08",
+      "subject": "feat(tbench): two-stack composition plan (engine run + task trial) (#1385, code portion)",
+      "touched_files": [
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/adapter.py",
+        "external_adapters/tolokaforge-adapter-terminal-bench/src/tolokaforge_adapter_terminal_bench/compose_synthesis.py",
+        "tests/canonical/snapshots/tbench_echo_hello/task_config.json",
+        "tests/canonical/snapshots/tbench_echo_hello/task_description.json",
+        "tests/canonical/snapshots/tbench_echo_hello_harness/synthesised_compose.json",
+        "tests/canonical/snapshots/tbench_echo_hello_skills_harness/synthesised_compose.json",
+        "tests/canonical/test_terminal_bench_adapter_canon.py",
+        "tests/unit/test_terminal_bench.py",
+        "tolokaforge/core/default_substrate_composer.py"
       ]
     }
   ]

--- a/tests/canonical/snapshots/tbench_echo_hello/task_config.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_config.json
@@ -16,18 +16,31 @@
     "network_policy": "full_internet",
     "security_context_defaults": null,
     "services": null,
-    "stack": {
-      "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
-      "db_port": null,
-      "db_service": null,
-      "inputs": {},
-      "rag_port": null,
-      "rag_service": null,
-      "runner_port": null,
-      "runner_service": "runner",
-      "stack_scope": null
-    },
-    "stacks": null
+    "stack": null,
+    "stacks": {
+      "engine": {
+        "compose_file": "<STAGING>/engine/docker-compose.engine.yaml",
+        "db_port": null,
+        "db_service": null,
+        "inputs": {},
+        "rag_port": null,
+        "rag_service": null,
+        "runner_port": null,
+        "runner_service": "runner",
+        "stack_scope": "run"
+      },
+      "task": {
+        "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
+        "db_port": null,
+        "db_service": null,
+        "inputs": {},
+        "rag_port": null,
+        "rag_service": null,
+        "runner_port": null,
+        "runner_service": null,
+        "stack_scope": "trial"
+      }
+    }
   },
   "grading": "__adapter__",
   "initial_state": {

--- a/tests/canonical/snapshots/tbench_echo_hello/task_description.json
+++ b/tests/canonical/snapshots/tbench_echo_hello/task_description.json
@@ -35,7 +35,7 @@
   "category": "terminal",
   "description": "Create a file /tmp/hello.txt containing the text \"Hello, World!\".\n",
   "environment_manifest": {
-    "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
+    "compose_file": "<STAGING>/engine/docker-compose.engine.yaml",
     "db_port": null,
     "db_service": null,
     "initial_state": {},
@@ -53,12 +53,6 @@
         "readiness": null,
         "reset": null
       },
-      "main": {
-        "isolation": "ephemeral",
-        "network_access": "default",
-        "readiness": null,
-        "reset": null
-      },
       "runner": {
         "isolation": "ephemeral",
         "network_access": "default",
@@ -69,10 +63,17 @@
     "stack_inputs": {},
     "stacks": [
       {
-        "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
+        "compose_file": "<STAGING>/engine/docker-compose.engine.yaml",
         "inputs": {},
         "runner_service": "runner",
-        "stack_id": "default",
+        "stack_id": "engine",
+        "stack_scope": "run"
+      },
+      {
+        "compose_file": "<STAGING>/echo-hello/docker-compose.tolokaforge.yaml",
+        "inputs": {},
+        "runner_service": null,
+        "stack_id": "task",
         "stack_scope": "trial"
       }
     ]

--- a/tests/canonical/snapshots/tbench_echo_hello_harness/synthesised_compose.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_harness/synthesised_compose.json
@@ -1,21 +1,5 @@
 {
   "services": {
-    "db-service": {
-      "healthcheck": {
-        "interval": "2s",
-        "retries": 30,
-        "start_period": "3s",
-        "test": [
-          "CMD-SHELL",
-          "curl -fs http://localhost:8000/health || exit 1"
-        ],
-        "timeout": "3s"
-      },
-      "image": "tolokaforge-db-service:local",
-      "ports": [
-        "8000"
-      ]
-    },
     "main": {
       "build": {
         "context": ".",
@@ -45,38 +29,10 @@
       "build": {
         "context": "./environment"
       },
+      "container_name": "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main-base",
       "image": "tbench-echo-hello:local",
       "profiles": [
         "tolokaforge-build"
-      ]
-    },
-    "runner": {
-      "depends_on": {
-        "db-service": {
-          "condition": "service_healthy"
-        },
-        "main": {
-          "condition": "service_started"
-        }
-      },
-      "environment": {
-        "DB_SERVICE_URL": "http://db-service:8000"
-      },
-      "healthcheck": {
-        "interval": "2s",
-        "retries": 30,
-        "start_period": "3s",
-        "test": [
-          "CMD",
-          "bash",
-          "-c",
-          "echo > /dev/tcp/127.0.0.1/50051"
-        ],
-        "timeout": "3s"
-      },
-      "image": "tolokaforge-runner:local",
-      "ports": [
-        "50051"
       ]
     }
   }

--- a/tests/canonical/snapshots/tbench_echo_hello_skills_harness/synthesised_compose.json
+++ b/tests/canonical/snapshots/tbench_echo_hello_skills_harness/synthesised_compose.json
@@ -1,21 +1,5 @@
 {
   "services": {
-    "db-service": {
-      "healthcheck": {
-        "interval": "2s",
-        "retries": 30,
-        "start_period": "3s",
-        "test": [
-          "CMD-SHELL",
-          "curl -fs http://localhost:8000/health || exit 1"
-        ],
-        "timeout": "3s"
-      },
-      "image": "tolokaforge-db-service:local",
-      "ports": [
-        "8000"
-      ]
-    },
     "main": {
       "build": {
         "context": ".",
@@ -45,38 +29,10 @@
       "build": {
         "context": "./environment"
       },
+      "container_name": "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main-base",
       "image": "tbench-echo-hello-skills:local",
       "profiles": [
         "tolokaforge-build"
-      ]
-    },
-    "runner": {
-      "depends_on": {
-        "db-service": {
-          "condition": "service_healthy"
-        },
-        "main": {
-          "condition": "service_started"
-        }
-      },
-      "environment": {
-        "DB_SERVICE_URL": "http://db-service:8000"
-      },
-      "healthcheck": {
-        "interval": "2s",
-        "retries": 30,
-        "start_period": "3s",
-        "test": [
-          "CMD",
-          "bash",
-          "-c",
-          "echo > /dev/tcp/127.0.0.1/50051"
-        ],
-        "timeout": "3s"
-      },
-      "image": "tolokaforge-runner:local",
-      "ports": [
-        "50051"
       ]
     }
   }

--- a/tests/canonical/test_terminal_bench_adapter_canon.py
+++ b/tests/canonical/test_terminal_bench_adapter_canon.py
@@ -16,12 +16,13 @@ SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
 def _normalize_paths(obj):
     """Replace absolute paths + the content digest with stable placeholders.
 
-    Adapter output contains two machine-varying strings: the absolute
+    Adapter output contains three machine-varying strings: the absolute
     prefix leading to ``tests/data/terminal_bench_tasks/`` (differs by
-    checkout root), and the staging directory name
+    checkout root), the task staging directory name
     ``<staging_root>/echo-hello-<16-hex-digest>/…`` (differs by the
-    per-test ``tmp_path``). Both are normalised to keep the snapshot
-    portable across machines and CI.
+    per-test ``tmp_path``), and the shared engine staging directory
+    ``<staging_root>/engine-<16-hex-digest>/…``. All three are normalised
+    to keep the snapshot portable across machines and CI.
     """
     text = json.dumps(obj)
     text = re.sub(
@@ -32,6 +33,11 @@ def _normalize_paths(obj):
     text = re.sub(
         r'"[^"]*?/echo-hello-[0-9a-f]{16}/',
         r'"<STAGING>/echo-hello/',
+        text,
+    )
+    text = re.sub(
+        r'"[^"]*?/engine-[0-9a-f]{16}/',
+        r'"<STAGING>/engine/',
         text,
     )
     return json.loads(text)

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -418,7 +418,8 @@ class TestTerminalBenchAdapterRemovedParams:
 
 
 class TestTerminalBenchAdapterEnvironmentManifest:
-    """``get_task`` emits an :class:`EnvironmentPatch`; ``to_task_description`` emits the resolved manifest.
+    """``get_task`` emits a two-stack :class:`EnvironmentPatch`;
+    ``to_task_description`` emits the resolved multi-scope manifest.
 
     Structural agreement, not object identity — one patch + one resolver.
     """
@@ -435,36 +436,56 @@ class TestTerminalBenchAdapterEnvironmentManifest:
             {"terminal_bench_dir": str(fixture_dir), "staging_root": str(tmp_path)}
         )
 
-    def test_task_config_carries_environment_patch(self, adapter):
+    def test_task_config_carries_two_stack_environment_patch(self, adapter):
+        """The task's ``EnvironmentPatch`` declares the two-stack plan
+        directly — an engine stack (run scope, owns the runner) and a task
+        stack (trial scope, owns the agent service). INV-12: only the
+        engine stack sets ``runner_service``."""
         task = adapter.get_task("echo-hello")
         assert isinstance(task.environment_manifest, EnvironmentPatch)
-        stack = task.environment_manifest.stack
-        assert stack is not None
+        assert task.environment_manifest.stack is None
+        stacks = task.environment_manifest.stacks
+        assert stacks is not None and set(stacks) == {"engine", "task"}
         env = adapter._environment("echo-hello")
-        assert stack.compose_file == env.compose_file
-        assert stack.runner_service == "runner"
+        assert stacks["engine"].compose_file == env.engine_compose_file
+        assert stacks["engine"].stack_scope == "run"
+        assert stacks["engine"].runner_service == "runner"
+        assert stacks["task"].compose_file == env.compose_file
+        assert stacks["task"].stack_scope == "trial"
+        assert stacks["task"].runner_service is None
         assert task.environment_manifest.network_policy is NetworkPolicy.FULL_INTERNET
 
-    def test_task_description_carries_resolved_manifest(self, adapter):
+    def test_task_description_carries_resolved_multi_scope_manifest(self, adapter):
+        """The resolved manifest classifies as ``MULTI_SCOPE``; the scalar
+        ``compose_file`` mirror is the engine stack (owner of ``runner_service``)."""
+        from tolokaforge.runner.models import PlanShape
+
         td = adapter.to_task_description("echo-hello")
         manifest = td.environment_manifest
         assert isinstance(manifest, EnvironmentManifest)
         env = adapter._environment("echo-hello")
-        assert manifest.compose_file == env.compose_file
+        assert manifest.compose_file == env.engine_compose_file
         assert manifest.runner_service == "runner"
-        assert set(manifest.services) == {"runner", "db-service", env.agent_service}
-        assert {name: spec.isolation for name, spec in manifest.services.items()} == {
-            "runner": "ephemeral",
-            "db-service": "ephemeral",
-            env.agent_service: "ephemeral",
-        }
-        assert manifest.requires_per_trial is True
+        assert manifest.plan_shape is PlanShape.MULTI_SCOPE
+        stack_ids = [decl.stack_id for decl in manifest.stacks]
+        assert stack_ids == ["engine", "task"]
+        by_id = {decl.stack_id: decl for decl in manifest.stacks}
+        assert by_id["engine"].stack_scope == "run"
+        assert by_id["engine"].runner_service == "runner"
+        assert by_id["engine"].compose_file == env.engine_compose_file
+        assert by_id["task"].stack_scope == "trial"
+        assert by_id["task"].runner_service is None
+        assert by_id["task"].compose_file == env.compose_file
         assert manifest.network_policy is NetworkPolicy.FULL_INTERNET
 
-    def test_patch_and_manifest_point_at_same_compose_file(self, adapter):
-        task = adapter.get_task("echo-hello")
-        td = adapter.to_task_description("echo-hello")
-        assert task.environment_manifest.stack.compose_file == td.environment_manifest.compose_file
+    def test_patch_and_manifest_point_at_same_compose_files(self, adapter):
+        """Every stack the patch declares appears in the resolved manifest
+        with the same compose-file pointer."""
+        patch = adapter.get_task("echo-hello").environment_manifest
+        manifest = adapter.to_task_description("echo-hello").environment_manifest
+        assert {sid: sp.compose_file for sid, sp in patch.stacks.items()} == {
+            decl.stack_id: decl.compose_file for decl in manifest.stacks
+        }
 
     def test_tool_source_extra_is_two_key_shape(self, adapter):
         td = adapter.to_task_description("echo-hello")
@@ -553,11 +574,12 @@ class TestTerminalBenchAdapterNoSubprocess:
         check_output_mock.assert_not_called()
 
 
-class TestTerminalBenchTasksProduceTrialScopedPlan:
-    """The terminal-bench adapter emits ``all-ephemeral`` manifests — the
-    composer sees a fully trial-scoped plan and provisions per trial."""
+class TestTerminalBenchTasksProduceMultiScopePlan:
+    """The terminal-bench adapter emits a two-stack MULTI_SCOPE plan —
+    engine services live for the whole run, task services materialise per
+    trial (ADR-0044 § 5)."""
 
-    def test_adapter_manifest_is_trial_scoped_only(self, tmp_path):
+    def test_adapter_manifest_is_multi_scope(self, tmp_path):
         from tolokaforge_adapter_terminal_bench.adapter import TerminalBenchAdapter
 
         from tolokaforge.core.models import (
@@ -586,7 +608,9 @@ class TestTerminalBenchTasksProduceTrialScopedPlan:
 
         manifest = orch._task_description("echo-hello").environment_manifest
         assert manifest is not None
-        assert manifest.plan_shape == PlanShape.TRIAL_SCOPED_ONLY
+        assert manifest.plan_shape is PlanShape.MULTI_SCOPE
+        scopes = {decl.stack_scope for decl in manifest.stacks}
+        assert scopes == {"run", "trial"}
 
 
 # =============================================================================
@@ -676,7 +700,8 @@ def _load_synthesised(env) -> dict:
 class TestComposeSynthesisFixBillingHolds:
     """The synthesised YAML for a real example task locks the emit contract."""
 
-    def test_emitted_shape(self, tmp_path):
+    def test_emitted_task_stack_shape(self, tmp_path):
+        """The task stack owns only task-declared services — no runner, no db-service."""
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
             materialise_task_environment,
         )
@@ -688,7 +713,7 @@ class TestComposeSynthesisFixBillingHolds:
         env = materialise_task_environment(tasks["fix-billing-holds"], staging_root=tmp_path)
 
         compose = _load_synthesised(env)
-        assert set(compose["services"]) == {"runner", "db-service", "main"}
+        assert set(compose["services"]) == {"main"}
         main = compose["services"]["main"]
         assert main["image"] == "tbench-fix-billing-holds:local"
         assert main["container_name"] == "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main"
@@ -699,7 +724,30 @@ class TestComposeSynthesisFixBillingHolds:
         assert "${CPUS}" not in text
         assert "${MEMORY}" not in text
 
-    def test_environment_manifest_accepts_emitted_file(self, tmp_path):
+    def test_engine_stack_owns_runner_and_db_service(self, tmp_path):
+        """The run-scope engine stack has just the engine's own services;
+        its runner depends only on db-service (INV: no cross-project depends_on)."""
+        import yaml as _yaml
+        from tolokaforge_adapter_terminal_bench.compose_synthesis import (
+            materialise_task_environment,
+        )
+        from tolokaforge_adapter_terminal_bench.task_parser import discover_tasks
+
+        examples_dir = Path(__file__).parent.parent.parent / "examples" / "terminal_bench"
+        tasks = discover_tasks(examples_dir)
+        env = materialise_task_environment(tasks["fix-billing-holds"], staging_root=tmp_path)
+
+        with env.engine_compose_file.open() as f:
+            engine = _yaml.safe_load(f)
+        assert set(engine["services"]) == {"runner", "db-service"}
+        assert engine["services"]["runner"]["depends_on"] == {
+            "db-service": {"condition": "service_healthy"},
+        }
+
+    def test_environment_manifest_accepts_engine_compose_file(self, tmp_path):
+        """The manifest's scalar ``compose_file`` mirrors the engine stack
+        (owner of ``runner_service``, per INV-12), so its safety validators
+        find the runner."""
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
             materialise_task_environment,
         )
@@ -711,7 +759,9 @@ class TestComposeSynthesisFixBillingHolds:
         tasks = discover_tasks(examples_dir)
         env = materialise_task_environment(tasks["fix-billing-holds"], staging_root=tmp_path)
 
-        manifest = EnvironmentManifest(compose_file=env.compose_file, runner_service="runner")
+        manifest = EnvironmentManifest(
+            compose_file=env.engine_compose_file, runner_service="runner"
+        )
         assert manifest.runner_service == "runner"
 
 
@@ -738,7 +788,7 @@ class TestComposeSynthesisAgentServiceResolution:
 
         assert env.agent_service == "app"
         compose = _load_synthesised(env)
-        assert set(compose["services"]) == {"runner", "db-service", "app"}
+        assert set(compose["services"]) == {"app"}
         assert (
             compose["services"]["app"]["container_name"] == "tbench_${TOLOKAFORGE_TRIAL_SLUG}_app"
         )
@@ -813,9 +863,13 @@ class TestComposeSynthesisStaging:
 
         assert first.staging_dir == second.staging_dir
         assert first.compose_file == second.compose_file
-        # Only one subdirectory under staging_root — the digest-named one.
-        subdirs = [p for p in staging_root.iterdir() if p.is_dir()]
-        assert len(subdirs) == 1
+        assert first.engine_compose_file == second.engine_compose_file
+        # Two subdirectories under staging_root — the task's digest-named
+        # staging + the engine stack's digest-named shared dir.
+        subdirs = sorted(p.name for p in staging_root.iterdir() if p.is_dir())
+        assert len(subdirs) == 2
+        assert any(name.startswith("engine-") for name in subdirs)
+        assert any(name.startswith("idempotent-") for name in subdirs)
 
     def test_root_run_tests_promoted_to_tests_test_sh(self, tmp_path):
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
@@ -885,6 +939,93 @@ class TestComposeSynthesisStaging:
 
         assert not (env.staging_dir / "tests" / "__pycache__").exists()
         assert (env.staging_dir / "tests" / "test_something.py").exists()
+
+
+class TestComposeSynthesisContainerNameInterpolation:
+    """Every task-stack service — agent, task-authored siblings, harness
+    base — carries ``container_name`` that interpolates
+    ``${TOLOKAFORGE_TRIAL_SLUG}``.
+
+    Without the stamp, a task-authored ``container_name`` (or an anonymous
+    service compose auto-names from the trial-scope project) can collide
+    with a leftover container from the previous trial's teardown — the
+    task stack materialises per trial, but Docker resource cleanup lags.
+    Interpolating the slug always makes trial 2's names disjoint from
+    trial 1's regardless of what the pack declared.
+    """
+
+    def test_task_authored_container_name_is_overwritten(self, tmp_path):
+        """A task that pinned ``container_name: my_static_pg`` cannot smuggle
+        that fixed name into the trial. The synthesis stamps its own."""
+        from tolokaforge_adapter_terminal_bench.compose_synthesis import (
+            materialise_task_environment,
+        )
+
+        meta = _write_task(
+            tmp_path,
+            "authored-name",
+            {
+                "services": {
+                    "main": {"image": "python:3.11-slim"},
+                    "helper": {"image": "postgres:16", "container_name": "my_static_pg"},
+                }
+            },
+        )
+        env = materialise_task_environment(meta, staging_root=tmp_path / "staging")
+        compose = _load_synthesised(env)
+        assert (
+            compose["services"]["helper"]["container_name"]
+            == "tbench_${TOLOKAFORGE_TRIAL_SLUG}_helper"
+        )
+        assert (
+            compose["services"]["main"]["container_name"] == "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main"
+        )
+        # The task's original literal never survives, so no collision with a
+        # leftover of the same name across trials.
+        assert "my_static_pg" not in env.compose_file.read_text()
+
+    def test_harness_base_service_also_carries_the_interpolation(self, tmp_path):
+        """The harness ``-base`` service is profile-gated (build-only, never
+        started), but is stamped uniformly so no service in the task doc
+        escapes the rule."""
+        from tolokaforge_adapter_terminal_bench.compose_synthesis import (
+            materialise_task_environment,
+        )
+
+        meta = _harness_task(tmp_path, "stamped", with_build=True)
+        env = materialise_task_environment(
+            meta, staging_root=tmp_path / "staging", agent_harness="claude-code"
+        )
+        compose = _load_synthesised(env)
+        assert (
+            compose["services"]["main-base"]["container_name"]
+            == "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main-base"
+        )
+
+    def test_engine_stack_services_carry_no_container_name(self, tmp_path):
+        """The engine stack is run-scope — its ``.env`` never carries
+        ``${TOLOKAFORGE_TRIAL_SLUG}``, so a container_name that referenced
+        the placeholder there would leave the literal unresolved and cause
+        an up-time collision. Engine services keep compose's own
+        project-scoped naming instead."""
+        import yaml as _yaml
+        from tolokaforge_adapter_terminal_bench.compose_synthesis import (
+            materialise_task_environment,
+        )
+
+        meta = _write_task(
+            tmp_path,
+            "engine-plain",
+            {"services": {"main": {"image": "python:3.11-slim"}}},
+        )
+        env = materialise_task_environment(meta, staging_root=tmp_path / "staging")
+        with env.engine_compose_file.open() as f:
+            engine_doc = _yaml.safe_load(f)
+        for name, body in engine_doc["services"].items():
+            assert "container_name" not in body, (
+                f"engine service {name!r} declared container_name — the run-scope stack "
+                "would leave ${TOLOKAFORGE_TRIAL_SLUG} unresolved and collide across runs"
+            )
 
 
 class TestComposeSynthesisReservedNameCollision:
@@ -1086,7 +1227,7 @@ class TestComposeSynthesisHarnessLayer:
         env = materialise_task_environment(meta, staging_root=tmp_path / "staging")
 
         compose = _load_synthesised(env)
-        assert set(compose["services"]) == {"main", "runner", "db-service"}
+        assert set(compose["services"]) == {"main"}
         assert compose["services"]["main"]["image"] == "tbench-plain:local"
         assert env.base_build_service is None
         assert not (env.staging_dir / "_harness").exists()
@@ -1102,7 +1243,7 @@ class TestComposeSynthesisHarnessLayer:
         )
 
         compose = _load_synthesised(env)
-        assert set(compose["services"]) == {"main", "main-base", "runner", "db-service"}
+        assert set(compose["services"]) == {"main", "main-base"}
 
         base = compose["services"]["main-base"]
         assert base["image"] == "tbench-layered:local"
@@ -1231,7 +1372,12 @@ class TestComposeSynthesisHarnessLayer:
             )
 
     def test_the_same_task_is_fine_without_a_harness(self, tmp_path):
-        """No harness, no injected base service — so nothing to collide with."""
+        """No harness, no injected base service — so nothing to collide with.
+
+        The task-authored ``main-base`` sibling survives verbatim except for
+        the ``container_name`` the trial-slug interpolation stamps on every
+        task-stack service.
+        """
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
             materialise_task_environment,
         )
@@ -1247,9 +1393,17 @@ class TestComposeSynthesisHarnessLayer:
             },
         )
         env = materialise_task_environment(meta, staging_root=tmp_path / "staging")
-        assert _load_synthesised(env)["services"]["main-base"] == {"image": "busybox"}
+        assert _load_synthesised(env)["services"]["main-base"] == {
+            "image": "busybox",
+            "container_name": "tbench_${TOLOKAFORGE_TRIAL_SLUG}_main-base",
+        }
 
     def test_layered_manifest_still_validates(self, tmp_path):
+        """The engine compose file is the manifest's scalar mirror (owns
+        ``runner_service`` per INV-12); the safety validators run against it.
+        The task compose file's ``main-base`` build-only service lives on
+        the task stack and is checked separately by ``_services_in_stack``."""
+        import yaml as _yaml
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
             materialise_task_environment,
         )
@@ -1258,8 +1412,13 @@ class TestComposeSynthesisHarnessLayer:
         env = materialise_task_environment(
             meta, staging_root=tmp_path / "staging", agent_harness="claude-code"
         )
-        manifest = EnvironmentManifest(compose_file=env.compose_file, runner_service="runner")
-        assert "main-base" in manifest.load_compose()["services"]
+        manifest = EnvironmentManifest(
+            compose_file=env.engine_compose_file, runner_service="runner"
+        )
+        assert "runner" in manifest.load_compose()["services"]
+        with env.compose_file.open() as f:
+            task_doc = _yaml.safe_load(f)
+        assert "main-base" in task_doc["services"]
 
 
 def _skills_task(tmp_path: Path, task_id: str, declared: str | None, files: dict[str, str]):
@@ -1604,7 +1763,9 @@ class TestProviderEnvWire:
             }
         )
 
-    def test_keys_land_in_stack_inputs(self, fixture_dir, tmp_path):
+    def test_keys_land_in_task_stack_inputs(self, fixture_dir, tmp_path):
+        """Provider keys ride the trial-scope task stack — its ``.env`` gets
+        the values written per-trial. The run-scope engine stack takes none."""
         adapter = self._adapter(
             fixture_dir,
             tmp_path,
@@ -1614,18 +1775,20 @@ class TestProviderEnvWire:
             },
         )
         patch_ = adapter.get_task("echo-hello").environment_manifest
-        assert patch_.stack.inputs == {
+        assert patch_.stacks["task"].inputs == {
             "TBENCH_PROVIDER_ANTHROPIC_API_KEY": "sk-test",
             "TBENCH_PROVIDER_ANTHROPIC_BASE_URL": "https://proxy.example",
         }
+        assert patch_.stacks["engine"].inputs == {}
 
-    def test_keys_survive_into_the_resolved_manifest(self, fixture_dir, tmp_path):
+    def test_keys_survive_into_the_resolved_task_stack(self, fixture_dir, tmp_path):
         adapter = self._adapter(
             fixture_dir, tmp_path, agent_provider_env={"OPENAI_API_KEY": "sk-openai"}
         )
         manifest = adapter.to_task_description("echo-hello").environment_manifest
         assert manifest is not None
-        assert manifest.stack_inputs["TBENCH_PROVIDER_OPENAI_API_KEY"] == "sk-openai"
+        task_decl = next(decl for decl in manifest.stacks if decl.stack_id == "task")
+        assert task_decl.inputs["TBENCH_PROVIDER_OPENAI_API_KEY"] == "sk-openai"
 
     def test_agent_service_binds_them_to_a_namespaced_compose_input(self, fixture_dir, tmp_path):
         """Names only in the compose file — the value comes from the ``.env``."""
@@ -1748,7 +1911,9 @@ class TestProviderEnvWire:
             {"terminal_bench_dir": str(fixture_dir), "staging_root": str(tmp_path)}
         )
         assert adapter.agent_provider_env == {}
-        assert adapter.get_task("echo-hello").environment_manifest.stack.inputs == {}
+        stacks = adapter.get_task("echo-hello").environment_manifest.stacks
+        assert stacks["task"].inputs == {}
+        assert stacks["engine"].inputs == {}
 
     def test_switching_keys_changes_the_staging_digest(self, tmp_path):
         from tolokaforge_adapter_terminal_bench.compose_synthesis import (
@@ -1965,8 +2130,9 @@ class TestHarnessPresetsFileOverlay:
         assert "${secret:" not in env.compose_file.read_text()
         manifest = adapter.to_task_description("echo-hello").environment_manifest
         assert manifest is not None
+        task_decl = next(decl for decl in manifest.stacks if decl.stack_id == "task")
         assert (
-            manifest.stack_inputs["TBENCH_PROVIDER_GOOGLE_GEMINI_BASE_URL"]
+            task_decl.inputs["TBENCH_PROVIDER_GOOGLE_GEMINI_BASE_URL"]
             == "https://litellm.example.test/gemini"
         )
 

--- a/tolokaforge/core/default_substrate_composer.py
+++ b/tolokaforge/core/default_substrate_composer.py
@@ -243,7 +243,7 @@ class DefaultSubstrateComposer:
                 log_capture=_trial_scope_log_capture(run_sub.log_capture, spec.trial_id),
                 write_compose_env=WriteComposeEnv(
                     trial_id=spec.trial_id,
-                    stack_inputs=manifest.stack_inputs,
+                    stack_inputs=decl.inputs,
                 ),
                 events=run_sub.events,
                 component_id_prefix=f"trial/{spec.trial_id}",
@@ -505,7 +505,7 @@ def _refuse_reserved_prefix(
     *,
     stage: ProvisionStage = "provision",
 ) -> None:
-    """Refuse a ``TOLOKAFORGE_``-prefixed key in ``stack_inputs``.
+    """Refuse a ``TOLOKAFORGE_``-prefixed key on any stack's ``inputs``.
 
     Both composer entry points guard the same invariant:
     :meth:`DefaultSubstrateComposer.materialise_run` passes
@@ -513,17 +513,23 @@ def _refuse_reserved_prefix(
     manifest with a reserved key fails before any docker call;
     :meth:`DefaultSubstrateComposer.provision_trial` (and
     :meth:`PerTrialRuntimeBackend.provision`) leave the default
-    ``stage="provision"``. Reason text is identical modulo the id.
+    ``stage="provision"``. Walks every stack's ``decl.inputs`` so a
+    multi-stack plan cannot smuggle a reserved key past the scalar mirror.
     """
-    reserved = sorted(
-        key for key in manifest.stack_inputs if key.startswith(TOLOKAFORGE_ENV_PREFIX)
-    )
-    if reserved:
+    seen: set[str] = set()
+    for decl in manifest.stacks:
+        seen.update(key for key in decl.inputs if key.startswith(TOLOKAFORGE_ENV_PREFIX))
+    # Legacy scalar path — a manifest that has not yet been through
+    # ``_synthesise_composition_plan`` carries its inputs on the scalar
+    # field alone.
+    seen.update(key for key in manifest.stack_inputs if key.startswith(TOLOKAFORGE_ENV_PREFIX))
+    if seen:
+        offending = sorted(seen)[0]
         raise ProvisionError(
             trial_id=trial_id,
             stage=stage,
             reason=(
-                f"stack_inputs key {reserved[0]!r} uses the reserved "
+                f"stack_inputs key {offending!r} uses the reserved "
                 f"{TOLOKAFORGE_ENV_PREFIX} prefix (engine-authored compose "
                 "variables); rename or remove it from the manifest"
             ),


### PR DESCRIPTION
Closes #1385 (code portion).

Final code-carrying slice of ADR-0044. `TerminalBenchAdapter` emits a two-stack composition plan (`engine` run-scope + `task` trial-scope), giving T-Bench evaluations the wall-clock story the milestone was designed to unlock: the runner + engine stays materialised for the whole run; only the task-side compose cycles per trial.

**Live-smoke portion deferred to user approval**: this PR is the code + snapshot regen only. Release cut (`v0.22.0`), T-Bench eval dispatch, and the comparison report on epic #1336 are the user's call.

## Design walkthrough

Single commit `8f6846fe`.

- **`TerminalBenchAdapter._environment_patch`** now emits an `EnvironmentPatch.stacks` block with two entries:
  - `engine` (run-scope): owns the runner + db-service. `runner_service="runner"`. One substrate materialised at `connect()` time, held live for every trial in the run.
  - `task` (trial-scope): owns the agent service and any task-authored siblings. `runner_service=None` (INV-12). Materialised fresh per trial via `composer.provision_trial` so state never leaks across trials.
- **`compose_synthesis`** interpolates `${TOLOKAFORGE_TRIAL_SLUG}` into every generated `container_name`. Under the pre-refactor per-trial-full-teardown model the collision was hidden; the two-stack shape breaks it because the engine stack stays live across trials while the task stack cycles — two trials in a row would otherwise try to bring up a container with a name already in use.
- **`DefaultSubstrateComposer` hardened for multi-stack semantics** (two small edits, both required by the two-stack shape):
  - The trial-scope materialise context now writes THIS stack's `decl.inputs` into `.env`, not `manifest.stack_inputs` (the scalar mirror). Multi-stack plans need per-stack inputs; the scalar mirror is a single-stack convenience.
  - `_refuse_reserved_prefix` walks every stack's `decl.inputs` alongside the scalar mirror. Multi-stack plans could otherwise smuggle a reserved `TOLOKAFORGE_` key on a non-mirror stack past the pre-existing scalar-only check.
- **Snapshot regens** (4 canonical snapshots): `tests/canonical/snapshots/tbench_echo_hello/{task_config,task_description}.json` + `tests/canonical/snapshots/tbench_echo_hello{,_skills}_harness/synthesised_compose.json`. These lock the two-stack shape as the adapter's canonical output.
- **Tests**: `tests/canonical/test_terminal_bench_adapter_canon.py` + `tests/unit/test_terminal_bench.py` extended to lock the two-stack emission (both entries present, correct `stack_scope` values, `runner_service` only on `engine`, `plan_shape == MULTI_SCOPE` on the resolved manifest).

## Test plan

- [x] 279 targeted tests pass (T-Bench adapter canon + unit, composer, baseline parity, backend contract, plugin registrations).
- [x] Full canonical sweep: 1800 passed / 1 skipped.
- [x] `ruff check` + `ruff format --check` clean on all touched files.
- [x] Byte-parity fixture at `tests/canonical/test_composition_baseline_parity.py` stayed green.
- [x] INV-12 (only one stack sets `runner_service`) enforced by the adapter.
- [ ] **Live-smoke validation** — deferred to user approval. Would cover: `v0.22.0` release cut, `eval/tbench-balanced-10-engine-loop` pin bump, kimi_k3 sample dispatch, wall-clock < 5h/shard target, pass-rate ≥ 87% target, comparison report on epic #1336.