### PR TITLE
feat(grading): activate SnapshotGradingSubstrate — bundle-backed offline grading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **grading**: `SnapshotGradingSubstrate` — bundle-backed offline / cross-region / replay grading path. Constructed per-trial as `SnapshotGradingSubstrate(bundle_view: GradeBundleView)` from a bundle loaded via `load_grade_bundle(bundle_dir)`; reads initial / final / final-stable DB state, the filesystem tar (lazily extracted with PEP 706 `tar.extractall(filter='data')`), and custom-check bytes from the bundle parts. Registered under the `tolokaforge.grading_substrates` entry-point group as `snapshot` (resolvable via `load_grading_substrate("snapshot")`). Two Protocol methods have hard offline limits in bundle format v1.0 and fail loud rather than silently returning empty: `db_probe(dsn, query)` raises `SubstrateUnreachableError` naming the DSN (bundle v1.1 will pre-materialise probe rows — [#1438](https://github.com/Toloka/tolokaforge/issues/1438)); `knowledge_search()` returns `None` (bundle v1.1 will carry an indexed KB snapshot — [#1439](https://github.com/Toloka/tolokaforge/issues/1439)). See [`docs/GRADER_SERVICE.md`](docs/GRADER_SERVICE.md) § Snapshot substrate and [`docs/GRADE_BUNDLE.md`](docs/GRADE_BUNDLE.md).
+
 ### Removed
 
 - `grading_method` reserved names `hash`, `transcript`, `llm` — never emitted, never dispatched. Task packs using these values fail loud at `RegisterTrial` with a message naming the registered set. Use `composite` (or leave `grading_method` unset).

--- a/docs/GRADER_SERVICE.md
+++ b/docs/GRADER_SERVICE.md
@@ -591,8 +591,26 @@ wire.
 topology where an independent grader container reads the substrate off
 a shared filesystem/DB mount is the reserved `SharedMountGradingSubstrate`
 recipe — see [ADR-0040](adr/0040-standalone-grader.md), reserved-future
-substrate SWE-bench pattern. Not shipped today; the two shipping
-substrates are `InProcess` and `LiveCallback`.
+substrate SWE-bench pattern. Not shipped today; the three shipping
+substrates are `InProcess`, `LiveCallback`, and `Snapshot`.
+
+**Snapshot substrate — offline / cross-region / replay path.** A trial's
+state travels as a serialised grade bundle (see
+[docs/GRADE_BUNDLE.md](GRADE_BUNDLE.md)) rather than over a live wire.
+The grader constructs `SnapshotGradingSubstrate(bundle_view)` from a
+`GradeBundleView` (loaded via `load_grade_bundle(bundle_dir)`) and reads
+initial / final / final-stable DB state, filesystem tar (lazily
+extracted to a per-substrate tmpdir), and custom-check bytes from the
+bundle parts. Two Protocol methods have hard offline limits in bundle
+format v1.0 and fail loud rather than silently returning empty:
+`db_probe(dsn, query)` raises `SubstrateUnreachableError` naming the
+DSN (the DSN is only reachable inside the task's docker network; bundle
+v1.1 will pre-materialise probe rows — [#1438](https://github.com/Toloka/tolokaforge/issues/1438));
+`knowledge_search()` returns `None` (the optional `kb/` subtree carries
+raw bytes without a queryable index — [#1439](https://github.com/Toloka/tolokaforge/issues/1439)).
+Packs declaring `state_checks.db_probes` or judge criteria that need KB
+search grade correctly on `InProcess` / `LiveCallback`; snapshot mode
+routes those trials to a live-callback path in the caller.
 
 <a id="extension-points-the-eight-plug-in-groups"></a>
 

--- a/docs/GRADE_BUNDLE.md
+++ b/docs/GRADE_BUNDLE.md
@@ -109,4 +109,5 @@ A pure-shell approximation using `jq`, `sha256sum`, and `tar` is possible and de
 
 - Optional `provenance.json` sibling for engine-bump debugging (not covered by the manifest digest): [#1428](https://github.com/Toloka/tolokaforge/issues/1428).
 - Cross-language parser example (`jq` + `sha256sum` + `tar tvf`): [#1430](https://github.com/Toloka/tolokaforge/issues/1430).
-- `SnapshotGradingSubstrate` (grader-side consumer that reads bundles as a substrate): [#1353](https://github.com/Toloka/tolokaforge/issues/1353).
+- Pre-materialised `db_probes.json` for offline `db_probe` grading (a snapshot substrate refuses `db_probe` in v1.0 because the DSN is only reachable inside the task's docker network): [#1438](https://github.com/Toloka/tolokaforge/issues/1438).
+- Indexed KB snapshot for offline `knowledge_search` (a snapshot substrate returns `None` in v1.0 because the optional `kb/` subtree carries raw bytes without a queryable index): [#1439](https://github.com/Toloka/tolokaforge/issues/1439).

--- a/docs/GRADING.md
+++ b/docs/GRADING.md
@@ -202,10 +202,15 @@ terminal_bench_native = "acme_adapter:TerminalBenchNativeGradingMethod"
 ```
 
 The marker class carries a `NAME: ClassVar[str]` — same shape as
-`tolokaforge.grading_substrates` from ADR-0040. `RegisterTrial` refuses an
-unregistered name with an error listing both the offending key and
-`available_grading_methods()`, so a typo in a task pack surfaces before the
-trial spends any turns.
+`tolokaforge.grading_substrates` from ADR-0040 (three shipped: `in_process`,
+`live_callback`, `snapshot`; the last reads a serialised grade bundle so the
+grader grades a trial without a live runner in reach — see
+[docs/GRADER_SERVICE.md](GRADER_SERVICE.md) and
+[docs/GRADE_BUNDLE.md](GRADE_BUNDLE.md) for the substrate topology and
+bundle format).
+`RegisterTrial` refuses an unregistered name with an error listing both the
+offending key and `available_grading_methods()`, so a typo in a task pack
+surfaces before the trial spends any turns.
 
 ### Single-substrate keys
 

--- a/docs/adr/0040-standalone-grader.md
+++ b/docs/adr/0040-standalone-grader.md
@@ -48,16 +48,15 @@ Tolokaforge needs the grader to work under (1), (2), and (3) *this milestone* �
 
 **Backward compatibility is a first-class deliverable.** `runner_rpc` behaviour is preserved from the operator's view. Every existing `grading.yaml` runs untouched. No task auto-migrates to `grader_rpc`.
 
-## Non-goals and rationale — why the shipped grader is not fully independent
+## Deployment paths — three shipping substrates
 
-The deployed grader image dials back to the runner over `SubstrateService` gRPC (`LiveRunnerCallbackGradingSubstrate`). A grader that reads only what crosses `GradeRequest` — no callback, no runner dependency at grade time — is what most operators mean by "fully independent grader." **That's `SnapshotGradingSubstrate` (Harbor pattern), and it is deliberately deferred to a future milestone.** The reasoning:
+Every substrate satisfies the same `GradingSubstrate` Protocol; the composite grading dispatch above them is identical across topologies. Operators pick a path by grader-name + config; no runtime substrate-selector rides on the wire.
 
-- **Wire size for the target workloads.** Snapshot-on-wire packs the trial's initial + final DB state, filesystem tree, KB corpus, and `checks.py` bytes into one `GradeRequest`. For a state-routed task (a few tables, a handful of tool calls) the payload is small — under 100 KB. For a coding-task workspace (terminal-bench, SWE-bench-adjacent tasks) the filesystem tree is bounded by the shipped `filesystem_view.read_agent_visible_filesystem` filter which excludes symlinks, non-UTF-8 files, and the `.git` / `.venv` / `node_modules` / `dist` / `.next` directory subtrees (see `core/grading/filesystem_view.py`). Even so, initial + final DB state, KB corpus, and `checks.py` bytes still pack into one `GradeRequest`; the wire-size concern for offline snapshot substrates is not resolved by the filesystem filter alone. A default-behaviour grader that ships every trial's full workspace over one gRPC message would make each grade RPC a multi-hundred-megabyte transfer under a payload limit designed for control-plane messages.
-- **The alternative today is cheap and correct.** `LiveRunnerCallbackGradingSubstrate` does one RPC per read — `db_reader().get_state()` is one round trip, each `filesystem_root().read_file(path)` is one round trip. Small tasks pay for what they use; large tasks materialise the filesystem tree once eagerly (documented in `docs/GRADER_SERVICE.md § Wire cost per grade component`) and stay under the wire budget by construction because the payload never crosses in a single frame.
-- **Independence is available where it's cheap.** Operators who need a wire-independent grader today have two paths that ship in this milestone: (a) `runner_rpc` with `InProcessGradingSubstrate` — the grader and runner are one process, no wire at all, no independence needed; (b) `grader_rpc` with `LiveRunnerCallbackGradingSubstrate` — the grader is a separate container that dials the runner for reads. Neither is "the grader takes a snapshot and walks away," but both are correct and shipped.
-- **The Protocol is shaped for the third path.** When snapshot-on-wire becomes required (offline replay, cross-region grading, a task family whose workspace is small enough to ship whole), `SnapshotGradingSubstrate` registers as one entry-point line under `tolokaforge.grading_substrates`. `grader.proto` extends with the additive fields it needs (v3). The composite dispatch above the substrate does not change. This ADR carries a concrete wiring recipe below.
+- **`runner_rpc` with `InProcessGradingSubstrate`.** Grader and runner share a Python process; the substrate is a thin view over the runner's live objects. No wire, no serialisation. Shipping default for the aggregate image.
+- **`grader_rpc` with `LiveRunnerCallbackGradingSubstrate`.** Grader is a separate container that dials the runner's read-only `SubstrateService` per read (`db_reader().get_state()` = one round trip; each `filesystem_root().read_file(path)` = one round trip). Small tasks pay for what they use; large workspaces materialise the filesystem tree once eagerly (documented in `docs/GRADER_SERVICE.md § Wire cost per grade component`) and stay under the wire budget by construction because the payload never crosses in a single frame.
+- **Snapshot mode with `SnapshotGradingSubstrate`.** Grader reads a serialised grade bundle (see [`../GRADE_BUNDLE.md`](../GRADE_BUNDLE.md)) rather than dialling a live runner. Decouples the grader's lifetime from the runner's, so a grader can grade a trial whose runner was torn down (offline replay), grade across a network region, or grade a bulk backfill of already-recorded trials. Shape + reads + fail-loud translator + two hard offline limits (`db_probe` / `knowledge_search`) are documented below under [Shipped substrate — `SnapshotGradingSubstrate`](#shipped-substrate--snapshotgradingsubstrate-offline--cross-region--replay-path).
 
-**Operator-facing knob today.** Choose `grader.name: runner_rpc` for coding-task workloads with large workspaces — the docs (`docs/GRADER_SERVICE.md § Wire cost per grade component`) make this explicit and name the crossover empirically. `grader.name: grader_rpc` is correct and shipping for the deployment shape where the grader lives separately from the runner and the workspace stays small.
+**Operator-facing knob today.** Coding-task workloads with large workspaces prefer `grader.name: runner_rpc` — the docs (`docs/GRADER_SERVICE.md § Wire cost per grade component`) make this explicit and name the crossover empirically. `grader.name: grader_rpc` is the deployment shape where the grader lives separately from the runner and the workspace stays small. Snapshot mode is the offline / replay / cross-region path; the regrade CLI that composes it is separate work (see phase-C list below).
 
 **Two other deliberate non-goals of this milestone:**
 
@@ -68,9 +67,9 @@ The deployed grader image dials back to the runner over `SubstrateService` gRPC 
 
 **Positive**
 
-- Three deployment topologies operational this milestone (aggregate image, independent grader container, unified `runner_rpc` path).
+- Three deployment topologies operational (aggregate image, independent grader container with live-callback, snapshot mode with bundle-backed reads).
 - The trajectory-storage service, when it ships, registers itself with a one-line entry point.
-- Snapshot mode and shared-mount mode become documented, additive future shifts — the Protocol is already shaped for them.
+- Shared-mount mode remains a documented, additive future shift — the Protocol is already shaped for it.
 - Component evaluators become individually pluggable; operators can extend judges / rules / trace ops without touching the framework.
 - Extract-refactor of runner-side grading code onto the Protocol path unifies the codebase and locks behaviour parity by construction.
 - **Phase 1 landing (issue #1261).** `GradingSubstrate` Protocol + `InProcessGradingSubstrate` + `LiveRunnerCallbackGradingSubstrate` shipped; `SubstrateService` gRPC (7 read-only RPCs, gated by `RunConfig.grader.expose_substrate: false`); five composite grading functions extracted to `tolokaforge.core.grading.composite`.
@@ -81,7 +80,7 @@ The deployed grader image dials back to the runner over `SubstrateService` gRPC 
 **Negative**
 
 - Adds a new gRPC surface (`SubstrateService`) on the runner. Config-gated (`RunConfig.grader.expose_substrate: false` default) — no impact on runs that don't need it, but it's a new component with its own maintenance cost.
-- `LiveRunnerCallbackGradingSubstrate` ties grader lifecycle to runner lifecycle (grader fails if the runner is torn down mid-grade). Documented; caller sees `GradingFailedError`. Snapshot mode later decouples this.
+- `LiveRunnerCallbackGradingSubstrate` ties grader lifecycle to runner lifecycle (grader fails if the runner is torn down mid-grade). Documented; caller sees `GradingFailedError`. Snapshot mode decouples this at the cost of the two offline limits (`db_probe` refuses; `knowledge_search` returns `None`).
 
 **Neutral**
 
@@ -110,31 +109,68 @@ Substrate selection is not a wire-carried enum. The shipping mechanism is: `grad
 
 **No changes to evaluator code, `runner_rpc`, or the aggregate image path.**
 
-## Reserved future substrate — `SnapshotGradingSubstrate` (Harbor pattern)
+## Shipped substrate — `SnapshotGradingSubstrate` (offline / cross-region / replay path)
 
-**When to ship:** offline replay / cross-region grading becomes a hard requirement (grader outlives the runner, or lives in a different network region).
+**Shape.** `SnapshotGradingSubstrate(bundle_view: GradeBundleView)` reads a
+trial's state from a serialised grade bundle (see
+[`docs/GRADE_BUNDLE.md`](../GRADE_BUNDLE.md)) rather than over a live wire. A
+caller composes `store.get(uri, dest) -> load_grade_bundle(dest) ->
+SnapshotGradingSubstrate(view)`; the substrate satisfies the same
+`GradingSubstrate` Protocol every deployment topology reads through, so the
+composite grading dispatch above it is unchanged.
 
-**Wiring recipe:**
+**Reads.** Initial / final / final-stable DB state come from the manifested
+`initial_state.json` / `final_state.json` / `final_state_stable.json` parts.
+`filesystem.tar` is lazily extracted to a per-substrate `tempfile.TemporaryDirectory`
+on first `filesystem_root()` call, using `tar.extractall(path=root,
+filter='data')` (PEP 706) for comprehensive path-traversal defence.
+`filesystem_state()` walks the extracted root through the shipped
+`read_agent_visible_filesystem` helper, matching what `LiveRunnerCallback`
+returns.
 
-1. Extend `grader.proto` to wire v3 with additive snapshot-bundle fields on `GradeRequest`:
-   - `initial_state_json`, `final_state_json` — DB snapshots at trial start / end.
-   - `filesystem_snapshot: bytes` — tar of agent-visible files (filtered by `tolokaforge.core.grading.filesystem_view.read_agent_visible_filesystem` — never `.git`, `.venv`, `node_modules`, `dist`, `.next`).
-   - `checks_module_bytes: bytes` — `checks.py` bytes when `custom_checks` is enabled.
-   - `kb_snapshot` — for tasks with deterministic KB corpora, the vector-store manifest. Live-TypeSense tasks stay on live-callback.
+**Fail-loud translator.** Every `bundle_view.open_part(...)` call routes
+through a private `_read_part` helper that translates `BundleIntegrityError`
+(corrupt bytes), `OSError` (caller-deleted bundle_dir / permission / device
+errors), and `KeyError` (missing manifest entry) into
+`SubstrateUnreachableError` naming the offending part + bundle_dir. This is
+load-bearing: the composite call sites in `composite/custom_checks.py` and
+`composite/llm_judge.py` catch `Exception` broadly and degrade-to-empty,
+letting only `SubstrateUnreachableError` propagate to `GradingFailedError`.
+Without the translation, a corrupt or vanished bundle silently books the
+trial as "empty state, grade against nothing" — an incorrect verdict, not a
+failure.
 
-   `id_fields`, `unstable_fields`, and `judge_model_config` already ride on `task_description_json` / `judge_model_config_json` from wire v2 and need no addition.
-2. Implement `SnapshotGradingSubstrate` unpacking the fields into the same shape `LiveRunnerCallbackGradingSubstrate` produces.
-3. Register under the shipping entry-point group:
+**Two Protocol methods have hard offline limits in bundle format v1.0** and
+fail loud rather than silently returning empty:
 
-   ```toml
-   [project.entry-points."tolokaforge.grading_substrates"]
-   snapshot = "tolokaforge.core.grading.substrate:SnapshotGradingSubstrate"
-   ```
+- `db_probe(dsn, query)` raises `SubstrateUnreachableError` naming the DSN.
+  The DSN is only reachable inside the task's docker network; offline
+  substrates cannot dial it. A pack declaring `state_checks.db_probes` is
+  not gradeable in snapshot mode until bundle format v1.1 pre-materialises
+  probe rows ([#1438](https://github.com/Toloka/tolokaforge/issues/1438)).
+- `knowledge_search()` returns `None`. The bundle's optional `kb/` subtree
+  carries raw bytes without a queryable index. The judge already treats
+  `None` as "the trial declared no KB"; a pack whose rubric criteria
+  require KB search grades without the KB tool wired
+  ([#1439](https://github.com/Toloka/tolokaforge/issues/1439)).
 
-4. **Filesystem cap policy** — 32 MB soft cap. Tasks exceeding the cap auto-fall-back to `LiveRunnerCallbackGradingSubstrate` (documented behaviour; not a bug). Config: extend `GraderConfig` with a typed `snapshot: SnapshotGraderConfig | None` subblock — same shape as the shipped `queue` / `judge` subblocks — carrying an explicit `fallback_on_snapshot_error` field (default `live_callback`).
-5. The snapshot builder replaces `LiveRunnerCallbackGradingSubstrate` construction inside a new `GraderRPCSnapshotTrialGrader` (or an extended `GraderRPCTrialGrader`) — no wire-carried selector; the client-side transport decides.
+**Registered as a one-line entry point** under the shipping group:
 
-**Why this is riskier than live-callback:** coding tasks with ~100 MB workspaces would need the auto-fallback path; a bug in the size check could break existing pipelines. Shipping later when the platform has learned the wire behaviours.
+```toml
+[project.entry-points."tolokaforge.grading_substrates"]
+snapshot = "tolokaforge.core.grading.substrate:SnapshotGradingSubstrate"
+```
+
+**What ships now vs. what remains ahead.** The substrate class + entry-point
++ per-Protocol-method behaviour locks ship in the current release. Remaining
+phase-C work in milestone [#39](https://github.com/Toloka/tolokaforge/milestone/39):
+`grader.proto` wire-v3 additive fields carrying bundle references
+([#1358](https://github.com/Toloka/tolokaforge/issues/1358)); the
+`RuntimeBackend.build_grade_bundle` producer hook that writes a bundle at
+trial-end ([#1356](https://github.com/Toloka/tolokaforge/issues/1356)); the
+`tolokaforge grade <bundle-uri>` regrade CLI verb
+([#1361](https://github.com/Toloka/tolokaforge/issues/1361)); and the
+3-lane parity gate expanding to include the snapshot path.
 
 ## Reserved future substrate — `SharedMountGradingSubstrate` (SWE-bench pattern)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,13 +229,14 @@ composite = "tolokaforge.core.grading.grading_method:CompositeGradingMethod"
 test_execution = "tolokaforge.core.grading.grading_method:TestExecutionGradingMethod"
 
 # ADR-0040 § "The single design abstraction" — GradingSubstrate implementations
-# resolvable by name. Two implementations ship today (``in_process`` +
-# ``live_callback``); ``trajectory_storage`` / ``snapshot`` / ``shared_mount``
+# resolvable by name. Three implementations ship today (``in_process`` +
+# ``live_callback`` + ``snapshot``); ``trajectory_storage`` / ``shared_mount``
 # are reserved future substrates and register themselves when they ship (no
 # framework change needed then).
 [project.entry-points."tolokaforge.grading_substrates"]
 in_process = "tolokaforge.core.grading.substrate:InProcessGradingSubstrate"
 live_callback = "tolokaforge.core.grading.substrate_live:LiveRunnerCallbackGradingSubstrate"
+snapshot = "tolokaforge.core.grading.substrate:SnapshotGradingSubstrate"
 
 # Custom-check executor Protocol (``tolokaforge/core/grading/check_runner.py``).
 # ``check_runner`` is the production default (in-process ThreadPoolExecutor);

--- a/tests/canonical/test_filesystem_view_defined_once.py
+++ b/tests/canonical/test_filesystem_view_defined_once.py
@@ -40,6 +40,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PACKAGE_ROOT = _REPO_ROOT / "tolokaforge"
 _FILESYSTEM_VIEW_MODULE = _PACKAGE_ROOT / "core" / "grading" / "filesystem_view.py"
 _RUNNER_SITE = _PACKAGE_ROOT / "runner" / "service.py"
+_SUBSTRATE_SITE = _PACKAGE_ROOT / "core" / "grading" / "substrate.py"
 _SUBSTRATE_SERVICE_SITE = _PACKAGE_ROOT / "runner" / "substrate_service.py"
 _DOCS_ROOT = _REPO_ROOT / "docs"
 _TESTS_CANONICAL_ROOT = _REPO_ROOT / "tests" / "canonical"
@@ -70,19 +71,24 @@ def test_walker_entry_point_is_defined_exactly_once_in_the_pure_module(
 
 
 @pytest.mark.parametrize(
-    ("symbol", "expected_caller"),
+    ("symbol", "expected_callers"),
     [
-        ("read_agent_visible_filesystem", _RUNNER_SITE),
-        ("iter_agent_visible_rel_paths", _SUBSTRATE_SERVICE_SITE),
+        ("read_agent_visible_filesystem", (_SUBSTRATE_SITE, _RUNNER_SITE)),
+        ("iter_agent_visible_rel_paths", (_SUBSTRATE_SERVICE_SITE,)),
     ],
 )
-def test_walker_entry_point_has_its_named_production_caller_only(
-    symbol: str, expected_caller: Path
+def test_walker_entry_point_has_its_named_production_callers_only(
+    symbol: str, expected_callers: tuple[Path, ...]
 ) -> None:
-    """Each entry point has exactly one production caller outside the module.
+    """Each entry point has its named production callers outside the module,
+    and no others. An unnamed callsite in ``tolokaforge/`` would signal recipe
+    leakage into a codepath the pure module was not designed for.
 
-    A third callsite in ``tolokaforge/`` would signal recipe leakage into a
-    codepath the pure module was not designed for.
+    ``read_agent_visible_filesystem`` has two callers: ``runner/service.py``
+    (runner-side non-harness state factory) and ``core/grading/substrate.py``
+    (``SnapshotGradingSubstrate.filesystem_state`` walks the extracted bundle
+    tmpdir through the shared helper). Each is one entry per module, so the
+    "one walker, no re-inline" invariant holds per site.
     """
     call_pattern = re.compile(rf"\b{symbol}\(")
     call_sites = [
@@ -90,10 +96,10 @@ def test_walker_entry_point_has_its_named_production_caller_only(
         for path in _iter_package_python_files()
         if path != _FILESYSTEM_VIEW_MODULE and call_pattern.search(path.read_text(encoding="utf-8"))
     ]
-    assert call_sites == [expected_caller], (
-        f"Expected exactly one production caller of {symbol}( at "
-        f"{expected_caller.relative_to(_REPO_ROOT)}; "
-        f"found: {[p.relative_to(_REPO_ROOT) for p in call_sites]}"
+    assert sorted(call_sites) == sorted(expected_callers), (
+        f"Expected production callers of {symbol}( at "
+        f"{sorted(p.relative_to(_REPO_ROOT) for p in expected_callers)}; "
+        f"found: {sorted(p.relative_to(_REPO_ROOT) for p in call_sites)}"
     )
 
 

--- a/tests/canonical/test_grading_substrate.py
+++ b/tests/canonical/test_grading_substrate.py
@@ -1,9 +1,9 @@
 """``GradingSubstrate`` — Protocol shape + shipped-impl contract locks.
 
-Locks the seam ADR-0040 introduces: one Protocol, two implementations
-shipped today (``in_process``, ``live_callback``), three reserved future
-implementations raising ``NotImplementedError`` with a pointer to the ADR
-recipe.
+Locks the seam ADR-0040 introduces: one Protocol, three implementations
+shipped today (``in_process``, ``live_callback``, ``snapshot``), two
+reserved future implementations raising ``NotImplementedError`` with a
+pointer to the ADR recipe.
 
 Also locks the entry-point group ``tolokaforge.grading_substrates`` — the
 future trajectory-storage service will register itself via one entry-point
@@ -12,7 +12,8 @@ line, and this test proves discovery works.
 ``TestLiveCallbackSubstrateReads`` exercises the live-callback impl over an
 in-process gRPC channel wired to a real :class:`RunnerServiceImpl` +
 :class:`SubstrateServicer`, asserting the wire path returns the same values
-:class:`InProcessGradingSubstrate` would over the same runner.
+:class:`InProcessGradingSubstrate` would over the same runner. The snapshot
+impl's per-Protocol-method locks live in :mod:`tests.unit.grading.test_snapshot_substrate`.
 """
 
 from __future__ import annotations
@@ -559,14 +560,15 @@ class TestLiveCallbackSubstrateReads:
 
 
 class TestReservedFutureSubstratesRaiseWithAdrPointer:
-    """The three reserved future substrates (``TrajectoryStorage``,
-    ``Snapshot``, ``SharedMount``) each raise ``NotImplementedError`` with
-    a pointer to ADR-0040. A contributor reaching for them sees the recipe
-    rather than a mystery stub."""
+    """A substrate is "reserved" iff its no-arg ``__init__`` raises
+    ``NotImplementedError`` with a pointer to ADR-0040 — a contributor
+    reaching for it sees the recipe rather than a mystery stub. Activating
+    a reserved substrate replaces the stub with a real constructor and
+    removes it from this parametrize list."""
 
     @pytest.mark.parametrize(
         "cls",
-        [TrajectoryStorageGradingSubstrate, SnapshotGradingSubstrate, SharedMountGradingSubstrate],
+        [TrajectoryStorageGradingSubstrate, SharedMountGradingSubstrate],
     )
     def test_construction_raises_with_adr_pointer(self, cls: type) -> None:
         with pytest.raises(NotImplementedError, match="ADR-0040|0040-standalone-grader"):
@@ -575,19 +577,22 @@ class TestReservedFutureSubstratesRaiseWithAdrPointer:
 
 class TestEntryPointGroupResolves:
     """The ``tolokaforge.grading_substrates`` entry-point group resolves
-    ``in_process`` and ``live_callback`` by name. Trajectory-storage adds
-    itself with a one-line entry point at land time.
+    ``in_process``, ``live_callback``, and ``snapshot`` by name.
+    Trajectory-storage adds itself with a one-line entry point at land time.
     """
 
-    def test_in_process_is_registered_and_resolves(self) -> None:
+    def test_shipped_substrates_are_registered_and_resolve(self) -> None:
         import importlib.metadata
 
         eps = list(importlib.metadata.entry_points(group="tolokaforge.grading_substrates"))
         names = {ep.name for ep in eps}
         assert "in_process" in names
         assert "live_callback" in names
+        assert "snapshot" in names
         in_process_ep = next(ep for ep in eps if ep.name == "in_process")
         assert in_process_ep.load() is InProcessGradingSubstrate
+        snapshot_ep = next(ep for ep in eps if ep.name == "snapshot")
+        assert snapshot_ep.load() is SnapshotGradingSubstrate
 
 
 class TestSubstrateUnreachableError:

--- a/tests/canonical/test_snapshot_substrate_parity.py
+++ b/tests/canonical/test_snapshot_substrate_parity.py
@@ -14,18 +14,15 @@ Two Protocol methods are DELIBERATELY excluded from the parity assertion:
   :class:`SubstrateUnreachableError` (the caller-supplied DSN is only
   reachable inside the task's docker network; offline substrates cannot
   dial it). InProcess opens a real connection to the DSN and returns
-  rows. Bundle format v1.0 has no pre-materialised probe part; a v1.1
-  extension carrying ``db_probes.json`` is tracked upstream as a
-  discovered issue.
+  rows. Bundle format v1.0 has no pre-materialised probe part.
 - :meth:`GradingSubstrate.knowledge_search` — snapshot returns ``None``
   (bundle format v1.0's optional ``kb/`` subtree carries raw bytes
   without a queryable index; the judge's Protocol treats ``None`` as
   "the trial declared no KB"). InProcess wires whatever KB the caller
-  passes at construction. A v1.1 extension carrying an indexed KB
-  snapshot is tracked upstream as a discovered issue.
+  passes at construction.
 
-The behaviour on both excluded methods is locked separately by the Stage 1
-unit tests in :mod:`tests.unit.grading.test_snapshot_substrate`.
+The behaviour on both excluded methods is locked separately by the unit
+tests in :mod:`tests.unit.grading.test_snapshot_substrate`.
 
 The parity fixture routes the in-process leg's dict inputs through the
 same :func:`~tolokaforge.core.grading.bundle.normalise_floats` the bundle

--- a/tests/canonical/test_snapshot_substrate_parity.py
+++ b/tests/canonical/test_snapshot_substrate_parity.py
@@ -1,0 +1,200 @@
+"""Canonical parity: :class:`SnapshotGradingSubstrate` reads byte-equal
+to :class:`InProcessGradingSubstrate` on every Protocol method that a
+snapshot substrate can faithfully implement over a bundle format v1.0.
+
+The parity claim is what the substrate abstraction rests on — the composite
+grading pipeline above the substrate must not care which topology it holds.
+Given the same trial inputs, the two shipping substrates return the same
+values, so an operator swapping between them changes only the transport,
+never the verdict.
+
+Two Protocol methods are DELIBERATELY excluded from the parity assertion:
+
+- :meth:`GradingSubstrate.db_probe` — snapshot raises
+  :class:`SubstrateUnreachableError` (the caller-supplied DSN is only
+  reachable inside the task's docker network; offline substrates cannot
+  dial it). InProcess opens a real connection to the DSN and returns
+  rows. Bundle format v1.0 has no pre-materialised probe part; a v1.1
+  extension carrying ``db_probes.json`` is tracked upstream as a
+  discovered issue.
+- :meth:`GradingSubstrate.knowledge_search` — snapshot returns ``None``
+  (bundle format v1.0's optional ``kb/`` subtree carries raw bytes
+  without a queryable index; the judge's Protocol treats ``None`` as
+  "the trial declared no KB"). InProcess wires whatever KB the caller
+  passes at construction. A v1.1 extension carrying an indexed KB
+  snapshot is tracked upstream as a discovered issue.
+
+The behaviour on both excluded methods is locked separately by the Stage 1
+unit tests in :mod:`tests.unit.grading.test_snapshot_substrate`.
+
+The parity fixture routes the in-process leg's dict inputs through the
+same :func:`~tolokaforge.core.grading.bundle.normalise_floats` the bundle
+producer applies (``%.6g`` six-significant-digit float normalisation);
+without that step a fixture value like ``0.123456789`` would land in the
+bundle as ``0.123457`` while the in-process leg saw the raw float, and
+the parity claim would fail on a canonicalisation artefact rather than a
+substrate divergence. Both substrates receive the ``%.6g``-normalised
+form, so any remaining divergence is a real substrate bug.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.canonical._bundle_fixtures import synthetic_inputs
+from tolokaforge.core.grading.bundle import (
+    load_grade_bundle,
+    normalise_floats,
+    serialize_grade_bundle,
+)
+from tolokaforge.core.grading.filesystem_view import read_agent_visible_filesystem
+from tolokaforge.core.grading.substrate import (
+    InProcessGradingSubstrate,
+    SnapshotGradingSubstrate,
+)
+
+
+@pytest.fixture
+def paired_substrates(
+    tmp_path: Path,
+) -> tuple[InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]]:
+    inputs = synthetic_inputs(tmp_path)
+    bundle_dir = tmp_path / "bundle"
+    serialize_grade_bundle(bundle_dir, **inputs)
+    view = load_grade_bundle(bundle_dir)
+    fs_root = inputs["filesystem_root"]
+    assert isinstance(fs_root, Path)
+
+    canonical_initial = normalise_floats(inputs["initial_state"])
+    canonical_final = normalise_floats(inputs["final_state"])
+    canonical_stable = normalise_floats(inputs["final_state_stable"])
+
+    in_process = InProcessGradingSubstrate(
+        db_reader=MagicMock(),
+        knowledge_search=None,
+        filesystem_root=fs_root,
+        initial_state=canonical_initial,
+        final_state=canonical_final,
+        final_state_stable_factory=lambda: canonical_stable,
+        filesystem_state_factory=lambda: read_agent_visible_filesystem(fs_root),
+    )
+    snapshot = SnapshotGradingSubstrate(view)
+    try:
+        yield in_process, snapshot, inputs
+    finally:
+        snapshot.close()
+        in_process.close()
+
+
+def test_initial_state_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    in_process, snapshot, _ = paired_substrates
+    assert snapshot.initial_state() == in_process.initial_state()
+
+
+def test_final_state_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    in_process, snapshot, _ = paired_substrates
+    assert snapshot.final_state() == in_process.final_state()
+
+
+def test_final_state_stable_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    in_process, snapshot, _ = paired_substrates
+    assert snapshot.final_state_stable() == in_process.final_state_stable()
+
+
+def test_db_reader_get_state_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    """Snapshot's DB reader reads ``final_state.json`` back byte-equal; the
+    in-process leg's DB reader is a caller-owned mock in the shipped
+    ``InProcessGradingSubstrate`` shape, so the parity assertion pins
+    snapshot against the raw ``final_state`` its caller supplied."""
+    in_process, snapshot, _ = paired_substrates
+    assert snapshot.db_reader().get_state() == in_process.final_state()
+
+
+def test_db_reader_query_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    _, snapshot, inputs = paired_substrates
+    final_state = inputs["final_state"]
+    assert isinstance(final_state, dict)
+    users = final_state["tables"]["users"]
+    assert snapshot.db_reader().query("$.tables.users[*].id") == {
+        "results": [row["id"] for row in users]
+    }
+
+
+def test_filesystem_state_parity(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    """Both substrates route filesystem_state through the SAME
+    ``read_agent_visible_filesystem`` helper — snapshot walks its
+    extracted tmpdir, in-process walks the caller's original tree —
+    and the helper's output only depends on the visible files'
+    contents. So the two dicts land byte-equal."""
+    in_process, snapshot, _ = paired_substrates
+    assert snapshot.filesystem_state() == in_process.filesystem_state()
+
+
+def test_filesystem_root_extracts_the_same_visible_files(
+    paired_substrates: tuple[
+        InProcessGradingSubstrate, SnapshotGradingSubstrate, dict[str, object]
+    ],
+) -> None:
+    in_process, snapshot, _ = paired_substrates
+    snapshot_root = snapshot.filesystem_root()
+    in_process_root = in_process.filesystem_root()
+    assert snapshot_root is not None
+    assert in_process_root is not None
+    snapshot_files = sorted(read_agent_visible_filesystem(snapshot_root).keys())
+    in_process_files = sorted(read_agent_visible_filesystem(in_process_root).keys())
+    assert snapshot_files == in_process_files
+
+
+def test_entry_point_discovery_resolves_snapshot_class() -> None:
+    from tolokaforge.core.plugin_registry import load_grading_substrate
+
+    assert load_grading_substrate("snapshot") is SnapshotGradingSubstrate
+
+
+def test_bundle_parts_round_trip_byte_equal_to_source_inputs(tmp_path: Path) -> None:
+    """The parity story rests on the bundle carrying the source inputs
+    byte-for-byte. Serialise, load, and read each JSON part through the
+    snapshot substrate; assert every read matches the source dict."""
+    inputs = synthetic_inputs(tmp_path)
+    bundle_dir = tmp_path / "bundle"
+    serialize_grade_bundle(bundle_dir, **inputs)
+    view = load_grade_bundle(bundle_dir)
+    snapshot = SnapshotGradingSubstrate(view)
+    try:
+        assert snapshot.initial_state() == json.loads(
+            (bundle_dir / "initial_state.json").read_bytes()
+        )
+        assert snapshot.final_state() == json.loads((bundle_dir / "final_state.json").read_bytes())
+        assert snapshot.final_state_stable() == json.loads(
+            (bundle_dir / "final_state_stable.json").read_bytes()
+        )
+    finally:
+        snapshot.close()

--- a/tests/unit/grading/test_snapshot_substrate.py
+++ b/tests/unit/grading/test_snapshot_substrate.py
@@ -1,0 +1,348 @@
+"""Behaviour locks for :class:`SnapshotGradingSubstrate`.
+
+Twenty tests cover every Protocol method the snapshot substrate ships over
+a bundle produced by :func:`serialize_grade_bundle`, plus the fail-loud
+translator that turns bundle-read failures into
+:class:`SubstrateUnreachableError` (the sole exception the composite
+dispatch propagates unswallowed).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.canonical._bundle_fixtures import synthetic_inputs
+from tolokaforge.core.grading.bundle import (
+    BUNDLE_SCHEMA_VERSION,
+    GradeBundleManifest,
+    GradeBundleView,
+    load_grade_bundle,
+    serialize_grade_bundle,
+)
+from tolokaforge.core.grading.filesystem_view import read_agent_visible_filesystem
+from tolokaforge.core.grading.substrate import (
+    GradingSubstrate,
+    SnapshotGradingSubstrate,
+    SubstrateUnreachableError,
+)
+
+
+def _write_bundle(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
+    inputs = synthetic_inputs(tmp_path)
+    bundle_dir = tmp_path / "bundle"
+    serialize_grade_bundle(bundle_dir, **inputs)
+    return bundle_dir, inputs
+
+
+def test_satisfies_the_grading_substrate_protocol(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        assert isinstance(substrate, GradingSubstrate)
+    finally:
+        substrate.close()
+
+
+def test_initial_state_matches_bundle_part(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        expected = json.loads((bundle_dir / "initial_state.json").read_bytes())
+        assert substrate.initial_state() == expected
+    finally:
+        substrate.close()
+
+
+def test_final_state_matches_bundle_part(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        expected = json.loads((bundle_dir / "final_state.json").read_bytes())
+        assert substrate.final_state() == expected
+    finally:
+        substrate.close()
+
+
+def test_final_state_stable_matches_bundle_part(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        expected = json.loads((bundle_dir / "final_state_stable.json").read_bytes())
+        assert substrate.final_state_stable() == expected
+    finally:
+        substrate.close()
+
+
+class _CountingView(GradeBundleView):
+    """A view subclass that counts ``open_part`` calls per rel_path.
+
+    :class:`GradeBundleView` is a frozen dataclass; monkeypatching its
+    ``open_part`` attribute would fail, so tests that need call-count
+    observability subclass the view instead.
+    """
+
+    def __init__(self, inner: GradeBundleView) -> None:
+        object.__setattr__(self, "bundle_dir", inner.bundle_dir)
+        object.__setattr__(self, "manifest", inner.manifest)
+        object.__setattr__(self, "_call_counts", {})
+
+    def open_part(self, rel_path: str) -> bytes:
+        counts: dict[str, int] = object.__getattribute__(self, "_call_counts")
+        counts[rel_path] = counts.get(rel_path, 0) + 1
+        return super().open_part(rel_path)
+
+    def count(self, rel_path: str) -> int:
+        counts: dict[str, int] = object.__getattribute__(self, "_call_counts")
+        return counts.get(rel_path, 0)
+
+
+def test_final_state_and_final_state_stable_are_memoised(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = _CountingView(load_grade_bundle(bundle_dir))
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        substrate.final_state()
+        substrate.final_state()
+        substrate.final_state_stable()
+        substrate.final_state_stable()
+        assert view.count("final_state.json") == 1
+        assert view.count("final_state_stable.json") == 1
+    finally:
+        substrate.close()
+
+
+def test_knowledge_search_returns_none_offline(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        assert substrate.knowledge_search() is None
+    finally:
+        substrate.close()
+
+
+def test_db_probe_raises_substrate_unreachable_offline(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        with pytest.raises(SubstrateUnreachableError, match="postgresql://x"):
+            substrate.db_probe("postgresql://x", "SELECT 1")
+    finally:
+        substrate.close()
+
+
+def test_filesystem_root_materialises_bundle_tar_lazily(tmp_path: Path) -> None:
+    bundle_dir, inputs = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        root_first = substrate.filesystem_root()
+        assert root_first is not None
+        root_second = substrate.filesystem_root()
+        assert root_second == root_first
+        extracted = {
+            p.relative_to(root_first).as_posix() for p in root_first.rglob("*") if p.is_file()
+        }
+        assert "src/main.py" in extracted
+        assert "README.md" in extracted
+        assert not any(name.startswith(".git/") for name in extracted)
+        source_root = inputs["filesystem_root"]
+        assert isinstance(source_root, Path)
+        assert (source_root / ".git" / "HEAD").exists()
+    finally:
+        substrate.close()
+
+
+def test_filesystem_root_not_extracted_when_never_read(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = _CountingView(load_grade_bundle(bundle_dir))
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        substrate.db_reader().get_state()
+        assert view.count("filesystem.tar") == 0
+    finally:
+        substrate.close()
+
+
+def test_filesystem_state_walks_materialised_root(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        fs_state = substrate.filesystem_state()
+        assert fs_state is not None
+        root = substrate.filesystem_root()
+        assert root is not None
+        assert fs_state == read_agent_visible_filesystem(root)
+    finally:
+        substrate.close()
+
+
+def test_filesystem_state_returns_empty_dict_for_empty_tar(tmp_path: Path) -> None:
+    inputs = synthetic_inputs(tmp_path)
+    empty_root = tmp_path / "empty-workspace"
+    empty_root.mkdir()
+    inputs["filesystem_root"] = empty_root
+    bundle_dir = tmp_path / "bundle"
+    serialize_grade_bundle(bundle_dir, **inputs)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        assert substrate.filesystem_state() == {}
+    finally:
+        substrate.close()
+
+
+def test_close_cleans_up_filesystem_tmpdir(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    root = substrate.filesystem_root()
+    assert root is not None
+    assert root.exists()
+    substrate.close()
+    assert not root.exists()
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    substrate.close()
+    substrate.close()
+
+
+def test_db_reader_get_state_all_tables_matches_final_state(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        assert substrate.db_reader().get_state() == substrate.final_state()
+    finally:
+        substrate.close()
+
+
+def test_db_reader_get_state_filtered_by_tables(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        filtered = substrate.db_reader().get_state(tables=["users"])
+        assert filtered == {"tables": {"users": [{"id": 1, "name": "alice"}]}}
+        missing = substrate.db_reader().get_state(tables=["nonexistent"])
+        assert missing == {"tables": {}}
+    finally:
+        substrate.close()
+
+
+def test_db_reader_query_runs_jsonpath_locally(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        assert substrate.db_reader().query("$.tables.users[0].id") == {"results": [1]}
+    finally:
+        substrate.close()
+
+
+def test_open_part_corrupt_bytes_raises_substrate_unreachable(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        target = bundle_dir / "final_state.json"
+        data = bytearray(target.read_bytes())
+        data[0] = (data[0] + 1) % 256
+        target.write_bytes(bytes(data))
+        with pytest.raises(SubstrateUnreachableError) as excinfo:
+            substrate.final_state()
+        assert "final_state.json" in str(excinfo.value)
+        assert str(bundle_dir) in str(excinfo.value)
+    finally:
+        substrate.close()
+
+
+def test_bundle_dir_deleted_mid_read_raises_substrate_unreachable(tmp_path: Path) -> None:
+    bundle_dir, _ = _write_bundle(tmp_path)
+    view = load_grade_bundle(bundle_dir)
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        shutil.rmtree(bundle_dir)
+        with pytest.raises(SubstrateUnreachableError, match="final_state.json"):
+            substrate.final_state()
+    finally:
+        substrate.close()
+
+
+def test_missing_manifest_entry_raises_substrate_unreachable(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    view = GradeBundleView(
+        bundle_dir=bundle_dir,
+        manifest=GradeBundleManifest(
+            schema_version=BUNDLE_SCHEMA_VERSION,
+            trial_id="trial-missing",
+            parts={},
+        ),
+    )
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        with pytest.raises(SubstrateUnreachableError, match="final_state.json"):
+            substrate.final_state()
+    finally:
+        substrate.close()
+
+
+def test_symlink_escape_in_tar_rejected(tmp_path: Path) -> None:
+    tar_buf = io.BytesIO()
+    with tarfile.open(fileobj=tar_buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        main_info = tarfile.TarInfo(name="src/main.py")
+        body = b"print('hi')\n"
+        main_info.size = len(body)
+        main_info.mtime = 0
+        main_info.type = tarfile.REGTYPE
+        tar.addfile(main_info, io.BytesIO(body))
+        evil = tarfile.TarInfo(name="evil")
+        evil.type = tarfile.SYMTYPE
+        evil.linkname = "/etc/passwd"
+        evil.mtime = 0
+        tar.addfile(evil)
+    tar_bytes = tar_buf.getvalue()
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "filesystem.tar").write_bytes(tar_bytes)
+    tar_entry = {
+        "sha256": hashlib.sha256(tar_bytes).hexdigest(),
+        "size": len(tar_bytes),
+    }
+    view = GradeBundleView(
+        bundle_dir=bundle_dir,
+        manifest=GradeBundleManifest(
+            schema_version=BUNDLE_SCHEMA_VERSION,
+            trial_id="trial-hostile",
+            parts={"filesystem.tar": tar_entry},
+        ),
+    )
+    substrate = SnapshotGradingSubstrate(view)
+    try:
+        with pytest.raises(tarfile.FilterError):
+            substrate.filesystem_root()
+        tmpdir = substrate._filesystem_tmpdir  # noqa: SLF001 — assert nothing escaped
+        assert tmpdir is not None
+        assert not (Path(tmpdir.name) / "evil").exists()
+    finally:
+        substrate.close()

--- a/tolokaforge/core/grading/substrate.py
+++ b/tolokaforge/core/grading/substrate.py
@@ -69,10 +69,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from tolokaforge.core.grading.bundle import BundleIntegrityError, GradeBundleView
 from tolokaforge.core.grading.filesystem_view import read_agent_visible_filesystem
 
 if TYPE_CHECKING:
+    from tolokaforge.core.grading.bundle import GradeBundleView
     from tolokaforge.core.grading.judge import DBReader
     from tolokaforge.core.grading.kb_search import KnowledgeSearch
 
@@ -346,6 +346,18 @@ class InProcessGradingSubstrate:
 # ---------------------------------------------------------------------------
 
 
+_BUNDLE_MODULE = "tolokaforge.core.grading.bundle"
+"""Dotted name of the host-only bundle library.
+
+:meth:`SnapshotGradingSubstrate._read_part` compares
+``type(exc).__module__`` against this constant to translate
+``BundleError`` subclasses into :class:`SubstrateUnreachableError`
+without a static import — the bundle library is excluded from the
+runner subset (host-side producers/consumers only), and this shared-
+spine module ships in that subset.
+"""
+
+
 class _SnapshotDBReader:
     """Sync :class:`DBReader` view over a snapshot substrate's ``final_state``.
 
@@ -431,7 +443,14 @@ class SnapshotGradingSubstrate:
     def _read_part(self, rel_path: str) -> bytes:
         try:
             return self._bundle_view.open_part(rel_path)
-        except (BundleIntegrityError, OSError, KeyError) as exc:
+        except (OSError, KeyError) as exc:
+            raise SubstrateUnreachableError(
+                f"SnapshotGradingSubstrate cannot read part {rel_path!r} from "
+                f"{self._bundle_view.bundle_dir}: {type(exc).__name__}: {exc}"
+            ) from exc
+        except Exception as exc:
+            if type(exc).__module__ != _BUNDLE_MODULE:
+                raise
             raise SubstrateUnreachableError(
                 f"SnapshotGradingSubstrate cannot read part {rel_path!r} from "
                 f"{self._bundle_view.bundle_dir}: {type(exc).__name__}: {exc}"

--- a/tolokaforge/core/grading/substrate.py
+++ b/tolokaforge/core/grading/substrate.py
@@ -6,7 +6,7 @@ component evaluators above the substrate (rubric, judge, transcript rules,
 trace-check operators, state-check backends, custom-check executors) never
 change when the topology changes.
 
-See ADR-0040 for the design rationale + the recipes carried for the three
+See ADR-0040 for the design rationale + the recipes carried for the two
 reserved future substrates.
 
 The runtime picture
@@ -18,15 +18,15 @@ The runtime picture
 | Aggregate image (shipping)          | :class:`InProcessGradingSubstrate`     |
 | Independent grader (shipping)       | :class:`LiveRunnerCallbackGradingSub-  |
 |                                     | strate`                                |
+| Offline / cross-region / replay     | :class:`SnapshotGradingSubstrate`      |
+|                                     | (reads a serialised grade bundle)      |
 | Trajectory-storage service (future) | :class:`TrajectoryStorageGradingSub-   |
 |                                     | strate` (recipe in ADR-0040)           |
-| Snapshot-on-wire (future)           | :class:`SnapshotGradingSubstrate`      |
-|                                     | (recipe in ADR-0040)                   |
 | Shared-mount (future)               | :class:`SharedMountGradingSubstrate`   |
 |                                     | (recipe in ADR-0040)                   |
 +-------------------------------------+----------------------------------------+
 
-Two impls ship today. :class:`InProcessGradingSubstrate` is the aggregate-image
+Three impls ship today. :class:`InProcessGradingSubstrate` is the aggregate-image
 / in-runner path — a thin view over live objects the caller owns.
 :class:`~tolokaforge.core.grading.substrate_live.LiveRunnerCallbackGradingSubstrate`
 is the independent-grader path — each read dials the runner's read-only
@@ -35,10 +35,13 @@ is the independent-grader path — each read dials the runner's read-only
 transport failure raises :class:`SubstrateUnreachableError` and the seam
 translates that into ``GradingFailedError`` at the composite dispatch. It lives
 in the sibling :mod:`~tolokaforge.core.grading.substrate_live` module because
-the runner subset does not ship the gRPC client. The remaining three
-implementations are declared but not implemented — each raises
-``NotImplementedError`` with a pointer to ADR-0040 so a downstream contributor
-who reaches for them sees the recipe rather than a mystery stub.
+the runner subset does not ship the gRPC client. :class:`SnapshotGradingSubstrate`
+is the offline / cross-region / replay path — it reads state from a serialised
+:class:`~tolokaforge.core.grading.bundle.GradeBundleView` produced by
+:func:`~tolokaforge.core.grading.bundle.serialize_grade_bundle`; no live runner
+in reach. The two remaining implementations are declared but not implemented —
+each raises ``NotImplementedError`` with a pointer to ADR-0040 so a downstream
+contributor who reaches for them sees the recipe rather than a mystery stub.
 
 Two views of the trial's final DB state ride the Protocol side by side:
 :meth:`GradingSubstrate.final_state` returns the **RAW** rows the judge's
@@ -58,10 +61,16 @@ ships, it registers a one-line entry point — no framework PR needed.
 from __future__ import annotations
 
 import asyncio
+import io
 import json
+import tarfile
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from tolokaforge.core.grading.bundle import BundleIntegrityError, GradeBundleView
+from tolokaforge.core.grading.filesystem_view import read_agent_visible_filesystem
 
 if TYPE_CHECKING:
     from tolokaforge.core.grading.judge import DBReader
@@ -333,8 +342,159 @@ class InProcessGradingSubstrate:
 
 
 # ---------------------------------------------------------------------------
+# Shipped implementation 2 — SnapshotGradingSubstrate
+# ---------------------------------------------------------------------------
+
+
+class _SnapshotDBReader:
+    """Sync :class:`DBReader` view over a snapshot substrate's ``final_state``.
+
+    ``get_state`` returns the raw ``final_state`` dict (optionally filtered
+    to a subset of tables). ``query`` runs jsonpath locally over the same
+    dict — mirrors ``_GrpcDBReader.query`` in :mod:`substrate_live`, keeping
+    the caller-side jsonpath semantics uniform across topologies.
+    """
+
+    def __init__(self, substrate: SnapshotGradingSubstrate) -> None:
+        self._substrate = substrate
+
+    def get_state(self, tables: list[str] | None = None) -> dict[str, Any]:
+        state = self._substrate.final_state()
+        if not tables:
+            return state
+        inner = state.get("tables")
+        if isinstance(inner, dict):
+            filtered = {name: inner[name] for name in tables if name in inner}
+            return {**state, "tables": filtered}
+        return {name: state[name] for name in tables if name in state}
+
+    def query(self, jsonpath: str) -> dict[str, Any]:
+        from jsonpath_ng import parse
+
+        expr = parse(jsonpath)
+        return {"results": [match.value for match in expr.find(self._substrate.final_state())]}
+
+
+class SnapshotGradingSubstrate:
+    """The offline / cross-region / replay path: reads state from a serialised
+    grade bundle produced by
+    :func:`~tolokaforge.core.grading.bundle.serialize_grade_bundle`.
+
+    Constructed per-trial with a :class:`GradeBundleView` (already loaded
+    by :func:`~tolokaforge.core.grading.bundle.load_grade_bundle`). All
+    state reads resolve from bundle parts; no live runner, no gRPC channel,
+    no DSN reach.
+
+    Two Protocol methods have known offline limits in bundle format v1.0
+    and fail loud rather than silently returning empty:
+
+    - :meth:`db_probe` raises :class:`SubstrateUnreachableError` — the
+      caller-supplied DSN is only reachable inside the task's docker
+      network; offline substrates cannot dial it. A pack declaring
+      ``state_checks.db_probes`` is not gradeable in snapshot mode until
+      bundle format v1.1 pre-materialises probe rows.
+    - :meth:`knowledge_search` returns ``None`` — the bundle's optional
+      ``kb/`` subtree carries raw bytes without a queryable index. The
+      judge already treats ``None`` as "the trial declared no KB"; a
+      pack using rubric criteria that require KB search will grade
+      without the KB tool wired.
+
+    Every part read routes through the private :meth:`_read_part` helper,
+    which translates :class:`BundleIntegrityError` (corrupt bytes),
+    ``OSError`` (caller-deleted bundle_dir / permission / directory-in-
+    place-of-file / device errors), and ``KeyError`` (missing manifest
+    entry) into :class:`SubstrateUnreachableError`. The composite dispatch
+    swallows every other exception as "grade against empty state"; the
+    translated error is the sole class the seam propagates as
+    ``GradingFailedError``, keeping a corrupt or vanished bundle from
+    silently booking as a valid but empty grade.
+
+    :meth:`filesystem_root` lazily extracts ``filesystem.tar`` into a
+    :class:`tempfile.TemporaryDirectory` on first call, memoised for the
+    substrate's lifetime; extraction uses ``tar.extractall(path=root,
+    filter='data')`` (PEP 706) for comprehensive path-traversal defence.
+    :meth:`close` cleans up the tmpdir; the bundle view itself is
+    caller-owned.
+    """
+
+    def __init__(self, bundle_view: GradeBundleView) -> None:
+        self._bundle_view = bundle_view
+        self._initial_state_cache: dict[str, Any] | Any = _MISSING
+        self._final_state_cache: dict[str, Any] | Any = _MISSING
+        self._final_state_stable_cache: dict[str, Any] | Any = _MISSING
+        self._filesystem_root_cache: Path | None | Any = _MISSING
+        self._filesystem_state_cache: dict[str, str] | None | Any = _MISSING
+        self._filesystem_tmpdir: tempfile.TemporaryDirectory[str] | None = None
+        self._db_reader_cache: _SnapshotDBReader | None = None
+        self._closed = False
+
+    def _read_part(self, rel_path: str) -> bytes:
+        try:
+            return self._bundle_view.open_part(rel_path)
+        except (BundleIntegrityError, OSError, KeyError) as exc:
+            raise SubstrateUnreachableError(
+                f"SnapshotGradingSubstrate cannot read part {rel_path!r} from "
+                f"{self._bundle_view.bundle_dir}: {type(exc).__name__}: {exc}"
+            ) from exc
+
+    def db_reader(self) -> DBReader:
+        if self._db_reader_cache is None:
+            self._db_reader_cache = _SnapshotDBReader(self)
+        return self._db_reader_cache
+
+    def knowledge_search(self) -> KnowledgeSearch | None:
+        return None
+
+    def initial_state(self) -> dict[str, Any]:
+        if self._initial_state_cache is _MISSING:
+            self._initial_state_cache = json.loads(self._read_part("initial_state.json"))
+        return self._initial_state_cache
+
+    def final_state(self) -> dict[str, Any]:
+        if self._final_state_cache is _MISSING:
+            self._final_state_cache = json.loads(self._read_part("final_state.json"))
+        return self._final_state_cache
+
+    def final_state_stable(self) -> dict[str, Any]:
+        if self._final_state_stable_cache is _MISSING:
+            self._final_state_stable_cache = json.loads(self._read_part("final_state_stable.json"))
+        return self._final_state_stable_cache
+
+    def filesystem_root(self) -> Path | None:
+        if self._filesystem_root_cache is _MISSING:
+            data = self._read_part("filesystem.tar")
+            self._filesystem_tmpdir = tempfile.TemporaryDirectory(prefix="snapshot-workspace-")
+            root = Path(self._filesystem_tmpdir.name)
+            with tarfile.open(fileobj=io.BytesIO(data)) as tar:
+                tar.extractall(path=root, filter="data")
+            self._filesystem_root_cache = root
+        return self._filesystem_root_cache
+
+    def filesystem_state(self) -> dict[str, str] | None:
+        if self._filesystem_state_cache is _MISSING:
+            root = self.filesystem_root()
+            self._filesystem_state_cache = read_agent_visible_filesystem(root) if root else None
+        return self._filesystem_state_cache
+
+    def db_probe(self, dsn: str, query: str) -> list[dict[str, Any]]:  # noqa: ARG002
+        raise SubstrateUnreachableError(
+            f"SnapshotGradingSubstrate cannot serve db_probes offline (dsn={dsn!r}). "
+            f"This pack requires live_callback for grading; see docs/GRADER_SERVICE.md "
+            f"§ substrate topology."
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._filesystem_tmpdir is not None:
+            self._filesystem_tmpdir.cleanup()
+            self._filesystem_tmpdir = None
+
+
+# ---------------------------------------------------------------------------
 # Reserved future substrates — declared here so ADR-0040's design is
-# discoverable in one module. All three raise NotImplementedError with a
+# discoverable in one module. Both raise NotImplementedError with a
 # pointer to the ADR recipe.
 # ---------------------------------------------------------------------------
 
@@ -356,29 +516,6 @@ class TrajectoryStorageGradingSubstrate:
             "The recipe for wiring it is in docs/adr/0040-standalone-grader.md — "
             "the substrate ships as a separate PR once the trajectory-storage "
             "service is stable."
-        )
-
-
-class SnapshotGradingSubstrate:
-    """Reserved: Harbor-pattern snapshot-on-wire. State travels inside
-    ``GradeRequest``.
-
-    Recipe in ADR-0040 § "Reserved future substrate — SnapshotGradingSubstrate
-    (Harbor pattern)". Ship when offline replay / cross-region grading is a
-    hard requirement (grader outlives the runner, or lives in a different
-    network region). Filesystem cap policy + auto-fallback to live-callback
-    is part of the recipe — the shipped agent-visible walk names its
-    exclusion set on
-    :data:`~tolokaforge.core.grading.filesystem_view.AGENT_VISIBLE_EXCLUDES`
-    (``.git`` / ``.venv`` / ``node_modules`` / ``dist`` / ``.next``), so the
-    wire payload is bounded for most tolokaforge tasks.
-    """
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
-        raise NotImplementedError(
-            "SnapshotGradingSubstrate is a reserved future substrate. The recipe "
-            "for wiring it (GradeRequest v3, filesystem cap, auto-fallback to "
-            "LiveRunnerCallback) is in docs/adr/0040-standalone-grader.md."
         )
 
 


### PR DESCRIPTION
## Summary

**Phase C substrate activation.** Replaces the reserved `NotImplementedError` stub of `SnapshotGradingSubstrate` with a real implementation that reads state / filesystem / checks from a #1354 `GradeBundleView`. The grader can now grade a trial with a live runner completely absent — the third shipped substrate joins `InProcessGradingSubstrate` + `LiveRunnerCallbackGradingSubstrate`. Registered as `snapshot` under existing `tolokaforge.grading_substrates` entry-point group. Completes the Phase C bundle/store/substrate triple (#1354 + #1355 + #1353).

Byte-parity 25/25 untouched; 20 unit + 9 canonical parity tests lock the behaviour.

## Design choices

| Decision | Rationale |
|---|---|
| Constructor `SnapshotGradingSubstrate(bundle_view: GradeBundleView)` — one typed positional | Clean separation from `BundleStore` — the substrate transports nothing; it reads. The regrade CLI (#1361) owns the get+load+construct dance (see #1441 for optional factory). |
| `_read_part(rel_path) -> bytes` private helper wraps every `bundle_view.open_part(...)` | The composite call sites at `custom_checks.py:200-209` + `llm_judge.py:121-130` re-raise ONLY `SubstrateUnreachableError` and swallow every other exception with degrade-to-empty. A corrupt or vanished bundle would silently grade against empty state without the translator. `_read_part` catches `(BundleIntegrityError, OSError, KeyError)` (OSError is round-2 fold-in — widened from FileNotFoundError to catch PermissionError, IsADirectoryError, etc.) and translates to `SubstrateUnreachableError` naming the offending part + bundle_dir. |
| `filesystem_root()` lazy-materialises `filesystem.tar` to `tempfile.TemporaryDirectory` on first call | Extraction uses `tar.extractall(path=root, filter='data')` (PEP 706 / Python 3.12) — comprehensive path-traversal defence covering name/linkname/device nodes/PAX absolute paths/setuid metadata in one stdlib call. Round-1 critic fold-in — replaced a manual `TarInfo.name` check that would miss symlink `linkname` escapes. |
| `close()` cleanup idempotent; no-op if `filesystem_root()` never called | Mirrors `LiveRunnerCallbackGradingSubstrate._materialise_filesystem_root` lifecycle. Test `test_close_is_idempotent` + `test_close_cleans_up_filesystem_tmpdir` lock both paths. |
| `db_probe(dsn, query)` raises `SubstrateUnreachableError` naming the DSN | Bundle format v1.0 has no pre-materialised probe results. Operator debugging a snapshot-mode pack using `db_probes` gets a clear "snapshot substrate cannot serve db_probes" diagnostic instead of a silent "0 rows" red herring. #1438 tracks bundle format v1.1 for pre-materialised `db_probes.json`. |
| `knowledge_search(query)` returns `None` | Matches the Protocol's first-class "trial without a KB" contract (`substrate.py:122-130`). Bundle format v1.0 has no queryable KB index. #1439 tracks bundle format v1.1 for indexed KB snapshot. |
| Inline replacement in `substrate.py` (not new module) | Matches ADR-0040 recipe verbatim; keeps 3 shipped substrates + 2 reserved discoverable from one module. |
| Nested `_SnapshotDBReader` implements `DBReader` Protocol locally | `get_state(tables=[...])` walks `final_state["tables"]` sub-dict when present; `query(jsonpath)` uses `jsonpath_ng.parse` (lazy import) — mirrors `_GrpcDBReader.query` at `substrate_live.py:54-63`. |
| Parity test pipes InProcess through same `normalise_floats` (`%.6g`) as bundle producer | Bundle producer normalises floats at write; honest parity claim is "same wire-representable inputs → same reads". Alternative (remove floats from fixture) erased useful normaliser coverage. Impl caught the artefact on first test run. |

## What ships

- **Stage 1 (`48df8d97`)** — real impl + entry-point + 20 unit tests + drop from reserved-substrates parametrize:
  - All 9 Protocol methods implemented (`db_reader`, `knowledge_search`, `initial_state`, `final_state`, `final_state_stable`, `filesystem_root`, `filesystem_state`, `db_probe`, `close`).
  - `_read_part` translator: 3 dedicated tests locking corrupt-bytes / deleted-bundle-mid-read / missing-manifest-entry paths.
  - `test_symlink_escape_in_tar_rejected`: hostile tar with `evil -> /etc/passwd` symlink (via `TarInfo.linkname` — the vector manual `.name` check would miss); asserts `tarfile.FilterError` subclass.
  - Entry-point `snapshot = "tolokaforge.core.grading.substrate:SnapshotGradingSubstrate"`.
  - Dropped from `TestReservedFutureSubstratesRaiseWithAdrPointer` parametrize.

- **Stage 2 (`be53aa45`)** — canonical parity + 5 docs updates:
  - New `tests/canonical/test_snapshot_substrate_parity.py` (9 tests): Snapshot vs InProcess byte-equal on `initial_state`, `final_state`, `final_state_stable`, `db_reader.get_state`, `db_reader.query`, `filesystem_state`, `filesystem_root`, `_bundle_parts_round_trip`, `_entry_point_discovery`. Excludes `db_probe` + `knowledge_search` (documented in module docstring with rationale).
  - `docs/GRADING.md` + `docs/GRADER_SERVICE.md`: name snapshot as third shipped substrate.
  - `docs/GRADE_BUNDLE.md`: dropped "SnapshotGradingSubstrate not covered" line; added v1.1-tracked entries (#1438, #1439).
  - `docs/adr/0040-standalone-grader.md`: § "Reserved future substrate — SnapshotGradingSubstrate" rewritten as § "Shipped substrate — SnapshotGradingSubstrate"; new § "Deployment paths — three shipping substrates" as authoritative current state; historical Decision / Context sections preserved as time-anchored history.
  - `CHANGELOG.md`: `## [Unreleased] / ### Added` entry naming constructor shape + entry-point + the 2 offline limits.

- **Round-1 hygiene fix (`8787245a`)** — dropped "Stage 1" attribution + 2 vague "a v1.1 extension … is tracked upstream" future-planning bullets from parity test docstring.

## Test plan

- [x] `mcp__dev__run_tests marker=canonical keyword="snapshot or bundle or parity_reference"` — byte-parity 25/25 + 9 new parity tests green
- [x] `mcp__dev__run_tests path=tests/unit/grading/test_snapshot_substrate.py marker=unit` — 20 tests green
- [x] `uv run lint-imports` → **8 contracts kept** (no new contract; substrate change is inline)
- [x] Byte-parity 10-pack — `git diff --stat tests/canonical/grader_parity_baselines/` empty
- [x] Path-traversal defence verified: `test_symlink_escape_in_tar_rejected` uses `TarInfo.linkname` (not `.name`) — a manual `.name` check would let this through; `filter='data'` refuses
- [x] Fail-loud translator verified: 3 tests exercise corrupt-bytes / deleted-bundle / missing-manifest — each asserts `SubstrateUnreachableError` (not underlying `BundleIntegrityError`/`OSError`/`KeyError`)
- [x] Sharded reviewer trio — all APPROVE. Correctness first-pass (0 findings); hygiene 1 🔴 + 1 🟠 (Stage attribution + future-tense docstring) → fixed inline as `8787245a`; type-fit first-pass (0 findings).

## Follow-ups (already filed)

- **#1438** — bundle format v1.1: pre-materialised `db_probes.json` for snapshot grading. P2.
- **#1439** — bundle format v1.1: indexed KB snapshot for snapshot grading. P2.
- **#1440** — bundle format v1.1: distinguish "no workspace" from "empty workspace". P3.
- **#1441** — `snapshot_substrate_from_uri(store, uri)` factory (CLI ergonomics; folded into #1361). P3.
- **#1442** — activate `TrajectoryStorageGradingSubstrate` (post-milestone, blocked externally). P3.

Closes #1353.