### PR TITLE
test(rc-smoke): expect fold-refusal on judge-errored packs

### DIFF
--- a/tests/integration/deploy/test_rc_smoke_parity_reference.py
+++ b/tests/integration/deploy/test_rc_smoke_parity_reference.py
@@ -231,14 +231,6 @@ def _baseline_components(pack: ParityPack) -> dict[str, float]:
     return {str(k): float(v) for k, v in components.items()}
 
 
-_NON_JUDGE_COMPONENT_FIELDS: tuple[str, ...] = (
-    "state_checks",
-    "transcript_rules",
-    "trace_checks",
-    "custom_checks",
-)
-
-
 @pytest.mark.parametrize("pack_id", _DETERMINISTIC_PACK_IDS, ids=list(_DETERMINISTIC_PACK_IDS))
 def test_reference_pack_parity_deterministic_tier(
     pack_id: str,
@@ -290,58 +282,35 @@ def test_reference_pack_parity_wire_shape_tier(
     pack_id: str,
     parity_stack: StackHandle,  # noqa: ARG001 — fixture usage; compose stack must be up
 ) -> None:
-    """Each judge pack keylessly errors the judge and preserves non-judge components.
+    """Each judge pack keylessly errors the judge and refuses the fold.
 
     Runs against a stack with no LLM keys in the container env: the judge
     dispatch construction succeeds (LLMClient accepts an empty key chain),
     the loop's first ``.generate()`` call raises an auth error inside
-    litellm, and :class:`LLMJudge.run` catches it into a fail-loud
-    ``JudgeStatus.ERRORED`` result. Byte-parity on ``judge_status`` and
-    ``JUDGE ERRORED`` in ``reasons`` proves the wire shape; byte-parity on
-    non-judge components against the baseline proves those seams still
-    produced the same output the canonical lane records.
+    litellm, and :class:`LLMJudge.run` catches it into a
+    ``JudgeStatus.ERRORED`` result. ``resolve_uncounted_fold`` then refuses
+    the composition — silently redistributing the weight the errored judge
+    was meant to carry across the surviving components would fabricate a
+    grade the operator cannot reconcile.
 
-    Refuses ``success=false``: on a judge-using pack that would mean the
-    grader gave up before completing composite dispatch, which is a
-    regression distinct from the intentional errored-judge outcome and one
-    this gate exists to catch.
+    The wire returns ``GradeResponse(success=false)`` whose ``error``
+    carries the ``produced no verdict`` refusal fragment. This gate locks
+    that behaviour end-to-end over the real gRPC wire.
     """
-    from tolokaforge.grader import grader_pb2
-
     pack = load_parity_pack(_BASELINES_ROOT / pack_id)
     _register_pack_trial(pack)
     response = _call_grade_over_wire(pack)
 
-    assert response.success, (
-        f"wire-shape tier pack {pack_id!r} came back success=false — the grader "
-        f"gave up before completing composite dispatch, which is a regression "
-        f"distinct from the intentional errored-judge outcome. error={response.error!r}"
+    assert not response.success, (
+        f"wire-shape tier pack {pack_id!r} came back success=true — the grader "
+        f"composed a grade for a judge-errored trial instead of refusing the "
+        f"fold. grade={response.grade!r}"
     )
-    assert (
-        not response.no_verdict
-    ), f"wire-shape tier pack {pack_id!r} reported no_verdict on a judge-using trial"
-    grade = response.grade
-    assert grade.judge_status == grader_pb2.JUDGE_STATUS_ERRORED, (
-        f"wire-shape tier pack {pack_id!r} did not report a keyless-judge ERRORED "
-        f"outcome (judge_status={grade.judge_status}); the runner container may "
-        f"be carrying an unexpected LLM key or the judge dispatch was skipped"
+    assert "produced no verdict" in (response.error or ""), (
+        f"wire-shape tier pack {pack_id!r} refused as expected but the error "
+        f"message does not carry the fold-refusal fragment "
+        f"'produced no verdict': {response.error!r}"
     )
-    assert "JUDGE ERRORED" in grade.reasons, (
-        f"wire-shape tier pack {pack_id!r} judge_status is ERRORED but reasons "
-        f"lack the 'JUDGE ERRORED' segment: {grade.reasons!r}"
-    )
-
-    baseline_components = _baseline_components(pack)
-    serialised = serialise_grade(grade)
-    wire_components = json.loads(serialised).get("components") or {}
-    for field in _NON_JUDGE_COMPONENT_FIELDS:
-        if field not in baseline_components:
-            continue
-        assert wire_components.get(field) == baseline_components[field], (
-            f"wire-shape tier pack {pack_id!r} non-judge component "
-            f"{field!r} diverged from the committed baseline: "
-            f"wire={wire_components.get(field)!r} baseline={baseline_components[field]!r}"
-        )
 
 
 def test_hash_refusal_end_to_end(


### PR DESCRIPTION
## Summary

The publish-images gate has been failing on \`0.22.2\`, \`0.22.3\`, and \`0.22.4\` because \`tests/integration/deploy/test_rc_smoke_parity_reference.py::test_reference_pack_parity_wire_shape_tier\` expects the pre-M#42 silent-redistribute-on-judge-error behaviour. Since #599 shipped, \`resolve_uncounted_fold\` refuses composition when the LLM judge produced no verdict — the wire returns \`GradeResponse(success=false)\` with \`'produced no verdict'\` in the error rather than a fabricated grade whose weight was silently reallocated.

Field impact: three consecutive release-image-promote workflow failures (\`image-v0.22.2-rc.1\`, \`image-v0.22.3-rc.1\`, \`image-v0.22.4-rc.1\`). The RC images build but never get promoted to their unversioned tags (\`0.22.4\`, etc.), so \`tolokaforge run\` on downstream repos (\`toloka-partners/tolokaforge-tasks\` v3 sanity) hits \`tag_missing: tolokasoft1/tolokaforge-runner:0.22.4\` and falls back to a doomed local build.

## Design choices

- **Rewrite the wire-shape assertions to expect refusal**, mirroring the sibling \`test_hash_refusal_end_to_end\` (an ADR-0040 refusal shape). The judge-errored refusal is the same class of contract: a declared component missing its verdict is not silently swept; the wire returns \`success=false\` with a canonical fragment (\`produced no verdict\`).
- **Drop** the byte-parity check against \`_NON_JUDGE_COMPONENT_FIELDS\`. Under the new contract, a judge-errored trial never produces a grade — there are no non-judge components on the wire to compare. The deterministic tier still exercises full component parity on judge-not-required packs.

## Concepts introduced

None. This aligns the RC smoke gate with the wire contract M#42 shipped in v0.22.2.

## Plan

Single-file test edit; no code change, no docs to update. \`test_hash_refusal_end_to_end\` is the model to match.

## Discovered issues

- **Fixed in this PR**: the publish-images gate for 0.22.2+ has been silently failing for a week. Landing this unblocks image promotion for v0.22.2 (M#42), v0.22.3 (M#43), v0.22.4 (\`#1483\`).
- **Downstream**: \`toloka-partners/tolokaforge-tasks\` PR #302 (v3 pin bump) needs to re-dispatch its sanity-scope run after this lands and the images promote to \`0.22.4\`.

## Test plan

- \`test_reference_pack_parity_wire_shape_tier\` collects cleanly (10 tests in the file, no orphan imports).
- The three parametrised cases (\`rubric_only\`, \`state_plus_judge\`, \`all_four_no_hash\`) now assert \`not response.success\` + \`"produced no verdict" in response.error\` — the M#42 fold-refusal contract from \`tolokaforge/core/grading/combine_weights.py\`.
- \`test_reference_pack_parity_deterministic_tier\` and \`test_hash_refusal_end_to_end\` untouched.
- **Full smoke lane runs on the RC image via this workflow** once merged; that is the confirmation.

## Follow-up nits (not blocking)

None.