### PR TITLE
integrate: anthropic/claude-fable-5.1

### DIFF
--- a/tolokaforge_models/src/tolokaforge_models/certificates/registry.py
+++ b/tolokaforge_models/src/tolokaforge_models/certificates/registry.py
@@ -520,6 +520,63 @@ _ALL: list[MC] = [
             }
         ),
     ),
+    # Claude Fable 5.1 — Anthropic adaptive thinker, landed via auto-resolve
+    # (Slack-requested integration, PR #1449). Routes through the
+    # model-specific ``anthropic_claude_fable_5_1`` preset (see
+    # model_presets.yaml): the generic ``anthropic`` axes (content/reasoning/
+    # cache = anthropic, supports_seed false) PLUS
+    # ``param_value_rules.reasoning_effort.medium -> override with high``.
+    #
+    # The observe (default) baseline surfaced ONE preset-fixable failure —
+    # ``thinking_emits_blocks`` 5/15, every failure the same assertion
+    # ("StructuredReasoning should be surfaced"). That probe is the only one
+    # sending effort_hint="medium"; the two siblings on the SAME anthropic
+    # reasoning codec and OpenRouter transport passed 15/15 — unsigned replay at
+    # effort="high" and signed replay at budget_tokens=4000 — so the model does
+    # emit structured signed thinking and "medium" merely under-allocates the
+    # adaptive budget. Overriding medium -> high took the reprobe to 5/5 on the
+    # fix-target, so THINKING_EMITS_BLOCKS is ``required`` here.
+    #
+    # Every other capability passed the observe baseline 15/15 under the
+    # anthropic axes and none went known_unsupported (decision.json ceilings
+    # were empty) — so, like the opus-5 sibling and UNLIKE
+    # opus-4.6/4.7/4.8/fable-5, UNSIGNED_THINKING_REPLAY,
+    # IMPLICIT_PROMPT_CACHING and DISCRIMINATED_UNION_TOOL_CALL are all
+    # required: this route recorded no such ceiling.
+    MC(
+        model_id="openrouter__anthropic_claude-fable-5.1",
+        provider="openrouter",
+        name="anthropic/claude-fable-5.1",
+        env_key="OPENROUTER_API_KEY",
+        required=frozenset(
+            {
+                C.ALLOF_MERGE_TOOL_CALL,
+                C.BASIC_COMPLETION,
+                C.COST_USD_POPULATED,
+                C.DECIMAL_FIELD_TOOL_CALL,
+                C.DICT_MAP_TOOL_CALL,
+                C.DISCRIMINATED_UNION_TOOL_CALL,
+                C.ENUM_SLASH_TOLERANCE,
+                C.HETEROGENEOUS_ARRAY_TOOL_CALL,
+                C.IMPLICIT_PROMPT_CACHING,
+                C.LEXICAL_TOOL_INVENTION,
+                C.MULTI_TURN_ERROR_RECOVERY,
+                C.MULTI_TURN_TOOL_USE,
+                C.PROGRESS_AFTER_SUCCESS,
+                C.PROMPT_CACHING,
+                C.RE2_PATTERN_TOLERANCE,
+                C.RECURSIVE_REF_TOOL_CALL,
+                C.REQUIRED_FIELDS_COMPLETE,
+                C.SIMPLE_TOOL_CALL,
+                C.THINKING_EMITS_BLOCKS,
+                C.THINKING_REPLAY_ROUNDTRIP,
+                C.TOOL_NAME_DISCIPLINE,
+                C.UNSIGNED_THINKING_REPLAY,
+                C.USAGE_METRICS_POPULATED,
+            }
+        ),
+        known_unsupported=frozenset(),
+    ),
     # Claude Opus 5 — Anthropic adaptive thinker, landed via auto-resolve
     # (Slack-requested integration, PR #614). Routes through the model-specific
     # ``anthropic_claude_opus_5`` preset (see model_presets.yaml): the generic

--- a/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
+++ b/tolokaforge_models/src/tolokaforge_models/data/model_presets.yaml
@@ -115,6 +115,69 @@ presets:
     params:
       supports_seed: false
 
+  # Claude Fable 5.1 — landed via auto-resolve (Slack-requested integration,
+  # PR #1449). Declared BEFORE the generic ``anthropic`` preset so
+  # first-match-wins routing picks it up. It is the generic ``anthropic`` preset
+  # this model already resolved to during observe (content/reasoning/cache =
+  # anthropic, supports_seed: false — restated verbatim so the superset rule
+  # holds) PLUS one fable-5.1-observed fix, scoped to THIS model's match globs
+  # so no sibling Anthropic route is affected:
+  #
+  #   * ``param_value_rules.reasoning_effort.medium -> override with high``. The
+  #     observe (default) baseline surfaced exactly ONE failure:
+  #     ``thinking_emits_blocks`` 5/15, all 10 failures the same assertion
+  #     ("StructuredReasoning should be surfaced", i.e. ``reasoning is None``).
+  #     The two sibling probes on the SAME anthropic reasoning codec and the
+  #     SAME OpenRouter transport passed 15/15 — ``unsigned_thinking_replay``
+  #     (adaptive, effort_hint="high") and ``thinking_replay_roundtrip``
+  #     (budget_tokens=4000), and the latter asserts *signed* turn-1 blocks — so
+  #     the model demonstrably emits structured signed thinking and the codec
+  #     demonstrably decodes it. The sole discriminator is the effort LEVEL:
+  #     only the failing probe sends effort_hint="medium". At
+  #     ``extra_body.reasoning={"effort":"medium","enabled":true}`` OpenRouter
+  #     allocates a small budget and this adaptive thinker frequently declines
+  #     to think at all; at "high" it always does. Effort-routing
+  #     under-allocation, not a capability gap — hence a params fix rather than
+  #     a ceiling. ``override`` (not ``reject``, which raises; not ``drop``,
+  #     which yields the provider default budget — the very under-allocation
+  #     that causes the miss) is the sanctioned action for this shape, and the
+  #     engine logs a WARNING naming both values on every substituted call.
+  #     "high" is untouched, so ``unsigned_thinking_replay``'s strict
+  #     ``extra_body.reasoning == {"effort":"high","enabled":true}`` assertion
+  #     still holds. Reprobe went 5/5 on the fix-target.
+  #
+  # ``reasoning_via_extra_body`` is deliberately NOT pinned here: it belongs to
+  # the ``providers.openrouter`` overlay, which merges AFTER the preset match
+  # and so survives untouched. Pinning it would wrongly force OpenRouter
+  # routing onto a direct-Anthropic route for the same model.
+  anthropic_claude_fable_5_1:
+    match:
+      - "anthropic/claude-fable-5.1*"
+      - "*claude-fable-5.1*"
+    content_policy: anthropic
+    reasoning_codec: anthropic
+    cache_policy: anthropic_ephemeral
+    params:
+      supports_seed: false
+      param_value_rules:
+        reasoning_effort:
+          medium:
+            action: override
+            with: high
+            evidence: >-
+              2026-09-02, openrouter/anthropic/claude-fable-5.1, engine
+              51a092e, observe 15 reps/probe:
+              extra_body.reasoning={"effort":"medium","enabled":true} surfaced
+              no StructuredReasoning on 10/15 runs
+              (test_thinking_emits_blocks 5/15), while the same anthropic
+              reasoning codec on the same OpenRouter transport passed 15/15 at
+              effort="high" (test_unsigned_thinking_replay) and 15/15 at
+              budget_tokens=4000 with SIGNED turn-1 blocks
+              (test_thinking_replay_roundtrip). The model emits structured
+              signed blocks; "medium" under-allocates the adaptive thinking
+              budget so it often declines to think at all. "high" is the
+              nearest level that reliably engages it.
+
   anthropic:
     match:
       - "anthropic/*"

--- a/tolokaforge_models/src/tolokaforge_models/data/pricing.json
+++ b/tolokaforge_models/src/tolokaforge_models/data/pricing.json
@@ -2,7 +2,7 @@
   "_meta": {
     "description": "Model pricing in USD per 1M tokens. Source: OpenRouter API.",
     "source_url": "https://openrouter.ai/api/v1/models",
-    "updated_at": "2026-08-14T10:17:21.788923+00:00",
+    "updated_at": "2026-09-02T09:51:31.333093+00:00",
     "notes": "Run `uv run pricing-updater update` to refresh from OpenRouter API."
   },
   "models": {
@@ -143,6 +143,12 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "anthropic/claude-fable-5.1": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "anthropic/claude-haiku-4.5": {


### PR DESCRIPTION
# integrate: anthropic/claude-fable-5.1

Adds `openrouter` / `anthropic/claude-fable-5.1` (`openrouter__anthropic_claude-fable-5.1`) as a
certified model. Integrated via **auto-resolve** — the observe → fix → reprobe loop converged on
iteration 1, and this branch is the mechanically-landed result of the proven overlay.

**Engine ref:** `51a092e`.

## Policy

One model-scoped preset, `anthropic_claude_fable_5_1`, declared before the generic `anthropic`
preset so first-match-wins routing picks it up for `anthropic/claude-fable-5.1*` /
`*claude-fable-5.1*` only. No shared glob was broadened; no new adapter class and no engine-side
change (data-only).

It restates the generic `anthropic` axes verbatim (content / reasoning / cache = anthropic,
`supports_seed: false`) plus one fix: `param_value_rules.reasoning_effort.medium → override with
high`. The observe baseline's only failure was `thinking_emits_blocks` 5/15 (all 10 failures
`reasoning is None`), and it is the only probe sending `effort_hint="medium"` — the same codec and
transport passed 15/15 at `"high"` and 15/15 with signed blocks in budget mode. "medium"
under-allocates the adaptive thinking budget, so the model often declines to think at all; that is
effort-routing under-allocation, not a capability ceiling. Reprobe: **5/5** on the fix-target.

## Ceilings

None. `known_unsupported` is empty and all 23 probed capabilities are `required`, including
`THINKING_EMITS_BLOCKS`, `UNSIGNED_THINKING_REPLAY`, `IMPLICIT_PROMPT_CACHING` and
`DISCRIMINATED_UNION_TOOL_CALL`.

## Changes

- `model_presets.yaml` — new `anthropic_claude_fable_5_1` preset entry.
- `certificates/registry.py` — new `MC(...)` cert (23 required, 0 known_unsupported).
- `data/pricing.json` — `anthropic/claude-fable-5.1` pricing (10.0 / 50.0 / 0.25 USD per 1M in / out / cache_read).
- `tests/canonical/snapshots/certify_suite_collection/collection.json` — regenerated for the new cert's probe nodeids.

> ⚠️ **Disposable test branch — do not merge.** This branch exists to exercise the auto-resolve
> integration path; it must not land on `main`.
