### PR TITLE
fix(loop): empty-completion fail-loud termination + bounded API-error retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project are documented in this file.
   additive on `Trajectory`; the failure-attribution table classifies it as
   `timeout_or_resource` (provider-side deterministic termination), and the
   runner-side graders auto-fail it without dispatching to `grade_trial`.
+- **loop**: transient `TerminationReason.API_ERROR` classifications are
+  retried once (bounded, hardcoded default via
+  `LoopConfig.api_error_retries=1` + `api_error_backoff_s=1.0`) before
+  terminating the trial. Rate limits, API timeouts, `TRIAL_LOST` and empty
+  completions remain one-shot. The retry budget resets at every outer
+  turn, and the `messages` list is unchanged on a failed attempt so the
+  retry attempts against the same prefix.
 
 ## v0.22.1 (2026-09-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fix
+
+- **loop**: empty completions (no text + no tool calls) now terminate with
+  `TerminationReason.EMPTY_COMPLETION` (fail-loud) instead of silently
+  appending an empty assistant message that Gemini and similar providers
+  reject on the next request as an API error. The termination reason is
+  additive on `Trajectory`; the failure-attribution table classifies it as
+  `timeout_or_resource` (provider-side deterministic termination), and the
+  runner-side graders auto-fail it without dispatching to `grade_trial`.
+
 ## v0.22.1 (2026-09-02)
 
 ## v0.22.0 (2026-09-02)

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1682,6 +1682,30 @@ as a compatibility surface — user overlay syntax and the
 `resolve_policy_names` fingerprint). Routing pinned by
 [`tests/canonical/test_message_assembly_filler_routing.py`](../tests/canonical/test_message_assembly_filler_routing.py).
 
+### Provider-side empty completion
+
+A generation that comes back with both `text == ""` and `tool_calls == []`
+is a *provider-side empty completion*: the request round-tripped and the
+provider chose to return nothing. `ToolCallingLoop._run_turn` recognises
+that shape immediately after `_generate` — before the assistant message
+would be appended — and terminates the trial with
+`TerminationReason.EMPTY_COMPLETION` and `TrialStatus.FAILED`. The empty
+assistant message is not appended, and the metrics sink still records the
+generation because the trial paid for the call.
+
+The distinction from `empty_assistant_filler` above is where the empty
+content lives. `empty_assistant_filler` handles empty **content the loop
+is about to send back to the provider on a tool-call turn** — Bedrock/Nova
+and Moonshot direct reject a request whose assistant turn has empty
+`content` alongside `tool_calls`, so those provider families opt in to a
+non-empty filler string. `EMPTY_COMPLETION` handles empty **content the
+provider produced**: appending it would send a request whose tail is a
+`role=model` turn with empty `content` and no `tool_calls` on the next
+iteration, and Gemini rejects that as an API error. The engine consumes
+this one wire-shape observation directly rather than routing it through
+`classify_loop_error` so post-run analysis can tell "the model produced
+nothing" apart from the API-error class that used to swallow it.
+
 ## `response_policy`
 
 Tool-call argument post-processing.

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -2119,6 +2119,40 @@ module boundary. `ToolCallingLoop` receives it via
 classifiers (`core/runner.py`'s user-simulator retry, `core/resume.py`) are
 separate and unaffected — `AllApiKeysExhaustedError` subclasses `RuntimeError`.
 
+### Bounded API-error retry
+
+`ToolCallingLoop.run` retries a classified `TerminationReason.API_ERROR` in
+place, without incrementing the outer turn counter. `LoopConfig.api_error_retries`
+bounds the retry budget (default `1` — one retry, then fail loud);
+`LoopConfig.api_error_backoff_s` is the sleep between attempts (default
+`1.0` s). Sleep is dispatched through `ToolCallingLoop.retry_sleep`, which
+defaults to `time.sleep` and is swapped for a no-op in unit tests.
+
+The retry class is `API_ERROR` only. `RATE_LIMIT`, `API_TIMEOUT`, `TRIAL_LOST`
+and `EMPTY_COMPLETION` stay one-shot terminal because each already owns a
+dedicated path — typed 429 handling in the `_build_retrying` /
+`_build_probe_retrying` outer controllers above, transport-timeout retry in
+`_call_completion_with_timeout_retry`, substrate re-registration in the runner
+protocol, and the provider-shape fail-loud at wire receipt (see
+`empty_assistant_filler` § *Provider-side empty completion*). Retrying them at
+the loop level would double-count the exclusion and confuse the denominator.
+
+The retry budget resets to zero at the start of every outer iteration, so a
+successful turn 0 followed by an API-error turn 1 gets a fresh budget. The
+`messages` mutation invariant on a failed attempt is what makes replay safe:
+`_run_turn` mutates `messages` only after `_generate` succeeds
+(`messages.append(self._assistant_message(...))` sits after the `_generate`
+call), so a raise before that line leaves `messages` unchanged and the retry
+attempts against the same prefix.
+
+Composition with the judge's own retry: `RubricJudge` runs a bounded retry loop
+around `submit_report` validation errors inside its `LLMJudge` shell; a bad
+provider response inside one rubric turn retries once at the loop level, and the
+outer judge loop retries `submit_report` semantics on top. The two retries are
+orthogonal — one covers wire-level API-error transience, the other covers
+grader-contract validation — so composing them does not double-count the
+budget.
+
 ### Probe telemetry recording sites
 
 Both sides of throughput are recorded by the two ends of the same pair of hooks

--- a/tests/canonical/test_termination_reason_reachability.py
+++ b/tests/canonical/test_termination_reason_reachability.py
@@ -225,6 +225,7 @@ def observed_outcomes() -> frozenset[tuple[TrialStatus, TerminationReason]]:
         _run_trial(_wrapped_rate_limit()),
         _run_trial(RuntimeError("OpenAI returned 500")),
         _run_trial(RuntimeError("something the classifier cannot name")),
+        _run_trial(GenerationResult(text="", tool_calls=[], usage=Usage(prompt_tokens=1))),
         _provision_failure_trajectory(),
         drive_lost_trial()[0],
     ]

--- a/tests/unit/test_failure_attribution.py
+++ b/tests/unit/test_failure_attribution.py
@@ -44,12 +44,12 @@ _UNGRADEABLE = TrialOutcomeClass.UNGRADEABLE
 # the handful of pairs a reader expects, any default looks like any other, so a
 # test restricted to them proves the table's scope and never its truth.
 #
-# The two columns disagree in four reachable cells — ``(error, api_error)``,
-# ``(error, error)``, ``(error, trial_lost)`` and ``(timeout, timeout)`` are
-# retried *and* counted — and that is the design, not a defect: whether an
-# attempt is worth repeating and whether it measured the agent are different
-# questions. Deriving either column from the other is what this table exists to
-# prevent.
+# The two columns disagree in six reachable cells — ``(error, api_error)``,
+# ``(error, error)``, ``(error, trial_lost)``, ``(timeout, timeout)``,
+# ``(timeout, empty_completion)`` and ``(error, empty_completion)`` are retried
+# *and* counted — and that is the design, not a defect: whether an attempt is
+# worth repeating and whether it measured the agent are different questions.
+# Deriving either column from the other is what this table exists to prevent.
 _GRADED_CELLS: tuple[tuple[TrialStatus, TerminationReason | None, TrialOutcomeClass, bool], ...] = (
     (TrialStatus.COMPLETED, TerminationReason.AGENT_DONE, _MEASURED, False),
     (TrialStatus.COMPLETED, TerminationReason.USER_STOP, _MEASURED, False),
@@ -60,6 +60,7 @@ _GRADED_CELLS: tuple[tuple[TrialStatus, TerminationReason | None, TrialOutcomeCl
     (TrialStatus.COMPLETED, TerminationReason.RATE_LIMIT, _ABORT, True),
     (TrialStatus.COMPLETED, TerminationReason.API_TIMEOUT, _ABORT, False),
     (TrialStatus.COMPLETED, TerminationReason.API_ERROR, _MEASURED, True),
+    (TrialStatus.COMPLETED, TerminationReason.EMPTY_COMPLETION, _MEASURED, False),
     (TrialStatus.COMPLETED, TerminationReason.PROVISION_ERROR, _ABORT, False),
     (TrialStatus.COMPLETED, TerminationReason.TRIAL_LOST, _HARNESS, False),
     (TrialStatus.COMPLETED, None, _MEASURED, False),
@@ -72,6 +73,7 @@ _GRADED_CELLS: tuple[tuple[TrialStatus, TerminationReason | None, TrialOutcomeCl
     (TrialStatus.FAILED, TerminationReason.RATE_LIMIT, _ABORT, True),
     (TrialStatus.FAILED, TerminationReason.API_TIMEOUT, _ABORT, False),
     (TrialStatus.FAILED, TerminationReason.API_ERROR, _MEASURED, True),
+    (TrialStatus.FAILED, TerminationReason.EMPTY_COMPLETION, _MEASURED, False),
     (TrialStatus.FAILED, TerminationReason.PROVISION_ERROR, _ABORT, False),
     (TrialStatus.FAILED, TerminationReason.TRIAL_LOST, _HARNESS, False),
     (TrialStatus.FAILED, None, _HARNESS, False),
@@ -84,6 +86,7 @@ _GRADED_CELLS: tuple[tuple[TrialStatus, TerminationReason | None, TrialOutcomeCl
     (TrialStatus.TIMEOUT, TerminationReason.RATE_LIMIT, _ABORT, True),
     (TrialStatus.TIMEOUT, TerminationReason.API_TIMEOUT, _ABORT, True),
     (TrialStatus.TIMEOUT, TerminationReason.API_ERROR, _MEASURED, True),
+    (TrialStatus.TIMEOUT, TerminationReason.EMPTY_COMPLETION, _MEASURED, True),
     (TrialStatus.TIMEOUT, TerminationReason.PROVISION_ERROR, _ABORT, False),
     (TrialStatus.TIMEOUT, TerminationReason.TRIAL_LOST, _HARNESS, True),
     (TrialStatus.TIMEOUT, None, _HARNESS, True),
@@ -96,6 +99,7 @@ _GRADED_CELLS: tuple[tuple[TrialStatus, TerminationReason | None, TrialOutcomeCl
     (TrialStatus.ERROR, TerminationReason.RATE_LIMIT, _ABORT, True),
     (TrialStatus.ERROR, TerminationReason.API_TIMEOUT, _ABORT, True),
     (TrialStatus.ERROR, TerminationReason.API_ERROR, _MEASURED, True),
+    (TrialStatus.ERROR, TerminationReason.EMPTY_COMPLETION, _MEASURED, True),
     (TrialStatus.ERROR, TerminationReason.PROVISION_ERROR, _ABORT, False),
     (TrialStatus.ERROR, TerminationReason.TRIAL_LOST, _HARNESS, True),
     (TrialStatus.ERROR, None, _HARNESS, True),
@@ -182,7 +186,7 @@ class TestOutcomeClassificationCrossProduct:
             for ungradeable in (False, True)
         }
         assert cells == expected
-        assert len(_OUTCOME_CELLS) == len(expected) == 96
+        assert len(_OUTCOME_CELLS) == len(expected) == 104
 
     def test_the_class_column_exhausts_the_declared_vocabulary(self) -> None:
         """The table is hand-maintained and the enum is declared in production,
@@ -212,6 +216,16 @@ class TestOutcomeClassificationCrossProduct:
             if classify_trial_outcome(_cell_trajectory(TrialStatus.ERROR, reason)) is not _ABORT
         }
         assert counted == set(TerminationReason) - EXCLUDED_TYPED_REASONS
+
+    def test_empty_completion_stays_in_the_measured_denominator(self) -> None:
+        """A trial whose provider returned nothing is a measurement of the
+        model, not evidence the substrate broke, so it stays in the denominator.
+        The guard names the mechanism: adding ``EMPTY_COMPLETION`` to the
+        excluded set here would silently drop it from
+        ``measured_trials`` without failing
+        ``test_an_unrecognised_reason_would_be_counted`` (which locks the shape
+        of the derivation, not which reasons appear on either side)."""
+        assert TerminationReason.EMPTY_COMPLETION not in EXCLUDED_TYPED_REASONS
 
 
 class TestRetryabilityIsIndependentOfCountability:
@@ -330,6 +344,26 @@ def test_provision_error_classification():
     summary = summarize_failure_attributions([attribution])
     assert summary["total_failed_attempts"] == 1
     assert summary["by_failure_class"]["provision_failure"] == 1
+
+
+def test_an_empty_completion_is_attributed_to_a_provider_side_resource_event() -> None:
+    """The misattribution this reason exists to end, one artifact over: an
+    empty-completion trial has no failed tool call to scan — the model produced
+    nothing — so without its own branch it falls through to ``model_reasoning``
+    at confidence 0.5, blaming the agent for what was a provider-side event
+    (both ``text`` and ``tool_calls`` empty in the wire response)."""
+    traj = _base_trajectory()
+    traj.status = TrialStatus.FAILED
+    traj.termination_reason = TerminationReason.EMPTY_COMPLETION
+
+    attribution = attribute_failure(traj)
+
+    assert attribution["failure_class"] == "timeout_or_resource"
+    assert attribution["deterministic"] is True
+    assert attribution["confidence"] == 1.0
+    assert attribution["evidence"] == [
+        {"kind": "termination_reason", "value": "empty_completion", "status": "failed"}
+    ]
 
 
 def test_a_lost_trial_is_attributed_to_the_substrate_not_to_the_model() -> None:

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -17,6 +17,7 @@ generate seam and a tool executor are faked, no over-mocking of the loop.
 import time
 
 import pytest
+from litellm.exceptions import RateLimitError
 
 from tolokaforge.core.llm.client import GenerationResult, LLMApiTimeoutError
 from tolokaforge.core.llm.usage import Usage
@@ -35,15 +36,22 @@ pytestmark = pytest.mark.unit
 
 
 class _ScriptedClient:
-    """Yields a fixed sequence of GenerationResults, one per generate call."""
+    """Yields a fixed sequence of GenerationResults, one per generate call.
 
-    def __init__(self, results: list[GenerationResult]) -> None:
+    An entry that is an ``Exception`` instance is raised on that call instead —
+    the retry-loop tests script provider failures this way.
+    """
+
+    def __init__(self, results: list[GenerationResult | Exception]) -> None:
         self._results = list(results)
         self.calls = 0
 
     def generate(self, system, messages, tools, tool_choice="auto", observation=None):
         self.calls += 1
-        return self._results.pop(0)
+        item = self._results.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
 
 
 class _RecordingExecutor:
@@ -83,17 +91,28 @@ def _classify_no_patterns(exc: Exception) -> TerminationDecision:
     return classify_loop_error(exc, ())
 
 
-def _loop(client, *, should_terminate, user_turn=None, max_turns=5, executor=None, sink=None):
+def _loop(
+    client,
+    *,
+    should_terminate,
+    user_turn=None,
+    max_turns=5,
+    executor=None,
+    sink=None,
+    config=None,
+    retry_sleep=None,
+):
     return ToolCallingLoop(
         llm_client=client,
         tool_executor=executor or _RecordingExecutor(),
         tool_schemas=[],
-        config=LoopConfig(max_turns=max_turns, episode_timeout_s=10_000),
+        config=config or LoopConfig(max_turns=max_turns, episode_timeout_s=10_000),
         metrics=sink or _CountingSink(),
         should_terminate=should_terminate,
         user_turn=user_turn,
         classify_error=_classify_no_patterns,
         logger=_logger(),
+        retry_sleep=retry_sleep or (lambda _s: None),
     )
 
 
@@ -352,6 +371,177 @@ def test_empty_completion_still_records_generation_usage():
 
     assert sink.generations == 1
     assert sink.prompt_tokens == 7
+
+
+def test_api_error_retry_recovers_on_second_attempt():
+    """Bounded retry: a transient API-error on turn 0 recovers on the retry,
+    the tool call executes, the trial completes without a SYSTEM error."""
+    sleeps: list[float] = []
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            RuntimeError("LLM API call failed: gemini rejected empty tail"),
+            GenerationResult(
+                text="ok",
+                tool_calls=[ToolCall(id="a", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+            ),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=1, episode_timeout_s=10_000, api_error_retries=1, api_error_backoff_s=0.0
+        ),
+        retry_sleep=lambda s: sleeps.append(s),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    assert outcome.status == TrialStatus.COMPLETED
+    assert executor.executed == [("query", {"q": 1}, "a")]
+    assert not any(m.role == MessageRole.SYSTEM and "API error" in m.content for m in messages)
+    assert sleeps == [0.0]
+
+
+def test_api_error_retry_exhausts_and_fails_loud():
+    """Retry budget spent: after ``api_error_retries + 1`` attempts, the trial
+    terminates with the classified system message intact."""
+    client = _ScriptedClient(
+        [
+            RuntimeError("LLM API call failed: gemini rejected empty tail"),
+            RuntimeError("LLM API call failed: gemini rejected empty tail"),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        config=LoopConfig(
+            max_turns=5, episode_timeout_s=10_000, api_error_retries=1, api_error_backoff_s=0.0
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 2
+    assert outcome.status == TrialStatus.ERROR
+    assert outcome.termination_reason == TerminationReason.API_ERROR
+    assert messages[-1].role == MessageRole.SYSTEM
+    assert messages[-1].content == (
+        "API error: LLM API call failed: gemini rejected empty tail. Dialogue terminated."
+    )
+
+
+def test_api_error_retry_does_not_mutate_messages_before_success():
+    """Invariant lock: a raised attempt leaves ``messages`` unchanged, so the
+    successful attempt's assistant message stands alone with no ghost entry
+    from the failed attempt above it."""
+    client = _ScriptedClient(
+        [
+            RuntimeError("LLM API call failed: gemini rejected empty tail"),
+            GenerationResult(text="recovered", usage=Usage(prompt_tokens=5)),
+        ]
+    )
+    messages: list[Message] = []
+    _loop(
+        client,
+        should_terminate=_never_terminate,
+        config=LoopConfig(
+            max_turns=1, episode_timeout_s=10_000, api_error_retries=1, api_error_backoff_s=0.0
+        ),
+    ).run("sys", messages, time.time())
+
+    assistant_messages = [m for m in messages if m.role == MessageRole.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].content == "recovered"
+
+
+def test_rate_limit_stays_one_shot():
+    """Rate limits are not retried at the loop level — the client's own probe
+    controller owns 429 recovery, and retrying them here would double-count
+    the exclusion."""
+
+    def _classify_with_rate_limit(exc: Exception) -> TerminationDecision:
+        return classify_loop_error(exc, ())
+
+    wrapped_rate_limit = RuntimeError(
+        f"LLM API call failed: {RateLimitError(message='quota', llm_provider='openrouter', model='anthropic/claude')}"
+    )
+    wrapped_rate_limit.__cause__ = RateLimitError(
+        message="quota", llm_provider="openrouter", model="anthropic/claude"
+    )
+    client = _ScriptedClient([wrapped_rate_limit])
+    messages: list[Message] = []
+    outcome = ToolCallingLoop(
+        llm_client=client,
+        tool_executor=_RecordingExecutor(),
+        tool_schemas=[],
+        config=LoopConfig(
+            max_turns=5, episode_timeout_s=10_000, api_error_retries=5, api_error_backoff_s=0.0
+        ),
+        metrics=_CountingSink(),
+        should_terminate=_never_terminate,
+        classify_error=_classify_with_rate_limit,
+        logger=_logger(),
+        retry_sleep=lambda _s: None,
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 1
+    assert outcome.termination_reason == TerminationReason.RATE_LIMIT
+
+
+def test_empty_completion_not_retried():
+    """Cross-check with Stage 1: even with a generous retry budget, an empty
+    completion terminates on the first turn — the wire-shape signal owns its
+    own dedicated fail-loud path."""
+    client = _ScriptedClient(
+        [GenerationResult(text="", tool_calls=[], usage=Usage(prompt_tokens=1))]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        config=LoopConfig(
+            max_turns=5, episode_timeout_s=10_000, api_error_retries=5, api_error_backoff_s=0.0
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 1
+    assert outcome.termination_reason == TerminationReason.EMPTY_COMPLETION
+    assert outcome.status == TrialStatus.FAILED
+
+
+def test_api_error_retry_budget_resets_per_outer_turn():
+    """A successful turn 0 followed by an API-error turn 1 gets a fresh retry
+    budget: the counter resets at the start of every outer iteration, so a
+    future refactor that carried retry state across turns fails loud here."""
+    executor = _RecordingExecutor()
+    client = _ScriptedClient(
+        [
+            GenerationResult(
+                text="first",
+                tool_calls=[ToolCall(id="a", name="query", arguments={"q": 1})],
+                usage=Usage(prompt_tokens=5),
+            ),
+            RuntimeError("LLM API call failed: gemini rejected empty tail"),
+            GenerationResult(text="recovered", usage=Usage(prompt_tokens=5)),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(
+        client,
+        should_terminate=_never_terminate,
+        executor=executor,
+        config=LoopConfig(
+            max_turns=2, episode_timeout_s=10_000, api_error_retries=1, api_error_backoff_s=0.0
+        ),
+    ).run("sys", messages, time.time())
+
+    assert client.calls == 3
+    assert outcome.status == TrialStatus.COMPLETED
+    assert executor.executed == [("query", {"q": 1}, "a")]
+    assert not any(m.role == MessageRole.SYSTEM and "API error" in m.content for m in messages)
 
 
 def test_effective_system_prompt_captured_from_first_generation_only():

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -492,9 +492,9 @@ def test_rate_limit_stays_one_shot():
 
 
 def test_empty_completion_not_retried():
-    """Cross-check with Stage 1: even with a generous retry budget, an empty
-    completion terminates on the first turn — the wire-shape signal owns its
-    own dedicated fail-loud path."""
+    """Even with a generous retry budget, an empty completion terminates on
+    the first turn — the wire-shape signal owns its own dedicated fail-loud
+    path."""
     client = _ScriptedClient(
         [GenerationResult(text="", tool_calls=[], usage=Usage(prompt_tokens=1))]
     )

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -313,6 +313,47 @@ def test_generation_error_is_classified_via_shared_classifier():
     assert messages[-1].role == MessageRole.SYSTEM
 
 
+def test_empty_completion_terminates_before_appending():
+    """A generation with no text and no tool calls terminates the loop with
+    ``EMPTY_COMPLETION``, without ever appending the empty assistant message
+    that a subsequent request would send to the provider."""
+    client = _ScriptedClient(
+        [
+            GenerationResult(text="", tool_calls=[], usage=Usage(prompt_tokens=1)),
+            GenerationResult(text="unreached", usage=Usage(prompt_tokens=1)),
+        ]
+    )
+    messages: list[Message] = []
+    outcome = _loop(client, should_terminate=_never_terminate, max_turns=5).run(
+        "sys", messages, time.time()
+    )
+
+    assert client.calls == 1
+    assert outcome.termination_reason == TerminationReason.EMPTY_COMPLETION
+    assert outcome.status == TrialStatus.FAILED
+    assert not any(
+        m.role == MessageRole.ASSISTANT and m.content == "" and not m.tool_calls for m in messages
+    )
+    assert messages[-1].role == MessageRole.SYSTEM
+    assert "empty completion" in messages[-1].content
+
+
+def test_empty_completion_still_records_generation_usage():
+    """The trial paid for the empty completion, so metrics record it — only the
+    assistant message is skipped."""
+    client = _ScriptedClient(
+        [GenerationResult(text="", tool_calls=[], usage=Usage(prompt_tokens=7))]
+    )
+    sink = _CountingSink()
+    messages: list[Message] = []
+    _loop(client, should_terminate=_never_terminate, sink=sink, max_turns=5).run(
+        "sys", messages, time.time()
+    )
+
+    assert sink.generations == 1
+    assert sink.prompt_tokens == 7
+
+
 def test_effective_system_prompt_captured_from_first_generation_only():
     client = _ScriptedClient(
         [

--- a/tolokaforge/core/failure_attribution.py
+++ b/tolokaforge/core/failure_attribution.py
@@ -162,6 +162,7 @@ def attribute_failure(trajectory: Trajectory) -> dict[str, Any]:
         TerminationReason.TIMEOUT,
         TerminationReason.RATE_LIMIT,
         TerminationReason.API_ERROR,
+        TerminationReason.EMPTY_COMPLETION,
         TerminationReason.ERROR,
     ):
         failure_class = "timeout_or_resource"

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -95,10 +95,20 @@ class LoopConfig:
     There is deliberately no per-turn timeout: per-turn LLM timeouts are handled
     inside :class:`~tolokaforge.core.llm.client.LLMClient` (``api_call_timeout_s``
     + bounded retry), so episode wall-time is the only loop-level time bound.
+
+    ``api_error_retries`` and ``api_error_backoff_s`` set the loop-level bounded
+    retry that fires only on :attr:`TerminationReason.API_ERROR` — a transient
+    provider fault the classifier could not attribute to a typed reason.
+    ``RATE_LIMIT``, ``API_TIMEOUT``, ``TRIAL_LOST`` and ``EMPTY_COMPLETION`` stay
+    one-shot terminal because each owns a dedicated path (typed 429 handling,
+    transport-timeout retry, substrate re-registration, provider-shape
+    fail-loud) and retrying them here would double-count them.
     """
 
     max_turns: int = 50
     episode_timeout_s: int = 1200
+    api_error_retries: int = 1
+    api_error_backoff_s: float = 1.0
 
 
 @dataclass(frozen=True)
@@ -285,6 +295,11 @@ class ToolCallingLoop:
         None
     )
     call_observation: LLMCallObservation | None = None
+    # Bounded API-error retry sleep seam. Parallels ``LLMClient._retry_sleep``:
+    # tests bind a no-op so the loop's retry backoff is instant. See
+    # :attr:`LoopConfig.api_error_backoff_s` for the wait, and the retry class
+    # rules in the config docstring for which classified reasons trigger it.
+    retry_sleep: Callable[[float], None] = time.sleep
     # The episode's id assigner. Injected rather than owned: a trial's second
     # actor executes tool calls outside this loop and must draw from the same
     # sequence, while a rubric judge's loop takes the default and disambiguates
@@ -306,28 +321,13 @@ class ToolCallingLoop:
         termination_reason: TerminationReason | None = None
 
         for turn in range(self.config.max_turns):
-            timeout_decision = self._check_episode_timeout(start_time)
-            if timeout_decision is not None:
-                status = timeout_decision.status or status
-                termination_reason = timeout_decision.reason
-                messages.append(self._system_message(timeout_decision.system_message))
+            outcome = self._attempt_turn(turn, system_prompt, messages, start_time)
+            if isinstance(outcome, TerminationDecision):
+                messages.append(self._system_message(outcome.system_message))
+                status = outcome.status or status
+                termination_reason = outcome.reason
                 break
-
-            try:
-                turn_status, turn_reason, stop = self._run_turn(turn, system_prompt, messages)
-            except Exception as exc:  # noqa: BLE001 — classified, then surfaced via status
-                self.logger.error(
-                    "Error during turn execution",
-                    turn=turn,
-                    error=str(exc),
-                    error_type=type(exc).__name__,
-                )
-                decision = self.classify_error(exc)
-                messages.append(self._system_message(decision.system_message))
-                status = decision.status or TrialStatus.ERROR
-                termination_reason = decision.reason
-                break
-
+            turn_status, turn_reason, stop = outcome
             if turn_status is not None:
                 status = turn_status
             if stop:
@@ -346,6 +346,57 @@ class ToolCallingLoop:
             termination_reason=termination_reason,
             captured_effective_system_prompt=self._captured_effective_prompt,
         )
+
+    def _attempt_turn(
+        self,
+        turn: int,
+        system_prompt: str,
+        messages: list[Message],
+        start_time: float,
+    ) -> TerminationDecision | tuple[TrialStatus | None, TerminationReason | None, bool]:
+        """Run one turn with the bounded API-error retry budget.
+
+        Returns the turn's ``(status_override, reason, stop)`` triple when the
+        attempt produced a result the outer loop should consume. Returns a
+        :class:`TerminationDecision` when the outer loop must stop — either
+        because the episode wall-time budget is spent, or because a classified
+        exception cannot be recovered by another attempt.
+
+        The API-error retry budget resets to zero on every call, so a
+        successful turn followed by an API-error turn gets a fresh budget.
+        Only :attr:`TerminationReason.API_ERROR` triggers a retry: rate limits,
+        API timeouts, trial-lost and empty completions stay one-shot terminal.
+        """
+        api_error_attempts = 0
+        while True:
+            timeout_decision = self._check_episode_timeout(start_time)
+            if timeout_decision is not None:
+                return timeout_decision
+            try:
+                return self._run_turn(turn, system_prompt, messages)
+            except Exception as exc:  # noqa: BLE001 — classified, then surfaced via status
+                self.logger.error(
+                    "Error during turn execution",
+                    turn=turn,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                decision = self.classify_error(exc)
+                if (
+                    decision.reason is TerminationReason.API_ERROR
+                    and api_error_attempts < self.config.api_error_retries
+                ):
+                    api_error_attempts += 1
+                    self.logger.info(
+                        "Retrying turn after classified API error",
+                        turn=turn,
+                        attempt=api_error_attempts,
+                        max_attempts=self.config.api_error_retries + 1,
+                        backoff_s=self.config.api_error_backoff_s,
+                    )
+                    self.retry_sleep(self.config.api_error_backoff_s)
+                    continue
+                return decision
 
     def _run_turn(
         self, turn: int, system_prompt: str, messages: list[Message]

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -8,7 +8,13 @@ the same machinery.
 The engine is deliberately behaviour-light: it owns turn structure (episode
 timeout, generate, accumulate, append assistant, terminate, execute tools,
 optional user turn, error classification, max-turns), and delegates every
-*policy* decision to pluggable seams:
+*policy* decision to pluggable seams. A provider-shaped *empty completion* —
+``result.text == "" and not result.tool_calls`` — is the one wire-shape
+observation the engine consumes directly: it terminates the trial with
+:attr:`TerminationReason.EMPTY_COMPLETION` before the empty assistant message
+is appended, because appending it would send a request whose tail is an empty
+``role=model`` turn on the next iteration and providers such as Gemini reject
+that as an API error rather than pass it through.
 
 * :class:`LoopLLMClient` — the provider-agnostic generate seam (the agent's
   :class:`~tolokaforge.core.llm.client.LLMClient` already satisfies it).
@@ -355,6 +361,16 @@ class ToolCallingLoop:
         self._capture_effective_prompt(result)
         self.metrics.record_generation(result)
         self._log_generation(turn, result)
+
+        if not result.text and not result.tool_calls:
+            messages.append(
+                self._system_message(
+                    "Model returned an empty completion (no text, no tool calls); "
+                    "trial terminated to keep the next request provider-legal."
+                )
+            )
+            return TrialStatus.FAILED, TerminationReason.EMPTY_COMPLETION, True
+
         messages.append(self._assistant_message(result))
 
         decision = self.should_terminate(result, turn, messages)

--- a/tolokaforge/core/models/trajectory.py
+++ b/tolokaforge/core/models/trajectory.py
@@ -105,6 +105,7 @@ class TerminationReason(str, Enum):
     RATE_LIMIT = "rate_limit"  # API rate limit error
     API_TIMEOUT = "api_timeout"  # API call timed out after retries
     API_ERROR = "api_error"  # Other API errors
+    EMPTY_COMPLETION = "empty_completion"  # Provider returned no text and no tool calls
     PROVISION_ERROR = "provision_error"  # Substrate provisioning failed before the trial body ran
     TRIAL_LOST = "trial_lost"  # The substrate no longer holds the trial the engine was running
 

--- a/tolokaforge/core/trial_grader.py
+++ b/tolokaforge/core/trial_grader.py
@@ -20,7 +20,10 @@ The conductor's job (per ``docs/CLOUD_RUNTIME_ARCHITECTURE.md`` §6.3) is to
      positive.
   3. ``TerminationReason.STUCK_DETECTED`` — auto-fail. A stuck agent fails
      even if the state hash happens to match the golden.
-  4. Otherwise — the runner's ``grade_trial`` gRPC computes state / rule /
+  4. ``TerminationReason.EMPTY_COMPLETION`` — auto-fail. The model returned
+     no text and no tool calls, so there is nothing to grade: dispatching to
+     the runner would score empty content against the golden.
+  5. Otherwise — the runner's ``grade_trial`` gRPC computes state / rule /
      judge components against the golden state and returns a raw dict that
      is parsed into :class:`Grade`. A grading run that could not produce a
      verdict raises :class:`GradingFailedError`; the verdict is the runner's
@@ -282,6 +285,20 @@ class RunnerRPCTrialGrader:
                 score=0.0,
                 components=GradeComponents(state_checks=0.0),
                 reasons="Agent got stuck (repeated actions without progress)",
+            )
+
+        if trajectory.termination_reason == TerminationReason.EMPTY_COMPLETION:
+            self.logger.info(
+                "Trial ended with an empty completion - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(state_checks=0.0),
+                reasons="Model returned an empty completion (no text, no tool calls)",
             )
 
         llm_messages_json = encode_transcript_wire(trajectory, agent_system_prompt)
@@ -629,6 +646,20 @@ class JudgeBackedTrialGrader:
                 reasons="Agent got stuck (repeated actions without progress)",
             )
 
+        if trajectory.termination_reason == TerminationReason.EMPTY_COMPLETION:
+            self.logger.info(
+                "Trial ended with an empty completion - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(llm_judge=0.0),
+                reasons="Model returned an empty completion (no text, no tool calls)",
+            )
+
         grade = self.judge_fn(spec, trajectory, agent_system_prompt)
         if grade is None:
             self.logger.info(
@@ -743,6 +774,20 @@ class GraderRPCTrialGrader:
                 score=0.0,
                 components=GradeComponents(state_checks=0.0),
                 reasons="Agent got stuck (repeated actions without progress)",
+            )
+
+        if trajectory.termination_reason == TerminationReason.EMPTY_COMPLETION:
+            self.logger.info(
+                "Trial ended with an empty completion - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(state_checks=0.0),
+                reasons="Model returned an empty completion (no text, no tool calls)",
             )
 
         _refuse_hash_grading_on_grader_rpc(spec)
@@ -933,6 +978,20 @@ class QueueTrialGrader:
                 score=0.0,
                 components=GradeComponents(state_checks=0.0),
                 reasons="Agent got stuck (repeated actions without progress)",
+            )
+
+        if trajectory.termination_reason == TerminationReason.EMPTY_COMPLETION:
+            self.logger.info(
+                "Trial ended with an empty completion - automatic fail",
+                task_id=task_id,
+                trial_index=trial_idx,
+                termination_reason=trajectory.termination_reason.value,
+            )
+            return Grade(
+                binary_pass=False,
+                score=0.0,
+                components=GradeComponents(state_checks=0.0),
+                reasons="Model returned an empty completion (no text, no tool calls)",
             )
 
         _refuse_hash_grading_on_grader_rpc(spec)


### PR DESCRIPTION
## Summary

- Provider-side empty completions (`text == "" and not tool_calls`) terminate the trial with a new `TerminationReason.EMPTY_COMPLETION` before the empty assistant message can be appended to the trajectory tail. Gemini's endpoint rejects a request whose last turn is an empty model turn; the current behaviour was to append silently, re-invoke the provider, and die with an unclassified `API_ERROR`. Field impact: 35 trials × 7 domains on the last v3 sample.
- Loop-level bounded API-error retry — one retry with a 1.0 s backoff on `TerminationReason.API_ERROR` only. `RATE_LIMIT` / `API_TIMEOUT` / `TRIAL_LOST` / `EMPTY_COMPLETION` stay one-shot terminal.

## Design choices

- **Fail-loud termination on empty completion, not synthetic filler.** A synthetic non-empty assistant tail would fake a model turn; Gemini pattern-matches such fillers back into future turns (gotcha #23) and hides the model failure from downstream analysis.
- **`TrialStatus.FAILED` for the empty-completion path.** The harness worked; the model produced nothing. Keeps the trial in the graded MEASURED denominator — `ERROR` would attribute the trial to us as a harness bug.
- **Retry defaults `api_error_retries=1, api_error_backoff_s=1.0` hardcoded on `LoopConfig`.** Smallest non-zero values that give a transient provider hiccup one recovery window without noticeable unit-test slowdown. Not exposed via `run_config.yaml` / CLI — no compatibility surface change.
- **Retry class is `API_ERROR` only.** Every other classified reason owns a dedicated recovery path (rate-limit probe, transport-timeout retry, substrate re-registration, provider-shape fail-loud). Retrying them at the loop level would double-count and confuse the denominator.
- **Grader auto-fail branch expansion.** Every `TrialGrader` subclass (`RunnerRPCTrialGrader`, `JudgeBackedTrialGrader`, `GraderRPCTrialGrader`, `QueueTrialGrader`) gains an `EMPTY_COMPLETION` auto-fail mirroring the existing `STUCK_DETECTED` shape, so the `test_only_reasons_from_a_completed_trial_reach_grade_trial` reachability invariant continues to hold (justified drift from plan, discovered during Stage 1 implementation).

## Concepts introduced

**`TerminationReason.EMPTY_COMPLETION`** — a wire-shape signal the engine consumes directly. The rest of the engine remains behaviour-light on provider payloads; empty completions are the one exception because the next request must stay provider-legal. Failure-attribution groups the reason with `TIMEOUT / RATE_LIMIT / API_ERROR / ERROR` under `failure_class="timeout_or_resource"`, `deterministic=True`.

**`LoopConfig.api_error_retries` / `api_error_backoff_s` + `ToolCallingLoop.retry_sleep`** — a bounded loop-level retry for the narrow class of transient `API_ERROR` classifications, plus an injectable sleep seam parallel to `LLMClient._retry_sleep`. Attempt counter resets to 0 at the start of each outer-turn iteration. The `_attempt_turn` helper carries the retry state machine; the outer `run` dispatches on its return type (`TerminationDecision | tuple[...]`).

## Plan

See `/Users/cirogam/.claude/plans/toloka-tolokaforge/issue-1443-empty-completion-and-retry.md` — 2 stages, plan-critic reviewed round 1 REVISE (2🔴 + 1🟠 + 3🟡) → round 2 APPROVE WITH NOTES.

## Discovered issues

- Filed: none
- Fixed in this PR: grader auto-fail expansion for `EMPTY_COMPLETION` (Stage 1 justified drift), documented in commit body.

## Test plan

- `pytest tests/unit/test_tool_calling_loop.py tests/unit/test_failure_attribution.py tests/canonical/test_termination_reason_reachability.py` — 246 passed.
- `pytest tests/unit/test_orchestrator_logic.py tests/unit/test_runner_logic.py tests/unit/loop/ tests/unit/grading/ tests/unit/test_metrics.py` — 2160+ passed.
- Sharded reviewers: correctness APPROVE WITH NITS (1 🔵 `test_api_error_classification` sleeps 1 s on the retry — optional follow-up), hygiene APPROVE WITH NITS (1 §7a docstring fix applied at 65639559), type-fit APPROVE (1 🟡 `_attempt_turn` union return type — refactor-when-needed).

## Follow-up nits (not blocking)

- **`test_api_error_classification` 1 s sleep** (`tests/unit/test_runner_logic.py:765`). Fix: wire `retry_sleep` through `TrialRunner` and inject a no-op in `_make_runner`, or set `api_error_backoff_s=0.0` on the specific test's `LoopConfig`. Marginal unit-test runtime cost only; no behaviour change.
- **`_attempt_turn` return-type union** (`tolokaforge/core/loop.py:350-356`). The `TerminationDecision | tuple[...]` return has clean `isinstance` dispatch today; the tuple's `stop: bool` field encodes both "advance" and "stop", so the type doesn't name the semantic distinction. Refactor when either `_run_turn` or `_attempt_turn` grows a third return arm.

Closes #1443