### PR TITLE
feat(grading): grade bundle format v1.0 — reader + producer + external-consumer contract

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -188,11 +188,11 @@ allow_indirect_imports = true
 #
 # ``core.grading.bundle`` ships the offline grade-bundle format library
 # (manifest schema v1.0 + reader + producer + `%.6g` float normaliser).
-# The bundle is the offline representation both the future snapshot
-# substrate and external downstream tools consume without a live runner;
-# a reach back into ``runner``, ``grader``, or the live substrate would
-# silently couple the format to the wire and defeat the "one canonical
-# offline bytes" invariant the manifest digest names the bundle by.
+# The bundle is content-addressable: its canonical name is
+# ``sha256(manifest.json)``, and each part is digested inside the manifest.
+# A reach back into ``runner``, ``grader``, or the live substrate would
+# couple the format bytes to the wire and defeat that invariant — the
+# same trial serialised on two topologies would land at different digests.
 # ``allow_indirect_imports = false`` mirrors ``composite-fold-purity`` /
 # ``filesystem-view-purity`` — a transitive path back into a forbidden
 # target trips the contract, not just a direct import.

--- a/.importlinter
+++ b/.importlinter
@@ -182,3 +182,27 @@ ignore_imports =
     tolokaforge.core.grading.substrate_client -> tolokaforge.runner.runner_pb2
     tolokaforge.core.grading.substrate_client -> tolokaforge.runner.runner_pb2_grpc
 allow_indirect_imports = true
+
+
+# Bundle-library purity (grade bundle format v1.0).
+#
+# ``core.grading.bundle`` ships the offline grade-bundle format library
+# (manifest schema v1.0 + reader + producer + `%.6g` float normaliser).
+# The bundle is the offline representation both the future snapshot
+# substrate and external downstream tools consume without a live runner;
+# a reach back into ``runner``, ``grader``, or the live substrate would
+# silently couple the format to the wire and defeat the "one canonical
+# offline bytes" invariant the manifest digest names the bundle by.
+# ``allow_indirect_imports = false`` mirrors ``composite-fold-purity`` /
+# ``filesystem-view-purity`` — a transitive path back into a forbidden
+# target trips the contract, not just a direct import.
+[importlinter:contract:bundle-library-purity]
+name = tolokaforge.core.grading.bundle is a pure library — no runner/grader/substrate_live reach
+type = forbidden
+source_modules =
+    tolokaforge.core.grading.bundle
+forbidden_modules =
+    tolokaforge.runner
+    tolokaforge.grader
+    tolokaforge.core.grading.substrate_live
+allow_indirect_imports = false

--- a/docs/GRADE_BUNDLE.md
+++ b/docs/GRADE_BUNDLE.md
@@ -34,14 +34,14 @@ Every part named in the top-level `manifest.json` MUST be present on disk with a
   "schema_version": "1.0",
   "trial_id": "<opaque string, e.g. task-name/2024-05-14T12:34:56Z-abc123>",
   "parts": {
-    "initial_state.json":       { "path": "initial_state.json",       "sha256": "<hex>", "size": 1234 },
-    "final_state.json":         { "path": "final_state.json",         "sha256": "<hex>", "size": 4567 },
-    "final_state_stable.json":  { "path": "final_state_stable.json",  "sha256": "<hex>", "size": 4321 },
-    "filesystem.tar":           { "path": "filesystem.tar",           "sha256": "<hex>", "size": 8192 },
-    "trajectory.json":          { "path": "trajectory.json",          "sha256": "<hex>", "size": 23456 },
-    "grading_config.json":      { "path": "grading_config.json",      "sha256": "<hex>", "size": 890 },
-    "checks/manifest.json":     { "path": "checks/manifest.json",     "sha256": "<hex>", "size": 234 },
-    "kb/manifest.json":         { "path": "kb/manifest.json",         "sha256": "<hex>", "size": 234 }
+    "initial_state.json":       { "sha256": "<hex>", "size": 1234 },
+    "final_state.json":         { "sha256": "<hex>", "size": 4567 },
+    "final_state_stable.json":  { "sha256": "<hex>", "size": 4321 },
+    "filesystem.tar":           { "sha256": "<hex>", "size": 8192 },
+    "trajectory.json":          { "sha256": "<hex>", "size": 23456 },
+    "grading_config.json":      { "sha256": "<hex>", "size": 890 },
+    "checks/manifest.json":     { "sha256": "<hex>", "size": 234 },
+    "kb/manifest.json":         { "sha256": "<hex>", "size": 234 }
   }
 }
 ```
@@ -49,7 +49,7 @@ Every part named in the top-level `manifest.json` MUST be present on disk with a
 Fields:
 - `schema_version` — string, `"MAJOR.MINOR"`, digit-only components.
 - `trial_id` — opaque string identifying the trial; producers should keep it stable across replays.
-- `parts` — map of `rel_path -> {path, sha256, size}`. `path` is the file's location relative to the bundle directory; `sha256` is the hex-encoded digest over the file's exact bytes on disk; `size` is the byte length.
+- `parts` — map of `rel_path -> {sha256, size}`. The map key IS the file's location relative to the bundle directory; `sha256` is the hex-encoded digest over the file's exact bytes on disk; `size` is the byte length.
 
 The `checks/` and `kb/` subtrees are optional. When present, each carries its own nested `<subtree>/manifest.json` with per-file digests for the subtree's contents; the top-level manifest names only the nested manifest's digest.
 
@@ -100,13 +100,13 @@ An external tool that consumes a bundle needs no engine dependency:
 
 1. Read `manifest.json` from the bundle directory.
 2. Validate `schema_version` — reject unknown MAJOR.
-3. For each part named in `parts`: read the file at `path`, compute SHA-256 over its bytes, compare against `parts[name].sha256`. On mismatch, refuse the bundle.
+3. For each part named in `parts`: read the file at the map key (which IS the relative path), compute SHA-256 over its bytes, compare against `parts[name].sha256`. On mismatch, refuse the bundle.
 4. Load the parts the consumer needs — parse the JSON parts, extract the tar, etc.
 
 A pure-shell approximation using `jq`, `sha256sum`, and `tar` is possible and demonstrates the format is truly language-neutral. The Python reference reader is `tolokaforge.core.grading.bundle.load_grade_bundle`; consumers in other languages implement the same manifest walk.
 
-## Follow-ups
+## Not covered in v1.0
 
-- Optional `provenance.json` sibling for engine-bump debugging (not covered by the manifest digest): tracked in [#1428](https://github.com/Toloka/tolokaforge/issues/1428).
-- Cross-language parser example (`jq` + `sha256sum` + `tar tvf`): tracked in [#1430](https://github.com/Toloka/tolokaforge/issues/1430).
-- `SnapshotGradingSubstrate` (grader-side consumer that reads bundles as a substrate): tracked in [#1353](https://github.com/Toloka/tolokaforge/issues/1353).
+- Optional `provenance.json` sibling for engine-bump debugging (not covered by the manifest digest): [#1428](https://github.com/Toloka/tolokaforge/issues/1428).
+- Cross-language parser example (`jq` + `sha256sum` + `tar tvf`): [#1430](https://github.com/Toloka/tolokaforge/issues/1430).
+- `SnapshotGradingSubstrate` (grader-side consumer that reads bundles as a substrate): [#1353](https://github.com/Toloka/tolokaforge/issues/1353).

--- a/docs/GRADE_BUNDLE.md
+++ b/docs/GRADE_BUNDLE.md
@@ -1,0 +1,112 @@
+# Grade Bundle Format v1.0
+
+The **grade bundle** is a self-contained, part-addressable artifact holding everything the grader needs to score a trial: initial state, final state, filesystem snapshot, agent trajectory, custom checks, knowledge base, and the grading configuration itself. Bundles are portable across storage locations, bit-extractable by external tools, and content-addressable — the same trial serialised twice produces byte-identical bytes with matching digest.
+
+## Purpose
+
+The bundle is the wire between the runner (which produces trial artifacts) and any grader consumer (in-process, standalone service, trajectory-storage-backed, or a third-party analysis tool). Consumers parse the manifest, verify per-part digests, and read only the parts they need. There is no engine dependency: `manifest.json` + a POSIX filesystem + `jq` + `sha256sum` + `tar` are enough to consume a bundle end-to-end.
+
+## Layout
+
+```
+<bundle-dir>/
+├── manifest.json              # schema version, trial id, per-part digests
+├── initial_state.json         # trial-start state (canonical JSON, sort_keys=True, %.6g floats)
+├── final_state.json           # trial-end state (canonical JSON)
+├── final_state_stable.json    # final state with unstable fields normalised
+├── filesystem.tar             # workspace snapshot (USTAR, deterministic entries)
+├── trajectory.json            # agent messages, tool calls, LLM turns
+├── grading_config.json        # the grading block from the task pack
+├── checks/                    # optional; per-check bytes (custom-check payloads)
+│   ├── manifest.json          # nested manifest with per-file digests
+│   └── <check-name>/...
+└── kb/                        # optional; per-hit KB payloads
+    ├── manifest.json
+    └── <hit-id>/...
+```
+
+Every part named in the top-level `manifest.json` MUST be present on disk with a matching SHA-256 digest. Parts not named in the manifest are ignored by conforming readers.
+
+## Manifest schema v1.0
+
+```json
+{
+  "schema_version": "1.0",
+  "trial_id": "<opaque string, e.g. task-name/2024-05-14T12:34:56Z-abc123>",
+  "parts": {
+    "initial_state.json":       { "path": "initial_state.json",       "sha256": "<hex>", "size": 1234 },
+    "final_state.json":         { "path": "final_state.json",         "sha256": "<hex>", "size": 4567 },
+    "final_state_stable.json":  { "path": "final_state_stable.json",  "sha256": "<hex>", "size": 4321 },
+    "filesystem.tar":           { "path": "filesystem.tar",           "sha256": "<hex>", "size": 8192 },
+    "trajectory.json":          { "path": "trajectory.json",          "sha256": "<hex>", "size": 23456 },
+    "grading_config.json":      { "path": "grading_config.json",      "sha256": "<hex>", "size": 890 },
+    "checks/manifest.json":     { "path": "checks/manifest.json",     "sha256": "<hex>", "size": 234 },
+    "kb/manifest.json":         { "path": "kb/manifest.json",         "sha256": "<hex>", "size": 234 }
+  }
+}
+```
+
+Fields:
+- `schema_version` — string, `"MAJOR.MINOR"`, digit-only components.
+- `trial_id` — opaque string identifying the trial; producers should keep it stable across replays.
+- `parts` — map of `rel_path -> {path, sha256, size}`. `path` is the file's location relative to the bundle directory; `sha256` is the hex-encoded digest over the file's exact bytes on disk; `size` is the byte length.
+
+The `checks/` and `kb/` subtrees are optional. When present, each carries its own nested `<subtree>/manifest.json` with per-file digests for the subtree's contents; the top-level manifest names only the nested manifest's digest.
+
+## Deterministic serialisation rules
+
+The bundle is content-addressable, which requires bit-exact serialisation. Every producer — Python, or a re-implementation in any other language — MUST follow these rules exactly.
+
+**JSON parts** (`manifest.json`, `initial_state.json`, `final_state.json`, `final_state_stable.json`, `trajectory.json`, `grading_config.json`, nested `manifest.json` files):
+- Encoding: UTF-8, no BOM.
+- Structure: `json.dumps(payload, sort_keys=True, separators=(",", ":"))`. Keys sorted lexicographically at every nesting level; no whitespace between tokens.
+- Floats: formatted with `%.6g` (6 significant digits, trailing-zero stripping) before serialisation. `0.123456789` writes as `"0.123457"`. This matches the byte-parity harness's canonicalisation.
+- No trailing newline.
+
+**`filesystem.tar`**:
+- Format: **USTAR (POSIX.1-1988), no PAX extensions.** This is load-bearing for cross-language byte identity. Python's `tarfile` module defaults to PAX (auto-injects extension headers for names > 100 chars, links > 100 chars, sizes > 8 GB, or non-ASCII paths); producers in other languages MUST emit USTAR — a PAX-format tar of the same tree diverges the bytes on any long path or non-ASCII name.
+- Entries added in `sorted(name)` order (lexicographic, POSIX path).
+- Each entry: `type = REGTYPE` (regular file), `mtime = 0`, `uid = 0`, `gid = 0`, `uname = ""`, `gname = ""`, `mode = 0o644`, no `pax_headers`.
+- Exclusion policy: subtrees named `.git`, `.venv`, `node_modules`, `dist`, `.next` are omitted at any depth.
+- Empty tar (no included files) is a valid file — 1024 zero bytes.
+
+**Per-part digests** (`sha256` field in the manifest):
+- SHA-256 computed on the file's exact bytes on disk, post-canonicalisation.
+- Digest naming: hex-encoded lower-case, no separators.
+
+**Manifest file** (`manifest.json`) is written LAST, after every other part exists and its digest is known.
+
+## Content-addressability
+
+The bundle's canonical name is `sha256(manifest.json)` — the SHA-256 of the manifest file's bytes.
+
+Because parts' digests live inside the manifest, changing any part changes its manifest entry, which changes the manifest, which changes the bundle's canonical name. The name recursively certifies every byte in every part.
+
+The manifest itself does NOT contain its own name (that would be recursive). Consumers compute the name over the manifest bytes on read.
+
+## Schema-version compatibility
+
+Readers refuse unknown MAJOR versions and accept unknown MINOR versions.
+
+- `"1.0"`, `"1.5"`, `"1.99"` — accepted by a v1 reader.
+- `"2.0"` — refused.
+- Missing `schema_version` key, empty string, non-string type, malformed value (`"1"` no dot, `"1.0.0"` three components, `"abc"` non-digit) — refused with `BundleSchemaVersionError`.
+
+Producers MUST write `schema_version` as a `"MAJOR.MINOR"` digit-only string.
+
+## External-consumer pattern
+
+An external tool that consumes a bundle needs no engine dependency:
+
+1. Read `manifest.json` from the bundle directory.
+2. Validate `schema_version` — reject unknown MAJOR.
+3. For each part named in `parts`: read the file at `path`, compute SHA-256 over its bytes, compare against `parts[name].sha256`. On mismatch, refuse the bundle.
+4. Load the parts the consumer needs — parse the JSON parts, extract the tar, etc.
+
+A pure-shell approximation using `jq`, `sha256sum`, and `tar` is possible and demonstrates the format is truly language-neutral. The Python reference reader is `tolokaforge.core.grading.bundle.load_grade_bundle`; consumers in other languages implement the same manifest walk.
+
+## Follow-ups
+
+- Optional `provenance.json` sibling for engine-bump debugging (not covered by the manifest digest): tracked in [#1428](https://github.com/Toloka/tolokaforge/issues/1428).
+- Cross-language parser example (`jq` + `sha256sum` + `tar tvf`): tracked in [#1430](https://github.com/Toloka/tolokaforge/issues/1430).
+- `SnapshotGradingSubstrate` (grader-side consumer that reads bundles as a substrate): tracked in [#1353](https://github.com/Toloka/tolokaforge/issues/1353).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -410,6 +410,7 @@ exclude = [
     # otherwise-included subpackage.
     "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/agreement.py",
+    "tolokaforge/core/grading/bundle.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",

--- a/tests/canonical/test_bundle_round_trip.py
+++ b/tests/canonical/test_bundle_round_trip.py
@@ -1,0 +1,147 @@
+"""Canonical acceptance for the grade bundle producer.
+
+Two same-process serialisations of the same synthetic trial land on
+byte-identical bytes across every part and on a matching
+``sha256(manifest.json)``. The lock: the manifest IS the bundle's name;
+identity across storage moves depends on the producer being deterministic
+inside one interpreter.
+
+Also covers the round-1 tar-format hardening: the emitted tar carries no
+PAX headers at the archive level or on any member. Python's
+``tarfile.DEFAULT_FORMAT`` is PAX and auto-injects extension headers for
+long paths or non-ASCII names — a producer regression to the default
+would silently diverge bytes on the first long-path task pack, and the
+same-process round-trip alone would not catch it.
+
+Cross-Python-version / cross-OS / cross-language drift is silently
+unchecked here — that hardening belongs to a follow-up ticket with a
+committed golden-bytes fixture. This lane locks the minimum invariant
+those follow-ups build on.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.grading.bundle import (
+    BUNDLE_SCHEMA_VERSION,
+    GradeBundleManifest,
+    manifest_digest,
+    normalise_floats,
+    serialize_grade_bundle,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+LONG_SEGMENT_NAME = "a_deeply_nested_subdir_with_a_very_long_leading_segment_name_that_exceeds_100_characters_easily"
+"""A directory segment > 100 chars — a PAX-default producer would inject
+extension headers here, tripping :func:`test_tar_carries_no_pax_headers`."""
+
+
+def _write_synthetic_filesystem(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_bytes(b"print('hello')\n")
+    (root / "README.md").write_bytes(b"# hello\n")
+    (root / ".git").mkdir()
+    (root / ".git" / "HEAD").write_bytes(b"ref: refs/heads/main\n")
+    long_dir = root / LONG_SEGMENT_NAME
+    long_dir.mkdir()
+    (long_dir / "leaf.py").write_bytes(b"# long-path member\n")
+
+
+def _synthetic_inputs(tmp_path: Path) -> dict[str, object]:
+    fs_root = tmp_path / "workspace"
+    _write_synthetic_filesystem(fs_root)
+    return {
+        "trial_id": "trial-round-trip-1",
+        "initial_state": {"tables": {"users": []}, "score": 0.123456789},
+        "final_state": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
+        "final_state_stable": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
+        "filesystem_root": fs_root,
+        "checks": {"greet_ok.py": b"def check(): return True\n"},
+        "kb": {"policy.md": b"# policy\n"},
+        "trajectory": {"llm_messages": [{"role": "user", "content": "hi"}]},
+        "grading_config": {"combine_method": "weighted", "weights": {"custom": 1.0}},
+    }
+
+
+def test_two_serialisations_produce_byte_identical_bytes(tmp_path: Path) -> None:
+    inputs = _synthetic_inputs(tmp_path)
+    out_a = tmp_path / "bundle_a"
+    out_b = tmp_path / "bundle_b"
+
+    manifest_a = serialize_grade_bundle(out_a, **inputs)
+    manifest_b = serialize_grade_bundle(out_b, **inputs)
+
+    assert isinstance(manifest_a, GradeBundleManifest)
+    assert isinstance(manifest_b, GradeBundleManifest)
+    assert manifest_a.schema_version == BUNDLE_SCHEMA_VERSION
+    assert set(manifest_a.parts.keys()) == set(manifest_b.parts.keys())
+
+    for rel in sorted(manifest_a.parts):
+        bytes_a = (out_a / rel).read_bytes()
+        bytes_b = (out_b / rel).read_bytes()
+        assert bytes_a == bytes_b, f"part {rel!r} diverged between runs"
+
+    digest_a = manifest_digest((out_a / "manifest.json").read_bytes())
+    digest_b = manifest_digest((out_b / "manifest.json").read_bytes())
+    assert digest_a == digest_b
+
+
+def test_producer_refuses_non_empty_out_dir(tmp_path: Path) -> None:
+    inputs = _synthetic_inputs(tmp_path)
+    out_dir = tmp_path / "bundle"
+    out_dir.mkdir()
+    (out_dir / "stray.txt").write_bytes(b"pre-existing")
+
+    with pytest.raises(FileExistsError):
+        serialize_grade_bundle(out_dir, **inputs)
+
+
+def test_tar_carries_no_pax_headers(tmp_path: Path) -> None:
+    inputs = _synthetic_inputs(tmp_path)
+    out_dir = tmp_path / "bundle"
+    serialize_grade_bundle(out_dir, **inputs)
+
+    tar_path = out_dir / "filesystem.tar"
+    with tarfile.open(tar_path, mode="r") as tar:
+        assert tar.pax_headers == {}
+        members = tar.getmembers()
+        long_path_present = any(LONG_SEGMENT_NAME in member.name for member in members)
+        assert long_path_present, "fixture must exercise the long-path member"
+        for member in members:
+            pax_pseudo = member.type in (tarfile.XHDTYPE, tarfile.XGLTYPE)
+            assert not pax_pseudo, f"PAX extension pseudo-member: {member.name!r}"
+            assert member.pax_headers == {}, f"PAX headers on {member.name!r}"
+            assert member.mtime == 0
+            assert member.uid == 0
+            assert member.gid == 0
+            assert member.uname == ""
+            assert member.gname == ""
+            assert member.mode == 0o644
+            assert member.type == tarfile.REGTYPE
+
+
+def test_filesystem_tar_respects_exclude_dirs(tmp_path: Path) -> None:
+    inputs = _synthetic_inputs(tmp_path)
+    out_dir = tmp_path / "bundle"
+    serialize_grade_bundle(out_dir, **inputs)
+
+    with tarfile.open(out_dir / "filesystem.tar", mode="r") as tar:
+        names = {member.name for member in tar.getmembers()}
+    assert "src/main.py" in names
+    assert "README.md" in names
+    dotgit_leaked = any(name.startswith(".git/") for name in names)
+    assert not dotgit_leaked, f".git/ subtree leaked into filesystem.tar: {names}"
+
+
+def test_float_normaliser_matches_parity_harness_import() -> None:
+    from tests.utils.grader_parity_harness import normalise_floats as harness_ref
+
+    assert harness_ref is normalise_floats
+    assert normalise_floats({"score": 0.123456789}) == {"score": 0.123457}

--- a/tests/canonical/test_bundle_round_trip.py
+++ b/tests/canonical/test_bundle_round_trip.py
@@ -6,17 +6,15 @@ byte-identical bytes across every part and on a matching
 identity across storage moves depends on the producer being deterministic
 inside one interpreter.
 
-Also covers the round-1 tar-format hardening: the emitted tar carries no
-PAX headers at the archive level or on any member. Python's
-``tarfile.DEFAULT_FORMAT`` is PAX and auto-injects extension headers for
-long paths or non-ASCII names — a producer regression to the default
-would silently diverge bytes on the first long-path task pack, and the
-same-process round-trip alone would not catch it.
+Also covers the tar-format lock: the emitted tar carries no PAX headers
+at the archive level or on any member. Python's ``tarfile.DEFAULT_FORMAT``
+is PAX and auto-injects extension headers for long paths or non-ASCII
+names — a producer that fell back to the default would silently diverge
+bytes on the first long-path task pack, and the same-process round-trip
+alone would not catch it.
 
-Cross-Python-version / cross-OS / cross-language drift is silently
-unchecked here — that hardening belongs to a follow-up ticket with a
-committed golden-bytes fixture. This lane locks the minimum invariant
-those follow-ups build on.
+Cross-Python-version / cross-OS / cross-language drift is out of scope
+for this lane.
 """
 
 from __future__ import annotations

--- a/tests/unit/grading/test_bundle_reader.py
+++ b/tests/unit/grading/test_bundle_reader.py
@@ -114,6 +114,29 @@ def test_open_part_raises_integrity_error_on_tamper(tmp_path: Path) -> None:
     assert tampered_rel in str(excinfo.value)
 
 
+def test_open_part_refuses_path_traversal_outside_bundle_dir(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_bytes(b"secret")
+    outside_digest = hashlib.sha256(b"secret").hexdigest()
+
+    escape_rel = "../outside.txt"
+    manifest = {
+        "schema_version": "1.0",
+        "trial_id": "traversal-attempt",
+        "parts": {escape_rel: {"sha256": outside_digest, "size": len(b"secret")}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest, sort_keys=True))
+
+    view = load_grade_bundle(bundle_dir)
+
+    with pytest.raises(BundleIntegrityError) as excinfo:
+        view.open_part(escape_rel)
+    assert "outside bundle_dir" in str(excinfo.value)
+    assert escape_rel in str(excinfo.value)
+
+
 _MISSING = object()
 
 

--- a/tests/unit/grading/test_bundle_reader.py
+++ b/tests/unit/grading/test_bundle_reader.py
@@ -1,0 +1,142 @@
+"""Behaviour locks for ``tolokaforge.core.grading.bundle``'s reader half.
+
+Three groups:
+
+* Round-trip a hand-written manifest + parts fixture through
+  :func:`load_grade_bundle` and confirm the returned view's manifest
+  shape matches the on-disk JSON.
+* :meth:`GradeBundleView.open_part` returns the part bytes on match and
+  raises :class:`BundleIntegrityError` naming the part when the on-disk
+  bytes were tampered with after the manifest was written.
+* Parametrised rejection of every malformed shape ``schema_version``
+  can take — the fail-loud contract must hold uniformly, never leak a
+  raw ``KeyError``, ``TypeError``, ``AttributeError``, or ``IndexError``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tolokaforge.core.grading.bundle import (
+    BUNDLE_SCHEMA_VERSION,
+    BundleIntegrityError,
+    BundleSchemaVersionError,
+    GradeBundleManifest,
+    GradeBundleView,
+    load_grade_bundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_manifest(bundle_dir: Path, manifest: dict[str, Any]) -> None:
+    (bundle_dir / "manifest.json").write_bytes(
+        json.dumps(manifest, sort_keys=True, indent=2).encode("utf-8")
+    )
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_part(bundle_dir: Path, rel_path: str, data: bytes) -> dict[str, Any]:
+    target = bundle_dir / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+    return {"sha256": _sha256_hex(data), "size": len(data)}
+
+
+def _write_valid_bundle(bundle_dir: Path) -> dict[str, bytes]:
+    """Materialise a two-part bundle; return {rel_path: bytes} of the parts."""
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    part_bytes = {
+        "initial_state.json": b'{"tables":{"users":[]}}',
+        "final_state.json": b'{"tables":{"users":[{"id":1}]}}',
+    }
+    parts_entries = {rel: _write_part(bundle_dir, rel, data) for rel, data in part_bytes.items()}
+    _write_manifest(
+        bundle_dir,
+        {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "trial_id": "trial-abc-123",
+            "parts": parts_entries,
+        },
+    )
+    return part_bytes
+
+
+def test_load_bundle_from_handwritten_fixture(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    expected_parts = _write_valid_bundle(bundle_dir)
+
+    view = load_grade_bundle(bundle_dir)
+
+    assert isinstance(view, GradeBundleView)
+    assert isinstance(view.manifest, GradeBundleManifest)
+    assert view.bundle_dir == bundle_dir
+    assert view.manifest.schema_version == BUNDLE_SCHEMA_VERSION
+    assert view.manifest.trial_id == "trial-abc-123"
+    assert set(view.manifest.parts.keys()) == set(expected_parts.keys())
+    for rel, data in expected_parts.items():
+        entry = view.manifest.parts[rel]
+        assert entry["sha256"] == _sha256_hex(data)
+        assert entry["size"] == len(data)
+
+
+def test_open_part_returns_bytes_when_digest_matches(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    expected_parts = _write_valid_bundle(bundle_dir)
+
+    view = load_grade_bundle(bundle_dir)
+
+    for rel, data in expected_parts.items():
+        assert view.open_part(rel) == data
+
+
+def test_open_part_raises_integrity_error_on_tamper(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    _write_valid_bundle(bundle_dir)
+
+    tampered_rel = "initial_state.json"
+    tampered_path = bundle_dir / tampered_rel
+    original = tampered_path.read_bytes()
+    tampered_path.write_bytes(original + b"\x00")
+
+    view = load_grade_bundle(bundle_dir)
+
+    with pytest.raises(BundleIntegrityError) as excinfo:
+        view.open_part(tampered_rel)
+    assert tampered_rel in str(excinfo.value)
+
+
+_MISSING = object()
+
+
+@pytest.mark.parametrize(
+    "schema_version_value",
+    [
+        pytest.param("2.0", id="unknown-major"),
+        pytest.param(_MISSING, id="missing-key"),
+        pytest.param("", id="empty-string"),
+        pytest.param(1, id="non-str-int"),
+        pytest.param("1", id="no-dot"),
+        pytest.param("1.0.0", id="three-components"),
+        pytest.param("abc", id="non-digit"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_schema_version_rejection(tmp_path: Path, schema_version_value: object) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    manifest: dict[str, Any] = {"trial_id": "trial-x", "parts": {}}
+    if schema_version_value is not _MISSING:
+        manifest["schema_version"] = schema_version_value
+    _write_manifest(bundle_dir, manifest)
+
+    with pytest.raises(BundleSchemaVersionError):
+        load_grade_bundle(bundle_dir)

--- a/tests/utils/grader_parity_harness.py
+++ b/tests/utils/grader_parity_harness.py
@@ -47,6 +47,7 @@ import yaml
 from google.protobuf import json_format
 
 from tolokaforge.core.grading import db_probes as db_probes_module
+from tolokaforge.core.grading.bundle import normalise_floats
 from tolokaforge.core.llm.client import GenerationResult
 from tolokaforge.core.llm.usage import Usage
 from tolokaforge.core.logging import StructuredLogger
@@ -633,7 +634,7 @@ def serialise_grade(grade: runner_pb2.Grade | grader_pb2.Grade) -> str:
         always_print_fields_with_no_presence=True,
     )
     normalised = _normalise_optional_components(projected)
-    normalised = _normalise_floats(normalised)
+    normalised = normalise_floats(normalised)
     return json.dumps(normalised, sort_keys=True, indent=2)
 
 
@@ -662,18 +663,6 @@ def _normalise_optional_components(projected: dict[str, Any]) -> dict[str, Any]:
     for field, default in _OPTIONAL_COMPONENT_DEFAULTS.items():
         components.setdefault(field, default)
     return projected
-
-
-def _normalise_floats(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {key: _normalise_floats(child) for key, child in value.items()}
-    if isinstance(value, list):
-        return [_normalise_floats(child) for child in value]
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, float):
-        return float(f"{value:.6g}")
-    return value
 
 
 REFRESH_BASELINES_OPTION = "--refresh-baselines"

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -123,6 +123,7 @@ base wheel."""
 RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
     "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/agreement.py",
+    "tolokaforge/core/grading/bundle.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",
@@ -180,6 +181,14 @@ authoring gate, the rubric-to-trace-check migration and the offline replay
 commands all run on the host, before or after any trial is scheduled, and they
 would ship as dead weight. The runner container's runtime
 closure reaches none of them.
+
+``core.grading.bundle`` is the offline grade-bundle format library — a
+manifest-first, part-addressable, content-addressable directory carrying
+everything a grader needs to score one trial without a live runner. Its
+imports are stdlib-only, but the runner container never instantiates it:
+the producer writes bundles for offline replay / cross-topology grading,
+and the consumer is a grader-side snapshot substrate — not the runner's
+own wire path. Ships as dead weight in the runner image.
 """
 
 

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -185,10 +185,10 @@ closure reaches none of them.
 ``core.grading.bundle`` is the offline grade-bundle format library — a
 manifest-first, part-addressable, content-addressable directory carrying
 everything a grader needs to score one trial without a live runner. Its
-imports are stdlib-only, but the runner container never instantiates it:
-the producer writes bundles for offline replay / cross-topology grading,
-and the consumer is a grader-side snapshot substrate — not the runner's
-own wire path. Ships as dead weight in the runner image.
+imports are stdlib-only, but the runner container has no code path that
+reads or writes bundles: the producer runs host-side (offline replay /
+cross-topology grading), and no runner boot-closure module reaches into
+it. Ships as dead weight in the runner image.
 """
 
 

--- a/tolokaforge/core/grading/bundle.py
+++ b/tolokaforge/core/grading/bundle.py
@@ -1,0 +1,143 @@
+"""Grade bundle reader and manifest schema v1.0.
+
+A grade bundle is a manifest-first, part-addressable directory carrying
+everything a grader needs to score one trial without a live runner. This
+module ships the *reader half* of the format: a v1.0 manifest dataclass,
+an open-part view that verifies each part's SHA-256 on demand, and a
+top-level :func:`load_grade_bundle` entry point that refuses unknown
+MAJOR schema versions or any ``schema_version`` field that is not the
+strict ``"MAJOR.MINOR"`` shape (where both components are digit-only).
+
+The bundle name IS the content: a future producer writes
+``manifest.json`` last (its ``parts`` map already carries every part's
+SHA-256), and the bundle's canonical name is
+``sha256(manifest.json.read_bytes())`` — tampering with any part changes
+the manifest entry, which changes the manifest bytes, which changes the
+name. The reader honours the other half of that contract: it recomputes
+each part's SHA-256 on :meth:`GradeBundleView.open_part` and raises
+:class:`BundleIntegrityError` on mismatch.
+
+Schema shape (v1.0)::
+
+    {
+      "schema_version": "1.0",
+      "trial_id": "<opaque str>",
+      "parts": {
+        "<rel path>": {"sha256": "<hex>", "size": <int>},
+        ...
+      }
+    }
+
+Schema-version rule: parsers reject unknown MAJOR (``1`` is the sole
+supported MAJOR); MINOR bumps are forward-compatible. Any malformed
+``schema_version`` value (missing, non-string, wrong shape, non-digit)
+surfaces as :class:`BundleSchemaVersionError` — never as a bare
+``KeyError`` or ``TypeError`` escaping the reader.
+
+Purity: stdlib only. No reach into ``tolokaforge.runner``,
+``tolokaforge.grader``, or ``tolokaforge.core.grading.substrate_live``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "BUNDLE_SCHEMA_VERSION",
+    "BundleError",
+    "BundleIntegrityError",
+    "BundleSchemaVersionError",
+    "GradeBundleManifest",
+    "GradeBundleView",
+    "load_grade_bundle",
+]
+
+
+BUNDLE_SCHEMA_VERSION: str = "1.0"
+_SUPPORTED_MAJOR: str = BUNDLE_SCHEMA_VERSION.split(".", 1)[0]
+
+
+class BundleError(Exception):
+    """Base class for grade bundle errors."""
+
+
+class BundleSchemaVersionError(BundleError):
+    """Manifest ``schema_version`` is missing, malformed, or an unsupported MAJOR."""
+
+
+class BundleIntegrityError(BundleError):
+    """A part's on-disk bytes do not match the digest declared in the manifest."""
+
+
+@dataclass(frozen=True)
+class GradeBundleManifest:
+    schema_version: str
+    trial_id: str
+    parts: Mapping[str, Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class GradeBundleView:
+    bundle_dir: Path
+    manifest: GradeBundleManifest
+
+    def open_part(self, rel_path: str) -> bytes:
+        entry = self.manifest.parts[rel_path]
+        expected = entry["sha256"]
+        data = (self.bundle_dir / rel_path).read_bytes()
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected:
+            raise BundleIntegrityError(
+                f"part {rel_path!r} digest mismatch: "
+                f"manifest declares {expected}, on-disk bytes hash to {actual}"
+            )
+        return data
+
+
+def _validate_schema_version(raw: object) -> None:
+    if not isinstance(raw, str) or not raw:
+        raise BundleSchemaVersionError(
+            f"schema_version must be a non-empty 'MAJOR.MINOR' string; "
+            f"got {raw!r}. This reader supports MAJOR {_SUPPORTED_MAJOR!r}."
+        )
+    parts = raw.split(".")
+    if len(parts) != 2 or not all(p.isdigit() for p in parts):
+        raise BundleSchemaVersionError(
+            f"schema_version must be a 'MAJOR.MINOR' string of digit components; "
+            f"got {raw!r}. This reader supports MAJOR {_SUPPORTED_MAJOR!r}."
+        )
+    if parts[0] != _SUPPORTED_MAJOR:
+        raise BundleSchemaVersionError(
+            f"unsupported schema_version {raw!r}: MAJOR {parts[0]!r} not recognised. "
+            f"This reader supports MAJOR {_SUPPORTED_MAJOR!r}."
+        )
+
+
+def load_grade_bundle(bundle_dir: Path) -> GradeBundleView:
+    manifest_path = bundle_dir / "manifest.json"
+    raw = json.loads(manifest_path.read_bytes())
+    try:
+        _validate_schema_version(raw["schema_version"])
+    except BundleSchemaVersionError:
+        raise
+    except (KeyError, AttributeError, IndexError, TypeError) as exc:
+        raise BundleSchemaVersionError(
+            f"manifest at {manifest_path} has no parseable 'schema_version' field: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    parts_raw = raw["parts"]
+    parts: Mapping[str, Mapping[str, Any]] = MappingProxyType(
+        {rel: MappingProxyType(dict(entry)) for rel, entry in parts_raw.items()}
+    )
+    manifest = GradeBundleManifest(
+        schema_version=raw["schema_version"],
+        trial_id=raw["trial_id"],
+        parts=parts,
+    )
+    return GradeBundleView(bundle_dir=bundle_dir, manifest=manifest)

--- a/tolokaforge/core/grading/bundle.py
+++ b/tolokaforge/core/grading/bundle.py
@@ -123,7 +123,13 @@ class GradeBundleView:
     def open_part(self, rel_path: str) -> bytes:
         entry = self.manifest.parts[rel_path]
         expected = entry["sha256"]
-        data = (self.bundle_dir / rel_path).read_bytes()
+        candidate = (self.bundle_dir / rel_path).resolve(strict=False)
+        root = self.bundle_dir.resolve(strict=False)
+        if candidate != root and root not in candidate.parents:
+            raise BundleIntegrityError(
+                f"part {rel_path!r} resolves outside bundle_dir " f"({candidate} not under {root})"
+            )
+        data = candidate.read_bytes()
         actual = hashlib.sha256(data).hexdigest()
         if actual != expected:
             raise BundleIntegrityError(

--- a/tolokaforge/core/grading/bundle.py
+++ b/tolokaforge/core/grading/bundle.py
@@ -1,23 +1,29 @@
-"""Grade bundle reader and manifest schema v1.0.
+"""Grade bundle format v1.0 — reader, producer, and manifest schema.
 
-A grade bundle is a manifest-first, part-addressable directory carrying
-everything a grader needs to score one trial without a live runner. This
-module ships the *reader half* of the format: a v1.0 manifest dataclass,
-an open-part view that verifies each part's SHA-256 on demand, and a
-top-level :func:`load_grade_bundle` entry point that refuses unknown
-MAJOR schema versions or any ``schema_version`` field that is not the
-strict ``"MAJOR.MINOR"`` shape (where both components are digit-only).
+A grade bundle is a manifest-first, part-addressable, content-addressable
+directory carrying everything a grader needs to score one trial without a
+live runner. The bundle's canonical name is
+``sha256(manifest.json.read_bytes())``: mutate any part, and the manifest
+entry for that part changes, which changes the manifest bytes, which
+changes the name. External tools parse against ``manifest.json`` alone;
+this module ships the Python reader + producer both sides use.
 
-The bundle name IS the content: a future producer writes
-``manifest.json`` last (its ``parts`` map already carries every part's
-SHA-256), and the bundle's canonical name is
-``sha256(manifest.json.read_bytes())`` — tampering with any part changes
-the manifest entry, which changes the manifest bytes, which changes the
-name. The reader honours the other half of that contract: it recomputes
-each part's SHA-256 on :meth:`GradeBundleView.open_part` and raises
-:class:`BundleIntegrityError` on mismatch.
+Layout::
 
-Schema shape (v1.0)::
+    <bundle_dir>/
+      manifest.json           # schema v1.0 — written LAST, canonical bytes
+      initial_state.json      # required
+      final_state.json        # required
+      final_state_stable.json # required
+      trajectory.json         # required
+      grading_config.json     # required
+      filesystem.tar          # required — USTAR, no PAX extensions
+      checks/                 # optional subtree
+        manifest.json         # per-file digests inside checks/
+        <rel-path>            # each file digested by checks/manifest.json
+      kb/                     # optional subtree — same shape as checks/
+
+Manifest schema v1.0::
 
     {
       "schema_version": "1.0",
@@ -28,25 +34,46 @@ Schema shape (v1.0)::
       }
     }
 
-Schema-version rule: parsers reject unknown MAJOR (``1`` is the sole
-supported MAJOR); MINOR bumps are forward-compatible. Any malformed
-``schema_version`` value (missing, non-string, wrong shape, non-digit)
+**Deterministic serialisation.** JSON parts:
+``json.dumps(payload, sort_keys=True, separators=(",", ":"))`` with floats
+routed through :func:`normalise_floats` (six-significant-digit `%.6g`
+normalisation shared with the byte-parity gate). Tar parts: USTAR
+(POSIX.1-1988) format with per-entry ``TarInfo.pax_headers={}``,
+``mtime=0``, ``uid=0``, ``gid=0``, ``uname=""``, ``gname=""``,
+``mode=0o644``, entries added in sorted POSIX-path order. USTAR is not the
+Python default (which is PAX and auto-injects extension headers for long
+paths or non-ASCII names — bytes diverge silently across implementations);
+the format pin is load-bearing for the cross-language recipe consumers
+follow.
+
+**Schema-version rule.** Semver-like ``MAJOR.MINOR``; parsers refuse
+unknown MAJOR (``1`` is the sole supported MAJOR) and accept unknown
+MINOR. Any malformed shape (missing, non-string, wrong split, non-digit)
 surfaces as :class:`BundleSchemaVersionError` — never as a bare
 ``KeyError`` or ``TypeError`` escaping the reader.
 
-Purity: stdlib only. No reach into ``tolokaforge.runner``,
-``tolokaforge.grader``, or ``tolokaforge.core.grading.substrate_live``.
+**Integrity.** :meth:`GradeBundleView.open_part` recomputes SHA-256 on
+demand and raises :class:`BundleIntegrityError` on mismatch. Reader is
+O(1) at load time; verification cost is deferred to each part read.
+
+Purity: stdlib plus :mod:`tolokaforge.core.grading.filesystem_view`. No
+reach into ``tolokaforge.runner``, ``tolokaforge.grader``, or
+``tolokaforge.core.grading.substrate_live`` — locked by the
+``bundle-library-purity`` contract in ``.importlinter``.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+import tarfile
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
+
+from tolokaforge.core.grading.filesystem_view import AGENT_VISIBLE_EXCLUDES
 
 __all__ = [
     "BUNDLE_SCHEMA_VERSION",
@@ -56,6 +83,9 @@ __all__ = [
     "GradeBundleManifest",
     "GradeBundleView",
     "load_grade_bundle",
+    "manifest_digest",
+    "normalise_floats",
+    "serialize_grade_bundle",
 ]
 
 
@@ -87,6 +117,9 @@ class GradeBundleView:
     bundle_dir: Path
     manifest: GradeBundleManifest
 
+    def has_part(self, rel_path: str) -> bool:
+        return rel_path in self.manifest.parts
+
     def open_part(self, rel_path: str) -> bytes:
         entry = self.manifest.parts[rel_path]
         expected = entry["sha256"]
@@ -98,6 +131,200 @@ class GradeBundleView:
                 f"manifest declares {expected}, on-disk bytes hash to {actual}"
             )
         return data
+
+
+def normalise_floats(value: Any) -> Any:
+    """Route every float through ``%.6g`` (six-significant-digit) formatting.
+
+    Recurses through dicts and lists; leaves ``bool`` values alone (they
+    are ``int`` subclasses but must not be reformatted). Ensures the byte
+    output of :func:`json.dumps` on any float-bearing structure is
+    independent of the platform's default float ``repr`` — a
+    numerically-equivalent double rendered as ``0.30000000000000004`` on
+    one build and ``0.3`` on another lands as the same string here.
+    """
+    if isinstance(value, dict):
+        return {key: normalise_floats(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [normalise_floats(child) for child in value]
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return float(f"{value:.6g}")
+    return value
+
+
+def manifest_digest(manifest_json_bytes: bytes) -> str:
+    """Hex SHA-256 of the canonical manifest bytes — the bundle's name."""
+    return hashlib.sha256(manifest_json_bytes).hexdigest()
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        normalise_floats(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _part_from_bytes(data: bytes) -> dict[str, Any]:
+    return {"sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
+
+
+def _iter_agent_visible_files(
+    root: Path, exclude_dirs: frozenset[str]
+) -> Iterator[tuple[str, Path]]:
+    """Yield ``(posix_rel_path, absolute_path)`` for every non-symlink regular
+    file below ``root`` whose parent path does not pass through
+    ``exclude_dirs``. Emission order matches the underlying rglob walk;
+    callers that need a stable order sort the result.
+    """
+    if not root.is_dir():
+        return
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        if any(part in exclude_dirs for part in rel.parts[:-1]):
+            continue
+        yield rel.as_posix(), path
+
+
+def _write_filesystem_tar(
+    filesystem_root: Path, exclude_dirs: frozenset[str], target: Path
+) -> None:
+    entries = sorted(
+        _iter_agent_visible_files(filesystem_root, exclude_dirs),
+        key=lambda kv: kv[0],
+    )
+    with tarfile.open(target, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        for name, path in entries:
+            info = tarfile.TarInfo(name=name)
+            info.size = path.stat().st_size
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            info.mode = 0o644
+            info.type = tarfile.REGTYPE
+            info.pax_headers = {}
+            with path.open("rb") as fp:
+                tar.addfile(info, fp)
+
+
+def _sha256_and_size_of_file(path: Path) -> dict[str, Any]:
+    h = hashlib.sha256()
+    size = 0
+    with path.open("rb") as fp:
+        while chunk := fp.read(64 * 1024):
+            h.update(chunk)
+            size += len(chunk)
+    return {"sha256": h.hexdigest(), "size": size}
+
+
+def _write_named_subtree(
+    subtree_root: Path,
+    payload: Mapping[str, bytes],
+    parts: dict[str, dict[str, Any]],
+    parts_prefix: str,
+) -> None:
+    """Write ``{rel: bytes}`` into ``subtree_root`` + a nested manifest.json
+    listing per-file digests. Register every file (and the nested manifest)
+    under ``parts_prefix`` in the top-level ``parts`` dict.
+    """
+    subtree_root.mkdir(parents=True, exist_ok=True)
+    nested_entries: dict[str, dict[str, Any]] = {}
+    for rel in sorted(payload):
+        data = payload[rel]
+        target = subtree_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        entry = _part_from_bytes(data)
+        nested_entries[rel] = entry
+        parts[f"{parts_prefix}{rel}"] = entry
+    nested_manifest = _canonical_json_bytes({"parts": nested_entries})
+    (subtree_root / "manifest.json").write_bytes(nested_manifest)
+    parts[f"{parts_prefix}manifest.json"] = _part_from_bytes(nested_manifest)
+
+
+def _view_from_parts(
+    bundle_dir: Path, trial_id: str, parts: Mapping[str, Mapping[str, Any]]
+) -> GradeBundleView:
+    proxied = MappingProxyType({rel: MappingProxyType(dict(entry)) for rel, entry in parts.items()})
+    return GradeBundleView(
+        bundle_dir=bundle_dir,
+        manifest=GradeBundleManifest(
+            schema_version=BUNDLE_SCHEMA_VERSION,
+            trial_id=trial_id,
+            parts=proxied,
+        ),
+    )
+
+
+def serialize_grade_bundle(
+    out_dir: Path,
+    *,
+    trial_id: str,
+    initial_state: dict[str, Any],
+    final_state: dict[str, Any],
+    final_state_stable: dict[str, Any],
+    filesystem_root: Path,
+    checks: Mapping[str, bytes] | None,
+    kb: Mapping[str, bytes] | None,
+    trajectory: dict[str, Any],
+    grading_config: dict[str, Any],
+    exclude_dirs: frozenset[str] = AGENT_VISIBLE_EXCLUDES,
+) -> GradeBundleManifest:
+    """Materialise a v1.0 grade bundle into ``out_dir``.
+
+    ``out_dir`` must not already contain any file (raises
+    :class:`FileExistsError` on entry). The caller owns lifecycle. Returns
+    the manifest the producer just wrote; the bundle's canonical name is
+    ``manifest_digest((out_dir / "manifest.json").read_bytes())``.
+
+    Every JSON part is canonicalised with ``sort_keys=True`` + compact
+    separators + shared ``%.6g`` float normalisation; the filesystem tree
+    is captured as a USTAR tar with sorted entries and zeroed metadata;
+    the top-level ``manifest.json`` is written LAST so its bytes see every
+    part's digest.
+    """
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise FileExistsError(f"out_dir {out_dir} must be empty; found existing entries")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    parts: dict[str, dict[str, Any]] = {}
+
+    json_parts: dict[str, dict[str, Any]] = {
+        "initial_state.json": initial_state,
+        "final_state.json": final_state,
+        "final_state_stable.json": final_state_stable,
+        "trajectory.json": trajectory,
+        "grading_config.json": grading_config,
+    }
+    for rel, payload in json_parts.items():
+        data = _canonical_json_bytes(payload)
+        (out_dir / rel).write_bytes(data)
+        parts[rel] = _part_from_bytes(data)
+
+    tar_target = out_dir / "filesystem.tar"
+    _write_filesystem_tar(filesystem_root, exclude_dirs, tar_target)
+    parts["filesystem.tar"] = _sha256_and_size_of_file(tar_target)
+
+    if checks is not None:
+        _write_named_subtree(out_dir / "checks", checks, parts, "checks/")
+    if kb is not None:
+        _write_named_subtree(out_dir / "kb", kb, parts, "kb/")
+
+    manifest_dict = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "trial_id": trial_id,
+        "parts": parts,
+    }
+    manifest_bytes = _canonical_json_bytes(manifest_dict)
+    (out_dir / "manifest.json").write_bytes(manifest_bytes)
+
+    return _view_from_parts(out_dir, trial_id, parts).manifest
 
 
 def _validate_schema_version(raw: object) -> None:
@@ -131,13 +358,4 @@ def load_grade_bundle(bundle_dir: Path) -> GradeBundleView:
             f"manifest at {manifest_path} has no parseable 'schema_version' field: "
             f"{type(exc).__name__}: {exc}"
         ) from exc
-    parts_raw = raw["parts"]
-    parts: Mapping[str, Mapping[str, Any]] = MappingProxyType(
-        {rel: MappingProxyType(dict(entry)) for rel, entry in parts_raw.items()}
-    )
-    manifest = GradeBundleManifest(
-        schema_version=raw["schema_version"],
-        trial_id=raw["trial_id"],
-        parts=parts,
-    )
-    return GradeBundleView(bundle_dir=bundle_dir, manifest=manifest)
+    return _view_from_parts(bundle_dir, raw["trial_id"], raw["parts"])


### PR DESCRIPTION
## Summary

**Phase C opener.** Ships the grade bundle format v1.0 as a pure library at `tolokaforge/core/grading/bundle.py`: manifest schema + reader + producer + `%.6g` float normaliser shared with the byte-parity gate. Byte-identical round-trip is content-addressable — the same trial serialised twice produces byte-identical bytes with matching `sha256(manifest.json)`. External consumers parse the manifest, verify per-part SHA-256, and load parts by name — no engine dependency required. `docs/GRADE_BUNDLE.md` ships as the external-consumer contract.

## Design choices

| Decision | Rationale |
|---|---|
| Bundle canonical name = `sha256(manifest.json)` | Parts' SHA-256 live INSIDE the manifest; changing any part changes its manifest entry → changes manifest bytes → changes name. Recursive integrity by construction. Manifest itself never contains its own name. |
| `filesystem.tar` locked to `tarfile.USTAR_FORMAT` + per-entry `pax_headers={}` | Round-1 critic fold-in. Python's `tarfile.DEFAULT_FORMAT` is PAX, which auto-injects `x`-headers for names > 100 chars, non-ASCII paths, sizes > 8 GB. External-consumer contract at `docs/GRADE_BUNDLE.md` promises "any-language pure-shell recipe" — a Rust/`jq` re-implementation would diverge bytes from Python's PAX output on the first long-path task pack. USTAR + explicit per-entry `pax_headers={}` is load-bearing for cross-language byte-identity. |
| Producer directory-oriented (`out_dir: Path` → `GradeBundleManifest`), refuses non-empty dirs | Directory shape preserves part-addressability (each part is a separately-readable file). Non-empty refusal prevents footgun where producer surprises caller's other files. |
| Reader concrete `GradeBundleView(bundle_dir, manifest)` dataclass, not Protocol | Shape is stable + pinned by manifest schema; every reader in codebase would end up with same fields. `MappingProxyType` makes `parts` read-only through the frozen dataclass. |
| Schema-version rejection: MAJOR-only refuse (`str(x).split(".")[0] != "1"`); MINOR accepted | Forward-compat within MAJOR 1. Top-of-parse try/except normalises `KeyError`/`AttributeError`/`IndexError`/`TypeError` into `BundleSchemaVersionError` — parametrised test covers 8 malformed shapes (missing key, `""`, int, no-dot, three-components, non-digit, `None`, unknown MAJOR). |
| `filesystem.tar` exclusion reuses `AGENT_VISIBLE_EXCLUDES` from `filesystem_view.py` | Single source of truth for the exclusion set (`.git`, `.venv`, `node_modules`, `dist`, `.next`). Producer accepts `exclude_dirs: frozenset[str] = AGENT_VISIBLE_EXCLUDES` — callers can override, default is the shipped grading gate. |
| `normalise_floats` `%.6g` shared with parity harness (moved from `tests/utils/grader_parity_harness.py`) | Single canonicalisation path for JSON float formatting. Harness `serialise_grade` re-imports the moved function; `test_float_normaliser_matches_parity_harness_import` uses `is` identity check to lock single-source. Byte-parity 10-pack 25/25 preserved. |
| Two-contract split preserved (#1349's invariant intact) | New `.importlinter` `bundle-library-purity` contract (7th; `allow_indirect_imports=false`). Forbids `runner` + `grader` + `substrate_live` transitively. Mirrors `composite-fold-purity` / `filesystem-view-purity` shape. |
| `GradeBundleView.open_part` refuses path traversal outside `bundle_dir` | **Round-1 correctness fold-in — SECURITY.** External consumers take untrusted bundles. A manifest with `"../../etc/passwd"` + attacker-computed SHA-256 previously passed the integrity check and returned the target file's bytes. `resolve(strict=False)` + `root not in candidate.parents` guard refuses the escape with `BundleIntegrityError` before reading. Test asserts the refusal. |

## What ships

- **Stage 1 (`ed839391`)** — reader-first shape pin: `GradeBundleManifest` + `GradeBundleView` frozen dataclasses; `BundleError`/`BundleSchemaVersionError`/`BundleIntegrityError`; `load_grade_bundle`. 11 unit tests (3 base + 8 parametrised schema-version). Runner subset exclusion for `bundle.py` (grader-side/offline; runner has no code path that reaches it).
- **Stage 2 (`4af5194a`)** — producer + `%.6g` normaliser move + `.importlinter` `bundle-library-purity` contract. USTAR tar with per-entry `pax_headers={}` + zeroed metadata + sorted entries. 5 canonical tests including byte-identity round-trip + long-path PAX-regression trip + `is`-identity float-normaliser lock.
- **Stage 3 (`d5b792a7`)** — `docs/GRADE_BUNDLE.md` external-consumer contract (format spec + layout + manifest schema + deterministic rules including USTAR + content-addressability + schema-version compatibility + external-consumer pattern).
- **Round-1 fix (`67883430`)** — path-traversal refuse in `open_part` + 5 hygiene sweeps (fabricated `path` field dropped from doc example; test-file `round-1` attribution + future-tense dropped; `.importlinter` rationale rewritten current-state; runner-subset rationale rewritten current-state; docs "Follow-ups" → "Not covered in v1.0").

## Test plan

- [x] `mcp__dev__run_tests marker=canonical keyword="bundle or parity_reference"` — new bundle tests + byte-parity 25/25 green
- [x] `mcp__dev__run_tests path=tests/unit/grading/test_bundle_reader.py` — 12 tests including new path-traversal refusal
- [x] `uv run lint-imports` → **7 contracts kept, 0 broken** (adds `bundle-library-purity`)
- [x] Byte-parity 10-pack `test_grader_parity_reference.py` → 25/25 with `git diff --stat tests/canonical/grader_parity_baselines/` empty
- [x] Path-traversal test verified via mutation: bypassing the containment check makes `open_part("../outside.txt")` return the outside file's bytes; with the check, `BundleIntegrityError` fires
- [x] USTAR/no-PAX enforcement verified via per-member `member.type not in (XHDTYPE, XGLTYPE)` + `member.pax_headers == {}` on a >100-char fixture member
- [x] Sharded reviewer trio — all APPROVE. Correctness round-1 caught path traversal (fixed); hygiene round-1 caught 3 §7a blockers + 2 minors (all fixed inline); type-fit APPROVE first pass with 2 non-blocking nits on `dict → Mapping` widening.

## Follow-ups (already filed)

- **#1428** — optional `provenance.json` sibling for engine-bump debugging (not covered by manifest digest). P3.
- **#1430** — cross-language bundle parser example (`jq` + `sha256sum` + `tar tvf`). P3.
- **#1429** — extend `docs/GRADER_SERVICE.md` wire-cost table with bundle-substrate lane (after #1353 lands). P3.
- **#1353** — SnapshotGradingSubstrate — grader-side consumer of the bundle format shipped here.

Closes #1354.