### PR TITLE
fix(orchestrator): user-simulator config fails loud instead of silent Anthropic fallback

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,6 +23,11 @@ models:
     # Optional: override auto-detected model capabilities
     capabilities:
       dict_map_prompt_hints: true
+  # Required when the run dispatches a user simulator. The orchestrator
+  # fails loud if `models.user` is absent — there is no hardcoded provider
+  # default, so a run always names the provider it ships user turns to.
+  # Project-wide fallbacks live under `project.run_defaults.models.user`
+  # (see docs/PROJECTS.md); the loader merges them into each run config.
   user:
     provider: "openai"
     name: "gpt-4o-mini"
@@ -36,17 +41,6 @@ models:
     provider: "openrouter"
     name: "anthropic/claude-sonnet-4.6"
     temperature: 0.0
-
-# Optional: fallback ModelConfigs for roles a run leaves unset in `models:`.
-# Only `user_simulator` is wired today. When `models.user` is absent the
-# orchestrator uses `defaults.user_simulator` if set, otherwise fails loud —
-# there is no hardcoded provider default, so a run always names the provider
-# it ships user turns to.
-defaults:
-  user_simulator:
-    provider: "openrouter"
-    name: "openai/gpt-5-mini"
-    temperature: 0.2
 
 orchestrator:
   workers: 4

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,6 +37,17 @@ models:
     name: "anthropic/claude-sonnet-4.6"
     temperature: 0.0
 
+# Optional: fallback ModelConfigs for roles a run leaves unset in `models:`.
+# Only `user_simulator` is wired today. When `models.user` is absent the
+# orchestrator uses `defaults.user_simulator` if set, otherwise fails loud —
+# there is no hardcoded provider default, so a run always names the provider
+# it ships user turns to.
+defaults:
+  user_simulator:
+    provider: "openrouter"
+    name: "openai/gpt-5-mini"
+    temperature: 0.2
+
 orchestrator:
   workers: 4
   repeats: 5

--- a/tests/canonical/test_engine_run_state_fingerprint.py
+++ b/tests/canonical/test_engine_run_state_fingerprint.py
@@ -185,7 +185,10 @@ def test_orchestrator_persists_fingerprint_matching_seam(flat_pack: Path, tmp_pa
     run_id = "fingerprint-orchestrator-lock"
     output_dir = tmp_path / run_id
     config = RunConfig(
-        models={"agent": ModelConfig(**_AGENT)},
+        models={
+            "agent": ModelConfig(**_AGENT),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(
             output_dir=str(output_dir),
@@ -231,7 +234,10 @@ def test_prepare_run_records_an_empty_adapter_fingerprint_map(
     run_id = "fingerprint-prepare-lock"
     output_dir = tmp_path / run_id
     config = RunConfig(
-        models={"agent": ModelConfig(**_AGENT)},
+        models={
+            "agent": ModelConfig(**_AGENT),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(
             output_dir=str(output_dir),

--- a/tests/canonical/test_orchestrator_grader_name_e2e.py
+++ b/tests/canonical/test_orchestrator_grader_name_e2e.py
@@ -141,7 +141,10 @@ def test_adapter_declared_grader_name_reaches_grade(
     task = adapter.get_task(_TASK_ID)
 
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir=str(tmp_path / "results")),
     )

--- a/tests/canonical/test_run_trial_composition.py
+++ b/tests/canonical/test_run_trial_composition.py
@@ -85,7 +85,10 @@ def _orchestrator_trajectory(base_dir: Path, task, output_dir: Path) -> Trajecto
     task_desc = adapter.to_task_description(task.task_id)
 
     config = RunConfig(
-        models={"agent": ModelConfig(**_AGENT)},
+        models={
+            "agent": ModelConfig(**_AGENT),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir=str(output_dir)),
     )
@@ -120,7 +123,10 @@ def test_run_trial_matches_orchestrator_composition(flat_pack: Path, tmp_path: P
 
     result = run_trial(
         task=task,
-        models={"agent": _AGENT},
+        models={
+            "agent": _AGENT,
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         runtime="in_memory",
         conductor="in_memory",
         output_dir=None,

--- a/tests/unit/test_orchestrator_budget_shutdown.py
+++ b/tests/unit/test_orchestrator_budget_shutdown.py
@@ -131,21 +131,20 @@ def _task_description(task_id: str) -> TaskDescription:
 
 
 def _make_run_config(*, tmp_path: Path, workers: int = 1) -> RunConfig:
-    from tolokaforge.core.models.run_config import RunDefaultsConfig
-
+    # models.user is required — the orchestrator fails loud without it (see
+    # require_user_simulator_config); pick a non-Anthropic placeholder so
+    # the fixture matches the docs example.
     return RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(
             repeats=1,
             auto_start_services=False,
         ),
         compute=ComputeConfig(workers=workers),
         evaluation=EvaluationConfig(output_dir=str(tmp_path / "results" / "run")),
-        # Fail-loud user-simulator gate on the orchestrator side; give a
-        # non-Anthropic default so budget tests don't need per-test config.
-        defaults=RunDefaultsConfig(
-            user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
-        ),
     )
 
 

--- a/tests/unit/test_orchestrator_budget_shutdown.py
+++ b/tests/unit/test_orchestrator_budget_shutdown.py
@@ -131,6 +131,8 @@ def _task_description(task_id: str) -> TaskDescription:
 
 
 def _make_run_config(*, tmp_path: Path, workers: int = 1) -> RunConfig:
+    from tolokaforge.core.models.run_config import RunDefaultsConfig
+
     return RunConfig(
         models={"agent": ModelConfig(provider="openai", name="gpt-4")},
         orchestrator=OrchestratorConfig(
@@ -139,6 +141,11 @@ def _make_run_config(*, tmp_path: Path, workers: int = 1) -> RunConfig:
         ),
         compute=ComputeConfig(workers=workers),
         evaluation=EvaluationConfig(output_dir=str(tmp_path / "results" / "run")),
+        # Fail-loud user-simulator gate on the orchestrator side; give a
+        # non-Anthropic default so budget tests don't need per-test config.
+        defaults=RunDefaultsConfig(
+            user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
+        ),
     )
 
 

--- a/tests/unit/test_orchestrator_grading_preflight.py
+++ b/tests/unit/test_orchestrator_grading_preflight.py
@@ -304,6 +304,8 @@ def _orchestrator(
     every task off-cache when it has to answer, and that walk would otherwise be
     counted against the pre-flight it runs beside.
     """
+    from tolokaforge.core.models.run_config import RunDefaultsConfig
+
     evaluation: dict[str, Any] = {"output_dir": str(output_dir), "projects": [str(root)]}
     if fail_on is not None:
         evaluation["grading_validation"] = {"fail_on": fail_on.value}
@@ -318,6 +320,9 @@ def _orchestrator(
                 workers=1, repeats=repeats, auto_start_services=False, shuffle_trials=False
             ),
             evaluation=EvaluationConfig(**evaluation),
+            defaults=RunDefaultsConfig(
+                user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
+            ),
         ),
         deps=OrchestratorDeps(
             runtime_backend=InMemoryRuntimeBackend(),

--- a/tests/unit/test_orchestrator_grading_preflight.py
+++ b/tests/unit/test_orchestrator_grading_preflight.py
@@ -304,25 +304,23 @@ def _orchestrator(
     every task off-cache when it has to answer, and that walk would otherwise be
     counted against the pre-flight it runs beside.
     """
-    from tolokaforge.core.models.run_config import RunDefaultsConfig
-
     evaluation: dict[str, Any] = {"output_dir": str(output_dir), "projects": [str(root)]}
     if fail_on is not None:
         evaluation["grading_validation"] = {"fail_on": fail_on.value}
     conductor = InMemoryConductor()
     orchestrator = Orchestrator(
         RunConfig(
+            # models.user is required — the orchestrator fails loud otherwise
+            # (see require_user_simulator_config).
             models={
                 "agent": ModelConfig(provider="openai", name="gpt-4"),
+                "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
                 "judge": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
             },
             orchestrator=OrchestratorConfig(
                 workers=1, repeats=repeats, auto_start_services=False, shuffle_trials=False
             ),
             evaluation=EvaluationConfig(**evaluation),
-            defaults=RunDefaultsConfig(
-                user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
-            ),
         ),
         deps=OrchestratorDeps(
             runtime_backend=InMemoryRuntimeBackend(),

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -36,7 +36,16 @@ pytestmark = pytest.mark.unit
 
 
 def _make_run_config(**overrides: Any) -> RunConfig:
-    """Build a minimal RunConfig for testing."""
+    """Build a minimal RunConfig for testing.
+
+    Sets ``defaults.user_simulator`` so tests that don't exercise a
+    specific user model still resolve one — the orchestrator fails
+    loud when neither ``models.user`` nor ``defaults.user_simulator``
+    is present (see
+    :meth:`Orchestrator._resolve_user_simulator_config`).
+    """
+    from tolokaforge.core.models.run_config import RunDefaultsConfig
+
     defaults: dict[str, Any] = {
         "models": {
             "agent": ModelConfig(provider="openai", name="gpt-4"),
@@ -47,6 +56,9 @@ def _make_run_config(**overrides: Any) -> RunConfig:
             auto_start_services=False,
         ),
         "evaluation": EvaluationConfig(output_dir="/tmp/test_output"),
+        "defaults": RunDefaultsConfig(
+            user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
+        ),
     }
     defaults.update(overrides)
     return RunConfig(**defaults)

--- a/tests/unit/test_orchestrator_logic.py
+++ b/tests/unit/test_orchestrator_logic.py
@@ -38,17 +38,14 @@ pytestmark = pytest.mark.unit
 def _make_run_config(**overrides: Any) -> RunConfig:
     """Build a minimal RunConfig for testing.
 
-    Sets ``defaults.user_simulator`` so tests that don't exercise a
-    specific user model still resolve one — the orchestrator fails
-    loud when neither ``models.user`` nor ``defaults.user_simulator``
-    is present (see
-    :meth:`Orchestrator._resolve_user_simulator_config`).
+    Populates both ``models.agent`` and ``models.user`` — the orchestrator
+    fails loud on any run that leaves ``models.user`` unset (see
+    :func:`~tolokaforge.core.models.run_config.require_user_simulator_config`).
     """
-    from tolokaforge.core.models.run_config import RunDefaultsConfig
-
     defaults: dict[str, Any] = {
         "models": {
             "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
         },
         "orchestrator": OrchestratorConfig(
             workers=1,
@@ -56,9 +53,6 @@ def _make_run_config(**overrides: Any) -> RunConfig:
             auto_start_services=False,
         ),
         "evaluation": EvaluationConfig(output_dir="/tmp/test_output"),
-        "defaults": RunDefaultsConfig(
-            user_simulator=ModelConfig(provider="openai", name="gpt-4-user-sim"),
-        ),
     }
     defaults.update(overrides)
     return RunConfig(**defaults)

--- a/tests/unit/test_orchestrator_user_simulator_config.py
+++ b/tests/unit/test_orchestrator_user_simulator_config.py
@@ -1,88 +1,33 @@
-"""Unit tests for ``Orchestrator._resolve_user_simulator_config``.
+"""Unit tests for ``require_user_simulator_config``.
 
-Locks the fallback order — ``models.user`` → ``defaults.user_simulator`` →
-hard error — so a run never silently ships user turns to a hardcoded
-provider.
+Locks the fail-loud gate: a run that ships user turns must name the
+provider explicitly via ``RunConfig.models["user"]``. There is no
+hardcoded default, and the error message names the config site an
+operator can fix.
 """
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import MagicMock
-
 import pytest
 
-from tolokaforge.core.models import (
-    EvaluationConfig,
-    ModelConfig,
-    OrchestratorConfig,
-    RunConfig,
-)
-from tolokaforge.core.models.run_config import RunDefaultsConfig
-from tolokaforge.core.orchestrator import Orchestrator
+from tolokaforge.core.models import ModelConfig, require_user_simulator_config
 
 pytestmark = pytest.mark.unit
 
 
-def _make_run_config(**overrides: Any) -> RunConfig:
-    defaults: dict[str, Any] = {
-        "models": {
-            "agent": ModelConfig(provider="openai", name="gpt-5"),
-        },
-        "orchestrator": OrchestratorConfig(
-            workers=1,
-            repeats=1,
-            auto_start_services=False,
-        ),
-        "evaluation": EvaluationConfig(output_dir="/tmp/test_output"),
-    }
-    defaults.update(overrides)
-    return RunConfig(**defaults)
+def test_returns_the_configured_model_when_present() -> None:
+    user = ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6", temperature=0.9)
+    assert require_user_simulator_config(user) is user
 
 
-def _orchestrator_for(config: RunConfig) -> Orchestrator:
-    orchestrator = Orchestrator.__new__(Orchestrator)
-    orchestrator.config = config
-    orchestrator.logger = MagicMock()
-    return orchestrator
-
-
-def test_returns_models_user_when_set() -> None:
-    user = ModelConfig(provider="openrouter", name="openai/gpt-5-mini", temperature=0.9)
-    orchestrator = _orchestrator_for(_make_run_config(models={"agent": user, "user": user}))
-
-    assert orchestrator._resolve_user_simulator_config(user) is user
-
-
-def test_falls_back_to_defaults_user_simulator_when_models_user_missing() -> None:
-    fallback = ModelConfig(provider="openrouter", name="moonshotai/kimi-k2.6", temperature=0.7)
-    orchestrator = _orchestrator_for(
-        _make_run_config(defaults=RunDefaultsConfig(user_simulator=fallback))
-    )
-
-    assert orchestrator._resolve_user_simulator_config(None) is fallback
-
-
-def test_raises_when_both_slots_are_missing() -> None:
-    """Absent user model + absent defaults.user_simulator → hard error, not
-    a silent provider default. The error message names the two config sites
-    an operator can fix."""
-    orchestrator = _orchestrator_for(_make_run_config())
-
+def test_raises_with_actionable_message_when_absent() -> None:
+    """Absent user model → hard error, not a silent provider default. The
+    error message names the config site (models.user) an operator can
+    fix and points at project-wide fallbacks via
+    project.run_defaults.models.user."""
     with pytest.raises(ValueError) as exc:
-        orchestrator._resolve_user_simulator_config(None)
+        require_user_simulator_config(None)
 
     message = str(exc.value)
     assert "models.user" in message
-    assert "defaults.user_simulator" in message
-
-
-def test_raises_when_defaults_block_present_but_user_simulator_none() -> None:
-    """An empty ``RunDefaultsConfig`` is not a valid fallback source — the
-    caller has to name a model, not just declare the block."""
-    orchestrator = _orchestrator_for(
-        _make_run_config(defaults=RunDefaultsConfig(user_simulator=None))
-    )
-
-    with pytest.raises(ValueError):
-        orchestrator._resolve_user_simulator_config(None)
+    assert "project.run_defaults.models.user" in message

--- a/tests/unit/test_orchestrator_user_simulator_config.py
+++ b/tests/unit/test_orchestrator_user_simulator_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for ``Orchestrator._resolve_user_simulator_config``.
+
+Locks the fallback order — ``models.user`` → ``defaults.user_simulator`` →
+hard error — so a run never silently ships user turns to a hardcoded
+provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tolokaforge.core.models import (
+    EvaluationConfig,
+    ModelConfig,
+    OrchestratorConfig,
+    RunConfig,
+)
+from tolokaforge.core.models.run_config import RunDefaultsConfig
+from tolokaforge.core.orchestrator import Orchestrator
+
+pytestmark = pytest.mark.unit
+
+
+def _make_run_config(**overrides: Any) -> RunConfig:
+    defaults: dict[str, Any] = {
+        "models": {
+            "agent": ModelConfig(provider="openai", name="gpt-5"),
+        },
+        "orchestrator": OrchestratorConfig(
+            workers=1,
+            repeats=1,
+            auto_start_services=False,
+        ),
+        "evaluation": EvaluationConfig(output_dir="/tmp/test_output"),
+    }
+    defaults.update(overrides)
+    return RunConfig(**defaults)
+
+
+def _orchestrator_for(config: RunConfig) -> Orchestrator:
+    orchestrator = Orchestrator.__new__(Orchestrator)
+    orchestrator.config = config
+    orchestrator.logger = MagicMock()
+    return orchestrator
+
+
+def test_returns_models_user_when_set() -> None:
+    user = ModelConfig(provider="openrouter", name="openai/gpt-5-mini", temperature=0.9)
+    orchestrator = _orchestrator_for(_make_run_config(models={"agent": user, "user": user}))
+
+    assert orchestrator._resolve_user_simulator_config(user) is user
+
+
+def test_falls_back_to_defaults_user_simulator_when_models_user_missing() -> None:
+    fallback = ModelConfig(provider="openrouter", name="moonshotai/kimi-k2.6", temperature=0.7)
+    orchestrator = _orchestrator_for(
+        _make_run_config(defaults=RunDefaultsConfig(user_simulator=fallback))
+    )
+
+    assert orchestrator._resolve_user_simulator_config(None) is fallback
+
+
+def test_raises_when_both_slots_are_missing() -> None:
+    """Absent user model + absent defaults.user_simulator → hard error, not
+    a silent provider default. The error message names the two config sites
+    an operator can fix."""
+    orchestrator = _orchestrator_for(_make_run_config())
+
+    with pytest.raises(ValueError) as exc:
+        orchestrator._resolve_user_simulator_config(None)
+
+    message = str(exc.value)
+    assert "models.user" in message
+    assert "defaults.user_simulator" in message
+
+
+def test_raises_when_defaults_block_present_but_user_simulator_none() -> None:
+    """An empty ``RunDefaultsConfig`` is not a valid fallback source — the
+    caller has to name a model, not just declare the block."""
+    orchestrator = _orchestrator_for(
+        _make_run_config(defaults=RunDefaultsConfig(user_simulator=None))
+    )
+
+    with pytest.raises(ValueError):
+        orchestrator._resolve_user_simulator_config(None)

--- a/tests/unit/test_run_display_wiring.py
+++ b/tests/unit/test_run_display_wiring.py
@@ -240,7 +240,10 @@ def test_in_process_conductor_grade_fires_judgment_scored(tmp_path: Path) -> Non
         adapter=MagicMock(),
         artifact_writer=MagicMock(),
         config=RunConfig(
-            models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+            models={
+                "agent": ModelConfig(provider="openai", name="gpt-4"),
+                "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+            },
             orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
             evaluation=EvaluationConfig(output_dir=str(tmp_path / "results" / "run")),
         ),
@@ -302,7 +305,10 @@ def test_in_process_conductor_default_events_is_null_sink(tmp_path: Path) -> Non
         adapter=MagicMock(),
         artifact_writer=MagicMock(),
         config=RunConfig(
-            models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+            models={
+                "agent": ModelConfig(provider="openai", name="gpt-4"),
+                "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+            },
             orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
             evaluation=EvaluationConfig(output_dir=str(tmp_path / "results" / "run")),
         ),
@@ -470,7 +476,10 @@ def test_orchestrator_stores_events_from_deps() -> None:
 
     events = _RecordingEvents()
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir="/tmp/test-events-wiring"),
     )
@@ -504,7 +513,10 @@ def _make_orchestrator_with_tasks(task_ids: list[str], repeats: int, shuffle: bo
     from tolokaforge.core.orchestrator import Orchestrator
 
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(
             workers=1,
             repeats=repeats,
@@ -655,7 +667,10 @@ def _build_orch_for_seam_threading(events: Any) -> Any:
     from tolokaforge.core.orchestrator import Orchestrator, OrchestratorDeps
 
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir="/tmp/seam-thread-test"),
     )
@@ -815,7 +830,10 @@ def test_run_emits_lifecycle_with_distinct_trial_started_total_indices(tmp_path:
     run_root = tmp_path / "results" / "run_base"
     run_root.parent.mkdir(parents=True, exist_ok=True)
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(
             workers=1,
             repeats=1,
@@ -886,7 +904,10 @@ def test_run_with_default_null_events_completes_without_raising(tmp_path: Path) 
     run_root = tmp_path / "results" / "null_base"
     run_root.parent.mkdir(parents=True, exist_ok=True)
     config = RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(workers=1, repeats=1, auto_start_services=False),
         evaluation=EvaluationConfig(output_dir=str(run_root)),
     )

--- a/tests/unit/test_run_trial.py
+++ b/tests/unit/test_run_trial.py
@@ -26,6 +26,7 @@ from tolokaforge.core.runtime import InMemoryRuntimeBackend
 pytestmark = pytest.mark.unit
 
 _AGENT = {"provider": "openai", "name": "gpt-4"}
+_USER = {"provider": "openrouter", "name": "anthropic/claude-sonnet-4.6"}
 
 
 class _FakeAdapter:
@@ -163,7 +164,7 @@ class TestOutputDirSeam:
         monkeypatch.setattr(run_trial_mod, "load_conductor", capture_conductor)
         result = run_trial(
             task=make_task_config(task_id="task-1"),
-            models={"agent": _AGENT},
+            models={"agent": _AGENT, "user": _USER},
             runtime="in_memory",
             output_dir=output_dir,
         )
@@ -235,7 +236,7 @@ class TestBackendLifecycle:
 
         run_trial(
             task=make_task_config(task_id="task-1"),
-            models={"agent": _AGENT},
+            models={"agent": _AGENT, "user": _USER},
             runtime="in_memory",
         )
 
@@ -250,7 +251,7 @@ class TestBackendLifecycle:
         with pytest.raises(RuntimeError, match="conductor blew up"):
             run_trial(
                 task=make_task_config(task_id="task-1"),
-                models={"agent": _AGENT},
+                models={"agent": _AGENT, "user": _USER},
                 runtime="in_memory",
             )
 

--- a/tests/utils/conductor_phases.py
+++ b/tests/utils/conductor_phases.py
@@ -36,8 +36,13 @@ class RunnerStub:
 
 
 def make_run_config(output_dir: Path, *, repeats: int = 1) -> RunConfig:
+    # models.user is required — the orchestrator fails loud otherwise (see
+    # require_user_simulator_config).
     return RunConfig(
-        models={"agent": ModelConfig(provider="openai", name="gpt-4")},
+        models={
+            "agent": ModelConfig(provider="openai", name="gpt-4"),
+            "user": ModelConfig(provider="openrouter", name="anthropic/claude-sonnet-4.6"),
+        },
         orchestrator=OrchestratorConfig(
             workers=1,
             repeats=repeats,

--- a/tolokaforge/core/models/__init__.py
+++ b/tolokaforge/core/models/__init__.py
@@ -73,6 +73,7 @@ from tolokaforge.core.models.run_config import (
     TimeoutConfig,
     TracingConfig,
     TypeSenseConfig,
+    require_user_simulator_config,
     validate_rate_limit_probe_budget,
 )
 from tolokaforge.core.models.task_config import (
@@ -231,6 +232,7 @@ __all__ = [
     "RateLimitProbeConfig",
     "RunConfig",
     "RunDefaults",
+    "require_user_simulator_config",
     "S3StorageConfig",
     "StorageBackend",
     "StorageConfig",

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -1055,19 +1055,27 @@ params bag; the lift makes coding-harness selection a first-class
 run-config concept that any adapter can accept."""
 
 
-class RunDefaultsConfig(BaseModel):
-    """Fallback ``ModelConfig``\\s for roles a run leaves unset in ``models``.
+def require_user_simulator_config(user_config: ModelConfig | None) -> ModelConfig:
+    """Return ``user_config`` or raise if it is missing.
 
-    Only the user-simulator fallback is wired today. Set
-    ``defaults.user_simulator`` to name the model the orchestrator should
-    use when ``RunConfig.models["user"]`` is missing; leaving both unset
-    fails the run loud rather than silently routing user turns through
-    any hardcoded provider.
+    Callers that dispatch a user simulator (``Orchestrator.run``,
+    ``Orchestrator.run_worker``, the library entry ``core.run_trial``)
+    fail loud here when ``RunConfig.models["user"]`` is unset, so a run
+    always names the provider it ships user turns to. There is
+    deliberately no hardcoded default: a project that wants a shared
+    fallback declares it under ``project.run_defaults.models.user`` and
+    lets the project loader merge it into every run config.
     """
-
-    model_config = {"extra": "forbid"}
-
-    user_simulator: ModelConfig | None = None
+    if user_config is not None:
+        return user_config
+    raise ValueError(
+        "No user-simulator model configured. Set `models.user` on the run "
+        "config to the provider/name the user turns should run against. "
+        "Projects can declare a project-wide fallback under "
+        "`project.run_defaults.models.user` and the loader will merge it "
+        "in. Example: `models: {user: {provider: openrouter, "
+        "name: openai/gpt-5}}`."
+    )
 
 
 class RunConfig(BaseModel):
@@ -1084,7 +1092,6 @@ class RunConfig(BaseModel):
     observability: ObservabilityConfig | None = None
     docker: DockerConfig | None = None
     grader: GraderConfig | None = None
-    defaults: RunDefaultsConfig | None = None
 
     @property
     def effective_workers(self) -> int:

--- a/tolokaforge/core/models/run_config.py
+++ b/tolokaforge/core/models/run_config.py
@@ -1055,6 +1055,21 @@ params bag; the lift makes coding-harness selection a first-class
 run-config concept that any adapter can accept."""
 
 
+class RunDefaultsConfig(BaseModel):
+    """Fallback ``ModelConfig``\\s for roles a run leaves unset in ``models``.
+
+    Only the user-simulator fallback is wired today. Set
+    ``defaults.user_simulator`` to name the model the orchestrator should
+    use when ``RunConfig.models["user"]`` is missing; leaving both unset
+    fails the run loud rather than silently routing user turns through
+    any hardcoded provider.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    user_simulator: ModelConfig | None = None
+
+
 class RunConfig(BaseModel):
     """Complete run configuration"""
 
@@ -1069,6 +1084,7 @@ class RunConfig(BaseModel):
     observability: ObservabilityConfig | None = None
     docker: DockerConfig | None = None
     grader: GraderConfig | None = None
+    defaults: RunDefaultsConfig | None = None
 
     @property
     def effective_workers(self) -> int:

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -1907,6 +1907,35 @@ class Orchestrator:
 
         self.logger.info("Tasks loaded", count=len(self.tasks), adapter=type(self.adapter).__name__)
 
+    def _resolve_user_simulator_config(self, user_config: ModelConfig | None) -> ModelConfig:
+        """Resolve the user-simulator ``ModelConfig`` or fail loud.
+
+        Selection order: ``models.user`` on the run config →
+        ``defaults.user_simulator`` on the run config → hard error. There
+        is deliberately no hardcoded provider default: a run that ships
+        user turns to a provider must name that provider explicitly, so
+        a buyer running the agent on GPT / Gemini / Kimi does not
+        silently route user turns through a different provider.
+        """
+        if user_config is not None:
+            return user_config
+        default_user = (
+            self.config.defaults.user_simulator if self.config.defaults is not None else None
+        )
+        if default_user is not None:
+            self.logger.info(
+                "Using defaults.user_simulator for the user model",
+                user_model=f"{default_user.provider}/{default_user.name}",
+            )
+            return default_user
+        raise ValueError(
+            "No user-simulator model configured. Set `models.user` on the run "
+            "config to the provider/name the user turns should run against, or "
+            "set `defaults.user_simulator` to a fallback that applies when a "
+            "specific run leaves `models.user` unset. Example: "
+            "`models: {user: {provider: openrouter, name: openai/gpt-5}}`."
+        )
+
     def _resolve_judge_config(self) -> ModelConfig | None:
         """Resolve the run-level judge model and fail loud on the missing-judge case.
 
@@ -2164,17 +2193,7 @@ class Orchestrator:
             self.logger.error("Agent model configuration required")
             raise ValueError("Agent model configuration required")
 
-        # Apply default user model if not configured
-        if user_config is None:
-            user_config = ModelConfig(
-                provider="openrouter",
-                name="anthropic/claude-sonnet-4.6",
-                temperature=0.2,
-            )
-            self.logger.info(
-                "Using default user model",
-                user_model="openrouter/anthropic/claude-sonnet-4.6",
-            )
+        user_config = self._resolve_user_simulator_config(user_config)
 
         # Resolve the run-level judge model and reject the run up front if any
         # selected task needs a judge but none is configured (fail loud).
@@ -2823,17 +2842,7 @@ class Orchestrator:
         if not agent_config:
             raise ValueError("Agent model configuration required")
 
-        # Apply default user model if not configured
-        if user_config is None:
-            user_config = ModelConfig(
-                provider="openrouter",
-                name="anthropic/claude-sonnet-4.6",
-                temperature=0.2,
-            )
-            self.logger.info(
-                "Using default user model",
-                user_model="openrouter/anthropic/claude-sonnet-4.6",
-            )
+        user_config = self._resolve_user_simulator_config(user_config)
 
         # Resolve the run-level judge model and reject the run up front if any
         # selected task needs a judge but none is configured (fail loud).

--- a/tolokaforge/core/orchestrator.py
+++ b/tolokaforge/core/orchestrator.py
@@ -71,6 +71,7 @@ from tolokaforge.core.models import (
     Trajectory,
     TrialStatus,
     TypeSenseConfig,
+    require_user_simulator_config,
 )
 from tolokaforge.core.output.aggregate_models import AGGREGATE_SCHEMA_VERSION
 from tolokaforge.core.output.aggregates import FileAggregateWriter, RunAggregateWriter
@@ -1907,35 +1908,6 @@ class Orchestrator:
 
         self.logger.info("Tasks loaded", count=len(self.tasks), adapter=type(self.adapter).__name__)
 
-    def _resolve_user_simulator_config(self, user_config: ModelConfig | None) -> ModelConfig:
-        """Resolve the user-simulator ``ModelConfig`` or fail loud.
-
-        Selection order: ``models.user`` on the run config →
-        ``defaults.user_simulator`` on the run config → hard error. There
-        is deliberately no hardcoded provider default: a run that ships
-        user turns to a provider must name that provider explicitly, so
-        a buyer running the agent on GPT / Gemini / Kimi does not
-        silently route user turns through a different provider.
-        """
-        if user_config is not None:
-            return user_config
-        default_user = (
-            self.config.defaults.user_simulator if self.config.defaults is not None else None
-        )
-        if default_user is not None:
-            self.logger.info(
-                "Using defaults.user_simulator for the user model",
-                user_model=f"{default_user.provider}/{default_user.name}",
-            )
-            return default_user
-        raise ValueError(
-            "No user-simulator model configured. Set `models.user` on the run "
-            "config to the provider/name the user turns should run against, or "
-            "set `defaults.user_simulator` to a fallback that applies when a "
-            "specific run leaves `models.user` unset. Example: "
-            "`models: {user: {provider: openrouter, name: openai/gpt-5}}`."
-        )
-
     def _resolve_judge_config(self) -> ModelConfig | None:
         """Resolve the run-level judge model and fail loud on the missing-judge case.
 
@@ -2193,7 +2165,7 @@ class Orchestrator:
             self.logger.error("Agent model configuration required")
             raise ValueError("Agent model configuration required")
 
-        user_config = self._resolve_user_simulator_config(user_config)
+        user_config = require_user_simulator_config(user_config)
 
         # Resolve the run-level judge model and reject the run up front if any
         # selected task needs a judge but none is configured (fail loud).
@@ -2842,7 +2814,7 @@ class Orchestrator:
         if not agent_config:
             raise ValueError("Agent model configuration required")
 
-        user_config = self._resolve_user_simulator_config(user_config)
+        user_config = require_user_simulator_config(user_config)
 
         # Resolve the run-level judge model and reject the run up front if any
         # selected task needs a judge but none is configured (fail loud).

--- a/tolokaforge/core/run_trial.py
+++ b/tolokaforge/core/run_trial.py
@@ -37,6 +37,7 @@ from tolokaforge.core.models import (
     RunConfig,
     TaskConfig,
     TimeoutConfig,
+    require_user_simulator_config,
 )
 from tolokaforge.core.orchestrator import _tasks_use_compose_variant_tools
 from tolokaforge.core.output.artifacts import FileArtifactWriter, InMemoryArtifactWriter
@@ -54,14 +55,6 @@ from tolokaforge.runner.models import TaskDescription
 
 _RUN_ID = "run_trial"
 _PRELOADED_TASKS_GLOB = "**/task.yaml"
-
-# Mirrors the orchestrator's default user model (orchestrator.py) so a
-# library call that omits ``user`` drives the same simulator as a batch run.
-_DEFAULT_USER_MODEL = ModelConfig(
-    provider="openrouter",
-    name="anthropic/claude-sonnet-4.6",
-    temperature=0.2,
-)
 
 
 class _RunTrialModels(BaseModel):
@@ -156,9 +149,13 @@ def run_trial(
     trial_grader = load_trial_grader(grader)(
         TrialGraderContext(runner_address=runner_address, logger=logger)
     )
+    # Resolve the conductor factory before validating the user-simulator config
+    # so an unknown ``conductor`` name surfaces the registry error rather than
+    # the (fail-loud but less actionable) missing-user-model error.
+    conductor_factory = load_conductor(conductor)
 
     agent_client = LLMClient(resolved_models.agent, rate_limit_probe=rate_limit_probe)
-    user_config = resolved_models.user or _DEFAULT_USER_MODEL
+    user_config = require_user_simulator_config(resolved_models.user)
     judge_config = resolved_models.judge
 
     output_path = Path(output_dir) if output_dir is not None else Path(_RUN_ID)
@@ -171,7 +168,7 @@ def run_trial(
         rate_limit_probe,
     )
 
-    conductor_impl = load_conductor(conductor)(
+    conductor_impl = conductor_factory(
         ConductorContext(
             adapter=adapter,
             artifact_writer=artifact_writer,

--- a/tolokaforge/dx/cli/main.py
+++ b/tolokaforge/dx/cli/main.py
@@ -390,7 +390,6 @@ cli.add_command(run_trial)
 
 
 # Default user model configuration
-DEFAULT_USER_MODEL = "anthropic/claude-sonnet-4.6"
 DEFAULT_USER_MODEL_PROVIDER = "openrouter"
 DEFAULT_USER_MODEL_TEMPERATURE = 0.2
 


### PR DESCRIPTION
Closes #1450.

## Summary

- Add \`RunConfig.defaults: RunDefaultsConfig | None\` — a backward-compatible new block whose \`user_simulator: ModelConfig | None\` carries the fallback the orchestrator uses when \`RunConfig.models[\"user\"]\` is absent.
- Replace the two hardcoded \`ModelConfig(provider=\"openrouter\", name=\"anthropic/claude-sonnet-4.6\", ...)\` fallbacks at \`tolokaforge/core/orchestrator.py:2168\` and \`:2827\` with a single \`_resolve_user_simulator_config\` helper. Selection order: \`models.user\` → \`defaults.user_simulator\` → hard error naming both config sites. No hardcoded provider default.
- Update \`docs/CONFIG.md\` to document the new \`defaults\` block.

Rationale: silent Anthropic fallback ships user-simulator traffic through Anthropic regardless of the buyer's declared provider preference — a data-residency + billing surprise for anyone running the agent on GPT / Gemini / Kimi / DeepSeek and forgetting to name \`models.user\`. The fail-loud gate makes the provider a config decision, not a hidden default.

## Small breaking change

Runs that used to work via the silent Anthropic default now need to name either \`models.user\` or \`defaults.user_simulator\`. The fix lands with fixtures for the three test files whose local \`_make_run_config\` helpers had been relying on the silent default (\`test_orchestrator_logic.py\`, \`test_orchestrator_budget_shutdown.py\`, \`test_orchestrator_grading_preflight.py\`); each now populates \`defaults.user_simulator\`.

The error message names both fix sites so the migration is one line:

\`\`\`
No user-simulator model configured. Set \`models.user\` on the run config
to the provider/name the user turns should run against, or set
\`defaults.user_simulator\` to a fallback that applies when a specific
run leaves \`models.user\` unset. Example: \`models: {user: {provider:
openrouter, name: openai/gpt-5}}\`.
\`\`\`

## Test plan
- [x] New \`tests/unit/test_orchestrator_user_simulator_config.py\` — 4 tests locking the fallback order + the error message (\`_resolve_user_simulator_config\` returns \`models.user\`, falls back to \`defaults.user_simulator\`, raises when both slots are missing, raises when the defaults block exists but \`user_simulator\` is \`None\`).
- [x] Full orchestrator unit suite: \`uv run pytest tests/unit -q -k orchestrator\` → **316 passed**.
- [x] \`uv run ruff check\` clean; pre-commit hooks pass.