### PR TITLE
fix(tools): schema-executor parity — validate against the sanitized schema (#1445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ### Fix
 
 - **grading**: runner-side `compute_state_diff` reports an `order_mismatch` verdict on the same-set-different-order class, so `hash_score: 0.0` never sits beside a `state_diff` that reads as identical. `TableDiff` gains an additive `order_mismatch: bool = False` field (JSON-wire additive, older readers ignore the extra key); `StateDiff.identical` widens to include the flag (#1444).
+- **tools**: `ToolExecuting.execute` grows a keyword-only `validation_schema: dict[str, Any] | None = None` parameter — when supplied, `ToolExecutor.execute` validates arguments against it instead of the tool's own `get_schema()["function"]["parameters"]`. `ToolCallingLoop` gains a `validation_schemas_by_tool` field wired at both loop construction sites (agent runner + rubric judge) from `LLMClient.sanitize_tools_for_execution(tools)`, so the executor validates against the sanitized schema the model actually saw. Closes the `INVALID_ARGUMENTS`-misroute class where a Gemini-flattened `oneOf`+`discriminator` tool argument conformed to the model's shown surface but was rejected by the executor's validation against the original nested shape. `DockerRunnerAdapter.execute` names `validation_schema` explicitly and discards it; the runner-side gRPC path does no jsonschema validation (#976). General `**kwargs`-smuggling hazard tracked at #1474 (#1445).
 
 ## v0.22.2 (2026-09-02)
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -378,7 +378,7 @@ wired at construction from `LLMClient.sanitize_tools_for_execution(tools)`.
 This invariant applies wherever `ToolExecutor` runs (LLM-judge tool loop,
 harness CLI invocations that go through the loop, direct instantiations).
 The runner-side gRPC path does no jsonschema validation at all; closing
-that asymmetry is tracked at [#976](https://github.com/toloka/tolokaforge/issues/976).
+that asymmetry is tracked at [#976](https://github.com/Toloka/tolokaforge/issues/976).
 
 ### `StrictSchema` contract — preserve information by default, fail loudly on hazards
 

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -368,6 +368,18 @@ Three concrete sanitizers ship today:
   dict-map → array transform. See [`AGENTS.md`](../AGENTS.md) gotcha #21
   for the wire-level symptom.
 
+**Executor validates against the sanitized surface.** The parameters
+schema the model was shown for a tool is the schema
+[`ToolExecutor.execute`](../tolokaforge/tools/registry.py) validates the
+model's argument dict against — not the tool's original
+`get_schema()["function"]["parameters"]`. The seam is
+[`ToolCallingLoop.validation_schemas_by_tool`](../tolokaforge/core/loop.py),
+wired at construction from `LLMClient.sanitize_tools_for_execution(tools)`.
+This invariant applies wherever `ToolExecutor` runs (LLM-judge tool loop,
+harness CLI invocations that go through the loop, direct instantiations).
+The runner-side gRPC path does no jsonschema validation at all; closing
+that asymmetry is tracked at [#976](https://github.com/toloka/tolokaforge/issues/976).
+
 ### `StrictSchema` contract — preserve information by default, fail loudly on hazards
 
 The sanitiser is **position-aware**: it walks the JSON-Schema tree

--- a/tests/canonical/test_executor_sanitizer_parity.py
+++ b/tests/canonical/test_executor_sanitizer_parity.py
@@ -27,8 +27,8 @@ locally with:
 The local extensions live in this module rather than in the shared file
 because the shared file drives snapshot tests
 (``test_sanitizer_contract_snapshot``) whose baselines are keyed by preset
-name and tool count; extending them here keeps this stage's landing
-snapshot-free.
+name and tool count; extending them here avoids regenerating those
+baselines.
 """
 
 from __future__ import annotations

--- a/tests/canonical/test_executor_sanitizer_parity.py
+++ b/tests/canonical/test_executor_sanitizer_parity.py
@@ -1,0 +1,407 @@
+"""Canonical parity: the sanitized schema IS the accepted-args schema.
+
+For every preset ``P`` and every tool ``T`` in the fixture set,
+
+    ToolExecutor.execute(
+        T.name, ARGS, call_id="canon", validation_schema=sanitize(T)
+    )
+
+accepts ``ARGS`` when ``ARGS`` conforms to ``sanitize(T)`` and rejects
+``ARGS`` when ``ARGS`` violates ``sanitize(T)``.
+
+Reuses the shared preset fixture (``_PRESET_SELECTORS``) and the tool
+description list (``_MODEL_SPECS``) from
+:mod:`tests.canonical.test_sanitizer_contract` unchanged, and extends both
+locally with:
+
+* one additional preset — ``gemini`` — because
+  :attr:`GeminiSchema.flatten_oneof_discriminator` is the only sanitizer
+  path that rewrites a ``oneOf``+``discriminator`` shape, and the shared
+  fixture does not carry a Gemini row;
+* one additional Pydantic model — :class:`DiscriminatedUnionInput` — whose
+  parameters carry ``Annotated[Ticket | Task, Field(discriminator="kind")]``.
+  Under the ``gemini`` preset this pair yields ``sanitize(T) != T``, so the
+  invariant here exercises the flatten seam rather than collapsing to
+  "the executor accepts what it always did".
+
+The local extensions live in this module rather than in the shared file
+because the shared file drives snapshot tests
+(``test_sanitizer_contract_snapshot``) whose baselines are keyed by preset
+name and tool count; extending them here keeps this stage's landing
+snapshot-free.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Annotated, Any, Literal
+
+import pytest
+from jsonschema import ValidationError
+from jsonschema import validate as jsonschema_validate
+from pydantic import BaseModel, Field, TypeAdapter
+
+from tests.canonical.test_sanitizer_contract import (
+    _MODEL_SPECS as _BASE_MODEL_SPECS,
+)
+from tests.canonical.test_sanitizer_contract import (
+    _PRESET_SELECTORS as _BASE_PRESET_SELECTORS,
+)
+from tolokaforge.core.llm import build_capabilities
+from tolokaforge.tools.registry import (
+    Tool,
+    ToolExecutionStatus,
+    ToolExecutor,
+    ToolRegistry,
+    ToolResult,
+)
+
+pytestmark = pytest.mark.canonical
+
+
+# ---------------------------------------------------------------------------
+# Local fixture extension — Gemini preset + discriminated-union model
+# ---------------------------------------------------------------------------
+
+
+class Ticket(BaseModel):
+    kind: Literal["ticket"]
+    ticket_id: str = Field(description="Ticket identifier.")
+    subject: str = Field(description="Ticket subject line.")
+
+
+class Task(BaseModel):
+    kind: Literal["task"]
+    task_id: str = Field(description="Task identifier.")
+    title: str = Field(description="Task title.")
+
+
+class DiscriminatedUnionInput(BaseModel):
+    """Pydantic-emitted ``oneOf`` + ``discriminator`` shape — the surface
+    :meth:`GeminiSchema._flatten_oneof_discriminator` collapses into a
+    single object schema unioning every branch's ``properties``."""
+
+    item: Annotated[Ticket | Task, Field(discriminator="kind")]
+
+
+_EXTENDED_MODEL_SPECS: list[tuple[str, type[BaseModel], str]] = list(_BASE_MODEL_SPECS) + [
+    (
+        "discriminated_union",
+        DiscriminatedUnionInput,
+        "Discriminated Ticket|Task item.",
+    ),
+]
+
+
+_EXTENDED_PRESET_SELECTORS: list[tuple[str, str, str]] = list(_BASE_PRESET_SELECTORS) + [
+    # ``google/gemini-3-pro-preview`` routes to :class:`GeminiSchema` (the
+    # base flatten-enabled sanitizer). A ``gemini-3.5-flash`` name routes to
+    # :class:`GeminiRecursiveSchema` (a subclass); either would exercise the
+    # flatten path, but the base preset stays closer to the canonical shape.
+    ("gemini", "google/gemini-3-pro-preview", "openrouter"),
+]
+
+
+def _build_extended_tool_list() -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for name, model, description in _EXTENDED_MODEL_SPECS:
+        schema = TypeAdapter(model).json_schema()
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": schema,
+                },
+            }
+        )
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Minimal-instance generator — dumb by design
+# ---------------------------------------------------------------------------
+
+
+def _minimal_instance(schema: dict[str, Any], defs: dict[str, Any] | None = None) -> Any:
+    """Return one minimal value conforming to ``schema``.
+
+    Handles the JSON-Schema constructs the fixture's sanitized outputs use:
+    ``enum`` / ``const`` (first value), ``$ref`` (resolved via ``defs``),
+    ``oneOf`` / ``anyOf`` / ``allOf`` (first branch), and the leaf types
+    (``object`` recurses into ``required``; ``array`` → ``[]``; scalars →
+    their zero value). Constraints the generator does not model (``pattern``,
+    ``minimum``, ``minLength``, …) are ignored; the round-trip assertion
+    below re-validates the produced instance and skips the row when the
+    witness lands invalid, keeping the generator "deliberately dumb" as
+    specified by the plan.
+    """
+    if not isinstance(schema, dict):
+        return None
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/$defs/") and defs is not None:
+        target = defs.get(ref.removeprefix("#/$defs/"))
+        if isinstance(target, dict):
+            return _minimal_instance(target, defs)
+    if "enum" in schema:
+        return schema["enum"][0]
+    if "const" in schema:
+        return schema["const"]
+    for key in ("oneOf", "anyOf", "allOf"):
+        branches = schema.get(key)
+        if isinstance(branches, list) and branches:
+            first = next((b for b in branches if isinstance(b, dict)), None)
+            if first is not None:
+                return _minimal_instance(first, defs)
+    node_type = schema.get("type")
+    if isinstance(node_type, list):
+        node_type = next((t for t in node_type if t != "null"), node_type[0])
+    if node_type == "object":
+        properties = schema.get("properties") or {}
+        required = schema.get("required") or []
+        result: dict[str, Any] = {}
+        for prop in required:
+            prop_schema = properties.get(prop)
+            if isinstance(prop_schema, dict):
+                result[prop] = _minimal_instance(prop_schema, defs)
+        return result
+    if node_type == "array":
+        return []
+    if node_type == "integer":
+        return 0
+    if node_type == "number":
+        return 0
+    if node_type == "boolean":
+        return False
+    if node_type == "null":
+        return None
+    return ""
+
+
+_WRONG_TYPE_SUBSTITUTES: dict[str, Any] = {
+    "string": 999,
+    "integer": "not an integer",
+    "number": "not a number",
+    "boolean": "not a boolean",
+    "object": "not an object",
+    "array": "not an array",
+}
+
+
+def _first_wrong_type_mutation(
+    schema: dict[str, Any], instance: dict[str, Any], defs: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Return a shallow-mutated instance whose first required field carries a
+    value of an incompatible type, or ``None`` when the schema declares no
+    required fields at the root. The mutation is enough to trip jsonschema's
+    ``type`` check on that field.
+    """
+    if schema.get("type") != "object":
+        return None
+    properties = schema.get("properties") or {}
+    for prop in schema.get("required") or []:
+        prop_schema = properties.get(prop)
+        if not isinstance(prop_schema, dict):
+            continue
+        prop_type = prop_schema.get("type")
+        if isinstance(prop_type, list):
+            prop_type = next((t for t in prop_type if t != "null"), None)
+        # Resolve one level of $ref when the sanitizer left it in place.
+        if prop_type is None and defs is not None:
+            ref = prop_schema.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                target = defs.get(ref.removeprefix("#/$defs/"))
+                if isinstance(target, dict):
+                    prop_type = target.get("type")
+        substitute = _WRONG_TYPE_SUBSTITUTES.get(prop_type)
+        if substitute is None:
+            continue
+        mutated = dict(instance)
+        mutated[prop] = substitute
+        return mutated
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Test tool — parameters come from the fixture's original (unsanitised) schema
+# ---------------------------------------------------------------------------
+
+
+class _AcceptingTool(Tool):
+    """A tool that reports success on any arg dict — the executor's
+    validation gate is the subject of these tests, not the tool's body."""
+
+    def __init__(self, tool_name: str, parameters: dict[str, Any]) -> None:
+        super().__init__(tool_name, "canonical parity fixture")
+        self._parameters = parameters
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": "canonical parity fixture",
+                "parameters": self._parameters,
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(success=True, output="ok")
+
+
+_PARITY_ROWS: list[tuple[str, str, str, str]] = [
+    (preset_name, model_name, provider, tool_name)
+    for preset_name, model_name, provider in _EXTENDED_PRESET_SELECTORS
+    for tool_name, _, _ in _EXTENDED_MODEL_SPECS
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixture-drift guard — the point of adding Gemini + discriminated_union
+# ---------------------------------------------------------------------------
+
+
+def test_at_least_one_row_has_sanitizer_rewriting_the_schema() -> None:
+    """Locks the fixture-extension precondition: without at least one
+    ``(preset, tool)`` pair where ``sanitize(T) != T``, every parametric row
+    below would exercise the trivial "sanitizer left it alone" path and the
+    invariant would not fire on a Gemini-flatten regression.
+    """
+    tools = _build_extended_tool_list()
+    tools_by_name = {t["function"]["name"]: t for t in tools}
+    rewrites = 0
+    for _preset_name, model_name, provider in _EXTENDED_PRESET_SELECTORS:
+        capabilities = build_capabilities(model_name, provider)
+        sanitised = capabilities.schema_sanitizer.sanitize(copy.deepcopy(tools))
+        for sanitised_tool in sanitised:
+            tool_name = sanitised_tool["function"]["name"]
+            if (
+                sanitised_tool["function"]["parameters"]
+                != tools_by_name[tool_name]["function"]["parameters"]
+            ):
+                rewrites += 1
+    assert rewrites > 0, (
+        "Fixture drift: every (preset, tool) row now has sanitize(T) == T. "
+        "The parity invariant collapses to the trivial case; add a "
+        "sanitizer-transforming (preset, model) pair to _EXTENDED_PRESET_SELECTORS "
+        "and _EXTENDED_MODEL_SPECS."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The parity invariant — accept a valid minimal instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("preset_name", "model_name", "provider", "tool_name"),
+    _PARITY_ROWS,
+    ids=[f"{row[0]}::{row[3]}" for row in _PARITY_ROWS],
+)
+def test_sanitized_schema_accepts_minimal_valid_instance(
+    preset_name: str,
+    model_name: str,
+    provider: str,
+    tool_name: str,
+) -> None:
+    """The ``ToolExecutor`` accepts a witness arg dict generated from the
+    sanitized schema. A regression that made the executor reject a
+    sanitized-conforming instance fires here with the specific ``(preset,
+    tool)`` row that first breaks."""
+    tools = _build_extended_tool_list()
+    original = next(t for t in tools if t["function"]["name"] == tool_name)
+    capabilities = build_capabilities(model_name, provider)
+    sanitised = capabilities.schema_sanitizer.sanitize(copy.deepcopy(tools))
+    sanitised_params = next(
+        t["function"]["parameters"] for t in sanitised if t["function"]["name"] == tool_name
+    )
+    assert isinstance(sanitised_params, dict) and sanitised_params.get("type") == "object", (
+        f"{preset_name}::{tool_name}: sanitized parameters root is not object-typed; "
+        "the fixture-drift guard should have caught this."
+    )
+
+    registry = ToolRegistry()
+    registry.register(_AcceptingTool(tool_name, original["function"]["parameters"]))
+    executor = ToolExecutor(registry)
+
+    defs = (
+        sanitised_params.get("$defs") if isinstance(sanitised_params.get("$defs"), dict) else None
+    )
+    args = _minimal_instance(sanitised_params, defs)
+    if not isinstance(args, dict):
+        pytest.skip(
+            f"{preset_name}::{tool_name}: generator produced a non-dict witness "
+            f"({type(args).__name__}); no witness derivable at this row."
+        )
+    try:
+        jsonschema_validate(instance=args, schema=sanitised_params)
+    except ValidationError as exc:
+        pytest.skip(
+            f"{preset_name}::{tool_name}: dumb generator's witness violates a "
+            f"constraint the generator does not model (pattern/min/max/…): {exc.message}"
+        )
+
+    result = executor.execute(tool_name, args, call_id="canon", validation_schema=sanitised_params)
+    assert result.success is True, (
+        f"{preset_name}::{tool_name}: sanitized-conforming witness rejected. "
+        f"status={result.status!r} error={result.error!r} args={args!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The parity invariant — reject an instance that violates the sanitized schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("preset_name", "model_name", "provider", "tool_name"),
+    _PARITY_ROWS,
+    ids=[f"{row[0]}::{row[3]}" for row in _PARITY_ROWS],
+)
+def test_sanitized_schema_rejects_wrong_type_at_required_scalar(
+    preset_name: str,
+    model_name: str,
+    provider: str,
+    tool_name: str,
+) -> None:
+    """The ``ToolExecutor`` rejects a witness with one required scalar
+    replaced by a wrong-typed value. A ``(preset, tool)`` row whose
+    sanitized schema has no required scalars (e.g. ``unions`` with only
+    optional fields) is skipped — the mutation surface is empty by
+    construction."""
+    tools = _build_extended_tool_list()
+    original = next(t for t in tools if t["function"]["name"] == tool_name)
+    capabilities = build_capabilities(model_name, provider)
+    sanitised = capabilities.schema_sanitizer.sanitize(copy.deepcopy(tools))
+    sanitised_params = next(
+        t["function"]["parameters"] for t in sanitised if t["function"]["name"] == tool_name
+    )
+
+    defs = (
+        sanitised_params.get("$defs") if isinstance(sanitised_params.get("$defs"), dict) else None
+    )
+    valid_args = _minimal_instance(sanitised_params, defs)
+    if not isinstance(valid_args, dict):
+        pytest.skip(f"{preset_name}::{tool_name}: cannot produce a base witness to mutate.")
+    mutated = _first_wrong_type_mutation(sanitised_params, valid_args, defs)
+    if mutated is None:
+        pytest.skip(
+            f"{preset_name}::{tool_name}: sanitized schema has no required scalar leaf "
+            "field to mutate; no witness of an invalid instance is derivable here."
+        )
+
+    registry = ToolRegistry()
+    registry.register(_AcceptingTool(tool_name, original["function"]["parameters"]))
+    executor = ToolExecutor(registry)
+
+    result = executor.execute(
+        tool_name, mutated, call_id="canon", validation_schema=sanitised_params
+    )
+    not_rejected_msg = f"{preset_name}::{tool_name}: mutation not rejected. args={mutated!r}"
+    assert not result.success, not_rejected_msg
+    wrong_status_msg = (
+        f"{preset_name}::{tool_name}: mutation rejected with wrong status "
+        f"{result.status!r}; parity invariant demands INVALID_ARGUMENTS."
+    )
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS, wrong_status_msg

--- a/tests/canonical/test_grader_composite_dispatch.py
+++ b/tests/canonical/test_grader_composite_dispatch.py
@@ -160,6 +160,9 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _install_scripted_client(monkeypatch: pytest.MonkeyPatch, script: list[Any]) -> None:
     monkeypatch.setattr(

--- a/tests/canonical/test_grader_composite_dispatch.py
+++ b/tests/canonical/test_grader_composite_dispatch.py
@@ -160,8 +160,8 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _install_scripted_client(monkeypatch: pytest.MonkeyPatch, script: list[Any]) -> None:

--- a/tests/canonical/test_grading_composite_llm_judge.py
+++ b/tests/canonical/test_grading_composite_llm_judge.py
@@ -86,8 +86,8 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 class _ScriptedJudgeModelProvider:

--- a/tests/canonical/test_grading_composite_llm_judge.py
+++ b/tests/canonical/test_grading_composite_llm_judge.py
@@ -86,6 +86,9 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 class _ScriptedJudgeModelProvider:
     """Test :class:`JudgeModelProvider` — returns a preloaded scripted client

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -250,6 +250,9 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 _JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
 
@@ -634,6 +637,9 @@ class _RaisingClient:
         from tolokaforge.core.loop import classify_loop_error
 
         return classify_loop_error(exc, ())
+
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
 
 
 def _install_raising_client(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/canonical/test_grading_substrate_dispatch.py
+++ b/tests/canonical/test_grading_substrate_dispatch.py
@@ -250,8 +250,8 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 _JUDGE_MODEL = ModelConfig(provider="openai", name="gpt-4o-mini", temperature=0.0)
@@ -638,8 +638,8 @@ class _RaisingClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _install_raising_client(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/canonical/test_lost_trial_attribution.py
+++ b/tests/canonical/test_lost_trial_attribution.py
@@ -90,6 +90,9 @@ class _CallingAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _calling_simulator() -> MagicMock:
     """The user's LLM, replaced by an opening turn that calls a tool."""

--- a/tests/canonical/test_lost_trial_attribution.py
+++ b/tests/canonical/test_lost_trial_attribution.py
@@ -90,8 +90,8 @@ class _CallingAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _calling_simulator() -> MagicMock:

--- a/tests/canonical/test_runner_turn_policy_wiring.py
+++ b/tests/canonical/test_runner_turn_policy_wiring.py
@@ -58,8 +58,8 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _agent(text: str) -> GenerationResult:

--- a/tests/canonical/test_runner_turn_policy_wiring.py
+++ b/tests/canonical/test_runner_turn_policy_wiring.py
@@ -58,6 +58,9 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _agent(text: str) -> GenerationResult:
     return GenerationResult(

--- a/tests/canonical/test_stuck_heuristics_are_satisfiable.py
+++ b/tests/canonical/test_stuck_heuristics_are_satisfiable.py
@@ -91,8 +91,8 @@ class _ScriptedTurns:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _usage() -> Usage:

--- a/tests/canonical/test_stuck_heuristics_are_satisfiable.py
+++ b/tests/canonical/test_stuck_heuristics_are_satisfiable.py
@@ -91,6 +91,9 @@ class _ScriptedTurns:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _usage() -> Usage:
     return Usage(prompt_tokens=10, completion_tokens=5)

--- a/tests/canonical/test_termination_reason_reachability.py
+++ b/tests/canonical/test_termination_reason_reachability.py
@@ -156,8 +156,8 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _text(body: str) -> GenerationResult:

--- a/tests/canonical/test_termination_reason_reachability.py
+++ b/tests/canonical/test_termination_reason_reachability.py
@@ -156,6 +156,9 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _text(body: str) -> GenerationResult:
     return GenerationResult(

--- a/tests/unit/grading/test_judge.py
+++ b/tests/unit/grading/test_judge.py
@@ -105,6 +105,13 @@ class ScriptedClient:
 
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        """Return ``None`` so the loop's no-override branch runs: judge fixtures
+        drive scripted tool calls whose arguments already conform to each tool's
+        declared schema, so the parity-check kwarg has no work to do here.
+        """
+        return None
+
 
 class FakeDBReader:
     def __init__(self, state: dict | None = None):
@@ -1069,6 +1076,9 @@ def test_judge_loop_crash_errors_not_scores():
             from tolokaforge.core.loop import classify_loop_error
 
             return classify_loop_error(exc, ())
+
+        def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+            return None
 
     result = _run_llm_judge(
         rubric=rubric,

--- a/tests/unit/grading/test_judge.py
+++ b/tests/unit/grading/test_judge.py
@@ -105,12 +105,13 @@ class ScriptedClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        """Return ``None`` so the loop's no-override branch runs: judge fixtures
-        drive scripted tool calls whose arguments already conform to each tool's
-        declared schema, so the parity-check kwarg has no work to do here.
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        """Return an empty map: judge fixtures drive scripted tool calls whose
+        arguments already conform to each tool's declared schema, so the
+        loop's per-tool ``.get()`` on the empty map yields ``None`` and the
+        executor falls back to the tool's own schema (the desired no-op).
         """
-        return None
+        return {}
 
 
 class FakeDBReader:
@@ -1077,8 +1078,8 @@ def test_judge_loop_crash_errors_not_scores():
 
             return classify_loop_error(exc, ())
 
-        def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-            return None
+        def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+            return {}
 
     result = _run_llm_judge(
         rubric=rubric,

--- a/tests/unit/test_run_display_wiring.py
+++ b/tests/unit/test_run_display_wiring.py
@@ -970,7 +970,14 @@ def _run_agent_loop_with(events: _RecordingEvents, *, call_observation: Any) -> 
     )
 
     class _NoopExecutor:
-        def execute(self, tool_name: str, arguments: Any) -> ToolResult:
+        def execute(
+            self,
+            tool_name: str,
+            arguments: Any,
+            *,
+            call_id: str = "",
+            validation_schema: dict[str, Any] | None = None,
+        ) -> ToolResult:
             return ToolResult(success=True, output="")
 
         def get_logs(self) -> list[dict[str, Any]]:

--- a/tests/unit/test_runner_logic.py
+++ b/tests/unit/test_runner_logic.py
@@ -42,7 +42,14 @@ class _EchoingUserToolExecutor:
     ``RecordedToolCall`` refuses a mock's attributes for ``status`` and ``output``.
     """
 
-    def execute(self, tool_name: str, arguments: dict | None = None, *, call_id: str) -> ToolResult:
+    def execute(
+        self,
+        tool_name: str,
+        arguments: dict | None = None,
+        *,
+        call_id: str,
+        validation_schema: dict | None = None,
+    ) -> ToolResult:
         return ToolResult(success=True, output=f"{tool_name} ran")
 
 
@@ -80,6 +87,11 @@ def _make_agent_client(responses: list[GenerationResult] | None = None) -> Magic
             cost_usd=0.01,
         )
     client.classify_loop_error.side_effect = lambda exc: classify_loop_error(exc, ())
+    # The loop reads this at construction to build ``validation_schemas_by_tool``.
+    # Returning ``None`` puts the loop in its no-override branch, so the executor
+    # call signature stays free of the ``validation_schema`` kwarg — matching what
+    # tests here assert on the ``execute`` mock.
+    client.sanitize_tools_for_execution.return_value = None
     return client
 
 

--- a/tests/unit/test_tool_call_recording.py
+++ b/tests/unit/test_tool_call_recording.py
@@ -178,9 +178,18 @@ class _CallIdWatchingExecutor(ToolExecutor):
         super().__init__(registry)
         self.call_ids: list[str] = []
 
-    def execute(self, tool_name: str, arguments: dict[str, Any], *, call_id: str) -> ToolResult:
+    def execute(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        call_id: str,
+        validation_schema: dict[str, Any] | None = None,
+    ) -> ToolResult:
         self.call_ids.append(call_id)
-        return super().execute(tool_name, arguments, call_id=call_id)
+        return super().execute(
+            tool_name, arguments, call_id=call_id, validation_schema=validation_schema
+        )
 
 
 class _ScriptedClient:
@@ -196,6 +205,13 @@ class _ScriptedClient:
 
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
+
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        """Return ``None`` so the loop takes its no-override branch: arguments are
+        validated against each tool's own declared schema, which is what these
+        recording-shape tests fix as the reference behaviour.
+        """
+        return None
 
 
 class _CountingSink(MetricsSink):

--- a/tests/unit/test_tool_call_recording.py
+++ b/tests/unit/test_tool_call_recording.py
@@ -206,12 +206,12 @@ class _ScriptedClient:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        """Return ``None`` so the loop takes its no-override branch: arguments are
-        validated against each tool's own declared schema, which is what these
-        recording-shape tests fix as the reference behaviour.
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        """Return an empty map: the loop's per-tool ``.get()`` yields ``None``,
+        so arguments are validated against each tool's own declared schema —
+        the reference behaviour these recording-shape tests pin.
         """
-        return None
+        return {}
 
 
 class _CountingSink(MetricsSink):

--- a/tests/unit/test_tool_calling_loop.py
+++ b/tests/unit/test_tool_calling_loop.py
@@ -60,7 +60,7 @@ class _RecordingExecutor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, dict, str]] = []
 
-    def execute(self, tool_name, arguments, *, call_id):
+    def execute(self, tool_name, arguments, *, call_id, validation_schema=None):
         self.executed.append((tool_name, arguments, call_id))
         return ToolResult(success=True, output=f"ran {tool_name}")
 
@@ -244,7 +244,7 @@ class _FailingTransportExecutor:
         self._raise_on = raise_on
         self.attempted: list[str] = []
 
-    def execute(self, tool_name, arguments, *, call_id):
+    def execute(self, tool_name, arguments, *, call_id, validation_schema=None):
         self.attempted.append(call_id)
         if call_id == self._raise_on:
             raise RuntimeError("runner unreachable")

--- a/tests/unit/test_user_executed_action_reachability.py
+++ b/tests/unit/test_user_executed_action_reachability.py
@@ -69,8 +69,8 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _simulator_calling(expression: str) -> MagicMock:

--- a/tests/unit/test_user_executed_action_reachability.py
+++ b/tests/unit/test_user_executed_action_reachability.py
@@ -69,6 +69,9 @@ class _ScriptedAgent:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _simulator_calling(expression: str) -> MagicMock:
     """The user's LLM, replaced by one tool-calling turn and a stop."""

--- a/tests/unit/test_user_reply_guard.py
+++ b/tests/unit/test_user_reply_guard.py
@@ -481,8 +481,8 @@ class _ScriptedAgentClient:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 def _run_trial(

--- a/tests/unit/test_user_reply_guard.py
+++ b/tests/unit/test_user_reply_guard.py
@@ -481,6 +481,9 @@ class _ScriptedAgentClient:
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 def _run_trial(
     *,

--- a/tests/unit/tools/test_executor_sanitized_schema_parity.py
+++ b/tests/unit/tools/test_executor_sanitized_schema_parity.py
@@ -1,0 +1,345 @@
+"""Schema-executor parity — the sanitized schema IS the accepted-args schema.
+
+The invariant this module locks: for every (provider-shaped tool schema,
+model-emitted arguments) pair,
+``ToolExecutor.execute(name, args, call_id=..., validation_schema=S)``
+accepts ``args`` iff ``args`` conforms to ``S``, where ``S`` is the parameters
+schema the model was shown for that tool (the output of
+``capabilities.schema_sanitizer.sanitize(tools)``). When ``validation_schema``
+is omitted the executor keeps its current behaviour: validate against
+``tool.get_schema()["function"]["parameters"]``.
+
+Cases 4a and 5a intentionally exercise the new ``validation_schema`` kwarg
+that Stage 2 lands. Until then they fail with
+``TypeError: unexpected keyword argument 'validation_schema'`` — the "red
+before green" side of the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from tolokaforge_models.policies.gemini import GeminiSchema
+
+from tolokaforge.core.docker_adapter import DockerRunnerAdapter
+from tolokaforge.tools.registry import (
+    Tool,
+    ToolExecutionStatus,
+    ToolExecutor,
+    ToolRegistry,
+    ToolResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# Tool fixtures
+# --------------------------------------------------------------------------
+
+
+class _FlatTool(Tool):
+    """A plain flat-schema tool: ``{a: str, b: int}``, both required."""
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": "flat_tool",
+                "description": "flat",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": "integer"},
+                    },
+                    "required": ["a", "b"],
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(success=True, output="flat-ok")
+
+
+class _OneOfTool(Tool):
+    """A tool whose ``item`` parameter is a Pydantic discriminated-union shape.
+
+    Mirrors the discovery repro: ``Annotated[Ticket | Task,
+    Field(discriminator='kind')]`` with per-branch ``additionalProperties:
+    false`` and branch-specific ``required``. The sanitiser's flatten pass
+    is lossy — the tight branch shape cannot be reconstructed from the flat
+    surface — which is what makes the parity invariant load-bearing.
+    """
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": "oneof_tool",
+                "description": "oneof",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "item": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "kind": {"type": "string", "const": "ticket"},
+                                        "ticket_id": {"type": "string"},
+                                        "subject": {"type": "string"},
+                                    },
+                                    "required": ["kind", "ticket_id", "subject"],
+                                    "additionalProperties": False,
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "kind": {"type": "string", "const": "task"},
+                                        "task_id": {"type": "string"},
+                                        "title": {"type": "string"},
+                                    },
+                                    "required": ["kind", "task_id", "title"],
+                                    "additionalProperties": False,
+                                },
+                            ],
+                            "discriminator": {"propertyName": "kind"},
+                        }
+                    },
+                    "required": ["item"],
+                },
+            },
+        }
+
+    def execute(self, **kwargs: Any) -> ToolResult:
+        return ToolResult(success=True, output="oneof-ok")
+
+
+def _make_flat_executor() -> ToolExecutor:
+    registry = ToolRegistry()
+    registry.register(_FlatTool("flat_tool", "flat"))
+    return ToolExecutor(registry)
+
+
+def _make_oneof_executor() -> tuple[ToolExecutor, dict[str, Any]]:
+    """Return an executor with the oneOf tool registered plus the sanitised
+    parameters schema Gemini would show the model."""
+    registry = ToolRegistry()
+    tool = _OneOfTool("oneof_tool", "oneof")
+    registry.register(tool)
+    executor = ToolExecutor(registry)
+    sanitised = GeminiSchema().sanitize([tool.get_schema()])
+    return executor, sanitised[0]["function"]["parameters"]
+
+
+# --------------------------------------------------------------------------
+# The six parity cases
+# --------------------------------------------------------------------------
+
+
+def test_case_1_baseline_pass_plain_schema_no_override() -> None:
+    """Case 1: plain schema, valid args, no override → SUCCESS.
+
+    Locks that omitting ``validation_schema`` preserves the executor's
+    current behaviour verbatim.
+    """
+    executor = _make_flat_executor()
+
+    result = executor.execute("flat_tool", {"a": "x", "b": 1}, call_id="c1")
+
+    assert result.success is True
+    assert result.status is None  # SUCCESS is expressed as ``status=None`` here
+
+
+def test_case_2_baseline_reject_plain_schema_no_override() -> None:
+    """Case 2: plain schema, missing required, no override → INVALID_ARGUMENTS.
+
+    Locks that jsonschema validation still fires when no override is passed.
+    """
+    executor = _make_flat_executor()
+
+    result = executor.execute("flat_tool", {"a": "x"}, call_id="c2")
+
+    assert result.success is False
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS
+
+
+def test_case_3_gemini_flatten_case_a_well_formed_branch_with_override() -> None:
+    """Case 3 (Case A): a well-formed ticket branch conforms to both the
+    original and the sanitised surface. With override → SUCCESS.
+    """
+    executor, sanitised_params = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {"item": {"kind": "ticket", "ticket_id": "T-42", "subject": "hi"}},
+        call_id="c3",
+        validation_schema=sanitised_params,
+    )
+
+    assert result.success is True
+    assert result.status is None
+
+
+def test_case_4a_gemini_flatten_case_b_stray_sibling_with_override() -> None:
+    """Case 4a (Case B with override): ticket branch plus a stray ``task_id``
+    conforms to the sanitised surface (both siblings are unioned into one
+    object schema). With override → SUCCESS.
+
+    Red until Stage 2 lands ``validation_schema=`` on ``ToolExecuting.execute``.
+    """
+    executor, sanitised_params = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {
+            "item": {
+                "kind": "ticket",
+                "ticket_id": "T-42",
+                "subject": "hi",
+                "task_id": "ignore",
+            }
+        },
+        call_id="c4a",
+        validation_schema=sanitised_params,
+    )
+
+    assert result.success is True
+    assert result.status is None
+
+
+def test_case_4b_gemini_flatten_case_b_without_override_still_rejects() -> None:
+    """Case 4b (Case B without override): the original nested oneOf schema
+    still rejects the flat args with the current stray-sibling failure. Locks
+    that the old-behaviour side of the contract survives Stage 2.
+    """
+    executor, _ = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {
+            "item": {
+                "kind": "ticket",
+                "ticket_id": "T-42",
+                "subject": "hi",
+                "task_id": "ignore",
+            }
+        },
+        call_id="c4b",
+    )
+
+    assert result.success is False
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS
+
+
+def test_case_5a_gemini_flatten_case_c_branch_required_missing_with_override() -> None:
+    """Case 5a (Case C with override): only the discriminator plus one branch
+    field, no branch-specific required. Conforms to the sanitised surface
+    (which reduces ``required`` to the discriminator intersection). With
+    override → SUCCESS.
+
+    Red until Stage 2 lands ``validation_schema=`` on ``ToolExecuting.execute``.
+    """
+    executor, sanitised_params = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {"item": {"kind": "ticket", "ticket_id": "T-42"}},
+        call_id="c5a",
+        validation_schema=sanitised_params,
+    )
+
+    assert result.success is True
+    assert result.status is None
+
+
+def test_case_5b_gemini_flatten_case_c_without_override_still_rejects() -> None:
+    """Case 5b (Case C without override): the original nested oneOf schema
+    still rejects the args on branch-required. Locks the old-behaviour side.
+    """
+    executor, _ = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {"item": {"kind": "ticket", "ticket_id": "T-42"}},
+        call_id="c5b",
+    )
+
+    assert result.success is False
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS
+
+
+def test_case_6_sanitized_schema_still_enforces_its_own_invariants() -> None:
+    """Case 6: ``kind`` outside the sanitised enum (``["task", "ticket"]``).
+    With override → INVALID_ARGUMENTS. Locks that the override *replaces*
+    the schema, not the gate — validation still runs.
+    """
+    executor, sanitised_params = _make_oneof_executor()
+
+    result = executor.execute(
+        "oneof_tool",
+        {"item": {"kind": "other"}},
+        call_id="c6",
+        validation_schema=sanitised_params,
+    )
+
+    assert result.success is False
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS
+
+
+# --------------------------------------------------------------------------
+# Docker-adapter kwarg refusal
+# --------------------------------------------------------------------------
+
+
+class _RecordingRuntime:
+    """A minimal ``RuntimeBackend`` stub that records the ``execute_tool``
+    call kwargs. Used to prove ``DockerRunnerAdapter.execute`` does not smuggle
+    ``validation_schema`` into the tool's ``arguments`` dict.
+    """
+
+    def __init__(self) -> None:
+        self.last_call: dict[str, Any] | None = None
+
+    def execute_tool(
+        self,
+        trial_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        executor: str = "agent",
+        *,
+        call_id: str,
+    ) -> ToolResult:
+        self.last_call = {
+            "trial_id": trial_id,
+            "tool_name": tool_name,
+            "arguments": dict(arguments),
+            "executor": executor,
+            "call_id": call_id,
+        }
+        return ToolResult(success=True, output="runtime-ok")
+
+
+def test_docker_adapter_accepts_validation_schema_without_smuggling_it_into_arguments() -> None:
+    """``DockerRunnerAdapter.execute`` accepts the ``validation_schema`` kwarg
+    but must NOT fold it into the tool's ``arguments`` dict — the runner-side
+    gRPC path does no jsonschema validation, so the schema has nowhere to go
+    and letting it leak into ``arguments`` would send it to the tool as a
+    parameter.
+    """
+    runtime = _RecordingRuntime()
+    adapter = DockerRunnerAdapter(runtime, trial_id="trial-1", executor="agent")
+
+    result = adapter.execute(
+        "some_tool",
+        {"a": "x"},
+        call_id="call-1",
+        validation_schema={"type": "object"},
+    )
+
+    assert result.success is True
+    assert runtime.last_call is not None
+    assert runtime.last_call["arguments"] == {"a": "x"}
+    assert "validation_schema" not in runtime.last_call["arguments"]

--- a/tests/unit/tools/test_executor_sanitized_schema_parity.py
+++ b/tests/unit/tools/test_executor_sanitized_schema_parity.py
@@ -6,13 +6,8 @@ model-emitted arguments) pair,
 accepts ``args`` iff ``args`` conforms to ``S``, where ``S`` is the parameters
 schema the model was shown for that tool (the output of
 ``capabilities.schema_sanitizer.sanitize(tools)``). When ``validation_schema``
-is omitted the executor keeps its current behaviour: validate against
+is omitted or ``None``, the executor validates against
 ``tool.get_schema()["function"]["parameters"]``.
-
-Cases 4a and 5a intentionally exercise the new ``validation_schema`` kwarg
-that Stage 2 lands. Until then they fail with
-``TypeError: unexpected keyword argument 'validation_schema'`` — the "red
-before green" side of the contract.
 """
 
 from __future__ import annotations
@@ -187,8 +182,6 @@ def test_case_4a_gemini_flatten_case_b_stray_sibling_with_override() -> None:
     """Case 4a (Case B with override): ticket branch plus a stray ``task_id``
     conforms to the sanitised surface (both siblings are unioned into one
     object schema). With override → SUCCESS.
-
-    Red until Stage 2 lands ``validation_schema=`` on ``ToolExecuting.execute``.
     """
     executor, sanitised_params = _make_oneof_executor()
 
@@ -212,8 +205,8 @@ def test_case_4a_gemini_flatten_case_b_stray_sibling_with_override() -> None:
 
 def test_case_4b_gemini_flatten_case_b_without_override_still_rejects() -> None:
     """Case 4b (Case B without override): the original nested oneOf schema
-    still rejects the flat args with the current stray-sibling failure. Locks
-    that the old-behaviour side of the contract survives Stage 2.
+    rejects the flat args on the stray sibling — the fallback path (no
+    override) validates against the tool's declared schema.
     """
     executor, _ = _make_oneof_executor()
 
@@ -239,8 +232,6 @@ def test_case_5a_gemini_flatten_case_c_branch_required_missing_with_override() -
     field, no branch-specific required. Conforms to the sanitised surface
     (which reduces ``required`` to the discriminator intersection). With
     override → SUCCESS.
-
-    Red until Stage 2 lands ``validation_schema=`` on ``ToolExecuting.execute``.
     """
     executor, sanitised_params = _make_oneof_executor()
 
@@ -257,7 +248,8 @@ def test_case_5a_gemini_flatten_case_c_branch_required_missing_with_override() -
 
 def test_case_5b_gemini_flatten_case_c_without_override_still_rejects() -> None:
     """Case 5b (Case C without override): the original nested oneOf schema
-    still rejects the args on branch-required. Locks the old-behaviour side.
+    rejects the args on branch-required — the fallback path validates against
+    the tool's declared schema.
     """
     executor, _ = _make_oneof_executor()
 
@@ -283,6 +275,44 @@ def test_case_6_sanitized_schema_still_enforces_its_own_invariants() -> None:
         {"item": {"kind": "other"}},
         call_id="c6",
         validation_schema=sanitised_params,
+    )
+
+    assert result.success is False
+    assert result.status is ToolExecutionStatus.INVALID_ARGUMENTS
+
+
+def test_case_7a_validation_schema_none_falls_back_to_tool_schema_pass() -> None:
+    """Case 7a: ``validation_schema=None`` explicit — the executor falls back
+    to the tool's own ``get_schema()["function"]["parameters"]``. Models the
+    :class:`ToolCallingLoop` state where ``validation_schemas_by_tool`` is set
+    but the current tool's name is missing from the map (``.get`` returns
+    ``None``); the fallback is intentional and this case documents it.
+    """
+    executor = _make_flat_executor()
+
+    result = executor.execute(
+        "flat_tool",
+        {"a": "x", "b": 1},
+        call_id="c7a",
+        validation_schema=None,
+    )
+
+    assert result.success is True
+    assert result.status is None
+
+
+def test_case_7b_validation_schema_none_falls_back_to_tool_schema_reject() -> None:
+    """Case 7b: same fallback path as 7a, but missing-required lands at the
+    tool's own schema — INVALID_ARGUMENTS. Locks that the fallback is not a
+    "no-op" — the tool's schema still gates the call.
+    """
+    executor = _make_flat_executor()
+
+    result = executor.execute(
+        "flat_tool",
+        {"a": "x"},
+        call_id="c7b",
+        validation_schema=None,
     )
 
     assert result.success is False

--- a/tests/utils/grader_parity_harness.py
+++ b/tests/utils/grader_parity_harness.py
@@ -300,6 +300,9 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
+        return None
+
 
 class _FakeDBServiceClient:
     """Deterministic DB stand-in that serves the pack's declared tables as

--- a/tests/utils/grader_parity_harness.py
+++ b/tests/utils/grader_parity_harness.py
@@ -300,8 +300,8 @@ class _ScriptedClient:
 
         return classify_loop_error(exc, ())
 
-    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict] | None:
-        return None
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}
 
 
 class _FakeDBServiceClient:

--- a/tolokaforge/core/docker_adapter.py
+++ b/tolokaforge/core/docker_adapter.py
@@ -63,6 +63,7 @@ class DockerRunnerAdapter:
         arguments: dict[str, Any] | None = None,
         *,
         call_id: str,
+        validation_schema: dict[str, Any] | None = None,
         **kwargs,
     ) -> ToolResult:
         """Execute a tool via the runtime backend under the bound
@@ -71,9 +72,11 @@ class DockerRunnerAdapter:
         Matches the :class:`~tolokaforge.tools.registry.ToolExecuting.execute`
         contract :class:`~tolokaforge.core.runner.TrialRunner` calls.
 
-        ``call_id`` is named explicitly rather than left to ``**kwargs``: this
-        method folds ``kwargs`` into the tool's own arguments, so an id arriving
-        that way would be sent to the tool as a parameter.
+        ``call_id`` and ``validation_schema`` are named explicitly rather than
+        left to ``**kwargs``: this method folds ``kwargs`` into the tool's own
+        arguments, so a name arriving that way would be sent to the tool as a
+        parameter. ``validation_schema`` is discarded — the runner-side gRPC
+        path does no jsonschema validation, tracked separately at #976.
         """
         if arguments is None:
             arguments = {}

--- a/tolokaforge/core/grading/judge.py
+++ b/tolokaforge/core/grading/judge.py
@@ -654,6 +654,7 @@ class LLMJudge:
             llm_client=client,
             tool_executor=tool_executor,
             tool_schemas=tool_schemas,
+            validation_schemas_by_tool=client.sanitize_tools_for_execution(tool_schemas),
             # Bounded by max_turns + wall-time (episode_timeout_s). There is no
             # per-turn loop timeout; the per-call LLM timeout lives in LLMClient.
             config=LoopConfig(max_turns=self._max_turns, episode_timeout_s=self._episode_timeout_s),

--- a/tolokaforge/core/grading/judge_model_provider.py
+++ b/tolokaforge/core/grading/judge_model_provider.py
@@ -27,7 +27,7 @@ the reference impl through it.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from tolokaforge.core.loop import LoopLLMClient, TerminationDecision
 from tolokaforge.core.models import ModelConfig
@@ -44,16 +44,23 @@ class JudgeModel(LoopLLMClient, Protocol):
     """The LLM callable surface an :class:`LLMJudge` consumes.
 
     Inherits :class:`~tolokaforge.core.loop.LoopLLMClient` for the
-    ``.generate(...)`` seam the shared :class:`ToolCallingLoop` drives, and
-    adds :meth:`classify_loop_error` because ``LLMJudge.run`` binds
+    ``.generate(...)`` seam the shared :class:`ToolCallingLoop` drives, adds
+    :meth:`classify_loop_error` because ``LLMJudge.run`` binds
     ``client.classify_loop_error`` as the loop's ``classify_error=``
-    argument. A downstream provider fronts a different LLM engine by
-    implementing these two methods and nothing more;
-    :class:`~tolokaforge.core.llm.client.LLMClient` already satisfies the
-    composed shape structurally.
+    argument, and adds :meth:`sanitize_tools_for_execution` because
+    ``LLMJudge.run`` also builds the loop's ``validation_schemas_by_tool``
+    map from it (so the tool executor validates against the schema the
+    judge model was shown, not the schema the tool declares). A downstream
+    provider fronts a different LLM engine by implementing these three
+    methods; :class:`~tolokaforge.core.llm.client.LLMClient` already
+    satisfies the composed shape structurally.
     """
 
     def classify_loop_error(self, exc: Exception) -> TerminationDecision: ...
+
+    def sanitize_tools_for_execution(
+        self, tools: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]: ...
 
 
 @runtime_checkable

--- a/tolokaforge/core/llm/client.py
+++ b/tolokaforge/core/llm/client.py
@@ -710,6 +710,27 @@ class LLMClient:
     def capabilities(self, value: ModelCapabilities) -> None:
         self._capabilities = value
 
+    def sanitize_tools_for_execution(
+        self, tools: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        """Return ``{tool_name: parameters_schema}`` after running this client's
+        :class:`~tolokaforge.core.llm.schema_sanitizer.ToolSchemaSanitizer` over
+        ``tools``. The per-tool schema in the returned map is what the model
+        actually saw for that tool, and is the schema
+        :class:`~tolokaforge.tools.registry.ToolExecutor` validates argument
+        dicts against when
+        :attr:`~tolokaforge.core.loop.ToolCallingLoop.validation_schemas_by_tool`
+        is wired to this method's result. See
+        ``docs/LLM_LAYER.md`` § ``schema_sanitizer``.
+        """
+        sanitised = self.capabilities.schema_sanitizer.sanitize(tools)
+        return {
+            t["function"]["name"]: t["function"]["parameters"]
+            for t in sanitised
+            if isinstance(t.get("function"), dict)
+            and isinstance(t["function"].get("parameters"), dict)
+        }
+
     # ------------------------------------------------------------------
     # Rate-limit classification — per-provider, closes over the binding's
     # compiled patterns so downstream callers never reach for internals.

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -295,6 +295,15 @@ class ToolCallingLoop:
         None
     )
     call_observation: LLMCallObservation | None = None
+    # Per-tool ``parameters`` schema the model was shown for this loop's tools,
+    # keyed by tool name. Wired at construction from
+    # :meth:`LLMClient.sanitize_tools_for_execution`. When present, the executor
+    # validates arguments against the schema for each call's tool; a call whose
+    # tool name is absent from the map falls back to the tool's own declared
+    # schema. When the whole field is ``None``, no schema is passed and the
+    # executor validates against the tool's declared schema — the path taken by
+    # tests that construct the loop without an LLM in scope.
+    validation_schemas_by_tool: Mapping[str, dict[str, Any]] | None = None
     # Bounded API-error retry sleep seam. Parallels ``LLMClient._retry_sleep``:
     # tests bind a no-op so the loop's retry backoff is instant. See
     # :attr:`LoopConfig.api_error_backoff_s` for the wait, and the retry class
@@ -496,7 +505,15 @@ class ToolCallingLoop:
         for tc in result.tool_calls:
             self._maybe_recover_arguments(tc, result.text)
             tool_start = time.time()
-            tool_result = self.tool_executor.execute(tc.name, tc.arguments, call_id=tc.id)
+            if self.validation_schemas_by_tool is None:
+                tool_result = self.tool_executor.execute(tc.name, tc.arguments, call_id=tc.id)
+            else:
+                tool_result = self.tool_executor.execute(
+                    tc.name,
+                    tc.arguments,
+                    call_id=tc.id,
+                    validation_schema=self.validation_schemas_by_tool.get(tc.name),
+                )
             tool_duration = time.time() - tool_start
             self.metrics.record_tool_call()
 

--- a/tolokaforge/core/loop.py
+++ b/tolokaforge/core/loop.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import re
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -303,7 +303,7 @@ class ToolCallingLoop:
     # schema. When the whole field is ``None``, no schema is passed and the
     # executor validates against the tool's declared schema — the path taken by
     # tests that construct the loop without an LLM in scope.
-    validation_schemas_by_tool: Mapping[str, dict[str, Any]] | None = None
+    validation_schemas_by_tool: dict[str, dict[str, Any]] | None = None
     # Bounded API-error retry sleep seam. Parallels ``LLMClient._retry_sleep``:
     # tests bind a no-op so the loop's retry backoff is instant. See
     # :attr:`LoopConfig.api_error_backoff_s` for the wait, and the retry class

--- a/tolokaforge/core/runner.py
+++ b/tolokaforge/core/runner.py
@@ -338,6 +338,9 @@ class TrialRunner:
                     llm_client=self.agent_client,
                     tool_executor=self.tool_executor,
                     tool_schemas=self.tool_schemas,
+                    validation_schemas_by_tool=self.agent_client.sanitize_tools_for_execution(
+                        self.tool_schemas
+                    ),
                     config=LoopConfig(
                         max_turns=self.max_turns,
                         episode_timeout_s=self.episode_timeout_s,

--- a/tolokaforge/tools/registry.py
+++ b/tolokaforge/tools/registry.py
@@ -346,7 +346,14 @@ class ToolExecuting(Protocol):
     for the one condition that does so.
     """
 
-    def execute(self, tool_name: str, arguments: dict[str, Any], *, call_id: str) -> ToolResult: ...
+    def execute(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        call_id: str,
+        validation_schema: dict[str, Any] | None = None,
+    ) -> ToolResult: ...
 
 
 class ToolExecutor:
@@ -362,7 +369,14 @@ class ToolExecutor:
         self.registry = registry
         self.env_client = env_client
 
-    def execute(self, tool_name: str, arguments: dict[str, Any], *, call_id: str) -> ToolResult:
+    def execute(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        call_id: str,
+        validation_schema: dict[str, Any] | None = None,
+    ) -> ToolResult:
         """
         Execute a tool with validation
 
@@ -378,6 +392,20 @@ class ToolExecutor:
             call_id: The trial's episode-unique tool-call id, carried by the
                 caller onto the trial's tool-call record so the call can be
                 joined to the tool result it produced
+            validation_schema: The parameters schema the model was shown for
+                this tool — the output of
+                ``capabilities.schema_sanitizer.sanitize(tools)`` at the loop's
+                construction site. When supplied, ``arguments`` are validated
+                against it instead of the tool's own
+                ``get_schema()["function"]["parameters"]``. The sanitizer is
+                lossy for provider-specific rewrites (Gemini's
+                ``oneOf``+``discriminator`` flatten) and the model emits args
+                that conform to what it saw, so validating against the tool's
+                original schema misroutes those args to
+                ``ToolExecutionStatus.INVALID_ARGUMENTS``. ``None`` falls back
+                to the tool's own schema — used by paths that construct
+                arguments without an LLM in the loop (see
+                :meth:`TrialRunner.run_harness`).
 
         Returns:
             ToolResult with output and metadata
@@ -397,8 +425,11 @@ class ToolExecutor:
 
         # Validate arguments against schema
         try:
-            schema = tool.get_schema()
-            parameters = schema.get("function", {}).get("parameters")
+            if validation_schema is not None:
+                parameters = validation_schema
+            else:
+                schema = tool.get_schema()
+                parameters = schema.get("function", {}).get("parameters")
 
             # Handle Nova/AWS Bedrock argument wrapping
             # Nova may send {'input': {...}} or {'input': '{"json": "string"}'}

--- a/tools/rubric-calibrator/tests/test_harness_scripted.py
+++ b/tools/rubric-calibrator/tests/test_harness_scripted.py
@@ -190,3 +190,6 @@ class _RouterJudge:
 
     def classify_loop_error(self, exc: Exception) -> TerminationDecision:
         return classify_loop_error(exc, ())
+
+    def sanitize_tools_for_execution(self, tools: list[dict]) -> dict[str, dict]:
+        return {}


### PR DESCRIPTION
## Summary

- Locks the **schema-executor-parity** invariant: for every preset `P` and every tool `T` the model was shown a sanitized schema for, `ToolExecutor.execute(T.name, ARGS, validation_schema=sanitize(T))` accepts `ARGS` iff `ARGS` conforms to `sanitize(T)`.
- Field impact: any Gemini-facing tool whose parameters carry a nested `oneOf` under a discriminator no longer produces false `INVALID_ARGUMENTS` rejections when the model emits the flattened surface. ~0.5pp production loss (53 trials on the last v3 sample) closed at the seam.

## Design choices

- **Option 2 (validate against sanitized), not Option 1 (reverse-normalize)**. The Gemini flatten is intentionally lossy (`additionalProperties: False`, per-branch `required`, the `oneOf`+`discriminator` triple are all dropped by design); reverse-normalization would have to invent data the model didn't send. Aligning the executor's validation surface with the model's shown surface is strictly cleaner.
- **`ToolExecuting` Protocol widened with a defaulted keyword-only `validation_schema: dict[str, Any] | None = None`**. Additive-with-default is the sanctioned migration path for existing Protocols; all in-tree implementers and test doubles updated. When `None`, the executor falls back to `tool.get_schema()["function"]["parameters"]` — current behaviour preserved verbatim.
- **`ToolCallingLoop.validation_schemas_by_tool: dict[str, dict[str, Any]] | None = None`**. Additive-with-default. `_execute_tool_calls` branches on `is None` so the call signature reduces to the pre-fix one exactly when the field is unset (protects every existing `assert_called_with(...)` assertion from churn).
- **`LLMClient.sanitize_tools_for_execution(tools) -> dict[name, schema]`**. One new public method on `LLMClient`; both loop construction sites (agent runner + rubric judge) build the map via it. Idempotent — the sanitizer already runs at wire time; this is a second cheap pass for a per-tool lookup.
- **`JudgeModel` Protocol widened with `sanitize_tools_for_execution`**. `judge.py:657` invokes it on a `JudgeModel`-typed client; without the Protocol declaration a downstream provider that implemented only `generate` + `classify_loop_error` would ship an `AttributeError`. Applied in the reviewer-fix commit.
- **`DockerRunnerAdapter.execute` accepts `validation_schema` as an explicit keyword-only param and discards it**. The runner-side gRPC path does no jsonschema validation ([#976](https://github.com/Toloka/tolokaforge/issues/976)); naming the kwarg explicitly guarantees it can't smuggle into `arguments` via the `**kwargs` fold (general hazard tracked at [#1474](https://github.com/Toloka/tolokaforge/issues/1474)).
- **Harness-CLI arm intentionally NOT wired**. `run_harness` code-constructs arguments with no LLM in the loop; the parity invariant is undefined there. Adding it would create a dead code path with no test to lock.

## Concepts introduced

**`ToolExecuting.execute(validation_schema=…)`** — a keyword-only kwarg on the tool-executor Protocol carrying the schema the model was shown. When provided, the executor validates argument dicts against it; when omitted, falls back to the tool's own declared schema. This is the seam by which "what the model saw" and "what the executor accepts" stay aligned.

**`ToolCallingLoop.validation_schemas_by_tool`** — an optional `{tool_name: parameters_schema}` map the loop threads into each `execute` call, per-tool. Populated by both loop construction sites (agent trial runner + rubric judge) via `<client>.sanitize_tools_for_execution(<tools>)`.

**`LLMClient.sanitize_tools_for_execution(tools) -> dict[str, dict[str, Any]]`** — a public method on `LLMClient` (and now on `JudgeModel`) that returns the sanitized parameters schema per tool. This is the one seam callers use to obtain "what the model actually sees"; the client already sanitizes tools once at wire time, this method exposes that outcome for downstream validation.

**Fixture drift guard** — the canonical parity test carries a small guard test asserting at least one `(preset, tool)` row has `sanitize(T) != T`. If the fixture ever narrows to only passthrough sanitizers, the invariant collapses to the trivial passthrough case; the guard catches that.

## Plan

See `~/.claude/plans/toloka-tolokaforge/issue-1445-schema-executor-parity.md` — 3 stages. Plan-critic reviewed round 1 APPROVE WITH NOTES (1 🟠 Stage 3 fixture didn't exercise Gemini flatten, 4 🟡 grounding/coverage). 🟠 folded inline into the plan as an implementer directive; four 🟡s recorded as inline plan notes and applied at commit time. No second critic round needed.

## Discovered issues

- **Filed**: [#1474](https://github.com/Toloka/tolokaforge/issues/1474) — `DockerRunnerAdapter.execute` `**kwargs` folds unknown kwargs into tool arguments (general kwargs-smuggling hazard). This PR closes the specific hazard for `validation_schema` by naming it explicitly; the general hazard is deferred design work.
- **Cross-linked**: [#976](https://github.com/Toloka/tolokaforge/issues/976) — runner-side gRPC path does no jsonschema validation. This PR does not close #976; it reduces the shared-stack vs core-stack asymmetry it names by moving the executor's gate to align with the model's shown surface.
- **Cross-linked**: [#599](https://github.com/Toloka/tolokaforge/issues/599) — the previous rejection landed as `INVALID_ARGUMENTS`, reading as an ordinary agent failure. This PR narrows how often that gate fires (fewer false positives); #599 owns the attribution of what remains.

## Test plan

- **Behaviour lock**: `tests/unit/tools/test_executor_sanitized_schema_parity.py` — 11 tests (5 baseline + Gemini flatten × 3 with/without-override cases + docker-adapter kwarg-refusal + 2 fallback-edge cases). All green.
- **Canonical round-trip lock**: `tests/canonical/test_executor_sanitizer_parity.py` — 127 parametric `(preset, tool)` rows (110 passed + 17 skipped where the dumb minimal-instance generator can't produce a valid witness on `pattern`/`minLength`/etc.). Load-bearing `gemini::discriminated_union` row passes on both accept and mutation-reject.
- **Fixture drift guard**: `test_at_least_one_row_has_sanitizer_rewriting_the_schema` asserts count > 0 (catches accidental narrowing of the fixture to only passthrough sanitizers).
- **Full canonical suite**: 1913 passed, 18 skipped.
- **Sharded reviewers**: correctness APPROVE (0 findings), hygiene REQUEST-CHANGES → APPROVE-after-fixes (1 Blocker 8 stage attribution + 1 nit URL casing, applied inline in `3250d994`), type-fit APPROVE-WITH-NITS → APPROVE-after-fixes (1 🟠 `JudgeModel` Protocol widening + 2 🟡 return-type + loop-field variance, all applied inline in `3250d994`).

## Follow-up nits (not blocking)

- **`.hypothesis` `norecursedirs` warning** — inherited from the M#43 base branch; one-line pyproject fix. Optional.

Closes #1445