### PR TITLE
feat(grading): BundleStore Protocol + LocalDisk + S3 (bundle://<store>/<hash> transport seam)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -206,3 +206,26 @@ forbidden_modules =
     tolokaforge.grader
     tolokaforge.core.grading.substrate_live
 allow_indirect_imports = false
+
+
+# Bundle-store purity (grade bundle transport seam).
+#
+# ``core.grading.bundle_store`` ships the ``BundleStore`` Protocol and its
+# built-in implementations. The seam moves an already-serialised bundle
+# between storage endpoints; a reach back into ``runner``, ``grader``, or
+# the live substrate would couple the transport to the wire and break the
+# seam that lets an offline grader consume a bundle produced anywhere.
+# ``bundle_store`` MAY reach ``tolokaforge.core.grading.bundle`` (for the
+# manifest digest primitive). ``allow_indirect_imports = false`` mirrors
+# ``bundle-library-purity`` — a transitive path back into a forbidden
+# target trips the contract, not just a direct import.
+[importlinter:contract:bundle-store-purity]
+name = tolokaforge.core.grading.bundle_store is a pure transport module — no runner/grader/substrate_live reach
+type = forbidden
+source_modules =
+    tolokaforge.core.grading.bundle_store
+forbidden_modules =
+    tolokaforge.runner
+    tolokaforge.grader
+    tolokaforge.core.grading.substrate_live
+allow_indirect_imports = false

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -647,6 +647,70 @@ top-level grader-name seam ADR-0038 shipped, already documented in
 A downstream package registering a new grader name lands there, not
 in any of the eight groups above.
 
+## Bundle store seam
+
+Offline grading operates on a **grade bundle** — a manifest-first,
+part-addressable directory whose canonical name is
+`sha256(manifest.json)`. See [docs/GRADE_BUNDLE.md](GRADE_BUNDLE.md) for
+the format itself. Two responsibilities are strictly separated: the
+producer (`tolokaforge.core.grading.bundle.serialize_grade_bundle`) owns
+the bytes; a `BundleStore` moves those bytes between a local directory
+and addressable storage. Every stored bundle is addressed uniformly by
+the URI scheme `bundle://<store-name>/<content-hash>`, and two puts of
+byte-identical bundles land at the same URI (content-addressable dedupe
+is implicit).
+
+The Protocol lives in `tolokaforge.core.grading.bundle_store`:
+
+```python
+class BundleStore(Protocol):
+    name: str
+    def put(self, bundle_dir: Path) -> str: ...
+    def get(self, uri: str, dest_dir: Path) -> Path: ...
+    def close(self) -> None: ...
+```
+
+Implementations are discovered through the `tolokaforge.bundle_stores`
+entry-point group and resolved with
+`plugin_registry.load_bundle_store(name)`. Two built-ins ship:
+
+- **`local_disk` — `LocalDiskBundleStore(root_dir=…)`.** Writes to
+  `<root_dir>/grade_bundles/<digest>/`, staging into a per-worker
+  `.<digest>.<uuid4>.tmp/` sibling and landing atomically via
+  `os.replace`. The per-worker suffix isolates concurrent puts of the
+  same digest so two workers never share a staging path. `get` refuses
+  a non-empty destination with `FileExistsError`.
+
+- **`s3` — `S3BundleStore(bucket=…, prefix="grade_bundles")`.** Uploads
+  each part under `<prefix>/<digest>/<rel>` in an S3-compatible bucket.
+  Every data part is uploaded first, then `manifest.json` LAST — a
+  crashed put leaves orphan parts but no manifest, so a subsequent `get`
+  fails cleanly with `BundleNotFoundError`. Idempotency is a
+  `head_object` on the manifest key: a second put of the same digest
+  returns the URI without re-uploading.
+
+`S3BundleStore` requires the optional extra `bundle-store-s3` (`uv add
+'tolokaforge[bundle-store-s3]'`). `boto3` is imported lazily inside the
+store's method bodies, so `import tolokaforge.core.grading.bundle_store`
+succeeds without `boto3` installed. Credentials come from the boto3
+default chain — environment variables, `~/.aws/credentials`, EC2 /
+IRSA — matching the credential model of every other AWS-facing surface
+in the codebase. To target an S3-compatible endpoint (MinIO, Ceph) or a
+non-default region, construct a boto3 client with `endpoint_url=` and
+`region_name=` and pass it as `client=` on the store.
+
+```python
+from pathlib import Path
+
+from tolokaforge.core.grading.bundle_store import (
+    LocalDiskBundleStore,
+    S3BundleStore,
+)
+
+local = LocalDiskBundleStore(root_dir=Path("/var/tolokaforge/bundles"))
+s3 = S3BundleStore(bucket="tolokaforge-bundles", prefix="grade_bundles")
+```
+
 ## Parity gate
 
 The `runner_rpc` and `grader_rpc` legs must produce byte-identical

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -641,11 +641,16 @@ my_state_backend = "my_package:my_state_backend_factory"
 my_operator = "my_package:my_operator"
 ```
 
-`tolokaforge.trial_graders` is the ninth registration point — the
-top-level grader-name seam ADR-0038 shipped, already documented in
+`tolokaforge.trial_graders` is the top-level grader-name seam ADR-0038
+shipped, already documented in
 [Registering a downstream grader](#registering-a-downstream-grader).
 A downstream package registering a new grader name lands there, not
 in any of the eight groups above.
+
+The bundle-transport seam `tolokaforge.bundle_stores` is documented in
+the [Bundle store seam](#bundle-store-seam) section below — it extends a
+different surface (offline bundle transport, not grader plug-ins) and
+uses the same entry-point-group + `load_bundle_store` shape.
 
 ## Bundle store seam
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,12 @@ adapters = [
 all = [
     "tolokaforge[dx,browser,server,rag,office,adapters,runner]",
 ]
+# S3-compatible bundle store transport (``S3BundleStore``). boto3 is a
+# lazy import inside the store's method bodies, so the pure module loads
+# without it; install this extra when a caller instantiates ``S3BundleStore``.
+bundle-store-s3 = [
+    "boto3>=1.34,<2",
+]
 
 [project.urls]
 Homepage = "https://github.com/Toloka/tolokaforge"
@@ -309,12 +315,16 @@ exists = "tolokaforge.core.grading.trace_check_operator:exists"
 equals_binding = "tolokaforge.core.grading.trace_check_operator:equals_binding"
 contains_binding = "tolokaforge.core.grading.trace_check_operator:contains_binding"
 
-# Bundle-store Protocol (``tolokaforge/core/grading/bundle_store.py``). One
-# built-in ships today: ``local_disk`` writes the bundle directory under
-# ``<root_dir>/grade_bundles/<digest>/`` with atomic per-worker staging.
-# S3-compatible transport plugs behind the same Protocol as a follow-up.
+# Bundle-store Protocol (``tolokaforge/core/grading/bundle_store.py``). Two
+# built-ins ship: ``local_disk`` writes the bundle directory under
+# ``<root_dir>/grade_bundles/<digest>/`` with atomic per-worker staging;
+# ``s3`` uploads each part to an S3-compatible bucket under
+# ``<prefix>/<digest>/`` and requires the ``bundle-store-s3`` extra
+# (``uv add 'tolokaforge[bundle-store-s3]'``) — ``boto3`` is imported
+# lazily inside the method bodies so the bare module loads without it.
 [project.entry-points."tolokaforge.bundle_stores"]
 local_disk = "tolokaforge.core.grading.bundle_store:LocalDiskBundleStore"
+s3 = "tolokaforge.core.grading.bundle_store:S3BundleStore"
 
 [tool.hatch.build]
 exclude = [
@@ -656,6 +666,10 @@ dev = [
     "tolokaforge-adapter-terminal-bench",
     "dev-mcp",
     "automation",
+    # boto3 pulled in for the S3BundleStore stubber tests
+    # (tests/unit/grading/test_bundle_store_s3.py drives
+    # ``botocore.stub.Stubber`` against a real boto3 S3 client).
+    "boto3>=1.34,<2",
     # Terminal front-end deps live in [project.optional-dependencies].dx.
     # Dev tooling exercises the terminal front-end tests, so pull them in
     # here explicitly rather than relying on `[dx]` being installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,13 @@ exists = "tolokaforge.core.grading.trace_check_operator:exists"
 equals_binding = "tolokaforge.core.grading.trace_check_operator:equals_binding"
 contains_binding = "tolokaforge.core.grading.trace_check_operator:contains_binding"
 
+# Bundle-store Protocol (``tolokaforge/core/grading/bundle_store.py``). One
+# built-in ships today: ``local_disk`` writes the bundle directory under
+# ``<root_dir>/grade_bundles/<digest>/`` with atomic per-worker staging.
+# S3-compatible transport plugs behind the same Protocol as a follow-up.
+[project.entry-points."tolokaforge.bundle_stores"]
+local_disk = "tolokaforge.core.grading.bundle_store:LocalDiskBundleStore"
+
 [tool.hatch.build]
 exclude = [
     "tasks/**",
@@ -411,6 +418,7 @@ exclude = [
     "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/agreement.py",
     "tolokaforge/core/grading/bundle.py",
+    "tolokaforge/core/grading/bundle_store.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",

--- a/tests/canonical/_bundle_fixtures.py
+++ b/tests/canonical/_bundle_fixtures.py
@@ -1,0 +1,56 @@
+"""Shared synthetic-bundle fixtures for the canonical grading-bundle tests.
+
+The bundle round-trip lock, the content-addressability lock, and any
+future bundle-shape test all want the same synthetic trial inputs.
+Extracted here so a fixture tweak lands in one place and every consumer
+sees the same shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+LONG_SEGMENT_NAME = "a_deeply_nested_subdir_with_a_very_long_leading_segment_name_that_exceeds_100_characters_easily"
+"""A directory segment > 100 chars — a PAX-default tar producer would
+inject extension headers here, tripping the round-trip test's PAX-header
+lock."""
+
+
+def write_synthetic_filesystem(root: Path) -> None:
+    """Populate ``root`` with the standard synthetic workspace tree.
+
+    Contains a normal source file, a README, a ``.git`` subtree (which the
+    filesystem-view exclude list must strip from the tar), and a long-path
+    member exercising the USTAR-format guard.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_bytes(b"print('hello')\n")
+    (root / "README.md").write_bytes(b"# hello\n")
+    (root / ".git").mkdir()
+    (root / ".git" / "HEAD").write_bytes(b"ref: refs/heads/main\n")
+    long_dir = root / LONG_SEGMENT_NAME
+    long_dir.mkdir()
+    (long_dir / "leaf.py").write_bytes(b"# long-path member\n")
+
+
+def synthetic_inputs(tmp_path: Path) -> dict[str, object]:
+    """Return the standard synthetic ``serialize_grade_bundle`` kwargs.
+
+    The returned mapping is ready to splat into
+    :func:`tolokaforge.core.grading.bundle.serialize_grade_bundle` (except
+    for ``out_dir``, which each caller owns).
+    """
+    fs_root = tmp_path / "workspace"
+    write_synthetic_filesystem(fs_root)
+    return {
+        "trial_id": "trial-round-trip-1",
+        "initial_state": {"tables": {"users": []}, "score": 0.123456789},
+        "final_state": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
+        "final_state_stable": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
+        "filesystem_root": fs_root,
+        "checks": {"greet_ok.py": b"def check(): return True\n"},
+        "kb": {"policy.md": b"# policy\n"},
+        "trajectory": {"llm_messages": [{"role": "user", "content": "hi"}]},
+        "grading_config": {"combine_method": "weighted", "weights": {"custom": 1.0}},
+    }

--- a/tests/canonical/_bundle_fixtures.py
+++ b/tests/canonical/_bundle_fixtures.py
@@ -1,9 +1,8 @@
 """Shared synthetic-bundle fixtures for the canonical grading-bundle tests.
 
-The bundle round-trip lock, the content-addressability lock, and any
-future bundle-shape test all want the same synthetic trial inputs.
-Extracted here so a fixture tweak lands in one place and every consumer
-sees the same shape.
+Every canonical test that grades a bundle reads its trial inputs from
+``synthetic_inputs``; a fixture tweak lands here and every reader sees
+the same shape.
 """
 
 from __future__ import annotations

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -23,7 +23,7 @@ from tolokaforge.core.conductor import (
     InMemoryConductor,
     InProcessConductor,
 )
-from tolokaforge.core.grading.bundle_store import LocalDiskBundleStore
+from tolokaforge.core.grading.bundle_store import LocalDiskBundleStore, S3BundleStore
 from tolokaforge.core.grading.grading_method import (
     CompositeGradingMethod,
     TestExecutionGradingMethod,
@@ -170,8 +170,15 @@ def test_grading_method_names_resolve_to_their_marker(name: str, expected_cls: t
     assert name == marker.NAME
 
 
-def test_bundle_store_name_resolves_to_its_class() -> None:
-    assert load_bundle_store("local_disk") is LocalDiskBundleStore
+@pytest.mark.parametrize(
+    ("name", "expected_cls"),
+    [
+        ("local_disk", LocalDiskBundleStore),
+        ("s3", S3BundleStore),
+    ],
+)
+def test_bundle_store_name_resolves_to_its_class(name: str, expected_cls: type) -> None:
+    assert load_bundle_store(name) is expected_cls
 
 
 def test_available_listings_match_the_builtin_set() -> None:
@@ -181,7 +188,7 @@ def test_available_listings_match_the_builtin_set() -> None:
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
     assert available_turn_policies() == ["agent_only", "conversational"]
     assert available_grading_methods() == ["composite", "test_execution"]
-    assert available_bundle_stores() == ["local_disk"]
+    assert available_bundle_stores() == ["local_disk", "s3"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
@@ -208,4 +215,4 @@ def test_raw_entry_point_probe_lists_grading_methods() -> None:
 
 def test_raw_entry_point_probe_lists_bundle_stores() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=BUNDLE_STORES_GROUP))
-    assert names == ["local_disk"]
+    assert names == ["local_disk", "s3"]

--- a/tests/canonical/test_builtin_plugin_registrations.py
+++ b/tests/canonical/test_builtin_plugin_registrations.py
@@ -23,12 +23,14 @@ from tolokaforge.core.conductor import (
     InMemoryConductor,
     InProcessConductor,
 )
+from tolokaforge.core.grading.bundle_store import LocalDiskBundleStore
 from tolokaforge.core.grading.grading_method import (
     CompositeGradingMethod,
     TestExecutionGradingMethod,
 )
 from tolokaforge.core.per_trial_runtime import PerTrialRuntimeBackend
 from tolokaforge.core.plugin_registry import (
+    BUNDLE_STORES_GROUP,
     GRADING_METHODS_GROUP,
     RUNTIME_BACKENDS_GROUP,
     SERVICE_READINESS_PROBES_GROUP,
@@ -36,12 +38,14 @@ from tolokaforge.core.plugin_registry import (
     RuntimeBackendBuildContext,
     TrialGraderContext,
     TurnPolicyContext,
+    available_bundle_stores,
     available_conductors,
     available_grading_methods,
     available_readiness_probes,
     available_runtime_backends,
     available_trial_graders,
     available_turn_policies,
+    load_bundle_store,
     load_conductor,
     load_grading_method,
     load_readiness_probe,
@@ -166,6 +170,10 @@ def test_grading_method_names_resolve_to_their_marker(name: str, expected_cls: t
     assert name == marker.NAME
 
 
+def test_bundle_store_name_resolves_to_its_class() -> None:
+    assert load_bundle_store("local_disk") is LocalDiskBundleStore
+
+
 def test_available_listings_match_the_builtin_set() -> None:
     assert available_runtime_backends() == ["in_memory", "per_trial", "shared"]
     assert available_trial_graders() == ["grader_rpc", "judge_only", "queue", "runner_rpc"]
@@ -173,6 +181,7 @@ def test_available_listings_match_the_builtin_set() -> None:
     assert available_readiness_probes() == ["grpc", "http", "tcp"]
     assert available_turn_policies() == ["agent_only", "conversational"]
     assert available_grading_methods() == ["composite", "test_execution"]
+    assert available_bundle_stores() == ["local_disk"]
 
 
 def test_raw_entry_point_probe_lists_runtime_backends() -> None:
@@ -195,3 +204,8 @@ def test_raw_entry_point_probe_lists_turn_policies() -> None:
 def test_raw_entry_point_probe_lists_grading_methods() -> None:
     names = sorted(ep.name for ep in importlib.metadata.entry_points(group=GRADING_METHODS_GROUP))
     assert names == ["composite", "test_execution"]
+
+
+def test_raw_entry_point_probe_lists_bundle_stores() -> None:
+    names = sorted(ep.name for ep in importlib.metadata.entry_points(group=BUNDLE_STORES_GROUP))
+    assert names == ["local_disk"]

--- a/tests/canonical/test_bundle_round_trip.py
+++ b/tests/canonical/test_bundle_round_trip.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.canonical._bundle_fixtures import LONG_SEGMENT_NAME, synthetic_inputs
 from tolokaforge.core.grading.bundle import (
     BUNDLE_SCHEMA_VERSION,
     GradeBundleManifest,
@@ -35,41 +36,8 @@ from tolokaforge.core.grading.bundle import (
 pytestmark = pytest.mark.canonical
 
 
-LONG_SEGMENT_NAME = "a_deeply_nested_subdir_with_a_very_long_leading_segment_name_that_exceeds_100_characters_easily"
-"""A directory segment > 100 chars — a PAX-default producer would inject
-extension headers here, tripping :func:`test_tar_carries_no_pax_headers`."""
-
-
-def _write_synthetic_filesystem(root: Path) -> None:
-    root.mkdir(parents=True, exist_ok=True)
-    (root / "src").mkdir()
-    (root / "src" / "main.py").write_bytes(b"print('hello')\n")
-    (root / "README.md").write_bytes(b"# hello\n")
-    (root / ".git").mkdir()
-    (root / ".git" / "HEAD").write_bytes(b"ref: refs/heads/main\n")
-    long_dir = root / LONG_SEGMENT_NAME
-    long_dir.mkdir()
-    (long_dir / "leaf.py").write_bytes(b"# long-path member\n")
-
-
-def _synthetic_inputs(tmp_path: Path) -> dict[str, object]:
-    fs_root = tmp_path / "workspace"
-    _write_synthetic_filesystem(fs_root)
-    return {
-        "trial_id": "trial-round-trip-1",
-        "initial_state": {"tables": {"users": []}, "score": 0.123456789},
-        "final_state": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
-        "final_state_stable": {"tables": {"users": [{"id": 1, "name": "alice"}]}},
-        "filesystem_root": fs_root,
-        "checks": {"greet_ok.py": b"def check(): return True\n"},
-        "kb": {"policy.md": b"# policy\n"},
-        "trajectory": {"llm_messages": [{"role": "user", "content": "hi"}]},
-        "grading_config": {"combine_method": "weighted", "weights": {"custom": 1.0}},
-    }
-
-
 def test_two_serialisations_produce_byte_identical_bytes(tmp_path: Path) -> None:
-    inputs = _synthetic_inputs(tmp_path)
+    inputs = synthetic_inputs(tmp_path)
     out_a = tmp_path / "bundle_a"
     out_b = tmp_path / "bundle_b"
 
@@ -92,7 +60,7 @@ def test_two_serialisations_produce_byte_identical_bytes(tmp_path: Path) -> None
 
 
 def test_producer_refuses_non_empty_out_dir(tmp_path: Path) -> None:
-    inputs = _synthetic_inputs(tmp_path)
+    inputs = synthetic_inputs(tmp_path)
     out_dir = tmp_path / "bundle"
     out_dir.mkdir()
     (out_dir / "stray.txt").write_bytes(b"pre-existing")
@@ -102,7 +70,7 @@ def test_producer_refuses_non_empty_out_dir(tmp_path: Path) -> None:
 
 
 def test_tar_carries_no_pax_headers(tmp_path: Path) -> None:
-    inputs = _synthetic_inputs(tmp_path)
+    inputs = synthetic_inputs(tmp_path)
     out_dir = tmp_path / "bundle"
     serialize_grade_bundle(out_dir, **inputs)
 
@@ -126,7 +94,7 @@ def test_tar_carries_no_pax_headers(tmp_path: Path) -> None:
 
 
 def test_filesystem_tar_respects_exclude_dirs(tmp_path: Path) -> None:
-    inputs = _synthetic_inputs(tmp_path)
+    inputs = synthetic_inputs(tmp_path)
     out_dir = tmp_path / "bundle"
     serialize_grade_bundle(out_dir, **inputs)
 

--- a/tests/canonical/test_bundle_store_content_addressability.py
+++ b/tests/canonical/test_bundle_store_content_addressability.py
@@ -1,0 +1,125 @@
+"""Canonical acceptance for ``LocalDiskBundleStore`` content-addressability.
+
+Locks the invariants that make bundle URIs safe to reuse across producers
+and workers: identical bundles dedupe to a single directory, distinct
+bundles map to distinct URIs, concurrent puts of the same digest never
+collide on staging, and a mid-put crash leaves no half-populated visible
+bundle.
+"""
+
+from __future__ import annotations
+
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.canonical._bundle_fixtures import synthetic_inputs
+from tolokaforge.core.grading.bundle import manifest_digest, serialize_grade_bundle
+from tolokaforge.core.grading.bundle_store import LocalDiskBundleStore, parse_bundle_uri
+
+pytestmark = pytest.mark.canonical
+
+
+def _bundle_at(tmp_path: Path, sub: str, inputs: dict[str, Any]) -> Path:
+    out_dir = tmp_path / sub
+    serialize_grade_bundle(out_dir, **inputs)
+    return out_dir
+
+
+def _bundle_dirs(store_root: Path) -> list[Path]:
+    grade_bundles = store_root / "grade_bundles"
+    if not grade_bundles.exists():
+        return []
+    return sorted(p for p in grade_bundles.iterdir() if p.is_dir())
+
+
+def test_put_same_bundle_twice_dedupes(tmp_path: Path) -> None:
+    inputs = synthetic_inputs(tmp_path / "fixture")
+    bundle_a = _bundle_at(tmp_path, "bundle_a", inputs)
+    bundle_b = _bundle_at(tmp_path, "bundle_b", inputs)
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+
+    uri_a = store.put(bundle_a)
+    uri_b = store.put(bundle_b)
+
+    assert uri_a == uri_b
+    dirs = _bundle_dirs(store.root_dir)
+    assert len(dirs) == 1, f"expected exactly one bundle directory, got {dirs}"
+    _, digest = parse_bundle_uri(uri_a)
+    assert dirs[0].name == digest
+
+
+def test_put_different_bundles_produce_different_uris(tmp_path: Path) -> None:
+    inputs_a = synthetic_inputs(tmp_path / "fx_a")
+    inputs_b = synthetic_inputs(tmp_path / "fx_b")
+    inputs_b["trial_id"] = "trial-round-trip-2"
+    bundle_a = _bundle_at(tmp_path, "bundle_a", inputs_a)
+    bundle_b = _bundle_at(tmp_path, "bundle_b", inputs_b)
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+
+    uri_a = store.put(bundle_a)
+    uri_b = store.put(bundle_b)
+
+    assert uri_a != uri_b
+    assert len(_bundle_dirs(store.root_dir)) == 2
+
+
+def test_concurrent_put_same_bundle(tmp_path: Path) -> None:
+    inputs = synthetic_inputs(tmp_path / "fixture")
+    bundle_a = _bundle_at(tmp_path, "bundle_a", inputs)
+    bundle_b = _bundle_at(tmp_path, "bundle_b", inputs)
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(store.put, bundle_a), pool.submit(store.put, bundle_b)]
+        uris = [f.result() for f in futures]
+
+    assert uris[0] == uris[1]
+
+    grade_bundles = store.root_dir / "grade_bundles"
+    dirs = sorted(p for p in grade_bundles.iterdir() if p.is_dir())
+    assert len(dirs) == 1, f"expected exactly one bundle directory, got {dirs}"
+
+    stragglers = sorted(p.name for p in grade_bundles.iterdir() if p.name.endswith(".tmp"))
+    assert stragglers == [], f"leftover staging directories: {stragglers}"
+
+    source_manifest = (bundle_a / "manifest.json").read_bytes()
+    dest_manifest = (dirs[0] / "manifest.json").read_bytes()
+    assert dest_manifest == source_manifest
+    assert dirs[0].name == manifest_digest(source_manifest)
+
+
+def test_atomic_staging_leaves_no_partial_state_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inputs = synthetic_inputs(tmp_path / "fixture")
+    bundle = _bundle_at(tmp_path, "bundle", inputs)
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+
+    real_copytree = shutil.copytree
+
+    def _boom(src: Any, dst: Any, *args: Any, **kwargs: Any) -> Any:
+        real_copytree(src, dst, *args, **kwargs)
+        raise RuntimeError("staged tree copy failed mid-put")
+
+    monkeypatch.setattr("tolokaforge.core.grading.bundle_store.shutil.copytree", _boom)
+
+    with pytest.raises(RuntimeError, match="staged tree copy failed mid-put"):
+        store.put(bundle)
+
+    grade_bundles = store.root_dir / "grade_bundles"
+    digest = manifest_digest((bundle / "manifest.json").read_bytes())
+    assert not (
+        grade_bundles / digest
+    ).exists(), "final <digest>/ directory must not exist after mid-put crash"
+    staging_dirs = sorted(
+        p.name
+        for p in grade_bundles.iterdir()
+        if p.name.startswith(f".{digest}.") and p.name.endswith(".tmp")
+    )
+    assert (
+        len(staging_dirs) == 1
+    ), f"expected exactly one orphan per-worker .<digest>.<uuid4>.tmp/, got {staging_dirs}"

--- a/tests/unit/grading/test_bundle_store_local_disk.py
+++ b/tests/unit/grading/test_bundle_store_local_disk.py
@@ -14,8 +14,11 @@ import pytest
 
 from tolokaforge.core.grading.bundle import serialize_grade_bundle
 from tolokaforge.core.grading.bundle_store import (
+    BundleNotFoundError,
     InvalidBundleURIError,
     LocalDiskBundleStore,
+    build_bundle_uri,
+    parse_bundle_uri,
 )
 
 pytestmark = pytest.mark.unit
@@ -97,3 +100,55 @@ def test_get_refuses_unknown_store_name(tmp_path: Path) -> None:
 
     with pytest.raises(InvalidBundleURIError, match="s3"):
         store.get(other_store_uri, dest)
+
+
+@pytest.mark.parametrize(
+    "malformed,match",
+    [
+        ("file:///tmp/x", "scheme"),
+        ("bundle:///" + "a" * 64, "netloc"),
+        ("bundle://local_disk/" + "a" * 64 + "?q=1", "query"),
+        ("bundle://local_disk/" + "a" * 64 + "#f", "fragment"),
+        ("bundle://local_disk/notenoughhex", "digest"),
+        ("bundle://local_disk/" + "Z" * 64, "digest"),
+    ],
+)
+def test_parse_bundle_uri_refuses_malformed(malformed: str, match: str) -> None:
+    with pytest.raises(InvalidBundleURIError, match=match):
+        parse_bundle_uri(malformed)
+
+
+@pytest.mark.parametrize(
+    "bad_name,bad_digest,match",
+    [
+        ("", "a" * 64, "store"),
+        ("has spaces", "a" * 64, "store"),
+        ("local_disk", "shorthex", "digest"),
+        ("local_disk", "Z" * 64, "digest"),
+    ],
+)
+def test_build_bundle_uri_refuses_malformed(bad_name: str, bad_digest: str, match: str) -> None:
+    with pytest.raises(InvalidBundleURIError, match=match):
+        build_bundle_uri(bad_name, bad_digest)
+
+
+def test_get_raises_bundle_not_found_for_unknown_digest(tmp_path: Path) -> None:
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+    dest = tmp_path / "dest"
+    missing_uri = build_bundle_uri("local_disk", "b" * 64)
+
+    with pytest.raises(BundleNotFoundError):
+        store.get(missing_uri, dest)
+
+
+def test_get_raises_bundle_not_found_for_partial_bundle(tmp_path: Path) -> None:
+    store_root = tmp_path / "store"
+    store = LocalDiskBundleStore(root_dir=store_root)
+    partial_dir = store_root / "grade_bundles" / ("c" * 64)
+    partial_dir.mkdir(parents=True)
+    (partial_dir / "final_state.json").write_text("{}")  # part exists, no manifest
+    dest = tmp_path / "dest"
+    partial_uri = build_bundle_uri("local_disk", "c" * 64)
+
+    with pytest.raises(BundleNotFoundError):
+        store.get(partial_uri, dest)

--- a/tests/unit/grading/test_bundle_store_local_disk.py
+++ b/tests/unit/grading/test_bundle_store_local_disk.py
@@ -1,0 +1,99 @@
+"""Unit acceptance for ``LocalDiskBundleStore``.
+
+Covers the URI shape returned by ``put``, byte-identical round-trip
+through ``get``, and the three refusal contracts (non-empty destination,
+non-bundle scheme, wrong store name).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tolokaforge.core.grading.bundle import serialize_grade_bundle
+from tolokaforge.core.grading.bundle_store import (
+    InvalidBundleURIError,
+    LocalDiskBundleStore,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_URI_RE = re.compile(r"^bundle://local_disk/[0-9a-f]{64}$")
+
+
+def _make_bundle(out_dir: Path, filesystem_root: Path, *, trial_id: str = "trial-1") -> Path:
+    filesystem_root.mkdir(parents=True, exist_ok=True)
+    (filesystem_root / "hello.txt").write_bytes(b"hello\n")
+    serialize_grade_bundle(
+        out_dir,
+        trial_id=trial_id,
+        initial_state={"score": 0.0},
+        final_state={"score": 1.0},
+        final_state_stable={"score": 1.0},
+        filesystem_root=filesystem_root,
+        checks=None,
+        kb=None,
+        trajectory={"llm_messages": []},
+        grading_config={"combine_method": "weighted"},
+    )
+    return out_dir
+
+
+def test_put_returns_bundle_uri(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+
+    uri = store.put(bundle)
+
+    assert _URI_RE.match(uri), f"URI {uri!r} does not match bundle://local_disk/<64-hex>"
+
+
+def test_get_reads_back_byte_identical_bundle(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+    uri = store.put(bundle)
+
+    dest = tmp_path / "dest"
+    returned = store.get(uri, dest)
+
+    assert returned == dest
+    source_files = {
+        p.relative_to(bundle).as_posix(): p.read_bytes() for p in bundle.rglob("*") if p.is_file()
+    }
+    dest_files = {
+        p.relative_to(dest).as_posix(): p.read_bytes() for p in dest.rglob("*") if p.is_file()
+    }
+    assert source_files == dest_files
+
+
+def test_get_refuses_non_empty_dest_dir(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+    uri = store.put(bundle)
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "stray.txt").write_bytes(b"pre-existing")
+
+    with pytest.raises(FileExistsError):
+        store.get(uri, dest)
+
+
+def test_get_refuses_unknown_uri_scheme(tmp_path: Path) -> None:
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+    dest = tmp_path / "dest"
+
+    with pytest.raises(InvalidBundleURIError, match="scheme"):
+        store.get("file:///tmp/whatever", dest)
+
+
+def test_get_refuses_unknown_store_name(tmp_path: Path) -> None:
+    store = LocalDiskBundleStore(root_dir=tmp_path / "store")
+    dest = tmp_path / "dest"
+    other_store_uri = "bundle://s3/" + "a" * 64
+
+    with pytest.raises(InvalidBundleURIError, match="s3"):
+        store.get(other_store_uri, dest)

--- a/tests/unit/grading/test_bundle_store_s3.py
+++ b/tests/unit/grading/test_bundle_store_s3.py
@@ -1,0 +1,218 @@
+"""Unit acceptance for ``S3BundleStore``.
+
+Driven by ``botocore.stub.Stubber`` — no live S3, no ``moto`` dep.
+Locks the upload-order invariant (parts first, manifest LAST), the
+dedupe short-circuit on an existing manifest, the byte-identical
+round-trip through ``put``/``get``, the non-empty dest refusal, and
+proves that ``import tolokaforge.core.grading.bundle_store`` succeeds
+when ``boto3`` is not installed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+from botocore.stub import Stubber  # noqa: E402
+
+from tolokaforge.core.grading.bundle import (  # noqa: E402
+    manifest_digest,
+    serialize_grade_bundle,
+)
+from tolokaforge.core.grading.bundle_store import S3BundleStore  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+BUCKET = "test-bundles"
+PREFIX = "grade_bundles"
+
+
+def _make_bundle(out_dir: Path, filesystem_root: Path, *, trial_id: str = "trial-s3") -> Path:
+    filesystem_root.mkdir(parents=True, exist_ok=True)
+    (filesystem_root / "hello.txt").write_bytes(b"hello\n")
+    serialize_grade_bundle(
+        out_dir,
+        trial_id=trial_id,
+        initial_state={"score": 0.0},
+        final_state={"score": 1.0},
+        final_state_stable={"score": 1.0},
+        filesystem_root=filesystem_root,
+        checks=None,
+        kb=None,
+        trajectory={"llm_messages": []},
+        grading_config={"combine_method": "weighted"},
+    )
+    return out_dir
+
+
+def _stubbed_client() -> tuple[Any, Stubber]:
+    client = boto3.client("s3", region_name="us-east-1")
+    stubber = Stubber(client)
+    return client, stubber
+
+
+def _key(digest: str, rel: str) -> str:
+    return f"{PREFIX}/{digest}/{rel}"
+
+
+def test_lazy_boto3_import(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    original = sys.modules.get("boto3")
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    try:
+        module = importlib.reload(importlib.import_module("tolokaforge.core.grading.bundle_store"))
+        bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+        store = module.S3BundleStore(bucket="x")
+        with pytest.raises(RuntimeError, match="bundle-store-s3"):
+            store.put(bundle)
+    finally:
+        if original is not None:
+            sys.modules["boto3"] = original
+        importlib.reload(importlib.import_module("tolokaforge.core.grading.bundle_store"))
+
+
+def test_put_uploads_parts_then_manifest_last(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    manifest_bytes = (bundle / "manifest.json").read_bytes()
+    digest = manifest_digest(manifest_bytes)
+    manifest = json.loads(manifest_bytes)
+    part_keys = sorted(rel for rel in manifest["parts"] if rel != "manifest.json")
+
+    client, stubber = _stubbed_client()
+    stubber.add_client_error(
+        "head_object",
+        service_error_code="404",
+        service_message="Not Found",
+        http_status_code=404,
+        expected_params={"Bucket": BUCKET, "Key": _key(digest, "manifest.json")},
+    )
+    call_order: list[str] = []
+    for rel in part_keys:
+        stubber.add_response(
+            "put_object",
+            service_response={},
+            expected_params={
+                "Bucket": BUCKET,
+                "Key": _key(digest, rel),
+                "Body": (bundle / rel).read_bytes(),
+            },
+        )
+        call_order.append(rel)
+    stubber.add_response(
+        "put_object",
+        service_response={},
+        expected_params={
+            "Bucket": BUCKET,
+            "Key": _key(digest, "manifest.json"),
+            "Body": manifest_bytes,
+        },
+    )
+    call_order.append("manifest.json")
+
+    stubber.activate()
+    try:
+        store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+        uri = store.put(bundle)
+    finally:
+        stubber.deactivate()
+    stubber.assert_no_pending_responses()
+
+    assert uri == f"bundle://s3/{digest}"
+    assert call_order[-1] == "manifest.json"
+    assert call_order[:-1] == part_keys
+
+
+def test_put_short_circuits_on_dedupe(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    digest = manifest_digest((bundle / "manifest.json").read_bytes())
+
+    client, stubber = _stubbed_client()
+    stubber.add_response(
+        "head_object",
+        service_response={"ContentLength": 1},
+        expected_params={"Bucket": BUCKET, "Key": _key(digest, "manifest.json")},
+    )
+    stubber.activate()
+    try:
+        store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+        uri = store.put(bundle)
+    finally:
+        stubber.deactivate()
+    stubber.assert_no_pending_responses()
+
+    assert uri == f"bundle://s3/{digest}"
+
+
+def test_get_downloads_and_writes_byte_identical_tree(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    manifest_bytes = (bundle / "manifest.json").read_bytes()
+    digest = manifest_digest(manifest_bytes)
+    manifest = json.loads(manifest_bytes)
+    part_rels = sorted(rel for rel in manifest["parts"] if rel != "manifest.json")
+
+    client, stubber = _stubbed_client()
+    stubber.add_response(
+        "head_object",
+        service_response={"ContentLength": len(manifest_bytes)},
+        expected_params={"Bucket": BUCKET, "Key": _key(digest, "manifest.json")},
+    )
+    stubber.add_response(
+        "get_object",
+        service_response={"Body": _StreamStub(manifest_bytes)},
+        expected_params={"Bucket": BUCKET, "Key": _key(digest, "manifest.json")},
+    )
+    for rel in part_rels:
+        data = (bundle / rel).read_bytes()
+        stubber.add_response(
+            "get_object",
+            service_response={"Body": _StreamStub(data)},
+            expected_params={"Bucket": BUCKET, "Key": _key(digest, rel)},
+        )
+
+    dest = tmp_path / "dest"
+    stubber.activate()
+    try:
+        store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+        returned = store.get(f"bundle://s3/{digest}", dest)
+    finally:
+        stubber.deactivate()
+    stubber.assert_no_pending_responses()
+
+    assert returned == dest
+    source_files = {
+        p.relative_to(bundle).as_posix(): p.read_bytes() for p in bundle.rglob("*") if p.is_file()
+    }
+    dest_files = {
+        p.relative_to(dest).as_posix(): p.read_bytes() for p in dest.rglob("*") if p.is_file()
+    }
+    assert source_files == dest_files
+
+
+def test_get_refuses_non_empty_dest_dir(tmp_path: Path) -> None:
+    client, _ = _stubbed_client()
+    store = S3BundleStore(bucket=BUCKET, prefix=PREFIX, client=client)
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    (dest / "stray.txt").write_bytes(b"pre-existing")
+    with pytest.raises(FileExistsError):
+        store.get("bundle://s3/" + "a" * 64, dest)
+
+
+class _StreamStub:
+    """Minimal file-like stand-in for a boto3 ``StreamingBody``."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self, amt: int | None = None) -> bytes:
+        if amt is None:
+            data, self._data = self._data, b""
+            return data
+        chunk, self._data = self._data[:amt], self._data[amt:]
+        return chunk

--- a/tests/unit/grading/test_bundle_store_s3.py
+++ b/tests/unit/grading/test_bundle_store_s3.py
@@ -10,8 +10,8 @@ when ``boto3`` is not installed.
 
 from __future__ import annotations
 
-import importlib
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -19,7 +19,7 @@ from typing import Any
 import pytest
 
 boto3 = pytest.importorskip("boto3")
-from botocore.stub import Stubber  # noqa: E402
+from botocore.stub import ANY, Stubber  # noqa: E402
 
 from tolokaforge.core.grading.bundle import (  # noqa: E402
     manifest_digest,
@@ -62,19 +62,36 @@ def _key(digest: str, rel: str) -> str:
     return f"{PREFIX}/{digest}/{rel}"
 
 
-def test_lazy_boto3_import(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    original = sys.modules.get("boto3")
-    monkeypatch.setitem(sys.modules, "boto3", None)
-    try:
-        module = importlib.reload(importlib.import_module("tolokaforge.core.grading.bundle_store"))
-        bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
-        store = module.S3BundleStore(bucket="x")
-        with pytest.raises(RuntimeError, match="bundle-store-s3"):
-            store.put(bundle)
-    finally:
-        if original is not None:
-            sys.modules["boto3"] = original
-        importlib.reload(importlib.import_module("tolokaforge.core.grading.bundle_store"))
+def test_lazy_boto3_import(tmp_path: Path) -> None:
+    # Verify (a) bundle_store imports without boto3 present, and (b) instantiating
+    # S3BundleStore + calling put raises RuntimeError naming the install extra.
+    # Runs in a subprocess so sys.modules pollution can't leak into sibling tests
+    # (importlib.reload swaps class identities and breaks `pytest.raises` in
+    # downstream tests that captured the pre-reload class at collection time).
+    bundle = _make_bundle(tmp_path / "bundle", tmp_path / "fs")
+    script = (
+        "import sys\n"
+        "sys.modules['boto3'] = None\n"
+        "from tolokaforge.core.grading.bundle_store import S3BundleStore\n"
+        f"store = S3BundleStore(bucket='x')\n"
+        "try:\n"
+        f"    store.put({str(bundle)!r})\n"
+        "except RuntimeError as exc:\n"
+        "    assert 'bundle-store-s3' in str(exc), str(exc)\n"
+        "    print('OK')\n"
+        "else:\n"
+        "    raise AssertionError('put did not raise RuntimeError')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert (
+        result.returncode == 0
+    ), f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert "OK" in result.stdout
 
 
 def test_put_uploads_parts_then_manifest_last(tmp_path: Path) -> None:
@@ -100,7 +117,7 @@ def test_put_uploads_parts_then_manifest_last(tmp_path: Path) -> None:
             expected_params={
                 "Bucket": BUCKET,
                 "Key": _key(digest, rel),
-                "Body": (bundle / rel).read_bytes(),
+                "Body": ANY,
             },
         )
         call_order.append(rel)
@@ -216,3 +233,10 @@ class _StreamStub:
             return data
         chunk, self._data = self._data[:amt], self._data[amt:]
         return chunk
+
+    def iter_chunks(self, chunk_size: int = 1024) -> Any:
+        while True:
+            chunk = self.read(chunk_size)
+            if not chunk:
+                return
+            yield chunk

--- a/tolokaforge/core/_runner_subset.py
+++ b/tolokaforge/core/_runner_subset.py
@@ -124,6 +124,7 @@ RUNNER_SUBSET_EXCLUDED_FILES: tuple[str, ...] = (
     "tolokaforge/core/actors/turn_policy.py",
     "tolokaforge/core/grading/agreement.py",
     "tolokaforge/core/grading/bundle.py",
+    "tolokaforge/core/grading/bundle_store.py",
     "tolokaforge/core/grading/combine.py",
     "tolokaforge/core/grading/config_validation.py",
     "tolokaforge/core/grading/corpus_curation.py",
@@ -189,6 +190,12 @@ imports are stdlib-only, but the runner container has no code path that
 reads or writes bundles: the producer runs host-side (offline replay /
 cross-topology grading), and no runner boot-closure module reaches into
 it. Ships as dead weight in the runner image.
+
+``core.grading.bundle_store`` ships the ``BundleStore`` Protocol and its
+built-in transports for the same offline grade-bundle format. Its
+producers and consumers live host-side (offline replay, cross-topology
+grading, standalone grader service); no runner boot-closure module
+reaches into it. Excluded on the same grounds as ``core.grading.bundle``.
 """
 
 

--- a/tolokaforge/core/grading/bundle_store.py
+++ b/tolokaforge/core/grading/bundle_store.py
@@ -25,6 +25,18 @@ the same digest so two workers never share a staging path. ``get`` refuses
 a non-empty destination with :class:`FileExistsError` (a merge into a used
 directory would silently mask stale parts from an earlier ``get``).
 
+``S3BundleStore`` uploads each part as a separate object under
+``<prefix>/<digest>/<rel>`` in an S3-compatible bucket. ``put`` uploads
+every data part first and ``manifest.json`` LAST — a crashed put leaves
+orphan parts but no manifest, so ``get`` fails cleanly with
+:class:`BundleNotFoundError`. Idempotency is a ``head_object`` on the
+manifest key; a second put of the same digest returns the URI without
+re-uploading. ``boto3`` is a lazy import inside method bodies — the pure
+module loads without ``boto3`` installed — and credentials come from the
+default AWS credential chain (env, ``~/.aws/credentials``, EC2 / IRSA).
+Install the optional extra with ``uv add 'tolokaforge[bundle-store-s3]'``
+before instantiating.
+
 Purity: stdlib + :mod:`tolokaforge.core.grading.bundle` for the manifest
 digest primitive. No reach into ``tolokaforge.runner``,
 ``tolokaforge.grader``, or ``tolokaforge.core.grading.substrate_live`` —
@@ -33,12 +45,13 @@ locked by the ``bundle-store-purity`` contract in ``.importlinter``.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
 from tolokaforge.core.grading.bundle import manifest_digest
@@ -50,6 +63,7 @@ __all__ = [
     "BundleStoreError",
     "InvalidBundleURIError",
     "LocalDiskBundleStore",
+    "S3BundleStore",
     "build_bundle_uri",
     "parse_bundle_uri",
 ]
@@ -216,3 +230,129 @@ class LocalDiskBundleStore:
 
     def close(self) -> None:
         return None
+
+
+_BOTO3_INSTALL_HINT = (
+    "S3BundleStore requires boto3. Install the optional extra with "
+    "'uv add tolokaforge[bundle-store-s3]' or 'pip install boto3'."
+)
+
+
+@dataclass
+class S3BundleStore:
+    """S3-compatible bundle store.
+
+    Layout in the bucket::
+
+        <prefix>/<digest>/manifest.json
+        <prefix>/<digest>/initial_state.json
+        <prefix>/<digest>/filesystem.tar
+        ...
+
+    ``put`` uploads every data part first, then ``manifest.json`` LAST —
+    a crashed put leaves orphan parts but no manifest, so ``get`` fails
+    cleanly with :class:`BundleNotFoundError`. Idempotency is a
+    ``head_object`` on the manifest key: a second put of the same digest
+    returns the URI without re-uploading any object.
+
+    ``boto3`` is a lazy import: the pure module loads without it, and
+    :meth:`put` / :meth:`get` build the client on first use if the caller
+    did not inject one. Credentials come from the boto3 default chain
+    (env vars, ``~/.aws/credentials``, EC2 / IRSA). To target
+    S3-compatible endpoints (MinIO, Ceph) or a custom region, construct a
+    boto3 client with ``endpoint_url=`` / ``region_name=`` and pass it as
+    ``client=``.
+    """
+
+    bucket: str
+    prefix: str = "grade_bundles"
+    name: str = "s3"
+    client: Any | None = field(default=None, kw_only=True)
+
+    def __post_init__(self) -> None:
+        self.prefix = self.prefix.strip("/")
+
+    def _boto3_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        try:
+            import boto3
+        except ImportError as e:
+            raise RuntimeError(_BOTO3_INSTALL_HINT) from e
+        self.client = boto3.client("s3")
+        return self.client
+
+    def _key(self, digest: str, rel: str) -> str:
+        base = f"{self.prefix}/{digest}" if self.prefix else digest
+        return f"{base}/{rel}"
+
+    def _manifest_present(self, client: Any, digest: str) -> bool:
+        from botocore.exceptions import ClientError
+
+        try:
+            client.head_object(Bucket=self.bucket, Key=self._key(digest, _MANIFEST_FILENAME))
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if code in {"404", "NoSuchKey", "NotFound"} or status == 404:
+                return False
+            raise
+        return True
+
+    def put(self, bundle_dir: Path) -> str:
+        bundle_dir = Path(bundle_dir)
+        manifest_bytes = (bundle_dir / _MANIFEST_FILENAME).read_bytes()
+        digest = manifest_digest(manifest_bytes)
+        client = self._boto3_client()
+        if self._manifest_present(client, digest):
+            return build_bundle_uri(self.name, digest)
+        manifest = json.loads(manifest_bytes)
+        for rel in sorted(manifest.get("parts", {})):
+            if rel == _MANIFEST_FILENAME:
+                continue
+            client.put_object(
+                Bucket=self.bucket,
+                Key=self._key(digest, rel),
+                Body=(bundle_dir / rel).read_bytes(),
+            )
+        client.put_object(
+            Bucket=self.bucket,
+            Key=self._key(digest, _MANIFEST_FILENAME),
+            Body=manifest_bytes,
+        )
+        return build_bundle_uri(self.name, digest)
+
+    def get(self, uri: str, dest_dir: Path) -> Path:
+        store_name, digest = parse_bundle_uri(uri)
+        if store_name != self.name:
+            raise InvalidBundleURIError(
+                f"URI {uri!r} targets store {store_name!r}; this store is {self.name!r}"
+            )
+        dest_dir = Path(dest_dir)
+        if dest_dir.exists() and any(dest_dir.iterdir()):
+            raise FileExistsError(f"dest_dir {dest_dir} must be empty; found existing entries")
+        client = self._boto3_client()
+        if not self._manifest_present(client, digest):
+            raise BundleNotFoundError(f"no bundle at {uri!r} in bucket {self.bucket!r}")
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        manifest_bytes = client.get_object(
+            Bucket=self.bucket, Key=self._key(digest, _MANIFEST_FILENAME)
+        )["Body"].read()
+        (dest_dir / _MANIFEST_FILENAME).write_bytes(manifest_bytes)
+        manifest = json.loads(manifest_bytes)
+        for rel in sorted(manifest.get("parts", {})):
+            if rel == _MANIFEST_FILENAME:
+                continue
+            body = client.get_object(Bucket=self.bucket, Key=self._key(digest, rel))["Body"].read()
+            target = dest_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(body)
+        return dest_dir
+
+    def close(self) -> None:
+        if self.client is None:
+            return
+        close = getattr(self.client, "close", None)
+        if callable(close):
+            close()
+        self.client = None

--- a/tolokaforge/core/grading/bundle_store.py
+++ b/tolokaforge/core/grading/bundle_store.py
@@ -307,14 +307,15 @@ class S3BundleStore:
         if self._manifest_present(client, digest):
             return build_bundle_uri(self.name, digest)
         manifest = json.loads(manifest_bytes)
-        for rel in sorted(manifest.get("parts", {})):
+        for rel in sorted(manifest["parts"]):
             if rel == _MANIFEST_FILENAME:
                 continue
-            client.put_object(
-                Bucket=self.bucket,
-                Key=self._key(digest, rel),
-                Body=(bundle_dir / rel).read_bytes(),
-            )
+            with (bundle_dir / rel).open("rb") as body:
+                client.put_object(
+                    Bucket=self.bucket,
+                    Key=self._key(digest, rel),
+                    Body=body,
+                )
         client.put_object(
             Bucket=self.bucket,
             Key=self._key(digest, _MANIFEST_FILENAME),
@@ -340,13 +341,15 @@ class S3BundleStore:
         )["Body"].read()
         (dest_dir / _MANIFEST_FILENAME).write_bytes(manifest_bytes)
         manifest = json.loads(manifest_bytes)
-        for rel in sorted(manifest.get("parts", {})):
+        for rel in sorted(manifest["parts"]):
             if rel == _MANIFEST_FILENAME:
                 continue
-            body = client.get_object(Bucket=self.bucket, Key=self._key(digest, rel))["Body"].read()
             target = dest_dir / rel
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_bytes(body)
+            response = client.get_object(Bucket=self.bucket, Key=self._key(digest, rel))
+            with target.open("wb") as out:
+                for chunk in response["Body"].iter_chunks(chunk_size=1024 * 1024):
+                    out.write(chunk)
         return dest_dir
 
     def close(self) -> None:

--- a/tolokaforge/core/grading/bundle_store.py
+++ b/tolokaforge/core/grading/bundle_store.py
@@ -1,0 +1,218 @@
+"""Grade bundle transport — ``BundleStore`` Protocol + built-in stores.
+
+A grade bundle is a manifest-first, part-addressable directory whose
+canonical name is ``sha256(manifest.json.read_bytes())`` (see
+:mod:`tolokaforge.core.grading.bundle`). This module ships the transport
+seam: a small ``BundleStore`` Protocol plus concrete implementations that
+move an already-serialised bundle between a producer directory and
+addressable storage, keyed uniformly by the URI scheme
+``bundle://<store-name>/<content-hash>``.
+
+Two responsibilities are strictly separated: :func:`serialize_grade_bundle`
+owns the *format* (canonical bytes, deterministic tar, manifest schema);
+:class:`BundleStore` owns *where the bytes live* and *how a reader pulls
+them back into a local directory*. A store never re-serialises — it copies
+byte-identical parts + manifest. Content-addressable dedupe follows for
+free: two puts of a byte-identical bundle land at the same URI, and the
+store short-circuits the second copy.
+
+``LocalDiskBundleStore`` writes to
+``<root_dir>/grade_bundles/<digest>/`` — a directory, matching the shipped
+bundle format verbatim. ``put`` stages into a per-worker
+``.<digest>.<uuid4>.tmp/`` sibling and lands atomically via
+:func:`os.replace`; the per-worker ``uuid4`` isolates concurrent puts of
+the same digest so two workers never share a staging path. ``get`` refuses
+a non-empty destination with :class:`FileExistsError` (a merge into a used
+directory would silently mask stale parts from an earlier ``get``).
+
+Purity: stdlib + :mod:`tolokaforge.core.grading.bundle` for the manifest
+digest primitive. No reach into ``tolokaforge.runner``,
+``tolokaforge.grader``, or ``tolokaforge.core.grading.substrate_live`` —
+locked by the ``bundle-store-purity`` contract in ``.importlinter``.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlparse
+
+from tolokaforge.core.grading.bundle import manifest_digest
+
+__all__ = [
+    "BUNDLE_URI_SCHEME",
+    "BundleNotFoundError",
+    "BundleStore",
+    "BundleStoreError",
+    "InvalidBundleURIError",
+    "LocalDiskBundleStore",
+    "build_bundle_uri",
+    "parse_bundle_uri",
+]
+
+
+BUNDLE_URI_SCHEME: str = "bundle"
+
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_STORE_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+_BUNDLE_SUBDIR = "grade_bundles"
+_MANIFEST_FILENAME = "manifest.json"
+
+
+class BundleStoreError(Exception):
+    """Base class for bundle store errors."""
+
+
+class BundleNotFoundError(BundleStoreError):
+    """The URI does not resolve to a stored bundle."""
+
+
+class InvalidBundleURIError(BundleStoreError):
+    """The URI is malformed, targets a different scheme, or names another store."""
+
+
+def build_bundle_uri(store_name: str, digest: str) -> str:
+    """Return ``bundle://<store_name>/<digest>``.
+
+    Rejects any ``store_name`` outside ``[a-z0-9_]+`` or ``digest`` that is
+    not 64 lowercase hex chars — both must match the entry-point naming
+    contract and the ``sha256`` output of :func:`manifest_digest`.
+    """
+    if not _STORE_NAME_RE.match(store_name):
+        raise InvalidBundleURIError(
+            f"invalid store name {store_name!r}: must match {_STORE_NAME_RE.pattern!r}"
+        )
+    if not _DIGEST_RE.match(digest):
+        raise InvalidBundleURIError(
+            f"invalid digest {digest!r}: must be 64 lowercase hex characters"
+        )
+    return f"{BUNDLE_URI_SCHEME}://{store_name}/{digest}"
+
+
+def parse_bundle_uri(uri: str) -> tuple[str, str]:
+    """Parse ``bundle://<store_name>/<digest>`` into ``(store_name, digest)``.
+
+    Refuses any scheme other than ``bundle``, missing netloc, path that is
+    not exactly ``/<64-hex>``, or a query/fragment. Never raises
+    :class:`ValueError` or :class:`KeyError` — always
+    :class:`InvalidBundleURIError`.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme != BUNDLE_URI_SCHEME:
+        raise InvalidBundleURIError(
+            f"URI {uri!r} scheme {parsed.scheme!r} is not {BUNDLE_URI_SCHEME!r}"
+        )
+    if not parsed.netloc:
+        raise InvalidBundleURIError(f"URI {uri!r} has no store name (netloc)")
+    if parsed.query or parsed.fragment:
+        raise InvalidBundleURIError(f"URI {uri!r} carries query or fragment; not allowed")
+    if not parsed.path.startswith("/"):
+        raise InvalidBundleURIError(f"URI {uri!r} has no digest path")
+    digest = parsed.path[1:]
+    if not _STORE_NAME_RE.match(parsed.netloc):
+        raise InvalidBundleURIError(
+            f"URI {uri!r} store name {parsed.netloc!r} must match {_STORE_NAME_RE.pattern!r}"
+        )
+    if not _DIGEST_RE.match(digest):
+        raise InvalidBundleURIError(
+            f"URI {uri!r} digest {digest!r} must be 64 lowercase hex characters"
+        )
+    return parsed.netloc, digest
+
+
+class BundleStore(Protocol):
+    """Transport of an already-serialised grade bundle directory.
+
+    A bundle is addressed as ``bundle://<store-name>/<content-hash>`` where
+    ``<content-hash>`` is the hex ``sha256`` of the bundle's
+    ``manifest.json`` bytes. Content-addressable dedupe is implicit: two
+    puts of byte-identical bundles land at the same URI, and the store
+    short-circuits the second copy.
+    """
+
+    name: str
+
+    def put(self, bundle_dir: Path) -> str:
+        """Upload ``bundle_dir`` to the store. Return its ``bundle://…`` URI.
+
+        Reads ``bundle_dir/manifest.json`` to derive the digest.
+        Idempotent: a second put of the same digest returns the existing
+        URI without recopying.
+        """
+        ...
+
+    def get(self, uri: str, dest_dir: Path) -> Path:
+        """Materialise the bundle at ``uri`` into ``dest_dir``.
+
+        ``dest_dir`` must be empty (raises :class:`FileExistsError` if
+        anything is present). Raises :class:`BundleNotFoundError` if the
+        URI does not resolve in this store,
+        :class:`InvalidBundleURIError` if the URI is malformed or targets
+        a different store. Returns ``dest_dir``.
+        """
+        ...
+
+    def close(self) -> None:
+        """Release store-held resources. Idempotent."""
+        ...
+
+
+@dataclass
+class LocalDiskBundleStore:
+    """Filesystem-backed bundle store rooted at ``root_dir/grade_bundles/``.
+
+    ``put`` stages into ``root_dir/grade_bundles/.<digest>.<uuid4>.tmp/``
+    (per-worker suffix isolates concurrent puts of the same digest — two
+    workers never share a staging directory), then lands atomically via
+    :func:`os.replace`. If ``root_dir/grade_bundles/<digest>/`` already
+    exists, ``put`` short-circuits and returns the URI without copying.
+    """
+
+    root_dir: Path
+    name: str = "local_disk"
+    _bundles_root: Path = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.root_dir = Path(self.root_dir).expanduser().resolve()
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+        self._bundles_root = self.root_dir / _BUNDLE_SUBDIR
+        self._bundles_root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, bundle_dir: Path) -> str:
+        manifest_path = bundle_dir / _MANIFEST_FILENAME
+        digest = manifest_digest(manifest_path.read_bytes())
+        final_dir = self._bundles_root / digest
+        if final_dir.exists():
+            return build_bundle_uri(self.name, digest)
+        staging_dir = self._bundles_root / f".{digest}.{uuid.uuid4()}.tmp"
+        shutil.copytree(bundle_dir, staging_dir)
+        try:
+            staging_dir.replace(final_dir)
+        except OSError:
+            if final_dir.exists():
+                shutil.rmtree(staging_dir, ignore_errors=True)
+            else:
+                raise
+        return build_bundle_uri(self.name, digest)
+
+    def get(self, uri: str, dest_dir: Path) -> Path:
+        store_name, digest = parse_bundle_uri(uri)
+        if store_name != self.name:
+            raise InvalidBundleURIError(
+                f"URI {uri!r} targets store {store_name!r}; this store is {self.name!r}"
+            )
+        source = self._bundles_root / digest
+        if not source.is_dir() or not (source / _MANIFEST_FILENAME).is_file():
+            raise BundleNotFoundError(f"no bundle at {uri!r} under {self.root_dir}")
+        dest_dir = Path(dest_dir)
+        if dest_dir.exists() and any(dest_dir.iterdir()):
+            raise FileExistsError(f"dest_dir {dest_dir} must be empty; found existing entries")
+        shutil.copytree(source, dest_dir, dirs_exist_ok=True)
+        return dest_dir
+
+    def close(self) -> None:
+        return None

--- a/tolokaforge/core/plugin_registry.py
+++ b/tolokaforge/core/plugin_registry.py
@@ -13,8 +13,8 @@ External code discovers and loads alternative implementations of the
 :class:`~tolokaforge.core.grading.rubric_evaluator.RubricEvaluator`,
 :class:`~tolokaforge.core.grading.transcript_rule_matcher.TranscriptRuleMatcher`,
 :class:`~tolokaforge.core.grading.state_check_backend.StateCheckBackend`,
-and
-:data:`~tolokaforge.core.grading.trace_check_operator.TraceCheckOperator`
+:data:`~tolokaforge.core.grading.trace_check_operator.TraceCheckOperator`,
+and :class:`~tolokaforge.core.grading.bundle_store.BundleStore`
 Protocols through ``importlib.metadata`` entry-point groups — no in-tree
 edit, no monkey-patch. Each holistic seam resolves to a *factory callable*,
 mirroring the existing :data:`~tolokaforge.core.conductor.ConductorFactory`
@@ -30,6 +30,10 @@ so callers instantiate the returned class themselves (see ADR-0040).
 The trace-check-operator loader resolves directly to the operator callable
 — one operator per entry point, no factory wrapper, since the callable
 itself IS the seam contract.
+The bundle-store loader mirrors the grading-substrate shape: resolves to
+the store *class*, and the caller instantiates with topology-specific
+arguments (``root_dir=`` for local disk, ``bucket=``/``endpoint_url=`` for
+S3-compatible endpoints).
 
 The groups:
 
@@ -46,6 +50,7 @@ The groups:
 * ``tolokaforge.transcript_rule_matchers`` → :data:`TranscriptRuleMatcherFactory`
 * ``tolokaforge.state_check_backends`` → :data:`StateCheckBackendFactory`
 * ``tolokaforge.trace_check_operators`` → :data:`TraceCheckOperator`
+* ``tolokaforge.bundle_stores`` → ``type[BundleStore]``
 
 Discovery is lazy and cached per group; it enumerates ``ep.name`` /
 ``ep.dist`` **without** calling ``ep.load()``. This splits the fail-loud
@@ -87,6 +92,7 @@ if TYPE_CHECKING:
     from tolokaforge.core.actors.turn_policy import TurnPolicy
     from tolokaforge.core.compose_materialisation import LogCaptureConfig
     from tolokaforge.core.conductor import Conductor, ConductorContext
+    from tolokaforge.core.grading.bundle_store import BundleStore
     from tolokaforge.core.logging import StructuredLogger
     from tolokaforge.core.models import SeedRef
     from tolokaforge.core.runtime import RuntimeBackend
@@ -121,6 +127,7 @@ __all__ = [
     "TurnPolicyContext",
     "TurnPolicyFactory",
     "UnknownImplementationError",
+    "available_bundle_stores",
     "available_conductors",
     "available_custom_check_executors",
     "available_grading_methods",
@@ -135,6 +142,7 @@ __all__ = [
     "available_trial_graders",
     "available_turn_policies",
     "discover_entry_points",
+    "load_bundle_store",
     "load_conductor",
     "load_custom_check_executor",
     "load_grading_method",
@@ -163,6 +171,7 @@ RUBRIC_EVALUATORS_GROUP = "tolokaforge.rubric_evaluators"
 TRANSCRIPT_RULE_MATCHERS_GROUP = "tolokaforge.transcript_rule_matchers"
 STATE_CHECK_BACKENDS_GROUP = "tolokaforge.state_check_backends"
 TRACE_CHECK_OPERATORS_GROUP = "tolokaforge.trace_check_operators"
+BUNDLE_STORES_GROUP = "tolokaforge.bundle_stores"
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +480,19 @@ def load_grading_method(name: str) -> type[GradingMethod]:
     return cast(type[GradingMethod], _load(GRADING_METHODS_GROUP, name))
 
 
+def load_bundle_store(name: str) -> type[BundleStore]:
+    """Resolve a registered bundle-store name to its implementation class.
+
+    Mirrors :func:`load_grading_substrate` — returns the store *class*, not
+    a factory. Bundle stores are constructed with topology-specific
+    arguments (``root_dir=`` for local, ``bucket=``/``endpoint_url=`` for
+    S3-compatible) that no shared context can generically supply, so the
+    caller instantiates the class it received. Fail-loud on unknown names
+    via :class:`UnknownImplementationError`.
+    """
+    return cast("type[BundleStore]", _load(BUNDLE_STORES_GROUP, name))
+
+
 def load_grading_substrate(name: str) -> type[GradingSubstrate]:
     """Resolve a registered grading-substrate name to its implementation class.
 
@@ -551,3 +573,8 @@ def available_state_check_backends() -> list[str]:
 def available_trace_check_operators() -> list[str]:
     """Sorted names registered in the ``tolokaforge.trace_check_operators`` group."""
     return sorted(discover_entry_points(TRACE_CHECK_OPERATORS_GROUP))
+
+
+def available_bundle_stores() -> list[str]:
+    """Sorted names registered in the ``tolokaforge.bundle_stores`` group."""
+    return sorted(discover_entry_points(BUNDLE_STORES_GROUP))

--- a/uv.lock
+++ b/uv.lock
@@ -443,6 +443,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.86"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a0/b8693637bee21e266a52f3e1b8bb9fe4897934aa62c55cc132f8721c1b8f/boto3-1.43.86.tar.gz", hash = "sha256:aca7b5d7f31a90ad37bec773552ec9bfb57e0029c9aa0f0f4d51d5bf9607b1c4", size = 112685, upload-time = "2026-09-01T19:24:02.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/dd/f4874f7bab882a778178b03965b1474c63f2e8bd2eea5dd714f06b0e8713/boto3-1.43.86-py3-none-any.whl", hash = "sha256:94543a5ce482df8bb6a0bf8a944bf5ccf6625889b1df0d7886dfc3311ebd4169", size = 140026, upload-time = "2026-09-01T19:24:00.638Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.86"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/77/0ed1c398b7d3aa5d02c1b15df32a049e07961339fe41640af1440079c2f7/botocore-1.43.86.tar.gz", hash = "sha256:0e943c77ab6a54aaaf4d57e6026ede5c3dca341af71ce91f71849a6eae9d5dbf", size = 16059433, upload-time = "2026-09-01T19:23:57.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/59/eb95d57ea576feaf1693f5e914f9f27ff9961429cf9ecbc85cef610a6d84/botocore-1.43.86-py3-none-any.whl", hash = "sha256:4efc7fbd6e7616edbd55623bb585a044906149b9a5d3d8558420506526e5a5ac", size = 15751556, upload-time = "2026-09-01T19:23:54.013Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -1977,6 +2005,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -4409,6 +4446,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "83.0.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4727,6 +4776,9 @@ browser = [
     { name = "pillow" },
     { name = "playwright" },
 ]
+bundle-store-s3 = [
+    { name = "boto3" },
+]
 dx = [
     { name = "click-repl" },
     { name = "prompt-toolkit" },
@@ -4762,6 +4814,7 @@ terminal-bench = [
 dev = [
     { name = "automation" },
     { name = "black" },
+    { name = "boto3" },
     { name = "build" },
     { name = "click-repl" },
     { name = "commitizen" },
@@ -4798,6 +4851,7 @@ requires-dist = [
     { name = "addict", specifier = ">=2.4.0" },
     { name = "alembic", marker = "extra == 'runner'", specifier = ">=1.13.0" },
     { name = "asyncpg", marker = "extra == 'runner'", specifier = ">=0.29.0" },
+    { name = "boto3", marker = "extra == 'bundle-store-s3'", specifier = ">=1.34,<2" },
     { name = "click", specifier = ">=8.1.0,<8.2" },
     { name = "click-repl", marker = "extra == 'dx'", specifier = ">=0.3.0" },
     { name = "deepdiff", specifier = ">=6.0.0" },
@@ -4846,12 +4900,13 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'runner'", specifier = ">=0.25.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.25.0" },
 ]
-provides-extras = ["dx", "browser", "server", "runner", "rag", "office", "terminal-bench", "adapters", "all"]
+provides-extras = ["dx", "browser", "server", "runner", "rag", "office", "terminal-bench", "adapters", "all", "bundle-store-s3"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "automation", editable = "tools/automation" },
     { name = "black", specifier = "==26.3.1" },
+    { name = "boto3", specifier = ">=1.34,<2" },
     { name = "build", specifier = ">=1.0.0" },
     { name = "click-repl", specifier = ">=0.3.0" },
     { name = "commitizen", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

Ships `BundleStore` Protocol at `tolokaforge/core/grading/bundle_store.py` with 2 implementations transporting bundles from #1354's format library:

- **`LocalDiskBundleStore`** — writes to `<root_dir>/grade_bundles/<digest>/` (directory-oriented, matches #1354's shipped format). Per-worker `.<digest>.<uuid4>.tmp/` staging + `Path.replace` atomic land + dedupe short-circuit on existing `<digest>/`. Concurrent-put safe by construction.
- **`S3BundleStore`** — S3-compatible. Lazy `import boto3` inside method bodies so the module loads without boto3 installed. `put` uploads parts first, manifest LAST (crashed put leaves no manifest → `get` refuses cleanly via `BundleNotFoundError`). `head_object(manifest_key)` dedupe short-circuit. Streaming file bodies (`Body=open("rb")` + `iter_chunks(1MB)`) — bounded memory per part.

Uniform address as `bundle://<store-name>/<content-hash>` via `urllib.parse.urlparse` + safety-checked helpers. New entry-point group `tolokaforge.bundle_stores` in `pyproject.toml`; loaded via `plugin_registry.load_bundle_store` (mirrors `load_grading_substrate` class shape). New optional dep `[project.optional-dependencies.bundle-store-s3] = ["boto3>=1.34,<2"]`.

## Design choices

| Decision | Rationale |
|---|---|
| LocalDisk stores as **directory** (`<root_dir>/grade_bundles/<digest>/`), not `<digest>.tar` | Umbrella pseudo-code said tar; #1354 shipped directory format. Storing as directory avoids a re-tar step that would need its own determinism proof + risk `sha256(manifest.json)` divergence. |
| `put(bundle_dir: Path) -> str` (URI); `get(uri, dest_dir: Path) -> Path` | Store transports already-serialised bundles; producer's producer. `get` refuses non-empty `dest_dir` with `FileExistsError` (prevents in-store mutation footgun). |
| Per-worker `.<digest>.<uuid4>.tmp/` staging (LocalDisk) | Round-1 critic caught: shared `.<digest>.tmp/` would race on `mkdir(exist_ok=True)` + POSIX `rename` over non-empty dir raises `ENOTEMPTY`. Per-worker uuid staging + `os.replace` → last replace wins with byte-identical content. `test_concurrent_put_same_bundle` (`ThreadPoolExecutor(max_workers=2)`) locks: same URI + exactly one `<digest>/` + no `.tmp` stragglers + manifest bytes match source. |
| S3 upload order: **parts first, manifest LAST**; dedupe via `head_object(manifest_key)` | Crashed put leaves parts but no manifest → next `get` refuses cleanly via `BundleNotFoundError` (no partial-state races). Idempotent PUTs (S3 object semantics); no lock file needed. |
| `boto3` behind optional extra `bundle-store-s3` + lazy `import boto3` inside method bodies | boto3 is a NEW dep to this codebase. Pure module loads without boto3 installed. Missing boto3 raises `RuntimeError` with `uv add tolokaforge[bundle-store-s3]` hint. Verified via `test_lazy_boto3_import` (subprocess-based to avoid `importlib.reload` sys.modules pollution). |
| S3 streams file bodies via `open("rb")` + `iter_chunks(1MB)` | Round-1 correctness reviewer flagged: `read_bytes()` slurps entire part into RAM — `filesystem.tar` can hit hundreds of MB or GB on real workspaces. Streaming keeps peak memory O(1) per part. |
| `manifest["parts"]` (KeyError on corrupted manifest) not `.get("parts", {})` | Round-1 correctness reviewer flagged: `.get(...)` would silently treat a manifest missing `parts` as "nothing to transport" and dedupe to a "successful" no-op. Fail-loud on corruption. |
| URI helpers `build_bundle_uri` / `parse_bundle_uri` refuse: non-`bundle` scheme, missing netloc, non-64-hex digest, query/fragment, non-conforming store name | Round-1 correctness reviewer added parametrised coverage — 6+4 refusal shapes each. Never leak raw `ValueError`/`KeyError`. |
| `BundleNotFoundError` on both LocalDisk + S3 for missing/partial bundles | Symmetric semantics across both impls. LocalDisk raises when `<digest>/` absent OR `<digest>/manifest.json` missing. |
| `plugin_registry.load_bundle_store` — class-shaped (`type[BundleStore]`), TYPE_CHECKING import | Mirrors `load_grading_substrate` shape. TYPE_CHECKING guard on Protocol import avoids dragging subset-excluded `bundle_store.py` into runner boot closure. |
| New `.importlinter` `bundle-store-purity` contract (8th) | Forbids `runner`+`grader`+`substrate_live` from `bundle_store`; `allow_indirect_imports=false`. Mirrors `bundle-library-purity` shape. |
| Shared `tests/canonical/_bundle_fixtures.py` extracted from #1354's test_bundle_round_trip.py | 4 in-tree callers (per critic verification). Prevents fixture divergence on first tweak. |

## What ships

- **Stage 1 (`403a003d`)** — Protocol + LocalDisk + entry-point + `bundle-store-purity` contract + shared fixtures. 13 new tests (5 unit + 4 canonical content-addressability incl. `test_concurrent_put_same_bundle` + `test_atomic_staging_leaves_no_partial_state_on_crash` + 3 plugin-registration extensions).
- **Stage 2 (`26e3b3c3`)** — S3BundleStore + `bundle-store-s3` optional extra + `docs/GRADER_SERVICE.md` § "Bundle store seam". 5 new S3 unit tests via `botocore.stub.Stubber`. Runner-subset partition preserved (TYPE_CHECKING guard on Protocol import; bundle_store excluded).
- **Round-1 hygiene fix (`32329841`)** — §7a rot in shared fixture docstring dropped; `docs/GRADER_SERVICE.md` § Extension points enumeration extended to name `tolokaforge.bundle_stores` as a peer transport seam.
- **Round-1 correctness fix (`09f249f0`)** — S3 streaming (put + get), `manifest["parts"]` fail-loud, `test_lazy_boto3_import` re-shaped as subprocess script (importlib.reload was breaking sibling `pytest.raises` identity checks), parametrised URI helper refusal tests (10 shapes), LocalDisk `BundleNotFoundError` tests.

## Test plan

- [x] `mcp__dev__run_tests marker=canonical keyword="bundle_store or bundle_round_trip or plugin_registrations or parity_reference or runner_subset_partition"` — **71+ passed** (byte-parity 25/25 + all Stage 1/2 tests)
- [x] `mcp__dev__run_tests path=tests/unit/grading marker=unit` — bundle_store unit tests green (post-streaming fix; `_StreamStub.iter_chunks` added)
- [x] `uv run lint-imports` → **8 contracts kept, 0 broken** (adds `bundle-store-purity`)
- [x] Concurrent-put invariant locked by `test_concurrent_put_same_bundle` (ThreadPoolExecutor)
- [x] Atomic-staging crash safety locked by `test_atomic_staging_leaves_no_partial_state_on_crash`
- [x] Lazy-boto3 import safety locked via subprocess (no sys.modules pollution into sibling tests)
- [x] `test_lazy_boto3_import`: `sys.modules["boto3"] = None` in subprocess → module imports; `S3BundleStore(bucket="x").put(...)` raises `RuntimeError` matching `bundle-store-s3`
- [x] Sharded reviewer trio — all APPROVE. Correctness had 3 🟡 nits + 1 🔵 (streaming, URI parametrise, LocalDisk NotFound, fail-loud) all inline-fixed in `09f249f0`. Hygiene had 1 🟡 + 1 nit (fixture docstring §7a + extension-points enumeration) inline-fixed in `32329841`. Type-fit APPROVE with 1 non-blocking nit (`client: Any → BaseClient` via TYPE_CHECKING) deferred.

## Follow-ups (already filed)

- **#1432** — MinIO live-integration lane (P3 test-infra)
- **#1433** — `RunConfig.grader.bundle_store` field + factory (P2 — likely folded into #1356)
- **#1434** — `S3StorageConfig` no-runtime-consumer decision (P3 cleanup)
- **#1435** — cross-store copy CLI helper (P3 dx)
- **#1436** — `moto[s3]` as optional dev dep for hermetic S3 lane (P3 test-infra)

Closes #1355.